### PR TITLE
ControlChannel primitive + drift kinds (part of #71)

### DIFF
--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 __version__ = "0.1.0"
 
 from goldfive.adapters.callable import CallableAdapter
+from goldfive.control import (
+    AckResult,
+    ControlAck,
+    ControlChannel,
+    ControlKind,
+    ControlMessage,
+)
 from goldfive.convenience import run, wrap
 from goldfive.drift import classify_refusal, classify_stop_reason, classify_tool_error
 from goldfive.executors.parallel import ParallelDAGExecutor
@@ -49,9 +56,14 @@ from goldfive.types import (
 
 __all__ = [
     "__version__",
+    "AckResult",
     "AgentAdapter",
     "BUILTIN_REPORTING_TOOLS",
     "CallableAdapter",
+    "ControlAck",
+    "ControlChannel",
+    "ControlKind",
+    "ControlMessage",
     "DefaultSteerer",
     "DriftEvent",
     "DriftKind",

--- a/goldfive/control.py
+++ b/goldfive/control.py
@@ -1,0 +1,122 @@
+"""Bidirectional async control channel between a Runner and external controllers.
+
+The :class:`ControlChannel` is the goldfive-side primitive that lets external
+processes (the harmonograf UI, a CLI, tests) steer a running ``Runner``: pause,
+resume, cancel, steer, rewind. Messages are queued asynchronously; runners poll
+:meth:`ControlChannel.receive` and publish acknowledgements via
+:meth:`ControlChannel.ack`. External bridges drain those acks via
+:meth:`ControlChannel.acks`.
+
+This module is intentionally dependency-light — only ``asyncio`` — so it can be
+imported by adapters and bridges without dragging in protobuf or grpc.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Optional
+
+
+class ControlKind(StrEnum):
+    PAUSE = "PAUSE"
+    RESUME = "RESUME"
+    CANCEL = "CANCEL"
+    STEER = "STEER"            # payload: {"note": "...", "suggested_action": "..."}
+    REWIND_TO = "REWIND_TO"    # payload: {"task_id": "..."}
+
+
+class AckResult(StrEnum):
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+    UNSUPPORTED = "UNSUPPORTED"
+
+
+@dataclass
+class ControlMessage:
+    kind: ControlKind
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    payload: dict[str, Any] = field(default_factory=dict)
+    issued_at_ms: int = 0
+
+
+@dataclass
+class ControlAck:
+    control_id: str
+    result: AckResult
+    detail: str = ""
+    acked_at_ms: int = 0
+
+
+class ControlChannel:
+    """Bidirectional async control channel between a Runner and external
+    controllers (harmonograf UI, CLI, tests).
+
+    External -> runner: ControlMessages pushed via :meth:`send`, consumed
+    by the runner via :meth:`receive`.
+
+    Runner -> external: ControlAcks emitted via :meth:`ack`, consumed by
+    the external bridge via :meth:`acks` async iterator.
+    """
+
+    def __init__(self) -> None:
+        self._inbox: asyncio.Queue[ControlMessage] = asyncio.Queue()
+        self._outbox: asyncio.Queue[ControlAck] = asyncio.Queue()
+        self._closed = False
+
+    async def send(self, msg: ControlMessage) -> None:
+        """External caller pushes a control message to the runner."""
+        await self._inbox.put(msg)
+
+    async def receive(self, timeout: float | None = None) -> Optional[ControlMessage]:
+        """Runner polls for the next control message.
+
+        Returns ``None`` on timeout or when the channel is closed.
+        """
+        if self._closed:
+            return None
+        try:
+            if timeout is None:
+                return await self._inbox.get()
+            return await asyncio.wait_for(self._inbox.get(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    async def ack(self, ack: ControlAck) -> None:
+        """Runner publishes an ack for a received message."""
+        await self._outbox.put(ack)
+
+    async def acks(self) -> AsyncIterator[ControlAck]:
+        """External bridge iterates ack output.
+
+        Yields acks until the channel is closed. Once :meth:`close` is
+        called, a sentinel is queued so a pending consumer wakes up and
+        the loop terminates without leaking the task.
+        """
+        while not self._closed:
+            ack = await self._outbox.get()
+            if ack is _CLOSE_SENTINEL:
+                break
+            yield ack
+
+    def close(self) -> None:
+        """Mark the channel closed.
+
+        After ``close()``: :meth:`receive` returns ``None`` immediately,
+        and any consumer blocked on :meth:`acks` is woken up via a
+        sentinel so it exits the iterator cleanly.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        # Wake any pending acks() consumer with a sentinel.
+        self._outbox.put_nowait(_CLOSE_SENTINEL)
+
+
+# A private sentinel pushed onto _outbox by close() so that a coroutine
+# blocked on acks() wakes up and exits the iterator. Comparing by identity
+# avoids accidental matches against real ControlAck values.
+_CLOSE_SENTINEL: Any = object()

--- a/goldfive/events.py
+++ b/goldfive/events.py
@@ -272,6 +272,39 @@ def task_cancelled_event(run_id: str, sequence: int, task_id: str, reason: str =
     return evt
 
 
+def control_received_event(
+    run_id: str,
+    sequence: int,
+    control_kind: Any,
+    control_id: str,
+) -> Any:
+    """Build a ``DriftDetected`` envelope for a received ControlMessage.
+
+    Phase 1 reuses the ``DriftDetected`` oneof (no proto regen). The mapping
+    from :class:`goldfive.control.ControlKind` to :class:`DriftKind` is:
+    ``PAUSE`` -> ``USER_PAUSE``, ``CANCEL`` -> ``USER_CANCEL``, everything
+    else (``STEER``, ``RESUME``, ``REWIND_TO``) -> ``USER_STEER``. The raw
+    control kind name is preserved in ``detail`` along with the control id
+    so downstream consumers can disambiguate.
+    """
+    from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+
+    kind_name = str(getattr(control_kind, "value", control_kind)).upper()
+    if kind_name == "PAUSE":
+        drift_kind = DriftKind.USER_PAUSE
+    elif kind_name == "CANCEL":
+        drift_kind = DriftKind.USER_CANCEL
+    else:
+        drift_kind = DriftKind.USER_STEER
+
+    drift = DriftEvent(
+        kind=drift_kind,
+        severity=DriftSeverity.WARNING,
+        detail=f"control:{kind_name}:{control_id}",
+    )
+    return drift_detected_event(run_id, sequence, drift)
+
+
 def drift_detected_event(run_id: str, sequence: int, drift: Any) -> Any:
     pb = _events_pb_module()
     evt = new_event(run_id, sequence)

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -28,6 +28,7 @@ class DriftKind(StrEnum):
     PLAN_DIVERGENCE = "plan_divergence"
     USER_STEER = "user_steer"
     USER_CANCEL = "user_cancel"
+    USER_PAUSE = "user_pause"
     TASK_FAILED_RECOVERABLE = "task_failed_recoverable"
     TASK_FAILED_FATAL = "task_failed_fatal"
     CONTEXT_PRESSURE = "context_pressure"

--- a/tests/test_control_primitive.py
+++ b/tests/test_control_primitive.py
@@ -1,0 +1,110 @@
+"""Unit tests for the ControlChannel primitive (goldfive/control.py).
+
+These tests pin the contract that Agent B (executor integration) and Agent E
+(harmonograf bridge) will build against. They do NOT exercise any runner
+behavior — pure send/receive/ack round-trip and lifecycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from goldfive.control import (
+    AckResult,
+    ControlAck,
+    ControlChannel,
+    ControlKind,
+    ControlMessage,
+)
+
+
+@pytest.mark.asyncio
+async def test_send_receive_round_trip() -> None:
+    channel = ControlChannel()
+    msg = ControlMessage(kind=ControlKind.STEER, payload={"note": "focus on slide 5"})
+
+    await channel.send(msg)
+    received = await channel.receive(timeout=0.1)
+
+    assert received is msg
+    assert received.kind == ControlKind.STEER
+    assert received.payload == {"note": "focus on slide 5"}
+    assert received.id  # auto-generated
+
+
+@pytest.mark.asyncio
+async def test_ack_round_trip() -> None:
+    channel = ControlChannel()
+    msg = ControlMessage(kind=ControlKind.PAUSE)
+
+    await channel.send(msg)
+    received = await channel.receive(timeout=0.1)
+    assert received is not None
+
+    ack = ControlAck(control_id=received.id, result=AckResult.SUCCESS, detail="paused")
+    await channel.ack(ack)
+
+    collected: list[ControlAck] = []
+
+    async def collect() -> None:
+        async for a in channel.acks():
+            collected.append(a)
+
+    task = asyncio.create_task(collect())
+    # Yield so the consumer picks up the ack, then close to terminate the iterator.
+    await asyncio.sleep(0.01)
+    channel.close()
+    await asyncio.wait_for(task, timeout=0.1)
+
+    assert len(collected) == 1
+    assert collected[0].control_id == received.id
+    assert collected[0].result == AckResult.SUCCESS
+    assert collected[0].detail == "paused"
+
+
+@pytest.mark.asyncio
+async def test_receive_timeout_returns_none() -> None:
+    channel = ControlChannel()
+    result = await channel.receive(timeout=0.05)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_close_stops_receive_and_acks() -> None:
+    channel = ControlChannel()
+
+    # A pending acks() consumer should wake up and exit the iterator on close.
+    seen: list[ControlAck] = []
+
+    async def consume_acks() -> None:
+        async for a in channel.acks():
+            seen.append(a)
+
+    consumer = asyncio.create_task(consume_acks())
+    await asyncio.sleep(0.01)  # let consumer block on _outbox.get()
+
+    channel.close()
+    await asyncio.wait_for(consumer, timeout=0.1)
+    assert seen == []
+
+    # After close, receive() returns None immediately even with no timeout.
+    result = await channel.receive()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_multiple_messages_queue_in_order() -> None:
+    channel = ControlChannel()
+    kinds = [ControlKind.PAUSE, ControlKind.RESUME, ControlKind.CANCEL]
+    for k in kinds:
+        await channel.send(ControlMessage(kind=k))
+
+    received_kinds = []
+    for _ in kinds:
+        msg = await channel.receive(timeout=0.1)
+        assert msg is not None
+        received_kinds.append(msg.kind)
+
+    assert received_kinds == kinds


### PR DESCRIPTION
## Summary

Foundation for Phase 1 live-steering (#71). Pure primitive — no executor or steerer changes (those land in Agents B and C).

- `goldfive/control.py` (new): `ControlChannel`, `ControlMessage`, `ControlKind`, `AckResult`, `ControlAck` exactly per the pinned spec in #71. Asyncio-only.
- `goldfive/types.py`: adds `DriftKind.USER_PAUSE` (USER_STEER and USER_CANCEL already existed).
- `goldfive/events.py`: `control_received_event(run_id, sequence, control_kind, control_id)` factory that maps a `ControlKind` to a `DriftDetected` envelope (PAUSE→USER_PAUSE, CANCEL→USER_CANCEL, everything else→USER_STEER, control kind + id encoded in `detail`).
- `goldfive/__init__.py`: exports `ControlChannel`, `ControlMessage`, `ControlKind`, `AckResult`, `ControlAck`.

Closes nothing; foundation for #71 parallel work.

## Test plan

- [x] `tests/test_control_primitive.py` — send/receive round-trip, ack round-trip, receive timeout, close lifecycle, queue ordering (5 new tests).
- [x] `uv run pytest -q` — 297 passed, 33 skipped, no regressions.
