### PR TITLE
Fix remaining ruff errors + exclude .claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ htmlcov/
 .idea/
 .vscode/
 .DS_Store
+.claude/

--- a/goldfive/control.py
+++ b/goldfive/control.py
@@ -18,7 +18,7 @@ import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any, Optional
+from typing import Any
 
 
 class ControlKind(StrEnum):
@@ -71,7 +71,7 @@ class ControlChannel:
         """External caller pushes a control message to the runner."""
         await self._inbox.put(msg)
 
-    async def receive(self, timeout: float | None = None) -> Optional[ControlMessage]:
+    async def receive(self, timeout: float | None = None) -> ControlMessage | None:
         """Runner polls for the next control message.
 
         Returns ``None`` on timeout or when the channel is closed.
@@ -82,7 +82,7 @@ class ControlChannel:
             if timeout is None:
                 return await self._inbox.get()
             return await asyncio.wait_for(self._inbox.get(), timeout=timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return None
 
     async def ack(self, ack: ControlAck) -> None:

--- a/goldfive/quickstart.py
+++ b/goldfive/quickstart.py
@@ -20,7 +20,6 @@ from goldfive.runner import Runner
 from goldfive.sinks.memory import InMemorySink
 from goldfive.types import Goal, Plan, Task
 
-
 _DEFAULT_AGENT_ID = "default"
 
 


### PR DESCRIPTION
CI still red after #73 because ruff surfaced more errors in goldfive/control.py + quickstart.py. Also excludes .claude/ worktree artifacts from lint.