### PR TITLE
Thorough documentation audit + update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to goldfive are documented in this file. Dates are ISO-8601.
 
+## Unreleased
+
+### Added
+
+- #57 `goldfive.quickstart(agent, goals)` — one-call `Runner` factory
+  wiring `SequentialExecutor`, `PassthroughGoalDeriver`, a
+  one-task-per-goal `StaticPlanner`, and an `InMemorySink`.
+- #58 `examples/harmonograf_observed/` — minimal `CallableAdapter`
+  agent wired to `InMemorySink` + `HarmonografSink`.
+- #59 `bench/run_100_tasks.py` orchestration-only benchmark and
+  `docs/performance.md` baseline (v0.1 snapshot).
+- #60 `docs/guides/choosing-a-sink.md` — decision matrix across all
+  shipped sinks.
+- #61 `examples/multi_sink_fanout.py`, `examples/drift_refinement.py`,
+  `examples/parallel_dag.py`.
+- #62 `docs/guides/troubleshooting.md`.
+- #63 README pointer to the 10-minute observability walkthrough.
+- #64 `docs/guides/observability-with-harmonograf.md`.
+- #67 `goldfive.wrap(agent)` / `goldfive.run(agent, input)` — one-line
+  wrapping with auto-detected `AgentAdapter` (callable, ADK, Claude
+  SDK), LLM auto-detection from ADK agent trees, and `LLMPlanner` /
+  `LLMGoalDeriver` by default. `goldfive.adapters.auto.auto_adapter`
+  exposes the dispatch standalone.
+- #68 `.agents/` — agent-facing skill folder.
+
+### Changed
+
+- #65 Follow-up cleanup from the Team Lead A drift audit
+  (`SequentialExecutor.max_plan_reinvocations` default raised
+  from 3 to 32; minor doc fixes).
+- #69 Reconciled `HarmonografSink` API docs with the shipped
+  `harmonograf_client.HarmonografSink(client)` shape and canonical
+  `:7531` port.
+
 ## 0.1.0 — 2026-04-18
 
 Initial public release. goldfive v0.1 is a framework-agnostic control loop

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ It does not ship an LLM client, a prompt DSL, or a tool registry. It wraps
 whatever agent runtime you already use (Google ADK, the Anthropic SDK, a
 plain callable, ...) behind a narrow `AgentAdapter` protocol and gives you:
 
-- a `Runner` that drives the agent turn by turn against a `Goal`
-- pluggable `Planner`, `DriftAnalyzer`, and `Steerer` components
-- a `TelemetrySink` stream of structured events you can log, render, or
+- a `Runner` (or one-line `goldfive.wrap` / `goldfive.run`) that drives
+  the agent turn by turn against a `Goal`
+- pluggable `GoalDeriver`, `Planner`, `Executor`, and `Steerer` components
+- an `EventSink` stream of proto-encoded events you can log, persist, or
   ship to an observability console
 
 goldfive is the orchestration half of
@@ -99,11 +100,15 @@ inspect the event stream. Concrete and runnable.
 ### Guides
 
 - [`docs/guides/getting-started.md`](docs/guides/getting-started.md) — install + first agent.
+- [`docs/guides/observability-with-harmonograf.md`](docs/guides/observability-with-harmonograf.md) — ten-minute end-to-end with the harmonograf UI.
 - [`docs/guides/writing-an-agent-adapter.md`](docs/guides/writing-an-agent-adapter.md) — wrap a new framework.
 - [`docs/guides/writing-an-event-sink.md`](docs/guides/writing-an-event-sink.md) — build a custom sink.
+- [`docs/guides/choosing-a-sink.md`](docs/guides/choosing-a-sink.md) — decision matrix across the five shipped sinks.
 - [`docs/guides/goals-and-plans.md`](docs/guides/goals-and-plans.md) — authoring custom `GoalDeriver` / `Planner`.
-- [`docs/guides/persistence-and-recovery.md`](docs/guides/persistence-and-recovery.md) — JSONL persistence + `Runner.resume()`.
+- [`docs/guides/persistence-and-recovery.md`](docs/guides/persistence-and-recovery.md) — JSONL + SQLite persistence, `Runner.resume()`.
+- [`docs/guides/grpc-transport.md`](docs/guides/grpc-transport.md) — `GRPCSink` + `GoldfiveIngressServer` for out-of-process observers.
 - [`docs/guides/harmonograf-integration.md`](docs/guides/harmonograf-integration.md) — plugging harmonograf in as a sink.
+- [`docs/guides/troubleshooting.md`](docs/guides/troubleshooting.md) — common setup / runtime failures.
 
 ### Reference
 

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -36,14 +36,14 @@ event, and optionally drives a replan.
 
 ## The six primitives
 
-| Primitive | Role | Default implementation |
+| Primitive | Role | Shipped implementations |
 |---|---|---|
-| `GoalDeriver` | Converts user input into an explicit list of `Goal`s. | `PassthroughGoalDeriver`, `LLMGoalDeriver` |
-| `Planner` | Produces and refines a `Plan` from goals. | `PassthroughPlanner`, `LLMPlanner` |
+| `GoalDeriver` | Converts user input into an explicit list of `Goal`s. | `PassthroughGoalDeriver`, `LiteralGoalDeriver`, `LLMGoalDeriver` |
+| `Planner` | Produces and refines a `Plan` from goals. | `PassthroughPlanner`, `StaticPlanner`, `LLMPlanner` |
 | `Executor` | Drives plan execution task-by-task. | `SequentialExecutor`, `ParallelDAGExecutor` |
 | `Steerer` | Owns the task state machine and classifies drift. | `DefaultSteerer` |
 | `AgentAdapter` | Wraps a specific agent framework. | `CallableAdapter`, `ADKAdapter`, `ClaudeAgentSDKAdapter` |
-| `EventSink` | Receives proto-encoded orchestration events. | `InMemorySink`, `LoggingSink`, `JSONLPersistenceSink` |
+| `EventSink` | Receives proto-encoded orchestration events. | `InMemorySink`, `LoggingSink`, `JSONLPersistenceSink`, `SQLitePersistenceSink`, `GRPCSink` |
 
 Each primitive is a `Protocol` (see [PROTOCOLS.md](PROTOCOLS.md)).
 goldfive ships default implementations but any conforming class can be
