### PR TITLE
Per-task retry-lineage cap to bound blast radius (TASK-LIFECYCLE.md §7.7)

### DIFF
--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from typing import TYPE_CHECKING
 
 from goldfive.events import (
@@ -70,6 +71,20 @@ class SequentialExecutor(Executor):
         still aborts via ``fail_fast`` or (in pathological cases) the
         budget; the old default of ``3`` was tuned to the harmonograf
         re-invocation cap and surprised callers running realistic plans.
+    max_retries_per_task_lineage:
+        Upper bound on the number of adapter ``invoke()`` calls that may
+        be spent on any one task "lineage" — the original task plus any
+        refine-spawned retries of it. A lineage is identified by stripping
+        ``retry_`` / ``retry2_`` / ``retryN_`` prefixes from the task id,
+        so e.g. ``t0``, ``retry_t0``, and ``retry2_retry_t0`` all share
+        the lineage root ``t0``. When the cap is reached, the next task
+        in that lineage is skipped (never sent to the adapter) and marked
+        ``FAILED`` in place; downstream tasks then block naturally via
+        ``_pick_next_task``'s dependency check. Defaults to ``3``, which
+        bounds worst-case blast radius to a small constant multiple of
+        the plan size even when a misbehaving refine keeps spawning
+        ``retry_<task>`` clones. Set to a very large number to disable.
+        See ``TASK-LIFECYCLE.md §7.7``.
     fail_fast:
         When ``True`` (default), the first task that ends up ``FAILED`` causes
         the executor to emit ``RunAborted`` and stop. When ``False``, failed
@@ -81,9 +96,11 @@ class SequentialExecutor(Executor):
         self,
         *,
         max_plan_reinvocations: int = 32,
+        max_retries_per_task_lineage: int = 3,
         fail_fast: bool = True,
     ) -> None:
         self.max_plan_reinvocations = int(max_plan_reinvocations)
+        self.max_retries_per_task_lineage = int(max_retries_per_task_lineage)
         self.fail_fast = bool(fail_fast)
 
     # ------------------------------------------------------------------
@@ -121,6 +138,15 @@ class SequentialExecutor(Executor):
         invocations = 0
         failure_reason = ""
         run_failed = False
+
+        # Per-lineage invocation count. The "lineage root" of a task is
+        # its id with any chain of ``retry_`` / ``retryN_`` prefixes
+        # stripped, so ``t0``, ``retry_t0``, and ``retry2_retry_t0`` all
+        # collapse to the same root ``t0``. Bounding this per-run bounds
+        # the worst-case cost of an LLM that keeps refining a failing
+        # task into new ``retry_<...>`` tasks forever. See
+        # ``max_retries_per_task_lineage``.
+        lineage_invocations: dict[str, int] = {}
 
         # Track the plan identity so we detect mid-run revisions by the steerer.
         last_plan_id = plan.id
@@ -188,12 +214,58 @@ class SequentialExecutor(Executor):
                 # and let the post-loop block decide success.
                 break
 
+            # Per-task-lineage cap. Before we spend an invocation on
+            # ``task``, check how many invocations we have already spent
+            # on tasks that share its lineage root. If the cap is
+            # already reached, do not invoke the adapter: transition
+            # ``task`` to FAILED in place and let the outer loop pick up
+            # the next eligible task (or abort if fail_fast). This keeps
+            # a runaway refine loop (``t0`` -> ``retry_t0`` -> ``retry2_retry_t0``
+            # -> ...) from ever reaching the adapter more than N times
+            # per lineage, independent of how many plan revisions happen.
+            lineage_root = _lineage_root(task.id)
+            lineage_count = lineage_invocations.get(lineage_root, 0)
+            if lineage_count >= self.max_retries_per_task_lineage:
+                log.warning(
+                    "SequentialExecutor: lineage cap reached for task=%s "
+                    "(lineage_root=%s, count=%d, cap=%d); marking FAILED "
+                    "without invoking adapter",
+                    task.id, lineage_root, lineage_count,
+                    self.max_retries_per_task_lineage,
+                )
+                await steerer.transition(
+                    task.id,
+                    TaskStatus.FAILED,
+                    detail=(
+                        f"retry-lineage cap reached: "
+                        f"{lineage_count} invocations already spent on "
+                        f"lineage root '{lineage_root}' "
+                        f"(cap={self.max_retries_per_task_lineage})"
+                    ),
+                    session=session,
+                )
+                failure_reason = (
+                    f"task {task.id} skipped: retry-lineage cap "
+                    f"({self.max_retries_per_task_lineage}) reached for "
+                    f"lineage root '{lineage_root}'"
+                )
+                if self.fail_fast:
+                    run_failed = True
+                    break
+                # fail_fast=False: loop around; downstream tasks that
+                # depended on this one will be blocked by _pick_next_task.
+                continue
+
             session.current_task_id = task.id
             invocations += 1
