### PR TITLE
Cascade CANCEL to downstream PENDINGs on task cancellation

### DIFF
--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -1,0 +1,386 @@
+# Plan lifecycle & refinement contract
+
+This document specifies goldfive's **plan-level** state machine — how a
+Plan evolves across refinements, what a refined plan must preserve
+relative to the plan it replaces, and what "run complete" actually
+means at the plan layer.
+
+It is the plan-layer counterpart to
+[STATE-MACHINE.md](STATE-MACHINE.md) (task-layer state transitions)
+and [TASK-LIFECYCLE.md](TASK-LIFECYCLE.md) (cross-protocol task
+choreography). A task is a vertex; a plan is the DAG those vertices
+live in. The graph itself has a lifecycle, and most steering /
+refinement bugs surface at the graph layer, not the vertex layer.
+
+Audiences:
+- reviewers validating that a proposed change to `LLMPlanner.refine`
+  or `DefaultSteerer._apply_revision` doesn't silently break a
+  cross-revision invariant,
+- implementers writing a new planner or executor who need to know
+  what a correct refinement produces,
+- operators triaging "run says success but no output was produced"
+  (§6 covers the termination predicate).
+
+All citations are `file:line` into `goldfive/` unless noted.
+
+---
+
+## 1. Plan states
+
+```
+[none]
+  │
+  ▼
+CREATED ────────► EXECUTING ────────► COMPLETE
+                      ▲ │
+                      │ ▼
+                  REVISING                   ABORTED
+                      ▲ │
+                      └─┘   (refine→refine is illegal; see §4.4)
+                                        ▲
+                                        │
+EXECUTING ──────────────────────────────┘
+  (unrecoverable drift cascade — see §6.2)
+```
+
+| State | Meaning |
+|---|---|
+| `CREATED` | `Planner.generate` returned a `Plan`; it has passed structural validation (§5) and been installed on `Session.plan`. No task has been invoked yet. |
+| `EXECUTING` | The executor is driving tasks. One or more tasks may be in `RUNNING`, others `PENDING`. The plan's `revision_index` is the current index. |
+| `REVISING` | `Steerer._handle_drift` has called `Planner.refine(...)`. The *executor* may still be mid-invocation on the currently-running task; the *planner* is generating the next plan. This is a transient state — the existing plan remains installed on `session.plan` for the duration. |
+| `COMPLETE` | Every task in the currently-installed plan is in a terminal status (COMPLETED, FAILED, CANCELLED), no orphan PENDINGs remain (§6.1), and the executor has returned an `Outcome` with a computed `success` verdict. |
+| `ABORTED` | An unrecoverable drift (`recoverable=False`) or a `USER_CANCEL` control message ended the run mid-flight. The cascade semantics in §6.2 apply. |
+
+**Invariant.** A plan never leaves `COMPLETE` or `ABORTED`. These are absorbing states at the plan layer, just as `COMPLETED` / `FAILED` / `CANCELLED` are at the task layer.
+
+**Invariant.** Only one plan revision is installed on a `Session` at a time. `session.plan` is a pointer to the current revision; prior revisions are not retained in-memory by the steerer (sinks may retain them via emitted `PlanRevised` events; the in-memory object is replaced atomically by `_apply_revision`, `steerer.py:~579`).
+
+---
+
+## 2. Plan metadata carried across revisions
+
+A `Plan` (see `types.py::Plan`) carries revision metadata:
+
+- `id: str` — unique plan id; **stays the same across revisions** so sinks can stitch a revision history.
+- `revision_index: int` — monotonically increasing; `rev=0` is the output of `Planner.generate`, refines produce `rev=N+1`.
+- `revision_kind: str` — the `DriftKind` value that triggered this refinement (`""` at rev 0).
+- `revision_severity: str` — the severity of the triggering drift.
+- `revision_reason: str` — free-text detail (the drift's `detail`).
+
+`_apply_revision` (`steerer.py:~579–599`) enforces:
+
+- `new.revision_index ≥ old.revision_index + 1` (bumps if the planner returned a smaller number).
+- `revision_kind` / `revision_severity` / `revision_reason` default to the triggering drift's values if the planner didn't set them.
+
+**Observability.** Every revision emits one `PlanRevised(old_id=..., new_id=..., revision_index=..., kind=..., severity=..., reason=...)` event on the sink channel. Sinks that cache plan structure MUST re-read `session.plan` on every `PlanRevised`.
+
+---
+
+## 3. The refinement contract
+
+A refined plan is not a free-form rewrite. It must satisfy five invariants relative to the plan it replaces. The steerer enforces these in `_apply_revision` (structural) and the planner is expected to uphold them (semantic).
+
+### 3.0 Task identity
+
+A task's identity is its `id`, nothing else. The framework has two identity rules, and every refinement invariant below is phrased in terms of them:
+
+1. **Same id, same task.** A task with id `X` in revision N and a task with id `X` in revision N+1 are the *same task* — and §3.1 says they must agree on status and most metadata. This is how "task history" is stitched across revisions.
+
+2. **Different id, different task.** A task in revision N+1 whose id does not appear in revision N is a *new task*, full stop. It starts PENDING with empty progress / notes / retry-lineage counters, regardless of whether its title, description, or intent resembles an earlier task. The planner is free to generate tasks like `draft_slides_kid_friendly` after a USER_STEER cancels `draft_slides` — the new task is not a "retry" of the old one unless it explicitly uses the `retry_` / `retry<N>_` naming convention that the per-task retry cap (#102) watches.
+
+Title overlap, assignee overlap, intent overlap — none of these create cross-revision identity. Only id does.
+
+**Corollary:** a planner that wants a "fresh attempt at the same work" should *emit a new id* (and optionally a `retry_` prefix to opt into the retry-lineage cap). Reusing an old id to "reset" a task is illegal — §3.1 will reject it as a status regression.
+
+### 3.1 Terminal tasks are frozen
+
+Every task whose status in the outgoing plan is terminal
+(`COMPLETED`, `FAILED`, `CANCELLED`) **must** appear in the new plan
+with:
+- the same `id`,
+- the same `status` (monotonic — a terminal task cannot be un-failed
+  or un-completed),
+- the same `title`, `description`, `assignee_agent_id`, and
+  `bound_span_id` (so harmonograf's cross-revision span lineage
+  stays intact).
+
+If a refined plan is missing a terminal task from the outgoing plan,
+or its status has regressed, the steerer rejects the revision and
+emits a CRITICAL `SCHEMA_VIOLATION` drift (see #100 /
+`_apply_revision`).
+
+### 3.2 Terminal→terminal edges are frozen
+
+If both endpoints of an edge in the outgoing plan were terminal,
+that edge **must** appear in the new plan. This preserves the
+historical topology so a later forensic replay is faithful.
+
+### 3.3 Terminal→mutable edges may be re-drawn
+
+An edge from a terminal task to a non-terminal task represents "the
+prior work feeds the next step." During refinement, the planner may:
+- drop the edge (the downstream step no longer consumes that work),
+- re-target it to a newly-added task,
+- keep it unchanged.
+
+The planner may NOT target a terminal edge at a brand-new terminal
+task (terminals cannot have mutable sources). Use a new PENDING
+task instead and let the refined plan execute it.
+
+### 3.4 Mutable edges are freely mutable
+
+Edges whose tail is non-terminal in the outgoing plan (i.e., between
+PENDING / RUNNING / BLOCKED tasks) may be added, removed, or
+rewritten arbitrarily by refine. This is where delete-and-replan
+(§4.2) operates.
+
+### 3.5 No cycles, no dangling edges
+
+`Plan.validate(for_revision=True)` (from #100) rejects any revision
+whose structure contains:
+- duplicate task IDs,
+- edges referencing an unknown task,
+- cycles (detected via `topological_stages`: any leftover task is a
+  cycle member).
+
+On validation failure, the revision is discarded, a CRITICAL
+`SCHEMA_VIOLATION` drift is emitted, and `session.plan` is
+unchanged. The refine-failure counter (§4.5) is also incremented.
+
+---
+
+## 4. Refinement modes
+
+Different drifts demand different rewrites of the DAG. The current
+planner implements three modes, each with its own preservation
+contract layered on top of the §3 invariants.
+
+### 4.1 Inline-edit (default)
+
+**Triggers:** `TOOL_ERROR`, `AGENT_REFUSAL`, `PLAN_DIVERGENCE`,
+`NEW_WORK_DISCOVERED`, `TASK_FAILED_RECOVERABLE`, `BLOCKED`,
+most WARNING-severity drifts.
+
+**Semantic:** "patch the plan around the failing task." The planner
+receives the full plan + drift context, emits a JSON plan that
+typically:
+- leaves all non-affected tasks untouched,
+- marks the offender FAILED or leaves it PENDING with updated
+  metadata,
+- inserts 1-3 new pending tasks to remediate (retry with different
+  assignee, add a prerequisite, add a fallback).
+
+**Preservation:** §3.1-3.5. In practice the planner preserves the
+bulk of the DAG.
+
+### 4.2 Delete-and-replan (USER_STEER)
+
+**Trigger:** `USER_STEER` drift (from a `ControlKind.STEER`
+message).
+
+**Semantic:** "the user has changed direction; discard everything
+pending and regenerate around the new intent." The planner:
+- preserves every terminal task verbatim (§3.1),
+- preserves edges between terminal tasks (§3.2),
+- **drops** every PENDING / RUNNING / BLOCKED task,
+- regenerates a fresh sub-DAG of PENDING tasks whose roots attach to
+  the terminal boundary.
+
+**Partial-state atomicity (the gap this doc formalises).** Before
+refine runs, `SequentialExecutor._apply_steer`
+(`executors/sequential.py:~247`) has already cancelled the currently
+running task. If the refine then **fails** (LLM returns `None`,
+raises, or produces an unparseable plan), the "delete" half of
+delete-and-replan has happened but the "replan" half has not. The
+outgoing plan is now inconsistent: it still lists the dropped
+PENDING tasks, but their upstream has been CANCELLED, orphaning
+them.
+
+The correct behaviour is not to roll back the cancel (the user
+asked for a steer; ignoring it violates the control contract). It
+is to roll **forward** the delete: cascade-CANCEL every task in the
+dropped set, so the plan lands in a consistent terminal-only shape
+with `success=False` and a clear `revision_reason`. This is
+implemented by the cascade semantics in §6.3.
+
+### 4.3 Fail-and-route (LOOPING_TOOL_CALL / LOOPING_REASONING)
+
+**Triggers:** `LOOPING_TOOL_CALL`, `LOOPING_REASONING`.
+
+**Semantic:** "the offender is stuck; mark it FAILED and generate
+alternative paths." Framework-level guarantee: even if the LLM
+refuses to mark the offender FAILED, the planner's deterministic
+fallback (`planner.py::_refine_looping_tool_call:~948`) forces the
+offender to FAILED in the returned plan. This is the one mode that
+cannot soft-fail into "plan unchanged" — the looping task always
+terminates.
+
+**Preservation:** §3.1-3.5 plus the offender's transition to FAILED
+is a hard constraint.
+
+### 4.4 Refine-within-refine is illegal
+
+While a refine is in flight (`REVISING` state), another drift MAY
+fire — but the steerer serializes its drift handling, so the
+in-flight refine either (a) completes and installs before the next
+drift is processed, or (b) completes and is discarded because the
+new drift's refine supersedes it. The steerer never runs two
+refines in parallel on the same session.
+
+Concrete enforcement: `DefaultSteerer._handle_drift` is an `async
+def` that awaits the planner's `refine` call sequentially.
+Concurrent dispatch into the same Session is not supported by the
+protocol (see [PROTOCOLS.md](PROTOCOLS.md#steerer)).
+
+### 4.5 Refine failure lifecycle
+
+A refine that raises, returns `None`, or produces a revision that
+fails `Plan.validate(for_revision=True)` is a **refine failure**.
+The steerer handles it in three layers (see TASK-LIFECYCLE.md §4):
+
+1. Visibility: emit a follow-up CRITICAL `DriftDetected` with
+   `detail="refine failed (<kind>): <reason>"`.
+2. Backoff: increment `session.refine_failure_counts[(kind,
+   task_id)]`; at `REFINE_FAILURE_THRESHOLD=2` consecutive failures,
+   mark the originating task FAILED and emit a CRITICAL
+   `REPEATED_FAILURE` drift (instead of attempting refine a third
+   time).
+3. Partial-state atomicity (§4.2 / §6.3): if the triggering drift
+   was `USER_STEER`, the delete has already happened — cascade-
+   CANCEL dependents so the plan lands in a consistent shape.
+
+Successful refine resets the counter for that `(kind, task_id)`.
+
+---
+
+## 5. Plan validation on creation and revision
+
+Called by `LLMPlanner.generate` (creation) and
+`DefaultSteerer._apply_revision` (revision), from #100.
+`Plan.validate()` enforces:
+
+- Every task has a non-empty `id`.
+- Task IDs are unique within the plan.
+- Every edge references existing task IDs.
+- No cycles (verified via `topological_stages`'s residual check).
+- **At creation only** (`for_revision=False`): every task is
+  `PENDING`. At revision (`for_revision=True`), terminal tasks are
+  allowed (expected, per §3.1).
+
+On failure: `ValueError` with a descriptive message. `generate`
+returns `None`; `_apply_revision` rejects the revision and emits
+`SCHEMA_VIOLATION`.
+
+---
+
+## 6. Run termination
+
+This is the section whose absence from prior docs allowed the
+"success=True with orphan PENDINGs" bug to ship.
+
+### 6.1 Successful completion
+
+A run completes successfully when **all three** hold:
+
+- **Every task is in a terminal status.** No `PENDING`, no
+  `RUNNING`, no `BLOCKED`.
+- **No cascade orphans remain** (§6.3). Every CANCELLED /
+  FAILED task's downstream PENDINGs have themselves been
+  cascade-terminated.
+- **Every goal's `success_predicate` returns True** (or is
+  `None`, treated as vacuously true).
+
+If all three hold: `Outcome.success = True`.
+
+If only the first two hold (everything is terminal, no orphans, but
+some goal predicates returned False): `Outcome.success = False`
+with `reason="goals unmet"`. This is a new verdict the current
+executor does not emit; see TASK-LIFECYCLE.md §7 follow-up.
+
+### 6.2 Unrecoverable cascade (ABORTED)
+
+When a drift fires with `recoverable=False` — today only
+`TASK_FAILED_FATAL`, `USER_CANCEL`, and `INTENT_DIVERGENCE` — the
+executor runs the unrecoverable cascade (STATE-MACHINE.md
+§"Cascade semantics"):
+
+1. Mark the current task FAILED (if not already terminal).
+2. Mark every RUNNING task FAILED.
+3. BFS downstream from each just-FAILED task; every reachable
+   PENDING → CANCELLED.
+4. Clear adapter-bound task context.
+5. Emit `RunAborted(reason=drift.kind, drift=drift)`.
+
+Outcome: `success=False`, reason carries the triggering drift.
+
+### 6.3 Cancellation cascade (recoverable path)
+
+Previously undocumented; implemented by the cascade worker
+(fix/cancel-cascade PR).
+
+When a task transitions to CANCELLED by any means —
+`mark_task_cancelled` from the executor, `mark_task_cancelled` from
+a reporting tool, or the implicit cancel in `_apply_steer` — the
+steerer walks the plan's edges forward from the cancelled task and
+cancels every reachable PENDING task with
+`reason="cascade from <original_task_id>"`. Already-terminal
+downstream tasks are left alone.
+
+This makes the CANCEL the primitive that delete-and-replan relies
+on (§4.2): the cancel alone gets the plan to a terminal-only shape;
+the replan adds fresh pending work that will run on top. If the
+replan fails, the cascaded CANCELs remain and the run ends cleanly
+as "incomplete but not broken."
+
+### 6.4 Reachability audit on executor exit
+
+Belt-and-suspenders for any cancellation path we missed: when the
+executor's `_pick_next_task` returns `None` while PENDING tasks
+remain (which should be impossible after §6.3 fires correctly), the
+executor:
+
+- Emits a CRITICAL `PLAN_DIVERGENCE` drift with detail listing the
+  orphan task IDs.
+- Cancels each orphan with `reason="reachability audit"`.
+- Records `Outcome.success = False` with reason
+  `"orphaned pending tasks after run"`.
+
+This catches regressions where a future refactor breaks the
+cascade primitive, without letting a silent "success with orphans"
+slip through.
+
+---
+
+## 7. Lifecycle invariants, stated
+
+These are the plan-level invariants the framework maintains.
+Violating any of them is a bug in goldfive.
+
+1. **Monotonic revision index.** `session.plan.revision_index`
+   strictly increases across plan swaps.
+2. **Stable plan id.** `session.plan.id` does not change across
+   revisions.
+3. **Terminal task preservation.** Every terminal task in revision
+   N appears with the same status in revision N+1.
+4. **Terminal edge preservation.** Every terminal→terminal edge in
+   revision N appears in revision N+1.
+5. **Plan validation on install.** Every plan installed on
+   `session.plan` passes `Plan.validate()`.
+6. **Refinement serialization.** Only one `planner.refine` call is
+   in flight per session at any time.
+7. **Atomic partial-state.** Cancel → cancel dependents; if refine
+   fails after a cancel, the cancel cascade has already fired.
+   There is no state "cancelled upstream, live downstream pending."
+8. **No orphan at COMPLETE.** A run in `COMPLETE` state has no
+   PENDING, RUNNING, or BLOCKED tasks remaining.
+9. **Success is not the default verdict.** `Outcome.success = True`
+   is computed from §6.1's conjunction, not "did anything fail?"
+
+---
+
+## 8. Known gaps (open)
+
+- **Goal success predicates are not evaluated.** `Goal.success_predicate` is defined on the type but never called. §6.1's third clause is specified but not yet implemented.
+- **Terminal→terminal edge preservation is not currently enforced.** `_apply_revision` does not yet check edge preservation; a buggy planner could silently drop terminal edges. Add to `Plan.validate(for_revision=True)`.
+- **Unrecoverable cascade (§6.2) does not currently use the same cascade primitive as §6.3** — they're two different code paths that happen to do similar work. Unify once both are implemented.
+- **No cross-revision lineage view.** Sinks receive `PlanRevised` events but the proto doesn't carry the full diff. Harmonograf's UI currently has to stitch revisions by plan_id + revision_index. A dedicated `revision_diff` sidecar would simplify the UI.

--- a/docs/design/STATE-MACHINE.md
+++ b/docs/design/STATE-MACHINE.md
@@ -183,6 +183,20 @@ This is why `FAILED` and `CANCELLED` must be absorbing: the cascade
 relies on being able to call `transition(..., CANCELLED)` on any
 downstream task without re-checking its history.
 
+### Cascade on task cancellation
+
+The same cascade rule applies when **any single task** is
+transitioned to `CANCELLED` — not only as part of the unrecoverable
+FAILED cascade above. `DefaultSteerer.mark_task_cancelled` BFS-walks
+forward from the cancelled task through `Plan.edges` and transitions
+every reachable non-terminal task (PENDING / RUNNING / BLOCKED) to
+`CANCELLED` with reason `"cascade from <task_id>"`. This closes the
+soundness gap where a `USER_STEER` whose refine produces no new plan
+would cancel the current task but leave downstream PENDING tasks
+silently orphaned (they never satisfy `_pick_next_task`'s "all
+predecessors COMPLETED" check). See
+[TASK-LIFECYCLE.md §6.1 — Cancellation cascade](TASK-LIFECYCLE.md#61-cancellation-cascade).
+
 ## Implementation notes
 
 The reference implementation is `DefaultSteerer` in

--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -320,7 +320,42 @@ translates). The executor handles it at two points:
   `_cancel_invoke_task(invoke_task)` — `task.cancel()` + up to 5s
   grace, then warning-log + move on.
 
-### 6.1 Known cleanup gap: orphaned tool_call_ids
+### 6.1 Cancellation cascade
+
+Cancelling a task is **not** a leaf operation: the task's downstream
+dependents have to end up cancelled too, otherwise the executor's
+dependency check (`_pick_next_task`: "all predecessors COMPLETED")
+silently orphans them.
+
+`DefaultSteerer.mark_task_cancelled` (`steerer.py`) therefore does two
+things on every legal cancel:
+
+1. Transition ``task_id`` to `CANCELLED` and emit `TaskCancelled`.
+2. BFS forward through ``session.plan.edges``; every reachable
+   non-terminal task (PENDING / RUNNING / BLOCKED) is transitioned to
+   `CANCELLED` with reason `"cascade from <task_id>"`, one
+   `TaskCancelled` event per task. Terminal tasks (`COMPLETED` /
+   `FAILED` / already-`CANCELLED`) are preserved verbatim and not
+   traversed past — a diamond DAG does not double-cancel.
+
+This mirrors the "unrecoverable drift" cascade documented in
+[STATE-MACHINE.md §"Cascade semantics on unrecoverable drift"](STATE-MACHINE.md#cascade-semantics-on-unrecoverable-drift).
+Whether the cancel arrives via (a) a control-channel `CANCEL`,
+(b) a `USER_STEER` whose refine returns no new plan (so the executor
+preserves the CANCELLED current task without replacing it), or
+(c) an explicit `mark_task_cancelled` call, the cascade fires at the
+same boundary in the steerer.
+
+The `SequentialExecutor` additionally runs a **reachability audit**
+at loop exit: if `_pick_next_task` returns None but some tasks are
+still `PENDING`, each is transitioned to `CANCELLED` with reason
+`"orphaned by plan revision failure"`, a CRITICAL `PLAN_DIVERGENCE`
+drift is emitted, and the run ends with `success=False`. This is a
+belt-and-suspenders catch for any cancellation path that fails to
+cascade (e.g. a future control-channel variant that bypasses the
+steerer).
+
+### 6.2 Known cleanup gap: orphaned tool_call_ids
 
 ADK's `run_async` may be mid-turn with an assistant message carrying
 `tool_calls` when the cancel raises `CancelledError`. The matching
@@ -433,6 +468,27 @@ agents this is ~32 × 500 = 16 000 LLM calls worst case.
 **Fix direction:** add a `max_retries_per_task_id` (default 3) to
 the executor. After N refines that target the same task id's
 lineage, mark the task FAILED and cascade CANCEL downstream.
+
+### 7.8 CANCELLED cascade to downstream PENDING tasks (closed)
+
+Historically, `mark_task_cancelled` transitioned only the target
+task and emitted a single `TaskCancelled` event. This implicitly
+assumed CANCELLED predecessors were non-terminal — but
+`_pick_next_task` only picks tasks whose predecessors are all
+`COMPLETED`, so a CANCELLED predecessor silently orphaned every
+descendant. Combined with a `USER_STEER` refine that returned no new
+plan, the sequential executor would run only the independent
+branches and exit with `success=True`, leaving the dependent branch
+stuck in `PENDING`. The "make a presentation about waffles" regression
+run (`research_history` cancelled by STEER; refine produced empty
+JSON; 7 downstream tasks left PENDING; executor reported success)
+was the in-the-wild trigger.
+
+**Fix (see §6.1):** `mark_task_cancelled` now BFS-cancels all
+downstream non-terminal tasks, and `SequentialExecutor` runs a
+reachability audit at loop exit that flips any remaining PENDING
+tasks to CANCELLED, emits a CRITICAL `PLAN_DIVERGENCE` drift, and
+fails the run. Closed by `fix/cancel-cascade`.
 
 ---
 

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING
 
 from goldfive.events import (
     emit,
+    new_event,
     plan_revised_event,
     run_aborted_event,
     run_completed_event,
@@ -49,7 +50,7 @@ from goldfive.executors._control import (
 )
 from goldfive.protocols import AgentAdapter, EventSink, Executor, Planner, Steerer
 from goldfive.results import ExecutionOutcome
-from goldfive.types import Plan, Session, Task, TaskStatus
+from goldfive.types import DriftKind, DriftSeverity, Plan, Session, Task, TaskStatus
 
 if TYPE_CHECKING:
     from goldfive.control import ControlChannel
@@ -176,9 +177,7 @@ class SequentialExecutor(Executor):
                 run_failed = True
                 break
             if steer_msg is not None:
-                await self._apply_steer(
-                    steer_msg, steerer=steerer, session=session
-                )
+                await self._apply_steer(steer_msg, steerer=steerer, session=session)
                 # The steerer swapped session.plan; pick up the revision
                 # on the next outer iteration.
 
@@ -230,7 +229,9 @@ class SequentialExecutor(Executor):
                     "SequentialExecutor: lineage cap reached for task=%s "
                     "(lineage_root=%s, count=%d, cap=%d); marking FAILED "
                     "without invoking adapter",
-                    task.id, lineage_root, lineage_count,
+                    task.id,
+                    lineage_root,
+                    lineage_count,
                     self.max_retries_per_task_lineage,
                 )
                 await steerer.transition(
@@ -263,8 +264,11 @@ class SequentialExecutor(Executor):
             log.debug(
                 "SequentialExecutor: invoking task=%s (invocation %d/%d, "
                 "lineage_root=%s, lineage_count=%d/%d)",
-                task.id, invocations, self.max_plan_reinvocations,
-                lineage_root, lineage_count + 1,
+                task.id,
+                invocations,
+                self.max_plan_reinvocations,
+                lineage_root,
+                lineage_count + 1,
                 self.max_retries_per_task_lineage,
             )
 
@@ -273,9 +277,7 @@ class SequentialExecutor(Executor):
             # case) still produce a TaskStarted event. The steerer's
             # transition is idempotent once the task leaves PENDING.
             if task.status == TaskStatus.PENDING:
-                await steerer.transition(
-                    task.id, TaskStatus.RUNNING, session=session
-                )
+                await steerer.transition(task.id, TaskStatus.RUNNING, session=session)
 
             # Race the adapter invocation against the control channel so a
             # CANCEL / STEER / PAUSE arriving mid-task can cancel (or at
@@ -316,9 +318,7 @@ class SequentialExecutor(Executor):
                 await self._mark_cancelled_if_live(
                     task_id=task.id, steerer=steerer, session=session
                 )
-                await self._apply_steer(
-                    outcome_payload, steerer=steerer, session=session
-                )
+                await self._apply_steer(outcome_payload, steerer=steerer, session=session)
                 continue
 
             # outcome_kind == "result"
@@ -328,13 +328,12 @@ class SequentialExecutor(Executor):
             # (but didn't raise), record it; the auto-transition block
             # below routes that through steerer.mark_task_failed unless
             # the agent already transitioned the task itself.
-            invocation_error = (
-                result is not None and getattr(result, "error", None) is not None
-            )
+            invocation_error = result is not None and getattr(result, "error", None) is not None
             if invocation_error:
                 log.warning(
                     "SequentialExecutor: InvocationResult.error=%s task=%s",
-                    result.error, task.id,
+                    result.error,
+                    task.id,
                 )
 
             # Route the invocation result through the steerer's observer so
@@ -352,9 +351,7 @@ class SequentialExecutor(Executor):
 
             # Re-read the task's tracked status after the invocation.
             tracked = _find_task(session.plan or current_plan, task.id)
-            tracked_status = (
-                tracked.status if tracked is not None else TaskStatus.PENDING
-            )
+            tracked_status = tracked.status if tracked is not None else TaskStatus.PENDING
 
             # If the agent returned without emitting a terminal reporting
             # call, auto-transition on its behalf: complete on a clean
@@ -380,9 +377,7 @@ class SequentialExecutor(Executor):
                         session=session,
                     )
                 tracked = _find_task(session.plan or current_plan, task.id)
-                tracked_status = (
-                    tracked.status if tracked is not None else TaskStatus.PENDING
-                )
+                tracked_status = tracked.status if tracked is not None else TaskStatus.PENDING
 
             if tracked_status == TaskStatus.FAILED:
                 failure_reason = f"task {task.id} failed"
@@ -444,6 +439,50 @@ class SequentialExecutor(Executor):
             )
             return ExecutionOutcome(success=False, session=session, reason=reason)
 
+        # Reachability audit: belt-and-suspenders for any cancellation path
+        # that failed to cascade. If we are about to report success but
+        # there are still PENDING tasks — and ``_pick_next_task`` already
+        # declined to return any of them — those tasks are orphaned (e.g.
+        # every path to them crosses a CANCELLED or FAILED predecessor
+        # and no refine produced a replacement plan). Mark them CANCELLED
+        # in place, emit a CRITICAL PLAN_DIVERGENCE drift so sinks see
+        # the incomplete ending, and fail the run. This catches cases
+        # the Steerer's cascade missed (and is a cheap safety net even
+        # when the cascade worked correctly).
+        orphaned = _pending_task_ids(session.plan or plan)
+        if orphaned:
+            log.warning(
+                "SequentialExecutor: %d task(s) still PENDING with no "
+                "eligible next task — run ending incomplete: %s",
+                len(orphaned),
+                ", ".join(orphaned),
+            )
+            for orphan_id in orphaned:
+                await steerer.transition(
+                    orphan_id,
+                    TaskStatus.CANCELLED,
+                    detail="orphaned by plan revision failure",
+                    session=session,
+                )
+            reason = (
+                f"{len(orphaned)} task(s) left PENDING with no eligible "
+                f"next task (orphaned by plan revision failure): "
+                f"{', '.join(orphaned)}"
+            )
+            await emit(
+                sinks,
+                _plan_divergence_drift_event(session, reason),
+            )
+            await emit(
+                sinks,
+                run_aborted_event(
+                    run_id=session.run_id,
+                    sequence=session.next_sequence(),
+                    reason=reason,
+                ),
+            )
+            return ExecutionOutcome(success=False, session=session, reason=reason)
+
         await emit(
             sinks,
             run_completed_event(
@@ -479,9 +518,7 @@ class SequentialExecutor(Executor):
         if control is None:
             return False, None
 
-        outcomes = await drain_controls(
-            control, session=session, steerer=steerer, sinks=sinks
-        )
+        outcomes = await drain_controls(control, session=session, steerer=steerer, sinks=sinks)
 
         cancel_run = False
         cancel_reason = ""
@@ -510,17 +547,13 @@ class SequentialExecutor(Executor):
                 # Channel closed — treat as resume so we don't wedge.
                 paused = False
                 break
-            outcome = await dispatch_control(
-                msg, session=session, steerer=steerer, sinks=sinks
-            )
+            outcome = await dispatch_control(msg, session=session, steerer=steerer, sinks=sinks)
             try:
                 await control.ack(outcome.ack)
             except Exception:  # noqa: BLE001
                 pass
             if outcome.cancel_run:
-                raise _ControlCancelled(
-                    outcome.cancel_reason or "cancelled by control"
-                )
+                raise _ControlCancelled(outcome.cancel_reason or "cancelled by control")
             if outcome.request_resume:
                 paused = False
             if outcome.steer_message is not None:
@@ -601,9 +634,7 @@ class SequentialExecutor(Executor):
                     return ("adapter_error", exc)
                 return ("result", result)
 
-            outcome = await dispatch_control(
-                msg, session=session, steerer=steerer, sinks=sinks
-            )
+            outcome = await dispatch_control(msg, session=session, steerer=steerer, sinks=sinks)
             try:
                 await control.ack(outcome.ack)
             except Exception:  # noqa: BLE001
@@ -642,8 +673,7 @@ class SequentialExecutor(Executor):
                 return
             await asyncio.sleep(0.05)
         log.warning(
-            "SequentialExecutor: adapter ignored task.cancel(); "
-            "abandoning after 5s grace window"
+            "SequentialExecutor: adapter ignored task.cancel(); abandoning after 5s grace window"
         )
 
     @staticmethod
@@ -683,9 +713,7 @@ class SequentialExecutor(Executor):
         try:
             await steerer.observe(message, session)
         except Exception as exc:  # noqa: BLE001
-            log.warning(
-                "SequentialExecutor: steerer.observe(STEER) raised: %s", exc
-            )
+            log.warning("SequentialExecutor: steerer.observe(STEER) raised: %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -760,6 +788,46 @@ def _lineage_root(task_id: str) -> str:
 
 def _any_failed(plan: Plan) -> bool:
     return any(t.status == TaskStatus.FAILED for t in plan.tasks)
+
+
+def _pending_task_ids(plan: Plan) -> list[str]:
+    """Return the ids of every task still in PENDING state.
+
+    Used by the reachability audit at loop exit: if ``_pick_next_task``
+    returned None but some tasks are still PENDING, those tasks are
+    orphaned (every path to them crosses a CANCELLED / FAILED predecessor
+    that no refine replaced). The audit then cancels them in place so
+    sinks see a coherent plan-end state instead of "stuck PENDING forever."
+    """
+    return [t.id for t in plan.tasks if t.status == TaskStatus.PENDING and t.id]
+
+
+def _plan_divergence_drift_event(session: Session, detail: str) -> object:
+    """Build a CRITICAL PLAN_DIVERGENCE ``DriftDetected`` envelope.
+
+    Mirrors ``DefaultSteerer._emit_drift_detected`` but built here so
+    the reachability audit can emit a drift event from the executor
+    directly (without routing through the steerer, which would
+    otherwise try to re-refine). Uses ``types_pb2``'s named enum
+    constants so the emitted event carries the real ``PLAN_DIVERGENCE``
+    / ``CRITICAL`` enum values rather than ``UNSPECIFIED``.
+    """
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    evt = new_event(session.run_id, session.next_sequence())
+    evt.drift_detected.kind = getattr(
+        types_pb2,
+        f"DRIFT_KIND_{DriftKind.PLAN_DIVERGENCE.name}",
+        0,
+    )
+    evt.drift_detected.severity = getattr(
+        types_pb2,
+        f"DRIFT_SEVERITY_{DriftSeverity.CRITICAL.name}",
+        0,
+    )
+    evt.drift_detected.detail = detail
+    evt.drift_detected.current_task_id = session.current_task_id or ""
+    return evt
 
 
 def _outcome_summary(session: Session) -> str:

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -268,14 +268,94 @@ class DefaultSteerer:
         session: Session,
         reason: str = "",
     ) -> None:
-        """Transition ``task_id`` to ``CANCELLED`` and emit ``TaskCancelled``."""
+        """Transition ``task_id`` to ``CANCELLED`` and emit ``TaskCancelled``.
+
+        Also **cascades** the cancellation forward through the plan's
+        edges: every non-terminal task reachable from ``task_id`` is
+        transitioned to ``CANCELLED`` with a "cascade from <task_id>"
+        reason. Without this cascade, downstream PENDING tasks with a
+        CANCELLED predecessor would never satisfy the executor's
+        "all deps COMPLETED" check — they would sit PENDING forever and
+        the executor would report the run as successful while leaving
+        them orphaned. See TASK-LIFECYCLE.md §"Cancellation cascade" and
+        STATE-MACHINE.md §"Cascade semantics on unrecoverable drift".
+        """
         task = self._find_task(session, task_id)
         if task is None:
             return
         if task.status in _TERMINAL_TASK_STATUSES:
+            # Already terminal (including already CANCELLED) — no-op, and
+            # crucially do NOT re-run the cascade: we would double-emit
+            # TaskCancelled events for downstream tasks on every call.
             return
         task.status = TaskStatus.CANCELLED
         await self._emit_task_cancelled(session, task_id, reason)
+        await self._cascade_cancel_downstream(session, task_id)
+
+    async def _cascade_cancel_downstream(
+        self,
+        session: Session,
+        cancelled_id: str,
+    ) -> None:
+        """BFS-cancel every downstream non-terminal task of ``cancelled_id``.
+
+        Walks ``session.plan.edges`` forward from ``cancelled_id`` and
+        transitions every reachable non-terminal task to ``CANCELLED``
+        in-place, emitting one ``TaskCancelled`` event per transition.
+        Terminal tasks (COMPLETED / FAILED / CANCELLED) are skipped so a
+        diamond DAG does not re-cancel a task through two paths and so
+        already-COMPLETED dependents are preserved verbatim.
+
+        Implemented as an iterative BFS on a precomputed adjacency list
+        (rather than recursing into :meth:`mark_task_cancelled`) so a
+        single top-level cancel produces one summary log line and a
+        predictable number of emitted events, independent of graph shape.
+        """
+        plan = session.plan
+        if plan is None:
+            return
+        # Precompute forward adjacency once.
+        downstream: dict[str, list[str]] = {}
+        for e in plan.edges:
+            downstream.setdefault(e.from_task_id, []).append(e.to_task_id)
+        tasks_by_id: dict[str, Task] = {t.id: t for t in plan.tasks if t.id}
+
+        cascade_reason = f"cascade from {cancelled_id}"
+        cascaded: list[str] = []
+        queue: list[str] = list(downstream.get(cancelled_id, []))
+        visited: set[str] = set()
+        while queue:
+            next_id = queue.pop(0)
+            if next_id in visited:
+                continue
+            visited.add(next_id)
+            dep = tasks_by_id.get(next_id)
+            if dep is None:
+                continue
+            if dep.status in _TERMINAL_TASK_STATUSES:
+                # Already terminal (COMPLETED/FAILED/CANCELLED) — preserve
+                # and do not traverse its children. A COMPLETED task that
+                # sits downstream of a late-cancelled ancestor keeps its
+                # completion; cascading past it would mean cancelling
+                # tasks whose preserved prerequisite is still valid.
+                continue
+            # Transition in place and emit. We deliberately do NOT
+            # recurse through ``mark_task_cancelled`` here; we fan out
+            # via our own BFS queue so the surrounding summary log and
+            # emission count stay deterministic.
+            dep.status = TaskStatus.CANCELLED
+            await self._emit_task_cancelled(session, next_id, cascade_reason)
+            cascaded.append(next_id)
+            for grandchild in downstream.get(next_id, []):
+                if grandchild not in visited:
+                    queue.append(grandchild)
+        if cascaded:
+            log.info(
+                "DefaultSteerer: cascade-cancelled %d downstream task(s) from %s: %s",
+                len(cascaded),
+                cancelled_id,
+                ", ".join(cascaded),
+            )
 
     # ------------------------------------------------------------------
     # Observer: drift detection + refine

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -171,7 +171,7 @@ class StubAdapter:
 def _linear_plan(n: int = 3, run_id: str = "run-1") -> Plan:
     """Return a linear plan t0 -> t1 -> ... -> t(n-1)."""
     tasks = [Task(id=f"t{i}", title=f"Task {i}") for i in range(n)]
-    edges = [TaskEdge(from_task_id=f"t{i}", to_task_id=f"t{i+1}") for i in range(n - 1)]
+    edges = [TaskEdge(from_task_id=f"t{i}", to_task_id=f"t{i + 1}") for i in range(n - 1)]
     return Plan(id="p0", run_id=run_id, goal_ids=[], tasks=tasks, edges=edges)
 
 
@@ -279,9 +279,7 @@ async def test_drift_mid_run_applies_refined_plan() -> None:
                 detail="found extra work",
                 current_task_id=task.id,
             )
-            revised = await planner.refine(
-                plan=session.plan, drift=drift, goals=session.goals
-            )
+            revised = await planner.refine(plan=session.plan, drift=drift, goals=session.goals)
             if revised is not None:
                 session.plan = revised
             return InvocationResult(task_id=task.id, text="done-with-drift")
@@ -425,9 +423,7 @@ async def test_budget_terminates_stuck_run() -> None:
         # executor auto-fails the task on its behalf (matching the
         # "InvocationResult.error is set" branch of the auto-transition
         # logic) so fail_fast aborts after the first invocation.
-        return InvocationResult(
-            task_id=task.id, text="", error=RuntimeError("stuck")
-        )
+        return InvocationResult(task_id=task.id, text="", error=RuntimeError("stuck"))
 
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_stuck)
 
@@ -531,9 +527,7 @@ async def test_retry_lineage_cap_fails_task_after_N_retries() -> None:
         )
         return InvocationResult(task_id=task.id, text="", stop_reason="failed")
 
-    adapter = StubAdapter(
-        steerer=steerer, planner=planner, on_invoke=_fail_and_spawn_retry
-    )
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_fail_and_spawn_retry)
 
     # cap=2 -> allow 2 invocations on lineage root "t0"; the 3rd clone
     # is refused before the adapter is called.
@@ -589,15 +583,13 @@ async def test_retry_lineage_cap_is_per_task_not_global() -> None:
     ) -> InvocationResult:
         # Derive the lineage root by stripping a single "retry_" prefix;
         # good enough for this 2-deep test.
-        root = task.id[len("retry_"):] if task.id.startswith("retry_") else task.id
+        root = task.id[len("retry_") :] if task.id.startswith("retry_") else task.id
         if not fail_once[root]:
             fail_once[root] = True
             await steerer.transition(task.id, TaskStatus.FAILED, session=session)
             # Add a retry clone so the plan still has work to do.
             new_tasks = list(session.plan.tasks) if session.plan else []
-            new_tasks.append(
-                Task(id=f"retry_{task.id}", title=f"retry of {task.title}")
-            )
+            new_tasks.append(Task(id=f"retry_{task.id}", title=f"retry of {task.title}"))
             session.plan = Plan(
                 id="p0",
                 run_id=session.run_id,
@@ -610,9 +602,7 @@ async def test_retry_lineage_cap_is_per_task_not_global() -> None:
         await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
         return InvocationResult(task_id=task.id, text=f"done:{task.id}")
 
-    adapter = StubAdapter(
-        steerer=steerer, planner=planner, on_invoke=_fail_first_then_succeed
-    )
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_fail_first_then_succeed)
 
     executor = SequentialExecutor(
         max_plan_reinvocations=32,
@@ -693,9 +683,7 @@ async def test_retry_lineage_cap_passes_on_successful_retry() -> None:
         await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
         return InvocationResult(task_id=task.id, text="ok")
 
-    adapter = StubAdapter(
-        steerer=steerer, planner=planner, on_invoke=_fail_then_retry_succeeds
-    )
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_fail_then_retry_succeeds)
 
     executor = SequentialExecutor(
         max_plan_reinvocations=32,
@@ -782,3 +770,149 @@ async def test_retry_lineage_cap_collapses_nested_retry_prefixes() -> None:
     assert by_id["t0"] == TaskStatus.COMPLETED
     assert by_id["retry_t0"] == TaskStatus.COMPLETED
     assert by_id["retry_retry_t0"] == TaskStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Reachability audit: orphaned PENDING tasks at loop exit.
+#
+# Belt-and-suspenders for the cancellation cascade (TASK-LIFECYCLE.md §6.1,
+# §7.8). If _pick_next_task returns None but PENDING tasks remain, the
+# executor must NOT report success=True — it must cancel the orphans,
+# emit a CRITICAL PLAN_DIVERGENCE drift, and return success=False.
+# ---------------------------------------------------------------------------
+
+
+async def test_executor_run_with_orphaned_pending_reports_failure() -> None:
+    """A cancelled task with a downstream PENDING dep ends the run as failure.
+
+    Reproduces the 'waffles' regression at the executor boundary: the
+    first task is cancelled (simulating USER_STEER whose refine failed
+    to produce a new plan). The downstream PENDING task has a
+    CANCELLED predecessor, so _pick_next_task refuses to pick it. The
+    executor must not reach run_completed with success=True; it must
+    cascade-cancel the orphan and emit RunAborted.
+    """
+    plan = _linear_plan(2)  # t0 -> t1
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _cancel_t0(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        # Simulate a STEER-cancel on the current task without any
+        # cascade and without a refine that replaces the plan. The
+        # StubSteerer.transition flips status directly; this mirrors
+        # what the real system used to do before the cascade fix.
+        await steerer.transition(task.id, TaskStatus.CANCELLED, session=session)
+        return InvocationResult(task_id=task.id, text="cancelled")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_cancel_t0)
+
+    executor = SequentialExecutor(max_plan_reinvocations=5)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # Only t0 was invoked (t1 is blocked by CANCELLED predecessor).
+    assert adapter.invocations == ["t0"]
+    # Reachability audit flipped t1 from PENDING to CANCELLED and
+    # ended the run as failure. Without the audit, outcome.success
+    # would be True and t1 would stay PENDING forever.
+    assert outcome.success is False
+    by_id = {t.id: t.status for t in plan.tasks}
+    assert by_id["t0"] == TaskStatus.CANCELLED
+    assert by_id["t1"] == TaskStatus.CANCELLED
+    # Terminal event is RunAborted (not RunCompleted).
+    assert sink.payload_kinds()[-1] == "run_aborted"
+
+
+async def test_executor_emits_plan_divergence_when_pending_orphaned() -> None:
+    """Audit emits a CRITICAL PLAN_DIVERGENCE drift before RunAborted."""
+    plan = _linear_plan(3)  # t0 -> t1 -> t2
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _cancel_t0(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        await steerer.transition(task.id, TaskStatus.CANCELLED, session=session)
+        return InvocationResult(task_id=task.id, text="cancelled")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_cancel_t0)
+
+    executor = SequentialExecutor(max_plan_reinvocations=5)
+    await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # The sink saw a DriftDetected(PLAN_DIVERGENCE, CRITICAL) before
+    # RunAborted. Match by poking the drift_detected payload fields.
+    drift_events = [
+        e
+        for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "drift_detected"
+    ]
+    assert drift_events, "expected at least one DriftDetected event"
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    audit_drifts = [
+        e for e in drift_events if e.drift_detected.kind == types_pb2.DRIFT_KIND_PLAN_DIVERGENCE
+    ]
+    assert audit_drifts, "expected a PLAN_DIVERGENCE drift from the audit"
+    assert audit_drifts[-1].drift_detected.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+    assert "orphaned" in audit_drifts[-1].drift_detected.detail.lower()
+
+
+async def test_executor_skips_audit_when_all_tasks_terminal() -> None:
+    """Audit is a no-op when no PENDING tasks remain — success stays True."""
+    plan = _linear_plan(2)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _complete_current(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_current)
+
+    executor = SequentialExecutor(max_plan_reinvocations=5)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is True
+    # No PLAN_DIVERGENCE drift was emitted (no orphans).
+    drift_payloads = [
+        e
+        for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "drift_detected"
+    ]
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    assert not any(
+        e.drift_detected.kind == types_pb2.DRIFT_KIND_PLAN_DIVERGENCE for e in drift_payloads
+    )
+    assert sink.payload_kinds()[-1] == "run_completed"

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -265,11 +265,19 @@ async def test_mark_task_blocked_transitions_and_emits_drift() -> None:
 
 async def test_mark_task_cancelled_transitions() -> None:
     steerer, session, sink, _ = _fresh()
+    # The default fixture plan has t1 -> t2; the cascade emits a
+    # TaskCancelled for t2 as well. Verify both the primary transition
+    # and the cascaded one; detailed cascade behaviour is exercised in
+    # the dedicated cascade tests below.
     await steerer.mark_task_cancelled("t1", session=session, reason="user cancelled")
     assert _task(session, "t1").status is TaskStatus.CANCELLED
-    assert len(sink.events) == 1
+    assert _task(session, "t2").status is TaskStatus.CANCELLED
+    assert len(sink.events) == 2
     assert sink.events[0].WhichOneof("payload") == "task_cancelled"
+    assert sink.events[0].task_cancelled.task_id == "t1"
     assert sink.events[0].task_cancelled.reason == "user cancelled"
+    assert sink.events[1].WhichOneof("payload") == "task_cancelled"
+    assert sink.events[1].task_cancelled.task_id == "t2"
 
 
 async def test_transition_dispatches_to_mark_methods() -> None:
@@ -817,3 +825,135 @@ async def test_bind_replaces_sinks() -> None:
     await steerer.mark_task_running("t1", session=session)
     assert sink_a.events == []
     assert len(sink_b.events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cancellation cascade (TASK-LIFECYCLE.md §6.1, STATE-MACHINE.md
+# §"Cascade on task cancellation")
+# ---------------------------------------------------------------------------
+
+
+async def test_mark_task_cancelled_cascades_to_downstream_pending() -> None:
+    """t1 -> t2 -> t3 linear chain; cancelling t1 cascades to t2 and t3.
+
+    Regression guard for the "make a presentation about waffles" bug:
+    a USER_STEER that cancels the current task while refine fails must
+    still end up cancelling downstream PENDING tasks, otherwise the
+    executor silently runs only the independent branches and reports
+    success while leaving the dependent branch stuck PENDING forever.
+    """
+    steerer = DefaultSteerer()
+    plan = _make_plan(("t1", "t2", "t3"))
+    session = _make_session(plan)
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+
+    await steerer.mark_task_cancelled("t1", session=session, reason="user cancelled")
+
+    # All three tasks end up CANCELLED.
+    assert _task(session, "t1").status is TaskStatus.CANCELLED
+    assert _task(session, "t2").status is TaskStatus.CANCELLED
+    assert _task(session, "t3").status is TaskStatus.CANCELLED
+
+    # One TaskCancelled event per task, in cascade order (t1 first,
+    # then BFS downstream).
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["task_cancelled", "task_cancelled", "task_cancelled"]
+    reasons = [e.task_cancelled.reason for e in sink.events]
+    ids = [e.task_cancelled.task_id for e in sink.events]
+    assert ids == ["t1", "t2", "t3"]
+    # The initiator keeps the caller's reason; the cascaded tasks
+    # carry a "cascade from <initiator>" reason so operators can
+    # trace the blast radius back to the trigger.
+    assert reasons[0] == "user cancelled"
+    for r in reasons[1:]:
+        assert "cascade" in r
+        assert "t1" in r
+
+
+async def test_mark_task_cancelled_does_not_cascade_to_completed() -> None:
+    """t1 -> t2 where t2 is already COMPLETED: t2 stays COMPLETED.
+
+    Terminal statuses absorb. A late cancel on an upstream task must
+    not retroactively un-complete a downstream done-task — all
+    refines already preserve completed tasks verbatim and the cascade
+    here must do the same.
+    """
+    steerer = DefaultSteerer()
+    plan = _make_plan(("t1", "t2"))
+    session = _make_session(plan)
+    _task(session, "t2").status = TaskStatus.COMPLETED
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+
+    await steerer.mark_task_cancelled("t1", session=session, reason="steer")
+
+    assert _task(session, "t1").status is TaskStatus.CANCELLED
+    assert _task(session, "t2").status is TaskStatus.COMPLETED
+    # Exactly one TaskCancelled event (for t1). t2 was preserved.
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["task_cancelled"]
+    assert sink.events[0].task_cancelled.task_id == "t1"
+
+
+async def test_mark_task_cancelled_multiple_downstream_paths() -> None:
+    """Diamond DAG t1 -> {t2, t3} -> t4: all three downstream cancel.
+
+    Confirms the BFS de-duplicates: t4 is reachable via both t2 and
+    t3 but must be cancelled (and emit TaskCancelled) exactly once.
+    """
+    steerer = DefaultSteerer()
+    plan = Plan(
+        id="p-diamond",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id=tid, title=tid.upper()) for tid in ("t1", "t2", "t3", "t4")],
+        edges=[
+            TaskEdge(from_task_id="t1", to_task_id="t2"),
+            TaskEdge(from_task_id="t1", to_task_id="t3"),
+            TaskEdge(from_task_id="t2", to_task_id="t4"),
+            TaskEdge(from_task_id="t3", to_task_id="t4"),
+        ],
+    )
+    session = _make_session(plan)
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+
+    await steerer.mark_task_cancelled("t1", session=session, reason="steer")
+
+    for tid in ("t1", "t2", "t3", "t4"):
+        assert _task(session, tid).status is TaskStatus.CANCELLED, tid
+
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["task_cancelled"] * 4
+    ids = [e.task_cancelled.task_id for e in sink.events]
+    # t1 first; then its direct children (t2, t3 in edge-order); then t4.
+    # De-duplication: t4 appears exactly once despite two paths.
+    assert ids[0] == "t1"
+    assert set(ids[1:3]) == {"t2", "t3"}
+    assert ids[3] == "t4"
+    assert ids.count("t4") == 1
+
+
+async def test_mark_task_cancelled_does_not_re_cancel() -> None:
+    """Cancelling an already-CANCELLED task is a full no-op.
+
+    No re-emission of TaskCancelled for the task itself and — critically
+    — no re-cascade into downstream tasks, which would double-emit
+    TaskCancelled events on every redundant call.
+    """
+    steerer = DefaultSteerer()
+    plan = _make_plan(("t1", "t2"))
+    session = _make_session(plan)
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+
+    await steerer.mark_task_cancelled("t1", session=session, reason="first")
+    first_event_count = len(sink.events)
+    assert first_event_count == 2  # t1 + cascaded t2
+
+    # Second call on the same already-terminal task: no new events.
+    await steerer.mark_task_cancelled("t1", session=session, reason="again")
+    assert len(sink.events) == first_event_count
+    assert _task(session, "t1").status is TaskStatus.CANCELLED
+    assert _task(session, "t2").status is TaskStatus.CANCELLED


### PR DESCRIPTION
## Observed bug

The \"make a presentation about waffles\" regression run (see
`/tmp/e2e-rez3-steered.out`):

```
[e2e-rez3-steered] starting (STEER=ON)
[e2e-rez3-steered] setup in 0.2s; running...
[e2e-rez3-steered] STEER injected at t+300.3s id=8b27d1ec
LLMPlanner._refine_user_steer: empty/non-string LLM response
DefaultSteerer._handle_drift: planner.refine(kind=user_steer) returned None; plan unchanged
[e2e-rez3-steered] DONE success=True in 514.6s
[e2e-rez3-steered] revision_index=0 reason=''
[e2e-rez3-steered] tasks: research_history=CANCELLED, research_types=COMPLETED,
  research_preparation=COMPLETED, compile_outline=PENDING, draft_content=PENDING,
  review_content=PENDING, revise_content=PENDING, format_presentation=PENDING,
  final_review=PENDING, deliver_presentations=PENDING
```

A user STEER made the run kid-friendly; `research_history` was cancelled,
`_refine_user_steer` got an empty LLM response and returned None, and the
executor then ran only the two non-dependent tasks (`research_types`,
`research_preparation`) before reporting `success=True` with seven
downstream tasks stuck in PENDING forever. No presentation was ever
produced.

## Root cause

`DefaultSteerer.mark_task_cancelled` transitioned only the target task and
emitted a single `TaskCancelled`. `SequentialExecutor._pick_next_task`
walks topological stages and only returns a PENDING task whose **deps are
all COMPLETED** — a CANCELLED predecessor does not satisfy that check, so
every descendant is orphaned.

When `_pick_next_task` returns None:
- the executor breaks out of its main loop,
- `run_failed` is False (no task FAILED),
- `_any_failed(...)` is False,
- → `RunCompleted` fires with `success=True`,
- downstream tasks silently stay PENDING.

## Fix

**Steerer (`goldfive/steerer.py`):** `mark_task_cancelled` now BFS-cancels
every reachable non-terminal task (PENDING / RUNNING / BLOCKED) from the
cancelled id, emitting one `TaskCancelled` per transition with reason
`\"cascade from <task_id>\"`. Terminal tasks (COMPLETED / FAILED /
already-CANCELLED) are preserved verbatim and not traversed past, so a
diamond DAG does not double-cancel. The cascade fires from *every*
cancellation entry point — control-channel `CANCEL`, `USER_STEER` whose
refine fails, explicit `mark_task_cancelled` calls — because they all
converge at `mark_task_cancelled`.

**Executor (`goldfive/executors/sequential.py`):** A **reachability
audit** at loop exit. If `_pick_next_task` returned None but some tasks
are still PENDING, the audit flips each to CANCELLED with reason
`\"orphaned by plan revision failure\"`, emits a CRITICAL
`PLAN_DIVERGENCE` drift so sinks see the incomplete ending, and returns
`success=False`. Belt-and-suspenders for any cancellation path that
fails to cascade.

**Docs:**
- `docs/design/TASK-LIFECYCLE.md` gains §6.1 \"Cancellation cascade\"
  and a §7.8 noting the closed soundness gap (see §7).
- `docs/design/STATE-MACHINE.md` \"Cascade semantics on unrecoverable
  drift\" now also covers the cascade-on-cancel case.

## Test plan

- [x] `uv run --extra dev --extra adk pytest -q` → **492 passed, 38
  skipped**
- [x] `uv run --extra dev ruff check .` → clean
- [x] `uv run --extra dev ruff format --check` on touched files → clean
- [x] New steerer tests: cascade to linear chain, preserve COMPLETED
  downstream, diamond DAG de-dup, idempotent re-cancel
- [x] New executor tests: orphaned PENDING triggers `success=False`;
  audit emits CRITICAL `PLAN_DIVERGENCE`; no audit drift when every
  task is terminal

## References

- [`docs/design/TASK-LIFECYCLE.md` §6.1, §7.8](https://github.com/pedapudi/goldfive/blob/fix/cancel-cascade/docs/design/TASK-LIFECYCLE.md)
- [`docs/design/STATE-MACHINE.md` \"Cascade semantics on unrecoverable drift\"](https://github.com/pedapudi/goldfive/blob/fix/cancel-cascade/docs/design/STATE-MACHINE.md)
