### PR TITLE
Add goldfive.quickstart() convenience factory

### DIFF
--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -22,6 +22,7 @@ from goldfive.protocols import (
     Planner,
     Steerer,
 )
+from goldfive.quickstart import quickstart
 from goldfive.reporting import BUILTIN_REPORTING_TOOLS, ReportingToolSpec
 from goldfive.results import ExecutionOutcome, InvocationResult
 from goldfive.runner import Runner
@@ -76,4 +77,5 @@ __all__ = [
     "classify_refusal",
     "classify_stop_reason",
     "classify_tool_error",
+    "quickstart",
 ]

--- a/goldfive/quickstart.py
+++ b/goldfive/quickstart.py
@@ -1,0 +1,135 @@
+"""``goldfive.quickstart`` — one-call Runner factory for new users.
+
+Wires a :class:`SequentialExecutor`, a :class:`PassthroughGoalDeriver`,
+a :class:`StaticPlanner` whose plan is one task per goal, and a single
+:class:`InMemorySink` so a caller can go from "I have an agent and some
+goals" to a runnable :class:`Runner` in one expression. Complements —
+does not replace — explicit :class:`Runner` construction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from goldfive.adapters.callable import CallableAdapter
+from goldfive.executors.sequential import SequentialExecutor
+from goldfive.goal_deriver import PassthroughGoalDeriver
+from goldfive.planner import StaticPlanner
+from goldfive.protocols import AgentAdapter, EventSink, Planner
+from goldfive.runner import Runner
+from goldfive.sinks.memory import InMemorySink
+from goldfive.types import Goal, Plan, Task
+
+
+_DEFAULT_AGENT_ID = "default"
+
+
+def _is_agent_adapter(obj: Any) -> bool:
+    """True when ``obj`` already satisfies the :class:`AgentAdapter` protocol."""
+    return isinstance(obj, AgentAdapter)
+
+
+def _coerce_goal_list(goals: str | Goal | list[str | Goal]) -> list[Goal]:
+    """Normalise ``goals`` into a non-empty ``list[Goal]``."""
+    if isinstance(goals, Goal):
+        return [goals]
+    if isinstance(goals, str):
+        if not goals.strip():
+            raise ValueError("quickstart: empty goal string")
+        return [Goal(id="g1", summary=goals)]
+    if not isinstance(goals, list):
+        raise TypeError(
+            f"quickstart: goals must be str | Goal | list[str | Goal], "
+            f"got {type(goals).__name__}"
+        )
+    if not goals:
+        raise ValueError("quickstart: empty goals list")
+    out: list[Goal] = []
+    for i, item in enumerate(goals, start=1):
+        if isinstance(item, Goal):
+            out.append(item)
+        elif isinstance(item, str):
+            if not item.strip():
+                raise ValueError(f"quickstart: empty goal string at index {i - 1}")
+            out.append(Goal(id=f"g{i}", summary=item))
+        else:
+            raise TypeError(
+                f"quickstart: goals[{i - 1}] must be str or Goal, "
+                f"got {type(item).__name__}"
+            )
+    return out
+
+
+def _default_plan(goals: list[Goal], assignee_agent_id: str) -> Plan:
+    """Build a one-task-per-goal linear plan with no edges."""
+    return Plan(
+        id="quickstart-plan",
+        run_id="",
+        goal_ids=[g.id for g in goals],
+        tasks=[
+            Task(
+                id=f"task_{g.id}",
+                title=g.summary[:60] or g.id,
+                description=g.summary,
+                assignee_agent_id=assignee_agent_id,
+            )
+            for g in goals
+        ],
+        edges=[],
+        summary="quickstart: one task per goal",
+    )
+
+
+def quickstart(
+    agent: Any,
+    goals: str | Goal | list[str | Goal],
+    *,
+    planner: Planner | None = None,
+    sinks: list[EventSink] | None = None,
+) -> Runner:
+    """Build a fully-wired :class:`Runner` with sensible defaults.
+
+    Parameters
+    ----------
+    agent:
+        Either an existing :class:`AgentAdapter` (used verbatim) or a
+        :class:`CallableAdapter`-compatible async callable (wrapped).
+    goals:
+        A single :class:`Goal`, a single summary string, or a list of
+        either. Each entry becomes one task in the default plan.
+    planner:
+        Optional override. Defaults to a :class:`StaticPlanner` whose
+        plan has one task per goal.
+    sinks:
+        Optional override. Defaults to ``[InMemorySink()]``.
+
+    Returns
+    -------
+    Runner
+        A :class:`Runner` ready for ``await runner.run(...)``.
+    """
+    goal_list = _coerce_goal_list(goals)
+
+    if _is_agent_adapter(agent):
+        adapter: AgentAdapter = agent
+    else:
+        adapter = CallableAdapter(agent, available_agents=[_DEFAULT_AGENT_ID])
+
+    available = list(adapter.available_agents) or [_DEFAULT_AGENT_ID]
+    assignee = available[0]
+
+    resolved_planner: Planner = (
+        planner if planner is not None else StaticPlanner(_default_plan(goal_list, assignee))
+    )
+    resolved_sinks: list[EventSink] = list(sinks) if sinks is not None else [InMemorySink()]
+
+    return Runner(
+        agent=adapter,
+        planner=resolved_planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver(goal_list),
+        sinks=resolved_sinks,
+    )
+
+
+__all__ = ["quickstart"]

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,0 +1,183 @@
+"""Tests for :func:`goldfive.quickstart`.
+
+Exercises the convenience factory across its accepted ``goals`` shapes
+and verifies that the returned :class:`Runner` is correctly wired with
+the documented defaults (and overrides them when supplied).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from goldfive import (
+    CallableAdapter,
+    ExecutionOutcome,
+    Goal,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    quickstart,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    """Reference agent: returns a non-empty result so the executor auto-completes."""
+    _ = (session, tools)
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+def _kinds(events: list[Any]) -> list[str]:
+    out: list[str] = []
+    for e in events:
+        if isinstance(e, dict):
+            out.append(e.get("kind") or "")
+        elif hasattr(e, "WhichOneof"):
+            name = e.WhichOneof("payload") or ""
+            out.append(
+                "".join(part.capitalize() for part in name.split("_")) if name else ""
+            )
+        else:
+            out.append(getattr(e, "kind", ""))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_quickstart_string_goal_runs_to_completion() -> None:
+    """``quickstart(agent, "single goal string")`` runs end-to-end."""
+    runner = quickstart(_happy_agent, "Say hello to the user")
+    assert isinstance(runner, Runner)
+
+    sink = runner.sinks[0]
+    assert isinstance(sink, InMemorySink)
+
+    outcome = await runner.run("ignored — passthrough deriver")
+    await runner.close()
+
+    assert isinstance(outcome, ExecutionOutcome)
+    assert outcome.success, outcome.reason
+
+    kinds = _kinds(sink.events)
+    assert kinds[0] == "RunStarted"
+    assert "GoalDerived" in kinds
+    assert "PlanSubmitted" in kinds
+    assert kinds[-1] == "RunCompleted"
+
+    # Exactly one task was generated for the single goal.
+    assert outcome.session.plan is not None
+    assert len(outcome.session.plan.tasks) == 1
+    assert len(outcome.session.goals) == 1
+    assert outcome.session.goals[0].summary == "Say hello to the user"
+
+
+async def test_quickstart_accepts_list_of_goals() -> None:
+    """A list of ``Goal`` objects produces one task per goal."""
+    goals = [
+        Goal(id="g1", summary="First outcome"),
+        Goal(id="g2", summary="Second outcome"),
+    ]
+    runner = quickstart(_happy_agent, goals)
+    sink = runner.sinks[0]
+    assert isinstance(sink, InMemorySink)
+
+    outcome = await runner.run("ignored")
+    await runner.close()
+
+    assert outcome.success, outcome.reason
+    assert outcome.session.plan is not None
+    assert len(outcome.session.plan.tasks) == 2
+    assert outcome.session.goals == goals
+
+
+async def test_quickstart_accepts_list_of_strings() -> None:
+    """A list of summary strings is normalised into ``Goal`` objects."""
+    runner = quickstart(_happy_agent, ["alpha", "beta", "gamma"])
+    outcome = await runner.run("ignored")
+    await runner.close()
+
+    assert outcome.success, outcome.reason
+    assert [g.summary for g in outcome.session.goals] == ["alpha", "beta", "gamma"]
+    assert outcome.session.plan is not None
+    assert len(outcome.session.plan.tasks) == 3
+
+
+async def test_quickstart_custom_sinks_override_default() -> None:
+    """A caller-supplied ``sinks`` argument replaces the InMemorySink default."""
+    custom_sink = InMemorySink()
+    runner = quickstart(_happy_agent, "do the thing", sinks=[custom_sink])
+
+    assert runner.sinks == [custom_sink]
+    # No second InMemorySink is silently appended.
+    assert len(runner.sinks) == 1
+
+    outcome = await runner.run("ignored")
+    await runner.close()
+    assert outcome.success, outcome.reason
+    # The override sink is the one that received events.
+    assert any(_kinds([e])[0] == "RunCompleted" for e in custom_sink.events)
+
+
+async def test_quickstart_returns_configured_runner_wiring() -> None:
+    """The returned object is a Runner with the documented default wiring."""
+    runner = quickstart(_happy_agent, "wiring check")
+
+    assert isinstance(runner, Runner)
+    assert isinstance(runner.executor, SequentialExecutor)
+    assert isinstance(runner.goal_deriver, PassthroughGoalDeriver)
+    assert isinstance(runner.planner, StaticPlanner)
+    assert len(runner.sinks) == 1
+    assert isinstance(runner.sinks[0], InMemorySink)
+
+
+async def test_quickstart_does_not_rewrap_existing_adapter() -> None:
+    """An existing ``AgentAdapter`` is used verbatim, not re-wrapped."""
+    adapter = CallableAdapter(_happy_agent, available_agents=["writer"])
+    runner = quickstart(adapter, "use my adapter")
+
+    assert runner.agent is adapter
+
+    outcome = await runner.run("ignored")
+    await runner.close()
+    assert outcome.success, outcome.reason
+
+
+async def test_quickstart_custom_planner_override() -> None:
+    """A caller-supplied ``planner`` replaces the default StaticPlanner."""
+    from goldfive.types import Plan
+
+    custom_plan = Plan(
+        id="custom",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[Task(id="only", title="Only task", assignee_agent_id="default")],
+        edges=[],
+        summary="custom override",
+    )
+    custom_planner = StaticPlanner(custom_plan)
+    runner = quickstart(_happy_agent, "anything", planner=custom_planner)
+
+    assert runner.planner is custom_planner
+
+    outcome = await runner.run("ignored")
+    await runner.close()
+    assert outcome.success, outcome.reason
+    assert outcome.session.plan is not None
+    assert [t.id for t in outcome.session.plan.tasks] == ["only"]


### PR DESCRIPTION
## Summary
- New `goldfive.quickstart(agent, goals, *, planner=None, sinks=None) -> Runner`
- Wires SequentialExecutor + sensible goal deriver + InMemorySink defaults
- Complements (does not replace) explicit Runner construction
- Exported from `goldfive` top-level

## Test plan
- [x] `tests/test_quickstart.py` - string goal, list of goals, custom sinks override
- [x] Full pytest suite still green

Note: the planning default uses `StaticPlanner` with one task per goal (rather than `PassthroughPlanner`, which returns `None` and would cause `Runner` to abort). This is the minimal-magic planner that turns goals -> tasks. `PassthroughGoalDeriver` is used because goals are accepted up front.

Generated with Claude Code
