### PR TITLE
Align docs/reference/ + README hello snippet with goldfive v0.1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,29 +32,73 @@ Optional extras: `goldfive[adk]`, `goldfive[claude]`, `goldfive[dev]`.
 
 ## Hello goldfive
 
-> **Intended API — coming in #15.** The types below do not exist yet; this
-> snippet is a sketch of how the package will feel once the core lands.
-
 ```python
 import asyncio
-from goldfive import Runner, Goal, CallableAdapter, InMemorySink
 
-async def agent(prompt: str) -> str:
-    return f"echo: {prompt}"
+from goldfive import (
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+
+
+async def greeter(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    text = {
+        "greet": "Hello!",
+        "ask": "What's your name?",
+        "thank": "Thanks for chatting!",
+    }.get(task.id, "")
+    return InvocationResult(task_id=task.id, text=text)
+
 
 async def main() -> None:
+    plan = Plan(
+        id="hello",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="greet", title="Greet", assignee_agent_id="greeter"),
+            Task(id="ask", title="Ask for a name", assignee_agent_id="greeter"),
+            Task(id="thank", title="Thank the user", assignee_agent_id="greeter"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="greet", to_task_id="ask"),
+            TaskEdge(from_task_id="ask", to_task_id="thank"),
+        ],
+        summary="Greet, ask, thank.",
+    )
+
     sink = InMemorySink()
     runner = Runner(
-        adapter=CallableAdapter(agent),
-        goal=Goal("Summarize today's standup in three bullets."),
-        sink=sink,
+        agent=CallableAdapter(greeter, available_agents=["greeter"]),
+        planner=StaticPlanner(plan),
+        executor=SequentialExecutor(),
+        sinks=[sink],
     )
-    await runner.run()
-    for event in sink.events:
-        print(event)
+
+    outcome = await runner.run("run the greeter workflow")
+    await runner.close()
+
+    print(f"success={outcome.success} events={len(sink.events)}")
+
 
 asyncio.run(main())
 ```
+
+A runnable copy of this example lives in
+[`examples/hello_callable.py`](examples/hello_callable.py).
 
 ## Docs
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -9,7 +9,8 @@ Related: [PROTOCOLS.md](../design/PROTOCOLS.md),
 
 ## Top-level imports
 
-Everything documented here is re-exported from `goldfive.__init__`:
+Everything documented here is re-exported from `goldfive.__init__`
+(see `goldfive.__all__` for the canonical list):
 
 ```python
 from goldfive import (
@@ -22,11 +23,22 @@ from goldfive import (
     # results
     InvocationResult, ExecutionOutcome,
     # reporting
-    ReportingToolSpec,
+    ReportingToolSpec, BUILTIN_REPORTING_TOOLS,
+    # default implementations re-exported at the package root
+    CallableAdapter,
+    SequentialExecutor, ParallelDAGExecutor,
+    PassthroughPlanner, StaticPlanner, LLMPlanner,
+    PassthroughGoalDeriver, LiteralGoalDeriver, LLMGoalDeriver,
+    DefaultSteerer,
+    InMemorySink,
+    # drift helpers
+    classify_tool_error, classify_refusal, classify_stop_reason,
 )
 ```
 
-Subpackages for implementations:
+Subpackages for implementations not included in the package-root
+re-exports (adapters gated behind optional extras, the heavier sinks
+that require the `proto` extra, etc.):
 
 ```python
 from goldfive.adapters.callable import CallableAdapter
@@ -36,11 +48,18 @@ from goldfive.adapters.claude import ClaudeAgentSDKAdapter  # extra: claude
 from goldfive.executors.sequential import SequentialExecutor
 from goldfive.executors.parallel import ParallelDAGExecutor
 
-from goldfive.planner import PassthroughPlanner, LLMPlanner
-from goldfive.goal_deriver import PassthroughGoalDeriver, LLMGoalDeriver
+from goldfive.planner import PassthroughPlanner, StaticPlanner, LLMPlanner
+from goldfive.goal_deriver import (
+    PassthroughGoalDeriver, LiteralGoalDeriver, LLMGoalDeriver,
+)
 from goldfive.steerer import DefaultSteerer
 
-from goldfive.sinks import InMemorySink, LoggingSink, JSONLPersistenceSink
+from goldfive.sinks import (
+    InMemorySink,
+    LoggingSink,
+    JSONLPersistenceSink,
+    SQLitePersistenceSink,
+)
 ```
 
 ## `Runner`
