### PR TITLE
Docs for live-steering control channel (closes #71)

### DIFF
--- a/.agents/debug-goldfive.md
+++ b/.agents/debug-goldfive.md
@@ -166,6 +166,47 @@ print(f"success={outcome.success}  reason={outcome.reason!r}")
 print(f"{len(sink.events)} events")
 ```
 
+## Control channel (live steering)
+
+When `Runner(control=channel)` is wired, a new class of failure modes
+shows up. Triage tree:
+
+```
+control message sent, nothing happens →
+├─ channel.acks() never yields anything
+│    → channel is not the same instance the Runner got. Print
+│      id(channel) on both ends to verify.
+├─ ack.result == AckResult.UNSUPPORTED
+│    → dispatcher doesn't recognize the kind. Phase-1 enum:
+│      PAUSE, RESUME, CANCEL, STEER, REWIND_TO, APPROVE, REJECT.
+│      STATUS_QUERY + INTERCEPT_TRANSFER accepted as string-kind.
+│      Anything else → you need a custom dispatcher (CONTROL.md §7).
+├─ ack.result == AckResult.FAILURE
+│    → the specific kind rejected the payload. Common causes:
+│        REWIND_TO with missing / unknown payload.task_id
+│        APPROVE/REJECT with target_id not in pending_approvals
+│      The ack.detail string names the exact reason.
+├─ STEER sent but plan never revises
+│    → planner.refine raised or returned None. Enable DEBUG on
+│      goldfive.planner. For LLMPlanner check call_llm output parses.
+├─ PAUSE sent, executor keeps running tasks
+│    → expected mid-task — the current task finishes, then pause
+│      takes effect. PAUSE never cancels in-flight work; only CANCEL
+│      and STEER do (both via invoke_task.cancel() with 5 s grace).
+├─ CANCEL sent, adapter keeps running after 5 s
+│    → adapter is ignoring asyncio.CancelledError. The run is
+│      unwedged (orphaned task + warning log) but the adapter process
+│      is leaking. Fix the adapter's cancellation handling.
+└─ APPROVE sent, report_awaiting_approval tool still blocked
+     → target_id mismatch. Flow A uses the task_id; Flow B uses
+       tool_context.function_call_id (shape `adk-<uuid>`). Check
+       session.pending_approvals keys against payload.target_id.
+```
+
+Full protocol and kind-by-kind behaviour:
+[docs/design/CONTROL.md](../docs/design/CONTROL.md). Approval-specific
+design: [docs/design/APPROVAL.md](../docs/design/APPROVAL.md).
+
 ## Common pitfalls
 
 - Reading `sink.events` before `await runner.close()` — buffered sinks
@@ -183,6 +224,7 @@ print(f"{len(sink.events)} events")
 ## Related
 
 - [docs/guides/troubleshooting.md](../docs/guides/troubleshooting.md) — detailed symptom → fix catalogue.
+- [docs/design/CONTROL.md](../docs/design/CONTROL.md) — live-steering protocol, per-kind behaviour, custom dispatcher hook.
 - [docs/design/VOCABULARY.md](../docs/design/VOCABULARY.md) — exhaustive type-system reference (start here when a name is confusing).
 - [docs/design/RATIONALE.md](../docs/design/RATIONALE.md) — design-rationale docs (start here when a choice feels arbitrary).
 - [docs/design/DRIFT.md](../docs/design/DRIFT.md) — drift taxonomy.

--- a/docs/design/CONTROL.md
+++ b/docs/design/CONTROL.md
@@ -1,0 +1,500 @@
+# Live steering and the control channel
+
+goldfive runs are not fire-and-forget. While the executor walks the
+plan, an external operator — a harmonograf UI user, a CLI, a test
+harness — can reach in and redirect it: pause between tasks, cancel
+the run, steer the planner into a different shape, rewind to an
+earlier task, approve or reject a tool call waiting for a human.
+
+Every one of those verbs travels through a single primitive: the
+**`ControlChannel`**. This document is the canonical reference for
+that primitive — what it is, what every verb means, how each one
+lands in the executor, and how a UI on the other side of a network
+hooks into it.
+
+Type-system view (enum tables, bridge tables, severity ladder) is in
+[VOCABULARY.md](VOCABULARY.md). Why-this-shape is in
+[RATIONALE.md](RATIONALE.md). This doc focuses on the mechanics.
+
+## 1. Why live steering exists
+
+Three forces made live steering first-class.
+
+**Long runs.** A slide-deck agent may take ten minutes end-to-end.
+An operator watching the harmonograf Gantt often realises at minute
+three that the plan is heading the wrong way. Mid-run steering
+replaces remaining work without losing what's already completed.
+
+**Human-in-the-loop approval.** Some tool calls must not land without
+a human yes/no — a billing call, a `DELETE FROM`, a production deploy.
+goldfive cannot reach the UI directly; the UI cannot touch goldfive-
+internal state directly. The ControlChannel plus
+`session.pending_approvals` is that bridge.
+
+**Tests and CLIs.** The same primitive that drives the UI drives test
+harnesses. Asserting "PAUSE emits `USER_PAUSE`" shouldn't need a UI
+server. `ControlChannel` is framework-neutral; tests instantiate one
+directly.
+
+The design constraint: **no polling, anywhere**. Both sides `await`
+queues (`asyncio.Queue` in-process, gRPC streams cross-process).
+
+## 2. The `ControlChannel` primitive
+
+One class, two queues, a dozen lines of interface. Lives at
+`goldfive/control.py` and re-exports at the package root
+(`goldfive.ControlChannel`).
+
+```python
+from goldfive import ControlChannel, ControlMessage, ControlKind, ControlAck, AckResult
+
+channel = ControlChannel()
+
+# Sender side (UI bridge, CLI, test)
+await channel.send(ControlMessage(kind=ControlKind.PAUSE))
+
+# Runner-internal side (executor)
+msg = await channel.receive(timeout=0.1)
+if msg is not None:
+    await channel.ack(ControlAck(control_id=msg.id, result=AckResult.SUCCESS))
+
+# Sender side: drain acks
+async for ack in channel.acks():
+    ...  # surface to the UI
+```
+
+### 2.a The shapes
+
+```python
+class ControlKind(StrEnum):
+    PAUSE = "PAUSE"
+    RESUME = "RESUME"
+    CANCEL = "CANCEL"
+    STEER = "STEER"            # payload: {"note": "...", "suggested_action": "..."}
+    REWIND_TO = "REWIND_TO"    # payload: {"task_id": "..."}
+    APPROVE = "APPROVE"        # payload: {"target_id": "...", "detail": "..."}
+    REJECT = "REJECT"          # payload: {"target_id": "...", "detail": "..."}
+
+
+class AckResult(StrEnum):
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+    UNSUPPORTED = "UNSUPPORTED"
+
+
+@dataclass
+class ControlMessage:
+    kind: ControlKind
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    payload: dict[str, Any] = field(default_factory=dict)
+    issued_at_ms: int = 0
+
+
+@dataclass
+class ControlAck:
+    control_id: str
+    result: AckResult
+    detail: str = ""
+    acked_at_ms: int = 0
+```
+
+`STATUS_QUERY` and `INTERCEPT_TRANSFER` are not yet in the Phase-1
+enum; the dispatcher recognizes them by string value. External
+bridges send them as `ControlMessage(kind="STATUS_QUERY", ...)`.
+
+### 2.b Send / receive / ack semantics
+
+**Bidirectional but asymmetric.** Two internal queues: `_inbox`
+(external senders push, runner consumes) and `_outbox` (runner
+pushes, external consumers iterate). Both sides `await`; neither
+polls.
+
+**Every message produces exactly one ack.** The executor dispatches,
+publishes the ack, then applies the effect. Errors after the ack
+surface as proto events, not late acks.
+
+**IDs are UUIDs, not sequence numbers.** Senders correlate
+`ControlAck.control_id` back to `ControlMessage.id`. Acks land in
+send order in practice because the runner consumes the inbox
+sequentially, but the contract imposes no ordering beyond that.
+
+**Close is idempotent.** `channel.close()` marks both queues closed.
+`receive()` returns `None`; `acks()` exits via an internal sentinel.
+In-flight messages drain first.
+
+### 2.c Lifecycle binding
+
+The channel is constructed by whoever owns the external end and
+passed to the Runner via `control=`:
+
+```python
+from goldfive import Runner, ControlChannel, SequentialExecutor
+
+channel = ControlChannel()
+runner = Runner(
+    agent=...,
+    planner=...,
+    executor=SequentialExecutor(),
+    control=channel,
+)
+```
+
+The Runner forwards `control=channel` into `executor.run(...)`. Both
+`SequentialExecutor` and `ParallelDAGExecutor` drain it between tasks
+and race it against the adapter via `asyncio.wait(...,
+return_when=FIRST_COMPLETED)` for mid-task cancel/steer.
+
+## 3. End-to-end path — UI click to plan revision
+
+Every arrow below is an `await` or a proto event on the wire;
+nothing polls.
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│ browser (harmonograf UI)                                           │
+│   user clicks [Steer]; form = {note: "focus on slide 3", ...}     │
+└──────────────────────────────────┬────────────────────────────────┘
+                                   │ gRPC-Web → ControlEvent(STEER)
+┌──────────────────────────────────▼────────────────────────────────┐
+│ harmonograf server (Python, gRPC :7531)                            │
+│   looks up the Client for this run_id; writes onto its control    │
+│   stream                                                           │
+└──────────────────────────────────┬────────────────────────────────┘
+                                   │ gRPC server-streaming
+┌──────────────────────────────────▼────────────────────────────────┐
+│ harmonograf_client.Client (in goldfive's process)                  │
+│   Client.observe() yields ControlEvent; bridge translates:        │
+│     harmonograf.ControlEvent(STEER, note, suggested_action)        │
+│       → goldfive.ControlMessage(kind=ControlKind.STEER,            │
+│                                  payload={"note": ...})            │
+│   await goldfive_channel.send(msg)                                 │
+└──────────────────────────────────┬────────────────────────────────┘
+                                   │ asyncio.Queue.put
+┌──────────────────────────────────▼────────────────────────────────┐
+│ goldfive.ControlChannel (_inbox) → channel.receive() unblocks      │
+├───────────────────────────────────────────────────────────────────┤
+│ SequentialExecutor / ParallelDAGExecutor                           │
+│   between tasks: drain_controls(channel, ...)                      │
+│   mid-task:      asyncio.wait({invoke, recv}, FIRST_COMPLETED)    │
+│   dispatch_control(msg) → ControlOutcome(steer_message=msg, ack)  │
+│   channel.ack(outcome.ack)  (flows back out)                       │
+└──────────────────────────────────┬────────────────────────────────┘
+                                   │ outcome.steer_message
+┌──────────────────────────────────▼────────────────────────────────┐
+│ steerer.observe(msg, session)                                      │
+│   → DriftEvent(USER_STEER, WARNING, note)                          │
+│ DefaultSteerer._handle_drift                                       │
+│   → emits DriftDetected; severity >= WARNING → planner.refine     │
+├───────────────────────────────────────────────────────────────────┤
+│ LLMPlanner.refine (USER_STEER, "delete-and-replan")                │
+│   drops pending, preserves completed, returns fresh Plan           │
+│ Steerer._apply_revision + PlanRevised event                        │
+│   session.plan = revised; revision_kind=USER_STEER                 │
+└───────────────────────────────────────────────────────────────────┘
+
+         Ack side mirrors outbound: _outbox → Client.acks()
+                 → harmonograf → gRPC-Web → UI toast.
+```
+
+Four processes, one proto schema, one logical channel. The UI
+round-trip for STEER is typically < 100 ms; total latency is
+dominated by the LLM refine call (seconds), not the transport.
+
+## 4. Every ControlKind — behaviour by kind
+
+Per-kind: between-task behaviour, mid-task behaviour, effect on the
+in-flight task / plan / session. Dispatcher lives in
+`goldfive/executors/_control.py::dispatch_control`.
+
+### `PAUSE`
+
+Pause the outer loop; keep the in-flight task running until it
+terminates on its own (aborting a partial artifact is usually worse).
+
+- *Between tasks:* drain sets `paused=True`; executor blocks on
+  `await control.receive()` until RESUME / CANCEL / STEER / REWIND_TO.
+- *Mid-task:* ack only; invoke runs to completion; pause takes effect
+  at the next between-task point.
+- *Session/plan:* unchanged. *Drift:* `USER_PAUSE/INFO` — visible in
+  the stream, below refine threshold.
+
+### `RESUME`
+
+Clear the paused flag. Between tasks (paused): exits the blocking
+`receive`. Otherwise: ack, no-op. Session/plan/drift: none.
+
+### `CANCEL`
+
+Abort the run. The only kind that cancels an in-flight invocation.
+
+- *Between tasks:* raises `_ControlCancelled`; executor emits
+  `RunAborted(reason=payload.reason or "cancelled by control")`.
+- *Mid-task:* `invoke_task.cancel()` with a 5 s grace. Adapters that
+  ignore cancellation are orphaned with a warning — we never wedge the
+  run.
+- *Session/plan:* running tasks cascade to CANCELLED. *Drift:*
+  `USER_CANCEL/CRITICAL` (audit only — executor short-circuits to
+  abort without routing through refine).
+
+### `STEER`
+
+Redirect the run — the canonical live-replan trigger. Payload
+`{"note": "...", "suggested_action": "..."}`. See §5 for semantics.
+
+- *Between tasks:* fed to `steerer.observe` → `USER_STEER/WARNING` →
+  `planner.refine`. Executor re-reads `session.plan` next iteration.
+- *Mid-task:* adapter task cancelled (5 s grace, same as CANCEL), then
+  the steer applies. Cancelled task → CANCELLED; refined plan
+  typically reintroduces it (or a replacement) as PENDING.
+- *Session/plan:* replaced; `revision_index` incremented. Completed
+  preserved; pending dropped. *Drift:* `USER_STEER/WARNING`.
+
+### `REWIND_TO`
+
+Reset a task and every downstream task to PENDING. Payload
+`{"task_id": "..."}`; unknown id → FAILURE ack.
+
+- *Between tasks:* `_rewind_plan` walks the reachable subgraph via
+  `plan.edges`, sets each status to `PENDING`, drops entries from
+  `session.completed_results` and `session.task_progress`.
+- *Mid-task:* ack only; reset lands at the next checkpoint. To cancel
+  the current task first, send CANCEL → REWIND_TO → RESUME.
+- *Session/plan:* structural reset — no plan revision, no refine.
+  *Drift:* none.
+
+### `STATUS_QUERY`
+
+Emit a run-state snapshot onto the sink stream — explicit "what are
+you working on?" ping rather than inferring from the last event.
+
+- *Any time:* emits `DriftDetected(kind=CUSTOM, severity=INFO)` with
+  detail `status_query control_id=... current_task=... completed=N/M
+  pending=t3,t4`.
+- *Session/plan/drift:* no side effects (CUSTOM/INFO is below refine).
+
+### `INTERCEPT_TRANSFER`
+
+Toggle `session._intercept_transfer`. Adapters that honour the flag
+(ADK) refuse subsequent agent-to-agent transfers and surface them as
+drift. Payload `{"enabled": true|false}`, default `true`.
+
+- *Any time:* flag set on the session; next invocation sees it.
+  Mid-task flips apply to the next task.
+- *Session:* `session._intercept_transfer = flag`. *Drift:* none
+  directly; ADK may synthesize `WRONG_AGENT` / `AGENT_TRANSFER`.
+
+### `APPROVE` / `REJECT`
+
+Resolve a pending approval waiter in `session.pending_approvals`.
+`target_id` can be a `task_id` (Flow A, task-level via
+`report_awaiting_approval`) or a `tool_call_id` (Flow B, ADK tool
+confirmation). Payload `{"target_id": "...", "detail": "..."}`. See
+§6 for the dual flow, [APPROVAL.md](APPROVAL.md) for the design.
+
+- *Any time:* looks up `pending_approvals[target_id]`; stamps
+  `meta["decision"]`, emits `ApprovalGranted` / `ApprovalRejected`,
+  sets the `asyncio.Event`. Absent target → FAILURE ack.
+- *Session:* `pending_approvals[target_id]` cleared. *Drift:* none —
+  approval is a separate stream.
+
+## 5. STEER — "delete-and-replan" semantics
+
+`STEER` is the only control kind that invokes the planner. On
+`USER_STEER` drift, `LLMPlanner.refine` follows a
+**delete-and-replan** branch in
+`goldfive/planner.py::_refine_user_steer`:
+
+1. **Preserve every COMPLETED task.** Its output in
+   `session.completed_results` stays available as context.
+2. **Drop every PENDING / RUNNING / BLOCKED / CANCELLED task.** The
+   steer implicitly says "what you were going to do is wrong."
+3. **Ask the LLM for a fresh plan** with the user's `note` /
+   `suggested_action` as primary directive, original goals as
+   background, completed outputs as ground truth.
+4. **Stamp revision metadata** — `revision_index = prev + 1`,
+   `revision_kind = USER_STEER`, `revision_severity = WARNING`,
+   `revision_reason = drift.detail`.
+
+### Example
+
+Four-task linear plan, mid-`draft`, user clicks [Steer] with
+`note="focus on fewer, higher-quality slides"`:
+
+```
+before:
+  t1 research   COMPLETED   results[t1] = "industry landscape..."
+  t2 draft      RUNNING     (partial output)
+  t3 review     PENDING
+  t4 publish    PENDING
+
+mid-task STEER cancels t2 (grace-window), observe → USER_STEER drift,
+refine runs _refine_user_steer, LLM returns a 2-task plan.
+
+after:
+  t1 research          COMPLETED   (preserved)
+  t5 draft_focused     PENDING
+  t6 polish_and_ship   PENDING
+  # revision_index = 1, revision_kind = USER_STEER
+
+events (in order):
+  TaskCancelled(t2)
+  DriftDetected(USER_STEER, WARNING, "focus on fewer...")
+  PlanRevised(revision_index=1, revision_kind=USER_STEER)
+```
+
+The next executor iteration picks up `t5` (no predecessors, PENDING)
+and dispatches. From the sink the cancel + revision straddle the
+steer; from the user the timeline re-orients.
+
+### Why delete rather than edit
+
+Refine-as-diff is cheaper but fragile — an LLM authoring a patch has
+to reason about edge semantics and per-task status, and mistakes
+compound across revisions. Deleting pending work and re-asking
+produces clean plans every time and matches user expectation:
+[Steer] feels like "redirect from here", not "edit the task list."
+See [RATIONALE.md](RATIONALE.md).
+
+## 6. APPROVE / REJECT — the dual flow
+
+Two flows both resolve via `APPROVE`/`REJECT` and the same three
+proto events (`ApprovalRequested`, `ApprovalGranted`,
+`ApprovalRejected`), so a single UI affordance works for either.
+
+### Flow A — task-level (any adapter)
+
+The agent calls the 8th reporting tool,
+`report_awaiting_approval(task_id, prompt, timeout_ms=...)`. Its
+handler:
+
+1. `steerer.mark_task_blocked(task_id, blocker="awaiting_approval")`.
+2. Registers `session.pending_approvals[task_id] = asyncio.Event()` and
+   stashes metadata in `session.pending_approvals_meta[task_id]`.
+3. Emits `ApprovalRequested{target_id=task_id, kind="task", prompt=...}`.
+4. `await`s the event.
+5. Returns `{"decision": "approve"|"reject"|"timeout", "detail": ...}`
+   to the agent.
+
+The UI renders buttons on `ApprovalRequested` and sends
+`ControlMessage(kind=APPROVE|REJECT, payload={"target_id": task_id})`.
+The agent decides what to do with the returned decision — goldfive
+does not auto-transition the task.
+
+### Flow B — ADK tool confirmation
+
+An ADK `FunctionTool` declared with `require_confirmation=True`.
+goldfive's ADK plugin intercepts in `before_tool_callback`:
+
+1. Uses `tool_context.function_call_id` (`adk-<uuid>`) as `target_id`.
+2. Registers `pending_approvals[tool_call_id]` with metadata
+   `{"kind": "tool", "tool_name": ..., "args": ...,
+   "task_id": session.current_task_id}`.
+3. Emits `ApprovalRequested{kind="tool", metadata={...}}`.
+4. `await`s the event.
+5. On APPROVE: emits `ApprovalGranted`, returns `None` → ADK runs the
+   tool.
+6. On REJECT: emits `ApprovalRejected`, returns
+   `{"skipped": True, "reason": "user_rejected"}` → ADK uses that as
+   the tool's response.
+
+The model never sees the interception; from its perspective the tool
+just took a while. Full ADK plugin reference is in
+[APPROVAL.md](APPROVAL.md).
+
+### Why one kind for two flows
+
+Both flows need a yes/no, a UI-renderable event, a correlation id,
+and a wait-then-resume mechanic. One pair of kinds + one pending map
+beats two parallel plumbings. `target_id` disambiguates: task ids are
+planner-authored; tool-call ids are ADK-authored (`adk-<uuid>`).
+
+## 7. Writing a custom control handler
+
+If you need a bespoke verb — "checkpoint", "inject a memo", "wait
+for task X" — two escape hatches.
+
+### 7.a Send a custom kind from the bridge
+
+Unknown kinds still deliver; the default dispatcher acks them as
+`UNSUPPORTED` until the runner-side dispatcher knows them:
+
+```python
+from goldfive import ControlChannel, ControlMessage
+
+channel = ControlChannel()
+await channel.send(ControlMessage(kind="CHECKPOINT", payload={"label": "pre-refine"}))
+```
+
+### 7.b Subclass the executor
+
+`drain_controls` and `dispatch_control` in
+`goldfive/executors/_control.py` are module-level helpers. Override
+the drain loop in your executor subclass and fall back to
+`dispatch_control` for kinds you don't handle:
+
+```python
+from goldfive.executors.sequential import SequentialExecutor
+from goldfive.executors._control import ControlOutcome, dispatch_control
+from goldfive.control import AckResult, ControlAck
+
+
+class CheckpointingExecutor(SequentialExecutor):
+    async def _handle_custom(self, msg, *, session, **kw):
+        kind = str(getattr(msg.kind, "value", msg.kind)).upper()
+        if kind == "CHECKPOINT":
+            label = str(msg.payload.get("label", ""))
+            session.agent_notes.setdefault("_checkpoints", []).append(label)
+            return ControlOutcome(
+                ack=ControlAck(
+                    control_id=msg.id,
+                    result=AckResult.SUCCESS,
+                    detail=f"checkpointed at {label}",
+                ),
+            )
+        return await dispatch_control(msg, session=session, **kw)
+```
+
+No registry yet — custom dispatchers usually also want custom
+executor state (the `_checkpoints` list above), so the override point
+is naturally the executor. File an issue if you write more than one.
+
+### 7.c Testing and running end-to-end
+
+`ControlChannel` is `asyncio.Queue`-backed. Tests instantiate one
+directly, drive it with `await channel.send(...)`, and assert on the
+acks iterator or on events captured by an `InMemorySink`. Patterns:
+`tests/test_control_primitive.py`, `tests/test_executor_control.py`,
+`tests/test_live_steering_e2e.py`. A runnable demo covering PAUSE /
+STEER / CANCEL against an offline canned-LLM planner lives at
+`examples/live_steering.py`.
+
+## 8. What ControlChannel is *not*
+
+- **Not a scheduler.** Send-order dispatch; no priority, no deadline
+  ordering, no cancelling pending messages. PAUSE then CANCEL pauses
+  first, then cancels.
+- **Not a transport.** Process-local (`asyncio.Queue`). Cross-process
+  transport is the bridge's problem (§3); the contract is the
+  `ControlMessage` dataclass.
+- **Not a persistence layer.** Raw control messages aren't logged to
+  sinks; their *effects* are (DriftDetected, TaskCancelled,
+  PlanRevised, ApprovalGranted). For an audit trail of raw messages,
+  emit a `CUSTOM`-kind drift from a custom dispatcher.
+- **Not required.** `Runner(control=None)` — the default — runs
+  end-to-end with zero live-steering surface.
+
+## See also
+
+- [VOCABULARY.md](VOCABULARY.md) — type-system reference, the
+  `ControlKind` × `DriftKind` bridge tables, worked STEER →
+  USER_STEER example.
+- [RATIONALE.md](RATIONALE.md) — why one channel, why STEER deletes,
+  why approval rides the control path.
+- [APPROVAL.md](APPROVAL.md) — approval design + ADK plugin API.
+- [DRIFT.md](DRIFT.md), [STATE-MACHINE.md](STATE-MACHINE.md),
+  [PROTOCOLS.md](PROTOCOLS.md) — related design docs.
+- [../reference/api.md](../reference/api.md) — control types in the
+  public API.
+- [../guides/getting-started.md](../guides/getting-started.md),
+  [../guides/observability-with-harmonograf.md](../guides/observability-with-harmonograf.md)
+  — hands-on walkthroughs.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -329,6 +329,54 @@ both). Full failure-mode walkthrough in
 [persistence-and-recovery.md](persistence-and-recovery.md); full sink
 matrix in [choosing-a-sink.md](choosing-a-sink.md).
 
