### PR TITLE
Add ADKAdapter.add_plugin for post-construction plugin install (closes #90)

### DIFF
--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -319,6 +319,26 @@ class ADKAdapter:
         self._steerer: Steerer | None = None
 
     # ------------------------------------------------------------------
+    # Post-construction plugin install
+    # ------------------------------------------------------------------
+
+    def add_plugin(self, plugin: Any) -> None:
+        """Install an ADK ``BasePlugin`` on the inner ``Runner``.
+
+        Tolerant of runners that don't expose a plugin manager (e.g. a
+        custom ``Runner`` shape) — logs at DEBUG and returns. Used by
+        observability integrations that need to attach a plugin after
+        the adapter has already been built.
+        """
+        if not _register_plugin_on_runner(self._runner, plugin):
+            log.debug(
+                "ADKAdapter.add_plugin: runner %r has no plugin manager; "
+                "plugin %r not installed",
+                type(self._runner).__name__,
+                type(plugin).__name__,
+            )
+
+    # ------------------------------------------------------------------
     # AgentAdapter protocol
     # ------------------------------------------------------------------
 

--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -289,6 +289,16 @@ class GoldfiveADKAgent(BaseAgent):
         """Register an async close hook on the inner :class:`Runner`."""
         self._runner.add_close_hook(hook)
 
+    def add_plugin(self, plugin: Any) -> None:
+        """Install an ADK ``BasePlugin`` on the underlying ADK Runner.
+
+        Delegates to :meth:`ADKAdapter.add_plugin` on the wrapped
+        adapter. Used by observability integrations (e.g.
+        ``harmonograf_client.observe()``) to attach telemetry plugins
+        after ``goldfive.wrap(...)`` has built the adapter.
+        """
+        self._runner.agent.add_plugin(plugin)
+
     @property
     def control(self) -> ControlChannel | None:
         """Expose the inner :class:`Runner`'s optional ControlChannel."""

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -421,6 +421,67 @@ async def test_register_reporting_tools_propagates_across_three_level_tree() -> 
     } <= discovered
 
 
+# ---------------------------------------------------------------------------
+# add_plugin — post-construction plugin install
+# ---------------------------------------------------------------------------
+
+
+async def test_add_plugin_installs_on_inner_runner() -> None:
+    """ADKAdapter.add_plugin must attach the plugin to the InMemoryRunner."""
+    from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    class _FakePlugin(BasePlugin):
+        def __init__(self) -> None:
+            super().__init__(name="fake_plugin")
+
+    adapter = ADKAdapter(_make_agent())
+    plugin = _FakePlugin()
+    adapter.add_plugin(plugin)
+
+    installed = list(getattr(adapter._runner.plugin_manager, "plugins", []))
+    assert plugin in installed
+
+
+async def test_add_plugin_no_op_when_runner_lacks_plugin_manager() -> None:
+    """add_plugin must not raise when the inner runner has no plugin support."""
+    from goldfive.adapters.adk import ADKAdapter
+
+    # Build the adapter normally, then swap in a runner stub with no
+    # plugin_manager. ADKAdapter.add_plugin should DEBUG-log + no-op.
+    adapter = ADKAdapter(_make_agent())
+
+    class _BareRunner:
+        agent = adapter._agent
+        run_async = adapter._runner.run_async
+        session_service = adapter._runner.session_service
+
+    adapter._runner = _BareRunner()
+    adapter.add_plugin(object())  # must not raise
+
+
+async def test_goldfive_adk_agent_add_plugin_delegates() -> None:
+    """GoldfiveADKAgent.add_plugin routes through ADKAdapter on the inner Runner."""
+    from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+
+    import goldfive
+    from goldfive.adapters.adk_wrap import GoldfiveADKAgent
+
+    class _FakePlugin(BasePlugin):
+        def __init__(self) -> None:
+            super().__init__(name="wrap_fake_plugin")
+
+    wrapped = goldfive.wrap(_make_agent())
+    assert isinstance(wrapped, GoldfiveADKAgent)
+    plugin = _FakePlugin()
+    wrapped.add_plugin(plugin)
+
+    adapter = wrapped._runner.agent
+    installed = list(getattr(adapter._runner.plugin_manager, "plugins", []))
+    assert plugin in installed
+
+
 async def test_register_reporting_tools_is_idempotent() -> None:
     """Registering twice must not duplicate the reporting tools on any agent."""
     from google.adk.agents.llm_agent import LlmAgent  # type: ignore


### PR DESCRIPTION
## Summary
- `ADKAdapter.add_plugin(plugin)` — installs an ADK `BasePlugin` on the inner `Runner`. Reuses the existing `_register_plugin_on_runner` helper (covers both `plugin_manager.register_plugin` and `plugins`-list shapes). DEBUG-logs and no-ops when the runner has no plugin manager.
- `GoldfiveADKAgent.add_plugin(plugin)` — delegates to the wrapped `ADKAdapter`, so callers using `goldfive.wrap(...)` can attach plugins to the returned object.
- Tests cover the happy path on `InMemoryRunner`, the no-op path for a runner without a plugin manager, and the `GoldfiveADKAgent` delegation path.

Unblocks harmonograf #40 — `harmonograf_client.observe()` will use this to auto-install `HarmonografTelemetryPlugin`.

## Test plan
- [x] `uv run pytest -q` (397 passed, 33 skipped)
- [x] `uv run ruff check goldfive tests` (clean)
