### PR TITLE
Consistency audit: fix API drift

### DIFF
--- a/goldfive/adapters/claude.py
+++ b/goldfive/adapters/claude.py
@@ -26,7 +26,7 @@ Key design points:
 * The system prompt template is public and overrideable — see
   :mod:`goldfive.adapters._claude_prompt`.
 
-This module is pinned to the shapes in ``INTERFACE_SPEC.md``.
+This module is pinned to the shapes in ``docs/design/PROTOCOLS.md``.
 """
 
 from __future__ import annotations

--- a/goldfive/executors/__init__.py
+++ b/goldfive/executors/__init__.py
@@ -1,7 +1,7 @@
 """Built-in executors.
 
 Each executor drives a :class:`Plan` to completion against an
-:class:`AgentAdapter`. See ``INTERFACE_SPEC.md`` for the contract.
+:class:`AgentAdapter`. See ``docs/design/PROTOCOLS.md`` for the contract.
 """
 
 from __future__ import annotations

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -569,6 +569,5 @@ class LLMPlanner:
 __all__ = [
     "LLMPlanner",
     "PassthroughPlanner",
-    "_plan_from_json",
-    "_strip_code_fences",
+    "StaticPlanner",
 ]

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1,6 +1,6 @@
 """Core dataclasses and enums for goldfive.
 
-Pinned by ``INTERFACE_SPEC.md`` (v0.1). See issue #4. Types in this module are
+Pinned by ``docs/design/PROTOCOLS.md`` (v0.1). Types in this module are
 pure data — mutation of live state happens only through a ``Steerer``.
 """
 


### PR DESCRIPTION
Fixes discovered during a proactive consistency audit for v0.1 API drift.

## Issues fixed

- **`goldfive/planner.py` `__all__` drift**: `StaticPlanner` (a public class re-exported from `goldfive/__init__.py`) was missing from `__all__`, while two private helpers (`_plan_from_json`, `_strip_code_fences`) were incorrectly included. Fixed.
- **Stale `INTERFACE_SPEC.md` docstring references**: That file has been deleted in favour of `docs/design/PROTOCOLS.md`. Three source files still pointed readers at the dead path: `goldfive/types.py`, `goldfive/executors/__init__.py`, and `goldfive/adapters/claude.py`. Updated to the live path.

## Scope

This is a drift-correction audit, not a refactor — changes are minimal (4 lines added, 5 removed). Runner/Executor/Steerer event emission is explicitly out of scope because issue #53 is fixing that in parallel.

## Test plan

- [x] `uv run pytest -q` — 269 passed, 32 skipped (baseline preserved)