### PR TITLE
feat: Claude Agent SDK adapter (#14)

### DIFF
--- a/goldfive/adapters/_claude_prompt.py
+++ b/goldfive/adapters/_claude_prompt.py
@@ -1,0 +1,128 @@
+"""System-prompt rendering for :class:`goldfive.adapters.claude.ClaudeAgentSDKAdapter`.
+
+The Claude Agent SDK has no shared ``session.state`` dict like Google ADK.
+To give the agent the same live context ADK gets via callbacks, goldfive
+re-renders a system prompt for every ``client.query(...)`` call. The
+template is a plain ``str.format(...)`` template — no Jinja, no extra
+dependencies — so it is trivially overrideable by callers.
+
+Template placeholders (all four are required):
+
+``{goal_block}``
+    Bulleted list of goal summaries (or ``"(no goals declared)"``).
+
+``{task_block}``
+    The current task's id, title, and description.
+
+``{plan_summary}``
+    One-line summary of the active plan (may be empty).
+
+``{completed_block}``
+    Bulleted list of previously completed task ids and their result
+    summaries (or ``"(none)"``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+from goldfive.types import Goal, Task
+
+# --------------------------------------------------------------------------- #
+# Default template
+# --------------------------------------------------------------------------- #
+
+#: Default system-prompt template used when the adapter caller does not
+#: supply one. Exported for documentation and override convenience — copy,
+#: edit, and pass the result to ``ClaudeAgentSDKAdapter(system_prompt_template=...)``.
+DEFAULT_SYSTEM_PROMPT_TEMPLATE: str = """\
+You are a goldfive-orchestrated agent. Stay on target.
+
+# Goals
+{goal_block}
+
+# Active plan
+{plan_summary}
+
+# Already completed
+{completed_block}
+
+# Your current task
+{task_block}
+
+# How to report progress
+You MUST call the goldfive reporting tools to keep the orchestrator
+informed. At minimum:
+
+  - Call `report_task_started` as soon as you begin work on the task.
+  - Call `report_task_progress` with a fraction (0.0-1.0) for long steps.
+  - When you finish, call exactly one of:
+      * `report_task_completed(task_id, summary, artifacts=...)`
+      * `report_task_failed(task_id, reason, recoverable=...)`
+      * `report_task_blocked(task_id, blocker, needed=...)`
+  - If you discover new work that is NOT part of your current task,
+    call `report_new_work_discovered` instead of silently doing it.
+  - If the plan no longer makes sense, call `report_plan_divergence`.
+
+Do not ask the user clarifying questions — the orchestrator is the only
+caller. Stay focused on the current task."""
+
+
+# --------------------------------------------------------------------------- #
+# Rendering helpers
+# --------------------------------------------------------------------------- #
+
+
+def _format_goal_block(goals: Iterable[Goal]) -> str:
+    items = list(goals)
+    if not items:
+        return "(no goals declared)"
+    lines: list[str] = []
+    for g in items:
+        lines.append(f"- {g.id}: {g.summary}")
+    return "\n".join(lines)
+
+
+def _format_task_block(task: Task) -> str:
+    description = task.description or "(no description)"
+    return (
+        f"id: {task.id}\n"
+        f"title: {task.title}\n"
+        f"description: {description}"
+    )
+
+
+def _format_completed_block(completed: Mapping[str, str]) -> str:
+    if not completed:
+        return "(none)"
+    lines: list[str] = []
+    for task_id, summary in completed.items():
+        summary_text = summary or "(no summary)"
+        lines.append(f"- {task_id}: {summary_text}")
+    return "\n".join(lines)
+
+
+def render_system_prompt(
+    template: str | None,
+    *,
+    task: Task,
+    goals: Iterable[Goal],
+    plan_summary: str,
+    completed: Mapping[str, str],
+) -> str:
+    """Render the adapter's system prompt.
+
+    Passing ``template=None`` selects :data:`DEFAULT_SYSTEM_PROMPT_TEMPLATE`.
+    The template must contain the four placeholders ``{goal_block}``,
+    ``{task_block}``, ``{plan_summary}``, ``{completed_block}``; a
+    ``KeyError`` from ``str.format`` surfaces unchanged so template bugs
+    are noisy instead of silent.
+    """
+
+    body = template if template is not None else DEFAULT_SYSTEM_PROMPT_TEMPLATE
+    return body.format(
+        goal_block=_format_goal_block(goals),
+        task_block=_format_task_block(task),
+        plan_summary=plan_summary or "(no active plan)",
+        completed_block=_format_completed_block(completed),
+    )

--- a/goldfive/adapters/claude.py
+++ b/goldfive/adapters/claude.py
@@ -1,0 +1,508 @@
+"""goldfive adapter for the Claude Agent SDK.
+
+The Claude Agent SDK (``claude_agent_sdk`` on PyPI) exposes its agent loop
+through :class:`claude_agent_sdk.ClaudeSDKClient`, a streaming client with
+no shared session-state dict. Unlike Google ADK — where per-step callbacks
+and a mutable ``session.state`` carry context across turns — goldfive has
+to re-render the agent's system prompt on every ``client.query(...)`` call
+and consume the returned message stream to drive the
+:class:`goldfive.protocols.Steerer`.
+
+Key design points:
+
+* The ``claude_agent_sdk`` import is **optional**; importing this module
+  without the SDK installed raises :class:`ImportError` with an install
+  hint (``pip install goldfive[claude]``). Every SDK type referenced in
+  type hints is guarded behind ``TYPE_CHECKING``.
+* Reporting tools are exposed to the agent as an **inline MCP server**
+  built from :class:`claude_agent_sdk.SdkMcpTool` — this is the SDK's
+  one and only path for bespoke tools. A matching ``PreToolUse`` hook
+  intercepts each reporting-tool invocation, routes it through the
+  goldfive :class:`~goldfive.reporting.ReportingToolSpec.handler`, and
+  blocks the SDK from running the handler a second time (by returning
+  ``permissionDecision="deny"`` with the handler's result payload as
+  the reason — the cleanest way to short-circuit a tool call from a
+  ``PreToolUse`` hook in the current SDK).
+* The system prompt template is public and overrideable — see
+  :mod:`goldfive.adapters._claude_prompt`.
+
+This module is pinned to the shapes in ``INTERFACE_SPEC.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable, Iterable
+from typing import TYPE_CHECKING, Any
+
+from goldfive.adapters._claude_prompt import (
+    DEFAULT_SYSTEM_PROMPT_TEMPLATE,
+    render_system_prompt,
+)
+from goldfive.drift import classify_stop_reason
+from goldfive.reporting import REPORTING_TOOL_NAMES, ReportingToolSpec
+from goldfive.results import InvocationResult
+from goldfive.types import Session, Task
+
+# --------------------------------------------------------------------------- #
+# Optional-dependency guard
+# --------------------------------------------------------------------------- #
+
+try:  # pragma: no cover - exercised by optional-install CI job
+    import claude_agent_sdk as _sdk  # noqa: F401
+except ImportError as _sdk_import_err:  # pragma: no cover
+    _SDK_IMPORT_ERROR: ImportError | None = _sdk_import_err
+    _sdk = None  # type: ignore[assignment]
+else:
+    _SDK_IMPORT_ERROR = None
+
+
+if TYPE_CHECKING:
+    # Imported only for type checkers; runtime code uses the module above.
+    from claude_agent_sdk import ClaudeSDKClient  # noqa: F401
+
+
+def _require_sdk() -> Any:
+    """Return the imported SDK module, or raise a clear error."""
+
+    if _SDK_IMPORT_ERROR is not None:
+        raise ImportError(
+            "claude_agent_sdk is not installed. Install the optional extra "
+            "with `pip install goldfive[claude]` to use "
+            "ClaudeAgentSDKAdapter."
+        ) from _SDK_IMPORT_ERROR
+    return _sdk
+
+
+# --------------------------------------------------------------------------- #
+# Type aliases
+# --------------------------------------------------------------------------- #
+
+ClientFactory = Callable[[], "ClaudeSDKClient"]
+SteererLike = Any  # goldfive.protocols.Steerer (avoid circular import)
+
+
+# --------------------------------------------------------------------------- #
+# Adapter
+# --------------------------------------------------------------------------- #
+
+
+class ClaudeAgentSDKAdapter:
+    """``AgentAdapter`` implementation backed by the Claude Agent SDK.
+
+    Parameters
+    ----------
+    client_factory:
+        Zero-arg callable returning a fresh ``ClaudeSDKClient``. Called
+        once per :meth:`invoke` so each task gets its own connection and
+        its own freshly-rendered system prompt — required because the
+        SDK treats ``system_prompt`` as immutable after ``connect()``.
+    steerer:
+        The :class:`goldfive.protocols.Steerer` to route observations
+        and reporting-tool calls through. Optional at construction time
+        so the adapter can be handed to a Runner that wires it later
+        via :meth:`bind_steerer`.
+    system_prompt_template:
+        Optional ``str.format``-style template overriding
+        :data:`goldfive.adapters._claude_prompt.DEFAULT_SYSTEM_PROMPT_TEMPLATE`.
+        See that module for the placeholder contract.
+    model:
+        Optional model alias (``"sonnet"``, ``"opus"``, ``"haiku"``) or
+        full model ID passed through to ``ClaudeAgentOptions.model``.
+    available_agents:
+        Identifiers surfaced by :attr:`available_agents` for planners
+        that need to know what agents the adapter can route to. Claude
+        Agent SDK treats subagents (``Task`` tool) opaquely in v0.1,
+        so this is a simple passthrough list.
+    """
+
+    # Name used for the inline MCP server that publishes the reporting
+    # tools. The SDK namespaces MCP tools as ``mcp__<server>__<tool>``,
+    # which we resolve transparently in the PreToolUse hook.
+    _MCP_SERVER_NAME: str = "goldfive_reporting"
+
+    def __init__(
+        self,
+        *,
+        client_factory: ClientFactory,
+        steerer: SteererLike | None = None,
+        system_prompt_template: str | None = None,
+        model: str | None = None,
+        available_agents: list[str] | None = None,
+    ) -> None:
+        _require_sdk()
+        self._client_factory: ClientFactory = client_factory
+        self._steerer: SteererLike | None = steerer
+        self._template: str | None = system_prompt_template
+        self._model: str | None = model
+        self._available_agents: list[str] = list(available_agents or [])
+
+        self._reporting_specs: dict[str, ReportingToolSpec] = {}
+        # Populated by register_reporting_tools. Kept separate so an
+        # adapter can be re-registered without losing the inline-tool
+        # configuration across Runner.run() invocations.
+        self._mcp_server_config: Any = None
+        self._mcp_tool_names: list[str] = []
+
+    # --------------------------------------------------------------- #
+    # Public AgentAdapter surface
+    # --------------------------------------------------------------- #
+
+    @property
+    def available_agents(self) -> list[str]:
+        return list(self._available_agents)
+
+    def bind_steerer(self, steerer: SteererLike) -> None:
+        """Wire a :class:`Steerer` in after construction.
+
+        The Runner/Executor typically calls this once per run so the
+        adapter and steerer share state. It is safe to overwrite.
+        """
+
+        self._steerer = steerer
+
+    async def register_reporting_tools(
+        self,
+        tools: list[ReportingToolSpec],
+    ) -> None:
+        """Translate goldfive specs into an inline SDK MCP server.
+
+        Each ``ReportingToolSpec`` becomes an
+        :class:`claude_agent_sdk.SdkMcpTool` with a no-op default handler
+        — the real routing happens in the PreToolUse hook, which blocks
+        the no-op before it runs.
+        """
+
+        sdk = _require_sdk()
+
+        self._reporting_specs = {spec.name: spec for spec in tools}
+
+        sdk_tools: list[Any] = []
+        qualified_names: list[str] = []
+
+        for spec in tools:
+            # The SDK's in-CLI tool name is ``mcp__<server>__<tool>``;
+            # goldfive registers tools under bare canonical names, so
+            # we track both.
+            qualified = f"mcp__{self._MCP_SERVER_NAME}__{spec.name}"
+            qualified_names.append(qualified)
+
+            # SdkMcpTool needs an input_schema (JSON Schema dict) plus an
+            # async handler. The handler here is the "no-op default" —
+            # the PreToolUse hook intercepts before this runs. We still
+            # return an SDK-shaped ``content`` payload so that if the
+            # hook is ever bypassed the agent gets a valid response.
+            sdk_tools.append(
+                sdk.SdkMcpTool(
+                    name=spec.name,
+                    description=spec.description,
+                    input_schema=spec.parameters,
+                    handler=_make_fallback_handler(spec.name),
+                )
+            )
+
+        self._mcp_server_config = sdk.create_sdk_mcp_server(
+            name=self._MCP_SERVER_NAME,
+            tools=sdk_tools,
+        )
+        self._mcp_tool_names = qualified_names
+
+    async def invoke(
+        self,
+        task: Task,
+        session: Session,
+    ) -> InvocationResult:
+        """Run one agent turn for ``task`` and return an :class:`InvocationResult`."""
+
+        sdk = _require_sdk()
+
+        prompt_text = _build_user_prompt(task)
+        system_prompt = render_system_prompt(
+            self._template,
+            task=task,
+            goals=session.goals,
+            plan_summary=_plan_summary(session),
+            completed=session.completed_results,
+        )
+
+        options = self._build_options(sdk=sdk, system_prompt=system_prompt, session=session)
+
+        client = self._client_factory()
+        # ``ClaudeSDKClient`` options are set on the instance; some
+        # factories already attach them. We only overwrite when the
+        # caller left ``options=None``.
+        if getattr(client, "options", None) is None:
+            try:
+                client.options = options  # type: ignore[attr-defined]
+            except Exception:  # pragma: no cover - exotic client subclasses
+                pass
+
+        final_text_parts: list[str] = []
+        stop_reason: str = ""
+        result_raw: Any = None
+        error: Exception | None = None
+
+        try:
+            # ``connect(None)`` leaves the input stream open so we can
+            # send one prompt and still iterate over responses.
+            await _maybe_await(client.connect(None))
+            await client.query(prompt_text)
+            async for message in client.receive_response():
+                result_raw = message
+                # Every message is observed by the steerer so it can do
+                # drift detection and emit events. Errors in observe
+                # must never kill the invocation loop.
+                await _safe_observe(self._steerer, message, session)
+
+                final_text_parts.extend(_collect_text_from(message))
+                if _is_result_message(message):
+                    stop_reason = getattr(message, "stop_reason", "") or ""
+                    break
+        except Exception as exc:  # noqa: BLE001 - surface to caller
+            error = exc
+        finally:
+            try:
+                await _maybe_await(client.disconnect())
+            except Exception:  # pragma: no cover - cleanup best-effort
+                pass
+
+        # Classify benign vs drift-worthy stop reasons. Only drift feeds
+        # the steerer — benign stops are reported via the return value.
+        drift = classify_stop_reason(
+            stop_reason,
+            current_task_id=task.id,
+            current_agent_id=task.assignee_agent_id,
+        )
+        if drift is not None and self._steerer is not None:
+            await _safe_observe(self._steerer, drift, session)
+
+        return InvocationResult(
+            task_id=task.id,
+            text="\n".join(p for p in final_text_parts if p),
+            stop_reason=stop_reason,
+            error=error,
+            raw=result_raw,
+        )
+
+    # --------------------------------------------------------------- #
+    # Internals
+    # --------------------------------------------------------------- #
+
+    def _build_options(
+        self,
+        *,
+        sdk: Any,
+        system_prompt: str,
+        session: Session,
+    ) -> Any:
+        """Assemble a fresh ``ClaudeAgentOptions`` for this invocation."""
+
+        hook_matcher = sdk.HookMatcher(
+            matcher="|".join(REPORTING_TOOL_NAMES),
+            hooks=[self._make_pretooluse_hook(session)],
+        )
+
+        kwargs: dict[str, Any] = {
+            "system_prompt": system_prompt,
+            "hooks": {"PreToolUse": [hook_matcher]},
+        }
+        if self._model is not None:
+            kwargs["model"] = self._model
+        if self._mcp_server_config is not None:
+            kwargs["mcp_servers"] = {
+                self._MCP_SERVER_NAME: self._mcp_server_config,
+            }
+            # Make sure the reporting tools are actually callable.
+            kwargs["allowed_tools"] = list(self._mcp_tool_names)
+        return sdk.ClaudeAgentOptions(**kwargs)
+
+    def _make_pretooluse_hook(
+        self,
+        session: Session,
+    ) -> Callable[..., Awaitable[dict[str, Any]]]:
+        """Build the async PreToolUse hook closed over this session.
+
+        The hook matches on reporting tool names (both the qualified
+        ``mcp__goldfive_reporting__*`` form the SDK emits and the bare
+        canonical name, to be robust to SDK naming changes), routes to
+        the goldfive handler, and returns a ``deny`` permission decision
+        so the SDK never executes the no-op stub inside the inline MCP
+        server. Returning the handler's ACK text in
+        ``permissionDecisionReason`` is the cleanest way to surface the
+        result to the model while short-circuiting execution.
+        """
+
+        specs = self._reporting_specs
+        steerer = self._steerer
+
+        async def _hook(
+            input_data: dict[str, Any],
+            tool_use_id: str | None,
+            _context: Any,
+        ) -> dict[str, Any]:
+            tool_name = input_data.get("tool_name", "") or ""
+            bare = _strip_mcp_prefix(tool_name)
+            spec = specs.get(bare)
+            if spec is None:
+                # Not a reporting tool — let the SDK run it normally.
+                return {}
+
+            tool_input = input_data.get("tool_input", {}) or {}
+            # Observe as well so the steerer sees tool_use alongside
+            # text blocks — useful for drift detectors that watch for
+            # report_plan_divergence / report_new_work_discovered.
+            await _safe_observe(
+                steerer,
+                _ToolCallObservation(
+                    name=bare,
+                    arguments=tool_input,
+                    tool_use_id=tool_use_id or "",
+                ),
+                session,
+            )
+
+            try:
+                ack = await spec.handler(tool_input, session, steerer)
+            except Exception as exc:  # noqa: BLE001 - surface to agent
+                ack = {"ok": False, "error": str(exc)}
+
+            reason = json.dumps(ack) if not isinstance(ack, str) else ack
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                },
+            }
+
+        return _hook
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+class _ToolCallObservation:
+    """Lightweight record passed to ``steerer.observe`` for tool_use.
+
+    Using a plain object (instead of an SDK type) keeps the steerer
+    framework-agnostic — it only needs ``name`` and ``arguments``.
+    """
+
+    __slots__ = ("name", "arguments", "tool_use_id")
+
+    def __init__(self, *, name: str, arguments: dict[str, Any], tool_use_id: str) -> None:
+        self.name = name
+        self.arguments = arguments
+        self.tool_use_id = tool_use_id
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"_ToolCallObservation(name={self.name!r}, args={self.arguments!r})"
+
+
+def _make_fallback_handler(tool_name: str) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
+    """Return an async handler that the SDK calls only if the hook is bypassed."""
+
+    async def _fallback(_args: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"goldfive: tool {tool_name!r} acknowledged via fallback "
+                        "handler (PreToolUse hook did not short-circuit)."
+                    ),
+                }
+            ]
+        }
+
+    return _fallback
+
+
+def _build_user_prompt(task: Task) -> str:
+    """Simple user-turn prompt — the heavy lifting lives in system_prompt."""
+
+    return (
+        f"Begin work on task {task.id!r}: {task.title}.\n"
+        "Use the goldfive reporting tools to report progress and completion."
+    )
+
+
+def _plan_summary(session: Session) -> str:
+    plan = session.plan
+    if plan is None:
+        return ""
+    if plan.summary:
+        return plan.summary
+    # Fall back to a bullet list of task titles.
+    return "; ".join(f"{t.id}: {t.title}" for t in plan.tasks)
+
+
+def _collect_text_from(message: Any) -> Iterable[str]:
+    """Yield text chunks from any SDK message type we care about."""
+
+    # AssistantMessage.content is a list of ContentBlock — we only pull
+    # TextBlock.text. ThinkingBlock stays private; ToolUseBlock text is
+    # exposed via the PreToolUse hook.
+    content = getattr(message, "content", None)
+    if isinstance(content, list):
+        for block in content:
+            text = getattr(block, "text", None)
+            if isinstance(text, str) and text:
+                yield text
+    # ResultMessage.result holds the final assistant text for non-stream
+    # runs; include it so callers always see something in .text.
+    result_text = getattr(message, "result", None)
+    if isinstance(result_text, str) and result_text:
+        yield result_text
+
+
+def _is_result_message(message: Any) -> bool:
+    """Best-effort check that works whether the SDK is installed or not."""
+
+    if _sdk is not None and isinstance(message, getattr(_sdk, "ResultMessage", ())):
+        return True
+    return type(message).__name__ == "ResultMessage"
+
+
+def _strip_mcp_prefix(name: str) -> str:
+    """``mcp__goldfive_reporting__report_task_started`` → ``report_task_started``."""
+
+    if name.startswith("mcp__"):
+        parts = name.split("__", 2)
+        if len(parts) == 3:
+            return parts[2]
+    return name
+
+
+async def _safe_observe(steerer: SteererLike | None, event: Any, session: Session) -> None:
+    """Call ``steerer.observe`` without letting exceptions escape."""
+
+    if steerer is None:
+        return
+    observe = getattr(steerer, "observe", None)
+    if observe is None:
+        return
+    try:
+        await observe(event, session)
+    except Exception:  # noqa: BLE001 - steerer errors must not kill the stream
+        pass
+
+
+async def _maybe_await(value: Any) -> Any:
+    """Await ``value`` if it is a coroutine; otherwise return it verbatim.
+
+    Some SDK subclasses/mocks make ``connect`` / ``disconnect`` sync; this
+    shim lets tests pass plain functions.
+    """
+
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+__all__ = [
+    "ClaudeAgentSDKAdapter",
+    "DEFAULT_SYSTEM_PROMPT_TEMPLATE",
+]

