### PR TITLE
Refine-failure retry backoff with per-(kind, task) counter (TASK-LIFECYCLE.md §7.3)

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -469,11 +469,29 @@ class DefaultSteerer:
     # --- Drift dispatch ----------------------------------------------
 
     async def _handle_drift(self, drift: DriftEvent, session: Session) -> None:
-        """Emit a ``DriftDetected`` event and (if severe enough) refine."""
+        """Emit a ``DriftDetected`` event and (if severe enough) refine.
+
+        Refine failures (either a raised exception or a ``None`` return)
+        are tracked per ``(drift.kind.value, drift.current_task_id)`` on
+        ``session.refine_failure_counts``. After
+        :attr:`REFINE_FAILURE_THRESHOLD` consecutive failures for the
+        same key we skip refine entirely, mark the offending task
+        ``FAILED`` (non-recoverable), and emit a CRITICAL
+        ``REPEATED_FAILURE`` drift so sinks see the back-off. This
+        bounds the loop that would otherwise re-fire the same drift
+        every tick until ``SequentialExecutor.max_plan_reinvocations``
+        tripped (see TASK-LIFECYCLE.md §7.3).
+        """
         await self._emit_drift_detected(session, drift)
         if not _severity_ge(drift.severity, DriftSeverity.WARNING):
             return
         if self._planner is None or session.plan is None:
+            return
+        counter_key = (drift.kind.value, drift.current_task_id)
+        # If this (kind, task) already tripped the threshold on a prior
+        # tick, stop trying to refine. The task is FAILED by now so any
+        # further drift for it will short-circuit at ``mark_task_failed``.
+        if session.refine_failure_counts.get(counter_key, 0) >= self.REFINE_FAILURE_THRESHOLD:
             return
         try:
             revised = await self._planner.refine(
@@ -494,6 +512,7 @@ class DefaultSteerer:
                 exc,
             )
             await self._emit_refine_failure(session, drift, reason=str(exc))
