### PR TITLE
Task-lifecycle soundness: quiescence + terminal rejection + volume cap + refine visibility

### DIFF
--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -1,0 +1,453 @@
+# Task lifecycle & protocol choreography
+
+This document reviews how the goldfive protocols (Planner, Executor,
+Adapter, Steerer, reporting-tool handlers) interact across a task's
+end-to-end lifecycle. It is the companion to
+[STATE-MACHINE.md](STATE-MACHINE.md), which focuses on *what* the
+states are; this doc focuses on *how* the protocols move a task
+through them and where the contracts between them sit.
+
+Audiences:
+- implementers writing a new adapter / executor / sink who need to
+  know what a correct implementation looks like,
+- operators triaging a stuck run who need to know which layer owns
+  which behaviour,
+- reviewers validating that a proposed change doesn't break an
+  invariant another layer depends on.
+
+Citations are file:line into `goldfive/` unless otherwise noted.
+
+---
+
+## 1. Creation protocol
+
+A Plan is the unit of work and a Task is an entry in a Plan. Two
+paths produce one.
+
+### 1.1 Planner.generate — initial plan
+
+`LLMPlanner.generate` (`planner.py:397–455`) takes `Goal[]` +
+available agent list, calls the configured LLM, parses the JSON
+response, and returns a `Plan`. Defaults:
+
+- Every task starts at `TaskStatus.PENDING` (`types.py`, `Task`
+  dataclass default).
+- `Plan.revision_index = 0`, `revision_reason = ""`.
+- `Plan.edges` are `TaskEdge(from_task_id, to_task_id)`. Topological
+  order is computed on demand by
+  `Plan.topological_stages()` (`types.py`), not cached.
+
+### 1.2 Planner.refine — revised plan
+
+`LLMPlanner.refine` (`planner.py:743–850`) branches on `drift.kind`
+and dispatches to one of three paths:
+
+- `USER_STEER` → `_refine_user_steer` (`planner.py:1010–1115`):
+  delete-and-replan. Completed / failed / cancelled tasks are
+  preserved verbatim by id; PENDING / RUNNING / BLOCKED tasks are
+  dropped. LLM generates fresh PENDING work. Final plan =
+  `done_tasks + fresh_pending`.
+- `LOOPING_TOOL_CALL` / `LOOPING_REASONING` →
+  `_refine_looping_tool_call` (`planner.py:849–945`): the looping
+  task is forced to FAILED (framework overrides the LLM if it
+  forgets). There is a **deterministic fallback** (`planner.py:948–1015`)
+  that marks the looper FAILED locally if the LLM is unreachable
+  entirely — refine cannot soft-fail into "no change."
+- All other drift kinds → generic refine prompt. The LLM may rewrite
+  arbitrarily, subject to the invariants enforced by
+  `_apply_revision` below.
+
+### 1.3 Invariants the steerer enforces on any refined plan
+
+`DefaultSteerer._apply_revision` (`steerer.py:512–531`):
+
+- `revision_index` monotonically increases: `new_index ≥
+  old_index + 1`.
+- `revision_kind` / `revision_severity` / `revision_reason` are
+  stamped from the triggering drift if the planner didn't set them.
+- `session.plan` is replaced as a single atomic assignment — readers
+  in the adapter / executor see either the old plan or the new plan,
+  never a half-merged state.
+
+**Soundness gap (open):** `Plan` has no structural validation at
+creation or revision — duplicate task IDs, edges referencing missing
+tasks, or cycles are silently accepted. `topological_stages()`
+tolerates cycles by appending un-placeable tasks to a final stage.
+See §7.
+
+---
+
+## 2. Assignment protocol
+
+Once a Plan exists, tasks move from `PENDING` to `RUNNING` via one of
+two entry points, and execution is driven by the Executor.
+
+### 2.1 Who picks the next task
+
+`SequentialExecutor._pick_next_task` (`executors/sequential.py:~624`)
+walks topological stages and returns the first task that is `PENDING`
+**and** whose incoming-edge predecessors are all `COMPLETED`.
+`BLOCKED` tasks are never picked — they can only return to `RUNNING`
+through a refine-driven transition (see STATE-MACHINE.md §"Blocked
+vs non-blocked resume").
+
+`ParallelDAGExecutor` (`executors/parallel_dag.py`) picks all
+ready-to-run tasks within a stage and invokes them concurrently; the
+Steerer's state mutations are serialised through an asyncio lock so
+concurrent `report_task_*` calls don't interleave state writes.
+
+### 2.2 Who drives PENDING → RUNNING
+
+Two entry points, reconciled by the terminal-status guard:
+
+1. **Executor pre-invoke transition.** Before calling
+   `adapter.invoke(...)`, the executor calls
+   `steerer.transition(task_id, RUNNING, ...)` so observability sinks
+   see a `TaskStarted` event even for adapters whose agent never
+   calls `report_task_started`.
+2. **Agent-driven transition.** When the agent calls
+   `report_task_started(task_id)`, the reporting-tool handler routes
+   through `DefaultSteerer.mark_task_running`
+   (`steerer.py:142–159`). If the task is already `RUNNING`, the
+   `_TERMINAL_TASK_STATUSES` check falls through harmlessly (RUNNING
+   is not terminal) and the second call is a no-op.
+
+These two entries converge on `DefaultSteerer.mark_task_running`,
+which is idempotent by design (`if task.status in _TERMINAL_…:
+return` + re-emit-suppression on same-status writes).
+
+### 2.3 The adapter contract for `invoke`
+
+`adapter.invoke(task, session) -> InvocationResult` is the single
+boundary between goldfive and the agent framework.
+
+- **Input:** exactly one task, plus the live session (so the adapter
+  can read the current plan / completed results / agent notes).
+- **Output:** `InvocationResult(task_id, text, stop_reason, error,
+  raw)`. `stop_reason` is a short string — see §3 for the set of
+  values the ADK adapter returns.
+- **During the call:** the agent may issue any number of LLM turns
+  and tool calls. Reporting-tool calls route through
+  `goldfive.adapters._tool_invocation.invoke_tool` (`§5`) which
+  mutates `session.plan` in place.
+- **Lifetime:** the adapter must return when the task is done.
+  "Done" means one of: the agent produced a final response, the
+  agent reported the task terminal (COMPLETED / FAILED / CANCELLED),
+  an exception propagated, or the executor cancelled the invoke
+  coroutine.
+
+---
+
+## 3. Quiescence protocol
+
+When does an invocation end? This is where symptomatic bugs have
+historically crept in — "the agent keeps running after it reports
+the task done" is a quiescence failure, not a reporting-tool bug.
+
+### 3.1 The ADK adapter's loop exits on four conditions
+
+`ADKAdapter.invoke` (`adapters/adk.py:463–537`) iterates events from
+`self._runner.run_async(...)` and stops when:
+
+| Exit | `stop_reason` | Cause |
+|---|---|---|
+| Final event | `final_response` | `_is_final_event(event)` returns True (the agent emitted a final response). |
+| Terminal task | `task_terminal` | `_task_is_terminal(task, session)` returns True — the agent reported the task COMPLETED/FAILED/CANCELLED via a reporting tool. *This is the structural fix for the call-budget-burn pattern — without it, the adapter would keep feeding events and let the agent spam reporting tools until ADK's 500-call ceiling triggers an error.* See `adapters/adk.py:~540–560`. |
+| Exception | `error:<ExcName>` | The generator raised; caught, logged, and stored in `InvocationResult.error`. |
+| Cancellation | (executor-driven) | The executor cancelled the invoke coroutine via `_cancel_invoke_task` (see §6). |
+
+### 3.2 Post-invoke reconciliation
+
+After `adapter.invoke` returns, the executor reads the *live* task
+status from `session.plan` (not from the `task` object passed in —
+it may be stale) and:
+
+- If status is already terminal (reporting-tool drove it), the
+  executor only emits a `TaskEnded`-style event for observability and
+  moves on.
+- If status is still `PENDING` or `RUNNING`, the executor
+  auto-transitions:
+  - `COMPLETED` if `result.error is None`,
+  - `FAILED` if `result.error is not None`.
+
+This means a correctly-written adapter never has to actively mark
+its task done — the executor will do it if the agent forgets.
+
+### 3.3 No goldfive-level timeout
+
+There is no goldfive-level wall-clock timeout on `invoke`. The ADK
+framework has its own per-invocation max-LLM-call ceiling (default
+500). If the agent hangs or stalls silently, the run relies on ADK's
+timeout, or the `LOOPING_TOOL_CALL` guard (§5), or a CANCEL on the
+control channel.
+
+**Soundness gap (open):** there is no cap on the number of
+invocations per task. A task can be re-invoked indirectly through a
+refine that produces a `retry_<task>` task; if the retry also loops,
+a new refine is triggered, and so on up to
+`SequentialExecutor.max_plan_reinvocations` (default 32). This
+bounds the blast radius at ~32 × 500 = 16 000 LLM calls per run
+worst case. See §7.
+
+---
+
+## 4. Revision protocol
+
+A drift event with `severity ≥ WARNING` triggers refine via
+`DefaultSteerer._handle_drift` (`steerer.py:492–555`). Drifts come
+from two places:
+
+- **Observed drift:** `Steerer.observe(event, session)` runs the
+  drift classifiers on raw adapter output (tool errors, refusals,
+  stop reasons).
+- **Reporting-tool drift:** the tool handlers call
+  `_handle_drift` directly — `mark_task_failed`,
+  `mark_task_blocked`, `report_new_work_discovered`,
+  `report_plan_divergence`, `report_awaiting_approval` (on timeout).
+
+### 4.1 What refine preserves
+
+All done tasks (`COMPLETED`, `FAILED`, `CANCELLED`) are preserved
+verbatim — same id, title, assignee, status, bound_span_id. This is
+enforced by:
+
+- The prompt to the LLM (don't rewrite done tasks).
+- `_refine_user_steer`'s explicit merge step
+  (`planner.py:~1080–1100`).
+- `_refine_looping_tool_call`'s deterministic fallback plan
+  (`planner.py:948–1015`).
+
+### 4.2 In-flight invocation during refine
+
+A refine that fires inside a reporting-tool handler does not cancel
+the ADK generator. The in-flight invocation keeps running but:
+
+- Reads from `session.plan` see the new plan (atomic swap).
+- The early-break quiescence check (§3.1) catches the case where
+  the refine marked the currently-running task terminal — the
+  adapter loop exits on the next event.
+- Subsequent tool calls from the still-running agent are checked
+  against the new plan by the terminal-task rejection layer (§5.1).
+
+### 4.3 Refine-failure surfacing
+
+If `planner.refine` raises **or** returns `None`,
+`_handle_drift` no longer silently swallows the failure. It logs a
+WARNING and emits a follow-up `DriftDetected` with `severity =
+CRITICAL` and `detail = "refine failed (<kind>): <reason>"`. This
+lets sinks (and the harmonograf UI) render the refine failure
+rather than hiding it behind a stale plan.
+
+**Soundness gap (open):** refine failures do not themselves
+terminate the run. If the LLM is down entirely, the same drift can
+retrigger → refine fails → drift emitted again. The executor's
+`max_plan_reinvocations` cap eventually stops the loop, but there
+is no per-drift-kind backoff or dedup. See §7.
+
+---
+
+## 5. Reporting-tool dispatch
+
+The three-layer defence in `_tool_invocation.invoke_tool`
+(`adapters/_tool_invocation.py:91–179`), in order:
+
+### 5.1 Layer 1 — terminal-task rejection (prevention)
+
+If the tool carries a `task_id` and the task is already in a
+terminal state (`COMPLETED` / `FAILED` / `CANCELLED`), the
+dispatcher returns a structured error:
+
+```python
+{
+    "acknowledged": False,
+    "error": "task_already_terminal",
+    "task_id": "<id>",
+    "current_status": "FAILED",
+    "message": "Task '<id>' is already FAILED. Do not call further "
+               "reporting tools for this task; wait for the "
+               "orchestrator to route you to the next task.",
+}
+```
+
+**Why a structured error and not a silent ACK.** `{"acknowledged":
+True}` cannot be read by the model as "stop." The structured error
+gives the agent clear, model-readable feedback that loops can
+respect. This is the primary line of defence; §3's quiescence check
+prevents the loop at the invocation level, but this layer is the
+fallback for tools that fire *before* the adapter has observed the
+terminal transition.
+
+### 5.2 Layer 2 — idempotency (silent dedup)
+
+If `(task_id, tool_name, args_hash)` has already been dispatched for
+this Session, return `{"acknowledged": True, "duplicate": True}`
+without invoking the handler.
+
+`report_awaiting_approval` is exempt — polling the same approval
+arguments is expected behaviour.
+
+### 5.3 Layer 3 — loop guard (safety net)
+
+Two triggers, either one fires a one-shot `LOOPING_TOOL_CALL` drift:
+
+- **Exact-signature burst** — the same `(name, args_hash)` appears
+  ≥ 6 times in the last 8 dispatches for this task.
+- **Per-tool volume cap** — cumulative calls to the same tool name
+  for this task cross 15. Catches loops where the agent varies
+  `reason` / `detail` strings on every call (defeating the
+  signature match).
+
+`report_awaiting_approval` is exempt from the volume cap because
+polling is its design.
+
+Once fired, `state.loop_flagged = True` prevents re-firing for the
+same task until refine resets the guard state.
+
+---
+
+## 6. Cancellation protocol
+
+Cancellation arrives on the control channel as
+`ControlKind.CANCEL` (or is induced by `USER_STEER` that the refine
+translates). The executor handles it at two points:
+
+- **Between tasks** (`sequential.py:137–155`): the executor drains
+  the control inbox before picking the next task. A CANCEL at this
+  point aborts the run cleanly.
+- **Mid-task** (`sequential.py:468–575`): the executor races
+  `adapter.invoke(...)` against the control channel via
+  `asyncio.wait(FIRST_COMPLETED)`. On CANCEL, it calls
+  `_cancel_invoke_task(invoke_task)` — `task.cancel()` + up to 5s
+  grace, then warning-log + move on.
+
+### 6.1 Known cleanup gap: orphaned tool_call_ids
+
+ADK's `run_async` may be mid-turn with an assistant message carrying
+`tool_calls` when the cancel raises `CancelledError`. The matching
+`tool_result` messages never get appended. The ADK session's
+conversation history is now malformed. On the next invocation, ADK's
+engine flags this as `"Missing tool results for tool_call_id(s): [...]"`
+(observable in driver logs) and/or LiteLLM's
+`heal_missing_tool_results` auto-inserts synthetic placeholders.
+
+This is the structural reason a USER_STEER refine on a still-running
+task can produce a truncated/malformed JSON response — the refine
+LLM call inherits a poisoned session history. The early-break
+quiescence fix (§3.1) addresses the happy path (agent reports
+terminal cleanly); it does not address the ADK session repair
+needed after a mid-tool-call cancel. See §7.
+
+---
+
+## 7. Known soundness gaps
+
+Open issues against the design, ranked by impact. The current
+implementation is sound for the common happy path; these are edge
+cases or failure-mode ergonomics.
+
+### 7.1 Multiple sources of truth for `_TERMINAL_TASK_STATUSES`
+
+Three modules each define the same frozenset:
+
+- `steerer.py:47–55`
+- `adapters/_tool_invocation.py:30–37`
+- `adapters/adk.py:239–244`
+
+Each carries a comment warning maintainers to update all three in
+lockstep. No automated check enforces it.
+
+**Fix direction:** extract to a single module (e.g.
+`goldfive.types._constants`) and import from it. Low effort, high
+impact.
+
+### 7.2 Weak plan validation at creation and revision
+
+`Plan.__post_init__` / `_apply_revision` do not check for:
+
+- duplicate task IDs,
+- edges referencing missing tasks,
+- cycles (topological_stages silently appends leftover tasks),
+- `TaskStatus` values that are not `PENDING` at creation time.
+
+**Fix direction:** add `Plan.validate()` called from
+`LLMPlanner.generate` before return and from
+`DefaultSteerer._apply_revision` before install. Emit a
+`PLAN_DIVERGENCE` drift (severity CRITICAL) if validation fails.
+
+### 7.3 Refine failure retry backoff
+
+If the configured LLM is down, the same drift re-fires → refine
+fails → drift re-emitted (now with "refine failed" surface, §4.3)
+→ but the underlying condition is unchanged → drift fires again on
+next tick. Eventually bounded by `max_plan_reinvocations`, but the
+budget is burned without forward progress.
+
+**Fix direction:** per-`(drift.kind, task_id)` refine-attempt
+counter. After N consecutive failures, mark the task FAILED
+directly (skip refine entirely) and emit a CRITICAL
+`REPEATED_FAILURE` drift. 2–3 attempts is probably right.
+
+### 7.4 Orphaned tool_call_ids on mid-invocation cancel
+
+Cancelling ADK mid-tool-call leaves the assistant message with
+`tool_calls` unmatched by `tool_result` messages. Described in §6.1.
+
+**Fix direction:** `ADKAdapter._cancel_and_heal(task_id,
+tool_call_ids)` — after `task.cancel()`, append synthetic
+`tool_result` messages (status="cancelled") for each pending
+tool_call_id. Requires ADK internals knowledge; medium-high effort,
+high impact for live-steering scenarios.
+
+### 7.5 Cross-task ADK session history pollution
+
+The ADK adapter reuses one `session_id` for the entire goldfive
+run. Agent conversation history (including turns from failed/
+cancelled tasks) carries forward into every subsequent invocation.
+Without truncation, the agent's context window grows linearly with
+the run and can see references to tasks that no longer exist in the
+plan (after a USER_STEER delete-and-replan).
+
+**Fix direction:** optional `truncate_conversation_on_revision`
+flag on the executor/adapter that trims the ADK session history at
+revision boundaries. Medium effort, medium impact.
+
+### 7.6 Soft reject vs hard stop on terminal-task reporting
+
+Layer 1 (§5.1) returns a structured error, but does not actively
+prevent the agent from calling again. A misbehaving agent can
+ignore the error and call `report_task_failed` 100 times; each call
+is cheap (no handler, no drift) but still consumes an ADK turn. The
+loop guard (§5.3) catches this at the 15-call threshold, so the
+worst-case wasted turns is bounded at 14 — acceptable.
+
+**Fix direction:** none required in the short term; the observed
+worst case is bounded.
+
+### 7.7 No per-task invocation cap
+
+If a refine produces a `retry_<task>` task and the retry also
+loops, another refine fires — bounded only by
+`max_plan_reinvocations` (default 32). For long runs on flaky
+agents this is ~32 × 500 = 16 000 LLM calls worst case.
+
+**Fix direction:** add a `max_retries_per_task_id` (default 3) to
+the executor. After N refines that target the same task id's
+lineage, mark the task FAILED and cascade CANCEL downstream.
+
+---
+
+## Appendix: event emission guarantees
+
+Every terminal transition in the state machine emits exactly one
+event. See [STATE-MACHINE.md §"Invariant 3"](STATE-MACHINE.md#invariant-3--transitions-emit-exactly-one-event)
+for the full table.
+
+Every drift triggers exactly one `DriftDetected` event, regardless
+of severity. A refine-failed follow-up (§4.3) emits a *second*
+`DriftDetected` of severity CRITICAL — sinks should treat this as
+"the prior drift was not handled" rather than a new distinct drift.
+
+A plan revision emits `PlanRevised(old_plan_id, new_plan_id,
+revision_index, kind, severity, reason)` after
+`_apply_revision` completes. Sinks that cache plan state should
+re-read `session.plan` on every `PlanRevised`.

--- a/goldfive/adapters/_tool_invocation.py
+++ b/goldfive/adapters/_tool_invocation.py
@@ -32,10 +32,11 @@ from goldfive.adapters._tool_loop_guard import (
     guard_for,
 )
 from goldfive.reporting import ReportingToolSpec
+from goldfive.types import TERMINAL_TASK_STATUSES
 
 if TYPE_CHECKING:  # pragma: no cover - type-only
     from goldfive.protocols import Steerer
-    from goldfive.types import Session
+    from goldfive.types import Session, Task
 
 
 # Tools that carry no task_id and represent plan-level signals — they
@@ -105,6 +106,31 @@ async def invoke_tool(
     is_plan_level = name in _PLAN_LEVEL_TOOLS
     sig = (name, args_signature(args))
 
+    # Terminal-task rejection (root-cause prevention). Models that have
+    # already reported a task as COMPLETED/FAILED/CANCELLED sometimes
+    # keep calling reporting tools for that task — the first call moved
+    # the task to a terminal status (the Steerer's ``mark_task_*``
+    # guards make subsequent transitions no-ops), but a bland ``ACK``
+    # back to the agent doesn't communicate "stop." Without this check,
+    # a model can burn dozens of reporting calls after the task is
+    # already done. We return a structured error response so the model
+    # has clear, actionable feedback to stop reporting against that
+    # task. Plan-level tools (no ``task_id``) bypass this path.
+    if not is_plan_level and task_id:
+        task = _find_task(session, task_id)
+        if task is not None and task.status in TERMINAL_TASK_STATUSES:
+            return {
+                "acknowledged": False,
+                "error": "task_already_terminal",
+                "task_id": task_id,
+                "current_status": task.status.value,
+                "message": (
+                    f"Task {task_id!r} is already {task.status.value}. Do not "
+                    "call further reporting tools for this task; wait for the "
+                    "orchestrator to route you to the next task."
+                ),
+            }
+
     guard = guard_for(session)
     state = guard.state_for(guard_key)
     state.window.append(sig)
@@ -127,6 +153,17 @@ async def invoke_tool(
 
     state.seen.add(sig)
     return await tool.handler(args, session, steerer)
+
+
+def _find_task(session: Session, task_id: str) -> Task | None:
+    """Return the task with ``task_id`` from ``session.plan``, or ``None``."""
+    plan = session.plan
+    if plan is None:
+        return None
+    for task in plan.tasks:
+        if task.id == task_id:
+            return task
+    return None
 
 
 __all__ = ["find_tool", "invoke_tool"]

--- a/goldfive/adapters/_tool_invocation.py
+++ b/goldfive/adapters/_tool_invocation.py
@@ -43,17 +43,13 @@ if TYPE_CHECKING:  # pragma: no cover - type-only
 # are exempt from the per-task idempotency guard, but still feed the
 # loop detector under a synthetic "(plan)" task key so a runaway
 # divergence-spam loop is still caught.
-_PLAN_LEVEL_TOOLS: frozenset[str] = frozenset(
-    {"report_plan_divergence"}
-)
+_PLAN_LEVEL_TOOLS: frozenset[str] = frozenset({"report_plan_divergence"})
 
 # Tools that are intentionally allowed to be called multiple times with
 # the same args (the dispatch is the entire point — e.g. blocking on an
 # approval decision). These bypass the idempotency table but still
 # count toward the loop detector window.
-_NON_IDEMPOTENT_TOOLS: frozenset[str] = frozenset(
-    {"report_awaiting_approval"}
-)
+_NON_IDEMPOTENT_TOOLS: frozenset[str] = frozenset({"report_awaiting_approval"})
 
 
 def find_tool(
@@ -143,12 +139,7 @@ async def invoke_tool(
             tool_name=name,
         )
 
-    if (
-        not is_plan_level
-        and name not in _NON_IDEMPOTENT_TOOLS
-        and task_id
-        and sig in state.seen
-    ):
+    if not is_plan_level and name not in _NON_IDEMPOTENT_TOOLS and task_id and sig in state.seen:
         return {"acknowledged": True, "duplicate": True}
 
     state.seen.add(sig)

--- a/goldfive/adapters/_tool_loop_guard.py
+++ b/goldfive/adapters/_tool_loop_guard.py
@@ -77,9 +77,7 @@ class _TaskGuardState:
     # signatures observed for this task. Includes both first-time and
     # duplicate calls — the loop signal we care about is volume of
     # matching calls in flight, not whether the first one already ran.
-    window: deque[tuple[str, str]] = field(
-        default_factory=lambda: deque(maxlen=_LOOP_WINDOW)
-    )
+    window: deque[tuple[str, str]] = field(default_factory=lambda: deque(maxlen=_LOOP_WINDOW))
     # Cumulative per-tool call count for this task. Used by the volume
     # cap to catch loops where the agent varies args on every call
     # (common in practice — e.g. a fresh ``reason`` string each time —
@@ -178,10 +176,7 @@ def detect_loop(state: _TaskGuardState, signature: tuple[str, str]) -> bool:
 
     # Volume cap: catches args-varying loops (the exact-signature check
     # below misses these because every call hashes differently).
-    if (
-        name not in _VOLUME_EXEMPT_TOOLS
-        and state.per_tool_count[name] >= _VOLUME_THRESHOLD
-    ):
+    if name not in _VOLUME_EXEMPT_TOOLS and state.per_tool_count[name] >= _VOLUME_THRESHOLD:
         state.loop_flagged = True
         return True
 

--- a/goldfive/adapters/_tool_loop_guard.py
+++ b/goldfive/adapters/_tool_loop_guard.py
@@ -49,6 +49,23 @@ if TYPE_CHECKING:  # pragma: no cover - type-only
 _LOOP_WINDOW = 8
 _LOOP_THRESHOLD = 6
 
+# Volume-based fallback: fire a loop drift once a single reporting tool
+# has been invoked this many times within one task, regardless of
+# whether the args repeat. Catches args-varying spam (e.g. a model
+# looping on ``report_task_failed`` with a fresh ``reason`` each call) —
+# the signature-based window misses this because every call hashes to a
+# different signature. Threshold is set well above any realistic
+# lifecycle count (start → 3 progress → complete = 5) but below the
+# point where the surrounding runtime (ADK's 500-LLM-call ceiling) will
+# burn out the whole task.
+_VOLUME_THRESHOLD = 15
+
+# Reporting tools that are expected to be polled — the agent legitimately
+# re-invokes them while waiting for an external decision, and the volume
+# cap would falsely fire on normal use. The exact-signature guard still
+# applies.
+_VOLUME_EXEMPT_TOOLS: frozenset[str] = frozenset({"report_awaiting_approval"})
+
 
 @dataclass
 class _TaskGuardState:
@@ -63,6 +80,11 @@ class _TaskGuardState:
     window: deque[tuple[str, str]] = field(
         default_factory=lambda: deque(maxlen=_LOOP_WINDOW)
     )
+    # Cumulative per-tool call count for this task. Used by the volume
+    # cap to catch loops where the agent varies args on every call
+    # (common in practice — e.g. a fresh ``reason`` string each time —
+    # which defeats the exact-signature window check).
+    per_tool_count: dict[str, int] = field(default_factory=dict)
     # Set once a LOOPING_TOOL_CALL drift has been emitted for this task,
     # so we don't pile on identical drifts every subsequent call. Cleared
     # by the planner when it refines/fails the task.
@@ -131,21 +153,45 @@ def guard_for(session: Session) -> ToolLoopGuard:
 
 
 def detect_loop(state: _TaskGuardState, signature: tuple[str, str]) -> bool:
-    """Return True iff the current window crosses the loop threshold for ``signature``.
+    """Return True iff the current call should fire a loop drift.
 
-    Counts occurrences of ``signature`` in the sliding window (which the
-    caller has already updated to include the current call). Sets
-    :attr:`_TaskGuardState.loop_flagged` so subsequent calls don't
-    re-fire the drift.
+    Two independent triggers, either one fires the one-shot drift:
+
+    * **Exact-signature burst** — the same ``(name, args_hash)`` appears
+      at least :data:`_LOOP_THRESHOLD` times within the last
+      :data:`_LOOP_WINDOW` calls. Catches byte-identical loops quickly.
+    * **Per-tool volume cap** — cumulative calls to the same tool name
+      for this task cross :data:`_VOLUME_THRESHOLD`. Catches loops that
+      vary their args on every call (a fresh ``reason`` / ``detail``
+      string etc.) which never collide in the signature window but
+      equally indicate no forward progress.
+
+    Callers have already appended ``signature`` to ``state.window``.
+    Sets :attr:`_TaskGuardState.loop_flagged` so subsequent calls don't
+    re-fire the drift for the same task.
     """
+    name = signature[0]
+    state.per_tool_count[name] = state.per_tool_count.get(name, 0) + 1
+
     if state.loop_flagged:
         return False
-    if len(state.window) < _LOOP_THRESHOLD:
-        return False
-    matching = sum(1 for s in state.window if s == signature)
-    if matching >= _LOOP_THRESHOLD:
+
+    # Volume cap: catches args-varying loops (the exact-signature check
+    # below misses these because every call hashes differently).
+    if (
+        name not in _VOLUME_EXEMPT_TOOLS
+        and state.per_tool_count[name] >= _VOLUME_THRESHOLD
+    ):
         state.loop_flagged = True
         return True
+
+    # Exact-signature burst: fastest path for byte-identical loops.
+    if len(state.window) >= _LOOP_THRESHOLD:
+        matching = sum(1 for s in state.window if s == signature)
+        if matching >= _LOOP_THRESHOLD:
+            state.loop_flagged = True
+            return True
+
     return False
 
 
@@ -168,9 +214,10 @@ async def emit_loop_drift(
         kind=DriftKind.LOOPING_TOOL_CALL,
         severity=DriftSeverity.CRITICAL,
         detail=(
-            f"task {task_id} kept calling {tool_name!r} with the same "
-            f"arguments ({_LOOP_THRESHOLD}+ of last {_LOOP_WINDOW} calls); "
-            "no forward progress detected"
+            f"task {task_id} kept calling {tool_name!r} without forward "
+            f"progress (either {_LOOP_THRESHOLD}+ identical signatures in "
+            f"the last {_LOOP_WINDOW} calls, or {_VOLUME_THRESHOLD}+ total "
+            "calls to this tool within the task)"
         ),
         current_task_id=task_id,
     )

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -43,11 +43,12 @@ from goldfive.adapters._adk_plugin import (
     make_adk_plugin,
 )
 from goldfive.results import InvocationResult
+from goldfive.types import TERMINAL_TASK_STATUSES
 
 if TYPE_CHECKING:
     from goldfive.protocols import Steerer
     from goldfive.reporting import ReportingToolSpec
-    from goldfive.types import Session, Task
+    from goldfive.types import Session, Task, TaskStatus  # noqa: F401
 
 log = logging.getLogger("goldfive.adapters.adk")
 
@@ -234,6 +235,29 @@ def _is_final_event(event: Any) -> bool:
         except Exception:
             return False
     return bool(attr)
+
+
+def _task_is_terminal(task: Task, session: Session) -> bool:
+    """Return True if ``task``'s status in the session's plan is terminal.
+
+    Reads status off the live ``session.plan`` entry (not the snapshot
+    ``task`` object passed into ``invoke``) so transitions driven by
+    reporting-tool handlers during the in-flight invocation are seen.
+
+    Uses :data:`goldfive.types.TERMINAL_TASK_STATUSES` — the single
+    source of truth shared with the steerer and the dispatch layer so a
+    new terminal status cannot silently diverge across modules.
+    """
+    task_id = getattr(task, "id", "") or ""
+    if not task_id:
+        return False
+    plan = getattr(session, "plan", None)
+    if plan is None:
+        return False
+    for live in getattr(plan, "tasks", ()) or ():
+        if getattr(live, "id", None) == task_id:
+            return getattr(live, "status", None) in TERMINAL_TASK_STATUSES
+    return False
 
 
 def _new_message_parts(task: Task) -> Any:
@@ -517,6 +541,17 @@ class ADKAdapter:
                     final_text = text
                 if _is_final_event(event):
                     stop_reason = "final_response"
+                # Early termination when the agent has reported this task
+                # as terminal (COMPLETED/FAILED/CANCELLED) via a reporting
+                # tool. Without this, the ADK generator keeps running —
+                # letting the agent take more LLM turns on an already-done
+                # task and burn through ADK's 500-LLM-call ceiling
+                # reporting redundant status. Breaking closes the
+                # generator cleanly so control returns to the executor
+                # which routes to the next pending task.
+                if _task_is_terminal(task, session):
+                    stop_reason = "task_terminal"
+                    break
         except Exception as exc:  # noqa: BLE001
             err = exc
             stop_reason = f"error:{type(exc).__name__}"

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -56,9 +56,7 @@ log = logging.getLogger("goldfive.adapters.adk")
 try:  # noqa: SIM105 — explicit import-time guard with install hint
     import google.adk  # type: ignore  # noqa: F401
 except ImportError:  # pragma: no cover — covered in tests via importorskip
-    raise ImportError(
-        "goldfive.adapters.adk requires 'pip install goldfive[adk]'"
-    ) from None
+    raise ImportError("goldfive.adapters.adk requires 'pip install goldfive[adk]'") from None
 
 
 def _build_ack_shim(name: str, description: str):
@@ -87,9 +85,7 @@ def _build_function_tool(spec: ReportingToolSpec) -> Any:
     return FunctionTool(shim)
 
 
-def _augment_subtree_with_reporting(
-    root_agent: Any, tools: list[Any], tool_names: set[str]
-) -> int:
+def _augment_subtree_with_reporting(root_agent: Any, tools: list[Any], tool_names: set[str]) -> int:
     """Append reporting ``tools`` to every agent reachable from ``root_agent``.
 
     Ported from harmonograf's ``_register_harmonograf_reporting_tools_for_test``.
@@ -131,9 +127,7 @@ def _augment_subtree_with_reporting(
             continue
         existing_names: set[str] = set()
         for t in existing:
-            n = getattr(t, "name", None) or getattr(
-                getattr(t, "func", None), "__name__", None
-            )
+            n = getattr(t, "name", None) or getattr(getattr(t, "func", None), "__name__", None)
             if n:
                 existing_names.add(str(n))
         if any(n in existing_names for n in tool_names):
@@ -204,10 +198,7 @@ def _looks_like_runner(obj: Any) -> bool:
     Runners expose ``run_async`` / ``agent`` / ``session_service``;
     agents may expose ``run_async_impl`` but not the session service.
     """
-    return (
-        callable(getattr(obj, "run_async", None))
-        and getattr(obj, "agent", None) is not None
-    )
+    return callable(getattr(obj, "run_async", None)) and getattr(obj, "agent", None) is not None
 
 
 def _extract_text_from_event(event: Any) -> str:
@@ -356,8 +347,7 @@ class ADKAdapter:
         """
         if not _register_plugin_on_runner(self._runner, plugin):
             log.debug(
-                "ADKAdapter.add_plugin: runner %r has no plugin manager; "
-                "plugin %r not installed",
+                "ADKAdapter.add_plugin: runner %r has no plugin manager; plugin %r not installed",
                 type(self._runner).__name__,
                 type(plugin).__name__,
             )
@@ -391,9 +381,7 @@ class ADKAdapter:
                     stack.append(nested)
         return names
 
-    async def register_reporting_tools(
-        self, tools: list[ReportingToolSpec]
-    ) -> None:
+    async def register_reporting_tools(self, tools: list[ReportingToolSpec]) -> None:
         """Register goldfive reporting tools with the wrapped agent tree.
 
         Each spec is wrapped as a ``google.adk.tools.FunctionTool`` (via
@@ -412,9 +400,7 @@ class ADKAdapter:
                 raise ValueError(f"ReportingToolSpec has no name: {spec!r}")
             handler = getattr(spec, "handler", None)
             if handler is None:
-                raise ValueError(
-                    f"ReportingToolSpec '{name}' missing handler"
-                )
+                raise ValueError(f"ReportingToolSpec '{name}' missing handler")
             self._tool_handlers[name] = handler
             function_tools.append(_build_function_tool(spec))
             names.add(name)
@@ -433,9 +419,7 @@ class ADKAdapter:
         else:
             existing_names: set[str] = set()
             for t in root_tools:
-                n = getattr(t, "name", None) or getattr(
-                    getattr(t, "func", None), "__name__", None
-                )
+                n = getattr(t, "name", None) or getattr(getattr(t, "func", None), "__name__", None)
                 if n:
                     existing_names.add(str(n))
             if not any(n in existing_names for n in names):
@@ -484,9 +468,7 @@ class ADKAdapter:
             return
         await observe(text, task=task, session=session, provider=provider)
 
-    async def invoke(
-        self, task: Task, session: Session
-    ) -> InvocationResult:
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:
         """Drive one ADK turn for ``task`` and return the result."""
         task_id = getattr(task, "id", "") or ""
         session_id = await self._ensure_session()

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -27,8 +27,6 @@ from goldfive.drift import (
     classify_stop_reason,
     classify_tool_error,
 )
-
-log = logging.getLogger(__name__)
 from goldfive.types import (
     TERMINAL_TASK_STATUSES,
     DriftEvent,
@@ -42,6 +40,8 @@ from goldfive.types import (
 
 if TYPE_CHECKING:
     from goldfive.protocols import EventSink, Planner
+
+log = logging.getLogger(__name__)
 
 
 __all__ = ["DefaultSteerer"]
@@ -116,21 +116,13 @@ class DefaultSteerer:
         if to is TaskStatus.RUNNING:
             await self.mark_task_running(task_id, session=session, detail=detail)
         elif to is TaskStatus.COMPLETED:
-            await self.mark_task_completed(
-                task_id, summary=detail, session=session
-            )
+            await self.mark_task_completed(task_id, summary=detail, session=session)
         elif to is TaskStatus.FAILED:
-            await self.mark_task_failed(
-                task_id, reason=detail, session=session
-            )
+            await self.mark_task_failed(task_id, reason=detail, session=session)
         elif to is TaskStatus.BLOCKED:
-            await self.mark_task_blocked(
-                task_id, blocker=detail, session=session
-            )
+            await self.mark_task_blocked(task_id, blocker=detail, session=session)
         elif to is TaskStatus.CANCELLED:
-            await self.mark_task_cancelled(
-                task_id, reason=detail, session=session
-            )
+            await self.mark_task_cancelled(task_id, reason=detail, session=session)
         # PENDING and UNSPECIFIED are intentionally not reachable from
         # here; transitions are always forward in the lifecycle.
 
@@ -224,14 +216,8 @@ class DefaultSteerer:
             return
         task.status = TaskStatus.FAILED
         await self._emit_task_failed(session, task_id, reason, recoverable)
-        kind = (
-            DriftKind.TASK_FAILED_RECOVERABLE
-            if recoverable
-            else DriftKind.TASK_FAILED_FATAL
-        )
-        severity = (
-            DriftSeverity.WARNING if recoverable else DriftSeverity.CRITICAL
-        )
+        kind = DriftKind.TASK_FAILED_RECOVERABLE if recoverable else DriftKind.TASK_FAILED_FATAL
+        severity = DriftSeverity.WARNING if recoverable else DriftSeverity.CRITICAL
         drift = DriftEvent(
             kind=kind,
             severity=severity,
@@ -262,15 +248,11 @@ class DefaultSteerer:
         # re-blocking a task that's already blocked (idempotent).
         task.status = TaskStatus.BLOCKED
         if blocker or needed:
-            session.agent_notes[task_id] = (
-                f"blocked: {blocker}"
-                + (f" (needed: {needed})" if needed else "")
+            session.agent_notes[task_id] = f"blocked: {blocker}" + (
+                f" (needed: {needed})" if needed else ""
             )
         await self._emit_task_blocked(session, task_id, blocker, needed)
-        detail = (
-            f"task {task_id} blocked: {blocker}"
-            + (f" (needed: {needed})" if needed else "")
-        )
+        detail = f"task {task_id} blocked: {blocker}" + (f" (needed: {needed})" if needed else "")
         drift = DriftEvent(
             kind=DriftKind.BLOCKED,
             severity=DriftSeverity.WARNING,
@@ -439,9 +421,8 @@ class DefaultSteerer:
         assignee: str = "",
     ) -> None:
         """Fire a ``NEW_WORK_DISCOVERED`` drift event → triggers refine."""
-        detail = (
-            f"new work under {parent_task_id}: {title}: {description}"
-            + (f" (assignee={assignee})" if assignee else "")
+        detail = f"new work under {parent_task_id}: {title}: {description}" + (
+            f" (assignee={assignee})" if assignee else ""
         )
         drift = DriftEvent(
             kind=DriftKind.NEW_WORK_DISCOVERED,
@@ -461,11 +442,7 @@ class DefaultSteerer:
     ) -> None:
         """Fire a ``PLAN_DIVERGENCE`` drift event → triggers refine."""
         session.divergence_flag = True
-        detail = (
-            f"{note} (suggested: {suggested_action})"
-            if suggested_action
-            else note
-        )
+        detail = f"{note} (suggested: {suggested_action})" if suggested_action else note
         drift = DriftEvent(
             kind=DriftKind.PLAN_DIVERGENCE,
             severity=DriftSeverity.WARNING,
@@ -512,8 +489,7 @@ class DefaultSteerer:
             # leaves session.plan unchanged and the executor re-enters
             # the same state on the next tick.
             log.warning(
-                "DefaultSteerer._handle_drift: planner.refine(kind=%s) raised %s; "
-                "plan unchanged",
+                "DefaultSteerer._handle_drift: planner.refine(kind=%s) raised %s; plan unchanged",
                 drift.kind.value,
                 exc,
             )
@@ -554,9 +530,7 @@ class DefaultSteerer:
         await self._emit_drift_detected(session, failure)
 
     @staticmethod
-    def _apply_revision(
-        session: Session, revised: Plan, drift: DriftEvent
-    ) -> None:
+    def _apply_revision(session: Session, revised: Plan, drift: DriftEvent) -> None:
         """Stamp revision metadata and install ``revised`` on the session.
 
         Preserves the existing ``revision_index`` monotonicity: the new
@@ -592,24 +566,18 @@ class DefaultSteerer:
         from goldfive.pb.goldfive.v1 import types_pb2
 
         name = f"DRIFT_KIND_{kind.name}"
-        return getattr(
-            types_pb2, name, getattr(types_pb2, "DRIFT_KIND_CUSTOM", 0)
-        )
+        return getattr(types_pb2, name, getattr(types_pb2, "DRIFT_KIND_CUSTOM", 0))
 
     @staticmethod
     def _drift_severity_pb_value(severity: DriftSeverity) -> int:
         from goldfive.pb.goldfive.v1 import types_pb2
 
         name = f"DRIFT_SEVERITY_{severity.name}"
-        return getattr(
-            types_pb2, name, getattr(types_pb2, "DRIFT_SEVERITY_UNSPECIFIED", 0)
-        )
+        return getattr(types_pb2, name, getattr(types_pb2, "DRIFT_SEVERITY_UNSPECIFIED", 0))
 
     # --- Concrete emitters -------------------------------------------
 
-    async def _emit_task_started(
-        self, session: Session, task_id: str, detail: str
-    ) -> None:
+    async def _emit_task_started(self, session: Session, task_id: str, detail: str) -> None:
         evt = self._new_envelope(session)
         evt.task_started.task_id = task_id
         evt.task_started.detail = detail
@@ -656,38 +624,28 @@ class DefaultSteerer:
         evt.task_blocked.needed = needed
         await self._emit(evt)
 
-    async def _emit_task_cancelled(
-        self, session: Session, task_id: str, reason: str
-    ) -> None:
+    async def _emit_task_cancelled(self, session: Session, task_id: str, reason: str) -> None:
         evt = self._new_envelope(session)
         evt.task_cancelled.task_id = task_id
         evt.task_cancelled.reason = reason
         await self._emit(evt)
 
-    async def _emit_drift_detected(
-        self, session: Session, drift: DriftEvent
-    ) -> None:
+    async def _emit_drift_detected(self, session: Session, drift: DriftEvent) -> None:
         evt = self._new_envelope(session)
         evt.drift_detected.kind = self._drift_kind_pb_value(drift.kind)
-        evt.drift_detected.severity = self._drift_severity_pb_value(
-            drift.severity
-        )
+        evt.drift_detected.severity = self._drift_severity_pb_value(drift.severity)
         evt.drift_detected.detail = drift.detail
         evt.drift_detected.current_task_id = drift.current_task_id
         evt.drift_detected.current_agent_id = drift.current_agent_id
         await self._emit(evt)
 
-    async def _emit_plan_revised(
-        self, session: Session, revised: Plan, drift: DriftEvent
-    ) -> None:
+    async def _emit_plan_revised(self, session: Session, revised: Plan, drift: DriftEvent) -> None:
         from goldfive.conv import to_pb_plan
 
         evt = self._new_envelope(session)
         evt.plan_revised.plan.CopyFrom(to_pb_plan(revised))
         evt.plan_revised.drift_kind = self._drift_kind_pb_value(drift.kind)
-        evt.plan_revised.severity = self._drift_severity_pb_value(
-            drift.severity
-        )
+        evt.plan_revised.severity = self._drift_severity_pb_value(drift.severity)
         evt.plan_revised.reason = drift.detail
         evt.plan_revised.revision_index = revised.revision_index
         await self._emit(evt)

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -19,6 +19,7 @@ sinks list and planner at run start.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 from goldfive.drift import (
@@ -26,7 +27,10 @@ from goldfive.drift import (
     classify_stop_reason,
     classify_tool_error,
 )
+
+log = logging.getLogger(__name__)
 from goldfive.types import (
+    TERMINAL_TASK_STATUSES,
     DriftEvent,
     DriftKind,
     DriftSeverity,
@@ -44,13 +48,11 @@ __all__ = ["DefaultSteerer"]
 
 
 # Task statuses that are terminal (no further transitions allowed).
-_TERMINAL_TASK_STATUSES: frozenset[TaskStatus] = frozenset(
-    {
-        TaskStatus.COMPLETED,
-        TaskStatus.FAILED,
-        TaskStatus.CANCELLED,
-    }
-)
+# Re-exported from :mod:`goldfive.types` — the canonical definition —
+# under the historical private name so existing imports in this module
+# keep working. Do NOT redefine; new consumers should import
+# ``TERMINAL_TASK_STATUSES`` from ``goldfive.types`` directly.
+_TERMINAL_TASK_STATUSES = TERMINAL_TASK_STATUSES
 
 
 # Ordered severities so we can compare with ``>=``.
@@ -502,12 +504,54 @@ class DefaultSteerer:
                 drift=drift,
                 goals=list(session.goals),
             )
-        except Exception:  # noqa: BLE001 — refine errors must not break the run
+        except Exception as exc:  # noqa: BLE001 — refine errors must not break the run
+            # Surface the failure via logging + a synthetic follow-up
+            # drift so operators don't silently see the same plan loop
+            # forever. Without this, a refine that raises (e.g. malformed
+            # LLM JSON after a mid-invocation cancel poisons the session)
+            # leaves session.plan unchanged and the executor re-enters
+            # the same state on the next tick.
+            log.warning(
+                "DefaultSteerer._handle_drift: planner.refine(kind=%s) raised %s; "
+                "plan unchanged",
+                drift.kind.value,
+                exc,
+            )
+            await self._emit_refine_failure(session, drift, reason=str(exc))
             return
         if revised is None:
+            log.warning(
+                "DefaultSteerer._handle_drift: planner.refine(kind=%s) returned None; "
+                "plan unchanged",
+                drift.kind.value,
+            )
+            await self._emit_refine_failure(
+                session, drift, reason="planner returned no revised plan"
+            )
             return
         self._apply_revision(session, revised, drift)
         await self._emit_plan_revised(session, revised, drift)
+
+    async def _emit_refine_failure(
+        self, session: Session, source: DriftEvent, *, reason: str
+    ) -> None:
+        """Surface a failed refine as a follow-up CRITICAL drift.
+
+        Reuses the source drift's kind and prefixes ``detail`` with
+        ``refine failed`` so sinks (and the harmonograf UI) get a durable,
+        CRITICAL signal that a prior drift's refine did not succeed —
+        without this event, a silently-swallowed refine leaves the
+        session pinned to the stale plan and the executor re-enters the
+        same state on the next tick.
+        """
+        failure = DriftEvent(
+            kind=source.kind,
+            severity=DriftSeverity.CRITICAL,
+            detail=f"refine failed ({source.kind.value}): {reason}",
+            current_task_id=source.current_task_id,
+            current_agent_id=source.current_agent_id,
+        )
+        await self._emit_drift_detected(session, failure)
 
     @staticmethod
     def _apply_revision(

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -22,6 +22,18 @@ class TaskStatus(StrEnum):
     BLOCKED = "BLOCKED"
 
 
+# Terminal statuses — a task in any of these cannot transition further
+# and must not be re-invoked. This set is the **single source of truth**
+# used by the steerer (state-transition guards), the tool-dispatch layer
+# (terminal-task rejection), and the ADK adapter (invoke-loop early
+# break). Do not duplicate this set; import from here. If ``TaskStatus``
+# gains a new terminal member, add it here and every consumer sees it.
+# See ``docs/design/TASK-LIFECYCLE.md`` §7.1 for the rationale.
+TERMINAL_TASK_STATUSES: frozenset[TaskStatus] = frozenset(
+    {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED}
+)
+
+
 class DriftKind(StrEnum):
     TOOL_ERROR = "tool_error"
     AGENT_REFUSAL = "agent_refusal"

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -114,8 +114,8 @@ class Plan:
     edges: list[TaskEdge]
     summary: str = ""
     revision_reason: str = ""
-    revision_kind: str = ""           # DriftKind value (str) or ""
-    revision_severity: str = ""       # DriftSeverity value (str) or ""
+    revision_kind: str = ""  # DriftKind value (str) or ""
+    revision_severity: str = ""  # DriftSeverity value (str) or ""
     revision_index: int = 0
 
     def topological_stages(self) -> list[list[Task]]:
@@ -171,7 +171,7 @@ class DriftEvent:
     detail: str = ""
     current_task_id: str = ""
     current_agent_id: str = ""
-    raw: Any = None   # original event that triggered detection
+    raw: Any = None  # original event that triggered detection
 
 
 @dataclasses.dataclass
@@ -201,15 +201,11 @@ class Session:
     # ``target_id``: task_id for Flow A (report_awaiting_approval) and the
     # ADK function_call_id for Flow B (ADK require_confirmation). The event
     # is set by the control dispatcher when APPROVE / REJECT arrives.
-    pending_approvals: dict[str, asyncio.Event] = dataclasses.field(
-        default_factory=dict
-    )
+    pending_approvals: dict[str, asyncio.Event] = dataclasses.field(default_factory=dict)
     # Per-approval metadata. Populated when the waiter is registered; the
     # dispatcher adds ``decision`` ("approve" | "reject") and optional
     # ``detail`` before setting the event.
-    pending_approvals_meta: dict[str, dict[str, Any]] = dataclasses.field(
-        default_factory=dict
-    )
+    pending_approvals_meta: dict[str, dict[str, Any]] = dataclasses.field(default_factory=dict)
     # Recent reasoning-content blocks emitted by the adapter's
     # ``emit_reasoning`` hook. Bounded to the last ``reasoning_history_max``
     # entries so long runs do not accumulate chain-of-thought forever.

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -116,8 +116,7 @@ async def test_reporting_tools_registered_on_root_agent() -> None:
     await adapter.register_reporting_tools([spec])
 
     names = [
-        getattr(t, "name", None)
-        or getattr(getattr(t, "func", None), "__name__", None)
+        getattr(t, "name", None) or getattr(getattr(t, "func", None), "__name__", None)
         for t in getattr(agent, "tools", None) or ()
     ]
     assert "report_task_started" in names
@@ -248,9 +247,7 @@ async def test_before_model_writes_goldfive_state_keys(state_ctx_cls) -> None:
         )
     }
 
-    await plugin.before_model_callback(
-        callback_context=state_ctx_cls(state), llm_request=None
-    )
+    await plugin.before_model_callback(callback_context=state_ctx_cls(state), llm_request=None)
 
     assert state.get(KEY_RUN_ID) == "run-abc"
     assert state.get(KEY_PLAN_ID) == "plan-1"
@@ -325,9 +322,7 @@ async def test_on_event_transfer_calls_steerer_observe(state_ctx_cls) -> None:
     class _Event:
         actions = _Actions()
 
-    await plugin.on_event_callback(
-        invocation_context=state_ctx_cls(state), event=_Event()
-    )
+    await plugin.on_event_callback(invocation_context=state_ctx_cls(state), event=_Event())
 
     assert len(steerer.events) == 1
     assert steerer.events[0]["kind"] == "agent_transfer"
@@ -358,9 +353,7 @@ def test_adapter_conforms_to_protocol() -> None:
 def _tool_names(agent: Any) -> set[str]:
     names: set[str] = set()
     for t in getattr(agent, "tools", None) or ():
-        n = getattr(t, "name", None) or getattr(
-            getattr(t, "func", None), "__name__", None
-        )
+        n = getattr(t, "name", None) or getattr(getattr(t, "func", None), "__name__", None)
         if n:
             names.add(str(n))
     return names
@@ -384,9 +377,7 @@ async def test_register_reporting_tools_propagates_across_three_level_tree() -> 
     from goldfive.reporting import BUILTIN_REPORTING_TOOLS, REPORTING_TOOL_NAMES
 
     def _mk(name: str) -> Any:
-        return LlmAgent(
-            name=name, model="fake-model", description=name, instruction="x"
-        )
+        return LlmAgent(name=name, model="fake-model", description=name, instruction="x")
 
     grandchild_a = _mk("grandchild_a")
     grandchild_b = _mk("grandchild_b")
@@ -406,9 +397,7 @@ async def test_register_reporting_tools_propagates_across_three_level_tree() -> 
     for agent in (root, child_a, grandchild_a, child_b_as_tool, grandchild_b):
         have = _tool_names(agent)
         missing = expected - have
-        assert not missing, (
-            f"agent {agent.name!r} missing reporting tools: {sorted(missing)}"
-        )
+        assert not missing, f"agent {agent.name!r} missing reporting tools: {sorted(missing)}"
 
     # available_agents discovers every node in the tree.
     discovered = set(adapter.available_agents)
@@ -536,8 +525,7 @@ async def test_invoke_breaks_when_task_reported_terminal_mid_stream() -> None:
 
     # Events 0, 1, 2 should be observed; 3 and 4 must not be.
     assert observed == [0, 1, 2], (
-        f"adapter should have broken after event #2 (terminal transition); "
-        f"observed {observed}"
+        f"adapter should have broken after event #2 (terminal transition); observed {observed}"
     )
     assert result.stop_reason == "task_terminal"
     assert result.task_id == "t1"
@@ -591,12 +579,8 @@ async def test_register_reporting_tools_is_idempotent() -> None:
     from goldfive.adapters.adk import ADKAdapter
     from goldfive.reporting import BUILTIN_REPORTING_TOOLS, REPORTING_TOOL_NAMES
 
-    child = LlmAgent(
-        name="child", model="fake-model", description="c", instruction="x"
-    )
-    root = LlmAgent(
-        name="root", model="fake-model", description="r", instruction="x"
-    )
+    child = LlmAgent(name="child", model="fake-model", description="c", instruction="x")
+    root = LlmAgent(name="root", model="fake-model", description="r", instruction="x")
     root.sub_agents = [child]
 
     adapter = ADKAdapter(root)
@@ -605,12 +589,10 @@ async def test_register_reporting_tools_is_idempotent() -> None:
 
     for agent in (root, child):
         names = [
-            getattr(t, "name", None)
-            or getattr(getattr(t, "func", None), "__name__", None)
+            getattr(t, "name", None) or getattr(getattr(t, "func", None), "__name__", None)
             for t in getattr(agent, "tools", None) or ()
         ]
         for reporting_name in REPORTING_TOOL_NAMES:
             assert names.count(reporting_name) == 1, (
-                f"{agent.name}: {reporting_name} registered "
-                f"{names.count(reporting_name)} times"
+                f"{agent.name}: {reporting_name} registered {names.count(reporting_name)} times"
             )

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -482,6 +482,108 @@ async def test_goldfive_adk_agent_add_plugin_delegates() -> None:
     assert plugin in installed
 
 
+async def test_invoke_breaks_when_task_reported_terminal_mid_stream() -> None:
+    """Adapter must stop driving the ADK runner once the agent has
+    reported the current task as terminal.
+
+    Without this, the ADK generator keeps running — letting the agent
+    take more LLM turns on an already-done task and burn through ADK's
+    500-LLM-call ceiling reporting redundant status. The fix checks
+    ``session.plan.tasks[task_id].status`` after each streamed event
+    and exits the ``async for`` loop as soon as it's terminal.
+    """
+    from dataclasses import dataclass, field
+
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Plan, Session, Task, TaskStatus
+
+    @dataclass
+    class _Event:
+        # ADK duck-types: no is_final_response → _is_final_event returns False.
+        marker: int = 0
+        content: Any = None
+
+    # A run_async that yields 5 events. On event #2, a "tool call" flips
+    # the task status to FAILED. The adapter should break at event #2 —
+    # events #3, #4, #5 must never be observed.
+    observed: list[int] = []
+
+    @dataclass
+    class _FakeRunner:
+        session_service: Any = None
+        plugin_manager: Any = field(default=None)
+
+        async def run_async(self, **kwargs: Any):  # noqa: ARG002
+            for i in range(5):
+                observed.append(i)
+                if i == 2:
+                    # Simulate a reporting-tool handler marking the task terminal.
+                    session.plan.tasks[0].status = TaskStatus.FAILED
+                yield _Event(marker=i)
+
+    task = Task(id="t1", title="do the thing")
+    session = Session(
+        run_id="r1",
+        goals=[],
+        plan=Plan(id="p1", run_id="r1", goal_ids=[], tasks=[task], edges=[]),
+    )
+
+    adapter = ADKAdapter(_make_agent())
+    adapter._runner = _FakeRunner()
+    adapter._session_id = "stub-session"
+
+    result = await adapter.invoke(task=task, session=session)
+
+    # Events 0, 1, 2 should be observed; 3 and 4 must not be.
+    assert observed == [0, 1, 2], (
+        f"adapter should have broken after event #2 (terminal transition); "
+        f"observed {observed}"
+    )
+    assert result.stop_reason == "task_terminal"
+    assert result.task_id == "t1"
+
+
+async def test_invoke_runs_to_completion_when_task_stays_non_terminal() -> None:
+    """If the task is never reported terminal, the adapter drains all
+    events — the new break must not short-circuit normal runs.
+    """
+    from dataclasses import dataclass, field
+
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Plan, Session, Task
+
+    @dataclass
+    class _Event:
+        marker: int = 0
+        content: Any = None
+
+    observed: list[int] = []
+
+    @dataclass
+    class _FakeRunner:
+        session_service: Any = None
+        plugin_manager: Any = field(default=None)
+
+        async def run_async(self, **kwargs: Any):  # noqa: ARG002
+            for i in range(3):
+                observed.append(i)
+                yield _Event(marker=i)
+
+    task = Task(id="t2", title="normal run")
+    session = Session(
+        run_id="r1",
+        goals=[],
+        plan=Plan(id="p1", run_id="r1", goal_ids=[], tasks=[task], edges=[]),
+    )
+
+    adapter = ADKAdapter(_make_agent())
+    adapter._runner = _FakeRunner()
+    adapter._session_id = "stub-session"
+
+    await adapter.invoke(task=task, session=session)
+    assert observed == [0, 1, 2]
+
+
 async def test_register_reporting_tools_is_idempotent() -> None:
     """Registering twice must not duplicate the reporting tools on any agent."""
     from google.adk.agents.llm_agent import LlmAgent  # type: ignore

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -92,9 +92,7 @@ class StubPlanner:
         drift: DriftEvent,
         goals: list[Goal],
     ) -> Plan | None:
-        self.refine_calls.append(
-            {"plan": plan, "drift": drift, "goals": goals}
-        )
+        self.refine_calls.append({"plan": plan, "drift": drift, "goals": goals})
         if self.raise_exc is not None:
             raise self.raise_exc
         return self.revised
@@ -179,9 +177,7 @@ async def test_mark_task_running_unknown_task_is_noop() -> None:
 
 async def test_mark_task_progress_records_and_emits() -> None:
     steerer, session, sink, _ = _fresh()
-    await steerer.mark_task_progress(
-        "t1", session=session, fraction=0.42, detail="halfway"
-    )
+    await steerer.mark_task_progress("t1", session=session, fraction=0.42, detail="halfway")
     assert session.task_progress["t1"] == pytest.approx(0.42)
     assert session.agent_notes["t1"] == "halfway"
     # Status is untouched by progress updates.
@@ -222,9 +218,7 @@ async def test_mark_task_completed_transitions_and_emits() -> None:
 
 async def test_mark_task_failed_recoverable_fires_drift() -> None:
     steerer, session, sink, planner = _fresh()
-    await steerer.mark_task_failed(
-        "t1", session=session, reason="boom", recoverable=True
-    )
+    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
     assert _task(session, "t1").status is TaskStatus.FAILED
     kinds = [e.WhichOneof("payload") for e in sink.events]
     # TaskFailed + DriftDetected + refine-failure DriftDetected (planner
@@ -244,9 +238,7 @@ async def test_mark_task_failed_recoverable_fires_drift() -> None:
 
 async def test_mark_task_failed_fatal_fires_critical_drift() -> None:
     steerer, session, sink, _planner = _fresh()
-    await steerer.mark_task_failed(
-        "t1", session=session, reason="unrecoverable", recoverable=False
-    )
+    await steerer.mark_task_failed("t1", session=session, reason="unrecoverable", recoverable=False)
     drift_evt = sink.events[1]
     from goldfive.pb.goldfive.v1 import types_pb2
 
@@ -273,9 +265,7 @@ async def test_mark_task_blocked_transitions_and_emits_drift() -> None:
 
 async def test_mark_task_cancelled_transitions() -> None:
     steerer, session, sink, _ = _fresh()
-    await steerer.mark_task_cancelled(
-        "t1", session=session, reason="user cancelled"
-    )
+    await steerer.mark_task_cancelled("t1", session=session, reason="user cancelled")
     assert _task(session, "t1").status is TaskStatus.CANCELLED
     assert len(sink.events) == 1
     assert sink.events[0].WhichOneof("payload") == "task_cancelled"
@@ -284,9 +274,7 @@ async def test_mark_task_cancelled_transitions() -> None:
 
 async def test_transition_dispatches_to_mark_methods() -> None:
     steerer, session, sink, _ = _fresh()
-    await steerer.transition(
-        "t1", TaskStatus.RUNNING, session=session, detail="go"
-    )
+    await steerer.transition("t1", TaskStatus.RUNNING, session=session, detail="go")
     assert _task(session, "t1").status is TaskStatus.RUNNING
     assert sink.events[0].WhichOneof("payload") == "task_started"
 
@@ -373,10 +361,7 @@ def test_detect_drift_prefers_tool_error_then_refusal_then_stop_reason() -> None
         is DriftKind.AGENT_REFUSAL
     )
     # Pure stop_reason goes to CONTEXT_PRESSURE.
-    assert (
-        s.detect_drift({"stop_reason": "MAX_TOKENS"}, sess).kind
-        is DriftKind.CONTEXT_PRESSURE
-    )
+    assert s.detect_drift({"stop_reason": "MAX_TOKENS"}, sess).kind is DriftKind.CONTEXT_PRESSURE
     # Nothing → None.
     assert s.detect_drift({"text": "all good"}, sess) is None
 
@@ -538,10 +523,7 @@ async def test_report_new_work_discovered_fires_drift() -> None:
     assert sink.events[0].WhichOneof("payload") == "drift_detected"
     from goldfive.pb.goldfive.v1 import types_pb2
 
-    assert (
-        sink.events[0].drift_detected.kind
-        == types_pb2.DRIFT_KIND_NEW_WORK_DISCOVERED
-    )
+    assert sink.events[0].drift_detected.kind == types_pb2.DRIFT_KIND_NEW_WORK_DISCOVERED
     assert planner.refine_calls[0]["drift"].kind is DriftKind.NEW_WORK_DISCOVERED
 
 
@@ -555,10 +537,7 @@ async def test_report_plan_divergence_sets_flag_and_fires_drift() -> None:
     assert session.divergence_flag is True
     from goldfive.pb.goldfive.v1 import types_pb2
 
-    assert (
-        sink.events[0].drift_detected.kind
-        == types_pb2.DRIFT_KIND_PLAN_DIVERGENCE
-    )
+    assert sink.events[0].drift_detected.kind == types_pb2.DRIFT_KIND_PLAN_DIVERGENCE
     assert planner.refine_calls[0]["drift"].kind is DriftKind.PLAN_DIVERGENCE
 
 

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -227,8 +227,9 @@ async def test_mark_task_failed_recoverable_fires_drift() -> None:
     )
     assert _task(session, "t1").status is TaskStatus.FAILED
     kinds = [e.WhichOneof("payload") for e in sink.events]
-    # TaskFailed + DriftDetected (planner returns None so no PlanRevised).
-    assert kinds == ["task_failed", "drift_detected"]
+    # TaskFailed + DriftDetected + refine-failure DriftDetected (planner
+    # returns None so no PlanRevised; the follow-up drift surfaces that).
+    assert kinds == ["task_failed", "drift_detected", "drift_detected"]
     assert sink.events[0].task_failed.recoverable is True
     drift_evt = sink.events[1]
     # Proto enum DriftKind values: first check by semantic comparison via module.
@@ -260,7 +261,9 @@ async def test_mark_task_blocked_transitions_and_emits_drift() -> None:
     )
     assert _task(session, "t1").status is TaskStatus.BLOCKED
     kinds = [e.WhichOneof("payload") for e in sink.events]
-    assert kinds == ["task_blocked", "drift_detected"]
+    # TaskBlocked + DriftDetected + refine-failure DriftDetected (stub
+    # planner returns None; the follow-up drift surfaces that).
+    assert kinds == ["task_blocked", "drift_detected", "drift_detected"]
     from goldfive.pb.goldfive.v1 import types_pb2
 
     assert sink.events[1].drift_detected.kind == types_pb2.DRIFT_KIND_BLOCKED
@@ -442,9 +445,44 @@ async def test_observe_swallows_planner_exceptions() -> None:
 
     # Must not raise even though refine() blows up.
     await steerer.observe({"error": "x"}, session)
-    # We emitted the drift but not the plan_revised (refine errored).
+    # We emit the original drift and a follow-up CRITICAL drift that
+    # surfaces the refine failure so sinks can render it — we never
+    # emit plan_revised because the refine errored.
     kinds = [e.WhichOneof("payload") for e in sink.events]
-    assert kinds == ["drift_detected"]
+    assert kinds == ["drift_detected", "drift_detected"]
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    follow_up = sink.events[1].drift_detected
+    assert follow_up.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+    assert "refine failed" in follow_up.detail
+    assert "planner down" in follow_up.detail
+
+
+async def test_observe_surfaces_refine_none_return() -> None:
+    """When refine returns None, a CRITICAL follow-up drift is emitted.
+
+    Without this, a silently-swallowed refine leaves session.plan pinned
+    to the stale plan and the executor will re-enter the same state on
+    the next tick with no observable signal.
+    """
+    planner = StubPlanner(revised=None)  # refine returns None
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    await steerer.observe({"error": "x"}, session)
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["drift_detected", "drift_detected"]
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    follow_up = sink.events[1].drift_detected
+    assert follow_up.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+    assert "refine failed" in follow_up.detail
+    assert "no revised plan" in follow_up.detail
+    # Session plan is unchanged.
+    assert session.plan is not None
+    assert session.plan.revision_index == 0
 
 
 # ---------------------------------------------------------------------------
@@ -495,7 +533,8 @@ async def test_report_new_work_discovered_fires_drift() -> None:
         description="double-check the numbers",
         assignee="analyst",
     )
-    assert len(sink.events) == 1
+    # Original drift + refine-failure drift (stub planner returns None).
+    assert len(sink.events) == 2
     assert sink.events[0].WhichOneof("payload") == "drift_detected"
     from goldfive.pb.goldfive.v1 import types_pb2
 

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -189,9 +189,10 @@ async def test_observe_cancel_triggers_critical_user_cancel_drift() -> None:
     assert drift.severity is DriftSeverity.CRITICAL
     assert drift.detail == "operator abort"
 
-    # DriftDetected emitted; no PlanRevised (planner returned None).
+    # Original DriftDetected + refine-failure follow-up DriftDetected
+    # (planner returned None); no PlanRevised.
     kinds = [e.WhichOneof("payload") for e in sink.events]
-    assert kinds.count("drift_detected") == 1
+    assert kinds.count("drift_detected") == 2
     assert "plan_revised" not in kinds
 
 

--- a/tests/test_tool_loop_guard.py
+++ b/tests/test_tool_loop_guard.py
@@ -45,9 +45,7 @@ class _RecordingSteerer:
         self.drifts: list[DriftEvent] = []
         self._sinks: list[Any] = []
 
-    async def mark_task_running(
-        self, task_id: str, *, session: Session, detail: str = ""
-    ) -> None:
+    async def mark_task_running(self, task_id: str, *, session: Session, detail: str = "") -> None:
         self.transitions.append((task_id, "RUNNING", {"detail": detail}))
         task = next(
             (t for t in (session.plan.tasks if session.plan else []) if t.id == task_id),
@@ -68,9 +66,7 @@ class _RecordingSteerer:
         fraction: float = 0.0,
         detail: str = "",
     ) -> None:
-        self.transitions.append(
-            (task_id, "PROGRESS", {"fraction": fraction, "detail": detail})
-        )
+        self.transitions.append((task_id, "PROGRESS", {"fraction": fraction, "detail": detail}))
         session.task_progress[task_id] = fraction
 
     async def mark_task_completed(
@@ -148,16 +144,22 @@ async def test_duplicate_call_returns_ack_and_skips_steerer() -> None:
     tools = [_spec("report_task_started")]
 
     first = await invoke_tool(
-        tools, "report_task_started", {"task_id": "t1", "detail": "kick"},
-        session, steerer,
+        tools,
+        "report_task_started",
+        {"task_id": "t1", "detail": "kick"},
+        session,
+        steerer,
     )
     assert first == {"acknowledged": True}
     assert session.plan.tasks[0].status is TaskStatus.RUNNING
 
     # Second identical call: should ACK as duplicate, no re-transition.
     second = await invoke_tool(
-        tools, "report_task_started", {"task_id": "t1", "detail": "kick"},
-        session, steerer,
+        tools,
+        "report_task_started",
+        {"task_id": "t1", "detail": "kick"},
+        session,
+        steerer,
     )
     assert second == {"acknowledged": True, "duplicate": True}
     # Only one transition recorded — handler was not re-entered.
@@ -446,9 +448,7 @@ async def test_frontier_style_progression_does_not_fire_drift() -> None:
         _spec("report_task_completed"),
     ]
 
-    await invoke_tool(
-        tools, "report_task_started", {"task_id": "t1"}, session, steerer
-    )
+    await invoke_tool(tools, "report_task_started", {"task_id": "t1"}, session, steerer)
     for frac, detail in [(0.2, "research"), (0.5, "draft"), (0.9, "review")]:
         await invoke_tool(
             tools,
@@ -505,9 +505,7 @@ async def test_llmplanner_refine_loops_drift_falls_back_when_llm_fails() -> None
         current_task_id="loop",
     )
     planner = LLMPlanner(call_llm=boom)
-    revised = await planner.refine(
-        plan=plan, drift=drift, goals=[Goal(id="g1", summary="do it")]
-    )
+    revised = await planner.refine(plan=plan, drift=drift, goals=[Goal(id="g1", summary="do it")])
     assert revised is not None
     by_id = {t.id: t for t in revised.tasks}
     assert by_id["loop"].status is TaskStatus.FAILED
@@ -553,9 +551,7 @@ async def test_llmplanner_refine_loops_drift_uses_llm_response() -> None:
         current_task_id="loop",
     )
     planner = LLMPlanner(call_llm=llm)
-    revised = await planner.refine(
-        plan=plan, drift=drift, goals=[Goal(id="g1", summary="do it")]
-    )
+    revised = await planner.refine(plan=plan, drift=drift, goals=[Goal(id="g1", summary="do it")])
     assert revised is not None
     by_id = {t.id: t for t in revised.tasks}
     # The planner forgot to mark it FAILED; the framework forces it.

--- a/tests/test_tool_loop_guard.py
+++ b/tests/test_tool_loop_guard.py
@@ -89,8 +89,25 @@ class _RecordingSteerer:
         if task is not None:
             task.status = TaskStatus.COMPLETED
 
-    async def mark_task_failed(self, *args: Any, **kwargs: Any) -> None:
-        self.transitions.append(("?", "FAILED", kwargs))
+    async def mark_task_failed(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        reason: str = "",
+        recoverable: bool = True,
+    ) -> None:
+        self.transitions.append((task_id, "FAILED", {"reason": reason}))
+        task = next(
+            (t for t in (session.plan.tasks if session.plan else []) if t.id == task_id),
+            None,
+        )
+        if task is not None and task.status not in {
+            TaskStatus.COMPLETED,
+            TaskStatus.FAILED,
+            TaskStatus.CANCELLED,
+        }:
+            task.status = TaskStatus.FAILED
 
     async def mark_task_blocked(self, *args: Any, **kwargs: Any) -> None:
         self.transitions.append(("?", "BLOCKED", kwargs))
@@ -220,6 +237,202 @@ async def test_alternating_args_does_not_fire_drift() -> None:
             steerer,
         )
 
