### PR TITLE
Add goldfive.wrap() / goldfive.run() one-line wrapping (closes #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,72 +52,34 @@ Optional extras:
 
 ## Hello goldfive
 
+The fastest path to a goldfive-wrapped agent is a single call to
+`goldfive.run`. It picks the right adapter for your agent, reuses
+the agent's LLM when it can detect one, and returns an
+`ExecutionOutcome`:
+
 ```python
 import asyncio
+import goldfive
 
-from goldfive import (
-    CallableAdapter,
-    InMemorySink,
-    InvocationResult,
-    Plan,
-    ReportingToolSpec,
-    Runner,
-    SequentialExecutor,
-    Session,
-    StaticPlanner,
-    Task,
-    TaskEdge,
-)
-
-
-async def greeter(
-    task: Task,
-    session: Session,
-    tools: list[ReportingToolSpec],
-) -> InvocationResult:
-    text = {
-        "greet": "Hello!",
-        "ask": "What's your name?",
-        "thank": "Thanks for chatting!",
-    }.get(task.id, "")
-    return InvocationResult(task_id=task.id, text=text)
-
-
-async def main() -> None:
-    plan = Plan(
-        id="hello",
-        run_id="",
-        goal_ids=["g1"],
-        tasks=[
-            Task(id="greet", title="Greet", assignee_agent_id="greeter"),
-            Task(id="ask", title="Ask for a name", assignee_agent_id="greeter"),
-            Task(id="thank", title="Thank the user", assignee_agent_id="greeter"),
-        ],
-        edges=[
-            TaskEdge(from_task_id="greet", to_task_id="ask"),
-            TaskEdge(from_task_id="ask", to_task_id="thank"),
-        ],
-        summary="Greet, ask, thank.",
-    )
-
-    sink = InMemorySink()
-    runner = Runner(
-        agent=CallableAdapter(greeter, available_agents=["greeter"]),
-        planner=StaticPlanner(plan),
-        executor=SequentialExecutor(),
-        sinks=[sink],
-    )
-
-    outcome = await runner.run("run the greeter workflow")
-    await runner.close()
-
-    print(f"success={outcome.success} events={len(sink.events)}")
-
-
-asyncio.run(main())
+# `agent` is any of: an ADK BaseAgent, a Claude SDK client factory,
+# an async (task, session, tools) -> InvocationResult callable, or
+# anything implementing goldfive.AgentAdapter.
+outcome = await goldfive.run(agent, "make a presentation about waffles")
 ```
 
-A runnable copy of this example lives in
+Prefer to keep the runner around (for `.resume()`, custom sinks, or
+multiple runs)? Use `goldfive.wrap`:
+
+```python
+runner = goldfive.wrap(agent, sinks=[my_sink])
+outcome = await runner.run("make a presentation about waffles")
+```
+
+Every default component is overridable — pass `planner=`,
+`executor=`, `sinks=`, `call_llm=`, `model=`, or
+`max_plan_reinvocations=` as keyword arguments to either function.
+
+A runnable demo lives in
 [`examples/hello_callable.py`](examples/hello_callable.py).
 
 ## Docs

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -43,6 +43,42 @@ uv sync --extra dev       # dev tools (pytest, ruff, mypy)
 uv sync --extra examples  # example-specific deps
 ```
 
+## One-line wrapping
+
+For the common case — "I already have an agent, wrap it with goldfive
+planning" — two helpers skip the hand-wired `Runner` construction:
+
+```python
+import goldfive
+
+# One line: wrap + run, get an ExecutionOutcome back.
+outcome = await goldfive.run(my_agent, "make a presentation about waffles")
+
+# Or, keep the Runner around:
+runner = goldfive.wrap(my_agent, sinks=[my_sink])
+outcome = await runner.run("make a presentation about waffles")
+```
+
+`wrap` auto-detects the adapter from the agent's shape:
+
+| Agent shape | Adapter chosen |
+|---|---|
+| Implements `goldfive.AgentAdapter` | passed through as-is |
+| `google.adk.agents.BaseAgent` (or an ADK `Runner`) | `ADKAdapter` (requires `goldfive[adk]`) |
+| Zero-arg factory returning `claude_agent_sdk.ClaudeSDKClient` | `ClaudeAgentSDKAdapter` (requires `goldfive[claude]`) |
+| `async (task, session, tools) -> InvocationResult` | `CallableAdapter` |
+
+It also tries to reuse the agent's LLM. For ADK agents, `wrap` walks
+the agent tree, finds the first `.model`, and wires a matching
+`LLMPlanner` + `LLMGoalDeriver`. For non-ADK agents you can supply
+`call_llm=` / `model=` yourself; if neither is provided, `wrap`
+degrades to `PassthroughPlanner` + `LiteralGoalDeriver` and logs a
+DEBUG line explaining the drop.
+
+Every default is overridable via keyword argument — `planner=`,
+`goal_deriver=`, `executor=`, `steerer=`, `sinks=`, and
+`max_plan_reinvocations=` all win over the auto-wiring when passed.
+
 ## Mental model in five sentences
 
 goldfive wraps an agent and runs it against an explicit plan.
@@ -243,14 +279,31 @@ agent primitive you have.
 ## Using an LLM planner instead
 
 `PassthroughPlanner` is great for demos because you hand it a plan
-up-front. For real workloads, let the LLM decompose:
+up-front. For real workloads, let the LLM decompose. If you already
+have a `call_llm` async binding, hand it to `goldfive.wrap` — it
+builds the `LLMPlanner` + `LLMGoalDeriver` pair for you:
 
 ```python
-from goldfive.planner import LLMPlanner
+import goldfive
 
 async def call_llm(system_prompt: str, user_prompt: str, model: str) -> str:
     # wire this to your LLM of choice.
     ...
+
+runner = goldfive.wrap(
+    my_agent,
+    call_llm=call_llm,
+    model="claude-opus-4-5-20251101",
+)
+outcome = await runner.run("build me a slide deck about Python")
+```
+
+Or the explicit form with `Runner(...)`:
+
+```python
+from goldfive import Runner, SequentialExecutor
+from goldfive.adapters.callable import CallableAdapter
+from goldfive.planner import LLMPlanner
 
 runner = Runner(
     agent=CallableAdapter(my_agent),

--- a/docs/guides/observability-with-harmonograf.md
+++ b/docs/guides/observability-with-harmonograf.md
@@ -288,17 +288,25 @@ including the sinks list, is unchanged. See
 wrap a new framework.
 
 If you just want the shortest possible Runner construction, the
-`goldfive.quickstart()` factory wires a `SequentialExecutor`, a
-`PassthroughGoalDeriver`, a `StaticPlanner` with one task per goal,
-and a single `InMemorySink`:
+one-line `goldfive.wrap` / `goldfive.run` helpers auto-detect the
+adapter and wire every default for you:
 
 ```python
-from goldfive import quickstart
+import goldfive
 
-runner = quickstart(my_agent, "summarise the notes")
-runner.sinks.append(HarmonografSink(client))  # if needed
-outcome = await runner.run("summarise the notes")
+runner = goldfive.wrap(root_agent, sinks=[HarmonografSink(client), LoggingSink()])
+outcome = await runner.run("make a presentation about waffles")
 ```
+
+`goldfive.wrap` picks `ADKAdapter`, `ClaudeAgentSDKAdapter`, or
+`CallableAdapter` automatically based on `root_agent`'s shape, and
+reuses the ADK agent's `.model` to configure `LLMPlanner` and
+`LLMGoalDeriver`. Override any default (`planner=`, `executor=`,
+`call_llm=`, `model=`, ...) by passing it as a keyword argument.
+
+The lower-level `goldfive.quickstart()` factory is still available
+for callers who want a ready-to-run `StaticPlanner` with one task per
+goal — see the source of `goldfive/quickstart.py`.
 
 ### Add persistence
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -62,6 +62,62 @@ from goldfive.sinks import (
 )
 ```
 
+## `goldfive.wrap` / `goldfive.run`
+
+One-line convenience wrappers over `Runner`. `wrap` returns a
+`Runner` pre-wired with sensible defaults and an auto-detected
+`AgentAdapter`; `run` is `wrap(...).run(user_input)` in a single
+call.
+
+```python
+def wrap(
+    agent: Any,
+    *,
+    planner: Optional[Planner] = None,
+    goal_deriver: Optional[GoalDeriver] = None,
+    executor: Optional[Executor] = None,
+    steerer: Optional[Steerer] = None,
+    sinks: Optional[list[EventSink]] = None,
+    call_llm: Optional[Callable[[str, str, str], Awaitable[str]]] = None,
+    model: Optional[str] = None,
+    max_plan_reinvocations: int = 32,
+) -> Runner: ...
+
+
+async def run(
+    agent: Any,
+    user_input: str | list[Goal],
+    *,
+    context: Optional[Mapping[str, Any]] = None,
+    **wrap_kwargs: Any,
+) -> ExecutionOutcome: ...
+```
+
+`agent` can be any of:
+
+- an object implementing `goldfive.AgentAdapter` (used verbatim),
+- a `google.adk.agents.BaseAgent` or ADK `Runner` (requires `goldfive[adk]`),
+- a zero-arg callable returning `claude_agent_sdk.ClaudeSDKClient` (requires `goldfive[claude]`),
+- an async `(task, session, tools) -> InvocationResult` callable.
+
+Adapter dispatch favours ADK over the async-callable path so ADK
+agents are not misrouted to `CallableAdapter`. Unknown shapes raise
+`TypeError` with a pointer to the supported options.
+
+When no `call_llm` is supplied and the agent does not expose an LLM
+surface `wrap` can detect (currently only ADK), `wrap` falls back to
+`PassthroughPlanner` + `LiteralGoalDeriver` and emits a `DEBUG`
+log line on the `goldfive.wrap` logger.
+
+Direct `auto_adapter` access is available for callers who want the
+dispatch logic without the Runner defaults:
+
+```python
+from goldfive.adapters.auto import auto_adapter
+
+adapter: AgentAdapter = auto_adapter(agent)
+```
+
 ## `Runner`
 
 The single entry point.

--- a/examples/hello_callable.py
+++ b/examples/hello_callable.py
@@ -1,9 +1,17 @@
 """hello_callable — the simplest possible goldfive run.
 
-Wires a :class:`CallableAdapter` to a :class:`StaticPlanner` with a
-hand-built plan, runs it through a :class:`SequentialExecutor`, and
-collects every event in an :class:`InMemorySink` so the full event log
-can be printed at the end.
+Shows the one-line :func:`goldfive.run` convenience wrapper: hand it a
+bare async callable that pretends to be an agent, hand it a user
+prompt, and let goldfive pick every default (auto-adapter,
+:class:`LiteralGoalDeriver`, :class:`PassthroughPlanner`,
+:class:`SequentialExecutor`, :class:`DefaultSteerer`,
+:class:`LoggingSink`).
+
+To see the full orchestration loop — an LLM planner decomposing the
+goal into tasks and the executor walking them — supply a
+``call_llm=`` callable to :func:`goldfive.wrap`. Real agents usually
+bring their own LLM via the ADK adapter path, in which case
+:func:`goldfive.wrap` will reuse the agent's model automatically.
 
 Run with::
 
@@ -13,39 +21,16 @@ Run with::
 from __future__ import annotations
 
 import asyncio
+import json
 
+import goldfive
 from goldfive import (
-    CallableAdapter,
     InMemorySink,
     InvocationResult,
-    PassthroughGoalDeriver,
-    Plan,
     ReportingToolSpec,
-    Runner,
-    SequentialExecutor,
     Session,
-    StaticPlanner,
     Task,
-    TaskEdge,
 )
-
-
-def build_plan() -> Plan:
-    return Plan(
-        id="hello-plan",
-        run_id="",
-        goal_ids=["g1"],
-        tasks=[
-            Task(id="greet", title="Greet the user", assignee_agent_id="greeter"),
-            Task(id="ask", title="Ask for a name", assignee_agent_id="greeter"),
-            Task(id="thank", title="Thank the user", assignee_agent_id="greeter"),
-        ],
-        edges=[
-            TaskEdge(from_task_id="greet", to_task_id="ask"),
-            TaskEdge(from_task_id="ask", to_task_id="thank"),
-        ],
-        summary="Greet, ask, thank.",
-    )
 
 
 async def greeter_agent(
@@ -53,48 +38,73 @@ async def greeter_agent(
     session: Session,
     tools: list[ReportingToolSpec],
 ) -> InvocationResult:
-    """A toy agent that produces one canned reply per task."""
-    _ = tools  # unused in this toy agent
-    text = {
-        "greet": "Hello!",
-        "ask": "What's your name?",
-        "thank": "Thanks for chatting!",
-    }.get(task.id, "(no-op)")
-    return InvocationResult(task_id=task.id, text=text)
+    """Return a short canned reply for the task goldfive assigns."""
+    _ = (session, tools)
+    return InvocationResult(
+        task_id=task.id,
+        text=f"greeted: {task.title}",
+    )
+
+
+def _build_stub_call_llm():
+    """Minimal deterministic ``call_llm`` so the demo needs no network.
+
+    Real callers would drop in their own LLM binding (OpenAI, Anthropic,
+    ADK's ``LLMRegistry``, etc.) — the contract is just
+    ``async (system_prompt, user_prompt, model) -> str`` where the
+    returned string is JSON matching the planner / goal-deriver schema.
+    """
+    plan_json = {
+        "summary": "Greet the user.",
+        "tasks": [
+            {
+                "id": "greet",
+                "title": "Say hello to the user",
+                "description": "Return a short greeting.",
+                "assignee_agent_id": "default",
+            }
+        ],
+        "edges": [],
+    }
+    goals_json = {"goals": [{"id": "g1", "summary": "Say hello"}]}
+    responses = iter([json.dumps(goals_json), json.dumps(plan_json)])
+
+    async def _call(system: str, user: str, model: str) -> str:
+        _ = (system, user, model)
+        try:
+            return next(responses)
+        except StopIteration:
+            return json.dumps({})
+
+    return _call
 
 
 async def main() -> None:
     sink = InMemorySink()
-    runner = Runner(
-        agent=CallableAdapter(greeter_agent, available_agents=["greeter"]),
-        planner=StaticPlanner(build_plan()),
-        executor=SequentialExecutor(),
-        goal_deriver=PassthroughGoalDeriver("Say hello, ask for a name, thank them"),
+    outcome = await goldfive.run(
+        greeter_agent,
+        "say hello to the user",
         sinks=[sink],
+        call_llm=_build_stub_call_llm(),
+        model="stub-model",
     )
 
-    outcome = await runner.run("run the greeter workflow")
-    await runner.close()
-
-    print(f"success={outcome.success}, reason={outcome.reason!r}")
+    print(f"success={outcome.success}  reason={outcome.reason!r}")
     print(f"run_id={outcome.session.run_id}")
     print(f"goals={[g.summary for g in outcome.session.goals]}")
     print(f"{len(sink.events)} events:")
-    for e in sink.events:
-        if isinstance(e, dict):
-            seq = e.get("sequence", "?")
-            kind = e.get("kind", "?")
-            payload = e.get("payload", {})
+    for evt in sink.events:
+        if isinstance(evt, dict):
+            seq = evt.get("sequence", "?")
+            kind = evt.get("kind", "?")
         else:
-            seq = getattr(e, "sequence", "?")
-            oneof = e.WhichOneof("payload") if hasattr(e, "WhichOneof") else None
+            seq = getattr(evt, "sequence", "?")
             kind = (
-                "".join(part.capitalize() for part in oneof.split("_"))
-                if oneof
+                evt.WhichOneof("payload")
+                if hasattr(evt, "WhichOneof")
                 else "?"
-            )
-            payload = getattr(e, oneof) if oneof else "{}"
-        print(f"  seq={seq:>3}  {kind:<16}  {payload}")
+            ) or "?"
+        print(f"  seq={seq:>3}  {kind}")
 
 
 if __name__ == "__main__":

--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 __version__ = "0.1.0"
 
 from goldfive.adapters.callable import CallableAdapter
+from goldfive.convenience import run, wrap
 from goldfive.drift import classify_refusal, classify_stop_reason, classify_tool_error
 from goldfive.executors.parallel import ParallelDAGExecutor
 from goldfive.executors.sequential import SequentialExecutor
@@ -87,4 +88,6 @@ __all__ = [
     "classify_stop_reason",
     "classify_tool_error",
     "quickstart",
+    "run",
+    "wrap",
 ]

--- a/goldfive/_llm_detect.py
+++ b/goldfive/_llm_detect.py
@@ -1,0 +1,158 @@
+"""Detect an LLM call surface on an existing agent, without hard deps.
+
+When a caller hands goldfive an ADK agent via :func:`goldfive.wrap`,
+the convenience layer tries to reuse whatever model that agent is
+already configured with so the planner and goal-deriver can talk to
+the same endpoint without the caller writing a bespoke ``call_llm``.
+
+This module exposes two helpers:
+
+* :func:`detect_llm` — inspect an agent and, if it looks like an ADK
+  ``BaseAgent`` with a usable ``.model`` attribute, return a
+  ``(call_llm, model_name)`` pair suitable for :class:`LLMPlanner` and
+  :class:`LLMGoalDeriver`.
+* :func:`make_default_adk_call_llm` — build a ``call_llm(system, user,
+  model) -> str`` coroutine that dispatches through ADK's
+  ``LLMRegistry`` / ``BaseLlm.generate_content_async`` stream.
+
+Neither helper hard-imports ``google.adk`` at module-import time. Both
+tolerate missing deps and return ``None`` when detection fails so the
+caller can fall back to a passthrough planner.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+log = logging.getLogger("goldfive.llm_detect")
+
+CallLLM = Callable[[str, str, str], Awaitable[str]]
+
+
+def _looks_like_adk_agent(agent: Any) -> bool:
+    """Duck-type check for an ADK ``BaseAgent`` without importing ADK."""
+    if agent is None:
+        return False
+    cls = type(agent)
+    mro_names = {f"{c.__module__}.{c.__name__}" for c in cls.__mro__}
+    for name in mro_names:
+        if name.startswith("google.adk."):
+            return True
+    if hasattr(agent, "sub_agents") and hasattr(agent, "name"):
+        return True
+    return False
+
+
+def _extract_adk_model(agent: Any) -> Any:
+    """Return the first ``.model`` found on ``agent`` or a sub-agent.
+
+    ADK coordinator trees often attach the model at the root; sub-agents
+    inherit the same model by convention. We walk ``sub_agents``,
+    ``inner_agent``, and ``tools[*].agent`` the same way the ADK
+    adapter does in :func:`goldfive.adapters.adk.ADKAdapter.available_agents`.
+    """
+    seen: set[int] = set()
+    stack: list[Any] = [agent]
+    while stack:
+        cur = stack.pop()
+        if cur is None or id(cur) in seen:
+            continue
+        seen.add(id(cur))
+        model = getattr(cur, "model", None)
+        if model:
+            return model
+        for sub in getattr(cur, "sub_agents", None) or ():
+            stack.append(sub)
+        inner = getattr(cur, "inner_agent", None)
+        if inner is not None:
+            stack.append(inner)
+        for t in getattr(cur, "tools", None) or ():
+            nested = getattr(t, "agent", None)
+            if nested is not None:
+                stack.append(nested)
+    return None
+
+
+def make_default_adk_call_llm(model: Any) -> CallLLM | None:
+    """Return a ``call_llm(system, user, model) -> str`` backed by ADK.
+
+    ``model`` may be a string alias (``"gpt-4o"``), a ``BaseLlm``
+    instance (including ``LiteLlm``), or anything ``LLMRegistry`` can
+    resolve. Returns ``None`` when ADK is not installed or the model
+    cannot be resolved to a ``BaseLlm``.
+    """
+    try:
+        from google.adk.models.base_llm import BaseLlm  # type: ignore
+        from google.adk.models.llm_request import LlmRequest  # type: ignore
+        from google.adk.models.registry import LLMRegistry  # type: ignore
+        from google.genai import types as genai_types  # type: ignore
+    except ImportError:
+        log.debug("goldfive._llm_detect: google.adk not installed")
+        return None
+
+    if isinstance(model, BaseLlm):
+        llm: Any = model
+    elif isinstance(model, str) and model:
+        try:
+            llm_cls = LLMRegistry.new_llm(model)  # type: ignore[arg-type]
+        except Exception as exc:  # noqa: BLE001
+            log.debug("goldfive._llm_detect: LLMRegistry.new_llm(%r) raised: %s", model, exc)
+            return None
+        llm = llm_cls
+    else:
+        return None
+
+    async def _call_llm(system: str, user: str, model_str: str) -> str:
+        _ = model_str  # ADK's BaseLlm is already model-bound
+        req = LlmRequest(
+            contents=[
+                genai_types.Content(
+                    role="user",
+                    parts=[genai_types.Part(text=user)],
+                ),
+            ],
+            config=genai_types.GenerateContentConfig(
+                system_instruction=system,
+            ),
+        )
+        chunks: list[str] = []
+        async for resp in llm.generate_content_async(req, stream=False):
+            content = getattr(resp, "content", None)
+            if content is None:
+                continue
+            for part in getattr(content, "parts", None) or ():
+                if getattr(part, "thought", False):
+                    continue
+                text = getattr(part, "text", "") or ""
+                if text:
+                    chunks.append(str(text))
+        return "".join(chunks).strip()
+
+    return _call_llm
+
+
+def detect_llm(agent: Any) -> tuple[CallLLM, str] | None:
+    """Detect an LLM surface on ``agent`` and return ``(call_llm, model)``.
+
+    Currently only ADK agents are supported. Returns ``None`` for
+    non-ADK shapes, for ADK agents without a resolvable model, or when
+    the ADK optional dep is not installed.
+    """
+    if not _looks_like_adk_agent(agent):
+        return None
+
+    model = _extract_adk_model(agent)
+    if model is None:
+        return None
+
+    call_llm = make_default_adk_call_llm(model)
+    if call_llm is None:
+        return None
+
+    model_name = getattr(model, "model", None) or (model if isinstance(model, str) else "")
+    return call_llm, str(model_name or "")
+
+
+__all__ = ["CallLLM", "detect_llm", "make_default_adk_call_llm"]

--- a/goldfive/adapters/auto.py
+++ b/goldfive/adapters/auto.py
@@ -1,0 +1,150 @@
+"""Auto-detect the right :class:`AgentAdapter` for an arbitrary agent object.
+
+Powers :func:`goldfive.wrap` / :func:`goldfive.run` by turning any of
+the four common "agent" shapes goldfive supports into a concrete
+:class:`~goldfive.protocols.AgentAdapter`:
+
+* an existing :class:`AgentAdapter` (passed through verbatim),
+* an ADK ``BaseAgent`` (wrapped in :class:`ADKAdapter`),
+* a Claude SDK client factory (wrapped in :class:`ClaudeAgentSDKAdapter`),
+* an async callable matching :data:`~goldfive.adapters.callable.AgentCallable`
+  (wrapped in :class:`CallableAdapter`).
+
+The detector avoids importing the ADK and Claude SDKs at module load
+so users who only install the default extras never pay the import
+cost. When detection is ambiguous the dispatch favours ADK over
+callable — an object that quacks like both is almost always an ADK
+agent (its ``sub_agents`` / ``.run_async`` coroutine methods make it
+look callable) and ADK takes precedence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+from goldfive.adapters.callable import CallableAdapter
+from goldfive.protocols import AgentAdapter
+
+
+def _looks_like_adk_agent(agent: Any) -> bool:
+    """Duck-type check for an ADK ``BaseAgent`` without importing ADK."""
+    if agent is None:
+        return False
+    cls = type(agent)
+    for base in cls.__mro__:
+        qualified = f"{base.__module__}.{base.__name__}"
+        if qualified.startswith("google.adk."):
+            return True
+    if hasattr(agent, "sub_agents") and hasattr(agent, "name"):
+        return True
+    return False
+
+
+def _looks_like_adk_runner(agent: Any) -> bool:
+    """Duck-type check for an ADK ``Runner``."""
+    return (
+        agent is not None
+        and callable(getattr(agent, "run_async", None))
+        and getattr(agent, "agent", None) is not None
+        and getattr(agent, "session_service", None) is not None
+    )
+
+
+def _looks_like_claude_client_factory(agent: Any) -> bool:
+    """Heuristic for a Claude SDK ``ClientFactory`` callable.
+
+    A client factory is a zero-arg callable returning a ``ClaudeSDKClient``.
+    Without importing the SDK, inspect the signature: no required
+    positional-or-keyword parameters. We also check the declared return
+    annotation's module when available.
+    """
+    if not callable(agent):
+        return False
+    if inspect.isclass(agent):
+        qualified = f"{agent.__module__}.{agent.__name__}"
+        if "claude_agent_sdk" in qualified:
+            return True
+    try:
+        sig = inspect.signature(agent)
+    except (TypeError, ValueError):
+        return False
+    required = [
+        p
+        for p in sig.parameters.values()
+        if p.default is inspect.Parameter.empty
+        and p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    ]
+    if required:
+        return False
+    ret = sig.return_annotation
+    if ret is inspect.Signature.empty:
+        return False
+    ret_repr = getattr(ret, "__module__", "") + "." + getattr(ret, "__name__", "")
+    return "claude_agent_sdk" in ret_repr or "ClaudeSDKClient" in str(ret)
+
+
+def _looks_like_async_agent_callable(agent: Any) -> bool:
+    """Check for an async ``(task, session, tools) -> InvocationResult`` callable."""
+    if not callable(agent):
+        return False
+    if asyncio.iscoroutinefunction(agent):
+        return True
+    # Instance with an async ``__call__`` method.
+    call_attr = inspect.getattr_static(type(agent), "__call__", None)
+    return asyncio.iscoroutinefunction(call_attr)
+
+
+def auto_adapter(agent: Any) -> AgentAdapter:
+    """Return a concrete :class:`AgentAdapter` for ``agent``.
+
+    Dispatch order:
+
+    1. If ``agent`` already implements :class:`AgentAdapter`, return it.
+    2. If it looks like an ADK ``BaseAgent`` or ``Runner``, build an
+       :class:`~goldfive.adapters.adk.ADKAdapter`. Raises
+       :class:`ImportError` when the ``adk`` extra is missing.
+    3. If it looks like a Claude SDK client factory, build a
+       :class:`~goldfive.adapters.claude.ClaudeAgentSDKAdapter`. Raises
+       :class:`ImportError` when the ``claude`` extra is missing.
+    4. If it is an async callable, wrap it in
+       :class:`~goldfive.adapters.callable.CallableAdapter`.
+    5. Otherwise, raise :class:`TypeError` with a list of the shapes
+       goldfive recognises.
+    """
+    if isinstance(agent, AgentAdapter):
+        return agent
+
+    if _looks_like_adk_agent(agent) or _looks_like_adk_runner(agent):
+        from goldfive.adapters.adk import ADKAdapter  # lazy: requires extra
+
+        return ADKAdapter(agent)
+
+    if _looks_like_claude_client_factory(agent):
+        from goldfive.adapters.claude import ClaudeAgentSDKAdapter  # lazy
+
+        return ClaudeAgentSDKAdapter(client_factory=agent)
+
+    if _looks_like_async_agent_callable(agent):
+        return CallableAdapter(agent, available_agents=["default"])
+
+    raise TypeError(
+        "goldfive.wrap: could not pick an AgentAdapter for "
+        f"{type(agent).__name__!s}. Supported shapes are:\n"
+        "  - any object implementing goldfive.AgentAdapter,\n"
+        "  - a google.adk.agents.BaseAgent (requires goldfive[adk]),\n"
+        "  - a zero-arg factory returning claude_agent_sdk.ClaudeSDKClient "
+        "(requires goldfive[claude]),\n"
+        "  - an async callable (task, session, tools) -> InvocationResult.\n"
+        "Pass an adapter directly with goldfive.Runner(agent=...) if "
+        "you need a shape goldfive does not auto-detect."
+    )
+
+
+__all__ = ["auto_adapter"]

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -1,0 +1,186 @@
+"""One-line ergonomics for wrapping an existing agent in goldfive.
+
+Most callers want a two-step flow:
+
+    runner = goldfive.wrap(my_agent)
+    outcome = await runner.run("do the thing")
+
+or, even shorter:
+
+    outcome = await goldfive.run(my_agent, "do the thing")
+
+:func:`wrap` picks a concrete :class:`~goldfive.protocols.AgentAdapter`
+via :func:`goldfive.adapters.auto.auto_adapter`, tries to reuse the
+agent's existing LLM surface (currently only ADK), and wires a
+:class:`~goldfive.Runner` with the usual defaults — a
+:class:`LLMPlanner` / :class:`LLMGoalDeriver` pair when an LLM is
+available, else the degraded :class:`PassthroughPlanner` /
+:class:`LiteralGoalDeriver` pair. Every component is overridable via
+keyword argument.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from goldfive._llm_detect import CallLLM, detect_llm
+from goldfive.adapters.auto import auto_adapter
+from goldfive.executors.sequential import SequentialExecutor
+from goldfive.goal_deriver import LiteralGoalDeriver, LLMGoalDeriver
+from goldfive.planner import LLMPlanner, PassthroughPlanner
+from goldfive.protocols import (
+    EventSink,
+    Executor,
+    GoalDeriver,
+    Planner,
+    Steerer,
+)
+from goldfive.results import ExecutionOutcome
+from goldfive.runner import Runner
+from goldfive.sinks import LoggingSink
+from goldfive.steerer import DefaultSteerer
+from goldfive.types import Goal
+
+log = logging.getLogger("goldfive.wrap")
+
+
+def wrap(
+    agent: Any,
+    *,
+    planner: Planner | None = None,
+    goal_deriver: GoalDeriver | None = None,
+    executor: Executor | None = None,
+    steerer: Steerer | None = None,
+    sinks: list[EventSink] | None = None,
+    call_llm: CallLLM | None = None,
+    model: str | None = None,
+    max_plan_reinvocations: int = 32,
+) -> Runner:
+    """Build a :class:`Runner` that drives ``agent`` with goldfive.
+
+    Parameters
+    ----------
+    agent:
+        Any of the shapes :func:`auto_adapter` accepts: an existing
+        :class:`AgentAdapter`, an ADK ``BaseAgent`` / ``Runner``, a
+        Claude SDK client factory, or an async ``(task, session, tools)
+        -> InvocationResult`` callable.
+    planner:
+        Optional :class:`Planner` override. Wins over the default
+        :class:`LLMPlanner` / :class:`PassthroughPlanner`.
+    goal_deriver:
+        Optional :class:`GoalDeriver` override. Wins over the default
+        :class:`LLMGoalDeriver` / :class:`LiteralGoalDeriver`.
+    executor:
+        Optional :class:`Executor` override. Defaults to
+        :class:`SequentialExecutor(max_plan_reinvocations=...)`.
+    steerer:
+        Optional :class:`Steerer` override. Defaults to
+        :class:`DefaultSteerer`.
+    sinks:
+        Optional sink list override. Defaults to ``[LoggingSink()]``.
+        Passing an explicit empty list suppresses all sinks.
+    call_llm:
+        Optional async ``(system, user, model) -> str`` callable. When
+        provided, it is used for both the default planner and the
+        default goal deriver, overriding any LLM surface detected on
+        the agent.
+    model:
+        Optional model name passed to :class:`LLMPlanner` /
+        :class:`LLMGoalDeriver`. Ignored when ``call_llm`` is omitted
+        and no LLM is detected on the agent.
+    max_plan_reinvocations:
+        Cap on how many times the executor may re-invoke the planner
+        for refine loops. Default ``32``; flowed into both the
+        :class:`SequentialExecutor` default and the :class:`Runner`.
+
+    Returns
+    -------
+    Runner
+        A ready-to-use :class:`Runner`. Call ``await runner.run(...)``
+        or use :func:`goldfive.run` for the one-line variant.
+    """
+    adapter = auto_adapter(agent)
+
+    resolved_call_llm: CallLLM | None = call_llm
+    resolved_model: str = model or ""
+
+    if resolved_call_llm is None and (planner is None or goal_deriver is None):
+        detected = detect_llm(agent)
+        if detected is not None:
+            resolved_call_llm, detected_model = detected
+            if not resolved_model:
+                resolved_model = detected_model
+
+    resolved_planner: Planner
+    if planner is not None:
+        resolved_planner = planner
+    elif resolved_call_llm is not None:
+        resolved_planner = LLMPlanner(call_llm=resolved_call_llm, model=resolved_model)
+    else:
+        log.debug(
+            "goldfive.wrap: no call_llm and no detectable LLM on agent "
+            "(%s); falling back to PassthroughPlanner",
+            type(agent).__name__,
+        )
+        resolved_planner = PassthroughPlanner()
+
+    resolved_goal_deriver: GoalDeriver
+    if goal_deriver is not None:
+        resolved_goal_deriver = goal_deriver
+    elif resolved_call_llm is not None:
+        resolved_goal_deriver = LLMGoalDeriver(
+            call_llm=resolved_call_llm,
+            model=resolved_model,
+        )
+    else:
+        log.debug(
+            "goldfive.wrap: no call_llm available; falling back to "
+            "LiteralGoalDeriver (user_input becomes a single Goal)"
+        )
+        resolved_goal_deriver = LiteralGoalDeriver()
+
+    resolved_executor: Executor = executor or SequentialExecutor(
+        max_plan_reinvocations=max_plan_reinvocations
+    )
+    resolved_steerer: Steerer = steerer or DefaultSteerer()
+    resolved_sinks: list[EventSink] = (
+        list(sinks) if sinks is not None else [LoggingSink()]
+    )
+
+    return Runner(
+        agent=adapter,
+        planner=resolved_planner,
+        executor=resolved_executor,
+        goal_deriver=resolved_goal_deriver,
+        steerer=resolved_steerer,
+        sinks=resolved_sinks,
+        max_plan_reinvocations=max_plan_reinvocations,
+    )
+
+
+async def run(
+    agent: Any,
+    user_input: str | list[Goal],
+    *,
+    context: Mapping[str, Any] | None = None,
+    **wrap_kwargs: Any,
+) -> ExecutionOutcome:
+    """Wrap ``agent`` and run it against ``user_input`` in one call.
+
+    Equivalent to::
+
+        runner = goldfive.wrap(agent, **wrap_kwargs)
+        return await runner.run(user_input, context=context)
+
+    Any keyword arguments other than ``context`` are forwarded to
+    :func:`wrap`. Does not call :meth:`Runner.close`; callers that
+    need deterministic sink teardown should build their own runner.
+    """
+    runner = wrap(agent, **wrap_kwargs)
+    return await runner.run(user_input, context=context)
+
+
+__all__ = ["run", "wrap"]

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -1,0 +1,338 @@
+"""Tests for :func:`goldfive.wrap` / :func:`goldfive.run`.
+
+Exercises the auto-adapter dispatch, LLM detection on ADK agents,
+the degraded fallback when no LLM can be detected, and every
+documented override knob.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+import goldfive
+from goldfive import (
+    CallableAdapter,
+    ExecutionOutcome,
+    InMemorySink,
+    InvocationResult,
+    LiteralGoalDeriver,
+    LLMGoalDeriver,
+    LLMPlanner,
+    LoggingSink,
+    PassthroughPlanner,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    Task,
+)
+from goldfive.adapters.auto import auto_adapter
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    """Reference agent: returns a non-empty result so the executor auto-completes."""
+    _ = (session, tools)
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+class _MinimalAdapter:
+    """Bare AgentAdapter that satisfies the protocol without extras."""
+
+    def __init__(self) -> None:
+        self._tools: list[ReportingToolSpec] = []
+
+    @property
+    def available_agents(self) -> list[str]:
+        return ["minimal"]
+
+    async def register_reporting_tools(
+        self, tools: list[ReportingToolSpec]
+    ) -> None:
+        self._tools = list(tools)
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text=f"minimal: {task.title}")
+
+
+# ---------------------------------------------------------------------------
+# Callable agents
+# ---------------------------------------------------------------------------
+
+
+async def test_wrap_callable_returns_runner() -> None:
+    """``wrap(callable)`` returns a :class:`Runner` configured with defaults."""
+    runner = goldfive.wrap(_happy_agent)
+
+    assert isinstance(runner, Runner)
+    assert isinstance(runner.agent, CallableAdapter)
+    assert isinstance(runner.executor, SequentialExecutor)
+    # No LLM detected on a bare callable → PassthroughPlanner + LiteralGoalDeriver.
+    assert isinstance(runner.planner, PassthroughPlanner)
+    assert isinstance(runner.goal_deriver, LiteralGoalDeriver)
+    # Default sinks = [LoggingSink()].
+    assert len(runner.sinks) == 1
+    assert isinstance(runner.sinks[0], LoggingSink)
+
+
+async def test_wrap_callable_runs_to_completion(stub_call_llm: Any) -> None:
+    """``await wrap(agent).run(...)`` produces a successful outcome.
+
+    A bare callable has no detectable LLM, so we supply ``call_llm=`` to
+    wire up the default :class:`LLMPlanner` / :class:`LLMGoalDeriver`
+    and exercise the full Runner loop end-to-end.
+    """
+    call_llm = stub_call_llm(
+        [
+            # LLMGoalDeriver response.
+            {"goals": [{"id": "g1", "summary": "say hello"}]},
+            # LLMPlanner response — one task routed to the default agent.
+            {
+                "summary": "one-task plan",
+                "tasks": [
+                    {
+                        "id": "t1",
+                        "title": "say hello",
+                        "description": "Say hello to the user",
+                        "assignee_agent_id": "default",
+                    }
+                ],
+                "edges": [],
+            },
+        ]
+    )
+    sink = InMemorySink()
+    runner = goldfive.wrap(
+        _happy_agent,
+        sinks=[sink],
+        call_llm=call_llm,
+        model="test-model",
+    )
+
+    outcome = await runner.run("say hello")
+    await runner.close()
+
+    assert isinstance(outcome, ExecutionOutcome)
+    assert outcome.success, outcome.reason
+    assert outcome.session.plan is not None
+    assert len(outcome.session.plan.tasks) == 1
+    assert len(sink.events) > 0
+
+
+async def test_run_convenience_returns_outcome() -> None:
+    """``await goldfive.run(agent, input)`` returns an ExecutionOutcome."""
+    outcome = await goldfive.run(
+        _happy_agent,
+        "do the thing",
+        sinks=[InMemorySink()],
+        planner=PassthroughPlanner(),  # explicit so the degraded path is OK
+    )
+    assert isinstance(outcome, ExecutionOutcome)
+
+
+# ---------------------------------------------------------------------------
+# Overrides
+# ---------------------------------------------------------------------------
+
+
+async def test_wrap_custom_sinks_override_default(caplog: pytest.LogCaptureFixture) -> None:
+    """Caller-supplied ``sinks`` replace the default ``LoggingSink``."""
+    sink = InMemorySink()
+    runner = goldfive.wrap(_happy_agent, sinks=[sink])
+
+    assert runner.sinks == [sink]
+    assert not any(isinstance(s, LoggingSink) for s in runner.sinks)
+
+
+async def test_wrap_empty_sinks_list_is_respected() -> None:
+    """An explicit empty list suppresses the default ``LoggingSink``."""
+    runner = goldfive.wrap(_happy_agent, sinks=[])
+    assert runner.sinks == []
+
+
+async def test_wrap_custom_planner_override_wins(stub_call_llm: Any) -> None:
+    """An explicit ``planner=`` argument wins over detection and defaults."""
+    call_llm = stub_call_llm([])  # never called — we override the planner
+    custom_planner = PassthroughPlanner()
+    runner = goldfive.wrap(
+        _happy_agent,
+        planner=custom_planner,
+        call_llm=call_llm,
+        model="irrelevant",
+    )
+    assert runner.planner is custom_planner
+    # goal_deriver should still use LLMGoalDeriver since call_llm was given.
+    assert isinstance(runner.goal_deriver, LLMGoalDeriver)
+
+
+async def test_wrap_call_llm_argument_drives_defaults(stub_call_llm: Any) -> None:
+    """An explicit ``call_llm=`` wires both planner and goal deriver."""
+    call_llm = stub_call_llm([])
+    runner = goldfive.wrap(
+        _happy_agent,
+        call_llm=call_llm,
+        model="test-model",
+    )
+    assert isinstance(runner.planner, LLMPlanner)
+    assert isinstance(runner.goal_deriver, LLMGoalDeriver)
+
+
+async def test_wrap_goal_deriver_override_wins() -> None:
+    """An explicit ``goal_deriver=`` argument is used verbatim."""
+    custom = LiteralGoalDeriver()
+    runner = goldfive.wrap(_happy_agent, goal_deriver=custom)
+    assert runner.goal_deriver is custom
+
+
+async def test_wrap_forwards_kwargs_to_runner() -> None:
+    """``max_plan_reinvocations`` flows into the constructed Runner."""
+    runner = goldfive.wrap(_happy_agent, max_plan_reinvocations=7)
+    assert runner.max_plan_reinvocations == 7
+    assert isinstance(runner.executor, SequentialExecutor)
+    assert runner.executor.max_plan_reinvocations == 7
+
+
+# ---------------------------------------------------------------------------
+# Degraded fallback
+# ---------------------------------------------------------------------------
+
+
+async def test_wrap_without_llm_falls_back_to_passthrough(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No LLM ⇒ PassthroughPlanner + LiteralGoalDeriver + DEBUG log line."""
+    caplog.set_level(logging.DEBUG, logger="goldfive.wrap")
+    runner = goldfive.wrap(_happy_agent)
+
+    assert isinstance(runner.planner, PassthroughPlanner)
+    assert isinstance(runner.goal_deriver, LiteralGoalDeriver)
+
+    # DEBUG-level explanation of the degradation is emitted.
+    messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "PassthroughPlanner" in messages
+    assert "LiteralGoalDeriver" in messages
+
+
+# ---------------------------------------------------------------------------
+# Adapter dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_wrap_passes_existing_adapter_through() -> None:
+    """A pre-built :class:`AgentAdapter` is reused, not re-wrapped."""
+    adapter = _MinimalAdapter()
+    runner = goldfive.wrap(adapter)
+    assert runner.agent is adapter
+
+
+async def test_auto_adapter_rejects_unknown_shapes() -> None:
+    """A non-adapter, non-callable argument raises :class:`TypeError`."""
+    with pytest.raises(TypeError) as excinfo:
+        auto_adapter(42)
+    msg = str(excinfo.value)
+    assert "goldfive.AgentAdapter" in msg
+    assert "google.adk" in msg
+    assert "claude_agent_sdk" in msg
+
+
+async def test_auto_adapter_rejects_sync_callable() -> None:
+    """A sync callable that doesn't look like a factory is rejected."""
+
+    def sync_thing(task, session, tools):  # noqa: ANN001
+        return None
+
+    with pytest.raises(TypeError):
+        auto_adapter(sync_thing)
+
+
+async def test_auto_adapter_picks_callable_for_async_function() -> None:
+    """Async functions with the agent signature get a :class:`CallableAdapter`."""
+    adapter = auto_adapter(_happy_agent)
+    assert isinstance(adapter, CallableAdapter)
+
+
+# ---------------------------------------------------------------------------
+# ADK-gated tests
+# ---------------------------------------------------------------------------
+
+
+def _has_adk() -> bool:
+    try:
+        import google.adk  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _has_adk(), reason="goldfive[adk] extra not installed")
+async def test_wrap_adk_agent_chooses_adk_adapter() -> None:
+    """An ADK ``BaseAgent`` dispatches to :class:`ADKAdapter`."""
+    from google.adk.agents.llm_agent import LlmAgent
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    adk_agent = LlmAgent(
+        name="test_agent",
+        model="fake-model",
+        description="Test agent",
+        instruction="Test.",
+    )
+    runner = goldfive.wrap(adk_agent, sinks=[InMemorySink()])
+    assert isinstance(runner.agent, ADKAdapter)
+
+
+@pytest.mark.skipif(not _has_adk(), reason="goldfive[adk] extra not installed")
+async def test_adk_agent_is_not_mistaken_for_callable() -> None:
+    """ADK takes precedence over callable detection when both match."""
+    from google.adk.agents.llm_agent import LlmAgent
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    adk_agent = LlmAgent(
+        name="test_agent",
+        model="fake-model",
+        description="Test agent",
+        instruction="Test.",
+    )
+    adapter = auto_adapter(adk_agent)
+    assert isinstance(adapter, ADKAdapter)
+    assert not isinstance(adapter, CallableAdapter)
+
+
+# ---------------------------------------------------------------------------
+# Claude-gated tests
+# ---------------------------------------------------------------------------
+
+
+def _has_claude_sdk() -> bool:
+    try:
+        import claude_agent_sdk  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(
+    not _has_claude_sdk(), reason="claude_agent_sdk not installed"
+)
+async def test_wrap_claude_sdk_factory_chooses_claude_adapter() -> None:
+    """A zero-arg factory returning ``ClaudeSDKClient`` dispatches to the Claude adapter."""
+    from claude_agent_sdk import ClaudeSDKClient
+
+    from goldfive.adapters.claude import ClaudeAgentSDKAdapter
+
+    def factory() -> ClaudeSDKClient:
+        return ClaudeSDKClient()
+
+    runner = goldfive.wrap(factory, sinks=[InMemorySink()])
+    assert isinstance(runner.agent, ClaudeAgentSDKAdapter)


### PR DESCRIPTION
## Summary

Closes #66. Adds two convenience wrappers on top of `Runner`:

```python
outcome = await goldfive.run(agent, "make a presentation about waffles")
# or
runner = goldfive.wrap(agent, sinks=[...])
outcome = await runner.run("...")
```

- `goldfive.wrap(agent, **kwargs) -> Runner` — auto-detects the adapter from the agent's shape (AgentAdapter passthrough · ADK `BaseAgent`/`Runner` · Claude SDK client factory · async callable), reuses the agent's LLM when detectable (via `goldfive._llm_detect` walking ADK's `.model` + `LLMRegistry`), and wires sensible defaults for every other Runner component. All fields overridable via kwargs.
- `goldfive.run(agent, user_input, **kwargs)` — one-shot convenience equivalent to `await wrap(agent, **kwargs).run(user_input)`.
- `goldfive.adapters.auto.auto_adapter(agent)` — dispatch logic exposed standalone for callers who want the detector without the Runner defaults. ADK takes precedence over callable so ADK agents are never misrouted.
- `goldfive._llm_detect` — helper that extracts a `call_llm` from an ADK agent's model without importing `google.adk` at module load.
- Rewrote `examples/hello_callable.py` around `goldfive.run(...)`.
- Updated README hello snippet, `docs/guides/getting-started.md` (new "one-line wrapping" section), `docs/guides/observability-with-harmonograf.md` quickstart, and `docs/reference/api.md`.

## Test plan

- [x] `uv run pytest -q` → 280 passed, 36 skipped (up from 266 / 36 on main — 14 new tests in `tests/test_wrap.py`).
- [x] `uv run ruff check` → clean.
- [x] `uv run mypy goldfive/convenience.py goldfive/adapters/auto.py goldfive/_llm_detect.py` → clean.
- [x] `uv run python examples/hello_callable.py` → `success=True`, 6 events emitted end-to-end.
- [x] ADK import stays lazy — `goldfive[adk]` not installed in the dev env; ADK-gated tests skip correctly.
- [x] Claude SDK import stays lazy — `claude_agent_sdk` not installed; Claude-gated tests skip correctly.
