### PR TITLE
Verify code snippets in docs/guides/ run against v0.1

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -78,7 +78,7 @@ import asyncio
 from goldfive import Runner
 from goldfive.adapters.callable import CallableAdapter
 from goldfive.executors.sequential import SequentialExecutor
-from goldfive.planner import PassthroughPlanner
+from goldfive.planner import StaticPlanner
 from goldfive.results import InvocationResult
 from goldfive.sinks import InMemorySink
 from goldfive.steerer import DefaultSteerer
@@ -92,21 +92,13 @@ from goldfive.types import Plan, Session, Task, TaskEdge
 #
 # `tools` is the list of reporting-tool specs the adapter registered.
 # In a real agent, this is where the LLM would be invoked and its
-# tool calls intercepted. Here, we just call the tools ourselves.
+# `report_task_*` tool calls intercepted.  The SequentialExecutor
+# auto-announces RUNNING before `invoke` and auto-completes the task
+# after a clean return, so a toy agent can just return a result.
 
 async def my_agent(task: Task, session: Session, tools) -> InvocationResult:
-    started = next(t for t in tools if t.name == "report_task_started")
-    completed = next(t for t in tools if t.name == "report_task_completed")
-
-    await started.handler({"task_id": task.id, "detail": ""}, session, None)
-    # ... do the "work" ...
-    result_text = f"did {task.title}"
-    await completed.handler(
-        {"task_id": task.id, "summary": result_text, "artifacts": {}},
-        session,
-        None,
-    )
-    return InvocationResult(task_id=task.id, text=result_text)
+    _ = tools  # unused in this toy agent
+    return InvocationResult(task_id=task.id, text=f"did {task.title}")
 
 
 # -- the plan -----------------------------------------------------------
