### PR TITLE
Define core protocols, reporting tool spec, and result dataclasses

### DIFF
--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -1,5 +1,7 @@
 """goldfive — agent orchestration: stay on target."""
 
+from __future__ import annotations
+
 __version__ = "0.0.1"
 
 # Public API re-exports are added by subsequent PRs.

--- a/goldfive/protocols.py
+++ b/goldfive/protocols.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from goldfive.reporting import ReportingToolSpec
+    from goldfive.results import ExecutionOutcome, InvocationResult
+    from goldfive.types import (
+        DriftEvent,
+        Goal,
+        Plan,
+        Session,
+        Task,
+        TaskStatus,
+    )
+
+
+@runtime_checkable
+class GoalDeriver(Protocol):
+    """Derives a list of ``Goal`` objects from free-form user input."""
+
+    async def derive(
+        self,
+        user_input: str,
+        *,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> list["Goal"]: ...
+
+
+@runtime_checkable
+class Planner(Protocol):
+    """Generates and refines ``Plan`` instances from goals and drift events."""
+
+    async def generate(
+        self,
+        *,
+        goals: list["Goal"],
+        available_agents: list[str],
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> Optional["Plan"]: ...
+
+    async def refine(
+        self,
+        *,
+        plan: "Plan",
+        drift: "DriftEvent",
+        goals: list["Goal"],
+    ) -> Optional["Plan"]: ...
+
+
+@runtime_checkable
+class Steerer(Protocol):
+    """Observes execution events, drives task transitions, and detects drift."""
+
+    async def observe(self, event: Any, session: "Session") -> None: ...
+
+    async def transition(
+        self,
+        task_id: str,
+        to: "TaskStatus",
+        *,
+        detail: str = "",
+        session: "Session",
+    ) -> None: ...
+
+    def detect_drift(
+        self,
+        event: Any,
+        session: "Session",
+    ) -> Optional["DriftEvent"]: ...
+
+    # Called by executors to wire sinks/planner into the steerer.
+    def bind(
+        self,
+        *,
+        sinks: list["EventSink"],
+        planner: Planner,
+    ) -> None: ...
+
+
+@runtime_checkable
+class AgentAdapter(Protocol):
+    """Wraps an underlying agent framework (ADK, Claude Agent SDK, etc.)."""
+
+    async def register_reporting_tools(
+        self,
+        tools: list["ReportingToolSpec"],
+    ) -> None: ...
+
+    async def invoke(
+        self,
+        task: "Task",
+        session: "Session",
+    ) -> "InvocationResult": ...
+
+    @property
+    def available_agents(self) -> list[str]: ...
+
+
+@runtime_checkable
+class Executor(Protocol):
+    """Executes a ``Plan`` by dispatching tasks to the adapter and steerer."""
+
+    async def run(
+        self,
+        *,
+        plan: "Plan",
+        session: "Session",
+        adapter: AgentAdapter,
+        steerer: Steerer,
+        planner: Planner,
+        sinks: list["EventSink"],
+    ) -> "ExecutionOutcome": ...
+
+
+@runtime_checkable
+class EventSink(Protocol):
+    """Receives proto ``Event`` messages emitted by executors and steerers."""
+
+    async def emit(self, event_pb: Any) -> None: ...  # pb Event message
+
+    async def close(self) -> None: ...

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+if TYPE_CHECKING:
+    from goldfive.protocols import Steerer
+    from goldfive.types import Session
+
+
+# Framework-agnostic async handler signature.
+# Handlers receive the tool-call arguments (already decoded to a dict),
+# the live Session, and the Steerer, and return a JSON-serializable dict.
+ReportingHandler = Callable[
+    [dict[str, Any], "Session", "Steerer"],
+    Awaitable[dict[str, Any]],
+]
+
+
+@dataclasses.dataclass
+class ReportingToolSpec:
+    """Framework-agnostic spec for a reporting tool.
+
+    Adapters translate one of these into whatever tool representation their
+    underlying framework expects (e.g., an ADK ``FunctionTool`` or a Claude
+    Agent SDK tool definition). The canonical set of tool names is pinned in
+    :data:`REPORTING_TOOL_NAMES`.
+    """
+
+    name: str
+    description: str
+    parameters: dict[str, Any]  # JSON schema for parameters
+    handler: ReportingHandler
+
+
+# The seven canonical reporting tool names. These are a stable contract: the
+# adapter must surface tools with exactly these names so that the Steerer can
+# interpret them uniformly across frameworks. Do not rename.
+REPORTING_TOOL_NAMES: tuple[str, ...] = (
+    "report_task_started",
+    "report_task_progress",
+    "report_task_completed",
+    "report_task_failed",
+    "report_task_blocked",
+    "report_new_work_discovered",
+    "report_plan_divergence",
+)

--- a/goldfive/results.py
+++ b/goldfive/results.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from goldfive.types import Session
+
+
+@dataclasses.dataclass
+class InvocationResult:
+    """Result returned by ``AgentAdapter.invoke`` for a single task.
+
+    ``text`` is the final assistant text, ``stop_reason`` is adapter-specific,
+    ``error`` is populated if the invocation raised, and ``raw`` carries the
+    adapter's native result object for debugging or downstream inspection.
+    """
+
+    task_id: str
+    text: str = ""
+    stop_reason: str = ""
+    error: Optional[Exception] = None
+    raw: Any = None
+
+
+@dataclasses.dataclass
+class ExecutionOutcome:
+    """Final outcome of an ``Executor.run`` invocation.
+
+    ``reason`` is populated when ``success`` is False to describe why the run
+    terminated (e.g., unrecoverable task failure, user cancellation).
+    """
+
+    success: bool
+    session: "Session"
+    reason: str = ""

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+import pytest
+
+from goldfive.protocols import (
+    AgentAdapter,
+    EventSink,
+    Executor,
+    GoalDeriver,
+    Planner,
+    Steerer,
+)
+
+ALL_PROTOCOLS = (GoalDeriver, Planner, Steerer, AgentAdapter, Executor, EventSink)
+
+
+@pytest.mark.parametrize("proto", ALL_PROTOCOLS)
+def test_protocol_is_runtime_checkable(proto: type) -> None:
+    # ``@runtime_checkable`` sets this dunder attribute on the Protocol class.
+    assert getattr(proto, "_is_runtime_protocol", False) is True
+
+
+# ---------------------------------------------------------------------------
+# Trivial stubs implementing each Protocol's surface area.
+# ---------------------------------------------------------------------------
+
+
+class _GoalDeriverStub:
+    async def derive(
+        self,
+        user_input: str,
+        *,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> list[Any]:
+        return []
+
+
+class _PlannerStub:
+    async def generate(
+        self,
+        *,
+        goals: list[Any],
+        available_agents: list[str],
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> Optional[Any]:
+        return None
+
+    async def refine(
+        self,
+        *,
+        plan: Any,
+        drift: Any,
+        goals: list[Any],
+    ) -> Optional[Any]:
+        return None
+
+
+class _SteererStub:
+    async def observe(self, event: Any, session: Any) -> None:
+        return None
+
+    async def transition(
+        self,
+        task_id: str,
+        to: Any,
+        *,
+        detail: str = "",
+        session: Any,
+    ) -> None:
+        return None
+
+    def detect_drift(self, event: Any, session: Any) -> Optional[Any]:
+        return None
+
+    def bind(self, *, sinks: list[Any], planner: Any) -> None:
+        return None
+
+
+class _AgentAdapterStub:
+    async def register_reporting_tools(self, tools: list[Any]) -> None:
+        return None
+
+    async def invoke(self, task: Any, session: Any) -> Any:
+        return None
+
+    @property
+    def available_agents(self) -> list[str]:
+        return []
+
+
+class _ExecutorStub:
+    async def run(
+        self,
+        *,
+        plan: Any,
+        session: Any,
+        adapter: Any,
+        steerer: Any,
+        planner: Any,
+        sinks: list[Any],
+    ) -> Any:
+        return None
+
+
+class _EventSinkStub:
+    async def emit(self, event_pb: Any) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.parametrize(
+    "stub, proto",
+    [
+        (_GoalDeriverStub(), GoalDeriver),
+        (_PlannerStub(), Planner),
+        (_SteererStub(), Steerer),
+        (_AgentAdapterStub(), AgentAdapter),
+        (_ExecutorStub(), Executor),
+        (_EventSinkStub(), EventSink),
+    ],
+)
+def test_stub_satisfies_protocol(stub: object, proto: type) -> None:
+    assert isinstance(stub, proto)


### PR DESCRIPTION
## Summary

- Adds `goldfive/protocols.py` with six `@runtime_checkable` Protocols: `GoalDeriver`, `Planner`, `Steerer`, `AgentAdapter`, `Executor`, `EventSink`. Signatures match `INTERFACE_SPEC.md` exactly (all methods async where specified; `Steerer.bind` / `Steerer.detect_drift` / `AgentAdapter.available_agents` are sync per spec).
- Adds `goldfive/reporting.py` with the framework-agnostic `ReportingToolSpec` dataclass and a `REPORTING_TOOL_NAMES` tuple pinning the seven canonical tool names. Handler implementations are intentionally deferred to issue #6.
- Adds `goldfive/results.py` with `InvocationResult` and `ExecutionOutcome` dataclasses.
- Adds `tests/test_protocols.py` verifying each Protocol is `runtime_checkable` and that a trivial stub class satisfies `isinstance` against it.

Type-only imports from `goldfive.types` are guarded under `TYPE_CHECKING` with string forward-refs so this PR can land before issue #4 without breaking runtime imports. `from __future__ import annotations` is set on every new module per the interface spec.

## Test plan

- [x] `uv run --with pytest pytest tests/test_protocols.py -v` — 12 passed
- [x] `python3 -c "from goldfive.protocols import *; from goldfive.reporting import *; from goldfive.results import *"` imports cleanly
- [x] `REPORTING_TOOL_NAMES` contains exactly the 7 canonical names
- [ ] Re-run mypy once issue #4 merges (currently reports only the expected `goldfive.types` import-not-found)

Closes #5

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>