@@ -81,10 +81,13 @@ whatever), invokes the agent, and routes intercepted tool calls and
 observed events back to the steerer.
 
 **EventSink** — consumes the proto-encoded event stream. goldfive
-ships three sinks (in-memory for tests, logging for dev,
-JSONL-persistence for crash recovery) and is designed to hand off to
-external observability systems. harmonograf is the canonical external
-sink (see [harmonograf-integration guide](../guides/harmonograf-integration.md)).
+ships five sinks: `InMemorySink` for tests, `LoggingSink` for dev,
+`JSONLPersistenceSink` / `SQLitePersistenceSink` for durable
+per-run / cross-run storage, and `GRPCSink` for streaming events to
+an out-of-process observer. harmonograf is the canonical external
+sink (see the
+[harmonograf-integration guide](../guides/harmonograf-integration.md)
+and [choosing-a-sink.md](../guides/choosing-a-sink.md)).
 
 ## How they compose
 
@@ -103,8 +106,8 @@ sink (see [harmonograf-integration guide](../guides/harmonograf-integration.md))
                                 │                  │                      │
                                 │                  ▼                      │
                                 │             EventSinks                  │
-                                │        (InMemory, Logging,              │
-                                │         JSONL, harmonograf, …)         │
+                                │      (InMemory, Logging, JSONL,         │
+                                │       SQLite, gRPC, harmonograf, …)     │
                                 └────────────────────────────────────────┘
                                                    │
                                                    ▼
@@ -157,11 +160,22 @@ outcome = await runner.run("build me a slide deck about Python")
 When the caller omits `goal_deriver`, `steerer`, or `sinks`, the
 `Runner` substitutes sane defaults:
 
-- `goal_deriver` → `PassthroughGoalDeriver()` (wraps the string in a
-  single `Goal`).
+- `goal_deriver` → `PassthroughGoalDeriver("run")` — returns a single
+  pre-configured `Goal(id="g1", summary="run")` regardless of the
+  `user_input`. Use `LiteralGoalDeriver` (or pass
+  `PassthroughGoalDeriver(user_input)`) if you want the input text to
+  flow through.
 - `steerer` → `DefaultSteerer()`.
 - `sinks` → `[]` (events go nowhere; recommended to supply at least
-  `InMemorySink` in dev and `JSONLPersistenceSink` in prod).
+  `InMemorySink` in dev and `JSONLPersistenceSink` /
+  `SQLitePersistenceSink` in prod).
+
+For the shortest possible construction, call `goldfive.wrap(agent)`
+or `goldfive.quickstart(agent, goals)`. `wrap` auto-detects the
+adapter for ADK / Claude SDK / callable agents and wires an
+LLM-backed planner when it can detect the agent's model;
+`quickstart` returns a `Runner` with a one-task-per-goal static plan
+and an `InMemorySink` already configured.
 
 ## The full lifecycle
 
@@ -169,22 +183,28 @@ One call to `runner.run(user_input)` walks the following steps. Every
 step emits one or more events (see [EVENT-MODEL.md](EVENT-MODEL.md) for
 the full taxonomy).
 
+**Event ownership.** The Runner owns the `Run*` lifecycle events —
+`RunStarted`, `GoalDerived`, `PlanSubmitted`, and a pre-executor
+`RunAborted` when setup fails. Executors own `Task*` events,
+`PlanRevised`, and the terminal `RunCompleted` / `RunAborted`. The
+steerer owns `DriftDetected` and per-task transitions. Every
+emission is a proto `Event` envelope built via the typed factories
+in `goldfive.events`.
+
 ### 1. Setup
 
-- Generate a fresh `run_id` (UUIDv7-style).
+- Generate a fresh `run_id` (`uuid.uuid4().hex`).
 - Construct a `Session(run_id=...)`. `Session` holds all live state for
   this invocation.
-- Emit `RunStarted(run_id, user_input, started_at)`.
+- Emit `RunStarted(run_id, goal_summary, started_at)`.
 
 ### 2. Goal derivation
 
-- Call `goal_deriver.derive(user_input, context=...)`.
+- If the caller passed a `list[Goal]` directly, skip derivation and
+  use it verbatim.
+- Otherwise call `goal_deriver.derive(user_input, context=...)`.
 - Store the returned `list[Goal]` in `session.goals`.
 - Emit `GoalDerived(goals=...)`.
-
-If the caller passed a `list[Goal]` directly to `runner.run(...)`, the
-`PassthroughGoalDeriver` returns it verbatim and goal derivation is a
-no-op.
 
 ### 3. Plan generation
 

--- a/docs/design/EVENT-MODEL.md
+++ b/docs/design/EVENT-MODEL.md
@@ -46,15 +46,17 @@ await emit(sinks, event)
 
 ## Event taxonomy
 
-Ten event kinds are defined in v0.1, grouped by the phase they fire in.
+Thirteen event kinds are defined in v0.1, grouped by the phase they
+fire in. Since #55 every event on the stream is a proto `Event`
+envelope — there is no mixed-shape stream on the sink side.
 
 ### Run lifecycle
 
 | Event | Fired by | When |
 |---|---|---|