@@ -70,19 +89,29 @@ class Runner:
 
     async def resume(
         self,
-        session: Session,
-    ) -> ExecutionOutcome: ...  # pairs with JSONLPersistenceSink
+        persistence_path: str,
+    ) -> ExecutionOutcome: ...  # best-effort JSONL replay
+
+    async def close(self) -> None: ...  # close every sink
 ```
+
+`Runner.resume(persistence_path)` loads a JSONL log written by
+`JSONLPersistenceSink`, replays it through
+`goldfive.sinks.reconstruct_session`, and returns an
+`ExecutionOutcome` whose `session` reflects the latest state seen in
+the log. v0.1 does not continue execution from the cursor — callers
+who want live continuation should build a fresh `Runner` from the
+recovered goals. Tracked in issue #15.
 
 | Parameter | Default | Notes |
 |---|---|---|
 | `agent` | required | Any `AgentAdapter`. |
 | `planner` | required | Any `Planner`. |
 | `executor` | required | Any `Executor`. Typically `SequentialExecutor()` or `ParallelDAGExecutor()`. |
-| `goal_deriver` | `PassthroughGoalDeriver()` | Optional; defaults substitute when `None`. |
+| `goal_deriver` | `PassthroughGoalDeriver("run")` | Optional. When `None`, the Runner substitutes a passthrough deriver that emits a single `Goal(id="g1", summary="run")`. |
 | `steerer` | `DefaultSteerer()` | Optional. |
 | `sinks` | `[]` | Optional. Recommended: at least `InMemorySink` in tests and `JSONLPersistenceSink` in prod. |
-| `max_plan_reinvocations` | `3` | Executor aborts after this many consecutive refine loops without net progress. |
+| `max_plan_reinvocations` | `3` | Stamped onto the planner context so executors that honour it can cap refine loops. |
 
 ## Data types (`goldfive.types`)
 
@@ -109,7 +138,7 @@ class DriftSeverity(StrEnum):
 
 ### `DriftKind`
 
-25+ values. See [DRIFT.md](../design/DRIFT.md) for the full
+25 values. See [DRIFT.md](../design/DRIFT.md) for the full
 taxonomy. Examples:
 
 ```python
@@ -238,15 +267,16 @@ class ExecutionOutcome:
 
 ## Protocols (`goldfive.protocols`)
 
-All are `@runtime_checkable`. Full contracts in
+All are `@runtime_checkable`. Every method is `async` unless explicitly
+marked otherwise below. Full contracts in
 [PROTOCOLS.md](../design/PROTOCOLS.md).
 
 | Protocol | Methods |
 |---|---|
 | `GoalDeriver` | `derive(user_input, *, context=None) -> list[Goal]` |
 | `Planner` | `generate(*, goals, available_agents, context=None) -> Optional[Plan]` · `refine(*, plan, drift, goals) -> Optional[Plan]` |
-| `Steerer` | `observe(event, session)` · `transition(task_id, to, *, detail="", session)` · `detect_drift(event, session) -> Optional[DriftEvent]` · `bind(*, sinks, planner)` |
-| `AgentAdapter` | `register_reporting_tools(tools)` · `invoke(task, session) -> InvocationResult` · property `available_agents: list[str]` |
+| `Steerer` | `observe(event, session)` · `transition(task_id, to, *, detail="", session)` · `detect_drift(event, session) -> Optional[DriftEvent]` (sync) · `bind(*, sinks, planner)` (sync) |
+| `AgentAdapter` | `register_reporting_tools(tools)` · `invoke(task, session) -> InvocationResult` · property `available_agents: list[str]` (sync) |
 | `Executor` | `run(*, plan, session, adapter, steerer, planner, sinks) -> ExecutionOutcome` |
 | `EventSink` | `emit(event_pb)` · `close()` |
 
