### PR TITLE
Port _AdkState state machine into DefaultSteerer

### DIFF
--- a/goldfive/conv.py
+++ b/goldfive/conv.py
@@ -170,6 +170,50 @@ def from_pb_task_edge(msg: Any) -> TaskEdge:
 # ---------------------------------------------------------------------------
 
 
+def _plan_revision_kind_to_pb(value: str, pb: Any) -> int:
+    """Convert a dataclass ``Plan.revision_kind`` (a ``DriftKind`` string
+    value or ``""``) into the matching proto enum int. Empty string →
+    ``DRIFT_KIND_UNSPECIFIED``; unknown value → ``DRIFT_KIND_CUSTOM``.
+    """
+    if not value:
+        return getattr(pb, "DRIFT_KIND_UNSPECIFIED", 0)
+    try:
+        kind = DriftKind(value)
+    except ValueError:
+        return getattr(pb, "DRIFT_KIND_CUSTOM", 0)
+    return _drift_kind_to_pb(kind, pb)
+
+
+def _plan_revision_severity_to_pb(value: str, pb: Any) -> int:
+    if not value:
+        return getattr(pb, "DRIFT_SEVERITY_UNSPECIFIED", 0)
+    try:
+        severity = DriftSeverity(value)
+    except ValueError:
+        return getattr(pb, "DRIFT_SEVERITY_UNSPECIFIED", 0)
+    return _drift_severity_to_pb(severity, pb)
+
+
+def _plan_revision_kind_from_pb(value: int, pb: Any) -> str:
+    try:
+        name = pb.DriftKind.Name(value)
+    except (ValueError, AttributeError):
+        return ""
+    if name == "DRIFT_KIND_UNSPECIFIED":
+        return ""
+    return _drift_kind_from_pb(value, pb).value
+
+
+def _plan_revision_severity_from_pb(value: int, pb: Any) -> str:
+    try:
+        name = pb.DriftSeverity.Name(value)
+    except (ValueError, AttributeError):
+        return ""
+    if name == "DRIFT_SEVERITY_UNSPECIFIED":
+        return ""
+    return _drift_severity_from_pb(value, pb).value
+
+
 def to_pb_plan(plan: Plan) -> Any:
     pb = _pb_module()
     msg = pb.Plan(
@@ -177,8 +221,8 @@ def to_pb_plan(plan: Plan) -> Any:
         run_id=plan.run_id,
         summary=plan.summary,
         revision_reason=plan.revision_reason,
-        revision_kind=plan.revision_kind,
-        revision_severity=plan.revision_severity,
+        revision_kind=_plan_revision_kind_to_pb(plan.revision_kind, pb),
+        revision_severity=_plan_revision_severity_to_pb(plan.revision_severity, pb),
         revision_index=plan.revision_index,
     )
     msg.goal_ids.extend(plan.goal_ids)
@@ -190,6 +234,7 @@ def to_pb_plan(plan: Plan) -> Any:
 
 
 def from_pb_plan(msg: Any) -> Plan:
+    pb = _pb_module()
     return Plan(
         id=msg.id,
         run_id=msg.run_id,
@@ -198,8 +243,8 @@ def from_pb_plan(msg: Any) -> Plan:
         edges=[from_pb_task_edge(e) for e in msg.edges],
         summary=msg.summary,
         revision_reason=msg.revision_reason,
-        revision_kind=msg.revision_kind,
-        revision_severity=msg.revision_severity,
+        revision_kind=_plan_revision_kind_from_pb(msg.revision_kind, pb),
+        revision_severity=_plan_revision_severity_from_pb(msg.revision_severity, pb),
         revision_index=msg.revision_index,
     )
 
@@ -233,11 +278,32 @@ def from_pb_goal(msg: Any) -> Goal:
 # ---------------------------------------------------------------------------
 
 
+def _events_pb_module() -> Any:
+    """Import ``goldfive.pb.goldfive.v1.events_pb2`` lazily.
+
+    ``DriftEvent`` is expressed on the wire as the ``DriftDetected``
+    payload of an ``Event`` envelope (see ``proto/goldfive/v1/events.proto``),
+    so the drift-event round-trip lives in the events module, not the
+    types module.
+    """
+    try:
+        from goldfive.pb.goldfive.v1 import events_pb2
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise ModuleNotFoundError(
+            "goldfive protobuf stubs not available; generate them via "
+            "`make proto` (requires the `proto` optional-dependency group) "
+            "or install the package with the `proto` extra. See issue #3."
+        ) from exc
+    return events_pb2
+
+
 def to_pb_drift_event(evt: DriftEvent) -> Any:
