### PR TITLE
Steerer + Planner USER_STEER delete-and-replan (part of #71)

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -30,11 +30,19 @@ from typing import Any
 
 from goldfive.types import (
     DriftEvent,
+    DriftKind,
+    DriftSeverity,
     Goal,
     Plan,
     Task,
     TaskEdge,
     TaskStatus,
+)
+
+# Task statuses that are "done" from a steering perspective — they are
+# preserved verbatim across a USER_STEER delete-and-replan.
+_TERMINAL_STATUSES: frozenset[TaskStatus] = frozenset(
+    {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED}
 )
 
 log = logging.getLogger("goldfive.planner")
@@ -100,6 +108,59 @@ markdown fences. Schema:
   "edges": [
     {"from_task_id": "research", "to_task_id": "draft"}
   ]
+}
+"""
+
+
+_USER_STEER_SYSTEM_PROMPT = """\
+You are a task-planning assistant for a multi-agent system. A human
+operator has just issued a STEERING directive against an in-flight
+plan: they want the remaining work reshaped to incorporate their note,
+while the work that has already finished must be preserved verbatim
+for auditability.
+
+You will receive:
+
+* The set of GOALS the plan is trying to satisfy.
+* A list of COMPLETED / FAILED / CANCELLED tasks (status history) —
+  these are shown to you purely as CONTEXT so you understand what has
+  already happened. You MUST NOT remove them, renumber them, or alter
+  their ids / titles / assignees / statuses. They belong verbatim at
+  the start of the returned plan's task list.
+* The operator's STEERING NOTE describing the change in direction.
+
+Your job is to produce the REMAINING work (fresh PENDING tasks) that
+satisfies the goals in light of the steering note. Existing pending
+tasks should be treated as DELETED — the operator's steer overrides
+whatever was pending. Design the new tasks from the ground up.
+
+Requirements:
+
+1. DO NOT repeat the completed tasks in your response. The caller
+   will prepend them to your task list. Respond only with the NEW
+   PENDING tasks and their edges.
+2. Any edge whose ``from_task_id`` is one of the completed tasks is
+   allowed — the caller will preserve those and wire them through.
+3. Stable ids: new task ids must be short, unique, and must not
+   collide with any completed-task id.
+4. GOAL COVERAGE: every unsatisfied goal must still be addressed.
+5. Honour the steering note: if it says "skip review", don't add a
+   review task; if it says "focus on X", center the remaining work
+   on X.
+
+Respond with a single JSON object and NOTHING ELSE:
+
+{
+  "summary": "...",
+  "tasks": [
+    {
+      "id": "...",
+      "title": "...",
+      "description": "...",
+      "assignee_agent_id": "..."
+    }
+  ],
+  "edges": [{"from_task_id": "...", "to_task_id": "..."}]
 }
 """
 
@@ -383,11 +444,15 @@ class LLMPlanner:
         model: str = "",
         system_prompt: str | None = None,
         refine_system_prompt: str | None = None,
+        user_steer_system_prompt: str | None = None,
     ) -> None:
         self._call_llm = call_llm
         self._model = model
         self._system_prompt = system_prompt or _DEFAULT_SYSTEM_PROMPT
         self._refine_system_prompt = refine_system_prompt or _REFINE_SYSTEM_PROMPT
+        self._user_steer_system_prompt = (
+            user_steer_system_prompt or _USER_STEER_SYSTEM_PROMPT
+        )
 
     @property
     def model(self) -> str:
@@ -431,6 +496,43 @@ class LLMPlanner:
             f"Goals:\n{goals_block}\n"
             f"{context_block}\n"
             "Respond with a single JSON object following the schema."
+        )
+
+    def _build_user_steer_prompt(
+        self,
+        completed: list[Task],
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> str:
+        """Build the delete-and-replan user prompt for a USER_STEER drift.
+
+        Completed tasks are shown as read-only context; the LLM is told
+        to produce only the remaining pending work in light of the
+        steering note. The caller prepends the completed tasks back onto
+        the returned plan so lineage is preserved verbatim.
+        """
+        history = [
+            {
+                "id": t.id,
+                "title": t.title,
+                "description": t.description,
+                "assignee_agent_id": t.assignee_agent_id,
+                "status": str(t.status),
+            }
+            for t in completed
+        ]
+        history_json = json.dumps(history, default=str)
+        goals_block = self._render_goals_block(goals)
+        note = drift.detail or "(no steering note provided)"
+        return (
+            f"Goals:\n{goals_block}\n\n"
+            f"Completed/Failed/Cancelled tasks (READ-ONLY CONTEXT — "
+            "preserve these verbatim at the start of the returned plan; "
+            f"do NOT repeat them in your response):\n{history_json}\n\n"
+            f"Operator steering note:\n{note}\n\n"
+            "Generate only the NEW PENDING tasks (and their edges) that "
+            "should run from here, taking the steering note into account. "
+            "Respond with JSON only."
         )
 
     def _build_refine_prompt(
@@ -530,6 +632,8 @@ class LLMPlanner:
     ) -> Plan | None:
         if plan is None:
             return None
+        if drift.kind is DriftKind.USER_STEER:
+            return await self._refine_user_steer(plan, drift, goals)
         try:
             user_prompt = self._build_refine_prompt(plan, drift, goals)
         except (TypeError, ValueError) as exc:
@@ -564,6 +668,106 @@ class LLMPlanner:
         revised.revision_severity = str(drift.severity)
         revised.revision_index = plan.revision_index + 1
         return revised
+
+    async def _refine_user_steer(
+        self,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        """Delete-and-replan path for ``USER_STEER`` drift.
+
+        Completed/failed/cancelled tasks are preserved verbatim (same
+        ids, titles, assignees, statuses). Pending/running/blocked
+        tasks are dropped; the LLM produces a fresh set of PENDING
+        tasks that honour the operator's steering note. The returned
+        plan reuses ``plan.id`` and ``plan.run_id`` so lineage stays
+        intact.
+        """
+        completed = [t for t in plan.tasks if t.status in _TERMINAL_STATUSES]
+        completed_ids = {t.id for t in completed}
+        try:
+            user_prompt = self._build_user_steer_prompt(completed, drift, goals)
+        except (TypeError, ValueError) as exc:
+            log.warning(
+                "LLMPlanner._refine_user_steer: failed to serialise inputs (%s)",
+                exc,
+            )
+            return None
+        try:
+            raw = await self._call_llm(
+                self._user_steer_system_prompt, user_prompt, self._model
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning("LLMPlanner._refine_user_steer: call_llm raised %s", exc)
+            return None
+        if not raw or not isinstance(raw, str):
+            log.warning(
+                "LLMPlanner._refine_user_steer: empty/non-string LLM response"
+            )
+            return None
+        cleaned = _strip_code_fences(raw).strip()
+        try:
+            parsed = json.loads(cleaned)
+        except (ValueError, TypeError) as exc:
+            log.warning(
+                "LLMPlanner._refine_user_steer: failed to parse LLM output "
+                "as JSON (%s)",
+                exc,
+            )
+            return None
+        fresh = _plan_from_json(
+            parsed,
+            run_id=plan.run_id,
+            goal_ids=[g.id for g in goals if g.id] or list(plan.goal_ids),
+            plan_id=plan.id,
+        )
+        if fresh is None:
+            log.warning(
+                "LLMPlanner._refine_user_steer: parsed JSON did not contain "
+                "a usable plan"
+            )
+            return None
+
+        # Prepend completed tasks verbatim; drop any new task whose id
+        # collides with a completed id so lineage ids stay stable.
+        new_pending = [t for t in fresh.tasks if t.id not in completed_ids]
+        merged_tasks = list(completed) + new_pending
+        # Edges: keep original edges that are still fully satisfiable
+        # (both endpoints either completed or new-pending), plus every
+        # new edge from the LLM.
+        known_ids = completed_ids | {t.id for t in new_pending}
+        preserved_edges = [
+            TaskEdge(from_task_id=e.from_task_id, to_task_id=e.to_task_id)
+            for e in plan.edges
+            if e.from_task_id in known_ids and e.to_task_id in known_ids
+        ]
+        new_edges = [
+            TaskEdge(from_task_id=e.from_task_id, to_task_id=e.to_task_id)
+            for e in fresh.edges
+        ]
+        # Deduplicate (same from/to pair) while preserving order.
+        seen: set[tuple[str, str]] = set()
+        merged_edges: list[TaskEdge] = []
+        for e in preserved_edges + new_edges:
+            key = (e.from_task_id, e.to_task_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            merged_edges.append(e)
+
+        return Plan(
+            id=plan.id,
+            run_id=plan.run_id,
+            goal_ids=list(fresh.goal_ids) or list(plan.goal_ids),
+            tasks=merged_tasks,
+            edges=merged_edges,
+            summary=fresh.summary or plan.summary,
+            revision_reason=f"user steering: {drift.detail}",
+            revision_kind=DriftKind.USER_STEER.value,
+            revision_severity=DriftSeverity.WARNING.value,
+            revision_index=plan.revision_index + 1,
+        )
 
 
 __all__ = [

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -300,14 +300,59 @@ class DefaultSteerer:
     async def observe(self, event: Any, session: Session) -> None:
         """Inspect ``event``, classify drift, and refine if severe enough.
 