--- a/goldfive/drift.py
+++ b/goldfive/drift.py
@@ -1,0 +1,59 @@
+"""Drift classifiers (minimal stub until #6 lands).
+
+Only the helpers consumed by the Claude adapter are implemented here;
+issue #6 will replace this file with the full taxonomy.
+"""
+
+from __future__ import annotations
+
+from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+
+# Claude Agent SDK stop-reason values that map to a goldfive drift kind.
+# See https://docs.claude.com/en/api/messages streaming docs — the SDK
+# surfaces stop_reason on ResultMessage / AssistantMessage verbatim.
+_CLAUDE_STOP_REASON_MAP: dict[str, DriftKind] = {
+    "max_turns": DriftKind.TOO_MANY_STEPS,
+    "max_tokens": DriftKind.TOO_MANY_STEPS,
+    "stop_sequence": DriftKind.STOPPED_EARLY,
+    "end_turn": DriftKind.STOPPED_EARLY,
+    "refusal": DriftKind.MODEL_REFUSAL,
+    "pause_turn": DriftKind.STOPPED_EARLY,
+}
+
+
+def classify_stop_reason(
+    stop_reason: str | None,
+    *,
+    current_task_id: str = "",
+    current_agent_id: str = "",
+    detail: str = "",
+    raw: object = None,
+) -> DriftEvent | None:
+    """Map an adapter-reported ``stop_reason`` to a :class:`DriftEvent`.
+
+    ``tool_use`` — the expected completion cause while the agent is
+    mid-flight — is explicitly a non-drift signal and returns ``None``.
+    Unknown reasons also return ``None`` so callers do not raise drift
+    for benign stops.
+    """
+
+    if not stop_reason:
+        return None
+    if stop_reason == "tool_use":
+        return None
+    kind = _CLAUDE_STOP_REASON_MAP.get(stop_reason)
+    if kind is None:
+        return None
+    severity = (
+        DriftSeverity.CRITICAL
+        if kind is DriftKind.MODEL_REFUSAL
+        else DriftSeverity.WARNING
+    )
+    return DriftEvent(
+        kind=kind,
+        severity=severity,
+        detail=detail or f"stop_reason={stop_reason}",
+        current_task_id=current_task_id,
+        current_agent_id=current_agent_id,
+        raw=raw,
+    )

