### PR TITLE
Add CallableAdapter (reference AgentAdapter)

### DIFF
--- a/goldfive/adapters/__init__.py
+++ b/goldfive/adapters/__init__.py
@@ -1,0 +1,12 @@
+"""Agent adapter implementations.
+
+Each adapter bridges an external agent SDK (or a plain async callable) to
+the :class:`goldfive.protocols.AgentAdapter` protocol. The CallableAdapter
+is the reference implementation — see :mod:`goldfive.adapters.callable`.
+"""
+
+from __future__ import annotations
+
+from goldfive.adapters.callable import CallableAdapter
+
+__all__ = ["CallableAdapter"]

--- a/goldfive/adapters/_tool_invocation.py
+++ b/goldfive/adapters/_tool_invocation.py
@@ -1,0 +1,49 @@
+"""Shared helper for invoking reporting tool handlers from adapters.
+
+Adapters typically receive a tool call from their SDK as ``(name, args)``
+and need to locate the matching :class:`ReportingToolSpec` and call its
+handler with ``(args, session, steerer)``. This helper centralises that
+lookup so that every adapter (CallableAdapter, ADK, Claude) routes through
+the same code path — keeping behaviour and error messages consistent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+from goldfive.reporting import ReportingToolSpec
+
+if TYPE_CHECKING:  # pragma: no cover - type-only
+    from goldfive.protocols import Steerer
+    from goldfive.types import Session
+
+
+def find_tool(
+    tools: Iterable[ReportingToolSpec],
+    name: str,
+) -> ReportingToolSpec | None:
+    """Return the first tool whose ``name`` matches, else ``None``."""
+    for tool in tools:
+        if tool.name == name:
+            return tool
+    return None
+
+
+async def invoke_tool(
+    tools: Iterable[ReportingToolSpec],
+    name: str,
+    args: dict[str, Any],
+    session: Session,
+    steerer: Steerer,
+) -> dict[str, Any]:
+    """Look up ``name`` in ``tools`` and invoke its handler.
+
+    Raises :class:`KeyError` if no tool with that name is registered — this
+    mirrors the behaviour a real SDK would exhibit when an agent hallucinates
+    a tool name, and lets adapters surface a clean error to the agent.
+    """
+    tool = find_tool(tools, name)
+    if tool is None:
+        raise KeyError(f"unknown reporting tool: {name!r}")
+    return await tool.handler(args, session, steerer)

--- a/goldfive/adapters/callable.py
+++ b/goldfive/adapters/callable.py
@@ -1,0 +1,71 @@
+"""CallableAdapter — the reference :class:`AgentAdapter` implementation.
+
+Wraps an async callable of shape::
+
+    async def agent(
+        task: Task,
+        session: Session,
+        tools: list[ReportingToolSpec],
+    ) -> InvocationResult
+
+The callable is free to invoke any of the registered reporting tool
+handlers directly (they are plain awaitables) to drive state transitions.
+This adapter is the canonical example other adapters (ADK, Claude) follow,
+and is the preferred vehicle for deterministic tests of the orchestration
+layer because it removes LLM non-determinism from the loop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from goldfive.reporting import ReportingToolSpec
+from goldfive.results import InvocationResult
+from goldfive.types import Session, Task
+
+AgentCallable = Callable[
+    [Task, Session, list[ReportingToolSpec]],
+    Awaitable[InvocationResult],
+]
+
+
+class CallableAdapter:
+    """Adapter that delegates :meth:`invoke` to a user-supplied async callable.
+
+    The adapter holds the reporting-tool specs registered by the executor
+    and forwards them to the callable on every invocation, so the callable
+    can invoke any reporting tool handler it needs (e.g. ``report_task_started``,
+    ``report_task_completed``) to drive the session state machine.
+
+    Parameters
+    ----------
+    agent:
+        Async callable invoked for each task.
+    available_agents:
+        Optional list of agent identifiers this adapter can dispatch to.
+        Exposed via the :attr:`available_agents` property so planners can
+        enumerate routable agents. Defaults to an empty list.
+    """
+
+    def __init__(
+        self,
+        agent: AgentCallable,
+        *,
+        available_agents: list[str] | None = None,
+    ) -> None:
+        self._agent = agent
+        self._available_agents: list[str] = list(available_agents) if available_agents else []
+        self._tools: list[ReportingToolSpec] = []
+
+    async def register_reporting_tools(self, tools: list[ReportingToolSpec]) -> None:
+        """Store the reporting tool specs for later forwarding to the callable."""
+        self._tools = list(tools)
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:
+        """Invoke the wrapped callable and return its :class:`InvocationResult`."""
+        return await self._agent(task, session, self._tools)
+
+    @property
+    def available_agents(self) -> list[str]:
+        """Return the configured list of available agent identifiers."""
+        return list(self._available_agents)

