### PR TITLE
Evaluate Goal.success_predicate when computing Outcome.success (closes PLAN-LIFECYCLE.md §8 gap #1)

### DIFF
--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -293,9 +293,14 @@ A run completes successfully when **all three** hold:
 If all three hold: `Outcome.success = True`.
 
 If only the first two hold (everything is terminal, no orphans, but
-some goal predicates returned False): `Outcome.success = False`
-with `reason="goals unmet"`. This is a new verdict the current
-executor does not emit; see TASK-LIFECYCLE.md §7 follow-up.
+some goal predicates returned False or raised): `Outcome.success =
+False` with `reason="goal '<summary>' unmet"` (or `"goal '<summary>'
+predicate raised: <exc>"` for an exception). Implemented by
+`goldfive.results.evaluate_goal_predicates` (`results.py:42`), called
+from `sequential.py:490` and `parallel.py:327` before each executor's
+`run_completed_event` emission. Predicates are evaluated in
+`session.goals` order and short-circuit on the first unmet goal; a
+predicate that raises is logged at WARNING and treated as unmet.
 
 ### 6.2 Unrecoverable cascade (ABORTED)
 
@@ -380,7 +385,6 @@ Violating any of them is a bug in goldfive.
 
 ## 8. Known gaps (open)
 
-- **Goal success predicates are not evaluated.** `Goal.success_predicate` is defined on the type but never called. §6.1's third clause is specified but not yet implemented.
 - **Terminal→terminal edge preservation is not currently enforced.** `_apply_revision` does not yet check edge preservation; a buggy planner could silently drop terminal edges. Add to `Plan.validate(for_revision=True)`.
 - **Unrecoverable cascade (§6.2) does not currently use the same cascade primitive as §6.3** — they're two different code paths that happen to do similar work. Unify once both are implemented.
 - **No cross-revision lineage view.** Sinks receive `PlanRevised` events but the proto doesn't carry the full diff. Harmonograf's UI currently has to stitch revisions by plan_id + revision_index. A dedicated `revision_diff` sidecar would simplify the UI.

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -49,7 +49,7 @@ from goldfive.protocols import (
     Planner,
     Steerer,
 )
-from goldfive.results import ExecutionOutcome, InvocationResult
+from goldfive.results import ExecutionOutcome, InvocationResult, evaluate_goal_predicates
 from goldfive.types import (
     DriftEvent,
     DriftSeverity,
@@ -319,6 +319,22 @@ class ParallelDAGExecutor:
                 ),
             )
             return ExecutionOutcome(success=False, session=session, reason=abort_reason)
+
+        # Goal success-predicate gate (PLAN-LIFECYCLE.md §6.1, third
+        # clause). Every stage has completed — now verify the caller's
+        # semantic goals. A predicate that returns False or raises
+        # fails the run.
+        unmet = evaluate_goal_predicates(session)
+        if unmet is not None:
+            await emit_event(
+                sinks,
+                run_aborted_event(
+                    run_id=session.run_id,
+                    sequence=session.next_sequence(),
+                    reason=unmet,
+                ),
+            )
+            return ExecutionOutcome(success=False, session=session, reason=unmet)
 
         await emit_event(
             sinks,

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -49,7 +49,7 @@ from goldfive.executors._control import (
     drain_controls,
 )
 from goldfive.protocols import AgentAdapter, EventSink, Executor, Planner, Steerer
-from goldfive.results import ExecutionOutcome
+from goldfive.results import ExecutionOutcome, evaluate_goal_predicates
 from goldfive.types import DriftKind, DriftSeverity, Plan, Session, Task, TaskStatus
 
 if TYPE_CHECKING:
@@ -482,6 +482,22 @@ class SequentialExecutor(Executor):
                 ),
             )
             return ExecutionOutcome(success=False, session=session, reason=reason)
