### PR TITLE
Fix three drift findings from Team Lead A audit

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -351,7 +351,7 @@ class SequentialExecutor(Executor):
     def __init__(
         self,
         *,
-        max_plan_reinvocations: int = 3,
+        max_plan_reinvocations: int = 32,
         fail_fast: bool = True,
     ) -> None: ...
 

--- a/examples/persistence_and_recovery.py
+++ b/examples/persistence_and_recovery.py
@@ -94,7 +94,7 @@ async def main() -> None:
     runner = Runner(
         agent=CallableAdapter(crashy_agent, available_agents=["worker"]),
         planner=StaticPlanner(build_plan()),
-        executor=SequentialExecutor(stop_on_failure=True),
+        executor=SequentialExecutor(fail_fast=True),
         goal_deriver=PassthroughGoalDeriver("Persist and recover"),
         sinks=[sink],
     )

--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -26,7 +26,13 @@ from goldfive.quickstart import quickstart
 from goldfive.reporting import BUILTIN_REPORTING_TOOLS, ReportingToolSpec
 from goldfive.results import ExecutionOutcome, InvocationResult
 from goldfive.runner import Runner
-from goldfive.sinks import GRPCSink, InMemorySink
+from goldfive.sinks import (
+    GRPCSink,
+    InMemorySink,
+    JSONLPersistenceSink,
+    LoggingSink,
+    SQLitePersistenceSink,
+)
 from goldfive.steerer import DefaultSteerer
 from goldfive.types import (
     DriftEvent,
@@ -57,9 +63,11 @@ __all__ = [
     "GoalDeriver",
     "InMemorySink",
     "InvocationResult",
+    "JSONLPersistenceSink",
     "LLMGoalDeriver",
     "LLMPlanner",
     "LiteralGoalDeriver",
+    "LoggingSink",
     "ParallelDAGExecutor",
     "PassthroughGoalDeriver",
     "PassthroughPlanner",
@@ -67,6 +75,7 @@ __all__ = [
     "Planner",
     "ReportingToolSpec",
     "Runner",
+    "SQLitePersistenceSink",
     "SequentialExecutor",
     "Session",
     "StaticPlanner",

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -55,8 +55,11 @@ class SequentialExecutor(Executor):
         Upper bound on the number of adapter ``invoke()`` calls a single
         :meth:`run` may issue. Each eligible task consumes one invocation;
         when drift triggers a plan revision, the new plan's remaining tasks
-        share the same budget. Defaults to ``3`` to mirror the harmonograf
-        re-invocation cap.
+        share the same budget. Defaults to ``32`` — comfortably covers a
+        plan with 10+ tasks plus a few refinement cycles. A stuck agent
+        still aborts via ``fail_fast`` or (in pathological cases) the
+        budget; the old default of ``3`` was tuned to the harmonograf
+        re-invocation cap and surprised callers running realistic plans.
     fail_fast:
         When ``True`` (default), the first task that ends up ``FAILED`` causes
         the executor to emit ``RunAborted`` and stop. When ``False``, failed
@@ -67,7 +70,7 @@ class SequentialExecutor(Executor):
     def __init__(
         self,
         *,
-        max_plan_reinvocations: int = 3,
+        max_plan_reinvocations: int = 32,
         fail_fast: bool = True,
     ) -> None:
         self.max_plan_reinvocations = int(max_plan_reinvocations)

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -197,6 +197,19 @@ class SequentialExecutor(Executor):
                     result.error, task.id,
                 )
 
+            # Route the invocation result through the steerer's observer so
+            # drift classification runs on the sequential path too. This
+            # mirrors ParallelDAGExecutor and lets drift enter via the raw
+            # invocation envelope (not only via reporting-tool handlers).
+            if result is not None:
+                try:
+                    await steerer.observe(result, session)
+                except Exception as observe_exc:  # noqa: BLE001
+                    log.debug(
+                        "SequentialExecutor: steerer.observe raised: %s",
+                        observe_exc,
+                    )
+
             # Re-read the task's tracked status after the invocation.
             tracked = _find_task(session.plan or current_plan, task.id)
             tracked_status = (


### PR DESCRIPTION
## Summary

Three drift issues reported in Team Lead A's audit:

1. **`examples/persistence_and_recovery.py` broken import.** `goldfive.__init__` re-exported `InMemorySink` and `GRPCSink` but not the other three built-in sinks, so `from goldfive import JSONLPersistenceSink` failed. Surface `JSONLPersistenceSink`, `LoggingSink`, and `SQLitePersistenceSink` symmetrically. Also fixed the same example's `stop_on_failure=` kwarg (doesn't exist) → `fail_fast=`.

2. **Executor drift-observation inconsistency.** `ParallelDAGExecutor` calls `steerer.observe(inv, session)` after each task invocation; `SequentialExecutor` didn't, so drift could only enter the sequential path via reporting-tool handlers. Mirror the parallel executor — call `observe` after each invocation (try/except'd so a misbehaving custom steerer can't abort a run).

3. **`SequentialExecutor.max_plan_reinvocations` default bumped 3 → 32.** The old default was tuned to harmonograf's re-invocation cap and surprised callers running realistic plans (Team Lead C's quickstart needed `8`). 32 comfortably covers a 10+ task plan with a few refinement cycles; a stuck agent still aborts via `fail_fast` or (in pathological refine loops) the budget.

Three logical commits, one per finding (+ the doc reference update bundled with #3).

## Test plan

- [x] `uv run pytest -q` → **276 passed, 32 skipped**
- [x] `uv run python examples/persistence_and_recovery.py` runs to completion (no `ImportError`, reports first-run crash + recovery as expected)
- [x] `uv run python examples/hello_callable.py` still prints the 3/3-task `RunCompleted` summary
