### PR TITLE
Add Runner entrypoint, DefaultSteerer, SequentialExecutor, and examples

### DIFF
--- a/examples/adk_agent.py
+++ b/examples/adk_agent.py
@@ -1,0 +1,79 @@
+"""adk_agent — wrap a Google ADK agent with goldfive.
+
+Gated on the ``adk`` extra. Install with::
+
+    uv pip install -e '.[adk]'
+
+The actual ADK adapter lives in ``goldfive.adapters.adk`` (delivered by
+issue #13). This example documents the intended wiring; it import-fails
+cleanly when either ADK itself or the goldfive ADK adapter is not yet
+installed.
+"""
+
+from __future__ import annotations
+
+try:
+    import google.adk  # type: ignore  # noqa: F401
+except ImportError as _adk_err:  # pragma: no cover
+    raise SystemExit("install goldfive[adk] to run this example") from _adk_err
+
+try:
+    from goldfive.adapters.adk import ADKAdapter  # type: ignore[attr-defined]
+except ImportError as _adk_adapter_err:  # pragma: no cover
+    raise SystemExit(
+        "goldfive.adapters.adk is not available yet; see issue #13"
+    ) from _adk_adapter_err
+
+import asyncio
+
+from goldfive import (
+    InMemorySink,
+    PassthroughGoalDeriver,
+    Plan,
+    Runner,
+    SequentialExecutor,
+    StaticPlanner,
+    Task,
+)
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="adk-demo",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="ADK task 1", assignee_agent_id="root"),
+            Task(id="t2", title="ADK task 2", assignee_agent_id="root"),
+        ],
+        edges=[],
+        summary="Two ADK tasks.",
+    )
+
+
+async def main() -> None:
+    # Construct an ADK root agent however you normally would, e.g.:
+    #   from google.adk.agents import Agent as ADKAgent
+    #   root_agent = ADKAgent(name="root", model="gemini-2.0-flash")
+    #   adapter = ADKAdapter(root_agent)
+    adapter = ADKAdapter.from_scratch(model="gemini-2.0-flash")  # placeholder
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=adapter,
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("Run two ADK tasks"),
+        sinks=[sink],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+    print(f"success={outcome.success}")
+    for e in sink.events:
+        kind = e["kind"] if isinstance(e, dict) else getattr(e, "kind", "?")
+        payload = e.get("payload") if isinstance(e, dict) else getattr(e, "payload", {})
+        print(f"  {kind:<16}  {payload}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/claude_agent.py
+++ b/examples/claude_agent.py
@@ -1,0 +1,75 @@
+"""claude_agent — wrap a Claude Agent SDK agent with goldfive.
+
+Gated on the ``claude`` extra. Install with::
+
+    uv pip install -e '.[claude]'
+
+The actual Claude adapter lives in ``goldfive.adapters.claude``
+(delivered by issue #14). This example documents the intended wiring;
+it import-fails cleanly when the SDK or the goldfive Claude adapter
+are not yet installed.
+"""
+
+from __future__ import annotations
+
+try:
+    import anthropic  # type: ignore  # noqa: F401
+except ImportError as _claude_err:  # pragma: no cover
+    raise SystemExit("install goldfive[claude] to run this example") from _claude_err
+
+try:
+    from goldfive.adapters.claude import ClaudeAdapter  # type: ignore[attr-defined]
+except ImportError as _claude_adapter_err:  # pragma: no cover
+    raise SystemExit(
+        "goldfive.adapters.claude is not available yet; see issue #14"
+    ) from _claude_adapter_err
+
+import asyncio
+
+from goldfive import (
+    InMemorySink,
+    PassthroughGoalDeriver,
+    Plan,
+    Runner,
+    SequentialExecutor,
+    StaticPlanner,
+    Task,
+)
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="claude-demo",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="Claude task 1", assignee_agent_id="claude"),
+            Task(id="t2", title="Claude task 2", assignee_agent_id="claude"),
+        ],
+        edges=[],
+        summary="Two Claude tasks.",
+    )
+
+
+async def main() -> None:
+    adapter = ClaudeAdapter(model="claude-sonnet-4-5")  # placeholder
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=adapter,
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("Run two Claude tasks"),
+        sinks=[sink],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+    print(f"success={outcome.success}")
+    for e in sink.events:
+        kind = e["kind"] if isinstance(e, dict) else getattr(e, "kind", "?")
+        payload = e.get("payload") if isinstance(e, dict) else getattr(e, "payload", {})
+        print(f"  {kind:<16}  {payload}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/hello_callable.py
+++ b/examples/hello_callable.py
@@ -1,0 +1,91 @@
+"""hello_callable — the simplest possible goldfive run.
+
+Wires a :class:`CallableAdapter` to a :class:`StaticPlanner` with a
+hand-built plan, runs it through a :class:`SequentialExecutor`, and
+collects every event in an :class:`InMemorySink` so the full event log
+can be printed at the end.
+
+Run with::
+
+    uv run python examples/hello_callable.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from goldfive import (
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="hello-plan",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="greet", title="Greet the user", assignee_agent_id="greeter"),
+            Task(id="ask", title="Ask for a name", assignee_agent_id="greeter"),
+            Task(id="thank", title="Thank the user", assignee_agent_id="greeter"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="greet", to_task_id="ask"),
+            TaskEdge(from_task_id="ask", to_task_id="thank"),
+        ],
+        summary="Greet, ask, thank.",
+    )
+
+
+async def greeter_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    """A toy agent that produces one canned reply per task."""
+    _ = tools  # unused in this toy agent
+    text = {
+        "greet": "Hello!",
+        "ask": "What's your name?",
+        "thank": "Thanks for chatting!",
+    }.get(task.id, "(no-op)")
+    return InvocationResult(task_id=task.id, text=text)
+
+
+async def main() -> None:
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(greeter_agent, available_agents=["greeter"]),
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("Say hello, ask for a name, thank them"),
+        sinks=[sink],
+    )
+
+    outcome = await runner.run("run the greeter workflow")
+    await runner.close()
+
+    print(f"success={outcome.success}, reason={outcome.reason!r}")
+    print(f"run_id={outcome.session.run_id}")
+    print(f"goals={[g.summary for g in outcome.session.goals]}")
+    print(f"{len(sink.events)} events:")
+    for e in sink.events:
+        seq = e["sequence"] if isinstance(e, dict) else getattr(e, "sequence", "?")
+        kind = e["kind"] if isinstance(e, dict) else getattr(e, "kind", "?")
+        payload = e.get("payload") if isinstance(e, dict) else getattr(e, "payload", {})
+        print(f"  seq={seq:>3}  {kind:<16}  {payload}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/persistence_and_recovery.py
+++ b/examples/persistence_and_recovery.py
@@ -1,0 +1,124 @@
+"""persistence_and_recovery — JSONL persistence + crash recovery flow.
+
+Runs a small plan with a :class:`JSONLPersistenceSink`, simulates a
+crash partway through by raising inside the adapter callable, then
+invokes :meth:`Runner.resume` to rebuild a :class:`Session` from the
+persisted log.
+
+The JSONL sink encodes proto ``Event`` messages, so this example
+requires the ``proto`` extra. Install with::
+
+    uv pip install -e '.[proto,dev]'
+    make proto  # generate the proto stubs
+
+Then run::
+
+    uv run python examples/persistence_and_recovery.py
+
+Until the ``proto`` extra is installed the example short-circuits with
+a friendly :class:`SystemExit` pointing at the install instructions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+from goldfive import (
+    CallableAdapter,
+    InvocationResult,
+    JSONLPersistenceSink,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+
+if JSONLPersistenceSink is None:  # type: ignore[truthy-function]
+    raise SystemExit(
+        "goldfive.sinks.JSONLPersistenceSink requires the `proto` extra; "
+        "install goldfive[proto] and run `make proto` to generate the "
+        "proto stubs, then retry."
+    )
+
+
+class _SimulatedCrash(RuntimeError):
+    """Marker — only raised to simulate a crash in the demo."""
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="persist-demo",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="First", assignee_agent_id="worker"),
+            Task(id="t2", title="Second", assignee_agent_id="worker"),
+            Task(id="t3", title="Third (crashes)", assignee_agent_id="worker"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="t1", to_task_id="t2"),
+            TaskEdge(from_task_id="t2", to_task_id="t3"),
+        ],
+        summary="Three steps; the third simulates a crash.",
+    )
+
+
+async def crashy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = tools
+    if task.id == "t3":
+        raise _SimulatedCrash("boom")
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+async def main() -> None:
+    tmp = tempfile.NamedTemporaryFile(
+        prefix="goldfive-demo-", suffix=".jsonl", delete=False
+    )
+    tmp.close()
+    path = tmp.name
+    print(f"persistence file: {path}")
+
+    # First run: crashes on t3.
+    sink = JSONLPersistenceSink(path)
+    runner = Runner(
+        agent=CallableAdapter(crashy_agent, available_agents=["worker"]),
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(stop_on_failure=True),
+        goal_deriver=PassthroughGoalDeriver("Persist and recover"),
+        sinks=[sink],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+    print(f"first run: success={outcome.success}, reason={outcome.reason!r}")
+
+    # Now recover from the persistence log. We construct a fresh Runner
+    # solely to call resume(); the components passed in are placeholders
+    # because resume() does not re-invoke the executor in v0.1.
+    placeholder = Runner(
+        agent=CallableAdapter(crashy_agent, available_agents=["worker"]),
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(),
+    )
+    recovered = await placeholder.resume(path)
+    print(
+        f"recovered: success={recovered.success}, reason={recovered.reason!r}, "
+        f"run_id={recovered.session.run_id}, "
+        f"completed={list(recovered.session.completed_results.keys())}"
+    )
+
+    os.unlink(path)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -2,8 +2,113 @@
 
 from __future__ import annotations
 
-from goldfive.executors import ParallelDAGExecutor
-
 __version__ = "0.0.1"
 
-__all__ = ["ParallelDAGExecutor", "__version__"]
+# Core dataclasses / enums.
+from goldfive.adapters import CallableAdapter
+from goldfive.executors import ParallelDAGExecutor, SequentialExecutor
+
+# Default component implementations.
+from goldfive.goal_deriver import (
+    LiteralGoalDeriver,
+    LLMGoalDeriver,
+    PassthroughGoalDeriver,
+)
+from goldfive.planner import LLMPlanner, PassthroughPlanner, StaticPlanner
+
+# Protocols.
+from goldfive.protocols import (
+    AgentAdapter,
+    EventSink,
+    Executor,
+    GoalDeriver,
+    Planner,
+    Steerer,
+)
+
+# Reporting tools.
+from goldfive.reporting import (
+    BUILTIN_REPORTING_TOOLS,
+    REPORTING_TOOL_NAMES,
+    ReportingHandler,
+    ReportingToolSpec,
+)
+
+# Results.
+from goldfive.results import ExecutionOutcome, InvocationResult
+
+# The Runner — public entrypoint.
+from goldfive.runner import Runner
+
+# Sinks. ``InMemorySink`` is always available; ``LoggingSink`` and
+# ``JSONLPersistenceSink`` depend on the optional ``proto`` extra and
+# are re-exported lazily below when their imports succeed.
+from goldfive.sinks.memory import InMemorySink
+
+try:
+    from goldfive.sinks.logging_sink import LoggingSink  # noqa: F401
+except ImportError:  # pragma: no cover — proto extra not installed
+    LoggingSink = None  # type: ignore[assignment]
+
+try:
+    from goldfive.sinks.persistence import (  # noqa: F401
+        JSONLPersistenceSink,
+        reconstruct_session,
+        replay_from_jsonl,
+    )
+except ImportError:  # pragma: no cover — proto extra not installed
+    JSONLPersistenceSink = None  # type: ignore[assignment]
+    reconstruct_session = None  # type: ignore[assignment]
+    replay_from_jsonl = None  # type: ignore[assignment]
+
+from goldfive.steerer import DefaultSteerer
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+__all__ = [
+    "BUILTIN_REPORTING_TOOLS",
+    "REPORTING_TOOL_NAMES",
+    "AgentAdapter",
+    "CallableAdapter",
+    "DefaultSteerer",
+    "DriftEvent",
+    "DriftKind",
+    "DriftSeverity",
+    "EventSink",
+    "ExecutionOutcome",
+    "Executor",
+    "Goal",
+    "GoalDeriver",
+    "InMemorySink",
+    "InvocationResult",
+    "JSONLPersistenceSink",
+    "LLMGoalDeriver",
+    "LLMPlanner",
+    "LiteralGoalDeriver",
+    "LoggingSink",
+    "ParallelDAGExecutor",
+    "PassthroughGoalDeriver",
+    "PassthroughPlanner",
+    "Plan",
+    "Planner",
+    "ReportingHandler",
+    "ReportingToolSpec",
+    "Runner",
+    "SequentialExecutor",
+    "Session",
+    "StaticPlanner",
+    "Steerer",
+    "Task",
+    "TaskEdge",
+    "TaskStatus",
+    "__version__",
+]

--- a/goldfive/executors/__init__.py
+++ b/goldfive/executors/__init__.py
@@ -1,12 +1,13 @@
 """Built-in executors.
 
 Each executor drives a :class:`Plan` to completion against an
-:class:`AgentAdapter`. See ``INTERFACE_SPEC.md`` and issue #10
-(``ParallelDAGExecutor``) for the contract.
+:class:`AgentAdapter`. See ``INTERFACE_SPEC.md`` and issues #9 / #10
+for the contracts pinned here.
 """
 
 from __future__ import annotations
 
 from goldfive.executors.parallel import ParallelDAGExecutor
+from goldfive.executors.sequential import SequentialExecutor
 
-__all__ = ["ParallelDAGExecutor"]
+__all__ = ["ParallelDAGExecutor", "SequentialExecutor"]

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -1,0 +1,138 @@
+"""Sequential executor — walks the plan one task at a time.
+
+Simplest correct :class:`Executor` implementation: for every task in
+topological order, invoke the adapter and advance the status. Useful
+for deterministic tests, adapters that aren't re-entrant, and CLIs that
+prefer linear output.
+
+The executor intentionally does NOT emit a ``RunStarted`` event — the
+runner is responsible for that so the lifecycle envelope stays under
+the runner's control. The executor emits ``RunCompleted`` (on success)
+or ``RunAborted`` (on failure / stop-on-failure) as the terminal
+envelope.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from goldfive.events import emit, make_event
+from goldfive.results import ExecutionOutcome
+from goldfive.types import Plan, Session, TaskStatus
+
+if TYPE_CHECKING:
+    from goldfive.protocols import AgentAdapter, EventSink, Planner, Steerer
+
+log = logging.getLogger("goldfive.executors.sequential")
+
+
+class SequentialExecutor:
+    """Run a plan one task at a time in topological order."""
+
+    def __init__(self, *, stop_on_failure: bool = True) -> None:
+        self.stop_on_failure = stop_on_failure
+
+    async def run(
+        self,
+        *,
+        plan: Plan,
+        session: Session,
+        adapter: AgentAdapter,
+        steerer: Steerer,
+        planner: Planner,
+        sinks: list[EventSink],
+    ) -> ExecutionOutcome:
+        # Bind sinks + planner on the steerer so transition() events flow.
+        try:
+            steerer.bind(sinks=sinks, planner=planner)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("steerer.bind raised: %s", exc)
+
+        session.plan = plan
+        stages = plan.topological_stages()
+        try:
+            for stage in stages:
+                for task in stage:
+                    await steerer.transition(
+                        task.id, TaskStatus.RUNNING, detail="", session=session
+                    )
+                    try:
+                        result = await adapter.invoke(task, session)
+                    except Exception as exc:  # noqa: BLE001
+                        log.exception("adapter.invoke raised for task %s", task.id)
+                        await steerer.transition(
+                            task.id,
+                            TaskStatus.FAILED,
+                            detail=f"adapter.invoke raised: {exc}",
+                            session=session,
+                        )
+                        if self.stop_on_failure:
+                            reason = f"task {task.id} failed: {exc}"
+                            await self._emit_aborted(session, sinks, reason)
+                            return ExecutionOutcome(
+                                success=False, session=session, reason=reason
+                            )
+                        continue
+
+                    # Let the steerer fan the raw result through its drift
+                    # detection and progress-forwarding machinery.
+                    await steerer.observe(result, session)
+
+                    cur = _current_status(session, task.id)
+                    if cur == TaskStatus.RUNNING:
+                        # Agent did not transition via a reporting tool —
+                        # auto-complete so the plan advances.
+                        summary = result.text or ""
+                        if summary:
+                            session.completed_results[task.id] = summary
+                        await steerer.transition(
+                            task.id,
+                            TaskStatus.COMPLETED,
+                            detail=summary,
+                            session=session,
+                        )
+                    elif cur == TaskStatus.FAILED and self.stop_on_failure:
+                        reason = f"task {task.id} reported FAILED"
+                        await self._emit_aborted(session, sinks, reason)
+                        return ExecutionOutcome(
+                            success=False, session=session, reason=reason
+                        )
+        except Exception as exc:  # noqa: BLE001
+            log.exception("SequentialExecutor.run raised")
+            reason = f"executor raised: {exc}"
+            await self._emit_aborted(session, sinks, reason)
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        evt = make_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            kind="RunCompleted",
+            payload={"plan_id": plan.id},
+        )
+        await emit(sinks, evt)
+        return ExecutionOutcome(success=True, session=session, reason="")
+
+    @staticmethod
+    async def _emit_aborted(
+        session: Session, sinks: list[EventSink], reason: str
+    ) -> None:
+        evt = make_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            kind="RunAborted",
+            payload={"reason": reason},
+        )
+        await emit(sinks, evt)
+
+
+def _current_status(session: Session, task_id: str) -> Any:
+    if session.plan is None:
+        return None
+    for t in session.plan.tasks:
+        if t.id == task_id:
+            return t.status
+    return None
+
+
+__all__ = ["SequentialExecutor"]

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -293,6 +293,66 @@ class PassthroughPlanner:
         return None
 
 
+class StaticPlanner:
+    """Planner that returns a pre-built :class:`Plan` verbatim.
+
+    Useful for tests, CLIs, and the ``hello_callable`` example where the
+    caller already knows the DAG it wants executed. On every call to
+    :meth:`generate` a fresh copy of the template is returned, with
+    ``run_id`` rewritten to match the current session and ``goal_ids``
+    aligned to the provided goals. :meth:`refine` always returns
+    ``None`` — refinement is out of scope when the plan is hard-coded.
+    """
+
+    def __init__(self, plan: Plan) -> None:
+        if plan is None:  # pragma: no cover - defensive
+            raise TypeError("StaticPlanner requires a non-None Plan")
+        self._template = plan
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Mapping[str, Any] | None = None,
+    ) -> Plan | None:
+        run_id = ""
+        if context is not None:
+            run_id = str(context.get("run_id") or "")
+        return Plan(
+            id=self._template.id or uuid.uuid4().hex,
+            run_id=run_id or self._template.run_id,
+            goal_ids=[g.id for g in goals if g.id] or list(self._template.goal_ids),
+            tasks=[
+                Task(
+                    id=t.id,
+                    title=t.title,
+                    description=t.description,
+                    assignee_agent_id=t.assignee_agent_id,
+                    status=t.status,
+                    predicted_start_ms=t.predicted_start_ms,
+                    predicted_duration_ms=t.predicted_duration_ms,
+                    bound_span_id=t.bound_span_id,
+                )
+                for t in self._template.tasks
+            ],
+            edges=[
+                TaskEdge(from_task_id=e.from_task_id, to_task_id=e.to_task_id)
+                for e in self._template.edges
+            ],
+            summary=self._template.summary,
+        )
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        return None
+
+
 class LLMPlanner:
     """Delegates to a caller-supplied async LLM callable.
 

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from goldfive.protocols import Steerer
@@ -45,3 +46,245 @@ REPORTING_TOOL_NAMES: tuple[str, ...] = (
     "report_new_work_discovered",
     "report_plan_divergence",
 )
+
+
+# ---------------------------------------------------------------------------
+# Built-in handlers
+#
+# Each handler mutates the live :class:`Session` via the :class:`Steerer`
+# (for status transitions) or directly (for progress / notes). The steerer
+# is responsible for fanning the corresponding event envelopes out to the
+# sinks, so handlers stay small and framework-agnostic.
+# ---------------------------------------------------------------------------
+
+
+async def _report_task_started(
+    args: dict[str, Any],
+    session: Session,
+    steerer: Steerer,
+) -> dict[str, Any]:
+    from goldfive.types import TaskStatus
+
+    task_id = str(args.get("task_id") or "")
+    detail = str(args.get("detail") or "")
+    if task_id:
+        await steerer.transition(task_id, TaskStatus.RUNNING, detail=detail, session=session)
+    return {"ok": True}
+
+
+async def _report_task_progress(
+    args: dict[str, Any],
+    session: Session,
+    steerer: Steerer,
+) -> dict[str, Any]:
+    task_id = str(args.get("task_id") or "")
+    fraction = float(args.get("fraction") or 0.0)
+    detail = str(args.get("detail") or "")
+    if task_id:
+        session.task_progress[task_id] = max(0.0, min(1.0, fraction))
+        if detail:
+            session.agent_notes[task_id] = detail
+        await steerer.observe(
+            {"kind": "task_progress", "task_id": task_id, "fraction": fraction, "detail": detail},
+            session,
+        )
+    return {"ok": True}
+
+
+async def _report_task_completed(
+    args: dict[str, Any],
+    session: Session,
+    steerer: Steerer,
+) -> dict[str, Any]:
+    from goldfive.types import TaskStatus
+
+    task_id = str(args.get("task_id") or "")
+    summary = str(args.get("summary") or "")
+    if task_id:
+        if summary:
+            session.completed_results[task_id] = summary
+        await steerer.transition(task_id, TaskStatus.COMPLETED, detail=summary, session=session)
+    return {"ok": True}
+
+
+async def _report_task_failed(
+    args: dict[str, Any],
+    session: Session,
+    steerer: Steerer,
+) -> dict[str, Any]:
+    from goldfive.types import TaskStatus
+
+    task_id = str(args.get("task_id") or "")
+    reason = str(args.get("reason") or "")
+    if task_id:
+        await steerer.transition(task_id, TaskStatus.FAILED, detail=reason, session=session)
+    return {"ok": True}
+
+
+async def _report_task_blocked(
+    args: dict[str, Any],
+    session: Session,
+    steerer: Steerer,
+) -> dict[str, Any]:
+    from goldfive.types import TaskStatus
+
+    task_id = str(args.get("task_id") or "")
+    blocker = str(args.get("blocker") or "")
+    if task_id:
+        await steerer.transition(task_id, TaskStatus.BLOCKED, detail=blocker, session=session)
+    return {"ok": True}
+
+
+async def _report_new_work_discovered(
+    args: dict[str, Any],
+    session: Session,
+    steerer: Steerer,
+) -> dict[str, Any]:
+    from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+
+    parent = str(args.get("parent_task_id") or "")
+    title = str(args.get("title") or "")
+    description = str(args.get("description") or "")
+    session.divergence_flag = True
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.INFO,
+        detail=f"{title}: {description}",
+        current_task_id=parent,
+    )
+    await steerer.observe({"kind": "drift", "drift": drift}, session)
+    return {"ok": True}
+
+
+async def _report_plan_divergence(
+    args: dict[str, Any],
+    session: Session,
+    steerer: Steerer,
+) -> dict[str, Any]:
+    from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+
+    note = str(args.get("note") or "")
+    suggested = str(args.get("suggested_action") or "")
+    session.divergence_flag = True
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail=f"{note} | suggested: {suggested}" if suggested else note,
+        current_task_id=session.current_task_id,
+    )
+    await steerer.observe({"kind": "drift", "drift": drift}, session)
+    return {"ok": True}
+
+
+def _schema(properties: dict[str, Any], required: list[str]) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+    }
+
+
+#: The seven canonical reporting tools, ready to hand to
+#: :meth:`AgentAdapter.register_reporting_tools`. Immutable at the module
+#: level; callers that want to customise descriptions should construct
+#: their own :class:`ReportingToolSpec` list.
+BUILTIN_REPORTING_TOOLS: list[ReportingToolSpec] = [
+    ReportingToolSpec(
+        name="report_task_started",
+        description="Report that work on a task has started.",
+        parameters=_schema(
+            {
+                "task_id": {"type": "string"},
+                "detail": {"type": "string"},
+            },
+            ["task_id"],
+        ),
+        handler=_report_task_started,
+    ),
+    ReportingToolSpec(
+        name="report_task_progress",
+        description="Report incremental progress on a task (0-1 fraction).",
+        parameters=_schema(
+            {
+                "task_id": {"type": "string"},
+                "fraction": {"type": "number"},
+                "detail": {"type": "string"},
+            },
+            ["task_id"],
+        ),
+        handler=_report_task_progress,
+    ),
+    ReportingToolSpec(
+        name="report_task_completed",
+        description="Report that a task has finished successfully.",
+        parameters=_schema(
+            {
+                "task_id": {"type": "string"},
+                "summary": {"type": "string"},
+                "artifacts": {"type": "object"},
+            },
+            ["task_id", "summary"],
+        ),
+        handler=_report_task_completed,
+    ),
+    ReportingToolSpec(
+        name="report_task_failed",
+        description="Report that a task has failed.",
+        parameters=_schema(
+            {
+                "task_id": {"type": "string"},
+                "reason": {"type": "string"},
+                "recoverable": {"type": "boolean"},
+            },
+            ["task_id", "reason"],
+        ),
+        handler=_report_task_failed,
+    ),
+    ReportingToolSpec(
+        name="report_task_blocked",
+        description="Report that a task is blocked on an external dependency.",
+        parameters=_schema(
+            {
+                "task_id": {"type": "string"},
+                "blocker": {"type": "string"},
+                "needed": {"type": "string"},
+            },
+            ["task_id", "blocker"],
+        ),
+        handler=_report_task_blocked,
+    ),
+    ReportingToolSpec(
+        name="report_new_work_discovered",
+        description="Report a new task surfaced during execution.",
+        parameters=_schema(
+            {
+                "parent_task_id": {"type": "string"},
+                "title": {"type": "string"},
+                "description": {"type": "string"},
+                "assignee": {"type": "string"},
+            },
+            ["parent_task_id", "title", "description"],
+        ),
+        handler=_report_new_work_discovered,
+    ),
+    ReportingToolSpec(
+        name="report_plan_divergence",
+        description="Report that the plan no longer matches reality.",
+        parameters=_schema(
+            {
+                "note": {"type": "string"},
+                "suggested_action": {"type": "string"},
+            },
+            ["note"],
+        ),
+        handler=_report_plan_divergence,
+    ),
+]
+
+
+__all__ = [
+    "BUILTIN_REPORTING_TOOLS",
+    "REPORTING_TOOL_NAMES",
+    "ReportingHandler",
+    "ReportingToolSpec",
+]

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -1,0 +1,327 @@
+"""The :class:`Runner` — goldfive's single public entrypoint.
+
+A Runner composes the six pluggable components of a goldfive run:
+
+* :class:`GoalDeriver` — turns ``user_input`` into ``list[Goal]``.
+* :class:`Planner` — turns goals into a :class:`Plan`.
+* :class:`Executor` — walks the plan, dispatches to the adapter.
+* :class:`AgentAdapter` — talks to the underlying agent framework.
+* :class:`Steerer` — runs the state machine, detects drift.
+* :class:`EventSink` — persists / observes the event stream.
+
+``Runner.run`` emits a ``RunStarted`` event, derives goals, generates a
+plan, registers the seven canonical reporting tools on the adapter,
+binds the steerer to the sinks+planner, and hands everything to the
+executor. The returned :class:`ExecutionOutcome` carries the final live
+:class:`Session` so callers can inspect completed tasks / artifacts.
+
+No ADK or Claude Agent SDK imports live in this module. Optional
+adapter implementations live under ``goldfive.adapters.<framework>``
+and are loaded lazily by callers.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from goldfive.events import emit, make_event
+from goldfive.goal_deriver import PassthroughGoalDeriver
+from goldfive.reporting import BUILTIN_REPORTING_TOOLS
+from goldfive.results import ExecutionOutcome
+from goldfive.steerer import DefaultSteerer
+from goldfive.types import Goal, Session
+
+if TYPE_CHECKING:
+    from goldfive.protocols import (
+        AgentAdapter,
+        EventSink,
+        Executor,
+        GoalDeriver,
+        Planner,
+        Steerer,
+    )
+
+log = logging.getLogger("goldfive.runner")
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+class Runner:
+    """The public entrypoint for a goldfive run.
+
+    Parameters
+    ----------
+    agent:
+        An :class:`AgentAdapter` wrapping the underlying agent framework.
+    planner:
+        A :class:`Planner` instance. Pass a planner configured with a
+        pre-baked plan when you already know the tasks (see
+        :class:`PassthroughGoalDeriver` for an analogous convenience on
+        the goals side).
+    executor:
+        An :class:`Executor` (e.g. :class:`SequentialExecutor` or
+        :class:`ParallelDAGExecutor`).
+    goal_deriver:
+        Optional — defaults to ``PassthroughGoalDeriver("run")``. When
+        the caller passes ``user_input`` as ``list[Goal]`` the deriver
+        is bypassed entirely.
+    steerer:
+        Optional — defaults to :class:`DefaultSteerer`.
+    sinks:
+        Optional list of :class:`EventSink` instances. Defaults to ``[]``.
+    max_plan_reinvocations:
+        Safety cap on plan refinement cycles. Passed through to the
+        executor (via ``context``) so executors that honour it can
+        enforce the cap.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent: AgentAdapter,
+        planner: Planner,
+        executor: Executor,
+        goal_deriver: GoalDeriver | None = None,
+        steerer: Steerer | None = None,
+        sinks: list[EventSink] | None = None,
+        max_plan_reinvocations: int = 3,
+    ) -> None:
+        self.agent = agent
+        self.planner = planner
+        self.executor = executor
+        self.goal_deriver: GoalDeriver = goal_deriver or PassthroughGoalDeriver("run")
+        self.steerer: Steerer = steerer or DefaultSteerer()
+        self.sinks: list[EventSink] = list(sinks) if sinks else []
+        self.max_plan_reinvocations = max_plan_reinvocations
+
+    # ------------------------------------------------------------------
+    # run
+    # ------------------------------------------------------------------
+
+    async def run(
+        self,
+        user_input: str | list[Goal],
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> ExecutionOutcome:
+        """Execute one end-to-end goldfive run and return the outcome."""
+
+        # 1. Build Session with a fresh run_id.
+        session = Session(
+            run_id=uuid.uuid4().hex,
+            started_at_ms=_now_ms(),
+        )
+
+        # 2. Emit RunStarted before anything else.
+        await self._emit(
+            session,
+            "RunStarted",
+            {
+                "started_at_ms": session.started_at_ms,
+                "input_kind": _input_kind(user_input),
+            },
+        )
+
+        # 3. Derive (or accept) goals.
+        try:
+            goals = await self._resolve_goals(user_input, context)
+        except Exception as exc:  # noqa: BLE001
+            reason = f"goal derivation failed: {exc}"
+            log.exception("goal derivation failed")
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+        session.goals = list(goals)
+
+        await self._emit(
+            session,
+            "GoalDerived",
+            {"goals": [{"id": g.id, "summary": g.summary} for g in session.goals]},
+        )
+
+        # Build the context passed to the planner — stamp run_id so LLM
+        # planners can include it in the plan envelope.
+        planner_context: dict[str, Any] = dict(context) if context else {}
+        planner_context.setdefault("run_id", session.run_id)
+        planner_context.setdefault("max_plan_reinvocations", self.max_plan_reinvocations)
+
+        # 4. Generate the plan.
+        try:
+            plan = await self.planner.generate(
+                goals=session.goals,
+                available_agents=list(self.agent.available_agents),
+                context=planner_context,
+            )
+        except Exception as exc:  # noqa: BLE001
+            reason = f"planner.generate raised: {exc}"
+            log.exception("planner.generate raised")
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        if plan is None:
+            reason = "no plan generated"
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        # Planners may leave run_id blank; stamp ours so downstream sinks
+        # correlate cleanly.
+        if not plan.run_id:
+            plan.run_id = session.run_id
+        session.plan = plan
+
+        await self._emit(
+            session,
+            "PlanSubmitted",
+            {
+                "plan_id": plan.id,
+                "summary": plan.summary,
+                "task_count": len(plan.tasks),
+                "edge_count": len(plan.edges),
+                "revision_index": plan.revision_index,
+            },
+        )
+
+        # 5. Register the seven canonical reporting tools on the adapter.
+        try:
+            await self.agent.register_reporting_tools(list(BUILTIN_REPORTING_TOOLS))
+        except Exception as exc:  # noqa: BLE001
+            reason = f"register_reporting_tools raised: {exc}"
+            log.exception("register_reporting_tools raised")
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        # 6. Bind the steerer. (The executor may re-bind — that's fine.)
+        try:
+            self.steerer.bind(sinks=list(self.sinks), planner=self.planner)
+        except Exception as exc:  # noqa: BLE001
+            reason = f"steerer.bind raised: {exc}"
+            log.exception("steerer.bind raised")
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        # 7. Hand off to the executor.
+        try:
+            outcome = await self.executor.run(
+                plan=session.plan,
+                session=session,
+                adapter=self.agent,
+                steerer=self.steerer,
+                planner=self.planner,
+                sinks=list(self.sinks),
+            )
+        except Exception as exc:  # noqa: BLE001
+            reason = f"executor.run raised: {exc}"
+            log.exception("executor.run raised")
+            await self._emit(session, "RunAborted", {"reason": reason})
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        return outcome
+
+    # ------------------------------------------------------------------
+    # resume — best-effort replay
+    # ------------------------------------------------------------------
+
+    async def resume(self, persistence_path: str) -> ExecutionOutcome:
+        """Replay a JSONL persistence log and return the recovered outcome.
+
+        Best-effort for v0.1: uses ``goldfive.sinks.reconstruct_session``
+        when the proto stubs are available (JSONL events are proto-
+        encoded). Returns the reconstructed session as an
+        :class:`ExecutionOutcome` reflecting the latest terminal marker
+        (``RunCompleted`` / ``RunAborted``) seen in the log.
+
+        We do **not** continue execution from the latest cursor — full
+        resume semantics require planner/executor co-operation that is
+        out-of-scope for this PR. Callers who need a live continuation
+        should construct a new :class:`Runner` with the goals recovered
+        from the log.
+
+        TODO(#15): once executors grow a ``resume_from`` hook, continue
+        execution from the latest un-finished task rather than returning
+        the recovered session as-is.
+        """
+        try:
+            from goldfive.sinks import reconstruct_session, replay_from_jsonl
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "goldfive.sinks.reconstruct_session is not available; "
+                "install the `proto` extra to enable JSONL replay."
+            ) from exc
+
+        events = replay_from_jsonl(persistence_path)
+        session = reconstruct_session(events)
+
+        success = False
+        reason = "run did not complete before persistence ended"
+        for evt in events:
+            payload = getattr(evt, "WhichOneof", lambda _: None)("payload")
+            if payload == "run_completed":
+                success = True
+                reason = ""
+            elif payload == "run_aborted":
+                success = False
+                reason = getattr(evt.run_aborted, "reason", "")
+
+        return ExecutionOutcome(success=success, session=session, reason=reason)
+
+    # ------------------------------------------------------------------
+    # close
+    # ------------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Close every sink. Best-effort — individual errors are logged."""
+        for sink in self.sinks:
+            try:
+                await sink.close()
+            except Exception as exc:  # noqa: BLE001
+                log.warning("sink.close() raised: %s", exc)
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    async def _resolve_goals(
+        self,
+        user_input: str | list[Goal],
+        context: Mapping[str, Any] | None,
+    ) -> list[Goal]:
+        if isinstance(user_input, list):
+            if not user_input:
+                raise ValueError("Runner.run: empty goal list")
+            if not all(isinstance(g, Goal) for g in user_input):
+                raise TypeError("Runner.run: list input must be list[Goal]")
+            return list(user_input)
+        if not isinstance(user_input, str):
+            raise TypeError(
+                f"Runner.run: user_input must be str or list[Goal], "
+                f"got {type(user_input).__name__}"
+            )
+        goals = await self.goal_deriver.derive(user_input, context=context)
+        if not goals:
+            raise ValueError("GoalDeriver returned an empty goals list")
+        return list(goals)
+
+    async def _emit(self, session: Session, kind: str, payload: dict[str, Any]) -> None:
+        evt = make_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            kind=kind,
+            payload=payload,
+        )
+        await emit(self.sinks, evt)
+
+
+def _input_kind(user_input: Any) -> str:
+    if isinstance(user_input, str):
+        return "str"
+    if isinstance(user_input, list):
+        return "list[Goal]"
+    return type(user_input).__name__
+
+
+__all__ = ["Runner"]

