### PR TITLE
Heal ADK session conversation history on mid-invocation cancel (TASK-LIFECYCLE.md §7.4)

### DIFF
--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -31,6 +31,7 @@ module is gated so ``import goldfive.adapters.adk`` raises a clear
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from collections.abc import Mapping
@@ -251,6 +252,105 @@ def _task_is_terminal(task: Task, session: Session) -> bool:
     return False
 
 
+def _function_call_ids_in_event(event: Any) -> list[tuple[str, str]]:
+    """Return ``(id, name)`` pairs for every function call in ``event``.
+
+    Tolerates events that don't expose the helper method (fake events in
+    tests) by walking ``event.content.parts`` directly.
+    """
+    getter = getattr(event, "get_function_calls", None)
+    if callable(getter):
+        try:
+            calls = getter() or []
+        except Exception:  # noqa: BLE001
+            calls = []
+    else:
+        calls = []
+        content = getattr(event, "content", None)
+        for part in getattr(content, "parts", None) or ():
+            fc = getattr(part, "function_call", None)
+            if fc is not None:
+                calls.append(fc)
+    out: list[tuple[str, str]] = []
+    for fc in calls:
+        fc_id = getattr(fc, "id", None)
+        if fc_id:
+            out.append((str(fc_id), str(getattr(fc, "name", "") or "")))
+    return out
+
+
+def _function_response_ids_in_event(event: Any) -> list[str]:
+    """Return the ``function_response.id`` values in ``event``.
+
+    Mirrors :func:`_function_call_ids_in_event` but for responses.
+    """
+    getter = getattr(event, "get_function_responses", None)
+    if callable(getter):
+        try:
+            responses = getter() or []
+        except Exception:  # noqa: BLE001
+            responses = []
+    else:
+        responses = []
+        content = getattr(event, "content", None)
+        for part in getattr(content, "parts", None) or ():
+            fr = getattr(part, "function_response", None)
+            if fr is not None:
+                responses.append(fr)
+    out: list[str] = []
+    for fr in responses:
+        fr_id = getattr(fr, "id", None)
+        if fr_id:
+            out.append(str(fr_id))
+    return out
+
+
+def _build_cancelled_response_event(
+    *,
+    function_call_id: str,
+    tool_name: str,
+    author: str,
+    invocation_id: str,
+    reason: str,
+) -> Any:
+    """Synthesize a ``function_response`` ADK :class:`Event` for ``function_call_id``.
+
+    Used on mid-invocation cancel: ADK's session conversation history would
+    otherwise contain an assistant event with a ``function_call`` that never
+    receives a matching ``function_response``, which confuses subsequent LLM
+    turns (the "Missing tool results for tool_call_id(s): [...]" symptom in
+    driver logs). This builder produces a minimally-shaped response event
+    that the next turn's request assembler will pair with the orphan call.
+    """
+    from google.adk.events.event import Event  # type: ignore
+    from google.genai import types  # type: ignore
+
+    part = types.Part.from_function_response(
+        name=tool_name or "unknown_tool",
+        response={
+            "goldfive_cancelled": True,
+            "reason": reason,
+            "detail": (
+                "Tool call was cancelled mid-invocation by goldfive "
+                "(USER_STEER / USER_CANCEL control). This synthetic "
+                "response was appended to preserve session history "
+                "well-formedness."
+            ),
+        },
+    )
+    # Preserve the pairing so ADK's find_event_by_function_call_id
+    # correctly matches this response to the orphan function_call.
+    if part.function_response is not None:
+        part.function_response.id = function_call_id
+
+    content = types.Content(role="user", parts=[part])
+    return Event(
+        invocation_id=invocation_id or "",
+        author=author or "user",
+        content=content,
+    )
+
+
 def _new_message_parts(task: Task) -> Any:
     """Build the ADK user ``Content`` the adapter sends for a task turn.
 
@@ -332,6 +432,15 @@ class ADKAdapter:
         self._tool_handlers: dict[str, Any] = {}
         # The current Steerer. Set by bind_steerer() before invoke().
         self._steerer: Steerer | None = None
+        # Pending ADK function_call ids observed in the current invoke()'s
+        # event stream that have not yet received a matching
+        # function_response. Maintained so _heal_pending_tool_calls can
+        # synthesize "cancelled" responses on mid-invocation cancel /
+        # unexpected exception and keep the ADK session's conversation
+        # history well-formed. Paired with _pending_tool_call_names so
+        # the synthetic response can name its tool.
+        self._pending_tool_call_ids: set[str] = set()
+        self._pending_tool_call_names: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Post-construction plugin install
@@ -510,6 +619,15 @@ class ADKAdapter:
         stop_reason = "completed"
         err: Exception | None = None
         last_event: Any = None
+        last_invocation_id = ""
+        # Reset per-invocation pending-id bookkeeping. An adapter is
+        # typically single-shot per invoke() so there shouldn't be
+        # leftover state, but be defensive — if a prior invoke()
+        # returned early without healing (shouldn't happen), we'd
+        # otherwise synthesize stale responses now.
+        self._pending_tool_call_ids.clear()
+        self._pending_tool_call_names.clear()
+        was_cancelled = False
         try:
             new_message = _new_message_parts(task)
             async for event in self._runner.run_async(
@@ -518,6 +636,18 @@ class ADKAdapter:
                 new_message=new_message,
             ):
                 last_event = event
+                inv_id = getattr(event, "invocation_id", "") or ""
+                if inv_id:
+                    last_invocation_id = inv_id
+                # Track outstanding function_call ids so we can heal
+                # history on mid-invocation cancel (see _heal_pending_tool_calls).
+                for fc_id, fc_name in _function_call_ids_in_event(event):
+                    self._pending_tool_call_ids.add(fc_id)
+                    if fc_name:
+                        self._pending_tool_call_names[fc_id] = fc_name
+                for fr_id in _function_response_ids_in_event(event):
+                    self._pending_tool_call_ids.discard(fr_id)
+                    self._pending_tool_call_names.pop(fr_id, None)
                 text = _extract_text_from_event(event)
                 if text:
                     final_text = text
@@ -534,11 +664,48 @@ class ADKAdapter:
                 if _task_is_terminal(task, session):
                     stop_reason = "task_terminal"
                     break
+        except asyncio.CancelledError:
+            was_cancelled = True
+            stop_reason = "cancelled"
+            # Heal session history BEFORE re-raising so the next
+            # invoke() doesn't hit a "Missing tool results for
+            # tool_call_id(s)" from LiteLLM / underlying providers.
+            await self._heal_pending_tool_calls(
+                session_id=session_id,
+                invocation_id=last_invocation_id,
+                reason="cancelled_mid_invocation",
+            )
+            raise
         except Exception as exc:  # noqa: BLE001
             err = exc
             stop_reason = f"error:{type(exc).__name__}"
             log.debug("ADKAdapter.invoke: runner.run_async raised: %s", exc)
+            # Also heal on non-cancel exceptions — the same malformed-
+            # history symptom can surface if the runner raises partway
+            # through a tool round-trip (e.g. provider 5xx between
+            # function_call and function_response).
+            await self._heal_pending_tool_calls(
+                session_id=session_id,
+                invocation_id=last_invocation_id,
+                reason=f"error:{type(exc).__name__}",
+            )
         finally:
+            if not was_cancelled:
+                # On normal completion there should be nothing pending,
+                # but if the stream ended with an orphan call (unusual —
+                # e.g. runner yielded a final event without the matching
+                # tool response) heal it so the next turn isn't poisoned.
+                if self._pending_tool_call_ids:
+                    log.warning(
+                        "ADKAdapter.invoke: %d function_call id(s) ended without "
+                        "responses on normal exit; healing session history",
+                        len(self._pending_tool_call_ids),
+                    )
+                    await self._heal_pending_tool_calls(
+                        session_id=session_id,
+                        invocation_id=last_invocation_id,
+                        reason="unexpected_orphan_on_normal_exit",
+                    )
             if isinstance(state, Mapping):
                 try:
                     state.pop(SESSION_CONTEXT_STATE_KEY, None)  # type: ignore[attr-defined]
@@ -582,6 +749,125 @@ class ADKAdapter:
             log.debug("ADKAdapter._ensure_session: create_session raised: %s", exc)
         self._session_id = new_id
         return new_id
+
+    async def _heal_pending_tool_calls(
+        self,
+        *,
+        session_id: str,
+        invocation_id: str,
+        reason: str,
+    ) -> None:
+        """Append synthetic ``function_response`` events for orphan tool calls.
+
+        Called from :meth:`invoke`'s cancel / exception paths. For every
+        ``function_call`` id still pending in :attr:`_pending_tool_call_ids`,
+        build a matching response event (see
+        :func:`_build_cancelled_response_event`) and append it to the ADK
+        session via ``session_service.append_event``. Best-effort: logs and
+        swallows individual failures so healing one orphan doesn't block
+        the others.
+
+        Investigated alternatives:
+
+        * ADK does not expose a higher-level "heal session" helper.
+          ``BaseSessionService.append_event`` is the public path used by
+          :class:`~google.adk.runners.Runner` itself (see
+          ``runners.py:1024`` and ``:857``).
+        * We intentionally don't re-enter ``runner.run_async`` with a
+          synthetic user message because the runner would then try to
+          drive another LLM turn, which is exactly what we're trying to
+          avoid after a cancel.
+        """
+        if not self._pending_tool_call_ids:
+            return
+
+        session_service = getattr(self._runner, "session_service", None)
+        if session_service is None:
+            log.debug(
+                "ADKAdapter._heal_pending_tool_calls: runner has no "
+                "session_service; cannot heal %d orphan tool call(s)",
+                len(self._pending_tool_call_ids),
+            )
+            self._pending_tool_call_ids.clear()
+            self._pending_tool_call_names.clear()
+            return
+
+        append = getattr(session_service, "append_event", None)
+        get = getattr(session_service, "get_session", None)
+        if not callable(append) or not callable(get):
+            log.debug(
+                "ADKAdapter._heal_pending_tool_calls: session_service lacks "
+                "append_event/get_session; cannot heal %d orphan tool call(s)",
+                len(self._pending_tool_call_ids),
+            )
+            self._pending_tool_call_ids.clear()
+            self._pending_tool_call_names.clear()
+            return
+
+        try:
+            coro = get(
+                app_name=self._app_name,
+                user_id=self._user_id,
+                session_id=session_id,
+            )
+            adk_session = await coro if hasattr(coro, "__await__") else coro
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "ADKAdapter._heal_pending_tool_calls: get_session raised: %s",
+                exc,
+            )
+            self._pending_tool_call_ids.clear()
+            self._pending_tool_call_names.clear()
+            return
+
+        if adk_session is None:
+            self._pending_tool_call_ids.clear()
+            self._pending_tool_call_names.clear()
+            return
+
+        host_author = str(getattr(self._agent, "name", "") or "") or "user"
+        pending_ids = sorted(self._pending_tool_call_ids)
+        healed = 0
+        for fc_id in pending_ids:
+            tool_name = self._pending_tool_call_names.get(fc_id, "")
+            try:
+                synth = _build_cancelled_response_event(
+                    function_call_id=fc_id,
+                    tool_name=tool_name,
+                    author=host_author,
+                    invocation_id=invocation_id,
+                    reason=reason,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "ADKAdapter._heal_pending_tool_calls: could not build "
+                    "synthetic event for %s: %s",
+                    fc_id,
+                    exc,
+                )
+                continue
+            try:
+                coro = append(session=adk_session, event=synth)
+                if hasattr(coro, "__await__"):
+                    await coro
+                healed += 1
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "ADKAdapter._heal_pending_tool_calls: append_event for %s raised: %s",
+                    fc_id,
+                    exc,
+                )
+
+        if healed:
+            log.info(
+                "goldfive ADKAdapter: healed %d orphan tool_call_id(s) after %s (pending=%s)",
+                healed,
+                reason,
+                pending_ids,
+            )
+
+        self._pending_tool_call_ids.clear()
+        self._pending_tool_call_names.clear()
 
     async def _get_session_state(self, session_id: str) -> Any:
         """Fetch the ADK session's mutable state dict for ``session_id``."""

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -596,3 +596,225 @@ async def test_register_reporting_tools_is_idempotent() -> None:
             assert names.count(reporting_name) == 1, (
                 f"{agent.name}: {reporting_name} registered {names.count(reporting_name)} times"
             )