-    pb = _pb_module()
-    return pb.DriftEvent(
-        kind=_drift_kind_to_pb(evt.kind, pb),
-        severity=_drift_severity_to_pb(evt.severity, pb),
+    """Convert a :class:`DriftEvent` to the wire ``DriftDetected`` proto."""
+    types_pb = _pb_module()
+    events_pb = _events_pb_module()
+    return events_pb.DriftDetected(
+        kind=_drift_kind_to_pb(evt.kind, types_pb),
+        severity=_drift_severity_to_pb(evt.severity, types_pb),
         detail=evt.detail,
         current_task_id=evt.current_task_id,
         current_agent_id=evt.current_agent_id,

--- a/goldfive/drift.py
+++ b/goldfive/drift.py
@@ -1,59 +1,214 @@
-"""Drift classifiers (minimal stub until #6 lands).
+"""Drift taxonomy and modular classifiers.
 
-Only the helpers consumed by the Claude adapter are implemented here;
-issue #6 will replace this file with the full taxonomy.
+This module is the single *runtime* entry point for drift taxonomy lookups.
+``DriftKind`` and ``DriftSeverity`` are re-exported from :mod:`goldfive.types`
+so callers that only care about classification can import from one place.
+
+The classifier helpers are deliberately simple, side-effect-free functions
+that take a best-effort view of an upstream event (which can be anything —
+an adapter-native object, a plain dict, a string) and return a
+:class:`DriftEvent` when a signal is detected or ``None`` otherwise.
+
+Heuristics here are ported from harmonograf's ``_AdkState.detect_drift``
+and the tool-response classifier. ADK-specific bits (``function_call``
+parts, ``session.state`` writes, gRPC submissions) are stripped; the
+classifiers operate on framework-neutral shapes.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 from goldfive.types import DriftEvent, DriftKind, DriftSeverity
 
-# Claude Agent SDK stop-reason values that map to a goldfive drift kind.
-# See https://docs.claude.com/en/api/messages streaming docs — the SDK
-# surfaces stop_reason on ResultMessage / AssistantMessage verbatim.
-_CLAUDE_STOP_REASON_MAP: dict[str, DriftKind] = {
-    "max_turns": DriftKind.TOO_MANY_STEPS,
-    "max_tokens": DriftKind.TOO_MANY_STEPS,
-    "stop_sequence": DriftKind.STOPPED_EARLY,
-    "end_turn": DriftKind.STOPPED_EARLY,
-    "refusal": DriftKind.MODEL_REFUSAL,
-    "pause_turn": DriftKind.STOPPED_EARLY,
-}
+__all__ = [
+    "DriftKind",
+    "DriftSeverity",
+    "DriftEvent",
+    "LLM_REFUSAL_MARKERS",
+    "CONTEXT_PRESSURE_STOP_REASONS",
+    "classify_tool_error",
+    "classify_refusal",
+    "classify_stop_reason",
+]
 
 
-def classify_stop_reason(
-    stop_reason: str | None,
-    *,
-    current_task_id: str = "",
-    current_agent_id: str = "",
-    detail: str = "",
-    raw: object = None,
-) -> DriftEvent | None:
-    """Map an adapter-reported ``stop_reason`` to a :class:`DriftEvent`.
+# ---------------------------------------------------------------------------
+# Marker tables (ported from harmonograf_client.adk)
+# ---------------------------------------------------------------------------
 
-    ``tool_use`` — the expected completion cause while the agent is
-    mid-flight — is explicitly a non-drift signal and returns ``None``.
-    Unknown reasons also return ``None`` so callers do not raise drift
-    for benign stops.
+
+# Substrings that indicate an LLM-level refusal in free-form text.
+LLM_REFUSAL_MARKERS: tuple[str, ...] = (
+    "i cannot",
+    "i can't",
+    "i won't",
+    "i will not",
+    "i'm unable",
+    "i am unable",
+    "i refuse",
+    "i must decline",
+    "i'm not able to",
+    "i am not able to",
+    "cannot assist",
+    "can't help with",
+)
+
+# Stop-reason / finish-reason values that indicate the model hit a length
+# cap, content filter, or other truncation event. Normalized to upper-case
+# suffix (after the last ``.``).
+CONTEXT_PRESSURE_STOP_REASONS: frozenset[str] = frozenset(
+    {
+        "MAX_TOKENS",
+        "LENGTH",
+        "MAX_OUTPUT_TOKENS",
+        "TRUNCATED",
+        "CONTENT_FILTER",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _first_marker(text: str, markers: tuple[str, ...]) -> str | None:
+    """Return the first marker from ``markers`` present in lowercased ``text``."""
+    if not text:
+        return None
+    lowered = text.lower()
+    for m in markers:
+        if m in lowered:
+            return m
+    return None
+
+
+def _extract_text(event: Any) -> str:
+    """Best-effort extraction of user-visible text from an opaque event.
+
+    Recognises (in order):
+      * plain ``str`` — returned as-is.
+      * ``dict`` with a ``text`` or ``content`` key — value is stringified.
+      * objects with a ``text`` attribute — the attribute is stringified.
+    Otherwise returns ``""``.
     """
+    if event is None:
+        return ""
+    if isinstance(event, str):
+        return event
+    if isinstance(event, dict):
+        for key in ("text", "content", "message"):
+            v = event.get(key)
+            if isinstance(v, str) and v:
+                return v
+        return ""
+    for attr in ("text", "content", "message"):
+        v = getattr(event, attr, None)
+        if isinstance(v, str) and v:
+            return v
+    return ""
 
-    if not stop_reason:
+
+# ---------------------------------------------------------------------------
+# Classifiers
+# ---------------------------------------------------------------------------
+
+
+def classify_tool_error(event: Any) -> DriftEvent | None:
+    """Return a ``DriftEvent`` of kind ``TOOL_ERROR`` if ``event`` looks
+    like a tool-call result that failed.
+
+    Recognises these shapes:
+      * ``dict`` with a truthy ``error`` key
+      * ``dict`` with ``status`` == ``"FAILED"`` / ``"ERROR"`` (case-insensitive)
+      * ``dict`` with ``ok`` == ``False``
+      * Objects exposing an ``error`` attribute that is truthy
+    """
+    if event is None:
         return None
-    if stop_reason == "tool_use":
+
+    err_detail: str = ""
+    tool_name: str = ""
+    task_id: str = ""
+
+    if isinstance(event, dict):
+        # Accept harmonograf-ish and OpenAI-ish shapes.
+        err = event.get("error")
+        status = str(event.get("status", "") or "").upper()
+        ok = event.get("ok")
+        if err:
+            err_detail = str(err)
+        elif status in {"FAILED", "ERROR"}:
+            err_detail = str(event.get("message", "") or status)
+        elif ok is False:
+            err_detail = str(event.get("message", "") or "tool returned ok=false")
+        tool_name = str(event.get("tool", "") or event.get("name", "") or "")
+        task_id = str(event.get("task_id", "") or "")
+    else:
+        err = getattr(event, "error", None)
+        if err:
+            err_detail = str(err)
+        tool_name = str(getattr(event, "tool", "") or getattr(event, "name", "") or "")
+        task_id = str(getattr(event, "task_id", "") or "")
+
+    if not err_detail:
         return None
-    kind = _CLAUDE_STOP_REASON_MAP.get(stop_reason)
-    if kind is None:
-        return None
-    severity = (
-        DriftSeverity.CRITICAL
-        if kind is DriftKind.MODEL_REFUSAL
-        else DriftSeverity.WARNING
+
+    detail = (
+        f"tool {tool_name!r} errored: {err_detail}"
+        if tool_name
+        else f"tool error: {err_detail}"
     )
     return DriftEvent(
-        kind=kind,
-        severity=severity,
-        detail=detail or f"stop_reason={stop_reason}",
-        current_task_id=current_task_id,
-        current_agent_id=current_agent_id,
-        raw=raw,
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.WARNING,
+        detail=detail,
+        current_task_id=task_id,
+        raw=event,
+    )
+
+
+def classify_refusal(text: Any) -> DriftEvent | None:
+    """Return a ``DriftEvent`` of kind ``AGENT_REFUSAL`` if the text
+    contains any of :data:`LLM_REFUSAL_MARKERS`.
+
+    ``text`` may be a raw string or any object from which
+    :func:`_extract_text` can pull a text payload. Case-insensitive.
+    """
+    s = text if isinstance(text, str) else _extract_text(text)
+    marker = _first_marker(s, LLM_REFUSAL_MARKERS)
+    if marker is None:
+        return None
+    snippet = s[:140]
+    return DriftEvent(
+        kind=DriftKind.AGENT_REFUSAL,
+        severity=DriftSeverity.WARNING,
+        detail=f"refusal marker {marker!r}: {snippet!r}",
+        raw=text,
+    )
+
+
+def classify_stop_reason(reason: Any) -> DriftEvent | None:
+    """Return a ``DriftEvent`` when ``reason`` names a context-pressure
+    stop reason (``MAX_TOKENS``, ``LENGTH``, ``TRUNCATED``, etc.).
+
+    Accepts either a raw string, an enum-like object with a ``.name``
+    attribute, or ``None``. The matched value is normalised to the
+    final ``.``-delimited segment, upper-cased.
+    """
+    if reason is None:
+        return None
+    # Prefer enum-style .name if present; otherwise fall back to str().
+    raw_name = getattr(reason, "name", None) or str(reason)
+    normalised = raw_name.upper().rsplit(".", 1)[-1].strip()
+    if not normalised:
+        return None
+    if normalised not in CONTEXT_PRESSURE_STOP_REASONS:
+        return None
+    return DriftEvent(
+        kind=DriftKind.CONTEXT_PRESSURE,
+        severity=DriftSeverity.WARNING,
+        detail=f"response truncated (stop_reason={normalised})",
+        raw=reason,
     )

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -1,7 +1,21 @@
+"""Reporting-tool specs and handlers.
+
+The seven canonical reporting tools — the agent-facing contract for
+driving the plan's task state machine and signalling plan mutations.
+Each :class:`ReportingToolSpec` pairs a stable tool name with a JSON-schema
+parameters block and an async handler. Handlers receive the decoded
+arguments, the live :class:`Session`, and the bound :class:`Steerer`, and
+route the call into the steerer's transition / drift pipeline.
+
+Adapters materialise these specs into whatever native tool shape their
+framework wants (ADK ``FunctionTool``, Claude Agent SDK tool blocks, …).
+"""
+
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from goldfive.protocols import Steerer
@@ -45,3 +59,301 @@ REPORTING_TOOL_NAMES: tuple[str, ...] = (
     "report_new_work_discovered",
     "report_plan_divergence",
 )
+
+
+# ---------------------------------------------------------------------------
+# Handler shims
+# ---------------------------------------------------------------------------
+
+
+_ACK: dict[str, Any] = {"acknowledged": True}
+
+
+def _str(args: dict[str, Any], key: str, default: str = "") -> str:
+    v = args.get(key, default)
+    if v is None:
+        return default
+    return str(v)
+
+
+def _float(args: dict[str, Any], key: str, default: float = 0.0) -> float:
+    v = args.get(key, default)
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _bool(args: dict[str, Any], key: str, default: bool = True) -> bool:
+    v = args.get(key, default)
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.lower() in {"true", "1", "yes"}
+    return bool(v) if v is not None else default
+
+
+async def _handle_task_started(
+    args: dict[str, Any], session: Session, steerer: Steerer
+) -> dict[str, Any]:
+    task_id = _str(args, "task_id")
+    detail = _str(args, "detail")
+    if task_id:
+        await steerer.mark_task_running(task_id, session=session, detail=detail)
+    return dict(_ACK)
+
+
+async def _handle_task_progress(
+    args: dict[str, Any], session: Session, steerer: Steerer
+) -> dict[str, Any]:
+    task_id = _str(args, "task_id")
+    fraction = _float(args, "fraction")
+    detail = _str(args, "detail")
+    if task_id:
+        await steerer.mark_task_progress(
+            task_id, session=session, fraction=fraction, detail=detail
+        )
+    return dict(_ACK)
+
+
+async def _handle_task_completed(
+    args: dict[str, Any], session: Session, steerer: Steerer
+) -> dict[str, Any]:
+    task_id = _str(args, "task_id")
+    summary = _str(args, "summary")
+    artifacts_raw = args.get("artifacts")
+    artifacts = {
+        str(k): str(v) for k, v in (artifacts_raw or {}).items()
+    } if isinstance(artifacts_raw, dict) else {}
+    if task_id:
+        await steerer.mark_task_completed(
+            task_id, session=session, summary=summary, artifacts=artifacts
+        )
+    return dict(_ACK)
+
+
+async def _handle_task_failed(
+    args: dict[str, Any], session: Session, steerer: Steerer
+) -> dict[str, Any]:
+    task_id = _str(args, "task_id")
+    reason = _str(args, "reason")
+    recoverable = _bool(args, "recoverable", default=True)
+    if task_id:
+        await steerer.mark_task_failed(
+            task_id,
+            session=session,
+            reason=reason,
+            recoverable=recoverable,
+        )
+    return dict(_ACK)
+
+
+async def _handle_task_blocked(
+    args: dict[str, Any], session: Session, steerer: Steerer
+) -> dict[str, Any]:
+    task_id = _str(args, "task_id")
+    blocker = _str(args, "blocker")
+    needed = _str(args, "needed")
+    if task_id:
+        await steerer.mark_task_blocked(
+            task_id, session=session, blocker=blocker, needed=needed
+        )
+    return dict(_ACK)
+
+
+async def _handle_new_work_discovered(
+    args: dict[str, Any], session: Session, steerer: Steerer
+) -> dict[str, Any]:
+    parent_task_id = _str(args, "parent_task_id")
+    title = _str(args, "title")
+    description = _str(args, "description")
+    assignee = _str(args, "assignee")
+    await steerer.report_new_work_discovered(
+        session=session,
+        parent_task_id=parent_task_id,
+        title=title,
+        description=description,
+        assignee=assignee,
+    )
+    return dict(_ACK)
+
+
+async def _handle_plan_divergence(
+    args: dict[str, Any], session: Session, steerer: Steerer
+) -> dict[str, Any]:
+    note = _str(args, "note")
+    suggested_action = _str(args, "suggested_action")
+    await steerer.report_plan_divergence(
+        session=session,
+        note=note,
+        suggested_action=suggested_action,
+    )
+    return dict(_ACK)
+
+
+# ---------------------------------------------------------------------------
+# Parameter schemas (JSON Schema draft-07 style)
+# ---------------------------------------------------------------------------
+
+
+def _object_schema(
+    *, required: list[str], properties: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+_SCHEMA_TASK_STARTED = _object_schema(
+    required=["task_id"],
+    properties={
+        "task_id": {"type": "string"},
+        "detail": {"type": "string"},
+    },
+)
+
+_SCHEMA_TASK_PROGRESS = _object_schema(
+    required=["task_id"],
+    properties={
+        "task_id": {"type": "string"},
+        "fraction": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "detail": {"type": "string"},
+    },
+)
+
+_SCHEMA_TASK_COMPLETED = _object_schema(
+    required=["task_id", "summary"],
+    properties={
+        "task_id": {"type": "string"},
+        "summary": {"type": "string"},
+        "artifacts": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
+    },
+)
+
+_SCHEMA_TASK_FAILED = _object_schema(
+    required=["task_id", "reason"],
+    properties={
+        "task_id": {"type": "string"},
+        "reason": {"type": "string"},
+        "recoverable": {"type": "boolean"},
+    },
+)
+
+_SCHEMA_TASK_BLOCKED = _object_schema(
+    required=["task_id", "blocker"],
+    properties={
+        "task_id": {"type": "string"},
+        "blocker": {"type": "string"},
+        "needed": {"type": "string"},
+    },
+)
+
+_SCHEMA_NEW_WORK_DISCOVERED = _object_schema(
+    required=["parent_task_id", "title", "description"],
+    properties={
+        "parent_task_id": {"type": "string"},
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+        "assignee": {"type": "string"},
+    },
+)
+
+_SCHEMA_PLAN_DIVERGENCE = _object_schema(
+    required=["note"],
+    properties={
+        "note": {"type": "string"},
+        "suggested_action": {"type": "string"},
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Built-in tool specs
+# ---------------------------------------------------------------------------
+
+
+BUILTIN_REPORTING_TOOLS: list[ReportingToolSpec] = [
+    ReportingToolSpec(
+        name="report_task_started",
+        description=(
+            "Report that you are beginning work on a planned task. Call this "
+            "BEFORE doing the actual work so the framework knows which task "
+            "is currently in progress."
+        ),
+        parameters=_SCHEMA_TASK_STARTED,
+        handler=_handle_task_started,
+    ),
+    ReportingToolSpec(
+        name="report_task_progress",
+        description=(
+            "Report mid-task progress. Optional — only call if the task has "
+            "meaningful sub-steps. 'fraction' is a 0.0-1.0 hint of how far "
+            "through the task you are."
+        ),
+        parameters=_SCHEMA_TASK_PROGRESS,
+        handler=_handle_task_progress,
+    ),
+    ReportingToolSpec(
+        name="report_task_completed",
+        description=(
+            "Report that you have completed a planned task successfully. "
+            "Call this AFTER producing the final output. 'summary' describes "
+            "the result in one or two sentences."
+        ),
+        parameters=_SCHEMA_TASK_COMPLETED,
+        handler=_handle_task_completed,
+    ),
+    ReportingToolSpec(
+        name="report_task_failed",
+        description=(
+            "Report that you were unable to complete a planned task. "
+            "'recoverable=True' lets the plan route around this failure; "
+            "'recoverable=False' means the whole workflow should probably stop."
+        ),
+        parameters=_SCHEMA_TASK_FAILED,
+        handler=_handle_task_failed,
+    ),
+    ReportingToolSpec(
+        name="report_task_blocked",
+        description=(
+            "Report that you cannot currently proceed with a task. Use this "
+            "when an external blocker prevents progress. 'blocker' describes "
+            "what is in the way; 'needed' describes what would unblock you."
+        ),
+        parameters=_SCHEMA_TASK_BLOCKED,
+        handler=_handle_task_blocked,
+    ),
+    ReportingToolSpec(
+        name="report_new_work_discovered",
+        description=(
+            "Report that you've discovered additional work the plan doesn't "
+            "know about. The framework will ask the planner to add this task "
+            "as a child of 'parent_task_id'."
+        ),
+        parameters=_SCHEMA_NEW_WORK_DISCOVERED,
+        handler=_handle_new_work_discovered,
+    ),
+    ReportingToolSpec(
+        name="report_plan_divergence",
+        description=(
+            "Report that the current plan no longer matches what needs to "
+            "happen. The framework will trigger an explicit replan."
+        ),
+        parameters=_SCHEMA_PLAN_DIVERGENCE,
+        handler=_handle_plan_divergence,
+    ),
+]
+
+
+__all__ = [
+    "ReportingHandler",
+    "ReportingToolSpec",
+    "REPORTING_TOOL_NAMES",
+    "BUILTIN_REPORTING_TOOLS",
+]

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -1,0 +1,570 @@
+"""The framework-agnostic :class:`DefaultSteerer`.
+
+Port of harmonograf's ``_AdkState`` task state machine and drift detector,
+with all ADK callback plumbing, ``session.state`` writes, and gRPC calls
+stripped out. The steerer's job is:
+
+* Mutate :class:`Session`'s plan task statuses in response to reporting
+  tool calls (the ``mark_task_*`` family).
+* Emit a corresponding proto ``Event`` to every bound ``EventSink`` for
+  each transition, drift detection, and plan revision.
+* Observe raw upstream events, classify drift, and — if the drift rises
+  to ``WARNING`` or above — call ``Planner.refine`` and apply the new
+  plan (emitting ``PlanRevised``).
+
+The steerer holds no gRPC / client references and touches no adapter
+internals. Executors call :meth:`DefaultSteerer.bind` to wire in the
+sinks list and planner at run start.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from goldfive.drift import (
+    classify_refusal,
+    classify_stop_reason,
+    classify_tool_error,
+)
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Plan,
+    Session,
+    Task,
+    TaskStatus,
+)
+
+if TYPE_CHECKING:
+    from goldfive.protocols import EventSink, Planner
+
+
+__all__ = ["DefaultSteerer"]
+
+
+# Task statuses that are terminal (no further transitions allowed).
+_TERMINAL_TASK_STATUSES: frozenset[TaskStatus] = frozenset(
+    {
+        TaskStatus.COMPLETED,
+        TaskStatus.FAILED,
+        TaskStatus.CANCELLED,
+    }
+)
+
+
+# Ordered severities so we can compare with ``>=``.
+_SEVERITY_ORDER: dict[DriftSeverity, int] = {
+    DriftSeverity.INFO: 0,
+    DriftSeverity.WARNING: 1,
+    DriftSeverity.CRITICAL: 2,
+}
+
+
+def _severity_ge(a: DriftSeverity, b: DriftSeverity) -> bool:
+    return _SEVERITY_ORDER[a] >= _SEVERITY_ORDER[b]
+
+
+# ---------------------------------------------------------------------------
+# DefaultSteerer
+# ---------------------------------------------------------------------------
+
+
+class DefaultSteerer:
+    """The canonical :class:`Steerer` implementation.
+
+    Bind via :meth:`bind`, then call the ``mark_task_*`` family (usually
+    from reporting-tool handlers) to drive task transitions. The executor
+    calls :meth:`observe` for each raw upstream event to let the steerer
+    classify drift and (optionally) trigger a plan refine.
+    """
+
+    def __init__(self) -> None:
+        self._sinks: list[Any] = []
+        self._planner: Any | None = None
+        # Per-session, per-kind last-refine bookkeeping. Purely advisory:
+        # callers can subclass to throttle on top of this if needed.
+        self._last_refine_kind: dict[tuple[str, DriftKind], int] = {}
+
+    # ------------------------------------------------------------------
+    # Protocol-required: wiring
+    # ------------------------------------------------------------------
+
+    def bind(self, *, sinks: list[EventSink], planner: Planner) -> None:
+        self._sinks = list(sinks)
+        self._planner = planner
+
+    # ------------------------------------------------------------------
+    # Protocol-required: transition (generic)
+    # ------------------------------------------------------------------
+
+    async def transition(
+        self,
+        task_id: str,
+        to: TaskStatus,
+        *,
+        detail: str = "",
+        session: Session,
+    ) -> None:
+        """Generic transition entry point.
+
+        Dispatches to the corresponding ``mark_task_*`` method. Unknown
+        target statuses are a no-op (we don't invent new transitions).
+        """
+        if to is TaskStatus.RUNNING:
+            await self.mark_task_running(task_id, session=session, detail=detail)
+        elif to is TaskStatus.COMPLETED:
+            await self.mark_task_completed(
+                task_id, summary=detail, session=session
+            )
+        elif to is TaskStatus.FAILED:
+            await self.mark_task_failed(
+                task_id, reason=detail, session=session
+            )
+        elif to is TaskStatus.BLOCKED:
+            await self.mark_task_blocked(
+                task_id, blocker=detail, session=session
+            )
+        elif to is TaskStatus.CANCELLED:
+            await self.mark_task_cancelled(
+                task_id, reason=detail, session=session
+            )
+        # PENDING and UNSPECIFIED are intentionally not reachable from
+        # here; transitions are always forward in the lifecycle.
+
+    # ------------------------------------------------------------------
+    # Task state machine
+    # ------------------------------------------------------------------
+
+    async def mark_task_running(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        detail: str = "",
+    ) -> None:
+        """Transition ``task_id`` to ``RUNNING`` and emit ``TaskStarted``."""
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return
+        task.status = TaskStatus.RUNNING
+        session.current_task_id = task_id
+        if detail:
+            session.agent_notes[task_id] = detail
+        await self._emit_task_started(session, task_id, detail)
+
+    async def mark_task_progress(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        fraction: float = 0.0,
+        detail: str = "",
+    ) -> None:
+        """Record mid-task progress and emit ``TaskProgress``.
+
+        No status transition — a progress update is a liveness ping only.
+        ``fraction`` is clamped to ``[0.0, 1.0]``.
+        """
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        try:
+            frac = float(fraction)
+        except (TypeError, ValueError):
+            frac = 0.0
+        frac = max(0.0, min(1.0, frac))
+        session.task_progress[task_id] = frac
+        if detail:
+            session.agent_notes[task_id] = detail
+        await self._emit_task_progress(session, task_id, frac, detail)
+
+    async def mark_task_completed(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        summary: str = "",
+        artifacts: dict[str, str] | None = None,
+    ) -> None:
+        """Transition ``task_id`` to ``COMPLETED`` and emit ``TaskCompleted``."""
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return
+        task.status = TaskStatus.COMPLETED
+        if summary:
+            session.completed_results[task_id] = summary
+        await self._emit_task_completed(session, task_id, summary, artifacts or {})
+
+    async def mark_task_failed(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        reason: str = "",
+        recoverable: bool = True,
+    ) -> None:
+        """Transition ``task_id`` to ``FAILED`` and emit ``TaskFailed``.
+
+        Also fires a drift event of kind ``TASK_FAILED_RECOVERABLE`` or
+        ``TASK_FAILED_FATAL``. The drift event is dispatched through the
+        same drift pipeline as observer-detected drift: if severity is
+        ``>= WARNING`` (both of these are) we invoke ``planner.refine``.
+        """
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return
+        task.status = TaskStatus.FAILED
+        await self._emit_task_failed(session, task_id, reason, recoverable)
+        kind = (
+            DriftKind.TASK_FAILED_RECOVERABLE
+            if recoverable
+            else DriftKind.TASK_FAILED_FATAL
+        )
+        severity = (
+            DriftSeverity.WARNING if recoverable else DriftSeverity.CRITICAL
+        )
+        drift = DriftEvent(
+            kind=kind,
+            severity=severity,
+            detail=f"task {task_id} failed: {reason}" if reason else f"task {task_id} failed",
+            current_task_id=task_id,
+        )
+        await self._handle_drift(drift, session)
+
+    async def mark_task_blocked(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        blocker: str = "",
+        needed: str = "",
+    ) -> None:
+        """Transition ``task_id`` to ``BLOCKED`` and emit ``TaskBlocked``.
+
+        Also fires a drift event of kind ``BLOCKED`` which flows through
+        the standard drift pipeline (WARNING severity → refine).
+        """
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return
+        # BLOCKED is not a terminal status but we still guard against
+        # re-blocking a task that's already blocked (idempotent).
+        task.status = TaskStatus.BLOCKED
+        if blocker or needed:
+            session.agent_notes[task_id] = (
+                f"blocked: {blocker}"
+                + (f" (needed: {needed})" if needed else "")
+            )
+        await self._emit_task_blocked(session, task_id, blocker, needed)
+        detail = (
+            f"task {task_id} blocked: {blocker}"
+            + (f" (needed: {needed})" if needed else "")
+        )
+        drift = DriftEvent(
+            kind=DriftKind.BLOCKED,
+            severity=DriftSeverity.WARNING,
+            detail=detail,
+            current_task_id=task_id,
+        )
+        await self._handle_drift(drift, session)
+
+    async def mark_task_cancelled(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        reason: str = "",
+    ) -> None:
+        """Transition ``task_id`` to ``CANCELLED`` and emit ``TaskCancelled``."""
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return
+        task.status = TaskStatus.CANCELLED
+        await self._emit_task_cancelled(session, task_id, reason)
+
+    # ------------------------------------------------------------------
+    # Observer: drift detection + refine
+    # ------------------------------------------------------------------
+
+    async def observe(self, event: Any, session: Session) -> None:
+        """Inspect ``event``, classify drift, and refine if severe enough.
+
+        Never raises on a normal event — a detector returning ``None``
+        simply means "nothing to report". Only explicit classifier
+        mis-behaviour would surface here, and we let that propagate.
+        """
+        drift = self.detect_drift(event, session)
+        if drift is None:
+            return
+        await self._handle_drift(drift, session)
+
+    def detect_drift(
+        self,
+        event: Any,
+        session: Session,  # noqa: ARG002 — reserved for future heuristics
+    ) -> DriftEvent | None:
+        """Classify ``event`` via the modular classifiers in :mod:`drift`.
+
+        Classifiers are tried in order of specificity: tool-error shapes
+        first (most structured), then refusal markers in text, then
+        stop-reason tokens. The first match wins.
+        """
+        drift = classify_tool_error(event)
+        if drift is not None:
+            return drift
+
+        # Refusal scan — tolerates raw strings, dicts, objects.
+        drift = classify_refusal(event)
+        if drift is not None:
+            return drift
+
+        # Stop-reason scan — prefer explicit field on dicts / objects.
+        stop_reason: Any = None
+        if isinstance(event, dict):
+            stop_reason = event.get("stop_reason") or event.get("finish_reason")
+        else:
+            stop_reason = getattr(event, "stop_reason", None) or getattr(
+                event, "finish_reason", None
+            )
+        if stop_reason is not None:
+            drift = classify_stop_reason(stop_reason)
+            if drift is not None:
+                return drift
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Plan-mutation drift hooks (invoked by reporting-tool handlers)
+    # ------------------------------------------------------------------
+
+    async def report_new_work_discovered(
+        self,
+        *,
+        session: Session,
+        parent_task_id: str,
+        title: str,
+        description: str,
+        assignee: str = "",
+    ) -> None:
+        """Fire a ``NEW_WORK_DISCOVERED`` drift event → triggers refine."""
+        detail = (
+            f"new work under {parent_task_id}: {title}: {description}"
+            + (f" (assignee={assignee})" if assignee else "")
+        )
+        drift = DriftEvent(
+            kind=DriftKind.NEW_WORK_DISCOVERED,
+            severity=DriftSeverity.WARNING,
+            detail=detail,
+            current_task_id=parent_task_id,
+            current_agent_id=assignee,
+        )
+        await self._handle_drift(drift, session)
+
+    async def report_plan_divergence(
+        self,
+        *,
+        session: Session,
+        note: str,
+        suggested_action: str = "",
+    ) -> None:
+        """Fire a ``PLAN_DIVERGENCE`` drift event → triggers refine."""
+        session.divergence_flag = True
+        detail = (
+            f"{note} (suggested: {suggested_action})"
+            if suggested_action
+            else note
+        )
+        drift = DriftEvent(
+            kind=DriftKind.PLAN_DIVERGENCE,
+            severity=DriftSeverity.WARNING,
+            detail=detail,
+            current_task_id=session.current_task_id,
+        )
+        await self._handle_drift(drift, session)
+
+    # ==================================================================
+    # Internals
+    # ==================================================================
+
+    # --- Plan lookup --------------------------------------------------
+
+    @staticmethod
+    def _find_task(session: Session, task_id: str) -> Task | None:
+        if not task_id or session.plan is None:
+            return None
+        for t in session.plan.tasks:
+            if t.id == task_id:
+                return t
+        return None
+
+    # --- Drift dispatch ----------------------------------------------
+
+    async def _handle_drift(self, drift: DriftEvent, session: Session) -> None:
+        """Emit a ``DriftDetected`` event and (if severe enough) refine."""
+        await self._emit_drift_detected(session, drift)
+        if not _severity_ge(drift.severity, DriftSeverity.WARNING):
+            return
+        if self._planner is None or session.plan is None:
+            return
+        try:
+            revised = await self._planner.refine(
+                plan=session.plan,
+                drift=drift,
+                goals=list(session.goals),
+            )
+        except Exception:  # noqa: BLE001 — refine errors must not break the run
+            return
+        if revised is None:
+            return
+        self._apply_revision(session, revised, drift)
+        await self._emit_plan_revised(session, revised, drift)
+
+    @staticmethod
+    def _apply_revision(
+        session: Session, revised: Plan, drift: DriftEvent
+    ) -> None:
+        """Stamp revision metadata and install ``revised`` on the session.
+
+        Preserves the existing ``revision_index`` monotonicity: the new
+        plan's index is at least ``old.revision_index + 1``.
+        """
+        prev = session.plan
+        next_index = (prev.revision_index + 1) if prev is not None else 1
+        if revised.revision_index < next_index:
+            revised.revision_index = next_index
+        if not revised.revision_kind:
+            revised.revision_kind = drift.kind.value
+        if not revised.revision_severity:
+            revised.revision_severity = drift.severity.value
+        if not revised.revision_reason:
+            revised.revision_reason = drift.detail
+        session.plan = revised
+
+    # --- Event construction ------------------------------------------
+
+    def _new_envelope(self, session: Session) -> Any:
+        """Build a fresh ``Event`` envelope via :mod:`goldfive.events`."""
+        from goldfive.events import new_event
+
+        return new_event(session.run_id, session.next_sequence())
+
+    async def _emit(self, event_pb: Any) -> None:
+        from goldfive.events import emit
+
+        await emit(self._sinks, event_pb)
+
+    @staticmethod
+    def _drift_kind_pb_value(kind: DriftKind) -> int:
+        from goldfive.pb.goldfive.v1 import types_pb2
+
+        name = f"DRIFT_KIND_{kind.name}"
+        return getattr(
+            types_pb2, name, getattr(types_pb2, "DRIFT_KIND_CUSTOM", 0)
+        )
+
+    @staticmethod
+    def _drift_severity_pb_value(severity: DriftSeverity) -> int:
+        from goldfive.pb.goldfive.v1 import types_pb2
+
+        name = f"DRIFT_SEVERITY_{severity.name}"
+        return getattr(
+            types_pb2, name, getattr(types_pb2, "DRIFT_SEVERITY_UNSPECIFIED", 0)
+        )
+
+    # --- Concrete emitters -------------------------------------------
+
+    async def _emit_task_started(
+        self, session: Session, task_id: str, detail: str
+    ) -> None:
+        evt = self._new_envelope(session)
+        evt.task_started.task_id = task_id
+        evt.task_started.detail = detail
+        await self._emit(evt)
+
+    async def _emit_task_progress(
+        self, session: Session, task_id: str, fraction: float, detail: str
+    ) -> None:
+        evt = self._new_envelope(session)
+        evt.task_progress.task_id = task_id
+        evt.task_progress.fraction = fraction
+        evt.task_progress.detail = detail
+        await self._emit(evt)
+
+    async def _emit_task_completed(
+        self,
+        session: Session,
+        task_id: str,
+        summary: str,
+        artifacts: dict[str, str],
+    ) -> None:
+        evt = self._new_envelope(session)
+        evt.task_completed.task_id = task_id
+        evt.task_completed.summary = summary
+        for k, v in artifacts.items():
+            evt.task_completed.artifacts[k] = v
+        await self._emit(evt)
+
+    async def _emit_task_failed(
+        self, session: Session, task_id: str, reason: str, recoverable: bool
+    ) -> None:
+        evt = self._new_envelope(session)
+        evt.task_failed.task_id = task_id
+        evt.task_failed.reason = reason
+        evt.task_failed.recoverable = recoverable
+        await self._emit(evt)
+
+    async def _emit_task_blocked(
+        self, session: Session, task_id: str, blocker: str, needed: str
+    ) -> None:
+        evt = self._new_envelope(session)
+        evt.task_blocked.task_id = task_id
+        evt.task_blocked.blocker = blocker
+        evt.task_blocked.needed = needed
+        await self._emit(evt)
+
+    async def _emit_task_cancelled(
+        self, session: Session, task_id: str, reason: str
+    ) -> None:
+        evt = self._new_envelope(session)
+        evt.task_cancelled.task_id = task_id
+        evt.task_cancelled.reason = reason
+        await self._emit(evt)
+
+    async def _emit_drift_detected(
+        self, session: Session, drift: DriftEvent
+    ) -> None:
+        evt = self._new_envelope(session)
+        evt.drift_detected.kind = self._drift_kind_pb_value(drift.kind)
+        evt.drift_detected.severity = self._drift_severity_pb_value(
+            drift.severity
+        )
+        evt.drift_detected.detail = drift.detail
+        evt.drift_detected.current_task_id = drift.current_task_id
+        evt.drift_detected.current_agent_id = drift.current_agent_id
+        await self._emit(evt)
+
+    async def _emit_plan_revised(
+        self, session: Session, revised: Plan, drift: DriftEvent
+    ) -> None:
+        from goldfive.conv import to_pb_plan
+
+        evt = self._new_envelope(session)
+        evt.plan_revised.plan.CopyFrom(to_pb_plan(revised))
+        evt.plan_revised.drift_kind = self._drift_kind_pb_value(drift.kind)
+        evt.plan_revised.severity = self._drift_severity_pb_value(
+            drift.severity
+        )
+        evt.plan_revised.reason = drift.detail
+        evt.plan_revised.revision_index = revised.revision_index
+        await self._emit(evt)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dev = [
     "pytest-asyncio>=0.23",
     "ruff>=0.5",
     "mypy>=1.10",
+    # Proto stubs are generated on demand by ``tests/_pbsetup.py`` so the
+    # steerer / reporting tests can exercise the real proto round-trip
+    # before issue #3 lands.
+    "protobuf>=4.25",
+    "grpcio-tools>=1.60",
 ]
 examples = [
     "rich>=13.0",
@@ -61,6 +66,7 @@ include = [
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+extend-exclude = ["goldfive/pb"]
 
 [tool.ruff.lint]
 select = [

--- a/tests/_pbsetup.py
+++ b/tests/_pbsetup.py
@@ -1,0 +1,97 @@
+"""Generate goldfive proto stubs on demand for steerer / reporting tests.
+
+This is imported (and invoked) only by the test modules that actually need
+the stubs. It intentionally lives outside ``conftest.py`` so modules with
+their own skip logic (``tests/test_conv.py``) are not forced to see the
+generated stubs — their skip predicate re-runs at their import time, and we
+don't want to flip their behaviour from "skipped" to "fail due to bugs in
+the sibling PR this PR consumes".
+
+When issue #3 lands and ``goldfive/pb`` is populated by ``make proto``,
+this helper is a no-op.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import pathlib
+import sys
+
+
+def _pb_available() -> bool:
+    try:
+        return (
+            importlib.util.find_spec("goldfive.pb.goldfive.v1.events_pb2") is not None
+        )
+    except (ModuleNotFoundError, ImportError):
+        return False
+
+
+def ensure_pb_available() -> bool:
+    """Return True iff ``goldfive.pb.goldfive.v1.*`` is importable.
+
+    Attempts one on-demand compilation of the vendored ``.proto`` sources
+    under ``tests/_proto/`` if ``grpc_tools.protoc`` is installed.
+    """
+    if _pb_available():
+        return True
+
+    try:
+        from grpc_tools import protoc  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        return False
+
+    tests_dir = pathlib.Path(__file__).resolve().parent
+    proto_root = tests_dir / "_proto"
+    if not proto_root.exists():
+        return False
+
+    repo_root = tests_dir.parent
+    out_dir = repo_root / "goldfive" / "pb"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # protoc emits absolute imports of the form ``from goldfive.v1 import
+    # types_pb2`` inside the generated modules. Because the outer package is
+    # also named ``goldfive``, those imports would normally fail: we extend
+    # the outer package's ``__path__`` from this inner ``__init__.py`` so
+    # ``goldfive.v1`` resolves to ``goldfive/pb/goldfive/v1/``.
+    init_body = (
+        "from __future__ import annotations\n"
+        "import os as _os\n"
+        "import sys as _sys\n"
+        "_inner = _os.path.join(_os.path.dirname(_os.path.abspath(__file__)), 'goldfive')\n"
+        "_outer = _sys.modules.get('goldfive')\n"
+        "if _outer is not None and hasattr(_outer, '__path__'):\n"
+        "    if _inner not in list(_outer.__path__):\n"
+        "        _outer.__path__.append(_inner)\n"
+    )
+    (out_dir / "__init__.py").write_text(init_body)
+    (out_dir / "goldfive").mkdir(parents=True, exist_ok=True)
+    (out_dir / "goldfive" / "__init__.py").touch(exist_ok=True)
+    (out_dir / "goldfive" / "v1").mkdir(parents=True, exist_ok=True)
+    (out_dir / "goldfive" / "v1" / "__init__.py").touch(exist_ok=True)
+
+    proto_files = list(proto_root.rglob("*.proto"))
+    if not proto_files:
+        return False
+
+    grpc_tools_pkg = pathlib.Path(protoc.__file__).resolve().parent
+    well_known = grpc_tools_pkg / "_proto"
+
+    args = [
+        "grpc_tools.protoc",
+        f"--proto_path={proto_root}",
+        f"--proto_path={well_known}",
+        f"--python_out={out_dir}",
+        f"--pyi_out={out_dir}",
+        *[str(p) for p in proto_files],
+    ]
+    rc = protoc.main(args)
+    if rc != 0:
+        return False
+
+    importlib.invalidate_caches()
+    # Force ``goldfive`` namespace re-scan so the new subpackage is picked up.
+    if "goldfive" in sys.modules:
+        importlib.reload(sys.modules["goldfive"])
+    return _pb_available()

--- a/tests/_proto/goldfive/v1/events.proto
+++ b/tests/_proto/goldfive/v1/events.proto
@@ -1,0 +1,173 @@
+// Goldfive v1 — EventSink wire surface.
+//
+// `Event` is the envelope every goldfive EventSink receives. The oneof
+// `payload` holds exactly one event-specific message. Sinks dispatch on
+// the payload case and render or forward accordingly.
+//
+// Ordering contract: within a single run_id the `sequence` field is
+// monotonically increasing and gap-free starting at 0. Sinks that batch
+// or reorder must reassemble by sequence before user-visible output.
+// `emitted_at` is advisory (wall clock, not monotonic) — use sequence
+// for ordering.
+
+syntax = "proto3";
+
+package goldfive.v1;
+
+import "google/protobuf/timestamp.proto";
+
+import "goldfive/v1/types.proto";
+
+option go_package = "github.com/pedapudi/goldfive/gen/goldfive/v1;goldfivev1";
+
+// ---------------------------------------------------------------------------
+// Event envelope
+// ---------------------------------------------------------------------------
+
+// Event is the uniform envelope wrapping every goldfive event. Sinks
+// receive a stream of these; the `payload` oneof identifies which
+// event-specific message is attached.
+message Event {
+  // Globally unique id for this event (UUIDv7 recommended so sinks can
+  // dedupe after a reconnect without comparing payload bytes).
+  string event_id = 1;
+  // Run this event belongs to. A "run" is one top-level invocation of
+  // the wrapped agent — same value on every event from RunStarted to
+  // RunCompleted / RunAborted.
+  string run_id = 2;
+  // Per-run monotonic sequence starting at 0. Gap-free.
+  uint64 sequence = 3;
+  // Wall-clock emission time. Advisory only; use `sequence` for order.
+  google.protobuf.Timestamp emitted_at = 4;
+
+  oneof payload {
+    RunStarted run_started = 10;
+    GoalDerived goal_derived = 11;
+    PlanSubmitted plan_submitted = 12;
+    PlanRevised plan_revised = 13;
+    TaskStarted task_started = 14;
+    TaskProgress task_progress = 15;
+    TaskCompleted task_completed = 16;
+    TaskFailed task_failed = 17;
+    TaskBlocked task_blocked = 18;
+    TaskCancelled task_cancelled = 19;
+    DriftDetected drift_detected = 20;
+    RunCompleted run_completed = 21;
+    RunAborted run_aborted = 22;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-event payloads
+// ---------------------------------------------------------------------------
+
+// First event on every run. The run_id here duplicates Event.run_id for
+// sinks that consume payloads without the envelope; the two MUST match.
+message RunStarted {
+  string run_id = 1;
+  // One-line natural-language description of what the user asked for,
+  // suitable for a sink header or notification.
+  string goal_summary = 2;
+  google.protobuf.Timestamp started_at = 3;
+}
+
+// Goals the goal-derivation step produced from the user's raw input.
+// Emitted once per run, before the first PlanSubmitted.
+message GoalDerived {
+  repeated Goal goals = 1;
+}
+
+// The planner's initial plan for the run. The plan's `revision_index`
+// MUST be 0; subsequent revisions arrive as PlanRevised events.
+message PlanSubmitted {
+  Plan plan = 1;
+}
+
+// A revised plan, emitted by the observer in response to drift. The
+// plan's `revision_index` is monotonically greater than the previous
+// plan on this run. `drift_kind`, `severity`, and `reason` duplicate
+// the same fields inside `plan` for sinks that want the revision
+// metadata without unpacking the plan.
+message PlanRevised {
+  Plan plan = 1;
+  DriftKind drift_kind = 2;
+  DriftSeverity severity = 3;
+  string reason = 4;
+  uint32 revision_index = 5;
+}
+
+// Task transitioned PENDING -> RUNNING.
+message TaskStarted {
+  string task_id = 1;
+  // Optional free-text detail (e.g. the tool about to be called).
+  string detail = 2;
+}
+
+// Progress update for a running task. `fraction` is [0.0, 1.0] if the
+// task supports progress reporting, otherwise 0. Sinks MAY render a
+// progress bar; most will surface `detail` as a live status line.
+message TaskProgress {
+  string task_id = 1;
+  float fraction = 2;
+  string detail = 3;
+}
+
+// Task transitioned RUNNING -> COMPLETED. `artifacts` is a free-form
+// map of artifact name -> opaque reference (URL, digest, path, etc.);
+// the framework does not interpret it, sinks surface it as-is.
+message TaskCompleted {
+  string task_id = 1;
+  string summary = 2;
+  map<string, string> artifacts = 3;
+}
+
+// Task transitioned to FAILED. `recoverable` signals whether the
+// framework will request a plan revision (true) vs. abort the run
+// (false).
+message TaskFailed {
+  string task_id = 1;
+  string reason = 2;
+  bool recoverable = 3;
+}
+
+// Task transitioned to BLOCKED. The framework typically follows this
+// with a DriftDetected of kind DRIFT_KIND_BLOCKED.
+message TaskBlocked {
+  string task_id = 1;
+  // Short description of what is blocking the task.
+  string blocker = 2;
+  // What would unblock it (a tool, an input, a human ack).
+  string needed = 3;
+}
+
+// Task transitioned to CANCELLED, usually in response to user steering
+// or a plan revision that dropped the task.
+message TaskCancelled {
+  string task_id = 1;
+  string reason = 2;
+}
+
+// Observer-detected drift. Sinks surface this as a timeline marker and
+// may forward it upstream (e.g. the harmonograf sink emits a
+// corresponding drift annotation). Typically followed by a PlanRevised
+// event once the framework produces a new plan.
+message DriftDetected {
+  DriftKind kind = 1;
+  DriftSeverity severity = 2;
+  string detail = 3;
+  // Task that was running when drift was detected, if any.
+  string current_task_id = 4;
+  // Agent that was active when drift was detected, if any.
+  string current_agent_id = 5;
+}
+
+// Terminal event on a successful run.
+message RunCompleted {
+  string outcome_summary = 1;
+}
+
+// Terminal event on an aborted run (framework-level failure, user
+// cancel, or a TaskFailed with recoverable=false).
+message RunAborted {
+  string reason = 1;
+}

--- a/tests/_proto/goldfive/v1/types.proto
+++ b/tests/_proto/goldfive/v1/types.proto
@@ -1,0 +1,159 @@
+// Goldfive v1 — core data types.
+//
+// These are the wire primitives that goldfive's EventSink surface
+// (events.proto) references. They are deliberately parallel to
+// harmonograf/v1/types.proto for the overlapping concepts (TaskStatus,
+// Task, TaskEdge, Plan revision metadata) so a goldfive -> harmonograf
+// sink can port values mechanically.
+//
+// Python-side dataclasses and converters live alongside the generated
+// stubs (see goldfive/conv.py, tracked separately in issue #4).
+
+syntax = "proto3";
+
+package goldfive.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/pedapudi/goldfive/gen/goldfive/v1;goldfivev1";
+
+// ---------------------------------------------------------------------------
+// Goals
+// ---------------------------------------------------------------------------
+
+// A Goal is the user's intent in a form the agent can plan against.
+// Goals are produced by the goal-derivation step that runs before the
+// planner sees the user's raw input.
+//
+// The framework lets callers attach a Python-side success predicate to a
+// goal (a callable evaluated against the run state). Predicates cannot
+// cross the proto boundary, so `has_success_predicate` just signals its
+// presence for observability; sinks render a badge or similar.
+message Goal {
+  string id = 1;
+  string summary = 2;
+  map<string, string> metadata = 3;
+  // True when the framework has a Python-side predicate attached to this
+  // goal. Predicate bodies are never serialized.
+  optional bool has_success_predicate = 4;
+}
+
+// ---------------------------------------------------------------------------
+// Plans and tasks
+// ---------------------------------------------------------------------------
+
+// Lifecycle of a task within a plan.
+//
+// Mirrors harmonograf.v1.TaskStatus with the addition of BLOCKED, which
+// goldfive emits when a task is waiting on an external input (a tool,
+// another agent, a human). Harmonograf does not need a BLOCKED status
+// because its data model expresses that state via AWAITING_HUMAN on the
+// bound span.
+enum TaskStatus {
+  TASK_STATUS_UNSPECIFIED = 0;
+  TASK_STATUS_PENDING = 1;
+  TASK_STATUS_RUNNING = 2;
+  TASK_STATUS_COMPLETED = 3;
+  TASK_STATUS_FAILED = 4;
+  TASK_STATUS_CANCELLED = 5;
+  TASK_STATUS_BLOCKED = 6;
+}
+
+// Severity of a drift event or of the drift that triggered a plan
+// revision. INFO is informational only (sinks may surface as a hint);
+// WARNING is actionable; CRITICAL requires human attention or stops the
+// run.
+enum DriftSeverity {
+  DRIFT_SEVERITY_UNSPECIFIED = 0;
+  DRIFT_SEVERITY_INFO = 1;
+  DRIFT_SEVERITY_WARNING = 2;
+  DRIFT_SEVERITY_CRITICAL = 3;
+}
+
+// Structured taxonomy of drift the observer can detect. Enum values
+// mirror harmonograf's drift kinds (see harmonograf client adk.py) so
+// sinks that forward to harmonograf can map 1:1 where the kinds overlap.
+// CUSTOM is an escape hatch paired with DriftDetected.detail.
+enum DriftKind {
+  DRIFT_KIND_UNSPECIFIED = 0;
+  DRIFT_KIND_TOOL_ERROR = 1;
+  DRIFT_KIND_AGENT_REFUSAL = 2;
+  DRIFT_KIND_NEW_WORK_DISCOVERED = 3;
+  DRIFT_KIND_PLAN_DIVERGENCE = 4;
+  DRIFT_KIND_USER_STEER = 5;
+  DRIFT_KIND_USER_CANCEL = 6;
+  DRIFT_KIND_TASK_FAILED_RECOVERABLE = 7;
+  DRIFT_KIND_TASK_FAILED_FATAL = 8;
+  DRIFT_KIND_CONTEXT_PRESSURE = 9;
+  DRIFT_KIND_BLOCKED = 10;
+  DRIFT_KIND_WRONG_AGENT = 11;
+  DRIFT_KIND_AGENT_TRANSFER = 12;
+  DRIFT_KIND_MODEL_REFUSAL = 13;
+  DRIFT_KIND_STOPPED_EARLY = 14;
+  DRIFT_KIND_TOO_MANY_STEPS = 15;
+  DRIFT_KIND_GOAL_UNREACHABLE = 16;
+  DRIFT_KIND_TASK_TIMEOUT = 17;
+  DRIFT_KIND_REPEATED_FAILURE = 18;
+  DRIFT_KIND_UNEXPECTED_OUTPUT = 19;
+  DRIFT_KIND_SCHEMA_VIOLATION = 20;
+  DRIFT_KIND_HALLUCINATION_SUSPECTED = 21;
+  DRIFT_KIND_SAFETY_CONCERN = 22;
+  DRIFT_KIND_RESOURCE_EXHAUSTED = 23;
+  DRIFT_KIND_AMBIGUOUS_INTENT = 24;
+  DRIFT_KIND_CUSTOM = 25;
+}
+
+// Directed edge in a plan's task dependency DAG. `from_task_id` must
+// reach a terminal status (COMPLETED, or — depending on the planner's
+// policy — FAILED/CANCELLED) before `to_task_id` can transition to
+// RUNNING.
+message TaskEdge {
+  string from_task_id = 1;
+  string to_task_id = 2;
+}
+
+// A single unit of work within a Plan.
+message Task {
+  string id = 1;
+  string title = 2;
+  string description = 3;
+  // Agent id expected to execute this task. May be empty if the planner
+  // has not assigned the task to an agent yet.
+  string assignee_agent_id = 4;
+  TaskStatus status = 5;
+  // Planner's predicted schedule, run-relative milliseconds. Sinks may
+  // fall back to stacking at t=0 when these are zero.
+  int64 predicted_start_ms = 6;
+  int64 predicted_duration_ms = 7;
+  // Optional. Span id that is executing (or has executed) this task.
+  // Populated by sinks that correlate goldfive tasks with harmonograf
+  // spans. Empty for sinks that do not track spans.
+  optional string bound_span_id = 8;
+}
+
+// A Plan is a DAG of Tasks with a revision history. The initial plan
+// submitted by the planner has `revision_index = 0`, `revision_reason`
+// empty, and `revision_kind` / `revision_severity` DRIFT_..._UNSPECIFIED.
+// Each subsequent revision (emitted by the observer in response to drift)
+// increments `revision_index` and fills in the drift metadata.
+message Plan {
+  string id = 1;
+  string run_id = 2;
+  // Goals this plan is working toward. References Goal.id values emitted
+  // by an earlier GoalDerived event on the same run.
+  repeated string goal_ids = 3;
+  string summary = 4;
+  repeated Task tasks = 5;
+  repeated TaskEdge edges = 6;
+
+  // Revision metadata. Empty / UNSPECIFIED on initial plans.
+  string revision_reason = 7;
+  DriftKind revision_kind = 8;
+  DriftSeverity revision_severity = 9;
+  // Monotonic revision index within a plan lineage. 0 for the initial
+  // plan, incrementing by one on each revision. Drives deterministic
+  // ordering in sink UIs.
+  uint32 revision_index = 10;
+
+  google.protobuf.Timestamp created_at = 11;
+}

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,249 @@
+"""Unit tests for goldfive.reporting.
+
+Covers:
+  * ``BUILTIN_REPORTING_TOOLS`` exposes all seven canonical tools by
+    name and each spec has a JSON-schema parameters block.
+  * Each tool's handler drives the expected Steerer transition /
+    drift hook when invoked with typical arguments.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.reporting import (  # noqa: E402
+    BUILTIN_REPORTING_TOOLS,
+    REPORTING_TOOL_NAMES,
+    ReportingToolSpec,
+)
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftKind,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class StubPlanner:
+    def __init__(self, revised: Plan | None = None) -> None:
+        self.revised = revised
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return self.revised
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        self.refine_calls.append(kwargs)
+        return self.revised
+
+
+def _plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="A"), Task(id="t2", title="B")],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+
+
+def _fresh() -> tuple[DefaultSteerer, Session, ListSink, StubPlanner]:
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do it")],
+        plan=_plan(),
+    )
+    sink = ListSink()
+    planner = StubPlanner()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    return steerer, session, sink, planner
+
+
+def _tool(name: str) -> ReportingToolSpec:
+    for t in BUILTIN_REPORTING_TOOLS:
+        if t.name == name:
+            return t
+    raise AssertionError(f"builtin tool {name!r} missing")
+
+
+# ---------------------------------------------------------------------------
+# Catalogue
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_tools_match_canonical_names() -> None:
+    names = [t.name for t in BUILTIN_REPORTING_TOOLS]
+    assert set(names) == set(REPORTING_TOOL_NAMES)
+    assert len(names) == len(REPORTING_TOOL_NAMES)
+
+
+def test_every_spec_has_schema_and_handler() -> None:
+    for t in BUILTIN_REPORTING_TOOLS:
+        assert isinstance(t, ReportingToolSpec)
+        assert t.description
+        assert t.parameters.get("type") == "object"
+        assert "properties" in t.parameters
+        assert callable(t.handler)
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def test_report_task_started_marks_running() -> None:
+    steerer, session, sink, _ = _fresh()
+    out = await _tool("report_task_started").handler(
+        {"task_id": "t1", "detail": "starting"}, session, steerer
+    )
+    assert out == {"acknowledged": True}
+    assert session.plan.tasks[0].status is TaskStatus.RUNNING
+    assert sink.events[-1].WhichOneof("payload") == "task_started"
+
+
+async def test_report_task_progress_records_progress() -> None:
+    steerer, session, sink, _ = _fresh()
+    await _tool("report_task_progress").handler(
+        {"task_id": "t1", "fraction": 0.75, "detail": "three of four done"},
+        session,
+        steerer,
+    )
+    assert session.task_progress["t1"] == pytest.approx(0.75)
+    assert sink.events[-1].WhichOneof("payload") == "task_progress"
+
+
+async def test_report_task_completed_transitions_and_stores_summary() -> None:
+    steerer, session, sink, _ = _fresh()
+    await _tool("report_task_completed").handler(
+        {
+            "task_id": "t1",
+            "summary": "all done",
+            "artifacts": {"result": "42"},
+        },
+        session,
+        steerer,
+    )
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+    assert session.completed_results["t1"] == "all done"
+    evt = sink.events[-1]
+    assert evt.WhichOneof("payload") == "task_completed"
+    assert dict(evt.task_completed.artifacts) == {"result": "42"}
+
+
+async def test_report_task_failed_transitions_and_refines() -> None:
+    steerer, session, sink, planner = _fresh()
+    await _tool("report_task_failed").handler(
+        {"task_id": "t1", "reason": "oops", "recoverable": True},
+        session,
+        steerer,
+    )
+    assert session.plan.tasks[0].status is TaskStatus.FAILED
+    # Sequence: TaskFailed, DriftDetected. Planner.refine invoked once.
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert "task_failed" in kinds and "drift_detected" in kinds
+    assert len(planner.refine_calls) == 1
+    assert planner.refine_calls[0]["drift"].kind is DriftKind.TASK_FAILED_RECOVERABLE
+
+
+async def test_report_task_blocked_transitions_and_refines() -> None:
+    steerer, session, sink, planner = _fresh()
+    await _tool("report_task_blocked").handler(
+        {
+            "task_id": "t1",
+            "blocker": "missing input",
+            "needed": "CSV file",
+        },
+        session,
+        steerer,
+    )
+    assert session.plan.tasks[0].status is TaskStatus.BLOCKED
+    assert len(planner.refine_calls) == 1
+    assert planner.refine_calls[0]["drift"].kind is DriftKind.BLOCKED
+
+
+async def test_report_new_work_discovered_fires_refine() -> None:
+    steerer, session, _sink, planner = _fresh()
+    await _tool("report_new_work_discovered").handler(
+        {
+            "parent_task_id": "t1",
+            "title": "dig deeper",
+            "description": "validate source freshness",
+            "assignee": "analyst",
+        },
+        session,
+        steerer,
+    )
+    assert len(planner.refine_calls) == 1
+    assert planner.refine_calls[0]["drift"].kind is DriftKind.NEW_WORK_DISCOVERED
+
+
+async def test_report_plan_divergence_fires_refine_and_sets_flag() -> None:
+    steerer, session, _sink, planner = _fresh()
+    await _tool("report_plan_divergence").handler(
+        {
+            "note": "plan is stale",
+            "suggested_action": "start from scratch",
+        },
+        session,
+        steerer,
+    )
+    assert session.divergence_flag is True
+    assert planner.refine_calls[0]["drift"].kind is DriftKind.PLAN_DIVERGENCE
+
+
+async def test_handler_tolerates_missing_optional_fields() -> None:
+    steerer, session, sink, _ = _fresh()
+    # Only required fields — should still transition.
+    await _tool("report_task_started").handler(
+        {"task_id": "t1"}, session, steerer
+    )
+    assert session.plan.tasks[0].status is TaskStatus.RUNNING
+    assert sink.events[-1].task_started.detail == ""
+
+
+async def test_handler_ignores_unknown_task_id_gracefully() -> None:
+    steerer, session, sink, _ = _fresh()
+    # Unknown task_id — the handler ack's but no event is emitted and
+    # no existing task is mutated.
+    out = await _tool("report_task_started").handler(
+        {"task_id": "bogus"}, session, steerer
+    )
+    assert out == {"acknowledged": True}
+    assert sink.events == []
+    assert all(t.status is TaskStatus.PENDING for t in session.plan.tasks)
+
+
+async def test_handler_recoverable_accepts_string_bool() -> None:
+    steerer, session, _sink, planner = _fresh()
+    await _tool("report_task_failed").handler(
+        {"task_id": "t1", "reason": "nope", "recoverable": "false"},
+        session,
+        steerer,
+    )
+    # "false" string → recoverable=False → TASK_FAILED_FATAL
+    assert planner.refine_calls[0]["drift"].kind is DriftKind.TASK_FAILED_FATAL

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -1,0 +1,553 @@
+"""Unit tests for ``goldfive.steerer.DefaultSteerer``.
+
+Covers every task transition, every drift classification, and the
+observe → detect → refine → apply pipeline. Uses a local in-memory
+sink stub to capture emitted proto ``Event`` messages.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.drift import (  # noqa: E402
+    classify_refusal,
+    classify_stop_reason,
+    classify_tool_error,
+)
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    """Minimal ``EventSink`` that records every emitted ``Event`` in a list."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+        self.closed: bool = False
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class StubPlanner:
+    """``Planner`` stub that returns a pre-canned revised plan (or None)."""
+
+    def __init__(
+        self,
+        *,
+        revised: Plan | None = None,
+        raise_exc: Exception | None = None,
+    ) -> None:
+        self.revised = revised
+        self.raise_exc = raise_exc
+        self.generate_calls: list[dict[str, Any]] = []
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Any | None = None,
+    ) -> Plan | None:
+        self.generate_calls.append(
+            {
+                "goals": goals,
+                "available_agents": available_agents,
+                "context": context,
+            }
+        )
+        return self.revised
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        self.refine_calls.append(
+            {"plan": plan, "drift": drift, "goals": goals}
+        )
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return self.revised
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_plan(task_ids: tuple[str, ...] = ("t1", "t2")) -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id=tid, title=tid.upper()) for tid in task_ids],
+        edges=[
+            TaskEdge(from_task_id=task_ids[i], to_task_id=task_ids[i + 1])
+            for i in range(len(task_ids) - 1)
+        ],
+    )
+
+
+def _make_session(plan: Plan | None = None) -> Session:
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do the thing")],
+        plan=plan if plan is not None else _make_plan(),
+    )
+
+
+def _fresh() -> tuple[DefaultSteerer, Session, ListSink, StubPlanner]:
+    s = DefaultSteerer()
+    sess = _make_session()
+    sink = ListSink()
+    planner = StubPlanner()
+    s.bind(sinks=[sink], planner=planner)
+    return s, sess, sink, planner
+
+
+# ---------------------------------------------------------------------------
+# Task transitions
+# ---------------------------------------------------------------------------
+
+
+def _task(session: Session, task_id: str) -> Task:
+    assert session.plan is not None
+    for t in session.plan.tasks:
+        if t.id == task_id:
+            return t
+    raise AssertionError(f"task {task_id!r} missing from plan")
+
+
+async def test_mark_task_running_transitions_and_emits() -> None:
+    steerer, session, sink, _ = _fresh()
+    await steerer.mark_task_running("t1", session=session, detail="kicking off")
+    assert _task(session, "t1").status is TaskStatus.RUNNING
+    assert session.current_task_id == "t1"
+    assert session.agent_notes["t1"] == "kicking off"
+    assert len(sink.events) == 1
+    evt = sink.events[0]
+    assert evt.WhichOneof("payload") == "task_started"
+    assert evt.task_started.task_id == "t1"
+    assert evt.task_started.detail == "kicking off"
+    assert evt.run_id == "r1"
+    assert evt.sequence == 0
+
+
+async def test_mark_task_running_no_op_on_terminal() -> None:
+    steerer, session, sink, _ = _fresh()
+    _task(session, "t1").status = TaskStatus.COMPLETED
+    await steerer.mark_task_running("t1", session=session)
+    assert _task(session, "t1").status is TaskStatus.COMPLETED
+    assert sink.events == []
+
+
+async def test_mark_task_running_unknown_task_is_noop() -> None:
+    steerer, session, sink, _ = _fresh()
+    await steerer.mark_task_running("bogus", session=session)
+    assert sink.events == []
+
+
+async def test_mark_task_progress_records_and_emits() -> None:
+    steerer, session, sink, _ = _fresh()
+    await steerer.mark_task_progress(
+        "t1", session=session, fraction=0.42, detail="halfway"
+    )
+    assert session.task_progress["t1"] == pytest.approx(0.42)
+    assert session.agent_notes["t1"] == "halfway"
+    # Status is untouched by progress updates.
+    assert _task(session, "t1").status is TaskStatus.PENDING
+    assert len(sink.events) == 1
+    evt = sink.events[0]
+    assert evt.WhichOneof("payload") == "task_progress"
+    assert evt.task_progress.task_id == "t1"
+    assert evt.task_progress.fraction == pytest.approx(0.42)
+    assert evt.task_progress.detail == "halfway"
+
+
+async def test_mark_task_progress_clamps_fraction() -> None:
+    steerer, session, _sink, _ = _fresh()
+    await steerer.mark_task_progress("t1", session=session, fraction=-1.0)
+    assert session.task_progress["t1"] == 0.0
+    await steerer.mark_task_progress("t1", session=session, fraction=9.0)
+    assert session.task_progress["t1"] == 1.0
+
+
+async def test_mark_task_completed_transitions_and_emits() -> None:
+    steerer, session, sink, _ = _fresh()
+    await steerer.mark_task_completed(
+        "t1",
+        session=session,
+        summary="done-zo",
+        artifacts={"file": "out.txt"},
+    )
+    assert _task(session, "t1").status is TaskStatus.COMPLETED
+    assert session.completed_results["t1"] == "done-zo"
+    assert len(sink.events) == 1
+    evt = sink.events[0]
+    assert evt.WhichOneof("payload") == "task_completed"
+    assert evt.task_completed.task_id == "t1"
+    assert evt.task_completed.summary == "done-zo"
+    assert dict(evt.task_completed.artifacts) == {"file": "out.txt"}
+
+
+async def test_mark_task_failed_recoverable_fires_drift() -> None:
+    steerer, session, sink, planner = _fresh()
+    await steerer.mark_task_failed(
+        "t1", session=session, reason="boom", recoverable=True
+    )
+    assert _task(session, "t1").status is TaskStatus.FAILED
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    # TaskFailed + DriftDetected (planner returns None so no PlanRevised).
+    assert kinds == ["task_failed", "drift_detected"]
+    assert sink.events[0].task_failed.recoverable is True
+    drift_evt = sink.events[1]
+    # Proto enum DriftKind values: first check by semantic comparison via module.
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    assert drift_evt.drift_detected.kind == types_pb2.DRIFT_KIND_TASK_FAILED_RECOVERABLE
+    assert drift_evt.drift_detected.severity == types_pb2.DRIFT_SEVERITY_WARNING
+    # Planner was asked to refine (WARNING ≥ WARNING).
+    assert len(planner.refine_calls) == 1
+    assert planner.refine_calls[0]["drift"].kind is DriftKind.TASK_FAILED_RECOVERABLE
+
+
+async def test_mark_task_failed_fatal_fires_critical_drift() -> None:
+    steerer, session, sink, _planner = _fresh()
+    await steerer.mark_task_failed(
+        "t1", session=session, reason="unrecoverable", recoverable=False
+    )
+    drift_evt = sink.events[1]
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    assert drift_evt.drift_detected.kind == types_pb2.DRIFT_KIND_TASK_FAILED_FATAL
+    assert drift_evt.drift_detected.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+
+
+async def test_mark_task_blocked_transitions_and_emits_drift() -> None:
+    steerer, session, sink, planner = _fresh()
+    await steerer.mark_task_blocked(
+        "t1", session=session, blocker="need API key", needed="credentials.json"
+    )
+    assert _task(session, "t1").status is TaskStatus.BLOCKED
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["task_blocked", "drift_detected"]
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    assert sink.events[1].drift_detected.kind == types_pb2.DRIFT_KIND_BLOCKED
+    assert len(planner.refine_calls) == 1
+    assert planner.refine_calls[0]["drift"].kind is DriftKind.BLOCKED
+
+
+async def test_mark_task_cancelled_transitions() -> None:
+    steerer, session, sink, _ = _fresh()
+    await steerer.mark_task_cancelled(
+        "t1", session=session, reason="user cancelled"
+    )
+    assert _task(session, "t1").status is TaskStatus.CANCELLED
+    assert len(sink.events) == 1
+    assert sink.events[0].WhichOneof("payload") == "task_cancelled"
+    assert sink.events[0].task_cancelled.reason == "user cancelled"
+
+
+async def test_transition_dispatches_to_mark_methods() -> None:
+    steerer, session, sink, _ = _fresh()
+    await steerer.transition(
+        "t1", TaskStatus.RUNNING, session=session, detail="go"
+    )
+    assert _task(session, "t1").status is TaskStatus.RUNNING
+    assert sink.events[0].WhichOneof("payload") == "task_started"
+
+
+# ---------------------------------------------------------------------------
+# Drift classifiers (unit-level; no proto, no sinks)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_tool_error_from_error_dict() -> None:
+    d = classify_tool_error({"tool": "search_web", "error": "boom"})
+    assert d is not None
+    assert d.kind is DriftKind.TOOL_ERROR
+    assert d.severity is DriftSeverity.WARNING
+
+
+def test_classify_tool_error_from_failed_status() -> None:
+    d = classify_tool_error({"name": "http_get", "status": "FAILED"})
+    assert d is not None and d.kind is DriftKind.TOOL_ERROR
+
+
+def test_classify_tool_error_from_ok_false() -> None:
+    d = classify_tool_error({"ok": False, "message": "no"})
+    assert d is not None and d.kind is DriftKind.TOOL_ERROR
+
+
+def test_classify_tool_error_none_on_success() -> None:
+    assert classify_tool_error({"result": 42, "ok": True}) is None
+    assert classify_tool_error("just a string") is None
+    assert classify_tool_error(None) is None
+
+
+def test_classify_refusal_detects_markers() -> None:
+    d = classify_refusal("I cannot help with that, sorry.")
+    assert d is not None
+    assert d.kind is DriftKind.AGENT_REFUSAL
+    assert d.severity is DriftSeverity.WARNING
+
+
+def test_classify_refusal_on_dict_content() -> None:
+    d = classify_refusal({"text": "I must decline."})
+    assert d is not None and d.kind is DriftKind.AGENT_REFUSAL
+
+
+def test_classify_refusal_none_on_normal_text() -> None:
+    assert classify_refusal("OK, I will do that.") is None
+
+
+def test_classify_stop_reason_max_tokens() -> None:
+    d = classify_stop_reason("MAX_TOKENS")
+    assert d is not None and d.kind is DriftKind.CONTEXT_PRESSURE
+
+
+def test_classify_stop_reason_enum_like() -> None:
+    class _Enum:
+        name = "FinishReason.LENGTH"
+
+    d = classify_stop_reason(_Enum())
+    assert d is not None and d.kind is DriftKind.CONTEXT_PRESSURE
+
+
+def test_classify_stop_reason_none_on_unknown() -> None:
+    assert classify_stop_reason("STOP") is None
+    assert classify_stop_reason(None) is None
+
+
+# ---------------------------------------------------------------------------
+# detect_drift / observe pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_detect_drift_prefers_tool_error_then_refusal_then_stop_reason() -> None:
+    s = DefaultSteerer()
+    sess = _make_session()
+    # Tool-error dict wins even if it also contains refusal text.
+    combo = {"error": "nope", "text": "I cannot"}
+    assert s.detect_drift(combo, sess).kind is DriftKind.TOOL_ERROR
+    # Refusal wins over stop_reason alone.
+    assert (
+        s.detect_drift(
+            {"text": "I can't help with that", "stop_reason": "MAX_TOKENS"},
+            sess,
+        ).kind
+        is DriftKind.AGENT_REFUSAL
+    )
+    # Pure stop_reason goes to CONTEXT_PRESSURE.
+    assert (
+        s.detect_drift({"stop_reason": "MAX_TOKENS"}, sess).kind
+        is DriftKind.CONTEXT_PRESSURE
+    )
+    # Nothing → None.
+    assert s.detect_drift({"text": "all good"}, sess) is None
+
+
+async def test_observe_emits_drift_and_refines() -> None:
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    revised = _make_plan(("t1", "t2", "t3"))
+    revised.id = "p1"
+    revised.run_id = "r1"
+    planner = StubPlanner(revised=revised)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    await steerer.observe({"error": "oh no"}, session)
+
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["drift_detected", "plan_revised"]
+    assert sink.events[0].drift_detected.kind == types_pb2.DRIFT_KIND_TOOL_ERROR
+    assert len(planner.refine_calls) == 1
+    # Session's plan is replaced with revised, and revision metadata stamped.
+    assert session.plan is revised
+    assert session.plan.revision_kind == DriftKind.TOOL_ERROR.value
+    assert session.plan.revision_severity == DriftSeverity.WARNING.value
+    assert session.plan.revision_index >= 1
+
+
+async def test_observe_skips_refine_when_no_drift() -> None:
+    steerer, session, sink, planner = _fresh()
+    await steerer.observe({"text": "nothing interesting"}, session)
+    assert sink.events == []
+    assert planner.refine_calls == []
+
+
+async def test_observe_skips_refine_on_info_severity() -> None:
+    # Craft a direct DriftEvent at INFO severity via a custom detector.
+    class InfoSteerer(DefaultSteerer):
+        def detect_drift(self, event, session):  # type: ignore[override]
+            return DriftEvent(
+                kind=DriftKind.CUSTOM,
+                severity=DriftSeverity.INFO,
+                detail="just a note",
+            )
+
+    planner = StubPlanner()
+    sink = ListSink()
+    steerer = InfoSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    await steerer.observe({}, session)
+    assert len(sink.events) == 1
+    assert sink.events[0].WhichOneof("payload") == "drift_detected"
+    # INFO is below the WARNING threshold — no refine.
+    assert planner.refine_calls == []
+
+
+async def test_observe_swallows_planner_exceptions() -> None:
+    planner = StubPlanner(raise_exc=RuntimeError("planner down"))
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    # Must not raise even though refine() blows up.
+    await steerer.observe({"error": "x"}, session)
+    # We emitted the drift but not the plan_revised (refine errored).
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["drift_detected"]
+
+
+# ---------------------------------------------------------------------------
+# Drift kind coverage — every DriftKind either has a classifier, a
+# transition that fires it, or is a reserved value that the steerer
+# itself doesn't emit (e.g., USER_STEER, AGENT_TRANSFER, CUSTOM).
+# This test enforces that every listed DriftKind is known.
+# ---------------------------------------------------------------------------
+
+
+def test_every_drift_kind_has_a_known_origin() -> None:
+    # Kinds the steerer fires directly from transitions / handlers.
+    steerer_emits = {
+        DriftKind.TASK_FAILED_RECOVERABLE,
+        DriftKind.TASK_FAILED_FATAL,
+        DriftKind.BLOCKED,
+        DriftKind.NEW_WORK_DISCOVERED,
+        DriftKind.PLAN_DIVERGENCE,
+    }
+    # Kinds the detect_drift classifiers produce.
+    classifier_emits = {
+        DriftKind.TOOL_ERROR,
+        DriftKind.AGENT_REFUSAL,
+        DriftKind.CONTEXT_PRESSURE,
+    }
+    # Kinds reserved for other components or future heuristics — the
+    # goldfive default steerer does not emit these itself but the
+    # taxonomy names them so sinks can render them.
+    reserved = set(DriftKind) - steerer_emits - classifier_emits
+    # Sanity: the union is exactly DriftKind.
+    assert steerer_emits | classifier_emits | reserved == set(DriftKind)
+    # And every reserved kind is a real enum member.
+    for k in reserved:
+        assert isinstance(k, DriftKind)
+
+
+# ---------------------------------------------------------------------------
+# Plan-mutation drift hooks
+# ---------------------------------------------------------------------------
+
+
+async def test_report_new_work_discovered_fires_drift() -> None:
+    steerer, session, sink, planner = _fresh()
+    await steerer.report_new_work_discovered(
+        session=session,
+        parent_task_id="t1",
+        title="follow-up",
+        description="double-check the numbers",
+        assignee="analyst",
+    )
+    assert len(sink.events) == 1
+    assert sink.events[0].WhichOneof("payload") == "drift_detected"
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    assert (
+        sink.events[0].drift_detected.kind
+        == types_pb2.DRIFT_KIND_NEW_WORK_DISCOVERED
+    )
+    assert planner.refine_calls[0]["drift"].kind is DriftKind.NEW_WORK_DISCOVERED
+
+
+async def test_report_plan_divergence_sets_flag_and_fires_drift() -> None:
+    steerer, session, sink, planner = _fresh()
+    await steerer.report_plan_divergence(
+        session=session,
+        note="agent is doing something different",
+        suggested_action="replan from here",
+    )
+    assert session.divergence_flag is True
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    assert (
+        sink.events[0].drift_detected.kind
+        == types_pb2.DRIFT_KIND_PLAN_DIVERGENCE
+    )
+    assert planner.refine_calls[0]["drift"].kind is DriftKind.PLAN_DIVERGENCE
+
+
+# ---------------------------------------------------------------------------
+# Event envelope invariants
+# ---------------------------------------------------------------------------
+
+
+async def test_event_sequence_is_monotonic_and_run_id_stamped() -> None:
+    steerer, session, sink, _ = _fresh()
+    await steerer.mark_task_running("t1", session=session)
+    await steerer.mark_task_progress("t1", session=session, fraction=0.5)
+    await steerer.mark_task_completed("t1", session=session, summary="ok")
+    assert [e.sequence for e in sink.events] == [0, 1, 2]
+    for e in sink.events:
+        assert e.run_id == "r1"
+        # emitted_at is a Timestamp — just sanity check it's populated.
+        assert e.emitted_at.seconds > 0 or e.emitted_at.nanos > 0
+
+
+async def test_bind_replaces_sinks() -> None:
+    steerer = DefaultSteerer()
+    planner = StubPlanner()
+    sink_a = ListSink()
+    sink_b = ListSink()
+    steerer.bind(sinks=[sink_a], planner=planner)
+    steerer.bind(sinks=[sink_b], planner=planner)
+    session = _make_session()
+    await steerer.mark_task_running("t1", session=session)
+    assert sink_a.events == []
+    assert len(sink_b.events) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -635,7 +635,9 @@ claude = [
     { name = "anthropic" },
 ]
 dev = [
+    { name = "grpcio-tools" },
     { name = "mypy" },
+    { name = "protobuf" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -654,9 +656,11 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'claude'", specifier = ">=0.39.0" },
     { name = "google-adk", marker = "extra == 'adk'", specifier = ">=0.1.0" },
     { name = "grpcio", marker = "extra == 'proto'", specifier = ">=1.60" },
+    { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.60" },
     { name = "grpcio-tools", marker = "extra == 'proto'", specifier = ">=1.60" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "mypy-protobuf", marker = "extra == 'proto'", specifier = ">=3.5" },
+    { name = "protobuf", marker = "extra == 'dev'", specifier = ">=4.25" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "rich", marker = "extra == 'examples'", specifier = ">=13.0" },


### PR DESCRIPTION
## Summary
- Implements the framework-agnostic `DefaultSteerer` (task state machine + drift detector) as a port of harmonograf's `_AdkState` with ADK callbacks / `session.state` writes / gRPC stripped out.
- Adds the seven `BUILTIN_REPORTING_TOOLS` (`report_task_started`, `report_task_progress`, `report_task_completed`, `report_task_failed`, `report_task_blocked`, `report_new_work_discovered`, `report_plan_divergence`) — each with a JSON-schema parameters block and an async handler that routes into the steerer.
- Extracts drift classification into `goldfive/drift.py` (`classify_tool_error`, `classify_refusal`, `classify_stop_reason`) with the harmonograf refusal markers and context-pressure stop-reasons ported over.

## What the steerer does
- `mark_task_{running,progress,completed,failed,blocked,cancelled}` each mutate the session's plan-task status and emit a matching proto `Event` via bound sinks.
- `observe(event, session)` runs `detect_drift`, emits `DriftDetected`, and if severity ≥ `WARNING` awaits `planner.refine(...)` and installs the revised plan (emits `PlanRevised`).
- `bind(sinks=..., planner=...)` wires collaborators at executor start.
- Refine policy: any drift of severity ≥ `WARNING` triggers a refine; `TASK_FAILED_FATAL` is raised at `CRITICAL`. Planner exceptions are swallowed so a bad refiner can't abort the run.

## Drive-by bug fixes in `goldfive/conv.py`
Two latent bugs in `conv.py` (PR #21's code) were exposed once the proto stubs became reachable from tests. Fixed here because the steerer blocks on them:
- `to_pb_plan` now converts the string `revision_kind`/`revision_severity` into proto enum ints.
- `to_pb_drift_event` / `from_pb_drift_event` target `events_pb2.DriftDetected` (there is no standalone `DriftEvent` proto — the taxonomy lives on the `DriftDetected` payload).

## Test scaffolding
Until issue #3 generates the canonical proto stubs, `tests/_pbsetup.py` compiles vendored `.proto` sources under `tests/_proto/` into `goldfive/pb/` (gitignored) so `test_steerer.py` and `test_reporting.py` can exercise the real proto round-trip. When #3 lands, the helper is a no-op.

## Test plan
- [x] `uv run pytest tests/test_steerer.py tests/test_reporting.py -q` → 43 passed
- [x] `uv run pytest -q` → 225 passed, 31 skipped, 1 pre-existing failure in `test_persistence_recovery.py::test_jsonl_persistence_sink_round_trip` (unrelated bug in `goldfive/sinks/persistence.py` from PR #24)
- [x] `uv run ruff check goldfive/steerer.py goldfive/drift.py goldfive/reporting.py goldfive/conv.py tests/test_steerer.py tests/test_reporting.py tests/_pbsetup.py` → clean
- [x] `DefaultSteerer` passes `isinstance(..., Steerer)` runtime protocol check

Closes #6