### PR TITLE
Add .agents/ skill folder

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,44 @@
+---
+name: agents-index
+description: Index of agent-facing skills for goldfive — what's here and when to read which.
+---
+
+# `.agents/` — agent-facing skills
+
+Canonical "how do I X" guides for agents (Claude Code sessions, internal
+tools, IDE integrations) that need to use, extend, or diagnose goldfive.
+Each skill is a short, focused markdown file whose snippets run against
+current `main`.
+
+These are distinct from `docs/`. `docs/` is human prose organised for
+learning and reference. `.agents/` is terse, task-shaped, and optimised
+for a sibling agent that wants the shortest correct path from intent to
+action.
+
+## When to read which
+
+| I want to… | Read |
+|---|---|
+| wrap my existing agent with goldfive | [use-goldfive.md](use-goldfive.md) |
+| add a feature, adapter, or sink to goldfive | [develop-goldfive.md](develop-goldfive.md) |
+| diagnose a broken run | [debug-goldfive.md](debug-goldfive.md) |
+| understand or implement an `AgentAdapter` | [adapters.md](adapters.md) |
+| understand or implement an `EventSink` | [sinks.md](sinks.md) |
+| know what events exist and how to emit one | [events.md](events.md) |
+| write a goldfive test | [testing.md](testing.md) |
+| cut a release | [release.md](release.md) |
+
+## How these get referenced
+
+Other agents either load the file directly (`cat .agents/use-goldfive.md`)
+or reference it by path from their own instructions. Keep each file
+self-contained so a reader arriving cold can complete the task without
+cross-loading the rest of the folder.
+
+## Conventions
+
+- Every snippet runs against current `main`. If you change goldfive's
+  public surface, update the affected skill in the same PR.
+- No emojis. Terse voice. Files under 200 lines.
+- Prefer pointing at `docs/` for long-form reference over duplicating
+  prose here.

--- a/.agents/adapters.md
+++ b/.agents/adapters.md
@@ -1,0 +1,154 @@
+---
+name: adapters
+description: The AgentAdapter protocol — what it is, how to implement one, and what ships in-box.
+applies-when: ["write an adapter", "wrap a framework", "AgentAdapter contract"]
+---
+
+# Adapters
+
+An `AgentAdapter` is the seam between goldfive's executor and whatever
+agent runtime actually does the work. It is how goldfive stays
+framework-agnostic.
+
+## Contract
+
+From `goldfive/protocols.py`:
+
+```python
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class AgentAdapter(Protocol):
+    async def register_reporting_tools(
+        self,
+        tools: list[ReportingToolSpec],
+    ) -> None: ...
+
+    async def invoke(
+        self,
+        task: Task,
+        session: Session,
+    ) -> InvocationResult: ...
+
+    @property
+    def available_agents(self) -> list[str]: ...
+```
+
+Three members. That's it.
+
+- **`register_reporting_tools`** — called once per run, between
+  planning and execution. You get the seven canonical reporting tool
+  specs (see [events.md](events.md)) and must surface them to the
+  underlying framework so the agent can call them during `invoke`.
+- **`invoke`** — called per task. Run the agent against `task`, using
+  the registered tools to report state changes. Return an
+  `InvocationResult` with the final text and/or artifacts.
+- **`available_agents`** — stable list of agent identifiers this
+  adapter can dispatch to. Planners consult this so they don't generate
+  tasks for non-existent agents.
+
+## Shipped implementations
+
+| Adapter | Module | Extra |
+|---|---|---|
+| `CallableAdapter` | `goldfive.adapters.callable` | (core) |
+| `ADKAdapter` | `goldfive.adapters.adk` | `goldfive[adk]` |
+| `ClaudeAgentSDKAdapter` | `goldfive.adapters.claude` | `goldfive[claude]` |
+
+`CallableAdapter` is the reference implementation and the preferred
+vehicle for deterministic tests — it wraps an async callable of
+shape `(task, session, tools) -> InvocationResult` and forwards tools
+verbatim.
+
+## Writing a new adapter
+
+Skeleton:
+
+```python
+from __future__ import annotations
+
+from goldfive.reporting import ReportingToolSpec
+from goldfive.results import InvocationResult
+from goldfive.types import Session, Task
+
+
+class MyFrameworkAdapter:
+    def __init__(self, underlying_agent) -> None:
+        self._agent = underlying_agent
+        self._tools: list[ReportingToolSpec] = []
+
+    async def register_reporting_tools(
+        self, tools: list[ReportingToolSpec]
+    ) -> None:
+        self._tools = list(tools)
+        # Translate each ReportingToolSpec into whatever your framework
+        # wants. For an SDK with an `add_tool(name, schema, fn)` API:
+        # for spec in tools:
+        #     self._agent.add_tool(spec.name, spec.parameters, spec.handler)
+
+    async def invoke(
+        self, task: Task, session: Session
+    ) -> InvocationResult:
+        # Dispatch to the framework. The agent's generated tool calls
+        # should land on the handlers you registered above.
+        text = await self._agent.run(task.description, tools=self._tools)
+        return InvocationResult(task_id=task.id, text=text)
+
+    @property
+    def available_agents(self) -> list[str]:
+        return ["my-framework-agent"]
+```
+
+## Key design constraints
+
+- **Tool handlers are `async`** and have signature
+  `(args: dict, session: Session, steerer: Steerer) -> dict`. When the
+  framework calls `handler`, it must pass the *live* `Session` and the
+  steerer bound by the Runner — `CallableAdapter` short-circuits this
+  by exposing the raw specs and letting the callable drive them; ADK
+  and Claude adapters do the wiring in native tool-call form.
+- **Return cleanly OR call a terminal tool. Don't half-do both.**
+  `SequentialExecutor` auto-completes a task that's still `PENDING` or
+  `RUNNING` when `invoke` returns. If the agent already called
+  `report_task_completed` / `_failed` / `_blocked` / `_cancelled`, the
+  auto-complete is a no-op. But if the agent transitioned the task
+  mid-flight to a non-terminal state without a terminal call, the
+  executor keeps re-invoking until `max_plan_reinvocations`.
+- **`invoke` must not crash on well-formed input.** If the underlying
+  framework raises, catch and return `InvocationResult(..., error=...)`
+  so the executor can surface it as a `TaskFailed`.
+- **Thread an `available_agents` list that matches what planners will
+  emit.** If your adapter wraps a sub-agent tree, enumerate every
+  routable leaf.
+
+## Quick reference
+
+Minimal test adapter for integration tests:
+
+```python
+from goldfive import CallableAdapter, InvocationResult
+
+async def agent(task, session, tools):
+    return InvocationResult(task_id=task.id, text=f"did {task.title}")
+
+adapter = CallableAdapter(agent, available_agents=["worker"])
+```
+
+## Common pitfalls
+
+- `register_reporting_tools` is a no-op → the agent never sees the
+  reporting tools → no state transitions → every task auto-completes
+  but nothing meaningful happens.
+- Framework's tool calls land on a handler you didn't wire to the
+  goldfive handler → state stays `PENDING` forever.
+- `available_agents` is empty → planners assume no routable agents
+  and either emit tasks with a default assignee or refuse to plan.
+- Swallowing framework exceptions inside `invoke` → task stays
+  `RUNNING`; either return `error=...` or let the executor catch it.
+
+## Related
+
+- [events.md](events.md) — the seven reporting tools the adapter surfaces.
+- [docs/guides/writing-an-agent-adapter.md](../docs/guides/writing-an-agent-adapter.md) — the full prose guide.
+- [docs/design/PROTOCOLS.md](../docs/design/PROTOCOLS.md) — protocol contracts with minimal implementations.
+- [docs/reference/tool-protocol.md](../docs/reference/tool-protocol.md) — canonical tool schemas.

