### PR TITLE
Add examples: multi-sink fanout, drift refinement, parallel DAG

### DIFF
--- a/examples/drift_refinement.py
+++ b/examples/drift_refinement.py
@@ -1,0 +1,194 @@
+"""drift_refinement — drift mid-plan triggers a planner refinement.
+
+The middle task in a 3-task plan reports a recoverable failure via the
+``report_task_failed`` reporting tool. That fires a WARNING drift through
+:class:`DefaultSteerer`, which calls ``planner.refine`` and swaps in a
+new plan that replaces the failed task with a fallback. Execution then
+continues on the revised plan.
+
+Run with::
+
+    uv run python examples/drift_refinement.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Mapping
+from typing import Any
+
+from goldfive import (
+    CallableAdapter,
+    DefaultSteerer,
+    DriftEvent,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    Task,
+    TaskEdge,
+)
+from goldfive.types import Goal, TaskStatus
+
+
+def build_initial_plan() -> Plan:
+    return Plan(
+        id="plan-initial",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="Gather sources", assignee_agent_id="worker"),
+            Task(
+                id="primary_api",
+                title="Call primary data API (will fail)",
+                assignee_agent_id="worker",
+            ),
+            Task(id="report", title="Write the report", assignee_agent_id="worker"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="primary_api"),
+            TaskEdge(from_task_id="primary_api", to_task_id="report"),
+        ],
+        summary="Research, fetch data, write a report.",
+    )
+
+
+class _RefiningPlanner:
+    """Returns ``build_initial_plan`` from generate; on refine swaps the
+    failed task for a fallback that still satisfies the goal."""
+
+    def __init__(self) -> None:
+        self.refine_calls: list[DriftEvent] = []
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Mapping[str, Any] | None = None,
+    ) -> Plan | None:
+        plan = build_initial_plan()
+        if context is not None:
+            plan.run_id = str(context.get("run_id") or "")
+        plan.goal_ids = [g.id for g in goals if g.id] or plan.goal_ids
+        return plan
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        self.refine_calls.append(drift)
+        preserved = [
+            Task(
+                id=t.id,
+                title=t.title,
+                description=t.description,
+                assignee_agent_id=t.assignee_agent_id,
+                status=t.status,
+            )
+            for t in plan.tasks
+            if t.status != TaskStatus.PENDING or t.id != drift.current_task_id
+        ]
+        fallback = Task(
+            id="fallback_api",
+            title="Call backup data API",
+            assignee_agent_id="worker",
+        )
+        report = next(
+            (t for t in preserved if t.id == "report"),
+            None,
+        )
+        if report is None:
+            preserved.append(
+                Task(id="report", title="Write the report", assignee_agent_id="worker")
+            )
+        new_tasks = preserved + [fallback]
+        new_edges = [
+            TaskEdge(from_task_id="research", to_task_id="fallback_api"),
+            TaskEdge(from_task_id="fallback_api", to_task_id="report"),
+        ]
+        return Plan(
+            id=f"plan-refined-{uuid.uuid4().hex[:8]}",
+            run_id=plan.run_id,
+            goal_ids=list(plan.goal_ids),
+            tasks=new_tasks,
+            edges=new_edges,
+            summary="Refined: primary API failed, routed via backup.",
+            revision_index=plan.revision_index + 1,
+            revision_reason=drift.detail,
+            revision_kind=str(drift.kind),
+            revision_severity=str(drift.severity),
+        )
+
+
+def _print_plan(label: str, plan: Plan) -> None:
+    print(f"  {label} (id={plan.id}, revision={plan.revision_index}):")
+    for t in plan.tasks:
+        print(f"    - {t.id:<14} status={t.status.value:<10} title={t.title!r}")
+    for e in plan.edges:
+        print(f"    edge {e.from_task_id} -> {e.to_task_id}")
+
+
+async def main() -> None:
+    steerer = DefaultSteerer()
+    sink = InMemorySink()
+    planner = _RefiningPlanner()
+
+    initial_plan = build_initial_plan()
+
+    async def worker_agent(
+        task: Task,
+        session: Session,
+        tools: list[ReportingToolSpec],
+    ) -> InvocationResult:
+        _ = tools
+        if task.id == "primary_api":
+            await steerer.mark_task_failed(
+                task.id,
+                session=session,
+                reason="primary API returned 503 (recoverable)",
+                recoverable=True,
+            )
+            return InvocationResult(task_id=task.id, text="primary API unavailable")
+        return InvocationResult(task_id=task.id, text=f"finished: {task.title}")
+
+    runner = Runner(
+        agent=CallableAdapter(worker_agent, available_agents=["worker"]),
+        planner=planner,
+        executor=SequentialExecutor(fail_fast=False, max_plan_reinvocations=6),
+        goal_deriver=PassthroughGoalDeriver("Produce a report from API data"),
+        steerer=steerer,
+        sinks=[sink],
+    )
+
+    print("Initial plan:")
+    _print_plan("initial", initial_plan)
+    print()
+
+    outcome = await runner.run("produce report")
+    await runner.close()
+
+    print(f"Run finished: success={outcome.success}, reason={outcome.reason!r}")
+    print(f"planner.refine() was called {len(planner.refine_calls)} time(s)")
+    if planner.refine_calls:
+        d = planner.refine_calls[0]
+        print(f"  drift kind={d.kind.value} severity={d.severity.value}")
+        print(f"  drift detail={d.detail!r}")
+    print()
+    print("Final plan after refinement:")
+    if outcome.session.plan is not None:
+        _print_plan("revised", outcome.session.plan)
+    print()
+    print(f"Total events captured: {len(sink.events)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/multi_sink_fanout.py
+++ b/examples/multi_sink_fanout.py
@@ -1,0 +1,113 @@
+"""multi_sink_fanout — fan one event stream out to three sinks at once.
+
+Wires :class:`InMemorySink`, :class:`LoggingSink`, and
+:class:`JSONLPersistenceSink` to the same :class:`Runner` so a single run
+populates an in-process buffer, a stdout log, and an on-disk JSONL file
+simultaneously. Demonstrates the additive nature of the ``sinks=`` list.
+
+Run with::
+
+    uv run python examples/multi_sink_fanout.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import tempfile
+
+from goldfive import (
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+from goldfive.sinks import JSONLPersistenceSink, LoggingSink
+
+if JSONLPersistenceSink is None or LoggingSink is None:  # type: ignore[truthy-function]
+    raise SystemExit(
+        "multi_sink_fanout requires the `proto` extra; install goldfive[proto] "
+        "and run `make proto` to generate the proto stubs, then retry."
+    )
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="fanout-plan",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="collect", title="Collect inputs", assignee_agent_id="worker"),
+            Task(id="process", title="Process them", assignee_agent_id="worker"),
+            Task(id="emit", title="Emit summary", assignee_agent_id="worker"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="collect", to_task_id="process"),
+            TaskEdge(from_task_id="process", to_task_id="emit"),
+        ],
+        summary="Three step pipeline emitted to three sinks.",
+    )
+
+
+async def worker_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = tools
+    return InvocationResult(task_id=task.id, text=f"finished: {task.title}")
+
+
+async def main() -> None:
+    tmp = tempfile.NamedTemporaryFile(
+        prefix="goldfive-fanout-", suffix=".jsonl", delete=False
+    )
+    tmp.close()
+    jsonl_path = tmp.name
+
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+        format="[LoggingSink] %(message)s",
+    )
+    logger = logging.getLogger("goldfive.examples.fanout")
+
+    memory_sink = InMemorySink()
+    logging_sink = LoggingSink(logger=logger)
+    jsonl_sink = JSONLPersistenceSink(jsonl_path, mode="write")
+
+    runner = Runner(
+        agent=CallableAdapter(worker_agent, available_agents=["worker"]),
+        planner=StaticPlanner(build_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("Run a 3-step pipeline"),
+        sinks=[memory_sink, logging_sink, jsonl_sink],
+    )
+
+    outcome = await runner.run("fan out events to three sinks")
+    await runner.close()
+
+    with open(jsonl_path, encoding="utf-8") as f:
+        jsonl_lines = sum(1 for line in f if line.strip())
+
+    print()
+    print(f"success={outcome.success}, reason={outcome.reason!r}")
+    print(f"InMemorySink captured {len(memory_sink.events)} events")
+    print(f"JSONLPersistenceSink wrote {jsonl_lines} lines to {jsonl_path}")
+    print("LoggingSink emitted one [LoggingSink] line per event on stderr above")
+
+    os.unlink(jsonl_path)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/parallel_dag.py
+++ b/examples/parallel_dag.py
@@ -1,0 +1,107 @@
+"""parallel_dag — diamond DAG executed concurrently.
+
+Builds a 5-task diamond plan (A -> {B, C, D} -> E) and runs it through
+:class:`ParallelDAGExecutor`. Each task records its start and finish
+timestamp so the output makes the parallelism of B, C, D visible.
+
+Run with::
+
+    uv run python examples/parallel_dag.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+
+from goldfive import (
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    ParallelDAGExecutor,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+
+
+def build_diamond_plan() -> Plan:
+    return Plan(
+        id="diamond",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="A", title="Prepare", assignee_agent_id="worker"),
+            Task(id="B", title="Branch B", assignee_agent_id="worker"),
+            Task(id="C", title="Branch C", assignee_agent_id="worker"),
+            Task(id="D", title="Branch D", assignee_agent_id="worker"),
+            Task(id="E", title="Join", assignee_agent_id="worker"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="A", to_task_id="B"),
+            TaskEdge(from_task_id="A", to_task_id="C"),
+            TaskEdge(from_task_id="A", to_task_id="D"),
+            TaskEdge(from_task_id="B", to_task_id="E"),
+            TaskEdge(from_task_id="C", to_task_id="E"),
+            TaskEdge(from_task_id="D", to_task_id="E"),
+        ],
+        summary="Diamond DAG: A then {B,C,D} in parallel then E.",
+    )
+
+
+async def main() -> None:
+    random.seed(42)
+    timeline: list[tuple[str, str, float]] = []
+    t0 = time.monotonic()
+
+    async def worker_agent(
+        task: Task,
+        session: Session,
+        tools: list[ReportingToolSpec],
+    ) -> InvocationResult:
+        _ = tools
+        timeline.append((task.id, "start", time.monotonic() - t0))
+        await asyncio.sleep(random.uniform(0.1, 0.3))
+        timeline.append((task.id, "finish", time.monotonic() - t0))
+        return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(worker_agent, available_agents=["worker"]),
+        planner=StaticPlanner(build_diamond_plan()),
+        executor=ParallelDAGExecutor(),
+        goal_deriver=PassthroughGoalDeriver("Run a diamond DAG"),
+        sinks=[sink],
+    )
+
+    outcome = await runner.run("execute diamond")
+    await runner.close()
+
+    print(f"success={outcome.success}, reason={outcome.reason!r}")
+    print(f"events captured: {len(sink.events)}")
+    print()
+    print("Per-task timeline (seconds since run start):")
+    print(f"  {'task':<6} {'event':<8} {'t (s)':>8}")
+    for task_id, kind, t in timeline:
+        print(f"  {task_id:<6} {kind:<8} {t:>8.3f}")
+
+    starts = {tid: t for tid, kind, t in timeline if kind == "start"}
+    finishes = {tid: t for tid, kind, t in timeline if kind == "finish"}
+    parallel_window_start = max(starts[k] for k in ("B", "C", "D"))
+    parallel_window_end = min(finishes[k] for k in ("B", "C", "D"))
+    print()
+    print(
+        f"B, C, D all started by t={parallel_window_start:.3f}s and were all "
+        f"still running until t={parallel_window_end:.3f}s -- "
+        f"overlap of {max(0.0, parallel_window_end - parallel_window_start):.3f}s"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- `examples/multi_sink_fanout.py` — InMemorySink + LoggingSink + JSONLPersistenceSink simultaneously
- `examples/drift_refinement.py` — drift mid-plan triggers planner refinement
- `examples/parallel_dag.py` — 5-task diamond DAG via ParallelDAGExecutor

## Test plan
- [x] All three examples run cleanly via `uv run python examples/<name>.py`
- [x] Parallel DAG demo shows actual concurrency in printed timestamps
- [x] Existing pytest suite unaffected
