### PR TITLE
README: add 10-minute tutorial pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ goldfive is the orchestration half of
 [harmonograf](https://github.com/pedapudi/harmonograf), extracted so you
 can use the control loop without the console.
 
+## Get running in 10 minutes
+
+The fastest way to see goldfive work end-to-end is with its observability
+console, [harmonograf](https://github.com/pedapudi/harmonograf). The
+walkthrough installs both, boots a local stack, runs the
+`examples/harmonograf_observed/` agent, and shows every event flowing
+into the UI — no LLM credentials required.
+
+1. `uv sync` in this repo (Python 3.11+, `uv` on your PATH).
+2. Clone and `make demo` in harmonograf (server + UI on :7531 and :5173).
+3. `uv run python examples/harmonograf_observed/agent.py`.
+
+Full walkthrough: **[observability-with-harmonograf.md](docs/guides/observability-with-harmonograf.md)**.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a prominent "Get running in 10 minutes" section near the top of the
goldfive README, between the intro and the `## Install` section. Points
new readers at the unified `docs/guides/observability-with-harmonograf.md`
walkthrough for an end-to-end onboarding flow (install both repos, `make
demo` in harmonograf, run the `examples/harmonograf_observed/` agent, see
events in the UI — no LLM credentials required).

Pairs with a matching addition to the harmonograf README.

## Test plan

- [ ] Verify relative link target `docs/guides/observability-with-harmonograf.md` resolves once the parallel doc PR merges.
- [ ] Confirm example path `examples/harmonograf_observed/agent.py` is correct (verified).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>