### PR TITLE
Implement Sequential executor

### DIFF
--- a/examples/adk_agent.py
+++ b/examples/adk_agent.py
@@ -1,0 +1,79 @@
+"""adk_agent — wrap a Google ADK agent with goldfive.
+
+Gated on the ``adk`` extra. Install with::
+
+    uv pip install -e '.[adk]'
+
+The actual ADK adapter lives in ``goldfive.adapters.adk`` (delivered by
+issue #13). This example documents the intended wiring; it import-fails
+cleanly when either ADK itself or the goldfive ADK adapter is not yet
+installed.
+"""
+
+from __future__ import annotations
+
+try:
+    import google.adk  # type: ignore  # noqa: F401
+except ImportError as _adk_err:  # pragma: no cover
+    raise SystemExit("install goldfive[adk] to run this example") from _adk_err
+
+try:
+    from goldfive.adapters.adk import ADKAdapter  # type: ignore[attr-defined]
+except ImportError as _adk_adapter_err:  # pragma: no cover
+    raise SystemExit(
+        "goldfive.adapters.adk is not available yet; see issue #13"
+    ) from _adk_adapter_err
+
+import asyncio
+
+from goldfive import (
+    InMemorySink,
+    PassthroughGoalDeriver,
+    Plan,
+    Runner,
+    SequentialExecutor,
+    StaticPlanner,
+    Task,
+)
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="adk-demo",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="ADK task 1", assignee_agent_id="root"),
+            Task(id="t2", title="ADK task 2", assignee_agent_id="root"),
+        ],
+        edges=[],
+        summary="Two ADK tasks.",
+    )
+
+
+async def main() -> None:
+    # Construct an ADK root agent however you normally would, e.g.:
+    #   from google.adk.agents import Agent as ADKAgent
+    #   root_agent = ADKAgent(name="root", model="gemini-2.0-flash")
+    #   adapter = ADKAdapter(root_agent)
+    adapter = ADKAdapter.from_scratch(model="gemini-2.0-flash")  # placeholder
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=adapter,
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("Run two ADK tasks"),
+        sinks=[sink],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+    print(f"success={outcome.success}")
+    for e in sink.events:
+        kind = e["kind"] if isinstance(e, dict) else getattr(e, "kind", "?")
+        payload = e.get("payload") if isinstance(e, dict) else getattr(e, "payload", {})
+        print(f"  {kind:<16}  {payload}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/claude_agent.py
+++ b/examples/claude_agent.py
@@ -1,0 +1,75 @@
+"""claude_agent — wrap a Claude Agent SDK agent with goldfive.
+
+Gated on the ``claude`` extra. Install with::
+
+    uv pip install -e '.[claude]'
+
+The actual Claude adapter lives in ``goldfive.adapters.claude``
+(delivered by issue #14). This example documents the intended wiring;
+it import-fails cleanly when the SDK or the goldfive Claude adapter
+are not yet installed.
+"""
+
+from __future__ import annotations
+
+try:
+    import anthropic  # type: ignore  # noqa: F401
+except ImportError as _claude_err:  # pragma: no cover
+    raise SystemExit("install goldfive[claude] to run this example") from _claude_err
+
+try:
+    from goldfive.adapters.claude import ClaudeAdapter  # type: ignore[attr-defined]
+except ImportError as _claude_adapter_err:  # pragma: no cover
+    raise SystemExit(
+        "goldfive.adapters.claude is not available yet; see issue #14"
+    ) from _claude_adapter_err
+
+import asyncio
+
+from goldfive import (
+    InMemorySink,
+    PassthroughGoalDeriver,
+    Plan,
+    Runner,
+    SequentialExecutor,
+    StaticPlanner,
+    Task,
+)
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="claude-demo",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="Claude task 1", assignee_agent_id="claude"),
+            Task(id="t2", title="Claude task 2", assignee_agent_id="claude"),
+        ],
+        edges=[],
+        summary="Two Claude tasks.",
+    )
+
+
+async def main() -> None:
+    adapter = ClaudeAdapter(model="claude-sonnet-4-5")  # placeholder
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=adapter,
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("Run two Claude tasks"),
+        sinks=[sink],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+    print(f"success={outcome.success}")
+    for e in sink.events:
+        kind = e["kind"] if isinstance(e, dict) else getattr(e, "kind", "?")
+        payload = e.get("payload") if isinstance(e, dict) else getattr(e, "payload", {})
+        print(f"  {kind:<16}  {payload}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/hello_callable.py
+++ b/examples/hello_callable.py
@@ -1,0 +1,91 @@
+"""hello_callable — the simplest possible goldfive run.
+
+Wires a :class:`CallableAdapter` to a :class:`StaticPlanner` with a
+hand-built plan, runs it through a :class:`SequentialExecutor`, and
+collects every event in an :class:`InMemorySink` so the full event log
+can be printed at the end.
+
+Run with::
+
+    uv run python examples/hello_callable.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from goldfive import (
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="hello-plan",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="greet", title="Greet the user", assignee_agent_id="greeter"),
+            Task(id="ask", title="Ask for a name", assignee_agent_id="greeter"),
+            Task(id="thank", title="Thank the user", assignee_agent_id="greeter"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="greet", to_task_id="ask"),
+            TaskEdge(from_task_id="ask", to_task_id="thank"),
+        ],
+        summary="Greet, ask, thank.",
+    )
+
+
+async def greeter_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    """A toy agent that produces one canned reply per task."""
+    _ = tools  # unused in this toy agent
+    text = {
+        "greet": "Hello!",
+        "ask": "What's your name?",
+        "thank": "Thanks for chatting!",
+    }.get(task.id, "(no-op)")
+    return InvocationResult(task_id=task.id, text=text)
+
+
+async def main() -> None:
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(greeter_agent, available_agents=["greeter"]),
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("Say hello, ask for a name, thank them"),
+        sinks=[sink],
+    )
+
+    outcome = await runner.run("run the greeter workflow")
+    await runner.close()
+
+    print(f"success={outcome.success}, reason={outcome.reason!r}")
+    print(f"run_id={outcome.session.run_id}")
+    print(f"goals={[g.summary for g in outcome.session.goals]}")
+    print(f"{len(sink.events)} events:")
+    for e in sink.events:
+        seq = e["sequence"] if isinstance(e, dict) else getattr(e, "sequence", "?")
+        kind = e["kind"] if isinstance(e, dict) else getattr(e, "kind", "?")
+        payload = e.get("payload") if isinstance(e, dict) else getattr(e, "payload", {})
+        print(f"  seq={seq:>3}  {kind:<16}  {payload}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/persistence_and_recovery.py
+++ b/examples/persistence_and_recovery.py
@@ -1,0 +1,124 @@
+"""persistence_and_recovery — JSONL persistence + crash recovery flow.
+
+Runs a small plan with a :class:`JSONLPersistenceSink`, simulates a
+crash partway through by raising inside the adapter callable, then
+invokes :meth:`Runner.resume` to rebuild a :class:`Session` from the
+persisted log.
+
+The JSONL sink encodes proto ``Event`` messages, so this example
+requires the ``proto`` extra. Install with::
+
+    uv pip install -e '.[proto,dev]'
+    make proto  # generate the proto stubs
+
+Then run::
+
+    uv run python examples/persistence_and_recovery.py
+
+Until the ``proto`` extra is installed the example short-circuits with
+a friendly :class:`SystemExit` pointing at the install instructions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+from goldfive import (
+    CallableAdapter,
+    InvocationResult,
+    JSONLPersistenceSink,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+
+if JSONLPersistenceSink is None:  # type: ignore[truthy-function]
+    raise SystemExit(
+        "goldfive.sinks.JSONLPersistenceSink requires the `proto` extra; "
+        "install goldfive[proto] and run `make proto` to generate the "
+        "proto stubs, then retry."
+    )
+
+
+class _SimulatedCrash(RuntimeError):
+    """Marker — only raised to simulate a crash in the demo."""
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="persist-demo",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="First", assignee_agent_id="worker"),
+            Task(id="t2", title="Second", assignee_agent_id="worker"),
+            Task(id="t3", title="Third (crashes)", assignee_agent_id="worker"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="t1", to_task_id="t2"),
+            TaskEdge(from_task_id="t2", to_task_id="t3"),
+        ],
+        summary="Three steps; the third simulates a crash.",
+    )
+
+
+async def crashy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = tools
+    if task.id == "t3":
+        raise _SimulatedCrash("boom")
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+async def main() -> None:
+    tmp = tempfile.NamedTemporaryFile(
+        prefix="goldfive-demo-", suffix=".jsonl", delete=False
+    )
+    tmp.close()
+    path = tmp.name
+    print(f"persistence file: {path}")
+
+    # First run: crashes on t3.
+    sink = JSONLPersistenceSink(path)
+    runner = Runner(
+        agent=CallableAdapter(crashy_agent, available_agents=["worker"]),
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(stop_on_failure=True),
+        goal_deriver=PassthroughGoalDeriver("Persist and recover"),
+        sinks=[sink],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+    print(f"first run: success={outcome.success}, reason={outcome.reason!r}")
+
+    # Now recover from the persistence log. We construct a fresh Runner
+    # solely to call resume(); the components passed in are placeholders
+    # because resume() does not re-invoke the executor in v0.1.
+    placeholder = Runner(
+        agent=CallableAdapter(crashy_agent, available_agents=["worker"]),
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(),
+    )
+    recovered = await placeholder.resume(path)
+    print(
+        f"recovered: success={recovered.success}, reason={recovered.reason!r}, "
+        f"run_id={recovered.session.run_id}, "
+        f"completed={list(recovered.session.completed_results.keys())}"
+    )
+
+    os.unlink(path)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -1,0 +1,359 @@
+"""Sequential executor.
+
+Drives a :class:`~goldfive.types.Plan` one task at a time, re-invoking the
+underlying agent (via the adapter) with a next-task nudge until the plan
+terminates or a safety cap trips.
+
+This is a port of ``_run_orchestrated`` / ``_run_sequential`` from
+``harmonograf_client/agent.py`` with the ADK-specific session/runner plumbing
+stripped out. The harmonograf version drives ADK's generator model directly;
+here we speak to the adapter through :meth:`AgentAdapter.invoke`, which is
+defined to return exactly once per call after the reporting tools inside have
+mutated task state via the Steerer.
+
+Key behaviors
+-------------
+* Emit :class:`RunStarted` once, then iterate tasks.
+* Honor the plan's topological order: only invoke tasks whose predecessors
+  are ``COMPLETED``. Walk tasks one-at-a-time (no parallelism).
+* After each invocation, re-read plan state: tasks may have moved to
+  ``COMPLETED`` / ``FAILED`` / ``BLOCKED`` via reporting tools; the steerer
+  may also have mutated the plan in response to drift (``PlanRevised``).
+* Budget the total number of adapter invocations with ``max_plan_reinvocations``
+  so a stuck agent cannot spin forever.
+* Terminate with :class:`RunCompleted` on success or :class:`RunAborted`
+  when ``fail_fast`` is set and a task fails fatally.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from goldfive.events import (
+    emit,
+    plan_revised_event,
+    run_aborted_event,
+    run_completed_event,
+    run_started_event,
+)
+from goldfive.protocols import AgentAdapter, EventSink, Executor, Planner, Steerer
+from goldfive.results import ExecutionOutcome
+from goldfive.types import Plan, Session, Task, TaskStatus
+
+log = logging.getLogger(__name__)
+
+
+class SequentialExecutor(Executor):
+    """Single-threaded executor that drives one task at a time.
+
+    Parameters
+    ----------
+    max_plan_reinvocations:
+        Upper bound on the number of adapter ``invoke()`` calls a single
+        :meth:`run` may issue. Each eligible task consumes one invocation;
+        when drift triggers a plan revision, the new plan's remaining tasks
+        share the same budget. Defaults to ``3`` to mirror the harmonograf
+        re-invocation cap.
+    fail_fast:
+        When ``True`` (default), the first task that ends up ``FAILED`` causes
+        the executor to emit ``RunAborted`` and stop. When ``False``, failed
+        tasks are recorded and the executor continues walking remaining
+        eligible tasks.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_plan_reinvocations: int = 3,
+        fail_fast: bool = True,
+    ) -> None:
+        self.max_plan_reinvocations = int(max_plan_reinvocations)
+        self.fail_fast = bool(fail_fast)
+
+    # ------------------------------------------------------------------
+    # Executor protocol
+    # ------------------------------------------------------------------
+
+    async def run(
+        self,
+        *,
+        plan: Plan,
+        session: Session,
+        adapter: AgentAdapter,
+        steerer: Steerer,
+        planner: Planner,
+        sinks: list[EventSink],
+    ) -> ExecutionOutcome:
+        """Walk ``plan`` end-to-end, driving ``adapter`` once per eligible task.
+
+        Returns an :class:`ExecutionOutcome` summarizing whether the run
+        succeeded and carrying the final ``session`` so callers can inspect
+        completed results / agent notes.
+        """
+        # Pin the plan onto the session so the steerer / reporting handlers
+        # see the same object the executor is iterating.
+        session.plan = plan
+
+        # Wire sinks + planner into the steerer so reporting-tool handlers
+        # can emit events and trigger planner.refine on drift.
+        steerer.bind(sinks=sinks, planner=planner)
+
+        # Emit RunStarted.
+        await emit(
+            sinks,
+            run_started_event(
+                run_id=session.run_id,
+                sequence=session.next_sequence(),
+                goal_summary=_goal_summary(session, plan),
+            ),
+        )
+
+        invocations = 0
+        failure_reason = ""
+        run_failed = False
+
+        # Track the plan identity so we detect mid-run revisions by the steerer.
+        last_plan_id = plan.id
+        last_revision_index = plan.revision_index
+
+        # Cap by max_plan_reinvocations: this is the number of adapter
+        # invocations we'll allow for the whole run. Each eligible task
+        # burns one; mid-run plan revisions do not refund any.
+        while invocations < self.max_plan_reinvocations:
+            current_plan = session.plan or plan
+
+            # Detect an out-of-band plan revision (steerer swapped the plan
+            # on the session). Emit PlanRevised so sinks see the boundary.
+            if (
+                current_plan.id != last_plan_id
+                or current_plan.revision_index != last_revision_index
+            ):
+                await emit(
+                    sinks,
+                    plan_revised_event(
+                        run_id=session.run_id,
+                        sequence=session.next_sequence(),
+                        plan=current_plan,
+                        drift_kind=current_plan.revision_kind,
+                        severity=current_plan.revision_severity,
+                        reason=current_plan.revision_reason,
+                        revision_index=current_plan.revision_index,
+                    ),
+                )
+                last_plan_id = current_plan.id
+                last_revision_index = current_plan.revision_index
+                # Restart iteration from the current cursor: pick_next_task
+                # below will naturally re-scan the (possibly new) plan.
+
+            task = _pick_next_task(current_plan)
+            if task is None:
+                # No eligible PENDING task: either the plan is done or
+                # everything remaining is blocked by failures. Break out
+                # and let the post-loop block decide success.
+                break
+
+            session.current_task_id = task.id
+            invocations += 1
+
+            log.debug(
+                "SequentialExecutor: invoking task=%s (invocation %d/%d)",
+                task.id, invocations, self.max_plan_reinvocations,
+            )
+
+            # Adapter.invoke drives the agent, which calls reporting tools,
+            # whose handlers route through the steerer to mutate task state
+            # (PENDING -> RUNNING -> COMPLETED/FAILED/BLOCKED) and emit the
+            # corresponding proto events via sinks.
+            try:
+                result = await adapter.invoke(task, session)
+            except Exception as exc:  # noqa: BLE001
+                # Hard adapter failure: nothing to do except abort.
+                log.exception(
+                    "SequentialExecutor: adapter.invoke raised for task=%s",
+                    task.id,
+                )
+                failure_reason = f"adapter.invoke raised for task={task.id}: {exc}"
+                run_failed = True
+                break
+
+            # If the adapter reported an error on the invocation envelope
+            # (but didn't raise), surface it as a failure when fail_fast is
+            # set. A well-behaved adapter will usually have already called
+            # report_task_failed through the agent.
+            if result is not None and getattr(result, "error", None) is not None:
+                log.warning(
+                    "SequentialExecutor: InvocationResult.error=%s task=%s",
+                    result.error, task.id,
+                )
+
+            # Re-read the task's tracked status after the invocation.
+            tracked = _find_task(session.plan or current_plan, task.id)
+            tracked_status = (
+                tracked.status if tracked is not None else TaskStatus.PENDING
+            )
+            if tracked_status == TaskStatus.PENDING:
+                # The agent did not report a terminal state for this task.
+                # Treat as a soft failure: mark it failed locally so
+                # _pick_next_task does not pick it again next iteration.
+                # The steerer is the authority on status; if it cares, it
+                # can transition this itself on a follow-up observe().
+                log.info(
+                    "SequentialExecutor: task=%s returned PENDING post-invoke; "
+                    "marking FAILED locally to avoid repick",
+                    task.id,
+                )
+                if tracked is not None:
+                    tracked.status = TaskStatus.FAILED
+                tracked_status = TaskStatus.FAILED
+
+            if tracked_status == TaskStatus.FAILED:
+                failure_reason = f"task {task.id} failed"
+                if self.fail_fast:
+                    run_failed = True
+                    break
+                # else: continue to next eligible task.
+
+            # Session.current_task_id gets reset by the next iteration.
+
+        # ------------------------------------------------------------------
+        # Terminal emission.
+        # ------------------------------------------------------------------
+
+        if run_failed:
+            await emit(
+                sinks,
+                run_aborted_event(
+                    run_id=session.run_id,
+                    sequence=session.next_sequence(),
+                    reason=failure_reason or "run aborted",
+                ),
+            )
+            return ExecutionOutcome(
+                success=False, session=session, reason=failure_reason or "run aborted"
+            )
+
+        # If we exhausted the invocation budget with work still pending,
+        # that is also a failure (stuck agent).
+        remaining = _pick_next_task(session.plan or plan)
+        if invocations >= self.max_plan_reinvocations and remaining is not None:
+            reason = (
+                f"exhausted max_plan_reinvocations={self.max_plan_reinvocations} "
+                f"with pending task {remaining.id}"
+            )
+            await emit(
+                sinks,
+                run_aborted_event(
+                    run_id=session.run_id,
+                    sequence=session.next_sequence(),
+                    reason=reason,
+                ),
+            )
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        # If fail_fast=False and some task ended FAILED, the run is only
+        # "successful" in the best-effort sense. Match harmonograf: report
+        # success=False with a reason when any task is terminal-failed.
+        any_failed = _any_failed(session.plan or plan)
+        if any_failed and not self.fail_fast:
+            reason = "one or more tasks failed (fail_fast=False)"
+            await emit(
+                sinks,
+                run_aborted_event(
+                    run_id=session.run_id,
+                    sequence=session.next_sequence(),
+                    reason=reason,
+                ),
+            )
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        await emit(
+            sinks,
+            run_completed_event(
+                run_id=session.run_id,
+                sequence=session.next_sequence(),
+                outcome_summary=_outcome_summary(session),
+            ),
+        )
+        return ExecutionOutcome(success=True, session=session)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pick_next_task(plan: Plan) -> Task | None:
+    """Return the first PENDING task whose deps are all COMPLETED.
+
+    Walks ``plan.topological_stages()`` in order. Status authority is
+    ``Task.status`` on the plan's tasks (the steerer mutates these in
+    place via reporting tool handlers).
+    """
+    tasks_by_id = {t.id: t for t in plan.tasks if t.id}
+    deps_by_task: dict[str, list[str]] = {}
+    for e in plan.edges:
+        deps_by_task.setdefault(e.to_task_id, []).append(e.from_task_id)
+
+    for stage in plan.topological_stages():
+        for task in stage:
+            if task.status != TaskStatus.PENDING:
+                continue
+            blocked = False
+            for dep_id in deps_by_task.get(task.id, []):
+                dep = tasks_by_id.get(dep_id)
+                if dep is None or dep.status != TaskStatus.COMPLETED:
+                    blocked = True
+                    break
+            if not blocked:
+                return task
+    return None
+
+
+def _find_task(plan: Plan, task_id: str) -> Task | None:
+    for t in plan.tasks:
+        if t.id == task_id:
+            return t
+    return None
+
+
+def _any_failed(plan: Plan) -> bool:
+    return any(t.status == TaskStatus.FAILED for t in plan.tasks)
+
+
+def _goal_summary(session: Session, plan: Plan) -> str:
+    """Best-effort one-line summary for the RunStarted event."""
+    if session.goals:
+        first = session.goals[0]
+        summary = getattr(first, "summary", "") or ""
+        if summary:
+            return summary
+    return plan.summary or f"plan {plan.id}"
+
+
+def _outcome_summary(session: Session) -> str:
+    """One-line summary for the RunCompleted event."""
+    plan = session.plan
+    if plan is None:
+        return "run completed"
+    total = len(plan.tasks)
+    completed = sum(1 for t in plan.tasks if t.status == TaskStatus.COMPLETED)
+    return f"{completed}/{total} tasks completed"
+
+
+def build_task_nudge(task: Task) -> str:
+    """Return the canonical next-task nudge string.
+
+    Ported from harmonograf's ``_build_nudge_content`` (minus the
+    ADK-specific ``genai_types.Content`` wrapping). Adapters that want
+    harmonograf-identical prompting can feed this string to their underlying
+    agent as the user turn that precedes each per-task invocation.
+    """
+    tid = task.id or ""
+    title = task.title or ""
+    description = task.description or ""
+    return (
+        f"Continue executing the plan. Your next task is {tid}: {title}. "
+        f"{description} "
+        "Execute it now, then proceed to the next pending task assigned "
+        "to you whose dependencies are complete."
+    ).strip()

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -293,6 +293,66 @@ class PassthroughPlanner:
         return None
 
 
