### PR TITLE
Add design docs, user guides, and reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,31 @@ asyncio.run(main())
 
 ## Docs
 
-See [`docs/guides/getting-started.md`](docs/guides/getting-started.md) for
-a longer walkthrough (doc coming in a later PR).
+**Start with [`docs/guides/getting-started.md`](docs/guides/getting-started.md)** —
+install, run your first goldfive-wrapped agent in about ten minutes,
+inspect the event stream. Concrete and runnable.
+
+### Design
+
+- [`docs/design/ARCHITECTURE.md`](docs/design/ARCHITECTURE.md) — overview of the six primitives, how they compose, full lifecycle.
+- [`docs/design/PROTOCOLS.md`](docs/design/PROTOCOLS.md) — the six protocol contracts with minimal implementations.
+- [`docs/design/STATE-MACHINE.md`](docs/design/STATE-MACHINE.md) — task lifecycle state diagram, transition rules, invariants.
+- [`docs/design/DRIFT.md`](docs/design/DRIFT.md) — full drift-kind taxonomy (25+), classification rules, refine policy.
+- [`docs/design/EVENT-MODEL.md`](docs/design/EVENT-MODEL.md) — proto event taxonomy, sequence semantics, `EventSink` contract.
+
+### Guides
+
+- [`docs/guides/getting-started.md`](docs/guides/getting-started.md) — install + first agent.
+- [`docs/guides/writing-an-agent-adapter.md`](docs/guides/writing-an-agent-adapter.md) — wrap a new framework.
+- [`docs/guides/writing-an-event-sink.md`](docs/guides/writing-an-event-sink.md) — build a custom sink.
+- [`docs/guides/goals-and-plans.md`](docs/guides/goals-and-plans.md) — authoring custom `GoalDeriver` / `Planner`.
+- [`docs/guides/persistence-and-recovery.md`](docs/guides/persistence-and-recovery.md) — JSONL persistence + `Runner.resume()`.
+- [`docs/guides/harmonograf-integration.md`](docs/guides/harmonograf-integration.md) — plugging harmonograf in as a sink.
+
+### Reference
+
+- [`docs/reference/api.md`](docs/reference/api.md) — public API surface.
+- [`docs/reference/tool-protocol.md`](docs/reference/tool-protocol.md) — the seven reporting tools.
 
 ## License
 

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -1,0 +1,288 @@
+# goldfive architecture
+
+goldfive is a framework-agnostic harness that wraps an agent and
+injects **planning, task tracking, drift analysis, and steering**. The
+agent does the thinking; goldfive decides what the agent thinks about
+and whether it is still on track.
+
+This document is the top-level architectural reference. It covers the
+six primitives, how they compose into a `Runner`, and the full lifecycle
+of one `Runner.run()` invocation. Downstream documents go deep on
+individual pieces:
+
+- [PROTOCOLS.md](PROTOCOLS.md) — the protocol contracts in detail.
+- [EVENT-MODEL.md](EVENT-MODEL.md) — the proto event taxonomy and the
+  EventSink contract.
+- [DRIFT.md](DRIFT.md) — the drift-kind taxonomy and refine policy.
+- [STATE-MACHINE.md](STATE-MACHINE.md) — the task lifecycle state
+  diagram.
+
+## The vision
+
+> "Stay on target."
+
+Agents wander. Left alone, a capable LLM agent will often:
+
+- Merge, split, or reorder work in ways the caller did not intend.
+- Declare a task "done" when it has only narrated an approach.
+- Blow through a context budget and truncate mid-turn.
+- Hallucinate artifacts that do not exist.
+- Silently abandon the user's real request.
+
+goldfive treats each of these as a **drift** — a structured observation
+that execution has diverged from an explicit plan derived from an
+explicit goal. Drift is first-class: it is classified, emitted as an
+event, and optionally drives a replan.
+
+## The six primitives
+
+| Primitive | Role | Default implementation |
+|---|---|---|
+| `GoalDeriver` | Converts user input into an explicit list of `Goal`s. | `PassthroughGoalDeriver`, `LLMGoalDeriver` |
+| `Planner` | Produces and refines a `Plan` from goals. | `PassthroughPlanner`, `LLMPlanner` |
+| `Executor` | Drives plan execution task-by-task. | `SequentialExecutor`, `ParallelDAGExecutor` |
+| `Steerer` | Owns the task state machine and classifies drift. | `DefaultSteerer` |
+| `AgentAdapter` | Wraps a specific agent framework. | `CallableAdapter`, `ADKAdapter`, `ClaudeAgentSDKAdapter` |
+| `EventSink` | Receives proto-encoded orchestration events. | `InMemorySink`, `LoggingSink`, `JSONLPersistenceSink` |
+
+Each primitive is a `Protocol` (see [PROTOCOLS.md](PROTOCOLS.md)).
+goldfive ships default implementations but any conforming class can be
+swapped in.
+
+### Primitive responsibilities
+
+**GoalDeriver** — one job: take whatever the caller handed in
+(`user_input: str` or a pre-built `list[Goal]`) and return an explicit
+list of `Goal`s. Each goal has a `summary` and, optionally, a
+`success_predicate: Callable[[Session], bool]` that the framework can
+consult to decide "are we done yet?".
+
+**Planner** — produces a `Plan` (DAG of `Task`s) from goals, and
+revises it on drift via `refine(plan, drift, goals)`. The planner is
+the only component that ever decides *what* tasks exist. Executors and
+steerers just mechanically walk whatever plan the planner hands them.
+
+**Executor** — walks the plan. Two executors ship in v0.1:
+`SequentialExecutor` runs tasks one at a time in topological order;
+`ParallelDAGExecutor` batches independent tasks per topological stage
+and runs the stage with `asyncio.gather`. The executor is the only
+component that calls `adapter.invoke(task, session)`.
+
+**Steerer** — owns the task state machine. It reacts to reporting tool
+calls (from the adapter) and to adapter-observed events, transitions
+task status monotonically, and runs drift classification. When drift
+crosses a severity threshold it invokes `planner.refine(...)`.
+
+**AgentAdapter** — the only primitive that knows about a specific
+agent framework (ADK, Claude Agent SDK, a bare callable, ...). It
+registers reporting tools, renders current-task context into whatever
+form the framework expects (shared session state, a system prompt,
+whatever), invokes the agent, and routes intercepted tool calls and
+observed events back to the steerer.
+
+**EventSink** — consumes the proto-encoded event stream. goldfive
+ships three sinks (in-memory for tests, logging for dev,
+JSONL-persistence for crash recovery) and is designed to hand off to
+external observability systems. harmonograf is the canonical external
+sink (see [harmonograf-integration guide](../guides/harmonograf-integration.md)).
+
+## How they compose
+
+```
+                                ┌────────────────────────────────────────┐
+                                │                Runner                  │
+                                │                                        │
+          user_input    ─────▶  │  GoalDeriver ─▶ Planner ─▶ Executor   │  ─────▶  ExecutionOutcome
+          (str or                │                  ▲            │        │
+           list[Goal])           │                  │            ▼        │
+                                │       refine(drift, goals)  adapter.   │
+                                │                  │          invoke()   │
+                                │                  │            │        │
+                                │              Steerer ◀────────┘        │
+                                │             (drift kinds)              │
+                                │                  │                      │
+                                │                  ▼                      │
+                                │             EventSinks                  │
+                                │        (InMemory, Logging,              │
+                                │         JSONL, harmonograf, …)         │
+                                └────────────────────────────────────────┘
+                                                   │
+                                                   ▼
+                                    proto Event stream (RunStarted,
+                                    PlanSubmitted, TaskStarted, …)
+```
+
+**Data direction:**
+
+- `user_input → goals → plan → tasks → invocations`. The "forward"
+  pipeline.
+- `agent output → steerer observations → drift events → refine(plan)`.
+  The "reverse" feedback loop.
+- Every state-affecting decision emits an `Event` to every `EventSink`
+  in `sinks`. Event emission is fan-out: sinks never see each other.
+
+**Control direction:**
+
+- The `Executor` owns the top-level loop. It calls `adapter.invoke()`
+  per task, then asks the `Steerer` whether drift occurred, then — if
+  so — calls `Planner.refine()` and swaps in the new plan before the
+  next iteration.
+- The `Steerer` is passive with respect to control; it classifies and
+  transitions, it does not drive execution.
+
+## The `Runner`
+
+`Runner` is the single public entry point. It composes the six
+primitives, owns a `Session`, and runs one invocation end-to-end. See
+[api.md](../reference/api.md#runner) for the full signature.
+
+Minimal construction:
+
+```python
+from goldfive import Runner
+from goldfive.adapters.callable import CallableAdapter
+from goldfive.planner import PassthroughPlanner
+from goldfive.executors.sequential import SequentialExecutor
+
+runner = Runner(
+    agent=CallableAdapter(my_async_callable),
+    planner=PassthroughPlanner(plan=precomputed_plan),
+    executor=SequentialExecutor(),
+)
+outcome = await runner.run("build me a slide deck about Python")
+```
+
+When the caller omits `goal_deriver`, `steerer`, or `sinks`, the
+`Runner` substitutes sane defaults:
+
+- `goal_deriver` → `PassthroughGoalDeriver()` (wraps the string in a
+  single `Goal`).
+- `steerer` → `DefaultSteerer()`.
+- `sinks` → `[]` (events go nowhere; recommended to supply at least
+  `InMemorySink` in dev and `JSONLPersistenceSink` in prod).
+
+## The full lifecycle
+
+One call to `runner.run(user_input)` walks the following steps. Every
+step emits one or more events (see [EVENT-MODEL.md](EVENT-MODEL.md) for
+the full taxonomy).
+
+### 1. Setup
+
+- Generate a fresh `run_id` (UUIDv7-style).
+- Construct a `Session(run_id=...)`. `Session` holds all live state for
+  this invocation.
+- Emit `RunStarted(run_id, user_input, started_at)`.
+
+### 2. Goal derivation
+
+- Call `goal_deriver.derive(user_input, context=...)`.
+- Store the returned `list[Goal]` in `session.goals`.
+- Emit `GoalDerived(goals=...)`.
+
+If the caller passed a `list[Goal]` directly to `runner.run(...)`, the
+`PassthroughGoalDeriver` returns it verbatim and goal derivation is a
+no-op.
+
+### 3. Plan generation
+
+- Collect `available_agents` from `adapter.available_agents`.
+- Call `planner.generate(goals=session.goals, available_agents=..., context=...)`.
+- If `None`: abort with `RunAborted(reason="planner returned no plan")`.
+- Otherwise: store the `Plan` on `session.plan` and emit
+  `PlanSubmitted(plan=...)`.
+
+### 4. Execution loop
+
+Delegated to `executor.run(plan=..., session=..., adapter=..., steerer=..., planner=..., sinks=...)`.
+
+The executor loop (simplified Sequential flow):
+
+```
+while session.plan has unfinished tasks:
+    for task in topological_order(session.plan):
+        if task.status != PENDING: continue
+        if any dep of task is not COMPLETED: skip
+        steerer.transition(task.id, RUNNING, session=session)
+        result = await adapter.invoke(task, session)    # agent runs here
+        # adapter has been forwarding reporting-tool calls
+        # to steerer throughout the invocation
+        drift = steerer.detect_drift(result, session)
+        if drift and drift.severity >= WARNING:
+            revised = await planner.refine(plan=session.plan, drift=drift, goals=session.goals)
+            if revised:
+                session.plan = revised
+                emit PlanRevised(plan=revised, revision_metadata=...)
+                break to outer loop  # restart walk with revised plan
+```
+
+ParallelDAGExecutor differs only in that each topological *stage* is
+an `asyncio.gather` over the stage's tasks; refine runs between
+stages, not mid-stage. See [PROTOCOLS.md](PROTOCOLS.md#executor) for
+the full contract.
+
+### 5. Termination
+
+One of three terminal events is emitted:
+
+- `RunCompleted(run_id, outcome_summary)` — all tasks reached a
+  terminal state and the plan is fully realized.
+- `RunAborted(run_id, reason)` — executor surrendered (e.g. hit
+  `max_plan_reinvocations` with tasks still PENDING, planner returned
+  `None` during refine, unrecoverable drift).
+- Exception propagation — uncaught exceptions surface to
+  `runner.run()`'s caller. Sinks still receive a `RunAborted` event
+  before the exception re-raises.
+
+The `ExecutionOutcome(success, session, reason)` returned to the
+caller captures the same information.
+
+### 6. Sink teardown
+
+- `await sink.close()` is called on every sink.
+- `JSONLPersistenceSink.close()` is the one that matters most: it
+  flushes buffered writes and releases the file lock. See the
+  [persistence guide](../guides/persistence-and-recovery.md).
+
+## Invariants
+
+Four invariants hold across every `Runner.run(...)` invocation:
+
+1. **Monotonic task state** — once a task reaches `COMPLETED`,
+   `FAILED`, or `CANCELLED`, it cannot transition out. The steerer
+   enforces this. See [STATE-MACHINE.md](STATE-MACHINE.md).
+2. **Plan revisions preserve history** — `planner.refine()` may add,
+   remove, or re-order tasks, but the executor only re-runs tasks that
+   have not yet reached a terminal state. Completed work is never
+   re-done.
+3. **Events are monotonically sequenced** — every event carries
+   `sequence = session.next_sequence()`. Sinks can rely on sequence
+   order to reconstruct state.
+4. **Sinks are side-effect-only** — goldfive never reads from a sink.
+   Sinks may be slow, lossy, or remote without affecting correctness.
+
+## What's out of scope for v0.1
+
+- **CLI.** goldfive is a library. Callers build CLIs on top.
+- **Multi-run coordination.** One `Runner.run()` = one `run_id`. For
+  resuming a crashed run, see [persistence-and-recovery.md](../guides/persistence-and-recovery.md).
+- **Human-in-the-loop mid-run steering.** Control actions (pause,
+  resume, external steer) are on the roadmap but not implemented in
+  v0.1. External systems can emit drift by synthesizing a
+  `DriftEvent(kind=USER_STEER)` and handing it to the steerer, but
+  there is no in-box protocol yet.
+- **Streaming to the caller.** `Runner.run()` is a batch call.
+  Streaming live progress is expected to happen through a caller-
+  supplied `EventSink`, not through an async generator.
+
+## Reading order
+
+If you're new, read this doc in order with:
+
+1. [PROTOCOLS.md](PROTOCOLS.md) — the shape contracts.
+2. [STATE-MACHINE.md](STATE-MACHINE.md) — how one task moves through
+   the lifecycle.
+3. [DRIFT.md](DRIFT.md) — what counts as drift and what to do about it.
+4. [EVENT-MODEL.md](EVENT-MODEL.md) — how observability flows out.
+
+For hands-on, jump to [getting-started.md](../guides/getting-started.md).

--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -1,0 +1,243 @@
+# Drift
+
+A **drift** is a structured observation that execution has diverged
+from the plan. goldfive treats drift as first-class: it has a
+taxonomy, a severity, a classification function, and a refine policy
+that decides whether to replan.
+
+This document enumerates every drift kind, covers classification
+rules, and explains when `planner.refine(...)` runs.
+
+Related: [ARCHITECTURE.md](ARCHITECTURE.md#control-direction),
+[STATE-MACHINE.md](STATE-MACHINE.md), [PROTOCOLS.md](PROTOCOLS.md#steerer).
+
+## The `DriftEvent` shape
+
+```python
+@dataclasses.dataclass
+class DriftEvent:
+    kind: DriftKind          # one of 25+ enum values
+    severity: DriftSeverity  # info | warning | critical
+    detail: str = ""
+    current_task_id: str = ""
+    current_agent_id: str = ""
+    raw: Any = None          # original trigger (event, exception, tool call)
+```
+
+`kind` and `severity` together determine whether refine runs. `detail`
+is the human-readable one-liner that flows through to the UI / logs /
+planner prompt. `current_task_id` and `current_agent_id` are filled in
+from `session` at emission time. `raw` is the trigger — a tool error,
+an adapter-streamed block, a reporting-tool call — preserved for
+post-hoc analysis.
+
+## Severity levels
+
+Three severities, as a `StrEnum`:
+
+| Severity | Meaning | Refine behavior |
+|---|---|---|
+| `info` | Noise-level — visible in the event stream, does not trigger refine. | no refine |
+| `warning` | The plan should adapt; refine runs. | refine triggered |
+| `critical` | Either refine urgently, or the run cannot recover. | refine triggered; may surface as `RunAborted` |
+
+The default refine policy is simple: **any drift of severity
+`warning` or above triggers `planner.refine(...)`**. Customizing the
+threshold is a matter of subclassing `DefaultSteerer` and overriding
+`should_refine(drift) -> bool`.
+
+## The taxonomy
+
+All kinds live in the `DriftKind` `StrEnum`. Mirrors harmonograf where
+analogous (goldfive owns the canonical list from v0.1 forward). The
+kinds group naturally into six categories.
+
+### Error category — the agent or a tool failed
+
+| Kind | Trigger | Default severity | Recoverable |
+|---|---|---|---|
+| `TOOL_ERROR` | Adapter observed a tool raising an exception or returning an error payload. | `warning` | yes |
+| `AGENT_REFUSAL` | LLM refused to proceed with polite language ("I can't help with that"). | `warning` | yes |
+| `MODEL_REFUSAL` | Hard refusal — safety-filter style. | `critical` | no |
+| `SAFETY_CONCERN` | Detected content policy / safety trigger from the model. | `critical` | no |
+| `TASK_FAILED_RECOVERABLE` | `report_task_failed(task_id, reason, recoverable=True)` | `warning` | yes |
+| `TASK_FAILED_FATAL` | `report_task_failed(task_id, reason, recoverable=False)` | `critical` | no |
+| `REPEATED_FAILURE` | Same task has now failed `>= N` times in one run. | `critical` | sometimes |
+| `TASK_TIMEOUT` | Task exceeded its predicted duration by a wide factor. | `warning` | yes |
+
+### Divergence category — work no longer matches the plan
+
+| Kind | Trigger | Default severity | Recoverable |
+|---|---|---|---|
+| `PLAN_DIVERGENCE` | `report_plan_divergence(note, suggested_action)` | `warning` | yes |
+| `STOPPED_EARLY` | Agent stopped emitting before marking the task terminal. | `warning` | yes |
+| `TOO_MANY_STEPS` | Adapter observed an unreasonable step count in a single invocation. | `warning` | yes |
+| `UNEXPECTED_OUTPUT` | Output did not match a caller-supplied schema / heuristic. | `warning` | yes |
+| `SCHEMA_VIOLATION` | Structured output failed validation. | `warning` | yes |
+| `HALLUCINATION_SUSPECTED` | Output references entities the session never produced. | `warning` | yes |
+
+### Structural category — the agent or the plan is shaped wrong
+
+| Kind | Trigger | Default severity | Recoverable |
+|---|---|---|---|
+| `WRONG_AGENT` | Reporting tool call came from an agent that is not `task.assignee_agent_id`. | `warning` | yes |
+| `AGENT_TRANSFER` | Adapter observed a transfer / delegation to an unplanned agent. | `info` | yes |
+| `CONTEXT_PRESSURE` | Adapter observed a `finish_reason` indicating the context window was hit. | `warning` | yes |
+| `RESOURCE_EXHAUSTED` | Adapter observed rate-limit or quota exhaustion. | `warning` | yes |
+| `BLOCKED` | `report_task_blocked(task_id, blocker)` with a structural blocker. | `warning` | sometimes |
+
+### Discovery category — new work that was not in the plan
+
+| Kind | Trigger | Default severity | Recoverable |
+|---|---|---|---|
+| `NEW_WORK_DISCOVERED` | `report_new_work_discovered(parent_task_id, title, description, assignee)` | `warning` | yes |
+
+### User category — external control signal
+
+| Kind | Trigger | Default severity | Recoverable |
+|---|---|---|---|
+| `USER_STEER` | Caller synthesized a `DriftEvent` to redirect the run. | `warning` | yes |
+| `USER_CANCEL` | Caller cancelled the run. | `critical` | no |
+
+### Goal category — we will not be able to finish
+
+| Kind | Trigger | Default severity | Recoverable |
+|---|---|---|---|
+| `GOAL_UNREACHABLE` | Planner returned `None` from refine; no further progress possible. | `critical` | no |
+| `AMBIGUOUS_INTENT` | Multiple plausible goal interpretations; needs clarification. | `warning` | yes |
+
+### Escape hatch
+
+| Kind | Trigger | Default severity |
+|---|---|---|
+| `CUSTOM` | Caller-supplied drift kind not covered by the enum. Detail carries the real kind as a free-form string. | caller chooses |
+
+`CUSTOM` exists to let external sinks or callers feed domain-specific
+drift signals without forcing a proto change. Prefer a named kind
+when one fits.
+
+## Classification
+
+`DefaultSteerer.detect_drift(event, session) -> DriftEvent | None`
+runs after every `adapter.invoke()` completes and during streamed
+adapter events (when the adapter supports streaming). It is a pure
+function of the event plus session state.
+
+The classification dispatch table:
+
+```mermaid
+flowchart TD
+    E[incoming event or tool call] --> K{what kind?}
+
+    K -->|tool exception| C1[classify_tool_error]
+    K -->|report_task_failed| C2{recoverable?}
+    K -->|refusal text| C3[classify_refusal]
+    K -->|stop_reason=length| C4[CONTEXT_PRESSURE]
+    K -->|stop_reason=max_turns| C5[TOO_MANY_STEPS]
+    K -->|report_plan_divergence| C6[PLAN_DIVERGENCE]
+    K -->|report_new_work_discovered| C7[NEW_WORK_DISCOVERED]
+    K -->|report_task_blocked| C8{structural blocker?}
+    K -->|transfer event| C9{to unplanned agent?}
+    K -->|schema validation failed| C10[SCHEMA_VIOLATION]
+
+    C1 --> R1[TOOL_ERROR / warning]
+    C2 -->|yes| R2[TASK_FAILED_RECOVERABLE / warning]
+    C2 -->|no| R3[TASK_FAILED_FATAL / critical]
+    C3 -->|hard| R4[MODEL_REFUSAL / critical]
+    C3 -->|soft| R5[AGENT_REFUSAL / warning]
+    C8 -->|structural| R6[BLOCKED / warning]
+    C8 -->|waiting| R7[none]
+    C9 -->|yes| R8[AGENT_TRANSFER + WRONG_AGENT]
+    C9 -->|no| R9[AGENT_TRANSFER / info]
+```
+
+The helper classifiers live in `goldfive/drift.py`:
+
+```python
+def classify_tool_error(err: Exception, tool_name: str) -> DriftEvent: ...
+def classify_refusal(text: str) -> DriftEvent | None: ...
+def classify_stop_reason(reason: str) -> DriftEvent | None: ...
+def classify_schema_violation(payload: Any, schema: Any) -> DriftEvent: ...
+```
+
+Subclasses of `DefaultSteerer` can override any of them to tune
+thresholds or add domain-specific signals.
+
+## Refine policy
+
+When `Steerer.detect_drift()` returns a `DriftEvent`, the executor
+decides whether to act on it:
+
+```python
+drift = steerer.detect_drift(result, session)
+if drift is None:
+    continue
+await emit_drift_detected(sinks, drift, session)
+
+if drift.severity == DriftSeverity.INFO:
+    continue  # informational; proceed
+
+if not drift_is_recoverable(drift):
+    await emit_run_aborted(sinks, reason=f"unrecoverable: {drift.kind}", drift=drift)
+    return ExecutionOutcome(success=False, session=session, reason=str(drift.kind))
+
+revised = await planner.refine(plan=session.plan, drift=drift, goals=session.goals)
+if revised is None:
+    # planner declined to revise — treat as goal-unreachable
+    await emit_run_aborted(sinks, reason="planner declined refine", drift=drift)
+    return ExecutionOutcome(success=False, session=session, reason="goal_unreachable")
+
+session.plan = revised
+await emit_plan_revised(sinks, plan=revised, drift=drift, session=session)
+```
+
+Three invariants govern the refine path:
+
+1. **Completed tasks are preserved.** `planner.refine()` implementations
+   must not return a plan that deletes or re-runs completed tasks.
+2. **Revision metadata is stamped.** The revised plan's
+   `revision_reason`, `revision_kind`, `revision_severity`, and
+   `revision_index` fields are set by the executor before emission.
+3. **Refine is throttled.** Multiple drifts of the same kind within
+   `DEFAULT_REFINE_THROTTLE_SECONDS` (2s) collapse into one refine
+   call. `critical` drifts bypass the throttle.
+
+## How drifts become events
+
+Every `DriftEvent` produces exactly one `DriftDetected` event in the
+proto stream. The event envelope carries:
+
+- `kind` — the `DriftKind` string value.
+- `severity` — the `DriftSeverity` string value.
+- `detail` — human-readable note.
+- `current_task_id`, `current_agent_id` — from the session at
+  emission time.
+- `recoverable` — derived from severity and kind.
+- `raw_summary` — a short stringification of `raw` (the full
+  untouched trigger is not serialized into the proto to avoid
+  bloating the wire; sinks that need the raw trigger should snapshot
+  it in-process).
+
+If refine runs and succeeds, the next event in the stream is
+`PlanRevised`, whose `revision_kind` / `revision_severity` / `revision_index`
+fields echo the drift. Callers reconstructing state from a JSONL
+recovery file can pair `DriftDetected` with the following `PlanRevised`
+unambiguously by sequence order.
+
+## Extending the taxonomy
+
+To add a new drift kind:
+
+1. Add a value to the `DriftKind` enum in `goldfive/types.py`.
+2. Mirror the value in `proto/goldfive/v1/types.proto` and regenerate.
+3. Add a row to the taxonomy table above.
+4. Add a classifier helper in `goldfive/drift.py` if the detection
+   logic is non-trivial.
+5. Wire the classifier into `DefaultSteerer.detect_drift()` (or a
+   subclass's override).
+6. Update the harmonograf sink front-end metadata so the UI renders it
+   with the correct icon / color / label.
+
+See [PROTOCOLS.md](PROTOCOLS.md#steerer) for the full Steerer contract
+and [writing-an-agent-adapter.md](../guides/writing-an-agent-adapter.md)
+for how adapters surface drift-triggering events.

--- a/docs/design/EVENT-MODEL.md
+++ b/docs/design/EVENT-MODEL.md
@@ -1,0 +1,270 @@
+# Event model
+
+goldfive emits a proto-encoded event stream during every run. Events
+are the only observability surface: nothing about run state is
+reconstructable without them, and nothing about run state is
+published except through them.
+
+This document covers:
+
+- The event taxonomy (what events exist, what each carries).
+- Sequence semantics (ordering and uniqueness guarantees).
+- The `EventSink` contract (what sinks may and may not do).
+- How to build a custom sink.
+
+Related: [ARCHITECTURE.md](ARCHITECTURE.md), [PROTOCOLS.md](PROTOCOLS.md#eventsink),
+and the [writing-an-event-sink guide](../guides/writing-an-event-sink.md).
+
+## Event envelope
+
+Every event, regardless of kind, carries a common envelope:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `event_id` | `string` | UUIDv7, unique per event. |
+| `run_id` | `string` | The owning `Session.run_id`. |
+| `emitted_at` | `google.protobuf.Timestamp` | Wall-clock time of emission. |
+| `sequence` | `uint64` | Monotonic per-run counter from `Session.next_sequence()`. |
+| `payload` | `oneof` | The event-specific body; see the taxonomy. |
+
+The envelope is defined in `proto/goldfive/v1/events.proto` (see
+[issue #3](https://github.com/pedapudi/goldfive/issues/3)). Generated
+Python lives under `goldfive/pb/goldfive/v1/events_pb2.py`.
+
+Helpers in `goldfive/events.py` produce envelopes:
+
+```python
+from goldfive.events import new_event, emit
+
+event = new_event(run_id=session.run_id, sequence=session.next_sequence())
+event.task_started.task_id = task.id
+event.task_started.detail = "beginning research phase"
+await emit(sinks, event)
+```
+
+## Event taxonomy
+
+Ten event kinds are defined in v0.1, grouped by the phase they fire in.
+
+### Run lifecycle
+
+| Event | Fired by | When |
+|---|---|---|
+| `RunStarted` | `Runner` | At the very top of `run()` before goal derivation. Carries `user_input` (truncated if long) and `started_at`. |
+| `RunCompleted` | `Runner` | When the executor returns `success=True`. Carries `outcome_summary` and `completed_task_ids`. |
+| `RunAborted` | `Runner`, `Executor` | When the executor surrenders or the runner catches an exception. Carries `reason` and `drift` (optional) explaining why. |
+
+### Goal and plan
+
+| Event | Fired by | When |
+|---|---|---|
+| `GoalDerived` | `Runner` | After `goal_deriver.derive()` returns. Carries the `list[Goal]`. Fired once per run. |
+| `PlanSubmitted` | `Runner` | After initial `planner.generate()` succeeds. Carries the full `Plan`. |
+| `PlanRevised` | `Executor` | After a successful `planner.refine()` swap. Carries the revised `Plan`, the `revision_reason`, the triggering `DriftKind`, severity, and a monotonically increasing `revision_index`. |
+
+### Task lifecycle
+
+One event per task state transition. Emitted by the `Steerer` when it
+applies the transition to the session.
+
+| Event | State transition |
+|---|---|
+| `TaskStarted` | PENDING → RUNNING |
+| `TaskProgress` | RUNNING → RUNNING (reports fraction 0.0–1.0; not a transition) |
+| `TaskCompleted` | RUNNING → COMPLETED |
+| `TaskFailed` | RUNNING → FAILED |
+| `TaskBlocked` | RUNNING → BLOCKED (or stays RUNNING with a blocker note) |
+| `TaskCancelled` | PENDING → CANCELLED (executor-driven, e.g. after an unrecoverable drift cascade) |
+
+Every task-lifecycle event carries `task_id`, a human-readable `detail`
+string, and an optional `artifacts` map for `TaskCompleted`.
+
+### Drift
+
+| Event | Fired by | When |
+|---|---|---|
+| `DriftDetected` | `Steerer` | Whenever `detect_drift()` returns a non-None `DriftEvent`. Always fired before the corresponding `PlanRevised` (if refine runs). Carries `kind`, `severity`, `detail`, `current_task_id`, and a summarized `raw` trigger. |
+
+See [DRIFT.md](DRIFT.md) for the full drift-kind taxonomy.
+
+## Sequence semantics
+
+`sequence` is assigned exactly once per event, via
+`Session.next_sequence()`:
+
+```python
+def next_sequence(self) -> int:
+    s = self._next_sequence
+    self._next_sequence = s + 1
+    return s
+```
+
+`next_sequence` is not thread-safe by itself; the `ParallelDAGExecutor`
+is careful to only call it from the executor's coroutine, not from
+inside `asyncio.gather`'d worker tasks. Steerer transitions happen
+serially.
+
+Sequence provides three guarantees:
+
+1. **Uniqueness.** No two events in one run share a sequence.
+2. **Monotonicity.** An event's sequence is always greater than
+   every prior event's sequence in the same run.
+3. **Total ordering.** Every event in a run has a sequence, and the
+   sequences form a total order that reflects the order events were
+   emitted.
+
+Sinks may rely on these to reconstruct state. In particular,
+`JSONLPersistenceSink` round-trips through sequence order when
+replaying a crashed run.
+
+### Happens-before relationships
+
+Beyond the per-run total order, goldfive guarantees:
+
+- `RunStarted` is the first event; `RunCompleted` or `RunAborted` is
+  the last.
+- `GoalDerived` precedes `PlanSubmitted`.
+- `PlanSubmitted` precedes every task-lifecycle event.
+- `TaskStarted(t)` precedes `TaskCompleted(t)`, `TaskFailed(t)`, or
+  `TaskBlocked(t)` for the same task `t`.
+- `DriftDetected` precedes `PlanRevised` when the drift triggered a
+  successful refine.
+
+## The EventSink contract
+
+```python
+@runtime_checkable
+class EventSink(Protocol):
+    async def emit(self, event_pb: Any) -> None: ...
+    async def close(self) -> None: ...
+```
+
+### What sinks may do
+
+- Serialize events to disk, database, gRPC, HTTP, stdout, anywhere.
+- Filter, transform, or batch internally.
+- Raise exceptions. goldfive catches and logs but does not re-raise
+  to the caller — one failing sink cannot take down the run.
+
+### What sinks must not do
+
+- **Block indefinitely.** `emit()` is on the critical path. A sink
+  that blocks stalls the executor. Use a bounded internal queue if
+  the downstream is slow.
+- **Read back.** goldfive never reads from a sink. If a sink wants to
+  expose a read interface (e.g. `InMemorySink.events`), that is
+  orthogonal to the goldfive protocol.
+- **Mutate the event.** The same event object is passed to every
+  sink. Treat it as immutable.
+- **Depend on other sinks.** Each sink receives the event
+  independently; order between sinks is unspecified.
+
+### Lifecycle
+
+`sink.emit()` is called once per event, in sequence order, from
+whichever coroutine is doing the emission. The calling coroutine
+awaits the returned coroutine, so slow sinks slow down the run.
+
+`sink.close()` is called once per run, after the terminal event
+(`RunCompleted` or `RunAborted`) has been emitted. Sinks must flush
+any buffered writes and release resources (file handles, sockets)
+before returning.
+
+## Built-in sinks
+
+### `InMemorySink`
+
+```python
+from goldfive.sinks import InMemorySink
+
+sink = InMemorySink()
+# ... run ...
+for event in sink.events:
+    print(event.WhichOneof("payload"), event.sequence)
+```
+
+Keeps every event in a list. For tests. Never use in production.
+
+### `LoggingSink`
+
+```python
+import logging
+from goldfive.sinks import LoggingSink
+
+logging.basicConfig(level=logging.INFO)
+sink = LoggingSink(logger=logging.getLogger("goldfive"), level=logging.INFO)
+```
+
+Logs a one-line summary per event via the standard `logging` module.
+Useful for local dev.
+
+### `JSONLPersistenceSink`
+
+```python
+from goldfive.sinks import JSONLPersistenceSink
+
+sink = JSONLPersistenceSink(path="./runs/{run_id}.jsonl")
+```
+
+Writes one JSON-encoded proto message per line. Paired with
+`from_jsonl(path)` for crash recovery. See the full
+[persistence guide](../guides/persistence-and-recovery.md).
+
+## Building a custom sink
+
+The shape is minimal:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from goldfive.protocols import EventSink
+
+
+class PrintingSink:
+    """Prints one line per event to stdout."""
+
+    async def emit(self, event_pb: Any) -> None:
+        kind = event_pb.WhichOneof("payload")
+        print(f"[{event_pb.sequence:4d}] {kind} (run={event_pb.run_id})")
+
+    async def close(self) -> None:
+        pass
+
+
+assert isinstance(PrintingSink(), EventSink)  # runtime-checkable
+```
+
+Plug into a `Runner`:
+
+```python
+runner = Runner(
+    agent=CallableAdapter(my_callable),
+    planner=PassthroughPlanner(plan),
+    executor=SequentialExecutor(),
+    sinks=[PrintingSink(), JSONLPersistenceSink("./runs/example.jsonl")],
+)
+```
+
+Every sink receives every event. Order between sinks is unspecified —
+do not design a sink that depends on another sink having already seen
+an event.
+
+For a more substantial example, see the
+[writing-an-event-sink guide](../guides/writing-an-event-sink.md) —
+it walks through a sink that forwards events to a custom observability
+backend.
+
+## Forward compatibility
+
+The proto event schema adheres to proto3 compatibility rules:
+
+- Never remove or renumber a field.
+- Add new event kinds by extending the `oneof payload`; old sinks
+  ignore unknown kinds.
+- Add new fields as `optional`; old sinks ignore them.
+
+The practical implication: **an event-sink written against v0.1 will
+continue to receive a valid event stream from later goldfive versions,
+with new fields and kinds appearing as unknowns.**

--- a/docs/design/PROTOCOLS.md
+++ b/docs/design/PROTOCOLS.md
@@ -1,0 +1,476 @@
+# Protocol contracts
+
+goldfive is assembled from six composable `Protocol`s. Each protocol
+is `@runtime_checkable`, so duck-typed implementations pass
+`isinstance(x, Protocol)` at construction time. This doc enumerates
+the contract of each protocol — the shape, the semantics, and the
+invariants a correct implementation must uphold — plus minimal
+working implementations.
+
+Related: [ARCHITECTURE.md](ARCHITECTURE.md), [api.md](../reference/api.md).
+
+All method signatures in this doc track `INTERFACE_SPEC.md` at the
+repository root. When they disagree, the spec wins until it is deleted
+(post-v0.1).
+
+## GoalDeriver
+
+```python
+@runtime_checkable
+class GoalDeriver(Protocol):
+    async def derive(
+        self,
+        user_input: str,
+        *,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> list[Goal]: ...
+```
+
+### Contract
+
+- Takes a single string (the user's raw request) and an optional
+  context map.
+- Returns a list of one or more `Goal` objects. Each `Goal` has a
+  unique `id`, a `summary` string, and an optional `success_predicate`.
+- Called exactly once per `Runner.run()`.
+- Must be pure with respect to the run state: no writes to the
+  session, no side effects on sinks.
+
+### Invariants
+
+1. Non-empty return. A goal-deriver that genuinely cannot derive any
+   goal must raise, not return `[]`. The `Runner` aborts on empty.
+2. Unique `Goal.id` within the returned list.
+3. No mutation of `user_input` or `context`.
+
+### Minimal implementation
+
+```python
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from goldfive.types import Goal
+
+
+class PassthroughGoalDeriver:
+    """Wraps the raw user input in a single Goal."""
+
+    async def derive(
+        self,
+        user_input: str,
+        *,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> list[Goal]:
+        return [Goal(id="g1", summary=user_input)]
+```
+
+See the [goals-and-plans guide](../guides/goals-and-plans.md) for when
+to write an `LLMGoalDeriver` instead.
+
+## Planner
+
+```python
+@runtime_checkable
+class Planner(Protocol):
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> Optional[Plan]: ...
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Optional[Plan]: ...
+```
+
+### Contract — `generate`
+
+- Called once per run, between goal derivation and executor dispatch.
+- Receives the full list of goals and the adapter's
+  `available_agents`.
+- Returns a `Plan` (DAG of `Task`s) whose tasks' `assignee_agent_id`
+  values are drawn from `available_agents`. Returning `None` aborts
+  the run with `goal_unreachable`.
+
+### Contract — `refine`
+
+- Called when the steerer classifies a drift of severity ≥ warning
+  and the current plan has unfinished tasks.
+- Receives the current (possibly already-revised) plan, the drift
+  event, and the original goals.
+- Returns a revised plan that **preserves every completed task's
+  identity and outcome**, or `None` to signal unrecoverable. Returning
+  the same plan object unchanged is legal but pointless; the executor
+  re-runs the outer loop regardless.
+
+### Invariants
+
+1. Generated plans are acyclic. `Plan.topological_stages()` raises on
+   a cycle; planners are responsible for producing valid DAGs.
+2. `plan.goal_ids` lists every goal the plan intends to satisfy.
+3. `refine()` preserves `Task.id` for completed tasks; it may add,
+   remove, or edit `PENDING` tasks freely.
+4. `refine()` monotonically increments `plan.revision_index`.
+
+### Minimal implementation
+
+```python
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from goldfive.types import DriftEvent, Goal, Plan
+
+
+class PassthroughPlanner:
+    """Returns a pre-baked plan; never refines."""
+
+    def __init__(self, plan: Plan) -> None:
+        self._plan = plan
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> Optional[Plan]:
+        return self._plan
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Optional[Plan]:
+        return None  # no refine capability
+```
+
+For the full `LLMPlanner` that parses JSON plans out of an LLM
+response, see `goldfive/planner.py` or
+[goals-and-plans.md](../guides/goals-and-plans.md#writing-a-custom-planner).
+
+## Steerer
+
+```python
+@runtime_checkable
+class Steerer(Protocol):
+    async def observe(self, event: Any, session: Session) -> None: ...
+
+    async def transition(
+        self,
+        task_id: str,
+        to: TaskStatus,
+        *,
+        detail: str = "",
+        session: Session,
+    ) -> None: ...
+
+    def detect_drift(self, event: Any, session: Session) -> Optional[DriftEvent]: ...
+
+    def bind(
+        self,
+        *,
+        sinks: list["EventSink"],
+        planner: Planner,
+    ) -> None: ...
+```
+
+### Contract
+
+- `observe(event, session)` — the adapter streams raw framework
+  events (LLM text, tool calls, stream chunks) here. The steerer may
+  classify drift, update per-task progress, or no-op. Must not mutate
+  `event`.
+- `transition(task_id, to, session)` — the single source-of-truth
+  state-mutating method. Enforces monotonicity (see
+  [STATE-MACHINE.md](STATE-MACHINE.md)) and emits one event per
+  successful transition.
+- `detect_drift(event, session)` — pure classifier. Returns a
+  `DriftEvent` or `None`. No state mutation, no event emission.
+- `bind(sinks, planner)` — called once by the executor before the
+  first `observe`. Wires the steerer to its downstream dependencies.
+
+### Invariants
+
+1. Terminal states absorb. `transition(t, to, ...)` is a no-op if `t`
+   is already in `{COMPLETED, FAILED, CANCELLED}`.
+2. Exactly one event emitted per successful transition.
+3. `detect_drift()` is side-effect-free.
+4. Steerer operations are serialized per-run (callers guarantee this).
+
+### Minimal implementation
+
+```python
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from goldfive.types import DriftEvent, Session, TaskStatus
+from goldfive.protocols import EventSink, Planner
+
+
+_TERMINAL = {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED}
+
+
+class MinimalSteerer:
+    """Minimal but compliant Steerer. No drift detection."""
+
+    def __init__(self) -> None:
+        self._sinks: list[EventSink] = []
+        self._planner: Optional[Planner] = None
+
+    def bind(self, *, sinks: list[EventSink], planner: Planner) -> None:
+        self._sinks = sinks
+        self._planner = planner
+
+    async def observe(self, event: Any, session: Session) -> None:
+        # no-op
+        return
+
+    async def transition(
+        self,
+        task_id: str,
+        to: TaskStatus,
+        *,
+        detail: str = "",
+        session: Session,
+    ) -> None:
+        assert session.plan is not None
+        task = next(t for t in session.plan.tasks if t.id == task_id)
+        if task.status in _TERMINAL:
+            return
+        task.status = to
+        # (skip event emission for brevity — see DefaultSteerer)
+
+    def detect_drift(self, event: Any, session: Session) -> Optional[DriftEvent]:
+        return None
+```
+
+The production `DefaultSteerer` in `goldfive/steerer.py` adds the full
+drift classifier and event emission.
+
+## AgentAdapter
+
+```python
+@runtime_checkable
+class AgentAdapter(Protocol):
+    async def register_reporting_tools(
+        self,
+        tools: list[ReportingToolSpec],
+    ) -> None: ...
+
+    async def invoke(
+        self,
+        task: Task,
+        session: Session,
+    ) -> InvocationResult: ...
+
+    @property
+    def available_agents(self) -> list[str]: ...
+```
+
+### Contract
+
+- `register_reporting_tools(tools)` — called once before the first
+  invoke. Adapter translates `ReportingToolSpec` into whatever form
+  its framework uses (ADK `FunctionTool`, Claude SDK inline tool,
+  etc.) and wires a hook that intercepts calls and routes them
+  through the steerer.
+- `invoke(task, session)` — runs the wrapped agent for one task.
+  Must render current-task context (task id, description, completed
+  results) into the agent's input channel. Returns an
+  `InvocationResult` with the final text and stop reason.
+- `available_agents` — names of agents the adapter can dispatch to.
+  Consumed by the planner.
+
+### Invariants
+
+1. `invoke` must not return until the agent has finished its turn.
+2. Reporting tool interceptions run through the steerer before the
+   tool body returns its `{"acknowledged": True}` ack.
+3. Observed events (tool calls, text chunks, stream blocks) are fed
+   to `steerer.observe()` in order. Drift classification happens in
+   the steerer, not the adapter.
+4. Exceptions raised by the wrapped agent propagate out of `invoke`.
+   The executor catches and classifies.
+
+### Minimal implementation (CallableAdapter)
+
+```python
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from goldfive.protocols import AgentAdapter
+from goldfive.reporting import ReportingToolSpec
+from goldfive.results import InvocationResult
+from goldfive.types import Session, Task
+
+
+AgentFn = Callable[
+    [Task, Session, list[ReportingToolSpec]],
+    Awaitable[InvocationResult],
+]
+
+
+class CallableAdapter:
+    """Wraps an async callable as an AgentAdapter."""
+
+    def __init__(
+        self,
+        agent: AgentFn,
+        *,
+        available_agents: list[str] | None = None,
+    ) -> None:
+        self._agent = agent
+        self._tools: list[ReportingToolSpec] = []
+        self._available_agents = available_agents or ["default"]
+
+    async def register_reporting_tools(
+        self,
+        tools: list[ReportingToolSpec],
+    ) -> None:
+        self._tools = tools
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:
+        return await self._agent(task, session, self._tools)
+
+    @property
+    def available_agents(self) -> list[str]:
+        return self._available_agents
+```
+
+See [writing-an-agent-adapter.md](../guides/writing-an-agent-adapter.md)
+for a full worked example that wraps a hypothetical new framework.
+
+## Executor
+
+```python
+@runtime_checkable
+class Executor(Protocol):
+    async def run(
+        self,
+        *,
+        plan: Plan,
+        session: Session,
+        adapter: AgentAdapter,
+        steerer: Steerer,
+        planner: Planner,
+        sinks: list["EventSink"],
+    ) -> ExecutionOutcome: ...
+```
+
+### Contract
+
+- Walks the plan in topological order.
+- For each `PENDING` task whose dependencies are `COMPLETED`:
+  - Calls `steerer.transition(task.id, RUNNING, session=session)`.
+  - Calls `adapter.invoke(task, session)` and awaits the result.
+  - Routes observed events / results to `steerer.observe()`.
+  - Calls `steerer.detect_drift(result, session)` after the task
+    returns.
+- On drift ≥ warning: calls `planner.refine(...)`, swaps the plan,
+  emits `PlanRevised`, and restarts the loop.
+- Enforces `max_plan_reinvocations` (typically 3): if the loop runs
+  that many times without net progress, aborts with `RunAborted`.
+- Emits `RunStarted` at entry and `RunCompleted` / `RunAborted` at
+  exit.
+
+### Invariants
+
+1. **No mid-stage replan (parallel).** Parallel-DAG finishes the
+   current stage before refining. Sequential can refine after any
+   task.
+2. **Termination.** Every `Executor.run()` terminates: either all
+   tasks reach a terminal state (success) or the reinvocation limit
+   is hit (abort).
+3. **Single-pass per task.** A task cannot transition out of `RUNNING`
+   without the executor having invoked the adapter for it.
+
+### Minimal implementation
+
+```python
+from __future__ import annotations
+
+from goldfive.protocols import AgentAdapter, EventSink, Executor, Planner, Steerer
+from goldfive.results import ExecutionOutcome
+from goldfive.types import Plan, Session, TaskStatus
+
+
+class LinearSequentialExecutor:
+    """Minimal executor — assumes a linear plan (no branching), no refine."""
+
+    async def run(
+        self,
+        *,
+        plan: Plan,
+        session: Session,
+        adapter: AgentAdapter,
+        steerer: Steerer,
+        planner: Planner,
+        sinks: list[EventSink],
+    ) -> ExecutionOutcome:
+        steerer.bind(sinks=sinks, planner=planner)
+        for task in plan.tasks:
+            if task.status != TaskStatus.PENDING:
+                continue
+            await steerer.transition(task.id, TaskStatus.RUNNING, session=session)
+            result = await adapter.invoke(task, session)
+            # adapter has been calling steerer.observe() throughout invoke()
+            final_status = (
+                TaskStatus.FAILED if result.error else TaskStatus.COMPLETED
+            )
+            await steerer.transition(task.id, final_status, session=session)
+        return ExecutionOutcome(success=True, session=session)
+```
+
+The production executors (`SequentialExecutor`, `ParallelDAGExecutor`)
+add topological scheduling, drift handling, refine, and the
+reinvocation loop.
+
+## EventSink
+
+```python
+@runtime_checkable
+class EventSink(Protocol):
+    async def emit(self, event_pb: Any) -> None: ...
+    async def close(self) -> None: ...
+```
+
+### Contract
+
+- `emit(event_pb)` is called once per event, in sequence order, from
+  whichever coroutine is emitting.
+- `close()` is called once per run after the terminal event.
+- Sinks may raise; goldfive catches and logs. One failing sink cannot
+  take down the run.
+
+See [EVENT-MODEL.md](EVENT-MODEL.md#the-eventsink-contract) for the
+full semantics and [writing-an-event-sink.md](../guides/writing-an-event-sink.md)
+for a walkthrough.
+
+### Minimal implementation
+
+```python
+class NullSink:
+    async def emit(self, event_pb):
+        return
+
+    async def close(self):
+        return
+```
+
+## Composition example
+
+See [getting-started.md](../guides/getting-started.md) for a full
+runnable `Runner` composed from these minimal implementations plus
+a 3-task plan.

--- a/docs/design/STATE-MACHINE.md
+++ b/docs/design/STATE-MACHINE.md
@@ -1,0 +1,201 @@
+# Task state machine
+
+Every task in a goldfive plan moves through a strict state machine. The
+machine is **monotonic**: once a task reaches a terminal state, it
+cannot leave. It is **owned by the Steerer**: every transition runs
+through `Steerer.transition(task_id, to, *, session)` and emits an
+event to every sink.
+
+Related: [DRIFT.md](DRIFT.md), [PROTOCOLS.md](PROTOCOLS.md#steerer),
+[EVENT-MODEL.md](EVENT-MODEL.md).
+
+## States
+
+```python
+class TaskStatus(StrEnum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+    BLOCKED = "BLOCKED"
+```
+
+| State | Meaning |
+|---|---|
+| `PENDING` | The task exists in the plan and has not been started. Default state when a plan is first submitted. |
+| `RUNNING` | The executor has invoked the adapter for this task. The agent is working. |
+| `COMPLETED` | Terminal success. `report_task_completed(...)` was called; the task's output summary is in `session.completed_results[task_id]`. |
+| `FAILED` | Terminal failure. `report_task_failed(...)` was called, or the adapter returned an exception, or the executor aborted the task. |
+| `CANCELLED` | Terminal. Executor-driven; e.g. after an unrecoverable upstream failure cascaded down to this task. |
+| `BLOCKED` | Non-terminal. An external condition prevents progress; the task may return to `RUNNING` once the blocker resolves. |
+
+## The diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING : task added to plan
+
+    PENDING --> RUNNING : executor invokes adapter\n(emits TaskStarted)
+    PENDING --> CANCELLED : upstream cancellation cascade\n(emits TaskCancelled)
+
+    RUNNING --> RUNNING : report_task_progress\n(emits TaskProgress; no transition)
+    RUNNING --> COMPLETED : report_task_completed\n(emits TaskCompleted)
+    RUNNING --> FAILED : report_task_failed or adapter error\n(emits TaskFailed)
+    RUNNING --> BLOCKED : report_task_blocked (structural)\n(emits TaskBlocked)
+    RUNNING --> CANCELLED : executor cancel\n(emits TaskCancelled)
+
+    BLOCKED --> RUNNING : blocker resolved by refine\n(emits TaskStarted with resume=true)
+    BLOCKED --> CANCELLED : refine decides not to resume\n(emits TaskCancelled)
+    BLOCKED --> FAILED : refine converts to failure\n(emits TaskFailed)
+
+    COMPLETED --> [*]
+    FAILED --> [*]
+    CANCELLED --> [*]
+```
+
+## Transition rules
+
+Every transition obeys three invariants.
+
+### Invariant 1 — Terminal states absorb
+
+Once a task is in `COMPLETED`, `FAILED`, or `CANCELLED`, no further
+transition is legal. `Steerer.transition()` rejects attempts to leave a
+terminal state:
+
+```python
+async def transition(self, task_id, to, *, detail="", session):
+    task = _find_task(session.plan, task_id)
+    if task.status in _TERMINAL_STATES:
+        logger.warning(
+            "ignoring transition %s → %s (already terminal)",
+            task.status, to,
+        )
+        return
+    ...
+```
+
+This is the single most load-bearing invariant in goldfive. Every
+feature downstream (progress reporting, refine, crash recovery,
+harmonograf integration) assumes it.
+
+### Invariant 2 — Reporting tools drive the machine
+
+In v0.1, the canonical path into the state machine is through
+**reporting tools** (see [tool-protocol.md](../reference/tool-protocol.md)).
+When an agent calls `report_task_started("t3")`, the adapter
+intercepts, and the steerer applies `PENDING → RUNNING` for task
+`t3`.
+
+There are three non-reporting-tool paths in:
+
+- **Executor-driven transitions.** When the executor first picks up a
+  `PENDING` task, it calls `steerer.transition(task_id, RUNNING, ...)`
+  directly. An agent that also calls `report_task_started` produces a
+  no-op (RUNNING → RUNNING).
+- **Adapter-observed failures.** If `adapter.invoke()` raises, the
+  executor catches, classifies the error as `TOOL_ERROR` or
+  `TASK_FAILED_FATAL`, and calls `steerer.transition(task_id, FAILED, ...)`.
+- **Cascade cancellations.** On an unrecoverable drift, the executor
+  walks downstream PENDING tasks via `Plan.topological_stages()` and
+  transitions each to `CANCELLED`.
+
+### Invariant 3 — Transitions emit exactly one event
+
+Every successful transition in `Steerer.transition()` emits one event:
+
+| Transition | Emitted event |
+|---|---|
+| `PENDING → RUNNING` | `TaskStarted` |
+| `RUNNING → RUNNING` (progress) | `TaskProgress` |
+| `RUNNING → COMPLETED` | `TaskCompleted` |
+| `RUNNING → FAILED` | `TaskFailed` |
+| `RUNNING → BLOCKED` | `TaskBlocked` |
+| `RUNNING → CANCELLED` | `TaskCancelled` |
+| `PENDING → CANCELLED` | `TaskCancelled` |
+| `BLOCKED → RUNNING` | `TaskStarted` (with `detail="resumed"`) |
+| `BLOCKED → *` | same as the `RUNNING → *` case |
+
+Rejected transitions (into or out of terminal states) emit no events,
+just a warning log.
+
+## Blocked vs non-blocked resume
+
+`BLOCKED` is the only non-terminal-non-default state. It exists because
+agents sometimes encounter waits that are not failures: "I need a
+human approval", "waiting on another process", "no network".
+
+Two ways out of `BLOCKED`:
+
+1. **Refine-driven resume.** The planner may issue a revised plan that
+   resolves the blocker (e.g. by adding an approval task, or rerouting
+   around the wait). The executor detects that the blocked task now
+   has its dependencies satisfied again and calls
+   `steerer.transition(task_id, RUNNING, detail="resumed")`.
+2. **Terminal conversion.** If refine decides the blocker cannot be
+   resolved, the planner returns a plan that converts the blocked task
+   to `FAILED` or `CANCELLED`.
+
+In v0.1, automatic blocker resolution (e.g. polling an external
+condition) is not in-box. The planner/caller is expected to handle
+resolution logic.
+
+## Progress reporting
+
+`report_task_progress(task_id, fraction, detail)` is **not a
+transition**. It:
+
+- Stays in `RUNNING`.
+- Writes `session.task_progress[task_id] = fraction`.
+- Writes `session.agent_notes[task_id] = detail`.
+- Emits `TaskProgress(task_id, fraction, detail)`.
+
+Sinks can use progress events for liveness indicators. goldfive does
+not use them internally (not even for drift — stalled tasks are
+detected via elapsed time, not via progress gaps).
+
+## Cascade semantics on unrecoverable drift
+
+When a drift carries `recoverable=False`, the executor runs the
+**unrecoverable cascade**:
+
+```
+1. Mark the current task FAILED (if not already terminal).
+2. Mark every RUNNING task FAILED.
+3. BFS downstream from each just-FAILED task and mark every
+   reachable PENDING task CANCELLED.
+4. Clear any adapter-bound task context (ContextVars).
+5. Emit RunAborted(reason=drift.kind, drift=drift).
+```
+
+This is why `FAILED` and `CANCELLED` must be absorbing: the cascade
+relies on being able to call `transition(..., CANCELLED)` on any
+downstream task without re-checking its history.
+
+## Implementation notes
+
+The reference implementation is `DefaultSteerer` in
+`goldfive/steerer.py`. It ports harmonograf's `_AdkState` to a
+framework-agnostic form.
+
+- **State storage.** The canonical state lives on `Task.status` in the
+  plan, not in a separate dict. `Session.plan` is the single source of
+  truth.
+- **Concurrency.** `Steerer.transition()` is async but assumes serial
+  invocation per run. The Sequential and Parallel-DAG executors both
+  uphold this: in Parallel-DAG, reporting-tool callbacks from
+  concurrent workers are serialized through an `asyncio.Lock` on the
+  steerer.
+- **Atomicity.** The state write and the event emission are both
+  `await`ed within `transition()`. If a sink raises, the state has
+  already changed; goldfive logs and continues. This means state is
+  authoritative, sinks are best-effort.
+
+## Testing the state machine
+
+`tests/test_steerer.py` covers every legal transition plus attempts at
+illegal ones (terminal → anything, missing task ids, duplicate
+completions). When porting this doc to a newer spec, the tests in
+[issue #16](https://github.com/pedapudi/goldfive/issues/16) are the
+executable contract.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,316 @@
+# Getting started with goldfive
+
+This is the hands-on entry point. Clone, install, and run your first
+goldfive-wrapped agent in about ten minutes. Every snippet is
+self-contained and runs against v0.1.
+
+If you want the motivation and design context first, start with
+[ARCHITECTURE.md](../design/ARCHITECTURE.md).
+
+## Prerequisites
+
+| Tool | Minimum | Notes |
+|---|---|---|
+| Python | 3.11 | `StrEnum` is required. |
+| [`uv`](https://github.com/astral-sh/uv) | recent | Primary package manager. `pip` works but is untested. |
+| `git` | any | For cloning. |
+
+No LLM credentials are required for this guide. The "hello-callable"
+walkthrough uses a scripted Python callable as the agent.
+
+## Install
+
+```bash
+git clone https://github.com/pedapudi/goldfive.git
+cd goldfive
+uv sync
+```
+
+Verify the import surface:
+
+```bash
+uv run python -c "from goldfive import Runner; print(Runner)"
+```
+
+You should see `<class 'goldfive.runner.Runner'>`.
+
+Optional extras (only install what you need):
+
+```bash
+uv sync --extra adk       # google-adk integration
+uv sync --extra claude    # claude-agent-sdk integration
+uv sync --extra dev       # dev tools (pytest, ruff, mypy)
+uv sync --extra examples  # example-specific deps
+```
+
+## Mental model in five sentences
+
+goldfive wraps an agent and runs it against an explicit plan.
+
+1. Your user input becomes one or more **Goals**.
+2. A **Planner** produces a **Plan** (a DAG of **Tasks**) that, if
+   executed, satisfies the goals.
+3. An **Executor** walks the plan. For each task, it calls your
+   **AgentAdapter**, which drives whatever underlying framework
+   (Claude, ADK, a bare callable) actually runs the agent.
+4. A **Steerer** watches the execution and classifies **drift** —
+   structured "we're off-track" signals.
+5. On drift, the planner revises the plan; every state change emits a
+   proto **Event** to every configured **EventSink**.
+
+Six primitives, one `Runner` object, one `await runner.run(...)` call.
+
+## Hello-callable: your first agent in 10 minutes
+
+We'll build the simplest possible goldfive run: a three-task plan,
+driven by an async Python callable pretending to be an agent, with an
+in-memory event sink you can inspect at the end.
+
+### Step 1 — Write the agent callable
+
+Create `hello.py`:
+
+```python
+from __future__ import annotations
+
+import asyncio
+
+from goldfive import Runner
+from goldfive.adapters.callable import CallableAdapter
+from goldfive.executors.sequential import SequentialExecutor
+from goldfive.planner import PassthroughPlanner
+from goldfive.results import InvocationResult
+from goldfive.sinks import InMemorySink
+from goldfive.steerer import DefaultSteerer
+from goldfive.types import Plan, Session, Task, TaskEdge
+
+
+# -- the "agent" --------------------------------------------------------
+#
+# A CallableAdapter expects an async callable with this shape:
+#   (task, session, tools) -> InvocationResult
+#
+# `tools` is the list of reporting-tool specs the adapter registered.
+# In a real agent, this is where the LLM would be invoked and its
+# tool calls intercepted. Here, we just call the tools ourselves.
+
+async def my_agent(task: Task, session: Session, tools) -> InvocationResult:
+    started = next(t for t in tools if t.name == "report_task_started")
+    completed = next(t for t in tools if t.name == "report_task_completed")
+
+    await started.handler({"task_id": task.id, "detail": ""}, session, None)
+    # ... do the "work" ...
+    result_text = f"did {task.title}"
+    await completed.handler(
+        {"task_id": task.id, "summary": result_text, "artifacts": {}},
+        session,
+        None,
+    )
+    return InvocationResult(task_id=task.id, text=result_text)
+
+
+# -- the plan -----------------------------------------------------------
+#
+# A linear 3-task plan: t1 → t2 → t3.
+
+plan = Plan(
+    id="p1",
+    run_id="",  # Runner stamps this at dispatch time
+    goal_ids=["g1"],
+    tasks=[
+        Task(id="t1", title="gather context", assignee_agent_id="default"),
+        Task(id="t2", title="draft response", assignee_agent_id="default"),
+        Task(id="t3", title="polish output", assignee_agent_id="default"),
+    ],
+    edges=[
+        TaskEdge(from_task_id="t1", to_task_id="t2"),
+        TaskEdge(from_task_id="t2", to_task_id="t3"),
+    ],
+    summary="3-step linear demo",
+)
+
+
+# -- the Runner ---------------------------------------------------------
+
+async def main() -> None:
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(my_agent),
+        planner=PassthroughPlanner(plan),
+        executor=SequentialExecutor(),
+        steerer=DefaultSteerer(),
+        sinks=[sink],
+    )
+    outcome = await runner.run("demo run")
+
+    print(f"success={outcome.success}, tasks={len(outcome.session.plan.tasks)}")
+    for event in sink.events:
+        kind = event.WhichOneof("payload")
+        print(f"  [{event.sequence:2d}] {kind}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### Step 2 — Run it
+
+```bash
+uv run python hello.py
+```
+
+Expected output:
+
+```
+success=True, tasks=3
+  [ 0] run_started
+  [ 1] goal_derived
+  [ 2] plan_submitted
+  [ 3] task_started
+  [ 4] task_completed
+  [ 5] task_started
+  [ 6] task_completed
+  [ 7] task_started
+  [ 8] task_completed
+  [ 9] run_completed
+```
+
+That's it. You have a full goldfive run, observable via the in-memory
+sink, walking a 3-task plan end-to-end.
+
+### Step 3 — Inspect what happened
+
+Everything you'd want to know is in `sink.events`:
+
+```python
+for event in sink.events:
+    kind = event.WhichOneof("payload")
+    if kind == "task_completed":
+        tc = event.task_completed
+        print(f"task {tc.task_id}: {tc.summary}")
+```
+
+For a run that was persisted to disk, use `JSONLPersistenceSink` —
+see [persistence-and-recovery.md](persistence-and-recovery.md).
+
+## Wiring a real agent
+
+The `CallableAdapter` is the simplest `AgentAdapter`: it just hands
+your callable the reporting tools and lets the callable do whatever it
+wants. For real agents, use:
+
+- **`CallableAdapter`** — you want full control (most custom harnesses).
+- **`ClaudeAgentSDKAdapter`** — you're using Anthropic's Claude Agent
+  SDK. Install with `uv sync --extra claude`.
+- **`ADKAdapter`** — you're using Google's Agent Development Kit.
+  Install with `uv sync --extra adk`.
+
+Swapping adapters is a one-line change:
+
+```python
+# was:
+# agent=CallableAdapter(my_agent),
+
+# now:
+from goldfive.adapters.claude import ClaudeAgentSDKAdapter
+agent=ClaudeAgentSDKAdapter(
+    system_prompt="You are a helpful assistant.",
+    model="claude-opus-4-5-20251101",
+)
+```
+
+The rest of the `Runner` construction is identical. That is the core
+payoff of goldfive: framework-agnostic orchestration over whatever
+agent primitive you have.
+
+## Using an LLM planner instead
+
+`PassthroughPlanner` is great for demos because you hand it a plan
+up-front. For real workloads, let the LLM decompose:
+
+```python
+from goldfive.planner import LLMPlanner
+
+async def call_llm(system_prompt: str, user_prompt: str, model: str) -> str:
+    # wire this to your LLM of choice.
+    ...
+
+runner = Runner(
+    agent=CallableAdapter(my_agent),
+    planner=LLMPlanner(call_llm=call_llm, model="claude-opus-4-5-20251101"),
+    executor=SequentialExecutor(),
+)
+outcome = await runner.run("build me a slide deck about Python")
+```
+
+See [goals-and-plans.md](goals-and-plans.md) for the planner prompt
+format and how to customize it.
+
+## Adding a persistence sink
+
+One line to make runs crash-recoverable:
+
+```python
+from goldfive.sinks import JSONLPersistenceSink
+
+runner = Runner(
+    agent=CallableAdapter(my_agent),
+    planner=PassthroughPlanner(plan),
+    executor=SequentialExecutor(),
+    sinks=[JSONLPersistenceSink(path=f"./runs/{run_id}.jsonl")],
+)
+```
+
+Full failure-mode walkthrough in
+[persistence-and-recovery.md](persistence-and-recovery.md).
+
+## Running in parallel
+
+Swap `SequentialExecutor` for `ParallelDAGExecutor`:
+
+```python
+from goldfive.executors.parallel import ParallelDAGExecutor
+
+runner = Runner(
+    agent=CallableAdapter(my_agent),
+    planner=PassthroughPlanner(plan),
+    executor=ParallelDAGExecutor(max_concurrency=4),
+)
+```
+
+Tasks whose dependencies are satisfied run concurrently via
+`asyncio.gather`. Refine is deferred to stage boundaries.
+
+## What's next
+
+- [writing-an-agent-adapter.md](writing-an-agent-adapter.md) — wrap a
+  new framework.
+- [writing-an-event-sink.md](writing-an-event-sink.md) — send events
+  to your own observability backend.
+- [goals-and-plans.md](goals-and-plans.md) — author custom
+  GoalDerivers and Planners.
+- [persistence-and-recovery.md](persistence-and-recovery.md) — crash
+  recovery with `JSONLPersistenceSink`.
+- [tool-protocol.md](../reference/tool-protocol.md) — the seven
+  reporting tools that drive task state.
+- [ARCHITECTURE.md](../design/ARCHITECTURE.md) — the full design
+  reference.
+
+## Troubleshooting
+
+**`ModuleNotFoundError: goldfive.adapters.claude`.** The Claude SDK
+adapter is gated behind the `claude` extra. `uv sync --extra claude`.
+
+**`ImportError: google.adk`.** Same idea for ADK:
+`uv sync --extra adk`. Plus you need Google's `adk-python` checked
+out somewhere your Python can find it.
+
+**Run hangs indefinitely.** Most common cause: your agent callable
+never calls `report_task_completed`. The executor waits for every
+task to reach a terminal state. Either fix the agent or add a
+timeout and use a drift-driven refine.
+
+**Every sink saw an event with sequence 0 twice.** Almost certainly a
+bug in a custom executor that called `Session.next_sequence()` from
+inside `asyncio.gather` without serialization. Serialize the call.
+See [EVENT-MODEL.md](../design/EVENT-MODEL.md#sequence-semantics).

--- a/docs/guides/goals-and-plans.md
+++ b/docs/guides/goals-and-plans.md
@@ -1,0 +1,402 @@
+# Goals and plans
+
+goldfive separates two concepts that most agent frameworks conflate:
+
+- **Goals** — what "done" means. Explicit, small in number, surfaced
+  to the planner and the drift classifier.
+- **Plans** — the DAG of tasks that, if executed, achieves the goals.
+
+This guide covers the split, when to author a custom `GoalDeriver` or
+`Planner`, and how `refine` works in practice.
+
+Related: [PROTOCOLS.md](../design/PROTOCOLS.md#goalderiver),
+[PROTOCOLS.md](../design/PROTOCOLS.md#planner),
+[DRIFT.md](../design/DRIFT.md).
+
+## The shapes
+
+```python
+@dataclasses.dataclass
+class Goal:
+    id: str
+    summary: str
+    success_predicate: Optional[Callable[["Session"], bool]] = None
+    metadata: dict[str, str] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass
+class Plan:
+    id: str
+    run_id: str
+    goal_ids: list[str]
+    tasks: list[Task]
+    edges: list[TaskEdge]
+    summary: str = ""
+    revision_reason: str = ""
+    revision_kind: str = ""
+    revision_severity: str = ""
+    revision_index: int = 0
+```
+
+A `Goal` is tiny on purpose. The `summary` is a natural-language
+one-liner; the optional `success_predicate` lets the caller encode
+"are we done?" as code rather than prose.
+
+A `Plan` is a DAG: a list of `Task`s plus `TaskEdge`s between them.
+`Plan.topological_stages()` returns the tasks grouped by dependency
+depth — that's what the executors walk.
+
+## Why the split
+
+Historically (and in most agent libraries today), the planner sees
+the raw user message and returns a task list. That works for
+demos but fails on real workloads for two reasons:
+
+1. **Goal drift is indistinguishable from plan drift.** If the only
+   representation of "what the user wanted" is the user message
+   verbatim, the planner can't tell whether a mid-run steer is
+   "same goal, different plan" or "different goal entirely".
+2. **Success predicates have nowhere to live.** You can't attach a
+   "did we actually achieve this" check to "write me a slide deck"
+   without a goal object to attach it to.
+
+goldfive's answer: **derive an explicit `list[Goal]` up-front, treat
+the plan as a derivative of the goals, and measure drift against the
+goals, not the plan.**
+
+## The default flow
+
+```mermaid
+flowchart LR
+    UI["user_input: str"] --> GD[GoalDeriver]
+    GD --> Gs["goals: list[Goal]"]
+    Gs --> PL[Planner.generate]
+    PL --> Pl["plan: Plan"]
+    Pl --> EX[Executor]
+    EX -. drift .-> RF[Planner.refine]
+    RF -.-> Pl
+    Gs -. consulted on refine .-> RF
+```
+
+- `GoalDeriver` runs once, at the top of `Runner.run()`.
+- `Planner.generate` runs once, after goals.
+- `Planner.refine` runs once per warning-or-higher drift.
+
+Goals never change mid-run in v0.1. Plans change whenever refine
+returns a non-None plan.
+
+## GoalDerivers
+
+### `PassthroughGoalDeriver`
+
+The default when the caller passed a `list[Goal]` directly to
+`runner.run(...)`, or when goldfive is embedded in a system that
+already has an explicit goal representation.
+
+```python
+from goldfive.goal_deriver import PassthroughGoalDeriver
+
+goals = [
+    Goal(id="g1", summary="ship the feature"),
+    Goal(id="g2", summary="write the docs"),
+]
+runner = Runner(
+    agent=...,
+    planner=...,
+    executor=...,
+    goal_deriver=PassthroughGoalDeriver(),
+)
+await runner.run(goals)  # list[Goal] directly
+```
+
+### `LLMGoalDeriver`
+
+Uses an LLM to extract explicit goals from prose user input. Useful
+when goldfive is the top of a product stack and the user is typing
+natural language.
+
+```python
+from goldfive.goal_deriver import LLMGoalDeriver
+
+
+async def call_llm(system_prompt: str, user_prompt: str, model: str) -> str:
+    # your LLM wrapper goes here
+    ...
+
+
+runner = Runner(
+    agent=...,
+    planner=...,
+    executor=...,
+    goal_deriver=LLMGoalDeriver(call_llm=call_llm, model="claude-opus-4-5-20251101"),
+)
+```
+
+The LLM sees the user input plus a short system prompt asking for a
+JSON array of goals with `id` and `summary`. Fence-stripping and JSON
+parsing follow the same pattern as `LLMPlanner`.
+
+### Writing a custom GoalDeriver
+
+One method to implement:
+
+```python
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from goldfive.types import Goal
+
+
+class MyGoalDeriver:
+    async def derive(
+        self,
+        user_input: str,
+        *,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> list[Goal]:
+        # your logic here
+        return [Goal(id="g1", summary=user_input.strip())]
+```
+
+When to write one:
+
+- Your product has a structured input form (not free-text) and you
+  want to map fields onto goals directly without an LLM hop.
+- You want to enforce business invariants on goals (maximum count,
+  forbidden content, required `success_predicate`s).
+- You're integrating with an upstream product that already produces a
+  goal-like object.
+
+Keep the deriver small. Complex logic belongs further down the stack.
+
+## Planners
+
+### `PassthroughPlanner`
+
+```python
+from goldfive.planner import PassthroughPlanner
+
+planner = PassthroughPlanner(plan=precomputed_plan)
+```
+
+Hands the caller-supplied plan back from `generate()`, returns `None`
+from `refine()`. For tests, demos, and cases where you're authoring
+plans ahead of time.
+
+### `LLMPlanner`
+
+```python
+from goldfive.planner import LLMPlanner
+
+
+async def call_llm(system_prompt: str, user_prompt: str, model: str) -> str:
+    ...
+
+
+planner = LLMPlanner(
+    call_llm=call_llm,
+    model="claude-opus-4-5-20251101",
+    system_prompt_override=None,  # optional
+    refine_system_prompt_override=None,  # optional
+)
+```
+
+The LLM sees the goals, available agents, and (on refine) the current
+plan and drift event. It returns a JSON plan. `LLMPlanner` strips
+markdown fences, parses, validates the shape, and returns a `Plan`
+(or `None` on parse failure or refusal).
+
+### Writing a custom Planner
+
+Two methods to implement:
+
+```python
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from goldfive.types import DriftEvent, Goal, Plan, Task, TaskEdge
+
+
+class MyPlanner:
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> Optional[Plan]:
+        # one task per goal, assigned to the first available agent
+        tasks = [
+            Task(
+                id=f"t-{i}",
+                title=g.summary[:80],
+                description=g.summary,
+                assignee_agent_id=available_agents[0],
+            )
+            for i, g in enumerate(goals)
+        ]
+        return Plan(
+            id="my-plan",
+            run_id="",  # Runner stamps this
+            goal_ids=[g.id for g in goals],
+            tasks=tasks,
+            edges=[],
+        )
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Optional[Plan]:
+        return None  # never refine
+```
+
+When to write one:
+
+- You have strong domain structure and an LLM would just get in the
+  way (e.g. you know the exact workflow for every goal type).
+- You want to enforce plan constraints the LLM would violate
+  (budget caps, agent availability, task templates).
+- You want a hybrid: deterministic skeleton, LLM fills in details.
+
+### The refine contract (important)
+
+`refine(plan, drift, goals)` must:
+
+1. **Preserve completed tasks verbatim.** The executor will skip any
+   task in a terminal state, but the revised plan should still list
+   them so downstream plan-diff consumers (sinks, UIs) can see the
+   full history. In practice, copy completed tasks into the new plan
+   unchanged.
+2. **Leave the plan semantically sensible even if the drift is
+   garbage.** If you can't do anything useful with the drift, return
+   `None`. `None` is a legitimate signal that means "I can't revise".
+3. **Increment `revision_index` and stamp `revision_reason`.** The
+   executor stamps these for you after `refine()` returns, but a
+   custom planner can pre-populate them if it's doing its own
+   tracking.
+
+A skeleton refine:
+
+```python
+async def refine(
+    self,
+    *,
+    plan: Plan,
+    drift: DriftEvent,
+    goals: list[Goal],
+) -> Optional[Plan]:
+    # Start from the current plan, preserving completed tasks.
+    preserved = [t for t in plan.tasks if t.status == TaskStatus.COMPLETED]
+    remaining = [t for t in plan.tasks if t.status != TaskStatus.COMPLETED]
+
+    if drift.kind == DriftKind.NEW_WORK_DISCOVERED:
+        # append the newly discovered task
+        new_task = Task(
+            id=f"t-new-{len(plan.tasks)}",
+            title=drift.detail[:80],
+            assignee_agent_id=drift.current_agent_id or "default",
+        )
+        return Plan(
+            id=plan.id,
+            run_id=plan.run_id,
+            goal_ids=plan.goal_ids,
+            tasks=preserved + remaining + [new_task],
+            edges=plan.edges,  # copy forward; add edge from parent if applicable
+        )
+
+    if drift.kind == DriftKind.TASK_FAILED_RECOVERABLE:
+        # drop the failed task's remaining pending children;
+        # the planner may re-plan how to achieve the original goal
+        ...
+
+    return None  # couldn't handle this drift kind
+```
+
+See [DRIFT.md](../design/DRIFT.md) for the full kind list.
+
+## Success predicates
+
+A `Goal` can carry an optional `success_predicate: Callable[[Session], bool]`
+that the caller or a future `Runner` can consult to decide "are we
+done yet?". In v0.1, the predicate is not auto-consulted — the
+`Runner` just carries it. Sinks and custom executors can call it; the
+contract is that the predicate is pure and cheap.
+
+A typical use:
+
+```python
+def deck_is_ready(session: Session) -> bool:
+    return "deck_url" in session.completed_results.values()
+
+goal = Goal(
+    id="g1",
+    summary="build a Python slide deck",
+    success_predicate=deck_is_ready,
+)
+```
+
+A future version is likely to consult the predicate between tasks and
+fire `GOAL_UNREACHABLE` drift if the plan hasn't made progress toward
+it after N tasks. For now, the mechanism is opt-in.
+
+## Tuning the LLM planner prompts
+
+`LLMPlanner` exposes two overrides: `system_prompt_override` and
+`refine_system_prompt_override`. The shipped prompts are in
+`goldfive/planner.py` under `_DEFAULT_SYSTEM_PROMPT` and
+`_REFINE_SYSTEM_PROMPT`. Port what you need from those; they're tuned
+for the JSON output format the parser expects.
+
+The default output shape (in the prompt):
+
+```json
+{
+  "summary": "short description of the plan",
+  "tasks": [
+    {"id": "t1", "title": "...", "description": "...", "assignee": "..."},
+    {"id": "t2", "title": "...", "description": "...", "assignee": "..."}
+  ],
+  "edges": [
+    {"from": "t1", "to": "t2"}
+  ]
+}
+```
+
+If you need to change this shape, subclass `LLMPlanner` and override
+the parser. Don't change the prompts without changing the parser —
+they're matched.
+
+## Recommended recipes
+
+**Structured input → one task per form field.** Use
+`PassthroughGoalDeriver` or a custom deriver that maps form state onto
+`Goal`s, and a custom `Planner` that issues a task per goal.
+
+**Free-text input → LLM-derived goals, LLM-planned execution.** Use
+`LLMGoalDeriver` + `LLMPlanner`. Default combo for general assistants.
+
+**Fixed workflow, variable details.** Use `PassthroughPlanner` with a
+plan template cloned per run, populated with the run-specific goal
+summaries.
+
+**Multiple possible strategies per goal.** Keep `PassthroughGoalDeriver`
+but write a custom planner that chooses a strategy based on metadata
+on the goal.
+
+## Anti-patterns
+
+- **Using goals as tasks.** A `Goal.summary` is a one-liner; a `Task`
+  has an assignee, a description, and is a unit of agent work.
+  Don't blur them.
+- **Calling `planner.refine()` from your own code.** Refine is the
+  executor's responsibility. If you want to force a replan from
+  outside, synthesize a `DriftEvent(kind=USER_STEER)` and hand it to
+  the steerer.
+- **Returning an unchanged plan from `refine()`.** Return `None`
+  instead. The executor handles `None` specifically (no plan change,
+  continue) and treats a non-None return as "the plan has changed".

--- a/docs/guides/harmonograf-integration.md
+++ b/docs/guides/harmonograf-integration.md
@@ -1,0 +1,236 @@
+# Harmonograf integration
+
+[harmonograf](https://github.com/pedapudi/harmonograf) is a console for
+observing and coordinating multi-agent systems — Gantt timeline,
+drawer inspector, live plan-diff banners. goldfive is designed to feed
+harmonograf as a first-class `EventSink`.
+
+This guide covers how the integration is intended to work. The
+concrete harmonograf sink implementation lands in a harmonograf repo
+PR (not in goldfive itself); this document is forward-looking and
+describes the contract goldfive provides.
+
+Related: [ARCHITECTURE.md](../design/ARCHITECTURE.md),
+[EVENT-MODEL.md](../design/EVENT-MODEL.md),
+[writing-an-event-sink.md](writing-an-event-sink.md).
+
+## Why this pairing
+
+goldfive and harmonograf were born together and split on purpose:
+
+- **harmonograf** owns the observability and human-coordination
+  surface: the Gantt, the drawer, the control tabs, the timeline
+  store. It is a product-shaped UI plus a server and a client
+  library.
+- **goldfive** owns the orchestration semantics: goal derivation,
+  planning, task tracking, drift classification, refine. It is a
+  framework-agnostic library.
+
+The interface between them is the goldfive proto event stream. Every
+orchestration decision goldfive makes produces an event; harmonograf
+consumes events to render the timeline, the plan-diff banner, the
+drift markers.
+
+## Architectural placement
+
+```
+┌───────────────────────┐        ┌──────────────────────┐
+│   your agent stack    │        │    harmonograf       │
+│ (ADK / Claude SDK /   │        │                      │
+│  callable / …)        │        │  server + frontend   │
+│                       │        │  (timeline, drawer)  │
+└──────────┬────────────┘        └──────────▲───────────┘
+           │                                │
+           │                                │
+┌──────────▼────────────┐    proto events   │
+│       goldfive        ├──────────────────▶│
+│       Runner          │    via EventSink  │
+└───────────────────────┘                   │
+                                            │
+           (separate repo)                  │
+           HarmonografSink ─────────────────┘
+           (goldfive EventSink that forwards
+            to harmonograf's gRPC stream)
+```
+
+Your code imports goldfive for orchestration and harmonograf's
+goldfive-adapter package for observability. The two are composed at
+the sink layer.
+
+## Proto alignment
+
+goldfive's proto is the wire surface (per [issue #3](https://github.com/pedapudi/goldfive/issues/3)).
+harmonograf adopts goldfive's proto directly — the same
+`TaskStatus`, `DriftKind`, `Plan`, `Task`, and `TaskEdge` messages
+flow from goldfive into harmonograf without translation.
+
+This is D1 and D7 in the [vision doc](https://github.com/pedapudi/goldfive/issues/1):
+
+> - **D1**: goldfive owns the proto layer; sinks (including
+>   harmonograf) consume goldfive's proto.
+> - **D7**: Harmonograf adopts goldfive's proto directly (replaces its
+>   own TaskPlan / UpdatedTaskStatus).
+
+The practical consequence: there is no field-by-field mapping layer.
+A `goldfive.v1.Plan` message is the same bytes harmonograf stores on
+disk and renders on-screen.
+
+## The forthcoming `HarmonografSink`
+
+Pseudocode for the sink that will ship in the harmonograf repo:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from harmonograf_client import Client  # harmonograf's python client
+from goldfive.protocols import EventSink
+
+
+class HarmonografSink:
+    """goldfive EventSink that forwards events to a harmonograf server."""
+
+    def __init__(
+        self,
+        *,
+        server_addr: str = "127.0.0.1:7531",
+        auth_token: str | None = None,
+    ) -> None:
+        self._client = Client.connect(server_addr, auth_token=auth_token)
+
+    async def emit(self, event_pb: Any) -> None:
+        # harmonograf's telemetry stream expects goldfive events directly
+        await self._client.emit_goldfive_event(event_pb)
+
+    async def close(self) -> None:
+        await self._client.close()
+```
+
+Usage pattern from a goldfive caller:
+
+```python
+from goldfive import Runner
+from goldfive.sinks import JSONLPersistenceSink
+from harmonograf_goldfive import HarmonografSink  # forthcoming
+
+
+runner = Runner(
+    agent=my_agent_adapter,
+    planner=my_planner,
+    executor=my_executor,
+    sinks=[
+        HarmonografSink(server_addr="127.0.0.1:7531"),
+        JSONLPersistenceSink(path=f"./runs/{run_id}.jsonl"),
+    ],
+)
+outcome = await runner.run("build me a slide deck about Python")
+```
+
+The run emits events to both sinks. harmonograf's UI lights up in
+real time with the plan, the task states, drift markers, and plan
+revisions. JSONL captures the same stream for crash recovery and
+offline replay.
+
+## What harmonograf renders, per event
+
+An informal mapping of goldfive events to harmonograf UI elements.
+The authoritative mapping lives in harmonograf's frontend
+(`frontend/src/gantt/`).
+
+| goldfive event | harmonograf UI effect |
+|---|---|
+| `RunStarted` | New session appears in the session picker; root agent row created. |
+| `GoalDerived` | Goal chips appear in the session header. |
+| `PlanSubmitted` | Initial Gantt bars materialize, one per task, in PENDING state. |
+| `PlanRevised` | Plan-diff banner shows added / removed / modified tasks; a revision marker is placed on the timeline. |
+| `TaskStarted` | Bar transitions to RUNNING color; liveness indicator starts pulsing. |
+| `TaskProgress` | Bar fills to the reported fraction; drawer shows latest `detail`. |
+| `TaskCompleted` | Bar transitions to COMPLETED color; `summary` surfaces in the drawer. |
+| `TaskFailed` | Bar transitions to FAILED color; `reason` surfaces with an error badge. |
+| `TaskBlocked` | Bar shows a blocked indicator; `blocker` surfaces in the drawer. |
+| `TaskCancelled` | Bar greys out; drawer shows the cancellation reason. |
+| `DriftDetected` | A drift marker drops onto the timeline with the `DriftKind` icon and color. |
+| `RunCompleted` / `RunAborted` | Session shows terminal badge; timeline scroll locks. |
+
+Drift markers are positioned at the drift's `emitted_at` timestamp.
+`PlanRevised` markers chain off of the drift that caused them so the
+UI can render a "drift → refine" trail.
+
+## Replacing harmonograf's existing `TaskPlan`
+
+harmonograf today has its own `TaskPlan` / `UpdatedTaskStatus`
+messages in its proto (see `proto/harmonograf/v1/types.proto` in
+harmonograf). Per D7 in the vision doc, those are superseded by
+goldfive's messages once the integration lands.
+
+The migration is mechanical:
+
+1. Add `goldfive.v1.Plan` and friends to harmonograf's proto imports
+   (or, ideally, drop harmonograf's task proto entirely and re-export
+   from goldfive).
+2. Switch `TaskRegistry.upsertPlan(...)` to consume a `goldfive.v1.Plan`.
+3. Switch the drift-detection path to consume
+   `goldfive.v1.DriftDetected` events from the stream.
+4. Retire harmonograf's internal `_AdkState` state machine; state now
+   comes from goldfive's `TaskStarted` / `TaskCompleted` / etc. events.
+
+Because the proto values mirror harmonograf's existing ones
+(`TaskStatus.COMPLETED` = `"COMPLETED"`, `DriftKind.NEW_WORK_DISCOVERED`
+= `"new_work_discovered"`, etc.), the frontend needs no changes other
+than pointing at the new messages.
+
+## Bidirectional control (future)
+
+In v0.1, goldfive is emit-only: the sink receives events but does not
+take control inputs. harmonograf's "steer", "pause", "cancel" control
+actions flow through a separate control channel from frontend → server
+→ client library.
+
+A future goldfive version will expose a control-input surface (a way
+for an external system to synthesize a `DriftEvent(kind=USER_STEER)`
+and hand it to the running steerer). When that lands, harmonograf's
+control actions will flow through it. For now, use the per-agent
+control hooks harmonograf already provides.
+
+## Running the two together (today, pre-sink-implementation)
+
+Even without a shipped `HarmonografSink`, you can combine them
+manually:
+
+1. Use goldfive with `JSONLPersistenceSink`.
+2. Write a small bridge that tails the JSONL and forwards to
+   harmonograf via its existing client library.
+
+This is a stepping-stone pattern; the real integration lands once
+harmonograf's sink implementation is published.
+
+## FAQ
+
+**Will goldfive depend on harmonograf?** No. The dependency is
+one-way: harmonograf has an optional dep on goldfive (for the proto).
+goldfive has no concept of harmonograf at the code level — it sees
+only an `EventSink`.
+
+**What about harmonograf's reporting tools?** They are the same seven
+tools goldfive defines (see [tool-protocol.md](../reference/tool-protocol.md)).
+The intent is that harmonograf's client library stops defining them
+and re-exports from goldfive.
+
+**What happens if goldfive emits an event harmonograf doesn't
+recognize?** harmonograf ignores unknown fields (standard proto3
+behavior). Adding new events or fields to goldfive is
+backwards-compatible for harmonograf.
+
+**What happens if the harmonograf server is down when a goldfive run
+fires?** The `HarmonografSink` buffers with bounded capacity; on
+overflow, events drop (with a log warning). The other sinks
+(especially `JSONLPersistenceSink`) are unaffected — the durable log
+is intact regardless of harmonograf's health.
+
+## Tracking issue
+
+- Main vision issue: [goldfive#1](https://github.com/pedapudi/goldfive/issues/1).
+- Proto definition: [goldfive#3](https://github.com/pedapudi/goldfive/issues/3).
+- The `HarmonografSink` itself lands in harmonograf's repo once the
+  goldfive proto is published.

--- a/docs/guides/persistence-and-recovery.md
+++ b/docs/guides/persistence-and-recovery.md
@@ -1,0 +1,319 @@
+# Persistence and recovery
+
+goldfive runs can crash. Processes get SIGKILL'd, hosts reboot,
+network partitions drop the LLM connection mid-invocation. In every
+case you'd like to pick up where you left off without redoing completed
+work.
+
+`JSONLPersistenceSink` + `Runner.resume()` is the answer.
+
+Related: [EVENT-MODEL.md](../design/EVENT-MODEL.md),
+[writing-an-event-sink.md](writing-an-event-sink.md).
+
+## The idea
+
+Every state-affecting event is already emitted to every sink. If one
+of those sinks is durable, the event stream is a log of everything
+that happened. Replaying the log reconstructs the session, and a new
+`Runner` can continue from the reconstructed state.
+
+```
+     first run                  crash!           resume run
+     ─────────                  ──────           ──────────
+┌──────────────┐           ┌──────────┐     ┌──────────────┐
+│   Runner.    │           │ process  │     │   Runner.    │
+│   run(...)   │           │  dies    │     │   resume(    │
+│              │           │          │     │     events   │
+│ emits events │           │          │     │   )          │
+│ to:          │           │          │     │              │
+│              │           │          │     │ reads events │
+└──────┬───────┘           └──────────┘     │ → rebuilds   │
+       │                                     │   session    │
+       ▼                                     │ → continues  │
+┌──────────────┐                             │   from the   │
+│  JSONL file  │────────────────────────────▶│   crash point│
+│  on disk     │   file persists             │              │
+└──────────────┘                             └──────────────┘
+```
+
+## The sink
+
+```python
+from goldfive.sinks import JSONLPersistenceSink
+
+sink = JSONLPersistenceSink(path="./runs/{run_id}.jsonl")
+
+runner = Runner(
+    agent=...,
+    planner=...,
+    executor=...,
+    sinks=[sink],
+)
+outcome = await runner.run("do the thing")
+```
+
+The sink writes one JSON-encoded proto `Event` per line. `{run_id}`
+in the path is substituted at run start.
+
+On-disk shape:
+
+```
+{"eventId":"01H...","runId":"abc","sequence":"0","emittedAt":"...","runStarted":{...}}
+{"eventId":"01H...","runId":"abc","sequence":"1","emittedAt":"...","goalDerived":{...}}
+{"eventId":"01H...","runId":"abc","sequence":"2","emittedAt":"...","planSubmitted":{...}}
+{"eventId":"01H...","runId":"abc","sequence":"3","emittedAt":"...","taskStarted":{...}}
+...
+```
+
+Every line is valid JSON on its own. You can `jq` the file, split it
+across workers, tail it live, or feed it to anything that speaks
+line-delimited JSON.
+
+### Atomicity
+
+`JSONLPersistenceSink.emit()` uses an `fcntl.flock(LOCK_EX)` around
+each line append. Concurrent writers (shouldn't happen in one run,
+but in case of shared files) serialize via the OS. On POSIX systems,
+a single `write()` of a line < `PIPE_BUF` (4096 bytes on Linux) is
+atomic — full events rarely exceed this, so partial writes are
+exceptional.
+
+On crash, the worst case is one truncated line at the tail. The
+recovery path tolerates this.
+
+### Close
+
+`await sink.close()` flushes and releases the file lock. Call this
+via the normal `Runner.run()` exit path; it happens automatically.
+
+## The recovery path
+
+```python
+from goldfive import Runner
+from goldfive.sinks import JSONLPersistenceSink
+
+
+# Step 1: load the events from the crashed run.
+events = JSONLPersistenceSink.from_jsonl("./runs/abc.jsonl")
+
+# Step 2: rebuild a Session from the events.
+from goldfive.recovery import reconstruct_session  # helper from issue #15
+session = reconstruct_session(events)
+
+# Step 3: construct a new Runner with the same components.
+runner = Runner(
+    agent=my_agent_adapter,   # same adapter configuration
+    planner=my_planner,
+    executor=my_executor,
+    sinks=[JSONLPersistenceSink(path="./runs/abc.jsonl")],  # same file, append
+)
+
+# Step 4: resume.
+outcome = await runner.resume(session=session)
+```
+
+`Runner.resume()` picks up from the reconstructed session. The
+reconstructed plan has tasks in whatever terminal states the log
+records (COMPLETED, FAILED, CANCELLED), RUNNING tasks are rolled
+back to PENDING (with a warning log — see below), and PENDING tasks
+are executed as normal.
+
+### What `reconstruct_session` does
+
+Given the ordered event list:
+
+1. Replays `RunStarted`, `GoalDerived`, and `PlanSubmitted` to
+   initialize `session.run_id`, `session.goals`, and `session.plan`.
+2. Replays `PlanRevised` in order to reach the latest revision.
+3. For every `TaskStarted` / `TaskCompleted` / `TaskFailed` /
+   `TaskBlocked` / `TaskCancelled`, applies the corresponding
+   status to the task in `session.plan`.
+4. Rebuilds `session.completed_results` from `TaskCompleted.summary`.
+5. Rebuilds `session.task_progress` from `TaskProgress.fraction` (last
+   write wins).
+6. Re-seeds `session._next_sequence` to one past the highest observed
+   sequence.
+
+If the log contains a `TaskStarted(t)` but no terminal event for `t`,
+that task is left in `RUNNING` in the raw replay but the resume path
+converts it to `PENDING` so the executor re-invokes the agent. This
+is the one place state is "rolled back" — the agent might have been
+mid-work when the process died.
+
+### Idempotency: will tasks re-run?
+
+The executor's walk is idempotent over completed tasks: it skips any
+task in a terminal state. So:
+
+- `COMPLETED` tasks — not re-run.
+- `FAILED` tasks — not re-run. (A refine might add a replacement
+  task; that one runs.)
+- `CANCELLED` tasks — not re-run.
+- `RUNNING` tasks in the log — reset to `PENDING` on resume and
+  re-run. This is the "we might have done some work already" case —
+  your agent needs to tolerate a retry.
+- `PENDING` tasks — run as normal.
+
+## Failure-mode walkthrough
+
+Four concrete failures and how they recover.
+
+### 1. Process killed mid-task
+
+```
+   emit RunStarted
+   emit GoalDerived
+   emit PlanSubmitted
+   emit TaskStarted(t1)
+   emit TaskCompleted(t1)
+   emit TaskStarted(t2)
+   <SIGKILL>
+```
+
+Resume:
+
+- Replay gives a session with `t1 = COMPLETED` and `t2 = RUNNING`.
+- Resume converts `t2 = RUNNING` back to `PENDING`.
+- Executor re-invokes `t2`.
+- `t3` runs as normal afterward.
+
+Your `t2` agent ran once and produced some output, but
+`report_task_completed` never fired. On resume, the agent runs again.
+If it's idempotent (most tool-using agents are with respect to
+reads), you get a clean completion. If it has side effects
+(file writes, API calls that mutate state), you either:
+
+- Tag side effects with the run-id so repeats are detected.
+- Add a check at the top of the agent's logic that notices the task
+  is already half-done.
+- Accept the repeat and make the final step idempotent.
+
+### 2. Agent raised mid-invocation
+
+```
+   emit RunStarted / GoalDerived / PlanSubmitted
+   emit TaskStarted(t1)
+   adapter.invoke(t1) raises ConnectionError
+   executor catches → emit TaskFailed(t1, reason="ConnectionError")
+   executor classifies as TASK_FAILED_RECOVERABLE
+   planner.refine(...) → returns revised plan with t1 replaced by t1'
+   emit PlanRevised(revision_index=1)
+   emit TaskStarted(t1')
+   ...
+```
+
+Here there's no crash. The run continues via the refine path. The log
+shows the failure and the revision; a resume-from-log would pick up
+in the middle of the revised plan.
+
+### 3. Sink failure doesn't crash the run
+
+```
+   emit TaskStarted(t1)     # to [JSONLSink, HttpSink]
+     → JSONL writes OK
+     → Http raises timeout
+   goldfive catches HttpSink error, logs, continues
+   emit TaskCompleted(t1)   # to [JSONLSink, HttpSink]
+     → JSONL writes OK
+     → Http raises again; logged, suppressed
+   ...
+```
+
+JSONL has the full log. Your HTTP backend missed some events. This is
+why `JSONLPersistenceSink` is the canonical "durable" sink — it does
+local disk writes with explicit locking and should only fail on disk
+exhaustion, which is a stop-the-world condition anyway.
+
+### 4. The log is itself truncated
+
+Your tail line is `{"eventId":"01H...","runId":"abc","sequenc...`
+(cut off).
+
+`JSONLPersistenceSink.from_jsonl()` skips unparseable lines with a
+warning log. The reconstructed session will be slightly behind the
+true crash point, but every event up to the last complete line is
+replayed. On resume, the executor reconstructs from that state and
+carries on. You may re-run a task that was actually completed, which
+loops back to the idempotency argument from case (1).
+
+## Operational guidance
+
+**Path layout.** One file per run is the default. For high volume,
+shard by date: `./runs/2026/04/18/{run_id}.jsonl`.
+
+**Retention.** Logs grow; rotate or delete completed runs after a
+window (hours for ephemeral work, weeks for audit).
+
+**Compression.** JSONL compresses well (typical event line is
+~200 bytes, ratio 5–10x with zstd). If you need compressed-at-rest,
+wrap the sink in a `zstd.ZstdCompressor` stream.
+
+**Multiple sinks.** Persistence is orthogonal to everything else. A
+typical prod config:
+
+```python
+sinks = [
+    JSONLPersistenceSink(path=f"./runs/{run_id}.jsonl"),
+    HttpBackendSink(endpoint="https://obs.example.com/events"),
+    LoggingSink(level=logging.INFO),
+]
+```
+
+JSONL is the durable log; the HTTP sink feeds your observability
+platform; logging gives you stdout visibility. Each sink is
+independent.
+
+**Monitoring.** Track three things per run:
+
+- JSONL file size as a proxy for "run complexity".
+- Time from `RunStarted` to terminal (`RunCompleted` / `RunAborted`)
+  — the run's wall-clock duration.
+- Count of `DriftDetected` / `PlanRevised` — the run's "turbulence".
+
+These three, dashboarded, give you an operational feel for goldfive
+without instrumenting anything beyond the sink.
+
+## What's explicitly not in v0.1
+
+- **Live replay** — feeding JSONL back through sinks in real time.
+  You can do this manually (read the file, emit to sinks), but there's
+  no `Runner.replay()` yet.
+- **Partial resume** — resuming in the middle of a refine call, or
+  mid-turn within a task. The resume boundary is between-tasks only.
+- **Concurrent resume** — two processes resuming the same run-id is
+  undefined. Use `flock` or a DB-backed coordinator if you need to
+  prevent it.
+
+## Verifying recovery works
+
+A quick smoke test:
+
+```python
+import asyncio, os
+from goldfive import Runner
+from goldfive.sinks import JSONLPersistenceSink
+
+# run 1 — interrupted after task 1
+path = "./runs/smoke.jsonl"
+if os.path.exists(path):
+    os.remove(path)
+
+runner_a = Runner(..., sinks=[JSONLPersistenceSink(path)])
+try:
+    # custom executor that raises after the first task, for the test
+    await asyncio.wait_for(runner_a.run("demo"), timeout=1.0)
+except Exception:
+    pass
+
+# run 2 — resume
+events = JSONLPersistenceSink.from_jsonl(path)
+from goldfive.recovery import reconstruct_session
+session = reconstruct_session(events)
+
+runner_b = Runner(..., sinks=[JSONLPersistenceSink(path)])
+outcome = await runner_b.resume(session=session)
+assert outcome.success
+```
+
+`tests/test_persistence_recovery.py` (in [issue #16](https://github.com/pedapudi/goldfive/issues/16))
+expands this into a full matrix across crash points.

--- a/docs/guides/writing-an-agent-adapter.md
+++ b/docs/guides/writing-an-agent-adapter.md
@@ -1,0 +1,322 @@
+# Writing an agent adapter
+
+goldfive is agent-framework-agnostic. The adapter is the one piece of
+the system that knows about a specific framework — ADK, Claude Agent
+SDK, LangGraph, an MCP server, a bare async callable, anything.
+
+This guide walks through writing a new `AgentAdapter` for a framework
+goldfive doesn't ship. Reference v0.1 adapters:
+
+- `goldfive.adapters.callable.CallableAdapter` — the simplest form.
+  Start here when prototyping a new adapter.
+- `goldfive.adapters.adk.ADKAdapter` — ports harmonograf's ADK plugin.
+- `goldfive.adapters.claude.ClaudeAgentSDKAdapter` — wraps Anthropic's
+  Claude Agent SDK.
+
+Related: [PROTOCOLS.md](../design/PROTOCOLS.md#agentadapter),
+[tool-protocol.md](../reference/tool-protocol.md).
+
+## The protocol
+
+```python
+@runtime_checkable
+class AgentAdapter(Protocol):
+    async def register_reporting_tools(
+        self,
+        tools: list[ReportingToolSpec],
+    ) -> None: ...
+
+    async def invoke(
+        self,
+        task: Task,
+        session: Session,
+    ) -> InvocationResult: ...
+
+    @property
+    def available_agents(self) -> list[str]: ...
+```
+
+Three responsibilities:
+
+1. **Register reporting tools.** The steerer hands you a list of
+   `ReportingToolSpec`s (see [tool-protocol.md](../reference/tool-protocol.md)).
+   Translate each spec into the tool shape your framework expects and
+   install a hook that routes calls to the spec's handler.
+2. **Invoke the agent for one task.** Render current-task context,
+   run the agent, stream observed events to the steerer, return an
+   `InvocationResult`.
+3. **Expose `available_agents`.** The names the planner can use as
+   `task.assignee_agent_id`.
+
+## The four things every adapter must do
+
+### Render task context
+
+The agent needs to know what task it's working on. Different
+frameworks expose this differently:
+
+- **ADK** — write `session.state["goldfive.current_task_id"]` and
+  friends in `before_model_callback`; the agent reads them.
+- **Claude Agent SDK** — inject task context into the system prompt
+  or the first user message.
+- **Custom callable** — pass it as a function argument.
+
+All three approaches are equivalent. Pick whichever matches your
+framework's idiom. The context the agent needs:
+
+- `task.id`, `task.title`, `task.description`
+- The summary of every completed task (from `session.completed_results`)
+- The plan summary (`session.plan.summary`)
+- Optionally: the goal summaries
+
+### Intercept reporting tool calls
+
+When the agent calls `report_task_completed("t3", summary="...")`,
+your adapter must:
+
+1. Recognize the tool name (it's in `REPORTING_TOOL_NAMES`).
+2. Parse the arguments.
+3. Invoke the spec's `handler(args, session, steerer)`.
+4. Return the handler's return value as the tool result.
+
+The handler is where the steerer applies the state transition.
+`{"acknowledged": True}` is the conventional response body.
+
+### Forward observed events to the steerer
+
+Events that aren't reporting tool calls — LLM text output, non-report
+tool calls, framework status events — should be fed to
+`steerer.observe(event, session)`. This is how drift detection sees
+refusals, context pressure, unexpected transfers, etc.
+
+The adapter does not classify drift itself; it just forwards raw
+observations. `DefaultSteerer.detect_drift()` is the classifier.
+
+### Return an `InvocationResult`
+
+```python
+@dataclasses.dataclass
+class InvocationResult:
+    task_id: str
+    text: str = ""
+    stop_reason: str = ""
+    error: Optional[Exception] = None
+    raw: Any = None
+```
+
+After the agent finishes its turn, return:
+
+- `task_id` — the id of the task that was invoked.
+- `text` — the final assistant text (the "answer"), for callers that
+  want to surface it.
+- `stop_reason` — framework-specific stop reason (e.g. `"end_turn"`,
+  `"max_tokens"`, `"tool_use"`). The steerer uses this for
+  `CONTEXT_PRESSURE` and `TOO_MANY_STEPS` classification.
+- `error` — an `Exception` if the framework raised, otherwise `None`.
+- `raw` — the original framework response object, preserved for
+  advanced sinks that want to introspect.
+
+## Worked example: wrapping a hypothetical `awesome_agent_sdk`
+
+Suppose you're using a framework called `awesome_agent_sdk` with this
+shape:
+
+```python
+# what awesome_agent_sdk looks like (for the purposes of this example):
+
+class AwesomeClient:
+    def __init__(self, system_prompt: str, tools: list[ToolDef]): ...
+    async def run(self, user_message: str) -> AsyncIterator[Block]: ...
+
+class ToolDef:
+    name: str
+    parameters_schema: dict
+    handler: Callable[[dict], Awaitable[dict]]
+
+class Block:
+    type: str   # "text" | "tool_use" | "stop"
+    text: str = ""
+    tool_name: str = ""
+    tool_args: dict = {}
+    stop_reason: str = ""
+```
+
+A full adapter for this fictional SDK is about 50 lines:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from awesome_agent_sdk import AwesomeClient, ToolDef  # fictional
+
+from goldfive.protocols import AgentAdapter
+from goldfive.reporting import ReportingToolSpec
+from goldfive.results import InvocationResult
+from goldfive.types import Session, Task
+
+
+class AwesomeAdapter:
+    """Adapter for awesome_agent_sdk."""
+
+    def __init__(
+        self,
+        *,
+        system_prompt: str,
+        available_agents: list[str] | None = None,
+    ) -> None:
+        self._system_prompt = system_prompt
+        self._tools: list[ReportingToolSpec] = []
+        self._available_agents = available_agents or ["default"]
+        self._steerer = None  # injected lazily by the executor
+
+    async def register_reporting_tools(
+        self,
+        tools: list[ReportingToolSpec],
+    ) -> None:
+        self._tools = tools
+
+    @property
+    def available_agents(self) -> list[str]:
+        return self._available_agents
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:
+        client = AwesomeClient(
+            system_prompt=self._render_prompt(task, session),
+            tools=[self._wrap_tool(spec, session) for spec in self._tools],
+        )
+
+        final_text, final_stop = "", ""
+        async for block in client.run(user_message=task.description):
+            if block.type == "text":
+                final_text += block.text
+                # feed to steerer for drift classification
+                if self._steerer is not None:
+                    await self._steerer.observe(block, session)
+            elif block.type == "tool_use":
+                # reporting tools are handled by the tool's handler;
+                # nothing to do here. Non-reporting tool calls would
+                # flow through the framework's own tool-call path.
+                if self._steerer is not None:
+                    await self._steerer.observe(block, session)
+            elif block.type == "stop":
+                final_stop = block.stop_reason
+
+        return InvocationResult(
+            task_id=task.id,
+            text=final_text,
+            stop_reason=final_stop,
+        )
+
+    def _render_prompt(self, task: Task, session: Session) -> str:
+        completed = "\n".join(
+            f"- {tid}: {summary}"
+            for tid, summary in session.completed_results.items()
+        )
+        return (
+            f"{self._system_prompt}\n\n"
+            f"Current task: {task.title}\n"
+            f"Description: {task.description}\n"
+            f"Task id: {task.id}\n"
+            f"Completed so far:\n{completed or '(nothing yet)'}\n"
+        )
+
+    def _wrap_tool(self, spec: ReportingToolSpec, session: Session):
+        async def handler(args: dict[str, Any]) -> dict[str, Any]:
+            return await spec.handler(args, session, self._steerer)
+
+        return ToolDef(
+            name=spec.name,
+            parameters_schema=spec.parameters,
+            handler=handler,
+        )
+```
+
+Use it:
+
+```python
+from goldfive import Runner
+from goldfive.executors.sequential import SequentialExecutor
+from goldfive.planner import PassthroughPlanner
+
+runner = Runner(
+    agent=AwesomeAdapter(system_prompt="You are a helpful assistant."),
+    planner=PassthroughPlanner(plan=my_plan),
+    executor=SequentialExecutor(),
+)
+outcome = await runner.run("do the thing")
+```
+
+That's it. ~50 lines, one new framework wrapped, full goldfive
+semantics on top.
+
+## The steerer reference
+
+In the example above, `self._steerer` is accessed but never set. In
+the real adapters, the executor injects the steerer via a protocol
+method or a framework-specific hook. For v0.1, the shape is under
+active iteration; check `goldfive.adapters.callable.CallableAdapter`
+for the current idiom and mirror it.
+
+A robust pattern:
+
+```python
+class AwesomeAdapter:
+    def bind_steerer(self, steerer):
+        self._steerer = steerer
+```
+
+The executor calls `adapter.bind_steerer(steerer)` before the first
+`invoke`. The `CallableAdapter` in `goldfive/adapters/callable.py` is
+the reference implementation.
+
+## Mapping drift-relevant signals
+
+Your adapter should forward the following signals to
+`steerer.observe()`:
+
+| Framework signal | Why it matters |
+|---|---|
+| LLM text chunk / block | Refusal phrases detected by `classify_refusal`. |
+| Non-reporting tool call with error | `TOOL_ERROR` drift. |
+| Agent transfer / delegation event | `AGENT_TRANSFER`, potentially `WRONG_AGENT`. |
+| Final stop reason | `CONTEXT_PRESSURE`, `TOO_MANY_STEPS`, `STOPPED_EARLY`. |
+| Unhandled exception in agent invocation | `TASK_FAILED_FATAL` if unrecoverable. |
+
+The [DRIFT.md](../design/DRIFT.md) taxonomy lists every kind and
+what the steerer looks for. You do not need to classify — just forward.
+
+## Optional: streaming observations
+
+If your framework supports streaming, you can call
+`steerer.observe()` on every chunk for real-time drift detection. If
+it doesn't, call `observe()` once with the final response. Both are
+legal; streaming gives the steerer an earlier chance to detect issues
+like context pressure.
+
+## Testing your adapter
+
+The `CallableAdapter`'s tests (in `tests/test_callable_adapter.py`)
+are the template. The pattern:
+
+1. Construct a fake framework response (a canned iterator, a mock
+   client).
+2. Plug it into your adapter.
+3. Run a single `invoke()` against a one-task plan.
+4. Assert the steerer saw the expected transitions and drift.
+5. Assert the `InvocationResult` carries the expected fields.
+
+For integration tests, use the adapter with a `DefaultSteerer` and
+`InMemorySink`, run a full plan, and inspect the event stream.
+
+## Publishing your adapter
+
+Adapters can live outside the goldfive repo. Publish as a separate
+package that depends on `goldfive` and whatever framework it wraps.
+The `@runtime_checkable` `AgentAdapter` protocol means no inheritance
+or registration is required — any class with the right methods works.
+
+If you want to contribute an adapter upstream, open an issue
+describing the framework and its shape; goldfive is receptive to
+merging adapters when the framework has momentum and the adapter is
+tested.

--- a/docs/guides/writing-an-event-sink.md
+++ b/docs/guides/writing-an-event-sink.md
@@ -1,0 +1,306 @@
+# Writing an event sink
+
+`EventSink` is how goldfive delivers observability to the outside
+world. Every state change — run started, task completed, drift
+detected, plan revised — produces a proto-encoded `Event` that is
+fanned out to every configured sink.
+
+This guide covers writing a custom sink. Read
+[EVENT-MODEL.md](../design/EVENT-MODEL.md) first if you haven't —
+it's the contract this guide assumes.
+
+## When to write a custom sink
+
+Write one when you want to:
+
+- Forward events to your own observability system (OpenTelemetry,
+  Datadog, a custom collector).
+- Push events to a live dashboard over WebSockets.
+- Fan events out to a message bus (Kafka, NATS, Redis Streams).
+- Drive a UI like harmonograf (see the
+  [harmonograf-integration guide](harmonograf-integration.md)).
+- Record runs for later replay or analysis.
+
+You don't need to write one for:
+
+- **Recording events for tests** — use `InMemorySink`.
+- **Logging to stdout** — use `LoggingSink`.
+- **Disk persistence for crash recovery** — use
+  `JSONLPersistenceSink`.
+
+## The protocol
+
+```python
+@runtime_checkable
+class EventSink(Protocol):
+    async def emit(self, event_pb: Any) -> None: ...
+    async def close(self) -> None: ...
+```
+
+Two methods. `emit(event_pb)` is called once per event, in per-run
+sequence order. `close()` is called once when the run ends. That's
+the entire contract.
+
+## A minimal stdout sink
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+
+class StdoutSink:
+    async def emit(self, event_pb: Any) -> None:
+        kind = event_pb.WhichOneof("payload")
+        print(f"[{event_pb.sequence:04d}] {kind} (run={event_pb.run_id})")
+
+    async def close(self) -> None:
+        pass
+```
+
+Plug it in:
+
+```python
+from goldfive import Runner
+runner = Runner(agent=..., planner=..., executor=..., sinks=[StdoutSink()])
+```
+
+## A richer example — forwarding to an HTTP backend
+
+Here's a sink that POSTs each event as JSON to an observability
+backend, with retries and a bounded in-process queue so network
+slowness doesn't stall the run.
+
+```python
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+from google.protobuf.json_format import MessageToJson
+
+
+class HttpBackendSink:
+    """Forwards events to an HTTP backend. Drops on overflow."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        max_queue: int = 1024,
+        timeout_s: float = 5.0,
+    ) -> None:
+        self._endpoint = endpoint
+        self._queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=max_queue)
+        self._timeout_s = timeout_s
+        self._client = httpx.AsyncClient(timeout=timeout_s)
+        self._worker = asyncio.create_task(self._drain())
+        self._closed = False
+
+    async def emit(self, event_pb: Any) -> None:
+        if self._closed:
+            return
+        try:
+            self._queue.put_nowait(event_pb)
+        except asyncio.QueueFull:
+            # drop on overflow — prefer ongoing execution over full fidelity
+            pass
+
+    async def close(self) -> None:
+        self._closed = True
+        await self._queue.put(None)  # poison pill
+        await self._worker
+        await self._client.aclose()
+
+    async def _drain(self) -> None:
+        while True:
+            item = await self._queue.get()
+            if item is None:
+                return
+            payload = json.loads(MessageToJson(item, preserving_proto_field_name=True))
+            try:
+                await self._client.post(self._endpoint, json=payload)
+            except httpx.HTTPError:
+                # real-world: structured logging + retry with backoff
+                pass
+```
+
+Key design points:
+
+- **The worker pattern.** `emit` enqueues; a background worker drains.
+  Under the hood, `emit` now returns almost immediately even if the
+  backend is slow.
+- **Bounded queue with drop-on-overflow.** Prevents unbounded memory
+  growth if the backend is persistently slow. A production sink
+  should log the drop and expose a metric.
+- **Poison pill on close.** Sends a sentinel to unblock the worker so
+  it can exit cleanly.
+- **Serialization via `MessageToJson`.** The canonical way to get a
+  wire-friendly JSON representation of a proto message.
+
+## Design considerations
+
+### Back-pressure
+
+goldfive awaits every `emit` call. A sink that blocks blocks the
+run. Always use one of:
+
+- A bounded internal queue with drop-on-overflow (the HTTP sink above).
+- A bounded internal queue with a short timeout (log and proceed on
+  timeout).
+- Synchronous, fast writes (the `LoggingSink` pattern — writes go to
+  the standard library's thread-safe `logging` layer).
+
+**Never** use an unbounded queue. Unbounded queues turn a slow
+backend into an OOM.
+
+### Error handling
+
+`emit` can raise. goldfive catches and logs; your run keeps going.
+But emit-time errors are costly — they indicate the sink is broken.
+Design for graceful degradation:
+
+- Log once, suppress subsequent errors for a cooldown window.
+- Expose a health signal so ops can notice.
+- If the sink is critical (e.g. it's the only durable store), crash
+  the process rather than silently dropping.
+
+### Ordering
+
+Events arrive in per-run sequence order. If your backend cares about
+order (most do), forward them in the same order. The HTTP sink above
+uses a single worker coroutine to preserve order; a concurrent worker
+pool would lose it.
+
+### Durability
+
+`emit` returns before the event has hit the wire in the queued
+design. If the process crashes after `emit` returns but before the
+worker drains, you lose events. If your sink needs strict durability
+(e.g. for audit logs), use a synchronous write (like
+`JSONLPersistenceSink`) or a queue backed by a durable store.
+
+### Multiple sinks at once
+
+goldfive passes the **same** event object to every sink. Treat it as
+immutable. If your sink needs to mutate (e.g. strip fields, transform
+types), clone first:
+
+```python
+event_copy = type(event_pb)()
+event_copy.CopyFrom(event_pb)
+# mutate event_copy freely
+```
+
+## Useful proto helpers
+
+```python
+from google.protobuf.json_format import MessageToDict, MessageToJson, ParseDict
+
+# event -> Python dict
+as_dict = MessageToDict(event_pb, preserving_proto_field_name=True)
+
+# event -> JSON string
+as_json = MessageToJson(event_pb, preserving_proto_field_name=True)
+
+# dict -> event (for replay)
+from goldfive.pb.goldfive.v1.events_pb2 import Event
+ev = Event()
+ParseDict(some_dict, ev)
+```
+
+These are the same helpers `JSONLPersistenceSink` uses for its
+round-trip. If you build a sink that wraps a transport, you'll
+probably re-use them.
+
+## Pattern: filtering sinks
+
+A common pattern is a sink that only forwards certain kinds. Compose
+rather than configure:
+
+```python
+from typing import Iterable
+
+
+class FilteringSink:
+    def __init__(self, inner, *, kinds: Iterable[str]) -> None:
+        self._inner = inner
+        self._kinds = set(kinds)
+
+    async def emit(self, event_pb) -> None:
+        if event_pb.WhichOneof("payload") in self._kinds:
+            await self._inner.emit(event_pb)
+
+    async def close(self) -> None:
+        await self._inner.close()
+```
+
+Used:
+
+```python
+sink = FilteringSink(
+    HttpBackendSink("https://obs.example.com/events"),
+    kinds={"drift_detected", "plan_revised", "run_aborted"},
+)
+```
+
+## Pattern: replay from `JSONLPersistenceSink`
+
+The persistence sink stores every event, so you can reconstruct any
+run:
+
+```python
+from goldfive.sinks import JSONLPersistenceSink
+
+events = JSONLPersistenceSink.from_jsonl("./runs/abc123.jsonl")
+for ev in events:
+    kind = ev.WhichOneof("payload")
+    print(ev.sequence, kind)
+```
+
+You can feed those events into a custom sink after the fact to
+rebuild external state (e.g. backfill a newly-added observability
+system from historical JSONL files).
+
+## Testing a custom sink
+
+Two patterns.
+
+**In isolation** — instantiate your sink, call `emit` with hand-built
+events, assert on side effects:
+
+```python
+import pytest
+from goldfive.pb.goldfive.v1.events_pb2 import Event
+
+
+@pytest.mark.asyncio
+async def test_http_sink_posts_events(httpx_mock):
+    httpx_mock.add_response(status_code=200)
+    sink = HttpBackendSink("http://mock.local/events")
+
+    ev = Event(run_id="r1", sequence=0)
+    ev.run_started.user_input = "hello"
+
+    await sink.emit(ev)
+    await sink.close()
+
+    assert httpx_mock.get_requests()  # at least one POST
+```
+
+**End-to-end** — wire it into a `Runner` run with a `CallableAdapter`
+and a known plan, then assert your sink received the expected events
+in order.
+
+## Upstream contribution
+
+If you write a sink that generalizes (popular framework, commonly-used
+observability product), goldfive is receptive to upstreaming. Open an
+issue with a spec and a test plan. Candidate "blessed" sinks:
+
+- OpenTelemetry (OTLP) forwarder.
+- Grafana / Tempo / Loki forwarders.
+- harmonograf integration (forthcoming as a separate package; see
+  [harmonograf-integration.md](harmonograf-integration.md)).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,484 @@
+# Public API surface
+
+Hand-maintained reference for goldfive's public API as of v0.1. When
+this doc disagrees with the code, trust the code and file a patch to
+fix the doc.
+
+Related: [PROTOCOLS.md](../design/PROTOCOLS.md),
+[ARCHITECTURE.md](../design/ARCHITECTURE.md).
+
+## Top-level imports
+
+Everything documented here is re-exported from `goldfive.__init__`:
+
+```python
+from goldfive import (
+    Runner,
+    # types
+    Goal, Plan, Task, TaskEdge, TaskStatus, DriftKind, DriftSeverity,
+    DriftEvent, Session,
+    # protocols
+    GoalDeriver, Planner, Executor, Steerer, AgentAdapter, EventSink,
+    # results
+    InvocationResult, ExecutionOutcome,
+    # reporting
+    ReportingToolSpec,
+)
+```
+
+Subpackages for implementations:
+
+```python
+from goldfive.adapters.callable import CallableAdapter
+from goldfive.adapters.adk import ADKAdapter          # extra: adk
+from goldfive.adapters.claude import ClaudeAgentSDKAdapter  # extra: claude
+
+from goldfive.executors.sequential import SequentialExecutor
+from goldfive.executors.parallel import ParallelDAGExecutor
+
+from goldfive.planner import PassthroughPlanner, LLMPlanner
+from goldfive.goal_deriver import PassthroughGoalDeriver, LLMGoalDeriver
+from goldfive.steerer import DefaultSteerer
+
+from goldfive.sinks import InMemorySink, LoggingSink, JSONLPersistenceSink
+```
+
+## `Runner`
+
+The single entry point.
+
+```python
+class Runner:
+    def __init__(
+        self,
+        *,
+        agent: AgentAdapter,
+        planner: Planner,
+        executor: Executor,
+        goal_deriver: Optional[GoalDeriver] = None,
+        steerer: Optional[Steerer] = None,
+        sinks: Optional[list[EventSink]] = None,
+        max_plan_reinvocations: int = 3,
+    ) -> None: ...
+
+    async def run(
+        self,
+        user_input: str | list[Goal],
+        *,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> ExecutionOutcome: ...
+
+    async def resume(
+        self,
+        session: Session,
+    ) -> ExecutionOutcome: ...  # pairs with JSONLPersistenceSink
+```
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `agent` | required | Any `AgentAdapter`. |
+| `planner` | required | Any `Planner`. |
+| `executor` | required | Any `Executor`. Typically `SequentialExecutor()` or `ParallelDAGExecutor()`. |
+| `goal_deriver` | `PassthroughGoalDeriver()` | Optional; defaults substitute when `None`. |
+| `steerer` | `DefaultSteerer()` | Optional. |
+| `sinks` | `[]` | Optional. Recommended: at least `InMemorySink` in tests and `JSONLPersistenceSink` in prod. |
+| `max_plan_reinvocations` | `3` | Executor aborts after this many consecutive refine loops without net progress. |
+
+## Data types (`goldfive.types`)
+
+### `TaskStatus`
+
+```python
+class TaskStatus(StrEnum):
+    PENDING
+    RUNNING
+    COMPLETED
+    FAILED
+    CANCELLED
+    BLOCKED
+```
+
+### `DriftSeverity`
+
+```python
+class DriftSeverity(StrEnum):
+    INFO
+    WARNING
+    CRITICAL
+```
+
+### `DriftKind`
+
+25+ values. See [DRIFT.md](../design/DRIFT.md) for the full
+taxonomy. Examples:
+
+```python
+class DriftKind(StrEnum):
+    TOOL_ERROR, AGENT_REFUSAL, NEW_WORK_DISCOVERED, PLAN_DIVERGENCE,
+    USER_STEER, USER_CANCEL, TASK_FAILED_RECOVERABLE,
+    TASK_FAILED_FATAL, CONTEXT_PRESSURE, BLOCKED, WRONG_AGENT, ...
+    CUSTOM
+```
+
+### `Task`
+
+```python
+@dataclass
+class Task:
+    id: str
+    title: str
+    description: str = ""
+    assignee_agent_id: str = ""
+    status: TaskStatus = TaskStatus.PENDING
+    predicted_start_ms: int = 0
+    predicted_duration_ms: int = 0
+    bound_span_id: str = ""
+```
+
+### `TaskEdge`
+
+```python
+@dataclass
+class TaskEdge:
+    from_task_id: str
+    to_task_id: str
+```
+
+### `Plan`
+
+```python
+@dataclass
+class Plan:
+    id: str
+    run_id: str
+    goal_ids: list[str]
+    tasks: list[Task]
+    edges: list[TaskEdge]
+    summary: str = ""
+    revision_reason: str = ""
+    revision_kind: str = ""        # DriftKind value or ""
+    revision_severity: str = ""    # DriftSeverity value or ""
+    revision_index: int = 0
+
+    def topological_stages(self) -> list[list[Task]]:
+        """Kahn's algorithm — returns tasks grouped by DAG depth."""
+```
+
+### `Goal`
+
+```python
+@dataclass
+class Goal:
+    id: str
+    summary: str
+    success_predicate: Optional[Callable[[Session], bool]] = None
+    metadata: dict[str, str] = field(default_factory=dict)
+```
+
+### `DriftEvent`
+
+```python
+@dataclass
+class DriftEvent:
+    kind: DriftKind
+    severity: DriftSeverity
+    detail: str = ""
+    current_task_id: str = ""
+    current_agent_id: str = ""
+    raw: Any = None
+```
+
+### `Session`
+
+```python
+@dataclass
+class Session:
+    run_id: str
+    goals: list[Goal] = field(default_factory=list)
+    plan: Optional[Plan] = None
+    current_task_id: str = ""
+    completed_results: dict[str, str] = field(default_factory=dict)
+    task_progress: dict[str, float] = field(default_factory=dict)
+    agent_notes: dict[str, str] = field(default_factory=dict)
+    divergence_flag: bool = False
+    history: list[Any] = field(default_factory=list)
+    started_at_ms: int = 0
+
+    def next_sequence(self) -> int:
+        """Monotonic event sequence counter."""
+```
+
+## Results (`goldfive.results`)
+
+### `InvocationResult`
+
+Returned by `AgentAdapter.invoke()`.
+
+```python
+@dataclass
+class InvocationResult:
+    task_id: str
+    text: str = ""
+    stop_reason: str = ""
+    error: Optional[Exception] = None
+    raw: Any = None
+```
+
+### `ExecutionOutcome`
+
+Returned by `Executor.run()` and `Runner.run()`.
+
+```python
+@dataclass
+class ExecutionOutcome:
+    success: bool
+    session: Session
+    reason: str = ""
+```
+
+## Protocols (`goldfive.protocols`)
+
+All are `@runtime_checkable`. Full contracts in
+[PROTOCOLS.md](../design/PROTOCOLS.md).
+
+| Protocol | Methods |
+|---|---|
+| `GoalDeriver` | `derive(user_input, *, context=None) -> list[Goal]` |
+| `Planner` | `generate(*, goals, available_agents, context=None) -> Optional[Plan]` · `refine(*, plan, drift, goals) -> Optional[Plan]` |
+| `Steerer` | `observe(event, session)` · `transition(task_id, to, *, detail="", session)` · `detect_drift(event, session) -> Optional[DriftEvent]` · `bind(*, sinks, planner)` |
+| `AgentAdapter` | `register_reporting_tools(tools)` · `invoke(task, session) -> InvocationResult` · property `available_agents: list[str]` |
+| `Executor` | `run(*, plan, session, adapter, steerer, planner, sinks) -> ExecutionOutcome` |
+| `EventSink` | `emit(event_pb)` · `close()` |
+
+## Default implementations
+
+### GoalDerivers (`goldfive.goal_deriver`)
+
+```python
+class PassthroughGoalDeriver(GoalDeriver):
+    async def derive(self, user_input, *, context=None): ...
+
+class LLMGoalDeriver(GoalDeriver):
+    def __init__(
+        self,
+        *,
+        call_llm: Callable[[str, str, str], Awaitable[str]],
+        model: str,
+    ): ...
+```
+
+### Planners (`goldfive.planner`)
+
+```python
+class PassthroughPlanner(Planner):
+    def __init__(self, *, plan: Plan): ...
+
+class LLMPlanner(Planner):
+    def __init__(
+        self,
+        *,
+        call_llm: Callable[[str, str, str], Awaitable[str]],
+        model: str,
+        system_prompt_override: Optional[str] = None,
+        refine_system_prompt_override: Optional[str] = None,
+    ): ...
+```
+
+### Steerer (`goldfive.steerer`)
+
+```python
+class DefaultSteerer(Steerer):
+    # Implements the full state machine + drift classifier from
+    # DRIFT.md and STATE-MACHINE.md. No required constructor args.
+```
+
+### Executors (`goldfive.executors`)
+
+```python
+class SequentialExecutor(Executor):
+    def __init__(
+        self,
+        *,
+        nudge_timeout_s: float = 60.0,
+    ): ...
+
+class ParallelDAGExecutor(Executor):
+    def __init__(
+        self,
+        *,
+        max_concurrency: Optional[int] = None,
+        drift_policy: Literal["cancel_stage", "finish_stage"] = "finish_stage",
+    ): ...
+```
+
+### Adapters (`goldfive.adapters`)
+
+```python
+# Always available
+class CallableAdapter(AgentAdapter):
+    def __init__(
+        self,
+        agent: Callable[
+            [Task, Session, list[ReportingToolSpec]],
+            Awaitable[InvocationResult],
+        ],
+        *,
+        available_agents: Optional[list[str]] = None,
+    ): ...
+
+# Requires `goldfive[adk]`
+class ADKAdapter(AgentAdapter):
+    def __init__(
+        self,
+        root_agent: Any,  # google.adk.BaseAgent
+        *,
+        runner: Optional[Any] = None,
+    ): ...
+
+# Requires `goldfive[claude]`
+class ClaudeAgentSDKAdapter(AgentAdapter):
+    def __init__(
+        self,
+        *,
+        system_prompt: str,
+        model: str,
+        client: Optional[Any] = None,  # claude_agent_sdk.ClaudeSDKClient
+    ): ...
+```
+
+### Sinks (`goldfive.sinks`)
+
+```python
+class InMemorySink(EventSink):
+    events: list[Event]  # attribute, inspect after the run
+
+class LoggingSink(EventSink):
+    def __init__(
+        self,
+        *,
+        logger: Optional[logging.Logger] = None,
+        level: int = logging.INFO,
+    ): ...
+
+class JSONLPersistenceSink(EventSink):
+    def __init__(
+        self,
+        path: str,  # may contain {run_id} placeholder
+    ): ...
+
+    @classmethod
+    def from_jsonl(cls, path: str) -> list[Event]:
+        """Load a run's events for replay / recovery."""
+```
+
+## Reporting (`goldfive.reporting`)
+
+```python
+@dataclass
+class ReportingToolSpec:
+    name: str
+    description: str
+    parameters: dict[str, Any]
+    handler: Callable[
+        [dict[str, Any], Session, Steerer],
+        Awaitable[dict[str, Any]],
+    ]
+
+
+# The seven canonical tool names (stable contract).
+REPORTING_TOOL_NAMES: frozenset[str] = frozenset({
+    "report_task_started",
+    "report_task_progress",
+    "report_task_completed",
+    "report_task_failed",
+    "report_task_blocked",
+    "report_new_work_discovered",
+    "report_plan_divergence",
+})
+
+
+def build_default_reporting_tools(steerer: Steerer) -> list[ReportingToolSpec]:
+    """The seven canonical tool specs, wired to `steerer`."""
+```
+
+See [tool-protocol.md](tool-protocol.md) for full semantics.
+
+## Events (`goldfive.events`)
+
+```python
+def new_event(run_id: str, sequence: int) -> Event:
+    """Fresh envelope with run_id, sequence, emitted_at populated."""
+
+def now_ts() -> google.protobuf.Timestamp:
+    """Current wall-clock time as a proto Timestamp."""
+
+async def emit(sinks: list[EventSink], event_pb: Event) -> None:
+    """Fan out to every sink; swallow per-sink exceptions."""
+```
+
+## Proto (`goldfive.pb.goldfive.v1`)
+
+Generated stubs committed to git. Key messages:
+
+```python
+# types_pb2
+Goal, Plan, Task, TaskEdge, TaskStatus, DriftKind, PlanRevision
+
+# events_pb2
+Event, RunStarted, GoalDerived, PlanSubmitted, PlanRevised,
+TaskStarted, TaskProgress, TaskCompleted, TaskFailed,
+TaskBlocked, TaskCancelled, DriftDetected, RunCompleted, RunAborted
+```
+
+The `Event` envelope has a `oneof payload` with one field per
+per-event message. See [EVENT-MODEL.md](../design/EVENT-MODEL.md) for
+the full catalog.
+
+## Convenience helpers (`goldfive.conv`)
+
+Proto ↔ dataclass round-trip:
+
+```python
+def to_pb_plan(plan: Plan) -> pb.Plan: ...
+def from_pb_plan(msg: pb.Plan) -> Plan: ...
+
+def to_pb_goal(goal: Goal) -> pb.Goal: ...
+def from_pb_goal(msg: pb.Goal) -> Goal: ...
+
+# ... similar for Task, TaskEdge, DriftEvent
+```
+
+## Recovery (`goldfive.recovery`)
+
+```python
+def reconstruct_session(events: list[Event]) -> Session:
+    """Replay events to rebuild a Session from scratch."""
+```
+
+Used by `Runner.resume()`. See
+[persistence-and-recovery.md](../guides/persistence-and-recovery.md).
+
+## Drift classifiers (`goldfive.drift`)
+
+For custom steerer subclasses that want to compose the standard
+classifiers:
+
+```python
+def classify_tool_error(err: Exception, tool_name: str) -> DriftEvent: ...
+def classify_refusal(text: str) -> Optional[DriftEvent]: ...
+def classify_stop_reason(reason: str) -> Optional[DriftEvent]: ...
+def classify_schema_violation(payload: Any, schema: Any) -> DriftEvent: ...
+```
+
+## Version compatibility
+
+- **v0.1** — the shapes in this document. Stable within v0.1.x patch
+  releases.
+- **v0.2+** — shapes may be extended (new fields, new enum values,
+  new methods on protocols with defaults). Anything in this doc is
+  expected to stay backwards-compatible through v1.0.
+- **Proto compatibility** — proto3 rules. Never remove or renumber a
+  field; add new events by extending the `oneof payload`.
+
+Anything not documented here is internal and subject to change
+without notice. Use the public surface.

--- a/docs/reference/tool-protocol.md
+++ b/docs/reference/tool-protocol.md
@@ -1,0 +1,370 @@
+# Reporting tools reference
+
+goldfive injects a small set of **reporting tools** into every agent
+wrapped by an `AgentAdapter`. These are how the agent explicitly
+communicates task state to the orchestrator — not inferred from span
+lifecycle, not guessed from prose, always called out.
+
+The tool *bodies* are trivial; each one returns
+`{"acknowledged": True}`. The real work happens in the adapter's
+interception path: when the agent calls `report_task_completed(...)`,
+the adapter routes it through the spec's handler, which invokes the
+steerer, which applies the state transition and emits an event.
+
+Related: [STATE-MACHINE.md](../design/STATE-MACHINE.md),
+[PROTOCOLS.md](../design/PROTOCOLS.md#agentadapter),
+[writing-an-agent-adapter.md](../guides/writing-an-agent-adapter.md).
+
+## The `ReportingToolSpec` shape
+
+```python
+@dataclasses.dataclass
+class ReportingToolSpec:
+    name: str
+    description: str
+    parameters: dict[str, Any]   # JSON schema for parameters
+    handler: Callable[
+        [dict[str, Any], "Session", "Steerer"],
+        Awaitable[dict[str, Any]],
+    ]
+```
+
+An `AgentAdapter` receives a list of these from
+`register_reporting_tools(tools)` at setup time and installs them in
+whatever form its framework expects.
+
+## When to call each
+
+Agents should call reporting tools at **task boundaries**, not from
+general chit-chat. The sub-agent instruction appendix wired in by
+goldfive gives models the minimum contract:
+
+```
+When you are working on a planned task:
+- Call report_task_started(task_id) before beginning work
+- Call report_task_completed(task_id, summary=...) after finishing
+- If you discover additional work, call report_new_work_discovered(...)
+- If you fail, call report_task_failed(task_id, reason=...)
+- If you are stuck on an external blocker, call
+  report_task_blocked(task_id, blocker=...)
+```
+
+The current `task_id` is made available to the agent by the adapter —
+either in a shared session-state dict (ADK), a system prompt (Claude
+SDK), or as a direct argument (CallableAdapter).
+
+## The seven tools
+
+Names are stable contract — do not rename. Mirrors harmonograf's
+canonical reporting tools; goldfive owns the list from v0.1 forward.
+
+### 1. `report_task_started`
+
+```python
+report_task_started(task_id: str, detail: str = "") -> dict
+```
+
+**Call when:** about to begin work on a planned task.
+
+**Side effects:**
+
+- Steerer transitions `task_id` from PENDING to RUNNING.
+- `session.current_task_id` is set.
+- `session.agent_notes[task_id] = detail`.
+- Emits `TaskStarted(task_id, detail)`.
+
+**Example:**
+
+```python
+# inside an agent callable or LLM tool call
+await report_task_started(task_id="t3", detail="starting research phase")
+```
+
+### 2. `report_task_progress`
+
+```python
+report_task_progress(
+    task_id: str,
+    fraction: float = 0.0,
+    detail: str = "",
+) -> dict
+```
+
+**Call when:** a long-running task has meaningful sub-steps to
+announce. Optional; not required for correct operation.
+
+**Side effects:**
+
+- `session.task_progress[task_id] = fraction`.
+- `session.agent_notes[task_id] = detail`.
+- Emits `TaskProgress(task_id, fraction, detail)`.
+- **No state transition.**
+
+**Example:**
+
+```python
+await report_task_progress(
+    task_id="t3",
+    fraction=0.5,
+    detail="draft complete; beginning polish",
+)
+```
+
+Sinks use progress events for liveness indicators. goldfive itself
+does not consume `fraction` — a stalled task is detected via elapsed
+time against `task.predicted_duration_ms`, not via progress gaps.
+
+### 3. `report_task_completed`
+
+```python
+report_task_completed(
+    task_id: str,
+    summary: str,
+    artifacts: dict[str, str] | None = None,
+) -> dict
+```
+
+**Call when:** the task is done. This is terminal.
+
+**Side effects:**
+
+- Steerer transitions `task_id` from RUNNING to COMPLETED.
+- `session.completed_results[task_id] = summary`. Downstream tasks
+  see this in their context.
+- Emits `TaskCompleted(task_id, summary, artifacts)`.
+
+**Example:**
+
+```python
+await report_task_completed(
+    task_id="t3",
+    summary="slide deck generated with 5 slides, saved to deck.pptx",
+    artifacts={"deck_url": "s3://bucket/deck.pptx"},
+)
+```
+
+The `artifacts` map is free-form `str → str`. Typical uses: URLs,
+content hashes, IDs. Sinks surface artifacts to the user; goldfive
+itself treats the map as opaque.
+
+### 4. `report_task_failed`
+
+```python
+report_task_failed(
+    task_id: str,
+    reason: str,
+    recoverable: bool = True,
+) -> dict
+```
+
+**Call when:** the task cannot complete.
+
+**Side effects:**
+
+- Steerer transitions `task_id` from RUNNING to FAILED.
+- `session.completed_results[task_id] = reason` (so failed tasks'
+  messages are still visible to downstream work).
+- Emits `TaskFailed(task_id, reason, recoverable)`.
+- Fires `DriftEvent(kind=TASK_FAILED_RECOVERABLE, severity=warning)`
+  if `recoverable=True`.
+- Fires `DriftEvent(kind=TASK_FAILED_FATAL, severity=critical)` if
+  `recoverable=False`; the executor runs the unrecoverable cascade.
+
+**Example:**
+
+```python
+await report_task_failed(
+    task_id="t3",
+    reason="API returned 503 after 3 retries",
+    recoverable=True,
+)
+```
+
+`recoverable=False` should be reserved for truly unrecoverable
+situations — the plan cannot proceed regardless of refine. Use
+sparingly.
+
+### 5. `report_task_blocked`
+
+```python
+report_task_blocked(
+    task_id: str,
+    blocker: str,
+    needed: str = "",
+) -> dict
+```
+
+**Call when:** an external condition prevents progress but the task
+hasn't failed. Examples: awaiting a human approval, waiting on an
+asynchronous external process, rate-limited.
+
+**Side effects:**
+
+- Depending on blocker type:
+  - If structural (can be resolved by replanning): task transitions
+    to BLOCKED and fires `DriftEvent(kind=BLOCKED)`.
+  - If transient (will resolve on its own): task stays RUNNING,
+    `agent_notes` captures the blocker.
+- Emits `TaskBlocked(task_id, blocker, needed)`.
+
+**Example:**
+
+```python
+await report_task_blocked(
+    task_id="t3",
+    blocker="awaiting user approval for destructive action",
+    needed="human confirmation via the approval queue",
+)
+```
+
+The distinction between structural and transient is made by the
+steerer based on the `blocker` string — a classifier inspects for
+keywords like "awaiting", "waiting on", "needs human", etc. Custom
+steerers can override.
+
+### 6. `report_new_work_discovered`
+
+```python
+report_new_work_discovered(
+    parent_task_id: str,
+    title: str,
+    description: str,
+    assignee: str = "",
+) -> dict
+```
+
+**Call when:** during work on `parent_task_id`, the agent realizes a
+new task exists that wasn't in the plan and is required for the
+parent to complete.
+
+**Side effects:**
+
+- Fires `DriftEvent(kind=NEW_WORK_DISCOVERED, severity=warning)` with
+  the new task's metadata attached to `drift.raw`.
+- The executor triggers `planner.refine(...)`; the planner is
+  expected to return a revised plan that adds the new task as a child
+  of `parent_task_id`.
+- Emits nothing directly (the `DriftDetected` and eventual
+  `PlanRevised` events cover it).
+- Task state is unchanged; the parent task keeps RUNNING.
+
+**Example:**
+
+```python
+await report_new_work_discovered(
+    parent_task_id="t2",
+    title="fetch corporate branding",
+    description="download the company logo SVG for slide 1",
+    assignee="web_developer",
+)
+```
+
+### 7. `report_plan_divergence`
+
+```python
+report_plan_divergence(
+    note: str,
+    suggested_action: str = "",
+) -> dict
+```
+
+**Call when:** the whole plan no longer matches reality. This is
+stronger than "new work exists" — it's "the current plan is wrong
+top-to-bottom".
+
+**Side effects:**
+
+- `session.divergence_flag = True`.
+- Fires `DriftEvent(kind=PLAN_DIVERGENCE, severity=warning)` with
+  `note` and `suggested_action` as hints for the planner.
+- Triggers refine.
+
+**Example:**
+
+```python
+await report_plan_divergence(
+    note="the user changed their mind — they want a podcast, not a deck",
+    suggested_action="scrap t2–t5; start over with audio production tasks",
+)
+```
+
+Use sparingly. Most drift should route through the more specific
+tools above; `report_plan_divergence` is the catch-all.
+
+## Summary table
+
+| Tool | Signature | Transition | Drift kind |
+|---|---|---|---|
+| `report_task_started` | `(task_id, detail="")` | PENDING → RUNNING | — |
+| `report_task_progress` | `(task_id, fraction=0.0, detail="")` | RUNNING → RUNNING | — |
+| `report_task_completed` | `(task_id, summary, artifacts=None)` | RUNNING → COMPLETED | — |
+| `report_task_failed` | `(task_id, reason, recoverable=True)` | RUNNING → FAILED | `TASK_FAILED_RECOVERABLE` or `TASK_FAILED_FATAL` |
+| `report_task_blocked` | `(task_id, blocker, needed="")` | RUNNING → BLOCKED (structural) or stays RUNNING | `BLOCKED` |
+| `report_new_work_discovered` | `(parent_task_id, title, description, assignee="")` | none | `NEW_WORK_DISCOVERED` |
+| `report_plan_divergence` | `(note, suggested_action="")` | none | `PLAN_DIVERGENCE` |
+
+## How the interception works
+
+Every adapter implements this flow:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Agent as Agent (LLM)
+    participant Adapter as AgentAdapter
+    participant Steerer
+    participant Sinks as EventSinks
+
+    Agent->>Adapter: tool_use: report_task_completed(t3, summary=...)
+    Adapter->>Adapter: recognize name in REPORTING_TOOL_NAMES
+    Adapter->>Steerer: spec.handler(args, session, steerer)
+    Steerer->>Steerer: apply RUNNING → COMPLETED
+    Steerer->>Sinks: emit TaskCompleted
+    Steerer-->>Adapter: return {"acknowledged": True}
+    Adapter-->>Agent: tool result
+```
+
+The tool body never actually runs arbitrary code — it returns
+`{"acknowledged": True}` synchronously. The interception in the
+adapter is what makes anything happen.
+
+This design means agents can call reporting tools like any other
+tool, without knowing goldfive exists. The state transitions happen
+behind the scenes.
+
+## Why not infer state from spans?
+
+Earlier iterations of this protocol (in harmonograf before the
+extraction) inferred task state from span lifecycle and from prose
+markers like "Task complete:" in the LLM response. That broke down
+for three reasons:
+
+1. **Long-running tool calls** looked "done" the moment the outer
+   LLM stopped, even when they were still working.
+2. **Prose parsing** couldn't distinguish "I will complete the task"
+   from "task complete".
+3. **Concurrent sub-agents** racing through a parallel plan produced
+   ordering bugs because state transitions lived in two places at
+   once.
+
+Reporting tools make the state machine **explicit and monotonic**:
+one call, one transition, one source of truth.
+
+Agents that narrate in prose instead of calling tools still work,
+degraded — the `Steerer.observe()` path scans streamed content for
+structured signals as a belt-and-suspenders. But explicit tools are
+the canonical protocol, and anyone writing a new adapter should
+prefer them.
+
+## Customizing the tool list
+
+The seven tools above are the minimum contract. Custom adapters can
+extend the list by appending to `tools` before calling
+`adapter.register_reporting_tools(tools)`. The steerer ignores names
+it doesn't recognize, so custom tools pass through to the framework's
+normal tool-call path. A typical extension: domain-specific reporting
+tools like `report_budget_remaining` or `report_confidence`.
+
+Renaming or removing the seven canonical tools is not supported.
+Downstream consumers (harmonograf, planners, sinks) pattern-match on
+the canonical names.


### PR DESCRIPTION
## Summary

- Adds the full docs tree under `docs/` — five design documents, six
  user guides, and two reference documents.
- Updates the top-level `README.md` to prominently link to
  `docs/guides/getting-started.md` plus every other new doc.

## What landed

**`docs/design/`** — conceptual foundation

- `ARCHITECTURE.md` — six primitives, composition, full lifecycle, ASCII data-flow diagram.
- `PROTOCOLS.md` — contract for each protocol with minimal working implementations.
- `STATE-MACHINE.md` — Mermaid state diagram, transition rules, invariants.
- `DRIFT.md` — full 25+ drift-kind taxonomy, classification dispatch, refine policy.
- `EVENT-MODEL.md` — proto event taxonomy, sequence semantics, `EventSink` contract.

**`docs/guides/`** — hands-on

- `getting-started.md` — install + 10-minute hello-callable walkthrough.
- `writing-an-agent-adapter.md` — worked ~50-line example wrapping a hypothetical SDK.
- `writing-an-event-sink.md` — from minimal stdout sink to queued HTTP backend.
- `goals-and-plans.md` — authoring custom `GoalDeriver` / `Planner`, how refine works.
- `persistence-and-recovery.md` — `JSONLPersistenceSink` + `Runner.resume()` with failure-mode walkthroughs.
- `harmonograf-integration.md` — forward-looking (sink implementation lands in the harmonograf repo).

**`docs/reference/`**

- `tool-protocol.md` — the seven canonical reporting tools.
- `api.md` — hand-maintained public API surface.

## Style conformance

- Prose-first with embedded runnable code examples.
- Mermaid diagrams for state machines and sequence flows; ASCII for the architecture overview.
- Cross-linked aggressively — each doc references every other doc it depends on.
- Every file under 500 lines (largest is `PROTOCOLS.md` at 476).
- No emojis; tone matches harmonograf's `AGENTS.md` voice.

## Test plan

- [ ] Skim each doc for broken cross-links.
- [ ] Sanity-check `getting-started.md` against the actual v0.1 API once `Runner` lands in #15.
- [ ] Verify Mermaid renders correctly in GitHub's markdown viewer.

Closes #17.