@@ -256,32 +286,47 @@ All are `@runtime_checkable`. Full contracts in
 
 ```python
 class PassthroughGoalDeriver(GoalDeriver):
-    async def derive(self, user_input, *, context=None): ...
+    def __init__(self, goals: str | list[str] | list[Goal]) -> None: ...
+    # ``derive(user_input, ...)`` ignores ``user_input`` and returns
+    # the pre-configured goals verbatim.
+
+class LiteralGoalDeriver(GoalDeriver):
+    def __init__(self) -> None: ...
+    # ``derive(user_input, ...)`` wraps a non-empty string as a single
+    # ``Goal(id="g1", summary=user_input)``.
 
 class LLMGoalDeriver(GoalDeriver):
     def __init__(
         self,
-        *,
         call_llm: Callable[[str, str, str], Awaitable[str]],
-        model: str,
-    ): ...
+        model: str = "",
+        *,
+        system_prompt: Optional[str] = None,
+    ) -> None: ...
 ```
 
 ### Planners (`goldfive.planner`)
 
 ```python
 class PassthroughPlanner(Planner):
-    def __init__(self, *, plan: Plan): ...
+    def __init__(self) -> None: ...
+    # generate() and refine() always return None.
+
+class StaticPlanner(Planner):
+    def __init__(self, plan: Plan) -> None: ...
+    # generate() returns a fresh copy of ``plan`` with run_id and
+    # goal_ids rewritten to match the current session. refine()
+    # always returns None.
 
 class LLMPlanner(Planner):
     def __init__(
         self,
         *,
         call_llm: Callable[[str, str, str], Awaitable[str]],
-        model: str,
-        system_prompt_override: Optional[str] = None,
-        refine_system_prompt_override: Optional[str] = None,
-    ): ...
+        model: str = "",
+        system_prompt: Optional[str] = None,
+        refine_system_prompt: Optional[str] = None,
+    ) -> None: ...
 ```
 
 ### Steerer (`goldfive.steerer`)
@@ -292,6 +337,13 @@ class DefaultSteerer(Steerer):
     # DRIFT.md and STATE-MACHINE.md. No required constructor args.
 ```
 
+In addition to the `Steerer` protocol methods, `DefaultSteerer`
+exposes `mark_task_running`, `mark_task_progress`,
+`mark_task_completed`, `mark_task_failed`, `mark_task_blocked`,
+`mark_task_cancelled`, `report_new_work_discovered`, and
+`report_plan_divergence` for the canonical reporting-tool handlers to
+call into.
+
 ### Executors (`goldfive.executors`)
 
 ```python
