### PR TITLE
Wire up public API re-exports and fix event helpers

### DIFF
--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -2,8 +2,77 @@
 
 from __future__ import annotations
 
-from goldfive.executors import ParallelDAGExecutor
-
 __version__ = "0.0.1"
 
-__all__ = ["ParallelDAGExecutor", "__version__"]
+from goldfive.adapters.callable import CallableAdapter
+from goldfive.drift import classify_refusal, classify_stop_reason, classify_tool_error
+from goldfive.executors.parallel import ParallelDAGExecutor
+from goldfive.executors.sequential import SequentialExecutor
+from goldfive.goal_deriver import (
+    LiteralGoalDeriver,
+    LLMGoalDeriver,
+    PassthroughGoalDeriver,
+)
+from goldfive.planner import LLMPlanner, PassthroughPlanner, StaticPlanner
+from goldfive.protocols import (
+    AgentAdapter,
+    EventSink,
+    Executor,
+    GoalDeriver,
+    Planner,
+    Steerer,
+)
+from goldfive.reporting import BUILTIN_REPORTING_TOOLS, ReportingToolSpec
+from goldfive.results import ExecutionOutcome, InvocationResult
+from goldfive.runner import Runner
+from goldfive.sinks import InMemorySink
+from goldfive.steerer import DefaultSteerer
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+__all__ = [
+    "__version__",
+    "AgentAdapter",
+    "BUILTIN_REPORTING_TOOLS",
+    "CallableAdapter",
+    "DefaultSteerer",
+    "DriftEvent",
+    "DriftKind",
+    "DriftSeverity",
+    "EventSink",
+    "ExecutionOutcome",
+    "Executor",
+    "Goal",
+    "GoalDeriver",
+    "InMemorySink",
+    "InvocationResult",
+    "LLMGoalDeriver",
+    "LLMPlanner",
+    "LiteralGoalDeriver",
+    "ParallelDAGExecutor",
+    "PassthroughGoalDeriver",
+    "PassthroughPlanner",
+    "Plan",
+    "Planner",
+    "ReportingToolSpec",
+    "Runner",
+    "SequentialExecutor",
+    "Session",
+    "StaticPlanner",
+    "Steerer",
+    "Task",
+    "TaskEdge",
+    "TaskStatus",
+    "classify_refusal",
+    "classify_stop_reason",
+    "classify_tool_error",
+]

--- a/goldfive/events.py
+++ b/goldfive/events.py
@@ -162,31 +162,42 @@ def plan_revised_event(
     sequence: int,
     plan: Any,
     drift: Any | None = None,
+    *,
+    drift_kind: str = "",
+    severity: str = "",
+    reason: str = "",
+    revision_index: int | None = None,
 ) -> Any:
     from goldfive.conv import to_pb_plan
 
     evt = new_event(run_id, sequence)
     evt.plan_revised.plan.CopyFrom(to_pb_plan(plan))
+
     if drift is not None:
+        drift_kind = drift_kind or str(getattr(drift, "kind", ""))
+        severity = severity or str(getattr(drift, "severity", ""))
+        reason = reason or getattr(drift, "detail", "")
+
+    if drift_kind:
         pb = _events_pb_module()
-        kind_name = str(getattr(drift, "kind", ""))
-        sev_name = str(getattr(drift, "severity", ""))
-        if kind_name:
-            try:
-                evt.plan_revised.drift_kind = pb.DriftKind.Value(
-                    kind_name.upper() if not kind_name.startswith("DRIFT_") else kind_name
-                )
-            except (ValueError, AttributeError):
-                pass
-        if sev_name:
-            try:
-                evt.plan_revised.severity = pb.DriftSeverity.Value(
-                    sev_name.upper() if not sev_name.startswith("DRIFT_SEVERITY_") else sev_name
-                )
-            except (ValueError, AttributeError):
-                pass
-        evt.plan_revised.reason = getattr(drift, "detail", "")
-    evt.plan_revised.revision_index = int(getattr(plan, "revision_index", 0))
+        try:
+            normalized = drift_kind.upper() if not drift_kind.startswith("DRIFT_") else drift_kind
+            evt.plan_revised.drift_kind = pb.DriftKind.Value(normalized)
+        except (ValueError, AttributeError):
+            pass
+    if severity:
+        pb = _events_pb_module()
+        try:
+            normalized = (
+                severity.upper() if not severity.startswith("DRIFT_SEVERITY_") else severity
+            )
+            evt.plan_revised.severity = pb.DriftSeverity.Value(normalized)
+        except (ValueError, AttributeError):
+            pass
+    evt.plan_revised.reason = reason
+    evt.plan_revised.revision_index = int(
+        revision_index if revision_index is not None else getattr(plan, "revision_index", 0)
+    )
     return evt
 
 