+
+        # Goal success-predicate gate (PLAN-LIFECYCLE.md §6.1, third
+        # clause). Tasks are terminal and no orphans remain — now
+        # verify the caller's semantic goals. A predicate that returns
+        # False or raises fails the run with a descriptive reason.
+        unmet = evaluate_goal_predicates(session)
+        if unmet is not None:
+            await emit(
+                sinks,
+                run_aborted_event(
+                    run_id=session.run_id,
+                    sequence=session.next_sequence(),
+                    reason=unmet,
+                ),
+            )
+            return ExecutionOutcome(success=False, session=session, reason=unmet)
 
         await emit(
             sinks,

--- a/goldfive/results.py
+++ b/goldfive/results.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import dataclasses
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from goldfive.types import Session
+
+log = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
@@ -34,3 +37,49 @@ class ExecutionOutcome:
     success: bool
     session: Session
     reason: str = ""
+
+
+def evaluate_goal_predicates(session: Session) -> str | None:
+    """Evaluate every ``Goal.success_predicate`` on ``session``.
+
+    Implements the third clause of :doc:`PLAN-LIFECYCLE.md §6.1
+    </design/PLAN-LIFECYCLE>`: a run is successful only if every goal's
+    ``success_predicate`` returns ``True`` (``None`` is treated as
+    vacuously met). Executors call this after the "every task terminal +
+    no orphans" gate and include the returned reason (if any) on the
+    :class:`ExecutionOutcome`.
+
+    Returns
+    -------
+    ``None``
+        All goals are met (or ``session.goals`` is empty) — the run
+        may be reported as successful.
+    ``str``
+        A human-readable reason describing the first unmet goal. The
+        caller should set ``Outcome.success = False`` and propagate
+        this string on ``Outcome.reason``.
+
+    Behavior
+    --------
+    * Predicates are evaluated in ``session.goals`` order; the first
+      one that is not met short-circuits.
+    * A predicate that raises is logged at WARNING and treated as unmet
+      (never as met): a crashing predicate is never a pass.
+    """
+    for goal in session.goals:
+        predicate = goal.success_predicate
+        if predicate is None:
+            continue
+        summary = goal.summary or goal.id or "<unnamed>"
+        try:
+            met = predicate(session)
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "goal predicate raised for goal %r: %s",
+                summary,
+                exc,
+            )
+            return f"goal '{summary}' predicate raised: {exc}"
+        if not met:
+            return f"goal '{summary}' unmet"
+    return None