--- a/tests/test_claude_adapter.py
+++ b/tests/test_claude_adapter.py
@@ -1,0 +1,360 @@
+"""Unit tests for :mod:`goldfive.adapters.claude`.
+
+These tests are gated on ``claude_agent_sdk`` being importable. When the
+optional dependency is missing the whole module is skipped via
+``pytest.importorskip`` — this matches the optional-install contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+pytest.importorskip("claude_agent_sdk")
+
+# Imports below are safe once the skip above has passed.
+from claude_agent_sdk import (  # noqa: E402
+    AssistantMessage,
+    ResultMessage,
+    TextBlock,
+    ToolUseBlock,
+)
+
+from goldfive.adapters._claude_prompt import (  # noqa: E402
+    DEFAULT_SYSTEM_PROMPT_TEMPLATE,
+    render_system_prompt,
+)
+from goldfive.adapters.claude import ClaudeAgentSDKAdapter  # noqa: E402
+from goldfive.drift import classify_stop_reason  # noqa: E402
+from goldfive.reporting import ReportingToolSpec  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftKind,
+    Goal,
+    Plan,
+    Session,
+    Task,
+)
+
+# --------------------------------------------------------------------------- #
+# Stubs
+# --------------------------------------------------------------------------- #
+
+
+class _RecordingSteerer:
+    """Collects every event ``observe`` sees so tests can assert on them."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+        self.transitions: list[tuple[str, str]] = []
+
+    async def observe(self, event: Any, session: Session) -> None:
+        self.events.append(event)
+
+    async def transition(
+        self,
+        task_id: str,
+        to: Any,
+        *,
+        detail: str = "",
+        session: Session,
+    ) -> None:
+        self.transitions.append((task_id, str(to)))
+
+    def detect_drift(self, event: Any, session: Session) -> None:
+        return None
+
+    def bind(self, *, sinks: list[Any], planner: Any) -> None:
+        pass
+
+
+class _StubClient:
+    """Minimal stand-in for :class:`claude_agent_sdk.ClaudeSDKClient`.
+
+    The real client streams from a subprocess; we hard-wire a scripted
+    message list so tests never touch the network.
+    """
+
+    def __init__(self, messages: list[Any]) -> None:
+        self._messages = messages
+        self.options: Any = None
+        self.queries: list[str] = []
+        self.connected = False
+
+    async def connect(self, prompt: Any = None) -> None:
+        self.connected = True
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+    async def query(self, prompt: str, session_id: str = "default") -> None:
+        self.queries.append(prompt)
+
+    async def receive_response(self) -> AsyncIterator[Any]:
+        for msg in self._messages:
+            yield msg
+
+
+def _make_result_message(stop_reason: str = "end_turn") -> ResultMessage:
+    return ResultMessage(
+        subtype="success",
+        duration_ms=10,
+        duration_api_ms=5,
+        is_error=False,
+        num_turns=1,
+        session_id="test",
+        stop_reason=stop_reason,
+        result="final",
+    )
+
+
+def _make_assistant_message(blocks: list[Any]) -> AssistantMessage:
+    return AssistantMessage(content=blocks, model="test-model", stop_reason="tool_use")
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+def test_prompt_render_default_template() -> None:
+    """The default template fills every placeholder without KeyError."""
+
+    task = Task(id="t1", title="Write report", description="Summarize findings")
+    goals = [Goal(id="g1", summary="deliver quarterly report")]
+    rendered = render_system_prompt(
+        None,
+        task=task,
+        goals=goals,
+        plan_summary="t1 -> t2",
+        completed={"t0": "kickoff done"},
+    )
+    assert "t1" in rendered
+    assert "Write report" in rendered
+    assert "deliver quarterly report" in rendered
+    assert "t0: kickoff done" in rendered
+    assert "t1 -> t2" in rendered
+
+
+def test_prompt_render_override_template() -> None:
+    """A custom template is honored — placeholders are resolved."""
+
+    template = (
+        "GOALS:\n{goal_block}\nPLAN:{plan_summary}\nDONE:{completed_block}\n"
+        "TASK:{task_block}\n"
+    )
+    rendered = render_system_prompt(
+        template,
+        task=Task(id="x", title="t"),
+        goals=[],
+        plan_summary="",
+        completed={},
+    )
+    assert rendered.startswith("GOALS:\n(no goals declared)\n")
+    assert "(no active plan)" in rendered
+    assert "(none)" in rendered
+
+
+def test_default_template_exports_required_placeholders() -> None:
+    """Sanity check: the published default contains every placeholder."""
+
+    for placeholder in ("{goal_block}", "{task_block}", "{plan_summary}", "{completed_block}"):
+        assert placeholder in DEFAULT_SYSTEM_PROMPT_TEMPLATE
+
+
+def test_classify_stop_reason_benign() -> None:
+    """``tool_use`` and unknown reasons do not produce drift."""
+
+    assert classify_stop_reason("tool_use") is None
+    assert classify_stop_reason(None) is None
+    assert classify_stop_reason("") is None
+    assert classify_stop_reason("some_future_reason") is None
+
+
+def test_classify_stop_reason_too_many_steps() -> None:
+    drift = classify_stop_reason("max_turns", current_task_id="t1")
+    assert drift is not None
+    assert drift.kind is DriftKind.TOO_MANY_STEPS
+    assert drift.current_task_id == "t1"
+
+
+def test_classify_stop_reason_refusal_is_critical() -> None:
+    drift = classify_stop_reason("refusal")
+    assert drift is not None
+    assert drift.kind is DriftKind.MODEL_REFUSAL
+    assert str(drift.severity) == "critical"
+
+
+def test_classify_stop_reason_stopped_early() -> None:
+    drift = classify_stop_reason("end_turn")
+    assert drift is not None
+    assert drift.kind is DriftKind.STOPPED_EARLY
+
+
+def test_adapter_invoke_routes_tool_use_to_steerer() -> None:
+    """A streamed tool_use for a reporting tool reaches the steerer and the handler."""
+
+    handler_calls: list[dict[str, Any]] = []
+
+    async def _report_completed(
+        args: dict[str, Any],
+        session: Session,
+        steerer: Any,
+    ) -> dict[str, Any]:
+        handler_calls.append(args)
+        return {"ok": True}
+
+    spec = ReportingToolSpec(
+        name="report_task_completed",
+        description="Mark a task complete",
+        parameters={
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string"},
+                "summary": {"type": "string"},
+            },
+            "required": ["task_id", "summary"],
+        },
+        handler=_report_completed,
+    )
+
+    # Scripted message stream: assistant says something, then emits a
+    # tool_use for report_task_completed, then the result message.
+    messages = [
+        _make_assistant_message(
+            [
+                TextBlock(text="Working on it."),
+                ToolUseBlock(
+                    id="tu_1",
+                    name="mcp__goldfive_reporting__report_task_completed",
+                    input={"task_id": "t1", "summary": "done"},
+                ),
+            ]
+        ),
+        _make_result_message(stop_reason="end_turn"),
+    ]
+    stub_client = _StubClient(messages)
+
+    steerer = _RecordingSteerer()
+    adapter = ClaudeAgentSDKAdapter(
+        client_factory=lambda: stub_client,
+        steerer=steerer,
+    )
+
+    async def _run() -> None:
+        await adapter.register_reporting_tools([spec])
+        # Simulate the SDK-side hook firing for the tool_use block. The
+        # adapter's invoke() streams messages straight from the stub,
+        # but the hook is only invoked by the real SDK runtime — we call
+        # it manually here to exercise the routing logic end-to-end.
+        hook = adapter._make_pretooluse_hook(  # noqa: SLF001 - test hook
+            Session(run_id="r1")
+        )
+        ack = await hook(
+            {
+                "tool_name": "mcp__goldfive_reporting__report_task_completed",
+                "tool_input": {"task_id": "t1", "summary": "done"},
+            },
+            "tu_1",
+            None,
+        )
+        # Hook should deny the no-op stub and embed the handler's ack.
+        spec_out = ack.get("hookSpecificOutput", {})
+        assert spec_out.get("permissionDecision") == "deny"
+        assert "ok" in spec_out.get("permissionDecisionReason", "")
+
+        session = Session(
+            run_id="r1",
+            goals=[Goal(id="g1", summary="complete t1")],
+            plan=Plan(
+                id="p1",
+                run_id="r1",
+                goal_ids=["g1"],
+                tasks=[Task(id="t1", title="Do thing")],
+                edges=[],
+                summary="single-task plan",
+            ),
+        )
+        result = await adapter.invoke(Task(id="t1", title="Do thing"), session)
+        assert result.task_id == "t1"
+        assert result.stop_reason == "end_turn"
+        assert "Working on it." in result.text
+
+    asyncio.run(_run())
+
+    # The handler fired exactly once with the correct args.
+    assert handler_calls == [{"task_id": "t1", "summary": "done"}]
+    # The steerer observed messages from the stream: at minimum the
+    # assistant message, the result message, and the tool-call observation.
+    observed_types = [type(e).__name__ for e in steerer.events]
+    assert "AssistantMessage" in observed_types
+    assert "ResultMessage" in observed_types
+    assert "_ToolCallObservation" in observed_types
+
+
+def test_adapter_invoke_reports_drift_on_max_turns() -> None:
+    """A ``max_turns`` stop_reason is classified and observed as drift."""
+
+    messages = [_make_result_message(stop_reason="max_turns")]
+    stub_client = _StubClient(messages)
+    steerer = _RecordingSteerer()
+    adapter = ClaudeAgentSDKAdapter(
+        client_factory=lambda: stub_client,
+        steerer=steerer,
+    )
+
+    async def _run() -> None:
+        session = Session(run_id="r2")
+        result = await adapter.invoke(Task(id="t1", title="Do thing"), session)
+        assert result.stop_reason == "max_turns"
+
+    asyncio.run(_run())
+
+    drift_events = [e for e in steerer.events if type(e).__name__ == "DriftEvent"]
+    assert len(drift_events) == 1
+    assert drift_events[0].kind is DriftKind.TOO_MANY_STEPS
+
+
+def test_adapter_available_agents_passthrough() -> None:
+    adapter = ClaudeAgentSDKAdapter(
+        client_factory=lambda: _StubClient([]),
+        available_agents=["planner", "executor"],
+    )
+    assert adapter.available_agents == ["planner", "executor"]
+    # Returned list is a copy — mutations don't leak.
+    adapter.available_agents.append("other")
+    assert adapter.available_agents == ["planner", "executor"]
+
+
+def test_pretooluse_hook_passes_through_non_reporting_tools() -> None:
+    """Non-reporting tools are not short-circuited."""
+
+    async def _noop(
+        args: dict[str, Any],
+        session: Session,
+        steerer: Any,
+    ) -> dict[str, Any]:
+        return {"ok": True}
+
+    spec = ReportingToolSpec(
+        name="report_task_started",
+        description="start",
+        parameters={"type": "object", "properties": {}, "required": []},
+        handler=_noop,
+    )
+
+    adapter = ClaudeAgentSDKAdapter(client_factory=lambda: _StubClient([]))
+
+    async def _run() -> dict[str, Any]:
+        await adapter.register_reporting_tools([spec])
+        hook = adapter._make_pretooluse_hook(Session(run_id="r"))  # noqa: SLF001
+        return await hook(
+            {"tool_name": "Bash", "tool_input": {"command": "ls"}},
+            "tu_bash",
+            None,
+        )
+
+    result = asyncio.run(_run())
+    assert result == {}


