### PR TITLE
Runner extension API (closes #86)

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -166,7 +166,18 @@ class Runner:
         persistence_path: str,
     ) -> ExecutionOutcome: ...  # best-effort JSONL replay
 
-    async def close(self) -> None: ...  # close every sink
+    async def close(self) -> None: ...  # close every sink, then run hooks
+
+    # Post-construction extension API. See "Extension API" below.
+    def add_sink(self, sink: EventSink) -> None: ...
+    def add_close_hook(
+        self, hook: Callable[[], Awaitable[None]]
+    ) -> None: ...
+
+    @property
+    def control(self) -> ControlChannel | None: ...
+    @control.setter
+    def control(self, value: ControlChannel) -> None: ...
 ```
 
 `Runner.resume(persistence_path)` loads a JSONL log written by
@@ -185,8 +196,32 @@ recovered goals. Tracked in issue #15.
 | `goal_deriver` | `PassthroughGoalDeriver("run")` | Optional. When `None`, the Runner substitutes a passthrough deriver that emits a single `Goal(id="g1", summary="run")`. |
 | `steerer` | `DefaultSteerer()` | Optional. |
 | `sinks` | `[]` | Optional. Recommended: at least `InMemorySink` in tests and `JSONLPersistenceSink` in prod. |
-| `control` | `None` | Optional `ControlChannel` for live pause / cancel / steer / rewind / approve / reject. When `None`, the run has no live-steering surface. See [../design/CONTROL.md](../design/CONTROL.md). |
+| `control` | `None` | Optional `ControlChannel` for live pause / cancel / steer / rewind / approve / reject. When `None`, the run has no live-steering surface. May also be attached post-construction via the `control` setter; see "Extension API" below. See [../design/CONTROL.md](../design/CONTROL.md). |
 | `max_plan_reinvocations` | `3` | Stamped onto the planner context so executors that honour it can cap refine loops. |
+
+### Extension API
+
+Three post-construction hooks let external integrations attach
+additional behaviour without subclassing or attribute mutation:
+
+- **`add_sink(sink)`** — append an `EventSink` after construction.
+  Takes effect for events emitted by subsequent `run()` calls;
+  in-flight runs keep the sink list they started with.
+- **`add_close_hook(hook)`** — register an async callable invoked by
+  `close()` *after* sinks are closed. Hooks fire in registration
+  order; an exception in one hook is logged and does not prevent the
+  rest from running. `close()` is idempotent — a second call is a
+  no-op and hooks fire exactly once.
+- **`control` setter** — attach a `ControlChannel` after construction.
+  Idempotent on identity (`is`) re-attach; raises `RuntimeError` if a
+  different channel is already attached. The constructor kwarg
+  `control=...` is unchanged; the setter is the post-construction
+  path.
+
+`GoldfiveADKAgent` (returned by `goldfive.wrap(adk_agent)`) mirrors
+the same contract and delegates to the inner `Runner`, so callers
+can use the extension API uniformly whether they hold a plain
+`Runner` or an ADK-wrapped one.
 
 ## Data types (`goldfive.types`)
 

--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -22,10 +22,12 @@ install hint.
 from __future__ import annotations
 
 import logging
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from goldfive.control import ControlChannel
+    from goldfive.protocols import EventSink
     from goldfive.results import ExecutionOutcome
     from goldfive.runner import Runner
     from goldfive.types import Goal
@@ -279,10 +281,23 @@ class GoldfiveADKAgent(BaseAgent):
         """Expose the inner :class:`Runner`'s sink list (mutable)."""
         return self._runner.sinks
 
+    def add_sink(self, sink: EventSink) -> None:
+        """Register an additional sink on the inner :class:`Runner`."""
+        self._runner.add_sink(sink)
+
+    def add_close_hook(self, hook: Callable[[], Awaitable[None]]) -> None:
+        """Register an async close hook on the inner :class:`Runner`."""
+        self._runner.add_close_hook(hook)
+
     @property
-    def control(self) -> Any:
+    def control(self) -> ControlChannel | None:
         """Expose the inner :class:`Runner`'s optional ControlChannel."""
         return self._runner.control
+
+    @control.setter
+    def control(self, value: ControlChannel) -> None:
+        """Attach a :class:`ControlChannel` on the inner :class:`Runner`."""
+        self._runner.control = value
 
     @property
     def inner_agent(self) -> Any:

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -36,7 +36,7 @@ and are loaded lazily by callers.
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from goldfive.conversation import Conversation
@@ -123,7 +123,9 @@ class Runner:
         self.goal_deriver: GoalDeriver = goal_deriver or PassthroughGoalDeriver("run")
         self.steerer: Steerer = steerer or DefaultSteerer()
         self.sinks: list[EventSink] = list(sinks) if sinks else []
-        self.control: ControlChannel | None = control
+        self._control: ControlChannel | None = control
+        self._close_hooks: list[Callable[[], Awaitable[None]]] = []
+        self._closed: bool = False
         self.max_plan_reinvocations = max_plan_reinvocations
         self._conversation: Conversation = conversation or Conversation.new()
         # Tracks whether we've emitted the ConversationStarted event for
@@ -374,12 +376,18 @@ class Runner:
     # ------------------------------------------------------------------
 
     async def close(self) -> None:
-        """Close every sink. Best-effort — individual errors are logged.
+        """Close every sink, then invoke registered close hooks. Idempotent.
 
         Emits ``ConversationEnded`` for the active Conversation (if any
         turns ran) before closing sinks, so persisted logs have a clean
-        terminal marker.
+        terminal marker. Close hooks registered via
+        :meth:`add_close_hook` run in registration order AFTER sinks are
+        closed; a raising hook is logged and does not prevent subsequent
+        hooks from running. A second call to :meth:`close` is a no-op.
         """
+        if self._closed:
+            return
+        self._closed = True
         if self._conversation_announced and self._last_session is not None:
             try:
                 await self._emit_conversation_ended(
@@ -395,6 +403,57 @@ class Runner:
                 await sink.close()
             except Exception as exc:  # noqa: BLE001
                 log.warning("sink.close() raised: %s", exc)
+        for hook in self._close_hooks:
+            try:
+                await hook()
+            except Exception as exc:  # noqa: BLE001
+                log.warning("close hook raised: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Extension API — post-construction wiring for sinks, hooks, control
+    # ------------------------------------------------------------------
+
+    def add_sink(self, sink: EventSink) -> None:
+        """Register an additional :class:`EventSink`.
+
+        Takes effect for events emitted by subsequent calls to
+        :meth:`run`. In-flight runs continue with whatever sink list
+        they were handed to the executor at kickoff.
+        """
+        self.sinks.append(sink)
+
+    def add_close_hook(self, hook: Callable[[], Awaitable[None]]) -> None:
+        """Register an async callable invoked by :meth:`close` after sinks.
+
+        Hooks fire in registration order, AFTER the Runner's internal
+        teardown (sinks closed). An exception in one hook is logged
+        via :mod:`logging` and does not prevent subsequent hooks from
+        running — failing cleanup must not hang a process.
+        """
+        self._close_hooks.append(hook)
+
+    @property
+    def control(self) -> ControlChannel | None:
+        """The attached :class:`~goldfive.control.ControlChannel`, if any."""
+        return self._control
+
+    @control.setter
+    def control(self, value: ControlChannel) -> None:
+        """Attach a :class:`ControlChannel` post-construction.
+
+        Idempotent when the same channel (by identity, ``is``) is
+        re-attached. Raises :class:`RuntimeError` if a different
+        channel is already attached — callers must construct a fresh
+        Runner rather than swap channels mid-lifetime.
+        """
+        if self._control is value:
+            return
+        if self._control is not None:
+            raise RuntimeError(
+                "Runner already has a control channel attached; "
+                "detach it first or construct the runner with a specific one."
+            )
+        self._control = value
 
     # ------------------------------------------------------------------
     # internals

--- a/tests/test_runner_extension.py
+++ b/tests/test_runner_extension.py
@@ -1,0 +1,267 @@
+"""Tests for the :class:`Runner` extension API.
+
+Covers the three post-construction extension points formalized in
+issue #86:
+
+* :meth:`Runner.add_sink` — append a sink after construction.
+* :meth:`Runner.add_close_hook` — register async cleanup run by
+  :meth:`Runner.close` after sinks close; close must be idempotent and
+  a raising hook must not block subsequent hooks.
+* :attr:`Runner.control` setter — idempotent on identity re-attach,
+  raises :class:`RuntimeError` on conflicting attach.
+
+Also covers the :class:`GoldfiveADKAgent` delegations (gated on the
+``adk`` extra).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from goldfive import (
+    CallableAdapter,
+    ControlChannel,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _one_task_plan() -> Plan:
+    return Plan(
+        id="plan-ext",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="only task", assignee_agent_id="writer")],
+        edges=[],
+        summary="single task",
+    )
+
+
+async def _happy_agent(
+    task: Task, session: Session, tools: list[ReportingToolSpec]
+) -> InvocationResult:
+    _ = tools, session
+    return InvocationResult(task_id=task.id, text="ok")
+
+
+def _make_runner(sinks: list[Any] | None = None) -> Runner:
+    return Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_one_task_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("go"),
+        sinks=sinks if sinks is not None else [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# add_sink
+# ---------------------------------------------------------------------------
+
+
+async def test_add_sink_receives_events_on_subsequent_run() -> None:
+    """A sink added post-construction sees the events of the next run."""
+    early = InMemorySink()
+    runner = _make_runner(sinks=[early])
+
+    late = InMemorySink()
+    runner.add_sink(late)
+
+    outcome = await runner.run("go")
+    await runner.close()
+
+    assert outcome.success
+    assert len(late.events) > 0
+    # Both sinks got the same event count.
+    assert len(late.events) == len(early.events)
+
+
+# ---------------------------------------------------------------------------
+# add_close_hook
+# ---------------------------------------------------------------------------
+
+
+async def test_close_hook_runs_exactly_once_on_close() -> None:
+    """Registered hook runs on close; a second close is a no-op."""
+    runner = _make_runner()
+    calls: list[int] = []
+
+    async def hook() -> None:
+        calls.append(1)
+
+    runner.add_close_hook(hook)
+
+    await runner.close()
+    await runner.close()  # idempotent — second call is a no-op.
+
+    assert calls == [1]
+
+
+async def test_close_hook_exception_is_logged_and_does_not_block_others(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raising hook is logged; subsequent hooks still run."""
+    runner = _make_runner()
+    calls: list[str] = []
+
+    async def hook_a() -> None:
+        calls.append("a")
+
+    async def hook_b() -> None:
+        calls.append("b")
+        raise RuntimeError("boom")
+
+    async def hook_c() -> None:
+        calls.append("c")
+
+    runner.add_close_hook(hook_a)
+    runner.add_close_hook(hook_b)
+    runner.add_close_hook(hook_c)
+
+    with caplog.at_level(logging.WARNING, logger="goldfive.runner"):
+        await runner.close()
+
+    assert calls == ["a", "b", "c"]
+    assert any("close hook raised" in rec.message for rec in caplog.records)
+
+
+async def test_close_hook_runs_after_sinks_close() -> None:
+    """Sinks are closed before hooks fire (hooks depend on teardown state)."""
+    order: list[str] = []
+
+    class _OrderedSink:
+        events: list[Any]
+
+        def __init__(self, label: str) -> None:
+            self.events = []
+            self._label = label
+
+        async def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+        async def close(self) -> None:
+            order.append(f"sink:{self._label}")
+
+    runner = _make_runner(sinks=[_OrderedSink("x"), _OrderedSink("y")])
+
+    async def hook() -> None:
+        order.append("hook")
+
+    runner.add_close_hook(hook)
+    await runner.close()
+
+    assert order == ["sink:x", "sink:y", "hook"]
+
+
+# ---------------------------------------------------------------------------
+# control setter
+# ---------------------------------------------------------------------------
+
+
+async def test_control_setter_attaches_when_unset() -> None:
+    """Setter on a fresh runner attaches the channel."""
+    runner = _make_runner()
+    assert runner.control is None
+
+    ch = ControlChannel()
+    runner.control = ch
+    assert runner.control is ch
+
+
+async def test_control_setter_idempotent_on_same_identity() -> None:
+    """Re-attaching the same channel (by ``is``) is a no-op, not an error."""
+    runner = _make_runner()
+    ch = ControlChannel()
+    runner.control = ch
+    runner.control = ch  # same identity — must not raise.
+    assert runner.control is ch
+
+
+async def test_control_setter_rejects_conflicting_channel() -> None:
+    """Attaching a different channel when one exists raises RuntimeError."""
+    runner = _make_runner()
+    runner.control = ControlChannel()
+    with pytest.raises(RuntimeError, match="already has a control channel"):
+        runner.control = ControlChannel()
+
+
+# ---------------------------------------------------------------------------
+# GoldfiveADKAgent delegations — gated on the adk extra
+# ---------------------------------------------------------------------------
+
+
+def _adk_or_skip() -> None:
+    pytest.importorskip("google.adk")
+
+
+def _build_adk_wrapped() -> Any:
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    import goldfive
+
+    inner = LlmAgent(
+        name="inner_agent",
+        model="fake-model",
+        description="wrapped",
+        instruction="follow",
+    )
+    return goldfive.wrap(
+        inner,
+        planner=StaticPlanner(_one_task_plan()),
+        sinks=[InMemorySink()],
+    )
+
+
+async def test_adk_wrapped_add_sink_delegates() -> None:
+    _adk_or_skip()
+    wrapped = _build_adk_wrapped()
+    late = InMemorySink()
+    wrapped.add_sink(late)
+    assert late in wrapped.runner.sinks
+
+
+async def test_adk_wrapped_close_hook_delegates() -> None:
+    _adk_or_skip()
+    wrapped = _build_adk_wrapped()
+    calls: list[int] = []
+
+    async def hook() -> None:
+        calls.append(1)
+
+    wrapped.add_close_hook(hook)
+    await wrapped.close()
+    await wrapped.close()
+    assert calls == [1]
+
+
+async def test_adk_wrapped_control_getter_and_setter_delegate() -> None:
+    _adk_or_skip()
+    wrapped = _build_adk_wrapped()
+    assert wrapped.control is None
+
+    ch = ControlChannel()
+    wrapped.control = ch
+    assert wrapped.control is ch
+    assert wrapped.runner.control is ch
+
+    # Idempotent on same identity.
+    wrapped.control = ch
+
+    # Conflicting channel raises.
+    with pytest.raises(RuntimeError, match="already has a control channel"):
+        wrapped.control = ControlChannel()


### PR DESCRIPTION
## Summary

Formalize three post-construction extension points on `goldfive.Runner` so external integrations (harmonograf_client.observe, future sinks) no longer rely on attribute mutation — which broke on `GoldfiveADKAgent`'s pydantic-backed model.

- `add_sink(sink)` appends a sink; takes effect for subsequent `run()` calls.
- `add_close_hook(hook)` registers async cleanup invoked by `close()` after sinks close. `close()` is now idempotent; a raising hook is logged without blocking subsequent hooks.
- `control` is a settable property: idempotent on identity (`is`) re-attach, raises `RuntimeError` on conflicting attach. Constructor kwarg unchanged.
- `GoldfiveADKAgent` mirrors all three, delegating to the inner Runner.
- Docs updated in `docs/reference/api.md`.

## Test plan

- [x] `uv run pytest -q` — 368 passed, 33 skipped (10 new tests in `tests/test_runner_extension.py`).
- [x] `uv run ruff check .` — clean.
- [x] New tests cover: add_sink seeing events on subsequent runs; close hook runs exactly once even on double close; raising hook logged + others still run; hooks fire after sinks close; control setter attach / idempotent / conflict; ADK wrapper delegations for all four.