+            await self._register_refine_failure(session, drift, counter_key)
             return
         if revised is None:
             log.warning(
@@ -504,13 +523,17 @@ class DefaultSteerer:
             await self._emit_refine_failure(
                 session, drift, reason="planner returned no revised plan"
             )
+            await self._register_refine_failure(session, drift, counter_key)
             return
         try:
             revised.validate(for_revision=True)
         except ValueError as exc:
             # Reject the revision and surface the failure as a CRITICAL
             # DriftDetected so operators can see the bad plan upstream.
-            # The session keeps its old plan.
+            # The session keeps its old plan. A bad revision also counts
+            # as a refine failure for backoff purposes — the planner
+            # produced an unusable plan, which is functionally the same
+            # as returning None.
             await self._emit_drift_detected(
                 session,
                 DriftEvent(
@@ -520,9 +543,62 @@ class DefaultSteerer:
                     current_task_id=session.current_task_id,
                 ),
             )
+            await self._register_refine_failure(session, drift, counter_key)
             return
+        # Successful refine — reset the back-off counter for this key
+        # so a future drift of the same kind starts fresh.
+        session.refine_failure_counts.pop(counter_key, None)
         self._apply_revision(session, revised, drift)
         await self._emit_plan_revised(session, revised, drift)
+
+    # Consecutive refine failures tolerated per (drift_kind, task_id)
+    # before we give up and mark the task FAILED. Class attribute so
+    # subclasses / tests can tune it without poking at instance state.
+    REFINE_FAILURE_THRESHOLD: int = 2
+
+    async def _register_refine_failure(
+        self,
+        session: Session,
+        drift: DriftEvent,
+        counter_key: tuple[str, str],
+    ) -> None:
+        """Bump the per-(kind, task) refine-failure counter and, if we
+        just crossed :attr:`REFINE_FAILURE_THRESHOLD`, mark the task
+        ``FAILED`` and emit a ``REPEATED_FAILURE`` drift.
+
+        Below the threshold this is a no-op beyond the increment:
+        callers return normally so the next trigger of the same drift
+        gets another chance to refine. See TASK-LIFECYCLE.md §7.3.
+        """
+        count = session.refine_failure_counts.get(counter_key, 0) + 1
+        session.refine_failure_counts[counter_key] = count
+        if count < self.REFINE_FAILURE_THRESHOLD:
+            return
+        task_id = drift.current_task_id
+        reason = f"refine repeatedly failed for {drift.kind.value}"
+        # mark_task_failed routes through _handle_drift for the TASK_FAILED
+        # drift; that path keys on a different drift kind so it cannot
+        # feed back into *this* counter and recurse.
+        if task_id:
+            await self.mark_task_failed(
+                task_id,
+                reason=reason,
+                recoverable=False,
+                session=session,
+            )
+        repeated = DriftEvent(
+            kind=DriftKind.REPEATED_FAILURE,
+            severity=DriftSeverity.CRITICAL,
+            detail=(
+                f"refine failed {count} consecutive times for "
+                f"{drift.kind.value} (task {task_id or 'n/a'})"
+            ),
+            current_task_id=task_id,
+            current_agent_id=drift.current_agent_id,
+        )
+        # Emit directly — do NOT go back through _handle_drift, which
+        # would try to refine again on the fresh drift.
+        await self._emit_drift_detected(session, repeated)
 
     async def _emit_refine_failure(
         self, session: Session, source: DriftEvent, *, reason: str

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -287,6 +287,15 @@ class Session:
     # Consumed by the reasoning-drift detectors (see ``goldfive.drift_reasoning``).
     reasoning_history: list[str] = dataclasses.field(default_factory=list)
     reasoning_history_max: int = 20
+    # Per-(drift_kind_value, task_id) consecutive refine-failure counter.
+    # Incremented each time ``planner.refine`` raises or returns ``None``
+    # for the given (kind, task) tuple; reset on a successful refine.
+    # Consumed by :class:`~goldfive.steerer.DefaultSteerer` to back off
+    # and mark the task FAILED after N consecutive failures, preventing
+    # the same drift from looping until ``max_plan_reinvocations`` trips.
+    refine_failure_counts: dict[tuple[str, str], int] = dataclasses.field(
+        default_factory=dict
+    )
     # monotonic event sequence counter for sinks
     _next_sequence: int = 0
 

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -430,9 +430,9 @@ async def test_observe_swallows_planner_exceptions() -> None:
 
     # Must not raise even though refine() blows up.
     await steerer.observe({"error": "x"}, session)
-    # We emit the original drift and a follow-up CRITICAL drift that
-    # surfaces the refine failure so sinks can render it — we never
-    # emit plan_revised because the refine errored.
+    # First failure: emit original drift + refine-failure visibility
+    # drift. Counter bumps to 1 (below the threshold), so we stay in
+    # visibility-only mode — no REPEATED_FAILURE, no mark_task_failed.
     kinds = [e.WhichOneof("payload") for e in sink.events]
     assert kinds == ["drift_detected", "drift_detected"]
     from goldfive.pb.goldfive.v1 import types_pb2
@@ -471,6 +471,148 @@ async def test_observe_surfaces_refine_none_return() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Refine-failure retry backoff (TASK-LIFECYCLE.md §7.3)
+# ---------------------------------------------------------------------------
+
+
+def _tool_error_drift(task_id: str = "t1") -> DriftEvent:
+    """Build a canned WARNING-severity drift routed through _handle_drift."""
+    return DriftEvent(
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.WARNING,
+        detail="simulated tool error",
+        current_task_id=task_id,
+    )
+
+
+async def test_refine_failure_counter_increments_on_exception() -> None:
+    planner = StubPlanner(raise_exc=RuntimeError("planner down"))
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    key = (DriftKind.TOOL_ERROR.value, "t1")
+    assert session.refine_failure_counts.get(key, 0) == 0
+
+    # Same drift is classified by detect_drift — use a dict the tool-error
+    # classifier picks up and that carries a task via current_task_id.
+    # Simpler: drive _handle_drift directly so the drift identity is stable.
+    await steerer._handle_drift(_tool_error_drift(), session)
+    assert session.refine_failure_counts[key] == 1
+    assert len(planner.refine_calls) == 1
+
+    await steerer._handle_drift(_tool_error_drift(), session)
+    # Second failure hits the threshold: _register_refine_failure calls
+    # mark_task_failed, which fires a TASK_FAILED_FATAL drift that routes
+    # through _handle_drift and triggers one more refine attempt (keyed
+    # on a different (kind, task) tuple, so the TOOL_ERROR counter stays
+    # at 2 and the TASK_FAILED_FATAL counter reaches 1).
+    assert session.refine_failure_counts[key] == 2
+    fatal_key = (DriftKind.TASK_FAILED_FATAL.value, "t1")
+    assert session.refine_failure_counts.get(fatal_key, 0) == 1
+
+
+async def test_refine_failure_counter_increments_on_none_return() -> None:
+    # revised=None is the default — refine returns None without raising.
+    planner = StubPlanner(revised=None)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    key = (DriftKind.TOOL_ERROR.value, "t1")
+    assert session.refine_failure_counts.get(key, 0) == 0
+
+    await steerer._handle_drift(_tool_error_drift(), session)
+    assert session.refine_failure_counts[key] == 1
+    assert len(planner.refine_calls) == 1
+
+    await steerer._handle_drift(_tool_error_drift(), session)
+    # Same cascade as the exception case: the TOOL_ERROR counter is
+    # clamped at the threshold (2), the cascaded TASK_FAILED_FATAL drift
+    # kicks off its own independent counter at 1.
+    assert session.refine_failure_counts[key] == 2
+    fatal_key = (DriftKind.TASK_FAILED_FATAL.value, "t1")
+    assert session.refine_failure_counts.get(fatal_key, 0) == 1
+
+
+async def test_two_consecutive_refine_failures_marks_task_failed() -> None:
+    planner = StubPlanner(raise_exc=RuntimeError("planner down"))
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    # First failure: visibility-only, task stays PENDING.
+    await steerer._handle_drift(_tool_error_drift(), session)
+    assert _task(session, "t1").status is TaskStatus.PENDING
+
+    # Second failure: backoff trips — task marked FAILED, REPEATED_FAILURE
+    # drift emitted.
+    await steerer._handle_drift(_tool_error_drift(), session)
+    assert _task(session, "t1").status is TaskStatus.FAILED
+
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    # Expected stream across both ticks:
+    #   tick 1: drift_detected (TOOL_ERROR)
+    #   tick 2: drift_detected (TOOL_ERROR),
+    #           task_failed,
+    #           drift_detected (TASK_FAILED_FATAL — from mark_task_failed),
+    #           drift_detected (REPEATED_FAILURE).
+    assert "task_failed" in kinds
+    drift_kinds = [
+        e.drift_detected.kind for e in sink.events if e.WhichOneof("payload") == "drift_detected"
+    ]
+    assert types_pb2.DRIFT_KIND_REPEATED_FAILURE in drift_kinds
+    # The REPEATED_FAILURE drift should be CRITICAL severity.
+    repeated_events = [
+        e
+        for e in sink.events
+        if e.WhichOneof("payload") == "drift_detected"
+        and e.drift_detected.kind == types_pb2.DRIFT_KIND_REPEATED_FAILURE
+    ]
+    assert len(repeated_events) == 1
+    assert repeated_events[0].drift_detected.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+    # After the threshold trip, a *third* trigger of the same drift must
+    # short-circuit without calling refine again — the counter wall
+    # prevents the loop that §7.3 targets.
+    calls_before = len(planner.refine_calls)
+    await steerer._handle_drift(_tool_error_drift(), session)
+    assert len(planner.refine_calls) == calls_before
+
+
+async def test_successful_refine_resets_failure_counter() -> None:
+    # Planner that we can flip between "raise" and "succeed" modes.
+    revised = _make_plan(("t1", "t2", "t3"))
+    planner = StubPlanner(raise_exc=RuntimeError("planner down"))
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    key = (DriftKind.TOOL_ERROR.value, "t1")
+
+    await steerer._handle_drift(_tool_error_drift(), session)
+    assert session.refine_failure_counts[key] == 1
+
+    # Flip planner to success mode BEFORE the counter hits the threshold
+    # so the next call takes the happy path and must clear the counter.
+    planner.raise_exc = None
+    planner.revised = revised
+
+    await steerer._handle_drift(_tool_error_drift(), session)
+    # Successful refine clears the key entirely (pop) — the counter is
+    # reset, not decremented, so a fresh run of failures starts at 0.
+    assert key not in session.refine_failure_counts
+    # And the plan actually got revised on the success.
+    assert session.plan is not None
+    assert [t.id for t in session.plan.tasks] == ["t1", "t2", "t3"]
+
+
+# ---------------------------------------------------------------------------
 # Drift kind coverage — every DriftKind either has a classifier, a
 # transition that fires it, or is a reserved value that the steerer
 # itself doesn't emit (e.g., USER_STEER, AGENT_TRANSFER, CUSTOM).
@@ -486,6 +628,9 @@ def test_every_drift_kind_has_a_known_origin() -> None:
         DriftKind.BLOCKED,
         DriftKind.NEW_WORK_DISCOVERED,
         DriftKind.PLAN_DIVERGENCE,
+        # Emitted by the refine-failure backoff in _handle_drift once the
+        # per-(kind, task) counter hits REFINE_FAILURE_THRESHOLD.
+        DriftKind.REPEATED_FAILURE,
     }
     # Kinds the detect_drift classifiers produce.
     classifier_emits = {


### PR DESCRIPTION
## Gap

If the configured LLM is down (or rate-limited, or transiently broken), the
drift pipeline loops pathologically:

1. Some event classifies as drift (say `TOOL_ERROR`).
2. `DefaultSteerer._handle_drift` calls `planner.refine(...)`.
3. Refine raises (or returns `None`) -- the exception is currently
   swallowed silently.
4. The same upstream condition persists -> same drift fires next tick -> GOTO 2.

Nothing in the steerer bounds this. The only backstop is
`SequentialExecutor.max_plan_reinvocations` (default 32), which counts
*total* refines, not per-drift-kind, so one broken drift burns the entire
budget without ever making progress.

## Fix

Track consecutive refine failures per `(drift_kind_value, current_task_id)`
tuple on the `Session`. After `REFINE_FAILURE_THRESHOLD` (default 2)
consecutive failures for the same key, stop calling refine and instead:

- Mark the affected task `FAILED` (non-recoverable) via
  `steerer.mark_task_failed(..., recoverable=False)`. Terminal status
  makes any future drift for that task a no-op at
  `mark_task_failed`.
- Emit a CRITICAL `DriftKind.REPEATED_FAILURE` drift citing the original
  kind + the failure count.

Successful refine resets the counter for that key, so a future drift of
the same kind starts fresh.

The cascaded `TASK_FAILED_FATAL` drift from `mark_task_failed` keys on its
own tuple, so the backoff cannot feed back into its own counter and recurse.

## Relation to PR #98

PR #98 (`fix/loop-guard-name-only`) adds *visibility* -- a CRITICAL
`DriftDetected` drift when refine fails so sinks see the failure. This PR
adds the *bound* -- we stop calling a broken refiner after two tries.

Both changes layer around the same swallow site in `_handle_drift`. The
conflict is trivially resolvable: keep #98's visibility drift in the
below-threshold branch, keep this PR's counter increment + threshold
check + REPEATED_FAILURE path in the at-threshold branch. Both PRs leave
the happy path untouched and scoped changes to `_handle_drift` +
`types.Session` for exactly this reason.

## Changes

- `goldfive/types.py`: add `Session.refine_failure_counts:
  dict[tuple[str, str], int]`.
- `goldfive/steerer.py`: rework `_handle_drift` to track failures via
  `_register_refine_failure`; add `REFINE_FAILURE_THRESHOLD` class attr
  for subclass tuning.
- `tests/test_steerer.py`: 4 new tests covering counter increment on
  exception, on `None` return, task-failure + REPEATED_FAILURE emission
  at threshold, and successful-refine reset.

## Test plan

- [x] `uv run --extra dev pytest -q` -> 414 passed, 45 skipped (no regressions)
- [x] `uv run --extra dev ruff check goldfive/steerer.py goldfive/types.py tests/test_steerer.py` -> clean
- [x] New tests cover all four design scenarios from TASK-LIFECYCLE.md §7.3
- [x] Existing `test_observe_swallows_planner_exceptions` still passes (one
      failure below threshold is still visibility-only)
- [x] `test_every_drift_kind_has_a_known_origin` updated to reflect that
      `REPEATED_FAILURE` is now a steerer-emitted kind