--- a/.agents/debug-goldfive.md
+++ b/.agents/debug-goldfive.md
@@ -1,0 +1,164 @@
+---
+name: debug-goldfive
+description: Diagnose a broken goldfive run — decision tree from symptom to root cause, plus the tools to see what's happening.
+applies-when: ["debug", "something is broken", "goldfive fails", "task stuck", "sink not receiving"]
+---
+
+# Debug goldfive
+
+Broken run? Start here. This is a triage tree. For the full symptom
+catalogue with quoted error messages, see
+[docs/guides/troubleshooting.md](../docs/guides/troubleshooting.md) —
+don't duplicate it; send people there for the specifics.
+
+## Decision tree
+
+```
+run fails →
+├─ outcome.reason == "no plan generated"
+│    → planner returned None. StaticPlanner(tasks=[])? LLMPlanner.call_llm
+│      raised or returned non-JSON? Empty goals?
+│    → see docs/guides/troubleshooting.md § "no plan generated"
+│
+├─ outcome.reason starts with "planner.generate raised:"
+│    → custom planner raised. Enable DEBUG on goldfive.runner.
+│
+├─ outcome.reason starts with "executor.run raised:"
+│    → executor crashed. Inspect InMemorySink.events before the crash.
+│
+├─ outcome.success is True but task never started
+│    → dependency cycle in plan.edges OR assignee_agent_id outside
+│      adapter.available_agents. Print plan.topological_stages().
+│
+├─ task stuck in RUNNING / PENDING
+│    → adapter returned without auto-completing AND didn't call
+│      report_task_completed / _failed / _blocked. See "state machine"
+│      in docs/guides/troubleshooting.md.
+│
+├─ sink registered but events is empty
+│    → sink passed somewhere other than Runner(sinks=[...])? forgot
+│      await runner.close()? run aborted before the first emission?
+│
+├─ ImportError: google.adk / anthropic / grpcio / LoggingSink
+│    → the optional extra isn't installed. See use-goldfive.md § Install.
+│
+└─ adapter never sees reporting tools
+     → your register_reporting_tools is a no-op; implement it. See
+       adapters.md.
+```
+
+## Observation tools
+
+### `InMemorySink` — the ground-truth event log
+
+```python
+from goldfive import InMemorySink, Runner
+
+sink = InMemorySink()
+runner = Runner(..., sinks=[sink])
+outcome = await runner.run("go")
+await runner.close()
+
+for e in sink.events:
+    kind = e.WhichOneof("payload") if hasattr(e, "DESCRIPTOR") else e.get("kind")
+    seq = e.sequence if hasattr(e, "DESCRIPTOR") else e.get("sequence")
+    print(f"seq={seq:>3}  kind={kind}")
+```
+
+Current `main` emits every event as a proto `Event` message with a
+`oneof` `payload`. `goldfive.events.make_event` still exists as a dict
+fallback for callers that don't want proto; old examples (and the
+troubleshooting guide) reference it — duck-type on `DESCRIPTOR` to
+tolerate both shapes.
+
+### `LoggingSink` — every event flying past
+
+```python
+import logging
+
+from goldfive.sinks import LoggingSink
+
+logging.basicConfig(level=logging.DEBUG)
+runner = Runner(..., sinks=[LoggingSink()])
+```
+
+One JSON line per event. Pair this with `InMemorySink` when you want
+both a live tail and a post-run assertion surface.
+
+### Runner-internal logging
+
+```python
+import logging
+logging.getLogger("goldfive.runner").setLevel(logging.DEBUG)
+logging.getLogger("goldfive.planner").setLevel(logging.DEBUG)
+```
+
+Exception traces from `planner.generate`, `executor.run`,
+`register_reporting_tools`, and `steerer.bind` are logged at `ERROR`
+with the outcome `reason` field summarising them.
+
+## Event ownership map
+
+When an event goes missing, look at who emits it:
+
+| Event | Emitted by |
+|---|---|
+| `RunStarted`, `GoalDerived`, `PlanSubmitted`, pre-executor `RunAborted` | `Runner` |
+| `TaskStarted`, `TaskProgress`, `TaskCompleted`, `TaskFailed`, `TaskBlocked`, `TaskCancelled` | `Steerer` (via `mark_task_*`) |
+| `PlanRevised`, terminal `RunCompleted` / `RunAborted` | `Executor` |
+| `DriftDetected` | `Steerer` |
+
+If your sink never sees `TaskStarted`, the executor never dispatched or
+the steerer is bypassed. If it never sees `RunCompleted`, the executor
+aborted — check `outcome.reason`.
+
+## Drift kinds and taxonomy
+
+25+ `DriftKind` values (`TOOL_ERROR`, `AGENT_REFUSAL`, `CONTEXT_PRESSURE`,
+...). Full catalogue with classification rules:
+[docs/design/DRIFT.md](../docs/design/DRIFT.md). The classifiers
+(`classify_refusal`, `classify_stop_reason`, `classify_tool_error`) are
+pure functions; call them on your own upstream signals to mint drift
+events outside the built-in detector.
+
+## Quick reference
+
+```python
+# minimal inspection harness
+import asyncio, logging
+from goldfive import InMemorySink, Runner
+
+logging.basicConfig(level=logging.DEBUG)
+
+sink = InMemorySink()
+runner = Runner(..., sinks=[sink])
+try:
+    outcome = await runner.run(user_input)
+finally:
+    await runner.close()
+
+print(f"success={outcome.success}  reason={outcome.reason!r}")
+print(f"{len(sink.events)} events")
+```
+
+## Common pitfalls
+
+- Reading `sink.events` before `await runner.close()` — buffered sinks
+  haven't flushed. `InMemorySink` is fine either way.
+- Assuming every event is proto. Current `main` is; historical logs
+  and `goldfive.events.make_event` still produce dict envelopes, so
+  duck-type on `DESCRIPTOR`.
+- Using `GRPCSink` alone with a sink that emits dict envelopes — it
+  only forwards objects with a proto `DESCRIPTOR`. Pair with
+  `JSONLPersistenceSink` if you mix shapes.
+- Mixing two different `events_pb2.Event` classes (goldfive's vs a
+  downstream-regenerated copy) → `isinstance` fails. See
+  `docs/guides/troubleshooting.md` § "Proto and types".
+
+## Related
+
+- [docs/guides/troubleshooting.md](../docs/guides/troubleshooting.md) — detailed symptom → fix catalogue.
+- [docs/design/DRIFT.md](../docs/design/DRIFT.md) — drift taxonomy.
+- [docs/design/EVENT-MODEL.md](../docs/design/EVENT-MODEL.md) — event ownership, sequence semantics.
+- [events.md](events.md) — emitting a new event.
+- [sinks.md](sinks.md) — sink contract.

