### PR TITLE
Verify design-doc code snippets against goldfive v0.1

### DIFF
--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -139,14 +139,16 @@ primitives, owns a `Session`, and runs one invocation end-to-end. See
 Minimal construction:
 
 ```python
+# pseudo-code: `my_async_callable` and `precomputed_plan` are stand-ins
+# for the caller's real agent and plan. Everything else is real.
 from goldfive import Runner
 from goldfive.adapters.callable import CallableAdapter
-from goldfive.planner import PassthroughPlanner
+from goldfive.planner import StaticPlanner
 from goldfive.executors.sequential import SequentialExecutor
 
 runner = Runner(
     agent=CallableAdapter(my_async_callable),
-    planner=PassthroughPlanner(plan=precomputed_plan),
+    planner=StaticPlanner(precomputed_plan),
     executor=SequentialExecutor(),
 )
 outcome = await runner.run("build me a slide deck about Python")

--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -14,6 +14,8 @@ Related: [ARCHITECTURE.md](ARCHITECTURE.md#control-direction),
 ## The `DriftEvent` shape
 
 ```python
+# pseudo-code: reproduces the live ``DriftEvent`` dataclass in
+# ``goldfive/types.py`` for reference.
 @dataclasses.dataclass
 class DriftEvent:
     kind: DriftKind          # one of 25+ enum values
@@ -154,14 +156,19 @@ flowchart TD
 The helper classifiers live in `goldfive/drift.py`:
 
 ```python
-def classify_tool_error(err: Exception, tool_name: str) -> DriftEvent: ...
-def classify_refusal(text: str) -> DriftEvent | None: ...
-def classify_stop_reason(reason: str) -> DriftEvent | None: ...
-def classify_schema_violation(payload: Any, schema: Any) -> DriftEvent: ...
+# pseudo-code: signature-only view. Live definitions are in
+# ``goldfive/drift.py``.
+def classify_tool_error(event: Any) -> DriftEvent | None: ...
+def classify_refusal(text: Any) -> DriftEvent | None: ...
+def classify_stop_reason(reason: Any) -> DriftEvent | None: ...
 ```
 
+Each helper takes an opaque event/text/reason (harmonograf-ish dicts,
+plain strings, or framework-native objects) and returns a
+``DriftEvent`` when a signal is recognised or ``None`` otherwise.
 Subclasses of `DefaultSteerer` can override any of them to tune
-thresholds or add domain-specific signals.
+thresholds or add domain-specific signals (for example a
+schema-violation classifier of your own).
 
 ## Refine policy
 
@@ -169,6 +176,11 @@ When `Steerer.detect_drift()` returns a `DriftEvent`, the executor
 decides whether to act on it:
 
 ```python
+# pseudo-code: `emit_drift_detected` / `emit_run_aborted` /
+# `emit_plan_revised` / `drift_is_recoverable` are illustrative
+# executor-local helpers. The real call sites live inline in
+# ``goldfive/executors/sequential.py`` and
+# ``goldfive/executors/parallel.py``.
 drift = steerer.detect_drift(result, session)
 if drift is None:
     continue

--- a/docs/design/EVENT-MODEL.md
+++ b/docs/design/EVENT-MODEL.md
@@ -34,6 +34,8 @@ Python lives under `goldfive/pb/goldfive/v1/events_pb2.py`.
 Helpers in `goldfive/events.py` produce envelopes:
 
 ```python
+# pseudo-code: `session`, `task`, and `sinks` are supplied by the caller;
+# the `await` runs inside an async function.
 from goldfive.events import new_event, emit
 
 event = new_event(run_id=session.run_id, sequence=session.next_sequence())
@@ -93,6 +95,8 @@ See [DRIFT.md](DRIFT.md) for the full drift-kind taxonomy.
 `Session.next_sequence()`:
 
 ```python
+# pseudo-code: reproduces the body of ``Session.next_sequence`` in
+# ``goldfive/types.py`` for reference.
 def next_sequence(self) -> int:
     s = self._next_sequence
     self._next_sequence = s + 1
@@ -133,6 +137,8 @@ Beyond the per-run total order, goldfive guarantees:
 ## The EventSink contract
 
 ```python
+# pseudo-code: signature only. The live definition is in
+# ``goldfive/protocols.py``.
 @runtime_checkable
 class EventSink(Protocol):
     async def emit(self, event_pb: Any) -> None: ...
