### PR TITLE
Add built-in EventSinks (InMemory, Logging, JSONL persistence)

### DIFF
--- a/goldfive/sinks/__init__.py
+++ b/goldfive/sinks/__init__.py
@@ -1,0 +1,33 @@
+"""Built-in EventSinks for goldfive.
+
+Three implementations ship in-box:
+
+* :class:`InMemorySink` — collects events in a list; used by tests and
+  ephemeral callers that want to inspect the stream after the run.
+* :class:`LoggingSink` — renders each event as a single JSON line onto a
+  :class:`logging.Logger`; drop-in for stdout/journald style observation.
+* :class:`JSONLPersistenceSink` — appends events to a newline-delimited
+  JSON file suitable for crash recovery. Paired with
+  :func:`replay_from_jsonl` and :func:`reconstruct_session` for resume.
+
+All sinks conform to the ``EventSink`` protocol pinned in
+``INTERFACE_SPEC.md`` (async ``emit`` / async ``close``).
+"""
+
+from __future__ import annotations
+
+from goldfive.sinks.logging_sink import LoggingSink
+from goldfive.sinks.memory import InMemorySink
+from goldfive.sinks.persistence import (
+    JSONLPersistenceSink,
+    reconstruct_session,
+    replay_from_jsonl,
+)
+
+__all__ = [
+    "InMemorySink",
+    "JSONLPersistenceSink",
+    "LoggingSink",
+    "reconstruct_session",
+    "replay_from_jsonl",
+]

--- a/goldfive/sinks/logging_sink.py
+++ b/goldfive/sinks/logging_sink.py
@@ -1,0 +1,60 @@
+"""Logging-backed EventSink — renders each event as a JSON log line.
+
+One ``Logger.log`` call per event, JSON-serialised via proto's
+``MessageToJson`` with proto field names preserved (so log lines match
+the JSONL persistence format). Callers supply their own logger so
+formatting, handlers, and filtering stay under their control; when no
+logger is provided the sink uses its own module logger.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from google.protobuf.json_format import MessageToJson
+
+_default_logger = logging.getLogger("goldfive.sinks.logging_sink")
+
+
+class LoggingSink:
+    """EventSink that logs each event as a one-line JSON string.
+
+    Parameters
+    ----------
+    logger:
+        Optional :class:`logging.Logger`. Defaults to this module's
+        logger so callers can configure it by name.
+    level:
+        Level passed to ``logger.log``. Defaults to ``logging.INFO``.
+    """
+
+    def __init__(
+        self,
+        logger: logging.Logger | None = None,
+        level: int = logging.INFO,
+    ) -> None:
+        self._logger = logger if logger is not None else _default_logger
+        self._level = level
+
+    async def emit(self, event: Any) -> None:
+        """Log a single JSON line for ``event``.
+
+        Uses ``MessageToJson(..., preserving_proto_field_name=True)`` and
+        strips newlines so each event produces exactly one log record.
+        Serialisation failures fall back to ``repr`` so a malformed event
+        never silently drops.
+        """
+        try:
+            payload = MessageToJson(
+                event,
+                preserving_proto_field_name=True,
+                indent=None,
+            )
+        except Exception:  # pragma: no cover - defensive
+            payload = repr(event)
+        self._logger.log(self._level, payload)
+
+    async def close(self) -> None:
+        """No-op. Loggers manage their own handler lifecycle."""
+        return None

--- a/goldfive/sinks/memory.py
+++ b/goldfive/sinks/memory.py
@@ -1,0 +1,39 @@
+"""In-memory EventSink — collects every emitted event in a list.
+
+Primarily a test fixture: the list is the canonical ground-truth of what
+a run emitted, and tests assert against it directly. Cheap enough to use
+in production callers that want a recent tail of events, but the whole
+stream is kept so long-running runs will grow unbounded.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class InMemorySink:
+    """EventSink that appends every event to a Python list.
+
+    The ``events`` attribute is a live list — emits mutate it in place and
+    readers see updates immediately. There is no thread/task safety beyond
+    what ``list.append`` already provides (which is atomic under CPython's
+    GIL); concurrent emits from multiple tasks are fine.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[Any] = []
+
+    @property
+    def events(self) -> list[Any]:
+        """The collected events, in emit order. Mutating the list is the
+        caller's prerogative — the sink does not defend against it."""
+        return self._events
+
+    async def emit(self, event: Any) -> None:
+        """Append ``event`` to the internal list. Never raises."""
+        self._events.append(event)
+
+    async def close(self) -> None:
+        """No-op. The list stays populated after close so tests can
+        inspect it post-run."""
+        return None