--- a/.agents/develop-goldfive.md
+++ b/.agents/develop-goldfive.md
@@ -1,0 +1,147 @@
+---
+name: develop-goldfive
+description: Add a feature, adapter, sink, or bug fix to goldfive itself — branch, test, PR, merge loop.
+applies-when: ["develop goldfive", "add a feature", "add an adapter", "contribute to goldfive"]
+---
+
+# Develop goldfive
+
+You're changing goldfive itself. This skill covers the repo layout,
+dev loop, and merge flow.
+
+## Repo layout
+
+```
+goldfive/
+  adapters/     # CallableAdapter, ADKAdapter, ClaudeAgentSDKAdapter
+  executors/    # SequentialExecutor, ParallelDAGExecutor
+  sinks/        # InMemory, Logging, JSONL, SQLite, gRPC
+  server/       # gRPC ingress server
+  pb/           # generated proto stubs (do not hand-edit)
+  runner.py     # the one public entrypoint
+  planner.py    # Static, Passthrough, LLM planners
+  steerer.py    # DefaultSteerer — state machine + drift detection
+  goal_deriver.py
+  drift.py      # classifiers + DriftKind/DriftSeverity re-export
+  events.py     # typed event factories (proto path)
+  reporting.py  # the seven canonical reporting tools
+  protocols.py  # six Protocol interfaces
+  types.py      # dataclasses (Goal, Plan, Task, Session, DriftEvent, ...)
+  conv.py       # dataclass <-> proto converters
+proto/          # .proto sources; `make proto` regenerates goldfive/pb/
+tests/          # pytest-asyncio; see testing.md
+examples/       # runnable end-to-end scripts
+docs/           # prose (design/, guides/, reference/)
+bench/          # perf benchmarks
+```
+
+## First-time setup
+
+```bash
+git clone git@github.com:pedapudi/goldfive.git
+cd goldfive
+uv sync --extra dev
+uv run pytest -q
+```
+
+## Dev loop
+
+```bash
+uv run pytest -q                    # full test suite (~7s)
+uv run pytest tests/test_runner.py  # target one module
+uv run ruff check .                 # lint
+uv run ruff format .                # auto-format
+```
+
+Tests use `pytest-asyncio` in auto mode (see `[tool.pytest.ini_options]`
+in `pyproject.toml`) — `async def test_*` works out of the box.
+
+## Adding a feature
+
+1. **Branch off current `main`.**
+   ```bash
+   git fetch origin && git checkout -B my-feature origin/main
+   ```
+2. **Implement.** Keep the public surface narrow — if you add a public
+   class, wire it into `goldfive/__init__.py` and the `__all__` list.
+3. **Test.** Add tests under `tests/`. See [testing.md](testing.md).
+4. **Lint.** `uv run ruff check .` and `uv run ruff format .`.
+5. **Docs.** If the change is user-facing, update the relevant
+   `docs/guides/*.md` and `docs/reference/api.md`.
+6. **PR.** `gh pr create` with a summary and a test plan.
+
+## Regenerating proto
+
+After editing anything under `proto/`:
+
+```bash
+make proto
+```
+
+This runs `grpc_tools.protoc` via `uv run --extra proto` and writes
+stubs into `goldfive/pb/goldfive/v1/`. Commit the regenerated stubs.
+
+## Working with adapters, sinks, events
+
+- Adding an adapter → [adapters.md](adapters.md).
+- Adding a sink → [sinks.md](sinks.md).
+- Adding an event or a new event factory → [events.md](events.md).
+
+## Conventions
+
+- **`from __future__ import annotations`** at the top of every file.
+- **Async-native** everywhere in the core pipeline. Sync code is
+  suspicious in `runner.py`, `steerer.py`, executors, adapters, sinks.
+- **Line length 100** (ruff-enforced).
+- **No emojis.** Not in code, docstrings, docs, commits, or PR bodies.
+- **Dataclasses**, not proto messages, are what callers pass around.
+  `goldfive.conv.to_pb_*` / `from_pb_*` bridges the two.
+- **No ADK or Claude SDK imports** outside `goldfive/adapters/adk.py`
+  and `goldfive/adapters/claude.py`. Lazy-import in the adapter module.
+- **Terse docstrings.** One-line summary plus a short block if the
+  behaviour isn't obvious.
+- **No trailing-summary comments** that restate the diff.
+
+## Merging
+
+`main` is the single long-lived branch. PRs merge via
+`gh pr merge --admin --squash --delete-branch` once CI is green and
+review is complete.
+
+## Quick reference
+
+```bash
+# start a feature
+git fetch origin && git checkout -B feat/my-thing origin/main
+
+# tight loop
+uv run pytest -q && uv run ruff check .
+
+# proto
+make proto
+
+# push + PR
+git push -u origin feat/my-thing
+gh pr create --title "Add X" --body "..."
+
+# merge (after review / CI green)
+gh pr merge --admin --squash --delete-branch
+```
+
+## Common pitfalls
+
+- Editing `goldfive/pb/` by hand. These are generated — change
+  `proto/` and re-run `make proto`.
+- Adding a public symbol but forgetting to re-export from
+  `goldfive/__init__.py`. The next consistency audit will revert it.
+- Tests that depend on real LLMs / network. Use `CallableAdapter` or
+  a mock `call_llm` to stay deterministic.
+- Dropping `from __future__ import annotations` in a new module —
+  breaks forward-reference typing on Python 3.11.
+
+## Related
+
+- [testing.md](testing.md) — test patterns and fixtures.
+- [adapters.md](adapters.md) / [sinks.md](sinks.md) / [events.md](events.md).
+- [release.md](release.md) — cutting a release.
+- [docs/design/ARCHITECTURE.md](../docs/design/ARCHITECTURE.md) — why things are shaped this way.