+            lineage_invocations[lineage_root] = lineage_count + 1
 
             log.debug(
-                "SequentialExecutor: invoking task=%s (invocation %d/%d)",
+                "SequentialExecutor: invoking task=%s (invocation %d/%d, "
+                "lineage_root=%s, lineage_count=%d/%d)",
                 task.id, invocations, self.max_plan_reinvocations,
+                lineage_root, lineage_count + 1,
+                self.max_retries_per_task_lineage,
             )
 
             # Auto-announce the task as RUNNING before invoke so agents
@@ -653,6 +725,37 @@ def _find_task(plan: Plan, task_id: str) -> Task | None:
         if t.id == task_id:
             return t
     return None
+
+
+# Precompiled once-per-module: matches a single ``retry_`` or
+# ``retry<N>_`` prefix (N >= 1), e.g. ``retry_``, ``retry2_``, ``retry42_``.
+_RETRY_PREFIX_RE = re.compile(r"^retry(?:\d+)?_")
+
+
+def _lineage_root(task_id: str) -> str:
+    """Return ``task_id`` with any chain of retry prefixes stripped.
+
+    Goldfive does not pin a single spelling for retry-task ids — an LLM
+    planner may emit ``retry_t0``, ``retry2_t0``, or even nested forms
+    like ``retry_retry_t0`` when regenerating a plan after a failure.
+    For per-lineage budgeting we collapse all of those to the same root
+    (here: ``t0``) by repeatedly stripping a leading ``retry_`` or
+    ``retry<N>_`` prefix.
+
+    Empty / None-like ids pass through unchanged so we do not crash on
+    malformed plans.
+    """
+    if not task_id:
+        return task_id
+    root = task_id
+    # Bound the loop so a pathological id like
+    # "retry_retry_retry_..." can't spin forever.
+    for _ in range(16):
+        stripped = _RETRY_PREFIX_RE.sub("", root, count=1)
+        if stripped == root:
+            break
+        root = stripped
+    return root
 
 
 def _any_failed(plan: Plan) -> bool:

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -461,3 +461,324 @@ def test_build_task_nudge_includes_id_title_and_description() -> None:
     assert "Do the thing" in nudge
     assert "Carefully and thoroughly." in nudge
     assert nudge.startswith("Continue executing the plan.")
