### PR TITLE
Add ADK presentation_agent reference example

### DIFF
--- a/examples/adk_presentation/README.md
+++ b/examples/adk_presentation/README.md
@@ -1,0 +1,77 @@
+# ADK presentation example
+
+A reference implementation showing how `goldfive.Runner` wraps a multi-subagent
+Google ADK tree. Ported from harmonograf's `presentation_agent` demo, with the
+orchestration layer swapped from `HarmonografAgent` to
+`goldfive.adapters.adk.ADKAdapter`.
+
+## What this demonstrates
+
+- **A coordinator that delegates to four specialists** — researcher, web
+  developer, reviewer, and debugger — via `AgentTool`.
+- **One wrap covers the whole tree.** Only the root `coordinator_agent`
+  is handed to `ADKAdapter(...)`. The adapter walks the tree (`sub_agents`,
+  `inner_agent`, and nested `AgentTool.agent`) and attaches goldfive's
+  seven canonical reporting tools to every subagent automatically.
+- **Planner + goal deriver are pluggable.** The example wires
+  `LLMPlanner` and `LLMGoalDeriver` behind a `call_llm` callable so you
+  can swap in any model provider without touching goldfive internals.
+- **Events per subagent.** Goldfive's executor emits `TaskStarted` /
+  `TaskCompleted` events for each of the four specialist tasks, even
+  though the adapter only invokes the coordinator root.
+
+## Agent tree
+
+```
+coordinator_agent
+├── research_agent         (AgentTool)
+├── web_developer_agent    (AgentTool, tool: write_webpage)
+├── reviewer_agent         (AgentTool, tool: read_presentation_files)
+└── debugger_agent         (AgentTool, tool: patch_file)
+```
+
+## Running
+
+### Mock mode — no credentials required
+
+```bash
+uv pip install -e '.[adk]'
+uv run python examples/adk_presentation/agent.py --mock
+```
+
+In this mode every ADK agent's model is a deterministic in-process
+`BaseLlm` subclass, and the planner / goal deriver use canned JSON. The
+run completes with `success=True` and emits a 13-event stream
+culminating in `run_completed`.
+
+### Live mode — OpenAI
+
+```bash
+uv pip install -e '.[adk]'
+pip install openai litellm
+export OPENAI_API_KEY=sk-...
+uv run python examples/adk_presentation/agent.py --topic "the Voyager missions"
+```
+
+Live mode uses the `openai` Python SDK for the planner / goal deriver
+and a LiteLLM model string (default `openai/gpt-4o-mini`) for the ADK
+subagents. Override the models via:
+
+- `GOLDFIVE_EXAMPLE_MODEL` — ADK agent model (LiteLLM format, e.g.
+  `openai/gpt-4o-mini`).
+- `GOLDFIVE_EXAMPLE_PLANNER_MODEL` — model id passed to the planner's
+  `call_llm`. Defaults to `gpt-4o-mini`.
+- `GOLDFIVE_EXAMPLE_GOAL_MODEL` — model id for the goal deriver.
+  Defaults to `gpt-4o-mini`.
+
+Generated slideshow files land under
+`examples/adk_presentation/output/<topic>/` (`index.html`,
+`styles.css`, `script.js`).
+
+## Flags
+
+| Flag | Effect |
+|---|---|
+| `--mock` | Replace every LLM with an in-process mock. No network. |
+| `--topic TEXT` | Override the presentation topic. |
+| `--verbose`, `-v` | Enable INFO logging from goldfive's `LoggingSink`. |

--- a/examples/adk_presentation/__init__.py
+++ b/examples/adk_presentation/__init__.py
@@ -1,0 +1,1 @@
+"""ADK presentation reference example — see ``agent.py``."""

