### PR TITLE
CallLLM cleanup protocol + example fix (fixes #93)

### DIFF
--- a/examples/adk_presentation/agent.py
+++ b/examples/adk_presentation/agent.py
@@ -323,6 +323,12 @@ def _make_openai_call_llm() -> Any:
     ``pip install openai``. Model identifiers default to
     ``gpt-4o-mini`` but can be overridden via
     ``GOLDFIVE_EXAMPLE_PLANNER_MODEL``.
+
+    The returned callable carries an async ``close`` attribute that
+    shuts down the underlying ``aiohttp`` session. Goldfive's
+    :class:`Runner.close` discovers and awaits it via the duck-typed
+    :class:`goldfive._llm.ClosableCallLLM` protocol, so callers don't
+    need to register a separate close hook.
     """
     try:
         from openai import AsyncOpenAI  # type: ignore
@@ -347,6 +353,10 @@ def _make_openai_call_llm() -> Any:
         )
         return resp.choices[0].message.content or ""
 
+    async def _close() -> None:
+        await client.close()
+
+    _call.close = _close  # type: ignore[attr-defined]
     return _call
 
 

--- a/goldfive/_llm.py
+++ b/goldfive/_llm.py
@@ -1,0 +1,79 @@
+"""Shared typing + lifecycle helpers for the planner / goal-deriver LLM callable.
+
+Goldfive accepts an opaque ``call_llm(system, user, model) -> str`` async
+callable for both :class:`LLMPlanner` and :class:`LLMGoalDeriver`. That
+keeps the framework decoupled from any specific SDK, but it also leaves
+resource cleanup ambiguous — the most common pattern (an OpenAI
+``AsyncClient`` whose ``aiohttp.ClientSession`` lives until garbage
+collection) leaks at process exit.
+
+This module standardises a duck-typed close protocol:
+
+* :class:`CallLLM` — a structural :class:`typing.Protocol` describing
+  the call signature. Pure documentation; runtime acceptance has always
+  been "anything callable with the right shape".
+* :class:`ClosableCallLLM` — extends :class:`CallLLM` with an optional
+  async ``close()``. Callables that own a network session implement
+  ``close``; bare lambdas don't, and that's fine — the runtime probes
+  via ``getattr(call_llm, "close", None)``.
+* :func:`maybe_close_call_llm` — utility used by :class:`Runner.close`
+  to fire the optional ``close`` if present, swallowing exceptions so a
+  misbehaving teardown can't hang the process.
+
+There is no breaking change for existing callers: existing call_llm
+callables continue to work because they just don't have a ``close``
+attribute and the helper short-circuits.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol, runtime_checkable
+
+log = logging.getLogger("goldfive.llm")
+
+
+@runtime_checkable
+class CallLLM(Protocol):
+    """Async callable shape: ``(system, user, model) -> str``.
+
+    Used by :class:`~goldfive.planner.LLMPlanner` and
+    :class:`~goldfive.goal_deriver.LLMGoalDeriver`. The ``model`` argument
+    may be empty when the callable is already model-bound.
+    """
+
+    async def __call__(self, system: str, user: str, model: str) -> str: ...
+
+
+@runtime_checkable
+class ClosableCallLLM(CallLLM, Protocol):
+    """Optional extension: a ``call_llm`` that owns network resources.
+
+    Implementations should define an async ``close()`` that releases the
+    underlying HTTP session (e.g. ``await openai_client.close()``).
+    Goldfive's :class:`Runner.close` will await it automatically.
+    """
+
+    async def close(self) -> None: ...
+
+
+async def maybe_close_call_llm(call_llm: Any, *, label: str = "call_llm") -> None:
+    """Await ``call_llm.close()`` if it exists. Swallow exceptions.
+
+    Returns immediately when ``call_llm`` is ``None`` or has no
+    ``close`` attribute. Logs and discards any exception raised by
+    ``close`` — Runner teardown must remain robust under partial
+    initialisation.
+    """
+    if call_llm is None:
+        return
+    closer = getattr(call_llm, "close", None)
+    if closer is None:
+        return
+    try:
+        await closer()
+    except Exception as exc:  # noqa: BLE001 - cleanup must not raise
+        log.warning("%s.close() raised %s; ignored", label, exc)
+
+
+__all__ = ["CallLLM", "ClosableCallLLM", "maybe_close_call_llm"]

--- a/goldfive/_llm_detect.py
+++ b/goldfive/_llm_detect.py
@@ -130,6 +130,45 @@ def make_default_adk_call_llm(model: Any) -> CallLLM | None:
                     chunks.append(str(text))
         return "".join(chunks).strip()
 
+    async def _close() -> None:
+        # ADK's BaseLlm doesn't pin a uniform close protocol, but several
+        # subclasses (LiteLlm, custom HTTP-backed adapters) wrap an
+        # aiohttp / httpx client. Probe a few known attribute names and
+        # await whichever exists. Silently no-op if nothing is found.
+        for attr_name in ("aclose", "close"):
+            target = getattr(llm, attr_name, None)
+            if callable(target):
+                try:
+                    result = target()
+                    if hasattr(result, "__await__"):
+                        await result
+                    return
+                except Exception as exc:  # noqa: BLE001
+                    log.debug("ADK call_llm.%s raised %s", attr_name, exc)
+                    return
+        # Some LiteLlm versions stash the client as ._client / .client.
+        for client_attr in ("_client", "client"):
+            client = getattr(llm, client_attr, None)
+            if client is None:
+                continue
+            for attr_name in ("aclose", "close"):
+                target = getattr(client, attr_name, None)
+                if callable(target):
+                    try:
+                        result = target()
+                        if hasattr(result, "__await__"):
+                            await result
+                        return
+                    except Exception as exc:  # noqa: BLE001
+                        log.debug(
+                            "ADK call_llm.%s.%s raised %s",
+                            client_attr,
+                            attr_name,
+                            exc,
+                        )
+                        return
+
+    _call_llm.close = _close  # type: ignore[attr-defined]
     return _call_llm
 
 

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -39,6 +39,7 @@ import logging
 from collections.abc import Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from goldfive._llm import maybe_close_call_llm
 from goldfive.conversation import Conversation
 from goldfive.events import (
     conversation_ended_event,
@@ -403,6 +404,17 @@ class Runner:
                 await sink.close()
             except Exception as exc:  # noqa: BLE001
                 log.warning("sink.close() raised: %s", exc)
+        # Auto-close LLM callables on the planner and goal-deriver if they
+        # implement the optional ``close`` shape (see goldfive._llm).
+        # Standard SDK clients (OpenAI AsyncOpenAI, ADK LiteLlm, …) own
+        # an aiohttp session that leaks unless explicitly closed.
+        await maybe_close_call_llm(
+            getattr(self.planner, "_call_llm", None), label="planner.call_llm"
+        )
+        await maybe_close_call_llm(
+            getattr(self.goal_deriver, "_call_llm", None),
+            label="goal_deriver.call_llm",
+        )
         for hook in self._close_hooks:
             try:
                 await hook()

--- a/tests/test_planner_close.py
+++ b/tests/test_planner_close.py
@@ -1,0 +1,115 @@
+"""Runner.close awaits optional close() on planner / goal_deriver call_llm.
+
+A common SDK pattern (OpenAI ``AsyncClient``, ADK ``LiteLlm`` over
+litellm) hands back a callable backed by an ``aiohttp.ClientSession``
+that leaks at process exit unless explicitly closed. We extend the
+``call_llm`` shape with an optional async ``close`` and have the
+Runner walk the planner / goal_deriver to fire it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from goldfive.adapters.callable import CallableAdapter
+from goldfive.executors.sequential import SequentialExecutor
+from goldfive.goal_deriver import LLMGoalDeriver
+from goldfive.planner import LLMPlanner
+from goldfive.results import InvocationResult
+from goldfive.runner import Runner
+from goldfive.types import Task
+
+
+class _ClosableLLM:
+    """A minimal call_llm with a ``close`` shim and a record-keeping flag."""
+
+    def __init__(self, response: str = "{}") -> None:
+        self._response = response
+        self.calls = 0
+        self.closed = False
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        self.calls += 1
+        return self._response
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _BareLLM:
+    """A call_llm with NO close attribute — Runner must tolerate this."""
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        return "{}"
+
+
+async def _stub_agent(task: Task, session: Any, tools: Any) -> InvocationResult:
+    return InvocationResult(task_id=task.id, text="ok", stop_reason="end_turn")
+
+
+def _runner_with(planner_llm: Any, goal_llm: Any) -> Runner:
+    adapter = CallableAdapter(_stub_agent, available_agents=["root"])
+    return Runner(
+        agent=adapter,
+        planner=LLMPlanner(call_llm=planner_llm),
+        executor=SequentialExecutor(),
+        goal_deriver=LLMGoalDeriver(goal_llm),
+    )
+
+
+async def test_runner_close_awaits_planner_call_llm_close() -> None:
+    planner_llm = _ClosableLLM()
+    goal_llm = _BareLLM()
+    runner = _runner_with(planner_llm, goal_llm)
+
+    await runner.close()
+
+    assert planner_llm.closed is True
+
+
+async def test_runner_close_awaits_goal_deriver_call_llm_close() -> None:
+    planner_llm = _BareLLM()
+    goal_llm = _ClosableLLM()
+    runner = _runner_with(planner_llm, goal_llm)
+
+    await runner.close()
+
+    assert goal_llm.closed is True
+
+
+async def test_runner_close_tolerates_bare_callable() -> None:
+    """Lambda-style call_llm without a close attribute: no error."""
+    runner = _runner_with(_BareLLM(), _BareLLM())
+    await runner.close()  # must not raise
+
+
+async def test_runner_close_swallows_exception_from_close() -> None:
+    """A raising close() must not propagate or break subsequent hooks."""
+
+    class _BoomLLM(_ClosableLLM):
+        async def close(self) -> None:
+            raise RuntimeError("boom")
+
+    boom = _BoomLLM()
+    fired: list[str] = []
+
+    async def hook() -> None:
+        fired.append("hook")
+
+    runner = _runner_with(boom, _BareLLM())
+    runner.add_close_hook(hook)
+    await runner.close()  # must not raise
+
+    # The hook still fired despite the failing close().
+    assert fired == ["hook"]
+
+
+async def test_runner_close_is_idempotent() -> None:
+    planner_llm = _ClosableLLM()
+    runner = _runner_with(planner_llm, _BareLLM())
+
+    await runner.close()
+    await runner.close()  # second call is a no-op (Runner._closed guard)
+
+    # Closer was called exactly once because the second close() short-circuits.
+    assert planner_llm.closed is True


### PR DESCRIPTION
## Summary

- New `goldfive/_llm.py` defines a duck-typed `ClosableCallLLM` protocol: async `__call__(system, user, model)` plus optional async `close()`. Bare lambdas continue to work — Runner only awaits `close` if present.
- `Runner.close()` walks `planner._call_llm` and `goal_deriver._call_llm` through `maybe_close_call_llm` so long-running services (always-on harmonograf deployments) stop leaking aiohttp sessions.
- `examples/adk_presentation/agent.py::_make_openai_call_llm` attaches an async `close` to the returned callable; Runner discovers it automatically — no manual `add_close_hook` needed.
- `goldfive/_llm_detect.py::make_default_adk_call_llm` mirrors the pattern for the ADK path, opportunistically closing the underlying `BaseLlm` (and its `_client` / `client` attribute, if present).

## Test plan

- [x] `tests/test_planner_close.py` — 5 new tests covering: planner close fires, goal_deriver close fires, bare lambdas tolerated, raising close swallowed (subsequent hooks still fire), close is idempotent.
- [x] `uv run pytest -q` — 411 passed, 34 skipped (411 = prior 406 + 5 new).
- [x] `uv run ruff check .` — clean.
- [x] `uv run python examples/adk_presentation/agent.py --mock --topic test` — exits cleanly, NO `Unclosed client session` warnings.

Closes #93.