+class StaticPlanner:
+    """Planner that returns a pre-built :class:`Plan` verbatim.
+
+    Useful for tests, CLIs, and the ``hello_callable`` example where the
+    caller already knows the DAG it wants executed. On every call to
+    :meth:`generate` a fresh copy of the template is returned, with
+    ``run_id`` rewritten to match the current session and ``goal_ids``
+    aligned to the provided goals. :meth:`refine` always returns
+    ``None`` — refinement is out of scope when the plan is hard-coded.
+    """
+
+    def __init__(self, plan: Plan) -> None:
+        if plan is None:  # pragma: no cover - defensive
+            raise TypeError("StaticPlanner requires a non-None Plan")
+        self._template = plan
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Mapping[str, Any] | None = None,
+    ) -> Plan | None:
+        run_id = ""
+        if context is not None:
+            run_id = str(context.get("run_id") or "")
+        return Plan(
+            id=self._template.id or uuid.uuid4().hex,
+            run_id=run_id or self._template.run_id,
+            goal_ids=[g.id for g in goals if g.id] or list(self._template.goal_ids),
+            tasks=[
+                Task(
+                    id=t.id,
+                    title=t.title,
+                    description=t.description,
+                    assignee_agent_id=t.assignee_agent_id,
+                    status=t.status,
+                    predicted_start_ms=t.predicted_start_ms,
+                    predicted_duration_ms=t.predicted_duration_ms,
+                    bound_span_id=t.bound_span_id,
+                )
+                for t in self._template.tasks
+            ],
+            edges=[
+                TaskEdge(from_task_id=e.from_task_id, to_task_id=e.to_task_id)
+                for e in self._template.edges
+            ],
+            summary=self._template.summary,
+        )
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        return None
+
+
 class LLMPlanner:
     """Delegates to a caller-supplied async LLM callable.
 

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -1,0 +1,327 @@
+"""The :class:`Runner` — goldfive's single public entrypoint.
+
+A Runner composes the six pluggable components of a goldfive run:
+
+* :class:`GoalDeriver` — turns ``user_input`` into ``list[Goal]``.
+* :class:`Planner` — turns goals into a :class:`Plan`.
+* :class:`Executor` — walks the plan, dispatches to the adapter.
+* :class:`AgentAdapter` — talks to the underlying agent framework.
+* :class:`Steerer` — runs the state machine, detects drift.
+* :class:`EventSink` — persists / observes the event stream.
+
+``Runner.run`` emits a ``RunStarted`` event, derives goals, generates a
+plan, registers the seven canonical reporting tools on the adapter,
+binds the steerer to the sinks+planner, and hands everything to the
+executor. The returned :class:`ExecutionOutcome` carries the final live
+:class:`Session` so callers can inspect completed tasks / artifacts.
+
+No ADK or Claude Agent SDK imports live in this module. Optional
+adapter implementations live under ``goldfive.adapters.<framework>``
+and are loaded lazily by callers.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from goldfive.events import emit, make_event
+from goldfive.goal_deriver import PassthroughGoalDeriver
+from goldfive.reporting import BUILTIN_REPORTING_TOOLS
+from goldfive.results import ExecutionOutcome
+from goldfive.steerer import DefaultSteerer
+from goldfive.types import Goal, Session
+
+if TYPE_CHECKING:
+    from goldfive.protocols import (
+        AgentAdapter,
+        EventSink,
+        Executor,
+        GoalDeriver,
+        Planner,
+        Steerer,
+    )
+
+log = logging.getLogger("goldfive.runner")
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+class Runner:
+    """The public entrypoint for a goldfive run.
+
+    Parameters
+    ----------
+    agent:
+        An :class:`AgentAdapter` wrapping the underlying agent framework.
+    planner:
+        A :class:`Planner` instance. Pass a planner configured with a
+        pre-baked plan when you already know the tasks (see
+        :class:`PassthroughGoalDeriver` for an analogous convenience on
+        the goals side).
+    executor:
+        An :class:`Executor` (e.g. :class:`SequentialExecutor` or
+        :class:`ParallelDAGExecutor`).
+    goal_deriver:
+        Optional — defaults to ``PassthroughGoalDeriver("run")``. When
+        the caller passes ``user_input`` as ``list[Goal]`` the deriver
+        is bypassed entirely.
+    steerer:
+        Optional — defaults to :class:`DefaultSteerer`.
+    sinks:
+        Optional list of :class:`EventSink` instances. Defaults to ``[]``.
+    max_plan_reinvocations:
+        Safety cap on plan refinement cycles. Passed through to the
+        executor (via ``context``) so executors that honour it can
+        enforce the cap.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent: AgentAdapter,
+        planner: Planner,
+        executor: Executor,
+        goal_deriver: GoalDeriver | None = None,
+        steerer: Steerer | None = None,
+        sinks: list[EventSink] | None = None,
+        max_plan_reinvocations: int = 3,
+    ) -> None:
+        self.agent = agent
+        self.planner = planner
+        self.executor = executor
+        self.goal_deriver: GoalDeriver = goal_deriver or PassthroughGoalDeriver("run")
+        self.steerer: Steerer = steerer or DefaultSteerer()
+        self.sinks: list[EventSink] = list(sinks) if sinks else []
+        self.max_plan_reinvocations = max_plan_reinvocations
+
+    # ------------------------------------------------------------------
+    # run
+    # ------------------------------------------------------------------
+
+    async def run(
+        self,
+        user_input: str | list[Goal],
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> ExecutionOutcome:
+        """Execute one end-to-end goldfive run and return the outcome."""
+
+        # 1. Build Session with a fresh run_id.
+        session = Session(
+            run_id=uuid.uuid4().hex,
+            started_at_ms=_now_ms(),
+        )
+
+        # 2. Emit RunStarted before anything else.
+        await self._emit(
+            session,
+            "RunStarted",
+            {
+                "started_at_ms": session.started_at_ms,
+                "input_kind": _input_kind(user_input),
+            },
+        )
+
+        # 3. Derive (or accept) goals.
+        try:
+            goals = await self._resolve_goals(user_input, context)
+        except Exception as exc:  # noqa: BLE001
+            reason = f"goal derivation failed: {exc}"
+            log.exception("goal derivation failed")
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+        session.goals = list(goals)
+
+        await self._emit(
+            session,
+            "GoalDerived",
+            {"goals": [{"id": g.id, "summary": g.summary} for g in session.goals]},
+        )
+
+        # Build the context passed to the planner — stamp run_id so LLM
+        # planners can include it in the plan envelope.
+        planner_context: dict[str, Any] = dict(context) if context else {}
+        planner_context.setdefault("run_id", session.run_id)
+        planner_context.setdefault("max_plan_reinvocations", self.max_plan_reinvocations)
+
+        # 4. Generate the plan.
+        try:
+            plan = await self.planner.generate(
+                goals=session.goals,
+                available_agents=list(self.agent.available_agents),
+                context=planner_context,
+            )
+        except Exception as exc:  # noqa: BLE001
+            reason = f"planner.generate raised: {exc}"
+            log.exception("planner.generate raised")
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        if plan is None:
+            reason = "no plan generated"
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        # Planners may leave run_id blank; stamp ours so downstream sinks
+        # correlate cleanly.
+        if not plan.run_id:
+            plan.run_id = session.run_id
+        session.plan = plan
+
+        await self._emit(
+            session,
+            "PlanSubmitted",
+            {
+                "plan_id": plan.id,
+                "summary": plan.summary,
+                "task_count": len(plan.tasks),
+                "edge_count": len(plan.edges),
+                "revision_index": plan.revision_index,
+            },
+        )
+
+        # 5. Register the seven canonical reporting tools on the adapter.
+        try:
+            await self.agent.register_reporting_tools(list(BUILTIN_REPORTING_TOOLS))
+        except Exception as exc:  # noqa: BLE001
+            reason = f"register_reporting_tools raised: {exc}"
+            log.exception("register_reporting_tools raised")
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        # 6. Bind the steerer. (The executor may re-bind — that's fine.)
+        try:
+            self.steerer.bind(sinks=list(self.sinks), planner=self.planner)
+        except Exception as exc:  # noqa: BLE001
+            reason = f"steerer.bind raised: {exc}"
+            log.exception("steerer.bind raised")
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        # 7. Hand off to the executor.
+        try:
+            outcome = await self.executor.run(
+                plan=session.plan,
+                session=session,
+                adapter=self.agent,
+                steerer=self.steerer,
+                planner=self.planner,
+                sinks=list(self.sinks),
+            )
+        except Exception as exc:  # noqa: BLE001
+            reason = f"executor.run raised: {exc}"
+            log.exception("executor.run raised")
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        return outcome
+
+    # ------------------------------------------------------------------
+    # resume — best-effort replay
+    # ------------------------------------------------------------------
+
+    async def resume(self, persistence_path: str) -> ExecutionOutcome:
+        """Replay a JSONL persistence log and return the recovered outcome.
+
+        Best-effort for v0.1: uses ``goldfive.sinks.reconstruct_session``
+        when the proto stubs are available (JSONL events are proto-
+        encoded). Returns the reconstructed session as an
+        :class:`ExecutionOutcome` reflecting the latest terminal marker
+        (``RunCompleted`` / ``RunAborted``) seen in the log.
+
+        We do **not** continue execution from the latest cursor — full
+        resume semantics require planner/executor co-operation that is
+        out-of-scope for this PR. Callers who need a live continuation
+        should construct a new :class:`Runner` with the goals recovered
+        from the log.
+
+        TODO(#15): once executors grow a ``resume_from`` hook, continue
+        execution from the latest un-finished task rather than returning
+        the recovered session as-is.
+        """
+        try:
+            from goldfive.sinks import reconstruct_session, replay_from_jsonl
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "goldfive.sinks.reconstruct_session is not available; "
+                "install the `proto` extra to enable JSONL replay."
+            ) from exc
+
+        events = replay_from_jsonl(persistence_path)
+        session = reconstruct_session(events)
+
+        success = False
+        reason = "run did not complete before persistence ended"
+        for evt in events:
+            payload = getattr(evt, "WhichOneof", lambda _: None)("payload")
+            if payload == "run_completed":
+                success = True
+                reason = ""
+            elif payload == "run_aborted":
+                success = False
+                reason = getattr(evt.run_aborted, "reason", "")
+
+        return ExecutionOutcome(success=success, session=session, reason=reason)
+
+    # ------------------------------------------------------------------
+    # close
+    # ------------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Close every sink. Best-effort — individual errors are logged."""
+        for sink in self.sinks:
+            try:
+                await sink.close()
+            except Exception as exc:  # noqa: BLE001
+                log.warning("sink.close() raised: %s", exc)
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    async def _resolve_goals(
+        self,
+        user_input: str | list[Goal],
+        context: Mapping[str, Any] | None,
+    ) -> list[Goal]:
+        if isinstance(user_input, list):
+            if not user_input:
+                raise ValueError("Runner.run: empty goal list")
+            if not all(isinstance(g, Goal) for g in user_input):
+                raise TypeError("Runner.run: list input must be list[Goal]")
+            return list(user_input)
+        if not isinstance(user_input, str):
+            raise TypeError(
+                f"Runner.run: user_input must be str or list[Goal], "
+                f"got {type(user_input).__name__}"
+            )
+        goals = await self.goal_deriver.derive(user_input, context=context)
+        if not goals:
+            raise ValueError("GoalDeriver returned an empty goals list")
+        return list(goals)
+
+    async def _emit(self, session: Session, kind: str, payload: dict[str, Any]) -> None:
+        evt = make_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            kind=kind,
+            payload=payload,
+        )
+        await emit(self.sinks, evt)
+
+
+def _input_kind(user_input: Any) -> str:
+    if isinstance(user_input, str):
+        return "str"
+    if isinstance(user_input, list):
+        return "list[Goal]"
+    return type(user_input).__name__
+
+
+__all__ = ["Runner"]

