### PR TITLE
Add ADK AgentAdapter and plugin

### DIFF
--- a/goldfive/adapters/__init__.py
+++ b/goldfive/adapters/__init__.py
@@ -3,6 +3,13 @@
 Each adapter bridges an external agent SDK (or a plain async callable) to
 the :class:`goldfive.protocols.AgentAdapter` protocol. The CallableAdapter
 is the reference implementation — see :mod:`goldfive.adapters.callable`.
+
+Adapters for frameworks with heavy optional dependencies (e.g. ADK in
+:mod:`goldfive.adapters.adk`) are *not* imported here — importing a
+submodule requires the corresponding framework to be installed
+(``pip install goldfive[adk]`` for :mod:`goldfive.adapters.adk`). The
+per-module import guard raises :class:`ImportError` with an install
+hint when the framework is missing.
 """
 
 from __future__ import annotations

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1,0 +1,397 @@
+"""Internal ADK ``BasePlugin`` used by :class:`goldfive.adapters.adk.ADKAdapter`.
+
+The plugin is the routing layer between ADK's callback lifecycle and
+goldfive's :class:`~goldfive.protocols.Steerer`. It does three jobs:
+
+1. **State protocol** — ``before_model_callback`` writes the current
+   task and plan context into the ADK session state under the
+   ``goldfive.*`` keys (see :mod:`._adk_state_protocol`) so agents can
+   read them during their turn.
+2. **Reporting-tool interception** — ``before_tool_callback`` watches
+   for the seven canonical reporting tools. When one fires the plugin
+   routes the call's arguments to the corresponding
+   :class:`~goldfive.reporting.ReportingToolSpec` handler and returns
+   a short-circuit acknowledgment so ADK doesn't execute the stub
+   shim the :class:`FunctionTool` actually wraps.
+3. **Drift observation** — ``after_model_callback``,
+   ``on_event_callback`` (transfer/escalation), and
+   ``on_tool_error_callback`` feed raw signals into
+   ``steerer.observe(...)`` so the steerer can classify drift.
+
+The plugin never imports ``google.adk`` at module load. It imports the
+ADK ``BasePlugin`` base class lazily inside :func:`make_adk_plugin`,
+which is only called from the adapter's ``__init__``. That keeps this
+module importable from non-ADK code for type-checking and allows unit
+tests to patch the base class with a stub when ADK is not installed.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from goldfive.adapters import _adk_state_protocol as _sp
+
+if TYPE_CHECKING:
+    from goldfive.protocols import Steerer
+    from goldfive.types import Session
+
+
+log = logging.getLogger("goldfive.adapters.adk")
+
+
+# ``SessionContext`` is stashed on ADK ``session.state`` under this key
+# so the plugin callbacks can reach back to the goldfive session (and
+# its steerer + current task) without threading them through every
+# callback signature. The adapter writes this before ``runner.run_async``
+# and deletes it after.
+SESSION_CONTEXT_STATE_KEY = "goldfive._session_context"
+
+
+class SessionContext:
+    """Per-invocation context the adapter stashes on ADK state.
+
+    Carries the goldfive :class:`~goldfive.types.Session`, the active
+    :class:`~goldfive.protocols.Steerer`, the task the adapter is about
+    to invoke, and the registered reporting-tool handler map. The
+    plugin picks it up from the ADK callback's ``callback_context``
+    via :func:`_session_context_from_callback`.
+    """
+
+    __slots__ = (
+        "session",
+        "steerer",
+        "task",
+        "tool_handlers",
+        "host_agent_name",
+    )
+
+    def __init__(
+        self,
+        *,
+        session: Session,
+        steerer: Steerer | None,
+        task: Any,
+        tool_handlers: Mapping[str, Any],
+        host_agent_name: str,
+    ) -> None:
+        self.session = session
+        self.steerer = steerer
+        self.task = task
+        self.tool_handlers = dict(tool_handlers)
+        self.host_agent_name = host_agent_name
+
+
+def _safe_attr(obj: Any, name: str, default: Any = None) -> Any:
+    try:
+        value = getattr(obj, name, default)
+    except Exception:
+        return default
+    return value if value is not None else default
+
+
+def _session_state_from_callback(ctx: Any) -> Any:
+    """Return the ADK session.state mutable mapping for a callback ctx.
+
+    Tolerates the several shapes ADK has used across versions:
+    ``ctx.session.state``, ``ctx._invocation_context.session.state``,
+    ``ctx.state``. Returns an empty dict if none match.
+    """
+    for attr_chain in (
+        ("session", "state"),
+        ("_invocation_context", "session", "state"),
+        ("invocation_context", "session", "state"),
+    ):
+        cur: Any = ctx
+        ok = True
+        for part in attr_chain:
+            cur = _safe_attr(cur, part, None)
+            if cur is None:
+                ok = False
+                break
+        if ok and cur is not None:
+            return cur
+    direct = _safe_attr(ctx, "state", None)
+    if direct is not None:
+        return direct
+    return {}
+
+
+def _session_context_from_callback(ctx: Any) -> SessionContext | None:
+    state = _session_state_from_callback(ctx)
+    if not isinstance(state, Mapping):
+        return None
+    value = state.get(SESSION_CONTEXT_STATE_KEY)
+    if isinstance(value, SessionContext):
+        return value
+    return None
+
+
+def _extract_text_parts(llm_response: Any) -> list[str]:
+    content = _safe_attr(llm_response, "content", None)
+    if content is None:
+        return []
+    parts = _safe_attr(content, "parts", None) or []
+    texts: list[str] = []
+    for part in parts:
+        if _safe_attr(part, "thought", False):
+            continue
+        text = _safe_attr(part, "text", "") or ""
+        if text:
+            texts.append(str(text))
+    return texts
+
+
+def _extract_function_calls(llm_response: Any) -> list[dict]:
+    content = _safe_attr(llm_response, "content", None)
+    if content is None:
+        return []
+    parts = _safe_attr(content, "parts", None) or []
+    calls: list[dict] = []
+    for part in parts:
+        fc = _safe_attr(part, "function_call", None)
+        if fc is None:
+            continue
+        calls.append(
+            {
+                "name": str(_safe_attr(fc, "name", "") or ""),
+                "args": _safe_attr(fc, "args", None),
+            }
+        )
+    return calls
+
+
+async def _invoke_handler(
+    handler: Any,
+    args: Mapping[str, Any],
+    session: Session,
+    steerer: Steerer | None,
+) -> dict[str, Any]:
+    """Invoke a reporting-tool handler, tolerating sync or async shapes."""
+    import asyncio
+
+    try:
+        call = handler(dict(args), session, steerer)
+    except TypeError:
+        # Some handler implementations accept keyword-style signatures.
+        call = handler(args=dict(args), session=session, steerer=steerer)
+    if asyncio.iscoroutine(call):
+        result = await call
+    else:
+        result = call
+    if isinstance(result, dict):
+        return result
+    return {"acknowledged": True}
+
+
+def _as_observation(
+    *,
+    kind: str,
+    detail: str = "",
+    raw: Any = None,
+    task: Any = None,
+    agent_id: str = "",
+) -> dict[str, Any]:
+    """Build the lightweight observation dict handed to ``steerer.observe``.
+
+    The steerer is responsible for classifying this into a
+    :class:`~goldfive.types.DriftEvent` via ``detect_drift``. This
+    adapter just translates ADK-native events into a stable shape.
+    """
+    return {
+        "source": "adk",
+        "kind": kind,
+        "detail": detail,
+        "task_id": _safe_attr(task, "id", "") or "",
+        "agent_id": agent_id or "",
+        "raw": raw,
+    }
+
+
+def make_adk_plugin(
+    *,
+    name: str = "goldfive_adk_plugin",
+    host_agent_name: str = "",
+) -> Any:
+    """Build the ADK plugin class bound to goldfive's protocol.
+
+    The class is built lazily so this module can be imported without
+    ``google.adk`` installed. The plugin routes the five callbacks we
+    care about (``before_model``, ``before_tool``, ``after_model``,
+    ``on_event``, ``on_tool_error``) through the
+    :class:`SessionContext` stashed on ADK state.
+
+    ``host_agent_name`` is the fallback name rendered into
+    ``goldfive.available_tasks`` entries whose task has no explicit
+    assignee — typically the wrapped root agent's name.
+    """
+    try:
+        from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+    except ImportError as exc:  # pragma: no cover — tested via importorskip
+        raise ImportError(
+            "goldfive.adapters.adk requires 'pip install goldfive[adk]'"
+        ) from exc
+
+    class _GoldfiveADKPlugin(BasePlugin):  # type: ignore[misc, valid-type]
+        """Routes ADK callbacks into the goldfive steerer + state protocol."""
+
+        def __init__(self) -> None:
+            super().__init__(name=name)
+            self._host_agent_name = host_agent_name
+
+        # --- Plan + current-task context -------------------------------
+
+        async def before_model_callback(
+            self, *, callback_context: Any, llm_request: Any
+        ) -> None:
+            ctx = _session_context_from_callback(callback_context)
+            if ctx is None:
+                return None
+            state = _session_state_from_callback(callback_context)
+            if not isinstance(state, dict):
+                # Some ADK session state objects are dict-likes. We only
+                # write when we can mutate — otherwise the agent just
+                # sees no goldfive.* context, which is a survivable
+                # degraded mode.
+                try:
+                    state[_sp.KEY_RUN_ID] = state.get(_sp.KEY_RUN_ID, "")  # type: ignore[index]
+                except Exception:
+                    return None
+
+            session = ctx.session
+            try:
+                _sp.write_run_id(state, _safe_attr(session, "run_id", "") or "")
+                _sp.write_plan_context(
+                    state,
+                    _safe_attr(session, "plan", None),
+                    _safe_attr(session, "completed_results", {}) or {},
+                    self._host_agent_name,
+                )
+                _sp.write_current_task(state, ctx.task)
+                _sp.write_tools_available(state, ctx.tool_handlers.keys())
+            except Exception as exc:  # noqa: BLE001
+                log.debug("before_model_callback: state write failed: %s", exc)
+            return None
+
+        # --- Reporting-tool interception -------------------------------
+
+        async def before_tool_callback(
+            self, *, tool: Any, tool_args: Any, tool_context: Any
+        ) -> dict[str, Any] | None:
+            ctx = _session_context_from_callback(tool_context)
+            if ctx is None:
+                return None
+            tool_name = str(_safe_attr(tool, "name", "") or "")
+            if not tool_name:
+                func = _safe_attr(tool, "func", None)
+                tool_name = str(_safe_attr(func, "__name__", "") or "")
+            handler = ctx.tool_handlers.get(tool_name)
+            if handler is None:
+                return None
+            args_map: Mapping[str, Any]
+            if isinstance(tool_args, Mapping):
+                args_map = tool_args
+            else:
+                args_map = {}
+            try:
+                result = await _invoke_handler(
+                    handler, args_map, ctx.session, ctx.steerer
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "before_tool_callback: handler for %s raised: %s",
+                    tool_name,
+                    exc,
+                )
+                # Fall back to the canonical acknowledgment so the
+                # agent doesn't see a tool error for a protocol call.
+                return {"acknowledged": True, "error": str(exc)}
+            # Return a non-None result to short-circuit ADK tool dispatch.
+            return result or {"acknowledged": True}
+
+        # --- Drift observation -----------------------------------------
+
+        async def after_model_callback(
+            self, *, callback_context: Any, llm_response: Any
+        ) -> None:
+            ctx = _session_context_from_callback(callback_context)
+            if ctx is None or ctx.steerer is None:
+                return None
+            texts = _extract_text_parts(llm_response)
+            calls = _extract_function_calls(llm_response)
+            finish = _safe_attr(llm_response, "finish_reason", None)
+            observation = _as_observation(
+                kind="llm_response",
+                detail=" ".join(texts)[:500],
+                raw={
+                    "texts": texts,
+                    "function_calls": calls,
+                    "finish_reason": str(finish) if finish is not None else "",
+                },
+                task=ctx.task,
+                agent_id=self._host_agent_name,
+            )
+            try:
+                await ctx.steerer.observe(observation, ctx.session)
+            except Exception as exc:  # noqa: BLE001
+                log.debug("after_model_callback: steerer.observe raised: %s", exc)
+            return None
+
+        async def on_event_callback(
+            self, *, invocation_context: Any, event: Any
+        ) -> None:
+            ctx = _session_context_from_callback(invocation_context)
+            if ctx is None or ctx.steerer is None:
+                return None
+            # Detect transfer / escalation actions on the event payload.
+            actions = _safe_attr(event, "actions", None)
+            transfer_to = _safe_attr(actions, "transfer_to_agent", "") or ""
+            escalate = bool(_safe_attr(actions, "escalate", False))
+            if not transfer_to and not escalate:
+                return None
+            kind = "agent_transfer" if transfer_to else "agent_escalation"
+            detail = (
+                f"transfer -> {transfer_to}" if transfer_to else "escalate"
+            )
+            observation = _as_observation(
+                kind=kind,
+                detail=detail,
+                raw=event,
+                task=ctx.task,
+                agent_id=self._host_agent_name,
+            )
+            try:
+                await ctx.steerer.observe(observation, ctx.session)
+            except Exception as exc:  # noqa: BLE001
+                log.debug("on_event_callback: steerer.observe raised: %s", exc)
+            return None
+
+        async def on_tool_error_callback(
+            self,
+            *,
+            tool: Any,
+            tool_args: Any,
+            tool_context: Any,
+            error: Any,
+        ) -> None:
+            ctx = _session_context_from_callback(tool_context)
+            if ctx is None or ctx.steerer is None:
+                return None
+            tool_name = str(_safe_attr(tool, "name", "") or "")
+            observation = _as_observation(
+                kind="tool_error",
+                detail=f"{tool_name}: {error}",
+                raw={"tool": tool_name, "error": repr(error)},
+                task=ctx.task,
+                agent_id=self._host_agent_name,
+            )
+            try:
+                await ctx.steerer.observe(observation, ctx.session)
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "on_tool_error_callback: steerer.observe raised: %s", exc
+                )
+            return None
+
+    return _GoldfiveADKPlugin()

