### PR TITLE
Verify ADK root-agent wrapping propagates across sub-agent tree

### DIFF
--- a/docs/guides/writing-an-agent-adapter.md
+++ b/docs/guides/writing-an-agent-adapter.md
@@ -250,6 +250,56 @@ outcome = await runner.run("do the thing")
 That's it. ~50 lines, one new framework wrapped, full goldfive
 semantics on top.
 
+## Just wrap the root agent (multi-agent trees)
+
+When a framework supports nested agents — ADK's `sub_agents`, agent-as-tool
+wrappers, or custom "inner agent" composites — the adapter must coordinate
+**the entire tree**, not just the root. A sub-agent that is missing the
+reporting tools cannot report task outcomes, and the steerer will never see
+its state transitions.
+
+The rule for goldfive adapters: **the caller wraps the root agent; the
+adapter handles subtree propagation itself.** Users should never have to
+attach reporting tools by hand on every node.
+
+`ADKAdapter` implements this by walking the agent graph in
+`register_reporting_tools`. The walk follows three edges:
+
+- `agent.sub_agents` — native ADK child agents.
+- `agent.inner_agent` — wrapper agents that compose a single child.
+- `tool.agent` for each tool in `agent.tools` — agents exposed to a parent
+  via `AgentTool` (agent-as-tool).
+
+Every node that carries a mutable `tools` list gets the reporting tools
+appended. The walk is idempotent: agents that already carry the canonical
+reporting tool names are skipped, so double-registration is a no-op.
+
+Because ADK's plugin callbacks are **runner-scoped**, not agent-scoped,
+the `before_tool_callback` / `before_model_callback` installed once on the
+`Runner` fires for tool calls from every sub-agent. That means the shared
+`SessionContext` (session, task, steerer, handler map) routes every
+sub-agent's `report_task_*` call through the same Steerer — no per-agent
+wiring needed.
+
+```python
+from goldfive.adapters.adk import ADKAdapter
+
+# Tree: root -> child -> grandchild, plus a sibling agent-as-tool.
+adapter = ADKAdapter(root_agent)  # that's it — every descendant is wired.
+```
+
+If you are writing an adapter for a different framework with its own
+nested-agent shape, mirror this pattern:
+
+1. Walk the agent graph from the root you were handed.
+2. For each node, attach the reporting tools (dedupe by name).
+3. Install a single shared intercept (plugin / middleware / callback) on
+   the framework's outermost runtime so every sub-agent's tool calls route
+   through one handler map.
+
+See `goldfive/adapters/adk.py::_augment_subtree_with_reporting` for the
+reference implementation.
+
 ## The steerer reference
 
 In the example above, `self._steerer` is accessed but never set. In

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -348,3 +348,106 @@ def test_adapter_conforms_to_protocol() -> None:
     assert isinstance(adapter, AgentAdapter)
     # available_agents includes the root agent name at minimum.
     assert "test_agent" in adapter.available_agents