+
+
+# ---------------------------------------------------------------------------
+# Mid-invocation cancel — heal ADK session history for orphan tool_call_ids
+# (TASK-LIFECYCLE.md §7.4). See goldfive.adapters.adk._heal_pending_tool_calls.
+# ---------------------------------------------------------------------------
+
+
+class _FakeADKSession:
+    """Minimal stand-in for ``google.adk.sessions.Session`` for heal tests.
+
+    Only the attributes ``events`` and ``state`` that
+    :meth:`BaseSessionService.append_event` needs are provided.
+    """
+
+    def __init__(self) -> None:
+        self.events: list = []
+        self.state: dict = {}
+
+
+class _FakeSessionService:
+    """Records ``append_event`` calls so heal-path tests can assert on them."""
+
+    def __init__(self) -> None:
+        self._session = _FakeADKSession()
+        self.appended: list = []
+
+    async def create_session(self, **_kwargs) -> _FakeADKSession:
+        return self._session
+
+    async def get_session(self, **_kwargs) -> _FakeADKSession:
+        return self._session
+
+    async def append_event(self, *, session, event):
+        self.appended.append(event)
+        session.events.append(event)
+        return event
+
+
+class _FakeRunner:
+    """Runner stub whose ``run_async`` yields a scripted sequence of events.
+
+    ``events_factory(cancel_event)`` is a zero-arg callable returning an async
+    generator (or an async function). The fixture tests pass a coroutine-like
+    factory that yields function_call events, optionally pauses on a
+    :class:`asyncio.Event`, and can raise :class:`asyncio.CancelledError` to
+    simulate the sequential executor's mid-invocation cancel.
+    """
+
+    def __init__(self, run_async_impl, agent) -> None:
+        self._run_async_impl = run_async_impl
+        self.agent = agent
+        self.app_name = getattr(agent, "name", "fake-app")
+        self.session_service = _FakeSessionService()
+        self.plugin_manager = None
+        self.plugins: list = []
+
+    async def run_async(self, **kwargs):  # noqa: ARG002 — runner signature
+        async for event in self._run_async_impl():
+            yield event
+
+
+def _mk_function_call_event(*, call_id: str, name: str, invocation_id: str = "inv-1"):
+    """Build an ADK ``Event`` carrying a single ``function_call`` part."""
+    from google.adk.events.event import Event  # type: ignore
+    from google.genai import types  # type: ignore
+
+    part = types.Part(function_call=types.FunctionCall(id=call_id, name=name))
+    return Event(
+        invocation_id=invocation_id,
+        author="test_agent",
+        content=types.Content(role="model", parts=[part]),
+    )
+
+
+def _mk_function_response_event(*, call_id: str, name: str, invocation_id: str = "inv-1"):
+    """Build an ADK ``Event`` carrying a matching ``function_response`` part."""
+    from google.adk.events.event import Event  # type: ignore
+    from google.genai import types  # type: ignore
+
+    part = types.Part.from_function_response(name=name, response={"ok": True})
+    part.function_response.id = call_id
+    return Event(
+        invocation_id=invocation_id,
+        author="test_agent",
+        content=types.Content(role="user", parts=[part]),
+    )
+
+
+async def test_cancel_mid_tool_call_heals_session() -> None:
+    """Cancellation mid-tool-round-trip must synthesize a function_response.
+
+    Scenario: runner yields a function_call event for ``call-1`` then the
+    task is cancelled (simulating SequentialExecutor._cancel_invoke_task on
+    a USER_STEER). ADKAdapter must append a synthetic function_response
+    event whose ``id`` matches ``call-1`` so the next invoke() doesn't hit
+    "Missing tool results for tool_call_id".
+    """
+    import asyncio
+
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _make_agent()
+
+    async def _run():
+        yield _mk_function_call_event(call_id="call-1", name="search")
+        # Hang forever; the outer task.cancel() will inject CancelledError.
+        await asyncio.Event().wait()
+        # Unreachable.
+        yield None  # pragma: no cover
+
+    runner = _FakeRunner(_run, agent)
+    adapter = ADKAdapter(runner, session_id="sess-1")
+
+    invoke_task = asyncio.create_task(adapter.invoke(Task(id="t1", title="x"), Session(run_id="r")))
+    # Give the runner a moment to emit the function_call event and start
+    # awaiting the never-set asyncio.Event, then cancel.
+    await asyncio.sleep(0.01)
+    invoke_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await invoke_task
+
+    appended = runner.session_service.appended
+    assert len(appended) == 1, f"expected 1 synthetic response; got {len(appended)}"
+    synth = appended[0]
+    responses = synth.get_function_responses()
+    assert len(responses) == 1
+    assert responses[0].id == "call-1"
+    # The payload flags this as goldfive-synthesized so downstream tools can
+    # tell it apart from a real tool return.
+    assert responses[0].response.get("goldfive_cancelled") is True
+
+
+async def test_multiple_pending_tool_calls_all_healed() -> None:
+    """When multiple function_calls are outstanding at cancel time, all heal.
+
+    Three parallel function_calls are yielded on a single "model turn" event.
+    Cancelling before any response arrives must produce three synthetic
+    function_response events, one per id.
+    """
+    import asyncio
+
+    from google.adk.events.event import Event  # type: ignore
+    from google.genai import types  # type: ignore
+
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _make_agent()
+
+    # Single event carrying three parallel function_call parts, mimicking
+    # ADK's "parallel tool call" shape.
+    multi_parts = [
+        types.Part(function_call=types.FunctionCall(id=f"call-{i}", name=f"t{i}"))
+        for i in (1, 2, 3)
+    ]
+    multi_event = Event(
+        invocation_id="inv-multi",
+        author="test_agent",
+        content=types.Content(role="model", parts=multi_parts),
+    )
+
+    async def _run():
+        yield multi_event
+        await asyncio.Event().wait()
+        yield None  # pragma: no cover
+
+    runner = _FakeRunner(_run, agent)
+    adapter = ADKAdapter(runner, session_id="sess-multi")
+
+    invoke_task = asyncio.create_task(adapter.invoke(Task(id="t1", title="x"), Session(run_id="r")))
+    await asyncio.sleep(0.01)
+    invoke_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await invoke_task
+
+    appended = runner.session_service.appended
+    healed_ids = set()
+    for ev in appended:
+        for fr in ev.get_function_responses():
+            healed_ids.add(fr.id)
+    assert healed_ids == {"call-1", "call-2", "call-3"}, (
+        f"expected all three orphan ids healed; got {healed_ids}"
+    )
+
+
+async def test_heal_is_noop_when_no_pending_calls() -> None:
+    """Clean exit with no orphan function_calls appends nothing.
+
+    Also covers the case where every emitted function_call received a
+    matching function_response before the stream ended — _pending_tool_call_ids
+    should be empty at exit and no synthetic event should be appended.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _make_agent()
+
+    async def _run_clean():
+        # Paired call/response, then quiet exit.
+        yield _mk_function_call_event(call_id="call-ok", name="search")
+        yield _mk_function_response_event(call_id="call-ok", name="search")
+
+    runner_clean = _FakeRunner(_run_clean, agent)
+    adapter_clean = ADKAdapter(runner_clean, session_id="sess-clean")
+    result = await adapter_clean.invoke(Task(id="t1", title="x"), Session(run_id="r"))
+    assert runner_clean.session_service.appended == [], (
+        "healed-path should not fire on a clean exit"
+    )
+    assert result.stop_reason != "cancelled"
+
+    # Also: a truly empty stream (no function_calls at all) — heal must no-op.
+    async def _run_empty():
+        if False:  # pragma: no cover — never yields
+            yield None
+        return
+
+    runner_empty = _FakeRunner(_run_empty, agent)
+    adapter_empty = ADKAdapter(runner_empty, session_id="sess-empty")
+    await adapter_empty.invoke(Task(id="t1", title="x"), Session(run_id="r"))
+    assert runner_empty.session_service.appended == []


### PR DESCRIPTION
## Summary

- Fixes the highest-impact remaining gap from TASK-LIFECYCLE.md §7.4: when `SequentialExecutor._cancel_invoke_task` interrupts `adapter.invoke` mid-ADK-turn on a USER_STEER / USER_CANCEL, ADK's session ends up with an assistant event carrying `function_call` parts but no matching `function_response` parts. The next invocation's LLM request is malformed and the provider returns `Missing tool results for tool_call_id(s): [...]` (per driver logs, repeated 4x with truncated-JSON fallout).
- `ADKAdapter` now tracks outstanding function_call IDs in its `run_async` event loop and, on `CancelledError` / exception / unexpected-orphan normal exit, synthesizes a `function_response` event per pending ID (flagged `goldfive_cancelled=True`) and appends via `session_service.append_event` to heal the conversation history before re-raising.
- Three new tests in `tests/test_adk_adapter.py` cover: cancel-mid-tool-call heals one ID, three parallel calls all heal, clean exits are no-ops. Full suite: 440 passed, 38 skipped.

Refs #98.

## Investigation

Explored the installed ADK package at `.venv/.../google/adk/` rather than assuming:

- `sessions/base_session_service.py` — `BaseSessionService.append_event(session, event)` is the public path; Runner itself uses it (`runners.py:1024`, `:857`, `:684`). No higher-level "heal" helper exists.
- `events/event.py` — `Event.get_function_calls()` / `get_function_responses()` walk `content.parts` and return genai objects carrying `.id` / `.name`.
- `flows/llm_flows/functions.py` `__build_response_event` — canonical shape for a response event is `types.Part.from_function_response(name=..., response={...})` with `part.function_response.id = function_call_id` to preserve pairing for `find_event_by_function_call_id`. We mirror this.
- LiteLLM does NOT ship a `heal_missing_tool_results` helper in the current venv; the error string is produced by the provider-side request validator, not ADK.

## Design trade-offs

- **Direct session mutation via `append_event`** (chosen). Minimal, uses the same API the Runner already uses. Best-effort per ID: individual failures are logged at DEBUG and don't block the others; missing `session_service` / `append_event` / `get_session` falls back to a clean no-op for stub runners (matching existing adapter tolerance).
- **Re-enter `runner.run_async` with a synthetic user message** (rejected, per the design-doc fallback). That would drive another LLM turn, which is exactly what we're avoiding on cancel.
- Heal runs **before** the `CancelledError` is re-raised so the next `invoke()` sees well-formed history. `SequentialExecutor` is untouched.
- Synthetic responses carry `{"goldfive_cancelled": True, "reason": ..., "detail": ...}` so downstream tools can distinguish them from real tool returns.

## Test plan

- [x] `uv run --extra dev --extra adk pytest -q tests/test_adk_adapter.py` — 16 passed
- [x] `uv run --extra dev --extra adk pytest -q` — 440 passed, 38 skipped
- [x] `uv run --extra dev ruff check goldfive/adapters/adk.py tests/test_adk_adapter.py` — clean
- [x] `uv run --extra dev ruff format --check goldfive/adapters/adk.py tests/test_adk_adapter.py` — clean
- [ ] Reviewer: exercise against harmonograf's live-steer scenario that originally surfaced the "Missing tool results" error and confirm the refine-after-steer invocation succeeds.

Do not merge without reviewer sign-off.

Generated with Claude Code.