### PR DESCRIPTION
## Summary

- Adds `goldfive.adapters.claude.ClaudeAgentSDKAdapter`, implementing `AgentAdapter` on top of `claude_agent_sdk.ClaudeSDKClient`.
- Exposes the seven canonical reporting tools as an inline SDK MCP server (`SdkMcpTool` + `create_sdk_mcp_server`) and intercepts them with a `PreToolUse` hook that routes through the goldfive `Steerer` and short-circuits the no-op stubs.
- Re-renders a publicly documented, overrideable system prompt per invoke — Claude Agent SDK has no shared `session.state` dict, so context must live in the system prompt.
- Classifies stream `stop_reason` values to `DriftKind` (`max_turns`, `max_tokens` → `too_many_steps`; `refusal` → `model_refusal`; `stop_sequence`, `end_turn`, `pause_turn` → `stopped_early`; `tool_use` is non-drift).
- `claude_agent_sdk` is an optional dependency — importing the adapter without it raises a clear `ImportError` pointing at `pip install goldfive[claude]`.
- Ships minimal stubs for `types.py`, `protocols.py`, `reporting.py`, `results.py`, `drift.py` pinned to `INTERFACE_SPEC.md` so this PR is self-sufficient until #4/#5/#6 merge (they will supersede the stubs).