+    assert steerer.drifts == []
+
+
+async def test_volume_cap_fires_on_args_varying_loop() -> None:
+    """The volume cap catches loops that vary args on every call.
+
+    Models in the wild often vary a free-text ``detail`` string on every
+    repeated progress report, which keeps every signature unique and
+    lets the exact-match window sail past without firing. The per-tool
+    cumulative counter catches this regardless of args.
+
+    Uses a non-terminal tool (``report_task_progress``) so the
+    terminal-task rejection layer doesn't short-circuit the flow — this
+    test is specifically for the volume-cap safety net when the task
+    itself hasn't transitioned out of ``RUNNING``.
+    """
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+    tools = [_spec("report_task_progress")]
+
+    # 14 calls with fresh details should stay below the volume cap.
+    for i in range(14):
+        await invoke_tool(
+            tools,
+            "report_task_progress",
+            {"task_id": "t1", "fraction": 0.01 * i, "detail": f"try #{i}"},
+            session,
+            steerer,
+        )
+    assert steerer.drifts == []
+
+    # The 15th call crosses the threshold and fires exactly one drift.
+    await invoke_tool(
+        tools,
+        "report_task_progress",
+        {"task_id": "t1", "fraction": 0.14, "detail": "try #14"},
+        session,
+        steerer,
+    )
+    assert len(steerer.drifts) == 1
+    drift = steerer.drifts[0]
+    assert drift.kind is DriftKind.LOOPING_TOOL_CALL
+    assert drift.current_task_id == "t1"
+    assert "report_task_progress" in drift.detail
+
+
+async def test_volume_cap_is_per_tool_not_cross_tool() -> None:
+    """Volume cap counts per tool name; mixing tools stays under the cap."""
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+    tools = [
+        _spec("report_task_progress"),
+        _spec("report_task_blocked"),
+    ]
+
+    # 14 progress + 14 blocked = 28 total, but neither tool alone crosses 15.
+    for i in range(14):
+        await invoke_tool(
+            tools,
+            "report_task_progress",
+            {"task_id": "t1", "fraction": 0.1 * i, "detail": f"p{i}"},
+            session,
+            steerer,
+        )
+        await invoke_tool(
+            tools,
+            "report_task_blocked",
+            {"task_id": "t1", "blocked_on": f"dep-{i}"},
+            session,
+            steerer,
+        )
+    assert steerer.drifts == []
+
+
+async def test_volume_cap_fires_once_per_task() -> None:
+    """Once the volume cap fires, further calls do not re-fire drift."""
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+    tools = [_spec("report_task_progress")]
+
+    for i in range(30):
+        await invoke_tool(
+            tools,
+            "report_task_progress",
+            {"task_id": "t1", "fraction": 0.01 * i, "detail": f"d{i}"},
+            session,
+            steerer,
+        )
+    assert len(steerer.drifts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Terminal-task rejection (prevention layer)
+# ---------------------------------------------------------------------------
+
+
+async def test_reporting_on_terminal_task_returns_structured_rejection() -> None:
+    """Once a task is terminal, further reporting calls get a clear stop
+    signal — NOT a bland ``acknowledged=true`` that the model would read
+    as "keep going."
+
+    The rejection carries the task id and current status so the model can
+    reason about state and route its next turn accordingly.
+    """
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+    tools = [_spec("report_task_failed"), _spec("report_task_progress")]
+
+    # First report: legitimate transition to FAILED.
+    first = await invoke_tool(
+        tools,
+        "report_task_failed",
+        {"task_id": "t1", "reason": "it broke"},
+        session,
+        steerer,
+    )
+    assert first == {"acknowledged": True}
+    assert session.plan.tasks[0].status is TaskStatus.FAILED
+
+    # Second report (on the now-terminal task) must be hard-rejected.
+    second = await invoke_tool(
+        tools,
+        "report_task_failed",
+        {"task_id": "t1", "reason": "it broke again"},
+        session,
+        steerer,
+    )
+    assert second["acknowledged"] is False
+    assert second["error"] == "task_already_terminal"
+    assert second["task_id"] == "t1"
+    assert second["current_status"] == "FAILED"
+    assert "do not" in second["message"].lower()
+
+    # A different reporting tool on the same terminal task is also rejected.
+    third = await invoke_tool(
+        tools,
+        "report_task_progress",
+        {"task_id": "t1", "fraction": 0.5, "detail": "still trying"},
+        session,
+        steerer,
+    )
+    assert third["acknowledged"] is False
+    assert third["error"] == "task_already_terminal"
+
+
+async def test_terminal_rejection_does_not_invoke_handler() -> None:
+    """A rejected call does not re-enter the Steerer transition table."""
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+    tools = [_spec("report_task_failed")]
+
+    # Pre-mark the task as COMPLETED (e.g., via a prior legitimate call).
+    session.plan.tasks[0].status = TaskStatus.COMPLETED
+
+    result = await invoke_tool(
+        tools,
+        "report_task_failed",
+        {"task_id": "t1", "reason": "late failure report"},
+        session,
+        steerer,
+    )
+    assert result["acknowledged"] is False
+    # Handler was never called → no transitions recorded → task stays COMPLETED.
+    assert steerer.transitions == []
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+
+
+async def test_terminal_rejection_flood_cannot_burn_llm_budget() -> None:
+    """100 rejected reports cost one lookup each, no handler, no drift.
+
+    This is the scenario we observed in the wild: an agent calls
+    ``report_task_failed`` hundreds of times with fresh ``reason``
+    strings on a task that's already FAILED, burning through ADK's
+    500-LLM-call limit. With the rejection layer, each call bounces
+    cheaply and gives the model a clear ``stop_reporting`` signal — no
+    handler cost, no drift pileup.
+    """
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+    tools = [_spec("report_task_failed")]
+
+    # Mark terminal up front.
+    session.plan.tasks[0].status = TaskStatus.FAILED
+
+    for i in range(100):
+        result = await invoke_tool(
+            tools,
+            "report_task_failed",
+            {"task_id": "t1", "reason": f"unique reason #{i}"},
+            session,
+            steerer,
+        )
+        assert result["acknowledged"] is False
+
+    # No handlers fired, no drift events emitted — rejection is cheap and silent.
+    assert steerer.transitions == []
     assert steerer.drifts == []
 
 


### PR DESCRIPTION
## Summary

Fixes the reporting-tool flood pattern observed in live runs where tasks burn ADK's 500-LLM-call ceiling. Four layered defences targeting distinct failure modes in the task lifecycle, plus a design-doc review of the surrounding protocols.

## Problem

Two live runs (steered + unsteered baseline) hit ADK's 500-LLM-call limit with 90%+ of calls being redundant reporting tools (`report_task_failed` / `report_task_progress` / `report_task_blocked`). #94's exact-signature guard missed these because every call varied free-text args (different `reason`/`detail` strings).

Root cause traced below observed symptom: `ADKAdapter.invoke` had no check on `task.status` during its `run_async` loop. After the agent reported a task terminal, nothing told ADK to stop — it kept feeding events until its own 500-call ceiling tripped.

## Changes

**Layer 0 — Adapter quiescence** (`adapters/adk.py`): break out of `run_async` when `task.status` in `session.plan` becomes terminal. This is the structural fix — prevents the agent from taking more LLM turns on a done task.

**Layer 1 — Terminal-task rejection** (`adapters/_tool_invocation.py`): return a structured `{"acknowledged": false, "error": "task_already_terminal", "message": ...}` dict instead of a bland ACK when the task is already terminal. Model gets actionable feedback.

**Layer 2 — Volume cap in loop guard** (`adapters/_tool_loop_guard.py`): add a per-tool volume threshold (15 calls) alongside the existing 6/8-window. Catches args-varying loops.

**Layer 3 — Refine-failure visibility** (`steerer.py`): when `planner.refine` raises or returns `None`, emit a follow-up CRITICAL `DriftDetected` instead of silently swallowing. Sinks now see refine failures.

**Single source of truth for terminal statuses** (`types.py`): exports `TERMINAL_TASK_STATUSES`; all three consumers (`steerer.py`, `_tool_invocation.py`, `adk.py`) import from it (previously each had its own copy with a "keep in sync" comment and no enforcement).

**New design doc** `docs/design/TASK-LIFECYCLE.md` — full protocol choreography review across creation, assignment, quiescence, revision, cancellation, and reporting-tool dispatch. Enumerates 7 known soundness gaps with fix directions. This PR closes 5; remaining 2 (ADK session heal on cancel, plan validation, refine-retry backoff, per-task invocation cap, conversation truncation on revision) are tracked in follow-up issues.

## Test plan

- [x] `tests/test_adk_adapter.py` — adapter early-break (terminal + non-terminal paths, 15 tests)
- [x] `tests/test_tool_loop_guard.py` — terminal rejection (basic + handler-not-invoked + 100-call flood) + volume cap (args-varying + per-tool scoping + one-shot)
- [x] `tests/test_steerer.py` + `test_steerer_usersteer.py` — refine-failure emits CRITICAL follow-up on both raise and None-return paths
- [x] Full suite: 446 passed, 38 skipped (was 417; new tests + existing tests updated for refine-failure drift)
- [ ] End-to-end re-run against Qwen3.5 with live-steering — to be run after merge (harmonograf submodule bump needed first)