--- a/tests/test_callable_adapter.py
+++ b/tests/test_callable_adapter.py
@@ -1,0 +1,276 @@
+"""Unit tests for :class:`goldfive.adapters.CallableAdapter`.
+
+These tests use minimal stand-in ``report_task_started`` and
+``report_task_completed`` tool handlers. Issue #5/#6 owns the real handler
+implementations — what we care about here is that the adapter:
+
+1. Stores tool specs on ``register_reporting_tools``.
+2. Forwards them to the wrapped callable on ``invoke``.
+3. Returns the callable's :class:`InvocationResult` verbatim.
+4. Exposes ``available_agents`` as configured.
+
+We also exercise the ``_tool_invocation`` helper via the stub agent, since
+it is the shared lookup path every adapter will use.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from goldfive.adapters import CallableAdapter
+from goldfive.adapters._tool_invocation import find_tool, invoke_tool
+from goldfive.reporting import ReportingToolSpec
+from goldfive.results import InvocationResult
+from goldfive.types import Session, Task, TaskStatus
+
+
+class _StubSteerer:
+    """Minimal ``Steerer``-shaped recorder used for tool handler tests.
+
+    Real handlers (issue #6) will route through the live steerer, but here
+    we only need something the stub handlers can call ``transition`` on and
+    that the adapter never inspects.
+    """
+
+    def __init__(self) -> None:
+        self.transitions: list[tuple[str, TaskStatus, str]] = []
+
+    async def transition(
+        self,
+        task_id: str,
+        to: TaskStatus,
+        *,
+        detail: str = "",
+        session: Session,
+    ) -> None:
+        self.transitions.append((task_id, to, detail))
+        # Mirror real steerer behaviour: update session state.
+        session.current_task_id = task_id
+        if session.plan is not None:
+            for t in session.plan.tasks:
+                if t.id == task_id:
+                    t.status = to
+
+    # Unused in these tests but kept so the stub is Steerer-shaped.
+    async def observe(self, event: Any, session: Session) -> None:  # pragma: no cover
+        pass
+
+    def detect_drift(self, event: Any, session: Session):  # pragma: no cover
+        return None
+
+    def bind(self, *, sinks, planner) -> None:  # pragma: no cover
+        pass
+
+
+def _make_started_tool(steerer: _StubSteerer) -> ReportingToolSpec:
+    async def handler(args: dict[str, Any], session: Session, st) -> dict[str, Any]:
+        await st.transition(
+            args["task_id"],
+            TaskStatus.RUNNING,
+            detail=args.get("detail", ""),
+            session=session,
+        )
+        return {"ok": True}
+
+    return ReportingToolSpec(
+        name="report_task_started",
+        description="Mark a task as started.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string"},
+                "detail": {"type": "string"},
+            },
+            "required": ["task_id"],
+        },
+        handler=handler,
+    )
+
+
+def _make_completed_tool(steerer: _StubSteerer) -> ReportingToolSpec:
+    async def handler(args: dict[str, Any], session: Session, st) -> dict[str, Any]:
+        await st.transition(
+            args["task_id"],
+            TaskStatus.COMPLETED,
+            detail=args.get("summary", ""),
+            session=session,
+        )
+        session.completed_results[args["task_id"]] = args.get("summary", "")
+        return {"ok": True}
+
+    return ReportingToolSpec(
+        name="report_task_completed",
+        description="Mark a task as completed.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string"},
+                "summary": {"type": "string"},
+                "artifacts": {"type": "object"},
+            },
+            "required": ["task_id", "summary"],
+        },
+        handler=handler,
+    )
+
+
+def _fresh_session() -> tuple[Session, Task]:
+    from goldfive.types import Plan
+
+    task = Task(id="t1", title="Do the thing")
+    session = Session(
+        run_id="run-1",
+        plan=Plan(
+            id="p1",
+            run_id="run-1",
+            goal_ids=["g1"],
+            tasks=[task],
+            edges=[],
+        ),
+    )
+    return session, task
+
+
+async def test_register_reporting_tools_stores_specs() -> None:
+    async def noop_agent(task, session, tools):
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter = CallableAdapter(noop_agent)
+    started = _make_started_tool(_StubSteerer())
+    completed = _make_completed_tool(_StubSteerer())
+
+    await adapter.register_reporting_tools([started, completed])
+
+    # Private attr intentionally inspected — adapter internals are small
+    # and this confirms forwarding is wired correctly.
+    assert adapter._tools == [started, completed]
+
+
+async def test_available_agents_defaults_to_empty_list() -> None:
+    async def noop_agent(task, session, tools):
+        return InvocationResult(task_id=task.id)
+
+    adapter = CallableAdapter(noop_agent)
+    assert adapter.available_agents == []
+
+
+async def test_available_agents_returns_configured_list() -> None:
+    async def noop_agent(task, session, tools):
+        return InvocationResult(task_id=task.id)
+
+    adapter = CallableAdapter(noop_agent, available_agents=["alpha", "beta"])
+    assert adapter.available_agents == ["alpha", "beta"]
+
+    # Returned list is a copy — caller mutations must not leak into adapter state.
+    adapter.available_agents.append("gamma")
+    assert adapter.available_agents == ["alpha", "beta"]
+
+
+async def test_invoke_forwards_tools_and_returns_result() -> None:
+    captured: dict[str, Any] = {}
+
+    async def agent(task, session, tools):
+        captured["task"] = task
+        captured["session"] = session
+        captured["tools"] = tools
+        return InvocationResult(task_id=task.id, text="hello", stop_reason="end_turn")
+
+    tool = _make_started_tool(_StubSteerer())
+    adapter = CallableAdapter(agent)
+    await adapter.register_reporting_tools([tool])
+
+    session, task = _fresh_session()
+    result = await adapter.invoke(task, session)
+
+    assert result.task_id == "t1"
+    assert result.text == "hello"
+    assert result.stop_reason == "end_turn"
+    assert captured["task"] is task
+    assert captured["session"] is session
+    assert captured["tools"] == [tool]
+
+
+async def test_tool_routing_drives_session_transitions() -> None:
+    """The canonical acceptance test for issue #12.
+
+    A stub agent calls ``report_task_started`` then ``report_task_completed``
+    via the ``_tool_invocation`` helper. We verify the task moves PENDING ->
+    RUNNING -> COMPLETED and that the completion summary lands in
+    ``session.completed_results``.
+    """
+    steerer = _StubSteerer()
+    started = _make_started_tool(steerer)
+    completed = _make_completed_tool(steerer)
+
+    async def agent(task, session, tools):
+        await invoke_tool(
+            tools,
+            "report_task_started",
+            {"task_id": task.id, "detail": "kicking off"},
+            session,
+            steerer,
+        )
+        await invoke_tool(
+            tools,
+            "report_task_completed",
+            {"task_id": task.id, "summary": "done deal"},
+            session,
+            steerer,
+        )
+        return InvocationResult(task_id=task.id, text="done deal", stop_reason="end_turn")
+
+    adapter = CallableAdapter(agent)
+    await adapter.register_reporting_tools([started, completed])
+
+    session, task = _fresh_session()
+    assert task.status == TaskStatus.PENDING
+
+    result = await adapter.invoke(task, session)
+
+    assert result.task_id == "t1"
+    assert result.text == "done deal"
+    assert task.status == TaskStatus.COMPLETED
+    assert session.completed_results == {"t1": "done deal"}
+    assert steerer.transitions == [
+        ("t1", TaskStatus.RUNNING, "kicking off"),
+        ("t1", TaskStatus.COMPLETED, "done deal"),
+    ]
+
+
+async def test_invoke_tool_raises_on_unknown_name() -> None:
+    session, _ = _fresh_session()
+    with pytest.raises(KeyError, match="unknown reporting tool"):
+        await invoke_tool([], "report_task_started", {}, session, _StubSteerer())
+
+
+def test_find_tool_returns_none_for_missing_name() -> None:
+    steerer = _StubSteerer()
+    tools = [_make_started_tool(steerer)]
+    assert find_tool(tools, "report_task_started") is tools[0]
+    assert find_tool(tools, "nope") is None
+
+
+async def test_register_reporting_tools_replaces_previous_tools() -> None:
+    """Re-registering drops the old spec list — executors re-bind per run."""
+
+    async def agent(task, session, tools):
+        return InvocationResult(task_id=task.id)
+
+    adapter = CallableAdapter(agent)
+    first = _make_started_tool(_StubSteerer())
+    await adapter.register_reporting_tools([first])
+    second = _make_completed_tool(_StubSteerer())
+    await adapter.register_reporting_tools([second])
+    assert adapter._tools == [second]
+
+
+async def test_adapter_conforms_to_agent_adapter_protocol() -> None:
+    from goldfive.protocols import AgentAdapter
+
+    async def agent(task, session, tools):
+        return InvocationResult(task_id=task.id)
+
+    adapter = CallableAdapter(agent)
+    assert isinstance(adapter, AgentAdapter)


### PR DESCRIPTION
## Summary
- Adds `CallableAdapter` — the reference `AgentAdapter` that wraps an async callable and forwards registered `ReportingToolSpec`s to it.
- Adds shared `goldfive/adapters/_tool_invocation.py` (`find_tool`, `invoke_tool`) used by every adapter for name-based tool lookup. Keeps routing behaviour and error messages consistent across CallableAdapter / ADK / Claude.
- Since #4 and #5 have not yet landed, this PR also includes minimal `goldfive/{types,results,reporting,protocols}.py` pinned to `INTERFACE_SPEC.md` v0.1 so the adapter can type-check and be exercised end-to-end. These modules are forward-compatible and intended to merge cleanly with the dedicated foundation PRs.

## Test plan
- [x] `uv run pytest` — 11 passed (9 adapter tests + 2 scaffold smoke tests)
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy goldfive` — clean
- [x] Acceptance test (`test_tool_routing_drives_session_transitions`): stub agent calls `report_task_started` then `report_task_completed` via the shared helper; task transitions `PENDING -> RUNNING -> COMPLETED` and `session.completed_results` is populated.
- [x] `isinstance(adapter, AgentAdapter)` — protocol conformance verified.

Closes #12
