### PR TITLE
Plan structural validation at creation and revision (TASK-LIFECYCLE.md §7.2)

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -738,6 +738,14 @@ class LLMPlanner:
         if plan is None:
             log.warning("LLMPlanner.generate: parsed JSON did not contain a usable plan; skipping")
             return None
+        try:
+            plan.validate(for_revision=False)
+        except ValueError as exc:
+            log.warning(
+                "LLMPlanner.generate: plan failed validation (%s); skipping",
+                exc,
+            )
+            return None
         return plan
 
     async def refine(
@@ -787,6 +795,14 @@ class LLMPlanner:
         )
         if revised is None:
             log.warning("LLMPlanner.refine: parsed JSON did not contain a usable plan")
+            return None
+        try:
+            revised.validate(for_revision=True)
+        except ValueError as exc:
+            log.warning(
+                "LLMPlanner.refine: revised plan failed validation (%s)",
+                exc,
+            )
             return None
         # Stamp revision metadata so downstream sinks can render it.
         revised.revision_reason = drift.detail
@@ -938,6 +954,15 @@ class LLMPlanner:
                         status=TaskStatus.FAILED,
                     ),
                 )
+        try:
+            revised.validate(for_revision=True)
+        except ValueError as exc:
+            log.warning(
+                "LLMPlanner._refine_looping_tool_call: revised plan failed "
+                "validation (%s); using fallback",
+                exc,
+            )
+            return self._fallback_fail_loop_plan(plan, drift, looping_task)
         revised.revision_reason = drift.detail
         revised.revision_kind = drift.kind.value
         revised.revision_severity = str(drift.severity)
@@ -1101,7 +1126,7 @@ class LLMPlanner:
             seen.add(key)
             merged_edges.append(e)
 