@@ -175,6 +181,8 @@ before returning.
 ### `InMemorySink`
 
 ```python
+# pseudo-code: the ``# ... run ...`` placeholder is where the caller's
+# Runner invocation populates the sink.
 from goldfive.sinks import InMemorySink
 
 sink = InMemorySink()
@@ -203,11 +211,14 @@ Useful for local dev.
 ```python
 from goldfive.sinks import JSONLPersistenceSink
 
-sink = JSONLPersistenceSink(path="./runs/{run_id}.jsonl")
+# ``path`` is a literal file path; there is no ``{run_id}`` templating
+# built in — callers that want one file per run format the path
+# themselves and construct a new sink each run.
+sink = JSONLPersistenceSink(path="./runs/example-run.jsonl")
 ```
 
 Writes one JSON-encoded proto message per line. Paired with
-`from_jsonl(path)` for crash recovery. See the full
+`replay_from_jsonl(path)` for crash recovery. See the full
 [persistence guide](../guides/persistence-and-recovery.md).
 
 ## Building a custom sink
@@ -239,9 +250,10 @@ assert isinstance(PrintingSink(), EventSink)  # runtime-checkable
 Plug into a `Runner`:
 
 ```python
+# pseudo-code: `my_callable` and `plan` are caller-supplied.
 runner = Runner(
     agent=CallableAdapter(my_callable),
-    planner=PassthroughPlanner(plan),
+    planner=StaticPlanner(plan),
     executor=SequentialExecutor(),
     sinks=[PrintingSink(), JSONLPersistenceSink("./runs/example.jsonl")],
 )

--- a/docs/design/PROTOCOLS.md
+++ b/docs/design/PROTOCOLS.md
@@ -9,13 +9,14 @@ working implementations.
 
 Related: [ARCHITECTURE.md](ARCHITECTURE.md), [api.md](../reference/api.md).
 
-All method signatures in this doc track `INTERFACE_SPEC.md` at the
-repository root. When they disagree, the spec wins until it is deleted
-(post-v0.1).
+All method signatures in this doc track `goldfive/protocols.py`. When
+they disagree, the source wins.
 
 ## GoalDeriver
 
 ```python
+# pseudo-code: protocol signature — live definition lives in
+# ``goldfive/protocols.py``.
 @runtime_checkable
 class GoalDeriver(Protocol):
     async def derive(
@@ -71,6 +72,8 @@ to write an `LLMGoalDeriver` instead.
 ## Planner
 
 ```python