--- a/goldfive/sinks/__init__.py
+++ b/goldfive/sinks/__init__.py
@@ -10,19 +10,36 @@ Three implementations ship in-box:
   JSON file suitable for crash recovery. Paired with
   :func:`replay_from_jsonl` and :func:`reconstruct_session` for resume.
 
+``InMemorySink`` is always importable. ``LoggingSink`` and
+``JSONLPersistenceSink`` depend on the optional ``proto`` extra
+(``google.protobuf``) — importing them when the extra is missing
+raises :class:`ImportError` with a friendly message. The top-level
+``goldfive`` module handles that import gracefully so the bulk of the
+public API stays usable without ``proto``.
+
 All sinks conform to the ``EventSink`` protocol pinned in
 ``INTERFACE_SPEC.md`` (async ``emit`` / async ``close``).
 """
 
 from __future__ import annotations
 
-from goldfive.sinks.logging_sink import LoggingSink
 from goldfive.sinks.memory import InMemorySink
-from goldfive.sinks.persistence import (
-    JSONLPersistenceSink,
-    reconstruct_session,
-    replay_from_jsonl,
-)
+
+try:
+    from goldfive.sinks.logging_sink import LoggingSink
+except ImportError:  # pragma: no cover — proto extra not installed
+    LoggingSink = None  # type: ignore[assignment]
+
+try:
+    from goldfive.sinks.persistence import (
+        JSONLPersistenceSink,
+        reconstruct_session,
+        replay_from_jsonl,
+    )
+except ImportError:  # pragma: no cover — proto extra not installed
+    JSONLPersistenceSink = None  # type: ignore[assignment]
+    reconstruct_session = None  # type: ignore[assignment]
+    replay_from_jsonl = None  # type: ignore[assignment]
 
 __all__ = [
     "InMemorySink",

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,295 @@
+"""Integration tests for :class:`goldfive.Runner`.
+
+Drives a :class:`CallableAdapter`-backed agent through goal derivation,
+planning, and execution. Asserts the public event order:
+
+    RunStarted, GoalDerived, PlanSubmitted,
+    (TaskStarted, TaskCompleted) xN,
+    RunCompleted
+
+These tests are the single largest exercise of the public API surface
+pinned by ``INTERFACE_SPEC.md`` — they touch every protocol.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from goldfive import (
+    BUILTIN_REPORTING_TOOLS,
+    CallableAdapter,
+    ExecutionOutcome,
+    Goal,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _hand_built_plan() -> Plan:
+    """Three-task linear plan: research → draft → review."""
+    return Plan(
+        id="plan-fixture",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="Research", assignee_agent_id="writer"),
+            Task(id="draft", title="Draft", assignee_agent_id="writer"),
+            Task(id="review", title="Review", assignee_agent_id="writer"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft"),
+            TaskEdge(from_task_id="draft", to_task_id="review"),
+        ],
+        summary="Research, draft, review.",
+    )
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    """Reference agent: returns a non-empty result so the executor auto-completes."""
+    _ = tools
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+def _kinds(events: list[Any]) -> list[str]:
+    return [e.get("kind") if isinstance(e, dict) else getattr(e, "kind", "") for e in events]
+
+
+def _payloads(events: list[Any]) -> list[dict[str, Any]]:
+    return [
+        (e.get("payload") if isinstance(e, dict) else getattr(e, "payload", {})) or {}
+        for e in events
+    ]
+
+
+def _sequences(events: list[Any]) -> list[int]:
+    out: list[int] = []
+    for e in events:
+        if isinstance(e, dict):
+            out.append(int(e.get("sequence") or 0))
+        else:
+            out.append(int(getattr(e, "sequence", 0) or 0))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_runner_end_to_end_event_sequence() -> None:
+    """Full end-to-end: derive → plan → execute → emit correct event sequence."""
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("Research, draft, review"),
+        sinks=[sink],
+    )
+
+    outcome = await runner.run("go")
+    await runner.close()
+
+    assert isinstance(outcome, ExecutionOutcome)
+    assert outcome.success, outcome.reason
+
+    kinds = _kinds(sink.events)
+
+    # Lifecycle envelope up-front.
+    assert kinds[0] == "RunStarted"
+    assert kinds[1] == "GoalDerived"
+    assert kinds[2] == "PlanSubmitted"
+
+    # For each of the three tasks: TaskStarted → TaskCompleted.
+    task_kinds = kinds[3:-1]  # strip initial trio and trailing RunCompleted
+    assert len(task_kinds) == 6, kinds
+    assert task_kinds[0::2] == ["TaskStarted"] * 3
+    assert task_kinds[1::2] == ["TaskCompleted"] * 3
+
+    # Run terminates with a RunCompleted.
+    assert kinds[-1] == "RunCompleted"
+
+    # Sequence numbers are strictly monotonic from zero.
+    seqs = _sequences(sink.events)
+    assert seqs == sorted(seqs)
+    assert len(seqs) == len(set(seqs))
+    assert seqs[0] == 0
+
+    # Task order respects the DAG: research → draft → review.
+    payloads = _payloads(sink.events)
+    task_ids_in_order = [
+        payloads[i]["task_id"] for i, k in enumerate(kinds) if k == "TaskStarted"
+    ]
+    assert task_ids_in_order == ["research", "draft", "review"]
+
+    # Session is fully populated.
+    assert outcome.session.plan is not None
+    assert len(outcome.session.goals) == 1
+    assert all(
+        outcome.session.plan.tasks[i].status.value == "COMPLETED" for i in range(3)
+    )
+
+
+async def test_runner_accepts_prebuilt_goal_list() -> None:
+    """list[Goal] input bypasses the deriver."""
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        sinks=[sink],
+    )
+    goals = [Goal(id="g1", summary="pre-baked")]
+    outcome = await runner.run(goals)
+    await runner.close()
+
+    assert outcome.success
+    assert outcome.session.goals == goals
+
+
+async def test_runner_aborts_when_planner_returns_none() -> None:
+    """No plan → ``RunAborted`` with a clear reason, no executor invocation."""
+    from goldfive import PassthroughPlanner
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=[]),
+        planner=PassthroughPlanner(),  # returns None from generate()
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("ignored"),
+        sinks=[sink],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+
+    assert not outcome.success
+    assert "no plan" in outcome.reason
+
+    assert _kinds(sink.events) == ["RunStarted", "GoalDerived", "RunAborted"]
+
+
+async def test_runner_registers_builtin_reporting_tools() -> None:
+    """The adapter receives the canonical seven reporting tools verbatim."""
+    captured: dict[str, Any] = {}
+
+    async def agent_fn(
+        task: Task, session: Session, tools: list[ReportingToolSpec]
+    ) -> InvocationResult:
+        captured.setdefault("tools", tools)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    runner = Runner(
+        agent=CallableAdapter(agent_fn, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("any"),
+        sinks=[InMemorySink()],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+    assert outcome.success
+
+    tools = captured["tools"]
+    names = [t.name for t in tools]
+    expected = [t.name for t in BUILTIN_REPORTING_TOOLS]
+    assert names == expected
+
+
+async def test_runner_close_closes_all_sinks() -> None:
+    """Runner.close() invokes ``close`` on every sink."""
+    closed: list[bool] = []
+
+    class _SpySink:
+        events: list[Any]
+
+        def __init__(self) -> None:
+            self.events = []
+
+        async def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+        async def close(self) -> None:
+            closed.append(True)
+
+    spy_a = _SpySink()
+    spy_b = _SpySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("close test"),
+        sinks=[spy_a, spy_b],
+    )
+    await runner.run("go")
+    await runner.close()
+
+    assert closed == [True, True]
+
+
+async def test_runner_input_type_errors() -> None:
+    """Non str / list[Goal] inputs raise cleanly and produce RunAborted."""
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        sinks=[sink],
+    )
+
+    outcome = await runner.run(42)  # type: ignore[arg-type]
+    await runner.close()
+    assert not outcome.success
+    assert "str or list[Goal]" in outcome.reason
+    kinds = _kinds(sink.events)
+    assert kinds == ["RunStarted", "RunAborted"]
+
+
+@pytest.mark.asyncio
+async def test_runner_protocol_compatibility() -> None:
+    """Every default implementation must satisfy its Protocol at runtime."""
+    from goldfive import (
+        AgentAdapter,
+        EventSink,
+        Executor,
+        GoalDeriver,
+        Planner,
+        Steerer,
+    )
+    from goldfive.steerer import DefaultSteerer
+
+    adapter = CallableAdapter(_happy_agent, available_agents=["writer"])
+    assert isinstance(adapter, AgentAdapter)
+
+    planner = StaticPlanner(_hand_built_plan())
+    assert isinstance(planner, Planner)
+
+    executor = SequentialExecutor()
+    assert isinstance(executor, Executor)
+
+    steerer = DefaultSteerer()
+    assert isinstance(steerer, Steerer)
+
+    deriver = PassthroughGoalDeriver("x")
+    assert isinstance(deriver, GoalDeriver)
+
+    sink = InMemorySink()
+    assert isinstance(sink, EventSink)

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -1,0 +1,450 @@
+"""Unit tests for :class:`goldfive.executors.SequentialExecutor`.
+
+The tests use lightweight stubs for :class:`AgentAdapter`, :class:`Steerer`,
+and :class:`Planner` that are just rich enough to exercise the three required
+scenarios:
+
+1. A 3-task linear plan runs to completion.
+2. Drift mid-run triggers ``planner.refine``, the executor applies the revised
+   plan and keeps going.
+3. ``fail_fast=True`` stops on the first task failure;
+   ``fail_fast=False`` walks past failures and reports success=False at the end.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from goldfive.executors import SequentialExecutor, build_task_nudge
+from goldfive.protocols import EventSink
+from goldfive.results import InvocationResult
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class RecordingSink:
+    """EventSink that accumulates everything emitted for later assertion."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+        self.closed = False
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def payload_kinds(self) -> list[str]:
+        return [getattr(e, "payload_kind", "") for e in self.events]
+
+
+class StubSteerer:
+    """Minimal Steerer stub that just forwards reporting-tool calls into
+    plan.Task.status mutations. Acts as the central authority over task state
+    the way a real Steerer would.
+    """
+
+    def __init__(self) -> None:
+        self._sinks: list[EventSink] = []
+        self._planner: Any = None
+        self.observed: list[Any] = []
+
+    def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
+        self._sinks = sinks
+        self._planner = planner
+
+    async def observe(self, event: Any, session: Session) -> None:
+        self.observed.append(event)
+
+    async def transition(
+        self,
+        task_id: str,
+        to: TaskStatus,
+        *,
+        detail: str = "",
+        session: Session,
+    ) -> None:
+        if session.plan is None:
+            return
+        for t in session.plan.tasks:
+            if t.id == task_id:
+                t.status = to
+                return
+
+    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
+        return None
+
+
+class StubPlanner:
+    """Planner that records ``refine`` calls and returns whatever the caller
+    supplied via ``set_refine_result``.
+    """
+
+    def __init__(self) -> None:
+        self.refine_calls: list[tuple[Plan, DriftEvent]] = []
+        self._refine_result: Plan | None = None
+
+    def set_refine_result(self, plan: Plan | None) -> None:
+        self._refine_result = plan
+
+    async def generate(
+        self,
+        *,
+        goals: list,
+        available_agents: list[str],
+        context: Any | None = None,
+    ) -> Plan | None:
+        return None
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list,
+    ) -> Plan | None:
+        self.refine_calls.append((plan, drift))
+        return self._refine_result
+
+
+class StubAdapter:
+    """Adapter whose ``invoke`` calls a per-task callback (provided by the
+    test). The callback receives ``(task, session, steerer, planner)`` and
+    typically mutates task status directly — emulating the reporting-tool
+    handler path.
+    """
+
+    def __init__(
+        self,
+        *,
+        steerer: StubSteerer,
+        planner: StubPlanner,
+        on_invoke: Callable[
+            [Task, Session, StubSteerer, StubPlanner],
+            Awaitable[InvocationResult],
+        ],
+    ) -> None:
+        self._steerer = steerer
+        self._planner = planner
+        self._on_invoke = on_invoke
+        self.invocations: list[str] = []
+
+    async def register_reporting_tools(self, tools: list[Any]) -> None:
+        return None
+
+    @property
+    def available_agents(self) -> list[str]:
+        return ["stub"]
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:
+        self.invocations.append(task.id)
+        return await self._on_invoke(task, session, self._steerer, self._planner)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _linear_plan(n: int = 3, run_id: str = "run-1") -> Plan:
+    """Return a linear plan t0 -> t1 -> ... -> t(n-1)."""
+    tasks = [Task(id=f"t{i}", title=f"Task {i}") for i in range(n)]
+    edges = [TaskEdge(from_task_id=f"t{i}", to_task_id=f"t{i+1}") for i in range(n - 1)]
+    return Plan(id="p0", run_id=run_id, goal_ids=[], tasks=tasks, edges=edges)
+
+
+def _fresh_session(run_id: str = "run-1") -> Session:
+    return Session(run_id=run_id)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: linear plan runs to completion.
+# ---------------------------------------------------------------------------
+
+
+async def test_linear_plan_runs_to_completion() -> None:
+    plan = _linear_plan(3)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _complete_current(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        # Simulate the reporting-tool handler path: transition the task to
+        # COMPLETED through the steerer.
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        session.completed_results[task.id] = f"done:{task.id}"
+        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_current)
+
+    # Default max_plan_reinvocations=3; allow exactly 3 tasks.
+    executor = SequentialExecutor(max_plan_reinvocations=3)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is True
+    assert outcome.session is session
+    assert adapter.invocations == ["t0", "t1", "t2"]
+    for t in plan.tasks:
+        assert t.status == TaskStatus.COMPLETED
+
+    kinds = sink.payload_kinds()
+    assert kinds[0] == "run_started"
+    assert kinds[-1] == "run_completed"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: drift mid-run triggers planner.refine; executor applies the new
+# plan and keeps going.
+# ---------------------------------------------------------------------------
+
+
+async def test_drift_mid_run_applies_refined_plan() -> None:
+    plan = _linear_plan(2)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    # The refined plan replaces t1 with t1b (still depending on t0). When
+    # the first invocation "drifts", it will swap session.plan to this one.
+    refined_tasks = [
+        Task(id="t0", title="Task 0", status=TaskStatus.COMPLETED),
+        Task(id="t1b", title="Task 1 revised"),
+    ]
+    refined_edges = [TaskEdge(from_task_id="t0", to_task_id="t1b")]
+    refined = Plan(
+        id="p1",
+        run_id=session.run_id,
+        goal_ids=[],
+        tasks=refined_tasks,
+        edges=refined_edges,
+        revision_reason="new work discovered",
+        revision_kind=DriftKind.NEW_WORK_DISCOVERED.value,
+        revision_severity=DriftSeverity.WARNING.value,
+        revision_index=1,
+    )
+    planner.set_refine_result(refined)
+
+    # Track how many times invoke has been called to script the drift on
+    # the very first invocation.
+    call_count = {"n": 0}
+
+    async def _maybe_drift(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        call_count["n"] += 1
+        # First call: complete t0, then trigger a drift-driven refine and
+        # swap the plan onto the session (emulating what a real Steerer
+        # would do on observing `report_plan_divergence`).
+        if call_count["n"] == 1:
+            await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+            drift = DriftEvent(
+                kind=DriftKind.NEW_WORK_DISCOVERED,
+                severity=DriftSeverity.WARNING,
+                detail="found extra work",
+                current_task_id=task.id,
+            )
+            revised = await planner.refine(
+                plan=session.plan, drift=drift, goals=session.goals
+            )
+            if revised is not None:
+                session.plan = revised
+            return InvocationResult(task_id=task.id, text="done-with-drift")
+        # Subsequent calls: just complete the task.
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_maybe_drift)
+
+    executor = SequentialExecutor(max_plan_reinvocations=5)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is True
+    # Invocations: t0 (original plan) then t1b (from the refined plan).
+    assert adapter.invocations == ["t0", "t1b"]
+    # planner.refine was called exactly once.
+    assert len(planner.refine_calls) == 1
+    # A PlanRevised event landed in the sink between run_started and run_completed.
+    kinds = sink.payload_kinds()
+    assert "plan_revised" in kinds
+    assert kinds.index("plan_revised") < kinds.index("run_completed")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: fail_fast behavior.
+# ---------------------------------------------------------------------------
+
+
+async def test_fail_fast_stops_on_task_failure() -> None:
+    plan = _linear_plan(3)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _fail_middle(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        if task.id == "t1":
+            await steerer.transition(task.id, TaskStatus.FAILED, session=session)
+            return InvocationResult(task_id=task.id, text="", stop_reason="failed")
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_fail_middle)
+
+    executor = SequentialExecutor(max_plan_reinvocations=5, fail_fast=True)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is False
+    # Walked exactly t0 then t1; did not continue to t2.
+    assert adapter.invocations == ["t0", "t1"]
+    # Terminal event is RunAborted.
+    assert sink.payload_kinds()[-1] == "run_aborted"
+    assert plan.tasks[2].status == TaskStatus.PENDING
+
+
+async def test_fail_fast_false_continues_past_failure() -> None:
+    # With an independent plan (two roots) a non-fatal failure on one branch
+    # should not block the other branch when fail_fast=False.
+    tasks = [
+        Task(id="a", title="A"),
+        Task(id="b", title="B"),
+        Task(id="c", title="C"),
+    ]
+    # No edges: all three are independent roots, so walker can still
+    # progress past a failed one.
+    plan = Plan(id="p0", run_id="run-1", goal_ids=[], tasks=tasks, edges=[])
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _fail_b(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        if task.id == "b":
+            await steerer.transition(task.id, TaskStatus.FAILED, session=session)
+            return InvocationResult(task_id=task.id, text="", stop_reason="failed")
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_fail_b)
+
+    executor = SequentialExecutor(max_plan_reinvocations=5, fail_fast=False)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # All three tasks were attempted.
+    assert set(adapter.invocations) == {"a", "b", "c"}
+    # The run is not "successful" because one task failed, but we did walk
+    # past the failure (that's the distinguishing behavior from fail_fast).
+    assert outcome.success is False
+    # Terminal event is RunAborted with a fail_fast=False reason.
+    assert sink.payload_kinds()[-1] == "run_aborted"
+    # Remaining tasks a and c are COMPLETED, b stayed FAILED.
+    by_id = {t.id: t.status for t in plan.tasks}
+    assert by_id == {
+        "a": TaskStatus.COMPLETED,
+        "b": TaskStatus.FAILED,
+        "c": TaskStatus.COMPLETED,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 (bonus): the re-invocation budget terminates a stuck run.
+# ---------------------------------------------------------------------------
+
+
+async def test_budget_terminates_stuck_run() -> None:
+    plan = _linear_plan(5)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _noop(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        # Deliberately do NOT transition the task. The executor should treat
+        # post-invoke PENDING as a local failure so the walker can move on,
+        # but it also will not progress past the failed task because the
+        # next edge depends on it.
+        return InvocationResult(task_id=task.id, text="")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_noop)
+
+    executor = SequentialExecutor(max_plan_reinvocations=2, fail_fast=True)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # fail_fast=True + first task ends FAILED (because it was left PENDING
+    # post-invoke and the executor marked it FAILED locally) -> aborts
+    # after the first invocation.
+    assert outcome.success is False
+    assert sink.payload_kinds()[-1] == "run_aborted"
+    assert adapter.invocations == ["t0"]
+
+
+# ---------------------------------------------------------------------------
+# build_task_nudge: canonical next-task nudge string.
+# ---------------------------------------------------------------------------
+
+
+def test_build_task_nudge_includes_id_title_and_description() -> None:
+    t = Task(id="t42", title="Do the thing", description="Carefully and thoroughly.")
+    nudge = build_task_nudge(t)
+    assert "t42" in nudge
+    assert "Do the thing" in nudge
+    assert "Carefully and thoroughly." in nudge
+    assert nudge.startswith("Continue executing the plan.")


### PR DESCRIPTION
Closes #9.

## Summary

- `SequentialExecutor` drives a `Plan` one task at a time, re-invoking the adapter with next-task context until the plan terminates; ported from harmonograf's `_run_orchestrated` + `_run_sequential` with ADK-specific session/runner plumbing removed.
- Emits `RunStarted` / `PlanRevised` (on mid-run revision) / `RunCompleted` / `RunAborted` proto `Event` messages through the sinks fan-out in `goldfive/events.py`.
- `max_plan_reinvocations=3` default matches harmonograf's re-invocation cap; `fail_fast=True` default matches the abort-on-first-failure semantics.
- Re-exports: `goldfive.executors.SequentialExecutor`, `goldfive.executors.build_task_nudge` (the `_build_nudge_content` port, minus the ADK `genai_types.Content` wrapping).

## Self-contained foundational shims

Because foundational PRs (#3–#7) are still in flight, this PR also lands the modules `SequentialExecutor` imports, pinned to `INTERFACE_SPEC.md` shapes:

- `goldfive/types.py` — dataclasses + enums (matches #4).
- `goldfive/protocols.py` — runtime-checkable protocols (matches #5).
- `goldfive/reporting.py` — `ReportingToolSpec` (matches #5/#6).
- `goldfive/results.py` — `InvocationResult`, `ExecutionOutcome` (matches #5).
- `goldfive/events.py` — `new_event`, `emit`, `run_started_event`, `run_completed_event`, `run_aborted_event`, `plan_revised_event`. Tries the generated `goldfive.pb.goldfive.v1.events_pb2` first and falls back to a Python dataclass shim with the same duck-typed shape.

Once the foundational PRs land, the overlap with this PR is byte-compatible; a rebase merge will either fast-forward or produce a trivial dedup.

## Test plan

All scenarios in `tests/test_sequential_executor.py`:

- [x] 3-task linear plan runs to completion; emits `run_started` first and `run_completed` last.
- [x] Drift mid-run triggers `planner.refine`; the executor applies the revised plan and emits `plan_revised` between `run_started` and `run_completed`.
- [x] `fail_fast=True` stops on first task failure; terminal event is `run_aborted`.
- [x] `fail_fast=False` walks past failures and reports `success=False` at the end.
- [x] Re-invocation budget terminates a stuck run (first task stays PENDING post-invoke, gets locally marked FAILED, fail_fast aborts).
- [x] `build_task_nudge` includes id/title/description.
- [x] `uv run pytest` — 8 passed.
- [x] `uv run ruff check .` — all checks passed.
