### PR TITLE
Release v0.1.0: changelog + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to goldfive are documented in this file. Dates are ISO-8601.
+
+## 0.1.0 — 2026-04-18
+
+Initial public release. goldfive v0.1 is a framework-agnostic control loop
+that wraps an agent with an explicit goal, a DAG-structured plan, per-turn
+drift analysis, and a steering loop — wired to a protobuf event stream you
+can persist, replay, or ship to an observability console. Adapters ship for
+Google ADK, the Claude Agent SDK, and plain async callables. Planners,
+executors, goal derivers, steerers, and event sinks are all pluggable
+behind narrow protocols.
+
+### Added
+
+- #18 Scaffold goldfive package
+- #19 Define core protocols, reporting tool spec, and result dataclasses
+- #20 Add CallableAdapter (reference AgentAdapter)
+- #21 Add core dataclasses, proto converters, and event helpers
+- #22 Add GoalDeriver variants (Passthrough, Literal, LLM)
+- #23 Add Parallel-DAG executor
+- #24 Add built-in EventSinks (InMemory, Logging, JSONL persistence)
+- #25 Implement Sequential executor
+- #26 Implement Planner (Passthrough + LLM) [closes #7]
+- #27 feat: Claude Agent SDK adapter (#14)
+- #29 Add ADK AgentAdapter and plugin
+- #30 Port _AdkState state machine into DefaultSteerer
+- #33 Add typed event factories to goldfive.events
+- #34 Wire up public API re-exports and fix event helpers
+- #36 Define goldfive proto schema + wire up Python codegen
+- #47 Add SQLitePersistenceSink
+- #48 Add ADK presentation_agent reference example
+- #52 Add goldfive gRPC transport (sink + server)
+
+### Changed
+
+- #28 Add umbrella test-suite for issue #16
+- #31 Add design docs, user guides, and reference documentation
+- #46 Verify ADK root-agent wrapping propagates across sub-agent tree
+- #49 Verify design-doc code snippets against goldfive v0.1
+- #50 Verify code snippets in docs/guides/ run against v0.1
+- #51 Align docs/reference/ + README hello snippet with goldfive v0.1 API
+- #54 Consistency audit: fix API drift
+
+### Fixed
+
+- #37 Executors auto-complete tasks when agent returns without reporting
+- #38 JSONLPersistenceSink accepts non-proto events
+- #55 Runner emits proto events consistently (fixes #53)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ uv add goldfive           # recommended
 pip install goldfive
 ```
 
-Optional extras: `goldfive[adk]`, `goldfive[claude]`, `goldfive[dev]`.
+Optional extras:
+
+- `goldfive[adk]` — Google ADK adapter (`google-adk`).
+- `goldfive[claude]` — Claude Agent SDK adapter (`anthropic`).
+- `goldfive[examples]` — runtime deps for the scripts in [`examples/`](examples/) (`rich`).
+- `goldfive[proto]` — regenerate proto stubs with `make proto` (`grpcio`, `grpcio-tools`, `mypy-protobuf`).
+- `goldfive[dev]` — test + lint tooling used by the repo itself (`pytest`, `ruff`, `mypy`, ...).
 
 ## Hello goldfive
 

--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 
 from goldfive.adapters.callable import CallableAdapter
 from goldfive.drift import classify_refusal, classify_stop_reason, classify_tool_error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldfive"
-version = "0.0.1"
+version = "0.1.0"
 description = "Agent orchestration: stay on target."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -12,7 +12,7 @@ license = { text = "Apache-2.0" }
 authors = [
     { name = "Sunil Pedapudi" },
 ]
-keywords = ["agents", "orchestration", "planning", "llm"]
+keywords = ["agents", "orchestration", "planning", "llm", "drift", "steering", "adk", "anthropic"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -52,6 +52,7 @@ proto = [
 Homepage = "https://github.com/pedapudi/goldfive"
 Repository = "https://github.com/pedapudi/goldfive"
 Issues = "https://github.com/pedapudi/goldfive/issues"
+Changelog = "https://github.com/pedapudi/goldfive/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 include = [

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -9,4 +9,4 @@ def test_version_is_set() -> None:
 
 
 def test_version_matches_pyproject() -> None:
-    assert goldfive.__version__ == "0.0.1"
+    assert goldfive.__version__ == "0.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -624,7 +624,7 @@ wheels = [
 
 [[package]]
 name = "goldfive"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Prepares the first tagged release of goldfive.

- Bumps `goldfive.__version__` and `pyproject.toml` version from `0.0.1` to `0.1.0`.
- Adds `CHANGELOG.md` at the repo root, listing every PR merged into v0.1 grouped Added / Changed / Fixed, plus a short paragraph describing what v0.1 delivers.
- Adds a `Changelog` project URL and a few extra keywords (`drift`, `steering`, `adk`, `anthropic`) to `pyproject.toml`.
- Expands the README "Optional extras" section to cover all five extras (`adk`, `claude`, `examples`, `proto`, `dev`) — the previous copy only mentioned three.
- Updates `tests/test_smoke.py::test_version_matches_pyproject` to the new literal.

## Verified

- `uv run pytest -q` → **269 passed, 32 skipped**.
- `make proto` → regenerates stubs with no diff against the committed protos.
- README hello snippet extracted and run standalone → `success=True events=10`.
- `examples/hello_callable.py` → runs end-to-end, emits the expected event stream.
- All five optional-dep groups (`adk`, `claude`, `dev`, `examples`, `proto`) install cleanly in an isolated env.

## Test plan

- [x] `uv run pytest -q` green
- [x] `make proto` idempotent
- [x] README snippet runs
- [x] `examples/hello_callable.py` runs
- [x] Each `goldfive[<extra>]` installs from a clean env