### PR TITLE
Runner emits proto events consistently (fixes #53)

### DIFF
--- a/examples/hello_callable.py
+++ b/examples/hello_callable.py
@@ -81,9 +81,19 @@ async def main() -> None:
     print(f"goals={[g.summary for g in outcome.session.goals]}")
     print(f"{len(sink.events)} events:")
     for e in sink.events:
-        seq = e["sequence"] if isinstance(e, dict) else getattr(e, "sequence", "?")
-        kind = e["kind"] if isinstance(e, dict) else getattr(e, "kind", "?")
-        payload = e.get("payload") if isinstance(e, dict) else getattr(e, "payload", {})
+        if isinstance(e, dict):
+            seq = e.get("sequence", "?")
+            kind = e.get("kind", "?")
+            payload = e.get("payload", {})
+        else:
+            seq = getattr(e, "sequence", "?")
+            oneof = e.WhichOneof("payload") if hasattr(e, "WhichOneof") else None
+            kind = (
+                "".join(part.capitalize() for part in oneof.split("_"))
+                if oneof
+                else "?"
+            )
+            payload = getattr(e, oneof) if oneof else "{}"
         print(f"  seq={seq:>3}  {kind:<16}  {payload}")
 
 

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -15,16 +15,27 @@ bound ``Steerer``; on a drift whose severity is at or above WARNING the
 tasks in the stage or (b) let siblings finish before refining. Plan
 refinement never happens mid-stage — that matches the harmonograf
 walker's semantics and keeps the DAG walk deterministic.
+
+Lifecycle ownership: ``RunStarted`` is emitted by :class:`~goldfive.Runner`,
+not by the executor. The executor owns the terminal ``RunCompleted`` /
+``RunAborted`` and the ``PlanRevised`` events it generates when the
+walker swaps in a refined plan.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Literal
+from typing import Literal
 
-from goldfive.events import emit as emit_event
-from goldfive.events import make_event
+from goldfive.events import (
+    emit as emit_event,
+)
+from goldfive.events import (
+    plan_revised_event,
+    run_aborted_event,
+    run_completed_event,
+)
 from goldfive.protocols import (
     AgentAdapter,
     EventSink,
@@ -119,12 +130,8 @@ class ParallelDAGExecutor:
         except Exception as exc:  # noqa: BLE001
             log.debug("ParallelDAGExecutor: steerer.bind raised: %s", exc)
 
-        await self._emit(
-            session,
-            sinks,
-            kind="RunStarted",
-            payload={"plan_id": plan.id, "goal_ids": list(plan.goal_ids)},
-        )
+        # NOTE: RunStarted is emitted by Runner, not by the executor. See
+        # Runner._emit_run_started.
 
         refinements_used = 0
         completed_stage_ids: set[str] = set()
@@ -154,17 +161,6 @@ class ParallelDAGExecutor:
                 stage_tasks = [t for t in stage if t.id not in completed_stage_ids]
                 if not stage_tasks:
                     continue
-
-                stage_index = len(completed_stage_ids)  # ordinal-ish, for logs
-                await self._emit(
-                    session,
-                    sinks,
-                    kind="StageStarted",
-                    payload={
-                        "stage_index": stage_index,
-                        "task_ids": [t.id for t in stage_tasks],
-                    },
-                )
 
                 stage_results, drift = await self._run_stage(
                     stage_tasks, session, adapter, steerer, sinks
@@ -209,16 +205,6 @@ class ParallelDAGExecutor:
                             session.completed_results[task.id] = inv.text
                     completed_stage_ids.add(task.id)
 
-                await self._emit(
-                    session,
-                    sinks,
-                    kind="StageCompleted",
-                    payload={
-                        "stage_index": stage_index,
-                        "task_ids": [t.id for t, *_ in stage_results],
-                    },
-                )
-
                 if drift is not None:
                     if refinements_used >= self.max_plan_reinvocations:
                         log.warning(
@@ -238,17 +224,14 @@ class ParallelDAGExecutor:
                     if refined is not None and refined is not (session.plan or plan):
                         refinements_used += 1
                         session.plan = refined
-                        await self._emit(
-                            session,
+                        await emit_event(
                             sinks,
-                            kind="PlanRevised",
-                            payload={
-                                "plan_id": refined.id,
-                                "revision_index": refined.revision_index,
-                                "reason": refined.revision_reason,
-                                "kind": refined.revision_kind,
-                                "severity": refined.revision_severity,
-                            },
+                            plan_revised_event(
+                                run_id=session.run_id,
+                                sequence=session.next_sequence(),
+                                plan=refined,
+                                drift=drift,
+                            ),
                         )
                         # Falls through to loop top: stages recomputed.
                         continue
@@ -256,30 +239,36 @@ class ParallelDAGExecutor:
                 # No drift (or no refinement): continue to next stage.
         except BaseException as exc:  # noqa: BLE001 — propagate reason, then re-raise
             abort_reason = f"{type(exc).__name__}: {exc}"
-            await self._emit(
-                session,
+            await emit_event(
                 sinks,
-                kind="RunAborted",
-                payload={"reason": abort_reason},
+                run_aborted_event(
+                    run_id=session.run_id,
+                    sequence=session.next_sequence(),
+                    reason=abort_reason,
+                ),
             )
             if isinstance(exc, asyncio.CancelledError):
                 raise
             return ExecutionOutcome(success=False, session=session, reason=abort_reason)
 
         if abort_reason:
-            await self._emit(
-                session,
+            await emit_event(
                 sinks,
-                kind="RunAborted",
-                payload={"reason": abort_reason},
+                run_aborted_event(
+                    run_id=session.run_id,
+                    sequence=session.next_sequence(),
+                    reason=abort_reason,
+                ),
             )
             return ExecutionOutcome(success=False, session=session, reason=abort_reason)
 
-        await self._emit(
-            session,
+        await emit_event(
             sinks,
-            kind="RunCompleted",
-            payload={"completed_task_ids": sorted(completed_stage_ids)},
+            run_completed_event(
+                run_id=session.run_id,
+                sequence=session.next_sequence(),
+                outcome_summary=_outcome_summary(completed_stage_ids),
+            ),
         )
         return ExecutionOutcome(success=True, session=session)
 
@@ -435,25 +424,13 @@ class ParallelDAGExecutor:
             return None
         return refined
 
-    # ------------------------------------------------------------------
-    # Event emission
-    # ------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
-    async def _emit(
-        self,
-        session: Session,
-        sinks: list[EventSink],
-        *,
-        kind: str,
-        payload: dict[str, Any],
-    ) -> None:
-        ev = make_event(
-            run_id=session.run_id,
-            sequence=session.next_sequence(),
-            kind=kind,
-            payload=payload,
-        )
-        await emit_event(sinks, ev)
+
+def _outcome_summary(completed_task_ids: set[str]) -> str:
+    return f"{len(completed_task_ids)} tasks completed"
 
 
 # Runtime conformance check — the class must satisfy the Executor protocol.

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -13,7 +13,6 @@ mutated task state via the Steerer.
 
 Key behaviors
 -------------
-* Emit :class:`RunStarted` once, then iterate tasks.
 * Honor the plan's topological order: only invoke tasks whose predecessors
   are ``COMPLETED``. Walk tasks one-at-a-time (no parallelism).
 * After each invocation, re-read plan state: tasks may have moved to
@@ -23,6 +22,11 @@ Key behaviors
   so a stuck agent cannot spin forever.
 * Terminate with :class:`RunCompleted` on success or :class:`RunAborted`
   when ``fail_fast`` is set and a task fails fatally.
+
+Lifecycle ownership: the executor does NOT emit ``RunStarted``. The
+:class:`Runner` owns ``Run*`` lifecycle events; the executor owns the
+terminal ``RunCompleted`` / ``RunAborted`` plus ``PlanRevised`` and the
+per-task ``Task*`` events (the latter via the steerer).
 """
 
 from __future__ import annotations
@@ -34,7 +38,6 @@ from goldfive.events import (
     plan_revised_event,
     run_aborted_event,
     run_completed_event,
-    run_started_event,
 )
 from goldfive.protocols import AgentAdapter, EventSink, Executor, Planner, Steerer
 from goldfive.results import ExecutionOutcome
@@ -98,15 +101,8 @@ class SequentialExecutor(Executor):
         # can emit events and trigger planner.refine on drift.
         steerer.bind(sinks=sinks, planner=planner)
 
-        # Emit RunStarted.
-        await emit(
-            sinks,
-            run_started_event(
-                run_id=session.run_id,
-                sequence=session.next_sequence(),
-                goal_summary=_goal_summary(session, plan),
-            ),
-        )
+        # NOTE: RunStarted is emitted by Runner, not by the executor. See
+        # Runner._emit_run_started.
 
         invocations = 0
         failure_reason = ""
@@ -344,16 +340,6 @@ def _find_task(plan: Plan, task_id: str) -> Task | None:
 
 def _any_failed(plan: Plan) -> bool:
     return any(t.status == TaskStatus.FAILED for t in plan.tasks)
-
-
-def _goal_summary(session: Session, plan: Plan) -> str:
-    """Best-effort one-line summary for the RunStarted event."""
-    if session.goals:
-        first = session.goals[0]
-        summary = getattr(first, "summary", "") or ""
-        if summary:
-            return summary
-    return plan.summary or f"plan {plan.id}"
 
 
 def _outcome_summary(session: Session) -> str:

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -15,6 +15,19 @@ binds the steerer to the sinks+planner, and hands everything to the
 executor. The returned :class:`ExecutionOutcome` carries the final live
 :class:`Session` so callers can inspect completed tasks / artifacts.
 
+Event lifecycle ownership
+-------------------------
+* The Runner owns ``Run*`` lifecycle events (``RunStarted``,
+  ``GoalDerived``, ``PlanSubmitted``, and pre-executor ``RunAborted``).
+* Executors own ``Task*`` events, ``PlanRevised``, and the terminal
+  ``RunCompleted`` / ``RunAborted`` they emit when their own state
+  machine reaches the end of the run.
+* The Steerer owns ``DriftDetected`` and the per-task ``mark_task_*``
+  emissions.
+
+All sink emissions are proto :class:`Event` envelopes — built via the
+typed factories in :mod:`goldfive.events`.
+
 No ADK or Claude Agent SDK imports live in this module. Optional
 adapter implementations live under ``goldfive.adapters.<framework>``
 and are loaded lazily by callers.
@@ -28,7 +41,13 @@ import uuid
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
-from goldfive.events import emit, make_event
+from goldfive.events import (
+    emit,
+    goal_derived_event,
+    plan_submitted_event,
+    run_aborted_event,
+    run_started_event,
+)
 from goldfive.goal_deriver import PassthroughGoalDeriver
 from goldfive.reporting import BUILTIN_REPORTING_TOOLS
 from goldfive.results import ExecutionOutcome
@@ -119,14 +138,7 @@ class Runner:
         )
 
         # 2. Emit RunStarted before anything else.
-        await self._emit(
-            session,
-            "RunStarted",
-            {
-                "started_at_ms": session.started_at_ms,
-                "input_kind": _input_kind(user_input),
-            },
-        )
+        await self._emit_run_started(session, user_input)
 
         # 3. Derive (or accept) goals.
         try:
@@ -134,15 +146,11 @@ class Runner:
         except Exception as exc:  # noqa: BLE001
             reason = f"goal derivation failed: {exc}"
             log.exception("goal derivation failed")
-            await self._emit(session, "RunAborted", {"reason": reason})
+            await self._emit_run_aborted(session, reason)
             return ExecutionOutcome(success=False, session=session, reason=reason)
         session.goals = list(goals)
 
-        await self._emit(
-            session,
-            "GoalDerived",
-            {"goals": [{"id": g.id, "summary": g.summary} for g in session.goals]},
-        )
+        await self._emit_goal_derived(session)
 
         # Build the context passed to the planner — stamp run_id so LLM
         # planners can include it in the plan envelope.
@@ -160,12 +168,12 @@ class Runner:
         except Exception as exc:  # noqa: BLE001
             reason = f"planner.generate raised: {exc}"
             log.exception("planner.generate raised")
-            await self._emit(session, "RunAborted", {"reason": reason})
+            await self._emit_run_aborted(session, reason)
             return ExecutionOutcome(success=False, session=session, reason=reason)
 
         if plan is None:
             reason = "no plan generated"
-            await self._emit(session, "RunAborted", {"reason": reason})
+            await self._emit_run_aborted(session, reason)
             return ExecutionOutcome(success=False, session=session, reason=reason)
 
         # Planners may leave run_id blank; stamp ours so downstream sinks
@@ -174,17 +182,7 @@ class Runner:
             plan.run_id = session.run_id
         session.plan = plan
 
-        await self._emit(
-            session,
-            "PlanSubmitted",
-            {
-                "plan_id": plan.id,
-                "summary": plan.summary,
-                "task_count": len(plan.tasks),
-                "edge_count": len(plan.edges),
-                "revision_index": plan.revision_index,
-            },
-        )
+        await self._emit_plan_submitted(session, plan)
 
         # 5. Register the seven canonical reporting tools on the adapter.
         try:
@@ -192,7 +190,7 @@ class Runner:
         except Exception as exc:  # noqa: BLE001
             reason = f"register_reporting_tools raised: {exc}"
             log.exception("register_reporting_tools raised")
-            await self._emit(session, "RunAborted", {"reason": reason})
+            await self._emit_run_aborted(session, reason)
             return ExecutionOutcome(success=False, session=session, reason=reason)
 
         # 6. Bind the steerer. (The executor may re-bind — that's fine.)
@@ -201,7 +199,7 @@ class Runner:
         except Exception as exc:  # noqa: BLE001
             reason = f"steerer.bind raised: {exc}"
             log.exception("steerer.bind raised")
-            await self._emit(session, "RunAborted", {"reason": reason})
+            await self._emit_run_aborted(session, reason)
             return ExecutionOutcome(success=False, session=session, reason=reason)
 
         # 7. Hand off to the executor.
@@ -217,7 +215,7 @@ class Runner:
         except Exception as exc:  # noqa: BLE001
             reason = f"executor.run raised: {exc}"
             log.exception("executor.run raised")
-            await self._emit(session, "RunAborted", {"reason": reason})
+            await self._emit_run_aborted(session, reason)
             return ExecutionOutcome(success=False, session=session, reason=reason)
 
         return outcome
@@ -306,22 +304,49 @@ class Runner:
             raise ValueError("GoalDeriver returned an empty goals list")
         return list(goals)
 
-    async def _emit(self, session: Session, kind: str, payload: dict[str, Any]) -> None:
-        evt = make_event(
+    async def _emit_run_started(
+        self, session: Session, user_input: str | list[Goal]
+    ) -> None:
+        evt = run_started_event(
             run_id=session.run_id,
             sequence=session.next_sequence(),
-            kind=kind,
-            payload=payload,
+            goal_summary=_initial_goal_summary(user_input),
+        )
+        await emit(self.sinks, evt)
+
+    async def _emit_goal_derived(self, session: Session) -> None:
+        evt = goal_derived_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            goals=list(session.goals),
+        )
+        await emit(self.sinks, evt)
+
+    async def _emit_plan_submitted(self, session: Session, plan: Any) -> None:
+        evt = plan_submitted_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            plan=plan,
+        )
+        await emit(self.sinks, evt)
+
+    async def _emit_run_aborted(self, session: Session, reason: str) -> None:
+        evt = run_aborted_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            reason=reason,
         )
         await emit(self.sinks, evt)
 
 
-def _input_kind(user_input: Any) -> str:
+def _initial_goal_summary(user_input: str | list[Goal]) -> str:
+    """Best-effort one-liner for the RunStarted event before goals derive."""
     if isinstance(user_input, str):
-        return "str"
-    if isinstance(user_input, list):
-        return "list[Goal]"
-    return type(user_input).__name__
+        return user_input
+    if isinstance(user_input, list) and user_input:
+        first = user_input[0]
+        return getattr(first, "summary", "") or ""
+    return ""
 
 
 __all__ = ["Runner"]

--- a/tests/test_parallel_executor.py
+++ b/tests/test_parallel_executor.py
@@ -178,6 +178,22 @@ def _new_session() -> Session:
     return Session(run_id="run-1")
 
 
+def _proto_kinds(events: list[Any]) -> list[str]:
+    """Return PascalCase kind names for proto Event envelopes."""
+    out: list[str] = []
+    for e in events:
+        if hasattr(e, "WhichOneof"):
+            name = e.WhichOneof("payload") or ""
+            out.append(
+                "".join(part.capitalize() for part in name.split("_")) if name else ""
+            )
+        elif isinstance(e, dict):
+            out.append(e.get("kind", ""))
+        else:
+            out.append(getattr(e, "kind", ""))
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -224,12 +240,12 @@ async def test_diamond_dag_runs_middle_stage_concurrently() -> None:
     for tid in ("A", "B", "C", "D", "E"):
         assert session.completed_results[tid] == f"result:{tid}"
 
-    # Sink saw RunStarted -> StageStarted/Completed pairs -> RunCompleted.
-    kinds = [ev["kind"] for ev in sink.events]
-    assert kinds[0] == "RunStarted"
+    # The executor only emits the terminal RunCompleted (Runner owns
+    # RunStarted; Stage* events were dropped because they have no proto
+    # equivalent and would have broken proto-wrapping sinks).
+    kinds = _proto_kinds(sink.events)
     assert kinds[-1] == "RunCompleted"
-    assert kinds.count("StageStarted") == 3
-    assert kinds.count("StageCompleted") == 3
+    assert "RunStarted" not in kinds
 
 
 @pytest.mark.asyncio
@@ -305,7 +321,7 @@ async def test_drift_in_parallel_task_finish_stage_then_refine() -> None:
     assert len(planner.refine_calls) == 1
     assert planner.refine_calls[0] is drift
     # A PlanRevised event was emitted.
-    kinds = [ev["kind"] for ev in sink.events]
+    kinds = _proto_kinds(sink.events)
     assert "PlanRevised" in kinds
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -132,22 +132,21 @@ async def test_runner_end_to_end_event_sequence() -> None:
 
     kinds = _kinds(sink.events)
 
-    # Lifecycle envelope up-front. The runner emits RunStarted +
-    # GoalDerived + PlanSubmitted; SequentialExecutor then emits its own
-    # RunStarted before driving tasks (it's also usable standalone, and
-    # its own tests assert it emits RunStarted on entry).
+    # Lifecycle envelope up-front. The Runner owns the Run* lifecycle
+    # events: RunStarted then GoalDerived then PlanSubmitted. The
+    # executor no longer emits its own RunStarted (that would duplicate
+    # the Runner's emission and produce a second event for sinks).
     assert kinds[0] == "RunStarted"
     assert kinds[1] == "GoalDerived"
     assert kinds[2] == "PlanSubmitted"
-    assert kinds[3] == "RunStarted"
 
     # For each of the three tasks: TaskStarted → TaskCompleted.
-    task_kinds = kinds[4:-1]  # strip initial quartet and trailing RunCompleted
+    task_kinds = kinds[3:-1]  # strip initial triple and trailing RunCompleted
     assert len(task_kinds) == 6, kinds
     assert task_kinds[0::2] == ["TaskStarted"] * 3
     assert task_kinds[1::2] == ["TaskCompleted"] * 3
 
-    # Run terminates with a RunCompleted.
+    # Run terminates with a RunCompleted from the executor.
     assert kinds[-1] == "RunCompleted"
 
     # Sequence numbers are strictly monotonic from zero.

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -219,9 +219,12 @@ async def test_linear_plan_runs_to_completion() -> None:
     for t in plan.tasks:
         assert t.status == TaskStatus.COMPLETED
 
+    # The executor itself owns only the terminal RunCompleted (Runner
+    # owns RunStarted / GoalDerived / PlanSubmitted). The StubSteerer
+    # emits nothing, so the only event the sink sees is run_completed.
     kinds = sink.payload_kinds()
-    assert kinds[0] == "run_started"
     assert kinds[-1] == "run_completed"
+    assert "run_started" not in kinds
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #53

## Summary

Sinks previously received a mix of dict and proto envelopes: the Runner emitted `RunStarted` / `GoalDerived` / `PlanSubmitted` / `RunAborted` via `make_event` (dicts), while executors and the steerer used the typed proto factories. Sinks that wrap incoming events in a proto envelope (e.g. harmonograf's `HarmonografSink`) crashed on the dict events with `ValueError: Protocol message Event has no "kind" field`.

This PR consolidates event ownership so every sink emission is a proto `Event`.

## Changes

- **`goldfive/runner.py`**: lifecycle events now use the typed factories (`run_started_event`, `goal_derived_event`, `plan_submitted_event`, `run_aborted_event`).
- **`goldfive/executors/sequential.py`**: removed the duplicate `RunStarted` emission. The Runner owns it.
- **`goldfive/executors/parallel.py`**: removed the duplicate `RunStarted`; converted `PlanRevised` / `RunAborted` / `RunCompleted` to the typed factories. Dropped `StageStarted` / `StageCompleted` — they have no proto equivalent and would still have broken proto-wrapping sinks.
- **`goldfive.events.make_event`**: kept for tests that want dict envelopes.
- **Lifecycle ownership** is now documented in both the Runner and executor docstrings: Runner owns `Run*` events; executors own `Task*` + `PlanRevised` + terminal `RunCompleted`/`RunAborted`; the steerer owns `DriftDetected` and per-task transitions.
- **Tests / example**: executor tests updated for the consolidated lifecycle; `examples/hello_callable.py` updated to render proto events.

## Test plan

- [x] `uv run pytest -q` — 259 passed, 33 skipped (matches `origin/main` baseline in this env; no regressions).
- [x] `uv run python examples/hello_callable.py` — prints success and the full proto event log: a single `RunStarted`, `GoalDerived`, `PlanSubmitted`, three `TaskStarted` / `TaskCompleted` pairs, and `RunCompleted` (10 events; previously emitted 11 with a duplicate `RunStarted`).