-        Never raises on a normal event — a detector returning ``None``
-        simply means "nothing to report". Only explicit classifier
-        mis-behaviour would surface here, and we let that propagate.
+        ``ControlMessage`` values are handled first — they carry explicit
+        user intent (STEER / CANCEL / PAUSE) and map directly to the
+        corresponding ``USER_*`` drift kinds without going through the
+        heuristic classifiers. Every other event falls through to
+        :meth:`detect_drift`.
         """
-        drift = self.detect_drift(event, session)
+        drift = self._drift_from_control(event, session)
+        if drift is None:
+            drift = self.detect_drift(event, session)
         if drift is None:
             return
         await self._handle_drift(drift, session)
+
+    @staticmethod
+    def _drift_from_control(event: Any, session: Session) -> DriftEvent | None:
+        """Map a :class:`ControlMessage` to the matching ``USER_*`` drift.
+
+        Returns ``None`` for anything that is not a ``ControlMessage`` so
+        the caller can fall through to the classifier pipeline. Unknown
+        control kinds return ``None`` as well — they are dispatched by
+        the executor, not the steerer.
+        """
+        from goldfive.control import ControlKind, ControlMessage
+
+        if not isinstance(event, ControlMessage):
+            return None
+        raw_kind = getattr(event, "kind", None)
+        kind_str = str(getattr(raw_kind, "value", raw_kind) or "").upper()
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        note = str(payload.get("note", "") or "")
+        reason = str(payload.get("reason", "") or "")
+        if kind_str == ControlKind.STEER.value:
+            return DriftEvent(
+                kind=DriftKind.USER_STEER,
+                severity=DriftSeverity.WARNING,
+                detail=note,
+                current_task_id=session.current_task_id,
+            )
+        if kind_str == ControlKind.CANCEL.value:
+            return DriftEvent(
+                kind=DriftKind.USER_CANCEL,
+                severity=DriftSeverity.CRITICAL,
+                detail=reason,
+                current_task_id=session.current_task_id,
+            )
+        if kind_str == ControlKind.PAUSE.value:
+            return DriftEvent(
+                kind=DriftKind.USER_PAUSE,
+                severity=DriftSeverity.INFO,
+                detail=note,
+                current_task_id=session.current_task_id,
+            )
+        return None
 
     def detect_drift(
         self,

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -1,0 +1,395 @@
+"""Tests for USER_STEER / USER_CANCEL / USER_PAUSE handling (part of #71).
+
+Covers:
+
+* :class:`DefaultSteerer.observe` translating ``ControlMessage`` values
+  into the matching ``USER_*`` drift and invoking ``planner.refine``
+  (or not, for ``PAUSE``).
+* :class:`LLMPlanner.refine` on a ``USER_STEER`` drift taking the
+  delete-and-replan path: completed tasks are preserved verbatim, the
+  LLM produces fresh pending work, and revision metadata is stamped
+  with ``revision_kind == "user_steer"``.
+* ``CANCEL`` producing a CRITICAL-severity drift.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.control import ControlKind, ControlMessage  # noqa: E402
+from goldfive.planner import LLMPlanner  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+        self.closed = False
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class RecordingPlanner:
+    """Planner stub that records ``refine`` calls and returns a fixed plan."""
+
+    def __init__(self, *, revised: Plan | None = None) -> None:
+        self.revised = revised
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Any | None = None,
+    ) -> Plan | None:
+        return None
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        self.refine_calls.append({"plan": plan, "drift": drift, "goals": goals})
+        return self.revised
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.COMPLETED),
+            Task(id="t2", title="T2", status=TaskStatus.RUNNING),
+            Task(id="t3", title="T3", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge(from_task_id="t1", to_task_id="t2"),
+            TaskEdge(from_task_id="t2", to_task_id="t3"),
+        ],
+    )
+
+
+def _make_session(plan: Plan | None = None) -> Session:
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="ship the thing")],
+        plan=plan if plan is not None else _make_plan(),
+        current_task_id="t2",
+    )
+
+
+def _bind_fresh() -> tuple[DefaultSteerer, Session, ListSink, RecordingPlanner]:
+    steerer = DefaultSteerer()
+    session = _make_session()
+    sink = ListSink()
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.COMPLETED),
+            Task(id="t2b", title="Replanned T2"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2b")],
+        revision_kind=DriftKind.USER_STEER.value,
+        revision_severity=DriftSeverity.WARNING.value,
+        revision_index=1,
+    )
+    planner = RecordingPlanner(revised=revised)
+    steerer.bind(sinks=[sink], planner=planner)
+    return steerer, session, sink, planner
+
+
+# ---------------------------------------------------------------------------
+# DefaultSteerer.observe — ControlMessage handling
+# ---------------------------------------------------------------------------
+
+
+async def test_observe_steer_triggers_user_steer_drift_and_refine() -> None:
+    steerer, session, sink, planner = _bind_fresh()
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        payload={"note": "focus on clarity"},
+    )
+
+    await steerer.observe(msg, session)
+
+    # Planner.refine was called with a USER_STEER drift carrying the note.
+    assert len(planner.refine_calls) == 1
+    drift: DriftEvent = planner.refine_calls[0]["drift"]
+    assert drift.kind is DriftKind.USER_STEER
+    assert drift.severity is DriftSeverity.WARNING
+    assert drift.detail == "focus on clarity"
+    assert drift.current_task_id == "t2"
+
+    # The revised plan was installed on the session.
+    assert session.plan is not None
+    assert [t.id for t in session.plan.tasks] == ["t1", "t2b"]
+
+    # DriftDetected + PlanRevised events were emitted.
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert "drift_detected" in kinds
+    assert "plan_revised" in kinds
+
+
+async def test_observe_cancel_triggers_critical_user_cancel_drift() -> None:
+    steerer, session, sink, planner = _bind_fresh()
+    # CANCEL also goes through the refine pipeline (CRITICAL >= WARNING).
+    # A planner that returns None for USER_CANCEL is fine — the drift
+    # still gets emitted.
+    planner.revised = None
+
+    msg = ControlMessage(
+        kind=ControlKind.CANCEL,
+        payload={"reason": "operator abort"},
+    )
+    await steerer.observe(msg, session)
+
+    assert len(planner.refine_calls) == 1
+    drift: DriftEvent = planner.refine_calls[0]["drift"]
+    assert drift.kind is DriftKind.USER_CANCEL
+    assert drift.severity is DriftSeverity.CRITICAL
+    assert drift.detail == "operator abort"
+
+    # DriftDetected emitted; no PlanRevised (planner returned None).
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds.count("drift_detected") == 1
+    assert "plan_revised" not in kinds
+
+
+async def test_observe_pause_emits_drift_but_does_not_refine() -> None:
+    steerer, session, sink, planner = _bind_fresh()
+    msg = ControlMessage(kind=ControlKind.PAUSE, payload={"note": "coffee"})
+
+    await steerer.observe(msg, session)
+
+    # INFO severity → refine must NOT be called.
+    assert planner.refine_calls == []
+
+    # DriftDetected was still emitted.
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["drift_detected"]
+    drift_pb = sink.events[0].drift_detected
+    # Detail carries the note.
+    assert drift_pb.detail == "coffee"
+
+
+async def test_observe_non_control_event_still_uses_classifier() -> None:
+    """Regression: intercepting ControlMessages must not shadow heuristics."""
+    steerer, session, sink, planner = _bind_fresh()
+
+    # A tool-error shape — detect_drift should still classify this.
+    await steerer.observe({"error": "boom"}, session)
+
+    # Should have produced a tool_error drift (classify_tool_error path).
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert "drift_detected" in kinds
+
+
+# ---------------------------------------------------------------------------
+# LLMPlanner.refine — USER_STEER delete-and-replan
+# ---------------------------------------------------------------------------
+
+
+def _canned_user_steer_json() -> str:
+    return json.dumps(
+        {
+            "summary": "Replanned to focus on clarity.",
+            "tasks": [
+                {
+                    "id": "clarify",
+                    "title": "Rewrite for clarity",
+                    "description": "Tighten prose to match operator steer.",
+                    "assignee_agent_id": "writer",
+                },
+                {
+                    "id": "final",
+                    "title": "Finalize",
+                    "description": "Prep for delivery.",
+                    "assignee_agent_id": "writer",
+                },
+            ],
+            "edges": [{"from_task_id": "clarify", "to_task_id": "final"}],
+        }
+    )
+
+
+class _StubLLM:
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        self.calls.append((system, user, model))
+        return self.response
+
+
+async def test_llm_planner_user_steer_preserves_completed_adds_pending() -> None:
+    plan = Plan(
+        id="plan-abc",
+        run_id="run-xyz",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="Research", status=TaskStatus.COMPLETED),
+            Task(id="draft", title="Draft", status=TaskStatus.FAILED),
+            Task(id="review", title="Review", status=TaskStatus.PENDING),
+            Task(id="publish", title="Publish", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft"),
+            TaskEdge(from_task_id="draft", to_task_id="review"),
+            TaskEdge(from_task_id="review", to_task_id="publish"),
+        ],
+        revision_index=2,
+    )
+    goals = [Goal(id="g1", summary="ship the blog post")]
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="skip formal review, focus on clarity",
+        current_task_id="review",
+    )
+
+    llm = _StubLLM(_canned_user_steer_json())
+    planner = LLMPlanner(call_llm=llm, model="test-model")
+
+    revised = await planner.refine(plan=plan, drift=drift, goals=goals)
+    assert revised is not None
+
+    # Lineage preserved.
+    assert revised.id == "plan-abc"
+    assert revised.run_id == "run-xyz"
+
+    # Completed/failed tasks preserved verbatim at the start.
+    ids = [t.id for t in revised.tasks]
+    assert ids[0] == "research"
+    assert ids[1] == "draft"
+    assert revised.tasks[0].status is TaskStatus.COMPLETED
+    assert revised.tasks[1].status is TaskStatus.FAILED
+    # Pending tasks from the old plan are gone.
+    assert "review" not in ids
+    assert "publish" not in ids
+    # New pending tasks from the LLM are present.
+    assert "clarify" in ids
+    assert "final" in ids
+    for t in revised.tasks[2:]:
+        assert t.status is TaskStatus.PENDING
+
+    # Revision metadata stamped.
+    assert revised.revision_kind == DriftKind.USER_STEER.value
+    assert revised.revision_severity == DriftSeverity.WARNING.value
+    assert revised.revision_reason == "user steering: skip formal review, focus on clarity"
+    assert revised.revision_index == plan.revision_index + 1
+
+    # The LLM was called once, and the user prompt explicitly told it
+    # to preserve completed tasks verbatim (delete-and-replan contract).
+    assert len(llm.calls) == 1
+    system_prompt, user_prompt, model = llm.calls[0]
+    assert model == "test-model"
+    assert "PRESERVE" in system_prompt.upper() or "preserve" in system_prompt
+    assert "skip formal review" in user_prompt
+    # History-context block is present; new work is not asked to repeat them.
+    assert "research" in user_prompt
+    assert "draft" in user_prompt
+
+    # Old edges that referenced dropped pending tasks are gone; edges
+    # that survive reference only known ids.
+    known = {t.id for t in revised.tasks}
+    for e in revised.edges:
+        assert e.from_task_id in known
+        assert e.to_task_id in known
+
+
+async def test_llm_planner_user_steer_empty_response_returns_none() -> None:
+    plan = _make_plan()
+    goals = [Goal(id="g1", summary="ship")]
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="pivot",
+    )
+    planner = LLMPlanner(call_llm=_StubLLM(""))
+    assert await planner.refine(plan=plan, drift=drift, goals=goals) is None
+
+
+async def test_llm_planner_non_user_steer_uses_default_refine_path() -> None:
+    """Regression: non-USER_STEER drift must keep the original refine contract."""
+    plan = _make_plan()
+    goals = [Goal(id="g1", summary="ship")]
+    drift = DriftEvent(
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.WARNING,
+        detail="api 500",
+    )
+    llm = _StubLLM(
+        json.dumps(
+            {
+                "summary": "retry path",
+                "tasks": [
+                    {
+                        "id": "t1",
+                        "title": "T1",
+                        "status": "COMPLETED",
+                        "assignee_agent_id": "a",
+                    },
+                    {
+                        "id": "t2",
+                        "title": "T2",
+                        "status": "RUNNING",
+                        "assignee_agent_id": "a",
+                    },
+                    {
+                        "id": "t3",
+                        "title": "T3",
+                        "status": "PENDING",
+                        "assignee_agent_id": "a",
+                    },
+                ],
+                "edges": [],
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=llm)
+    revised = await planner.refine(plan=plan, drift=drift, goals=goals)
+    assert revised is not None
+    # Default-path stamping uses str(drift.kind), not "user_steer".
+    assert revised.revision_kind == str(DriftKind.TOOL_ERROR)
+    assert revised.revision_reason == "api 500"


### PR DESCRIPTION
## Summary

- `DefaultSteerer.observe` now recognises `ControlMessage` values (STEER / CANCEL / PAUSE) and maps them to the matching `USER_*` drift kinds (WARNING / CRITICAL / INFO respectively) before falling through to the existing classifier pipeline. Non-control events flow through `detect_drift` unchanged.
- `LLMPlanner.refine` branches on `DriftKind.USER_STEER` to a delete-and-replan path: completed / failed / cancelled tasks are preserved verbatim (same ids, titles, statuses) while pending tasks are dropped and replaced with fresh LLM-generated tasks that honour the operator steering note. `Plan.id` / `run_id` are preserved so lineage stays intact; revision metadata is stamped with `revision_kind="user_steer"`.
- New system prompt explicitly instructs the LLM to treat completed tasks as read-only context and generate only the remaining pending work — the caller prepends the history back onto the returned plan.

## Test plan

- [x] `uv run pytest -q` — 313 passed, 33 skipped.
- [x] `tests/test_steerer_usersteer.py` — 7 new tests covering STEER / CANCEL / PAUSE observe dispatch, the delete-and-replan preservation contract, and a regression check that non-USER_STEER drift still uses the default refine path.
- [x] `uv run ruff check goldfive/ tests/` — all checks passed.