--- a/examples/adk_presentation/agent.py
+++ b/examples/adk_presentation/agent.py
@@ -1,0 +1,452 @@
+"""ADK presentation reference example — goldfive wrapping a multi-subagent tree.
+
+Ports harmonograf's ``presentation_agent`` demo to goldfive. The ADK tree
+is unchanged: a ``coordinator_agent`` exposes four specialists as
+``AgentTool`` s (researcher, web developer, reviewer, debugger). The
+whole tree is wrapped with :class:`goldfive.adapters.adk.ADKAdapter`
+and driven by a :class:`goldfive.Runner` with an ``LLMPlanner`` and
+``LLMGoalDeriver``.
+
+Two run modes:
+
+* ``--mock`` — no network. Every ADK agent's model is replaced with an
+  in-process ``_MockLlm`` that returns canned text, and the planner /
+  goal-deriver use mock ``call_llm`` callables that emit deterministic
+  JSON. Verifies goldfive wiring end-to-end without credentials.
+* Default — uses ``OPENAI_API_KEY`` via the ``openai`` Python SDK for
+  both planner / deriver and a ``LiteLLM`` model string (e.g.
+  ``openai/gpt-4o-mini``) for the ADK subagents. Requires the
+  ``openai`` and ``litellm`` packages.
+
+Gated on the ``adk`` extra::
+
+    uv pip install -e '.[adk]'
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+from collections.abc import AsyncGenerator
+from typing import Any
+
+try:
+    from google.adk.agents import Agent
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_request import LlmRequest
+    from google.adk.models.llm_response import LlmResponse
+    from google.adk.tools import AgentTool, FunctionTool
+    from google.genai import types as genai_types
+except ImportError as _adk_err:  # pragma: no cover
+    raise SystemExit(
+        "install goldfive[adk] to run this example"
+    ) from _adk_err
+
+from goldfive import (
+    InMemorySink,
+    LLMGoalDeriver,
+    LLMPlanner,
+    Runner,
+    SequentialExecutor,
+)
+from goldfive.adapters.adk import ADKAdapter
+from goldfive.sinks import LoggingSink
+
+log = logging.getLogger("examples.adk_presentation")
+
+
+# ---------------------------------------------------------------------------
+# ADK tools — mirror harmonograf's presentation_agent tool surface.
+# ---------------------------------------------------------------------------
+
+
+def write_webpage(
+    topic: str, html_content: str, css_content: str, js_content: str
+) -> str:
+    """Write an interactive webpage (HTML + CSS + JS) under ``output/``."""
+    topic_filename = topic.lower().replace(" ", "_").replace("/", "_")
+    output_dir = os.path.join(os.path.dirname(__file__), "output", topic_filename)
+    os.makedirs(output_dir, exist_ok=True)
+    try:
+        with open(os.path.join(output_dir, "index.html"), "w") as f:
+            f.write(html_content)
+        with open(os.path.join(output_dir, "styles.css"), "w") as f:
+            f.write(css_content)
+        with open(os.path.join(output_dir, "script.js"), "w") as f:
+            f.write(js_content)
+        return f"Successfully created presentation on '{topic}' at {output_dir}"
+    except OSError as e:
+        return f"Error writing file: {e}"
+
+
+def read_presentation_files(topic: str) -> dict[str, str]:
+    """Read the generated presentation files and return a name → content map."""
+    topic_filename = topic.lower().replace(" ", "_").replace("/", "_")
+    output_dir = os.path.join(os.path.dirname(__file__), "output", topic_filename)
+    files: dict[str, str] = {}
+    for name in ("index.html", "styles.css", "script.js"):
+        path = os.path.join(output_dir, name)
+        try:
+            with open(path) as f:
+                files[name] = f.read()
+        except OSError as e:
+            files[name] = f"<error reading {path}: {e}>"
+    return files
+
+
+def patch_file(path: str, new_content: str) -> str:
+    """Overwrite ``path`` with ``new_content`` (rooted under ``output/``)."""
+    if not os.path.isabs(path):
+        path = os.path.join(os.path.dirname(__file__), "output", path)
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(new_content)
+        return f"Successfully patched {path}"
+    except OSError as e:
+        return f"Error patching file: {e}"
+
+
+write_webpage_tool = FunctionTool(write_webpage)
+read_presentation_files_tool = FunctionTool(read_presentation_files)
+patch_file_tool = FunctionTool(patch_file)
+
+
+# ---------------------------------------------------------------------------
+# Agent tree construction
+# ---------------------------------------------------------------------------
+
+
+def _build_agent_tree(model: str | BaseLlm) -> Any:
+    """Build the coordinator + four specialist subagents and return the root."""
+    research_agent = Agent(
+        name="research_agent",
+        model=model,
+        instruction=(
+            "You are a researcher. Gather key facts about the topic the user "
+            "provides and synthesise them into concise bullet points suitable "
+            "for a short presentation."
+        ),
+        description=(
+            "Agent that synthesises research bullet points for a topic."
+        ),
+        tools=[],
+    )
+
+    web_developer_agent = Agent(
+        name="web_developer_agent",
+        model=model,
+        instruction=(
+            "You are an expert frontend developer. Given research notes, "
+            "generate a single-page HTML slideshow plus CSS and JavaScript, "
+            "then call the write_webpage tool to save the files."
+        ),
+        description=(
+            "Frontend agent that produces and saves an interactive "
+            "HTML/CSS/JS slideshow."
+        ),
+        tools=[write_webpage_tool],
+    )
+
+    reviewer_agent = Agent(
+        name="reviewer_agent",
+        model=model,
+        instruction=(
+            "You are a senior frontend reviewer. Call read_presentation_files "
+            "with the topic, then return a structured list of issues "
+            "(each with a severity of critical / major / minor) or an empty "
+            "list if the output looks clean."
+        ),
+        description=(
+            "Reviewer agent that critiques the generated presentation files."
+        ),
+        tools=[read_presentation_files_tool],
+    )
+
+    debugger_agent = Agent(
+        name="debugger_agent",
+        model=model,
+        instruction=(
+            "You are a debugging agent. Given a list of issues flagged by "
+            "the reviewer, call patch_file with the corrected contents for "
+            "each affected file."
+        ),
+        description=(
+            "Debugger agent that patches presentation files flagged by the "
+            "reviewer."
+        ),
+        tools=[patch_file_tool],
+    )
+
+    coordinator_agent = Agent(
+        name="coordinator_agent",
+        model=model,
+        instruction=(
+            "You are the Coordinator. Drive a presentation workflow by "
+            "delegating to research_agent, then web_developer_agent, then "
+            "reviewer_agent, and finally debugger_agent if the reviewer "
+            "flagged critical issues."
+        ),
+        description=(
+            "Coordinator that delegates research / build / review / debug "
+            "steps to specialist subagents."
+        ),
+        tools=[
+            AgentTool(research_agent),
+            AgentTool(web_developer_agent),
+            AgentTool(reviewer_agent),
+            AgentTool(debugger_agent),
+        ],
+    )
+    return coordinator_agent
+
+
+# ---------------------------------------------------------------------------
+# Mock LLM — used by --mock mode so the demo runs without credentials.
+# ---------------------------------------------------------------------------
+
+
+class _MockLlm(BaseLlm):
+    """Minimal BaseLlm that returns a single canned text response.
+
+    Short-circuits ADK's model layer so the coordinator and every
+    subagent produce a deterministic reply in ``--mock`` mode. The
+    executor's auto-complete behaviour (goldfive #37) then marks each
+    task COMPLETED based on the wrapped adapter returning cleanly.
+    """
+
+    @classmethod
+    def supported_models(cls) -> list[str]:
+        return [r"mock/.*"]
+
+    async def generate_content_async(
+        self, llm_request: LlmRequest, stream: bool = False
+    ) -> AsyncGenerator[LlmResponse, None]:
+        text = (
+            f"[mock:{self.model}] acknowledged task and deferred real work to "
+            "a production run."
+        )
+        yield LlmResponse(
+            content=genai_types.Content(
+                role="model",
+                parts=[genai_types.Part(text=text)],
+            ),
+            partial=False,
+            turn_complete=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mock call_llm callables — used by LLMPlanner / LLMGoalDeriver under --mock.
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_planner_llm(topic: str) -> Any:
+    """Return an async ``call_llm`` that produces a canned presentation plan.
+
+    Matches ``LLMPlanner``'s ``(system_prompt, user_prompt, model) -> str``
+    signature and returns a plan with one task per specialist subagent so
+    the executor emits ``TaskStarted`` / ``TaskCompleted`` for each.
+    """
+
+    plan_json = {
+        "summary": f"Build a slideshow presentation on '{topic}'.",
+        "tasks": [
+            {
+                "id": "research",
+                "title": "Gather research bullet points on the topic",
+                "description": "Summarise key facts about the topic.",
+                "assignee_agent_id": "research_agent",
+            },
+            {
+                "id": "build",
+                "title": "Generate HTML/CSS/JS slideshow",
+                "description": "Produce the presentation files and save them.",
+                "assignee_agent_id": "web_developer_agent",
+            },
+            {
+                "id": "review",
+                "title": "Review the generated presentation",
+                "description": "Critique the generated slideshow for issues.",
+                "assignee_agent_id": "reviewer_agent",
+            },
+            {
+                "id": "debug",
+                "title": "Patch any critical issues the reviewer flagged",
+                "description": "Apply fixes to the presentation files.",
+                "assignee_agent_id": "debugger_agent",
+            },
+        ],
+        "edges": [
+            {"from_task_id": "research", "to_task_id": "build"},
+            {"from_task_id": "build", "to_task_id": "review"},
+            {"from_task_id": "review", "to_task_id": "debug"},
+        ],
+    }
+
+    async def _call(system: str, prompt: str, model: str) -> str:
+        return json.dumps(plan_json)
+
+    return _call
+
+
+def _make_mock_goal_llm(topic: str) -> Any:
+    """Return an async ``call_llm`` that produces a single canned goal."""
+
+    goals_json = {
+        "goals": [
+            {
+                "id": "g1",
+                "summary": f"Produce an interactive slideshow on '{topic}'.",
+            }
+        ]
+    }
+
+    async def _call(system: str, prompt: str, model: str) -> str:
+        return json.dumps(goals_json)
+
+    return _call
+
+
+# ---------------------------------------------------------------------------
+# Real call_llm — OpenAI via the official SDK.
+# ---------------------------------------------------------------------------
+
+
+def _make_openai_call_llm() -> Any:
+    """Return an async ``call_llm`` backed by the OpenAI Python SDK.
+
+    Used when ``--mock`` is not passed. Requires ``OPENAI_API_KEY`` and
+    ``pip install openai``. Model identifiers default to
+    ``gpt-4o-mini`` but can be overridden via
+    ``GOLDFIVE_EXAMPLE_PLANNER_MODEL``.
+    """
+    try:
+        from openai import AsyncOpenAI  # type: ignore
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit(
+            "pip install openai to run this example without --mock"
+        ) from exc
+
+    client = AsyncOpenAI()
+
+    async def _call(system: str, prompt: str, model: str) -> str:
+        resolved = model or os.environ.get(
+            "GOLDFIVE_EXAMPLE_PLANNER_MODEL", "gpt-4o-mini"
+        )
+        resp = await client.chat.completions.create(
+            model=resolved,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+        return resp.choices[0].message.content or ""
+
+    return _call
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def run(
+    *,
+    topic: str,
+    mock: bool,
+) -> None:
+    """Drive one end-to-end presentation generation."""
+
+    if mock:
+        model: str | BaseLlm = _MockLlm(model="mock/presentation-agent")
+        planner_call_llm = _make_mock_planner_llm(topic)
+        goal_call_llm = _make_mock_goal_llm(topic)
+        planner_model = "mock/planner"
+        goal_model = "mock/goal-deriver"
+    else:
+        model = os.environ.get(
+            "GOLDFIVE_EXAMPLE_MODEL", "openai/gpt-4o-mini"
+        )
+        openai_call_llm = _make_openai_call_llm()
+        planner_call_llm = openai_call_llm
+        goal_call_llm = openai_call_llm
+        planner_model = os.environ.get(
+            "GOLDFIVE_EXAMPLE_PLANNER_MODEL", "gpt-4o-mini"
+        )
+        goal_model = os.environ.get(
+            "GOLDFIVE_EXAMPLE_GOAL_MODEL", "gpt-4o-mini"
+        )
+
+    root_agent = _build_agent_tree(model)
+    adapter = ADKAdapter(root_agent)
+
+    memory_sink = InMemorySink()
+    logging_sink = LoggingSink()
+    runner = Runner(
+        agent=adapter,
+        planner=LLMPlanner(call_llm=planner_call_llm, model=planner_model),
+        executor=SequentialExecutor(max_plan_reinvocations=8),
+        goal_deriver=LLMGoalDeriver(call_llm=goal_call_llm, model=goal_model),
+        sinks=[memory_sink, logging_sink],
+        max_plan_reinvocations=8,
+    )
+
+    outcome = await runner.run(
+        f"Create a short interactive slideshow presentation on {topic}."
+    )
+    await runner.close()
+
+    print(f"\nsuccess={outcome.success}  reason={outcome.reason!r}")
+    print(f"events emitted: {len(memory_sink.events)}")
+    for evt in memory_sink.events:
+        if isinstance(evt, dict):
+            kind = evt.get("kind", "?")
+            run_id = evt.get("run_id", "")
+            seq = evt.get("sequence", 0)
+        else:
+            kind = (
+                getattr(evt, "WhichOneof", lambda _: None)("payload") or "?"
+            )
+            run_id = getattr(evt, "run_id", "")
+            seq = getattr(evt, "sequence", 0)
+        print(f"  seq={seq:>3}  run={run_id[:8]:<8}  {kind}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--topic",
+        default="the history of the espresso machine",
+        help="Topic for the slideshow presentation.",
+    )
+    parser.add_argument(
+        "--mock",
+        action="store_true",
+        help=(
+            "Run without network calls — uses an in-process MockLlm for "
+            "every ADK agent and canned JSON for the goldfive planner and "
+            "goal deriver."
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable INFO-level logging from goldfive sinks.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s %(name)s %(message)s",
+    )
+    asyncio.run(run(topic=args.topic, mock=args.mock))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #42

## Summary
- Adds `examples/adk_presentation/{agent.py,README.md,__init__.py}` — ports harmonograf's multi-subagent `presentation_agent` demo to goldfive as a reference for wrapping a nested ADK agent tree (coordinator + researcher + web developer + reviewer + debugger, with the specialists exposed as `AgentTool`s).
- Only the coordinator root is handed to `ADKAdapter(...)`. The adapter's existing `_augment_subtree_with_reporting` walk (`sub_agents` / `inner_agent` / `AgentTool.agent`) already propagates goldfive's seven canonical reporting tools to every descendant, so no adapter changes were needed — PR #46 locked that contract in place, and this example exercises it end-to-end.
- `--mock` mode replaces every ADK agent's model with an in-process `BaseLlm` subclass and feeds canned JSON to `LLMPlanner` / `LLMGoalDeriver`, so the example runs without any credentials and emits a `RunStarted → GoalDerived → PlanSubmitted → (TaskStarted+TaskCompleted) × 4 → RunCompleted` event stream (13 events).

## Test plan
- [x] `uv run python examples/adk_presentation/agent.py --mock` — runs end-to-end, `success=True`, emits TaskStarted+TaskCompleted for each of the 4 specialist tasks.
- [x] `uv run --extra adk --extra claude --extra proto pytest -q` — 262 passed, 32 skipped (no regressions).
- [x] `uv run --with ruff python -m ruff check examples/adk_presentation/ goldfive/` — clean.