@@ -132,11 +124,25 @@ plan = Plan(
 
 # -- the Runner ---------------------------------------------------------
 
+def event_kind(event) -> str:
+    # Runner emits dict events; executors/steerers emit proto Event
+    # messages whose payload is a oneof. Handle both shapes.
+    if isinstance(event, dict):
+        return event.get("kind", "?")
+    return event.WhichOneof("payload") or "?"
+
+
+def event_sequence(event) -> int:
+    if isinstance(event, dict):
+        return int(event.get("sequence", 0))
+    return int(getattr(event, "sequence", 0))
+
+
 async def main() -> None:
     sink = InMemorySink()
     runner = Runner(
         agent=CallableAdapter(my_agent),
-        planner=PassthroughPlanner(plan),
+        planner=StaticPlanner(plan),
         executor=SequentialExecutor(),
         steerer=DefaultSteerer(),
         sinks=[sink],
@@ -145,8 +151,7 @@ async def main() -> None:
 
     print(f"success={outcome.success}, tasks={len(outcome.session.plan.tasks)}")
     for event in sink.events:
-        kind = event.WhichOneof("payload")
-        print(f"  [{event.sequence:2d}] {kind}")
+        print(f"  [{event_sequence(event):2d}] {event_kind(event)}")
 
 
 if __name__ == "__main__":
@@ -163,27 +168,39 @@ Expected output:
 
 ```
 success=True, tasks=3
-  [ 0] run_started
-  [ 1] goal_derived
-  [ 2] plan_submitted
-  [ 3] task_started
-  [ 4] task_completed
-  [ 5] task_started
-  [ 6] task_completed
-  [ 7] task_started
-  [ 8] task_completed
-  [ 9] run_completed
+  [ 0] RunStarted
+  [ 1] GoalDerived
+  [ 2] PlanSubmitted
+  [ 3] run_started
+  [ 4] task_started
+  [ 5] task_completed
+  [ 6] task_started
+  [ 7] task_completed
+  [ 8] task_started
+  [ 9] task_completed
+  [10] run_completed
 ```
+
+Sequences 0–2 come from the Runner (it emits dict envelopes with a
+``kind`` field) and the rest come from the executor and steerer (proto
+``Event`` messages whose oneof payload is matched by ``WhichOneof``).
+You'll see a second ``run_started`` at sequence 3 because the
+executor also announces its start — treat the two together as the
+run's start marker.
 
 That's it. You have a full goldfive run, observable via the in-memory
 sink, walking a 3-task plan end-to-end.
 
 ### Step 3 — Inspect what happened
 
-Everything you'd want to know is in `sink.events`:
+Everything you'd want to know is in `sink.events`. The executor and
+steerer emit proto ``Event`` messages — use ``WhichOneof`` to pick out
+the payload, skipping the dict envelopes the Runner emits:
 
 ```python
 for event in sink.events:
+    if isinstance(event, dict):
+        continue  # Runner envelope: RunStarted / GoalDerived / PlanSubmitted
     kind = event.WhichOneof("payload")
     if kind == "task_completed":
         tc = event.task_completed

--- a/docs/guides/goals-and-plans.md
+++ b/docs/guides/goals-and-plans.md
@@ -95,6 +95,7 @@ already has an explicit goal representation.
 
 ```python
 from goldfive.goal_deriver import PassthroughGoalDeriver
+from goldfive.types import Goal
 
 goals = [
     Goal(id="g1", summary="ship the feature"),
@@ -104,10 +105,16 @@ runner = Runner(
     agent=...,
     planner=...,
     executor=...,
-    goal_deriver=PassthroughGoalDeriver(),
+    goal_deriver=PassthroughGoalDeriver(goals),  # deriver is bypassed anyway
 )
-await runner.run(goals)  # list[Goal] directly
+await runner.run(goals)  # list[Goal] directly — deriver is not consulted
 ```
+
+`PassthroughGoalDeriver` requires a seed (``str``, ``list[str]``, or
+``list[Goal]``) so it can still serve ``derive()`` if anything calls
+it. When ``Runner.run`` receives a ``list[Goal]`` directly, the
+deriver is bypassed entirely, so what you pass as the seed is largely
+cosmetic.
 
 ### `LLMGoalDeriver`
 
@@ -128,7 +135,7 @@ runner = Runner(
     agent=...,
     planner=...,
     executor=...,
-    goal_deriver=LLMGoalDeriver(call_llm=call_llm, model="claude-opus-4-5-20251101"),
+    goal_deriver=LLMGoalDeriver(call_llm, model="claude-opus-4-5"),
 )
 ```
 
@@ -172,17 +179,24 @@ Keep the deriver small. Complex logic belongs further down the stack.
 
 ## Planners
 
-### `PassthroughPlanner`
+### `PassthroughPlanner` and `StaticPlanner`
 
 ```python
-from goldfive.planner import PassthroughPlanner
+from goldfive.planner import PassthroughPlanner, StaticPlanner
 
-planner = PassthroughPlanner(plan=precomputed_plan)
+# PassthroughPlanner is a no-op: generate() and refine() both return
+# None. Useful as a default when planning is opt-in.
+planner = PassthroughPlanner()
+
+# StaticPlanner hands a pre-built plan back from generate() verbatim
+# (with run_id / goal_ids stamped onto the returned copy).
+planner = StaticPlanner(precomputed_plan)
 ```
 
-Hands the caller-supplied plan back from `generate()`, returns `None`
-from `refine()`. For tests, demos, and cases where you're authoring
-plans ahead of time.
+Use ``PassthroughPlanner`` when planning is opt-in and a no-op is
+acceptable. Use ``StaticPlanner`` for tests, demos, and cases where
+you're authoring plans ahead of time. Both return ``None`` from
+``refine()`` — they don't mutate the plan in response to drift.
 
 ### `LLMPlanner`
 
@@ -196,9 +210,9 @@ async def call_llm(system_prompt: str, user_prompt: str, model: str) -> str:
 
 planner = LLMPlanner(
     call_llm=call_llm,
-    model="claude-opus-4-5-20251101",
-    system_prompt_override=None,  # optional
-    refine_system_prompt_override=None,  # optional
+    model="claude-opus-4-5",
+    system_prompt=None,          # optional override for goal→plan prompt
+    refine_system_prompt=None,   # optional override for refine prompt
 )
 ```
 
@@ -346,8 +360,8 @@ it after N tasks. For now, the mechanism is opt-in.
 
 ## Tuning the LLM planner prompts
 
-`LLMPlanner` exposes two overrides: `system_prompt_override` and
-`refine_system_prompt_override`. The shipped prompts are in
+`LLMPlanner` exposes two overrides: `system_prompt` and
+`refine_system_prompt`. The shipped prompts are in
 `goldfive/planner.py` under `_DEFAULT_SYSTEM_PROMPT` and
 `_REFINE_SYSTEM_PROMPT`. Port what you need from those; they're tuned
 for the JSON output format the parser expects.
@@ -358,11 +372,11 @@ The default output shape (in the prompt):
 {
   "summary": "short description of the plan",
   "tasks": [
-    {"id": "t1", "title": "...", "description": "...", "assignee": "..."},
-    {"id": "t2", "title": "...", "description": "...", "assignee": "..."}
+    {"id": "t1", "title": "...", "description": "...", "assignee_agent_id": "..."},
+    {"id": "t2", "title": "...", "description": "...", "assignee_agent_id": "..."}
   ],
   "edges": [
-    {"from": "t1", "to": "t2"}
+    {"from_task_id": "t1", "to_task_id": "t2"}
   ]
 }
 ```
@@ -380,7 +394,7 @@ they're matched.
 **Free-text input → LLM-derived goals, LLM-planned execution.** Use
 `LLMGoalDeriver` + `LLMPlanner`. Default combo for general assistants.
 
-**Fixed workflow, variable details.** Use `PassthroughPlanner` with a
+**Fixed workflow, variable details.** Use `StaticPlanner` with a
 plan template cloned per run, populated with the run-specific goal
 summaries.
 

--- a/docs/guides/persistence-and-recovery.md
+++ b/docs/guides/persistence-and-recovery.md
@@ -39,9 +39,11 @@ that happened. Replaying the log reconstructs the session, and a new
 ## The sink
 
 ```python
+import uuid
 from goldfive.sinks import JSONLPersistenceSink
 
-sink = JSONLPersistenceSink(path="./runs/{run_id}.jsonl")
+run_id = uuid.uuid4().hex
+sink = JSONLPersistenceSink(f"./runs/{run_id}.jsonl")
 
 runner = Runner(
     agent=...,
@@ -52,8 +54,13 @@ runner = Runner(
 outcome = await runner.run("do the thing")
 ```
 
-The sink writes one JSON-encoded proto `Event` per line. `{run_id}`
-in the path is substituted at run start.
+The sink writes one JSON-encoded event per line: proto ``Event``
+messages from the executor and steerer go through
+``google.protobuf.json_format.MessageToJson`` and Runner-level dict
+envelopes go through plain ``json.dumps``. The ``path`` is a literal
+string — pick a filename yourself (for example, by generating a
+``run_id`` up-front and formatting it in) since the sink does not
+substitute placeholders.
 
 On-disk shape:
 
@@ -90,14 +97,17 @@ via the normal `Runner.run()` exit path; it happens automatically.
 
 ```python
 from goldfive import Runner
-from goldfive.sinks import JSONLPersistenceSink
+from goldfive.sinks import (
+    JSONLPersistenceSink,
+    reconstruct_session,
+    replay_from_jsonl,
+)
 
 
 # Step 1: load the events from the crashed run.
-events = JSONLPersistenceSink.from_jsonl("./runs/abc.jsonl")
+events = replay_from_jsonl("./runs/abc.jsonl")
 
 # Step 2: rebuild a Session from the events.
-from goldfive.recovery import reconstruct_session  # helper from issue #15
 session = reconstruct_session(events)
 
 # Step 3: construct a new Runner with the same components.
@@ -105,18 +115,25 @@ runner = Runner(
     agent=my_agent_adapter,   # same adapter configuration
     planner=my_planner,
     executor=my_executor,
-    sinks=[JSONLPersistenceSink(path="./runs/abc.jsonl")],  # same file, append
+    sinks=[JSONLPersistenceSink("./runs/abc.jsonl")],  # same file, append
 )
 
-# Step 4: resume.
-outcome = await runner.resume(session=session)
+# Step 4: resume from the persisted log. ``resume`` replays the
+# events internally, reports the last terminal marker as the
+# outcome, and returns the reconstructed session on
+# ``outcome.session``. v0.1 does not yet continue execution from the
+# last un-finished task — see "What's explicitly not in v0.1" below.
+outcome = await runner.resume("./runs/abc.jsonl")
 ```
 
-`Runner.resume()` picks up from the reconstructed session. The
+`Runner.resume()` replays the JSONL log and returns an
+`ExecutionOutcome` carrying the reconstructed session. The
 reconstructed plan has tasks in whatever terminal states the log
-records (COMPLETED, FAILED, CANCELLED), RUNNING tasks are rolled
-back to PENDING (with a warning log — see below), and PENDING tasks
-are executed as normal.
+records (COMPLETED, FAILED, CANCELLED); tasks that were mid-flight
+when the log ended stay RUNNING in ``reconstruct_session``'s output
+but the resume path will be converted to PENDING once live
+continuation lands (TODO in ``Runner.resume``). PENDING tasks are
+executed as normal when continuation is implemented.
 
 ### What `reconstruct_session` does
 
@@ -229,12 +246,14 @@ exhaustion, which is a stop-the-world condition anyway.
 Your tail line is `{"eventId":"01H...","runId":"abc","sequenc...`
 (cut off).
 
-`JSONLPersistenceSink.from_jsonl()` skips unparseable lines with a
-warning log. The reconstructed session will be slightly behind the
-true crash point, but every event up to the last complete line is
-replayed. On resume, the executor reconstructs from that state and
-carries on. You may re-run a task that was actually completed, which
-loops back to the idempotency argument from case (1).
+`replay_from_jsonl()` currently raises on unparseable lines. Callers
+that want best-effort tail-tolerant replay should catch
+``google.protobuf.json_format.ParseError`` and stop at the last
+parsed event. The reconstructed session then reflects every event up
+to the last complete line. On resume, the executor reconstructs from
+that state and carries on. You may re-run a task that was actually
+completed, which loops back to the idempotency argument from
+case (1).
 
 ## Operational guidance
 
@@ -381,30 +400,43 @@ SQLitePersistenceSink("./shared.db", table="harmonograf_events")
 A quick smoke test:
 
 ```python
-import asyncio, os
-from goldfive import Runner
-from goldfive.sinks import JSONLPersistenceSink
+import asyncio
+import os
 
-# run 1 — interrupted after task 1
+from goldfive import Runner
+from goldfive.sinks import (
+    JSONLPersistenceSink,
+    reconstruct_session,
+    replay_from_jsonl,
+)
+
 path = "./runs/smoke.jsonl"
 if os.path.exists(path):
     os.remove(path)
 
-runner_a = Runner(..., sinks=[JSONLPersistenceSink(path)])
+# run 1 — write events to disk.
+runner_a = Runner(..., sinks=[JSONLPersistenceSink(path, mode="write")])
 try:
-    # custom executor that raises after the first task, for the test
     await asyncio.wait_for(runner_a.run("demo"), timeout=1.0)
 except Exception:
     pass
+await runner_a.close()
 
-# run 2 — resume
-events = JSONLPersistenceSink.from_jsonl(path)
-from goldfive.recovery import reconstruct_session
+# Inspect what made it to the log (optional).
+events = replay_from_jsonl(path)
 session = reconstruct_session(events)
+print(
+    f"recovered run_id={session.run_id}, "
+    f"statuses={[t.status.value for t in (session.plan.tasks if session.plan else [])]}"
+)
 
-runner_b = Runner(..., sinks=[JSONLPersistenceSink(path)])
-outcome = await runner_b.resume(session=session)
-assert outcome.success
+# run 2 — resume from the log. v0.1 replays the events and
+# surfaces the last terminal marker via outcome.success; live
+# continuation of pending work is tracked as future work on
+# Runner.resume.
+runner_b = Runner(...)
+outcome = await runner_b.resume(path)
+print(f"resume outcome: success={outcome.success}")
 ```
 
 `tests/test_persistence_recovery.py` (in [issue #16](https://github.com/pedapudi/goldfive/issues/16))

--- a/docs/guides/writing-an-agent-adapter.md
+++ b/docs/guides/writing-an-agent-adapter.md
@@ -237,11 +237,11 @@ Use it:
 ```python
 from goldfive import Runner
 from goldfive.executors.sequential import SequentialExecutor
-from goldfive.planner import PassthroughPlanner
+from goldfive.planner import StaticPlanner
 
 runner = Runner(
     agent=AwesomeAdapter(system_prompt="You are a helpful assistant."),
-    planner=PassthroughPlanner(plan=my_plan),
+    planner=StaticPlanner(my_plan),
     executor=SequentialExecutor(),
 )
 outcome = await runner.run("do the thing")

--- a/docs/guides/writing-an-event-sink.md
+++ b/docs/guides/writing-an-event-sink.md
@@ -37,9 +37,16 @@ class EventSink(Protocol):
     async def close(self) -> None: ...
 ```
 
-Two methods. `emit(event_pb)` is called once per event, in per-run
+Two methods. `emit(event)` is called once per event, in per-run
 sequence order. `close()` is called once when the run ends. That's
 the entire contract.
+
+One wrinkle: v0.1 emits two event shapes on the same stream. The
+Runner emits dict envelopes (``{"run_id", "sequence", "emitted_at",
+"kind", "payload"}``) for run-lifecycle markers, and executors/
+steerers emit proto ``Event`` messages for per-task state changes.
+Sinks must accept both. ``JSONLPersistenceSink`` is the reference for
+how to fan out: proto via ``MessageToJson``, dict via ``json.dumps``.
 
 ## A minimal stdout sink
 
@@ -50,9 +57,16 @@ from typing import Any
 
 
 class StdoutSink:
-    async def emit(self, event_pb: Any) -> None:
-        kind = event_pb.WhichOneof("payload")
-        print(f"[{event_pb.sequence:04d}] {kind} (run={event_pb.run_id})")
+    async def emit(self, event: Any) -> None:
+        if isinstance(event, dict):
+            seq = int(event.get("sequence", 0))
+            kind = event.get("kind", "?")
+            run_id = event.get("run_id", "")
+        else:
+            seq = int(getattr(event, "sequence", 0))
+            kind = event.WhichOneof("payload") or "?"
+            run_id = getattr(event, "run_id", "")
+        print(f"[{seq:04d}] {kind} (run={run_id})")
 
     async def close(self) -> None:
         pass
@@ -119,7 +133,12 @@ class HttpBackendSink:
             item = await self._queue.get()
             if item is None:
                 return
-            payload = json.loads(MessageToJson(item, preserving_proto_field_name=True))
+            if isinstance(item, dict):
+                payload = item
+            else:
+                payload = json.loads(
+                    MessageToJson(item, preserving_proto_field_name=True)
+                )
             try:
                 await self._client.post(self._endpoint, json=payload)
             except httpx.HTTPError:
@@ -229,9 +248,13 @@ class FilteringSink:
         self._inner = inner
         self._kinds = set(kinds)
 
-    async def emit(self, event_pb) -> None:
-        if event_pb.WhichOneof("payload") in self._kinds:
-            await self._inner.emit(event_pb)
+    async def emit(self, event) -> None:
+        if isinstance(event, dict):
+            kind = event.get("kind", "")
+        else:
+            kind = event.WhichOneof("payload") or ""
+        if kind in self._kinds:
+            await self._inner.emit(event)
 
     async def close(self) -> None:
         await self._inner.close()
@@ -249,12 +272,12 @@ sink = FilteringSink(
 ## Pattern: replay from `JSONLPersistenceSink`
 
 The persistence sink stores every event, so you can reconstruct any
-run:
+run with the module-level ``replay_from_jsonl`` helper:
 
 ```python
-from goldfive.sinks import JSONLPersistenceSink
+from goldfive.sinks import replay_from_jsonl
 
-events = JSONLPersistenceSink.from_jsonl("./runs/abc123.jsonl")
+events = replay_from_jsonl("./runs/abc123.jsonl")
 for ev in events:
     kind = ev.WhichOneof("payload")
     print(ev.sequence, kind)
@@ -282,7 +305,8 @@ async def test_http_sink_posts_events(httpx_mock):
     sink = HttpBackendSink("http://mock.local/events")
 
     ev = Event(run_id="r1", sequence=0)
-    ev.run_started.user_input = "hello"
+    ev.run_started.run_id = "r1"
+    ev.run_started.goal_summary = "hello"
 
     await sink.emit(ev)
     await sink.close()


### PR DESCRIPTION
Closes #40.

## Summary

Every ``python`` snippet in ``docs/guides/`` was extracted and checked
against the live v0.1 surface. Each guide now matches what actually
ships.

## What changed

**``getting-started.md``**
- ``PassthroughPlanner(plan)`` → ``StaticPlanner(plan)`` — passthrough
  takes no args; ``StaticPlanner`` is the one that accepts a pre-baked
  plan.
- ``my_agent`` no longer calls ``report_task_*`` handlers with
  ``None`` as the steerer (that raised ``AttributeError``). Relies on
  the auto-complete behaviour introduced in #37 so a toy agent just
  returns an ``InvocationResult``.
- Event loop uses helpers that handle both Runner dict envelopes and
  proto ``Event`` messages; expected-output block matches the real
  stream (including the executor's duplicate ``run_started``).
- Claude swap example uses ``client_factory`` (real SDK shape) instead
  of the non-existent ``system_prompt=`` kwarg.
- Persistence snippet no longer pretends ``{run_id}`` is substituted.
- Model IDs point at ``claude-opus-4-5`` (not retired).

**``writing-an-agent-adapter.md``**
- Usage example uses ``StaticPlanner(my_plan)`` instead of
  ``PassthroughPlanner(plan=my_plan)``.

**``writing-an-event-sink.md``**
- Flags the v0.1 reality that sinks receive **both** dict envelopes
  (from Runner) and proto ``Event`` messages (from executors/steerer).
- ``StdoutSink``, ``HttpBackendSink`` drain loop, and ``FilteringSink``
  now accept both shapes.
- Replay example uses ``replay_from_jsonl`` (the module-level helper)
  instead of the non-existent ``JSONLPersistenceSink.from_jsonl``.
- Test snippet sets ``run_started.goal_summary`` (the real field)
  instead of ``user_input`` (not in the proto).

**``goals-and-plans.md``**
- ``PassthroughGoalDeriver`` now passed its required seed argument.
- Planner section covers ``PassthroughPlanner`` (no-op) and
  ``StaticPlanner`` (pre-baked plan) as distinct planners.
- ``LLMPlanner`` kwargs corrected: ``system_prompt`` /
  ``refine_system_prompt`` (the real names), not the
  ``*_override`` variants.
- Default-output JSON schema uses ``assignee_agent_id`` /
  ``from_task_id`` / ``to_task_id`` to match the shipped system
  prompt.

**``persistence-and-recovery.md``**
- Recovery import path: ``from goldfive.sinks import reconstruct_session,
  replay_from_jsonl`` (replacing the ``goldfive.recovery`` /
  ``JSONLPersistenceSink.from_jsonl`` references that never existed).
- ``Runner.resume`` signature corrected to the real
  ``resume(persistence_path)`` shape, with a note that live
  continuation is still TODO in v0.1.
- Truncated-tail paragraph matches actual ``replay_from_jsonl``
  behaviour (propagates ``ParseError`` on bad lines).

**``harmonograf-integration.md``** — no changes. The ``HarmonografSink``
and ``harmonograf_client`` snippets are clearly labelled as
forward-looking / in the harmonograf repo, and their shape matches
what goldfive's v0.1 ``EventSink`` protocol actually asks of them.

## Test plan

- [x] ``uv run pytest -q`` — 262 passed, 32 skipped (unchanged from main).
- [x] ``uv run --with ruff python -m ruff check goldfive/ tests/`` — clean.
- [x] ``hello.py`` lifted verbatim from ``getting-started.md`` runs and
  emits the documented sequence.
- [x] ``StdoutSink`` and ``FilteringSink`` lifted from
  ``writing-an-event-sink.md`` wired into a ``Runner`` produce the
  expected filtered event list.
- [x] ``MyGoalDeriver`` and ``MyPlanner`` from ``goals-and-plans.md``
  drive a ``Runner`` to ``success=True, tasks=1``.
- [x] Syntax check over every ``python`` snippet in all six guides
  parses as valid Python (the one skip is an indented fenced-block
  inside a markdown list — a display detail, not drift).