+# pseudo-code: protocol signature — live definition lives in
+# ``goldfive/protocols.py``.
 @runtime_checkable
 class Planner(Protocol):
     async def generate(
@@ -130,10 +133,12 @@ from goldfive.types import DriftEvent, Goal, Plan
 
 
 class PassthroughPlanner:
-    """Returns a pre-baked plan; never refines."""
+    """No-op planner — ``generate`` and ``refine`` both return ``None``.
 
-    def __init__(self, plan: Plan) -> None:
-        self._plan = plan
+    Makes it safe to wire a ``planner=`` kwarg everywhere without
+    forcing callers to opt in to planning on day one. Mirrors the
+    live implementation in ``goldfive/planner.py``.
+    """
 
     async def generate(
         self,
@@ -142,7 +147,7 @@ class PassthroughPlanner:
         available_agents: list[str],
         context: Optional[Mapping[str, Any]] = None,
     ) -> Optional[Plan]:
-        return self._plan
+        return None
 
     async def refine(
         self,
@@ -151,16 +156,20 @@ class PassthroughPlanner:
         drift: DriftEvent,
         goals: list[Goal],
     ) -> Optional[Plan]:
-        return None  # no refine capability
+        return None
 ```
 
-For the full `LLMPlanner` that parses JSON plans out of an LLM
+Callers who already have a pre-built plan use ``StaticPlanner(plan)``
+instead — it returns the supplied plan verbatim and also declines to
+refine. For the full `LLMPlanner` that parses JSON plans out of an LLM
 response, see `goldfive/planner.py` or
 [goals-and-plans.md](../guides/goals-and-plans.md#writing-a-custom-planner).
 
 ## Steerer
 
 ```python
+# pseudo-code: protocol signature — live definition lives in
+# ``goldfive/protocols.py``.
 @runtime_checkable
 class Steerer(Protocol):
     async def observe(self, event: Any, session: Session) -> None: ...
@@ -261,6 +270,8 @@ drift classifier and event emission.
 ## AgentAdapter
 
 ```python
+# pseudo-code: protocol signature — live definition lives in
+# ``goldfive/protocols.py``.
 @runtime_checkable
 class AgentAdapter(Protocol):
     async def register_reporting_tools(
@@ -355,6 +366,8 @@ for a full worked example that wraps a hypothetical new framework.
 ## Executor
 
 ```python
+# pseudo-code: protocol signature — live definition lives in
+# ``goldfive/protocols.py``.
 @runtime_checkable
 class Executor(Protocol):
     async def run(
@@ -440,6 +453,8 @@ reinvocation loop.
 ## EventSink
 
 ```python
+# pseudo-code: protocol signature — live definition lives in
+# ``goldfive/protocols.py``.
 @runtime_checkable
 class EventSink(Protocol):
     async def emit(self, event_pb: Any) -> None: ...

--- a/docs/design/STATE-MACHINE.md
+++ b/docs/design/STATE-MACHINE.md
@@ -12,6 +12,8 @@ Related: [DRIFT.md](DRIFT.md), [PROTOCOLS.md](PROTOCOLS.md#steerer),
 ## States
 
 ```python
+# pseudo-code: reproduces the live ``TaskStatus`` ``StrEnum`` in
+# ``goldfive/types.py`` for reference.
 class TaskStatus(StrEnum):
     PENDING = "PENDING"
     RUNNING = "RUNNING"
@@ -65,6 +67,9 @@ transition is legal. `Steerer.transition()` rejects attempts to leave a
 terminal state:
 
 ```python
+# pseudo-code: illustrative of the absorbing-terminal-state guard.
+# The real transition method lives in
+# ``goldfive/steerer.py::DefaultSteerer.transition``.
 async def transition(self, task_id, to, *, detail="", session):
     task = _find_task(session.plan, task_id)
     if task.status in _TERMINAL_STATES:


### PR DESCRIPTION
Closes #39

## Summary
- Walked every fenced ```python``` block in `docs/design/*.md`, ran the self-contained ones against goldfive v0.1, and annotated fragments that cannot stand alone with a `# pseudo-code: ...` comment (with a reason).
- Fixed every class/function name that did not match real code.

## What was wrong

- `ARCHITECTURE.md` / `EVENT-MODEL.md`: composed a `Runner` with `PassthroughPlanner(plan=...)`. The live `PassthroughPlanner` takes no args and always returns `None`; the plan-returning planner is `StaticPlanner`. Fixed.
- `PROTOCOLS.md` "Minimal implementation" of `PassthroughPlanner` stored a plan and returned it — a direct contradiction of the live class. Rewrote to mirror reality; added a sentence pointing readers to `StaticPlanner` for the plan-returning variant.
- `DRIFT.md` claimed a `classify_schema_violation` helper that never existed, and gave `classify_tool_error(err: Exception, tool_name: str)` when the real signature is `classify_tool_error(event: Any)`. Updated to match `goldfive/drift.py`.
- `EVENT-MODEL.md` suggested `./runs/{run_id}.jsonl` as the JSONL path — there is no `{run_id}` templating. Swapped for a concrete path, and fixed `from_jsonl` → `replay_from_jsonl` (the real exported name).
- `PROTOCOLS.md` preamble still pointed at the removed `INTERFACE_SPEC.md`; updated to point at `goldfive/protocols.py`.

## Verification
- Ran every self-contained block end-to-end: `CallableAdapter`/`StaticPlanner`/`SequentialExecutor` Runner, `LoggingSink`/`JSONLPersistenceSink` construction, the `PrintingSink` + `isinstance(..., EventSink)` runtime-checkable assertion, and every minimal `Passthrough*` / `MinimalSteerer` / `LinearSequentialExecutor` / `NullSink` class from `PROTOCOLS.md`.
- Verified all relative markdown links in `docs/design/*.md` resolve.
- `uv run --extra dev pytest -q` → 252 passed, 33 skipped.
- `uv run --with ruff python -m ruff check .` → clean.

## Test plan
- [x] `pytest` passes (no test churn; doc-only diff).
- [x] `ruff` passes.
- [x] Every self-contained snippet executes against goldfive v0.1.
- [x] Every fragment snippet carries a `# pseudo-code: ...` annotation.
- [x] Every relative `[...](...)` link in `docs/design/*.md` resolves to an existing file.