### PR TITLE
Add SQLitePersistenceSink

### DIFF
--- a/docs/guides/persistence-and-recovery.md
+++ b/docs/guides/persistence-and-recovery.md
@@ -273,6 +273,98 @@ independent.
 These three, dashboarded, give you an operational feel for goldfive
 without instrumenting anything beyond the sink.
 
+## SQLite: cross-run queryable persistence
+
+JSONL is perfect when you want the full event stream for a single run
+in one file you can `jq` and tail. It is less useful when you want to
+ask questions like "how many drift events across all runs this week?"
+or "what's the latest plan the harmonograf dashboard should render?"
+For that, goldfive ships `SQLitePersistenceSink`:
+
+```python
+from goldfive.sinks import (
+    SQLitePersistenceSink,
+    list_runs,
+    replay_from_sqlite,
+)
+
+sink = SQLitePersistenceSink("./runs/goldfive.db")
+runner = Runner(..., sinks=[sink])
+await runner.run("do the thing")
+```
+
+Each event is written to a single table (`goldfive_events` by default)
+with schema:
+
+```sql
+CREATE TABLE goldfive_events (
+    run_id       TEXT    NOT NULL,
+    sequence     INTEGER NOT NULL,
+    emitted_at   INTEGER NOT NULL,   -- milliseconds since epoch
+    kind         TEXT    NOT NULL,   -- e.g. "task_started", "drift_detected"
+    payload_json TEXT    NOT NULL,   -- full proto Event as JSON
+    PRIMARY KEY (run_id, sequence)
+);
+```
+
+The `(run_id, sequence)` primary key enforces at-most-one row per
+emitted event and makes per-run replay an indexed lookup. Concurrent
+`emit` coroutines are serialised with `asyncio.Lock`, same as the JSONL
+sink, so writes never interleave.
+
+### Queries
+
+```python
+# What runs are in the database?
+list_runs("./runs/goldfive.db")          # ['run-A', 'run-B', ...]
+
+# Replay one run as parsed proto Events.
+events = replay_from_sqlite("./runs/goldfive.db", run_id="run-A")
+
+# Pass to the same reconstructor used by JSONL recovery.
+from goldfive.sinks import reconstruct_session
+session = reconstruct_session(events)
+```
+
+Because `payload_json` is the full proto-encoded Event, raw SQL works
+too:
+
+```sql
+-- drift events across the database
+SELECT run_id, sequence, json_extract(payload_json, '$.driftDetected.kind')
+FROM goldfive_events
+WHERE kind = 'drift_detected';
+
+-- which runs actually completed
+SELECT DISTINCT run_id
+FROM goldfive_events
+WHERE kind = 'run_completed';
+```
+
+### When to pick which
+
+- Single run, durable audit, happy with files: **JSONL**.
+- Cross-run dashboards, shared integrations (e.g. a harmonograf server
+  reading goldfive events from the same file as observability data),
+  ad-hoc SQL: **SQLite**.
+- Both at once is fine — the two sinks are independent:
+  ```python
+  sinks = [
+      JSONLPersistenceSink(path=f"./runs/{run_id}.jsonl"),
+      SQLitePersistenceSink("./runs/goldfive.db"),
+  ]
+  ```
+
+### Custom tables
+
+Pass `table=` to co-locate goldfive events alongside existing schemas:
+
+```python
+SQLitePersistenceSink("./shared.db", table="harmonograf_events")
+```
+
+`replay_from_sqlite` and `list_runs` take the same `table=` argument.
+
 ## What's explicitly not in v0.1
 
 - **Live replay** — feeding JSONL back through sinks in real time.

