### PR TITLE
Add design vocabulary and rationale docs

### DIFF
--- a/.agents/debug-goldfive.md
+++ b/.agents/debug-goldfive.md
@@ -121,6 +121,31 @@ aborted — check `outcome.reason`.
 pure functions; call them on your own upstream signals to mint drift
 events outside the built-in detector.
 
+## Consulting VOCABULARY to diagnose
+
+When a bug is shaped like "two names that sound similar behave
+differently" or "I can't tell which enum value to reach for",
+[docs/design/VOCABULARY.md](../docs/design/VOCABULARY.md) is the
+single-source answer. It enumerates every `TaskStatus`, `DriftKind`,
+`DriftSeverity`, `ControlKind`, every `Event` payload variant, and the
+bridges between them — with emitter + consumer listed for each.
+
+Quick triage table:
+
+| Symptom | VOCABULARY section |
+|---|---|
+| "I sent a STEER but saw `DriftKind.USER_STEER`, is that right?" | [§2](../docs/design/VOCABULARY.md#2-controlkind-vs-driftkind--a-worked-example) — the STEER → USER_STEER flow diagram |
+| "Which `DriftKind` should I synthesize for X?" | [§5](../docs/design/VOCABULARY.md#5-driftkind-taxonomy) — all 26 kinds grouped by trigger |
+| "Who emits `PlanRevised`?" | [§6](../docs/design/VOCABULARY.md#6-event-payload-kinds) — event factory + emitter + "when" table |
+| "Can a task go from BLOCKED to COMPLETED?" | [§4](../docs/design/VOCABULARY.md#4-taskstatus-state-machine) — transition ownership table + state diagram |
+| "Does severity WARN trigger refine, or just log?" | [§7](../docs/design/VOCABULARY.md#7-severity-ladder) — severity ladder with the exact `_severity_ge` comparison |
+| "What are all the ControlKinds and which ones touch the planner?" | [§3](../docs/design/VOCABULARY.md#3-all-control--drift-bridges) — control → drift bridge table |
+
+For the "why is it this way" questions that pair with the vocabulary
+answers — e.g. *why* does STEER delete-and-replan, *why* is there both
+a status and a drift kind named `BLOCKED` — see
+[docs/design/RATIONALE.md](../docs/design/RATIONALE.md).
+
 ## Quick reference
 
 ```python
@@ -158,6 +183,8 @@ print(f"{len(sink.events)} events")
 ## Related
 
 - [docs/guides/troubleshooting.md](../docs/guides/troubleshooting.md) — detailed symptom → fix catalogue.
+- [docs/design/VOCABULARY.md](../docs/design/VOCABULARY.md) — exhaustive type-system reference (start here when a name is confusing).
+- [docs/design/RATIONALE.md](../docs/design/RATIONALE.md) — design-rationale docs (start here when a choice feels arbitrary).
 - [docs/design/DRIFT.md](../docs/design/DRIFT.md) — drift taxonomy.
 - [docs/design/EVENT-MODEL.md](../docs/design/EVENT-MODEL.md) — event ownership, sequence semantics.
 - [events.md](events.md) — emitting a new event.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ inspect the event stream. Concrete and runnable.
 - [`docs/design/DRIFT.md`](docs/design/DRIFT.md) — full drift-kind taxonomy (25+), classification rules, refine policy.
 - [`docs/design/EVENT-MODEL.md`](docs/design/EVENT-MODEL.md) — proto event taxonomy, sequence semantics, `EventSink` contract.
 
+### Further reading — the "why" docs
+
+- [`docs/design/VOCABULARY.md`](docs/design/VOCABULARY.md) — exhaustive type-system reference. Every enum value, every bridge between types, side-by-side. Start here if `ControlKind.STEER` vs `DriftKind.USER_STEER` ever confuses you.
+- [`docs/design/RATIONALE.md`](docs/design/RATIONALE.md) — design-rationale "why is it this way?" for each major abstraction. Read when a choice feels arbitrary.
+
 ### Guides
 
 - [`docs/guides/getting-started.md`](docs/guides/getting-started.md) — install + first agent.

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -11,6 +11,10 @@ of one `Runner.run()` invocation. Downstream documents go deep on
 individual pieces:
 
 - [PROTOCOLS.md](PROTOCOLS.md) — the protocol contracts in detail.
+- [VOCABULARY.md](VOCABULARY.md) — exhaustive type-system reference:
+  every enum value, every bridge between types.
+- [RATIONALE.md](RATIONALE.md) — design-rationale "why" document for
+  each major abstraction.
 - [EVENT-MODEL.md](EVENT-MODEL.md) — the proto event taxonomy and the
   EventSink contract.
 - [DRIFT.md](DRIFT.md) — the drift-kind taxonomy and refine policy.
@@ -297,14 +301,78 @@ Four invariants hold across every `Runner.run(...)` invocation:
   Streaming live progress is expected to happen through a caller-
   supplied `EventSink`, not through an async generator.
 
+## Layering: goldfive inside, harmonograf outside
+
+goldfive and [harmonograf](https://github.com/pedapudi/harmonograf) are
+two cooperating layers, not one product split awkwardly in two.
+Understanding the boundary between them keeps contributions on the
+right side of the line.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ harmonograf (observability + UI)                            │
+│                                                             │
+│  - harmonograf server — gRPC ingest of Event streams        │
+│  - harmonograf UI — React console for live runs             │
+│  - harmonograf_client.observe(runner) — attaches a Sink +   │
+│    an optional ControlChannel bridge for live steering      │
+│                                                             │
+│  Reads: proto Event stream (via GRPCSink or HarmonografSink)│
+│  Writes back: ControlMessages into goldfive.ControlChannel  │
+└──────────────────────┬──────────────────────────────────────┘
+                       │   Event stream ▲    Control msgs ▼
+                       │                │                 │
+┌──────────────────────▼─────────────────────────────────────┐
+│ goldfive (orchestration: planning, steering, dispatch)     │
+│                                                            │
+│  - Runner / Executor / Steerer / Planner / Adapter / Sink  │
+│  - Runs one Session against one Plan                       │
+│  - Emits proto Events on every state change                │
+│  - Accepts ControlMessages on an optional ControlChannel   │
+│                                                            │
+│  Knows nothing about: UI frameworks, dashboards, gRPC      │
+│  servers, React, harmonograf proto                         │
+└────────────────────────────────────────────────────────────┘
+```
+
+**Invariants:**
+
+- **goldfive never imports harmonograf.** Every observer-side concern
+  is implementable against the public `EventSink` and `ControlChannel`
+  primitives.
+- **harmonograf never edits goldfive's Session.** Control flows only
+  through `ControlChannel.send()`; state mutation only happens inside
+  goldfive (via the Steerer).
+- **Events are the contract.** A proto `Event` written against the v1
+  schema is readable by both layers; future versions add fields only.
+
+**`wrap` vs `observe`.** Two orthogonal verbs:
+
+- `goldfive.wrap(agent, ...)` — wraps an agent as an adapter + picks a
+  planner/deriver/executor/steerer. *Inside* goldfive's layer.
+- `harmonograf_client.observe(runner, ...)` — attaches a sink (and
+  optionally a control bridge) to a `Runner`. *Outside* goldfive's
+  layer.
+
+Callers often use both: `runner = goldfive.wrap(agent); observe(runner)`.
+
+For the full "why" behind this split, see
+[RATIONALE.md §"Why harmonograf is a sink rather than an executor
+plugin"](RATIONALE.md#why-harmonograf-is-a-sink-rather-than-an-executor-plugin).
+For the type-system view of what flows across the boundary, see
+[VOCABULARY.md](VOCABULARY.md).
+
 ## Reading order
 
 If you're new, read this doc in order with:
 
-1. [PROTOCOLS.md](PROTOCOLS.md) — the shape contracts.
-2. [STATE-MACHINE.md](STATE-MACHINE.md) — how one task moves through
+1. [VOCABULARY.md](VOCABULARY.md) — the vocabulary (enums, types,
+   bridges) the rest of the docs assume.
+2. [PROTOCOLS.md](PROTOCOLS.md) — the shape contracts.
+3. [STATE-MACHINE.md](STATE-MACHINE.md) — how one task moves through
    the lifecycle.
-3. [DRIFT.md](DRIFT.md) — what counts as drift and what to do about it.
-4. [EVENT-MODEL.md](EVENT-MODEL.md) — how observability flows out.
+4. [DRIFT.md](DRIFT.md) — what counts as drift and what to do about it.
+5. [EVENT-MODEL.md](EVENT-MODEL.md) — how observability flows out.
+6. [RATIONALE.md](RATIONALE.md) — why each piece is the way it is.
 
 For hands-on, jump to [getting-started.md](../guides/getting-started.md).

--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -9,7 +9,11 @@ This document enumerates every drift kind, covers classification
 rules, and explains when `planner.refine(...)` runs.
 
 Related: [ARCHITECTURE.md](ARCHITECTURE.md#control-direction),
-[STATE-MACHINE.md](STATE-MACHINE.md), [PROTOCOLS.md](PROTOCOLS.md#steerer).
+[STATE-MACHINE.md](STATE-MACHINE.md), [PROTOCOLS.md](PROTOCOLS.md#steerer),
+[VOCABULARY.md §5 — DriftKind taxonomy](VOCABULARY.md#5-driftkind-taxonomy)
+(the authoritative per-kind reference; this doc covers classification
+logic and severity bands),
+[RATIONALE.md §"Why drift severity is a 3-level enum"](RATIONALE.md#why-drift-severity-is-a-3-level-enum-infowarningcritical-not-a-number).
 
 ## The `DriftEvent` shape
 

--- a/docs/design/EVENT-MODEL.md
+++ b/docs/design/EVENT-MODEL.md
@@ -13,6 +13,10 @@ This document covers:
 - How to build a custom sink.
 
 Related: [ARCHITECTURE.md](ARCHITECTURE.md), [PROTOCOLS.md](PROTOCOLS.md#eventsink),
+[VOCABULARY.md §6 — Event payload kinds](VOCABULARY.md#6-event-payload-kinds)
+(exhaustive factory-to-emitter reference for every `oneof` variant),
+[RATIONALE.md §"Why `EventSink` protocol is proto-Event-shaped, not
+dict-shaped"](RATIONALE.md#why-eventsink-protocol-is-proto-event-shaped-not-dict-shaped),
 and the [writing-an-event-sink guide](../guides/writing-an-event-sink.md).
 
 ## Event envelope

--- a/docs/design/PROTOCOLS.md
+++ b/docs/design/PROTOCOLS.md
@@ -7,7 +7,10 @@ the contract of each protocol — the shape, the semantics, and the
 invariants a correct implementation must uphold — plus minimal
 working implementations.
 
-Related: [ARCHITECTURE.md](ARCHITECTURE.md), [api.md](../reference/api.md).
+Related: [ARCHITECTURE.md](ARCHITECTURE.md), [api.md](../reference/api.md),
+[VOCABULARY.md](VOCABULARY.md) for the enums and dataclasses these
+signatures reference, [RATIONALE.md](RATIONALE.md) for the design
+decisions behind each protocol.
 
 All method signatures in this doc track `goldfive/protocols.py`. When
 they disagree, the source wins.
@@ -267,6 +270,13 @@ class MinimalSteerer:
 The production `DefaultSteerer` in `goldfive/steerer.py` adds the full
 drift classifier and event emission.
 
+> See [RATIONALE.md §"Why `Steerer` is a protocol, and what
+> `DefaultSteerer` does"](RATIONALE.md#why-steerer-is-a-protocol-and-what-defaultsteerer-does)
+> for the state-vs-observation-vs-drift split rationale, and
+> [RATIONALE.md §"Why the Steerer invokes `planner.refine` and not the
+> Executor"](RATIONALE.md#why-the-steerer-invokes-plannerrefine-and-not-the-executor)
+> for why refine lives here.
+
 ## AgentAdapter
 
 ```python
@@ -363,6 +373,10 @@ class CallableAdapter:
 See [writing-an-agent-adapter.md](../guides/writing-an-agent-adapter.md)
 for a full worked example that wraps a hypothetical new framework.
 
+> See [RATIONALE.md §"Why `AgentAdapter` exists and isn't the agent
+> itself"](RATIONALE.md#why-agentadapter-exists-and-isnt-the-agent-itself)
+> for the "how to invoke" vs "how to be invoked" split.
+
 ## Executor
 
 ```python
@@ -450,6 +464,10 @@ The production executors (`SequentialExecutor`, `ParallelDAGExecutor`)
 add topological scheduling, drift handling, refine, and the
 reinvocation loop.
 
+> See [RATIONALE.md §"Why `Executor` is a protocol instead of a
+> function"](RATIONALE.md#why-executor-is-a-protocol-instead-of-a-function)
+> for why this shape was chosen.
+
 ## EventSink
 
 ```python
@@ -472,6 +490,13 @@ class EventSink(Protocol):
 See [EVENT-MODEL.md](EVENT-MODEL.md#the-eventsink-contract) for the
 full semantics and [writing-an-event-sink.md](../guides/writing-an-event-sink.md)
 for a walkthrough.
+
+> See [RATIONALE.md §"Why `EventSink` protocol is proto-Event-shaped,
+> not dict-shaped"](RATIONALE.md#why-eventsink-protocol-is-proto-event-shaped-not-dict-shaped)
+> for why the contract is proto, and
+> [RATIONALE.md §"Why `make_event` (dict) coexists with typed
+> factories"](RATIONALE.md#why-make_event-dict-coexists-with-typed-factories-proto)
+> for why the dict escape hatch stays.
 
 ### Minimal implementation
 

--- a/docs/design/RATIONALE.md
+++ b/docs/design/RATIONALE.md
@@ -1,0 +1,807 @@
+# Design rationale
+
+This document answers the question "why is goldfive shaped this way?"
+for each major abstraction. Every entry uses the same template:
+
+- **Observation** — what someone new to the code will notice first.
+- **Intent** — what the design is trying to achieve.
+- **Alternatives considered** — sibling designs that were rejected.
+- **Tradeoffs** — what we gave up.
+- **Signals this might be wrong** — the futures that would send us back
+  to the drawing board.
+- **Related** — pointers into the rest of the docs.
+
+If you are reading goldfive for the first time and any choice feels
+arbitrary, check here before assuming it is.
+
+Related:
+
+- [VOCABULARY.md](VOCABULARY.md) — the type-system reference.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — the six primitives.
+- [PROTOCOLS.md](PROTOCOLS.md) — the protocol contracts.
+- [STATE-MACHINE.md](STATE-MACHINE.md) — task lifecycle.
+- [DRIFT.md](DRIFT.md) — drift taxonomy.
+- [EVENT-MODEL.md](EVENT-MODEL.md) — event envelope.
+
+## Why `Goal` is first-class
+
+**Observation.** `Runner.run` takes `user_input: str | list[Goal]`.
+Every run begins with a `list[Goal]` in `session.goals`. The `Goal`
+dataclass has `id`, `summary`, `success_predicate`, and `metadata`. The
+plan's `goal_ids` list names goals explicitly.
+
+**Intent.** Separate *what the user asked for* from *what the agent
+is currently working on*. A `Goal` outlives a plan revision; a `Task`
+does not. When `planner.refine` produces a fresh plan after a
+`USER_STEER`, the goals stay the same while tasks get rewritten.
+
+**Alternatives considered.**
+
+1. `user_input: str` only — drop `Goal` entirely. Rejected: every
+   planner would have to re-derive its own interpretation of intent,
+   and a refine after STEER would have no stable handle on "the user's
+   original request."
+2. `Goal` = `str` alias — no dataclass. Rejected: we need the
+   `success_predicate` escape hatch for closed-loop goals (e.g. "don't
+   stop until this predicate returns True on the session"), and a
+   `metadata` dict for planner-private context. Promoting to a
+   dataclass costs almost nothing.
+3. Merge `Goal` and `Plan` — always have the caller supply a plan.
+   Rejected: most callers either want the planner to produce the plan
+   or want a single-goal passthrough. Forcing plan authorship removes
+   the main ergonomic win.
+
+**Tradeoffs.** Two-layer modelling (goal → plan) is slightly more to
+teach than one layer. In return, refine has a stable anchor and logs
+carry enough provenance to reconstruct intent after many revisions.
+
+**Signals this might be wrong.** If in practice every goal is the
+literal user prompt with no predicate and no metadata, we have paid
+for a layer nobody uses. The `LiteralGoalDeriver` / `PassthroughGoalDeriver`
+pair makes this cheap, so even in that limit the cost is minimal.
+
+**Related.** [PROTOCOLS.md §GoalDeriver](PROTOCOLS.md#goalderiver),
+[VOCABULARY.md §"`Goal`"](VOCABULARY.md#1-the-four-semantic-enums).
+
+## Why `Plan` and `Session` are separate
+
+**Observation.** `Plan` is a DAG of tasks; `Session` holds `plan:
+Plan | None` plus `run_id`, `goals`, `completed_results`,
+`task_progress`, `agent_notes`, `history`, `divergence_flag`, and a
+sequence counter. The Plan can be swapped by `refine` mid-run; the
+Session persists across the swap.
+
+**Intent.** Make the plan mutable-by-replacement while keeping durable
+state (what completed, what the agent wrote down) on an object that
+does not churn on every revision. When refine returns a new plan, the
+Steerer reassigns `session.plan = revised` — everything else stays put.
+
+**Alternatives considered.**
+
+1. One big `RunState` object — fold the plan's tasks and edges into
+   `Session`. Rejected: refine would need to reach into the Session and
+   surgically edit tasks, losing the nice property that "a plan is a
+   value you can log, serialize, and diff."
+2. Multiple `Session` objects per run, one per plan revision. Rejected:
+   sequence counters, `completed_results`, and progress state have to
+   be continuous; threading them across session objects is error-prone.
+3. Put `completed_results` on the plan itself. Rejected: completed
+   results are tied to a `Task.id`, and we preserve `Task.id` across
+   revisions — but we also don't want to assume *every* completed task
+   survives a revision as-is. Keeping results on the session means a
+   refine can drop a completed task from the plan without destroying
+   its recorded output. (In practice refine must not drop completed
+   tasks, but the invariant belongs in the planner contract, not in
+   the data layout.)
+
+**Tradeoffs.** Two types to teach instead of one. In return, refine is
+a single-pointer reassignment and the serialization story for plans
+(log them into `PlanSubmitted` / `PlanRevised` events verbatim) falls
+out for free.
+
+**Signals this might be wrong.** If callers frequently want to iterate
+a session's task history and find themselves reaching for
+`session.plan.tasks + session.history` patterns, we may need a helper
+method or a flatter layout.
+
+**Related.** [ARCHITECTURE.md](ARCHITECTURE.md),
+[VOCABULARY.md §4](VOCABULARY.md#4-taskstatus-state-machine).
+
+## Why `GoalDeriver` is a separate protocol from `Planner`
+
+**Observation.** `GoalDeriver.derive(user_input) -> list[Goal]` and
+`Planner.generate(goals, available_agents, context) -> Plan | None` are
+two different protocols. In many runs they are backed by the same LLM.
+
+**Intent.** Separate the concerns so a caller can replace one without
+replacing the other. The set of goals is the contract the run is judged
+against; the plan is a tactical artifact. Callers that already know
+their goals (a REST API, a cron job) bypass derivation entirely by
+passing `list[Goal]` to `Runner.run`. Callers that want to own planning
+but not derivation (a product with a fixed goal vocabulary but flexible
+agent dispatch) swap only the planner.
+
+**Alternatives considered.**
+
+1. One `PlanGenerator` interface — `(user_input, available_agents) ->
+   (goals, plan)`. Rejected: fuses two independently-useful swaps.
+2. `Goal` is derived by the planner on the fly during `generate`.
+   Rejected: `PlanSubmitted` events would have to carry goals
+   retroactively, and `Runner.run(list[Goal])` would have to simulate a
+   passthrough planner.
+3. Put derivation on the adapter. Rejected: deriving goals is
+   framework-agnostic reasoning about user intent; it should not depend
+   on the agent framework.
+
+**Tradeoffs.** Two protocols instead of one. Callers writing both
+must decide how to share an LLM between them; `wrap` handles this by
+detecting the LLM and passing the same `call_llm` to both.
+
+**Signals this might be wrong.** If in every real deployment the
+`GoalDeriver` and `Planner` share an LLM, a shared prompt, and are
+always replaced together, the separation is paying no dividend.
+
+**Related.** [PROTOCOLS.md §GoalDeriver](PROTOCOLS.md#goalderiver),
+[PROTOCOLS.md §Planner](PROTOCOLS.md#planner).
+
+## Why `Runner` is the public entry point instead of calling `Executor` directly
+
+**Observation.** You cannot use goldfive without a `Runner` — even
+`goldfive.wrap` returns a `Runner`. Yet the executor's `run(...)`
+method has a full signature (plan, session, adapter, steerer, planner,
+sinks). It would be tempting to construct a session by hand and call
+`executor.run(...)` directly.
+
+**Intent.** The Runner owns the `Run*` lifecycle semantics that are
+universal and which should not be re-implemented per executor:
+
+- Generating `run_id`.
+- Emitting `RunStarted` / `GoalDerived` / `PlanSubmitted` at the right
+  moments.
+- Calling `goal_deriver.derive` (or accepting `list[Goal]` directly).
+- Calling `planner.generate` and swapping the result onto the session.
+- Registering the seven canonical reporting tools on the adapter.
+- Binding the steerer to sinks+planner.
+- Emitting `RunAborted` on any pre-executor failure.
+
+Without the Runner, every new executor would re-implement those eight
+steps, and the event-ownership invariants would drift. With the
+Runner, executors only need to own the per-task loop, task events, and
+the terminal `RunCompleted`/`RunAborted`.
+
+**Alternatives considered.**
+
+1. Make the Executor the entry point; have the Runner be a thin wrapper
+   that future-deprecates. Rejected: the Runner is not a wrapper, it
+   is the *composition* of all six primitives. It is where sink
+   fan-out, pre-executor aborts, and `close()` live.
+2. Make the user construct a `Session` and hand it to the Executor.
+   Rejected: too much ceremony; quickstart would become five lines
+   longer for no gain.
+
+**Tradeoffs.** Two concepts to teach (Runner vs Executor) instead of
+one. In return, the event ownership map is stable: Runner-owned events
+vs Executor-owned events vs Steerer-owned events never overlap.
+
+**Signals this might be wrong.** If a new executor wanted to skip one
+of the Runner's pre-executor steps (say, decline to register reporting
+tools), we would need a way to opt out — at which point the current
+split would bend. Currently no such need has surfaced.
+
+**Related.** `goldfive/runner.py` module docstring,
+[ARCHITECTURE.md §"The full lifecycle"](ARCHITECTURE.md#the-full-lifecycle).
+
+## Why `Executor` is a protocol instead of a function
+
+**Observation.** `SequentialExecutor` and `ParallelDAGExecutor` both
+satisfy a single protocol. The protocol has one method, `async run`.
+You could imagine compressing it into a callable.
+
+**Intent.** Executors hold non-trivial per-run state (in-flight task
+map, rewind bookkeeping, reinvocation counter, paused flag, control
+drain helpers). A protocol lets each executor keep its own state
+without forcing every caller to thread the state through function
+parameters. It also means third parties can drop in a custom executor
+(domain-specific scheduling, cloud-native fan-out) without goldfive
+needing to know about it.
+
+**Alternatives considered.**
+
+1. `Executor = Callable[[...], Awaitable[ExecutionOutcome]]`.
+   Rejected: in-flight state has to go somewhere; closures or context
+   objects end up reconstituting a class with extra steps.
+2. One concrete `Executor` class with a `mode` enum. Rejected: fans
+   out the implementation into conditionals, and closes the door on
+   custom executors that don't fit either mode.
+
+**Tradeoffs.** Callers pay the cost of knowing about "protocols" and
+the naming overhead of each concrete class.
+
+**Signals this might be wrong.** If in every non-trivial use the
+parallel/sequential distinction collapses into a single implementation
+with a concurrency knob, we have two classes where we needed one.
+
+**Related.** [PROTOCOLS.md §Executor](PROTOCOLS.md#executor),
+[VOCABULARY.md §6](VOCABULARY.md#6-event-payload-kinds).
+
+## Why `Steerer` is a protocol, and what `DefaultSteerer` does
+
+**Observation.** The Steerer protocol has four methods: `observe`,
+`transition`, `detect_drift`, `bind`. `DefaultSteerer` is the canonical
+implementation and owns:
+
+- The task state machine (`mark_task_*` → `TaskStatus` transitions).
+- Drift classification (`detect_drift`).
+- Drift handling (`_handle_drift` → emit `DriftDetected`, optionally
+  call `planner.refine`, apply the revision).
+- Event fan-out to sinks for every transition.
+
+**Intent.** The Steerer is the **only** component that mutates live
+run state. Executors compute, adapters run agents, planners compute
+plans — the Steerer is the funnel through which all state-changing
+decisions flow. Making it a protocol lets callers swap in a custom
+policy (different refine threshold, different drift taxonomy, an LLM-
+driven drift classifier) without replacing the executor.
+
+**Alternatives considered.**
+
+1. Fold the state machine into the Executor. Rejected: every executor
+   would re-implement the same transitions with the same off-by-one
+   bugs. And a custom executor wouldn't get drift detection for free.
+2. Fold drift detection into the Adapter. Rejected: drift signals come
+   from multiple places — tool errors, text refusals, stop reasons,
+   reporting-tool calls, user steers. Putting all of that in the
+   adapter layer would make adapters enormous and framework-specific.
+3. One monolithic `Engine` that combines Steerer + Executor. Rejected:
+   blurs the "what is going on" (Steerer) vs "what do I do next"
+   (Executor) split that makes the rest of the contract clean.
+
+**Tradeoffs.** Three protocols touch each other (Executor calls
+Steerer, Steerer calls Planner, all emit to Sinks). In return, every
+responsibility has a name and a contract.
+
+**Signals this might be wrong.** If a user of goldfive wants to add a
+new reporting tool and finds they have to edit both the Adapter
+(register) and the Steerer (mutate on call), the handoff may be too
+costly. Today the reporting-tool protocol in
+`goldfive/reporting.py` keeps this small.
+
+**Related.** [PROTOCOLS.md §Steerer](PROTOCOLS.md#steerer),
+`goldfive/steerer.py`.
+
+## Why `AgentAdapter` exists and isn't the agent itself
+
+**Observation.** You cannot hand a Google ADK `BaseAgent` or a Claude
+SDK client to `Runner` directly. You must wrap it in an
+`AgentAdapter` (or let `goldfive.wrap` do it for you).
+
+**Intent.** Separate "how to invoke" from "how to be invoked." The
+adapter knows how to:
+
+- Render the current `Task` + `Session` into whatever input channel
+  the framework expects.
+- Register the seven canonical reporting tools in the framework's
+  tool-registration format.
+- Intercept tool calls and route them through the Steerer.
+- Return an `InvocationResult` with the stop reason and final text.
+
+The agent itself — the `BaseAgent`, the client, the callable — does
+none of this. It just answers. Putting the adapter concerns on the
+agent would force every agent author to learn goldfive's contract.
+
+**Alternatives considered.**
+
+1. Subclass `BaseAgent` with goldfive hooks. Rejected: requires
+   framework modification, prevents dropping in an off-the-shelf agent.
+2. Monkeypatch the agent at wrap time. Rejected: opaque, fragile, and
+   forbidden in many agent frameworks.
+3. Make the adapter optional — accept "either an AgentAdapter or a
+   bare agent" in `Runner`. Rejected: the logic to figure out which is
+   which still lives somewhere; we simply moved the decision inside
+   `Runner` instead of making the caller pass `wrap`.
+
+**Tradeoffs.** One extra class per supported framework. We ship three
+(`CallableAdapter`, `ADKAdapter`, `ClaudeAgentSDKAdapter`) and
+`auto_adapter` auto-selects at wrap time.
+
+**Signals this might be wrong.** If a new framework resists being
+adapted — say its invocation model is not request/response but
+infinite streaming — we may need to generalize `AgentAdapter.invoke`
+or add a sibling protocol.
+
+**Related.** [PROTOCOLS.md §AgentAdapter](PROTOCOLS.md#agentadapter),
+`goldfive/adapters/`, [.agents/adapters.md](../../.agents/adapters.md).
+
+## Why `EventSink` protocol is proto-Event-shaped, not dict-shaped
+
+**Observation.** `EventSink.emit(event_pb: Any)` takes a proto `Event`
+envelope. Typed factories in `goldfive/events.py` build those
+envelopes. There is also a `make_event(run_id, sequence, kind,
+payload)` helper that returns a `dict`.
+
+**Intent.** Proto is the source of truth. The schema in
+`proto/goldfive/v1/events.proto` gives us:
+
+- **Wire stability.** Field numbers are frozen; sinks written against
+  v0.1 keep working on future versions.
+- **Observability integration.** Downstream systems (harmonograf, gRPC
+  clients, SQLite readers) can deserialize without a goldfive import.
+- **Forward compatibility.** New event kinds extend the `oneof`
+  payload; old sinks ignore unknowns.
+
+The `make_event` dict path coexists as an **escape hatch**: tests and
+lightweight tools that don't want the `proto` extra installed can still
+emit dict envelopes, and dict-aware sinks (`JSONLPersistenceSink`,
+`InMemorySink`, `LoggingSink`) round-trip them.
+
+**Alternatives considered.**
+
+1. Dict-only schema. Rejected: no wire stability, no
+   cross-language consumption, types drift.
+2. Proto-only with no escape hatch. Rejected: tests that don't need
+   proto would have to install the extra, and `make_event` is the
+   single place where a minimal dict envelope gets formatted.
+
+**Tradeoffs.** Two envelope shapes exist in parallel. Sinks must
+duck-type on `DESCRIPTOR`. Issue #53 tracked a bug caused by mixing
+shapes incorrectly; the fix was careful sink authoring, not removal
+of either path.
+
+**Signals this might be wrong.** If we grow a third envelope shape
+(some new serialization format), we should seriously consider
+consolidating back to proto-only.
+
+**Related.** [EVENT-MODEL.md](EVENT-MODEL.md),
+[.agents/debug-goldfive.md §"Common pitfalls"](../../.agents/debug-goldfive.md#common-pitfalls).
+
+<!-- TODO: once docs/design/CONTROL.md lands, cross-link from the
+ControlChannel, STEER "delete-and-replan", and "Phase 1 mid-task cancel"
+entries below. -->
+
+## Why `ControlChannel` is a primitive rather than methods on Runner
+
+**Observation.** `Runner.pause()` / `Runner.cancel()` / `Runner.steer()`
+do not exist. Instead, callers construct a `ControlChannel`, pass it
+to `Runner(control=...)` (or `wrap(control=...)`), and send
+`ControlMessage` objects through the channel.
+
+**Intent.** Control is **bidirectional** and **external**. The UI runs
+in a different process. A test harness runs in a different task. A CLI
+runs in a different thread. Making the control surface an async
+queue-pair means:
+
+- The Runner never has to be reachable by the caller mid-run — the
+  channel is.
+- Acks flow back through the same primitive, so external callers know
+  whether their control took effect.
+- Bridges (e.g. `harmonograf_client.observe`) can translate their own
+  wire protocol into `ControlMessage` and plug in without knowing
+  anything about goldfive's internals.
+
+**Alternatives considered.**
+
+1. `Runner.pause()` etc. as methods. Rejected: requires a stable
+   reference to the Runner across processes, couples control semantics
+   to the Runner lifetime, and has no natural place for async acks.
+2. A single `asyncio.Queue[ControlMessage]` (no acks). Rejected: the
+   UI needs to know whether its cancel was honored or whether it
+   arrived after a terminal state.
+3. Signals (SIGINT, SIGUSR1). Rejected: not expressive enough for
+   STEER's payload; signals don't cross process boundaries cleanly in
+   general agent deployments.
+
+**Tradeoffs.** Two queues instead of zero. Callers must understand
+that they drain acks on a separate async iterator. In practice the
+bridge hides both queues from the UI caller.
+
+**Signals this might be wrong.** If every real-world caller ends up
+writing the same ack-draining bridge by hand, we should either ship a
+default bridge or build ack handling into the Runner.
+
+**Related.** [VOCABULARY.md §2](VOCABULARY.md#2-controlkind-vs-driftkind--a-worked-example),
+`goldfive/control.py`.
+
+## Why STEER is "delete-and-replan" instead of "modify-in-place"
+
+**Observation.** When the user steers, the planner's `refine` for
+`USER_STEER` drops every non-completed task and generates a fresh task
+list. Completed tasks are preserved. It does not surgically modify the
+existing plan.
+
+**Intent.** User steering is a **semantic signal**, not a diff. When
+the user says "focus on slide 3 instead", they are not asking for the
+planner to tweak task descriptions; they are asking for a new
+conception of the remaining work that takes their note seriously.
+Delete-and-replan guarantees:
+
+- Completed work's identity and output is preserved (invariant from
+  Planner contract, cross-referenced below).
+- Every remaining task was *generated in light of the steering note*,
+  not inherited from a pre-steering plan.
+- The revision is visible and auditable: `PlanRevised` carries the
+  full new plan, not a patch.
+
+**Alternatives considered.**
+
+1. In-place edit: planner modifies task titles, shuffles
+   dependencies, leaves some pending tasks. Rejected: the invariant
+   "every pending task reflects current user intent" becomes hard to
+   state, and diff-style refine output complicates the event record.
+2. User-supplied task list (no LLM). Rejected: takes the intelligence
+   out of the loop for the very case where we need it most.
+3. Refine is "appendonly" — new tasks are appended to existing pending
+   tasks. Rejected: the user's steer is a redirection, not an
+   addition; appendonly makes that case awkward.
+
+**Tradeoffs.** Wasted compute on pending tasks whose work would have
+overlapped with the new plan. In practice, the pending tasks have not
+yet executed, so no agent-time is lost — only planning time.
+
+**Signals this might be wrong.** If deployments show heavy LLM-planner
+cost per steer, or if callers write custom planners that *do* do
+in-place edits and want first-class support, we'd revisit.
+
+**Related.** `DriftKind.USER_STEER` in
+[VOCABULARY.md §5.d](VOCABULARY.md#5d-user-driven--an-external-verb-entered-the-pipeline).
+
+## Why `goldfive.wrap()` exists when `Runner(...)` would do
+
+**Observation.** `Runner.__init__` requires five named pieces:
+`agent`, `planner`, `executor`, plus the optional `goal_deriver`,
+`steerer`, `sinks`, `control`, `max_plan_reinvocations`. Most callers
+have one of {`BaseAgent`, `Client`, `callable`} and want to say "just
+run this with sensible defaults." `goldfive.wrap(agent)` does that in
+one call.
+
+**Intent.** Close the ergonomics gap between "I have an agent" and "I
+have a `Runner`." `wrap` does three things:
+
+1. **Auto-adapter detection.** `auto_adapter(agent)` dispatches to
+   `ADKAdapter`, `ClaudeAgentSDKAdapter`, `CallableAdapter`, or
+   passes through an existing `AgentAdapter`.
+2. **LLM detection.** If the agent carries an LLM handle goldfive
+   knows how to reuse (currently ADK), it threads that into an
+   `LLMPlanner` and `LLMGoalDeriver`.
+3. **Sensible defaults.** Falls back to `PassthroughPlanner` +
+   `LiteralGoalDeriver` when no LLM is detected, so `wrap` never
+   crashes at construction.
+
+**Alternatives considered.**
+
+1. Make `Runner.__init__` auto-detect too. Rejected: the Runner's
+   signature is intentionally explicit — it's the contract. `wrap`
+   can *relax* that contract; `Runner` cannot.
+2. `quickstart(agent, goals)` only. Rejected: doesn't cover callers who
+   want `.run(user_input)` with auto-derivation. `quickstart` already
+   exists as a more opinionated cousin (static plan from goals).
+
+**Tradeoffs.** Two entry points (`Runner` and `wrap`) — plus `run` and
+`quickstart`. Three idioms to teach. The docs pick one canonical path
+(`wrap` for most callers) and show the others as escape hatches.
+
+**Signals this might be wrong.** If `wrap`'s auto-detection silently
+picks a wrong adapter or planner, callers get baffling behavior. The
+current debug-log messages help; a future `wrap(dry_run=True)` that
+prints the resolved component list would help more.
+
+**Related.** `goldfive/convenience.py`,
+[README.md](../../README.md#hello-goldfive).
+
+## Why harmonograf is a sink rather than an executor plugin
+
+**Observation.** You plug harmonograf in by supplying a sink to
+`Runner(sinks=[HarmonografSink(...)])` (or via
+`harmonograf_client.observe(runner)`), not by passing an "observed"
+executor. Observability lives one level outside orchestration.
+
+**Intent.** Layer boundaries:
+
+- **goldfive** is the **orchestration library**. It plans, executes,
+  steers, and emits events.
+- **harmonograf** is the **observability console**. It subscribes to
+  events and optionally sends control messages back.
+
+Keeping observability on the sink boundary means you can:
+
+- Run goldfive with no observer (production CLI).
+- Run goldfive with logging-only observability.
+- Run goldfive with harmonograf.
+- Run goldfive with your own custom observer.
+
+…all without touching the orchestration layer.
+
+**Alternatives considered.**
+
+1. Executor-plugin API: `SequentialExecutor(plugins=[harmonograf])`.
+   Rejected: conflates "what schedules work" with "what watches work",
+   and every new executor would need its own plugin contract.
+2. Direct harmonograf dependency from goldfive. Rejected: goldfive has
+   to be usable without harmonograf installed.
+
+**Tradeoffs.** `observe(runner)` is two different concepts from
+`wrap(agent)` — the first adds a sink (and, for live steering, a
+control bridge), the second adds an adapter. New users sometimes
+conflate them. The docs split them cleanly by file and by
+verb.
+
+**Signals this might be wrong.** If observability features routinely
+need hooks that sinks can't reach (executor decisions, steerer internal
+state), we may need a more expressive contract. So far the event
+stream has been enough.
+
+**Related.** `goldfive/sinks/`, [harmonograf-integration guide][hg].
+
+[hg]: ../guides/harmonograf-integration.md
+
+## Why drift severity is a 3-level enum (`INFO`/`WARNING`/`CRITICAL`) not a number
+
+**Observation.** Severities are discrete: `INFO`, `WARNING`,
+`CRITICAL`. No `NOTICE`, `ERROR`, `FATAL`, or numeric scales.
+
+**Intent.** Three levels map to three discrete operator actions:
+
+- `INFO`: see it in the log, take no action.
+- `WARNING`: take the "replan" action.
+- `CRITICAL`: take the "abort or replan-then-maybe-abort" action.
+
+Finer granularity would require each level to correspond to a specific
+automated action, and we do not have more than three actions to
+assign.
+
+**Alternatives considered.**
+
+1. Numeric severity (0-100). Rejected: forces every caller to pick a
+   number, and forces the Steerer to pick a threshold that looks
+   arbitrary.
+2. Five-level (`DEBUG, INFO, WARN, ERROR, FATAL`). Rejected: extra
+   levels without extra actions just confuse operators.
+3. Boolean `is_recoverable` flag. Rejected: conflates severity with
+   recoverability; some `WARNING`s are not recoverable (a permanent
+   schema violation) and some `CRITICAL`s are recoverable with a
+   major replan.
+
+**Tradeoffs.** Callers with domain-specific gradation have to shoehorn
+into three buckets. They can always extend the detail string or use a
+caller-owned label in `metadata`.
+
+**Signals this might be wrong.** If we find ourselves repeatedly
+synthesizing drifts at "WARNING but really WARNING-er" severity and
+writing custom threshold comparisons, the enum is too coarse.
+
+**Related.** [DRIFT.md §"Severity levels"](DRIFT.md#severity-levels),
+[VOCABULARY.md §7](VOCABULARY.md#7-severity-ladder).
+
+## Why `make_event` (dict) coexists with typed factories (proto)
+
+**Observation.** `goldfive/events.py` exports both
+`run_started_event(...)` (proto) and `make_event(run_id, sequence,
+kind, payload)` (dict). Tests and a couple of lightweight paths use
+the dict shape. `GRPCSink` only accepts proto.
+
+**Intent.** Keep goldfive usable without the `proto` optional
+dependency. The proto stubs are large and require `grpcio-tools` at
+generation time. Some tests and some downstream tools (the
+`harmonograf_client` ack formatters, small scripts) don't need proto;
+forcing it would bloat their install footprint.
+
+**Alternatives considered.**
+
+1. Proto-only. Rejected: the `proto` extra becomes effectively
+   required, breaking the "pure Python" promise for some use cases.
+2. Dict-only. Rejected: loses wire stability and forward compatibility.
+3. Convert dict ↔ proto on every emission. Rejected: adds cost to the
+   hot path and a subtle class of mixed-shape bugs.
+
+**Tradeoffs.** Sinks have to duck-type on `DESCRIPTOR` to distinguish
+the two shapes. An earlier bug (#53) came from `LoggingSink` assuming
+proto; the fix was a dict fallback. We kept dict anyway because the
+alternative — forcing proto everywhere — is worse.
+
+**Signals this might be wrong.** If downstream tooling uniformly
+installs the proto extra, the dict path is dead code. Today it is
+not — `make_event` is called from several test scenarios and from
+`harmonograf_client` fallbacks.
+
+**Related.** [EVENT-MODEL.md §"Forward compatibility"](EVENT-MODEL.md#forward-compatibility),
+[.agents/debug-goldfive.md §"Common pitfalls"](../../.agents/debug-goldfive.md#common-pitfalls).
+
+## Why `max_plan_reinvocations` is a budget, not a time limit
+
+**Observation.** `Runner(..., max_plan_reinvocations=32)` and its
+per-executor equivalent cap the **number** of times the executor may
+re-invoke the planner (or, in the sequential executor, dispatch a
+task) before the run aborts. There is no wall-clock timeout at this
+layer.
+
+**Intent.** Differentiate **stuck** from **slow**. An agent that takes
+ten minutes per task is slow (fine, maybe). An agent that loops
+through five refines per minute is stuck (not fine). A time budget
+would punish the slow case; an invocation budget only punishes the
+loopy case.
+
+**Alternatives considered.**
+
+1. Wall-clock timeout. Rejected: too blunt for mixed workloads.
+2. Exponential-backoff between refines. Rejected: doesn't bound total
+   work, just spaces it.
+3. No cap. Rejected: loops happen.
+
+**Tradeoffs.** A stuck agent can still burn 32 refines before we
+notice. The cap is intentionally generous because the signal "we hit
+the cap" is more important than the signal "we hit it fast."
+
+**Signals this might be wrong.** If callers regularly want wall-clock
+timeouts, we may need a sibling knob. Today none do.
+
+**Related.** `goldfive/runner.py::Runner` constructor docstring,
+[ARCHITECTURE.md §"5. Termination"](ARCHITECTURE.md#5-termination).
+
+## Why `BLOCKED` is a task status rather than a drift kind
+
+**Observation.** Both `TaskStatus.BLOCKED` and `DriftKind.BLOCKED`
+exist. They represent different aspects of the same event.
+
+**Intent.** Status and drift are orthogonal:
+
+- `TaskStatus.BLOCKED` is a **position in the task lifecycle** — the
+  task is still alive, not terminal, and may resume. Executors use the
+  status to decide what to dispatch on the next tick.
+- `DriftKind.BLOCKED` is the **observation that a task *just* entered
+  BLOCKED** — it is a one-shot signal that flows through refine. The
+  planner decides whether to route around the blocker, wait, or give
+  up.
+
+Most drift kinds do not need a status counterpart. `CONTEXT_PRESSURE`
+is about an invocation, not a task lifecycle state. `TOOL_ERROR` is
+about a tool call. Only `BLOCKED` is both a durable lifecycle state
+and a refinable event.
+
+**Alternatives considered.**
+
+1. `BLOCKED` as drift only; no status. Rejected: the executor needs a
+   way to say "this task is waiting" when it iterates. Without a
+   status, it would have to cross-reference the drift history on
+   every tick.
+2. `BLOCKED` as status only; no drift. Rejected: refining out of
+   blocked is the happy path. Without a drift, `_handle_drift` would
+   not fire and the planner would not hear about the blocker.
+
+**Tradeoffs.** Two `BLOCKED` symbols can confuse a reader. The tables
+in [VOCABULARY.md §4](VOCABULARY.md#4-taskstatus-state-machine) and
+[§5.c](VOCABULARY.md#5c-runtime--the-environment-limited-progress)
+show them side-by-side so the dual role is visible.
+
+**Signals this might be wrong.** If callers routinely want a task to
+enter `BLOCKED` silently (no drift, no refine), we would need a
+severity-zero variant or a separate `mark_task_waiting`. Today no such
+need has surfaced.
+
+**Related.** [VOCABULARY.md §4](VOCABULARY.md#4-taskstatus-state-machine),
+[STATE-MACHINE.md §"Blocked vs non-blocked resume"](STATE-MACHINE.md#blocked-vs-non-blocked-resume).
+
+## Why Phase 1 includes mid-task cancel
+
+**Observation.** The sequential executor races `adapter.invoke(task,
+session)` against `channel.receive()` so a CANCEL or STEER mid-task
+interrupts an in-flight adapter call. The parallel executor does the
+same per stage.
+
+**Intent.** Live UX requires mid-task cancel. A user who clicks
+"Cancel" while the agent is still typing expects it to stop — not in
+30 seconds when the task finishes, but now. Between-task-only cancel
+would be a regression from the console's current behavior.
+
+**Best-effort, not guaranteed.** The executor calls `invoke_task.cancel()`
+and waits up to a small timeout; after that, it abandons the coroutine
+and proceeds with the cancel. If the adapter doesn't honor
+`CancelledError` (e.g. wraps it in a `try/except Exception`), the
+adapter coroutine continues running in the background until it
+completes naturally. That's acceptable because:
+
+- The cancel effect is about run control, not adapter resource
+  cleanup. The run aborts either way.
+- Adapters that *do* honor cancellation get the fast path.
+- Adapters that don't will eventually finish and become orphan tasks;
+  asyncio's garbage collection logs them.
+
+**Alternatives considered.**
+
+1. Between-task-only cancel. Rejected: UX regression, see above.
+2. Forcible thread kill. Rejected: Python doesn't support it cleanly,
+   and adapters may hold locks.
+3. Wait arbitrarily long for cancel. Rejected: defeats the purpose.
+
+**Tradeoffs.** "Best-effort" is a contract users have to accept.
+Adapter authors who want first-class mid-task cancel must cooperate
+with `CancelledError`.
+
+**Signals this might be wrong.** If common adapters routinely leak
+tasks past cancel, we may need a stricter kill mechanism (process
+boundary, subprocess executor).
+
+**Related.** `goldfive/executors/sequential.py::_invoke_with_control`,
+`goldfive/executors/_control.py::_ControlCancelled`.
+
+## Why we preserve completed task outputs across a STEER replan
+
+**Observation.** After `USER_STEER` refine, `session.completed_results`
+still contains every completed task's output. The planner contract
+requires preserving completed tasks' identity and outcome in the
+revised plan.
+
+**Intent.** Avoid wasted work and preserve user-visible progress. A
+user steers because the current direction is wrong *going forward*,
+not because everything done so far was wrong. If steering threw away
+the research phase output, users would learn to never steer — they'd
+restart from zero instead, which is strictly worse.
+
+Preserving completed tasks also:
+
+- Makes `session.completed_results` a durable record across revisions.
+- Gives the planner's refine prompt concrete context ("here's what
+  you've already produced; incorporate or set aside, don't redo").
+- Keeps `revision_index` meaningful — the run has a continuous history.
+
+**Alternatives considered.**
+
+1. Discard everything on STEER. Rejected: see above. Also degrades
+   event history — replay would show work being done and then
+   ignored.
+2. Let the planner decide per-task. Rejected: leaks the "preserve
+   identity of completed tasks" invariant into every planner
+   implementation. The current contract makes it impossible to violate.
+3. Branching runs: old run stops, new run starts with the outputs as
+   seed data. Rejected: heavyweight, conflicts with `run_id` being a
+   single identifier per `Runner.run()`.
+
+**Tradeoffs.** If the steer is "abandon everything and start over,"
+callers must send a `CANCEL` followed by a fresh `runner.run(...)`
+rather than a `STEER` — because `STEER` always preserves completed
+work.
+
+**Signals this might be wrong.** If users routinely want "STEER that
+also drops completed X", we'd add a `drop_completed_task_ids` payload
+to the STEER message rather than change the default.
+
+**Related.** [VOCABULARY.md §2](VOCABULARY.md#2-controlkind-vs-driftkind--a-worked-example),
+[PROTOCOLS.md §Planner](PROTOCOLS.md#planner).
+
+## Why the Steerer invokes `planner.refine` and not the Executor
+
+**Observation.** The refine call lives in
+`DefaultSteerer._handle_drift`, not in the executor's task loop. The
+executor only observes the resulting `session.plan` change.
+
+**Intent.** Refine is a *reaction to drift*, and drift is the Steerer's
+domain. Keeping refine in the Steerer:
+
+- Makes the drift pipeline uniform: every drift goes through one
+  place, regardless of where it was synthesized (executor-detected
+  failure, reporting-tool call, external STEER).
+- Lets the Steerer be the single authority on "what drift means" —
+  severity threshold, throttling, pre-refine emission of
+  `DriftDetected`.
+- Keeps executors simple: they check `session.plan` at each iteration,
+  which is idempotent and doesn't care how the plan changed.
+
+**Alternatives considered.**
+
+1. Executor calls refine. Rejected: every executor would re-implement
+   the drift handling pipeline, and custom steerer policies (throttle,
+   skip, upgrade severity) would not have one place to live.
+2. Planner self-refines on any drift (no pipeline). Rejected: the
+   gating on severity and the `DriftDetected` emission have to live
+   somewhere; the Steerer is the natural home.
+
+**Tradeoffs.** The Steerer's `_handle_drift` is a bit magical — it
+does four things (emit, gate, refine, apply). A reader has to follow
+that thread. The alternative is to spread those four things across
+three classes, which is worse for local reasoning.
+
+**Signals this might be wrong.** If we grow per-executor refine
+policies (e.g. parallel-specific logic that can't fit in a Steerer),
+we may need to split the responsibility. So far the Steerer has been
+enough.
+
+**Related.** `goldfive/steerer.py::DefaultSteerer._handle_drift`,
+[STATE-MACHINE.md](STATE-MACHINE.md).

--- a/docs/design/STATE-MACHINE.md
+++ b/docs/design/STATE-MACHINE.md
@@ -7,7 +7,12 @@ through `Steerer.transition(task_id, to, *, session)` and emits an
 event to every sink.
 
 Related: [DRIFT.md](DRIFT.md), [PROTOCOLS.md](PROTOCOLS.md#steerer),
-[EVENT-MODEL.md](EVENT-MODEL.md).
+[EVENT-MODEL.md](EVENT-MODEL.md),
+[VOCABULARY.md §4 — TaskStatus state machine](VOCABULARY.md#4-taskstatus-state-machine)
+(enum-value reference, owner-per-transition table, and rationale for
+why BLOCKED is a status rather than a drift kind),
+[RATIONALE.md §"Why `BLOCKED` is a task status rather than a drift
+kind"](RATIONALE.md#why-blocked-is-a-task-status-rather-than-a-drift-kind).
 
 ## States
 

--- a/docs/design/VOCABULARY.md
+++ b/docs/design/VOCABULARY.md
@@ -1,0 +1,550 @@
+# Vocabulary
+
+goldfive's surface looks small — six protocols, four enums, a handful of
+dataclasses — but each name carries a specific, load-bearing meaning
+that is easy to confuse with a neighbour. This document is the exhaustive
+type-system reference. Every enum value, every dataclass field, every
+protocol method that plays a semantic role is enumerated here with its
+purpose, its emitter/consumer, and its bridges to other types.
+
+If you have ever asked any of these questions, this doc is for you:
+
+- "What's the difference between `ControlKind.STEER` and
+  `DriftKind.USER_STEER`?"
+- "Is `BLOCKED` a task status or a drift kind? Both?"
+- "Who fires `PlanRevised` — the Runner, the Executor, or the Steerer?"
+- "Why does `DriftSeverity.WARNING` trigger refine but `INFO` doesn't?"
+
+Related:
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — the six primitives, top-level
+  lifecycle.
+- [PROTOCOLS.md](PROTOCOLS.md) — the protocol contracts in detail.
+- [STATE-MACHINE.md](STATE-MACHINE.md) — the task lifecycle diagram.
+- [DRIFT.md](DRIFT.md) — the drift taxonomy and classifier rules.
+- [EVENT-MODEL.md](EVENT-MODEL.md) — the proto event envelope.
+- [RATIONALE.md](RATIONALE.md) — design-rationale "why" document.
+
+> All enums in this doc are `StrEnum` and live in `goldfive/types.py`
+> (`TaskStatus`, `DriftKind`, `DriftSeverity`) or `goldfive/control.py`
+> (`ControlKind`, `AckResult`). Values match the string literal spellings
+> shown below.
+
+## 1. The four semantic enums
+
+goldfive has four enums that classify run state. They do not overlap,
+but they do *bridge* to one another — a `ControlKind` can become a
+`DriftKind`, a `DriftKind` can induce a `TaskStatus` transition. This
+section tabulates all four side-by-side so the shapes sit next to each
+other.
+
+| Enum | Module | Purpose | Emitted by | Consumed by |
+|---|---|---|---|---|
+| `ControlKind` | `goldfive/control.py` | Verbs an **external controller** (UI, CLI, tests) can issue to a running `Runner`. | External bridge (e.g. `harmonograf_client.observe`, a CLI, a test harness) via `ControlChannel.send(ControlMessage)`. | Executors drain via `ControlChannel.receive()` and dispatch in `goldfive/executors/_control.py::dispatch_control`. |
+| `DriftKind` | `goldfive/types.py` | Taxonomy of **observations that execution has diverged from the plan**. A classification, not a verb. | Steerer (via `classify_*` helpers, reporting-tool handlers, and explicit synthesis on USER_* bridges). Also by executors surfacing task failures. | `DefaultSteerer._handle_drift` decides whether to trigger `planner.refine` based on `DriftKind` + `DriftSeverity`. Sinks receive `DriftDetected` events. |
+| `DriftSeverity` | `goldfive/types.py` | Ordinal urgency of a drift: `INFO`, `WARNING`, `CRITICAL`. | Attached to every `DriftEvent` by whoever synthesizes it. | `DefaultSteerer._handle_drift` gates refine on `severity >= WARNING`; executors may abort on `CRITICAL`. |
+| `TaskStatus` | `goldfive/types.py` | The per-task state machine: `PENDING`, `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`, `BLOCKED`. | Transitions owned by `DefaultSteerer.mark_task_*` methods (called from reporting tools, adapters, or the executor). | Every layer reads `Task.status`; executors filter by it to decide what to dispatch; sinks emit `Task*` events on transitions. |
+
+### Why four enums, not three or five?
+
+- `TaskStatus` describes **one task's place in its lifecycle**. It never
+  describes user intent or drift severity.
+- `DriftKind` describes **the category of a divergence**. It is
+  informational — knowing the kind does not yet dictate an action.
+- `DriftSeverity` is **the orthogonal axis** that turns a kind into a
+  policy decision (refine vs ignore vs abort).
+- `ControlKind` describes **external verbs**. It is the *only* enum
+  whose values are not derived from observing execution — they are
+  injected from outside.
+
+The symmetry: a `ControlKind` (external verb) is often *bridged* into a
+`DriftKind` (internal observation) before it acts on the plan. The
+next section walks one such bridge end-to-end.
+
+<!-- TODO: once docs/design/CONTROL.md lands, add cross-links in §2 and §3. -->
+
+## 2. `ControlKind` vs `DriftKind` — a worked example
+
+The subtlest distinction in goldfive is between the five `ControlKind`
+values and the three `USER_*` `DriftKind` values that mirror some of
+them. This section uses `ControlKind.STEER → DriftKind.USER_STEER` as
+the worked example because it has the richest downstream behavior.
+
+### The cast of characters
+
+- `ControlKind.STEER` — a **verb** the UI issues. "Redirect the run."
+  It is one of five `ControlKind` values (`PAUSE`, `RESUME`, `CANCEL`,
+  `STEER`, `REWIND_TO`). Always carries a payload
+  `{"note": "...", "suggested_action": "..."}`.
+- `DriftKind.USER_STEER` — an **observation** the Steerer emits. "The
+  user has steered the run." It is one of three `USER_*` drift kinds
+  (`USER_STEER`, `USER_CANCEL`, `USER_PAUSE`).
+- `ControlMessage` — the envelope carrying a `ControlKind` + payload +
+  id.
+- `ControlChannel` — the bidirectional async queue pair in
+  `goldfive/control.py`.
+- `DriftEvent` — the in-memory dataclass the Steerer builds; it has
+  `kind: DriftKind`, `severity: DriftSeverity`, `detail`,
+  `current_task_id`, `raw`.
+
+### Flow: click → refine
+
+```
+┌─────────────┐      user clicks "Steer" in harmonograf UI
+│   UI / CLI  │
+└──────┬──────┘
+       │ ControlEvent(kind=STEER, payload={"note": "focus on slide 3"})
+       │
+┌──────▼──────────────────────────────────────────────────────────┐
+│ harmonograf_client.observe bridge (external to goldfive)         │
+│  - translates harmonograf ControlEvent → goldfive ControlMessage │
+│  - ControlMessage(kind=ControlKind.STEER, payload={...},         │
+│                   id="c-7af1...")                                │
+└──────┬──────────────────────────────────────────────────────────┘
+       │ channel.send(msg)
+       │
+┌──────▼──────────┐
+│ ControlChannel  │  inbox queue (asyncio.Queue[ControlMessage])
+└──────┬──────────┘
+       │
+       │ executor drains: channel.receive() → msg
+       │
+┌──────▼─────────────────────────────────────────────────────────┐
+│ goldfive/executors/_control.py::dispatch_control(msg)          │
+│  - kind == "STEER" → ControlOutcome(steer_message=msg,         │
+│                                     ack=ACK/SUCCESS)           │
+│  - channel.ack(outcome.ack) flows back out to the UI           │
+└──────┬─────────────────────────────────────────────────────────┘
+       │ outcome.steer_message
+       │
+┌──────▼─────────────────────────────────────────────────────────┐
+│ executor._apply_steer(msg, steerer, session)                   │
+│  - calls steerer.observe(msg, session)                         │
+└──────┬─────────────────────────────────────────────────────────┘
+       │ steerer.observe sees a ControlMessage with STEER →
+       │ synthesizes DriftEvent(kind=USER_STEER, severity=WARNING,
+       │                        detail="control:STEER:c-7af1...",
+       │                        raw=msg)
+       │
+┌──────▼─────────────────────────────────────────────────────────┐
+│ DefaultSteerer._handle_drift(drift, session)                   │
+│  - emits DriftDetected event on sinks                          │
+│  - severity WARNING ≥ WARNING → calls planner.refine(...)      │
+└──────┬─────────────────────────────────────────────────────────┘
+       │ planner.refine(plan, drift=DriftEvent(USER_STEER), goals)
+       │
+┌──────▼─────────────────────────────────────────────────────────┐
+│ LLMPlanner.refine (or any custom planner)                      │
+│  - For USER_STEER: preserve completed tasks, drop pending      │
+│    tasks, generate a fresh plan that honours drift.detail.     │
+│  - Returns revised Plan.                                       │
+└──────┬─────────────────────────────────────────────────────────┘
+       │ session.plan = revised
+       │
+┌──────▼─────────────────────────────────────────────────────────┐
+│ PlanRevised event emitted; revision_kind=USER_STEER,           │
+│ revision_severity=WARNING, revision_reason=drift.detail        │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### What each boundary does
+
+1. **UI → bridge** — a product-level click becomes a transport-level
+   message. The bridge is the only component that touches both
+   harmonograf's proto schema and goldfive's public API.
+2. **Bridge → ControlChannel** — the bridge picks the right
+   `ControlKind` from the harmonograf verb and wraps the payload. This
+   is the point where `harmonograf.ControlEvent.STEER` *becomes*
+   `ControlKind.STEER`.
+3. **ControlChannel → dispatch_control** — the executor drains, the
+   dispatcher builds a `ControlOutcome`. `STEER` is special: the outcome
+   carries the whole `ControlMessage` so the executor can feed it to
+   the steerer on the next step.
+4. **dispatch → steerer.observe** — this is the **bridge from
+   `ControlKind.STEER` to `DriftKind.USER_STEER`**. The Steerer sees a
+   ControlMessage; it synthesizes a `DriftEvent` with
+   `kind=DriftKind.USER_STEER`. From here on, `STEER` the verb is gone;
+   only `USER_STEER` the observation remains.
+5. **_handle_drift → planner.refine** — the standard drift pipeline
+   takes over. `USER_STEER` is `WARNING` severity, so refine runs.
+6. **planner → revised plan** — for `USER_STEER` specifically, the
+   planner semantics are "delete-and-replan": completed tasks are
+   preserved as context, pending tasks are dropped, a new plan is
+   generated that incorporates the steering note.
+
+### Why `ControlKind` and `DriftKind` don't share values
+
+They describe different things:
+
+- `ControlKind` is an **imperative verb from outside**. It has no
+  severity, no current task, no detail that is meant for an LLM.
+- `DriftKind` is a **categorized observation from inside**. It has
+  severity, current-task context, and a detail string meant for the
+  planner's refine prompt.
+
+The bridge `USER_STEER`/`USER_CANCEL`/`USER_PAUSE` exists because once
+the Steerer has synthesized a `DriftEvent`, the rest of the machinery
+is pipeline-shaped: it only knows how to react to drift. Any external
+verb that wants to trigger replanning has to enter that pipeline, and
+the `USER_*` drift kinds are the canonical entry points.
+
+## 3. All control → drift bridges
+
+Five `ControlKind` values, three `USER_*` `DriftKind` bridges, two
+non-bridging outcomes. Here is the mapping:
+
+| `ControlKind` | Bridges to `DriftKind`? | Severity of resulting drift | Triggers `planner.refine`? | Non-drift effect |
+|---|---|---|---|---|
+| `PAUSE` | `USER_PAUSE` | `INFO` (observational) | No (INFO is below threshold) | Executor sets paused flag; blocks its outer loop on `channel.receive()` until RESUME/CANCEL/STEER arrives. |
+| `RESUME` | — (no drift) | — | — | Clears the paused flag in the executor. |
+| `CANCEL` | `USER_CANCEL` | `CRITICAL` | No (the executor aborts before refine runs) | Executor raises `_ControlCancelled`; emits `RunAborted` with the cancel reason. |
+| `STEER` | `USER_STEER` | `WARNING` | **Yes** — this is the canonical live-replan trigger. | None — the entire effect is via the drift pipeline. |
+| `REWIND_TO` | — (no drift; handled inline) | — | No (reset is structural, not a planner decision) | `_rewind_plan` walks downstream from `payload.task_id` and marks every reachable task `PENDING`; the executor's next iteration re-walks them. |
+
+Two notes on this table:
+
+- **`PAUSE` emits `USER_PAUSE` at `INFO` severity.** That means the
+  drift is visible in the event stream (sinks see a `DriftDetected`),
+  but the default refine policy does not fire. The pause effect comes
+  entirely from the executor's blocking-wait behavior on the next
+  control poll, not from replanning.
+- **`CANCEL` synthesizes `USER_CANCEL` at `CRITICAL` severity, but the
+  executor has already decided to abort by the time the drift would
+  fire refine.** The `USER_CANCEL` drift is produced in
+  `goldfive.events.control_received_event` (used by historical
+  harmonograf bridges for audit trails); the executor's `dispatch_control`
+  short-circuits the cancel path into a `ControlOutcome(cancel_run=True)`
+  without routing through `steerer.observe`. Either path ends in a
+  `RunAborted` event.
+
+### Which bridges go through `steerer.observe` today
+
+Only `STEER` is currently wired so that the Steerer synthesizes the
+drift. `PAUSE` and `CANCEL` have their corresponding `USER_*` drift
+kinds defined so *external* emitters (a bridge, a test, a custom
+adapter) can synthesize them and feed them to `steerer.observe` if they
+want refine to run. In the in-box Phase 1 executor path, pause is a
+blocking wait and cancel is a direct abort.
+
+## 4. `TaskStatus` state machine
+
+Six states, monotonic once terminal. Full transition rules live in
+[STATE-MACHINE.md](STATE-MACHINE.md); this section is the canonical
+enum reference.
+
+| State | String | Terminal? | Meaning |
+|---|---|---|---|
+| `PENDING` | `"PENDING"` | no | Task exists in the plan, has not been started. Default on every new task in a fresh plan. |
+| `RUNNING` | `"RUNNING"` | no | Executor has dispatched `adapter.invoke(task, session)`. Agent is working. |
+| `COMPLETED` | `"COMPLETED"` | **yes** | Terminal success. Output is in `session.completed_results[task_id]`. Reached via `report_task_completed` or the executor's default-complete path. |
+| `FAILED` | `"FAILED"` | **yes** | Terminal failure. Reached via `report_task_failed`, adapter exception, or executor-driven failure. |
+| `CANCELLED` | `"CANCELLED"` | **yes** | Terminal. Reached via executor cancellation cascade or `report_task_cancelled`. |
+| `BLOCKED` | `"BLOCKED"` | no | External condition prevents progress. Task can return to `RUNNING` if the planner resolves the blocker, or convert to `FAILED`/`CANCELLED`. |
+
+### State diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING : task added to plan
+
+    PENDING --> RUNNING : executor invokes adapter / mark_task_running
+    PENDING --> CANCELLED : upstream cascade / REWIND_TO downstream
+
+    RUNNING --> RUNNING : mark_task_progress (no transition)
+    RUNNING --> COMPLETED : mark_task_completed
+    RUNNING --> FAILED : mark_task_failed / adapter exception
+    RUNNING --> BLOCKED : mark_task_blocked (structural)
+    RUNNING --> CANCELLED : mark_task_cancelled / executor cancel
+
+    BLOCKED --> RUNNING : blocker resolved via refine
+    BLOCKED --> CANCELLED : refine declines resume
+    BLOCKED --> FAILED : refine converts to failure
+
+    COMPLETED --> [*]
+    FAILED --> [*]
+    CANCELLED --> [*]
+```
+
+### Who owns each transition
+
+| Transition | Owner | Entry point |
+|---|---|---|
+| `PENDING → RUNNING` | Steerer | `DefaultSteerer.mark_task_running` (called by executor on task dispatch or by a reporting tool handler) |
+| `RUNNING → RUNNING` (progress) | Steerer | `DefaultSteerer.mark_task_progress` (reporting tool) |
+| `RUNNING → COMPLETED` | Steerer | `DefaultSteerer.mark_task_completed` (reporting tool) |
+| `RUNNING → FAILED` | Steerer | `DefaultSteerer.mark_task_failed` (reporting tool, or executor on adapter exception) |
+| `RUNNING → BLOCKED` | Steerer | `DefaultSteerer.mark_task_blocked` (reporting tool) |
+| `RUNNING → CANCELLED` | Steerer | `DefaultSteerer.mark_task_cancelled` (executor on cascade or control CANCEL) |
+| `PENDING → CANCELLED` | Steerer | `DefaultSteerer.mark_task_cancelled` (executor on cascade) |
+| `BLOCKED → RUNNING` | Steerer | `DefaultSteerer.mark_task_running` after planner refinement |
+
+All six transitions share two properties:
+
+1. **They emit exactly one event per successful transition.** The event
+   kinds are listed in the table below.
+2. **They are idempotent on terminal states.** Attempting to transition
+   out of `COMPLETED`/`FAILED`/`CANCELLED` is a silent no-op.
+
+### Transition → event table
+
+| Transition | Emitted event |
+|---|---|
+| `PENDING → RUNNING` | `TaskStarted` |
+| `RUNNING → RUNNING` (progress ping) | `TaskProgress` |
+| `RUNNING → COMPLETED` | `TaskCompleted` |
+| `RUNNING → FAILED` | `TaskFailed` |
+| `RUNNING → BLOCKED` | `TaskBlocked` |
+| `* → CANCELLED` | `TaskCancelled` |
+
+### Why `BLOCKED` is a status, not just a drift kind
+
+There is both `TaskStatus.BLOCKED` and `DriftKind.BLOCKED`. They are
+not duplicates — they are two ends of one semantic.
+
+- `TaskStatus.BLOCKED` says "this task is waiting on something external
+  and cannot make forward progress right now." It is a **position in
+  the lifecycle** — the task is still alive and may resume. It does not
+  imply any replanning intent.
+- `DriftKind.BLOCKED` says "we have observed that a task became
+  blocked, and the plan may need to adapt." It is an **observation
+  about that transition** and flows through the refine pipeline.
+
+When a reporting tool calls `report_task_blocked(t, blocker, needed)`,
+`DefaultSteerer.mark_task_blocked` does *both* things: it transitions
+the task to `TaskStatus.BLOCKED` (emitting `TaskBlocked`) *and*
+synthesizes a `DriftEvent(kind=DriftKind.BLOCKED, severity=WARNING)`
+which flows into `_handle_drift`. Refine may then revise the plan to
+route around the blocker. If refine declines (returns `None`), the
+blocked task sits in `BLOCKED` until something else — another refine,
+a `REWIND_TO` control, or a cascade cancel — moves it.
+
+Contrast this with, say, `CONTEXT_PRESSURE` drift: there is no
+corresponding `TaskStatus.CONTEXT_PRESSED`. Why? Because context
+pressure is **about a single invocation**, not about the task as a
+whole. The task is still `RUNNING`; what the drift tells us is "that
+run truncated, consider a refine that splits the task smaller or
+re-orders context." The status axis and the drift axis are orthogonal
+and should stay that way.
+
+See [RATIONALE.md §"Why `BLOCKED` is a task status rather than a drift
+kind"](RATIONALE.md#why-blocked-is-a-task-status-rather-than-a-drift-kind)
+for the long-form rationale.
+
+## 5. `DriftKind` taxonomy
+
+26 values total (25 named kinds + `CUSTOM`). Every value is defined in
+`goldfive/types.py::DriftKind`; enum values are the lower-snake-case
+strings on the right of the `=` in that file. Grouped here by what
+*triggers* them.
+
+### 5.a Model-driven — the LLM itself signalled something
+
+Kinds synthesized from signals coming out of the model or adapter layer.
+
+| `DriftKind` | Value | Default severity | Trigger |
+|---|---|---|---|
+| `TOOL_ERROR` | `"tool_error"` | `WARNING` | `classify_tool_error(event)` matched a tool-result shape with a truthy error / `status=FAILED`/`ok=False`. |
+| `AGENT_REFUSAL` | `"agent_refusal"` | `WARNING` | `classify_refusal(text)` found an `LLM_REFUSAL_MARKERS` substring ("I cannot", "I refuse", ...). |
+| `MODEL_REFUSAL` | `"model_refusal"` | `CRITICAL` | Adapter-specific hard refusal path (safety-filter style). Not classified by default; adapters synthesize directly. |
+| `HALLUCINATION_SUSPECTED` | `"hallucination_suspected"` | `WARNING` | Output references entities the session never produced. Caller-supplied heuristic; no default classifier. |
+| `STOPPED_EARLY` | `"stopped_early"` | `WARNING` | Agent emitted nothing before exiting its turn. Adapter-detected. |
+| `UNEXPECTED_OUTPUT` | `"unexpected_output"` | `WARNING` | Output failed a caller-supplied schema / heuristic. |
+| `SCHEMA_VIOLATION` | `"schema_violation"` | `WARNING` | Structured-output validation failed. |
+| `SAFETY_CONCERN` | `"safety_concern"` | `CRITICAL` | Safety-filter trigger observed by the adapter. |
+
+### 5.b Plan-driven — the plan is wrong or incomplete
+
+Kinds that mean "the plan, as written, is not the right plan for this
+run."
+
+| `DriftKind` | Value | Default severity | Trigger |
+|---|---|---|---|
+| `PLAN_DIVERGENCE` | `"plan_divergence"` | `WARNING` | Reporting tool `report_plan_divergence(note, suggested_action)` called. Flags `session.divergence_flag`. |
+| `NEW_WORK_DISCOVERED` | `"new_work_discovered"` | `WARNING` | Reporting tool `report_new_work_discovered(parent_task_id, title, description, assignee)` called. |
+| `GOAL_UNREACHABLE` | `"goal_unreachable"` | `CRITICAL` | Planner returned `None` from `refine`; the plan cannot be revised to reach the goal. |
+| `AMBIGUOUS_INTENT` | `"ambiguous_intent"` | `WARNING` | Multiple plausible goal interpretations; needs user clarification. Typically synthesized at plan-generation time. |
+
+### 5.c Runtime — the environment limited progress
+
+Kinds that mean "progress stalled or failed due to limits on the runtime
+rather than a reasoning error."
+
+| `DriftKind` | Value | Default severity | Trigger |
+|---|---|---|---|
+| `CONTEXT_PRESSURE` | `"context_pressure"` | `WARNING` | `classify_stop_reason` matched a `CONTEXT_PRESSURE_STOP_REASONS` value (`MAX_TOKENS`, `LENGTH`, `TRUNCATED`, `CONTENT_FILTER`, `MAX_OUTPUT_TOKENS`). |
+| `TOO_MANY_STEPS` | `"too_many_steps"` | `WARNING` | Adapter observed an unreasonable step count in a single invocation. Adapter-synthesized. |
+| `TASK_TIMEOUT` | `"task_timeout"` | `WARNING` | Task exceeded its predicted duration by a large factor. |
+| `REPEATED_FAILURE` | `"repeated_failure"` | `CRITICAL` | Same task has now failed `>= N` times in one run. |
+| `RESOURCE_EXHAUSTED` | `"resource_exhausted"` | `WARNING` | Rate-limit or quota exhaustion observed by the adapter. |
+| `TASK_FAILED_RECOVERABLE` | `"task_failed_recoverable"` | `WARNING` | `mark_task_failed(..., recoverable=True)` (default). |
+| `TASK_FAILED_FATAL` | `"task_failed_fatal"` | `CRITICAL` | `mark_task_failed(..., recoverable=False)`. |
+| `BLOCKED` | `"blocked"` | `WARNING` | `mark_task_blocked(task_id, blocker, needed)` — both a `TaskBlocked` event and a drift. |
+
+### 5.d User-driven — an external verb entered the pipeline
+
+Kinds that mirror `ControlKind` verbs after the bridge. See §3 above for
+the full bridge table.
+
+| `DriftKind` | Value | Default severity | Bridges from |
+|---|---|---|---|
+| `USER_STEER` | `"user_steer"` | `WARNING` | `ControlKind.STEER` (via `steerer.observe(ControlMessage)`). |
+| `USER_CANCEL` | `"user_cancel"` | `CRITICAL` | `ControlKind.CANCEL` (synthesized in `control_received_event` for audit; executor short-circuits to `RunAborted`). |
+| `USER_PAUSE` | `"user_pause"` | `INFO` | `ControlKind.PAUSE` (synthesized for audit; executor blocks on next poll). |
+
+### 5.e Transfer — the wrong agent picked something up
+
+Kinds about who is doing the work.
+
+| `DriftKind` | Value | Default severity | Trigger |
+|---|---|---|---|
+| `WRONG_AGENT` | `"wrong_agent"` | `WARNING` | A reporting tool call arrived from an agent that is not `task.assignee_agent_id`. Typically paired with `AGENT_TRANSFER`. |
+| `AGENT_TRANSFER` | `"agent_transfer"` | `INFO` when planned; `WARNING` when unplanned | Adapter observed a transfer/delegation event. |
+| `INTERCEPT_TRANSFER` | — (not an enum value; handled via `session._intercept_transfer` flag in `_control.py`) | — | `ControlKind.INTERCEPT_TRANSFER` message toggles the flag; adapters that honour it refuse subsequent transfers. |
+
+`INTERCEPT_TRANSFER` is listed here for completeness even though it is
+not currently in the `DriftKind` enum. It is recognized as a control
+kind-by-string (see `_control.py::dispatch_control`) and its effect is
+session-state mutation, not drift synthesis.
+
+### 5.f Escape hatch
+
+| `DriftKind` | Value | Default severity | Trigger |
+|---|---|---|---|
+| `CUSTOM` | `"custom"` | caller's choice | Caller-supplied drift kind. Used by `emit_status_report` for `STATUS_QUERY` audit events (severity `INFO`). Prefer a named kind when one fits. |
+
+### Count check
+
+Categories: 8 (model-driven) + 4 (plan-driven) + 8 (runtime) + 3
+(user-driven) + 2 (transfer, excluding the non-enum `INTERCEPT_TRANSFER`)
++ 1 (custom) = 26 enum values. This matches the 26 members of
+`DriftKind` in `goldfive/types.py`.
+
+## 6. Event payload kinds
+
+Every event on every sink is a proto `Event` envelope (see
+[EVENT-MODEL.md](EVENT-MODEL.md) for the envelope spec). The payload
+is a `oneof` with thirteen variants. This section lists all thirteen
+and who emits each. Factories for every kind live in `goldfive/events.py`.
+
+| Payload `oneof` variant | Factory | Emitter | When |
+|---|---|---|---|
+| `run_started` | `run_started_event` | **Runner** | First event of every run; before goal derivation. |
+| `goal_derived` | `goal_derived_event` | **Runner** | After `goal_deriver.derive` returns (or the caller's `list[Goal]` is accepted). |
+| `plan_submitted` | `plan_submitted_event` | **Runner** | After `planner.generate` returns a non-None `Plan`. |
+| `plan_revised` | `plan_revised_event` | **Steerer** (from `_handle_drift`, after a successful `planner.refine`) | After each successful refine. Carries `revision_kind`, `revision_severity`, `reason`, `revision_index`. |
+| `task_started` | `task_started_event` | **Steerer** | `mark_task_running` — `PENDING → RUNNING`. |
+| `task_progress` | `task_progress_event` | **Steerer** | `mark_task_progress` — no transition, just a liveness ping. |
+| `task_completed` | `task_completed_event` | **Steerer** | `mark_task_completed` — `RUNNING → COMPLETED`. |
+| `task_failed` | `task_failed_event` | **Steerer** | `mark_task_failed` — `RUNNING → FAILED`. |
+| `task_blocked` | `task_blocked_event` | **Steerer** | `mark_task_blocked` — `RUNNING → BLOCKED`. |
+| `task_cancelled` | `task_cancelled_event` | **Steerer** | `mark_task_cancelled` — `* → CANCELLED`. |
+| `drift_detected` | `drift_detected_event` | **Steerer** | Every successful `_handle_drift` call. Also used by `control_received_event` and `emit_status_report`. |
+| `run_completed` | `run_completed_event` | **Executor** | Terminal success — all tasks reached a terminal state with the plan fully realized. |
+| `run_aborted` | `run_aborted_event` | **Runner** *or* **Executor** | Runner emits on setup failure (pre-executor). Executor emits on reinvocation cap, cancel, or unrecoverable drift. |
+
+### Who each sink cares about
+
+| Sink | Typical consumption |
+|---|---|
+| `InMemorySink` | Everything; test assertions on `sink.events`. |
+| `LoggingSink` | Everything at `INFO`; useful for dev tail. |
+| `JSONLPersistenceSink` | Everything; round-trips through sequence for replay. |
+| `SQLitePersistenceSink` | Everything; enables cross-run SQL queries keyed by `(run_id, sequence)`. |
+| `GRPCSink` | Everything; streams to out-of-process observers. Requires proto `DESCRIPTOR` on the event (will skip dict envelopes from `make_event`). |
+| Custom UI sinks (harmonograf, dashboards) | Often filter: `run_*` for run-bar state, `task_*` for per-task cards, `drift_detected`/`plan_revised` for highlight badges, `goal_derived`/`plan_submitted` for structural updates. |
+
+### Event → sink invariants
+
+- Every successful `Steerer.mark_task_*` emits **exactly one** task
+  event. Rejected transitions (terminal-state absorbing) emit nothing.
+- Every `_handle_drift` call emits **exactly one** `drift_detected`
+  event and, if refine succeeds, a subsequent `plan_revised`.
+- `sequence` is monotonic per run (`Session.next_sequence()`), so sinks
+  can rely on ordering.
+- A sink raising from `emit()` is logged but does not stop the run.
+
+## 7. Severity ladder
+
+`DriftSeverity` is a three-level `StrEnum`:
+
+```python
+# pseudo-code: mirrors the live enum in ``goldfive/types.py``.
+class DriftSeverity(StrEnum):
+    INFO = "info"
+    WARNING = "warning"
+    CRITICAL = "critical"
+```
+
+Ordinal ranks come from `_SEVERITY_RANK` in the same module:
+
+| Severity | Rank |
+|---|---|
+| `INFO` | 0 |
+| `WARNING` | 1 |
+| `CRITICAL` | 2 |
+
+### Semantics
+
+- **`INFO`** — observation-only. Something happened that operators may
+  want to see, but no automatic action is taken. Examples: planned
+  `AGENT_TRANSFER`, `USER_PAUSE`, `CUSTOM`-kind status queries.
+- **`WARNING`** — the plan should adapt. `_handle_drift` triggers
+  `planner.refine` on any `WARNING`-or-above drift. Examples:
+  `TOOL_ERROR`, `PLAN_DIVERGENCE`, `USER_STEER`,
+  `TASK_FAILED_RECOVERABLE`, `CONTEXT_PRESSURE`.
+- **`CRITICAL`** — the run cannot continue or can only continue after a
+  full rethink. The Steerer still runs `planner.refine`, but if the
+  planner returns `None`, the executor's expectation is to abort with
+  `RunAborted`. Examples: `TASK_FAILED_FATAL`, `GOAL_UNREACHABLE`,
+  `USER_CANCEL`, `MODEL_REFUSAL`, `SAFETY_CONCERN`, `REPEATED_FAILURE`.
+
+### The refine threshold
+
+One comparison in `DefaultSteerer._handle_drift` drives the whole
+policy:
+
+```python
+# goldfive/steerer.py — actual code
+if not _severity_ge(drift.severity, DriftSeverity.WARNING):
+    return
+```
+
+Anything below `WARNING` (i.e. `INFO`) does not call `refine`. Anything
+at or above `WARNING` does. `CRITICAL` does not have its own threshold;
+it rides the same comparison, and its "critical-ness" is expressed in
+what the planner and executor do *after* refine:
+
+- Planner may refuse to refine (`return None`) on `CRITICAL` — e.g.
+  `GOAL_UNREACHABLE`.
+- Executor may emit `RunAborted` on `CRITICAL` drift when the
+  planner also declines.
+
+### Comparing severities
+
+`goldfive/types.py::severity_rank(sev)` returns the numeric rank.
+`_SEVERITY_ORDER` in `steerer.py` does the same. Callers never need to
+compare string values directly — use the helpers.
+
+## Cross-references by enum
+
+### If you came here looking for…
+
+- **"Where does this enum value get emitted?"** — every value appears
+  in the tables in §4, §5, §6.
+- **"What's the difference between `STEER` and `USER_STEER`?"** — §2.
+- **"Can a task be both `BLOCKED` and have a `BLOCKED` drift?"** — yes,
+  §4 and §5.c explain why both exist.
+- **"Who fires `PlanRevised`?"** — Steerer (§6 table).
+- **"Why is there no `TaskStatus.BLOCKED → COMPLETED` transition?"** —
+  see [STATE-MACHINE.md](STATE-MACHINE.md); blocked tasks always return
+  to `RUNNING` first.
+
+### Cross-references out
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) for how the primitives compose.
+- [PROTOCOLS.md](PROTOCOLS.md) for the exact async signatures.
+- [STATE-MACHINE.md](STATE-MACHINE.md) for the task lifecycle rules.
+- [DRIFT.md](DRIFT.md) for the classification flow.
+- [EVENT-MODEL.md](EVENT-MODEL.md) for the envelope spec.
+- [RATIONALE.md](RATIONALE.md) for why each of these shapes is the way
+  it is.


### PR DESCRIPTION
## Summary

Adds two new design docs that explain goldfive's type-system and design rationale in depth, and cross-links them from existing docs.

- **`docs/design/VOCABULARY.md`** (550 lines) — exhaustive type reference: all four enums side-by-side, the `ControlKind.STEER → DriftKind.USER_STEER` worked example with ASCII flow diagram, the complete control→drift bridge table, `TaskStatus` state machine with per-transition ownership, all 26 `DriftKind` values grouped by trigger, every proto `Event` payload variant with its emitter, and the severity ladder.
- **`docs/design/RATIONALE.md`** (807 lines) — design-rationale entries for 19 topics (Goal first-class, Plan vs Session split, GoalDeriver vs Planner, Runner vs Executor, Executor / Steerer / AgentAdapter as protocols, EventSink proto shape, ControlChannel primitive, STEER delete-and-replan, wrap ergonomics, harmonograf layering, severity 3-level enum, make_event coexistence, max_plan_reinvocations budget, BLOCKED dual-role, Phase 1 mid-task cancel, completed-task preservation, Steerer-owned refine). Each entry follows the `Observation / Intent / Alternatives / Tradeoffs / Signals` template.

Cross-links added in:
- `docs/design/ARCHITECTURE.md` — new **Layering** section separating goldfive (orchestration) from harmonograf (observability); reading-order list updated.
- `docs/design/DRIFT.md` — Related header points to VOCABULARY.md §5 (taxonomy).
- `docs/design/STATE-MACHINE.md` — Related header points to VOCABULARY.md §4 (TaskStatus).
- `docs/design/PROTOCOLS.md` — Related header + per-protocol pointers (Executor, Steerer, AgentAdapter, EventSink) to RATIONALE entries.
- `docs/design/EVENT-MODEL.md` — Related header points to VOCABULARY.md §6.
- `README.md` — new "Further reading" section.
- `.agents/debug-goldfive.md` — new "Consulting VOCABULARY to diagnose" section with symptom → section table.

`docs/design/CONTROL.md` is being written by a sibling agent in parallel; cross-links to it are deferred with inline TODOs.

## Test plan

- [x] Every symbol cited (`ControlKind`, `DriftKind`, `DriftSeverity`, `TaskStatus`, the six protocols, `Runner`, `wrap`, `run`, classifiers, all sinks, etc.) verified present in `goldfive.__all__`.
- [x] Enum member counts verified against runtime: `DriftKind` = 26, `DriftSeverity` = 3, `TaskStatus` = 6, `ControlKind` = 5, `AckResult` = 3.
- [x] `uv run pytest -q` — 306 passed, 33 skipped, 0 failed.
- [x] Docs-only change; no Python sources touched.