@@ -299,16 +351,17 @@ class SequentialExecutor(Executor):
     def __init__(
         self,
         *,
-        nudge_timeout_s: float = 60.0,
-    ): ...
+        max_plan_reinvocations: int = 3,
+        fail_fast: bool = True,
+    ) -> None: ...
 
 class ParallelDAGExecutor(Executor):
     def __init__(
         self,
-        *,
-        max_concurrency: Optional[int] = None,
+        max_concurrency: int = 0,  # 0 = unbounded fan-out
         drift_policy: Literal["cancel_stage", "finish_stage"] = "finish_stage",
-    ): ...
+        max_plan_reinvocations: int = 3,
+    ) -> None: ...
 ```
 
 ### Adapters (`goldfive.adapters`)
@@ -324,33 +377,40 @@ class CallableAdapter(AgentAdapter):
         ],
         *,
         available_agents: Optional[list[str]] = None,
-    ): ...
+    ) -> None: ...
 
 # Requires `goldfive[adk]`
 class ADKAdapter(AgentAdapter):
     def __init__(
         self,
-        root_agent: Any,  # google.adk.BaseAgent
+        agent_or_runner: Any,  # google.adk.BaseAgent OR an existing Runner
         *,
-        runner: Optional[Any] = None,
-    ): ...
+        user_id: str = "goldfive_user",
+        session_id: Optional[str] = None,
+        app_name: Optional[str] = None,
+    ) -> None: ...
 
 # Requires `goldfive[claude]`
 class ClaudeAgentSDKAdapter(AgentAdapter):
     def __init__(
         self,
         *,
-        system_prompt: str,
-        model: str,
-        client: Optional[Any] = None,  # claude_agent_sdk.ClaudeSDKClient
-    ): ...
+        client_factory: Callable[[], Any],  # () -> claude_agent_sdk.ClaudeSDKClient
+        steerer: Optional[Steerer] = None,
+        system_prompt_template: Optional[str] = None,
+        model: Optional[str] = None,
+        available_agents: Optional[list[str]] = None,
+    ) -> None: ...
+
+    def bind_steerer(self, steerer: Steerer) -> None:
+        """Wire a :class:`Steerer` in after construction."""
 ```
 
 ### Sinks (`goldfive.sinks`)
 
 ```python
 class InMemorySink(EventSink):
-    events: list[Event]  # attribute, inspect after the run
+    events: list[Any]  # property — the live event list
 
 class LoggingSink(EventSink):
     def __init__(
@@ -358,18 +418,53 @@ class LoggingSink(EventSink):
         *,
         logger: Optional[logging.Logger] = None,
         level: int = logging.INFO,
-    ): ...
+    ) -> None: ...
 
 class JSONLPersistenceSink(EventSink):
     def __init__(
         self,
-        path: str,  # may contain {run_id} placeholder
-    ): ...
+        path: str | Path,
+        mode: Literal["append", "write"] = "append",
+    ) -> None: ...
 
-    @classmethod
-    def from_jsonl(cls, path: str) -> list[Event]:
-        """Load a run's events for replay / recovery."""
+class SQLitePersistenceSink(EventSink):
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        table: str = "goldfive_events",
+    ) -> None: ...
+
+
+# Module-level replay / reconstruction helpers.
+def replay_from_jsonl(path: str | Path) -> list[Any]:
+    """Parse a JSONL log written by ``JSONLPersistenceSink`` into Event
+    proto messages, in emit order."""
+
+def replay_from_sqlite(
+    path: str | Path,
+    run_id: str,
+    *,
+    table: str = "goldfive_events",
+) -> list[Any]:
+    """Read a single run's events from a SQLite database, ordered by
+    sequence."""
+
+def list_runs(
+    path: str | Path,
+    *,
+    table: str = "goldfive_events",
+) -> list[str]:
+    """Return the distinct run_ids present in a SQLite database."""
+
+def reconstruct_session(events: list[Any]) -> Session:
+    """Replay events to rebuild a best-effort :class:`Session`."""
 ```
+
+`LoggingSink`, `JSONLPersistenceSink`, `SQLitePersistenceSink`, and
+the replay helpers require the `proto` extra (they lean on
+`google.protobuf`). When the extra is missing the symbols resolve to
+``None`` at import time so the rest of the package stays usable.
 
 ## Reporting (`goldfive.reporting`)
 
@@ -378,7 +473,7 @@ class JSONLPersistenceSink(EventSink):
 class ReportingToolSpec:
     name: str
     description: str