--- a/goldfive/sinks/__init__.py
+++ b/goldfive/sinks/__init__.py
@@ -1,6 +1,6 @@
 """Built-in EventSinks for goldfive.
 
-Three implementations ship in-box:
+Four implementations ship in-box:
 
 * :class:`InMemorySink` — collects events in a list; used by tests and
   ephemeral callers that want to inspect the stream after the run.
@@ -9,13 +9,15 @@ Three implementations ship in-box:
 * :class:`JSONLPersistenceSink` — appends events to a newline-delimited
   JSON file suitable for crash recovery. Paired with
   :func:`replay_from_jsonl` and :func:`reconstruct_session` for resume.
+* :class:`SQLitePersistenceSink` — writes events into a SQLite table so
+  dashboards and shared-DB integrations can query across runs. Paired
+  with :func:`replay_from_sqlite` and :func:`list_runs`.
 
-``InMemorySink`` is always importable. ``LoggingSink`` and
-``JSONLPersistenceSink`` depend on the optional ``proto`` extra
-(``google.protobuf``) — importing them when the extra is missing
-raises :class:`ImportError` with a friendly message. The top-level
-``goldfive`` module handles that import gracefully so the bulk of the
-public API stays usable without ``proto``.
+``InMemorySink`` is always importable. The other three depend on the
+optional ``proto`` extra (``google.protobuf``) — importing them when
+the extra is missing raises :class:`ImportError` with a friendly
+message. The top-level ``goldfive`` module handles that import
+gracefully so the bulk of the public API stays usable without ``proto``.
 
 All sinks conform to the ``EventSink`` protocol pinned in
 ``INTERFACE_SPEC.md`` (async ``emit`` / async ``close``).
@@ -41,10 +43,24 @@ except ImportError:  # pragma: no cover — proto extra not installed
     reconstruct_session = None  # type: ignore[assignment]
     replay_from_jsonl = None  # type: ignore[assignment]
 
+try:
+    from goldfive.sinks.sqlite_sink import (
+        SQLitePersistenceSink,
+        list_runs,
+        replay_from_sqlite,
+    )
+except ImportError:  # pragma: no cover — proto extra not installed
+    SQLitePersistenceSink = None  # type: ignore[assignment]
+    list_runs = None  # type: ignore[assignment]
+    replay_from_sqlite = None  # type: ignore[assignment]
+
 __all__ = [
     "InMemorySink",
     "JSONLPersistenceSink",
     "LoggingSink",
+    "SQLitePersistenceSink",
+    "list_runs",
     "reconstruct_session",
     "replay_from_jsonl",
+    "replay_from_sqlite",
 ]

--- a/goldfive/sinks/sqlite_sink.py
+++ b/goldfive/sinks/sqlite_sink.py
@@ -1,0 +1,269 @@
+"""SQLite persistence sink and replay helpers.
+
+:class:`SQLitePersistenceSink` writes each event as a single row in a
+SQLite table. The table carries the minimum needed for cross-run query
+and replay::
+
+    CREATE TABLE goldfive_events (
+        run_id       TEXT    NOT NULL,
+        sequence     INTEGER NOT NULL,
+        emitted_at   INTEGER NOT NULL,
+        kind         TEXT    NOT NULL,
+        payload_json TEXT    NOT NULL,
+        PRIMARY KEY (run_id, sequence)
+    )
+
+The ``(run_id, sequence)`` primary key is what makes per-run replay an
+indexed lookup, and unique-per-run sequence numbers fall out for free.
+
+The sink is async-safe: concurrent ``emit`` coroutines are serialised by
+an :class:`asyncio.Lock` so the shared connection is only used by one
+writer at a time. SQLite writes inside the lock are synchronous — that's
+fine for the event volumes goldfive runs produce and keeps the
+dependency surface to stdlib only.
+
+JSONL's sibling module (:mod:`goldfive.sinks.persistence`) is the richer
+format: per-event JSON lines with full proto round-trip. SQLite trades
+a little replay fidelity for cross-run queryability. The two sinks can
+coexist on the same run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from google.protobuf.json_format import MessageToJson, Parse
+
+if TYPE_CHECKING:
+    from goldfive.pb.goldfive.v1 import events_pb2 as _events_pb2  # noqa: F401
+
+
+_DEFAULT_TABLE = "goldfive_events"
+
+
+def _events_module() -> Any:
+    """Lazy-import the generated ``events_pb2`` module."""
+    try:
+        from goldfive.pb.goldfive.v1 import events_pb2
+    except ModuleNotFoundError as exc:  # pragma: no cover — exercised by tests
+        raise ModuleNotFoundError(
+            "goldfive protobuf stubs not available; generate them via "
+            "`make proto` (requires the `proto` optional-dependency group) "
+            "or install the package with the `proto` extra. See issue #3."
+        ) from exc
+    return events_pb2
+
+
+def _validate_table(name: str) -> str:
+    """Return ``name`` if it is a safe SQL identifier, else raise.
+
+    SQLite parameter binding does not cover table names so we template
+    the table name into the DDL/DML ourselves. Accept the conservative
+    ``[A-Za-z_][A-Za-z0-9_]*`` shape to keep the surface injection-free.
+    """
+    if not name:
+        raise ValueError("table name must be non-empty")
+    if not (name[0].isalpha() or name[0] == "_"):
+        raise ValueError(f"invalid table name {name!r}")
+    if not all(c.isalnum() or c == "_" for c in name):
+        raise ValueError(f"invalid table name {name!r}")
+    return name
+
+
+def _event_fields(event: Any) -> tuple[str, int, int, str, str]:
+    """Extract ``(run_id, sequence, emitted_at_ms, kind, payload_json)``.
+
+    Proto ``Event`` messages are serialised via ``MessageToJson`` with
+    sorted keys. Dict-shaped events fall through to ``json.dumps`` so
+    tests that pre-date the proto wiring still round-trip.
+    """
+    if hasattr(event, "DESCRIPTOR"):
+        run_id = str(getattr(event, "run_id", "") or "")
+        sequence = int(getattr(event, "sequence", 0) or 0)
+        emitted_at_ms = 0
+        if event.HasField("emitted_at"):
+            ts = event.emitted_at
+            emitted_at_ms = int(ts.seconds) * 1000 + int(ts.nanos) // 1_000_000
+        kind = event.WhichOneof("payload") or ""
+        payload_json = MessageToJson(event, sort_keys=True, indent=None)
+        return run_id, sequence, emitted_at_ms, kind, payload_json
+
+    if hasattr(event, "to_dict"):
+        data = event.to_dict()
+    elif isinstance(event, dict):
+        data = dict(event)
+    else:
+        data = {k: v for k, v in vars(event).items() if not k.startswith("_")}
+
+    run_id = str(data.get("run_id", "") or "")
+    sequence = int(data.get("sequence", 0) or 0)
+    emitted_at_ms = int(data.get("emitted_at_ms", data.get("emitted_at", 0)) or 0)
+    kind = str(data.get("kind", "") or "")
+    payload_json = json.dumps(data, sort_keys=True, default=str)
+    return run_id, sequence, emitted_at_ms, kind, payload_json
+
+
+class SQLitePersistenceSink:
+    """EventSink that persists events into a SQLite table.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to the SQLite database. Parent directories are
+        created on first emit if they do not already exist. Pass
+        ``":memory:"`` for an in-process database — useful in tests.
+    table:
+        Name of the table to write into. Defaults to ``goldfive_events``.
+        Must match ``[A-Za-z_][A-Za-z0-9_]*``; see :func:`_validate_table`.
+
+    Notes
+    -----
+    The connection is opened lazily on the first ``emit`` so building
+    the sink is side-effect-free and can happen off-loop. ``close``
+    closes the connection; subsequent emits reopen it.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        table: str = _DEFAULT_TABLE,
+    ) -> None:
+        self._path = path if path == ":memory:" else Path(path)
+        self._table = _validate_table(table)
+        self._conn: sqlite3.Connection | None = None
+        # Created lazily so the sink can be built off-loop and attached
+        # to an event loop later (asyncio.Lock binds to the running loop
+        # at first await).
+        self._lock = asyncio.Lock()
+
+    def _open(self) -> None:
+        if self._conn is not None:
+            return
+        if isinstance(self._path, Path):
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            target: str = str(self._path)
+        else:
+            target = self._path
+        # ``isolation_level=None`` puts sqlite3 in autocommit mode so
+        # each INSERT lands immediately — matches the write-through
+        # semantics of the JSONL sink.
+        self._conn = sqlite3.connect(target, isolation_level=None)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute(
+            f"""CREATE TABLE IF NOT EXISTS {self._table} (
+                run_id       TEXT    NOT NULL,
+                sequence     INTEGER NOT NULL,
+                emitted_at   INTEGER NOT NULL,
+                kind         TEXT    NOT NULL,
+                payload_json TEXT    NOT NULL,
+                PRIMARY KEY (run_id, sequence)
+            )"""
+        )
+        self._conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{self._table}_run_id "
+            f"ON {self._table}(run_id)"
+        )
+
+    async def emit(self, event: Any) -> None:
+        """Insert ``event`` into the events table.
+
+        Proto messages are serialised with ``MessageToJson(sort_keys=True)``
+        so :func:`replay_from_sqlite` can round-trip via ``Parse``.
+        Dict-shaped events store the dict JSON directly. Concurrent
+        callers are serialised by an :class:`asyncio.Lock`.
+        """
+        row = _event_fields(event)
+        async with self._lock:
+            self._open()
+            assert self._conn is not None
+            self._conn.execute(
+                f"INSERT INTO {self._table} "
+                "(run_id, sequence, emitted_at, kind, payload_json) "
+                "VALUES (?, ?, ?, ?, ?)",
+                row,
+            )
+
+    async def close(self) -> None:
+        """Close the underlying connection. Safe to call repeatedly."""
+        async with self._lock:
+            if self._conn is not None:
+                try:
+                    self._conn.close()
+                finally:
+                    self._conn = None
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+
+def replay_from_sqlite(
+    path: str | Path,
+    run_id: str,
+    *,
+    table: str = _DEFAULT_TABLE,
+) -> list[Any]:
+    """Return all events for ``run_id`` as parsed ``Event`` messages.
+
+    Rows are fetched ordered by ``sequence`` so the return value is the
+    emit-order timeline for the run. Each ``payload_json`` is parsed via
+    ``google.protobuf.json_format.Parse`` into a fresh ``Event``; rows
+    whose JSON is not a valid ``Event`` propagate the parser's exception.
+    """
+    pb = _events_module()
+    table = _validate_table(table)
+    target = str(path) if path == ":memory:" else str(Path(path))
+    events: list[Any] = []
+    conn = sqlite3.connect(target)
+    try:
+        cursor = conn.execute(
+            f"SELECT payload_json FROM {table} WHERE run_id = ? ORDER BY sequence",
+            (run_id,),
+        )
+        for (payload_json,) in cursor:
+            msg = pb.Event()
+            Parse(payload_json, msg)
+            events.append(msg)
+    finally:
+        conn.close()
+    return events
+
+
+def list_runs(
+    path: str | Path,
+    *,
+    table: str = _DEFAULT_TABLE,
+) -> list[str]:
+    """Return the distinct ``run_id`` values present in the database.
+
+    Ordered by the earliest ``sequence`` seen for each run so the
+    return value roughly follows emit order. Returns an empty list if
+    the database or table does not yet exist.
+    """
+    table = _validate_table(table)
+    target = str(path) if path == ":memory:" else str(Path(path))
+    conn = sqlite3.connect(target)
+    try:
+        # If the table isn't there yet treat the database as empty.
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table,),
+        ).fetchone()
+        if row is None:
+            return []
+        # Order by ROWID rather than emitted_at so ``list_runs`` reflects
+        # the actual insertion order of the first row per run. emitted_at
+        # can collide across runs when clocks are low-resolution or when
+        # tests use synthetic timestamps; rowid never does.
+        cursor = conn.execute(
+            f"SELECT run_id FROM {table} GROUP BY run_id ORDER BY MIN(rowid)"
+        )
+        return [run_id for (run_id,) in cursor]
+    finally:
+        conn.close()

--- a/tests/test_sqlite_sink.py
+++ b/tests/test_sqlite_sink.py
@@ -1,0 +1,252 @@
+"""Unit tests for :class:`SQLitePersistenceSink`.
+
+Covers:
+* proto round-trip via emit/close + replay_from_sqlite
+* concurrent emits do not corrupt the primary key or drop rows
+* list_runs / replay_from_sqlite across multiple run_ids in one DB
+* non-proto (dict-shaped) events still persist
+* helpers tolerate a missing table cleanly
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+import pytest
+
+from goldfive.pb.goldfive.v1 import events_pb2
+from goldfive.sinks import (
+    SQLitePersistenceSink,
+    list_runs,
+    replay_from_sqlite,
+)
+
+
+def _make_event(seq: int, run_id: str = "run-1") -> events_pb2.Event:
+    """Build a minimal valid Event with a TaskStarted payload."""
+    evt = events_pb2.Event(event_id=f"evt-{run_id}-{seq}", run_id=run_id, sequence=seq)
+    evt.emitted_at.seconds = 1_700_000_000 + seq
+    evt.task_started.task_id = f"task-{seq}"
+    evt.task_started.detail = f"starting {seq}"
+    return evt
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+async def test_sqlite_sink_roundtrip(tmp_path) -> None:
+    db = tmp_path / "events.db"
+    sink = SQLitePersistenceSink(db)
+    events = [_make_event(i) for i in range(5)]
+    for e in events:
+        await sink.emit(e)
+    await sink.close()
+
+    replayed = replay_from_sqlite(db, run_id="run-1")
+    assert len(replayed) == 5
+    for original, round_tripped in zip(events, replayed, strict=True):
+        assert original == round_tripped
+
+
+async def test_sqlite_sink_creates_parent_dirs(tmp_path) -> None:
+    db = tmp_path / "nested" / "a" / "events.db"
+    sink = SQLitePersistenceSink(db)
+    await sink.emit(_make_event(0))
+    await sink.close()
+    assert db.exists()
+
+
+async def test_sqlite_sink_preserves_schema_columns(tmp_path) -> None:
+    db = tmp_path / "schema.db"
+    sink = SQLitePersistenceSink(db)
+    await sink.emit(_make_event(0, run_id="schema-run"))
+    await sink.close()
+
+    conn = sqlite3.connect(db)
+    try:
+        cursor = conn.execute(
+            "SELECT run_id, sequence, emitted_at, kind FROM goldfive_events"
+        )
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+    assert rows == [("schema-run", 0, 1_700_000_000_000, "task_started")]
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+async def test_sqlite_sink_concurrent_emit_persists_every_row(tmp_path) -> None:
+    db = tmp_path / "concurrent.db"
+    sink = SQLitePersistenceSink(db)
+    n = 50
+    events = [_make_event(i) for i in range(n)]
+    await asyncio.gather(*(sink.emit(e) for e in events))
+    await sink.close()
+
+    replayed = replay_from_sqlite(db, run_id="run-1")
+    assert len(replayed) == n
+    replayed_ids = sorted(e.event_id for e in replayed)
+    expected_ids = sorted(e.event_id for e in events)
+    assert replayed_ids == expected_ids
+    # Rows come back ordered by sequence even under concurrent writes.
+    assert [e.sequence for e in replayed] == list(range(n))
+
+
+# ---------------------------------------------------------------------------
+# Multi-run queries
+# ---------------------------------------------------------------------------
+
+
+async def test_list_runs_and_replay_isolate_by_run_id(tmp_path) -> None:
+    db = tmp_path / "multi.db"
+    sink = SQLitePersistenceSink(db)
+    for seq in range(3):
+        await sink.emit(_make_event(seq, run_id="run-A"))
+    for seq in range(2):
+        await sink.emit(_make_event(seq, run_id="run-B"))
+    await sink.close()
+
+    runs = list_runs(db)
+    assert set(runs) == {"run-A", "run-B"}
+
+    events_a = replay_from_sqlite(db, run_id="run-A")
+    events_b = replay_from_sqlite(db, run_id="run-B")
+    assert [e.sequence for e in events_a] == [0, 1, 2]
+    assert [e.sequence for e in events_b] == [0, 1]
+    assert all(e.run_id == "run-A" for e in events_a)
+    assert all(e.run_id == "run-B" for e in events_b)
+
+
+async def test_list_runs_orders_by_first_emit(tmp_path) -> None:
+    db = tmp_path / "ordering.db"
+    sink = SQLitePersistenceSink(db)
+    # run-B fires first, run-A second. list_runs should reflect that.
+    await sink.emit(_make_event(0, run_id="run-B"))
+    await sink.emit(_make_event(0, run_id="run-A"))
+    await sink.emit(_make_event(1, run_id="run-B"))
+    await sink.close()
+    assert list_runs(db) == ["run-B", "run-A"]
+
+
+def test_list_runs_on_missing_table_returns_empty(tmp_path) -> None:
+    db = tmp_path / "empty.db"
+    # Create an empty SQLite file with no tables.
+    sqlite3.connect(db).close()
+    assert list_runs(db) == []
+
+
+def test_list_runs_on_missing_file_returns_empty(tmp_path) -> None:
+    # sqlite3.connect creates the file on demand, so this should not raise;
+    # the table check still reports empty.
+    db = tmp_path / "nope.db"
+    assert list_runs(db) == []
+
+
+# ---------------------------------------------------------------------------
+# Restart / append semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_sqlite_sink_reopen_appends(tmp_path) -> None:
+    db = tmp_path / "append.db"
+    sink1 = SQLitePersistenceSink(db)
+    await sink1.emit(_make_event(0))
+    await sink1.emit(_make_event(1))
+    await sink1.close()
+
+    sink2 = SQLitePersistenceSink(db)
+    await sink2.emit(_make_event(2))
+    await sink2.emit(_make_event(3))
+    await sink2.close()
+
+    replayed = replay_from_sqlite(db, run_id="run-1")
+    assert [e.sequence for e in replayed] == [0, 1, 2, 3]
+
+
+async def test_sqlite_sink_duplicate_primary_key_raises(tmp_path) -> None:
+    db = tmp_path / "dup.db"
+    sink = SQLitePersistenceSink(db)
+    await sink.emit(_make_event(0))
+    with pytest.raises(sqlite3.IntegrityError):
+        await sink.emit(_make_event(0))
+    await sink.close()
+
+
+# ---------------------------------------------------------------------------
+# Custom table name
+# ---------------------------------------------------------------------------
+
+
+async def test_sqlite_sink_custom_table(tmp_path) -> None:
+    db = tmp_path / "custom.db"
+    sink = SQLitePersistenceSink(db, table="harmonograf_events")
+    await sink.emit(_make_event(0, run_id="run-X"))
+    await sink.close()
+
+    replayed = replay_from_sqlite(db, run_id="run-X", table="harmonograf_events")
+    assert len(replayed) == 1
+    assert list_runs(db, table="harmonograf_events") == ["run-X"]
+    # Default table does not carry the row.
+    assert list_runs(db) == []
+
+
+def test_sqlite_sink_rejects_injection_table_name(tmp_path) -> None:
+    with pytest.raises(ValueError):
+        SQLitePersistenceSink(tmp_path / "x.db", table="events; DROP TABLE")
+
+
+# ---------------------------------------------------------------------------
+# Non-proto events (dicts)
+# ---------------------------------------------------------------------------
+
+
+class _DictEvent:
+    """Dict-shaped event exposing ``to_dict`` — matches the JSONL sink's
+    duck-typed fallback path so both sinks accept the same shapes."""
+
+    def __init__(self, run_id: str, sequence: int, kind: str, payload: dict) -> None:
+        self.run_id = run_id
+        self.sequence = sequence
+        self.kind = kind
+        self.payload = payload
+
+    def to_dict(self) -> dict:
+        return {
+            "run_id": self.run_id,
+            "sequence": self.sequence,
+            "kind": self.kind,
+            "emitted_at_ms": 42,
+            "payload": self.payload,
+        }
+
+
+async def test_sqlite_sink_accepts_dict_events(tmp_path) -> None:
+    db = tmp_path / "dicts.db"
+    sink = SQLitePersistenceSink(db)
+    await sink.emit(_DictEvent("run-dict", 0, "custom", {"x": 1}))
+    await sink.emit(_DictEvent("run-dict", 1, "custom", {"x": 2}))
+    await sink.close()
+
+    assert list_runs(db) == ["run-dict"]
+
+    # The row is there even if it isn't a proto-parseable Event: inspect
+    # directly to avoid the Parse step in replay_from_sqlite.
+    conn = sqlite3.connect(db)
+    try:
+        rows = conn.execute(
+            "SELECT run_id, sequence, kind, emitted_at FROM goldfive_events "
+            "WHERE run_id = ? ORDER BY sequence",
+            ("run-dict",),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [
+        ("run-dict", 0, "custom", 42),
+        ("run-dict", 1, "custom", 42),
+    ]


### PR DESCRIPTION
Closes #44.

## Summary
- `goldfive/sinks/sqlite_sink.py` — `SQLitePersistenceSink(path, *, table="goldfive_events")` persists events into a SQLite table keyed by `(run_id, sequence)`; emits are serialised by `asyncio.Lock`.
- Module helpers `replay_from_sqlite(path, run_id)` and `list_runs(path)` cover the read side. Custom `table=` is validated against a conservative SQL-identifier pattern so injection attempts are rejected up-front.
- Re-exported from `goldfive.sinks` alongside the existing JSONL helpers.
- Extends `docs/guides/persistence-and-recovery.md` with a SQLite section (schema, SQL examples, when-to-pick-which).

## Schema
```sql
CREATE TABLE goldfive_events (
    run_id       TEXT    NOT NULL,
    sequence     INTEGER NOT NULL,
    emitted_at   INTEGER NOT NULL,  -- ms since epoch
    kind         TEXT    NOT NULL,  -- oneof payload name
    payload_json TEXT    NOT NULL,  -- MessageToJson(event, sort_keys=True)
    PRIMARY KEY (run_id, sequence)
);
```

## Test plan
- [x] Proto Event round-trip (emit → SELECT → parse) preserves every field.
- [x] 50 concurrent `emit` calls all land, ordered by sequence, no dropped rows.
- [x] `list_runs` + `replay_from_sqlite` isolate by `run_id` across a mixed DB.
- [x] `list_runs` follows first-emit order (MIN(rowid)) rather than timestamp ties.
- [x] Reopening the sink appends rather than truncates.
- [x] Duplicate `(run_id, sequence)` raises `IntegrityError` (primary key holds).
- [x] Custom `table=` works for both writes and replay; rejects injection strings.
- [x] Dict-shaped events (`to_dict`) still persist, matching the JSONL duck-type path.
- [x] Full suite still green: `uv run pytest -q` — 252 passed / 33 skipped.
- [x] `uv run --with ruff python -m ruff check goldfive/ tests/` — all checks pass.