+## Live steering — pause, cancel, redirect
+
+Long runs benefit from an operator who can reach in and steer
+mid-flight. goldfive ships a single primitive for this: a
+`ControlChannel` passed into `Runner(control=...)`. Here is the
+smallest possible PAUSE / RESUME demo, still against the three-task
+`hello.py` plan:
+
+```python
+import asyncio
+
+from goldfive import ControlChannel, ControlKind, ControlMessage
+
+
+async def drive(channel: ControlChannel) -> None:
+    # Give the run a moment, then PAUSE, then RESUME.
+    await asyncio.sleep(0.05)
+    await channel.send(ControlMessage(kind=ControlKind.PAUSE))
+    await asyncio.sleep(0.1)
+    await channel.send(ControlMessage(kind=ControlKind.RESUME))
+
+
+async def main() -> None:
+    channel = ControlChannel()
+    runner = Runner(
+        agent=CallableAdapter(my_agent, available_agents=["default"]),
+        planner=StaticPlanner(plan),
+        executor=SequentialExecutor(),
+        control=channel,
+    )
+    # Run the agent and the controller concurrently.
+    _, outcome = await asyncio.gather(
+        drive(channel),
+        runner.run("demo run"),
+    )
+    await runner.close()
+    channel.close()
+    print(f"success={outcome.success}")
+```
+
+Beyond PAUSE / RESUME, `ControlKind` supports `CANCEL` (abort the run),
+`STEER` (redirect via planner refine), `REWIND_TO` (reset a task and
+its downstream), and `APPROVE` / `REJECT` (resolve pending approvals).
+Full semantics and the end-to-end UI path are in
+[../design/CONTROL.md](../design/CONTROL.md). A runnable demo covering
+PAUSE, STEER, and CANCEL against an offline canned-LLM planner is at
+[`examples/live_steering.py`](../../examples/live_steering.py).
+
 ## Running in parallel
 
 Swap `SequentialExecutor` for `ParallelDAGExecutor`:
@@ -362,6 +410,8 @@ Tasks whose dependencies are satisfied run concurrently via
   recovery with `JSONLPersistenceSink` / `SQLitePersistenceSink`.
 - [grpc-transport.md](grpc-transport.md) — streaming events to an
   out-of-process observer.
+- [../design/CONTROL.md](../design/CONTROL.md) — live steering and the
+  control channel.
 - [troubleshooting.md](troubleshooting.md) — common install / run-time
   failures.
 - [tool-protocol.md](../reference/tool-protocol.md) — the seven

--- a/docs/guides/observability-with-harmonograf.md
+++ b/docs/guides/observability-with-harmonograf.md
@@ -331,6 +331,51 @@ complement cleanly. See
 recovery protocol and [choosing-a-sink.md](choosing-a-sink.md) for
 the full sink matrix.
 
+### Live steering from the harmonograf UI
+
+Observability goes two ways. Once the harmonograf UI is rendering
+your run, the same connection carries control *back* — pause,
+cancel, steer, rewind, approve/reject buttons on the frontend
+become `ControlMessage` values on a goldfive `ControlChannel`.
+
+The bridge wiring:
+
+```python
+from goldfive import ControlChannel, Runner
+
+channel = ControlChannel()
+runner = Runner(
+    agent=...,
+    planner=...,
+    executor=SequentialExecutor(),
+    control=channel,
+    sinks=[HarmonografSink(client)],
+)
+
+# In a companion task, drain client.observe() and translate harmonograf
+# ControlEvents to goldfive ControlMessages:
+#
+#   async for control_event in client.observe():
+#       await channel.send(bridge_to_goldfive(control_event))
+#
+# The ack path is the mirror — iterate channel.acks() and forward
+# them back to harmonograf.
+```
+
+End-to-end, a single STEER click in the browser travels:
+
+```
+UI click → harmonograf server (:7531) → harmonograf_client.observe →
+  goldfive ControlChannel → executor.dispatch_control →
+    steerer.observe → DriftEvent(USER_STEER) → planner.refine →
+      PlanRevised event on sinks → UI re-renders
+```
+
+Round-trip is typically sub-100 ms on the transport; total latency is
+dominated by the LLM refine (seconds). Full protocol walkthrough,
+per-kind behaviour, and approval flows are in
+[../design/CONTROL.md](../design/CONTROL.md).
+
 ### Read the architectural depth
 
 - [harmonograf-integration.md](harmonograf-integration.md) — why the

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -24,6 +24,8 @@ from goldfive import (
     InvocationResult, ExecutionOutcome,
     # reporting
     ReportingToolSpec, BUILTIN_REPORTING_TOOLS,
+    # live steering
+    ControlChannel, ControlMessage, ControlAck, ControlKind, AckResult,
     # default implementations re-exported at the package root
     CallableAdapter,
     SequentialExecutor, ParallelDAGExecutor,
@@ -148,6 +150,7 @@ class Runner:
         goal_deriver: Optional[GoalDeriver] = None,
         steerer: Optional[Steerer] = None,
         sinks: Optional[list[EventSink]] = None,
+        control: Optional[ControlChannel] = None,
         max_plan_reinvocations: int = 3,
     ) -> None: ...
 
