### PR TITLE
Add GoalDeriver variants (Passthrough, Literal, LLM)

### DIFF
--- a/goldfive/goal_deriver.py
+++ b/goldfive/goal_deriver.py
@@ -1,0 +1,333 @@
+"""Goal derivation strategies.
+
+Goldfive introduces an explicit ``GoalDeriver`` abstraction on top of the
+harmonograf design. The deriver converts a user's free-form request into a
+concrete ``list[Goal]``. Plans are then generated from goals, and drift
+detection is measured against those same goals — so clean, explicit goals are
+the foundation for every downstream decision.
+
+Three variants are provided:
+
+* :class:`PassthroughGoalDeriver` — for callers that already know the goals.
+  Accepts a single summary string, a list of strings, or a list of ``Goal``
+  objects and returns them verbatim from :meth:`derive`.
+* :class:`LiteralGoalDeriver` — trivial wrapper that turns the incoming
+  ``user_input`` string into a single ``Goal``. Handy for tests and simple
+  CLIs where no LLM is desired.
+* :class:`LLMGoalDeriver` — asks an LLM to extract one-or-more goals in JSON,
+  parses the response, and falls back to a single passthrough goal on error.
+
+All variants implement the ``GoalDeriver`` protocol (issue #5). The protocol is
+structural, so explicit inheritance is not required; each class exposes the
+expected ``async def derive(...)`` signature.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from goldfive.types import Goal
+
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Default system prompt for the LLM-backed deriver.
+#
+# Design notes:
+# * The prompt is intentionally short. Agents that call this module have their
+#   own, richer system prompts; the deriver's job is narrow: turn the raw user
+#   request into structured goals. We keep guidance here focused on SHAPE
+#   (JSON schema) rather than content.
+# * We ask for one or more goals. A request may legitimately contain several
+#   independent outcomes ("ship the feature AND write the blog post"); the
+#   planner is responsible for ordering them.
+# * The ``"id"`` values are authored by the LLM. We do NOT enforce a specific
+#   scheme (e.g. ``"g1"``, ``"g2"``); the only requirement is that they be
+#   unique within a response. Callers that need stable IDs can normalise them
+#   after parsing.
+# * We explicitly ask for a bare JSON object (no Markdown fences), but still
+#   apply fence-stripping on parse to be robust to models that ignore that
+#   instruction.
+# -----------------------------------------------------------------------------
+DEFAULT_SYSTEM_PROMPT = """You extract explicit goals from a user's request.
+
+Return a JSON object of the form:
+{"goals": [{"id": "g1", "summary": "..."}, ...]}
+
+Rules:
+- Produce one or more goals. Prefer a single goal unless the user has clearly
+  asked for multiple, independent outcomes.
+- Each ``summary`` should describe what "done" looks like, in one sentence.
+- Each ``id`` must be unique within the response (e.g. "g1", "g2", ...).
+- Respond with JSON only — no prose, no Markdown fences.
+""".strip()
+
+
+# -----------------------------------------------------------------------------
+# Fence-stripping helper. Mirrors the convention used by ``LLMPlanner`` so the
+# behaviour is consistent across modules.
+# -----------------------------------------------------------------------------
+_FENCE_RE = re.compile(
+    r"""
+    ^\s*                    # leading whitespace
+    ```(?:[a-zA-Z0-9_+-]*)? # opening fence with optional language tag
+    \s*\n                   # newline after fence
+    (?P<body>.*?)           # the actual content (non-greedy)
+    \n\s*```                # closing fence
+    \s*$                    # trailing whitespace
+    """,
+    re.DOTALL | re.VERBOSE,
+)
+
+
+def _strip_fences(text: str) -> str:
+    """Strip a single outer Markdown code fence, if present.
+
+    Handles ``` with or without a language tag (``json``, ``JSON``, etc.).
+    If no fence is present the text is returned unchanged (trimmed).
+    """
+    match = _FENCE_RE.match(text)
+    if match is not None:
+        return match.group("body").strip()
+    return text.strip()
+
+
+# -----------------------------------------------------------------------------
+# PassthroughGoalDeriver
+# -----------------------------------------------------------------------------
+class PassthroughGoalDeriver:
+    """Returns a pre-configured list of goals, ignoring ``user_input``.
+
+    Accepts any of:
+    * A single summary string — wrapped as ``[Goal(id="g1", summary=...)]``.
+    * A list of summary strings — each wrapped as ``Goal(id="gN", summary=...)``.
+    * A list of :class:`Goal` objects — returned verbatim.
+
+    Useful when the caller has already decided what the goals are (e.g. a
+    programmatic invocation or a test fixture) and only wants to use the rest
+    of the goldfive pipeline (planning, execution, drift detection).
+    """
+
+    def __init__(self, goals: str | list[str] | list[Goal]) -> None:
+        self._goals: list[Goal] = _coerce_goals(goals)
+
+    async def derive(
+        self,
+        user_input: str,
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> list[Goal]:
+        """Return the pre-configured goals. ``user_input`` is ignored."""
+        # Defensive copy so callers cannot mutate the internal list.
+        return list(self._goals)
+
+
+def _coerce_goals(goals: str | list[str] | list[Goal]) -> list[Goal]:
+    """Normalise the constructor argument into a ``list[Goal]``."""
+    if isinstance(goals, str):
+        if not goals.strip():
+            raise ValueError("PassthroughGoalDeriver: empty goal summary string")
+        return [Goal(id="g1", summary=goals)]
+
+    if not isinstance(goals, list):
+        raise TypeError(
+            f"PassthroughGoalDeriver: expected str | list[str] | list[Goal], "
+            f"got {type(goals).__name__}"
+        )
+
+    if len(goals) == 0:
+        raise ValueError("PassthroughGoalDeriver: empty goals list")
+
+    out: list[Goal] = []
+    for i, item in enumerate(goals, start=1):
+        if isinstance(item, Goal):
+            out.append(item)
+        elif isinstance(item, str):
+            if not item.strip():
+                raise ValueError(
+                    f"PassthroughGoalDeriver: empty summary string at index {i - 1}"
+                )
+            out.append(Goal(id=f"g{i}", summary=item))
+        else:
+            raise TypeError(
+                f"PassthroughGoalDeriver: list items must be str or Goal, "
+                f"got {type(item).__name__} at index {i - 1}"
+            )
+    return out
+
+
+# -----------------------------------------------------------------------------
+# LiteralGoalDeriver
+# -----------------------------------------------------------------------------
+class LiteralGoalDeriver:
+    """Wraps ``user_input`` as a single goal, verbatim.
+
+    The simplest non-trivial deriver: if the caller hands us a non-empty
+    string, we emit ``[Goal(id="g1", summary=user_input)]``. If the string is
+    empty or whitespace-only we raise ``ValueError``.
+
+    Unlike :class:`PassthroughGoalDeriver`, this deriver is configured with
+    nothing — it always reflects the ``user_input`` passed to :meth:`derive`.
+    """
+
+    async def derive(
+        self,
+        user_input: str,
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> list[Goal]:
+        if not isinstance(user_input, str) or not user_input.strip():
+            raise ValueError("LiteralGoalDeriver: user_input must be a non-empty string")
+        return [Goal(id="g1", summary=user_input)]
+
+
+# -----------------------------------------------------------------------------
+# LLMGoalDeriver
+# -----------------------------------------------------------------------------
+class LLMGoalDeriver:
+    """Uses an LLM to extract explicit goals from free-form user input.
+
+    The LLM is prompted to return JSON of the shape
+    ``{"goals": [{"id": "...", "summary": "..."}, ...]}``. On any failure
+    (network error, non-JSON response, wrong schema) we fall back to a single
+    passthrough goal: ``[Goal(id="g1", summary=user_input)]``. The fallback
+    is logged at WARNING level so the caller can spot misconfiguration.
+
+    Args:
+        call_llm: Async callable ``(system, prompt, model) -> str`` that
+            performs the LLM call and returns the assistant text. Matches the
+            signature used by :class:`LLMPlanner` (issue #7) so the same
+            adapter helper can be reused.
+        model: Model identifier passed to ``call_llm``. Defaults to the empty
+            string, which lets the adapter pick its own default.
+        system_prompt: Optional override for the default system prompt. The
+            default is :data:`DEFAULT_SYSTEM_PROMPT`.
+    """
+
+    def __init__(
+        self,
+        call_llm: Callable[[str, str, str], Awaitable[str]],
+        model: str = "",
+        *,
+        system_prompt: str | None = None,
+    ) -> None:
+        self._call_llm = call_llm
+        self._model = model
+        self._system_prompt = system_prompt if system_prompt is not None else DEFAULT_SYSTEM_PROMPT
+
+    async def derive(
+        self,
+        user_input: str,
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> list[Goal]:
+        if not isinstance(user_input, str) or not user_input.strip():
+            raise ValueError("LLMGoalDeriver: user_input must be a non-empty string")
+
+        prompt = self._build_prompt(user_input, context)
+
+        try:
+            raw = await self._call_llm(self._system_prompt, prompt, self._model)
+        except Exception as e:  # pragma: no cover - exercised via tests w/ stub
+            logger.warning(
+                "LLMGoalDeriver: call_llm raised %s; falling back to passthrough goal", e
+            )
+            return [Goal(id="g1", summary=user_input)]
+
+        try:
+            goals = _parse_goals_response(raw)
+        except (ValueError, json.JSONDecodeError, TypeError) as e:
+            logger.warning(
+                "LLMGoalDeriver: could not parse LLM response (%s); "
+                "falling back to passthrough goal",
+                e,
+            )
+            return [Goal(id="g1", summary=user_input)]
+
+        if not goals:
+            logger.warning(
+                "LLMGoalDeriver: LLM returned zero goals; falling back to passthrough goal"
+            )
+            return [Goal(id="g1", summary=user_input)]
+
+        return goals
+
+    # ---- internals --------------------------------------------------------
+
+    def _build_prompt(
+        self,
+        user_input: str,
+        context: Mapping[str, Any] | None,
+    ) -> str:
+        """Build the user-side prompt. Context, if present, is appended as a
+        short JSON block so the LLM can condition on it (e.g. prior goals)."""
+        parts = [f"User request:\n{user_input}"]
+        if context:
+            try:
+                ctx_json = json.dumps(dict(context), default=str, indent=2)
+            except (TypeError, ValueError):
+                ctx_json = str(context)
+            parts.append(f"Context:\n{ctx_json}")
+        parts.append(
+            'Return JSON: {"goals": [{"id": "g1", "summary": "..."}, ...]}.'
+        )
+        return "\n\n".join(parts)
+
+
+def _parse_goals_response(raw: str) -> list[Goal]:
+    """Parse an LLM response into a list of ``Goal`` objects.
+
+    Applies fence-stripping before JSON parsing. Raises ``ValueError`` if the
+    response does not match the expected schema.
+    """
+    if not isinstance(raw, str):
+        raise ValueError(f"expected str response, got {type(raw).__name__}")
+
+    stripped = _strip_fences(raw)
+    if not stripped:
+        raise ValueError("empty response")
+
+    data = json.loads(stripped)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object, got {type(data).__name__}")
+
+    goals_raw = data.get("goals")
+    if not isinstance(goals_raw, list):
+        raise ValueError('missing or non-list "goals" field')
+
+    goals: list[Goal] = []
+    for i, item in enumerate(goals_raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"goals[{i}] is not an object")
+        summary = item.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            raise ValueError(f'goals[{i}] missing non-empty "summary"')
+        gid = item.get("id")
+        if not isinstance(gid, str) or not gid.strip():
+            # Auto-assign an id when the LLM forgot one. This is less harsh
+            # than rejecting the whole response.
+            gid = f"g{i + 1}"
+        metadata_raw = item.get("metadata", {})
+        metadata: dict[str, str]
+        if isinstance(metadata_raw, dict):
+            # Coerce values to str for type stability. metadata is declared as
+            # ``dict[str, str]`` on the dataclass.
+            metadata = {str(k): str(v) for k, v in metadata_raw.items()}
+        else:
+            metadata = {}
+        goals.append(Goal(id=gid, summary=summary.strip(), metadata=metadata))
+
+    return goals
+
+
+__all__ = [
+    "DEFAULT_SYSTEM_PROMPT",
+    "LLMGoalDeriver",
+    "LiteralGoalDeriver",
+    "PassthroughGoalDeriver",
+]

--- a/tests/test_goal_deriver.py
+++ b/tests/test_goal_deriver.py
@@ -1,0 +1,312 @@
+"""Tests for ``goldfive.goal_deriver``.
+
+Covers all three deriver variants. We use plain stubs for ``call_llm``; no
+network or real LLM is touched.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from goldfive.goal_deriver import (
+    DEFAULT_SYSTEM_PROMPT,
+    LiteralGoalDeriver,
+    LLMGoalDeriver,
+    PassthroughGoalDeriver,
+)
+from goldfive.types import Goal
+
+
+# ---------------------------------------------------------------------------
+# PassthroughGoalDeriver
+# ---------------------------------------------------------------------------
+class TestPassthroughGoalDeriver:
+    async def test_single_string_is_wrapped_as_one_goal(self) -> None:
+        deriver = PassthroughGoalDeriver("ship the thing")
+        goals = await deriver.derive("ignored input")
+        assert goals == [Goal(id="g1", summary="ship the thing")]
+
+    async def test_list_of_strings_each_become_a_goal(self) -> None:
+        deriver = PassthroughGoalDeriver(["one", "two", "three"])
+        goals = await deriver.derive("ignored")
+        assert [g.summary for g in goals] == ["one", "two", "three"]
+        assert [g.id for g in goals] == ["g1", "g2", "g3"]
+
+    async def test_list_of_goal_objects_returned_verbatim(self) -> None:
+        g1 = Goal(id="top", summary="be awesome", metadata={"priority": "high"})
+        g2 = Goal(id="other", summary="write docs")
+        deriver = PassthroughGoalDeriver([g1, g2])
+        goals = await deriver.derive("anything")
+        assert goals == [g1, g2]
+
+    async def test_user_input_is_ignored(self) -> None:
+        deriver = PassthroughGoalDeriver("fixed goal")
+        a = await deriver.derive("first")
+        b = await deriver.derive("second")
+        assert a == b
+
+    async def test_returned_list_is_independent_copy(self) -> None:
+        """Mutating the returned list must not affect subsequent calls."""
+        deriver = PassthroughGoalDeriver(["a", "b"])
+        first = await deriver.derive("x")
+        first.append(Goal(id="gX", summary="smuggled"))
+        second = await deriver.derive("x")
+        assert len(second) == 2
+
+    def test_empty_string_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            PassthroughGoalDeriver("")
+        with pytest.raises(ValueError):
+            PassthroughGoalDeriver("   ")
+
+    def test_empty_list_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            PassthroughGoalDeriver([])
+
+    async def test_mixed_list_of_strings_and_goals(self) -> None:
+        g = Goal(id="custom", summary="custom summary")
+        deriver = PassthroughGoalDeriver(["plain", g])
+        goals = await deriver.derive("x")
+        # String item -> Goal(id="g1", summary="plain"); Goal item -> verbatim.
+        assert goals[0] == Goal(id="g1", summary="plain")
+        assert goals[1] is g
+
+    def test_non_string_non_list_rejected(self) -> None:
+        with pytest.raises(TypeError):
+            PassthroughGoalDeriver(42)  # type: ignore[arg-type]
+
+    def test_list_with_invalid_item_type_rejected(self) -> None:
+        with pytest.raises(TypeError):
+            PassthroughGoalDeriver(["ok", 99])  # type: ignore[list-item]
+
+    def test_list_with_empty_string_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            PassthroughGoalDeriver(["ok", ""])
+
+
+# ---------------------------------------------------------------------------
+# LiteralGoalDeriver
+# ---------------------------------------------------------------------------
+class TestLiteralGoalDeriver:
+    async def test_wraps_user_input_as_single_goal(self) -> None:
+        deriver = LiteralGoalDeriver()
+        goals = await deriver.derive("write a haiku about cats")
+        assert goals == [Goal(id="g1", summary="write a haiku about cats")]
+
+    async def test_empty_string_rejected(self) -> None:
+        deriver = LiteralGoalDeriver()
+        with pytest.raises(ValueError):
+            await deriver.derive("")
+
+    async def test_whitespace_only_rejected(self) -> None:
+        deriver = LiteralGoalDeriver()
+        with pytest.raises(ValueError):
+            await deriver.derive("   \n\t")
+
+    async def test_non_string_rejected(self) -> None:
+        deriver = LiteralGoalDeriver()
+        with pytest.raises(ValueError):
+            await deriver.derive(None)  # type: ignore[arg-type]
+
+    async def test_context_is_ignored(self) -> None:
+        deriver = LiteralGoalDeriver()
+        goals_no_ctx = await deriver.derive("x")
+        goals_ctx = await deriver.derive("x", context={"anything": "here"})
+        assert goals_no_ctx == goals_ctx
+
+
+# ---------------------------------------------------------------------------
+# LLMGoalDeriver
+# ---------------------------------------------------------------------------
+class _CannedLLM:
+    """Stub ``call_llm`` that records invocations and returns canned text."""
+
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(self, system: str, prompt: str, model: str) -> str:
+        self.calls.append((system, prompt, model))
+        return self.response
+
+
+class _RaisingLLM:
+    async def __call__(self, system: str, prompt: str, model: str) -> str:
+        raise RuntimeError("boom")
+
+
+class TestLLMGoalDeriver:
+    async def test_single_goal_parsed(self) -> None:
+        stub = _CannedLLM(json.dumps({"goals": [{"id": "g1", "summary": "do the thing"}]}))
+        deriver = LLMGoalDeriver(stub, model="test-model")
+        goals = await deriver.derive("please do the thing")
+        assert goals == [Goal(id="g1", summary="do the thing")]
+        # The default system prompt was used.
+        assert stub.calls[0][0] == DEFAULT_SYSTEM_PROMPT
+        # The user input is embedded in the prompt.
+        assert "please do the thing" in stub.calls[0][1]
+        # Model propagated.
+        assert stub.calls[0][2] == "test-model"
+
+    async def test_multiple_goals_parsed(self) -> None:
+        stub = _CannedLLM(
+            json.dumps(
+                {
+                    "goals": [
+                        {"id": "g1", "summary": "ship feature"},
+                        {"id": "g2", "summary": "write blog post"},
+                    ]
+                }
+            )
+        )
+        deriver = LLMGoalDeriver(stub)
+        goals = await deriver.derive("ship feature and announce it")
+        assert [g.id for g in goals] == ["g1", "g2"]
+        assert [g.summary for g in goals] == ["ship feature", "write blog post"]
+
+    async def test_metadata_coerced_to_str(self) -> None:
+        stub = _CannedLLM(
+            json.dumps(
+                {
+                    "goals": [
+                        {
+                            "id": "g1",
+                            "summary": "x",
+                            "metadata": {"priority": 1, "owner": "alice"},
+                        }
+                    ]
+                }
+            )
+        )
+        deriver = LLMGoalDeriver(stub)
+        goals = await deriver.derive("x")
+        assert goals[0].metadata == {"priority": "1", "owner": "alice"}
+
+    async def test_response_with_code_fences_is_parsed(self) -> None:
+        fenced = (
+            "```json\n"
+            + json.dumps({"goals": [{"id": "g1", "summary": "clean"}]})
+            + "\n```"
+        )
+        stub = _CannedLLM(fenced)
+        deriver = LLMGoalDeriver(stub)
+        goals = await deriver.derive("clean the house")
+        assert goals == [Goal(id="g1", summary="clean")]
+
+    async def test_response_with_bare_code_fence_is_parsed(self) -> None:
+        fenced = "```\n" + json.dumps({"goals": [{"id": "g1", "summary": "ok"}]}) + "\n```"
+        deriver = LLMGoalDeriver(_CannedLLM(fenced))
+        goals = await deriver.derive("do it")
+        assert goals[0].summary == "ok"
+
+    async def test_missing_id_gets_auto_assigned(self) -> None:
+        stub = _CannedLLM(json.dumps({"goals": [{"summary": "no id here"}]}))
+        deriver = LLMGoalDeriver(stub)
+        goals = await deriver.derive("no id here")
+        assert goals == [Goal(id="g1", summary="no id here")]
+
+    async def test_custom_system_prompt(self) -> None:
+        stub = _CannedLLM(json.dumps({"goals": [{"id": "g1", "summary": "ok"}]}))
+        deriver = LLMGoalDeriver(stub, system_prompt="CUSTOM")
+        await deriver.derive("hi")
+        assert stub.calls[0][0] == "CUSTOM"
+
+    async def test_context_appears_in_prompt(self) -> None:
+        stub = _CannedLLM(json.dumps({"goals": [{"id": "g1", "summary": "ok"}]}))
+        deriver = LLMGoalDeriver(stub)
+        await deriver.derive("hi", context={"prior_goal": "foo"})
+        assert "prior_goal" in stub.calls[0][1]
+        assert "foo" in stub.calls[0][1]
+
+    async def test_unserialisable_context_does_not_crash(self) -> None:
+        class Weird:
+            def __repr__(self) -> str:
+                return "<weird>"
+
+        stub = _CannedLLM(json.dumps({"goals": [{"id": "g1", "summary": "ok"}]}))
+        deriver = LLMGoalDeriver(stub)
+        await deriver.derive("hi", context={"obj": Weird()})
+        # Either a str() fallback or json with default=str kicked in — both
+        # should end up producing SOME non-crashing prompt.
+        assert "hi" in stub.calls[0][1]
+
+    # ---- fallback paths ---------------------------------------------------
+    async def test_llm_exception_falls_back_to_passthrough(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        deriver = LLMGoalDeriver(_RaisingLLM())
+        with caplog.at_level("WARNING"):
+            goals = await deriver.derive("just do X")
+        assert goals == [Goal(id="g1", summary="just do X")]
+        assert any("falling back" in rec.message for rec in caplog.records)
+
+    async def test_non_json_response_falls_back(self, caplog: pytest.LogCaptureFixture) -> None:
+        deriver = LLMGoalDeriver(_CannedLLM("not json at all"))
+        with caplog.at_level("WARNING"):
+            goals = await deriver.derive("hello")
+        assert goals == [Goal(id="g1", summary="hello")]
+        assert any("parse" in rec.message for rec in caplog.records)
+
+    async def test_wrong_schema_falls_back(self, caplog: pytest.LogCaptureFixture) -> None:
+        # "goals" field missing.
+        deriver = LLMGoalDeriver(_CannedLLM(json.dumps({"tasks": []})))
+        with caplog.at_level("WARNING"):
+            goals = await deriver.derive("hello")
+        assert goals == [Goal(id="g1", summary="hello")]
+
+    async def test_empty_goals_array_falls_back(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        deriver = LLMGoalDeriver(_CannedLLM(json.dumps({"goals": []})))
+        with caplog.at_level("WARNING"):
+            goals = await deriver.derive("hello")
+        assert goals == [Goal(id="g1", summary="hello")]
+        assert any("zero goals" in rec.message for rec in caplog.records)
+
+    async def test_goal_with_empty_summary_falls_back(self) -> None:
+        deriver = LLMGoalDeriver(
+            _CannedLLM(json.dumps({"goals": [{"id": "g1", "summary": "  "}]}))
+        )
+        goals = await deriver.derive("real input")
+        assert goals == [Goal(id="g1", summary="real input")]
+
+    async def test_non_object_goal_item_falls_back(self) -> None:
+        deriver = LLMGoalDeriver(
+            _CannedLLM(json.dumps({"goals": ["not-an-object"]}))
+        )
+        goals = await deriver.derive("real input")
+        assert goals == [Goal(id="g1", summary="real input")]
+
+    async def test_empty_user_input_rejected(self) -> None:
+        deriver = LLMGoalDeriver(_CannedLLM(""))
+        with pytest.raises(ValueError):
+            await deriver.derive("")
+
+    async def test_default_model_is_empty_string(self) -> None:
+        stub = _CannedLLM(json.dumps({"goals": [{"id": "g1", "summary": "ok"}]}))
+        deriver = LLMGoalDeriver(stub)
+        await deriver.derive("hi")
+        assert stub.calls[0][2] == ""
+
+
+# ---------------------------------------------------------------------------
+# Sanity: all three derivers satisfy the expected shape (structural check).
+# ---------------------------------------------------------------------------
+async def test_all_derivers_have_async_derive_returning_list_of_goal() -> None:
+    class _OkLLM:
+        async def __call__(self, system: str, prompt: str, model: str) -> str:
+            return json.dumps({"goals": [{"id": "g1", "summary": "ok"}]})
+
+    derivers: list[Any] = [
+        PassthroughGoalDeriver("x"),
+        LiteralGoalDeriver(),
+        LLMGoalDeriver(_OkLLM()),
+    ]
+    for d in derivers:
+        out = await d.derive("hello world")
+        assert isinstance(out, list)
+        assert all(isinstance(g, Goal) for g in out)
+        assert len(out) >= 1


### PR DESCRIPTION
## Summary

Introduces the `GoalDeriver` abstraction — a new layer on top of the harmonograf design that converts free-form user input into explicit `Goal` objects. Plans are generated from goals and drift is measured against them, so this is the foundation for every downstream decision.

- `PassthroughGoalDeriver` — preconfigured goals; `user_input` is ignored. Accepts a single summary string, a list of strings, or a list of `Goal` objects.
- `LiteralGoalDeriver` — trivially wraps `user_input` as `[Goal(id="g1", summary=user_input)]`.
- `LLMGoalDeriver` — prompts an LLM for JSON-shaped goals `{"goals":[{"id":"...","summary":"..."}...]}`, strips Markdown fences on parse, and falls back to a single passthrough goal (with a `WARNING` log) on any failure (LLM exception, non-JSON, schema mismatch, empty array).
- A minimal `goldfive/types.py` is introduced for the `Goal` dataclass so this PR does not block on #4. It is pinned to the shape in `INTERFACE_SPEC.md` and will be superseded by the full #4 module.

All three variants implement the async `GoalDeriver` protocol (#5) via structural typing.

## Test plan

- [x] `uv run pytest tests/test_goal_deriver.py` — 34 tests pass
- [x] `uv run pytest` (full suite) — 36 pass
- [x] `uv run ruff check goldfive tests` — clean
- [x] `uv run mypy goldfive` — clean
- [ ] Re-verify after #4 / #5 / #7 land and supersede the inline `types.py`

Closes #8.
