### PR TITLE
goldfive.wrap() polymorphism for ADK BaseAgent (closes #77)

### DIFF
--- a/docs/guides/adk-web-integration.md
+++ b/docs/guides/adk-web-integration.md
@@ -1,0 +1,131 @@
+# Using goldfive with `adk web`
+
+`adk web` is Google ADK's local web UI for driving an agent
+interactively. It expects the module it loads to expose an
+`App(root_agent=...)` whose `root_agent` is a
+`google.adk.agents.BaseAgent`. Before goldfive Phase 2,
+`goldfive.wrap(agent)` always returned a `goldfive.Runner` — great for
+programmatic use, but *not* a `BaseAgent`, so the ADK UI couldn't load
+it.
+
+As of issue [#77], `goldfive.wrap(adk_agent)` returns a polymorphic
+[`GoldfiveADKAgent`](../../goldfive/adapters/adk_wrap.py). The same
+object now works in both contexts:
+
+| Call site | Needs | What goldfive returns |
+|---|---|---|
+| `adk web` | `BaseAgent` with `run_async(ctx)` | `GoldfiveADKAgent` — it IS a `BaseAgent`. |
+| Programmatic | `await runner.run(user_input)` | `GoldfiveADKAgent` — same object, same method. |
+
+No new entry points, no second wrap variant — the existing call site
+just works.
+
+## The recipe
+
+Swap the line that constructs the `root_agent` for `goldfive.wrap(...)`
+and leave the rest of your ADK code untouched:
+
+```python
+# agent.py — what `adk web` loads
+from google.adk.agents import Agent
+from google.adk.apps.app import App
+import goldfive
+
+real_agent = Agent(
+    name="coordinator",
+    model="gpt-4o-mini",
+    sub_agents=[...],
+)
+
+# Before: root_agent = real_agent
+root_agent = goldfive.wrap(real_agent)
+
+app = App(name="my-demo", root_agent=root_agent)
+```
+
+Run it:
+
+```bash
+uv pip install -e '.[adk]'
+adk web agent.py
+```
+
+Every user turn the UI submits now flows through goldfive's pipeline —
+goal-derive → plan → execute → emit events — and the ADK UI renders a
+short stream of `Event` objects summarising the plan + each completed
+task.
+
+A complete runnable file lives at
+[`examples/adk_web_wrapped.py`](../../examples/adk_web_wrapped.py).
+
+## What the UI sees each turn
+
+When ADK invokes `root_agent.run_async(ctx)`, goldfive:
+
+1. Extracts the latest user text from `ctx.user_content` (falling back
+   to the session's event history).
+2. Runs one `Runner.run(user_input, context={"adk_ctx": ctx})` pass.
+3. Synthesises an `Event` stream from the resulting
+   [`ExecutionOutcome`](../../goldfive/results.py):
+   - A **plan summary** event (the first message).
+   - One event per completed task, keyed by `Task.title`.
+   - One line per drift event observed during the turn.
+   - A terminal `turn_complete=True` event closing the turn.
+
+This is deliberately minimal — enough for `adk web` to render a coherent
+turn without duplicating what goldfive emits into its own event sinks.
+Richer views come from attaching a sink to the wrapped runner (see
+below).
+
+## Programmatic use still works
+
+```python
+root_agent = goldfive.wrap(real_agent)
+
+# Same object. Different call site.
+outcome = await root_agent.run("plan a presentation about waffles")
+```
+
+`GoldfiveADKAgent.run(user_input, **kwargs)` delegates straight to the
+inner `Runner.run(...)`, so every Runner knob — `context=`, cancellation
+via `ControlChannel`, drift handling — behaves as before.
+
+## Harmonograf observability composes cleanly
+
+The wrapper exposes the inner `Runner`'s sink list as a property, so
+`harmonograf_client.observe()` (which appends a `HarmonografSink`) works
+unchanged:
+
+```python
+import goldfive
+import harmonograf_client
+
+root_agent = harmonograf_client.observe(goldfive.wrap(real_agent))
+# observe() appended a sink to root_agent.sinks — the returned object is
+# still the same GoldfiveADKAgent. adk web will load it just the same.
+
+app = App(name="observed-demo", root_agent=root_agent)
+```
+
+## What is and is not shared with the adk-web session
+
+The goldfive pipeline that runs for each turn uses its own internal
+`InMemoryRunner` (via `ADKAdapter`). That is independent of the ADK
+session that `adk web` hosts. In practice this means:
+
+- Per-turn goldfive state (plan, drift history, reporting tool calls)
+  lives in goldfive's `Session` and on goldfive's sinks.
+- The ADK UI sees the synthesised `Event` stream from step 3 above.
+- Cross-turn memory / state shared at the *adk web session* level is on
+  the Phase 3 roadmap (the sibling agent currently wires
+  conversation-level continuity through `run()`; see issue #71).
+
+## Limitations
+
+- `ControlChannel` steering from a harmonograf UI does not yet reach the
+  adk-web-driven pipeline — Phase 4 follow-up.
+- Only ADK-shaped agents get the polymorphic return. Callable agents and
+  Claude SDK factories still return a plain `Runner`; that's intentional
+  (they can't satisfy `BaseAgent` anyway).
+
+[#77]: https://github.com/pedapudi/goldfive/issues/77

--- a/examples/adk_web_wrapped.py
+++ b/examples/adk_web_wrapped.py
@@ -1,0 +1,79 @@
+"""``adk web`` integration example — drop goldfive into an ADK web app.
+
+Since Phase 2 (issue #77) ``goldfive.wrap(adk_agent)`` returns a
+polymorphic :class:`~goldfive.adapters.adk_wrap.GoldfiveADKAgent` that
+*is* a ``google.adk.agents.BaseAgent``. That means ``adk web`` can load
+it as ``root_agent`` directly — every user turn flows through goldfive's
+goal-derive → plan → execute pipeline and comes back as a short stream
+of ``Event`` s rendered in the ADK UI.
+
+Usage::
+
+    uv pip install -e '.[adk]'
+    adk web examples/adk_web_wrapped.py
+
+This file is loaded by ``adk web`` rather than executed directly — it
+must expose an ``App`` via the module-level ``app`` binding that
+``adk web`` discovers. It does not run a turn unless driven by the UI.
+
+Programmatic use of the same object still works — see the final block
+for an optional one-shot run.
+"""
+
+from __future__ import annotations
+
+import os
+
+try:
+    from google.adk.agents import Agent
+    from google.adk.apps.app import App
+except ImportError as _adk_err:  # pragma: no cover
+    raise SystemExit(
+        "install goldfive[adk] to run this example"
+    ) from _adk_err
+
+import goldfive
+
+# ---------------------------------------------------------------------------
+# The "real" ADK agent — the one you'd write without goldfive.
+# ---------------------------------------------------------------------------
+# Keep this tree as vanilla ADK so it's easy to see what goldfive adds. For
+# a non-trivial example, see ``examples/adk_presentation/agent.py``.
+_MODEL = os.getenv("GOLDFIVE_EXAMPLE_MODEL", "gpt-4o-mini")
+
+real_agent = Agent(
+    name="coordinator",
+    model=_MODEL,
+    description="A thin demo agent that answers user questions.",
+    instruction=(
+        "You are a helpful assistant. Keep answers to under three "
+        "sentences unless asked otherwise."
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# One-line goldfive wrap. Same call site that works programmatically now
+# also satisfies adk web's root_agent BaseAgent contract.
+# ---------------------------------------------------------------------------
+root_agent = goldfive.wrap(real_agent)
+
+# ADK web discovers `app` at module level.
+app = App(name="goldfive-wrapped-demo", root_agent=root_agent)
+
+
+# ---------------------------------------------------------------------------
+# Optional: demonstrate the programmatic call site still works. Leaving
+# this under the ``if __name__ == "__main__"`` gate keeps ``adk web``
+# load-time side-effect free while letting ``python examples/…`` drive a
+# one-shot turn.
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import asyncio
+
+    async def _main() -> None:
+        outcome = await root_agent.run(
+            "summarise goldfive's value proposition in one line"
+        )
+        print("success=", outcome.success, "reason=", outcome.reason)
+
+    asyncio.run(_main())

--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -1,0 +1,298 @@
+"""Polymorphic wrapper that makes a goldfive :class:`Runner` look like an ADK agent.
+
+``goldfive.wrap(adk_agent)`` returns a :class:`GoldfiveADKAgent` — a
+``google.adk.agents.BaseAgent`` subclass that also exposes the
+programmatic :meth:`Runner.run` / :meth:`Runner.close` surface. The
+single return value works in two different contexts without the caller
+having to choose:
+
+* ``adk web`` loads the object as a ``BaseAgent`` and drives it via
+  ``run_async(ctx)``. Each invocation flows through goldfive's
+  goal-derive → plan → execute pipeline and is reported back to the ADK
+  UI as a short stream of ``Event`` objects.
+* Programmatic callers can still ``await wrapped.run("do the thing")``
+  and receive a regular :class:`~goldfive.results.ExecutionOutcome`.
+
+The ADK SDK is an optional install — this module lazy-imports ``google.adk``
+inside the class body so importing :mod:`goldfive.adapters.adk_wrap`
+without the ``adk`` extra raises a clear :class:`ImportError` with an
+install hint.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator, Mapping
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from goldfive.results import ExecutionOutcome
+    from goldfive.runner import Runner
+    from goldfive.types import Goal
+
+log = logging.getLogger("goldfive.adapters.adk_wrap")
+
+
+try:  # noqa: SIM105 — explicit import-time guard with install hint
+    from google.adk.agents import BaseAgent  # type: ignore
+    from google.adk.agents.invocation_context import InvocationContext  # type: ignore
+    from google.adk.events import Event  # type: ignore
+    from google.adk.events.event_actions import EventActions  # type: ignore
+    from google.genai.types import Content, Part  # type: ignore
+    from pydantic import PrivateAttr
+except ImportError:  # pragma: no cover — covered via importorskip in tests
+    raise ImportError(
+        "goldfive.adapters.adk_wrap requires 'pip install goldfive[adk]'"
+    ) from None
+
+
+def _extract_user_input(ctx: InvocationContext) -> str:
+    """Return the latest user-turn text from an ADK :class:`InvocationContext`.
+
+    ADK's context shape varies across versions — the most stable signal
+    is ``ctx.user_content``, a ``google.genai.types.Content`` with one
+    or more ``Part`` children. If that is missing we fall back to
+    ``ctx.session.events`` and pick the last user author. As a last
+    resort we return an empty string so the goldfive pipeline can still
+    degrade gracefully rather than raising mid-run.
+    """
+    # Preferred: the user_content on the invocation context.
+    content = getattr(ctx, "user_content", None)
+    text = _text_from_content(content)
+    if text:
+        return text
+
+    # Fallback: walk the session's event history for the last user turn.
+    session = getattr(ctx, "session", None)
+    events = getattr(session, "events", None) or ()
+    for event in reversed(list(events)):
+        if getattr(event, "author", "") != "user":
+            continue
+        text = _text_from_content(getattr(event, "content", None))
+        if text:
+            return text
+
+    return ""
+
+
+def _text_from_content(content: Any) -> str:
+    """Best-effort join of the non-empty ``text`` parts of an ADK Content."""
+    if content is None:
+        return ""
+    parts = getattr(content, "parts", None) or ()
+    out: list[str] = []
+    for part in parts:
+        text = getattr(part, "text", "") or ""
+        if text:
+            out.append(str(text))
+    return "\n".join(out).strip()
+
+
+def _plan_summary_event(outcome: ExecutionOutcome, author: str, invocation_id: str) -> Event:
+    """Build the opening Event that summarises the plan we're about to run."""
+    session = outcome.session
+    plan = getattr(session, "plan", None)
+    summary = getattr(plan, "summary", "") or "goldfive plan"
+    tasks = list(getattr(plan, "tasks", None) or ())
+    lines = [f"**{summary}**"]
+    for idx, task in enumerate(tasks, 1):
+        title = getattr(task, "title", "") or task.id
+        lines.append(f"{idx}. {title}")
+    return _text_event("\n".join(lines), author=author, invocation_id=invocation_id)
+
+
+def _task_result_event(
+    task_id: str, title: str, text: str, author: str, invocation_id: str
+) -> Event:
+    """Build an Event reporting one completed task's result."""
+    headline = f"**{title or task_id}**"
+    body = text.strip() if text else "(no output)"
+    return _text_event(f"{headline}\n{body}", author=author, invocation_id=invocation_id)
+
+
+def _drift_event(detail: str, author: str, invocation_id: str) -> Event:
+    """Build an Event surfacing a drift observation as a warning line."""
+    return _text_event(f"drift: {detail}", author=author, invocation_id=invocation_id)
+
+
+def _terminal_event(
+    outcome: ExecutionOutcome, author: str, invocation_id: str
+) -> Event:
+    """Build the final Event that closes out a run for the ADK UI."""
+    if outcome.success:
+        text = "goldfive run complete."
+    else:
+        reason = outcome.reason or "run aborted"
+        text = f"goldfive run aborted: {reason}"
+    evt = _text_event(text, author=author, invocation_id=invocation_id)
+    evt.turn_complete = True
+    return evt
+
+
+def _text_event(text: str, *, author: str, invocation_id: str) -> Event:
+    """Construct a minimal assistant-authored Event carrying a text payload."""
+    return Event(
+        invocation_id=invocation_id or "",
+        author=author or "goldfive",
+        content=Content(role="model", parts=[Part(text=text)]),
+        actions=EventActions(),
+    )
+
+
+async def _outcome_to_adk_events(
+    outcome: ExecutionOutcome, ctx: InvocationContext, author: str
+) -> AsyncIterator[Event]:
+    """Yield one Event per interesting step of ``outcome`` for the ADK UI.
+
+    The stream is intentionally minimal: a plan summary up top, one
+    Event per completed task, a best-effort line per recorded drift,
+    and a terminal turn-complete Event at the end. This is enough for
+    adk web to render a coherent turn; richer views can subscribe to
+    goldfive's own Event stream via a sink.
+    """
+    invocation_id = str(getattr(ctx, "invocation_id", "") or "")
+    yield _plan_summary_event(outcome, author=author, invocation_id=invocation_id)
+
+    session = outcome.session
+    completed = getattr(session, "completed_results", None) or {}
+    plan = getattr(session, "plan", None)
+    tasks_by_id = {t.id: t for t in (getattr(plan, "tasks", None) or ())}
+
+    for task_id, result_text in completed.items():
+        task = tasks_by_id.get(task_id)
+        title = getattr(task, "title", "") if task is not None else ""
+        yield _task_result_event(
+            task_id=task_id,
+            title=title,
+            text=result_text,
+            author=author,
+            invocation_id=invocation_id,
+        )
+
+    history = getattr(session, "history", None) or ()
+    for entry in history:
+        detail = _drift_detail(entry)
+        if detail:
+            yield _drift_event(detail, author=author, invocation_id=invocation_id)
+
+    yield _terminal_event(outcome, author=author, invocation_id=invocation_id)
+
+
+def _drift_detail(entry: Any) -> str:
+    """Return a short one-line drift description from a session history entry."""
+    if entry is None:
+        return ""
+    kind = getattr(entry, "kind", None)
+    if kind is None:
+        return ""
+    detail = getattr(entry, "detail", "") or ""
+    kind_str = getattr(kind, "value", None) or str(kind)
+    if detail:
+        return f"{kind_str}: {detail}"
+    return kind_str
+
+
+class GoldfiveADKAgent(BaseAgent):
+    """BaseAgent that runs goldfive's pipeline for each invocation.
+
+    Appears to ADK as a normal agent — it carries the inner agent's
+    ``name``, ``description``, and ``sub_agents`` so adk web can render
+    it. When the ADK runtime invokes :meth:`_run_async_impl` (via the
+    final :meth:`BaseAgent.run_async`), we extract the latest user turn,
+    drive the inner goldfive :class:`Runner` for that input, and yield
+    synthesized ADK ``Event`` objects summarising the outcome.
+
+    The same instance also exposes the programmatic :meth:`run` /
+    :meth:`close` surface of :class:`Runner` so existing goldfive
+    callers keep working unchanged::
+
+        root_agent = goldfive.wrap(my_adk_agent)
+        app = App(name="demo", root_agent=root_agent)  # adk web path
+        outcome = await root_agent.run("do the thing")  # programmatic path
+    """
+
+    _inner: Any = PrivateAttr(default=None)
+    _runner: Runner = PrivateAttr(default=None)  # type: ignore[assignment]
+
+    def __init__(self, *, inner: Any, runner: Runner) -> None:
+        super().__init__(
+            name=getattr(inner, "name", "goldfive_agent"),
+            description=getattr(inner, "description", "") or "",
+            sub_agents=list(getattr(inner, "sub_agents", None) or ()),
+        )
+        self._inner = inner
+        self._runner = runner
+
+    # ------------------------------------------------------------------
+    # BaseAgent extension point
+    # ------------------------------------------------------------------
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncIterator[Event]:
+        """Drive one goldfive run for the latest user turn in ``ctx``.
+
+        :meth:`BaseAgent.run_async` is ``@final`` — overriding this
+        protected hook is ADK's documented extension seam.
+        """
+        user_input = _extract_user_input(ctx)
+        if not user_input:
+            yield _text_event(
+                "goldfive: no user input found in invocation context.",
+                author=self.name,
+                invocation_id=str(getattr(ctx, "invocation_id", "") or ""),
+            )
+            return
+
+        outcome = await self._runner.run(
+            user_input, context={"adk_ctx": ctx}
+        )
+        async for adk_event in _outcome_to_adk_events(
+            outcome, ctx, author=self.name
+        ):
+            yield adk_event
+
+    # ------------------------------------------------------------------
+    # Runner passthrough — keeps the programmatic entry point working.
+    # ------------------------------------------------------------------
+
+    async def run(
+        self,
+        user_input: str | list[Goal],
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> ExecutionOutcome:
+        """Run the wrapped goldfive pipeline programmatically."""
+        return await self._runner.run(user_input, context=context)
+
+    async def close(self) -> None:
+        """Close the wrapped :class:`Runner` (flushes every sink)."""
+        await self._runner.close()
+
+    # ------------------------------------------------------------------
+    # Runner attribute access — enables harmonograf_client.observe() and
+    # anything else that expects to see the Runner's sinks / control.
+    # ------------------------------------------------------------------
+
+    @property
+    def sinks(self) -> list[Any]:
+        """Expose the inner :class:`Runner`'s sink list (mutable)."""
+        return self._runner.sinks
+
+    @property
+    def control(self) -> Any:
+        """Expose the inner :class:`Runner`'s optional ControlChannel."""
+        return self._runner.control
+
+    @property
+    def inner_agent(self) -> Any:
+        """Return the wrapped ADK ``BaseAgent`` — used by subtree walks."""
+        return self._inner
+
+    @property
+    def runner(self) -> Runner:
+        """Return the wrapped goldfive :class:`Runner`."""
+        return self._runner
+
+
+__all__ = ["GoldfiveADKAgent"]

--- a/goldfive/adapters/auto.py
+++ b/goldfive/adapters/auto.py
@@ -42,6 +42,19 @@ def _looks_like_adk_agent(agent: Any) -> bool:
     return False
 
 
+def is_adk_agent(agent: Any) -> bool:
+    """Return True when ``agent`` looks like a Google ADK ``BaseAgent``.
+
+    Public wrapper over the internal duck-type check. Used by
+    :func:`goldfive.wrap` to decide whether to return a plain
+    :class:`~goldfive.runner.Runner` or a polymorphic
+    :class:`~goldfive.adapters.adk_wrap.GoldfiveADKAgent` that also
+    satisfies the ``BaseAgent`` contract. Runs without importing ADK,
+    so callers that never install the extra don't pay the import cost.
+    """
+    return _looks_like_adk_agent(agent)
+
+
 def _looks_like_adk_runner(agent: Any) -> bool:
     """Duck-type check for an ADK ``Runner``."""
     return (
@@ -147,4 +160,4 @@ def auto_adapter(agent: Any) -> AgentAdapter:
     )
 
 
-__all__ = ["auto_adapter"]
+__all__ = ["auto_adapter", "is_adk_agent"]

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -26,7 +26,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from goldfive._llm_detect import CallLLM, detect_llm
-from goldfive.adapters.auto import auto_adapter
+from goldfive.adapters.auto import auto_adapter, is_adk_agent
 from goldfive.executors.sequential import SequentialExecutor
 from goldfive.goal_deriver import LiteralGoalDeriver, LLMGoalDeriver
 from goldfive.planner import LLMPlanner, PassthroughPlanner
@@ -109,6 +109,15 @@ def wrap(
     Runner
         A ready-to-use :class:`Runner`. Call ``await runner.run(...)``
         or use :func:`goldfive.run` for the one-line variant.
+
+        When ``agent`` is an ADK ``BaseAgent``, the returned object is
+        a :class:`~goldfive.adapters.adk_wrap.GoldfiveADKAgent` — a
+        ``BaseAgent`` subclass that *also* exposes the Runner surface,
+        so the same call site works both programmatically and as the
+        ``root_agent`` of an ``adk web`` app. The declared return type
+        stays :class:`Runner` for ergonomics; callers who rely on the
+        ``BaseAgent`` side can annotate
+        ``cast(GoldfiveADKAgent, goldfive.wrap(...))`` themselves.
     """
     adapter = auto_adapter(agent)
 
@@ -158,7 +167,7 @@ def wrap(
         list(sinks) if sinks is not None else [LoggingSink()]
     )
 
-    return Runner(
+    runner = Runner(
         agent=adapter,
         planner=resolved_planner,
         executor=resolved_executor,
@@ -168,6 +177,14 @@ def wrap(
         control=control,
         max_plan_reinvocations=max_plan_reinvocations,
     )
+
+    if is_adk_agent(agent):
+        # Lazy import so callers without the ADK extra don't pay for it.
+        from goldfive.adapters.adk_wrap import GoldfiveADKAgent
+
+        return GoldfiveADKAgent(inner=agent, runner=runner)
+
+    return runner
 
 
 async def run(

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -276,10 +276,17 @@ def _has_adk() -> bool:
 
 @pytest.mark.skipif(not _has_adk(), reason="goldfive[adk] extra not installed")
 async def test_wrap_adk_agent_chooses_adk_adapter() -> None:
-    """An ADK ``BaseAgent`` dispatches to :class:`ADKAdapter`."""
+    """An ADK ``BaseAgent`` dispatches to :class:`ADKAdapter`.
+
+    Since Phase 2 (issue #77) :func:`goldfive.wrap` returns a
+    polymorphic :class:`GoldfiveADKAgent` for ADK inputs. The underlying
+    :class:`Runner` — reachable via ``.runner`` — still carries an
+    :class:`ADKAdapter`, which is what this test verifies.
+    """
     from google.adk.agents.llm_agent import LlmAgent
 
     from goldfive.adapters.adk import ADKAdapter
+    from goldfive.adapters.adk_wrap import GoldfiveADKAgent
 
     adk_agent = LlmAgent(
         name="test_agent",
@@ -287,8 +294,9 @@ async def test_wrap_adk_agent_chooses_adk_adapter() -> None:
         description="Test agent",
         instruction="Test.",
     )
-    runner = goldfive.wrap(adk_agent, sinks=[InMemorySink()])
-    assert isinstance(runner.agent, ADKAdapter)
+    wrapped = goldfive.wrap(adk_agent, sinks=[InMemorySink()])
+    assert isinstance(wrapped, GoldfiveADKAgent)
+    assert isinstance(wrapped.runner.agent, ADKAdapter)
 
 
 @pytest.mark.skipif(not _has_adk(), reason="goldfive[adk] extra not installed")

--- a/tests/test_wrap_adk.py
+++ b/tests/test_wrap_adk.py
@@ -1,0 +1,263 @@
+"""Tests for :func:`goldfive.wrap` polymorphism on ADK ``BaseAgent``.
+
+Gated on the ``adk`` extra — skipped entirely when ``google.adk`` is
+not installed. See ``docs/guides/adk-web-integration.md`` for the
+motivation: adk web loads a ``BaseAgent`` as its ``root_agent``, so the
+existing ``Runner`` return value from :func:`goldfive.wrap` could not
+be used there. The polymorphic :class:`GoldfiveADKAgent` unifies the
+two call sites.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+import goldfive
+from goldfive import InMemorySink, Runner, StaticPlanner
+from goldfive.types import Plan, Task
+
+
+def _one_task_planner(task_id: str = "t1", title: str = "the task") -> StaticPlanner:
+    """Return a :class:`StaticPlanner` that always emits one task routed to ``inner_agent``."""
+    return StaticPlanner(
+        Plan(
+            id="p1",
+            run_id="",
+            goal_ids=["g1"],
+            tasks=[
+                Task(
+                    id=task_id,
+                    title=title,
+                    description=title,
+                    assignee_agent_id="inner_agent",
+                )
+            ],
+            edges=[],
+            summary="one task plan",
+        )
+    )
+
+
+def _mk_inner(name: str = "inner_agent") -> Any:
+    """Construct a bare ADK ``LlmAgent`` to wrap."""
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(
+        name=name,
+        model="fake-model",
+        description="a wrapped agent",
+        instruction="follow instructions",
+    )
+
+
+def _mk_wrapped(**kwargs: Any) -> Any:
+    """Build a GoldfiveADKAgent over a fresh inner LlmAgent."""
+    inner = _mk_inner()
+    return goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity / type contract
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_returns_goldfive_adk_agent() -> None:
+    """``goldfive.wrap(adk_agent)`` returns a :class:`GoldfiveADKAgent`."""
+    from goldfive.adapters.adk_wrap import GoldfiveADKAgent
+
+    wrapped = _mk_wrapped()
+    assert isinstance(wrapped, GoldfiveADKAgent)
+
+
+def test_wrapped_is_adk_base_agent() -> None:
+    """The returned object satisfies ``isinstance(result, BaseAgent)``."""
+    from google.adk.agents import BaseAgent  # type: ignore
+
+    wrapped = _mk_wrapped()
+    assert isinstance(wrapped, BaseAgent)
+
+
+def test_wrapped_exposes_base_agent_passthroughs() -> None:
+    """Name / description / sub_agents mirror the inner agent."""
+    inner = _mk_inner(name="parent_agent")
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+    assert wrapped.name == "parent_agent"
+    assert wrapped.description == inner.description
+    assert wrapped.sub_agents == list(inner.sub_agents)
+
+
+def test_wrapped_exposes_runner_surface() -> None:
+    """The wrapped object exposes ``run``, ``close``, ``sinks``, ``control``."""
+    wrapped = _mk_wrapped()
+    assert callable(getattr(wrapped, "run", None))
+    assert callable(getattr(wrapped, "close", None))
+    assert isinstance(wrapped.sinks, list)
+    # control is optional and defaults to None on the inner Runner.
+    assert wrapped.control is None
+
+
+# ---------------------------------------------------------------------------
+# Programmatic run()
+# ---------------------------------------------------------------------------
+
+
+async def test_run_programmatically_returns_outcome(stub_call_llm: Any) -> None:
+    """``await wrapped.run(...)`` still produces a valid ExecutionOutcome."""
+    from unittest.mock import AsyncMock
+
+    from goldfive import ExecutionOutcome, InvocationResult, SequentialExecutor
+
+    inner = _mk_inner()
+    # Patch the ADK adapter invoke path: we don't want to actually drive
+    # an ADK runner in this unit test. A tiny substitute adapter keeps
+    # the Runner happy without spinning up a real LlmAgent turn.
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text=f"ok: {task.title}")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_plan_reinvocations=3)
+
+    outcome = await wrapped.run(
+        [goldfive.Goal(id="g1", summary="say hi")],
+    )
+    assert isinstance(outcome, ExecutionOutcome)
+    assert outcome.success, outcome.reason
+
+
+# ---------------------------------------------------------------------------
+# run_async yields Events
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """Minimal stub for ``InvocationContext.session`` used in tests."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+
+class _FakeCtx:
+    """Stand-in for an ``InvocationContext`` carrying a user turn.
+
+    The wrapper only reads ``user_content``, ``invocation_id`` and
+    ``session`` off the context — everything else is unused by goldfive's
+    code path, so we can supply these three attributes and skip the
+    ``InvocationContext`` pydantic validation entirely.
+    """
+
+    def __init__(self, text: str) -> None:
+        from google.genai.types import Content, Part  # type: ignore
+
+        self.user_content = Content(role="user", parts=[Part(text=text)])
+        self.session = _FakeSession()
+        self.invocation_id = "invocation-test-1"
+        self.end_invocation = False
+
+
+async def test_run_async_yields_events_for_user_turn(stub_call_llm: Any) -> None:
+    """``_run_async_impl`` yields at least a plan + terminal Event pair."""
+    from unittest.mock import AsyncMock
+
+    from goldfive import InvocationResult, SequentialExecutor
+
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text=f"ok: {task.title}")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_plan_reinvocations=3)
+
+    ctx = _FakeCtx("make a thing")
+    events = [evt async for evt in wrapped._run_async_impl(ctx)]
+
+    assert len(events) >= 2
+    # First event should carry the plan summary.
+    first_text = _event_text(events[0])
+    assert first_text, "plan summary event has no text"
+    # Last event closes the turn.
+    last = events[-1]
+    assert last.turn_complete is True
+
+
+async def test_run_async_with_empty_input_yields_a_fallback_event() -> None:
+    """A context with no user turn gets a single explanatory Event."""
+    from google.genai.types import Content  # type: ignore
+
+    wrapped = _mk_wrapped()
+
+    ctx = _FakeCtx("")
+    # Replace user_content with an empty Content so both fallbacks fail.
+    ctx.user_content = Content(role="user", parts=[])
+
+    events = [evt async for evt in wrapped._run_async_impl(ctx)]
+    assert len(events) == 1
+    text = _event_text(events[0])
+    assert "no user input" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Callable agents must NOT come back as a GoldfiveADKAgent
+# ---------------------------------------------------------------------------
+
+
+async def test_wrap_callable_still_returns_plain_runner() -> None:
+    """Non-ADK agents must keep returning a plain :class:`Runner`."""
+    from goldfive.adapters.adk_wrap import GoldfiveADKAgent
+
+    async def _bare_agent(task: Any, session: Any, tools: Any) -> Any:
+        from goldfive import InvocationResult
+
+        return InvocationResult(task_id=task.id, text="ok")
+
+    runner = goldfive.wrap(_bare_agent, sinks=[InMemorySink()])
+    assert isinstance(runner, Runner)
+    assert not isinstance(runner, GoldfiveADKAgent)
+
+
+# ---------------------------------------------------------------------------
+# harmonograf-style sink injection
+# ---------------------------------------------------------------------------
+
+
+async def test_sinks_mutation_propagates_to_inner_runner() -> None:
+    """``wrapped.sinks.append(sink)`` reaches the inner Runner."""
+    wrapped = _mk_wrapped()
+    new_sink = InMemorySink()
+    wrapped.sinks.append(new_sink)
+    assert new_sink in wrapped.runner.sinks
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _event_text(event: Any) -> str:
+    content = getattr(event, "content", None)
+    parts = getattr(content, "parts", None) or ()
+    return "\n".join(str(getattr(p, "text", "") or "") for p in parts).strip()


### PR DESCRIPTION
## Summary

- `goldfive.wrap(adk_agent)` now returns a `GoldfiveADKAgent` — a `google.adk.agents.BaseAgent` subclass that also exposes the full `Runner.run` / `Runner.close` surface.
- Same call site works for both programmatic use (`await wrapped.run(...)`) and `adk web` (`App(root_agent=wrapped)`). No new entry points.
- Non-ADK inputs (callable agents, Claude SDK factories) still return a plain `Runner` — behaviour unchanged.
- New guide at `docs/guides/adk-web-integration.md`; runnable example at `examples/adk_web_wrapped.py`.
- ADK import stays lazy: `goldfive.adapters.adk_wrap` only imports when the ADK branch of `wrap()` fires.

## Design

The polymorphic return type sidesteps the existing "there's no goldfive-on-adk-web story" gap without forcing callers to pick a second wrapper. `GoldfiveADKAgent._run_async_impl` — ADK's documented extension seam under the `@final run_async` method — extracts the latest user turn from the invocation context, drives one goldfive `Runner.run(...)` pass, and synthesises a short `Event` stream (plan summary + one event per completed task + drift warnings + terminal turn-complete) so the ADK UI renders a coherent turn.

`harmonograf_client.observe()` keeps working because the wrapper exposes the inner Runner's `sinks` list as a property.

## Test plan

- [x] `uv run pytest -q` — 322 passed, 33 skipped.
- [x] 9 new tests in `tests/test_wrap_adk.py` cover: identity/type contract, name/sub_agents passthrough, programmatic `.run()`, `_run_async_impl` yielding Events for a user turn, empty-input fallback, callable agents still returning a plain Runner, and sink-list mutation propagation (harmonograf integration path).
- [x] Existing `tests/test_wrap.py::test_wrap_adk_agent_chooses_adk_adapter` updated — the returned object is now a `GoldfiveADKAgent`; `.runner.agent` still carries the underlying `ADKAdapter`.
- [x] `uv run ruff check` clean.

Closes #77.