--- a/goldfive/executors/__init__.py
+++ b/goldfive/executors/__init__.py
@@ -1,12 +1,12 @@
 """Built-in executors.
 
 Each executor drives a :class:`Plan` to completion against an
-:class:`AgentAdapter`. See ``INTERFACE_SPEC.md`` and issue #10
-(``ParallelDAGExecutor``) for the contract.
+:class:`AgentAdapter`. See ``INTERFACE_SPEC.md`` for the contract.
 """
 
 from __future__ import annotations
 
 from goldfive.executors.parallel import ParallelDAGExecutor
+from goldfive.executors.sequential import SequentialExecutor, build_task_nudge
 
-__all__ = ["ParallelDAGExecutor"]
+__all__ = ["ParallelDAGExecutor", "SequentialExecutor", "build_task_nudge"]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -70,14 +70,32 @@ async def _happy_agent(
 
 
 def _kinds(events: list[Any]) -> list[str]:
-    return [e.get("kind") if isinstance(e, dict) else getattr(e, "kind", "") for e in events]
+    def _one(e: Any) -> str:
+        if isinstance(e, dict):
+            return e.get("kind") or ""
+        if hasattr(e, "WhichOneof"):
+            name = e.WhichOneof("payload") or ""
+            return "".join(part.capitalize() for part in name.split("_")) if name else ""
+        return getattr(e, "kind", "")
+    return [_one(e) for e in events]
 
 
 def _payloads(events: list[Any]) -> list[dict[str, Any]]:
-    return [
-        (e.get("payload") if isinstance(e, dict) else getattr(e, "payload", {})) or {}
-        for e in events
-    ]
+    def _one(e: Any) -> dict[str, Any]:
+        if isinstance(e, dict):
+            return e.get("payload") or {}
+        if hasattr(e, "WhichOneof"):
+            name = e.WhichOneof("payload")
+            if not name:
+                return {}
+            msg = getattr(e, name)
+            # For each field, surface its value; gracefully handle missing attrs.
+            out: dict[str, Any] = {}
+            for fd, v in msg.ListFields():
+                out[fd.name] = v
+            return out
+        return getattr(e, "payload", {}) or {}
+    return [_one(e) for e in events]
 
 
 def _sequences(events: list[Any]) -> list[int]:

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -49,7 +49,15 @@ class RecordingSink:
         self.closed = True
 
     def payload_kinds(self) -> list[str]:
-        return [getattr(e, "payload_kind", "") for e in self.events]
+        kinds: list[str] = []
+        for e in self.events:
+            if hasattr(e, "WhichOneof"):
+                kinds.append(e.WhichOneof("payload") or "")
+            elif isinstance(e, dict):
+                kinds.append(e.get("kind", ""))
+            else:
+                kinds.append(getattr(e, "payload_kind", ""))
+        return kinds
 
 
 class StubSteerer:


### PR DESCRIPTION
## Summary

Cleanup after the 14-agent parallel landing: wire up the public API surface in `goldfive/__init__.py`, re-export SequentialExecutor from `goldfive.executors`, extend `plan_revised_event` to accept explicit drift metadata kwargs (matching what SequentialExecutor passes), and fix two test files that read `event.payload_kind` (which never existed on proto Event messages) instead of `event.WhichOneof("payload")`.

## Test status

- Before: multiple collection errors + 8 test failures
- After: 205 passed, 32 skipped, 3 failed

The remaining 3 failures are all in `tests/test_runner.py` and concern runner-auto-completion behavior when the test agent returns an InvocationResult without calling reporting tools. Tracked as a follow-up.