-| `RunStarted` | `Runner` | At the very top of `run()` before goal derivation. Carries `user_input` (truncated if long) and `started_at`. |
-| `RunCompleted` | `Runner` | When the executor returns `success=True`. Carries `outcome_summary` and `completed_task_ids`. |
-| `RunAborted` | `Runner`, `Executor` | When the executor surrenders or the runner catches an exception. Carries `reason` and `drift` (optional) explaining why. |
+| `RunStarted` | `Runner` | At the very top of `run()` before goal derivation. Carries `goal_summary` (the incoming `user_input` or the first goal's summary) and `started_at`. |
+| `RunCompleted` | `Executor` | When every task has reached a terminal state and the plan is fully realized. Carries `outcome_summary`. |
+| `RunAborted` | `Runner`, `Executor` | The `Runner` emits it when setup fails (goal derivation, plan generation, tool registration, steerer bind); the executor emits it when the plan cannot be driven to completion (e.g. `max_plan_reinvocations` exhausted, unrecoverable drift). Carries `reason`. |
 
 ### Goal and plan
 
@@ -178,6 +180,10 @@ before returning.
 
 ## Built-in sinks
 
+Five sinks ship in `goldfive.sinks`. Pick per use-case; they compose
+freely. See [choosing-a-sink.md](../guides/choosing-a-sink.md) for the
+full decision matrix.
+
 ### `InMemorySink`
 
 ```python
@@ -217,9 +223,36 @@ from goldfive.sinks import JSONLPersistenceSink
 sink = JSONLPersistenceSink(path="./runs/example-run.jsonl")
 ```
 
-Writes one JSON-encoded proto message per line. Paired with
+Writes one proto-canonical JSON line per event. Paired with
 `replay_from_jsonl(path)` for crash recovery. See the full
 [persistence guide](../guides/persistence-and-recovery.md).
+
+### `SQLitePersistenceSink`
+
+```python
+from goldfive.sinks import SQLitePersistenceSink
+
+sink = SQLitePersistenceSink("./runs/goldfive.db")
+```
+
+Inserts each event into a `goldfive_events` table keyed by
+`(run_id, sequence)`. Pairs with `replay_from_sqlite(path, run_id)`
+and `list_runs(path)`. Useful when you want cross-run SQL queries or
+a single shared store for many runs.
+
+### `GRPCSink`
+
+```python
+from goldfive.sinks import GRPCSink
+
+sink = GRPCSink("observer.internal:50051")
+```
+
+Streams proto `Event` messages to a `GoldfiveIngressServer` over a
+client-streaming RPC. Enqueues on an `asyncio.Queue`, drains in the
+background, reconnects on transient RPC errors by default. See
+[grpc-transport.md](../guides/grpc-transport.md) for TLS, reconnect
+semantics, and the server side.
 
 ## Building a custom sink
 

--- a/docs/guides/choosing-a-sink.md
+++ b/docs/guides/choosing-a-sink.md
@@ -10,19 +10,19 @@ more (`LoggingSink`, `JSONLPersistenceSink`, `SQLitePersistenceSink`,
 
 ## Quick decision matrix
 
-| Sink | In-process? | Persistent? | Cross-process? | Proto+dict? | Install |
+| Sink | In-process? | Persistent? | Cross-process? | Accepts | Install |
 | --- | --- | --- | --- | --- | --- |
-| `InMemorySink` | yes | no | no | both | stdlib |
-| `LoggingSink` | yes | via logging config | no | proto cleanly, else `repr` | `proto` extra |
-| `JSONLPersistenceSink` | yes | yes (file) | no | both | `proto` extra |
-| `SQLitePersistenceSink` | yes | yes (DB) | via DB reads | both | `proto` extra |
-| `GRPCSink` | no (streams out) | no (the server persists) | yes | proto only | `proto` extra + `grpcio` |
-| `HarmonografSink` | no (streams out) | no (harmonograf persists) | yes | proto only | `harmonograf_client` |
+| `InMemorySink` | yes | no | no | any | stdlib |
+| `LoggingSink` | yes | via logging config | no | proto `Event` (dicts render via `repr`) | `proto` extra |
+| `JSONLPersistenceSink` | yes | yes (file) | no | proto `Event` (and dicts, via `json.dumps`) | `proto` extra |
+| `SQLitePersistenceSink` | yes | yes (DB) | via DB reads | proto `Event` (and dicts) | `proto` extra |
+| `GRPCSink` | no (streams out) | no (the server persists) | yes | proto `Event` only | `proto` extra + `grpcio` |
+| `HarmonografSink` | no (streams out) | no (harmonograf persists) | yes | proto `Event` only | `harmonograf_client` |
 
-"Proto+dict" means the sink accepts both the Runner's dict lifecycle
-envelopes and the executor's proto `Event` messages. `GRPCSink` and
-`HarmonografSink` drop non-proto events with a debug log — the wire
-formats are strictly proto.
+Since #55 the goldfive Runner/executor/steerer all emit proto
+`Event` envelopes. Custom components that hand dict envelopes (from
+`goldfive.events.make_event`) to `GRPCSink` / `HarmonografSink` have
+them dropped with a debug log — both transports are proto-only.
 
 ## Comparison
 
@@ -292,11 +292,13 @@ the exception; the remaining sinks still see the event; the run keeps
 going. Design your sink for graceful degradation — see
 [writing-an-event-sink.md](writing-an-event-sink.md).
 
-**Which sinks accept dict events?** All local sinks accept both shapes.
-The Runner emits dict envelopes for lifecycle markers; executors emit
-proto `Event` messages for per-task state. `GRPCSink` and
-`HarmonografSink` are proto-only and drop non-proto events with a
-debug log.
+**Which sinks accept dict events?** All local sinks (`InMemorySink`,
+`LoggingSink`, `JSONLPersistenceSink`, `SQLitePersistenceSink`)
+tolerate both proto `Event` envelopes and dict envelopes built via
+`goldfive.events.make_event`. Since #55 the built-in components only
+emit proto, so the dict path is dormant unless a custom sink /
+component hands one in. `GRPCSink` and `HarmonografSink` are
+proto-only and drop non-proto events with a debug log.
 
 **I want a new sink — where do I start?**
 [writing-an-event-sink.md](writing-an-event-sink.md). The protocol is

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -111,14 +111,19 @@ from __future__ import annotations
 
 import asyncio
 
-from goldfive import Runner
-from goldfive.adapters.callable import CallableAdapter
-from goldfive.executors.sequential import SequentialExecutor
-from goldfive.planner import StaticPlanner
-from goldfive.results import InvocationResult
-from goldfive.sinks import InMemorySink
-from goldfive.steerer import DefaultSteerer
-from goldfive.types import Plan, Session, Task, TaskEdge
+from goldfive import (
+    CallableAdapter,
+    DefaultSteerer,
+    InMemorySink,
+    InvocationResult,
+    Plan,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
 
 
 # -- the "agent" --------------------------------------------------------
@@ -160,34 +165,22 @@ plan = Plan(
 
 # -- the Runner ---------------------------------------------------------
 
-def event_kind(event) -> str:
-    # Runner emits dict events; executors/steerers emit proto Event
-    # messages whose payload is a oneof. Handle both shapes.
-    if isinstance(event, dict):
-        return event.get("kind", "?")
-    return event.WhichOneof("payload") or "?"
-
-
-def event_sequence(event) -> int:
-    if isinstance(event, dict):
-        return int(event.get("sequence", 0))
-    return int(getattr(event, "sequence", 0))
-
-
 async def main() -> None:
     sink = InMemorySink()
     runner = Runner(
-        agent=CallableAdapter(my_agent),
+        agent=CallableAdapter(my_agent, available_agents=["default"]),
         planner=StaticPlanner(plan),
         executor=SequentialExecutor(),
         steerer=DefaultSteerer(),
         sinks=[sink],
     )
     outcome = await runner.run("demo run")
+    await runner.close()
 
     print(f"success={outcome.success}, tasks={len(outcome.session.plan.tasks)}")
     for event in sink.events:
-        print(f"  [{event_sequence(event):2d}] {event_kind(event)}")
+        kind = event.WhichOneof("payload")
+        print(f"  [{event.sequence:2d}] {kind}")
 
 
 if __name__ == "__main__":
@@ -197,6 +190,7 @@ if __name__ == "__main__":
 ### Step 2 — Run it
 
 ```bash
+uv sync --extra proto
 uv run python hello.py
 ```
 
@@ -204,47 +198,42 @@ Expected output:
 
 ```
 success=True, tasks=3
-  [ 0] RunStarted
-  [ 1] GoalDerived
-  [ 2] PlanSubmitted
-  [ 3] run_started
-  [ 4] task_started
-  [ 5] task_completed
-  [ 6] task_started
-  [ 7] task_completed
-  [ 8] task_started
-  [ 9] task_completed
-  [10] run_completed
+  [ 0] run_started
+  [ 1] goal_derived
+  [ 2] plan_submitted
+  [ 3] task_started
+  [ 4] task_completed
+  [ 5] task_started
+  [ 6] task_completed
+  [ 7] task_started
+  [ 8] task_completed
+  [ 9] run_completed
 ```
 
-Sequences 0–2 come from the Runner (it emits dict envelopes with a
-``kind`` field) and the rest come from the executor and steerer (proto
-``Event`` messages whose oneof payload is matched by ``WhichOneof``).
-You'll see a second ``run_started`` at sequence 3 because the
-executor also announces its start — treat the two together as the
-run's start marker.
+Every event is a proto `Event` with a `oneof payload` you extract via
+`WhichOneof("payload")`. Sequences are a monotonic per-run counter
+produced by `Session.next_sequence()`.
 
 That's it. You have a full goldfive run, observable via the in-memory
 sink, walking a 3-task plan end-to-end.
 
 ### Step 3 — Inspect what happened
 
-Everything you'd want to know is in `sink.events`. The executor and
-steerer emit proto ``Event`` messages — use ``WhichOneof`` to pick out
-the payload, skipping the dict envelopes the Runner emits:
+Everything you'd want to know is in `sink.events`. Every entry is a
+proto `Event`; dispatch on the `oneof payload`:
 
 ```python
 for event in sink.events:
-    if isinstance(event, dict):
-        continue  # Runner envelope: RunStarted / GoalDerived / PlanSubmitted
     kind = event.WhichOneof("payload")
     if kind == "task_completed":
         tc = event.task_completed
         print(f"task {tc.task_id}: {tc.summary}")
 ```
 
-For a run that was persisted to disk, use `JSONLPersistenceSink` —
-see [persistence-and-recovery.md](persistence-and-recovery.md).
+For a run that was persisted to disk, use `JSONLPersistenceSink` or
+`SQLitePersistenceSink` — see
+[persistence-and-recovery.md](persistence-and-recovery.md) and
+[choosing-a-sink.md](choosing-a-sink.md).
 
 ## Wiring a real agent
 
@@ -266,8 +255,14 @@ Swapping adapters is a one-line change:
 
 # now:
 from goldfive.adapters.claude import ClaudeAgentSDKAdapter
-agent=ClaudeAgentSDKAdapter(
-    system_prompt="You are a helpful assistant.",
+
+def make_client():
+    from claude_agent_sdk import ClaudeSDKClient
+    return ClaudeSDKClient(...)  # your client config
+
+agent = ClaudeAgentSDKAdapter(
+    client_factory=make_client,
+    system_prompt_template="You are a helpful assistant.",
     model="claude-opus-4-5-20251101",
 )
 ```
@@ -301,12 +296,10 @@ outcome = await runner.run("build me a slide deck about Python")
 Or the explicit form with `Runner(...)`:
 
 ```python
-from goldfive import Runner, SequentialExecutor
-from goldfive.adapters.callable import CallableAdapter
-from goldfive.planner import LLMPlanner
+from goldfive import CallableAdapter, LLMPlanner, Runner, SequentialExecutor
 
 runner = Runner(
-    agent=CallableAdapter(my_agent),
+    agent=CallableAdapter(my_agent, available_agents=["default"]),
     planner=LLMPlanner(call_llm=call_llm, model="claude-opus-4-5-20251101"),
     executor=SequentialExecutor(),
 )
@@ -321,29 +314,31 @@ format and how to customize it.
 One line to make runs crash-recoverable:
 
 ```python
-from goldfive.sinks import JSONLPersistenceSink
+from goldfive import JSONLPersistenceSink
 
 runner = Runner(
-    agent=CallableAdapter(my_agent),
-    planner=PassthroughPlanner(plan),
+    agent=CallableAdapter(my_agent, available_agents=["default"]),
+    planner=StaticPlanner(plan),
     executor=SequentialExecutor(),
     sinks=[JSONLPersistenceSink(path=f"./runs/{run_id}.jsonl")],
 )
 ```
 
-Full failure-mode walkthrough in
-[persistence-and-recovery.md](persistence-and-recovery.md).
+For cross-run queries, swap in `SQLitePersistenceSink` (or pair
+both). Full failure-mode walkthrough in
+[persistence-and-recovery.md](persistence-and-recovery.md); full sink
+matrix in [choosing-a-sink.md](choosing-a-sink.md).
 
 ## Running in parallel
 
 Swap `SequentialExecutor` for `ParallelDAGExecutor`:
 
 ```python
-from goldfive.executors.parallel import ParallelDAGExecutor
+from goldfive import ParallelDAGExecutor
 
 runner = Runner(
-    agent=CallableAdapter(my_agent),
-    planner=PassthroughPlanner(plan),
+    agent=CallableAdapter(my_agent, available_agents=["default"]),
+    planner=StaticPlanner(plan),
     executor=ParallelDAGExecutor(max_concurrency=4),
 )
 ```
@@ -353,14 +348,22 @@ Tasks whose dependencies are satisfied run concurrently via
 
 ## What's next
 
+- [observability-with-harmonograf.md](observability-with-harmonograf.md) —
+  end-to-end: boot the harmonograf UI and watch this same run animate.
 - [writing-an-agent-adapter.md](writing-an-agent-adapter.md) — wrap a
   new framework.
 - [writing-an-event-sink.md](writing-an-event-sink.md) — send events
   to your own observability backend.
+- [choosing-a-sink.md](choosing-a-sink.md) — picking between the five
+  shipped sinks.
 - [goals-and-plans.md](goals-and-plans.md) — author custom
   GoalDerivers and Planners.
 - [persistence-and-recovery.md](persistence-and-recovery.md) — crash
-  recovery with `JSONLPersistenceSink`.
+  recovery with `JSONLPersistenceSink` / `SQLitePersistenceSink`.
+- [grpc-transport.md](grpc-transport.md) — streaming events to an
+  out-of-process observer.
+- [troubleshooting.md](troubleshooting.md) — common install / run-time
+  failures.
 - [tool-protocol.md](../reference/tool-protocol.md) — the seven
   reporting tools that drive task state.
 - [ARCHITECTURE.md](../design/ARCHITECTURE.md) — the full design

--- a/docs/guides/grpc-transport.md
+++ b/docs/guides/grpc-transport.md
@@ -113,13 +113,11 @@ sink = GRPCSink("observer.internal:443", credentials=creds)
 
 ### Proto only
 
-`GRPCSink` forwards **only** proto `Event` messages. The executor's
-typed event factories (`task_started_event`, `task_completed_event`,
-etc.) return proto; those cross the wire. The Runner's own lifecycle
-emits — built by `make_event` — are dicts today and are silently
-dropped by `GRPCSink`. If you need the full lifecycle log on the wire,
-pair `GRPCSink` with `JSONLPersistenceSink` locally and ship the log
-out-of-band. Unifying the emit path is tracked for a future release.
+`GRPCSink` forwards **only** proto `Event` messages. Since #55 the
+Runner, executor, and steerer all emit proto, so the full lifecycle
+crosses the wire. If a caller (or a custom component) hands a dict
+envelope to the sink, it is silently dropped with a debug log —
+pair with `JSONLPersistenceSink` locally if you need that path.
 
 ### Reconnect semantics
 

--- a/docs/guides/observability-with-harmonograf.md
+++ b/docs/guides/observability-with-harmonograf.md
@@ -58,9 +58,10 @@ cd goldfive
 uv sync --extra proto
 ```
 
-The `proto` extra pulls in `grpcio` and `protobuf`, which the example
-needs to emit proto `Event` messages. A plain `uv sync` works if you
-only want the dict-event path, but `HarmonografSink` is proto-only.
+The `proto` extra pulls in `grpcio` and `protobuf`. Since #55 every
+goldfive event is a proto `Event`, so the extra is required for the
+`LoggingSink` / `JSONLPersistenceSink` / `SQLitePersistenceSink` /
+`GRPCSink` / `HarmonografSink` paths.
 
 Verify the import surface:
 
@@ -234,16 +235,17 @@ markers. For the full ADK walkthrough, see harmonograf's
 What travels on the wire when you hit run:
 
 1. `Runner.run(user_input)` starts a new session and emits
-   `RunStarted` (a dict lifecycle envelope) to every sink.
-2. `PassthroughGoalDeriver` turns `user_input` into one `Goal`; the
+   `RunStarted` (a proto `Event`) to every sink.
+2. `PassthroughGoalDeriver` returns its pre-configured `Goal`; the
    Runner emits `GoalDerived`.
 3. `StaticPlanner.generate` returns the four-task plan; the Runner
    emits `PlanSubmitted`.
-4. `SequentialExecutor` walks the DAG. For each task it emits a proto
-   `TaskStarted` before invoking the adapter and a `TaskCompleted`
+4. `SequentialExecutor` walks the DAG. For each task it emits
+   `TaskStarted` before invoking the adapter and `TaskCompleted`
    (or `TaskFailed`) after.
-5. On run termination the Runner emits `RunCompleted` or
-   `RunAborted`.
+5. On run termination the executor emits `RunCompleted` (success) or
+   `RunAborted` (surrender); setup failures surface a `RunAborted`
+   emitted by the Runner itself.
 
 Inside `HarmonografSink.emit` the work is non-blocking: each proto
 `Event` is pushed onto the `Client`'s ring buffer and returns
@@ -322,9 +324,9 @@ sinks = [
 ]
 ```
 
-`JSONLPersistenceSink` accepts both the Runner's dict envelopes and
-the executor's proto events; `HarmonografSink` only forwards proto.
-They complement cleanly. See
+`JSONLPersistenceSink` writes every proto `Event` to disk;
+`HarmonografSink` streams the same events to the live UI. They
+complement cleanly. See
 [persistence-and-recovery.md](persistence-and-recovery.md) for the
 recovery protocol and [choosing-a-sink.md](choosing-a-sink.md) for
 the full sink matrix.

--- a/docs/guides/persistence-and-recovery.md
+++ b/docs/guides/persistence-and-recovery.md
@@ -54,13 +54,13 @@ runner = Runner(
 outcome = await runner.run("do the thing")
 ```
 
-The sink writes one JSON-encoded event per line: proto ``Event``
-messages from the executor and steerer go through
-``google.protobuf.json_format.MessageToJson`` and Runner-level dict
-envelopes go through plain ``json.dumps``. The ``path`` is a literal
-string — pick a filename yourself (for example, by generating a
-``run_id`` up-front and formatting it in) since the sink does not
-substitute placeholders.
+The sink writes one JSON-encoded event per line via
+`google.protobuf.json_format.MessageToJson(..., sort_keys=True)`
+(since #55 every event on the stream is a proto `Event`). The
+`path` is a literal string — pick a filename yourself (for
+example, by generating a `run_id` up-front and formatting it in)
+since the sink does not substitute placeholders. Pass `mode="write"`
+to truncate on open; the default is append.
 
 On-disk shape:
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -240,16 +240,19 @@ finally:
 
 ### Symptom: `GRPCSink` appears to drop events
 
-**What you see.** The upstream server sees fewer events than expected
-— typically no `RunStarted`, `GoalDerived`, or `PlanSubmitted`.
+**What you see.** The upstream server sees fewer events than expected.
 
 **Why it happens.** `GRPCSink` only forwards objects with a proto
-`DESCRIPTOR` attribute. The Runner's lifecycle envelopes in v0.1 are
-dicts (built by `goldfive.events.make_event`) and are silently dropped
-with a debug log. See [grpc-transport.md](grpc-transport.md#proto-only).
+`DESCRIPTOR` attribute. Since #55 every goldfive component emits
+proto, so the full lifecycle crosses the wire — but a custom sink
+or caller that hands a dict (e.g. built via
+`goldfive.events.make_event`) to `GRPCSink.emit` has it silently
+dropped with a debug log. See
+[grpc-transport.md](grpc-transport.md#proto-only).
 
-**Fix.** Pair `GRPCSink` with a local `JSONLPersistenceSink` (which
-accepts both shapes):
+**Fix.** Either ensure the upstream component emits proto, or pair
+`GRPCSink` with a local `JSONLPersistenceSink` as a durable
+fallback:
 
 ```python
 runner = Runner(..., sinks=[

--- a/docs/guides/writing-an-agent-adapter.md
+++ b/docs/guides/writing-an-agent-adapter.md
@@ -302,23 +302,26 @@ reference implementation.
 
 ## The steerer reference
 
-In the example above, `self._steerer` is accessed but never set. In
-the real adapters, the executor injects the steerer via a protocol
-method or a framework-specific hook. For v0.1, the shape is under
-active iteration; check `goldfive.adapters.callable.CallableAdapter`
-for the current idiom and mirror it.
+In the example above, `self._steerer` is accessed but never set. The
+`AgentAdapter` protocol deliberately does not mandate how the steerer
+reaches the adapter — different frameworks need different wiring:
 
-A robust pattern:
+- **CallableAdapter** — the shipped reference adapter does not bind a
+  steerer at all. Reporting-tool handlers close over the steerer
+  (the `Runner` stamps them in via `register_reporting_tools`) and
+  the callable forwards the tool list to user code.
+- **ClaudeAgentSDKAdapter** — exposes `bind_steerer(steerer)`
+  explicitly so the adapter can install `before_model` / observer
+  hooks against it.
+- **ADKAdapter** — the executor / plugin injects the steerer through
+  ADK's own plugin callbacks; the adapter doesn't need a setter.
 
-```python
-class AwesomeAdapter:
-    def bind_steerer(self, steerer):
-        self._steerer = steerer
-```
-
-The executor calls `adapter.bind_steerer(steerer)` before the first
-`invoke`. The `CallableAdapter` in `goldfive/adapters/callable.py` is
-the reference implementation.
+If your framework wants per-turn drift observation, expose a public
+`bind_steerer` (or accept the `Steerer` at construction) and have
+the executor hand in the `Steerer` before the first `invoke`.
+Otherwise, rely on the closure that `register_reporting_tools`
+establishes: the reporting-tool handlers already carry a reference
+to the steerer wired up by the `Runner`.
 
 ## Mapping drift-relevant signals
 

--- a/docs/guides/writing-an-event-sink.md
+++ b/docs/guides/writing-an-event-sink.md
@@ -41,12 +41,12 @@ Two methods. `emit(event)` is called once per event, in per-run
 sequence order. `close()` is called once when the run ends. That's
 the entire contract.
 
-One wrinkle: v0.1 emits two event shapes on the same stream. The
-Runner emits dict envelopes (``{"run_id", "sequence", "emitted_at",
-"kind", "payload"}``) for run-lifecycle markers, and executors/
-steerers emit proto ``Event`` messages for per-task state changes.
-Sinks must accept both. ``JSONLPersistenceSink`` is the reference for
-how to fan out: proto via ``MessageToJson``, dict via ``json.dumps``.
+Since #55 the Runner, executor, and steerer all emit proto `Event`
+envelopes — a sink only needs to handle that one shape. Dispatch on
+`event.WhichOneof("payload")` to branch on kind.
+`goldfive.events.make_event` still returns a dict envelope for
+callers who want the simpler shape without proto, but no shipped
+goldfive component feeds dicts to sinks today.
 
 ## A minimal stdout sink
 
@@ -58,15 +58,9 @@ from typing import Any
 
 class StdoutSink:
     async def emit(self, event: Any) -> None:
-        if isinstance(event, dict):
-            seq = int(event.get("sequence", 0))
-            kind = event.get("kind", "?")
-            run_id = event.get("run_id", "")
-        else:
-            seq = int(getattr(event, "sequence", 0))
-            kind = event.WhichOneof("payload") or "?"
-            run_id = getattr(event, "run_id", "")
-        print(f"[{seq:04d}] {kind} (run={run_id})")
+        seq = int(getattr(event, "sequence", 0))
+        kind = event.WhichOneof("payload") or "?"
+        print(f"[{seq:04d}] {kind} (run={event.run_id})")
 
     async def close(self) -> None:
         pass
@@ -133,12 +127,9 @@ class HttpBackendSink:
             item = await self._queue.get()
             if item is None:
                 return
-            if isinstance(item, dict):
-                payload = item
-            else:
-                payload = json.loads(
-                    MessageToJson(item, preserving_proto_field_name=True)
-                )
+            payload = json.loads(
+                MessageToJson(item, preserving_proto_field_name=True)
+            )
             try:
                 await self._client.post(self._endpoint, json=payload)
             except httpx.HTTPError:
@@ -249,10 +240,7 @@ class FilteringSink:
         self._kinds = set(kinds)
 
     async def emit(self, event) -> None:
-        if isinstance(event, dict):
-            kind = event.get("kind", "")
-        else:
-            kind = event.WhichOneof("payload") or ""
+        kind = event.WhichOneof("payload") or ""
         if kind in self._kinds:
             await self._inner.emit(event)
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -14,7 +14,7 @@ Everything documented here is re-exported from `goldfive.__init__`
 
 ```python
 from goldfive import (
-    Runner,
+    Runner, wrap, run, quickstart,
     # types
     Goal, Plan, Task, TaskEdge, TaskStatus, DriftKind, DriftSeverity,
     DriftEvent, Session,
@@ -30,37 +30,28 @@ from goldfive import (
     PassthroughPlanner, StaticPlanner, LLMPlanner,
     PassthroughGoalDeriver, LiteralGoalDeriver, LLMGoalDeriver,
     DefaultSteerer,
-    InMemorySink,
+    InMemorySink, LoggingSink,
+    JSONLPersistenceSink, SQLitePersistenceSink, GRPCSink,
     # drift helpers
     classify_tool_error, classify_refusal, classify_stop_reason,
 )
 ```
 
-Subpackages for implementations not included in the package-root
-re-exports (adapters gated behind optional extras, the heavier sinks
-that require the `proto` extra, etc.):
+Subpackages for framework adapters gated behind optional extras:
 
 ```python
 from goldfive.adapters.callable import CallableAdapter
 from goldfive.adapters.adk import ADKAdapter          # extra: adk
 from goldfive.adapters.claude import ClaudeAgentSDKAdapter  # extra: claude
-
-from goldfive.executors.sequential import SequentialExecutor
-from goldfive.executors.parallel import ParallelDAGExecutor
-
-from goldfive.planner import PassthroughPlanner, StaticPlanner, LLMPlanner
-from goldfive.goal_deriver import (
-    PassthroughGoalDeriver, LiteralGoalDeriver, LLMGoalDeriver,
-)
-from goldfive.steerer import DefaultSteerer
-
-from goldfive.sinks import (
-    InMemorySink,
-    LoggingSink,
-    JSONLPersistenceSink,
-    SQLitePersistenceSink,
-)
+from goldfive.adapters.auto import auto_adapter
 ```
+
+`LoggingSink`, `JSONLPersistenceSink`, `SQLitePersistenceSink`, and
+`GRPCSink` require the `proto` extra at runtime (they import
+`google.protobuf` eagerly; `GRPCSink` also needs `grpcio`). They
+appear in `goldfive.__all__` unconditionally; when the extra is
+missing the module attribute resolves to `None` at import time,
+surfacing the missing dependency at construction rather than import.
 
 ## `goldfive.wrap` / `goldfive.run`
 
@@ -117,6 +108,30 @@ from goldfive.adapters.auto import auto_adapter
 
 adapter: AgentAdapter = auto_adapter(agent)
 ```
+
+## `quickstart`
+
+One-call `Runner` factory for the common case. Complements `wrap` —
+`quickstart` always uses a static one-task-per-goal plan rather than
+an LLM-driven planner.
+
+```python
+def quickstart(
+    agent: Any,
+    goals: str | Goal | list[str | Goal],
+    *,
+    planner: Planner | None = None,
+    sinks: list[EventSink] | None = None,
+) -> Runner: ...
+```
+
+- `agent` — either an existing `AgentAdapter` (used verbatim) or a
+  `CallableAdapter`-compatible async callable (wrapped).
+- `goals` — a single string, a single `Goal`, or a list of either.
+  Each entry becomes one task in the default plan.
+- `planner` / `sinks` — optional overrides. Defaults to a
+  `StaticPlanner` whose plan has one task per goal and
+  `[InMemorySink()]` respectively.
 
 ## `Runner`
 
@@ -491,6 +506,16 @@ class SQLitePersistenceSink(EventSink):
         table: str = "goldfive_events",
     ) -> None: ...
 
+class GRPCSink(EventSink):
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        credentials: Optional[grpc.ChannelCredentials] = None,
+        reconnect: bool = True,
+        max_queue: int = 0,  # 0 = unbounded
+    ) -> None: ...
+
 
 # Module-level replay / reconstruction helpers.
 def replay_from_jsonl(path: str | Path) -> list[Any]:
@@ -517,10 +542,32 @@ def reconstruct_session(events: list[Any]) -> Session:
     """Replay events to rebuild a best-effort :class:`Session`."""
 ```
 
-`LoggingSink`, `JSONLPersistenceSink`, `SQLitePersistenceSink`, and
-the replay helpers require the `proto` extra (they lean on
-`google.protobuf`). When the extra is missing the symbols resolve to
-``None`` at import time so the rest of the package stays usable.
+`LoggingSink`, `JSONLPersistenceSink`, `SQLitePersistenceSink`,
+`GRPCSink`, and the replay helpers require the `proto` extra (they
+lean on `google.protobuf`; `GRPCSink` also requires `grpcio`). When
+the extra is missing the symbols resolve to `None` at import time
+so the rest of the package stays usable.
+
+### Ingress server (`goldfive.server`)
+
+```python
+class GoldfiveIngressServer:
+    def __init__(
+        self,
+        sinks: list[EventSink],
+        *,
+        credentials: Any = None,
+        server_options: list[tuple[str, Any]] | None = None,
+    ) -> None: ...
+    async def start(self, host: str = "127.0.0.1", port: int = 50051) -> int: ...
+    async def stop(self, grace: float | None = 1.0) -> None: ...
+    async def run(self, host: str = "127.0.0.1", port: int = 50051) -> None: ...
+```
+
+The companion server for `GRPCSink`. Receives proto `Event` messages
+over the `GoldfiveIngress.StreamEvents` RPC (defined in
+`proto/goldfive/v1/service.proto`) and fans them out to local
+sinks. See [grpc-transport.md](../guides/grpc-transport.md).
 
 ## Reporting (`goldfive.reporting`)
 


### PR DESCRIPTION
## Summary

- Swept every markdown file in `docs/`, `README.md`, `CHANGELOG.md`, and the `examples/*/README.md` against the current main. Fixed 20+ points of drift between docs and code.
- The single biggest stale story: the guides still said "the Runner emits dict lifecycle envelopes, the executor emits proto Events, sinks must handle both." Since #55 the whole stream is proto. All affected snippets, narrations, FAQs, and the `getting-started` expected-output block are now aligned.
- Filled in every shipped-but-undocumented implementation: 5 sinks (was 3), 3 goal derivers (was 2), 3 planners (was 2), plus `goldfive.quickstart`, `goldfive.wrap` / `goldfive.run` (landed in #67), and the `GoldfiveIngressServer` paired with `GRPCSink`.
- `CHANGELOG.md` had no entries past v0.1.0; added an Unreleased block for PRs #57–#69.

## What was stale, what I fixed

### README
- Top pitch said 'DriftAnalyzer' and 'TelemetrySink' — neither name exists. Replaced with `Steerer` / `EventSink` (the real protocol names) and mentioned `goldfive.wrap` / `goldfive.run`.
- Docs section only listed 6 of the 11 guides — added observability-with-harmonograf, choosing-a-sink, grpc-transport, troubleshooting.

### CHANGELOG
- Added Unreleased entries for #57 (quickstart), #58 (harmonograf_observed), #59 (perf baseline), #60 (choosing-a-sink), #61 (multi-sink/drift/parallel examples), #62 (troubleshooting), #63 (README pointer), #64 (observability-with-harmonograf), #67 (wrap/run), #68 (.agents/), #65 (`max_plan_reinvocations` 3→32 cleanup), #69 (HarmonografSink doc reconcile).

### Design docs
- `ARCHITECTURE.md` — primitives table now lists every shipped impl (3+3+5 instead of 2+2+3); event-ownership note (Runner vs Executor vs Steerer); real default goal deriver is `PassthroughGoalDeriver(\"run\")`, not "wraps the string"; real run_id source is `uuid.uuid4().hex`; pointed at `wrap` / `quickstart`.
- `EVENT-MODEL.md` — "ten event kinds" was wrong (13); `RunStarted` carries `goal_summary`, not truncated `user_input`; `RunCompleted` / `RunAborted` ownership corrected; added SQLitePersistenceSink + GRPCSink subsections.

### Guides
- `getting-started.md` — new hello snippet using real public re-exports; expected output matches the actual 10-event proto stream (no duplicate `run_started` at seq 3). Fixed `ClaudeAgentSDKAdapter` snippet (needs `client_factory`) and `PassthroughPlanner(plan)` → `StaticPlanner(plan)`. Expanded What's Next to include all five newer guides.
- `writing-an-event-sink.md` — dropped "two event shapes" section and dict-branch defensive code in the minimal / HTTP / Filtering sinks.
- `writing-an-agent-adapter.md` — "executor calls `adapter.bind_steerer`" was made-up. Replaced with the real per-adapter wiring matrix (`CallableAdapter`: no binding; `ClaudeAgentSDKAdapter`: `bind_steerer`; `ADKAdapter`: plugin callbacks).
- `persistence-and-recovery.md`, `grpc-transport.md`, `troubleshooting.md`, `choosing-a-sink.md`, `observability-with-harmonograf.md` — removed / corrected the "Runner emits dicts" framing in each place it surfaced.

### Reference
- `api.md` — re-exports block now matches `goldfive.__all__` (adds `wrap` / `run` / `quickstart` / `LoggingSink` / `SQLitePersistenceSink` / `GRPCSink`). Added `quickstart` signature section. Added `GRPCSink` to the Sinks block. New `GoldfiveIngressServer` section with the real `__init__` / `start` / `stop` / `run` shape.

### Examples
- `examples/*/README.md` already on main (merged while I was working) — re-read both and confirmed they're accurate.

## Scope check

- Everything in the brief: README, CHANGELOG, all 5 design docs, all 10 guides, both reference docs, both example READMEs.
- Every Python snippet I touched was run against current main: `/tmp/snippet_readme.py` (10 events, success) and `/tmp/snippet_getting_started.py` (10 events, success). Matches the expected-output blocks in the docs.
- `uv run pytest -q` → 280 passed, 36 skipped. No test regressions.

## Files touched

15 files: README.md, CHANGELOG.md, docs/design/ARCHITECTURE.md, docs/design/EVENT-MODEL.md, docs/guides/getting-started.md, docs/guides/writing-an-event-sink.md, docs/guides/writing-an-agent-adapter.md, docs/guides/persistence-and-recovery.md, docs/guides/grpc-transport.md, docs/guides/troubleshooting.md, docs/guides/choosing-a-sink.md, docs/guides/observability-with-harmonograf.md, docs/reference/api.md. (Plus `docs/design/DRIFT.md`, `docs/design/PROTOCOLS.md`, `docs/design/STATE-MACHINE.md`, `docs/reference/tool-protocol.md`, `docs/guides/goals-and-plans.md`, `docs/guides/harmonograf-integration.md`, `docs/performance.md`, and the example READMEs — re-read for drift and left unchanged.)

## Test plan

- [x] `uv run pytest -q` — 280 passed, 36 skipped.
- [x] README hello snippet runs and emits 10 events.
- [x] Getting-started hello snippet runs and matches the new expected-output block byte-for-byte.
- [x] `examples/hello_callable.py` runs end-to-end.
- [ ] Reviewer skims the CHANGELOG Unreleased block against `gh pr list --state all` to confirm no PR is missing.