--- a/goldfive/sinks/persistence.py
+++ b/goldfive/sinks/persistence.py
@@ -1,0 +1,258 @@
+"""JSONL persistence sink and replay/reconstruction helpers.
+
+:class:`JSONLPersistenceSink` writes each event as one JSON document per
+line (newline-delimited JSON, a.k.a. JSONL). The format is proto-
+canonical: a full ``MessageToJson`` of the event with keys sorted so
+byte-level diffs stay stable across runs.
+
+Crash recovery is a three-step dance driven from the Runner (issue #15):
+
+1. Load the JSONL with :func:`replay_from_jsonl` — returns the parsed
+   ``Event`` messages in emit order.
+2. Call :func:`reconstruct_session` on that list — returns a best-effort
+   :class:`goldfive.types.Session` reflecting the latest plan and task
+   statuses.
+3. Hand the session back to ``Runner.resume()`` (not implemented in this
+   PR; tracked in the Runner issue).
+
+The sink is async-safe: a single :class:`asyncio.Lock` serialises
+writes so concurrent ``emit`` coroutines cannot interleave bytes. The
+write itself is a synchronous ``file.write`` + ``flush`` inside the
+lock, which is fine for the file sizes goldfive runs produce and keeps
+the dependency surface to stdlib only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from google.protobuf.json_format import MessageToJson, Parse
+
+if TYPE_CHECKING:
+    # Importing the generated proto module at module load would force
+    # every goldfive user to have the `proto` extra installed. Defer it
+    # to first use; the functions that need it import locally.
+    from goldfive.pb.goldfive.v1 import events_pb2 as _events_pb2  # noqa: F401
+
+
+def _events_module() -> Any:
+    """Lazy-import the generated ``events_pb2`` module."""
+    try:
+        from goldfive.pb.goldfive.v1 import events_pb2
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised by tests
+        raise ModuleNotFoundError(
+            "goldfive protobuf stubs not available; generate them via "
+            "`make proto` (requires the `proto` optional-dependency group) "
+            "or install the package with the `proto` extra. See issue #3."
+        ) from exc
+    return events_pb2
+
+
+class JSONLPersistenceSink:
+    """EventSink that appends events to a JSONL file.
+
+    Parameters
+    ----------
+    path:
+        File path to write to. Parent directories are created on first
+        emit if they do not already exist.
+    mode:
+        ``"append"`` (default) opens the file with ``"a"`` so reruns
+        extend the existing log. ``"write"`` opens with ``"w"`` and
+        truncates — useful for deterministic tests and for callers that
+        manage one-file-per-run themselves.
+
+    Notes
+    -----
+    The file handle is opened lazily on the first ``emit`` so constructing
+    the sink is side-effect-free. ``close`` flushes and closes the handle;
+    subsequent emits reopen it.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        mode: Literal["append", "write"] = "append",
+    ) -> None:
+        self._path = Path(path)
+        if mode not in ("append", "write"):
+            raise ValueError(f"mode must be 'append' or 'write', got {mode!r}")
+        self._mode = mode
+        self._handle: Any = None
+        # Created lazily so the sink can be built off-loop and attached
+        # to an event loop later (asyncio.Lock binds to the running loop
+        # at first await).
+        self._lock = asyncio.Lock()
+
+    def _open(self) -> None:
+        if self._handle is not None:
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        flag = "a" if self._mode == "append" else "w"
+        # Line-buffered text mode so each write lands on disk promptly;
+        # the explicit flush inside ``emit`` backs this up for buffered
+        # configurations (e.g. when stdout is redirected into the handle).
+        self._handle = open(self._path, flag, buffering=1, encoding="utf-8")
+
+    async def emit(self, event: Any) -> None:
+        """Serialise ``event`` to one JSON line and append it to the file.
+
+        Uses ``MessageToJson(event, sort_keys=True, indent=None)`` so the
+        line is valid JSONL (no embedded newlines) and byte-stable across
+        runs. Concurrent callers are serialised by an :class:`asyncio.Lock`
+        so lines never interleave.
+        """
+        line = MessageToJson(event, sort_keys=True, indent=None) + "\n"
+        async with self._lock:
+            self._open()
+            assert self._handle is not None
+            self._handle.write(line)
+            self._handle.flush()
+
+    async def close(self) -> None:
+        """Flush and close the file handle. Safe to call repeatedly."""
+        async with self._lock:
+            if self._handle is not None:
+                try:
+                    self._handle.flush()
+                finally:
+                    self._handle.close()
+                    self._handle = None
+
+
+# ---------------------------------------------------------------------------
+# Replay helpers
+# ---------------------------------------------------------------------------
+
+
+def replay_from_jsonl(path: str | Path) -> list[Any]:
+    """Read ``path`` and return a list of parsed ``Event`` messages.
+
+    Each non-empty line is parsed via ``google.protobuf.json_format.Parse``
+    into a fresh ``Event``. Blank lines are skipped. Malformed lines
+    propagate the parser's exception; callers that want best-effort
+    replay can wrap the call and filter by line number.
+    """
+    pb = _events_module()
+    p = Path(path)
+    events: list[Any] = []
+    with open(p, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            msg = pb.Event()
+            Parse(line, msg)
+            events.append(msg)
+    return events
+
+
+def reconstruct_session(events: list[Any]) -> Any:
+    """Rebuild a :class:`goldfive.types.Session` from a list of events.
+
+    Best-effort: walks events in order, applying the side-effects a real
+    run would have produced:
+
+    * ``RunStarted`` seeds ``run_id`` and ``started_at_ms``.
+    * ``GoalDerived`` populates ``session.goals``.
+    * ``PlanSubmitted`` / ``PlanRevised`` replace ``session.plan``. The
+      latest plan wins.
+    * ``TaskStarted`` / ``TaskCompleted`` / ``TaskFailed`` /
+      ``TaskBlocked`` / ``TaskCancelled`` update the matching task's
+      ``status`` on the current plan (if present).
+    * ``TaskCompleted.summary`` is written into
+      ``session.completed_results``.
+    * ``TaskProgress`` writes ``fraction`` into ``session.task_progress``
+      and ``detail`` into ``session.agent_notes``.
+    * ``session._next_sequence`` advances past the highest seen sequence
+      so resumed runs keep the counter monotonic.
+
+    The reconstruction is intentionally forgiving — unknown task ids are
+    ignored rather than raised, because a later plan revision may have
+    dropped a task that earlier events referenced. Callers that need
+    strict validation should walk the events themselves.
+    """
+    # Local imports: we do not want this module to hard-require the
+    # dataclasses package at import time (it pulls ``goldfive.types``,
+    # which is fine, but keeping the import local matches the lazy proto
+    # import above).
+    from goldfive.conv import from_pb_goal, from_pb_plan
+    from goldfive.types import Session, TaskStatus
+
+    session = Session(run_id="")
+
+    # Track the maximum sequence we have seen so the counter can resume.
+    max_seq = -1
+
+    def _update_task_status(task_id: str, status: TaskStatus) -> None:
+        if session.plan is None or not task_id:
+            return
+        for t in session.plan.tasks:
+            if t.id == task_id:
+                t.status = status
+                return
+
+    for evt in events:
+        seq = int(getattr(evt, "sequence", 0) or 0)
+        if seq > max_seq:
+            max_seq = seq
+        payload = evt.WhichOneof("payload")
+        if payload is None:
+            continue
+        if payload == "run_started":
+            rs = evt.run_started
+            session.run_id = rs.run_id or evt.run_id or session.run_id
+            if rs.HasField("started_at"):
+                session.started_at_ms = (
+                    rs.started_at.seconds * 1000 + rs.started_at.nanos // 1_000_000
+                )
+        elif payload == "goal_derived":
+            session.goals = [from_pb_goal(g) for g in evt.goal_derived.goals]
+        elif payload == "plan_submitted":
+            session.plan = from_pb_plan(evt.plan_submitted.plan)
+        elif payload == "plan_revised":
+            session.plan = from_pb_plan(evt.plan_revised.plan)
+        elif payload == "task_started":
+            ts = evt.task_started
+            session.current_task_id = ts.task_id
+            _update_task_status(ts.task_id, TaskStatus.RUNNING)
+        elif payload == "task_progress":
+            tp = evt.task_progress
+            if tp.task_id:
+                session.task_progress[tp.task_id] = float(tp.fraction)
+                if tp.detail:
+                    session.agent_notes[tp.task_id] = tp.detail
+        elif payload == "task_completed":
+            tc = evt.task_completed
+            _update_task_status(tc.task_id, TaskStatus.COMPLETED)
+            if tc.task_id:
+                session.completed_results[tc.task_id] = tc.summary
+            if session.current_task_id == tc.task_id:
+                session.current_task_id = ""
+        elif payload == "task_failed":
+            tf = evt.task_failed
+            _update_task_status(tf.task_id, TaskStatus.FAILED)
+            if session.current_task_id == tf.task_id:
+                session.current_task_id = ""
+        elif payload == "task_blocked":
+            tb = evt.task_blocked
+            _update_task_status(tb.task_id, TaskStatus.BLOCKED)
+        elif payload == "task_cancelled":
+            tc2 = evt.task_cancelled
+            _update_task_status(tc2.task_id, TaskStatus.CANCELLED)
+            if session.current_task_id == tc2.task_id:
+                session.current_task_id = ""
+        elif payload == "drift_detected":
+            session.divergence_flag = True
+        # run_completed / run_aborted are terminal markers; the caller
+        # decides whether to resume. We leave session state as-is.
+
+        # Mirror the event-history convention used by live runs so
+        # downstream consumers see the raw stream as well.
+        session.history.append(evt)
+
+    if max_seq >= 0:
+        session._next_sequence = max_seq + 1
+    return session

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -1,0 +1,296 @@
+"""Unit tests for the built-in EventSinks."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from goldfive.pb.goldfive.v1 import events_pb2, types_pb2
+from goldfive.sinks import (
+    InMemorySink,
+    JSONLPersistenceSink,
+    LoggingSink,
+    reconstruct_session,
+    replay_from_jsonl,
+)
+from goldfive.types import TaskStatus
+
+
+def _make_event(seq: int, run_id: str = "run-1") -> events_pb2.Event:
+    """Build a minimal valid Event with a TaskStarted payload."""
+    evt = events_pb2.Event(event_id=f"evt-{seq}", run_id=run_id, sequence=seq)
+    evt.task_started.task_id = f"task-{seq}"
+    evt.task_started.detail = f"starting {seq}"
+    return evt
+
+
+# ---------------------------------------------------------------------------
+# InMemorySink
+# ---------------------------------------------------------------------------
+
+
+async def test_in_memory_sink_collects_events() -> None:
+    sink = InMemorySink()
+    e1 = _make_event(0)
+    e2 = _make_event(1)
+    await sink.emit(e1)
+    await sink.emit(e2)
+    assert sink.events == [e1, e2]
+    # close is a no-op and does not clear the list
+    await sink.close()
+    assert sink.events == [e1, e2]
+
+
+async def test_in_memory_sink_events_property_is_live() -> None:
+    sink = InMemorySink()
+    snapshot_before = sink.events
+    await sink.emit(_make_event(0))
+    # Same list object, not a copy — callers see the append immediately.
+    assert sink.events is snapshot_before
+    assert len(snapshot_before) == 1
+
+
+# ---------------------------------------------------------------------------
+# LoggingSink
+# ---------------------------------------------------------------------------
+
+
+async def test_logging_sink_writes_one_line_per_event(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = logging.getLogger("test.goldfive.logging_sink")
+    logger.setLevel(logging.DEBUG)
+    sink = LoggingSink(logger=logger, level=logging.INFO)
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        await sink.emit(_make_event(0))
+        await sink.emit(_make_event(1))
+    records = [r for r in caplog.records if r.name == logger.name]
+    assert len(records) == 2
+    # Each log message is a single line with no embedded newlines
+    for r in records:
+        assert "\n" not in r.getMessage()
+    # Proto field names are preserved (snake_case), not JSON camelCase.
+    assert "task_started" in records[0].getMessage()
+    assert "task_id" in records[0].getMessage()
+    assert "task-0" in records[0].getMessage()
+    assert "task-1" in records[1].getMessage()
+
+
+async def test_logging_sink_respects_custom_level(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = logging.getLogger("test.goldfive.logging_sink_level")
+    logger.setLevel(logging.DEBUG)
+    sink = LoggingSink(logger=logger, level=logging.WARNING)
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        await sink.emit(_make_event(0))
+    records = [r for r in caplog.records if r.name == logger.name]
+    assert len(records) == 1
+    assert records[0].levelno == logging.WARNING
+
+
+# ---------------------------------------------------------------------------
+# JSONLPersistenceSink
+# ---------------------------------------------------------------------------
+
+
+async def test_jsonl_persistence_sink_roundtrip(tmp_path) -> None:
+    path = tmp_path / "run.jsonl"
+    sink = JSONLPersistenceSink(path)
+    events = [_make_event(i) for i in range(5)]
+    for e in events:
+        await sink.emit(e)
+    await sink.close()
+
+    # File has one line per event.
+    contents = path.read_text(encoding="utf-8")
+    lines = [ln for ln in contents.splitlines() if ln]
+    assert len(lines) == 5
+    for ln in lines:
+        assert "\n" not in ln  # each line is a single JSON doc
+
+    # Replay produces equal Event messages.
+    replayed = replay_from_jsonl(path)
+    assert len(replayed) == len(events)
+    for original, round_tripped in zip(events, replayed, strict=True):
+        assert original == round_tripped
+
+
+async def test_jsonl_persistence_sink_append_mode(tmp_path) -> None:
+    path = tmp_path / "run.jsonl"
+    # First session: write two events and close.
+    sink1 = JSONLPersistenceSink(path, mode="append")
+    await sink1.emit(_make_event(0))
+    await sink1.emit(_make_event(1))
+    await sink1.close()
+    # Second session: append two more events.
+    sink2 = JSONLPersistenceSink(path, mode="append")
+    await sink2.emit(_make_event(2))
+    await sink2.emit(_make_event(3))
+    await sink2.close()
+
+    replayed = replay_from_jsonl(path)
+    assert [e.sequence for e in replayed] == [0, 1, 2, 3]
+
+
+async def test_jsonl_persistence_sink_write_mode_truncates(tmp_path) -> None:
+    path = tmp_path / "run.jsonl"
+    sink1 = JSONLPersistenceSink(path, mode="write")
+    await sink1.emit(_make_event(0))
+    await sink1.close()
+    sink2 = JSONLPersistenceSink(path, mode="write")
+    await sink2.emit(_make_event(9))
+    await sink2.close()
+    replayed = replay_from_jsonl(path)
+    assert [e.sequence for e in replayed] == [9]
+
+
+async def test_jsonl_persistence_sink_concurrent_emit_does_not_corrupt(
+    tmp_path,
+) -> None:
+    import asyncio as _asyncio
+
+    path = tmp_path / "concurrent.jsonl"
+    sink = JSONLPersistenceSink(path)
+    n = 50
+    events = [_make_event(i) for i in range(n)]
+    await _asyncio.gather(*(sink.emit(e) for e in events))
+    await sink.close()
+
+    replayed = replay_from_jsonl(path)
+    assert len(replayed) == n
+    # Every emitted event round-trips; order may vary under concurrency
+    # but no line is corrupted.
+    replayed_ids = sorted(e.event_id for e in replayed)
+    expected_ids = sorted(e.event_id for e in events)
+    assert replayed_ids == expected_ids
+
+
+def test_jsonl_persistence_sink_rejects_bad_mode(tmp_path) -> None:
+    with pytest.raises(ValueError):
+        JSONLPersistenceSink(tmp_path / "x.jsonl", mode="nope")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# reconstruct_session
+# ---------------------------------------------------------------------------
+
+
+def _plan_pb(run_id: str = "run-rec") -> types_pb2.Plan:
+    plan = types_pb2.Plan(id="plan-0", run_id=run_id, summary="mini run")
+    for tid, title in (("t1", "one"), ("t2", "two"), ("t3", "three")):
+        plan.tasks.add(
+            id=tid,
+            title=title,
+            status=types_pb2.TASK_STATUS_PENDING,
+        )
+    return plan
+
+
+async def test_reconstruct_session_from_mini_run(tmp_path) -> None:
+    path = tmp_path / "mini.jsonl"
+    sink = JSONLPersistenceSink(path)
+    run_id = "run-rec"
+
+    seq = 0
+
+    def _env() -> events_pb2.Event:
+        nonlocal seq
+        e = events_pb2.Event(event_id=f"e-{seq}", run_id=run_id, sequence=seq)
+        seq += 1
+        return e
+
+    # RunStarted
+    e = _env()
+    e.run_started.run_id = run_id
+    e.run_started.goal_summary = "mini"
+    await sink.emit(e)
+
+    # PlanSubmitted
+    e = _env()
+    e.plan_submitted.plan.CopyFrom(_plan_pb(run_id))
+    await sink.emit(e)
+
+    # t1: started then completed
+    e = _env()
+    e.task_started.task_id = "t1"
+    await sink.emit(e)
+
+    e = _env()
+    e.task_completed.task_id = "t1"
+    e.task_completed.summary = "done-1"
+    await sink.emit(e)
+
+    # t2: started then failed
+    e = _env()
+    e.task_started.task_id = "t2"
+    await sink.emit(e)
+
+    e = _env()
+    e.task_failed.task_id = "t2"
+    e.task_failed.reason = "boom"
+    e.task_failed.recoverable = True
+    await sink.emit(e)
+
+    # t3: blocked
+    e = _env()
+    e.task_blocked.task_id = "t3"
+    e.task_blocked.blocker = "waiting on human"
+    await sink.emit(e)
+
+    await sink.close()
+
+    replayed = replay_from_jsonl(path)
+    session = reconstruct_session(replayed)
+
+    assert session.run_id == run_id
+    assert session.plan is not None
+    statuses = {t.id: t.status for t in session.plan.tasks}
+    assert statuses == {
+        "t1": TaskStatus.COMPLETED,
+        "t2": TaskStatus.FAILED,
+        "t3": TaskStatus.BLOCKED,
+    }
+    assert session.completed_results == {"t1": "done-1"}
+    # sequence counter resumes past the highest seen sequence
+    assert session._next_sequence == seq
+
+
+async def test_reconstruct_session_plan_revision_uses_latest(tmp_path) -> None:
+    path = tmp_path / "revised.jsonl"
+    sink = JSONLPersistenceSink(path)
+    run_id = "run-rev"
+
+    # Initial plan with two tasks, t1 already completed.
+    e0 = events_pb2.Event(event_id="e0", run_id=run_id, sequence=0)
+    e0.plan_submitted.plan.CopyFrom(_plan_pb(run_id))
+    await sink.emit(e0)
+
+    e1 = events_pb2.Event(event_id="e1", run_id=run_id, sequence=1)
+    e1.task_completed.task_id = "t1"
+    e1.task_completed.summary = "ok"
+    await sink.emit(e1)
+
+    # Revised plan: drop t3, keep t1/t2. Replay should use the revised
+    # plan's tasks (so no "t3" in statuses).
+    revised = types_pb2.Plan(id="plan-1", run_id=run_id, summary="revised")
+    revised.tasks.add(id="t1", title="one", status=types_pb2.TASK_STATUS_PENDING)
+    revised.tasks.add(id="t2", title="two", status=types_pb2.TASK_STATUS_PENDING)
+    revised.revision_index = 1
+    e2 = events_pb2.Event(event_id="e2", run_id=run_id, sequence=2)
+    e2.plan_revised.plan.CopyFrom(revised)
+    e2.plan_revised.revision_index = 1
+    await sink.emit(e2)
+
+    await sink.close()
+
+    replayed = replay_from_jsonl(path)
+    session = reconstruct_session(replayed)
+    assert session.plan is not None
+    assert [t.id for t in session.plan.tasks] == ["t1", "t2"]
+    # t1's completion event fired before the revision; since the revised
+    # plan replaced the task list, t1 on the new plan is PENDING again
+    # (the framework re-applies completion in a later event if the
+    # task carries over). completed_results still remembers the summary.
+    assert session.completed_results == {"t1": "ok"}


### PR DESCRIPTION
## Summary

Implements the three built-in `EventSink` protocol conformers pinned in `INTERFACE_SPEC.md`.

- `InMemorySink` — appends events to a list; exposes `events` property for tests and post-run inspection.
- `LoggingSink` — renders each event as a one-line JSON string via `MessageToJson(..., preserving_proto_field_name=True)` onto a `logging.Logger` at a configurable level.
- `JSONLPersistenceSink` — appends events as newline-delimited JSON (`MessageToJson(event, sort_keys=True) + "\n"`, single-line form via `indent=None`) to a file. Async-safe: serialises writes behind an `asyncio.Lock` so concurrent `emit` coroutines never interleave bytes. Supports `append` (default) and `write` modes.
- `replay_from_jsonl(path)` — returns parsed `Event` messages in emit order.
- `reconstruct_session(events)` — rebuilds a best-effort `Session` reflecting latest plan, task statuses (from `TaskStarted` / `TaskCompleted` / `TaskFailed` / `TaskBlocked` / `TaskCancelled`), `completed_results` from `TaskCompleted.summary`, and a monotonic `_next_sequence` counter ready for `Runner.resume()` (tracked in #15).

All emits are `async def`; `close()` flushes and closes the file handle.

Depends on #3 (proto stubs) and #4 (dataclasses). References both via lazy imports so the sinks module itself does not hard-require the `proto` extra at import time. Closes #11.

## Test plan

- [x] `tests/test_sinks.py` — 11 tests covering `InMemorySink`, `LoggingSink` (caplog), JSONL round-trip, append vs write modes, 50-way concurrent emit (no corruption), `reconstruct_session` mini-run, and plan-revision handling.
- [x] `uv run pytest` — 13/13 passing (11 new + 2 scaffold smoke).
- [x] `uv run ruff check goldfive/sinks/ tests/test_sinks.py` — clean.

Closes #11