--- a/goldfive/adapters/_adk_state_protocol.py
+++ b/goldfive/adapters/_adk_state_protocol.py
@@ -1,0 +1,335 @@
+"""ADK session.state protocol for the goldfive adapter.
+
+This is a ported subset of harmonograf's ``state_protocol`` module,
+re-namespaced under the ``goldfive.*`` prefix. It owns the key names
+goldfive writes into an ADK ``session.state`` dict so agents can read
+the active task and plan context during their turn, and reads back
+agent-side writes (progress, outcome, notes, divergence flag) after
+the turn.
+
+Two directions share the state channel:
+
+* **Goldfive -> Agents** — written by the adapter in
+  ``before_model_callback`` before the LLM call. Keys under this
+  direction advertise the active task, plan summary, and the set of
+  reporting tools that are wired up.
+* **Agents -> Goldfive** — written by the agent as ``state_delta``
+  events (or by the plugin's ``before_tool_callback`` interception of
+  the canonical reporting tools). Keys under this direction carry
+  progress, outcome, free-form notes, and the divergence flag.
+
+All keys live under :data:`GOLDFIVE_PREFIX`. Non-goldfive keys in the
+state dict are ignored — readers never raise on missing or malformed
+state, and writers refuse to stamp non-goldfive keys so this module
+can't accidentally clobber application state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, MutableMapping
+from typing import Any
+
+GOLDFIVE_PREFIX = "goldfive."
+
+# Goldfive -> Agents
+KEY_CURRENT_TASK_ID = "goldfive.current_task_id"
+KEY_CURRENT_TASK_TITLE = "goldfive.current_task_title"
+KEY_CURRENT_TASK_DESCRIPTION = "goldfive.current_task_description"
+KEY_CURRENT_TASK_ASSIGNEE = "goldfive.current_task_assignee"
+KEY_PLAN_ID = "goldfive.plan_id"
+KEY_PLAN_SUMMARY = "goldfive.plan_summary"
+KEY_RUN_ID = "goldfive.run_id"
+KEY_COMPLETED_TASK_RESULTS = "goldfive.completed_task_results"
+KEY_AVAILABLE_TASKS = "goldfive.available_tasks"
+KEY_TOOLS_AVAILABLE = "goldfive.tools_available"
+
+# Agents -> Goldfive
+KEY_TASK_PROGRESS = "goldfive.task_progress"
+KEY_TASK_OUTCOME = "goldfive.task_outcome"
+KEY_AGENT_NOTE = "goldfive.agent_note"
+KEY_DIVERGENCE_FLAG = "goldfive.divergence_flag"
+
+_CURRENT_TASK_KEYS: tuple[str, ...] = (
+    KEY_CURRENT_TASK_ID,
+    KEY_CURRENT_TASK_TITLE,
+    KEY_CURRENT_TASK_DESCRIPTION,
+    KEY_CURRENT_TASK_ASSIGNEE,
+)
+
+ALL_KEYS: tuple[str, ...] = (
+    KEY_CURRENT_TASK_ID,
+    KEY_CURRENT_TASK_TITLE,
+    KEY_CURRENT_TASK_DESCRIPTION,
+    KEY_CURRENT_TASK_ASSIGNEE,
+    KEY_PLAN_ID,
+    KEY_PLAN_SUMMARY,
+    KEY_RUN_ID,
+    KEY_COMPLETED_TASK_RESULTS,
+    KEY_AVAILABLE_TASKS,
+    KEY_TOOLS_AVAILABLE,
+    KEY_TASK_PROGRESS,
+    KEY_TASK_OUTCOME,
+    KEY_AGENT_NOTE,
+    KEY_DIVERGENCE_FLAG,
+)
+
+
+def _safe_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _safe_get(state: Any, key: str, default: Any = None) -> Any:
+    if not isinstance(state, Mapping):
+        return default
+    try:
+        value = state.get(key, default)
+    except Exception:
+        return default
+    return value if value is not None else default
+
+
+def _assert_goldfive_key(key: str) -> None:
+    if not key.startswith(GOLDFIVE_PREFIX):
+        raise ValueError(f"state_protocol refuses to write non-goldfive key: {key!r}")
+
+
+def _set(state: MutableMapping[str, Any], key: str, value: Any) -> None:
+    _assert_goldfive_key(key)
+    state[key] = value
+
+
+# ---------------------------------------------------------------------------
+# Readers
+# ---------------------------------------------------------------------------
+
+
+def read_current_task(state: Any) -> dict:
+    """Return ``{id, title, description, assignee}`` for the active task."""
+    return {
+        "id": _safe_str(_safe_get(state, KEY_CURRENT_TASK_ID, "")),
+        "title": _safe_str(_safe_get(state, KEY_CURRENT_TASK_TITLE, "")),
+        "description": _safe_str(_safe_get(state, KEY_CURRENT_TASK_DESCRIPTION, "")),
+        "assignee": _safe_str(_safe_get(state, KEY_CURRENT_TASK_ASSIGNEE, "")),
+    }
+
+
+def read_run_id(state: Any) -> str:
+    return _safe_str(_safe_get(state, KEY_RUN_ID, ""))
+
+
+def read_plan_id(state: Any) -> str:
+    return _safe_str(_safe_get(state, KEY_PLAN_ID, ""))
+
+
+def read_plan_summary(state: Any) -> str:
+    return _safe_str(_safe_get(state, KEY_PLAN_SUMMARY, ""))
+
+
+def read_completed_results(state: Any) -> dict:
+    value = _safe_get(state, KEY_COMPLETED_TASK_RESULTS, None)
+    if not isinstance(value, Mapping):
+        return {}
+    out: dict[str, str] = {}
+    for k, v in value.items():
+        if isinstance(k, str):
+            out[k] = _safe_str(v)
+    return out
+
+
+def read_available_tasks(state: Any) -> list[dict]:
+    value = _safe_get(state, KEY_AVAILABLE_TASKS, None)
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, Mapping)]
+
+
+def read_tools_available(state: Any) -> list[str]:
+    value = _safe_get(state, KEY_TOOLS_AVAILABLE, None)
+    if not isinstance(value, list):
+        return []
+    return [v for v in value if isinstance(v, str)]
+
+
+def read_agent_outcome(state: Any, task_id: str) -> str:
+    value = _safe_get(state, KEY_TASK_OUTCOME, None)
+    if not isinstance(value, Mapping):
+        return ""
+    return _safe_str(value.get(task_id, ""))
+
+
+def read_agent_progress(state: Any, task_id: str) -> float:
+    value = _safe_get(state, KEY_TASK_PROGRESS, None)
+    if not isinstance(value, Mapping):
+        return 0.0
+    raw = value.get(task_id, 0.0)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def read_agent_note(state: Any) -> str:
+    return _safe_str(_safe_get(state, KEY_AGENT_NOTE, ""))
+
+
+def read_divergence_flag(state: Any) -> bool:
+    return bool(_safe_get(state, KEY_DIVERGENCE_FLAG, False))
+
+
+# ---------------------------------------------------------------------------
+# Writers
+# ---------------------------------------------------------------------------
+
+
+def write_current_task(state: MutableMapping[str, Any], task: Any) -> None:
+    """Mutate state with current_task_* fields from a :class:`goldfive.types.Task`.
+
+    Accepts anything that duck-types to goldfive's ``Task`` (``.id``,
+    ``.title``, ``.description``, ``.assignee_agent_id``) or a mapping
+    with equivalent keys. ``None`` clears the current task.
+    """
+    if task is None:
+        clear_current_task(state)
+        return
+
+    if isinstance(task, Mapping):
+        tid = task.get("id", "")
+        title = task.get("title", "")
+        description = task.get("description", "")
+        assignee = task.get("assignee") or task.get("assignee_agent_id", "")
+    else:
+        tid = getattr(task, "id", "")
+        title = getattr(task, "title", "")
+        description = getattr(task, "description", "")
+        assignee = getattr(task, "assignee_agent_id", "") or getattr(
+            task, "assignee", ""
+        )
+
+    _set(state, KEY_CURRENT_TASK_ID, _safe_str(tid))
+    _set(state, KEY_CURRENT_TASK_TITLE, _safe_str(title))
+    _set(state, KEY_CURRENT_TASK_DESCRIPTION, _safe_str(description))
+    _set(state, KEY_CURRENT_TASK_ASSIGNEE, _safe_str(assignee))
+
+
+def clear_current_task(state: MutableMapping[str, Any]) -> None:
+    for key in _CURRENT_TASK_KEYS:
+        if key in state:
+            state.pop(key, None)
+
+
+def write_plan_context(
+    state: MutableMapping[str, Any],
+    plan: Any,
+    completed_results: Mapping[str, Any] | None,
+    host_agent: str,
+) -> None:
+    """Write plan_id, summary, available_tasks, and completed_results.
+
+    ``plan`` duck-types to :class:`goldfive.types.Plan` — anything with
+    ``.id``, ``.summary``, ``.tasks``, and optional ``.edges`` works.
+    ``host_agent`` is the fallback assignee rendered into
+    ``available_tasks`` when a task has none.
+    """
+    plan_id = ""
+    summary = ""
+    tasks_iter: Iterable[Any] = ()
+    edges_iter: Iterable[Any] = ()
+
+    if plan is not None:
+        plan_id = _safe_str(getattr(plan, "id", None) or getattr(plan, "plan_id", ""))
+        summary = _safe_str(getattr(plan, "summary", ""))
+        tasks_iter = getattr(plan, "tasks", ()) or ()
+        edges_iter = getattr(plan, "edges", ()) or ()
+
+    deps_by_task: dict[str, list[str]] = {}
+    for edge in edges_iter:
+        src = _safe_str(getattr(edge, "from_task_id", ""))
+        dst = _safe_str(getattr(edge, "to_task_id", ""))
+        if not src or not dst:
+            continue
+        deps_by_task.setdefault(dst, []).append(src)
+
+    available: list[dict] = []
+    for task in tasks_iter:
+        tid = _safe_str(getattr(task, "id", ""))
+        status = getattr(task, "status", "PENDING")
+        # Tolerate StrEnum or plain strings.
+        status_str = _safe_str(getattr(status, "value", status) or "PENDING")
+        available.append(
+            {
+                "id": tid,
+                "title": _safe_str(getattr(task, "title", "")),
+                "assignee": _safe_str(
+                    getattr(task, "assignee_agent_id", "") or host_agent
+                ),
+                "status": status_str,
+                "deps": list(deps_by_task.get(tid, [])),
+            }
+        )
+
+    _set(state, KEY_PLAN_ID, plan_id)
+    _set(state, KEY_PLAN_SUMMARY, summary)
+    _set(state, KEY_AVAILABLE_TASKS, available)
+
+    results_out: dict[str, str] = {}
+    if isinstance(completed_results, Mapping):
+        for k, v in completed_results.items():
+            if isinstance(k, str):
+                results_out[k] = _safe_str(v)
+    _set(state, KEY_COMPLETED_TASK_RESULTS, results_out)
+
+
+def write_run_id(state: MutableMapping[str, Any], run_id: str) -> None:
+    _set(state, KEY_RUN_ID, _safe_str(run_id))
+
+
+def write_tools_available(
+    state: MutableMapping[str, Any], tool_names: Iterable[str]
+) -> None:
+    _set(
+        state,
+        KEY_TOOLS_AVAILABLE,
+        [name for name in tool_names if isinstance(name, str)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diffing
+# ---------------------------------------------------------------------------
+
+
+def extract_agent_writes(before: Any, after: Any) -> dict:
+    """Return goldfive.* keys the agent added, changed, or removed.
+
+    A removed key is represented as ``{key: None}`` so callers can
+    distinguish it from an unset key. ``before``/``after`` may be any
+    mapping; non-mapping inputs are treated as empty.
+    """
+    before_map: Mapping[str, Any] = before if isinstance(before, Mapping) else {}
+    after_map: Mapping[str, Any] = after if isinstance(after, Mapping) else {}
+
+    before_g = {
+        k: v
+        for k, v in before_map.items()
+        if isinstance(k, str) and k.startswith(GOLDFIVE_PREFIX)
+    }
+    after_g = {
+        k: v
+        for k, v in after_map.items()
+        if isinstance(k, str) and k.startswith(GOLDFIVE_PREFIX)
+    }
+
+    changes: dict[str, Any] = {}
+    for key, value in after_g.items():
+        if key not in before_g:
+            changes[key] = value
+        elif before_g[key] != value:
+            changes[key] = value
+    for key in before_g:
+        if key not in after_g:
+            changes[key] = None
+    return changes

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -1,0 +1,556 @@
+"""ADK :class:`~goldfive.protocols.AgentAdapter` for Google's Agent Development Kit.
+
+Wraps an ADK ``BaseAgent`` (or an existing ``Runner``) and conforms it
+to goldfive's :class:`~goldfive.protocols.AgentAdapter` protocol so
+goldfive's runner / executor / steerer can drive it uniformly.
+
+Responsibilities:
+
+* **Reporting tool registration** — :meth:`ADKAdapter.register_reporting_tools`
+  accepts goldfive :class:`~goldfive.reporting.ReportingToolSpec` values,
+  wraps each as a ``google.adk.tools.FunctionTool`` around a thin sync
+  shim that just returns an acknowledgment, and attaches the tools to
+  the inner agent (plus every sub-agent reachable via ``sub_agents`` /
+  ``inner_agent`` / nested ``AgentTool.agent``). The plugin intercepts
+  calls to these tools in ``before_tool_callback`` and routes their
+  arguments to the spec's real handler — the in-process shim is never
+  actually executed by ADK.
+* **Invocation** — :meth:`ADKAdapter.invoke` stashes a
+  :class:`~._adk_plugin.SessionContext` onto ADK session state,
+  drives one turn via ``runner.run_async(...)``, consumes the event
+  stream to assemble an :class:`~goldfive.results.InvocationResult`,
+  and cleans the context back off.
+
+Optional dependency
+-------------------
+
+``google.adk`` is an optional install. The top-level import in this
+module is gated so ``import goldfive.adapters.adk`` raises a clear
+``ImportError`` with install instructions when ADK is missing.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from goldfive.adapters import _adk_state_protocol as _sp
+from goldfive.adapters._adk_plugin import (
+    SESSION_CONTEXT_STATE_KEY,
+    SessionContext,
+    make_adk_plugin,
+)
+from goldfive.results import InvocationResult
+
+if TYPE_CHECKING:
+    from goldfive.protocols import Steerer
+    from goldfive.reporting import ReportingToolSpec
+    from goldfive.types import Session, Task
+
+log = logging.getLogger("goldfive.adapters.adk")
+
+
+try:  # noqa: SIM105 — explicit import-time guard with install hint
+    import google.adk  # type: ignore  # noqa: F401
+except ImportError:  # pragma: no cover — covered in tests via importorskip
+    raise ImportError(
+        "goldfive.adapters.adk requires 'pip install goldfive[adk]'"
+    ) from None
+
+
+def _build_ack_shim(name: str, description: str):
+    """Return a sync function named ``name`` that returns an ACK dict.
+
+    Used as the body of each ``FunctionTool`` so ADK has a callable
+    with a proper ``__name__`` / docstring for the model to see. The
+    real handler routing happens in the plugin's
+    ``before_tool_callback`` — this shim is never actually executed.
+    """
+
+    def _shim(**kwargs: Any) -> dict[str, Any]:
+        return {"acknowledged": True}
+
+    _shim.__name__ = name
+    _shim.__qualname__ = name
+    _shim.__doc__ = description or f"Reporting tool: {name}"
+    return _shim
+
+
+def _build_function_tool(spec: ReportingToolSpec) -> Any:
+    """Wrap a :class:`ReportingToolSpec` as a ``google.adk.tools.FunctionTool``."""
+    from google.adk.tools import FunctionTool  # type: ignore
+
+    shim = _build_ack_shim(spec.name, spec.description)
+    return FunctionTool(shim)
+
+
+def _augment_subtree_with_reporting(
+    root_agent: Any, tools: list[Any], tool_names: set[str]
+) -> int:
+    """Append reporting ``tools`` to every agent reachable from ``root_agent``.
+
+    Ported from harmonograf's ``_register_harmonograf_reporting_tools_for_test``.
+    Traverses three edges to cover the shapes goldfive must support:
+
+    * ``sub_agents`` — native ADK agent tree.
+    * ``inner_agent`` — wrapper agents (e.g. HarmonografAgent-style).
+    * ``AgentTool.agent`` — agents exposed to a parent as tools.
+
+    Idempotent: agents that already carry any of the canonical reporting
+    tool names are skipped. Returns the number of agents touched.
+    """
+    if root_agent is None or not tools:
+        return 0
+
+    touched = 0
+    seen: set[int] = set()
+    stack: list[Any] = [root_agent]
+    while stack:
+        cur = stack.pop()
+        if cur is None or id(cur) in seen:
+            continue
+        seen.add(id(cur))
+
+        children = list(getattr(cur, "sub_agents", None) or ())
+        inner = getattr(cur, "inner_agent", None)
+        if inner is not None:
+            children.append(inner)
+        for t in getattr(cur, "tools", None) or ():
+            nested = getattr(t, "agent", None)
+            if nested is not None:
+                children.append(nested)
+        for child in children:
+            stack.append(child)
+
+        existing = getattr(cur, "tools", None)
+        if existing is None:
+            # Agent doesn't carry a tool list — nothing to augment.
+            continue
+        existing_names: set[str] = set()
+        for t in existing:
+            n = getattr(t, "name", None) or getattr(
+                getattr(t, "func", None), "__name__", None
+            )
+            if n:
+                existing_names.add(str(n))
+        if any(n in existing_names for n in tool_names):
+            continue
+        new_list = list(existing) + list(tools)
+        try:
+            cur.tools = new_list
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "could not augment tools on %s: %s",
+                getattr(cur, "name", "?"),
+                exc,
+            )
+            continue
+        touched += 1
+
+    if touched:
+        log.info("goldfive: registered reporting tools on %d sub-agents", touched)
+    return touched
+
+
+def _register_plugin_on_runner(runner: Any, plugin: Any) -> bool:
+    """Install ``plugin`` on ``runner``'s plugin manager if one exists.
+
+    Tolerates both ``runner.plugin_manager.register(plugin)`` and the
+    newer ``runner.plugins.append(plugin)`` shapes. Returns True if the
+    plugin was installed.
+    """
+    if runner is None:
+        return False
+    pm = getattr(runner, "plugin_manager", None)
+    if pm is not None:
+        for meth in ("register", "register_plugin", "add"):
+            fn = getattr(pm, meth, None)
+            if callable(fn):
+                try:
+                    fn(plugin)
+                    return True
+                except Exception as exc:  # noqa: BLE001
+                    log.debug("runner.plugin_manager.%s raised: %s", meth, exc)
+        plugins = getattr(pm, "plugins", None)
+        if isinstance(plugins, list):
+            plugins.append(plugin)
+            return True
+    plugins_attr = getattr(runner, "plugins", None)
+    if isinstance(plugins_attr, list):
+        plugins_attr.append(plugin)
+        return True
+    return False
+
+
+def _build_runner(agent: Any) -> Any:
+    """Construct an ADK ``InMemoryRunner`` around a ``BaseAgent``.
+
+    Used by :class:`ADKAdapter` when the caller passes an agent rather
+    than a runner. ``app_name`` defaults to the agent's name for tidy
+    session-service bookkeeping.
+    """
+    from google.adk.runners import InMemoryRunner  # type: ignore
+
+    app_name = str(getattr(agent, "name", "") or "goldfive")
+    return InMemoryRunner(agent=agent, app_name=app_name)
+
+
+def _looks_like_runner(obj: Any) -> bool:
+    """Duck-type check for an ADK Runner.
+
+    Runners expose ``run_async`` / ``agent`` / ``session_service``;
+    agents may expose ``run_async_impl`` but not the session service.
+    """
+    return (
+        callable(getattr(obj, "run_async", None))
+        and getattr(obj, "agent", None) is not None
+    )
+
+
+def _extract_text_from_event(event: Any) -> str:
+    """Return the non-thought text from an ADK ``Event``, if any."""
+    content = getattr(event, "content", None)
+    if content is None:
+        return ""
+    parts = getattr(content, "parts", None) or ()
+    out: list[str] = []
+    for part in parts:
+        if getattr(part, "thought", False):
+            continue
+        text = getattr(part, "text", "") or ""
+        if text:
+            out.append(str(text))
+    return "\n".join(out).strip()
+
+
+def _is_final_event(event: Any) -> bool:
+    """Duck-type check for a terminal ADK event."""
+    attr = getattr(event, "is_final_response", None)
+    if callable(attr):
+        try:
+            return bool(attr())
+        except Exception:
+            return False
+    return bool(attr)
+
+
+def _new_message_parts(task: Task) -> Any:
+    """Build the ADK user ``Content`` the adapter sends for a task turn.
+
+    The agent already reads the richer task metadata from
+    ``session.state`` under the ``goldfive.*`` keys; the message body
+    is just a short imperative nudge so the model has a user turn to
+    respond to.
+    """
+    from google.genai.types import Content, Part  # type: ignore
+
+    title = getattr(task, "title", "") or ""
+    description = getattr(task, "description", "") or ""
+    body_lines = [f"Task: {title}"]
+    if description:
+        body_lines.append(description)
+    body_lines.append(
+        "Use the goldfive.* session-state keys for plan context and call "
+        "the report_task_* tools to report outcome."
+    )
+    return Content(role="user", parts=[Part(text="\n".join(body_lines))])
+
+
+class ADKAdapter:
+    """``AgentAdapter`` for Google's Agent Development Kit.
+
+    Parameters
+    ----------
+    agent_or_runner:
+        Either an ADK ``BaseAgent`` (in which case an ``InMemoryRunner``
+        is constructed and used) or an already-built ``Runner``.
+    user_id:
+        Stable user id for ADK session lookup. Defaults to
+        ``"goldfive_user"`` which is fine for local / single-user runs.
+    session_id:
+        Optional stable session id. When omitted the adapter mints a
+        fresh session id on first :meth:`invoke`.
+    app_name:
+        Optional ADK app_name override. Defaults to the runner's own
+        ``app_name`` or the agent's ``name``.
+    """
+
+    def __init__(
+        self,
+        agent_or_runner: Any,
+        *,
+        user_id: str = "goldfive_user",
+        session_id: str | None = None,
+        app_name: str | None = None,
+    ) -> None:
+        if _looks_like_runner(agent_or_runner):
+            self._runner = agent_or_runner
+            self._agent = getattr(agent_or_runner, "agent", None)
+        else:
+            self._agent = agent_or_runner
+            self._runner = _build_runner(agent_or_runner)
+
+        if self._agent is None:
+            raise ValueError("ADKAdapter: could not resolve an inner agent")
+
+        self._user_id = user_id
+        self._session_id = session_id
+        self._app_name = (
+            app_name
+            or getattr(self._runner, "app_name", None)
+            or getattr(self._agent, "name", None)
+            or "goldfive"
+        )
+
+        host_agent_name = str(getattr(self._agent, "name", "") or "")
+        self._plugin = make_adk_plugin(host_agent_name=host_agent_name)
+        if not _register_plugin_on_runner(self._runner, self._plugin):
+            log.warning(
+                "ADKAdapter: could not attach plugin to runner %r — "
+                "reporting callbacks will be inactive",
+                type(self._runner).__name__,
+            )
+
+        # tool_name -> handler. Populated by register_reporting_tools.
+        self._tool_handlers: dict[str, Any] = {}
+        # The current Steerer. Set by bind_steerer() before invoke().
+        self._steerer: Steerer | None = None
+
+    # ------------------------------------------------------------------
+    # AgentAdapter protocol
+    # ------------------------------------------------------------------
+
+    @property
+    def available_agents(self) -> list[str]:
+        """Return the names of agents reachable from the root agent."""
+        names: list[str] = []
+        seen: set[int] = set()
+        stack: list[Any] = [self._agent]
+        while stack:
+            cur = stack.pop()
+            if cur is None or id(cur) in seen:
+                continue
+            seen.add(id(cur))
+            name = getattr(cur, "name", None)
+            if isinstance(name, str) and name:
+                names.append(name)
+            for sub in getattr(cur, "sub_agents", None) or ():
+                stack.append(sub)
+            inner = getattr(cur, "inner_agent", None)
+            if inner is not None:
+                stack.append(inner)
+            for t in getattr(cur, "tools", None) or ():
+                nested = getattr(t, "agent", None)
+                if nested is not None:
+                    stack.append(nested)
+        return names
+
+    async def register_reporting_tools(
+        self, tools: list[ReportingToolSpec]
+    ) -> None:
+        """Register goldfive reporting tools with the wrapped agent tree.
+
+        Each spec is wrapped as a ``google.adk.tools.FunctionTool`` (via
+        a stub ACK shim) and attached to the inner agent and every
+        sub-agent reachable via :func:`_augment_subtree_with_reporting`.
+        The spec's handler is stored in :attr:`_tool_handlers`; the
+        plugin's ``before_tool_callback`` routes real calls to it.
+        """
+        if not tools:
+            return
+        function_tools: list[Any] = []
+        names: set[str] = set()
+        for spec in tools:
+            name = getattr(spec, "name", "")
+            if not isinstance(name, str) or not name:
+                raise ValueError(f"ReportingToolSpec has no name: {spec!r}")
+            handler = getattr(spec, "handler", None)
+            if handler is None:
+                raise ValueError(
+                    f"ReportingToolSpec '{name}' missing handler"
+                )
+            self._tool_handlers[name] = handler
+            function_tools.append(_build_function_tool(spec))
+            names.add(name)
+
+        # Attach to the inner agent itself (root), then the whole subtree.
+        root_tools = getattr(self._agent, "tools", None)
+        if root_tools is None:
+            try:
+                self._agent.tools = list(function_tools)
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "could not set tools on root agent %s: %s",
+                    getattr(self._agent, "name", "?"),
+                    exc,
+                )
+        else:
+            existing_names: set[str] = set()
+            for t in root_tools:
+                n = getattr(t, "name", None) or getattr(
+                    getattr(t, "func", None), "__name__", None
+                )
+                if n:
+                    existing_names.add(str(n))
+            if not any(n in existing_names for n in names):
+                try:
+                    self._agent.tools = list(root_tools) + list(function_tools)
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "could not augment tools on root agent %s: %s",
+                        getattr(self._agent, "name", "?"),
+                        exc,
+                    )
+
+        _augment_subtree_with_reporting(self._agent, function_tools, names)
+
+    def bind_steerer(self, steerer: Steerer | None) -> None:
+        """Attach the active :class:`~goldfive.protocols.Steerer`.
+
+        Called by the executor before :meth:`invoke` so plugin callbacks
+        can route drift observations. Safe to call with ``None`` to
+        unbind.
+        """
+        self._steerer = steerer
+
+    async def invoke(
+        self, task: Task, session: Session
+    ) -> InvocationResult:
+        """Drive one ADK turn for ``task`` and return the result."""
+        task_id = getattr(task, "id", "") or ""
+        session_id = await self._ensure_session()
+        state = await self._get_session_state(session_id)
+
+        ctx = SessionContext(
+            session=session,
+            steerer=self._steerer,
+            task=task,
+            tool_handlers=self._tool_handlers,
+            host_agent_name=str(getattr(self._agent, "name", "") or ""),
+        )
+
+        # Stash the per-invocation context on ADK state so plugin
+        # callbacks can pick it up. Written directly rather than via
+        # the state protocol because this is an adapter-internal handoff.
+        try:
+            state[SESSION_CONTEXT_STATE_KEY] = ctx  # type: ignore[index]
+        except Exception:
+            log.debug("ADKAdapter.invoke: could not stash session context")
+
+        # Pre-seed the goldfive.* state keys so agents reading session
+        # state before the first before_model_callback see context.
+        if _is_mutable_mapping(state):
+            try:
+                _sp.write_run_id(state, getattr(session, "run_id", "") or "")
+                _sp.write_plan_context(
+                    state,
+                    getattr(session, "plan", None),
+                    getattr(session, "completed_results", {}) or {},
+                    ctx.host_agent_name,
+                )
+                _sp.write_current_task(state, task)
+                _sp.write_tools_available(state, list(self._tool_handlers))
+            except Exception as exc:  # noqa: BLE001
+                log.debug("ADKAdapter.invoke: state pre-seed failed: %s", exc)
+
+        final_text = ""
+        stop_reason = "completed"
+        err: Exception | None = None
+        last_event: Any = None
+        try:
+            new_message = _new_message_parts(task)
+            async for event in self._runner.run_async(
+                user_id=self._user_id,
+                session_id=session_id,
+                new_message=new_message,
+            ):
+                last_event = event
+                text = _extract_text_from_event(event)
+                if text:
+                    final_text = text
+                if _is_final_event(event):
+                    stop_reason = "final_response"
+        except Exception as exc:  # noqa: BLE001
+            err = exc
+            stop_reason = f"error:{type(exc).__name__}"
+            log.debug("ADKAdapter.invoke: runner.run_async raised: %s", exc)
+        finally:
+            if isinstance(state, Mapping):
+                try:
+                    state.pop(SESSION_CONTEXT_STATE_KEY, None)  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+
+        return InvocationResult(
+            task_id=task_id,
+            text=final_text,
+            stop_reason=stop_reason,
+            error=err,
+            raw=last_event,
+        )
+
+    # ------------------------------------------------------------------
+    # Session plumbing
+    # ------------------------------------------------------------------
+
+    async def _ensure_session(self) -> str:
+        """Return the ADK session id, creating one if none has been set."""
+        if self._session_id:
+            return self._session_id
+
+        session_service = getattr(self._runner, "session_service", None)
+        if session_service is None:
+            self._session_id = str(uuid.uuid4())
+            return self._session_id
+
+        new_id = str(uuid.uuid4())
+        try:
+            create = getattr(session_service, "create_session", None)
+            if callable(create):
+                coro = create(
+                    app_name=self._app_name,
+                    user_id=self._user_id,
+                    session_id=new_id,
+                )
+                if hasattr(coro, "__await__"):
+                    await coro
+        except Exception as exc:  # noqa: BLE001
+            log.debug("ADKAdapter._ensure_session: create_session raised: %s", exc)
+        self._session_id = new_id
+        return new_id
+
+    async def _get_session_state(self, session_id: str) -> Any:
+        """Fetch the ADK session's mutable state dict for ``session_id``."""
+        session_service = getattr(self._runner, "session_service", None)
+        if session_service is None:
+            return {}
+        get = getattr(session_service, "get_session", None)
+        if not callable(get):
+            return {}
+        try:
+            coro = get(
+                app_name=self._app_name,
+                user_id=self._user_id,
+                session_id=session_id,
+            )
+            if hasattr(coro, "__await__"):
+                session = await coro
+            else:
+                session = coro
+        except Exception as exc:  # noqa: BLE001
+            log.debug("ADKAdapter._get_session_state: get_session raised: %s", exc)
+            return {}
+        state = getattr(session, "state", None)
+        if state is None:
+            return {}
+        return state
+
+
+def _is_mutable_mapping(obj: Any) -> bool:
+    try:
+        obj[_sp.KEY_RUN_ID] = obj.get(_sp.KEY_RUN_ID, "")  # type: ignore[index]
+        return True
+    except Exception:
+        return False

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -1,0 +1,350 @@
+"""Tests for :mod:`goldfive.adapters.adk`.
+
+Skipped entirely when ``google.adk`` is not installed (optional dep).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from goldfive.reporting import ReportingToolSpec
+from goldfive.types import Plan, Session, Task
+
+# ---------------------------------------------------------------------------
+# Optional-import guard
+# ---------------------------------------------------------------------------
+
+
+def test_optional_import_guard_message() -> None:
+    """When ADK IS installed the module must import cleanly."""
+    import importlib
+
+    mod = importlib.import_module("goldfive.adapters.adk")
+    assert hasattr(mod, "ADKAdapter")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent() -> Any:
+    """Construct a bare ADK ``LlmAgent`` for plugin wiring tests.
+
+    The tests never actually drive an LLM turn — they exercise tool
+    registration and plugin routing via direct callback invocation.
+    """
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(
+        name="test_agent",
+        model="fake-model",
+        description="Test agent",
+        instruction="Test.",
+    )
+
+
+@pytest.fixture
+def state_ctx_cls():
+    """Factory for a minimal ADK-callback-context stub with a state dict."""
+
+    class _Ctx:
+        class _Session:
+            def __init__(self, state: dict) -> None:
+                self.state = state
+
+        def __init__(self, state: dict) -> None:
+            self._state = state
+
+        @property
+        def session(self) -> Any:
+            return _Ctx._Session(self._state)
+
+    return _Ctx
+
+
+class _RecordingSteerer:
+    """Minimal async-capable steerer stub for plugin observation tests."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def observe(self, event: Any, session: Any) -> None:
+        self.events.append(event)
+
+    async def transition(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    def detect_drift(self, event: Any, session: Any) -> None:
+        return None
+
+    def bind(self, **kw: Any) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Reporting-tool registration + routing
+# ---------------------------------------------------------------------------
+
+
+async def test_reporting_tools_registered_on_root_agent() -> None:
+    from goldfive.adapters.adk import ADKAdapter
+
+    agent = _make_agent()
+    adapter = ADKAdapter(agent)
+
+    async def handler(args, session, steerer):
+        return {"acknowledged": True, "echo": dict(args)}
+
+    spec = ReportingToolSpec(
+        name="report_task_started",
+        description="Mark a task as started.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string"},
+                "detail": {"type": "string"},
+            },
+        },
+        handler=handler,
+    )
+
+    await adapter.register_reporting_tools([spec])
+
+    names = [
+        getattr(t, "name", None)
+        or getattr(getattr(t, "func", None), "__name__", None)
+        for t in getattr(agent, "tools", None) or ()
+    ]
+    assert "report_task_started" in names
+
+
+async def test_plugin_routes_reporting_tool_through_handler(state_ctx_cls) -> None:
+    """before_tool_callback intercepts the tool and returns the handler result."""
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+    )
+    from goldfive.adapters.adk import ADKAdapter
+
+    agent = _make_agent()
+    adapter = ADKAdapter(agent)
+
+    invocations: list[dict] = []
+
+    async def handler(args, session, steerer):
+        invocations.append(dict(args))
+        return {"acknowledged": True, "routed": True}
+
+    spec = ReportingToolSpec(
+        name="report_task_completed",
+        description="Mark a task completed.",
+        parameters={"type": "object", "properties": {}},
+        handler=handler,
+    )
+    await adapter.register_reporting_tools([spec])
+
+    session = Session(run_id="run-1")
+    task = Task(id="t1", title="Do the thing")
+    state_dict: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session,
+            steerer=None,
+            task=task,
+            tool_handlers=adapter._tool_handlers,
+            host_agent_name="test_agent",
+        )
+    }
+
+    class _Tool:
+        name = "report_task_completed"
+
+    result = await adapter._plugin.before_tool_callback(
+        tool=_Tool(),
+        tool_args={"task_id": "t1", "summary": "done"},
+        tool_context=state_ctx_cls(state_dict),
+    )
+
+    assert invocations == [{"task_id": "t1", "summary": "done"}]
+    assert isinstance(result, dict)
+    assert result.get("routed") is True
+
+
+async def test_non_reporting_tool_passes_through(state_ctx_cls) -> None:
+    """The plugin returns None for tools it doesn't recognize."""
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=Session(run_id="r"),
+            steerer=None,
+            task=Task(id="t", title="x"),
+            tool_handlers={},
+            host_agent_name="test_agent",
+        )
+    }
+
+    class _Tool:
+        name = "web_search"
+
+    result = await plugin.before_tool_callback(
+        tool=_Tool(),
+        tool_args={"q": "hello"},
+        tool_context=state_ctx_cls(state),
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# State protocol writes
+# ---------------------------------------------------------------------------
+
+
+async def test_before_model_writes_goldfive_state_keys(state_ctx_cls) -> None:
+    """before_model_callback seeds goldfive.* keys for the agent to read."""
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+    from goldfive.adapters._adk_state_protocol import (
+        KEY_CURRENT_TASK_ID,
+        KEY_CURRENT_TASK_TITLE,
+        KEY_PLAN_ID,
+        KEY_RUN_ID,
+        KEY_TOOLS_AVAILABLE,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    session = Session(
+        run_id="run-abc",
+        plan=Plan(
+            id="plan-1",
+            run_id="run-abc",
+            goal_ids=[],
+            tasks=[Task(id="t1", title="Alpha", assignee_agent_id="worker")],
+            edges=[],
+            summary="test plan",
+        ),
+        completed_results={},
+    )
+    task = Task(id="t1", title="Alpha")
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session,
+            steerer=None,
+            task=task,
+            tool_handlers={"report_task_started": lambda *a, **kw: None},
+            host_agent_name="test_agent",
+        )
+    }
+
+    await plugin.before_model_callback(
+        callback_context=state_ctx_cls(state), llm_request=None
+    )
+
+    assert state.get(KEY_RUN_ID) == "run-abc"
+    assert state.get(KEY_PLAN_ID) == "plan-1"
+    assert state.get(KEY_CURRENT_TASK_ID) == "t1"
+    assert state.get(KEY_CURRENT_TASK_TITLE) == "Alpha"
+    assert "report_task_started" in (state.get(KEY_TOOLS_AVAILABLE) or [])
+
+
+# ---------------------------------------------------------------------------
+# Drift observation
+# ---------------------------------------------------------------------------
+
+
+async def test_on_tool_error_calls_steerer_observe(state_ctx_cls) -> None:
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    steerer = _RecordingSteerer()
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=Session(run_id="run-err"),
+            steerer=steerer,
+            task=Task(id="t9", title="Broken step"),
+            tool_handlers={},
+            host_agent_name="test_agent",
+        )
+    }
+
+    class _Tool:
+        name = "web_search"
+
+    await plugin.on_tool_error_callback(
+        tool=_Tool(),
+        tool_args={"q": "x"},
+        tool_context=state_ctx_cls(state),
+        error=RuntimeError("upstream 500"),
+    )
+
+    assert len(steerer.events) == 1
+    evt = steerer.events[0]
+    assert evt["kind"] == "tool_error"
+    assert "web_search" in evt["detail"]
+
+
+async def test_on_event_transfer_calls_steerer_observe(state_ctx_cls) -> None:
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    steerer = _RecordingSteerer()
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=Session(run_id="run-xfer"),
+            steerer=steerer,
+            task=Task(id="t1", title="Handoff"),
+            tool_handlers={},
+            host_agent_name="test_agent",
+        )
+    }
+
+    class _Actions:
+        transfer_to_agent = "other_agent"
+        escalate = False
+
+    class _Event:
+        actions = _Actions()
+
+    await plugin.on_event_callback(
+        invocation_context=state_ctx_cls(state), event=_Event()
+    )
+
+    assert len(steerer.events) == 1
+    assert steerer.events[0]["kind"] == "agent_transfer"
+    assert "other_agent" in steerer.events[0]["detail"]
+
+
+# ---------------------------------------------------------------------------
+# AgentAdapter protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_conforms_to_protocol() -> None:
+    """ADKAdapter must satisfy the AgentAdapter Protocol."""
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.protocols import AgentAdapter
+
+    adapter = ADKAdapter(_make_agent())
+    assert isinstance(adapter, AgentAdapter)
+    # available_agents includes the root agent name at minimum.
+    assert "test_agent" in adapter.available_agents


