### PR TITLE
Cross-turn conversation state (closes #78)

### DIFF
--- a/docs/guides/multi-turn.md
+++ b/docs/guides/multi-turn.md
@@ -1,0 +1,184 @@
+# Multi-turn conversations
+
+Most agent UIs are conversations, not one-shot runs: a user asks for
+something, sees the result, and follows up — *"actually, make it
+funnier"*, *"now tighten the rhymes"*. goldfive's `Runner` supports
+this out of the box via a `Conversation` that persists cross-turn
+state so the planner can see what the previous turns produced.
+
+This guide covers how the `Conversation` works, what each turn sees,
+how to reset it, and what lifecycle events sinks observe.
+
+Related: [Getting started](getting-started.md),
+[Goals and plans](goals-and-plans.md),
+[EVENT-MODEL.md](../design/EVENT-MODEL.md).
+
+## The shapes
+
+Every `Runner` owns a `Conversation`. On each `runner.run(user_input)`
+call the Runner seeds a fresh `Session` from the Conversation, runs the
+usual derive → plan → execute loop, then folds the outcome back into
+the Conversation so the next turn starts from the updated state.
+
+```python
+@dataclasses.dataclass
+class Conversation:
+    id: str                                # stable across turns
+    started_at_ms: int
+    goals: list[Goal]                      # accumulated, deduped by id
+    completed_results: dict[str, str]      # task_id -> summary, cross-turn
+    turns: list[TurnRecord]                # one record per completed turn
+
+
+@dataclasses.dataclass
+class TurnRecord:
+    run_id: str
+    user_input_summary: str
+    plan_summary: str
+    outcome_success: bool
+    outcome_reason: str
+    completed_task_ids: list[str]
+    started_at_ms: int
+    ended_at_ms: int
+```
+
+Single-turn callers never need to touch either class — the Runner
+constructs a fresh `Conversation` on `__init__` and the surface of
+`runner.run()` is unchanged.
+
+## The minimal multi-turn flow
+
+```python
+import goldfive
+
+runner = goldfive.wrap(my_agent)   # owns a fresh Conversation
+
+out1 = await runner.run("Write a limerick about cats")
+out2 = await runner.run("Actually, make it funnier")
+out3 = await runner.run("Now tighten the rhymes")
+
+# out2's session was seeded with turn 1's completed_results; the
+# planner's prompt for turn 2 contains a rendered summary of turn 1's
+# output. Turn 3 sees both turn 1 and turn 2. No caller plumbing.
+```
+
+Every turn still emits its own `RunStarted` → … → `RunCompleted` event
+sequence; the `conversation_id` field on the `Session` (and on the
+`ConversationStarted` lifecycle event) is what ties them together for
+observers.
+
+See [examples/multi_turn_chat.py](../../examples/multi_turn_chat.py) for
+a full runnable demo that uses a scripted LLM stub.
+
+## What each turn sees
+
+When turn `N` runs, the `Session` the executor receives starts with:
+
+| Field                    | Seeded from                    |
+|--------------------------|--------------------------------|
+| `run_id`                 | fresh UUID (per turn)          |
+| `conversation_id`        | `conversation.id` (stable)     |
+| `goals`                  | `conversation.goals` (copy)    |
+| `completed_results`      | `conversation.completed_results` (copy) |
+| `plan`                   | `None` — planned per turn      |
+| `history`                | `[]` (v1)                      |
+
+The planner additionally receives a `context` dict that includes:
+
+- `conversation_id`
+- `turn_index` — how many turns have already finished
+- `prior_completed_results` — the full cross-turn result map
+- `prior_turns` — the last 3 `TurnRecord`s (windowed to keep prompts
+  bounded)
+
+`LLMPlanner.generate()` renders these into a human-readable
+"Prior-turn context" block in its prompt so the LLM can reason about
+follow-up intent without the caller doing anything. If you're writing
+a custom planner, read the same keys off your `context: Mapping[str,
+Any]` parameter.
+
+## Resetting: `runner.new_conversation()`
+
+When the current conversation has ended and the next `runner.run()`
+should start from a blank slate:
+
+```python
+await runner.new_conversation()
+```
+
+Effects:
+
+- The outgoing Conversation emits a terminal `ConversationEnded` event.
+- A fresh `Conversation` is installed. `runner.conversation_id` now
+  returns a different value.
+- The next `runner.run()` emits a new `ConversationStarted` event
+  before its `RunStarted`.
+
+Use this whenever a follow-up should *not* carry prior context: the
+user switched tasks, a new support session started, a test needs
+isolation between cases.
+
+## Injecting a pre-built Conversation
+
+For persistence-aware hosts (e.g. rehydrating a chat session from
+storage), construct a `Conversation` directly and pass it to the
+`Runner`:
+
+```python
+conv = goldfive.Conversation.new()
+conv.goals = [goldfive.Goal(id="g1", summary="Original ask")]
+conv.completed_results = {"prior_task": "prior output"}
+
+runner = goldfive.Runner(
+    agent=my_adapter,
+    planner=my_planner,
+    executor=my_executor,
+    conversation=conv,
+)
+```
+
+The Runner's first `run()` will see that pre-loaded state exactly as
+if it had been produced by an earlier turn on the same Runner.
+
+## Observability
+
+Phase 3 adds two event payloads to the `Event` envelope:
+
+- `ConversationStarted` — emitted once per Conversation on the first
+  turn that uses it. Carries `conversation_id` and `started_at`.
+- `ConversationEnded` — emitted when `new_conversation()` is called or
+  when `runner.close()` runs after a used Conversation. Carries
+  `conversation_id`, `turn_count`, and a short `reason` string.
+
+Both ride the existing `Event` envelope (proto regenerates via
+`make proto`) so every sink — `LoggingSink`, `JSONLPersistenceSink`,
+`SQLitePersistenceSink`, `GRPCSink` — picks them up with no code
+change.
+
+Note: the envelope's `run_id` on a `ConversationStarted`/`Ended` is
+the anchoring turn's run_id (first turn / last turn respectively). The
+stable conversation identifier is inside the payload.
+
+## What's *not* in Phase 3
+
+- **Cross-turn plan lineage.** Each turn still plans from scratch;
+  v2 will expose the prior plan DAG to the planner so it can revise
+  rather than replace. Today the LLM sees prior `completed_results` as
+  text context instead.
+- **Persistence across process restarts.** A Runner's Conversation
+  lives in memory. Use `JSONLPersistenceSink` to log the event stream;
+  `Runner.resume()` can replay it, but rehydrating a live Conversation
+  from a log is a Phase 3.5 follow-up.
+- **Multi-user conversation routing.** One Runner, one Conversation.
+  Multi-user systems should build a per-user Runner pool.
+
+## Summary
+
+| Question                                     | Answer                                            |
+|----------------------------------------------|---------------------------------------------------|
+| Do I need to change anything for single-turn?| No — the default Conversation is invisible.       |
+| Does turn 2 see turn 1's results?            | Yes, on `session.completed_results`.              |
+| Does turn 2's planner see turn 1's output?   | Yes, via rendered context in the prompt.          |
+| How do I reset state?                        | `await runner.new_conversation()`.                |
+| How do I check the current id?               | `runner.conversation_id`.                         |
+| What lifecycle events fire?                  | `ConversationStarted` / `ConversationEnded`.      |

--- a/examples/multi_turn_chat.py
+++ b/examples/multi_turn_chat.py
@@ -1,0 +1,156 @@
+"""multi_turn_chat — a three-turn conversation on one Runner.
+
+Shows :meth:`goldfive.Runner.run` called multiple times on the same
+Runner instance. The Runner owns a :class:`goldfive.Conversation` that
+persists cross-turn state — ``completed_results`` and goals from turn
+1 are visible to the planner on turn 2, and turn 2's output is visible
+on turn 3. This is what enables "actually, make it funnier" follow-up
+phrasing to land without the caller stitching context by hand.
+
+Run with::
+
+    uv run python examples/multi_turn_chat.py
+
+The example uses a scripted ``call_llm`` stub so it needs no network
+credentials. Real callers drop in their own LLM binding and the
+cross-turn behaviour is identical.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import goldfive
+from goldfive import (
+    InMemorySink,
+    InvocationResult,
+    ReportingToolSpec,
+    Session,
+    Task,
+)
+
+
+async def writer_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    """Return a canned 'written' artefact for each task goldfive assigns."""
+    _ = (session, tools)
+    return InvocationResult(
+        task_id=task.id,
+        text=f"Draft produced for {task.title!r}: a limerick about cats.",
+    )
+
+
+def _build_scripted_call_llm():
+    """Six scripted responses: (goals, plan) for each of three turns.
+
+    Real integrations delegate to a real model; the point of the script
+    is that the planner's *prompt* on turns 2 and 3 now contains a
+    rendered summary of prior-turn completed_results and user inputs.
+    """
+    scripted = [
+        # Turn 1 — goals, then plan.
+        {"goals": [{"id": "g1", "summary": "Write a limerick about cats"}]},
+        {
+            "summary": "Draft a cat limerick",
+            "tasks": [
+                {
+                    "id": "draft",
+                    "title": "Draft limerick",
+                    "description": "Write five rhyming lines about a cat.",
+                    "assignee_agent_id": "writer",
+                }
+            ],
+            "edges": [],
+        },
+        # Turn 2 — user says 'make it funnier'.
+        {"goals": [{"id": "g2", "summary": "Make the prior limerick funnier"}]},
+        {
+            "summary": "Revise the existing limerick for humour",
+            "tasks": [
+                {
+                    "id": "revise",
+                    "title": "Punch up the limerick",
+                    "description": "Rewrite the existing draft with stronger humour.",
+                    "assignee_agent_id": "writer",
+                }
+            ],
+            "edges": [],
+        },
+        # Turn 3 — user says 'now make it rhyme better'.
+        {"goals": [{"id": "g3", "summary": "Tighten the rhymes"}]},
+        {
+            "summary": "Polish rhymes in the revised limerick",
+            "tasks": [
+                {
+                    "id": "polish",
+                    "title": "Polish rhymes",
+                    "description": "Tighten the AABBA rhyme scheme.",
+                    "assignee_agent_id": "writer",
+                }
+            ],
+            "edges": [],
+        },
+    ]
+    queue = iter(scripted)
+
+    async def _call(system: str, user: str, model: str) -> str:
+        _ = (system, user, model)
+        try:
+            return json.dumps(next(queue))
+        except StopIteration:
+            return "{}"
+
+    return _call
+
+
+async def main() -> None:
+    sink = InMemorySink()
+    runner = goldfive.wrap(
+        writer_agent,
+        sinks=[sink],
+        call_llm=_build_scripted_call_llm(),
+        model="scripted",
+    )
+
+    print(f"conversation_id: {runner.conversation_id}")
+    print()
+
+    for turn_number, user_input in enumerate(
+        [
+            "Write a limerick about cats",
+            "Actually, make it funnier",
+            "Now tighten the rhymes",
+        ],
+        start=1,
+    ):
+        print(f"--- turn {turn_number}: {user_input!r} ---")
+        outcome = await runner.run(user_input)
+        print(f"  success={outcome.success}")
+        print(
+            f"  session.run_id={outcome.session.run_id[:8]}..."
+            f"  session.conversation_id={outcome.session.conversation_id[:8]}..."
+        )
+        print(f"  goals so far: {[g.summary for g in outcome.session.goals]}")
+        print(
+            f"  completed_results so far: "
+            f"{list(outcome.session.completed_results.keys())}"
+        )
+        print()
+
+    print(f"total turns on conversation: {len(runner.conversation.turns)}")
+    print()
+    print("Now resetting with runner.new_conversation() — the next run would")
+    print("start with empty cross-turn state and a fresh conversation_id.")
+    old_id = runner.conversation_id
+    await runner.new_conversation()
+    print(f"  old conversation_id={old_id[:8]}..., new={runner.conversation_id[:8]}...")
+
+    await runner.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -13,6 +13,7 @@ from goldfive.control import (
     ControlMessage,
 )
 from goldfive.convenience import run, wrap
+from goldfive.conversation import Conversation, TurnRecord
 from goldfive.drift import classify_refusal, classify_stop_reason, classify_tool_error
 from goldfive.executors.parallel import ParallelDAGExecutor
 from goldfive.executors.sequential import SequentialExecutor
@@ -64,6 +65,7 @@ __all__ = [
     "ControlChannel",
     "ControlKind",
     "ControlMessage",
+    "Conversation",
     "DefaultSteerer",
     "DriftEvent",
     "DriftKind",
@@ -96,6 +98,7 @@ __all__ = [
     "Task",
     "TaskEdge",
     "TaskStatus",
+    "TurnRecord",
     "classify_refusal",
     "classify_stop_reason",
     "classify_tool_error",

--- a/goldfive/conversation.py
+++ b/goldfive/conversation.py
@@ -1,0 +1,203 @@
+"""Cross-turn conversation state for :class:`goldfive.Runner`.
+
+A :class:`Conversation` persists state across successive
+``runner.run()`` calls on the same Runner instance. Each ``run()`` is
+still a distinct goldfive *run* with its own ``run_id`` and its own
+``RunStarted``/``RunCompleted`` lifecycle — but the Runner seeds each
+turn's :class:`Session` from the Conversation, then folds the turn's
+outcome back in when it finishes. This gives the planner access to
+prior-turn ``completed_results`` and an append-only history of goals,
+which is the primary UX win: a user can say "make it funnier" on
+turn 2 and the planner sees turn 1's output as context.
+
+Phase 3 scope (see issue #78):
+
+* ``session.goals`` accumulates across turns (deduplicated by id).
+* ``session.completed_results`` carries over from prior turns.
+* ``session.plan`` resets per turn. Cross-turn plan lineage is v2.
+* :class:`TurnRecord` captures a one-sentence summary of each turn so
+  the planner can reference them in its prompt.
+
+A Runner always owns a Conversation — single-turn callers never notice
+because the Conversation is fresh on construction and discarded with
+the Runner.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+import uuid
+from typing import TYPE_CHECKING
+
+from goldfive.types import Goal, Session
+
+if TYPE_CHECKING:
+    from goldfive.results import ExecutionOutcome
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+@dataclasses.dataclass
+class TurnRecord:
+    """Summary of one completed turn within a :class:`Conversation`.
+
+    Stored on the Conversation and surfaced to the planner as
+    prior-turn context on subsequent turns. Keep fields compact —
+    these are serialised into planner prompts.
+    """
+
+    run_id: str
+    user_input_summary: str = ""
+    plan_summary: str = ""
+    outcome_success: bool = True
+    outcome_reason: str = ""
+    completed_task_ids: list[str] = dataclasses.field(default_factory=list)
+    started_at_ms: int = 0
+    ended_at_ms: int = 0
+
+
+@dataclasses.dataclass
+class Conversation:
+    """Cross-turn state owned by a :class:`~goldfive.Runner`.
+
+    Attributes
+    ----------
+    id:
+        Stable identifier for the conversation. Survives across turns;
+        only changes when the caller invokes
+        :meth:`Runner.new_conversation`.
+    started_at_ms:
+        Wall-clock ms when the Conversation was constructed.
+    goals:
+        Append-only list of goals seen across every turn. Deduplicated
+        by ``Goal.id`` so a goal that is genuinely re-stated on a later
+        turn does not appear twice.
+    completed_results:
+        Merged ``task_id -> summary`` map across every turn. Each new
+        turn sees prior turns' completed task outputs as planner
+        context.
+    turns:
+        Log of :class:`TurnRecord` entries, one per completed turn.
+        Used by :meth:`prior_turn_context` to give the planner a
+        capped recent-history window.
+    """
+
+    id: str
+    started_at_ms: int
+    goals: list[Goal] = dataclasses.field(default_factory=list)
+    completed_results: dict[str, str] = dataclasses.field(default_factory=dict)
+    turns: list[TurnRecord] = dataclasses.field(default_factory=list)
+
+    @classmethod
+    def new(cls) -> Conversation:
+        """Build a fresh, empty Conversation with a new UUID."""
+        return cls(id=uuid.uuid4().hex, started_at_ms=_now_ms())
+
+    # ------------------------------------------------------------------
+    # Turn lifecycle
+    # ------------------------------------------------------------------
+
+    def next_turn_session(self) -> Session:
+        """Build a :class:`Session` seeded with cross-turn state.
+
+        The returned Session has a fresh ``run_id``, inherits the
+        Conversation's ``id`` as ``conversation_id``, and copies
+        (not aliases) the accumulated ``goals`` and ``completed_results``
+        so the executor's in-turn mutations do not retroactively
+        rewrite the Conversation's record.
+        """
+        return Session(
+            run_id=uuid.uuid4().hex,
+            conversation_id=self.id,
+            started_at_ms=_now_ms(),
+            goals=list(self.goals),
+            completed_results=dict(self.completed_results),
+        )
+
+    def absorb_turn(
+        self,
+        outcome: ExecutionOutcome,
+        *,
+        user_input_summary: str = "",
+    ) -> TurnRecord:
+        """Fold a turn's outcome back into the Conversation.
+
+        Called by the Runner after ``executor.run`` returns (successful
+        or not — we record the failure so the next turn's planner can
+        see it). Returns the newly-appended :class:`TurnRecord`.
+        """
+        session = outcome.session
+        # Merge goals by id so a restated goal doesn't duplicate.
+        seen_ids = {g.id for g in self.goals if g.id}
+        for g in session.goals:
+            if g.id and g.id in seen_ids:
+                continue
+            self.goals.append(g)
+            if g.id:
+                seen_ids.add(g.id)
+
+        # Completed results merge: later turns win on id collisions so
+        # that a revised result on a follow-up turn is visible to the
+        # turn after it.
+        self.completed_results.update(session.completed_results)
+
+        plan_summary = ""
+        completed_ids: list[str] = []
+        if session.plan is not None:
+            plan_summary = session.plan.summary or ""
+            completed_ids = [
+                t.id
+                for t in session.plan.tasks
+                if t.status.value == "COMPLETED" and t.id
+            ]
+
+        record = TurnRecord(
+            run_id=session.run_id,
+            user_input_summary=user_input_summary,
+            plan_summary=plan_summary,
+            outcome_success=bool(outcome.success),
+            outcome_reason=outcome.reason or "",
+            completed_task_ids=completed_ids,
+            started_at_ms=session.started_at_ms,
+            ended_at_ms=_now_ms(),
+        )
+        self.turns.append(record)
+        return record
+
+    # ------------------------------------------------------------------
+    # Planner context
+    # ------------------------------------------------------------------
+
+    def prior_turn_context(self, *, recent_turns: int = 3) -> dict[str, object]:
+        """Return the cross-turn context dict passed to the planner.
+
+        ``recent_turns`` caps how many ``TurnRecord`` entries are
+        forwarded so prompts do not grow unbounded on very long
+        conversations. The returned dict is safe to merge into the
+        caller's own planner context via ``dict.update``.
+        """
+        if recent_turns < 0:
+            recent_turns = 0
+        window = self.turns[-recent_turns:] if recent_turns else []
+        return {
+            "conversation_id": self.id,
+            "prior_completed_results": dict(self.completed_results),
+            "prior_turns": [
+                {
+                    "run_id": t.run_id,
+                    "user_input_summary": t.user_input_summary,
+                    "plan_summary": t.plan_summary,
+                    "outcome_success": t.outcome_success,
+                    "outcome_reason": t.outcome_reason,
+                    "completed_task_ids": list(t.completed_task_ids),
+                }
+                for t in window
+            ],
+            "turn_index": len(self.turns),
+        }
+
+
+__all__ = ["Conversation", "TurnRecord"]

--- a/goldfive/events.py
+++ b/goldfive/events.py
@@ -305,6 +305,46 @@ def control_received_event(
     return drift_detected_event(run_id, sequence, drift)
 
 
+def conversation_started_event(
+    run_id: str,
+    sequence: int,
+    conversation_id: str,
+    started_at: Any | None = None,
+) -> Any:
+    """Build a ``ConversationStarted`` envelope.
+
+    Emitted once per :class:`~goldfive.conversation.Conversation` on
+    the first turn that uses it. ``run_id`` on the envelope carries
+    the first turn's run id; the ``conversation_id`` field inside the
+    payload is the stable identifier shared by every turn.
+    """
+    evt = new_event(run_id, sequence)
+    evt.conversation_started.conversation_id = conversation_id
+    evt.conversation_started.started_at.CopyFrom(started_at or now_ts())
+    return evt
+
+
+def conversation_ended_event(
+    run_id: str,
+    sequence: int,
+    conversation_id: str,
+    turn_count: int = 0,
+    reason: str = "",
+) -> Any:
+    """Build a ``ConversationEnded`` envelope.
+
+    Emitted when a caller resets the Runner's conversation (via
+    :meth:`Runner.new_conversation`) or tears the Runner down. ``run_id``
+    on the envelope is the last turn's run id so sinks can anchor the
+    event in the run timeline.
+    """
+    evt = new_event(run_id, sequence)
+    evt.conversation_ended.conversation_id = conversation_id
+    evt.conversation_ended.turn_count = int(turn_count)
+    evt.conversation_ended.reason = reason
+    return evt
+
+
 def drift_detected_event(run_id: str, sequence: int, drift: Any) -> Any:
     pb = _events_pb_module()
     evt = new_event(run_id, sequence)

--- a/goldfive/pb/goldfive/v1/events_pb2.py
+++ b/goldfive/pb/goldfive/v1/events_pb2.py
@@ -26,7 +26,7 @@ from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__
 from goldfive.v1 import types_pb2 as goldfive_dot_v1_dot_types__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18goldfive/v1/events.proto\x12\x0bgoldfive.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17goldfive/v1/types.proto\"\x8e\x06\n\x05\x45vent\x12\x10\n\x08\x65vent_id\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08sequence\x18\x03 \x01(\x04\x12.\n\nemitted_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12.\n\x0brun_started\x18\n \x01(\x0b\x32\x17.goldfive.v1.RunStartedH\x00\x12\x30\n\x0cgoal_derived\x18\x0b \x01(\x0b\x32\x18.goldfive.v1.GoalDerivedH\x00\x12\x34\n\x0eplan_submitted\x18\x0c \x01(\x0b\x32\x1a.goldfive.v1.PlanSubmittedH\x00\x12\x30\n\x0cplan_revised\x18\r \x01(\x0b\x32\x18.goldfive.v1.PlanRevisedH\x00\x12\x30\n\x0ctask_started\x18\x0e \x01(\x0b\x32\x18.goldfive.v1.TaskStartedH\x00\x12\x32\n\rtask_progress\x18\x0f \x01(\x0b\x32\x19.goldfive.v1.TaskProgressH\x00\x12\x34\n\x0etask_completed\x18\x10 \x01(\x0b\x32\x1a.goldfive.v1.TaskCompletedH\x00\x12.\n\x0btask_failed\x18\x11 \x01(\x0b\x32\x17.goldfive.v1.TaskFailedH\x00\x12\x30\n\x0ctask_blocked\x18\x12 \x01(\x0b\x32\x18.goldfive.v1.TaskBlockedH\x00\x12\x34\n\x0etask_cancelled\x18\x13 \x01(\x0b\x32\x1a.goldfive.v1.TaskCancelledH\x00\x12\x34\n\x0e\x64rift_detected\x18\x14 \x01(\x0b\x32\x1a.goldfive.v1.DriftDetectedH\x00\x12\x32\n\rrun_completed\x18\x15 \x01(\x0b\x32\x19.goldfive.v1.RunCompletedH\x00\x12.\n\x0brun_aborted\x18\x16 \x01(\x0b\x32\x17.goldfive.v1.RunAbortedH\x00\x42\t\n\x07payload\"b\n\nRunStarted\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x14\n\x0cgoal_summary\x18\x02 \x01(\t\x12.\n\nstarted_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"/\n\x0bGoalDerived\x12 \n\x05goals\x18\x01 \x03(\x0b\x32\x11.goldfive.v1.Goal\"0\n\rPlanSubmitted\x12\x1f\n\x04plan\x18\x01 \x01(\x0b\x32\x11.goldfive.v1.Plan\"\xb0\x01\n\x0bPlanRevised\x12\x1f\n\x04plan\x18\x01 \x01(\x0b\x32\x11.goldfive.v1.Plan\x12*\n\ndrift_kind\x18\x02 \x01(\x0e\x32\x16.goldfive.v1.DriftKind\x12,\n\x08severity\x18\x03 \x01(\x0e\x32\x1a.goldfive.v1.DriftSeverity\x12\x0e\n\x06reason\x18\x04 \x01(\t\x12\x16\n\x0erevision_index\x18\x05 \x01(\r\".\n\x0bTaskStarted\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\"A\n\x0cTaskProgress\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x10\n\x08\x66raction\x18\x02 \x01(\x02\x12\x0e\n\x06\x64\x65tail\x18\x03 \x01(\t\"\xa1\x01\n\rTaskCompleted\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0f\n\x07summary\x18\x02 \x01(\t\x12<\n\tartifacts\x18\x03 \x03(\x0b\x32).goldfive.v1.TaskCompleted.ArtifactsEntry\x1a\x30\n\x0e\x41rtifactsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"B\n\nTaskFailed\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06reason\x18\x02 \x01(\t\x12\x13\n\x0brecoverable\x18\x03 \x01(\x08\"?\n\x0bTaskBlocked\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0f\n\x07\x62locker\x18\x02 \x01(\t\x12\x0e\n\x06needed\x18\x03 \x01(\t\"0\n\rTaskCancelled\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06reason\x18\x02 \x01(\t\"\xa6\x01\n\rDriftDetected\x12$\n\x04kind\x18\x01 \x01(\x0e\x32\x16.goldfive.v1.DriftKind\x12,\n\x08severity\x18\x02 \x01(\x0e\x32\x1a.goldfive.v1.DriftSeverity\x12\x0e\n\x06\x64\x65tail\x18\x03 \x01(\t\x12\x17\n\x0f\x63urrent_task_id\x18\x04 \x01(\t\x12\x18\n\x10\x63urrent_agent_id\x18\x05 \x01(\t\"\'\n\x0cRunCompleted\x12\x17\n\x0foutcome_summary\x18\x01 \x01(\t\"\x1c\n\nRunAborted\x12\x0e\n\x06reason\x18\x01 \x01(\tB9Z7github.com/pedapudi/goldfive/gen/goldfive/v1;goldfivev1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18goldfive/v1/events.proto\x12\x0bgoldfive.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17goldfive/v1/types.proto\"\x8e\x07\n\x05\x45vent\x12\x10\n\x08\x65vent_id\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08sequence\x18\x03 \x01(\x04\x12.\n\nemitted_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12.\n\x0brun_started\x18\n \x01(\x0b\x32\x17.goldfive.v1.RunStartedH\x00\x12\x30\n\x0cgoal_derived\x18\x0b \x01(\x0b\x32\x18.goldfive.v1.GoalDerivedH\x00\x12\x34\n\x0eplan_submitted\x18\x0c \x01(\x0b\x32\x1a.goldfive.v1.PlanSubmittedH\x00\x12\x30\n\x0cplan_revised\x18\r \x01(\x0b\x32\x18.goldfive.v1.PlanRevisedH\x00\x12\x30\n\x0ctask_started\x18\x0e \x01(\x0b\x32\x18.goldfive.v1.TaskStartedH\x00\x12\x32\n\rtask_progress\x18\x0f \x01(\x0b\x32\x19.goldfive.v1.TaskProgressH\x00\x12\x34\n\x0etask_completed\x18\x10 \x01(\x0b\x32\x1a.goldfive.v1.TaskCompletedH\x00\x12.\n\x0btask_failed\x18\x11 \x01(\x0b\x32\x17.goldfive.v1.TaskFailedH\x00\x12\x30\n\x0ctask_blocked\x18\x12 \x01(\x0b\x32\x18.goldfive.v1.TaskBlockedH\x00\x12\x34\n\x0etask_cancelled\x18\x13 \x01(\x0b\x32\x1a.goldfive.v1.TaskCancelledH\x00\x12\x34\n\x0e\x64rift_detected\x18\x14 \x01(\x0b\x32\x1a.goldfive.v1.DriftDetectedH\x00\x12\x32\n\rrun_completed\x18\x15 \x01(\x0b\x32\x19.goldfive.v1.RunCompletedH\x00\x12.\n\x0brun_aborted\x18\x16 \x01(\x0b\x32\x17.goldfive.v1.RunAbortedH\x00\x12@\n\x14\x63onversation_started\x18\x17 \x01(\x0b\x32 .goldfive.v1.ConversationStartedH\x00\x12<\n\x12\x63onversation_ended\x18\x18 \x01(\x0b\x32\x1e.goldfive.v1.ConversationEndedH\x00\x42\t\n\x07payload\"b\n\nRunStarted\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x14\n\x0cgoal_summary\x18\x02 \x01(\t\x12.\n\nstarted_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"/\n\x0bGoalDerived\x12 \n\x05goals\x18\x01 \x03(\x0b\x32\x11.goldfive.v1.Goal\"0\n\rPlanSubmitted\x12\x1f\n\x04plan\x18\x01 \x01(\x0b\x32\x11.goldfive.v1.Plan\"\xb0\x01\n\x0bPlanRevised\x12\x1f\n\x04plan\x18\x01 \x01(\x0b\x32\x11.goldfive.v1.Plan\x12*\n\ndrift_kind\x18\x02 \x01(\x0e\x32\x16.goldfive.v1.DriftKind\x12,\n\x08severity\x18\x03 \x01(\x0e\x32\x1a.goldfive.v1.DriftSeverity\x12\x0e\n\x06reason\x18\x04 \x01(\t\x12\x16\n\x0erevision_index\x18\x05 \x01(\r\".\n\x0bTaskStarted\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\"A\n\x0cTaskProgress\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x10\n\x08\x66raction\x18\x02 \x01(\x02\x12\x0e\n\x06\x64\x65tail\x18\x03 \x01(\t\"\xa1\x01\n\rTaskCompleted\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0f\n\x07summary\x18\x02 \x01(\t\x12<\n\tartifacts\x18\x03 \x03(\x0b\x32).goldfive.v1.TaskCompleted.ArtifactsEntry\x1a\x30\n\x0e\x41rtifactsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"B\n\nTaskFailed\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06reason\x18\x02 \x01(\t\x12\x13\n\x0brecoverable\x18\x03 \x01(\x08\"?\n\x0bTaskBlocked\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0f\n\x07\x62locker\x18\x02 \x01(\t\x12\x0e\n\x06needed\x18\x03 \x01(\t\"0\n\rTaskCancelled\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06reason\x18\x02 \x01(\t\"\xa6\x01\n\rDriftDetected\x12$\n\x04kind\x18\x01 \x01(\x0e\x32\x16.goldfive.v1.DriftKind\x12,\n\x08severity\x18\x02 \x01(\x0e\x32\x1a.goldfive.v1.DriftSeverity\x12\x0e\n\x06\x64\x65tail\x18\x03 \x01(\t\x12\x17\n\x0f\x63urrent_task_id\x18\x04 \x01(\t\x12\x18\n\x10\x63urrent_agent_id\x18\x05 \x01(\t\"\'\n\x0cRunCompleted\x12\x17\n\x0foutcome_summary\x18\x01 \x01(\t\"\x1c\n\nRunAborted\x12\x0e\n\x06reason\x18\x01 \x01(\t\"^\n\x13\x43onversationStarted\x12\x17\n\x0f\x63onversation_id\x18\x01 \x01(\t\x12.\n\nstarted_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"P\n\x11\x43onversationEnded\x12\x17\n\x0f\x63onversation_id\x18\x01 \x01(\t\x12\x12\n\nturn_count\x18\x02 \x01(\r\x12\x0e\n\x06reason\x18\x03 \x01(\tB9Z7github.com/pedapudi/goldfive/gen/goldfive/v1;goldfivev1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -37,33 +37,37 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_TASKCOMPLETED_ARTIFACTSENTRY']._loaded_options = None
   _globals['_TASKCOMPLETED_ARTIFACTSENTRY']._serialized_options = b'8\001'
   _globals['_EVENT']._serialized_start=100
-  _globals['_EVENT']._serialized_end=882
-  _globals['_RUNSTARTED']._serialized_start=884
-  _globals['_RUNSTARTED']._serialized_end=982
-  _globals['_GOALDERIVED']._serialized_start=984
-  _globals['_GOALDERIVED']._serialized_end=1031
-  _globals['_PLANSUBMITTED']._serialized_start=1033
-  _globals['_PLANSUBMITTED']._serialized_end=1081
-  _globals['_PLANREVISED']._serialized_start=1084
-  _globals['_PLANREVISED']._serialized_end=1260
-  _globals['_TASKSTARTED']._serialized_start=1262
-  _globals['_TASKSTARTED']._serialized_end=1308
-  _globals['_TASKPROGRESS']._serialized_start=1310
-  _globals['_TASKPROGRESS']._serialized_end=1375
-  _globals['_TASKCOMPLETED']._serialized_start=1378
-  _globals['_TASKCOMPLETED']._serialized_end=1539
-  _globals['_TASKCOMPLETED_ARTIFACTSENTRY']._serialized_start=1491
-  _globals['_TASKCOMPLETED_ARTIFACTSENTRY']._serialized_end=1539
-  _globals['_TASKFAILED']._serialized_start=1541
-  _globals['_TASKFAILED']._serialized_end=1607
-  _globals['_TASKBLOCKED']._serialized_start=1609
-  _globals['_TASKBLOCKED']._serialized_end=1672
-  _globals['_TASKCANCELLED']._serialized_start=1674
-  _globals['_TASKCANCELLED']._serialized_end=1722
-  _globals['_DRIFTDETECTED']._serialized_start=1725
-  _globals['_DRIFTDETECTED']._serialized_end=1891
-  _globals['_RUNCOMPLETED']._serialized_start=1893
-  _globals['_RUNCOMPLETED']._serialized_end=1932
-  _globals['_RUNABORTED']._serialized_start=1934
-  _globals['_RUNABORTED']._serialized_end=1962
+  _globals['_EVENT']._serialized_end=1010
+  _globals['_RUNSTARTED']._serialized_start=1012
+  _globals['_RUNSTARTED']._serialized_end=1110
+  _globals['_GOALDERIVED']._serialized_start=1112
+  _globals['_GOALDERIVED']._serialized_end=1159
+  _globals['_PLANSUBMITTED']._serialized_start=1161
+  _globals['_PLANSUBMITTED']._serialized_end=1209
+  _globals['_PLANREVISED']._serialized_start=1212
+  _globals['_PLANREVISED']._serialized_end=1388
+  _globals['_TASKSTARTED']._serialized_start=1390
+  _globals['_TASKSTARTED']._serialized_end=1436
+  _globals['_TASKPROGRESS']._serialized_start=1438
+  _globals['_TASKPROGRESS']._serialized_end=1503
+  _globals['_TASKCOMPLETED']._serialized_start=1506
+  _globals['_TASKCOMPLETED']._serialized_end=1667
+  _globals['_TASKCOMPLETED_ARTIFACTSENTRY']._serialized_start=1619
+  _globals['_TASKCOMPLETED_ARTIFACTSENTRY']._serialized_end=1667
+  _globals['_TASKFAILED']._serialized_start=1669
+  _globals['_TASKFAILED']._serialized_end=1735
+  _globals['_TASKBLOCKED']._serialized_start=1737
+  _globals['_TASKBLOCKED']._serialized_end=1800
+  _globals['_TASKCANCELLED']._serialized_start=1802
+  _globals['_TASKCANCELLED']._serialized_end=1850
+  _globals['_DRIFTDETECTED']._serialized_start=1853
+  _globals['_DRIFTDETECTED']._serialized_end=2019
+  _globals['_RUNCOMPLETED']._serialized_start=2021
+  _globals['_RUNCOMPLETED']._serialized_end=2060
+  _globals['_RUNABORTED']._serialized_start=2062
+  _globals['_RUNABORTED']._serialized_end=2090
+  _globals['_CONVERSATIONSTARTED']._serialized_start=2092
+  _globals['_CONVERSATIONSTARTED']._serialized_end=2186
+  _globals['_CONVERSATIONENDED']._serialized_start=2188
+  _globals['_CONVERSATIONENDED']._serialized_end=2268
 # @@protoc_insertion_point(module_scope)

--- a/goldfive/pb/goldfive/v1/events_pb2.pyi
+++ b/goldfive/pb/goldfive/v1/events_pb2.pyi
@@ -11,7 +11,7 @@ from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union
 DESCRIPTOR: _descriptor.FileDescriptor
 
 class Event(_message.Message):
-    __slots__ = ("event_id", "run_id", "sequence", "emitted_at", "run_started", "goal_derived", "plan_submitted", "plan_revised", "task_started", "task_progress", "task_completed", "task_failed", "task_blocked", "task_cancelled", "drift_detected", "run_completed", "run_aborted")
+    __slots__ = ("event_id", "run_id", "sequence", "emitted_at", "run_started", "goal_derived", "plan_submitted", "plan_revised", "task_started", "task_progress", "task_completed", "task_failed", "task_blocked", "task_cancelled", "drift_detected", "run_completed", "run_aborted", "conversation_started", "conversation_ended")
     EVENT_ID_FIELD_NUMBER: _ClassVar[int]
     RUN_ID_FIELD_NUMBER: _ClassVar[int]
     SEQUENCE_FIELD_NUMBER: _ClassVar[int]
@@ -29,6 +29,8 @@ class Event(_message.Message):
     DRIFT_DETECTED_FIELD_NUMBER: _ClassVar[int]
     RUN_COMPLETED_FIELD_NUMBER: _ClassVar[int]
     RUN_ABORTED_FIELD_NUMBER: _ClassVar[int]
+    CONVERSATION_STARTED_FIELD_NUMBER: _ClassVar[int]
+    CONVERSATION_ENDED_FIELD_NUMBER: _ClassVar[int]
     event_id: str
     run_id: str
     sequence: int
@@ -46,7 +48,9 @@ class Event(_message.Message):
     drift_detected: DriftDetected
     run_completed: RunCompleted
     run_aborted: RunAborted
-    def __init__(self, event_id: _Optional[str] = ..., run_id: _Optional[str] = ..., sequence: _Optional[int] = ..., emitted_at: _Optional[_Union[datetime.datetime, _timestamp_pb2.Timestamp, _Mapping]] = ..., run_started: _Optional[_Union[RunStarted, _Mapping]] = ..., goal_derived: _Optional[_Union[GoalDerived, _Mapping]] = ..., plan_submitted: _Optional[_Union[PlanSubmitted, _Mapping]] = ..., plan_revised: _Optional[_Union[PlanRevised, _Mapping]] = ..., task_started: _Optional[_Union[TaskStarted, _Mapping]] = ..., task_progress: _Optional[_Union[TaskProgress, _Mapping]] = ..., task_completed: _Optional[_Union[TaskCompleted, _Mapping]] = ..., task_failed: _Optional[_Union[TaskFailed, _Mapping]] = ..., task_blocked: _Optional[_Union[TaskBlocked, _Mapping]] = ..., task_cancelled: _Optional[_Union[TaskCancelled, _Mapping]] = ..., drift_detected: _Optional[_Union[DriftDetected, _Mapping]] = ..., run_completed: _Optional[_Union[RunCompleted, _Mapping]] = ..., run_aborted: _Optional[_Union[RunAborted, _Mapping]] = ...) -> None: ...
+    conversation_started: ConversationStarted
+    conversation_ended: ConversationEnded
+    def __init__(self, event_id: _Optional[str] = ..., run_id: _Optional[str] = ..., sequence: _Optional[int] = ..., emitted_at: _Optional[_Union[datetime.datetime, _timestamp_pb2.Timestamp, _Mapping]] = ..., run_started: _Optional[_Union[RunStarted, _Mapping]] = ..., goal_derived: _Optional[_Union[GoalDerived, _Mapping]] = ..., plan_submitted: _Optional[_Union[PlanSubmitted, _Mapping]] = ..., plan_revised: _Optional[_Union[PlanRevised, _Mapping]] = ..., task_started: _Optional[_Union[TaskStarted, _Mapping]] = ..., task_progress: _Optional[_Union[TaskProgress, _Mapping]] = ..., task_completed: _Optional[_Union[TaskCompleted, _Mapping]] = ..., task_failed: _Optional[_Union[TaskFailed, _Mapping]] = ..., task_blocked: _Optional[_Union[TaskBlocked, _Mapping]] = ..., task_cancelled: _Optional[_Union[TaskCancelled, _Mapping]] = ..., drift_detected: _Optional[_Union[DriftDetected, _Mapping]] = ..., run_completed: _Optional[_Union[RunCompleted, _Mapping]] = ..., run_aborted: _Optional[_Union[RunAborted, _Mapping]] = ..., conversation_started: _Optional[_Union[ConversationStarted, _Mapping]] = ..., conversation_ended: _Optional[_Union[ConversationEnded, _Mapping]] = ...) -> None: ...
 
 class RunStarted(_message.Message):
     __slots__ = ("run_id", "goal_summary", "started_at")
@@ -172,3 +176,21 @@ class RunAborted(_message.Message):
     REASON_FIELD_NUMBER: _ClassVar[int]
     reason: str
     def __init__(self, reason: _Optional[str] = ...) -> None: ...
+
+class ConversationStarted(_message.Message):
+    __slots__ = ("conversation_id", "started_at")
+    CONVERSATION_ID_FIELD_NUMBER: _ClassVar[int]
+    STARTED_AT_FIELD_NUMBER: _ClassVar[int]
+    conversation_id: str
+    started_at: _timestamp_pb2.Timestamp
+    def __init__(self, conversation_id: _Optional[str] = ..., started_at: _Optional[_Union[datetime.datetime, _timestamp_pb2.Timestamp, _Mapping]] = ...) -> None: ...
+
+class ConversationEnded(_message.Message):
+    __slots__ = ("conversation_id", "turn_count", "reason")
+    CONVERSATION_ID_FIELD_NUMBER: _ClassVar[int]
+    TURN_COUNT_FIELD_NUMBER: _ClassVar[int]
+    REASON_FIELD_NUMBER: _ClassVar[int]
+    conversation_id: str
+    turn_count: int
+    reason: str
+    def __init__(self, conversation_id: _Optional[str] = ..., turn_count: _Optional[int] = ..., reason: _Optional[str] = ...) -> None: ...

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -475,6 +475,52 @@ class LLMPlanner:
     def _render_agents_block(available_agents: list[str]) -> str:
         return "\n".join(f"- {a}" for a in available_agents) or "- (none listed)"
 
+    @staticmethod
+    def _render_prior_turns_block(context: Mapping[str, Any] | None) -> str:
+        """Render cross-turn context from a Conversation into a prompt block.
+
+        Reads ``prior_completed_results`` and ``prior_turns`` off the
+        planner context (see :class:`~goldfive.conversation.Conversation`)
+        and produces a human-readable section for the planner to reason
+        about. Returns ``""`` when the caller is not running inside a
+        multi-turn Conversation (first turn, or single-turn use).
+        """
+        if not context:
+            return ""
+        turns = context.get("prior_turns") or []
+        prior_results = context.get("prior_completed_results") or {}
+        if not turns and not prior_results:
+            return ""
+        lines: list[str] = ["\nPrior-turn context (this is a multi-turn conversation):"]
+        if turns:
+            lines.append("\nEarlier turns (most recent last):")
+            for i, t in enumerate(turns, start=1):
+                if not isinstance(t, Mapping):
+                    continue
+                ui = str(t.get("user_input_summary") or "")
+                plan_summary = str(t.get("plan_summary") or "")
+                success = bool(t.get("outcome_success", True))
+                status = "succeeded" if success else "failed"
+                reason = str(t.get("outcome_reason") or "")
+                reason_frag = f" ({reason})" if (not success and reason) else ""
+                lines.append(
+                    f"  {i}. user: {ui!r} -> {status}{reason_frag}"
+                    f"{f'; plan: {plan_summary}' if plan_summary else ''}"
+                )
+        if prior_results:
+            lines.append(
+                "\nResults already produced in earlier turns "
+                "(task_id -> summary):"
+            )
+            for task_id, summary in prior_results.items():
+                lines.append(f"  - {task_id}: {summary}")
+        lines.append(
+            "\nWhen planning this turn, treat the user's current input as a "
+            "follow-up. Reuse prior results where relevant, and only "
+            "re-do work that the user's new input actually requires."
+        )
+        return "\n".join(lines) + "\n"
+
     def _build_generate_prompt(
         self,
         goals: list[Goal],
@@ -483,17 +529,34 @@ class LLMPlanner:
     ) -> str:
         goals_block = self._render_goals_block(goals)
         agents_block = self._render_agents_block(available_agents)
+        prior_block = self._render_prior_turns_block(context)
         context_block = ""
         if context:
-            try:
-                context_block = (
-                    f"\nAdditional context (JSON):\n{json.dumps(dict(context), default=str)}\n"
-                )
-            except (TypeError, ValueError):
-                context_block = ""
+            # Exclude the verbose cross-turn fields from the raw JSON
+            # dump — they're already rendered as a human-readable
+            # block above. Keep everything else.
+            filtered = {
+                k: v
+                for k, v in dict(context).items()
+                if k
+                not in {
+                    "prior_completed_results",
+                    "prior_turns",
+                    "turn_index",
+                    "conversation_id",
+                }
+            }
+            if filtered:
+                try:
+                    context_block = (
+                        f"\nAdditional context (JSON):\n{json.dumps(filtered, default=str)}\n"
+                    )
+                except (TypeError, ValueError):
+                    context_block = ""
         return (
             f"Available agents:\n{agents_block}\n\n"
             f"Goals:\n{goals_block}\n"
+            f"{prior_block}"
             f"{context_block}\n"
             "Respond with a single JSON object following the schema."
         )

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -36,12 +36,13 @@ and are loaded lazily by callers.
 from __future__ import annotations
 
 import logging
-import time
-import uuid
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
+from goldfive.conversation import Conversation
 from goldfive.events import (
+    conversation_ended_event,
+    conversation_started_event,
     emit,
     goal_derived_event,
     plan_submitted_event,
@@ -66,10 +67,6 @@ if TYPE_CHECKING:
     )
 
 log = logging.getLogger("goldfive.runner")
-
-
-def _now_ms() -> int:
-    return int(time.time() * 1000)
 
 
 class Runner:
@@ -118,6 +115,7 @@ class Runner:
         sinks: list[EventSink] | None = None,
         control: ControlChannel | None = None,
         max_plan_reinvocations: int = 3,
+        conversation: Conversation | None = None,
     ) -> None:
         self.agent = agent
         self.planner = planner
@@ -127,6 +125,15 @@ class Runner:
         self.sinks: list[EventSink] = list(sinks) if sinks else []
         self.control: ControlChannel | None = control
         self.max_plan_reinvocations = max_plan_reinvocations
+        self._conversation: Conversation = conversation or Conversation.new()
+        # Tracks whether we've emitted the ConversationStarted event for
+        # the current Conversation. Flips back to False on new_conversation().
+        self._conversation_announced: bool = False
+        # Last turn's Session, held past the turn so that ConversationEnded
+        # can piggy-back on its ``next_sequence()`` counter (sequence must
+        # be monotonic within a run_id, so the terminal marker needs the
+        # session that produced the run's other events).
+        self._last_session: Session | None = None
 
     # ------------------------------------------------------------------
     # run
@@ -140,32 +147,59 @@ class Runner:
     ) -> ExecutionOutcome:
         """Execute one end-to-end goldfive run and return the outcome."""
 
-        # 1. Build Session with a fresh run_id.
-        session = Session(
-            run_id=uuid.uuid4().hex,
-            started_at_ms=_now_ms(),
-        )
+        # 1. Build Session seeded by the Conversation. The Session's
+        #    run_id is fresh for this turn; conversation_id is stable
+        #    across turns; goals / completed_results are pre-populated
+        #    with prior-turn state.
+        session = self._conversation.next_turn_session()
+        self._last_session = session
 
-        # 2. Emit RunStarted before anything else.
+        # 2. Announce the Conversation on the first turn.
+        if not self._conversation_announced:
+            await self._emit_conversation_started(session)
+            self._conversation_announced = True
+
+        # 3. Emit RunStarted before anything else for this turn.
         await self._emit_run_started(session, user_input)
 
-        # 3. Derive (or accept) goals.
+        # 4. Derive (or accept) goals for this turn. Cross-turn state
+        #    lives on ``session.goals`` already (seeded by the
+        #    Conversation); we append newly-derived goals that weren't
+        #    already present by id so the planner sees the full history.
         try:
-            goals = await self._resolve_goals(user_input, context)
+            new_goals = await self._resolve_goals(user_input, context)
         except Exception as exc:  # noqa: BLE001
             reason = f"goal derivation failed: {exc}"
             log.exception("goal derivation failed")
             await self._emit_run_aborted(session, reason)
-            return ExecutionOutcome(success=False, session=session, reason=reason)
-        session.goals = list(goals)
+            outcome = ExecutionOutcome(success=False, session=session, reason=reason)
+            self._conversation.absorb_turn(
+                outcome, user_input_summary=_initial_goal_summary(user_input)
+            )
+            return outcome
+
+        existing_ids = {g.id for g in session.goals if g.id}
+        for g in new_goals:
+            if g.id and g.id in existing_ids:
+                continue
+            session.goals.append(g)
+            if g.id:
+                existing_ids.add(g.id)
 
         await self._emit_goal_derived(session)
 
-        # Build the context passed to the planner — stamp run_id so LLM
-        # planners can include it in the plan envelope.
-        planner_context: dict[str, Any] = dict(context) if context else {}
-        planner_context.setdefault("run_id", session.run_id)
-        planner_context.setdefault("max_plan_reinvocations", self.max_plan_reinvocations)
+        # Build the context passed to the planner. Stamp run_id (so LLM
+        # planners can include it in the plan envelope), max
+        # reinvocations, and cross-turn context from the Conversation.
+        # Caller-supplied context wins on key collisions.
+        planner_context: dict[str, Any] = {
+            "run_id": session.run_id,
+            "max_plan_reinvocations": self.max_plan_reinvocations,
+        }
+        planner_context.update(self._conversation.prior_turn_context())
+        if context:
+            planner_context.update(context)
+        planner_context["run_id"] = session.run_id
 
         # 4. Generate the plan.
         try:
@@ -178,12 +212,20 @@ class Runner:
             reason = f"planner.generate raised: {exc}"
             log.exception("planner.generate raised")
             await self._emit_run_aborted(session, reason)
-            return ExecutionOutcome(success=False, session=session, reason=reason)
+            outcome = ExecutionOutcome(success=False, session=session, reason=reason)
+            self._conversation.absorb_turn(
+                outcome, user_input_summary=_initial_goal_summary(user_input)
+            )
+            return outcome
 
         if plan is None:
             reason = "no plan generated"
             await self._emit_run_aborted(session, reason)
-            return ExecutionOutcome(success=False, session=session, reason=reason)
+            outcome = ExecutionOutcome(success=False, session=session, reason=reason)
+            self._conversation.absorb_turn(
+                outcome, user_input_summary=_initial_goal_summary(user_input)
+            )
+            return outcome
 
         # Planners may leave run_id blank; stamp ours so downstream sinks
         # correlate cleanly.
@@ -200,7 +242,11 @@ class Runner:
             reason = f"register_reporting_tools raised: {exc}"
             log.exception("register_reporting_tools raised")
             await self._emit_run_aborted(session, reason)
-            return ExecutionOutcome(success=False, session=session, reason=reason)
+            outcome = ExecutionOutcome(success=False, session=session, reason=reason)
+            self._conversation.absorb_turn(
+                outcome, user_input_summary=_initial_goal_summary(user_input)
+            )
+            return outcome
 
         # 6. Bind the steerer. (The executor may re-bind — that's fine.)
         try:
@@ -209,7 +255,11 @@ class Runner:
             reason = f"steerer.bind raised: {exc}"
             log.exception("steerer.bind raised")
             await self._emit_run_aborted(session, reason)
-            return ExecutionOutcome(success=False, session=session, reason=reason)
+            outcome = ExecutionOutcome(success=False, session=session, reason=reason)
+            self._conversation.absorb_turn(
+                outcome, user_input_summary=_initial_goal_summary(user_input)
+            )
+            return outcome
 
         # 7. Hand off to the executor.
         try:
@@ -228,8 +278,15 @@ class Runner:
             reason = f"executor.run raised: {exc}"
             log.exception("executor.run raised")
             await self._emit_run_aborted(session, reason)
-            return ExecutionOutcome(success=False, session=session, reason=reason)
+            aborted = ExecutionOutcome(success=False, session=session, reason=reason)
+            self._conversation.absorb_turn(
+                aborted, user_input_summary=_initial_goal_summary(user_input)
+            )
+            return aborted
 
+        self._conversation.absorb_turn(
+            outcome, user_input_summary=_initial_goal_summary(user_input)
+        )
         return outcome
 
     # ------------------------------------------------------------------
@@ -280,11 +337,59 @@ class Runner:
         return ExecutionOutcome(success=success, session=session, reason=reason)
 
     # ------------------------------------------------------------------
+    # cross-turn conversation
+    # ------------------------------------------------------------------
+
+    @property
+    def conversation_id(self) -> str:
+        """The current Conversation's stable id. Changes only via :meth:`new_conversation`."""
+        return self._conversation.id
+
+    @property
+    def conversation(self) -> Conversation:
+        """The live :class:`Conversation` object. Read-only handle for inspection."""
+        return self._conversation
+
+    async def new_conversation(self, *, reason: str = "") -> None:
+        """Reset cross-turn state. The next :meth:`run` starts a fresh Conversation.
+
+        Emits a ``ConversationEnded`` event for the outgoing Conversation
+        (if it had any turns), then installs a fresh one. The new
+        Conversation is announced lazily — ``ConversationStarted`` fires
+        on the next :meth:`run` call.
+        """
+        outgoing = self._conversation
+        if self._conversation_announced and self._last_session is not None:
+            await self._emit_conversation_ended(
+                conversation=outgoing,
+                session_anchor=self._last_session,
+                reason=reason or "new_conversation",
+            )
+        self._conversation = Conversation.new()
+        self._conversation_announced = False
+        self._last_session = None
+
+    # ------------------------------------------------------------------
     # close
     # ------------------------------------------------------------------
 
     async def close(self) -> None:
-        """Close every sink. Best-effort — individual errors are logged."""
+        """Close every sink. Best-effort — individual errors are logged.
+
+        Emits ``ConversationEnded`` for the active Conversation (if any
+        turns ran) before closing sinks, so persisted logs have a clean
+        terminal marker.
+        """
+        if self._conversation_announced and self._last_session is not None:
+            try:
+                await self._emit_conversation_ended(
+                    conversation=self._conversation,
+                    session_anchor=self._last_session,
+                    reason="runner_close",
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.warning("conversation_ended emission raised: %s", exc)
+            self._conversation_announced = False
         for sink in self.sinks:
             try:
                 await sink.close()
@@ -346,6 +451,32 @@ class Runner:
         evt = run_aborted_event(
             run_id=session.run_id,
             sequence=session.next_sequence(),
+            reason=reason,
+        )
+        await emit(self.sinks, evt)
+
+    async def _emit_conversation_started(self, session: Session) -> None:
+        evt = conversation_started_event(
+            run_id=session.run_id,
+            sequence=session.next_sequence(),
+            conversation_id=self._conversation.id,
+        )
+        await emit(self.sinks, evt)
+
+    async def _emit_conversation_ended(
+        self,
+        *,
+        conversation: Conversation,
+        session_anchor: Session,
+        reason: str,
+    ) -> None:
+        # Piggy-back on the last turn's sequence counter so the
+        # envelope's sequence field stays monotonic within its run_id.
+        evt = conversation_ended_event(
+            run_id=session_anchor.run_id,
+            sequence=session_anchor.next_sequence(),
+            conversation_id=conversation.id,
+            turn_count=len(conversation.turns),
             reason=reason,
         )
         await emit(self.sinks, evt)

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -158,9 +158,16 @@ class DriftEvent:
 
 @dataclasses.dataclass
 class Session:
-    """Live state for one Runner.run() invocation."""
+    """Live state for one Runner.run() invocation.
+
+    ``conversation_id`` links this turn to the owning :class:`~goldfive.conversation.Conversation`
+    and is stable across successive turns on the same Runner. It
+    defaults to ``""`` for legacy callers that build Sessions directly
+    without going through a Conversation.
+    """
 
     run_id: str
+    conversation_id: str = ""
     goals: list[Goal] = dataclasses.field(default_factory=list)
     plan: Plan | None = None
     current_task_id: str = ""

--- a/proto/goldfive/v1/events.proto
+++ b/proto/goldfive/v1/events.proto
@@ -54,6 +54,8 @@ message Event {
     DriftDetected drift_detected = 20;
     RunCompleted run_completed = 21;
     RunAborted run_aborted = 22;
+    ConversationStarted conversation_started = 23;
+    ConversationEnded conversation_ended = 24;
   }
 }
 
@@ -170,4 +172,24 @@ message RunCompleted {
 // cancel, or a TaskFailed with recoverable=false).
 message RunAborted {
   string reason = 1;
+}
+
+// Emitted once per Conversation on the first turn that uses it. Sinks
+// that render cross-turn chat history use this to open a new
+// conversation context. `run_id` on the envelope is the first turn's
+// run_id; `conversation_id` below is the stable identifier shared by
+// every turn in the conversation.
+message ConversationStarted {
+  string conversation_id = 1;
+  google.protobuf.Timestamp started_at = 2;
+}
+
+// Emitted when a caller invokes `Runner.new_conversation()` or closes
+// the Runner. Signals that no further turns will share this
+// conversation_id. `turn_count` is the number of turns that ran before
+// the reset, so sinks can render "3-turn conversation ended".
+message ConversationEnded {
+  string conversation_id = 1;
+  uint32 turn_count = 2;
+  string reason = 3;
 }

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,442 @@
+"""Tests for cross-turn conversation state (issue #78).
+
+Exercises the guarantees the Phase 3 design pins:
+
+* A second ``runner.run()`` on the same Runner sees turn 1's
+  ``completed_results`` in its ``Session`` and in the planner's context.
+* ``runner.new_conversation()`` resets cross-turn state and changes
+  ``runner.conversation_id``.
+* ``runner.conversation_id`` is stable across turns.
+* The planner's prompt includes prior-turn context.
+* ``ConversationStarted`` / ``ConversationEnded`` lifecycle events
+  bracket the conversation.
+* Session carries ``conversation_id`` equal to the Runner's.
+* Single-turn callers are unaffected (backward compatibility).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from goldfive import (
+    CallableAdapter,
+    Conversation,
+    Goal,
+    InMemorySink,
+    InvocationResult,
+    LLMPlanner,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+    TurnRecord,
+)
+from goldfive.conversation import Conversation as _ConversationClass  # noqa: F401
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _linear_plan(suffix: str = "") -> Plan:
+    """Two-task linear plan suitable for a single turn."""
+    prefix = f"{suffix}_" if suffix else ""
+    return Plan(
+        id=f"plan-{prefix}fixture",
+        run_id="",
+        goal_ids=["g"],
+        tasks=[
+            Task(id=f"{prefix}research", title="Research", assignee_agent_id="writer"),
+            Task(id=f"{prefix}draft", title="Draft", assignee_agent_id="writer"),
+        ],
+        edges=[
+            TaskEdge(from_task_id=f"{prefix}research", to_task_id=f"{prefix}draft"),
+        ],
+        summary=f"Research then draft ({suffix})" if suffix else "Research then draft",
+    )
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = tools, session
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+def _kinds(events: list[Any]) -> list[str]:
+    out: list[str] = []
+    for e in events:
+        name = e.WhichOneof("payload") or ""
+        out.append("".join(part.capitalize() for part in name.split("_")) if name else "")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Conversation dataclass — pure unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_conversation_new_generates_unique_id() -> None:
+    a = Conversation.new()
+    b = Conversation.new()
+    assert a.id and b.id and a.id != b.id
+    assert a.turns == [] and a.goals == [] and a.completed_results == {}
+
+
+def test_conversation_next_turn_session_inherits_state() -> None:
+    conv = Conversation.new()
+    conv.goals = [Goal(id="g1", summary="greet")]
+    conv.completed_results = {"t_prior": "hello"}
+
+    s = conv.next_turn_session()
+
+    assert s.conversation_id == conv.id
+    assert s.run_id and s.run_id != conv.id
+    # Copies, not aliases — mutating the session must not rewrite history.
+    assert s.goals == conv.goals
+    assert s.goals is not conv.goals
+    assert s.completed_results == conv.completed_results
+    assert s.completed_results is not conv.completed_results
+    s.goals.append(Goal(id="g2", summary="new"))
+    s.completed_results["t_new"] = "x"
+    assert [g.id for g in conv.goals] == ["g1"]
+    assert "t_new" not in conv.completed_results
+
+
+def test_conversation_absorb_turn_merges_goals_and_results() -> None:
+    from goldfive.results import ExecutionOutcome
+
+    conv = Conversation.new()
+    conv.goals = [Goal(id="g1", summary="first")]
+
+    session = conv.next_turn_session()
+    # Turn adds a new goal and one completed result.
+    session.goals.append(Goal(id="g2", summary="second"))
+    session.completed_results["task1"] = "researched"
+    session.plan = _linear_plan()
+    # Mark one task completed so the record reflects it.
+    session.plan.tasks[0].status = session.plan.tasks[0].status.COMPLETED
+
+    outcome = ExecutionOutcome(success=True, session=session)
+    record = conv.absorb_turn(outcome, user_input_summary="write a haiku")
+
+    assert [g.id for g in conv.goals] == ["g1", "g2"]
+    assert conv.completed_results == {"task1": "researched"}
+    assert isinstance(record, TurnRecord)
+    assert record.run_id == session.run_id
+    assert record.user_input_summary == "write a haiku"
+    assert record.outcome_success is True
+    assert "research" in record.completed_task_ids
+    assert len(conv.turns) == 1
+
+
+def test_conversation_absorb_turn_deduplicates_goal_ids() -> None:
+    from goldfive.results import ExecutionOutcome
+
+    conv = Conversation.new()
+    conv.goals = [Goal(id="g1", summary="already here")]
+    session = conv.next_turn_session()
+    # Session sees g1 from conversation seeding; if an executor added it
+    # again by mistake, absorb_turn must not duplicate.
+    session.goals.append(Goal(id="g1", summary="already here"))
+    outcome = ExecutionOutcome(success=True, session=session)
+    conv.absorb_turn(outcome)
+    assert [g.id for g in conv.goals] == ["g1"]
+
+
+def test_conversation_prior_turn_context_caps_window() -> None:
+    conv = Conversation.new()
+    # Manually seed five turn records.
+    for i in range(5):
+        conv.turns.append(TurnRecord(run_id=f"r{i}", user_input_summary=f"t{i}"))
+    ctx = conv.prior_turn_context(recent_turns=3)
+    assert len(ctx["prior_turns"]) == 3
+    assert [t["run_id"] for t in ctx["prior_turns"]] == ["r2", "r3", "r4"]
+    assert ctx["turn_index"] == 5
+    assert ctx["conversation_id"] == conv.id
+
+
+# ---------------------------------------------------------------------------
+# Runner integration
+# ---------------------------------------------------------------------------
+
+
+async def test_runner_has_stable_conversation_id_across_turns() -> None:
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+    conv_id = runner.conversation_id
+    assert conv_id
+
+    await runner.run("turn one")
+    await runner.run("turn two")
+    await runner.close()
+
+    assert runner.conversation_id == conv_id
+
+
+async def test_runner_second_turn_session_sees_prior_completed_results() -> None:
+    """The central guarantee: turn 2 sees turn 1's completed_results."""
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    out1 = await runner.run("turn one")
+    assert out1.success
+    # The executor populated completed_results via the reporting tools;
+    # if the adapter didn't auto-complete, emulate it via the
+    # SequentialExecutor's text-fallback path (which writes
+    # completed_results[task.id] = text).
+    assert out1.session.completed_results, "turn 1 should have completed results"
+    turn1_results = dict(out1.session.completed_results)
+
+    out2 = await runner.run("turn two")
+    await runner.close()
+
+    # Session for turn 2 was seeded with turn 1's completed_results.
+    for k, v in turn1_results.items():
+        assert k in out2.session.completed_results
+        assert out2.session.completed_results[k] == v
+
+
+async def test_runner_session_carries_conversation_id() -> None:
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    out1 = await runner.run("a")
+    out2 = await runner.run("b")
+    await runner.close()
+
+    assert out1.session.conversation_id == runner.conversation_id
+    assert out2.session.conversation_id == runner.conversation_id
+    assert out1.session.run_id != out2.session.run_id
+
+
+async def test_runner_new_conversation_resets_state() -> None:
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+    first_id = runner.conversation_id
+
+    out1 = await runner.run("first conversation turn one")
+    assert out1.success
+    assert out1.session.completed_results
+
+    await runner.new_conversation()
+    assert runner.conversation_id != first_id
+
+    await runner.run("second conversation, fresh")
+    await runner.close()
+
+    # Turn after reset must not see the earlier turn's task ids unless
+    # the new plan itself produced them (our fixture uses the same
+    # task ids, so check against the *prior-turn context* the planner
+    # saw rather than completed_results).
+    assert runner.conversation.turns, "the fresh conversation should record its own turn"
+    # And the fresh conversation's record count is 1, not 2.
+    assert len(runner.conversation.turns) == 1
+
+
+async def test_runner_emits_conversation_lifecycle_events() -> None:
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+    await runner.run("turn one")
+    await runner.run("turn two")
+    await runner.new_conversation()
+    await runner.run("fresh conversation")
+    await runner.close()
+
+    kinds = _kinds(sink.events)
+    # One ConversationStarted per fresh conversation.
+    assert kinds.count("ConversationStarted") == 2
+    # One ConversationEnded for the first conversation (on reset) plus
+    # one for the second (on close).
+    assert kinds.count("ConversationEnded") == 2
+    # The first ConversationStarted precedes the first RunStarted.
+    assert kinds.index("ConversationStarted") < kinds.index("RunStarted")
+
+
+async def test_runner_planner_sees_prior_turn_context() -> None:
+    """LLMPlanner.generate receives prior-turn context on turn 2."""
+    captured_prompts: list[str] = []
+
+    async def capturing_llm(system: str, user: str, model: str) -> str:
+        _ = system, model
+        captured_prompts.append(user)
+        # Return a valid plan JSON every time.
+        return (
+            '{"summary":"t","tasks":[{"id":"t1","title":"T","assignee_agent_id":"writer"}]}'
+        )
+
+    planner = LLMPlanner(call_llm=capturing_llm, model="stub")
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[InMemorySink()],
+    )
+    out1 = await runner.run("write a limerick about cats")
+    assert out1.success
+    await runner.run("make it funnier")
+    await runner.close()
+
+    assert len(captured_prompts) == 2
+    first_prompt, second_prompt = captured_prompts
+    # First turn's prompt has no prior-turn block.
+    assert "Prior-turn context" not in first_prompt
+    # Second turn's prompt references prior turn summaries and results.
+    assert "Prior-turn context" in second_prompt
+    assert "Earlier turns" in second_prompt
+    # And actually references turn 1's task output.
+    assert "t1" in second_prompt
+
+
+async def test_conversation_kwarg_lets_caller_inject_existing_state() -> None:
+    """A caller can resume a conversation by passing a pre-built Conversation."""
+    conv = Conversation.new()
+    conv.goals = [Goal(id="existing", summary="already accumulated")]
+    conv.completed_results = {"prior_task": "prior output"}
+
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[InMemorySink()],
+        conversation=conv,
+    )
+    assert runner.conversation_id == conv.id
+
+    out = await runner.run("continue")
+    await runner.close()
+
+    # The session for this "first" run (from Runner's perspective) was
+    # actually seeded with injected prior state.
+    assert "prior_task" in out.session.completed_results
+    assert any(g.id == "existing" for g in out.session.goals)
+
+
+async def test_runner_turn_records_accumulate() -> None:
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[InMemorySink()],
+    )
+    await runner.run("one")
+    await runner.run("two")
+    await runner.run("three")
+    await runner.close()
+
+    assert len(runner.conversation.turns) == 3
+    run_ids = [t.run_id for t in runner.conversation.turns]
+    assert len(set(run_ids)) == 3
+
+
+async def test_single_turn_backward_compatibility() -> None:
+    """A single-turn caller that never references Conversation still works."""
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+    out = await runner.run("one shot")
+    await runner.close()
+
+    assert out.success
+    # Plain users still get a well-formed outcome + event stream.
+    kinds = _kinds(sink.events)
+    assert "RunStarted" in kinds
+    assert "RunCompleted" in kinds
+
+
+# ---------------------------------------------------------------------------
+# Convenience: goldfive.wrap() builds a Runner with a Conversation
+# ---------------------------------------------------------------------------
+
+
+async def test_wrap_runner_has_conversation() -> None:
+    """goldfive.wrap() produces a Runner that already owns a Conversation."""
+    from goldfive import wrap
+
+    async def agent_fn(
+        task: Task, session: Session, tools: list[ReportingToolSpec]
+    ) -> InvocationResult:
+        _ = tools, session
+        return InvocationResult(task_id=task.id, text="ok")
+
+    runner = wrap(
+        CallableAdapter(agent_fn, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        sinks=[InMemorySink()],
+    )
+    assert runner.conversation_id
+    await runner.close()
+
+
+# ---------------------------------------------------------------------------
+# Proto round-trip smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_conversation_events_serialize_over_proto() -> None:
+    """ConversationStarted / ConversationEnded survive proto encoding."""
+    pytest.importorskip("goldfive.pb.goldfive.v1.events_pb2")
+    from goldfive.events import conversation_ended_event, conversation_started_event
+    from goldfive.pb.goldfive.v1 import events_pb2
+
+    started = conversation_started_event(run_id="r1", sequence=0, conversation_id="c1")
+    assert started.WhichOneof("payload") == "conversation_started"
+    assert started.conversation_started.conversation_id == "c1"
+
+    blob = started.SerializeToString()
+    roundtrip = events_pb2.Event()
+    roundtrip.ParseFromString(blob)
+    assert roundtrip.conversation_started.conversation_id == "c1"
+
+    ended = conversation_ended_event(
+        run_id="r1", sequence=5, conversation_id="c1", turn_count=3, reason="close"
+    )
+    assert ended.conversation_ended.turn_count == 3
+    assert ended.conversation_ended.reason == "close"

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -75,10 +75,13 @@ async def test_quickstart_string_goal_runs_to_completion() -> None:
     assert outcome.success, outcome.reason
 
     kinds = _kinds(sink.events)
-    assert kinds[0] == "RunStarted"
-    assert "GoalDerived" in kinds
-    assert "PlanSubmitted" in kinds
-    assert kinds[-1] == "RunCompleted"
+    # ConversationStarted precedes the per-run lifecycle; ConversationEnded
+    # is emitted by runner.close() when turns ran.
+    run_kinds = [k for k in kinds if not k.startswith("Conversation")]
+    assert run_kinds[0] == "RunStarted"
+    assert "GoalDerived" in run_kinds
+    assert "PlanSubmitted" in run_kinds
+    assert run_kinds[-1] == "RunCompleted"
 
     # Exactly one task was generated for the single goal.
     assert outcome.session.plan is not None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -131,23 +131,27 @@ async def test_runner_end_to_end_event_sequence() -> None:
     assert outcome.success, outcome.reason
 
     kinds = _kinds(sink.events)
+    # Filter out the Conversation lifecycle events (ConversationStarted
+    # prepends, ConversationEnded appends on close) — this test
+    # pre-dates Phase 3 and exercises the per-run lifecycle only.
+    run_kinds = [k for k in kinds if not k.startswith("Conversation")]
 
     # Lifecycle envelope up-front. The Runner owns the Run* lifecycle
     # events: RunStarted then GoalDerived then PlanSubmitted. The
     # executor no longer emits its own RunStarted (that would duplicate
     # the Runner's emission and produce a second event for sinks).
-    assert kinds[0] == "RunStarted"
-    assert kinds[1] == "GoalDerived"
-    assert kinds[2] == "PlanSubmitted"
+    assert run_kinds[0] == "RunStarted"
+    assert run_kinds[1] == "GoalDerived"
+    assert run_kinds[2] == "PlanSubmitted"
 
     # For each of the three tasks: TaskStarted → TaskCompleted.
-    task_kinds = kinds[3:-1]  # strip initial triple and trailing RunCompleted
-    assert len(task_kinds) == 6, kinds
+    task_kinds = run_kinds[3:-1]  # strip initial triple and trailing RunCompleted
+    assert len(task_kinds) == 6, run_kinds
     assert task_kinds[0::2] == ["TaskStarted"] * 3
     assert task_kinds[1::2] == ["TaskCompleted"] * 3
 
     # Run terminates with a RunCompleted from the executor.
-    assert kinds[-1] == "RunCompleted"
+    assert run_kinds[-1] == "RunCompleted"
 
     # Sequence numbers are strictly monotonic from zero.
     seqs = _sequences(sink.events)
@@ -205,7 +209,8 @@ async def test_runner_aborts_when_planner_returns_none() -> None:
     assert not outcome.success
     assert "no plan" in outcome.reason
 
-    assert _kinds(sink.events) == ["RunStarted", "GoalDerived", "RunAborted"]
+    run_kinds = [k for k in _kinds(sink.events) if not k.startswith("Conversation")]
+    assert run_kinds == ["RunStarted", "GoalDerived", "RunAborted"]
 
 
 async def test_runner_registers_builtin_reporting_tools() -> None:
@@ -280,8 +285,8 @@ async def test_runner_input_type_errors() -> None:
     await runner.close()
     assert not outcome.success
     assert "str or list[Goal]" in outcome.reason
-    kinds = _kinds(sink.events)
-    assert kinds == ["RunStarted", "RunAborted"]
+    run_kinds = [k for k in _kinds(sink.events) if not k.startswith("Conversation")]
+    assert run_kinds == ["RunStarted", "RunAborted"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Phase 3 lands a `Conversation` primitive on `Runner` so successive `runner.run()` calls on the same instance share state.

- `goldfive/conversation.py` — new `Conversation` + `TurnRecord` dataclasses. `Conversation.next_turn_session()` seeds each turn's `Session` from the accumulated cross-turn state; `absorb_turn()` folds the outcome back in (goals merged by id, completed_results merged, turn record appended).
- `goldfive/runner.py` — Runner owns a Conversation. `run()` seeds, executes, absorbs. New `new_conversation()` method (resets state, emits `ConversationEnded`, installs a fresh Conversation), `conversation_id` / `conversation` properties. A `conversation=` kwarg lets callers inject pre-built state (e.g. rehydrating from persistence).
- `goldfive/planner.py` — `LLMPlanner.generate()` renders `prior_completed_results` + `prior_turns` from `context` into a human-readable "Prior-turn context" block in its prompt so follow-up phrasing ("actually, make it funnier") works without caller plumbing.
- `goldfive/types.py` — `Session.conversation_id: str` (default `""` for legacy callers).
- `proto/goldfive/v1/events.proto` — adds `ConversationStarted` (oneof 23) and `ConversationEnded` (oneof 24); stubs regenerated via `make proto`.
- `goldfive/events.py` — `conversation_started_event` / `conversation_ended_event` factories.
- `tests/test_conversation.py` — 16 new tests covering unit behaviour of `Conversation` (state seeding, goal dedup, context windowing), Runner integration (stable id, prior-results visibility, new_conversation reset, lifecycle events, planner prompt contains prior context, `wrap()` builds a conversational Runner), backward compatibility, and proto round-trip.
- `tests/test_quickstart.py` / `tests/test_runner.py` — two existing event-sequence tests updated to filter the new `Conversation*` envelope events (per issue guidance).
- `examples/multi_turn_chat.py` — runnable 3-turn demo with a scripted LLM.
- `docs/guides/multi-turn.md` — canonical guide.

Single-turn callers see no change; the default Conversation is invisible.

## Test plan

- [x] `uv run pytest -q` → 317 passed, 37 skipped
- [x] `uv run ruff check .` → clean
- [x] `make proto` → regenerates cleanly
- [x] `uv run python examples/multi_turn_chat.py` → three turns accumulate `completed_results` on the same `conversation_id`, `new_conversation()` swaps in a fresh id