### PR TITLE
Executor + Runner hooks for ControlChannel (part of #71)

### DIFF
--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from goldfive._llm_detect import CallLLM, detect_llm
 from goldfive.adapters.auto import auto_adapter
@@ -43,6 +43,9 @@ from goldfive.sinks import LoggingSink
 from goldfive.steerer import DefaultSteerer
 from goldfive.types import Goal
 
+if TYPE_CHECKING:
+    from goldfive.control import ControlChannel
+
 log = logging.getLogger("goldfive.wrap")
 
 
@@ -54,6 +57,7 @@ def wrap(
     executor: Executor | None = None,
     steerer: Steerer | None = None,
     sinks: list[EventSink] | None = None,
+    control: ControlChannel | None = None,
     call_llm: CallLLM | None = None,
     model: str | None = None,
     max_plan_reinvocations: int = 32,
@@ -82,6 +86,10 @@ def wrap(
     sinks:
         Optional sink list override. Defaults to ``[LoggingSink()]``.
         Passing an explicit empty list suppresses all sinks.
+    control:
+        Optional :class:`~goldfive.control.ControlChannel` forwarded
+        into the :class:`Runner`. Enables live pause / resume / cancel /
+        steer / rewind from an external controller.
     call_llm:
         Optional async ``(system, user, model) -> str`` callable. When
         provided, it is used for both the default planner and the
@@ -157,6 +165,7 @@ def wrap(
         goal_deriver=resolved_goal_deriver,
         steerer=resolved_steerer,
         sinks=resolved_sinks,
+        control=control,
         max_plan_reinvocations=max_plan_reinvocations,
     )
 

--- a/goldfive/executors/_control.py
+++ b/goldfive/executors/_control.py
@@ -1,0 +1,349 @@
+"""Shared control-message helpers for executors.
+
+Both :class:`~goldfive.executors.SequentialExecutor` and
+:class:`~goldfive.executors.ParallelDAGExecutor` interpret the same
+:class:`~goldfive.control.ControlMessage` vocabulary. This module centralizes
+the dispatch logic so the two executors stay in sync.
+
+The helpers here:
+
+* :func:`dispatch_control` — handle one message, mutate session state
+  and/or call into the steerer, and return a :class:`ControlOutcome`
+  the executor should apply. The ack is pre-built on the outcome; the
+  caller publishes it via ``channel.ack(outcome.ack)``.
+* :func:`drain_controls` — non-blocking drain of every message currently
+  queued on the channel, dispatching each in order and returning the
+  outcomes for the caller.
+* :class:`_ControlCancelled` — internal exception the executor raises
+  when it needs to short-circuit the run loop on CANCEL.
+* :class:`ControlOutcome` — rich per-message result the caller uses to
+  decide what to do next (abort the run, apply a steer, rewind, ...).
+
+Control kinds recognized (strings match both ``ControlKind`` enum
+members and their raw string equivalents — ``ControlKind`` is a
+``StrEnum``):
+
+* ``PAUSE`` / ``RESUME`` — pause / unpause the run loop between tasks.
+* ``CANCEL`` — abort the run; executor emits ``RunAborted``.
+* ``STEER`` — feed the message to ``steerer.observe`` so the planner
+  can produce a fresh plan on the ``USER_STEER`` drift.
+* ``REWIND_TO`` — mark a task and every downstream task ``PENDING``
+  so the executor re-walks them.
+* ``STATUS_QUERY`` — synthesize a status-snapshot event on the sinks
+  (forward-compat; not in the Phase-1 ``ControlKind`` enum, but
+  recognized if an external caller sends the string).
+* ``INTERCEPT_TRANSFER`` — toggle ``session._intercept_transfer`` so
+  adapters that honour the flag refuse transfers.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from goldfive.types import Session, TaskStatus
+
+if TYPE_CHECKING:
+    from goldfive.control import ControlAck, ControlChannel, ControlMessage
+    from goldfive.protocols import EventSink, Steerer
+
+log = logging.getLogger(__name__)
+
+
+__all__ = [
+    "ControlOutcome",
+    "_ControlCancelled",
+    "dispatch_control",
+    "drain_controls",
+    "emit_status_report",
+]
+
+
+class _ControlCancelled(BaseException):
+    """Internal signal: a CANCEL control message reached the executor.
+
+    Uses :class:`BaseException` (not :class:`Exception`) so stray ``except
+    Exception`` handlers inside adapter code do not swallow it.
+    """
+
+    def __init__(self, detail: str = "cancelled by control") -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+@dataclasses.dataclass
+class ControlOutcome:
+    """Per-message dispatch result the caller folds into its run loop."""
+
+    # The ack that should be published back on the channel.
+    ack: ControlAck
+    # True when the executor should stop its outer loop and abort the run.
+    cancel_run: bool = False
+    # The STEER ControlMessage (if any) — the executor feeds this to the
+    # steerer so planner.refine can build a fresh plan.
+    steer_message: ControlMessage | None = None
+    # True when the executor should enter its paused wait after the
+    # current in-flight task (if any) finishes.
+    request_pause: bool = False
+    # True when a RESUME arrived — clears any pending pause.
+    request_resume: bool = False
+    # task_id the REWIND target should reset to, or "" for none.
+    rewind_task_id: str = ""
+    # Reason string, populated when cancel_run=True.
+    cancel_reason: str = ""
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _build_ack(
+    msg: ControlMessage,
+    *,
+    result: Any = None,
+    detail: str = "",
+) -> ControlAck:
+    """Construct a :class:`ControlAck` for ``msg``."""
+    from goldfive.control import AckResult, ControlAck
+
+    if result is None:
+        result = AckResult.SUCCESS
+    return ControlAck(
+        control_id=msg.id,
+        result=result,
+        detail=detail,
+        acked_at_ms=_now_ms(),
+    )
+
+
+def _kind_value(msg: ControlMessage) -> str:
+    """Return the control-kind as an uppercased string for matching."""
+    raw = getattr(msg, "kind", "")
+    return str(getattr(raw, "value", raw)).upper()
+
+
+async def emit_status_report(
+    *,
+    session: Session,
+    sinks: list[EventSink],
+    control_id: str,
+) -> None:
+    """Emit a synthetic status report as a ``DriftDetected`` event.
+
+    STATUS_QUERY messages ask the runner "what are you working on right
+    now?" Reuses the existing ``DriftDetected`` payload (no proto regen
+    for Phase 1 — see issue #71) with kind ``CUSTOM`` and a detail
+    string that encodes a compact status snapshot. External observers
+    pick the message up off the sink stream and surface it to the UI.
+    """
+    from goldfive.events import drift_detected_event
+    from goldfive.events import emit as emit_event
+    from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+
+    plan = session.plan
+    total = len(plan.tasks) if plan is not None else 0
+    completed_ids: list[str] = []
+    pending_ids: list[str] = []
+    current = session.current_task_id or ""
+    if plan is not None:
+        for t in plan.tasks:
+            if t.status == TaskStatus.COMPLETED:
+                completed_ids.append(t.id)
+            elif t.status in (
+                TaskStatus.PENDING,
+                TaskStatus.RUNNING,
+                TaskStatus.BLOCKED,
+            ):
+                pending_ids.append(t.id)
+    detail = (
+        f"status_query control_id={control_id} current_task={current} "
+        f"completed={len(completed_ids)}/{total} "
+        f"pending={','.join(pending_ids) or '-'}"
+    )
+    drift = DriftEvent(
+        kind=DriftKind.CUSTOM,
+        severity=DriftSeverity.INFO,
+        detail=detail,
+        current_task_id=current,
+    )
+    try:
+        evt = drift_detected_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            drift=drift,
+        )
+    except Exception as exc:  # noqa: BLE001 — proto stubs may be missing
+        log.debug("emit_status_report: proto event build failed: %s", exc)
+        return
+    try:
+        await emit_event(sinks, evt)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("emit_status_report: sink emit raised: %s", exc)
+
+
+async def dispatch_control(
+    msg: ControlMessage,
+    *,
+    session: Session,
+    steerer: Steerer,
+    sinks: list[EventSink],
+) -> ControlOutcome:
+    """Dispatch a single control message; return the outcome to apply."""
+    from goldfive.control import AckResult
+
+    kind = _kind_value(msg)
+
+    if kind == "CANCEL":
+        reason = str(msg.payload.get("reason", "")) or "cancelled by control"
+        return ControlOutcome(
+            ack=_build_ack(msg, result=AckResult.SUCCESS, detail="cancel acknowledged"),
+            cancel_run=True,
+            cancel_reason=reason,
+        )
+
+    if kind == "PAUSE":
+        return ControlOutcome(
+            ack=_build_ack(msg, result=AckResult.SUCCESS, detail="paused"),
+            request_pause=True,
+        )
+
+    if kind == "RESUME":
+        return ControlOutcome(
+            ack=_build_ack(msg, result=AckResult.SUCCESS, detail="resumed"),
+            request_resume=True,
+        )
+
+    if kind == "STEER":
+        return ControlOutcome(
+            ack=_build_ack(msg, result=AckResult.SUCCESS, detail="steer queued"),
+            steer_message=msg,
+        )
+
+    if kind == "REWIND_TO":
+        target = str(msg.payload.get("task_id", ""))
+        if not target:
+            return ControlOutcome(
+                ack=_build_ack(
+                    msg,
+                    result=AckResult.FAILURE,
+                    detail="rewind_to requires payload.task_id",
+                ),
+            )
+        ok = _rewind_plan(session, target)
+        if not ok:
+            return ControlOutcome(
+                ack=_build_ack(
+                    msg,
+                    result=AckResult.FAILURE,
+                    detail=f"rewind_to: unknown task_id={target!r}",
+                ),
+            )
+        return ControlOutcome(
+            ack=_build_ack(
+                msg,
+                result=AckResult.SUCCESS,
+                detail=f"rewound to {target}",
+            ),
+            rewind_task_id=target,
+        )
+
+    if kind == "STATUS_QUERY":
+        await emit_status_report(session=session, sinks=sinks, control_id=msg.id)
+        return ControlOutcome(
+            ack=_build_ack(msg, result=AckResult.SUCCESS, detail="status emitted"),
+        )
+
+    if kind == "INTERCEPT_TRANSFER":
+        flag = bool(msg.payload.get("enabled", True))
+        session._intercept_transfer = flag
+        return ControlOutcome(
+            ack=_build_ack(
+                msg,
+                result=AckResult.SUCCESS,
+                detail=f"intercept_transfer={'on' if flag else 'off'}",
+            ),
+        )
+
+    # Unknown / unsupported kind.
+    return ControlOutcome(
+        ack=_build_ack(
+            msg,
+            result=AckResult.UNSUPPORTED,
+            detail=f"unsupported control kind: {kind!r}",
+        ),
+    )
+
+
+async def drain_controls(
+    channel: ControlChannel | None,
+    *,
+    session: Session,
+    steerer: Steerer,
+    sinks: list[EventSink],
+) -> list[ControlOutcome]:
+    """Drain every message currently queued on ``channel`` and dispatch.
+
+    Non-blocking: returns an empty list when ``channel`` is ``None`` or
+    empty. The caller is responsible for applying each outcome; the
+    ack has already been published on the channel before return.
+    """
+    if channel is None:
+        return []
+    outcomes: list[ControlOutcome] = []
+    inbox = getattr(channel, "_inbox", None)
+    if inbox is None:
+        return outcomes
+    while not inbox.empty():
+        try:
+            msg = inbox.get_nowait()
+        except Exception:  # noqa: BLE001 — empty race is benign
+            break
+        outcome = await dispatch_control(
+            msg, session=session, steerer=steerer, sinks=sinks
+        )
+        outcomes.append(outcome)
+        try:
+            await channel.ack(outcome.ack)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("drain_controls: channel.ack raised: %s", exc)
+    return outcomes
+
+
+def _rewind_plan(session: Session, target_task_id: str) -> bool:
+    """Reset ``target`` and every downstream task back to ``PENDING``.
+
+    Any task transitively reachable from ``target`` via ``plan.edges``
+    is considered downstream. Returns ``True`` if ``target`` exists
+    in the session's plan, else ``False``.
+    """
+    plan = session.plan
+    if plan is None:
+        return False
+    tasks_by_id = {t.id: t for t in plan.tasks if t.id}
+    if target_task_id not in tasks_by_id:
+        return False
+
+    children: dict[str, list[str]] = {tid: [] for tid in tasks_by_id}
+    for e in plan.edges:
+        if e.from_task_id in tasks_by_id and e.to_task_id in tasks_by_id:
+            children[e.from_task_id].append(e.to_task_id)
+
+    affected: set[str] = set()
+    stack = [target_task_id]
+    while stack:
+        cur = stack.pop()
+        if cur in affected:
+            continue
+        affected.add(cur)
+        for child in children.get(cur, []):
+            if child not in affected:
+                stack.append(child)
+
+    for tid in affected:
+        task = tasks_by_id[tid]
+        task.status = TaskStatus.PENDING
+        session.completed_results.pop(tid, None)
+        session.task_progress.pop(tid, None)
+    return True

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from goldfive.events import (
     emit as emit_event,
@@ -35,6 +35,12 @@ from goldfive.events import (
     plan_revised_event,
     run_aborted_event,
     run_completed_event,
+)
+from goldfive.executors._control import (
+    ControlOutcome,
+    _ControlCancelled,
+    dispatch_control,
+    drain_controls,
 )
 from goldfive.protocols import (
     AgentAdapter,
@@ -53,6 +59,9 @@ from goldfive.types import (
     TaskStatus,
     severity_rank,
 )
+
+if TYPE_CHECKING:
+    from goldfive.control import ControlChannel
 
 log = logging.getLogger(__name__)
 
@@ -120,6 +129,7 @@ class ParallelDAGExecutor:
         steerer: Steerer,
         planner: Planner,
         sinks: list[EventSink],
+        control: ControlChannel | None = None,
     ) -> ExecutionOutcome:
         session.plan = plan
 
@@ -138,6 +148,28 @@ class ParallelDAGExecutor:
         abort_reason = ""
         try:
             while True:
+                # Pre-stage: drain pending controls; honour PAUSE by
+                # blocking on the channel until RESUME/CANCEL/STEER
+                # arrives.
+                try:
+                    stop, pending_steer = await self._apply_pre_stage_controls(
+                        control=control,
+                        session=session,
+                        steerer=steerer,
+                        sinks=sinks,
+                    )
+                except _ControlCancelled as cancelled:
+                    abort_reason = cancelled.detail
+                    break
+                if stop:
+                    abort_reason = "cancelled by control"
+                    break
+                if pending_steer is not None:
+                    await self._apply_steer(
+                        pending_steer, steerer=steerer, session=session
+                    )
+                    # Fall through: refresh plan on next iteration.
+
                 # Recompute stages from current plan each outer iteration;
                 # tasks already completed in previous stages are filtered
                 # out by ``topological_stages`` (they sit in a terminal
@@ -162,9 +194,19 @@ class ParallelDAGExecutor:
                 if not stage_tasks:
                     continue
 
-                stage_results, drift = await self._run_stage(
-                    stage_tasks, session, adapter, steerer, sinks
+                stage_results, drift, control_outcome = await self._run_stage(
+                    stage_tasks, session, adapter, steerer, sinks, control
                 )
+
+                if control_outcome is not None and control_outcome.cancel_run:
+                    abort_reason = (
+                        control_outcome.cancel_reason or "cancelled by control"
+                    )
+                    for task, _inv, _drift, _err in stage_results:
+                        await self._mark_cancelled_if_live(
+                            task_id=task.id, steerer=steerer, session=session
+                        )
+                    break
 
                 # Fold terminal statuses + results back into the session.
                 # If the agent already transitioned the task via reporting
@@ -204,6 +246,22 @@ class ParallelDAGExecutor:
                         if inv is not None:
                             session.completed_results[task.id] = inv.text
                     completed_stage_ids.add(task.id)
+
+                # If a STEER arrived mid-stage, apply it now (stage was
+                # cancelled by _run_stage, so the fold-back above has
+                # already recorded the tasks as CANCELLED).
+                if (
+                    control_outcome is not None
+                    and control_outcome.steer_message is not None
+                ):
+                    await self._apply_steer(
+                        control_outcome.steer_message,
+                        steerer=steerer,
+                        session=session,
+                    )
+                    # New plan installed on session; drop the stage-level
+                    # drift (if any) so we don't double-refine.
+                    drift = None
 
                 if drift is not None:
                     if refinements_used >= self.max_plan_reinvocations:
@@ -283,14 +341,24 @@ class ParallelDAGExecutor:
         adapter: AgentAdapter,
         steerer: Steerer,
         sinks: list[EventSink],
-    ) -> tuple[list[_StageResult], DriftEvent | None]:
+        control: ControlChannel | None = None,
+    ) -> tuple[list[_StageResult], DriftEvent | None, ControlOutcome | None]:
         """Run one stage's tasks concurrently.
 
-        Returns the per-task results in stage order plus the first drift
-        event (at severity >= WARNING) observed while the stage ran, or
-        ``None`` if the stage finished clean. Under ``cancel_stage`` the
-        surviving in-flight tasks are cancelled as soon as a qualifying
-        drift is spotted.
+        Returns ``(results, first_drift, control_outcome)``:
+
+        * ``results`` — the per-task results in stage order.
+        * ``first_drift`` — the first drift (at severity >= WARNING)
+          observed while the stage ran, or ``None``.
+        * ``control_outcome`` — the first cancelling :class:`ControlOutcome`
+          (cancel_run or steer_message) received mid-stage, or ``None``.
+          Callers inspect this to decide whether to abort the run or
+          apply a STEER before moving on.
+
+        Under ``cancel_stage`` the surviving in-flight tasks are
+        cancelled as soon as a qualifying drift is spotted. A CANCEL
+        or STEER control also cancels every in-flight task in the
+        stage, regardless of drift_policy.
         """
         sem: asyncio.Semaphore | None = (
             asyncio.Semaphore(self.max_concurrency) if self.max_concurrency > 0 else None
@@ -346,15 +414,95 @@ class ParallelDAGExecutor:
         )
 
         first_drift: DriftEvent | None = None
+        stage_control_outcome: ControlOutcome | None = None
         results: dict[str, _StageResult] = {}
         pending: set[asyncio.Task[_StageResult]] = set(aio_tasks)
 
+        recv_task: asyncio.Task | None = None
+
+        def _ensure_recv_task() -> asyncio.Task | None:
+            nonlocal recv_task
+            if control is None:
+                return None
+            if recv_task is None or recv_task.done():
+                recv_task = asyncio.create_task(
+                    control.receive(), name="goldfive-stage-control"
+                )
+            return recv_task
+
+        async def _cancel_stage_tasks() -> None:
+            if not pending:
+                return
+            for p in pending:
+                p.cancel()
+            cancelled_done, _still = await asyncio.wait(
+                pending, return_when=asyncio.ALL_COMPLETED
+            )
+            for cd in cancelled_done:
+                t2 = task_by_aio[cd]
+                try:
+                    results[t2.id] = cd.result()
+                except asyncio.CancelledError:
+                    results[t2.id] = (t2, None, None, asyncio.CancelledError())
+                except BaseException as exc:  # noqa: BLE001
+                    results[t2.id] = (t2, None, None, exc)
+            pending.clear()
+
         try:
             while pending:
-                done, pending = await asyncio.wait(
-                    pending, return_when=asyncio.FIRST_COMPLETED
+                waitables: set[asyncio.Future] = set(pending)
+                rt = _ensure_recv_task()
+                if rt is not None:
+                    waitables.add(rt)
+                done, _pending_set = await asyncio.wait(
+                    waitables, return_when=asyncio.FIRST_COMPLETED
                 )
+
+                # Process the control receive first so a mid-stage CANCEL
+                # / STEER short-circuits before we fold in stage results.
+                if rt is not None and rt in done:
+                    try:
+                        msg = rt.result()
+                    except BaseException:  # noqa: BLE001
+                        msg = None
+                    recv_task = None
+                    if msg is not None:
+                        outcome = await dispatch_control(
+                            msg,
+                            session=session,
+                            steerer=steerer,
+                            sinks=sinks,
+                        )
+                        try:
+                            await control.ack(outcome.ack)  # type: ignore[union-attr]
+                        except Exception:  # noqa: BLE001
+                            pass
+                        if outcome.cancel_run or outcome.steer_message is not None:
+                            # Fold any tasks that already completed in
+                            # this done-set before cancelling the stage.
+                            for d in done - {rt}:
+                                task = task_by_aio[d]
+                                pending.discard(d)
+                                try:
+                                    results[task.id] = d.result()
+                                except asyncio.CancelledError:
+                                    results[task.id] = (
+                                        task, None, None, asyncio.CancelledError()
+                                    )
+                                except BaseException as exc:  # noqa: BLE001
+                                    results[task.id] = (task, None, None, exc)
+                            stage_control_outcome = outcome
+                            await _cancel_stage_tasks()
+                            break
+                        # Non-interrupting control (PAUSE/RESUME/
+                        # REWIND_TO/STATUS_QUERY/INTERCEPT_TRANSFER):
+                        # Apply and keep the stage running. PAUSE mid-
+                        # stage lets the stage finish per spec.
+
                 for d in done:
+                    if d is rt:
+                        continue
+                    pending.discard(d)
                     task = task_by_aio[d]
                     try:
                         res = d.result()
@@ -372,36 +520,29 @@ class ParallelDAGExecutor:
                     ):
                         first_drift = drift
                         if self.drift_policy == "cancel_stage" and pending:
-                            for p in pending:
-                                p.cancel()
-                            # Drain the cancelled tasks so they don't leak.
-                            cancelled_done, _ = await asyncio.wait(
-                                pending, return_when=asyncio.ALL_COMPLETED
-                            )
-                            for cd in cancelled_done:
-                                t2 = task_by_aio[cd]
-                                try:
-                                    results[t2.id] = cd.result()
-                                except asyncio.CancelledError:
-                                    results[t2.id] = (
-                                        t2, None, None, asyncio.CancelledError()
-                                    )
-                                except BaseException as exc:  # noqa: BLE001
-                                    results[t2.id] = (t2, None, None, exc)
-                            pending = set()
+                            await _cancel_stage_tasks()
         except asyncio.CancelledError:
             # Outer cancellation: make sure every inner task is reaped.
             for p in pending:
                 p.cancel()
             if pending:
                 await asyncio.gather(*pending, return_exceptions=True)
+            if recv_task is not None and not recv_task.done():
+                recv_task.cancel()
             raise
+        finally:
+            if recv_task is not None and not recv_task.done():
+                recv_task.cancel()
+                try:
+                    await recv_task
+                except BaseException:  # noqa: BLE001
+                    pass
 
         # Preserve stage-input order in the return.
         ordered: list[_StageResult] = [
             results[t.id] for t in stage_tasks if t.id in results
         ]
-        return ordered, first_drift
+        return ordered, first_drift, stage_control_outcome
 
     # ------------------------------------------------------------------
     # Plan refinement
@@ -423,6 +564,120 @@ class ParallelDAGExecutor:
             log.warning("ParallelDAGExecutor: planner.refine raised: %s", exc)
             return None
         return refined
+
+    # ------------------------------------------------------------------
+    # Control helpers
+    # ------------------------------------------------------------------
+
+    async def _apply_pre_stage_controls(
+        self,
+        *,
+        control: ControlChannel | None,
+        session: Session,
+        steerer: Steerer,
+        sinks: list[EventSink],
+    ) -> tuple[bool, object | None]:
+        """Drain queued controls before the next stage; honour PAUSE.
+
+        Returns ``(cancel_run, steer_message)``. Pre-stage PAUSE blocks
+        on :meth:`ControlChannel.receive` until RESUME / CANCEL / STEER
+        arrives.
+        """
+        if control is None:
+            return False, None
+
+        outcomes = await drain_controls(
+            control, session=session, steerer=steerer, sinks=sinks
+        )
+
+        cancel_reason = ""
+        cancel_run = False
+        steer_msg: object | None = None
+        paused = False
+        for o in outcomes:
+            if o.cancel_run:
+                cancel_run = True
+                cancel_reason = o.cancel_reason
+                break
+            if o.steer_message is not None:
+                steer_msg = o.steer_message
+            if o.request_pause:
+                paused = True
+            if o.request_resume:
+                paused = False
+
+        if cancel_run:
+            raise _ControlCancelled(cancel_reason or "cancelled by control")
+
+        while paused:
+            msg = await control.receive()
+            if msg is None:
+                paused = False
+                break
+            outcome = await dispatch_control(
+                msg, session=session, steerer=steerer, sinks=sinks
+            )
+            try:
+                await control.ack(outcome.ack)
+            except Exception:  # noqa: BLE001
+                pass
+            if outcome.cancel_run:
+                raise _ControlCancelled(
+                    outcome.cancel_reason or "cancelled by control"
+                )
+            if outcome.request_resume:
+                paused = False
+            if outcome.steer_message is not None:
+                steer_msg = outcome.steer_message
+                paused = False
+            if outcome.rewind_task_id:
+                paused = False
+
+        return False, steer_msg
+
+    @staticmethod
+    async def _mark_cancelled_if_live(
+        *,
+        task_id: str,
+        steerer: Steerer,
+        session: Session,
+    ) -> None:
+        """Transition a not-yet-terminal task to CANCELLED."""
+        if session.plan is None:
+            return
+        for t in session.plan.tasks:
+            if t.id == task_id:
+                if t.status in _TERMINAL_TASK_STATUSES:
+                    return
+                try:
+                    await steerer.transition(
+                        task_id,
+                        TaskStatus.CANCELLED,
+                        detail="cancelled by control",
+                        session=session,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "ParallelDAGExecutor: cancelled transition raised: %s",
+                        exc,
+                    )
+                return
+
+    @staticmethod
+    async def _apply_steer(
+        message: object,
+        *,
+        steerer: Steerer,
+        session: Session,
+    ) -> None:
+        """Feed a STEER :class:`ControlMessage` to the steerer."""
+        try:
+            await steerer.observe(message, session)
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "ParallelDAGExecutor: steerer.observe(STEER) raised: %s", exc
+            )
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -31,7 +31,9 @@ per-task ``Task*`` events (the latter via the steerer).
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import TYPE_CHECKING
 
 from goldfive.events import (
     emit,
@@ -39,9 +41,17 @@ from goldfive.events import (
     run_aborted_event,
     run_completed_event,
 )
+from goldfive.executors._control import (
+    _ControlCancelled,
+    dispatch_control,
+    drain_controls,
+)
 from goldfive.protocols import AgentAdapter, EventSink, Executor, Planner, Steerer
 from goldfive.results import ExecutionOutcome
 from goldfive.types import Plan, Session, Task, TaskStatus
+
+if TYPE_CHECKING:
+    from goldfive.control import ControlChannel
 
 log = logging.getLogger(__name__)
 
@@ -89,6 +99,7 @@ class SequentialExecutor(Executor):
         steerer: Steerer,
         planner: Planner,
         sinks: list[EventSink],
+        control: ControlChannel | None = None,
     ) -> ExecutionOutcome:
         """Walk ``plan`` end-to-end, driving ``adapter`` once per eligible task.
 
@@ -119,6 +130,32 @@ class SequentialExecutor(Executor):
         # invocations we'll allow for the whole run. Each eligible task
         # burns one; mid-run plan revisions do not refund any.
         while invocations < self.max_plan_reinvocations:
+            # ------------------------------------------------------------------
+            # Control channel: drain any pending messages before picking
+            # the next task. PAUSE here blocks until RESUME arrives.
+            # ------------------------------------------------------------------
+            try:
+                stop, steer_msg = await self._apply_pre_task_controls(
+                    control=control,
+                    session=session,
+                    steerer=steerer,
+                    sinks=sinks,
+                )
+            except _ControlCancelled as cancelled:
+                failure_reason = cancelled.detail
+                run_failed = True
+                break
+            if stop:
+                failure_reason = "cancelled by control"
+                run_failed = True
+                break
+            if steer_msg is not None:
+                await self._apply_steer(
+                    steer_msg, steerer=steerer, session=session
+                )
+                # The steerer swapped session.plan; pick up the revision
+                # on the next outer iteration.
+
             current_plan = session.plan or plan
 
             # Detect an out-of-band plan revision (steerer swapped the plan
@@ -168,14 +205,33 @@ class SequentialExecutor(Executor):
                     task.id, TaskStatus.RUNNING, session=session
                 )
 
-            # Adapter.invoke drives the agent, which calls reporting tools,
-            # whose handlers route through the steerer to mutate task state
-            # (PENDING -> RUNNING -> COMPLETED/FAILED/BLOCKED) and emit the
-            # corresponding proto events via sinks.
-            try:
-                result = await adapter.invoke(task, session)
-            except Exception as exc:  # noqa: BLE001
-                # Hard adapter failure: nothing to do except abort.
+            # Race the adapter invocation against the control channel so a
+            # CANCEL / STEER / PAUSE arriving mid-task can cancel (or at
+            # least observe) the in-flight task. The helper returns
+            # ``(kind, payload)``:
+            #   ("result", InvocationResult | None)   normal completion
+            #   ("adapter_error", BaseException)      invoke raised
+            #   ("cancelled", reason_str)             CANCEL interrupted
+            #   ("steer", ControlMessage)             STEER interrupted
+            outcome_kind, outcome_payload = await self._invoke_with_control(
+                adapter=adapter,
+                task=task,
+                session=session,
+                steerer=steerer,
+                sinks=sinks,
+                control=control,
+            )
+
+            if outcome_kind == "cancelled":
+                await self._mark_cancelled_if_live(
+                    task_id=task.id, steerer=steerer, session=session
+                )
+                failure_reason = str(outcome_payload) or "cancelled by control"
+                run_failed = True
+                break
+
+            if outcome_kind == "adapter_error":
+                exc = outcome_payload
                 log.exception(
                     "SequentialExecutor: adapter.invoke raised for task=%s",
                     task.id,
@@ -183,6 +239,18 @@ class SequentialExecutor(Executor):
                 failure_reason = f"adapter.invoke raised for task={task.id}: {exc}"
                 run_failed = True
                 break
+
+            if outcome_kind == "steer":
+                await self._mark_cancelled_if_live(
+                    task_id=task.id, steerer=steerer, session=session
+                )
+                await self._apply_steer(
+                    outcome_payload, steerer=steerer, session=session
+                )
+                continue
+
+            # outcome_kind == "result"
+            result = outcome_payload
 
             # If the adapter reported an error on the invocation envelope
             # (but didn't raise), record it; the auto-transition block
@@ -313,6 +381,239 @@ class SequentialExecutor(Executor):
             ),
         )
         return ExecutionOutcome(success=True, session=session)
+
+    # ------------------------------------------------------------------
+    # Control helpers
+    # ------------------------------------------------------------------
+
+    async def _apply_pre_task_controls(
+        self,
+        *,
+        control: ControlChannel | None,
+        session: Session,
+        steerer: Steerer,
+        sinks: list[EventSink],
+    ) -> tuple[bool, object | None]:
+        """Drain queued controls before the next task; honour PAUSE.
+
+        Returns ``(cancel_run, steer_message)``. The steer message is
+        the last STEER control observed (the steerer consumes them one
+        at a time, so queued STEERs after the first are applied in
+        order on subsequent loop iterations).
+
+        A PAUSE here blocks on ``channel.receive()`` until a RESUME (or
+        CANCEL) arrives.
+        """
+        if control is None:
+            return False, None
+
+        outcomes = await drain_controls(
+            control, session=session, steerer=steerer, sinks=sinks
+        )
+
+        cancel_run = False
+        cancel_reason = ""
+        steer_msg: object | None = None
+        paused = False
+        for o in outcomes:
+            if o.cancel_run:
+                cancel_run = True
+                cancel_reason = o.cancel_reason
+                break
+            if o.steer_message is not None:
+                steer_msg = o.steer_message
+            if o.request_pause:
+                paused = True
+            if o.request_resume:
+                paused = False
+
+        if cancel_run:
+            raise _ControlCancelled(cancel_reason or "cancelled by control")
+
+        # Honour PAUSE by blocking on the channel until a RESUME /
+        # CANCEL / STEER arrives.
+        while paused:
+            msg = await control.receive()
+            if msg is None:
+                # Channel closed — treat as resume so we don't wedge.
+                paused = False
+                break
+            outcome = await dispatch_control(
+                msg, session=session, steerer=steerer, sinks=sinks
+            )
+            try:
+                await control.ack(outcome.ack)
+            except Exception:  # noqa: BLE001
+                pass
+            if outcome.cancel_run:
+                raise _ControlCancelled(
+                    outcome.cancel_reason or "cancelled by control"
+                )
+            if outcome.request_resume:
+                paused = False
+            if outcome.steer_message is not None:
+                steer_msg = outcome.steer_message
+                paused = False
+            if outcome.rewind_task_id:
+                paused = False
+
+        return False, steer_msg
+
+    async def _invoke_with_control(
+        self,
+        *,
+        adapter: AgentAdapter,
+        task: Task,
+        session: Session,
+        steerer: Steerer,
+        sinks: list[EventSink],
+        control: ControlChannel | None,
+    ) -> tuple[str, object | None]:
+        """Run ``adapter.invoke(task, session)`` while watching ``control``.
+
+        Returns ``(kind, payload)`` where ``kind`` is one of
+        ``"result"`` (normal completion), ``"adapter_error"``,
+        ``"cancelled"`` (CANCEL received), or ``"steer"`` (STEER
+        received). Non-cancelling controls (PAUSE, RESUME, REWIND_TO,
+        STATUS_QUERY, INTERCEPT_TRANSFER) are acked and do not
+        interrupt the task.
+        """
+        invoke_task: asyncio.Task = asyncio.create_task(
+            adapter.invoke(task, session),
+            name=f"goldfive-invoke-{task.id}",
+        )
+
+        if control is None:
+            try:
+                result = await invoke_task
+            except BaseException as exc:  # noqa: BLE001
+                if isinstance(exc, asyncio.CancelledError):
+                    raise
+                return ("adapter_error", exc)
+            return ("result", result)
+
+        while True:
+            recv_task = asyncio.create_task(control.receive(), name="control-recv")
+            done, _pending = await asyncio.wait(
+                {invoke_task, recv_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if invoke_task in done:
+                if not recv_task.done():
+                    recv_task.cancel()
+                    try:
+                        await recv_task
+                    except BaseException:  # noqa: BLE001
+                        pass
+                try:
+                    result = invoke_task.result()
+                except asyncio.CancelledError:
+                    return ("cancelled", "invoke cancelled")
+                except BaseException as exc:  # noqa: BLE001
+                    return ("adapter_error", exc)
+                return ("result", result)
+
+            # recv_task completed first: a control message arrived.
+            try:
+                msg = recv_task.result()
+            except BaseException:  # noqa: BLE001
+                msg = None
+            if msg is None:
+                # Channel closed; fall back to awaiting the adapter task.
+                try:
+                    result = await invoke_task
+                except BaseException as exc:  # noqa: BLE001
+                    if isinstance(exc, asyncio.CancelledError):
+                        return ("cancelled", "invoke cancelled")
+                    return ("adapter_error", exc)
+                return ("result", result)
+
+            outcome = await dispatch_control(
+                msg, session=session, steerer=steerer, sinks=sinks
+            )
+            try:
+                await control.ack(outcome.ack)
+            except Exception:  # noqa: BLE001
+                pass
+
+            if outcome.cancel_run:
+                await self._cancel_invoke_task(invoke_task)
+                return ("cancelled", outcome.cancel_reason or "cancelled by control")
+
+            if outcome.steer_message is not None:
+                await self._cancel_invoke_task(invoke_task)
+                return ("steer", outcome.steer_message)
+
+            # Non-cancelling control: keep waiting on the adapter task.
+            # (PAUSE mid-task lets the current task finish per spec;
+            # REWIND_TO / STATUS_QUERY / INTERCEPT_TRANSFER are applied
+            # in-line and execution continues.)
+
+    @staticmethod
+    async def _cancel_invoke_task(invoke_task: asyncio.Task) -> None:
+        """Cancel ``invoke_task`` with a 5s grace window.
+
+        Defensive: adapters that ignore ``task.cancel()`` shouldn't wedge
+        the run. Polls for up to 5s; if the task still isn't done, we
+        log a warning and return (the orphaned task is left for the
+        event loop to reap).
+        """
+        if invoke_task.done():
+            return
+        invoke_task.cancel()
+        import time as _time
+
+        deadline = _time.monotonic() + 5.0
+        while _time.monotonic() < deadline:
+            if invoke_task.done():
+                return
+            await asyncio.sleep(0.05)
+        log.warning(
+            "SequentialExecutor: adapter ignored task.cancel(); "
+            "abandoning after 5s grace window"
+        )
+
+    @staticmethod
+    async def _mark_cancelled_if_live(
+        *,
+        task_id: str,
+        steerer: Steerer,
+        session: Session,
+    ) -> None:
+        """Transition a not-yet-terminal task to CANCELLED."""
+        if session.plan is None:
+            return
+        for t in session.plan.tasks:
+            if t.id == task_id:
+                if t.status in (
+                    TaskStatus.COMPLETED,
+                    TaskStatus.FAILED,
+                    TaskStatus.CANCELLED,
+                ):
+                    return
+                await steerer.transition(
+                    task_id,
+                    TaskStatus.CANCELLED,
+                    detail="cancelled by control",
+                    session=session,
+                )
+                return
+
+    @staticmethod
+    async def _apply_steer(
+        message: object,
+        *,
+        steerer: Steerer,
+        session: Session,
+    ) -> None:
+        """Feed a STEER :class:`ControlMessage` to the steerer."""
+        try:
+            await steerer.observe(message, session)
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "SequentialExecutor: steerer.observe(STEER) raised: %s", exc
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -55,6 +55,7 @@ from goldfive.steerer import DefaultSteerer
 from goldfive.types import Goal, Session
 
 if TYPE_CHECKING:
+    from goldfive.control import ControlChannel
     from goldfive.protocols import (
         AgentAdapter,
         EventSink,
@@ -94,6 +95,12 @@ class Runner:
         Optional — defaults to :class:`DefaultSteerer`.
     sinks:
         Optional list of :class:`EventSink` instances. Defaults to ``[]``.
+    control:
+        Optional :class:`~goldfive.control.ControlChannel` for live
+        pause / resume / cancel / steer / rewind from an external
+        controller (harmonograf UI, CLI, tests). When provided, the
+        Runner forwards it into the executor, which polls the channel
+        between tasks and races against adapter invocations mid-task.
     max_plan_reinvocations:
         Safety cap on plan refinement cycles. Passed through to the
         executor (via ``context``) so executors that honour it can
@@ -109,6 +116,7 @@ class Runner:
         goal_deriver: GoalDeriver | None = None,
         steerer: Steerer | None = None,
         sinks: list[EventSink] | None = None,
+        control: ControlChannel | None = None,
         max_plan_reinvocations: int = 3,
     ) -> None:
         self.agent = agent
@@ -117,6 +125,7 @@ class Runner:
         self.goal_deriver: GoalDeriver = goal_deriver or PassthroughGoalDeriver("run")
         self.steerer: Steerer = steerer or DefaultSteerer()
         self.sinks: list[EventSink] = list(sinks) if sinks else []
+        self.control: ControlChannel | None = control
         self.max_plan_reinvocations = max_plan_reinvocations
 
     # ------------------------------------------------------------------
@@ -204,7 +213,7 @@ class Runner:
 
         # 7. Hand off to the executor.
         try:
-            outcome = await self.executor.run(
+            executor_kwargs: dict[str, Any] = dict(
                 plan=session.plan,
                 session=session,
                 adapter=self.agent,
@@ -212,6 +221,9 @@ class Runner:
                 planner=self.planner,
                 sinks=list(self.sinks),
             )
+            if self.control is not None:
+                executor_kwargs["control"] = self.control
+            outcome = await self.executor.run(**executor_kwargs)
         except Exception as exc:  # noqa: BLE001
             reason = f"executor.run raised: {exc}"
             log.exception("executor.run raised")

--- a/tests/test_executor_control.py
+++ b/tests/test_executor_control.py
@@ -1,0 +1,758 @@
+"""Executor integration tests for ControlChannel (part of #71).
+
+These tests exercise the goldfive executors' ControlChannel hooks:
+pause/resume between tasks, mid-task cancel, mid-task steer, rewind,
+and the synthetic status-report emission.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from goldfive.control import (
+    AckResult,
+    ControlAck,
+    ControlChannel,
+    ControlKind,
+    ControlMessage,
+)
+from goldfive.executors import ParallelDAGExecutor, SequentialExecutor
+from goldfive.protocols import EventSink
+from goldfive.results import InvocationResult
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers — minimal stubs
+# ---------------------------------------------------------------------------
+
+
+class RecordingSink:
+    """EventSink that accumulates everything emitted for later assertion."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+        self.closed = False
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def payload_kinds(self) -> list[str]:
+        kinds: list[str] = []
+        for e in self.events:
+            if hasattr(e, "WhichOneof"):
+                kinds.append(e.WhichOneof("payload") or "")
+            elif isinstance(e, dict):
+                kinds.append(e.get("kind", ""))
+            else:
+                kinds.append(getattr(e, "payload_kind", ""))
+        return kinds
+
+    def drift_events(self) -> list[Any]:
+        out: list[Any] = []
+        for e in self.events:
+            if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "drift_detected":
+                out.append(e.drift_detected)
+        return out
+
+
+class StubSteerer:
+    """Steerer stub that applies transitions directly and records observations.
+
+    When ``refine_result`` is set, ``observe(msg)`` calls it on
+    ``ControlMessage`` and swaps session.plan with the result. This
+    emulates the real DefaultSteerer's USER_STEER behavior.
+    """
+
+    def __init__(self, *, refine_result: Plan | None = None) -> None:
+        self._sinks: list[EventSink] = []
+        self._planner: Any = None
+        self.observed: list[Any] = []
+        self.refine_result = refine_result
+
+    def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
+        self._sinks = sinks
+        self._planner = planner
+
+    async def observe(self, event: Any, session: Session) -> None:
+        self.observed.append(event)
+        # Emulate DefaultSteerer steering: when observing a STEER
+        # ControlMessage, swap the plan on the session.
+        kind = getattr(event, "kind", None)
+        if (
+            self.refine_result is not None
+            and kind is not None
+            and str(getattr(kind, "value", kind)).upper() == "STEER"
+        ):
+            session.plan = self.refine_result
+
+    async def transition(
+        self,
+        task_id: str,
+        to: TaskStatus,
+        *,
+        detail: str = "",
+        session: Session,
+    ) -> None:
+        if session.plan is None:
+            return
+        for t in session.plan.tasks:
+            if t.id == task_id:
+                t.status = to
+                if to == TaskStatus.COMPLETED and detail:
+                    session.completed_results[task_id] = detail
+                return
+
+    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
+        return None
+
+
+class StubPlanner:
+    def __init__(self) -> None:
+        self.refine_calls: list[tuple[Plan, DriftEvent]] = []
+        self._refine_result: Plan | None = None
+
+    def set_refine_result(self, plan: Plan | None) -> None:
+        self._refine_result = plan
+
+    async def generate(
+        self, *, goals: list, available_agents: list[str], context: Any | None = None
+    ) -> Plan | None:
+        return None
+
+    async def refine(
+        self, *, plan: Plan, drift: DriftEvent, goals: list
+    ) -> Plan | None:
+        self.refine_calls.append((plan, drift))
+        return self._refine_result
+
+
+class StubAdapter:
+    def __init__(
+        self,
+        *,
+        on_invoke: Callable[[Task, Session], Awaitable[InvocationResult]],
+    ) -> None:
+        self._on_invoke = on_invoke
+        self.invocations: list[str] = []
+
+    async def register_reporting_tools(self, tools: list[Any]) -> None:
+        return None
+
+    @property
+    def available_agents(self) -> list[str]:
+        return ["stub"]
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:
+        self.invocations.append(task.id)
+        return await self._on_invoke(task, session)
+
+
+def _linear_plan(ids: list[str], run_id: str = "run-1") -> Plan:
+    tasks = [Task(id=t, title=f"Task {t}") for t in ids]
+    edges = [
+        TaskEdge(from_task_id=a, to_task_id=b)
+        for a, b in zip(ids, ids[1:], strict=False)
+    ]
+    return Plan(id="p0", run_id=run_id, goal_ids=[], tasks=tasks, edges=edges)
+
+
+def _fresh_session(run_id: str = "run-1") -> Session:
+    return Session(run_id=run_id)
+
+
+async def _drain_acks(
+    channel: ControlChannel, *, count: int, timeout: float = 1.0
+) -> list[ControlAck]:
+    acks: list[ControlAck] = []
+
+    async def _consume() -> None:
+        async for a in channel.acks():
+            acks.append(a)
+            if len(acks) >= count:
+                return
+
+    try:
+        await asyncio.wait_for(_consume(), timeout=timeout)
+    except TimeoutError:
+        pass
+    return acks
+
+
+# ---------------------------------------------------------------------------
+# Sequential executor: mid-task CANCEL
+# ---------------------------------------------------------------------------
+
+
+async def test_sequential_cancel_mid_task_aborts_run() -> None:
+    plan = _linear_plan(["t0", "t1"])
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+    channel = ControlChannel()
+
+    cancel_sent = asyncio.Event()
+    task_started = asyncio.Event()
+
+    async def _long_running(task: Task, session: Session) -> InvocationResult:
+        task_started.set()
+        # Adapter cooperates with cancellation: awaits a long sleep, which
+        # raises CancelledError on task.cancel().
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            cancel_sent.set()
+            raise
+        return InvocationResult(task_id=task.id, text="done")
+
+    adapter = StubAdapter(on_invoke=_long_running)
+
+    async def _send_cancel() -> None:
+        await task_started.wait()
+        await channel.send(
+            ControlMessage(
+                kind=ControlKind.CANCEL, payload={"reason": "user aborted"}
+            )
+        )
+
+    executor = SequentialExecutor(max_plan_reinvocations=5)
+
+    runner_task = asyncio.create_task(
+        executor.run(
+            plan=plan,
+            session=session,
+            adapter=adapter,
+            steerer=steerer,
+            planner=planner,
+            sinks=[sink],
+            control=channel,
+        )
+    )
+    await _send_cancel()
+    outcome = await asyncio.wait_for(runner_task, timeout=5.0)
+
+    assert outcome.success is False
+    assert "user aborted" in (outcome.reason or "")
+    # Adapter task received CancelledError.
+    assert cancel_sent.is_set()
+    # RunAborted emitted.
+    assert sink.payload_kinds()[-1] == "run_aborted"
+    # Second task never ran.
+    assert adapter.invocations == ["t0"]
+    # Task was marked CANCELLED.
+    assert plan.tasks[0].status == TaskStatus.CANCELLED
+    # Ack published.
+    acks = await _drain_acks(channel, count=1, timeout=1.0)
+    assert len(acks) == 1 and acks[0].result == AckResult.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Sequential executor: mid-task STEER
+# ---------------------------------------------------------------------------
+
+
+async def test_sequential_steer_mid_task_cancels_and_replans() -> None:
+    plan = _linear_plan(["t0", "t1", "t2"])
+    session = _fresh_session()
+
+    # Refined plan: t0 cancelled, new t0b → t1b.
+    refined = Plan(
+        id="p1",
+        run_id=session.run_id,
+        goal_ids=[],
+        tasks=[
+            Task(id="t0b", title="New Task 0"),
+            Task(id="t1b", title="New Task 1"),
+        ],
+        edges=[TaskEdge(from_task_id="t0b", to_task_id="t1b")],
+        revision_reason="user steer",
+        revision_kind=DriftKind.USER_STEER.value,
+        revision_severity=DriftSeverity.WARNING.value,
+        revision_index=1,
+    )
+    steerer = StubSteerer(refine_result=refined)
+    planner = StubPlanner()
+    sink = RecordingSink()
+    channel = ControlChannel()
+
+    task_started = asyncio.Event()
+
+    async def _handler(task: Task, session: Session) -> InvocationResult:
+        if task.id == "t0":
+            task_started.set()
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                raise
+        # Subsequent tasks: complete immediately.
+        for t in session.plan.tasks:
+            if t.id == task.id:
+                t.status = TaskStatus.COMPLETED
+                break
+        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+
+    adapter = StubAdapter(on_invoke=_handler)
+
+    async def _send_steer() -> None:
+        await task_started.wait()
+        await channel.send(
+            ControlMessage(
+                kind=ControlKind.STEER,
+                payload={"note": "change the approach"},
+            )
+        )
+
+    executor = SequentialExecutor(max_plan_reinvocations=8)
+
+    runner_task = asyncio.create_task(
+        executor.run(
+            plan=plan,
+            session=session,
+            adapter=adapter,
+            steerer=steerer,
+            planner=planner,
+            sinks=[sink],
+            control=channel,
+        )
+    )
+    await _send_steer()
+    outcome = await asyncio.wait_for(runner_task, timeout=5.0)
+
+    # The in-flight task was cancelled; refined plan's tasks executed.
+    assert outcome.success is True
+    assert adapter.invocations[0] == "t0"
+    assert "t0b" in adapter.invocations and "t1b" in adapter.invocations
+    # Steerer observed the STEER ControlMessage.
+    steer_obs = [
+        o for o in steerer.observed
+        if str(getattr(getattr(o, "kind", None), "value", "")).upper() == "STEER"
+    ]
+    assert len(steer_obs) == 1
+    # Original t0 was marked CANCELLED.
+    original_t0 = next(t for t in plan.tasks if t.id == "t0")
+    assert original_t0.status == TaskStatus.CANCELLED
+
+
+# ---------------------------------------------------------------------------
+# Sequential executor: PAUSE/RESUME between tasks
+# ---------------------------------------------------------------------------
+
+
+async def test_sequential_pause_blocks_next_task_until_resume() -> None:
+    plan = _linear_plan(["t0", "t1", "t2"])
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+    channel = ControlChannel()
+
+    # t0 completes, then we PAUSE; t1 should not start until RESUME.
+    t0_done = asyncio.Event()
+    t1_started = asyncio.Event()
+
+    async def _handler(task: Task, session: Session) -> InvocationResult:
+        if task.id == "t0":
+            for t in session.plan.tasks:
+                if t.id == "t0":
+                    t.status = TaskStatus.COMPLETED
+            t0_done.set()
+            return InvocationResult(task_id=task.id, text="done:t0")
+        if task.id == "t1":
+            t1_started.set()
+        for t in session.plan.tasks:
+            if t.id == task.id:
+                t.status = TaskStatus.COMPLETED
+        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+
+    adapter = StubAdapter(on_invoke=_handler)
+
+    # Send PAUSE before anything starts; pre-task drain picks it up.
+    await channel.send(ControlMessage(kind=ControlKind.PAUSE))
+
+    executor = SequentialExecutor(max_plan_reinvocations=8)
+
+    runner_task = asyncio.create_task(
+        executor.run(
+            plan=plan,
+            session=session,
+            adapter=adapter,
+            steerer=steerer,
+            planner=planner,
+            sinks=[sink],
+            control=channel,
+        )
+    )
+
+    # Give the executor a moment to enter the paused loop.
+    await asyncio.sleep(0.1)
+    assert not t0_done.is_set(), "t0 must not have started under PAUSE"
+    assert not runner_task.done()
+
+    # Resume: executor should now run all three tasks.
+    await channel.send(ControlMessage(kind=ControlKind.RESUME))
+
+    outcome = await asyncio.wait_for(runner_task, timeout=5.0)
+    assert outcome.success is True
+    assert adapter.invocations == ["t0", "t1", "t2"]
+    assert t0_done.is_set()
+    assert t1_started.is_set()
+
+    # Two acks published (pause + resume).
+    acks = await _drain_acks(channel, count=2, timeout=1.0)
+    assert len(acks) == 2
+    assert all(a.result == AckResult.SUCCESS for a in acks)
+
+
+# ---------------------------------------------------------------------------
+# Sequential executor: REWIND_TO resets downstream tasks
+# ---------------------------------------------------------------------------
+
+
+async def test_sequential_rewind_between_tasks_re_executes_target() -> None:
+    """Pre-queue PAUSE+REWIND+RESUME so the rewind happens cleanly between
+    tasks (no mid-task race) and the executor re-executes the rewound
+    task on resume.
+    """
+    plan = _linear_plan(["t0", "t1"])
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+    channel = ControlChannel()
+
+    counts: dict[str, int] = {"t0": 0, "t1": 0}
+
+    async def _handler(task: Task, session: Session) -> InvocationResult:
+        counts[task.id] += 1
+        for t in session.plan.tasks:
+            if t.id == task.id:
+                t.status = TaskStatus.COMPLETED
+        # After t0's first run, queue PAUSE / REWIND t0 / RESUME so the
+        # next pre-task drain reinstates t0 as PENDING before picking.
+        if task.id == "t0" and counts["t0"] == 1:
+            await channel.send(ControlMessage(kind=ControlKind.PAUSE))
+            await channel.send(
+                ControlMessage(
+                    kind=ControlKind.REWIND_TO, payload={"task_id": "t0"}
+                )
+            )
+            await channel.send(ControlMessage(kind=ControlKind.RESUME))
+        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+
+    adapter = StubAdapter(on_invoke=_handler)
+
+    executor = SequentialExecutor(max_plan_reinvocations=12)
+    outcome = await asyncio.wait_for(
+        executor.run(
+            plan=plan,
+            session=session,
+            adapter=adapter,
+            steerer=steerer,
+            planner=planner,
+            sinks=[sink],
+            control=channel,
+        ),
+        timeout=5.0,
+    )
+
+    assert outcome.success is True
+    # t0 re-executed once after the rewind; t1 ran once (since rewind
+    # was to t0, t1 was also downstream and re-set to PENDING).
+    assert counts == {"t0": 2, "t1": 1}
+    for t in plan.tasks:
+        assert t.status == TaskStatus.COMPLETED
+
+
+async def test_rewind_helper_resets_target_and_downstream_only() -> None:
+    """Direct test of _rewind_plan (dispatch_control's REWIND_TO path)."""
+    from goldfive.executors._control import dispatch_control
+
+    plan = _linear_plan(["t0", "t1", "t2"])
+    for t in plan.tasks:
+        t.status = TaskStatus.COMPLETED
+    session = _fresh_session()
+    session.plan = plan
+    session.completed_results = {"t0": "a", "t1": "b", "t2": "c"}
+    steerer = StubSteerer()
+
+    msg = ControlMessage(kind=ControlKind.REWIND_TO, payload={"task_id": "t1"})
+    outcome = await dispatch_control(
+        msg, session=session, steerer=steerer, sinks=[]
+    )
+
+    assert outcome.ack.result == AckResult.SUCCESS
+    assert outcome.rewind_task_id == "t1"
+    # t0 unchanged; t1 and t2 reset to PENDING with completed_results cleared.
+    assert plan.tasks[0].status == TaskStatus.COMPLETED
+    assert plan.tasks[1].status == TaskStatus.PENDING
+    assert plan.tasks[2].status == TaskStatus.PENDING
+    assert "t0" in session.completed_results
+    assert "t1" not in session.completed_results
+    assert "t2" not in session.completed_results
+
+    # Unknown task id yields FAILURE ack.
+    msg_unknown = ControlMessage(
+        kind=ControlKind.REWIND_TO, payload={"task_id": "does_not_exist"}
+    )
+    outcome_unknown = await dispatch_control(
+        msg_unknown, session=session, steerer=steerer, sinks=[]
+    )
+    assert outcome_unknown.ack.result == AckResult.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# Sequential executor: STATUS_QUERY emits a synthetic event
+# ---------------------------------------------------------------------------
+
+
+async def test_sequential_status_query_emits_event_and_acks_success() -> None:
+    plan = _linear_plan(["t0", "t1"])
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+    channel = ControlChannel()
+
+    status_sent = asyncio.Event()
+
+    async def _handler(task: Task, session: Session) -> InvocationResult:
+        if task.id == "t0":
+            # Send a STATUS_QUERY while t0 is running. Using a raw
+            # string kind is the forward-compat path; ControlMessage's
+            # kind field is not runtime-enforced.
+            await channel.send(
+                ControlMessage(kind="STATUS_QUERY", payload={})  # type: ignore[arg-type]
+            )
+            status_sent.set()
+            # Brief sleep so the executor has time to pick up the
+            # control message before the adapter returns.
+            await asyncio.sleep(0.1)
+        for t in session.plan.tasks:
+            if t.id == task.id:
+                t.status = TaskStatus.COMPLETED
+        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+
+    adapter = StubAdapter(on_invoke=_handler)
+
+    executor = SequentialExecutor(max_plan_reinvocations=8)
+    outcome = await asyncio.wait_for(
+        executor.run(
+            plan=plan,
+            session=session,
+            adapter=adapter,
+            steerer=steerer,
+            planner=planner,
+            sinks=[sink],
+            control=channel,
+        ),
+        timeout=5.0,
+    )
+
+    assert outcome.success is True
+    assert status_sent.is_set()
+    # A DriftDetected event was emitted for the status report.
+    drifts = sink.drift_events()
+    assert any("status_query" in (getattr(d, "detail", "")) for d in drifts)
+    # Ack was SUCCESS.
+    acks = await _drain_acks(channel, count=1, timeout=1.0)
+    assert len(acks) == 1 and acks[0].result == AckResult.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Sequential executor: defensive 5s timeout on adapter that ignores cancel
+# ---------------------------------------------------------------------------
+
+
+async def test_sequential_cancel_abandons_uncooperative_adapter() -> None:
+    """Adapter that swallows CancelledError: executor still aborts.
+
+    The defensive 5s grace window means this test takes ~5s. We mark
+    it with a short override by monkey-patching the helper's deadline.
+    """
+    import time as _time
+
+    plan = _linear_plan(["t0"])
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+    channel = ControlChannel()
+
+    started = asyncio.Event()
+
+    async def _uncooperative(task: Task, session: Session) -> InvocationResult:
+        started.set()
+        # Swallow cancels for a bounded number of attempts, then let the
+        # coroutine return so pytest-asyncio can tear down cleanly. The
+        # executor has already aborted by then via its grace window.
+        for _ in range(40):
+            try:
+                await asyncio.sleep(0.05)
+            except asyncio.CancelledError:
+                # Swallow the cancel, keep going briefly.
+                pass
+        return InvocationResult(task_id=task.id, text="eventually returned")
+
+    adapter = StubAdapter(on_invoke=_uncooperative)
+
+    executor = SequentialExecutor(max_plan_reinvocations=5)
+
+    # Shrink the grace window via a targeted monkey-patch so the test
+    # runs in ~0.3s, not 5s.
+    original = SequentialExecutor._cancel_invoke_task
+
+    @staticmethod
+    async def _quick_cancel(invoke_task: asyncio.Task) -> None:
+        if invoke_task.done():
+            return
+        invoke_task.cancel()
+        deadline = _time.monotonic() + 0.3
+        while _time.monotonic() < deadline:
+            if invoke_task.done():
+                return
+            await asyncio.sleep(0.02)
+
+    SequentialExecutor._cancel_invoke_task = _quick_cancel  # type: ignore[assignment]
+
+    try:
+        runner_task = asyncio.create_task(
+            executor.run(
+                plan=plan,
+                session=session,
+                adapter=adapter,
+                steerer=steerer,
+                planner=planner,
+                sinks=[sink],
+                control=channel,
+            )
+        )
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+        await channel.send(ControlMessage(kind=ControlKind.CANCEL))
+        outcome = await asyncio.wait_for(runner_task, timeout=3.0)
+        assert outcome.success is False
+        assert sink.payload_kinds()[-1] == "run_aborted"
+    finally:
+        SequentialExecutor._cancel_invoke_task = original  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Parallel executor: mid-stage CANCEL cancels all in-flight tasks
+# ---------------------------------------------------------------------------
+
+
+async def test_parallel_cancel_mid_stage_cancels_all_tasks() -> None:
+    # One stage with three parallel tasks.
+    tasks = [Task(id=t, title=f"Task {t}") for t in ("a", "b", "c")]
+    plan = Plan(id="p0", run_id="run-1", goal_ids=[], tasks=tasks, edges=[])
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+    channel = ControlChannel()
+
+    started: set[str] = set()
+    cancelled: set[str] = set()
+    all_started = asyncio.Event()
+
+    async def _long_running(task: Task, session: Session) -> InvocationResult:
+        started.add(task.id)
+        if len(started) == 3:
+            all_started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            cancelled.add(task.id)
+            raise
+        return InvocationResult(task_id=task.id, text="done")
+
+    adapter = StubAdapter(on_invoke=_long_running)
+
+    async def _send_cancel() -> None:
+        await all_started.wait()
+        await channel.send(ControlMessage(kind=ControlKind.CANCEL))
+
+    executor = ParallelDAGExecutor(max_concurrency=0)
+
+    runner_task = asyncio.create_task(
+        executor.run(
+            plan=plan,
+            session=session,
+            adapter=adapter,
+            steerer=steerer,
+            planner=planner,
+            sinks=[sink],
+            control=channel,
+        )
+    )
+    await _send_cancel()
+    outcome = await asyncio.wait_for(runner_task, timeout=5.0)
+
+    assert outcome.success is False
+    assert started == {"a", "b", "c"}
+    assert cancelled == {"a", "b", "c"}
+    assert sink.payload_kinds()[-1] == "run_aborted"
+
+
+# ---------------------------------------------------------------------------
+# Parallel executor: PAUSE mid-stage lets the stage finish, then blocks
+# ---------------------------------------------------------------------------
+
+
+async def test_parallel_pause_before_stage_blocks_until_resume() -> None:
+    tasks = [Task(id=t, title=f"Task {t}") for t in ("a", "b")]
+    plan = Plan(id="p0", run_id="run-1", goal_ids=[], tasks=tasks, edges=[])
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+    channel = ControlChannel()
+
+    started: set[str] = set()
+
+    async def _handler(task: Task, session: Session) -> InvocationResult:
+        started.add(task.id)
+        # Let caller observe the state; don't block.
+        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+
+    adapter = StubAdapter(on_invoke=_handler)
+
+    # PAUSE in advance: pre-stage control drain picks it up before any
+    # invocation happens.
+    await channel.send(ControlMessage(kind=ControlKind.PAUSE))
+
+    executor = ParallelDAGExecutor(max_concurrency=0)
+
+    runner_task = asyncio.create_task(
+        executor.run(
+            plan=plan,
+            session=session,
+            adapter=adapter,
+            steerer=steerer,
+            planner=planner,
+            sinks=[sink],
+            control=channel,
+        )
+    )
+
+    await asyncio.sleep(0.1)
+    assert started == set(), "no task should have started while paused"
+    assert not runner_task.done()
+
+    await channel.send(ControlMessage(kind=ControlKind.RESUME))
+    outcome = await asyncio.wait_for(runner_task, timeout=5.0)
+    assert outcome.success is True
+    assert started == {"a", "b"}


### PR DESCRIPTION
## Summary

Wires Agent A's `ControlChannel` primitive into both goldfive executors so live-steering messages can interrupt a running `Runner`. Part of issue #71 (Phase 1 live-steering).

- Runner gains `control: ControlChannel | None` kwarg; forwards into the executor.
- `goldfive.wrap()` / `goldfive.run()` accept and forward `control=`.
- New `goldfive/executors/_control.py` with shared dispatch logic for all 7 Phase-1 control kinds.
- `SequentialExecutor`: pre-task drain; mid-task race between `adapter.invoke` and `control.receive`. CANCEL and STEER mid-task cancel the asyncio.Task. PAUSE blocks at the next pre-task boundary until RESUME.
- `ParallelDAGExecutor`: same pattern; CANCEL / STEER mid-stage cancels every in-flight task in the stage. PAUSE lets the stage finish per spec.
- 5s defensive grace window so adapters that swallow `CancelledError` don't wedge the run.
- Dispatch uses string matching on the kind so `STATUS_QUERY` / `INTERCEPT_TRANSFER` work today via the string API and stay forward-compatible if Agent A later adds them to `ControlKind`.

## Test plan

- [x] `uv run pytest tests/test_executor_control.py -v` — 9 new tests green
- [x] `uv run pytest -q` — 306 passed, 33 skipped (no regressions)
- [x] `uv run ruff check .` — clean
- [x] Manual smoke: import Runner, ControlChannel, wrap — no import errors

Test coverage:
1. Mid-task CANCEL aborts the run with RunAborted; task receives CancelledError
2. Mid-task STEER cancels the task, calls `steerer.observe`, executes the refined plan
3. Pre-task PAUSE blocks the runner until RESUME arrives
4. REWIND_TO (via PAUSE → REWIND → RESUME) re-executes downstream tasks
5. `_rewind_plan` helper: target and downstream reset, upstream preserved; unknown task_id returns FAILURE ack
6. STATUS_QUERY emits a synthetic DriftDetected event and acks SUCCESS
7. Uncooperative adapter (swallows CancelledError) — executor still aborts after the grace window
8. Parallel CANCEL mid-stage cancels every in-flight task
9. Parallel pre-stage PAUSE blocks until RESUME