--- a/tests/test_parallel_executor.py
+++ b/tests/test_parallel_executor.py
@@ -23,6 +23,7 @@ from goldfive.types import (
     DriftEvent,
     DriftKind,
     DriftSeverity,
+    Goal,
     Plan,
     Session,
     Task,
@@ -549,3 +550,129 @@ async def test_reinvocation_budget_exhaustion_aborts() -> None:
     assert outcome.success is False
     assert "budget" in outcome.reason
     assert len(planner.refine_calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Goal success predicates (PLAN-LIFECYCLE.md §6.1, third clause).
+#
+# Mirrors the sequential executor's coverage: a run is only successful
+# when every ``Goal.success_predicate`` on the session returns True (or
+# is None). The parallel executor must apply the same check before
+# reporting success.
+# ---------------------------------------------------------------------------
+
+
+def _simple_two_task_plan() -> Plan:
+    """A -> B linear plan (simpler than the diamond for goal tests)."""
+    return Plan(
+        id="plan-goals",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[Task(id="A", title="A"), Task(id="B", title="B")],
+        edges=[TaskEdge("A", "B")],
+    )
+
+
+async def _run_happy_parallel_executor(
+    *,
+    goals: list[Goal],
+) -> tuple[Any, Session, NoopSink]:
+    """Run a 2-task plan that completes cleanly; return outcome + sink."""
+    plan = _simple_two_task_plan()
+    session = _new_session()
+    session.goals = list(goals)
+    adapter = TracingAdapter(delay=0.005)
+    steerer = RecordingSteerer()
+    planner = RecordingPlanner()
+    sink = NoopSink()
+
+    executor = ParallelDAGExecutor(max_concurrency=0)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+    return outcome, session, sink
+
+
+@pytest.mark.asyncio
+async def test_parallel_run_with_unmet_goal_reports_failure() -> None:
+    """Tasks all succeed but a goal predicate returns False -> run fails."""
+    goals = [
+        Goal(
+            id="g1",
+            summary="deliver the thing",
+            success_predicate=lambda _s: False,
+        ),
+    ]
+    outcome, _session, sink = await _run_happy_parallel_executor(goals=goals)
+
+    assert outcome.success is False
+    assert "deliver the thing" in outcome.reason
+    assert "unmet" in outcome.reason.lower()
+    kinds = _proto_kinds(sink.events)
+    assert kinds[-1] == "RunAborted"
+
+
+@pytest.mark.asyncio
+async def test_parallel_run_with_none_predicate_treats_as_met() -> None:
+    """``success_predicate=None`` is vacuously true -> success."""
+    goals = [
+        Goal(id="g1", summary="vacuous goal", success_predicate=None),
+    ]
+    outcome, _session, sink = await _run_happy_parallel_executor(goals=goals)
+
+    assert outcome.success is True
+    assert outcome.reason == ""
+    kinds = _proto_kinds(sink.events)
+    assert kinds[-1] == "RunCompleted"
+
+
+@pytest.mark.asyncio
+async def test_parallel_run_with_raising_predicate_treats_as_unmet() -> None:
+    """A predicate that raises is logged and treated as unmet."""
+
+    def _boom(_session: Session) -> bool:
+        raise RuntimeError("evaluation exploded")
+
+    goals = [
+        Goal(id="g1", summary="raising goal", success_predicate=_boom),
+    ]
+    outcome, _session, sink = await _run_happy_parallel_executor(goals=goals)
+
+    assert outcome.success is False
+    assert "raising goal" in outcome.reason
+    assert "raised" in outcome.reason.lower()
+    assert "evaluation exploded" in outcome.reason
+    kinds = _proto_kinds(sink.events)
+    assert kinds[-1] == "RunAborted"
+
+
+@pytest.mark.asyncio
+async def test_parallel_all_goals_met_returns_success() -> None:
+    """Standard happy path: every predicate returns True -> success."""
+    calls: list[str] = []
+
+    def _met_a(session: Session) -> bool:
+        calls.append("a")
+        assert session.plan is not None
+        return True
+
+    def _met_b(_s: Session) -> bool:
+        calls.append("b")
+        return True
+
+    goals = [
+        Goal(id="g1", summary="goal A", success_predicate=_met_a),
+        Goal(id="g2", summary="goal B", success_predicate=_met_b),
+    ]
+    outcome, _session, sink = await _run_happy_parallel_executor(goals=goals)
+
+    assert outcome.success is True
+    assert outcome.reason == ""
+    assert calls == ["a", "b"]
+    kinds = _proto_kinds(sink.events)
+    assert kinds[-1] == "RunCompleted"

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -23,6 +23,7 @@ from goldfive.types import (
     DriftEvent,
     DriftKind,
     DriftSeverity,
+    Goal,
     Plan,
     Session,
     Task,
@@ -916,3 +917,162 @@ async def test_executor_skips_audit_when_all_tasks_terminal() -> None:
         e.drift_detected.kind == types_pb2.DRIFT_KIND_PLAN_DIVERGENCE for e in drift_payloads
     )
     assert sink.payload_kinds()[-1] == "run_completed"
+
+
+# ---------------------------------------------------------------------------
+# Goal success predicates (PLAN-LIFECYCLE.md §6.1, third clause).
+#
+# A run is only successful when every ``Goal.success_predicate`` on the
+# session returns True (or is None, vacuously met). If all tasks finish
+# but a goal predicate reports the semantic outcome as unmet, the run
+# must end with ``success=False`` and a reason that names the goal.
+# ---------------------------------------------------------------------------
+
+
+async def _run_happy_executor(
+    *,
+    goals: list[Goal],
+) -> tuple[Any, Session, RecordingSink]:
+    """Helper: run a 2-task linear plan that completes cleanly.
+
+    All goal-predicate tests share the same "all tasks succeed" setup;
+    what varies is ``session.goals``. Returns the outcome, the session,
+    and the recording sink so tests can assert on both the Outcome and
+    the terminal event.
+    """
+    plan = _linear_plan(2)
+    session = _fresh_session()
+    session.goals = list(goals)
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _complete_current(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_current)
+    executor = SequentialExecutor(max_plan_reinvocations=5)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+    return outcome, session, sink
+
+
+async def test_run_with_unmet_goal_reports_failure() -> None:
+    """Tasks all succeed but a goal predicate returns False -> run fails.
+
+    The happy-path "every task terminal + no orphans" gate passes, but
+    the goal predicate tells us the semantic outcome wasn't reached.
+    The executor must fail the run and name the goal in the reason.
+    """
+    goals = [
+        Goal(id="g1", summary="deliver the thing", success_predicate=lambda _s: False),
+    ]
+    outcome, _session, sink = await _run_happy_executor(goals=goals)
+
+    assert outcome.success is False
+    # Reason names the goal by its summary so operators can triage.
+    assert "deliver the thing" in outcome.reason
+    assert "unmet" in outcome.reason.lower()
+    # Terminal event is RunAborted (not RunCompleted).
+    assert sink.payload_kinds()[-1] == "run_aborted"
+
+
+async def test_run_with_none_predicate_treats_as_met() -> None:
+    """``success_predicate=None`` is vacuously true — run reports success."""
+    goals = [
+        Goal(id="g1", summary="vacuous goal", success_predicate=None),
+    ]
+    outcome, _session, sink = await _run_happy_executor(goals=goals)
+
+    assert outcome.success is True
+    assert outcome.reason == ""
+    assert sink.payload_kinds()[-1] == "run_completed"
+
+
+async def test_run_with_raising_predicate_treats_as_unmet() -> None:
+    """A predicate that raises is logged and treated as unmet."""
+
+    def _boom(_session: Session) -> bool:
+        raise RuntimeError("evaluation exploded")
+
+    goals = [
+        Goal(id="g1", summary="raising goal", success_predicate=_boom),
+    ]
+    outcome, _session, sink = await _run_happy_executor(goals=goals)
+
+    assert outcome.success is False
+    # Reason carries both the goal name and the exception message.
+    assert "raising goal" in outcome.reason
+    assert "raised" in outcome.reason.lower()
+    assert "evaluation exploded" in outcome.reason
+    assert sink.payload_kinds()[-1] == "run_aborted"
+
+
+async def test_all_goals_met_returns_success() -> None:
+    """Standard happy path: every predicate returns True -> success."""
+    calls: list[str] = []
+
+    def _met_a(session: Session) -> bool:
+        calls.append("a")
+        # Predicate sees the actual session (tasks terminal by now).
+        assert session.plan is not None
+        return True
+
+    def _met_b(session: Session) -> bool:
+        calls.append("b")
+        return True
+
+    goals = [
+        Goal(id="g1", summary="goal A", success_predicate=_met_a),
+        Goal(id="g2", summary="goal B", success_predicate=_met_b),
+    ]
+    outcome, _session, sink = await _run_happy_executor(goals=goals)
+
+    assert outcome.success is True
+    assert outcome.reason == ""
+    # Both predicates were evaluated.
+    assert calls == ["a", "b"]
+    assert sink.payload_kinds()[-1] == "run_completed"
+
+
+async def test_run_with_empty_goals_returns_success() -> None:
+    """No goals at all: vacuously met -> success."""
+    outcome, _session, sink = await _run_happy_executor(goals=[])
+    assert outcome.success is True
+    assert outcome.reason == ""
+    assert sink.payload_kinds()[-1] == "run_completed"
+
+
+async def test_unmet_goal_short_circuits_on_first_false() -> None:
+    """Goals are evaluated in order; the first unmet goal short-circuits."""
+    calls: list[str] = []
+
+    def _first_fails(_s: Session) -> bool:
+        calls.append("first")
+        return False
+
+    def _second(_s: Session) -> bool:
+        calls.append("second")
+        return True
+
+    goals = [
+        Goal(id="g1", summary="first goal", success_predicate=_first_fails),
+        Goal(id="g2", summary="second goal", success_predicate=_second),
+    ]
+    outcome, _session, _sink = await _run_happy_executor(goals=goals)
+
+    assert outcome.success is False
+    # Only the first predicate ran; we short-circuited on its False.
+    assert calls == ["first"]
+    # Reason names the first goal, not the second.
+    assert "first goal" in outcome.reason
+    assert "second goal" not in outcome.reason


### PR DESCRIPTION
## Summary

- Closes PLAN-LIFECYCLE.md §8 gap #1: `Goal.success_predicate` was defined on the type but never called, so §6.1's third success-predicate clause was silently unimplemented — runs whose tasks all finished cleanly returned `Outcome.success=True` even when the caller's semantic outcome was unmet.
- Adds `goldfive.results.evaluate_goal_predicates` as the single source of truth: evaluates `session.goals` in order, short-circuits on the first unmet goal, treats `None` predicates as vacuously true, and treats raising predicates as unmet (logged at WARNING).
- Wires the evaluator into both `SequentialExecutor` and `ParallelDAGExecutor` right before their `run_completed_event` emission. An unmet goal drives `Outcome.success=False`, a reason that names the goal, and `RunAborted` instead of `RunCompleted`.
- Updates `docs/design/PLAN-LIFECYCLE.md` §6.1 to cite the implementation call sites and removes gap #1 from §8.

## Test plan

- [x] `test_run_with_unmet_goal_reports_failure` (sequential) — predicate returns `False` → `Outcome.success=False`, reason names the goal, terminal event is `RunAborted`.
- [x] `test_run_with_none_predicate_treats_as_met` — `None` predicate stays vacuously true.
- [x] `test_run_with_raising_predicate_treats_as_unmet` — raising predicate is treated as unmet, reason carries the exception message.
- [x] `test_all_goals_met_returns_success` — standard happy path; both predicates evaluated in order.
- [x] `test_run_with_empty_goals_returns_success` — no goals at all is vacuously met.
- [x] `test_unmet_goal_short_circuits_on_first_false` — evaluation stops at the first unmet predicate.
- [x] Equivalent `test_parallel_*` coverage in `tests/test_parallel_executor.py`.
- [x] Full suite `uv run --extra dev --extra adk pytest -q` → 502 passed, 38 skipped.
- [x] `uv run --extra dev ruff check .` → clean.