-    parameters: dict[str, Any]
+    parameters: dict[str, Any]   # JSON schema
     handler: Callable[
         [dict[str, Any], Session, Steerer],
         Awaitable[dict[str, Any]],
@@ -386,7 +481,7 @@ class ReportingToolSpec:
 
 
 # The seven canonical tool names (stable contract).
-REPORTING_TOOL_NAMES: frozenset[str] = frozenset({
+REPORTING_TOOL_NAMES: tuple[str, ...] = (
     "report_task_started",
     "report_task_progress",
     "report_task_completed",
@@ -394,11 +489,13 @@ REPORTING_TOOL_NAMES: frozenset[str] = frozenset({
     "report_task_blocked",
     "report_new_work_discovered",
     "report_plan_divergence",
-})
+)
 
 
-def build_default_reporting_tools(steerer: Steerer) -> list[ReportingToolSpec]:
-    """The seven canonical tool specs, wired to `steerer`."""
+# Pre-built list of the seven canonical specs. ``Runner`` registers
+# these with the adapter automatically; custom adapters can consume
+# the list directly.
+BUILTIN_REPORTING_TOOLS: list[ReportingToolSpec]
 ```
 
 See [tool-protocol.md](tool-protocol.md) for full semantics.
@@ -406,15 +503,32 @@ See [tool-protocol.md](tool-protocol.md) for full semantics.
 ## Events (`goldfive.events`)
 
 ```python
-def new_event(run_id: str, sequence: int) -> Event:
+def new_event(run_id: str, sequence: int) -> Any:
     """Fresh envelope with run_id, sequence, emitted_at populated."""
 
-def now_ts() -> google.protobuf.Timestamp:
-    """Current wall-clock time as a proto Timestamp."""
+def make_event(
+    *,
+    run_id: str,
+    sequence: int,
+    kind: str,
+    payload: dict[str, Any],
+) -> Any:
+    """Build an envelope from a ``kind`` + ``payload`` dict. Falls back
+    to a plain dict when the ``proto`` extra is not installed."""
 
-async def emit(sinks: list[EventSink], event_pb: Event) -> None:
+def now_ts() -> Any:
+    """Current wall-clock time as a proto ``Timestamp``."""
+
+async def emit(sinks: list[EventSink], event_pb: Any) -> None:
     """Fan out to every sink; swallow per-sink exceptions."""
 ```
+
+Per-event builders (`run_started_event`, `run_completed_event`,
+`run_aborted_event`, `goal_derived_event`, `plan_submitted_event`,
+`plan_revised_event`, `task_started_event`, `task_progress_event`,
+`task_completed_event`, `task_failed_event`, `task_blocked_event`,
+`task_cancelled_event`, `drift_detected_event`) are also available in
+`goldfive.events` as convenience constructors for sink implementations.
 
 ## Proto (`goldfive.pb.goldfive.v1`)
 
@@ -445,14 +559,27 @@ def from_pb_plan(msg: pb.Plan) -> Plan: ...
 def to_pb_goal(goal: Goal) -> pb.Goal: ...
 def from_pb_goal(msg: pb.Goal) -> Goal: ...
 
-# ... similar for Task, TaskEdge, DriftEvent
+def to_pb_task(task: Task) -> pb.Task: ...
+def from_pb_task(msg: pb.Task) -> Task: ...
+
+def to_pb_task_edge(edge: TaskEdge) -> pb.TaskEdge: ...
+def from_pb_task_edge(msg: pb.TaskEdge) -> TaskEdge: ...
+
+def to_pb_drift_event(evt: DriftEvent) -> pb.DriftEvent: ...
+def from_pb_drift_event(msg: pb.DriftEvent) -> DriftEvent: ...
 ```
 
-## Recovery (`goldfive.recovery`)
+## Recovery (`goldfive.sinks`)
 
 ```python
-def reconstruct_session(events: list[Event]) -> Session:
-    """Replay events to rebuild a Session from scratch."""
+def replay_from_jsonl(path: str | Path) -> list[Any]:
+    """Parse a JSONL log into ``Event`` proto messages, in emit order."""
+
+def replay_from_sqlite(path: str | Path, run_id: str) -> list[Any]:
+    """Read a single run's events from a SQLite database."""
+
+def reconstruct_session(events: list[Any]) -> Session:
+    """Replay events to rebuild a best-effort :class:`Session`."""
 ```
 
 Used by `Runner.resume()`. See
@@ -464,11 +591,16 @@ For custom steerer subclasses that want to compose the standard
 classifiers:
 
 ```python
-def classify_tool_error(err: Exception, tool_name: str) -> DriftEvent: ...
-def classify_refusal(text: str) -> Optional[DriftEvent]: ...
-def classify_stop_reason(reason: str) -> Optional[DriftEvent]: ...
-def classify_schema_violation(payload: Any, schema: Any) -> DriftEvent: ...
+def classify_tool_error(event: Any) -> Optional[DriftEvent]: ...
+def classify_refusal(text: Any) -> Optional[DriftEvent]: ...
+def classify_stop_reason(reason: Any) -> Optional[DriftEvent]: ...
 ```
+
+Each returns `None` when the input does not match the classifier's
+signal; callers compose them into a steerer's `detect_drift`
+pipeline. The module also exposes the marker tables
+`LLM_REFUSAL_MARKERS: tuple[str, ...]` and
+`CONTEXT_PRESSURE_STOP_REASONS: tuple[str, ...]` for downstream reuse.
 
 ## Version compatibility
 

--- a/docs/reference/tool-protocol.md
+++ b/docs/reference/tool-protocol.md
@@ -68,9 +68,10 @@ report_task_started(task_id: str, detail: str = "") -> dict
 
 **Side effects:**
 
-- Steerer transitions `task_id` from PENDING to RUNNING.
-- `session.current_task_id` is set.
-- `session.agent_notes[task_id] = detail`.
+- Steerer transitions `task_id` to RUNNING (unless the task is
+  already in a terminal status, in which case the call is a no-op).
+- `session.current_task_id = task_id`.
+- `session.agent_notes[task_id] = detail` when `detail` is non-empty.
 - Emits `TaskStarted(task_id, detail)`.
 
 **Example:**
@@ -95,8 +96,8 @@ announce. Optional; not required for correct operation.
 
 **Side effects:**
 
-- `session.task_progress[task_id] = fraction`.
-- `session.agent_notes[task_id] = detail`.
+- `session.task_progress[task_id] = fraction` (clamped to `[0.0, 1.0]`).
+- `session.agent_notes[task_id] = detail` when `detail` is non-empty.
 - Emits `TaskProgress(task_id, fraction, detail)`.
 - **No state transition.**
 
@@ -128,7 +129,8 @@ report_task_completed(
 
 **Side effects:**
 
-- Steerer transitions `task_id` from RUNNING to COMPLETED.
+- Steerer transitions `task_id` to COMPLETED (no-op if already
+  terminal).
 - `session.completed_results[task_id] = summary`. Downstream tasks
   see this in their context.
 - Emits `TaskCompleted(task_id, summary, artifacts)`.
@@ -161,9 +163,7 @@ report_task_failed(
 
 **Side effects:**
 
-- Steerer transitions `task_id` from RUNNING to FAILED.
-- `session.completed_results[task_id] = reason` (so failed tasks'
-  messages are still visible to downstream work).
+- Steerer transitions `task_id` to FAILED (no-op if already terminal).
 - Emits `TaskFailed(task_id, reason, recoverable)`.
 - Fires `DriftEvent(kind=TASK_FAILED_RECOVERABLE, severity=warning)`
   if `recoverable=True`.
@@ -200,12 +200,12 @@ asynchronous external process, rate-limited.
 
 **Side effects:**
 
-- Depending on blocker type:
-  - If structural (can be resolved by replanning): task transitions
-    to BLOCKED and fires `DriftEvent(kind=BLOCKED)`.
-  - If transient (will resolve on its own): task stays RUNNING,
-    `agent_notes` captures the blocker.
+- Steerer transitions `task_id` to BLOCKED (no-op if already terminal).
+- `session.agent_notes[task_id]` captures a `"blocked: <blocker>"`
+  message (and `(needed: <needed>)` when `needed` is non-empty).
 - Emits `TaskBlocked(task_id, blocker, needed)`.
+- Fires `DriftEvent(kind=BLOCKED, severity=warning)` which flows
+  through the standard drift pipeline (≥ WARNING → `planner.refine`).
 
 **Example:**
 
@@ -216,11 +216,6 @@ await report_task_blocked(
     needed="human confirmation via the approval queue",
 )
 ```
-
-The distinction between structural and transient is made by the
-steerer based on the `blocker` string — a classifier inspects for
-keywords like "awaiting", "waiting on", "needs human", etc. Custom
-steerers can override.
 
 ### 6. `report_new_work_discovered`
 
@@ -299,7 +294,7 @@ tools above; `report_plan_divergence` is the catch-all.
 | `report_task_progress` | `(task_id, fraction=0.0, detail="")` | RUNNING → RUNNING | — |
 | `report_task_completed` | `(task_id, summary, artifacts=None)` | RUNNING → COMPLETED | — |
 | `report_task_failed` | `(task_id, reason, recoverable=True)` | RUNNING → FAILED | `TASK_FAILED_RECOVERABLE` or `TASK_FAILED_FATAL` |
-| `report_task_blocked` | `(task_id, blocker, needed="")` | RUNNING → BLOCKED (structural) or stays RUNNING | `BLOCKED` |
+| `report_task_blocked` | `(task_id, blocker, needed="")` | RUNNING → BLOCKED | `BLOCKED` |
 | `report_new_work_discovered` | `(parent_task_id, title, description, assignee="")` | none | `NEW_WORK_DISCOVERED` |
 | `report_plan_divergence` | `(note, suggested_action="")` | none | `PLAN_DIVERGENCE` |
 


### PR DESCRIPTION
Closes #41.

Walks `docs/reference/api.md`, `docs/reference/tool-protocol.md`, and the
README hello snippet against the merged goldfive v0.1 surface and fixes
every signature / side-effect / import drift found.

## Summary

- **`docs/reference/api.md`** — comprehensive rewrite to match live code:
  - `Runner.resume(persistence_path: str)` (was documented as taking a `Session`)
  - Adds `StaticPlanner`, `LiteralGoalDeriver`, `SQLitePersistenceSink`, and the
    module-level replay/reconstruction helpers (`replay_from_jsonl`,
    `replay_from_sqlite`, `list_runs`, `reconstruct_session`)
  - Corrects constructor shapes: `PassthroughPlanner()`, `PassthroughGoalDeriver(goals)`,
    `LLMPlanner(system_prompt=…, refine_system_prompt=…)`, `LLMGoalDeriver(call_llm, model, *, system_prompt)`,
    `SequentialExecutor(*, max_plan_reinvocations, fail_fast)`,
    `ParallelDAGExecutor(max_concurrency, drift_policy, max_plan_reinvocations)`,
    `ADKAdapter(agent_or_runner, *, user_id, session_id, app_name)`,
    `ClaudeAgentSDKAdapter(*, client_factory, steerer, system_prompt_template, model, available_agents)`
  - Replaces the fictional `build_default_reporting_tools(steerer)` with the actual
    `BUILTIN_REPORTING_TOOLS` constant; flips `REPORTING_TOOL_NAMES` from `frozenset`
    to `tuple`
  - Moves recovery helpers under `goldfive.sinks` (there is no `goldfive.recovery`)
  - Fixes `classify_tool_error(event)` signature and drops nonexistent
    `classify_schema_violation`
  - Adds `Path`/`mode`/`table` parameters on the persistence sinks

- **`docs/reference/tool-protocol.md`** — drops the fictional structural-vs-transient
  blocker classifier (no such classifier exists in `DefaultSteerer`); corrects
  `TaskFailed` side-effects (it does **not** write into `completed_results`); fixes
  the summary table's Blocked transition.

- **`README.md`** — replaces the stale placeholder snippet (which referenced
  non-existent `Runner(adapter=…, goal=…, sink=…)` shape and the "Intended API —
  coming in #15" banner) with a runnable snippet that mirrors
  `examples/hello_callable.py` and drives `StaticPlanner` + `SequentialExecutor`.

## Test plan

- [x] `uv run pytest -q` — 262 passed, 32 skipped, no regressions
- [x] `uv run python -m ruff check .` — all checks passed
- [x] Extracted the first `python` block from `README.md` and ran it end-to-end —
  `success=True events=11`
- [x] Wrote a consumer script exercising every `from goldfive import …` line in the
  api.md top-level-imports block and every `from goldfive.X import …` subpackage
  line — all imports resolve