## SDK-API observations vs the spec

- The SDK's only supported path for custom tools is an MCP server (either subprocess or in-process `SdkMcpTool`); there is no plain "inline tool schema dict" on `ClaudeAgentOptions`. The adapter therefore builds an **in-process MCP server** via `create_sdk_mcp_server(...)` — functionally identical to the spec's option (b) but implemented with the types the SDK actually exposes.
- `PreToolUse` hooks do not have a direct "return result and stop" path. The idiomatic short-circuit is `hookSpecificOutput.permissionDecision = "deny"` with the handler's ACK encoded in `permissionDecisionReason` — that is what the adapter does so the model still sees the ACK string and the no-op inline handler never runs.
- Tool names in the stream arrive as `mcp__goldfive_reporting__<name>`; the adapter strips the `mcp__<server>__` prefix before dispatching, and the hook matcher is a `|`-joined regex over the bare canonical names.
- `ClaudeAgentOptions.tools` is either a list of built-in tool names or a preset; custom tools live under `mcp_servers` and must be allow-listed on `allowed_tools` with the qualified name.
- Message streaming uses `client.receive_response()` (auto-terminates on `ResultMessage`); assistant text comes from `AssistantMessage.content: list[TextBlock|ThinkingBlock|ToolUseBlock|ToolResultBlock]` and the final `stop_reason` surfaces on `ResultMessage`.

## Test plan

- [x] `pytest tests/test_claude_adapter.py` — 11 tests, all pass (gated on `claude_agent_sdk` being installable; auto-skips if missing).
- [x] `ruff check goldfive tests` — clean.
- [x] Full suite (`pytest tests`) — 13 passed.
- [ ] Manual smoke against a live Claude Agent SDK run (not covered here — requires real credentials).

Closes #14

---

## Dependencies note

This PR carries minimal stubs for `goldfive/{types,protocols,reporting,results,drift}.py` because issues #4/#5/#6 have not merged yet. Those PRs will replace the stubs with the full implementations; shapes are pinned to `INTERFACE_SPEC.md` so the adapter will continue to work unchanged.