+
+
+# ---------------------------------------------------------------------------
+# Per-task retry-lineage cap (TASK-LIFECYCLE.md §7.7).
+#
+# The executor bounds how many times any one "task lineage" may be sent to
+# the adapter inside a single run. A lineage is identified by stripping
+# chained ``retry_`` / ``retry<N>_`` prefixes from the task id, so
+# ``t0``, ``retry_t0``, ``retry2_retry_t0`` all share the same root ``t0``
+# and share one invocation budget. This caps blast radius when a
+# misbehaving planner keeps regenerating ``retry_<task>`` clones.
+# ---------------------------------------------------------------------------
+
+
+def test_retry_lineage_cap_default_is_3() -> None:
+    """Sanity: the default lineage cap is 3 (see TASK-LIFECYCLE.md §7.7)."""
+    executor = SequentialExecutor()
+    assert executor.max_retries_per_task_lineage == 3
+
+
+async def test_retry_lineage_cap_fails_task_after_N_retries() -> None:
+    """With cap=2, the 3rd invocation on the same lineage is skipped.
+
+    We simulate a refine loop that keeps producing ``retry_<prev>``
+    versions of a failing task. After 2 invocations on the lineage the
+    executor should refuse to invoke the 3rd clone and transition it
+    to FAILED in place. We run with ``fail_fast=False`` to keep the
+    run going long enough to observe the 3rd clone being refused
+    (fail_fast=True would abort after the first task failure).
+    """
+    # Start with a single task t0. After each failed invocation, the
+    # adapter simulates a refine by swapping session.plan to a new plan
+    # whose only pending task is a ``retry_<prev>`` clone.
+    initial_plan = Plan(
+        id="p0",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[Task(id="t0", title="Task 0")],
+        edges=[],
+    )
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _fail_and_spawn_retry(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        # Fail the current task, then swap in a new plan whose only
+        # pending task is a retry clone. This mirrors what a misbehaving
+        # planner.refine would do.
+        await steerer.transition(task.id, TaskStatus.FAILED, session=session)
+        new_id = f"retry_{task.id}"
+        # Keep prior tasks (all FAILED) so the plan history stays
+        # consistent; append the fresh PENDING retry clone.
+        new_tasks = [
+            Task(id=t.id, title=t.title, status=TaskStatus.FAILED)
+            for t in (session.plan.tasks if session.plan else [])
+        ]
+        new_tasks.append(Task(id=new_id, title=f"retry of {task.title}"))
+        session.plan = Plan(
+            id="p0",
+            run_id=session.run_id,
+            goal_ids=[],
+            tasks=new_tasks,
+            edges=[],
+            revision_index=(session.plan.revision_index if session.plan else 0) + 1,
+        )
+        return InvocationResult(task_id=task.id, text="", stop_reason="failed")
+
+    adapter = StubAdapter(
+        steerer=steerer, planner=planner, on_invoke=_fail_and_spawn_retry
+    )
+
+    # cap=2 -> allow 2 invocations on lineage root "t0"; the 3rd clone
+    # is refused before the adapter is called.
+    executor = SequentialExecutor(
+        max_plan_reinvocations=32,
+        max_retries_per_task_lineage=2,
+        fail_fast=False,
+    )
+    outcome = await executor.run(
+        plan=initial_plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # Adapter saw t0 and retry_t0 only; retry_retry_t0 was refused.
+    assert adapter.invocations == ["t0", "retry_t0"]
+    assert outcome.success is False
+    # The skipped lineage task must be marked FAILED in the session's
+    # current plan without ever hitting the adapter.
+    final = session.plan
+    assert final is not None
+    by_id = {t.id: t.status for t in final.tasks}
+    assert by_id.get("retry_retry_t0") == TaskStatus.FAILED
+
+
+async def test_retry_lineage_cap_is_per_task_not_global() -> None:
+    """Two independent lineages each get their own budget.
+
+    Plan ``a`` and ``b`` are independent roots. With cap=2 each lineage
+    may burn 2 invocations; a cross-lineage invocation must NOT count
+    against a sibling lineage's budget.
+    """
+    tasks = [
+        Task(id="a", title="A"),
+        Task(id="b", title="B"),
+    ]
+    plan = Plan(id="p0", run_id="run-1", goal_ids=[], tasks=tasks, edges=[])
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    # Per-lineage state held outside the closure: each lineage fails
+    # exactly once, then the retry succeeds. Both lineages therefore
+    # spend exactly 2 invocations each and both complete.
+    fail_once: dict[str, bool] = {"a": False, "b": False}
+
+    async def _fail_first_then_succeed(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        # Derive the lineage root by stripping a single "retry_" prefix;
+        # good enough for this 2-deep test.
+        root = task.id[len("retry_"):] if task.id.startswith("retry_") else task.id
+        if not fail_once[root]:
+            fail_once[root] = True
+            await steerer.transition(task.id, TaskStatus.FAILED, session=session)
+            # Add a retry clone so the plan still has work to do.
+            new_tasks = list(session.plan.tasks) if session.plan else []
+            new_tasks.append(
+                Task(id=f"retry_{task.id}", title=f"retry of {task.title}")
+            )
+            session.plan = Plan(
+                id="p0",
+                run_id=session.run_id,
+                goal_ids=[],
+                tasks=new_tasks,
+                edges=list(session.plan.edges) if session.plan else [],
+                revision_index=(session.plan.revision_index if session.plan else 0) + 1,
+            )
+            return InvocationResult(task_id=task.id, text="", stop_reason="failed")
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+
+    adapter = StubAdapter(
+        steerer=steerer, planner=planner, on_invoke=_fail_first_then_succeed
+    )
+
+    executor = SequentialExecutor(
+        max_plan_reinvocations=32,
+        max_retries_per_task_lineage=2,
+        fail_fast=False,
+    )
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # Each lineage got its own budget: we saw exactly four invocations
+    # (original + one retry for each of the two lineages). Neither
+    # lineage was throttled by the other's spending. The original
+    # ``a`` / ``b`` tasks stay FAILED (that's how the retry was
+    # spawned) so ``outcome.success`` is False, but the point of the
+    # test is the invocation count and retry completion below — we
+    # specifically did NOT let one lineage exhaust the cap because the
+    # other's invocations don't count against it.
+    assert adapter.invocations == ["a", "b", "retry_a", "retry_b"]
+    # Both retry clones were invoked and completed — no lineage hit
+    # the cap.
+    final = session.plan
+    assert final is not None
+    by_id = {t.id: t.status for t in final.tasks}
+    assert by_id["retry_a"] == TaskStatus.COMPLETED
+    assert by_id["retry_b"] == TaskStatus.COMPLETED
+    # Nothing was lineage-capped: had the cap been global at 2,
+    # ``retry_b`` would have been refused (4 > 2) and ended FAILED.
+    _ = outcome  # explicitly acknowledge we don't gate on success
+
+
+async def test_retry_lineage_cap_passes_on_successful_retry() -> None:
+    """If a task fails once and its retry succeeds, the cap must not impede.
+
+    With cap=3, a lineage that consumes only 2 invocations (original +
+    one successful retry) should run cleanly to completion — the cap
+    only bites when a lineage exhausts its budget.
+    """
+    initial_plan = Plan(
+        id="p0",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[Task(id="t0", title="Task 0")],
+        edges=[],
+    )
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    attempts = {"n": 0}
+
+    async def _fail_then_retry_succeeds(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        attempts["n"] += 1
+        if task.id == "t0" and attempts["n"] == 1:
+            await steerer.transition(task.id, TaskStatus.FAILED, session=session)
+            # Spawn a retry clone.
+            session.plan = Plan(
+                id="p0",
+                run_id=session.run_id,
+                goal_ids=[],
+                tasks=[
+                    Task(id="t0", title="Task 0", status=TaskStatus.FAILED),
+                    Task(id="retry_t0", title="retry of Task 0"),
+                ],
+                edges=[],
+                revision_index=1,
+            )
+            return InvocationResult(task_id=task.id, text="", stop_reason="failed")
+        # retry_t0 (second invocation in the lineage) succeeds.
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter = StubAdapter(
+        steerer=steerer, planner=planner, on_invoke=_fail_then_retry_succeeds
+    )
+
+    executor = SequentialExecutor(
+        max_plan_reinvocations=32,
+        max_retries_per_task_lineage=3,
+        fail_fast=False,
+    )
+    outcome = await executor.run(
+        plan=initial_plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # Exactly two invocations: the original failing call plus the
+    # successful retry. The cap (3) is never exhausted, so the retry
+    # was allowed through and completed.
+    assert adapter.invocations == ["t0", "retry_t0"]
+    final = session.plan
+    assert final is not None
+    by_id = {t.id: t.status for t in final.tasks}
+    assert by_id["retry_t0"] == TaskStatus.COMPLETED
+    # The original ``t0`` is FAILED (that was how the retry got
+    # spawned) so ``outcome.success`` is False under fail_fast=False;
+    # the behavior under test is that the retry survived the cap, not
+    # that the run summary is a clean pass.
+    _ = outcome
+
+
+async def test_retry_lineage_cap_collapses_nested_retry_prefixes() -> None:
+    """``retry_retry_t0`` and ``retry2_t0`` share lineage root ``t0``.
+
+    Explicit coverage for the prefix-stripping convention so a future
+    change to the regex doesn't silently let nested retry ids escape
+    the lineage cap.
+    """
+    # Construct a plan where all three tasks share the same lineage
+    # root ``t0``. With cap=2 exactly two of them may be invoked; the
+    # third must be skipped.
+    tasks = [
+        Task(id="t0", title="Task 0"),
+        Task(id="retry_t0", title="retry of Task 0"),
+        Task(id="retry_retry_t0", title="retry of retry of Task 0"),
+    ]
+    # Chain them so the executor sees them in order: t0 -> retry_t0 -> retry_retry_t0.
+    edges = [
+        TaskEdge(from_task_id="t0", to_task_id="retry_t0"),
+        TaskEdge(from_task_id="retry_t0", to_task_id="retry_retry_t0"),
+    ]
+    plan = Plan(id="p0", run_id="run-1", goal_ids=[], tasks=tasks, edges=edges)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _complete_task(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_task)
+
+    executor = SequentialExecutor(
+        max_plan_reinvocations=32,
+        max_retries_per_task_lineage=2,
+        fail_fast=False,
+    )
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # Only t0 and retry_t0 are invoked; retry_retry_t0 is refused by the
+    # lineage cap and marked FAILED without hitting the adapter.
+    assert adapter.invocations == ["t0", "retry_t0"]
+    assert outcome.success is False  # one task ended FAILED (retry_retry_t0)
+    by_id = {t.id: t.status for t in plan.tasks}
+    assert by_id["t0"] == TaskStatus.COMPLETED
+    assert by_id["retry_t0"] == TaskStatus.COMPLETED
+    assert by_id["retry_retry_t0"] == TaskStatus.FAILED


### PR DESCRIPTION
## Summary
Fix for #98 / TASK-LIFECYCLE.md §7.7 ("No per-task invocation cap").

`SequentialExecutor.max_plan_reinvocations` (default 32) bounds total invocations across a whole run, but nothing stops a misbehaving planner from producing `retry_<task>` → `retry_retry_<task>` → … indefinitely. Worst-case blast radius is ~32 × 500 = 16 000 LLM calls before the global cap trips. This PR adds a per-task-lineage cap so runaway retries can't burn that budget.

## Gap addressed
- Before: the only invocation cap was global (`max_plan_reinvocations`). A refine that keeps spawning retry clones can spend the entire global budget on a single failing task lineage, starving the rest of the plan.
- After: each "lineage" (a task id and any number of `retry_`/`retryN_` prefixes wrapping it) has its own small budget (default 3). Once exhausted, subsequent clones in that lineage are transitioned to FAILED without hitting the adapter.

## Design
Chose the **simpler of the two designs** sketched in the task spec — count invocations per **lineage root**, where the lineage root is computed at invoke time by stripping a chain of `retry_` / `retry<N>_` prefixes (so `t0`, `retry_t0`, `retry2_retry_t0` all collapse to root `t0`). No Session state, no new field on `Task`, no `lineage_root_id` dataclass field — the prefix convention carries the lineage info and the executor keeps a local `dict[str, int]` keyed by root for the duration of one `run()`.

Why the simpler design:
- User concern in §7.7 is bounding blast radius, not provenance; no downstream consumer needs lineage metadata on Session/Task.
- Executor-local counters work because `max_retries_per_task_lineage` is a per-run bound; refreshing on each `run()` is the intended semantic.
- Fewer surfaces changed → smaller blast radius of the fix itself.

Key changes:
- `SequentialExecutor.__init__` gains `max_retries_per_task_lineage: int = 3`.
- Before `adapter.invoke`, the executor computes `lineage_root` and checks its running count. At-cap tasks are marked FAILED via `steerer.transition` (never invoked) and the outer loop continues. Under `fail_fast=True` this aborts the run; under `fail_fast=False`, downstream tasks depending on the skipped task are naturally blocked by `_pick_next_task`'s dependency-satisfaction check, so no separate cascade logic is needed.
- New `_lineage_root()` helper uses a precompiled regex `^retry(?:\d+)?_` with a bounded strip loop.

Semantics of the cap value: `max_retries_per_task_lineage=N` allows up to N total invocations on one lineage. (The name says "retries" but the tests verify total-invocation semantics — cap=2 → 3rd invocation skipped. Renaming would be disruptive, and the docstring spells the exact meaning out.)

## Test plan
Added four new tests in `tests/test_sequential_executor.py`:
- [x] `test_retry_lineage_cap_default_is_3` — default value sanity check.
- [x] `test_retry_lineage_cap_fails_task_after_N_retries` — cap=2, simulated refine loop `t0 → retry_t0 → retry_retry_t0`; verify adapter saw only `t0, retry_t0` and the 3rd clone is FAILED in place.
- [x] `test_retry_lineage_cap_is_per_task_not_global` — two independent lineages (`a`, `b`), each allowed their own budget; both retries complete without cross-lineage throttling.
- [x] `test_retry_lineage_cap_passes_on_successful_retry` — fail-then-succeed inside budget; the retry lands and completes.
- [x] `test_retry_lineage_cap_collapses_nested_retry_prefixes` — explicit coverage that `retry_retry_t0` shares root `t0` so the regex convention can't silently regress.

Full suite green:
- [x] `uv run --extra dev pytest -q` → 415 passed, 45 skipped.
- [x] `uv run --extra dev ruff check .` → all checks passed.

Closes #98 — reference per task instructions.