@@ -182,6 +185,7 @@ recovered goals. Tracked in issue #15.
 | `goal_deriver` | `PassthroughGoalDeriver("run")` | Optional. When `None`, the Runner substitutes a passthrough deriver that emits a single `Goal(id="g1", summary="run")`. |
 | `steerer` | `DefaultSteerer()` | Optional. |
 | `sinks` | `[]` | Optional. Recommended: at least `InMemorySink` in tests and `JSONLPersistenceSink` in prod. |
+| `control` | `None` | Optional `ControlChannel` for live pause / cancel / steer / rewind / approve / reject. When `None`, the run has no live-steering surface. See [../design/CONTROL.md](../design/CONTROL.md). |
 | `max_plan_reinvocations` | `3` | Stamped onto the planner context so executors that honour it can cap refine loops. |
 
 ## Data types (`goldfive.types`)
@@ -568,6 +572,77 @@ The companion server for `GRPCSink`. Receives proto `Event` messages
 over the `GoldfiveIngress.StreamEvents` RPC (defined in
 `proto/goldfive/v1/service.proto`) and fans them out to local
 sinks. See [grpc-transport.md](../guides/grpc-transport.md).
+
+## Live steering (`goldfive.control`)
+
+Primitive for external pause / resume / cancel / steer / rewind /
+approve / reject. Full design in
+[../design/CONTROL.md](../design/CONTROL.md).
+
+### `ControlKind`
+
+```python
+class ControlKind(StrEnum):
+    PAUSE = "PAUSE"
+    RESUME = "RESUME"
+    CANCEL = "CANCEL"
+    STEER = "STEER"          # payload: {"note": "...", "suggested_action": "..."}
+    REWIND_TO = "REWIND_TO"  # payload: {"task_id": "..."}
+    APPROVE = "APPROVE"      # payload: {"target_id": "...", "detail": "..."}
+    REJECT = "REJECT"        # payload: {"target_id": "...", "detail": "..."}
+```
+
+`STATUS_QUERY` and `INTERCEPT_TRANSFER` are not in the Phase-1 enum
+but are accepted as raw strings by the executor's dispatcher.
+
+### `AckResult`
+
+```python
+class AckResult(StrEnum):
+    SUCCESS
+    FAILURE
+    UNSUPPORTED
+```
+
+### `ControlMessage`
+
+```python
+@dataclass
+class ControlMessage:
+    kind: ControlKind
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    payload: dict[str, Any] = field(default_factory=dict)
+    issued_at_ms: int = 0
+```
+
+### `ControlAck`
+
+```python
+@dataclass
+class ControlAck:
+    control_id: str
+    result: AckResult
+    detail: str = ""
+    acked_at_ms: int = 0
+```
+
+### `ControlChannel`
+
+```python
+class ControlChannel:
+    def __init__(self) -> None: ...
+
+    async def send(self, msg: ControlMessage) -> None: ...
+    async def receive(self, timeout: float | None = None) -> ControlMessage | None: ...
+    async def ack(self, ack: ControlAck) -> None: ...
+    def acks(self) -> AsyncIterator[ControlAck]: ...
+    def close(self) -> None: ...
+```
+
+Bidirectional: external callers push via `send` and iterate acks via
+`acks()`; the runner consumes via `receive()` and publishes via
+`ack()`. Dependency-light (`asyncio.Queue` under the hood) — tests
+instantiate directly.
 
 ## Reporting (`goldfive.reporting`)
 


### PR DESCRIPTION
## Summary

- New `docs/design/CONTROL.md` (500 lines): ControlChannel primitive, end-to-end UI → bridge → executor → steerer → planner path, per-kind behaviour, STEER delete-and-replan example, APPROVE/REJECT dual flow, custom dispatcher hook.
- Cross-links added in `docs/guides/getting-started.md` (new live-steering subsection with runnable PAUSE/RESUME snippet), `docs/guides/observability-with-harmonograf.md` (UI → goldfive steering flow), `docs/reference/api.md` (ControlChannel/ControlMessage/ControlAck/ControlKind/AckResult + new `Runner.control=` kwarg), and `.agents/debug-goldfive.md` (control-channel troubleshooting decision tree).

## Test plan

- [x] `uv run --extra proto --extra dev pytest -q` — 337 passed, 37 skipped.
- [x] Verified live-steering snippet from getting-started.md runs end-to-end.
- [x] Verified custom CheckpointingExecutor subclass snippet compiles.