--- a/.agents/events.md
+++ b/.agents/events.md
@@ -1,0 +1,151 @@
+---
+name: events
+description: The goldfive event taxonomy and reporting tools — what exists, who emits it, how to emit a new one.
+applies-when: ["what events exist", "emit an event", "reporting tool", "plan revised"]
+---
+
+# Events
+
+goldfive speaks in events. Every state change is a proto `Event`
+message fanned out to every configured sink. This skill is the
+one-page map.
+
+## Event taxonomy
+
+Lifecycle (run-scoped):
+
+- `RunStarted` — emitted by `Runner` once at the top of `run`.
+- `GoalDerived` — goals resolved or passed through. Emitted by `Runner`.
+- `PlanSubmitted` — initial plan accepted. Emitted by `Runner`.
+- `PlanRevised` — plan refined by the planner in response to drift.
+  Emitted by `Executor`.
+- `RunCompleted` / `RunAborted` — terminal. Emitted by `Executor` in
+  the happy path and at executor-level aborts. `Runner` emits
+  `RunAborted` for pre-executor failures (goal derivation, planning,
+  reporting-tool registration, steerer bind).
+
+Task-scoped (all emitted by the `Steerer` via `mark_task_*`):
+
+- `TaskStarted` — task transitioned to `RUNNING`.
+- `TaskProgress` — optional mid-task progress hint (0.0–1.0 fraction).
+- `TaskCompleted` — terminal success.
+- `TaskFailed` — terminal failure; `recoverable` toggles whether the
+  planner may route around it.
+- `TaskBlocked` — non-terminal stall; needs an external unblock.
+- `TaskCancelled` — terminal cancellation.
+
+Drift:
+
+- `DriftDetected` — emitted by the `Steerer` when `detect_drift`
+  returns a non-`None` `DriftEvent`.
+
+## Envelope shapes
+
+Current `main` emits every event (Runner, Executor, Steerer) as a proto
+`Event` message — see PR #55. The dict envelope
+`{run_id, sequence, emitted_at, kind, payload}` from
+`goldfive.events.make_event` is still exported as a fallback for
+callers that can't use the `proto` extra; sinks should tolerate both.
+
+Common idiom for dispatch:
+
+```python
+if hasattr(event, "DESCRIPTOR"):
+    kind = event.WhichOneof("payload")
+    payload = getattr(event, kind) if kind else None
+else:
+    kind, payload = event["kind"], event["payload"]
+```
+
+## The seven reporting tools
+
+Surfaced to every adapter via `Runner.register_reporting_tools`. Names
+are a stable contract — don't rename.
+
+| Tool | Purpose |
+|---|---|
+| `report_task_started` | Agent is beginning a task. |
+| `report_task_progress` | Mid-task progress hint. |
+| `report_task_completed` | Task done; includes `summary` and optional `artifacts`. |
+| `report_task_failed` | Task failed; `recoverable` flag. |
+| `report_task_blocked` | Need external unblock; describes `blocker` and `needed`. |
+| `report_new_work_discovered` | Unplanned work; planner may add it as a child of `parent_task_id`. |
+| `report_plan_divergence` | Current plan no longer matches reality; triggers replan. |
+
+Full schemas: `goldfive.reporting.BUILTIN_REPORTING_TOOLS` and
+[docs/reference/tool-protocol.md](../docs/reference/tool-protocol.md).
+
+## Emitting an event
+
+Typed factories live in `goldfive.events` — one per event kind.
+
+```python
+from goldfive.events import emit, task_completed_event
+
+evt = task_completed_event(
+    run_id=session.run_id,
+    sequence=session.next_sequence(),
+    task_id="t1",
+    summary="did the thing",
+    artifacts={"draft": "s3://..."},
+)
+await emit(sinks, evt)
+```
+
+`session.next_sequence()` is the canonical monotonic counter. Serialise
+your call to it — two concurrent `asyncio` tasks calling it inside
+`gather` without a lock race and can emit duplicate sequence numbers
+(see `docs/design/EVENT-MODEL.md` § sequence semantics).
+
+## Adding a new event
+
+Rare — the taxonomy is a contract. If you genuinely need a new kind:
+
+1. Add it to `proto/goldfive/v1/events.proto` as a new oneof case on
+   `Event.payload`.
+2. `make proto` to regenerate stubs.
+3. Add a typed factory in `goldfive/events.py`.
+4. Decide who emits it (Runner, Executor, or Steerer) and wire it in.
+5. Update `docs/design/EVENT-MODEL.md` with the new kind and its
+   ownership.
+6. Update any sinks that do per-kind dispatch.
+
+Prefer piggybacking on an existing kind (e.g. encoding a custom
+signal as a `DriftKind.CUSTOM` `DriftDetected`) over adding a new
+payload type.
+
+## Quick reference
+
+```python
+# Every lifecycle event factory
+from goldfive.events import (
+    run_started_event, run_completed_event, run_aborted_event,
+    goal_derived_event, plan_submitted_event, plan_revised_event,
+    task_started_event, task_progress_event, task_completed_event,
+    task_failed_event, task_blocked_event, task_cancelled_event,
+    drift_detected_event,
+    emit,            # fan-out helper
+    make_event,      # dict envelope fallback
+)
+```
+
+## Common pitfalls
+
+- Calling `session.next_sequence()` from inside `asyncio.gather`
+  without a lock → duplicate sequences. Serialise.
+- Using `make_event` (dict) when proto stubs are available — mix and
+  match confuses sinks that only accept one shape.
+- Agent skips `report_task_started` and jumps to `report_task_completed`
+  → the steerer rejects the transition (task isn't `RUNNING`) and the
+  executor eventually auto-completes.
+- Emitting the same `Event` to multiple sinks *sequentially* with
+  awaits between — use `goldfive.events.emit`, which fans out via
+  `gather`.
+
+## Related
+
+- [adapters.md](adapters.md) — how the reporting tools reach the agent.
+- [sinks.md](sinks.md) — where events go.
+- [docs/design/EVENT-MODEL.md](../docs/design/EVENT-MODEL.md) — sequence semantics, ownership rules.
+- [docs/reference/tool-protocol.md](../docs/reference/tool-protocol.md) — tool schemas.
+- [docs/design/DRIFT.md](../docs/design/DRIFT.md) — drift taxonomy for `DriftDetected`.

--- a/.agents/release.md
+++ b/.agents/release.md
@@ -1,0 +1,87 @@
+---
+name: release
+description: Cut a goldfive release — version bumps, changelog, proto regeneration, tag + push.
+applies-when: ["cut a release", "bump version", "tag goldfive", "publish"]
+---
+
+# Release
+
+Releases are manual in v0.1 — there's no automated publishing pipeline
+yet. The process is short.
+
+## Steps
+
+1. **Pick the new version.** SemVer. Alpha line so far (`0.1.0`).
+2. **Bump it in two places.**
+   - `pyproject.toml` → `[project] version = "X.Y.Z"`.
+   - `goldfive/__init__.py` → `__version__ = "X.Y.Z"`.
+3. **Regenerate proto if `proto/*.proto` changed since the last
+   release.**
+   ```bash
+   make proto
+   ```
+   Commit any drift under `goldfive/pb/`.
+4. **Update `CHANGELOG.md`.** Add a new top section with the ISO date
+   and group entries under `### Added`, `### Changed`, `### Fixed`.
+   The existing `0.1.0` entry is the format reference.
+5. **Confirm green.**
+   ```bash
+   uv run pytest -q
+   uv run ruff check .
+   ```
+6. **Commit on a release branch, PR, review, merge `--admin --squash`.**
+   Title: `Release vX.Y.Z`.
+7. **Tag and push.**
+   ```bash
+   git checkout main && git pull
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+Tagging is not automated yet. A future PR will wire a GitHub Actions
+release workflow (see issue tracker).
+
+## Pre-flight checklist
+
+- [ ] `pyproject.toml` version matches `goldfive/__init__.py` `__version__`.
+- [ ] `CHANGELOG.md` has a dated entry for the new version.
+- [ ] `make proto` was re-run if `proto/` changed.
+- [ ] `uv run pytest -q` passes on a clean checkout.
+- [ ] `uv run ruff check .` passes.
+- [ ] README `Install` / `Hello goldfive` snippets still work.
+- [ ] `docs/reference/api.md` re-export list matches `goldfive.__all__`.
+
+## Quick reference
+
+```bash
+# version bumps
+sed -i 's/^version = ".*"/version = "X.Y.Z"/' pyproject.toml
+sed -i 's/^__version__ = ".*"/__version__ = "X.Y.Z"/' goldfive/__init__.py
+
+# verify
+grep ^version pyproject.toml
+grep __version__ goldfive/__init__.py
+
+# pre-flight
+make proto && uv run pytest -q && uv run ruff check .
+
+# tag
+git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z
+```
+
+## Common pitfalls
+
+- Bumping one version string and not the other → PyPI metadata
+  disagrees with `__version__`.
+- Forgetting `make proto` after editing `proto/*.proto` → users of the
+  new wheel see stale stubs.
+- CHANGELOG entry missing a PR reference → harder to trace back what
+  changed. Link the PR number (`#66`) for every bullet.
+- Tagging before the release PR merges → tag points at a commit that
+  isn't on `main`.
+
+## Related
+
+- [develop-goldfive.md](develop-goldfive.md) — dev loop and merge flow.
+- [docs/performance.md](../docs/performance.md) — perf baseline to re-run before major releases.
+- `CHANGELOG.md` — prior release entries for format reference.

--- a/.agents/sinks.md
+++ b/.agents/sinks.md
@@ -1,0 +1,149 @@
+---
+name: sinks
+description: The EventSink protocol — shipped implementations, how to pick one, how to write your own.
+applies-when: ["write a sink", "send events somewhere", "EventSink contract", "persist events"]
+---
+
+# Sinks
+
+An `EventSink` receives proto `Event` messages (and a small number of
+dict envelopes from the Runner) as a run unfolds. Sinks are the
+integration surface for logging, persistence, dashboards, and
+downstream services.
+
+## Contract
+
+From `goldfive/protocols.py`:
+
+```python
+from typing import Protocol, runtime_checkable
+from typing import Any
+
+@runtime_checkable
+class EventSink(Protocol):
+    async def emit(self, event_pb: Any) -> None: ...
+    async def close(self) -> None: ...
+```
+
+Two methods. `emit` is called once per event. `close` is called once
+from `Runner.close` — buffered sinks flush there.
+
+**`emit` may receive two shapes.** Current `main` emits every event
+as a proto `Event` (PR #55). A dict fallback from
+`goldfive.events.make_event` is still supported for callers that don't
+have the `proto` extra. Sinks that only accept proto should duck-type
+on `hasattr(event, "DESCRIPTOR")` and skip dicts cleanly.
+
+## Shipped implementations
+
+| Sink | Module | Extra | Use |
+|---|---|---|---|
+| `InMemorySink` | `goldfive.sinks.memory` | (core) | Tests, ephemeral inspection. |
+| `LoggingSink` | `goldfive.sinks.logging_sink` | `proto` | stdout / journald-style logs. |
+| `JSONLPersistenceSink` | `goldfive.sinks.persistence` | `proto` | Crash recovery via `replay_from_jsonl`. |
+| `SQLitePersistenceSink` | `goldfive.sinks.sqlite_sink` | `proto` | Cross-run dashboards, shared DB. |
+| `GRPCSink` | `goldfive.sinks.grpc_sink` | `proto` | Stream to a `GoldfiveIngress` server (harmonograf). |
+
+`InMemorySink` is always importable. The others depend on the `proto`
+extra. When it is missing, the import guard in
+`goldfive/sinks/__init__.py` sets the class attribute to `None` so the
+top-level package stays importable.
+
+## Picking one
+
+Decision tree in [docs/guides/choosing-a-sink.md](../docs/guides/choosing-a-sink.md).
+Quick version:
+
+- Just want to inspect post-run → `InMemorySink`.
+- Want logs → `LoggingSink`.
+- Need crash recovery or replay → `JSONLPersistenceSink`.
+- Need cross-run dashboards in-process → `SQLitePersistenceSink`.
+- Streaming to harmonograf or a server → `GRPCSink` (+ a local JSONL
+  sink if you care about the Runner lifecycle dict envelopes).
+
+Multiple sinks compose — `Runner(sinks=[a, b, c])` fans each emit out
+concurrently. See `examples/multi_sink_fanout.py`.
+
+## Writing a new sink
+
+Skeleton:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+
+class MySink:
+    def __init__(self, client) -> None:
+        self._client = client
+        self._buffer: list[Any] = []
+
+    async def emit(self, event: Any) -> None:
+        # Handle both shapes.
+        if hasattr(event, "DESCRIPTOR"):
+            self._buffer.append(event)
+        else:
+            # dict envelope from the Runner; translate or skip.
+            return
+        if len(self._buffer) >= 64:
+            await self._flush()
+
+    async def close(self) -> None:
+        if self._buffer:
+            await self._flush()
+        await self._client.shutdown()
+
+    async def _flush(self) -> None:
+        batch, self._buffer = self._buffer, []
+        await self._client.send_many(batch)
+```
+
+## Key design constraints
+
+- **`emit` must not raise on the happy path.** Exceptions bubble up
+  through `goldfive.events.emit`'s `asyncio.gather(return_exceptions=True)`
+  and are re-raised after all sinks have been awaited — one faulty sink
+  shouldn't prevent the others from seeing the event, but it will
+  still propagate. Catch and log if you want best-effort.
+- **Flush in `close`.** `runner.close()` calls `sink.close()` in turn.
+  Anything buffered in-process is lost if you don't.
+- **Be prepared for dict envelopes.** At minimum, skip them cleanly.
+- **Ordering.** Events are emitted in sequence order per run. Don't
+  reorder within a sink.
+
+## Quick reference
+
+```python
+from goldfive import InMemorySink, Runner
+from goldfive.sinks import JSONLPersistenceSink, LoggingSink
+
+# multi-sink fanout
+runner = Runner(
+    ...,
+    sinks=[
+        InMemorySink(),                            # post-run assertions
+        LoggingSink(),                             # live stdout tail
+        JSONLPersistenceSink("./runs/run.jsonl"),  # crash recovery
+    ],
+)
+```
+
+## Common pitfalls
+
+- Forgot `await runner.close()` → buffered sinks drop data.
+- Sink passed somewhere other than `Runner(sinks=[...])` → not plumbed
+  to executor / steerer.
+- Sink class is `None` because the `proto` extra isn't installed →
+  `Runner(sinks=[None])` silently accepts it. Assert not-None.
+- `GRPCSink` missing early events — it filters to proto-only. Pair
+  with a local JSONL sink or upgrade the server to accept dicts.
+- Emitting blocking I/O from `emit` without awaiting → starves the
+  event loop. Use `asyncio.to_thread` or an async client.
+
+## Related
+
+- [events.md](events.md) — what events exist and who emits them.
+- [docs/guides/choosing-a-sink.md](../docs/guides/choosing-a-sink.md) — which shipped sink to use.
+- [docs/guides/writing-an-event-sink.md](../docs/guides/writing-an-event-sink.md) — full prose guide.
+- [docs/design/EVENT-MODEL.md](../docs/design/EVENT-MODEL.md) — sink contract and sequence semantics.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -1,0 +1,159 @@
+---
+name: testing
+description: How to write a goldfive test — pytest-asyncio patterns, CallableAdapter harness, optional-extra skips.
+applies-when: ["write a test", "test goldfive", "pytest"]
+---
+
+# Testing
+
+goldfive's test suite lives under `tests/` and runs in ~7 seconds.
+
+## Setup
+
+```bash
+uv sync --extra dev
+uv run pytest -q
+```
+
+`pytest-asyncio` is on in auto mode (`asyncio_mode = "auto"` in
+`pyproject.toml`). `async def test_*` works without a decorator.
+
+## Where tests live
+
+- `tests/test_runner.py`, `tests/test_runner_integration.py` — end-to-end.
+- `tests/test_<component>.py` — one file per component
+  (`test_planner.py`, `test_steerer.py`, `test_sequential_executor.py`, ...).
+- `tests/test_<adapter>_adapter.py` — adapter tests.
+- `tests/test_<sink>.py` — sink tests.
+- `tests/_pbsetup.py`, `tests/conftest.py` — shared fixtures / proto
+  bootstrap.
+- `tests/test_smoke.py` — top-level import / re-export smoke tests.
+
+## The canonical integration test pattern
+
+Every integration test uses `CallableAdapter` to remove LLM
+non-determinism:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from goldfive import (
+    CallableAdapter, InMemorySink, InvocationResult, Plan, ReportingToolSpec,
+    Runner, SequentialExecutor, Session, StaticPlanner, Task, TaskEdge,
+)
+
+
+async def test_runner_completes_linear_plan() -> None:
+    async def agent(
+        task: Task, session: Session, tools: list[ReportingToolSpec]
+    ) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text=task.title)
+
+    plan = Plan(
+        id="p", run_id="", goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="a", assignee_agent_id="worker"),
+            Task(id="t2", title="b", assignee_agent_id="worker"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+        summary="",
+    )
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(agent, available_agents=["worker"]),
+        planner=StaticPlanner(plan),
+        executor=SequentialExecutor(),
+        sinks=[sink],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+
+    assert outcome.success
+    kinds = [e.WhichOneof("payload") for e in sink.events if hasattr(e, "DESCRIPTOR")]
+    assert "task_completed" in kinds
+```
+
+## Optional-extras tests
+
+Tests that need `google-adk`, `anthropic`, or the `proto` extra must
+`pytest.importorskip` so the suite stays green on a minimal install:
+
+```python
+import pytest
+
+pytest.importorskip("google.adk")
+
+from goldfive.adapters.adk import ADKAdapter  # noqa: E402
+
+async def test_adk_adapter_wraps_root_agent() -> None:
+    ...
+```
+
+For sinks that require `proto`:
+
+```python
+from goldfive.sinks import JSONLPersistenceSink
+
+pytestmark = pytest.mark.skipif(
+    JSONLPersistenceSink is None, reason="goldfive[proto] not installed"
+)
+```
+
+## Fixtures
+
+Most tests don't need fixtures beyond what's in `tests/conftest.py`.
+When you do, keep them local to the test module — the suite avoids
+shared mutable state across files.
+
+## Running subsets
+
+```bash
+uv run pytest tests/test_runner.py              # one file
+uv run pytest tests/test_runner.py::test_x      # one test
+uv run pytest -k drift                          # by keyword
+uv run pytest -q --lf                           # last-failed
+```
+
+## Deterministic LLM stubs
+
+When a component takes `call_llm`, inject a pure-Python stub:
+
+```python
+async def fake_call_llm(system_prompt: str, user_prompt: str, model: str) -> str:
+    return '{"tasks": [{"id": "t1", "title": "do it"}], "summary": ""}'
+
+from goldfive.planner import LLMPlanner
+planner = LLMPlanner(call_llm=fake_call_llm, model="stub")
+```
+
+## Quick reference
+
+```bash
+uv run pytest -q                        # full suite
+uv run pytest tests/test_runner.py -v   # one module, verbose
+uv run ruff check . && uv run ruff format --check .
+```
+
+## Common pitfalls
+
+- Forgetting `await runner.close()` in a test → buffered sinks (none
+  in the default set, but e.g. `GRPCSink`) drop events and the test
+  flakes.
+- Using the `@pytest.mark.asyncio` decorator — unnecessary in auto
+  mode and inconsistent with the existing suite.
+- Tests that depend on wall-clock time. Mock `time.time` / `time_ns`
+  or assert on relative ordering.
+- Hitting real networks or LLMs. Always use `CallableAdapter` +
+  stubbed `call_llm` in tests.
+- Expecting every event to be proto — current `main` is (PR #55), but
+  legacy callers produce dict envelopes from `goldfive.events.make_event`.
+  Duck-type on `DESCRIPTOR` if you assert across both.
+
+## Related
+
+- [develop-goldfive.md](develop-goldfive.md) — dev loop and merge flow.
+- [adapters.md](adapters.md) / [sinks.md](sinks.md) — what you're testing.
+- [docs/design/EVENT-MODEL.md](../docs/design/EVENT-MODEL.md) — event shapes.

--- a/.agents/use-goldfive.md
+++ b/.agents/use-goldfive.md
@@ -1,0 +1,174 @@
+---
+name: use-goldfive
+description: Wrap an existing agent with goldfive's planning, drift, and event stream — minimal install-to-first-run path.
+applies-when: ["wrap my agent", "use goldfive", "add orchestration", "goldfive quickstart"]
+---
+
+# Use goldfive to wrap an agent
+
+You have an agent (ADK, Claude SDK, or a plain async callable) and want
+goldfive to plan, drive, observe, and steer it. This skill is the
+shortest correct path.
+
+## Install
+
+```bash
+uv add goldfive           # recommended
+# or
+pip install goldfive
+```
+
+Optional extras, install only what you need:
+
+- `goldfive[adk]` — Google ADK adapter.
+- `goldfive[claude]` — Claude Agent SDK adapter.
+- `goldfive[proto]` — enables `LoggingSink`, `JSONLPersistenceSink`,
+  `SQLitePersistenceSink`, `GRPCSink`. Required any time you want
+  events on the wire or on disk.
+- `goldfive[examples]` — runtime deps for scripts in `examples/`.
+
+## The one-liner (`quickstart`)
+
+For callers who just want a runnable `Runner` with sensible defaults:
+
+```python
+import asyncio
+
+from goldfive import InvocationResult, quickstart
+
+
+async def agent(task, session, tools):
+    return InvocationResult(task_id=task.id, text=f"did {task.title}")
+
+
+async def main() -> None:
+    runner = quickstart(agent, "Say hello, ask a name, thank them")
+    outcome = await runner.run("go")
+    await runner.close()
+    print(f"success={outcome.success}")
+
+
+asyncio.run(main())
+```
+
+`quickstart` wires a `CallableAdapter`, `StaticPlanner` (one task per
+goal), `SequentialExecutor`, and a single `InMemorySink`. Pass
+`planner=` or `sinks=` to override.
+
+> `goldfive.run(agent, "...")` is tracked by issue #66 and not yet
+> merged. Until then, use `quickstart` or construct a `Runner` directly.
+
+## The explicit form (`Runner`)
+
+Reach for this when you want a custom plan, a specific executor, or
+multiple sinks.
+
+```python
+import asyncio
+
+from goldfive import (
+    CallableAdapter, InMemorySink, InvocationResult, Plan, ReportingToolSpec,
+    Runner, SequentialExecutor, Session, StaticPlanner, Task, TaskEdge,
+)
+
+
+async def worker(
+    task: Task, session: Session, tools: list[ReportingToolSpec]
+) -> InvocationResult:
+    return InvocationResult(task_id=task.id, text=f"did {task.title}")
+
+
+async def main() -> None:
+    plan = Plan(
+        id="demo", run_id="", goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="gather", assignee_agent_id="worker"),
+            Task(id="t2", title="draft",  assignee_agent_id="worker"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+        summary="linear demo",
+    )
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(worker, available_agents=["worker"]),
+        planner=StaticPlanner(plan),
+        executor=SequentialExecutor(),
+        sinks=[sink],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+    print(f"success={outcome.success} events={len(sink.events)}")
+
+
+asyncio.run(main())
+```
+
+## Swapping in a real framework
+
+Change one line — the rest of the `Runner` construction stays identical:
+
+```python
+# ADK (requires goldfive[adk])
+from goldfive.adapters.adk import ADKAdapter
+agent = ADKAdapter(root_agent)
+
+# Claude Agent SDK (requires goldfive[claude])
+from goldfive.adapters.claude import ClaudeAgentSDKAdapter
+agent = ClaudeAgentSDKAdapter(
+    system_prompt="You are a helpful assistant.",
+    model="claude-sonnet-4-5",
+)
+```
+
+See [adapters.md](adapters.md) for the contract and
+[docs/guides/writing-an-agent-adapter.md](../docs/guides/writing-an-agent-adapter.md)
+for wrapping a new framework.
+
+## Observability
+
+To see every event live, pair goldfive with harmonograf. The full
+ten-minute walkthrough (install both, boot the stack, stream events
+to the console) is in
+[docs/guides/observability-with-harmonograf.md](../docs/guides/observability-with-harmonograf.md).
+
+To log events from a test or script without harmonograf, use
+`LoggingSink` or `InMemorySink` — see [sinks.md](sinks.md).
+
+## Quick reference
+
+```python
+from goldfive import (
+    # entry points
+    Runner, quickstart,
+    # adapters
+    CallableAdapter,
+    # planners
+    StaticPlanner, PassthroughPlanner, LLMPlanner,
+    # executors
+    SequentialExecutor, ParallelDAGExecutor,
+    # sinks
+    InMemorySink, LoggingSink, JSONLPersistenceSink, SQLitePersistenceSink, GRPCSink,
+    # results / types
+    InvocationResult, ExecutionOutcome, Plan, Task, TaskEdge, Goal,
+)
+```
+
+Always call `await runner.close()`. Buffered sinks (`GRPCSink`,
+harmonograf) flush there.
+
+## Common pitfalls
+
+- Forgot `await runner.close()` — buffered sinks drop events on exit.
+- `StaticPlanner(Plan(tasks=[]))` → outcome has `reason="no plan generated"`.
+- `Task.assignee_agent_id` doesn't match anything in
+  `adapter.available_agents` → the executor invokes the adapter anyway
+  and the agent gets an unroutable task.
+- Using a `proto`-gated sink without the extra — the class is `None`,
+  not raising. Guard with `assert LoggingSink is not None`.
+
+## Related
+
+- [adapters.md](adapters.md) — adapter contract.
+- [sinks.md](sinks.md) — sink contract and shipped implementations.
+- [debug-goldfive.md](debug-goldfive.md) — when something breaks.
+- [docs/guides/getting-started.md](../docs/guides/getting-started.md) — full prose walkthrough.


### PR DESCRIPTION
## Summary

- Adds `.agents/` — a folder of agent-facing skill markdowns
  (README, use-goldfive, develop-goldfive, debug-goldfive, adapters,
  sinks, events, testing, release).
- Distinct from `docs/`: terser, more task-shaped, optimised for a
  sibling agent looking for the shortest correct path from intent to
  action.
- Every code snippet was extracted and executed against current main;
  `uv run pytest -q` stays green (266 passed, 33 skipped).
- `debug-goldfive.md` references `docs/guides/troubleshooting.md`
  rather than duplicating its symptom catalogue.

## Test plan

- [x] `uv run pytest -q` — 266 passed, 33 skipped.
- [x] Every snippet in `.agents/*.md` runs against current main
      (verified via standalone scripts: quickstart, explicit Runner,
      InMemorySink + LoggingSink, typed event factories, adapter
      skeleton, MySink + multi-sink fanout, testing integration
      pattern).
- [x] Every file under 200 lines.
- [x] No emojis.