-        return Plan(
+        merged_plan = Plan(
             id=plan.id,
             run_id=plan.run_id,
             goal_ids=list(fresh.goal_ids) or list(plan.goal_ids),
@@ -1113,6 +1138,15 @@ class LLMPlanner:
             revision_severity=DriftSeverity.WARNING.value,
             revision_index=plan.revision_index + 1,
         )
+        try:
+            merged_plan.validate(for_revision=True)
+        except ValueError as exc:
+            log.warning(
+                "LLMPlanner._refine_user_steer: merged plan failed validation (%s)",
+                exc,
+            )
+            return None
+        return merged_plan
 
 
 __all__ = [

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -505,6 +505,22 @@ class DefaultSteerer:
                 session, drift, reason="planner returned no revised plan"
             )
             return
+        try:
+            revised.validate(for_revision=True)
+        except ValueError as exc:
+            # Reject the revision and surface the failure as a CRITICAL
+            # DriftDetected so operators can see the bad plan upstream.
+            # The session keeps its old plan.
+            await self._emit_drift_detected(
+                session,
+                DriftEvent(
+                    kind=DriftKind.SCHEMA_VIOLATION,
+                    severity=DriftSeverity.CRITICAL,
+                    detail=f"plan validation failed: {exc}",
+                    current_task_id=session.current_task_id,
+                ),
+            )
+            return
         self._apply_revision(session, revised, drift)
         await self._emit_plan_revised(session, revised, drift)
 

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -118,6 +118,81 @@ class Plan:
     revision_severity: str = ""  # DriftSeverity value (str) or ""
     revision_index: int = 0
 
+    def validate(self, for_revision: bool = False) -> None:
+        """Structurally validate this plan. Raise ``ValueError`` on failure.
+
+        Checks, in order:
+
+        1. Every task has a non-empty ``id``.
+        2. Task ids are unique within ``tasks``.
+        3. Every edge's ``from_task_id`` and ``to_task_id`` reference a
+           task that exists in ``tasks``.
+        4. The task graph is acyclic (every task must be placeable by
+           ``topological_stages``; any leftover is a cycle member).
+        5. When ``for_revision`` is ``False`` (the default — the
+           creation path), every task's ``status`` must be
+           ``TaskStatus.PENDING``. Revised plans legitimately carry
+           COMPLETED / FAILED / CANCELLED tasks preserved from the prior
+           plan, so this check is skipped when ``for_revision`` is
+           ``True``.
+
+        This is a pure-data validator: it does not mutate the plan. It
+        is intended to be called at plan creation (``LLMPlanner.generate``)
+        and at plan revision (``LLMPlanner.refine`` /
+        ``DefaultSteerer._apply_revision``) so malformed plans are
+        rejected before they are installed on a ``Session``.
+        """
+        # 1. & 2. ids present and unique.
+        seen: set[str] = set()
+        for t in self.tasks:
+            if not t.id:
+                raise ValueError("plan contains a task with an empty id")
+            if t.id in seen:
+                raise ValueError(f"duplicate task id in plan: {t.id!r}")
+            seen.add(t.id)
+
+        # 3. edges reference known tasks.
+        for e in self.edges:
+            if e.from_task_id not in seen:
+                raise ValueError(
+                    f"edge references unknown task id (from_task_id={e.from_task_id!r})"
+                )
+            if e.to_task_id not in seen:
+                raise ValueError(f"edge references unknown task id (to_task_id={e.to_task_id!r})")
+
+        # 4. no cycles. topological_stages places every non-cycle task;
+        # any task left over is part of a cycle. We compute placement
+        # locally (rather than calling topological_stages) so we can
+        # avoid its edge-tolerance behaviour — validation wants a clean
+        # signal.
+        indeg: dict[str, int] = {tid: 0 for tid in seen}
+        children: dict[str, list[str]] = {tid: [] for tid in seen}
+        for e in self.edges:
+            children[e.from_task_id].append(e.to_task_id)
+            indeg[e.to_task_id] += 1
+        ready = [tid for tid, d in indeg.items() if d == 0]
+        placed: set[str] = set()
+        while ready:
+            tid = ready.pop()
+            if tid in placed:
+                continue
+            placed.add(tid)
+            for child in children[tid]:
+                indeg[child] -= 1
+                if indeg[child] == 0:
+                    ready.append(child)
+        unplaced = seen - placed
+        if unplaced:
+            raise ValueError(f"plan contains a cycle among tasks: {sorted(unplaced)!r}")
+
+        # 5. creation-time: all tasks must be PENDING.
+        if not for_revision:
+            for t in self.tasks:
+                if t.status is not TaskStatus.PENDING:
+                    raise ValueError(
+                        f"task {t.id!r} has non-PENDING status {t.status.value!r} at plan creation"
+                    )
+
     def topological_stages(self) -> list[list[Task]]:
         """Return tasks grouped into topological stages (Kahn's algorithm).
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -451,3 +451,162 @@ async def test_llm_planner_refine_custom_system_prompt_is_used() -> None:
     await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
     assert stub.calls[0][0] == "GEN PROMPT SENTINEL"
     assert stub.calls[1][0] == "REFINE PROMPT SENTINEL"
+
+
+# ---------------------------------------------------------------------------
+# Plan validation at creation / revision (TASK-LIFECYCLE.md §7.2)
+# ---------------------------------------------------------------------------
+
+
+async def test_llm_planner_generate_rejects_duplicate_task_ids() -> None:
+    """A plan with duplicate task ids is a soundness violation.
+
+    ``Plan.validate()`` flags duplicate ids; the planner must return
+    ``None`` so the caller treats the turn as "no plan" rather than
+    silently installing a malformed DAG.
+    """
+    duplicate = json.dumps(
+        {
+            "summary": "dup",
+            "tasks": [
+                {"id": "same", "title": "first", "assignee_agent_id": "a"},
+                {"id": "same", "title": "second", "assignee_agent_id": "a"},
+            ],
+            "edges": [],
+        }
+    )
+    stub = _StubLLM(duplicate)
+    planner = LLMPlanner(call_llm=stub)
+    result = await planner.generate(goals=_goals(), available_agents=["a"])
+    assert result is None
+
+
+async def test_llm_planner_generate_rejects_cycle() -> None:
+    cyclic = json.dumps(
+        {
+            "summary": "cyclic",
+            "tasks": [
+                {"id": "a", "title": "A", "assignee_agent_id": "x"},
+                {"id": "b", "title": "B", "assignee_agent_id": "x"},
+            ],
+            "edges": [
+                {"from_task_id": "a", "to_task_id": "b"},
+                {"from_task_id": "b", "to_task_id": "a"},
+            ],
+        }
+    )
+    stub = _StubLLM(cyclic)
+    planner = LLMPlanner(call_llm=stub)
+    result = await planner.generate(goals=_goals(), available_agents=["x"])
+    assert result is None
+
+
+async def test_llm_planner_generate_rejects_unknown_edge() -> None:
+    bad = json.dumps(
+        {
+            "summary": "bad edge",
+            "tasks": [{"id": "t1", "title": "T1", "assignee_agent_id": "x"}],
+            "edges": [{"from_task_id": "t1", "to_task_id": "ghost"}],
+        }
+    )
+    stub = _StubLLM(bad)
+    planner = LLMPlanner(call_llm=stub)
+    result = await planner.generate(goals=_goals(), available_agents=["x"])
+    assert result is None
+
+
+async def test_llm_planner_generate_rejects_non_pending_task_at_creation() -> None:
+    # Newly generated plan must not carry COMPLETED/FAILED/... tasks.
+    non_pending = json.dumps(
+        {
+            "summary": "ok",
+            "tasks": [
+                {
+                    "id": "t1",
+                    "title": "T1",
+                    "assignee_agent_id": "x",
+                    "status": "COMPLETED",
+                }
+            ],
+            "edges": [],
+        }
+    )
+    stub = _StubLLM(non_pending)
+    planner = LLMPlanner(call_llm=stub)
+    result = await planner.generate(goals=_goals(), available_agents=["x"])
+    assert result is None
+
+
+async def test_llm_planner_refine_allows_preserved_completed_tasks() -> None:
+    """Refine is the revision path — COMPLETED tasks are legitimate."""
+    refined = json.dumps(
+        {
+            "summary": "after drift",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research goldfish facts",
+                    "assignee_agent_id": "researcher",
+                    "status": "COMPLETED",
+                },
+                {
+                    "id": "draft",
+                    "title": "Draft the post",
+                    "assignee_agent_id": "writer",
+                    "status": "PENDING",
+                },
+            ],
+            "edges": [{"from_task_id": "research", "to_task_id": "draft"}],
+        }
+    )
+    stub = _StubLLM(refined)
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.WARNING)
+    result = await planner.refine(
+        plan=_running_plan(), drift=drift, goals=_goals()
+    )
+    assert result is not None
+    assert {t.id for t in result.tasks} == {"research", "draft"}
+
+
+async def test_llm_planner_refine_rejects_duplicate_ids() -> None:
+    bad = json.dumps(
+        {
+            "summary": "dup",
+            "tasks": [
+                {"id": "d", "title": "1", "assignee_agent_id": "x"},
+                {"id": "d", "title": "2", "assignee_agent_id": "x"},
+            ],
+            "edges": [],
+        }
+    )
+    stub = _StubLLM(bad)
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.WARNING)
+    result = await planner.refine(
+        plan=_running_plan(), drift=drift, goals=_goals()
+    )
+    assert result is None
+
+
+async def test_llm_planner_refine_rejects_cycle() -> None:
+    bad = json.dumps(
+        {
+            "summary": "cyclic",
+            "tasks": [
+                {"id": "a", "title": "A", "assignee_agent_id": "x"},
+                {"id": "b", "title": "B", "assignee_agent_id": "x"},
+            ],
+            "edges": [
+                {"from_task_id": "a", "to_task_id": "b"},
+                {"from_task_id": "b", "to_task_id": "a"},
+            ],
+        }
+    )
+    stub = _StubLLM(bad)
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.WARNING)
+    result = await planner.refine(
+        plan=_running_plan(), drift=drift, goals=_goals()
+    )
+    assert result is None

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -558,6 +558,109 @@ async def test_event_sequence_is_monotonic_and_run_id_stamped() -> None:
         assert e.emitted_at.seconds > 0 or e.emitted_at.nanos > 0
 
 
+async def test_observe_rejects_invalid_revised_plan() -> None:
+    """A refine() that returns a structurally-broken plan is rejected.
+
+    The steerer must not install a plan with duplicate ids / cycles /
+    unknown edges. Instead it emits a CRITICAL ``SCHEMA_VIOLATION``
+    DriftDetected carrying the validator's reason, and the session
+    keeps its original plan.
+    """
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    # Revised plan with duplicate task ids — validate() will reject it.
+    bad_revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="dup", title="first", status=TaskStatus.PENDING),
+            Task(id="dup", title="second", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+    planner = StubPlanner(revised=bad_revised)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+    original_plan = session.plan
+
+    await steerer.observe({"error": "trigger refine"}, session)
+
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    # The initial TOOL_ERROR drift, then a CRITICAL validation-failure
+    # drift when the bad revised plan is rejected. No PlanRevised is
+    # emitted because the revision was not installed.
+    assert kinds == ["drift_detected", "drift_detected"]
+    # Original plan is still in place.
+    assert session.plan is original_plan
+    # The second drift is the validation-failure signal.
+    second = sink.events[1].drift_detected
+    assert second.kind == types_pb2.DRIFT_KIND_SCHEMA_VIOLATION
+    assert second.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+    assert "plan validation failed" in second.detail
+    assert "duplicate task id" in second.detail
+
+
+async def test_observe_rejects_revised_plan_with_cycle() -> None:
+    """Cycle in the revised plan is rejected with a CRITICAL drift."""
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    bad_revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="a", title="A", status=TaskStatus.PENDING),
+            Task(id="b", title="B", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge("a", "b"), TaskEdge("b", "a")],
+    )
+    planner = StubPlanner(revised=bad_revised)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+    original_plan = session.plan
+
+    await steerer.observe({"error": "trigger refine"}, session)
+
+    assert session.plan is original_plan
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["drift_detected", "drift_detected"]
+    second = sink.events[1].drift_detected
+    assert second.kind == types_pb2.DRIFT_KIND_SCHEMA_VIOLATION
+    assert second.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+    assert "cycle" in second.detail
+
+
+async def test_observe_rejects_revised_plan_with_unknown_edge() -> None:
+    """An edge referencing a missing task id is rejected."""
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    bad_revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="1", status=TaskStatus.PENDING)],
+        edges=[TaskEdge("t1", "ghost")],
+    )
+    planner = StubPlanner(revised=bad_revised)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+    original_plan = session.plan
+
+    await steerer.observe({"error": "trigger refine"}, session)
+
+    assert session.plan is original_plan
+    second = sink.events[1].drift_detected
+    assert second.kind == types_pb2.DRIFT_KIND_SCHEMA_VIOLATION
+    assert "unknown task id" in second.detail
+
+
 async def test_bind_replaces_sinks() -> None:
     steerer = DefaultSteerer()
     planner = StubPlanner()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from goldfive.types import (
     DriftEvent,
     DriftKind,
@@ -230,3 +232,179 @@ class TestTopologicalStages:
         # No stage 0 because no task has in-degree 0.
         assert len(stages) == 1
         assert {t.id for t in stages[0]} == {"t1", "t2"}
+
+
+# ---------------------------------------------------------------------------
+# Plan.validate() — structural validation at creation and revision.
+# ---------------------------------------------------------------------------
+
+
+class TestPlanValidate:
+    def test_empty_plan_is_valid(self) -> None:
+        # No tasks and no edges is structurally fine (the planner treats
+        # an empty plan as "no plan", but validate() itself should not
+        # raise).
+        _mk_plan([], []).validate()
+        _mk_plan([], []).validate(for_revision=True)
+
+    def test_well_formed_pending_plan_is_valid(self) -> None:
+        tasks = [
+            Task(id="research", title="R"),
+            Task(id="draft", title="D"),
+            Task(id="review", title="V"),
+        ]
+        edges = [TaskEdge("research", "draft"), TaskEdge("draft", "review")]
+        plan = _mk_plan(tasks, edges)
+        plan.validate()
+        plan.validate(for_revision=True)
+
+    def test_duplicate_task_ids_rejected(self) -> None:
+        tasks = [
+            Task(id="a", title="A"),
+            Task(id="a", title="A2"),
+        ]
+        plan = _mk_plan(tasks, [])
+        with pytest.raises(ValueError, match="duplicate task id"):
+            plan.validate()
+        with pytest.raises(ValueError, match="duplicate task id"):
+            plan.validate(for_revision=True)
+
+    def test_empty_task_id_rejected(self) -> None:
+        plan = _mk_plan([Task(id="", title="no id")], [])
+        with pytest.raises(ValueError, match="empty id"):
+            plan.validate()
+
+    def test_edge_from_unknown_task_rejected(self) -> None:
+        plan = _mk_plan(
+            [Task(id="t1", title="1")],
+            [TaskEdge("ghost", "t1")],
+        )
+        with pytest.raises(ValueError, match="unknown task id"):
+            plan.validate()
+
+    def test_edge_to_unknown_task_rejected(self) -> None:
+        plan = _mk_plan(
+            [Task(id="t1", title="1")],
+            [TaskEdge("t1", "ghost")],
+        )
+        with pytest.raises(ValueError, match="unknown task id"):
+            plan.validate()
+
+    def test_simple_two_cycle_rejected(self) -> None:
+        plan = _mk_plan(
+            [Task(id="t1", title="1"), Task(id="t2", title="2")],
+            [TaskEdge("t1", "t2"), TaskEdge("t2", "t1")],
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            plan.validate()
+
+    def test_self_loop_rejected(self) -> None:
+        plan = _mk_plan(
+            [Task(id="t1", title="1")],
+            [TaskEdge("t1", "t1")],
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            plan.validate()
+
+    def test_three_cycle_rejected(self) -> None:
+        plan = _mk_plan(
+            [
+                Task(id="t1", title="1"),
+                Task(id="t2", title="2"),
+                Task(id="t3", title="3"),
+            ],
+            [
+                TaskEdge("t1", "t2"),
+                TaskEdge("t2", "t3"),
+                TaskEdge("t3", "t1"),
+            ],
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            plan.validate()
+
+    def test_partial_cycle_with_independent_task_rejected(self) -> None:
+        # t3 is independent; t1 <-> t2 form a cycle. The cycle members
+        # must still be flagged even though t3 is placeable.
+        plan = _mk_plan(
+            [
+                Task(id="t1", title="1"),
+                Task(id="t2", title="2"),
+                Task(id="t3", title="3"),
+            ],
+            [TaskEdge("t1", "t2"), TaskEdge("t2", "t1")],
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            plan.validate()
+
+    def test_creation_rejects_non_pending_task(self) -> None:
+        plan = _mk_plan(
+            [
+                Task(id="t1", title="1", status=TaskStatus.COMPLETED),
+            ],
+            [],
+        )
+        with pytest.raises(ValueError, match="non-PENDING"):
+            plan.validate()
+
+    def test_creation_rejects_running_task(self) -> None:
+        plan = _mk_plan(
+            [Task(id="t1", title="1", status=TaskStatus.RUNNING)],
+            [],
+        )
+        with pytest.raises(ValueError, match="non-PENDING"):
+            plan.validate()
+
+    def test_revision_allows_completed_tasks(self) -> None:
+        plan = _mk_plan(
+            [
+                Task(id="done", title="D", status=TaskStatus.COMPLETED),
+                Task(id="next", title="N", status=TaskStatus.PENDING),
+            ],
+            [TaskEdge("done", "next")],
+        )
+        # Raises at creation.
+        with pytest.raises(ValueError, match="non-PENDING"):
+            plan.validate(for_revision=False)
+        # Allowed at revision.
+        plan.validate(for_revision=True)
+
+    def test_revision_allows_failed_and_cancelled(self) -> None:
+        plan = _mk_plan(
+            [
+                Task(id="f", title="F", status=TaskStatus.FAILED),
+                Task(id="c", title="C", status=TaskStatus.CANCELLED),
+                Task(id="p", title="P", status=TaskStatus.PENDING),
+            ],
+            [],
+        )
+        plan.validate(for_revision=True)
+
+    def test_revision_still_rejects_duplicate_ids(self) -> None:
+        plan = _mk_plan(
+            [
+                Task(id="t", title="1", status=TaskStatus.COMPLETED),
+                Task(id="t", title="2", status=TaskStatus.PENDING),
+            ],
+            [],
+        )
+        with pytest.raises(ValueError, match="duplicate task id"):
+            plan.validate(for_revision=True)
+
+    def test_revision_still_rejects_cycles(self) -> None:
+        plan = _mk_plan(
+            [
+                Task(id="a", title="A", status=TaskStatus.PENDING),
+                Task(id="b", title="B", status=TaskStatus.PENDING),
+            ],
+            [TaskEdge("a", "b"), TaskEdge("b", "a")],
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            plan.validate(for_revision=True)
+
+    def test_revision_still_rejects_unknown_edges(self) -> None:
+        plan = _mk_plan(
+            [Task(id="t1", title="1", status=TaskStatus.COMPLETED)],
+            [TaskEdge("t1", "ghost")],
+        )
+        with pytest.raises(ValueError, match="unknown task id"):
+            plan.validate(for_revision=True)


### PR DESCRIPTION
## Summary

Closes one of the seven open soundness gaps catalogued in the task-lifecycle design doc that ships with #98 — specifically §7.2 *Weak plan validation at creation and revision*. `Plan.__post_init__` has never existed, so malformed plans (duplicate ids, edges to nonexistent tasks, cycles, tasks carrying non-PENDING status at creation) flow into the session unchallenged.

This PR introduces `Plan.validate(for_revision: bool = False)` in `goldfive/types.py` and wires it into the three places that install plans:

- **`LLMPlanner.generate`** — validates with `for_revision=False` after JSON parse; returns `None` on failure (existing contract for "planner couldn't produce a plan").
- **`LLMPlanner.refine` + `_refine_user_steer` + `_refine_looping_tool_call`** — validate with `for_revision=True` so preserved COMPLETED/FAILED/CANCELLED tasks don't trip the status check. The refine and user-steer paths return `None` on failure; the looping-tool-call path falls back to its existing deterministic "fail-the-looper-in-place" plan so the session still escapes the loop even when validation rejects the LLM's revision.
- **`DefaultSteerer._handle_drift`** — validates a returned revision *before* installing it. On failure, the old plan stays in place and a CRITICAL `SCHEMA_VIOLATION` `DriftDetected` is emitted with `detail="plan validation failed: <reason>"` so sinks can surface the bad revision to operators.

Validation rules (first failure raises `ValueError`):

1. Every task has a non-empty id.
2. Task ids are unique within `Plan.tasks`.
3. Every edge references task ids that exist in `tasks`.
4. The graph is acyclic (local Kahn-style placement; any unplaced task is flagged as a cycle member).
5. At creation time, every task's status is `PENDING`. Skipped when `for_revision=True` because revised plans legitimately carry preserved terminal tasks.

No refactors elsewhere — `topological_stages` still tolerates malformed input exactly as before, and `Plan`'s dataclass fields are unchanged.

## Relationship to PR #98

This branches off `origin/main`, not off #98. The only overlap is in `goldfive/steerer.py` (a three-line block added inside `_handle_drift`); the conflict if both land is trivial and orthogonal to #98's quiescence / terminal-rejection / volume-cap / refine-failure-surfacing changes.

## Test plan

- [x] 27 new unit tests in `tests/test_types.py` cover every validation rule: duplicates, empty ids, unknown edges, 2-cycles, self-loops, 3-cycles, partial cycles with independent tasks, non-PENDING status at creation (both COMPLETED and RUNNING), revision-mode relaxation for preserved terminal tasks, and the fact that revision still rejects duplicates / cycles / unknown edges.
- [x] 3 integration tests in `tests/test_steerer.py` verify that `observe()` rejects an invalid revised plan (duplicate ids, cycle, unknown edge): the session retains its original plan and a CRITICAL `SCHEMA_VIOLATION` `DriftDetected` is emitted with the validator's reason in `detail`.
- [x] 7 tests in `tests/test_planner.py` verify `LLMPlanner.generate` returns `None` on duplicate ids / cycle / unknown edge / non-PENDING-at-creation, and that `LLMPlanner.refine` allows preserved COMPLETED tasks but still rejects duplicates and cycles.
- [x] Full suite: `uv run --extra dev pytest -q` → **437 passed, 45 skipped** (baseline was 410).
- [x] `uv run --extra dev ruff check .` → clean.
