### PR TITLE
Add harmonograf_observed example

### DIFF
--- a/examples/harmonograf_observed/README.md
+++ b/examples/harmonograf_observed/README.md
@@ -1,0 +1,68 @@
+# harmonograf_observed example
+
+Minimal `CallableAdapter` agent wired to both an `InMemorySink` and a
+`HarmonografSink` so every goldfive event lands in the harmonograf UI.
+No LLM, no ADK, no Claude SDK — just a four-task `StaticPlanner` and a
+canned-reply callable.
+
+## What this shows
+
+- A single goldfive `Runner` fanning events out to two sinks.
+- The standard `Client` / `HarmonografSink` wiring from
+  `harmonograf-client` and the paired `runner.close()` +
+  `client.shutdown(flush_timeout=5.0)` teardown.
+- Graceful fallback: if `harmonograf_client` is not installed the
+  example still runs end-to-end with `InMemorySink` + `LoggingSink` and
+  prints a pointer to the observability guide.
+- The event counts reported by `InMemorySink` match what the harmonograf
+  console renders — useful as a sanity check when debugging the sink.
+
+## Prerequisites
+
+A harmonograf server reachable at `127.0.0.1:7531` (override with
+`HARMONOGRAF_SERVER=host:port`). See the harmonograf operator
+quickstart for `make demo`. Without a server running the example falls
+back to the in-process sinks and still completes — the UI just stays
+empty.
+
+## How to run
+
+With harmonograf installed and a server up:
+
+```bash
+uv pip install harmonograf-client
+uv run python examples/harmonograf_observed/agent.py
+```
+
+Without harmonograf (fallback path, zero extra deps):
+
+```bash
+uv run python examples/harmonograf_observed/agent.py
+```
+
+Point at a non-default server:
+
+```bash
+HARMONOGRAF_SERVER=10.0.0.5:7531 \
+  uv run python examples/harmonograf_observed/agent.py
+```
+
+## What to look for in the UI
+
+- The plan materialising with four tasks (`research`, `draft`,
+  `review`, `publish`) and three edges between them.
+- A `TaskStarted` / `TaskCompleted` pair per task as the sequential
+  executor walks the DAG.
+- A `RunCompleted` event closing the stream — the session row should
+  flip to green.
+- Matching event sequence numbers between the UI and the
+  `InMemorySink captured N events.` line printed at the end.
+
+## See also
+
+- [docs/guides/observability-with-harmonograf.md](../../docs/guides/observability-with-harmonograf.md)
+  — full walkthrough covering plan diffs, drift markers, and control
+  actions from the UI.
+- [examples/hello_callable.py](../hello_callable.py) — the same shape
+  without the harmonograf dependency, useful as a zero-deps starting
+  point.

--- a/examples/harmonograf_observed/agent.py
+++ b/examples/harmonograf_observed/agent.py
@@ -1,0 +1,129 @@
+"""harmonograf_observed — CallableAdapter agent wired to a HarmonografSink.
+
+A zero-LLM, four-task :class:`StaticPlanner` demo that ships every event
+to both an :class:`InMemorySink` and a :class:`HarmonografSink`, so a
+newcomer can see goldfive events light up the harmonograf UI without
+standing up an ADK or Claude SDK agent first. If ``harmonograf_client``
+is not installed, the script falls back to ``InMemorySink`` +
+``LoggingSink`` and prints a pointer to the observability guide.
+
+Run with::
+
+    uv run python examples/harmonograf_observed/agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from goldfive import (
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+from goldfive.sinks import LoggingSink  # None when the proto extra is missing
+
+try:
+    from harmonograf_client import Client, HarmonografSink
+except ImportError:
+    Client = None  # type: ignore[assignment,misc]
+    HarmonografSink = None  # type: ignore[assignment,misc]
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="observed-plan",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="Gather notes", assignee_agent_id="worker"),
+            Task(id="draft", title="Draft summary", assignee_agent_id="worker"),
+            Task(id="review", title="Review draft", assignee_agent_id="worker"),
+            Task(id="publish", title="Publish result", assignee_agent_id="worker"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft"),
+            TaskEdge(from_task_id="draft", to_task_id="review"),
+            TaskEdge(from_task_id="review", to_task_id="publish"),
+        ],
+        summary="Research, draft, review, publish.",
+    )
+
+
+async def worker_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = session, tools
+    text = {
+        "research": "Collected three bullet points.",
+        "draft": "Drafted a two-paragraph summary.",
+        "review": "Reviewed — looks good.",
+        "publish": "Published to the demo channel.",
+    }.get(task.id, "(no-op)")
+    return InvocationResult(task_id=task.id, text=text)
+
+
+async def main() -> None:
+    server_addr = os.environ.get("HARMONOGRAF_SERVER", "127.0.0.1:7531")
+    memory_sink = InMemorySink()
+    sinks: list = [memory_sink]
+    client = None
+
+    if Client is not None and HarmonografSink is not None:
+        client = Client(name="harmonograf_observed", server_addr=server_addr)
+        sinks.append(HarmonografSink(client))
+        active = f"[InMemorySink, HarmonografSink -> {server_addr}]"
+    else:
+        print(
+            "harmonograf_client not installed — run with [InMemorySink] only. "
+            "See docs/guides/observability-with-harmonograf.md to add the console."
+        )
+        if LoggingSink is not None:
+            sinks.append(LoggingSink())
+            active = "[InMemorySink, LoggingSink]"
+        else:
+            active = "[InMemorySink]"
+
+    runner = Runner(
+        agent=CallableAdapter(worker_agent, available_agents=["worker"]),
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(max_plan_reinvocations=8),
+        goal_deriver=PassthroughGoalDeriver("Research, draft, review, publish"),
+        sinks=sinks,
+    )
+
+    outcome = await runner.run("run the observed workflow")
+    await runner.close()
+    if client is not None:
+        client.shutdown(flush_timeout=5.0)
+
+    print(f"success={outcome.success}, reason={outcome.reason!r}")
+    print(f"run_id={outcome.session.run_id}")
+    print(f"sinks={active}")
+    print(f"InMemorySink captured {len(memory_sink.events)} events.")
+    if client is not None:
+        print(
+            f"Open the harmonograf UI (server at {server_addr}) to inspect the "
+            "plan, task timeline, and drift markers for this run."
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(message)s",
+    )
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- New `examples/harmonograf_observed/` directory: minimal `CallableAdapter` agent wired to both `InMemorySink` and `HarmonografSink`, with `HARMONOGRAF_SERVER` env override (default `127.0.0.1:7531`).
- Graceful fallback: if `harmonograf_client` is not installed the script runs with `InMemorySink` + `LoggingSink`, prints a pointer to `docs/guides/observability-with-harmonograf.md`, and still completes.
- README (under 80 lines) pointing at the unified observability guide and at `examples/hello_callable.py` for the zero-dependency version — the guide walkthrough is owned elsewhere.

## Test plan

- [x] `uv run python examples/harmonograf_observed/agent.py` (fallback path, no harmonograf installed) — completes with `success=True`, 4/4 tasks, 12 events captured by `InMemorySink`, and the fallback message printed.
- [ ] Live path with `harmonograf-client` installed and a server running at `127.0.0.1:7531` — verify events land in the UI. (Not run here; lead to verify on the demo stack.)