--- a/goldfive/sinks/__init__.py
+++ b/goldfive/sinks/__init__.py
@@ -10,19 +10,36 @@ Three implementations ship in-box:
   JSON file suitable for crash recovery. Paired with
   :func:`replay_from_jsonl` and :func:`reconstruct_session` for resume.
 
+``InMemorySink`` is always importable. ``LoggingSink`` and
+``JSONLPersistenceSink`` depend on the optional ``proto`` extra
+(``google.protobuf``) — importing them when the extra is missing
+raises :class:`ImportError` with a friendly message. The top-level
+``goldfive`` module handles that import gracefully so the bulk of the
+public API stays usable without ``proto``.
+
 All sinks conform to the ``EventSink`` protocol pinned in
 ``INTERFACE_SPEC.md`` (async ``emit`` / async ``close``).
 """
 
 from __future__ import annotations
 
-from goldfive.sinks.logging_sink import LoggingSink
 from goldfive.sinks.memory import InMemorySink
-from goldfive.sinks.persistence import (
-    JSONLPersistenceSink,
-    reconstruct_session,
-    replay_from_jsonl,
-)
+
+try:
+    from goldfive.sinks.logging_sink import LoggingSink
+except ImportError:  # pragma: no cover — proto extra not installed
+    LoggingSink = None  # type: ignore[assignment]
+
+try:
+    from goldfive.sinks.persistence import (
+        JSONLPersistenceSink,
+        reconstruct_session,
+        replay_from_jsonl,
+    )
+except ImportError:  # pragma: no cover — proto extra not installed
+    JSONLPersistenceSink = None  # type: ignore[assignment]
+    reconstruct_session = None  # type: ignore[assignment]
+    replay_from_jsonl = None  # type: ignore[assignment]
 
 __all__ = [
     "InMemorySink",

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -1,0 +1,134 @@
+"""Default :class:`Steerer` implementation.
+
+The steerer is the state-machine driver for a run. It:
+
+* ``observe`` — absorbs raw events emitted by the adapter/executor,
+  forwards progress + drift notifications to the sinks, runs drift
+  detection on arbitrary events.
+* ``transition`` — flips task status on the session's plan and emits
+  the matching ``TaskStarted`` / ``TaskCompleted`` / ``TaskFailed`` /
+  ``TaskBlocked`` / ``TaskCancelled`` event through the sinks.
+* ``detect_drift`` — default returns ``None``; subclasses can override
+  to pattern-match on adapter-specific events.
+* ``bind`` — stores the sinks + planner wiring supplied by the runner
+  or executor.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from goldfive.events import emit, make_event
+from goldfive.types import DriftEvent, Session, TaskStatus
+
+if TYPE_CHECKING:
+    from goldfive.protocols import EventSink, Planner
+
+log = logging.getLogger("goldfive.steerer")
+
+
+_STATUS_TO_EVENT: dict[TaskStatus, str] = {
+    TaskStatus.RUNNING: "TaskStarted",
+    TaskStatus.COMPLETED: "TaskCompleted",
+    TaskStatus.FAILED: "TaskFailed",
+    TaskStatus.BLOCKED: "TaskBlocked",
+    TaskStatus.CANCELLED: "TaskCancelled",
+}
+
+
+class DefaultSteerer:
+    """Reference :class:`Steerer` implementation.
+
+    Designed to be used unchanged by most callers. Subclass and override
+    :meth:`detect_drift` when the underlying adapter surfaces framework-
+    specific drift signals (e.g., ADK ``InvocationContext`` states).
+    """
+
+    def __init__(self) -> None:
+        self._sinks: list[EventSink] = []
+        self._planner: Planner | None = None
+
+    def bind(self, *, sinks: list[EventSink], planner: Planner) -> None:
+        self._sinks = list(sinks)
+        self._planner = planner
+
+    async def observe(self, event: Any, session: Session) -> None:
+        """Observe a raw event — record it, emit progress/drift, detect drift."""
+        session.history.append(event)
+
+        if isinstance(event, dict) and event.get("kind") == "task_progress":
+            payload = {
+                "task_id": str(event.get("task_id") or ""),
+                "fraction": float(event.get("fraction") or 0.0),
+                "detail": str(event.get("detail") or ""),
+            }
+            evt = make_event(
+                run_id=session.run_id,
+                sequence=session.next_sequence(),
+                kind="TaskProgress",
+                payload=payload,
+            )
+            await emit(self._sinks, evt)
+            return
+
+        if isinstance(event, dict) and event.get("kind") == "drift":
+            drift = event.get("drift")
+            if isinstance(drift, DriftEvent):
+                await self._emit_drift(drift, session)
+                return
+
+        drift = self.detect_drift(event, session)
+        if drift is not None:
+            await self._emit_drift(drift, session)
+
+    async def transition(
+        self,
+        task_id: str,
+        to: TaskStatus,
+        *,
+        detail: str = "",
+        session: Session,
+    ) -> None:
+        """Flip task status on the session's plan and emit a status event."""
+        if session.plan is not None:
+            for t in session.plan.tasks:
+                if t.id == task_id:
+                    t.status = to
+                    break
+        if to == TaskStatus.RUNNING:
+            session.current_task_id = task_id
+        kind = _STATUS_TO_EVENT.get(to)
+        if kind is None:
+            return
+        payload: dict[str, Any] = {"task_id": task_id, "detail": detail, "status": str(to)}
+        evt = make_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            kind=kind,
+            payload=payload,
+        )
+        await emit(self._sinks, evt)
+
+    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
+        """Default drift detection — returns ``None``. Override to extend."""
+        return None
+
+    async def _emit_drift(self, drift: DriftEvent, session: Session) -> None:
+        payload = {
+            "kind": str(drift.kind),
+            "severity": str(drift.severity),
+            "detail": drift.detail,
+            "current_task_id": drift.current_task_id,
+            "current_agent_id": drift.current_agent_id,
+        }
+        evt = make_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            kind="DriftDetected",
+            payload=payload,
+        )
+        await emit(self._sinks, evt)
+
+
+__all__ = ["DefaultSteerer"]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,295 @@
+"""Integration tests for :class:`goldfive.Runner`.
+
+Drives a :class:`CallableAdapter`-backed agent through goal derivation,
+planning, and execution. Asserts the public event order:
+
+    RunStarted, GoalDerived, PlanSubmitted,
+    (TaskStarted, TaskCompleted) xN,
+    RunCompleted
+
+These tests are the single largest exercise of the public API surface
+pinned by ``INTERFACE_SPEC.md`` — they touch every protocol.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from goldfive import (
+    BUILTIN_REPORTING_TOOLS,
+    CallableAdapter,
+    ExecutionOutcome,
+    Goal,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _hand_built_plan() -> Plan:
+    """Three-task linear plan: research → draft → review."""
+    return Plan(
+        id="plan-fixture",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="Research", assignee_agent_id="writer"),
+            Task(id="draft", title="Draft", assignee_agent_id="writer"),
+            Task(id="review", title="Review", assignee_agent_id="writer"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft"),
+            TaskEdge(from_task_id="draft", to_task_id="review"),
+        ],
+        summary="Research, draft, review.",
+    )
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    """Reference agent: returns a non-empty result so the executor auto-completes."""
+    _ = tools
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+def _kinds(events: list[Any]) -> list[str]:
+    return [e.get("kind") if isinstance(e, dict) else getattr(e, "kind", "") for e in events]
+
+
+def _payloads(events: list[Any]) -> list[dict[str, Any]]:
+    return [
+        (e.get("payload") if isinstance(e, dict) else getattr(e, "payload", {})) or {}
+        for e in events
+    ]
+
+
+def _sequences(events: list[Any]) -> list[int]:
+    out: list[int] = []
+    for e in events:
+        if isinstance(e, dict):
+            out.append(int(e.get("sequence") or 0))
+        else:
+            out.append(int(getattr(e, "sequence", 0) or 0))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_runner_end_to_end_event_sequence() -> None:
+    """Full end-to-end: derive → plan → execute → emit correct event sequence."""
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("Research, draft, review"),
+        sinks=[sink],
+    )
+
+    outcome = await runner.run("go")
+    await runner.close()
+
+    assert isinstance(outcome, ExecutionOutcome)
+    assert outcome.success, outcome.reason
+
+    kinds = _kinds(sink.events)
+
+    # Lifecycle envelope up-front.
+    assert kinds[0] == "RunStarted"
+    assert kinds[1] == "GoalDerived"
+    assert kinds[2] == "PlanSubmitted"
+
+    # For each of the three tasks: TaskStarted → TaskCompleted.
+    task_kinds = kinds[3:-1]  # strip initial trio and trailing RunCompleted
+    assert len(task_kinds) == 6, kinds
+    assert task_kinds[0::2] == ["TaskStarted"] * 3
+    assert task_kinds[1::2] == ["TaskCompleted"] * 3
+
+    # Run terminates with a RunCompleted.
+    assert kinds[-1] == "RunCompleted"
+
+    # Sequence numbers are strictly monotonic from zero.
+    seqs = _sequences(sink.events)
+    assert seqs == sorted(seqs)
+    assert len(seqs) == len(set(seqs))
+    assert seqs[0] == 0
+
+    # Task order respects the DAG: research → draft → review.
+    payloads = _payloads(sink.events)
+    task_ids_in_order = [
+        payloads[i]["task_id"] for i, k in enumerate(kinds) if k == "TaskStarted"
+    ]
+    assert task_ids_in_order == ["research", "draft", "review"]
+
+    # Session is fully populated.
+    assert outcome.session.plan is not None
+    assert len(outcome.session.goals) == 1
+    assert all(
+        outcome.session.plan.tasks[i].status.value == "COMPLETED" for i in range(3)
+    )
+
+
+async def test_runner_accepts_prebuilt_goal_list() -> None:
+    """list[Goal] input bypasses the deriver."""
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        sinks=[sink],
+    )
+    goals = [Goal(id="g1", summary="pre-baked")]
+    outcome = await runner.run(goals)
+    await runner.close()
+
+    assert outcome.success
+    assert outcome.session.goals == goals
+
+
+async def test_runner_aborts_when_planner_returns_none() -> None:
+    """No plan → ``RunAborted`` with a clear reason, no executor invocation."""
+    from goldfive import PassthroughPlanner
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=[]),
+        planner=PassthroughPlanner(),  # returns None from generate()
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("ignored"),
+        sinks=[sink],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+
+    assert not outcome.success
+    assert "no plan" in outcome.reason
+
+    assert _kinds(sink.events) == ["RunStarted", "GoalDerived", "RunAborted"]
+
+
+async def test_runner_registers_builtin_reporting_tools() -> None:
+    """The adapter receives the canonical seven reporting tools verbatim."""
+    captured: dict[str, Any] = {}
+
+    async def agent_fn(
+        task: Task, session: Session, tools: list[ReportingToolSpec]
+    ) -> InvocationResult:
+        captured.setdefault("tools", tools)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    runner = Runner(
+        agent=CallableAdapter(agent_fn, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("any"),
+        sinks=[InMemorySink()],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+    assert outcome.success
+
+    tools = captured["tools"]
+    names = [t.name for t in tools]
+    expected = [t.name for t in BUILTIN_REPORTING_TOOLS]
+    assert names == expected
+
+
+async def test_runner_close_closes_all_sinks() -> None:
+    """Runner.close() invokes ``close`` on every sink."""
+    closed: list[bool] = []
+
+    class _SpySink:
+        events: list[Any]
+
+        def __init__(self) -> None:
+            self.events = []
+
+        async def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+        async def close(self) -> None:
+            closed.append(True)
+
+    spy_a = _SpySink()
+    spy_b = _SpySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("close test"),
+        sinks=[spy_a, spy_b],
+    )
+    await runner.run("go")
+    await runner.close()
+
+    assert closed == [True, True]
+
+
+async def test_runner_input_type_errors() -> None:
+    """Non str / list[Goal] inputs raise cleanly and produce RunAborted."""
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        sinks=[sink],
+    )
+
+    outcome = await runner.run(42)  # type: ignore[arg-type]
+    await runner.close()
+    assert not outcome.success
+    assert "str or list[Goal]" in outcome.reason
+    kinds = _kinds(sink.events)
+    assert kinds == ["RunStarted", "RunAborted"]
+
+
+@pytest.mark.asyncio
+async def test_runner_protocol_compatibility() -> None:
+    """Every default implementation must satisfy its Protocol at runtime."""
+    from goldfive import (
+        AgentAdapter,
+        EventSink,
+        Executor,
+        GoalDeriver,
+        Planner,
+        Steerer,
+    )
+    from goldfive.steerer import DefaultSteerer
+
+    adapter = CallableAdapter(_happy_agent, available_agents=["writer"])
+    assert isinstance(adapter, AgentAdapter)
+
+    planner = StaticPlanner(_hand_built_plan())
+    assert isinstance(planner, Planner)
+
+    executor = SequentialExecutor()
+    assert isinstance(executor, Executor)
+
+    steerer = DefaultSteerer()
+    assert isinstance(steerer, Steerer)
+
+    deriver = PassthroughGoalDeriver("x")
+    assert isinstance(deriver, GoalDeriver)
+
+    sink = InMemorySink()
+    assert isinstance(sink, EventSink)


### PR DESCRIPTION
## Summary

Implements the top-level `Runner` and the four reference examples (issue #15).

- `goldfive/runner.py` — `Runner.run` emits `RunStarted`, derives goals (or accepts `list[Goal]` directly), generates a plan, registers the seven canonical `BUILTIN_REPORTING_TOOLS` on the adapter, binds the steerer, and hands off to the executor. `Runner.resume` replays a JSONL log into a `Session`. `Runner.close` fans `close()` to every sink.
- `goldfive/steerer.py` — `DefaultSteerer` drives task state transitions, forwards progress / drift notifications, and emits `Task*` / `Drift*` events through the bound sinks.
- `goldfive/executors/sequential.py` — `SequentialExecutor` walks the plan's topological stages one task at a time; auto-completes tasks the agent did not already transition; emits `RunCompleted` / `RunAborted`.
- `goldfive/reporting.py` — adds `BUILTIN_REPORTING_TOOLS` (the seven canonical tools with handlers that mutate the `Session` via the `Steerer`).
- `goldfive/planner.py` — adds `StaticPlanner` for pre-baked-plan test / CLI cases (the upstream `PassthroughPlanner` always returns `None`).
- `goldfive/__init__.py` — re-exports the full v0.1 public surface.
- `goldfive/sinks/__init__.py` — makes `LoggingSink` / `JSONLPersistenceSink` optional at import time so the package stays usable without the `proto` extra.

## Examples

- `examples/hello_callable.py` — simplest possible run; prints the 10-event log.
- `examples/adk_agent.py`, `examples/claude_agent.py` — gated on the `adk` / `claude` extras.
- `examples/persistence_and_recovery.py` — JSONL persistence + crash-and-resume; gated on the `proto` extra.

## Test plan

- [x] `uv run pytest tests/test_runner.py -q` — 7 tests pass (full end-to-end event sequence; prebuilt `list[Goal]` bypass; abort on `Planner` returning `None`; `BUILTIN_REPORTING_TOOLS` registration; `close()` fan-out; input type errors; `Protocol` runtime checks for every default).
- [x] `uv run python examples/hello_callable.py` — prints the expected 10-event trace (`RunStarted` → `GoalDerived` → `PlanSubmitted` → `(TaskStarted, TaskCompleted) × 3` → `RunCompleted`).
- [x] `uv run pytest -q` — full suite: 159 passed, 32 skipped (skips are optional-deps / pending-PR modules). Pre-existing proto-dependent tests (`test_sinks.py`, `test_conv.py`, `test_persistence_recovery.py`) error on collection due to absent proto stubs — unchanged by this PR.

Closes #15