### PR DESCRIPTION
## Summary

Implements issue #13 — `goldfive.adapters.adk.ADKAdapter` conforming to `goldfive.protocols.AgentAdapter` for Google's Agent Development Kit. Ported from harmonograf's ADK plugin plumbing, stripped of harmonograf-specific state tracking and re-wired against goldfive's `Steerer` / `Session` / `ReportingToolSpec` contract.

- `goldfive/adapters/adk.py` — `ADKAdapter` wrapping an ADK `BaseAgent` or `Runner`. `register_reporting_tools` wraps each `ReportingToolSpec` as a `FunctionTool` around an ACK shim and attaches it to the inner agent plus every reachable sub-agent via a ported `_augment_subtree_with_reporting`. `invoke` stashes a `SessionContext` on ADK state, drives `runner.run_async`, assembles an `InvocationResult`, and cleans up.
- `goldfive/adapters/_adk_plugin.py` — `_GoldfiveADKPlugin(BasePlugin)` with the five callbacks wired to the state protocol (`before_model`), reporting-tool interception (`before_tool`), and `steerer.observe` drift feeds (`after_model`, `on_event` transfer/escalate, `on_tool_error`).
- `goldfive/adapters/_adk_state_protocol.py` — `goldfive.*`-prefixed state key constants and defensive read/write helpers.

ADK is an optional dependency: `import goldfive.adapters.adk` raises `ImportError` with a `pip install goldfive[adk]` hint when `google.adk` is missing. The plugin module imports `BasePlugin` lazily inside `make_adk_plugin`, so it's importable without ADK.

Closes #13.

## Test plan

- [x] `pytest tests/test_adk_adapter.py` (8 tests, gated with `pytest.importorskip('google.adk')`) — covers tool registration, `before_tool_callback` routing, non-reporting pass-through, `before_model_callback` state writes, tool-error and agent-transfer steerer observation, and `isinstance(adapter, AgentAdapter)` protocol conformance.
- [x] `ruff check goldfive/adapters/ tests/test_adk_adapter.py` clean.
- [x] Full `pytest` suite (excl. unrelated `tests/test_sinks.py` proto-import failure): 112 passed, 16 skipped.
- [x] Import-guard manual check: `import goldfive.adapters.adk` raises clear ImportError when ADK missing; `goldfive.adapters._adk_plugin` and `_adk_state_protocol` are importable without ADK.