+
+
+# ---------------------------------------------------------------------------
+# Subtree propagation — wrapping the root coordinates every sub-agent
+# ---------------------------------------------------------------------------
+
+
+def _tool_names(agent: Any) -> set[str]:
+    names: set[str] = set()
+    for t in getattr(agent, "tools", None) or ():
+        n = getattr(t, "name", None) or getattr(
+            getattr(t, "func", None), "__name__", None
+        )
+        if n:
+            names.add(str(n))
+    return names
+
+
+async def test_register_reporting_tools_propagates_across_three_level_tree() -> None:
+    """Wrapping the root agent must attach reporting tools to every descendant.
+
+    Tree shape:
+
+        root
+        ├── child_a           (via sub_agents)
+        │   └── grandchild_a  (via sub_agents)
+        └── child_b_as_tool   (via AgentTool in root.tools)
+            └── grandchild_b  (via sub_agents)
+    """
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+    from google.adk.tools.agent_tool import AgentTool  # type: ignore
+
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.reporting import BUILTIN_REPORTING_TOOLS, REPORTING_TOOL_NAMES
+
+    def _mk(name: str) -> Any:
+        return LlmAgent(
+            name=name, model="fake-model", description=name, instruction="x"
+        )
+
+    grandchild_a = _mk("grandchild_a")
+    grandchild_b = _mk("grandchild_b")
+    child_a = _mk("child_a")
+    child_a.sub_agents = [grandchild_a]
+    child_b_as_tool = _mk("child_b_as_tool")
+    child_b_as_tool.sub_agents = [grandchild_b]
+
+    root = _mk("root")
+    root.sub_agents = [child_a]
+    root.tools = [AgentTool(agent=child_b_as_tool)]
+
+    adapter = ADKAdapter(root)
+    await adapter.register_reporting_tools(list(BUILTIN_REPORTING_TOOLS))
+
+    expected = set(REPORTING_TOOL_NAMES)
+    for agent in (root, child_a, grandchild_a, child_b_as_tool, grandchild_b):
+        have = _tool_names(agent)
+        missing = expected - have
+        assert not missing, (
+            f"agent {agent.name!r} missing reporting tools: {sorted(missing)}"
+        )
+
+    # available_agents discovers every node in the tree.
+    discovered = set(adapter.available_agents)
+    assert {
+        "root",
+        "child_a",
+        "grandchild_a",
+        "child_b_as_tool",
+        "grandchild_b",
+    } <= discovered
+
+
+async def test_register_reporting_tools_is_idempotent() -> None:
+    """Registering twice must not duplicate the reporting tools on any agent."""
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.reporting import BUILTIN_REPORTING_TOOLS, REPORTING_TOOL_NAMES
+
+    child = LlmAgent(
+        name="child", model="fake-model", description="c", instruction="x"
+    )
+    root = LlmAgent(
+        name="root", model="fake-model", description="r", instruction="x"
+    )
+    root.sub_agents = [child]
+
+    adapter = ADKAdapter(root)
+    await adapter.register_reporting_tools(list(BUILTIN_REPORTING_TOOLS))
+    await adapter.register_reporting_tools(list(BUILTIN_REPORTING_TOOLS))
+
+    for agent in (root, child):
+        names = [
+            getattr(t, "name", None)
+            or getattr(getattr(t, "func", None), "__name__", None)
+            for t in getattr(agent, "tools", None) or ()
+        ]
+        for reporting_name in REPORTING_TOOL_NAMES:
+            assert names.count(reporting_name) == 1, (
+                f"{agent.name}: {reporting_name} registered "
+                f"{names.count(reporting_name)} times"
+            )


### PR DESCRIPTION
Closes #43

## Summary
- Audits `ADKAdapter._augment_subtree_with_reporting` — confirms the existing logic already covers the three edges an ADK agent graph can expose (`sub_agents`, `inner_agent`, `AgentTool.agent`), and that a single runner-scoped plugin intercepts tool calls from every sub-agent.
- Adds two regression tests that lock the "just wrap the root" contract in:
  - `test_register_reporting_tools_propagates_across_three_level_tree` — builds a 3-level tree with a sibling agent-as-tool subtree, wraps only the root, asserts every descendant carries all 7 canonical reporting tools and appears in `available_agents`.
  - `test_register_reporting_tools_is_idempotent` — registering twice does not duplicate tools.
- Documents the "just wrap the root agent" idiom in `docs/guides/writing-an-agent-adapter.md`, including the traversal rules other adapters should mirror when their framework has its own nested-agent shape.

No changes to `goldfive/adapters/adk.py` — the runtime already did the right thing; this PR verifies it and prevents regression.

## Test plan
- [x] `uv run pytest tests/test_adk_adapter.py -q` — 10 passed (8 existing + 2 new)
- [x] `uv run pytest -q` — 249 passed, 32 skipped (was 247 passed on main; +2 from this PR, no regressions)
- [x] `uv run --with ruff python -m ruff check tests/test_adk_adapter.py docs/` — clean
