### PR TITLE
Implement Planner (Passthrough + LLM) [closes #7]

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -1,0 +1,514 @@
+"""Planner implementations for goldfive.
+
+A ``Planner`` turns a list of :class:`Goal` s into a :class:`Plan` (a DAG
+of :class:`Task` s) and, after the plan starts running, produces a
+revised plan in response to drift. v0.1 is strictly goal-oriented:
+``generate`` takes ``list[Goal]`` rather than raw user input. Deriving
+goals from free text is out-of-scope here and is handled by
+``GoalDeriver`` (issue #8).
+
+Two concrete implementations ship in this module:
+
+* :class:`PassthroughPlanner` — ``generate`` and ``refine`` always
+  return ``None``. Useful as a default when planning is opt-in.
+* :class:`LLMPlanner` — delegates to a caller-supplied async
+  ``call_llm`` callable, parses its JSON output, and is robust to
+  markdown code fences.
+
+Neither implementation raises into the host: any LLM or parse failure
+is logged and becomes ``None``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from goldfive.types import (
+    DriftEvent,
+    Goal,
+    Plan,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+log = logging.getLogger("goldfive.planner")
+
+
+# ---------------------------------------------------------------------------
+# System prompts (goal-oriented variants ported from harmonograf_client)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_SYSTEM_PROMPT = """\
+You are a task-planning assistant for a multi-agent system. Your job
+is to produce the COMPLETE end-to-end execution plan that satisfies a
+set of high-level GOALS before any agent begins work. Do not plan just
+the first step — enumerate every task you expect the system to perform
+from start to finish, so a human can see the whole shape of the
+workflow upfront.
+
+Requirements for the plan:
+
+1. COMPREHENSIVENESS. Decompose the goals into the full DAG of tasks
+   needed to satisfy every goal end-to-end. A typical plan has between
+   5 and 20 tasks. Smaller is OK only for genuinely trivial goal sets;
+   larger is OK for complex multi-phase work. Do not stop at "first
+   research, then draft" — include verification, revision, handoffs,
+   synthesis, and any follow-up the goals imply.
+
+2. GOAL COVERAGE. Every goal in the provided list must be addressed by
+   at least one task. Keep the mapping clear: prefer task descriptions
+   that name the goal(s) they advance.
+
+3. DEPENDENCIES. Use `edges` to declare ordering between tasks: an
+   edge {from_task_id, to_task_id} means the "from" task must finish
+   before the "to" task starts. Parallel tasks (no edge between them)
+   may run concurrently. Build a real DAG, not a single linear chain,
+   when independent work exists.
+
+4. ASSIGNMENTS. Every task's `assignee_agent_id` MUST be drawn from
+   the provided available_agents list. If multiple agents could do a
+   task, pick the most specialised one. If no agent fits, assign it
+   to the coordinator/root agent rather than inventing an id.
+
+5. STABILITY. Task ids must be short, unique, and stable strings
+   (e.g. "research", "draft_intro", "review_final"). Descriptions
+   should be one sentence describing what "done" looks like for the
+   task.
+
+6. SUMMARY. Provide a one-sentence `summary` describing the overall
+   goal of the plan, as if writing a PR title.
+
+Respond with a single JSON object and NOTHING ELSE — no prose, no
+markdown fences. Schema:
+
+{
+  "summary": "<one-sentence description of the overall plan>",
+  "tasks": [
+    {
+      "id": "research",
+      "title": "short human-readable title",
+      "description": "one sentence defining 'done' for this task",
+      "assignee_agent_id": "<agent id from available list>"
+    }
+  ],
+  "edges": [
+    {"from_task_id": "research", "to_task_id": "draft"}
+  ]
+}
+"""
+
+
+_REFINE_SYSTEM_PROMPT = """\
+You are a task-planning assistant maintaining an ACTIVE plan for a
+multi-agent system. You will receive:
+
+* The set of GOALS the plan is trying to satisfy.
+* The current plan as JSON (each task carries its live `status` — one
+  of PENDING, RUNNING, COMPLETED, FAILED, CANCELLED, BLOCKED).
+* A single drift event describing what just happened that warrants
+  re-planning (tool error, new work discovered, agent transfer, etc.).
+
+Your job is to return the COMPLETE updated plan that reflects both
+what has happened so far and what the system still needs to do to
+satisfy the goals.
+
+You MUST:
+
+1. PRESERVE HISTORY. Tasks that are already COMPLETED, FAILED, or
+   CANCELLED must appear in the returned plan with the same id,
+   title, assignee, and status. Do NOT drop or renumber them — the
+   Gantt-chart view must be able to show the timeline continuously.
+
+2. UPDATE STATUSES. If the drift event reveals that a RUNNING task
+   has finished, mark it COMPLETED (or FAILED if the event is an
+   error). If a PENDING task has implicitly become the current focus,
+   you may leave it PENDING and let the executor mark it RUNNING when
+   work actually starts.
+
+3. ADD NEW TASKS. If the drift reveals work that the original plan
+   did not anticipate (e.g., a tool result surfaces a follow-up
+   question, an error requires a retry/fallback path, a transfer
+   introduces a sub-workflow), ADD new PENDING tasks for that work
+   with fresh stable ids and appropriate edges back into the DAG.
+
+4. DROP OBSOLETE PENDING TASKS. If the drift makes a PENDING task
+   unnecessary (e.g., a goal has been satisfied early, a dependency
+   collapsed), you may omit it from the returned plan. Never drop
+   tasks that already ran.
+
+5. REASSIGN. If a task is better handled by a different available
+   agent in light of the drift, update its `assignee_agent_id`.
+
+6. KEEP IDS STABLE. When the underlying work is the same, keep the
+   task id unchanged. Reuse ids only for the same logical task.
+
+7. STILL COVER THE GOALS. The revised plan must still have at least
+   one task addressing each goal that is not yet satisfied.
+
+8. RETURN A COMPLETE PLAN. Always return the full plan, not a delta.
+
+Respond with a single JSON object and NOTHING ELSE:
+
+{
+  "summary": "...",
+  "tasks": [
+    {
+      "id": "...",
+      "title": "...",
+      "description": "...",
+      "assignee_agent_id": "...",
+      "status": "PENDING|RUNNING|COMPLETED|FAILED|CANCELLED|BLOCKED"
+    }
+  ],
+  "edges": [{"from_task_id": "...", "to_task_id": "..."}]
+}
+
+If nothing needs to change, return the current plan unchanged (but
+still as a complete JSON plan, not an empty object).
+"""
+
+
+# ---------------------------------------------------------------------------
+# JSON parsing helpers (ported from harmonograf_client.planner)
+# ---------------------------------------------------------------------------
+
+_VALID_TASK_STATUSES = frozenset(s.value for s in TaskStatus)
+
+_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*\n?(.*?)\n?```\s*$", re.DOTALL)
+
+
+def _strip_code_fences(raw: str) -> str:
+    """Remove a surrounding ```json ... ``` or ``` ... ``` fence, if any."""
+    if not raw:
+        return raw
+    match = _FENCE_RE.match(raw)
+    if match:
+        return match.group(1)
+    return raw
+
+
+def _coerce_status(raw: Any) -> TaskStatus:
+    text = str(raw or "PENDING").upper()
+    if text not in _VALID_TASK_STATUSES:
+        return TaskStatus.PENDING
+    return TaskStatus(text)
+
+
+def _plan_from_json(
+    obj: Any,
+    *,
+    run_id: str,
+    goal_ids: list[str],
+    plan_id: str | None = None,
+) -> Plan | None:
+    """Build a :class:`Plan` from a dict-shaped JSON object.
+
+    Returns ``None`` if the payload is not a mapping or contains no
+    usable tasks. ``run_id`` and ``goal_ids`` come from the caller and
+    are stamped onto the plan envelope; the LLM only supplies the
+    ``summary``, ``tasks``, and ``edges`` fields.
+    """
+    if not isinstance(obj, Mapping):
+        return None
+    raw_tasks = obj.get("tasks") or []
+    raw_edges = obj.get("edges") or []
+    if not isinstance(raw_tasks, list):
+        return None
+    tasks: list[Task] = []
+    for t in raw_tasks:
+        if not isinstance(t, Mapping):
+            continue
+        tid = str(t.get("id") or "").strip()
+        title = str(t.get("title") or "").strip()
+        if not tid or not title:
+            continue
+        tasks.append(
+            Task(
+                id=tid,
+                title=title,
+                description=str(t.get("description") or ""),
+                assignee_agent_id=str(t.get("assignee_agent_id") or ""),
+                status=_coerce_status(t.get("status")),
+                predicted_start_ms=int(t.get("predicted_start_ms") or 0),
+                predicted_duration_ms=int(t.get("predicted_duration_ms") or 0),
+                bound_span_id=str(t.get("bound_span_id") or ""),
+            )
+        )
+    if not tasks:
+        return None
+    edges: list[TaskEdge] = []
+    if isinstance(raw_edges, list):
+        for e in raw_edges:
+            if not isinstance(e, Mapping):
+                continue
+            frm = str(e.get("from_task_id") or "").strip()
+            to = str(e.get("to_task_id") or "").strip()
+            if frm and to:
+                edges.append(TaskEdge(from_task_id=frm, to_task_id=to))
+    summary = str(obj.get("summary") or "")
+    return Plan(
+        id=plan_id or uuid.uuid4().hex,
+        run_id=run_id,
+        goal_ids=list(goal_ids),
+        tasks=tasks,
+        edges=edges,
+        summary=summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Planner implementations
+# ---------------------------------------------------------------------------
+
+
+class PassthroughPlanner:
+    """No-op planner — ``generate`` and ``refine`` always return ``None``.
+
+    Makes it safe to wire a ``planner=`` kwarg everywhere without
+    forcing callers to opt in to planning on day one.
+    """
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Mapping[str, Any] | None = None,
+    ) -> Plan | None:
+        return None
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        return None
+
+
+class LLMPlanner:
+    """Delegates to a caller-supplied async LLM callable.
+
+    Parameters
+    ----------
+    call_llm:
+        An async callable ``(system_prompt, user_prompt, model) -> str``.
+        The returned string must be JSON conforming to the plan schema
+        described in the default system prompt (it may be wrapped in
+        triple-backtick ``json`` fences; this class will strip them).
+    model:
+        Model name passed through to ``call_llm``. Empty string is
+        allowed; the callable may substitute its own default.
+    system_prompt:
+        Optional override for the goal-oriented planning prompt.
+    refine_system_prompt:
+        Optional override for the refinement prompt.
+
+    On any parse error or exception raised by ``call_llm``, both
+    :meth:`generate` and :meth:`refine` log a warning and return
+    ``None`` — the host continues without a plan update.
+    """
+
+    def __init__(
+        self,
+        *,
+        call_llm: Callable[[str, str, str], Awaitable[str]],
+        model: str = "",
+        system_prompt: str | None = None,
+        refine_system_prompt: str | None = None,
+    ) -> None:
+        self._call_llm = call_llm
+        self._model = model
+        self._system_prompt = system_prompt or _DEFAULT_SYSTEM_PROMPT
+        self._refine_system_prompt = refine_system_prompt or _REFINE_SYSTEM_PROMPT
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    # ---- prompt builders -------------------------------------------------
+
+    @staticmethod
+    def _render_goals_block(goals: list[Goal]) -> str:
+        if not goals:
+            return "- (no goals provided)"
+        lines: list[str] = []
+        for g in goals:
+            gid = g.id or "(no-id)"
+            summary = g.summary or "(no summary)"
+            lines.append(f"- [{gid}] {summary}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _render_agents_block(available_agents: list[str]) -> str:
+        return "\n".join(f"- {a}" for a in available_agents) or "- (none listed)"
+
+    def _build_generate_prompt(
+        self,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Mapping[str, Any] | None,
+    ) -> str:
+        goals_block = self._render_goals_block(goals)
+        agents_block = self._render_agents_block(available_agents)
+        context_block = ""
+        if context:
+            try:
+                context_block = (
+                    f"\nAdditional context (JSON):\n{json.dumps(dict(context), default=str)}\n"
+                )
+            except (TypeError, ValueError):
+                context_block = ""
+        return (
+            f"Available agents:\n{agents_block}\n\n"
+            f"Goals:\n{goals_block}\n"
+            f"{context_block}\n"
+            "Respond with a single JSON object following the schema."
+        )
+
+    def _build_refine_prompt(
+        self,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> str:
+        current = {
+            "id": plan.id,
+            "summary": plan.summary,
+            "tasks": [
+                {
+                    "id": t.id,
+                    "title": t.title,
+                    "description": t.description,
+                    "assignee_agent_id": t.assignee_agent_id,
+                    "status": str(t.status),
+                    "predicted_start_ms": t.predicted_start_ms,
+                    "predicted_duration_ms": t.predicted_duration_ms,
+                }
+                for t in plan.tasks
+            ],
+            "edges": [
+                {"from_task_id": e.from_task_id, "to_task_id": e.to_task_id} for e in plan.edges
+            ],
+        }
+        drift_payload = {
+            "kind": str(drift.kind),
+            "severity": str(drift.severity),
+            "detail": drift.detail,
+            "current_task_id": drift.current_task_id,
+            "current_agent_id": drift.current_agent_id,
+        }
+        plan_json = json.dumps(current, default=str)
+        drift_json = json.dumps(drift_payload, default=str)
+        goals_block = self._render_goals_block(goals)
+        return (
+            f"Goals:\n{goals_block}\n\n"
+            f"Current plan:\n{plan_json}\n\n"
+            f"Drift event:\n{drift_json}\n\n"
+            "If the plan should change in light of this drift event, respond "
+            "with an updated JSON plan using the same schema. If no change "
+            "is warranted, respond with the current plan unchanged. Respond "
+            "with JSON only."
+        )
+
+    # ---- Planner protocol ------------------------------------------------
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Mapping[str, Any] | None = None,
+    ) -> Plan | None:
+        if not goals:
+            log.debug("LLMPlanner.generate: no goals provided; skipping plan")
+            return None
+        prompt = self._build_generate_prompt(goals, available_agents, context)
+        try:
+            raw = await self._call_llm(self._system_prompt, prompt, self._model)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("LLMPlanner.generate: call_llm raised %s; skipping plan", exc)
+            return None
+        if not raw or not isinstance(raw, str):
+            log.warning("LLMPlanner.generate: empty/non-string LLM response; skipping plan")
+            return None
+        cleaned = _strip_code_fences(raw).strip()
+        try:
+            parsed = json.loads(cleaned)
+        except (ValueError, TypeError) as exc:
+            log.warning(
+                "LLMPlanner.generate: failed to parse LLM output as JSON (%s); skipping",
+                exc,
+            )
+            return None
+        run_id = ""
+        if context is not None:
+            run_id = str(context.get("run_id") or "")
+        plan = _plan_from_json(
+            parsed,
+            run_id=run_id,
+            goal_ids=[g.id for g in goals if g.id],
+        )
+        if plan is None:
+            log.warning("LLMPlanner.generate: parsed JSON did not contain a usable plan; skipping")
+            return None
+        return plan
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        if plan is None:
+            return None
+        try:
+            user_prompt = self._build_refine_prompt(plan, drift, goals)
+        except (TypeError, ValueError) as exc:
+            log.warning("LLMPlanner.refine: failed to serialise inputs (%s)", exc)
+            return None
+        try:
+            raw = await self._call_llm(self._refine_system_prompt, user_prompt, self._model)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("LLMPlanner.refine: call_llm raised %s", exc)
+            return None
+        if not raw or not isinstance(raw, str):
+            log.warning("LLMPlanner.refine: empty/non-string LLM response")
+            return None
+        cleaned = _strip_code_fences(raw).strip()
+        try:
+            parsed = json.loads(cleaned)
+        except (ValueError, TypeError) as exc:
+            log.warning("LLMPlanner.refine: failed to parse LLM output as JSON (%s)", exc)
+            return None
+        revised = _plan_from_json(
+            parsed,
+            run_id=plan.run_id,
+            goal_ids=[g.id for g in goals if g.id] or list(plan.goal_ids),
+            plan_id=plan.id,
+        )
+        if revised is None:
+            log.warning("LLMPlanner.refine: parsed JSON did not contain a usable plan")
+            return None
+        # Stamp revision metadata so downstream sinks can render it.
+        revised.revision_reason = drift.detail
+        revised.revision_kind = str(drift.kind)
+        revised.revision_severity = str(drift.severity)
+        revised.revision_index = plan.revision_index + 1
+        return revised
+
+
+__all__ = [
+    "LLMPlanner",
+    "PassthroughPlanner",
+    "_plan_from_json",
+    "_strip_code_fences",
+]

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,453 @@
+"""Unit tests for ``goldfive.planner``.
+
+Covers both ``PassthroughPlanner`` (trivial) and ``LLMPlanner`` (the
+interesting case: stubbed async ``call_llm`` returning canned JSON,
+markdown-fence stripping, refinement preserving completed tasks, and
+error paths that must degrade gracefully to ``None``).
+"""
+
+from __future__ import annotations
+
+import json
+
+from goldfive.planner import (
+    LLMPlanner,
+    PassthroughPlanner,
+    _plan_from_json,
+    _strip_code_fences,
+)
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _goals() -> list[Goal]:
+    return [
+        Goal(id="g1", summary="Draft a blog post about goldfish."),
+        Goal(id="g2", summary="Get one round of editorial review."),
+    ]
+
+
+def _canned_plan_json() -> str:
+    return json.dumps(
+        {
+            "summary": "Draft and review a goldfish blog post.",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research goldfish facts",
+                    "description": "Gather 5 cited facts.",
+                    "assignee_agent_id": "researcher",
+                },
+                {
+                    "id": "draft",
+                    "title": "Draft the post",
+                    "description": "Write a 500-word first draft.",
+                    "assignee_agent_id": "writer",
+                },
+                {
+                    "id": "review",
+                    "title": "Review the draft",
+                    "description": "Produce reviewer comments.",
+                    "assignee_agent_id": "editor",
+                },
+            ],
+            "edges": [
+                {"from_task_id": "research", "to_task_id": "draft"},
+                {"from_task_id": "draft", "to_task_id": "review"},
+            ],
+        }
+    )
+
+
+class _StubLLM:
+    """Records the last call and returns a scripted response."""
+
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        self.calls.append((system, user, model))
+        return self.response
+
+
+# ---------------------------------------------------------------------------
+# PassthroughPlanner
+# ---------------------------------------------------------------------------
+
+
+async def test_passthrough_generate_returns_none() -> None:
+    planner = PassthroughPlanner()
+    result = await planner.generate(
+        goals=_goals(),
+        available_agents=["a", "b"],
+        context=None,
+    )
+    assert result is None
+
+
+async def test_passthrough_refine_returns_none() -> None:
+    planner = PassthroughPlanner()
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="Do the thing")],
+        edges=[],
+    )
+    drift = DriftEvent(kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.WARNING)
+    result = await planner.refine(plan=plan, drift=drift, goals=_goals())
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _strip_code_fences
+# ---------------------------------------------------------------------------
+
+
+def test_strip_code_fences_json_tag() -> None:
+    raw = '```json\n{"a": 1}\n```'
+    assert _strip_code_fences(raw).strip() == '{"a": 1}'
+
+
+def test_strip_code_fences_plain_fence() -> None:
+    raw = '```\n{"a": 1}\n```'
+    assert _strip_code_fences(raw).strip() == '{"a": 1}'
+
+
+def test_strip_code_fences_no_fence() -> None:
+    raw = '{"a": 1}'
+    assert _strip_code_fences(raw) == raw
+
+
+def test_strip_code_fences_empty() -> None:
+    assert _strip_code_fences("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _plan_from_json
+# ---------------------------------------------------------------------------
+
+
+def test_plan_from_json_happy_path() -> None:
+    plan = _plan_from_json(
+        json.loads(_canned_plan_json()),
+        run_id="run-abc",
+        goal_ids=["g1", "g2"],
+    )
+    assert plan is not None
+    assert plan.run_id == "run-abc"
+    assert plan.goal_ids == ["g1", "g2"]
+    assert [t.id for t in plan.tasks] == ["research", "draft", "review"]
+    assert all(t.status == TaskStatus.PENDING for t in plan.tasks)
+    assert plan.summary == "Draft and review a goldfish blog post."
+    assert len(plan.edges) == 2
+
+
+def test_plan_from_json_non_mapping_returns_none() -> None:
+    assert _plan_from_json("not a mapping", run_id="", goal_ids=[]) is None
+    assert _plan_from_json(None, run_id="", goal_ids=[]) is None
+
+
+def test_plan_from_json_empty_tasks_returns_none() -> None:
+    assert _plan_from_json({"tasks": []}, run_id="", goal_ids=[]) is None
+
+
+def test_plan_from_json_skips_malformed_tasks() -> None:
+    payload = {
+        "tasks": [
+            {"id": "", "title": "no id"},  # dropped
+            {"id": "t1", "title": ""},  # dropped
+            "not a mapping",  # dropped
+            {"id": "t2", "title": "ok"},
+        ]
+    }
+    plan = _plan_from_json(payload, run_id="r", goal_ids=[])
+    assert plan is not None
+    assert [t.id for t in plan.tasks] == ["t2"]
+
+
+def test_plan_from_json_invalid_status_falls_back_to_pending() -> None:
+    payload = {
+        "tasks": [
+            {"id": "t1", "title": "ok", "status": "BOGUS"},
+        ]
+    }
+    plan = _plan_from_json(payload, run_id="r", goal_ids=[])
+    assert plan is not None
+    assert plan.tasks[0].status == TaskStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# LLMPlanner.generate
+# ---------------------------------------------------------------------------
+
+
+async def test_llm_planner_generate_parses_canned_json() -> None:
+    stub = _StubLLM(_canned_plan_json())
+    planner = LLMPlanner(call_llm=stub, model="test-model")
+    plan = await planner.generate(
+        goals=_goals(),
+        available_agents=["researcher", "writer", "editor"],
+        context={"run_id": "run-xyz"},
+    )
+    assert plan is not None
+    assert plan.run_id == "run-xyz"
+    assert plan.goal_ids == ["g1", "g2"]
+    assert [t.id for t in plan.tasks] == ["research", "draft", "review"]
+
+    # Sanity: the prompt the LLM saw mentioned the goals and agents.
+    assert stub.calls, "stub should have been invoked"
+    _system, user, model = stub.calls[0]
+    assert model == "test-model"
+    assert "g1" in user and "g2" in user
+    assert "Draft a blog post about goldfish." in user
+    assert "researcher" in user
+
+
+async def test_llm_planner_generate_strips_code_fences() -> None:
+    fenced = "```json\n" + _canned_plan_json() + "\n```"
+    stub = _StubLLM(fenced)
+    planner = LLMPlanner(call_llm=stub)
+    plan = await planner.generate(
+        goals=_goals(),
+        available_agents=["researcher", "writer", "editor"],
+    )
+    assert plan is not None
+    assert len(plan.tasks) == 3
+
+
+async def test_llm_planner_generate_empty_goals_returns_none() -> None:
+    stub = _StubLLM(_canned_plan_json())
+    planner = LLMPlanner(call_llm=stub)
+    result = await planner.generate(goals=[], available_agents=["a"])
+    assert result is None
+    # LLM must not be invoked when there are no goals.
+    assert stub.calls == []
+
+
+async def test_llm_planner_generate_handles_invalid_json() -> None:
+    stub = _StubLLM("not json at all {")
+    planner = LLMPlanner(call_llm=stub)
+    result = await planner.generate(goals=_goals(), available_agents=["a"])
+    assert result is None
+
+
+async def test_llm_planner_generate_handles_empty_response() -> None:
+    stub = _StubLLM("")
+    planner = LLMPlanner(call_llm=stub)
+    result = await planner.generate(goals=_goals(), available_agents=["a"])
+    assert result is None
+
+
+async def test_llm_planner_generate_handles_call_llm_exception() -> None:
+    async def boom(system: str, user: str, model: str) -> str:
+        raise RuntimeError("LLM unavailable")
+
+    planner = LLMPlanner(call_llm=boom)
+    result = await planner.generate(goals=_goals(), available_agents=["a"])
+    assert result is None
+
+
+async def test_llm_planner_generate_handles_json_without_tasks() -> None:
+    stub = _StubLLM(json.dumps({"summary": "nothing to do"}))
+    planner = LLMPlanner(call_llm=stub)
+    result = await planner.generate(goals=_goals(), available_agents=["a"])
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# LLMPlanner.refine
+# ---------------------------------------------------------------------------
+
+
+def _running_plan() -> Plan:
+    return Plan(
+        id="plan-1",
+        run_id="run-1",
+        goal_ids=["g1", "g2"],
+        tasks=[
+            Task(
+                id="research",
+                title="Research goldfish facts",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="draft",
+                title="Draft the post",
+                assignee_agent_id="writer",
+                status=TaskStatus.RUNNING,
+            ),
+            Task(
+                id="review",
+                title="Review the draft",
+                assignee_agent_id="editor",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft"),
+            TaskEdge(from_task_id="draft", to_task_id="review"),
+        ],
+        summary="Draft and review a goldfish blog post.",
+        revision_index=0,
+    )
+
+
+async def test_llm_planner_refine_preserves_completed_tasks() -> None:
+    # The LLM returns a plan that keeps the COMPLETED research task,
+    # marks draft COMPLETED, leaves review PENDING, and injects a new
+    # fact-check task between draft and review.
+    revised_payload = {
+        "summary": "Draft, fact-check, and review the goldfish post.",
+        "tasks": [
+            {
+                "id": "research",
+                "title": "Research goldfish facts",
+                "assignee_agent_id": "researcher",
+                "status": "COMPLETED",
+            },
+            {
+                "id": "draft",
+                "title": "Draft the post",
+                "assignee_agent_id": "writer",
+                "status": "COMPLETED",
+            },
+            {
+                "id": "fact_check",
+                "title": "Fact-check the draft",
+                "assignee_agent_id": "researcher",
+                "status": "PENDING",
+            },
+            {
+                "id": "review",
+                "title": "Review the draft",
+                "assignee_agent_id": "editor",
+                "status": "PENDING",
+            },
+        ],
+        "edges": [
+            {"from_task_id": "research", "to_task_id": "draft"},
+            {"from_task_id": "draft", "to_task_id": "fact_check"},
+            {"from_task_id": "fact_check", "to_task_id": "review"},
+        ],
+    }
+    stub = _StubLLM(json.dumps(revised_payload))
+    planner = LLMPlanner(call_llm=stub, model="m")
+    plan = _running_plan()
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.INFO,
+        detail="Reviewer asked for citations before review",
+        current_task_id="draft",
+    )
+
+    revised = await planner.refine(plan=plan, drift=drift, goals=_goals())
+
+    assert revised is not None
+    by_id = {t.id: t for t in revised.tasks}
+    # Historical tasks preserved.
+    assert by_id["research"].status == TaskStatus.COMPLETED
+    assert by_id["draft"].status == TaskStatus.COMPLETED
+    # New task added, pending task preserved.
+    assert "fact_check" in by_id
+    assert by_id["review"].status == TaskStatus.PENDING
+
+    # Plan envelope identity is preserved across refinement.
+    assert revised.id == plan.id
+    assert revised.run_id == plan.run_id
+    assert revised.goal_ids == ["g1", "g2"]
+
+    # Revision metadata stamped from the drift.
+    assert revised.revision_reason == "Reviewer asked for citations before review"
+    assert revised.revision_kind == DriftKind.NEW_WORK_DISCOVERED.value
+    assert revised.revision_severity == DriftSeverity.INFO.value
+    assert revised.revision_index == 1
+
+    # The prompt included goals, the current plan JSON, and the drift.
+    _system, user_prompt, _model = stub.calls[0]
+    assert "Goals:" in user_prompt
+    assert "Current plan:" in user_prompt
+    assert "Drift event:" in user_prompt
+    assert "new_work_discovered" in user_prompt
+    assert "research" in user_prompt and "draft" in user_prompt
+
+
+async def test_llm_planner_refine_strips_fences() -> None:
+    payload = {
+        "summary": "same",
+        "tasks": [
+            {"id": "research", "title": "Research", "status": "COMPLETED"},
+            {"id": "draft", "title": "Draft", "status": "RUNNING"},
+            {"id": "review", "title": "Review", "status": "PENDING"},
+        ],
+        "edges": [],
+    }
+    stub = _StubLLM("```json\n" + json.dumps(payload) + "\n```")
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.WARNING)
+    revised = await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+    assert revised is not None
+    assert len(revised.tasks) == 3
+
+
+async def test_llm_planner_refine_handles_bad_json() -> None:
+    stub = _StubLLM("not json")
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.WARNING)
+    revised = await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+    assert revised is None
+
+
+async def test_llm_planner_refine_handles_call_llm_exception() -> None:
+    async def boom(system: str, user: str, model: str) -> str:
+        raise RuntimeError("boom")
+
+    planner = LLMPlanner(call_llm=boom)
+    drift = DriftEvent(kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.WARNING)
+    revised = await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+    assert revised is None
+
+
+async def test_llm_planner_refine_increments_revision_index() -> None:
+    payload = {
+        "summary": "same",
+        "tasks": [{"id": "draft", "title": "Draft", "status": "RUNNING"}],
+        "edges": [],
+    }
+    stub = _StubLLM(json.dumps(payload))
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.WARNING)
+
+    plan = _running_plan()
+    plan.revision_index = 3
+    revised = await planner.refine(plan=plan, drift=drift, goals=_goals())
+    assert revised is not None
+    assert revised.revision_index == 4
+
+
+async def test_llm_planner_refine_custom_system_prompt_is_used() -> None:
+    stub = _StubLLM(json.dumps({"tasks": [{"id": "t", "title": "t"}], "edges": []}))
+    planner = LLMPlanner(
+        call_llm=stub,
+        system_prompt="GEN PROMPT SENTINEL",
+        refine_system_prompt="REFINE PROMPT SENTINEL",
+    )
+    await planner.generate(goals=_goals(), available_agents=["a"])
+    drift = DriftEvent(kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.WARNING)
+    await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+    assert stub.calls[0][0] == "GEN PROMPT SENTINEL"
+    assert stub.calls[1][0] == "REFINE PROMPT SENTINEL"


### PR DESCRIPTION
## Summary

Implements the `Planner` variants described in issue #7 as goal-oriented planners (v0.1 takes `list[Goal]`, not raw user input — goal derivation is tracked separately under #8).

- **`PassthroughPlanner`** — async `generate` / `refine` always return `None`. Safe default for callers that opt out of planning.
- **`LLMPlanner`** — delegates to a caller-supplied **async** `call_llm: Callable[[str, str, str], Awaitable[str]]`. Parses JSON, tolerates ` ```json ` fences, and degrades to `None` on any parse/LLM failure so the host never sees an exception. `refine()` stamps `revision_reason`, `revision_kind`, `revision_severity`, and increments `revision_index` onto the returned plan.
- System prompts are goal-oriented adaptations of harmonograf_client's `_DEFAULT_SYSTEM_PROMPT` / `_REFINE_SYSTEM_PROMPT`: the user block now renders a `Goals:` section (each goal's id + summary) instead of a single `User request` string. Refine prompts carry the goals block alongside the current plan JSON and the drift event.

Also introduces a minimal `goldfive/types.py` carrying the subset of dataclasses this module needs (`Task`, `TaskEdge`, `Plan`, `Goal`, `DriftEvent`, `TaskStatus`, `DriftKind`, `DriftSeverity`) matching `INTERFACE_SPEC.md`. The canonical owner of that file is issue #4 — that PR will reconcile on merge. Including it here keeps this PR self-contained and testable.

Harmonograf's `call_llm` was sync; goldfive's is async per the interface-spec conventions.

## Test plan

- [x] `PassthroughPlanner.generate` / `refine` return `None` regardless of input.
- [x] `LLMPlanner.generate` parses canned JSON from a stubbed async `call_llm` and produces a `Plan` stamped with `run_id` from `context` and `goal_ids` from the goals list.
- [x] `LLMPlanner.generate` strips ` ```json ` fences.
- [x] `LLMPlanner.generate` returns `None` on: empty goals (without calling LLM), invalid JSON, empty LLM response, LLM exception, JSON without a `tasks` array.
- [x] `LLMPlanner.refine` returns a revised plan that preserves `COMPLETED` / `RUNNING` → `COMPLETED` tasks, admits new `PENDING` tasks, and keeps historical ids stable.
- [x] `LLMPlanner.refine` stamps `revision_reason` / `revision_kind` / `revision_severity` from the `DriftEvent` and increments `revision_index`.
- [x] `LLMPlanner.refine` preserves `plan.id` and `plan.run_id` across revisions.
- [x] Custom `system_prompt` / `refine_system_prompt` overrides are used.
- [x] `ruff check` clean, `ruff format --check` clean, `mypy goldfive` clean.
- [x] 26 unit tests pass locally (`uv run pytest -q`).

Closes #7. Depends on #4 / #5; the minimal shim in `goldfive/types.py` is a bridge until those land.
