### PR TITLE
Enforce terminal task + terminal-edge preservation on plan revision (closes PLAN-LIFECYCLE.md §8 gap #2)

### DIFF
--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -107,13 +107,23 @@ with:
 If a refined plan is missing a terminal task from the outgoing plan,
 or its status has regressed, the steerer rejects the revision and
 emits a CRITICAL `SCHEMA_VIOLATION` drift (see #100 /
-`_apply_revision`).
+`_apply_revision`). Enforced by `Plan.validate(for_revision=True,
+prior=session.plan)` in `types.py`, called from
+`DefaultSteerer._apply_revision`; id / status preservation is the
+machine-checked half of this invariant. Title / description /
+assignee / `bound_span_id` preservation remains a planner-semantic
+contract.
 
 ### 3.2 Terminal→terminal edges are frozen
 
 If both endpoints of an edge in the outgoing plan were terminal,
 that edge **must** appear in the new plan. This preserves the
 historical topology so a later forensic replay is faithful.
+Enforced by `Plan.validate(for_revision=True, prior=session.plan)`
+in `types.py`: a revision that drops a terminal→terminal edge is
+rejected with a `ValueError`, which the steerer surfaces as a
+CRITICAL `SCHEMA_VIOLATION` drift while leaving the prior plan
+installed.
 
 ### 3.3 Terminal→mutable edges may be re-drawn
 
@@ -266,6 +276,15 @@ Called by `LLMPlanner.generate` (creation) and
 - **At creation only** (`for_revision=False`): every task is
   `PENDING`. At revision (`for_revision=True`), terminal tasks are
   allowed (expected, per §3.1).
+- **At revision with a `prior` plan supplied**
+  (`for_revision=True, prior=old_plan`): every terminal task in
+  `prior` appears in the revision with the same id and the same
+  terminal status (no regression, no drop) — §3.1 — and every
+  terminal→terminal edge in `prior` appears in the revision — §3.2.
+  The steerer calls `validate(for_revision=True, prior=session.plan)`
+  in `_apply_revision`, and `LLMPlanner.refine` / `_refine_user_steer`
+  / `_refine_looping_tool_call` likewise thread `prior=plan` so the
+  planner catches its own violations before the steerer does.
 
 On failure: `ValueError` with a descriptive message. `generate`
 returns `None`; `_apply_revision` rejects the revision and emits
@@ -385,6 +404,5 @@ Violating any of them is a bug in goldfive.
 
 ## 8. Known gaps (open)
 
-- **Terminal→terminal edge preservation is not currently enforced.** `_apply_revision` does not yet check edge preservation; a buggy planner could silently drop terminal edges. Add to `Plan.validate(for_revision=True)`.
 - **Unrecoverable cascade (§6.2) does not currently use the same cascade primitive as §6.3** — they're two different code paths that happen to do similar work. Unify once both are implemented.
 - **No cross-revision lineage view.** Sinks receive `PlanRevised` events but the proto doesn't carry the full diff. Harmonograf's UI currently has to stitch revisions by plan_id + revision_index. A dedicated `revision_diff` sidecar would simplify the UI.

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -797,7 +797,7 @@ class LLMPlanner:
             log.warning("LLMPlanner.refine: parsed JSON did not contain a usable plan")
             return None
         try:
-            revised.validate(for_revision=True)
+            revised.validate(for_revision=True, prior=plan)
         except ValueError as exc:
             log.warning(
                 "LLMPlanner.refine: revised plan failed validation (%s)",
@@ -955,7 +955,7 @@ class LLMPlanner:
                     ),
                 )
         try:
-            revised.validate(for_revision=True)
+            revised.validate(for_revision=True, prior=plan)
         except ValueError as exc:
             log.warning(
                 "LLMPlanner._refine_looping_tool_call: revised plan failed "
@@ -1139,7 +1139,7 @@ class LLMPlanner:
             revision_index=plan.revision_index + 1,
         )
         try:
-            merged_plan.validate(for_revision=True)
+            merged_plan.validate(for_revision=True, prior=plan)
         except ValueError as exc:
             log.warning(
                 "LLMPlanner._refine_user_steer: merged plan failed validation (%s)",

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -606,14 +606,17 @@ class DefaultSteerer:
             await self._register_refine_failure(session, drift, counter_key)
             return
         try:
-            revised.validate(for_revision=True)
+            revised.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
             # Reject the revision and surface the failure as a CRITICAL
             # DriftDetected so operators can see the bad plan upstream.
             # The session keeps its old plan. A bad revision also counts
             # as a refine failure for backoff purposes — the planner
             # produced an unusable plan, which is functionally the same
-            # as returning None.
+            # as returning None. Passing ``prior=session.plan`` enables
+            # PLAN-LIFECYCLE.md §3.1 (terminal task preservation) and
+            # §3.2 (terminal->terminal edge preservation) on top of the
+            # usual structural checks.
             await self._emit_drift_detected(
                 session,
                 DriftEvent(

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -118,7 +118,7 @@ class Plan:
     revision_severity: str = ""  # DriftSeverity value (str) or ""
     revision_index: int = 0
 
-    def validate(self, for_revision: bool = False) -> None:
+    def validate(self, for_revision: bool = False, *, prior: Plan | None = None) -> None:
         """Structurally validate this plan. Raise ``ValueError`` on failure.
 
         Checks, in order:
@@ -135,6 +135,19 @@ class Plan:
            COMPLETED / FAILED / CANCELLED tasks preserved from the prior
            plan, so this check is skipped when ``for_revision`` is
            ``True``.
+        6. When ``for_revision`` is ``True`` and a ``prior`` plan is
+           supplied, enforce the cross-revision preservation contract
+           from ``docs/design/PLAN-LIFECYCLE.md`` §3.1 and §3.2:
+
+           - **Terminal task preservation (§3.1).** Every task in
+             ``prior.tasks`` whose status is terminal must appear in
+             ``self.tasks`` with the same id AND the same terminal
+             status — no regression from COMPLETED back to PENDING is
+             allowed, and dropping a terminal task is forbidden.
+           - **Terminal→terminal edge preservation (§3.2).** Every
+             edge in ``prior.edges`` where both endpoints were terminal
+             in ``prior`` must appear in ``self.edges``. Historical
+             topology between frozen tasks is frozen.
 
         This is a pure-data validator: it does not mutate the plan. It
         is intended to be called at plan creation (``LLMPlanner.generate``)
@@ -191,6 +204,36 @@ class Plan:
                 if t.status is not TaskStatus.PENDING:
                     raise ValueError(
                         f"task {t.id!r} has non-PENDING status {t.status.value!r} at plan creation"
+                    )
+
+        # 6. revision-time with a prior plan: enforce terminal-task and
+        # terminal->terminal-edge preservation (PLAN-LIFECYCLE.md §3.1,
+        # §3.2). Skipped when ``prior`` is None — callers that do not
+        # supply the outgoing plan get the legacy structural checks only.
+        if for_revision and prior is not None:
+            new_by_id: dict[str, Task] = {t.id: t for t in self.tasks}
+            prior_terminal_ids: set[str] = set()
+            for t in prior.tasks:
+                if t.status not in TERMINAL_TASK_STATUSES:
+                    continue
+                prior_terminal_ids.add(t.id)
+                new_t = new_by_id.get(t.id)
+                if new_t is None:
+                    raise ValueError(f"terminal task {t.id!r} missing in revision")
+                if new_t.status is not t.status:
+                    raise ValueError(f"terminal task {t.id!r} regressed to {new_t.status.value!r}")
+            # Every terminal->terminal edge in the outgoing plan must
+            # appear verbatim in the revision.
+            new_edges: set[tuple[str, str]] = {(e.from_task_id, e.to_task_id) for e in self.edges}
+            for e in prior.edges:
+                if (
+                    e.from_task_id in prior_terminal_ids
+                    and e.to_task_id in prior_terminal_ids
+                    and (e.from_task_id, e.to_task_id) not in new_edges
+                ):
+                    raise ValueError(
+                        "terminal->terminal edge "
+                        f"{e.from_task_id!r} -> {e.to_task_id!r} missing in revision"
                     )
 
     def topological_stages(self) -> list[list[Task]]:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -423,9 +423,20 @@ async def test_llm_planner_refine_handles_call_llm_exception() -> None:
 
 
 async def test_llm_planner_refine_increments_revision_index() -> None:
+    # Must preserve the COMPLETED ``research`` task from ``_running_plan``
+    # verbatim so PLAN-LIFECYCLE.md §3.1 terminal-preservation holds at
+    # validation time.
     payload = {
         "summary": "same",
-        "tasks": [{"id": "draft", "title": "Draft", "status": "RUNNING"}],
+        "tasks": [
+            {
+                "id": "research",
+                "title": "Research goldfish facts",
+                "assignee_agent_id": "researcher",
+                "status": "COMPLETED",
+            },
+            {"id": "draft", "title": "Draft", "status": "RUNNING"},
+        ],
         "edges": [],
     }
     stub = _StubLLM(json.dumps(payload))

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -814,6 +814,113 @@ async def test_observe_rejects_revised_plan_with_unknown_edge() -> None:
     assert "unknown task id" in second.detail
 
 
+async def test_apply_revision_emits_schema_violation_on_terminal_regression() -> None:
+    """A refine that regresses a terminal task's status is rejected.
+
+    PLAN-LIFECYCLE.md §3.1: terminal tasks are frozen — once a task
+    lands in COMPLETED / FAILED / CANCELLED, subsequent revisions must
+    preserve id AND status. The steerer must reject a revision that
+    flips a previously-COMPLETED task back to PENDING, emit a CRITICAL
+    SCHEMA_VIOLATION drift with the validator's reason, and keep the
+    original plan installed.
+    """
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    # Seed the session with a plan where t1 is COMPLETED, t2 is PENDING.
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="done", status=TaskStatus.COMPLETED),
+            Task(id="t2", title="next", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge("t1", "t2")],
+    )
+    # Bad revision: t1 has regressed from COMPLETED -> PENDING.
+    bad_revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="done", status=TaskStatus.PENDING),
+            Task(id="t2", title="next", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge("t1", "t2")],
+    )
+    planner = StubPlanner(revised=bad_revised)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session(plan=prior)
+
+    await steerer.observe({"error": "trigger refine"}, session)
+
+    # Plan unchanged; two drift events (the original trigger + the
+    # schema-violation report); no PlanRevised emitted.
+    assert session.plan is prior
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["drift_detected", "drift_detected"]
+    second = sink.events[1].drift_detected
+    assert second.kind == types_pb2.DRIFT_KIND_SCHEMA_VIOLATION
+    assert second.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+    assert "plan validation failed" in second.detail
+    assert "terminal task 't1' regressed" in second.detail
+
+
+async def test_apply_revision_emits_schema_violation_on_missing_terminal_edge() -> None:
+    """A refine that drops a terminal->terminal edge is rejected.
+
+    PLAN-LIFECYCLE.md §3.2: edges whose both endpoints were terminal in
+    the outgoing plan are frozen and must appear verbatim in any
+    revision. The steerer must reject a revision that drops such an
+    edge, emit a CRITICAL SCHEMA_VIOLATION, and keep the prior plan.
+    """
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    # Seed the session with a plan where both t1 and t2 are terminal
+    # with an edge between them.
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="1", status=TaskStatus.COMPLETED),
+            Task(id="t2", title="2", status=TaskStatus.COMPLETED),
+            Task(id="t3", title="3", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge("t1", "t2"), TaskEdge("t2", "t3")],
+    )
+    # Bad revision: preserves terminals but drops the t1 -> t2 edge.
+    bad_revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="1", status=TaskStatus.COMPLETED),
+            Task(id="t2", title="2", status=TaskStatus.COMPLETED),
+            Task(id="t3", title="3", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge("t2", "t3")],
+    )
+    planner = StubPlanner(revised=bad_revised)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session(plan=prior)
+
+    await steerer.observe({"error": "trigger refine"}, session)
+
+    assert session.plan is prior
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["drift_detected", "drift_detected"]
+    second = sink.events[1].drift_detected
+    assert second.kind == types_pb2.DRIFT_KIND_SCHEMA_VIOLATION
+    assert second.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+    assert "plan validation failed" in second.detail
+    assert "terminal->terminal edge 't1' -> 't2'" in second.detail
+
+
 async def test_bind_replaces_sinks() -> None:
     steerer = DefaultSteerer()
     planner = StubPlanner()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -408,3 +408,134 @@ class TestPlanValidate:
         )
         with pytest.raises(ValueError, match="unknown task id"):
             plan.validate(for_revision=True)
+
+    # ------------------------------------------------------------------
+    # Cross-revision preservation (PLAN-LIFECYCLE.md §3.1, §3.2). When
+    # ``prior`` is supplied, ``validate`` enforces that terminal tasks
+    # survive the revision with the same id + status, and that every
+    # terminal->terminal edge in ``prior`` appears in the revision.
+    # ------------------------------------------------------------------
+
+    def test_validate_revision_rejects_terminal_task_missing(self) -> None:
+        prior = _mk_plan(
+            [
+                Task(id="t1", title="done", status=TaskStatus.COMPLETED),
+                Task(id="t2", title="next", status=TaskStatus.PENDING),
+            ],
+            [TaskEdge("t1", "t2")],
+        )
+        # Revision drops the terminal t1 entirely — that is forbidden.
+        revision = _mk_plan(
+            [Task(id="t2", title="next", status=TaskStatus.PENDING)],
+            [],
+        )
+        with pytest.raises(
+            ValueError, match=r"terminal task 't1' missing in revision"
+        ):
+            revision.validate(for_revision=True, prior=prior)
+
+    def test_validate_revision_rejects_terminal_task_status_regression(self) -> None:
+        prior = _mk_plan(
+            [Task(id="t1", title="done", status=TaskStatus.COMPLETED)],
+            [],
+        )
+        # Revision keeps the id but regresses status to PENDING.
+        revision = _mk_plan(
+            [Task(id="t1", title="done", status=TaskStatus.PENDING)],
+            [],
+        )
+        with pytest.raises(
+            ValueError, match=r"terminal task 't1' regressed to 'PENDING'"
+        ):
+            revision.validate(for_revision=True, prior=prior)
+
+    def test_validate_revision_rejects_terminal_task_status_flip(self) -> None:
+        # A terminal task whose status flips COMPLETED -> FAILED also
+        # breaks the monotonic-terminal invariant (a terminal status is
+        # absorbing; the only allowed "transition" is identity).
+        prior = _mk_plan(
+            [Task(id="t1", title="done", status=TaskStatus.COMPLETED)],
+            [],
+        )
+        revision = _mk_plan(
+            [Task(id="t1", title="done", status=TaskStatus.FAILED)],
+            [],
+        )
+        with pytest.raises(
+            ValueError, match=r"terminal task 't1' regressed to 'FAILED'"
+        ):
+            revision.validate(for_revision=True, prior=prior)
+
+    def test_validate_revision_accepts_terminal_task_unchanged(self) -> None:
+        prior = _mk_plan(
+            [
+                Task(id="t1", title="done", status=TaskStatus.COMPLETED),
+                Task(id="t2", title="next", status=TaskStatus.PENDING),
+            ],
+            [TaskEdge("t1", "t2")],
+        )
+        revision = _mk_plan(
+            [
+                Task(id="t1", title="done", status=TaskStatus.COMPLETED),
+                Task(id="t2", title="next", status=TaskStatus.PENDING),
+                Task(id="t3", title="added", status=TaskStatus.PENDING),
+            ],
+            [TaskEdge("t1", "t2"), TaskEdge("t2", "t3")],
+        )
+        # Does not raise.
+        revision.validate(for_revision=True, prior=prior)
+
+    def test_validate_revision_rejects_missing_terminal_edge(self) -> None:
+        prior = _mk_plan(
+            [
+                Task(id="t1", title="1", status=TaskStatus.COMPLETED),
+                Task(id="t2", title="2", status=TaskStatus.COMPLETED),
+            ],
+            [TaskEdge("t1", "t2")],
+        )
+        # Revision keeps both terminal tasks but drops the
+        # terminal->terminal edge — forbidden by §3.2.
+        revision = _mk_plan(
+            [
+                Task(id="t1", title="1", status=TaskStatus.COMPLETED),
+                Task(id="t2", title="2", status=TaskStatus.COMPLETED),
+            ],
+            [],
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"terminal->terminal edge 't1' -> 't2' missing in revision",
+        ):
+            revision.validate(for_revision=True, prior=prior)
+
+    def test_validate_revision_accepts_missing_mutable_edge(self) -> None:
+        # terminal -> PENDING edge in ``prior`` may be dropped freely;
+        # only terminal->terminal edges are frozen by §3.2.
+        prior = _mk_plan(
+            [
+                Task(id="t1", title="1", status=TaskStatus.COMPLETED),
+                Task(id="t2", title="2", status=TaskStatus.PENDING),
+            ],
+            [TaskEdge("t1", "t2")],
+        )
+        revision = _mk_plan(
+            [
+                Task(id="t1", title="1", status=TaskStatus.COMPLETED),
+                Task(id="t2", title="2", status=TaskStatus.PENDING),
+            ],
+            [],
+        )
+        # Does not raise — the dropped edge's ``to`` endpoint was
+        # non-terminal in ``prior``.
+        revision.validate(for_revision=True, prior=prior)
+
+    def test_validate_revision_without_prior_skips_preservation(self) -> None:
+        # Backwards-compat: callers that do not supply ``prior`` get the
+        # legacy structural checks only; a revision that would violate
+        # §3.1/§3.2 still validates as long as it is structurally sound.
+        revision = _mk_plan(
+            [Task(id="t1", title="done", status=TaskStatus.PENDING)],
+            [],
+        )
+        # No prior supplied -> no terminal-preservation check.
+        revision.validate(for_revision=True)


### PR DESCRIPTION
## Summary

- Extends `Plan.validate(for_revision=True)` with an optional `prior: Plan | None` kwarg that enforces PLAN-LIFECYCLE.md §3.1 (terminal tasks frozen — same id + same terminal status, no regression, no drop) and §3.2 (terminal->terminal edges frozen).
- `DefaultSteerer._apply_revision` now threads `prior=session.plan` through `validate` so a buggy planner that silently drops a terminal task, regresses COMPLETED back to PENDING, or omits a terminal->terminal edge is rejected — the existing `SCHEMA_VIOLATION` drift path from #100 keeps the prior plan installed and increments the refine-failure counter.
- `LLMPlanner.refine` and its two specialised paths (`_refine_user_steer`, `_refine_looping_tool_call`) also thread `prior=plan` so the planner catches its own violations before the steerer does, improving the error surface.
- Closes PLAN-LIFECYCLE.md §8 gap #2; §3.1, §3.2, and §5 updated to reference the now-enforced validator.

## Test plan

- [x] `test_validate_revision_rejects_terminal_task_missing` — prior has t1=COMPLETED, revision omits t1 -> ValueError.
- [x] `test_validate_revision_rejects_terminal_task_status_regression` — prior t1=COMPLETED, revision t1=PENDING -> ValueError.
- [x] `test_validate_revision_rejects_terminal_task_status_flip` — COMPLETED -> FAILED is also a regression.
- [x] `test_validate_revision_accepts_terminal_task_unchanged` — prior t1=COMPLETED, revision t1=COMPLETED -> OK.
- [x] `test_validate_revision_rejects_missing_terminal_edge` — prior edges t1(C)->t2(C), revision drops that edge -> ValueError.
- [x] `test_validate_revision_accepts_missing_mutable_edge` — prior edges t1(C)->t2(P), revision drops it -> OK (mutable edges are free).
- [x] `test_validate_revision_without_prior_skips_preservation` — backwards-compat: no `prior` -> no preservation check.
- [x] `test_apply_revision_emits_schema_violation_on_terminal_regression` — regression -> CRITICAL SCHEMA_VIOLATION emitted, `session.plan` unchanged.
- [x] `test_apply_revision_emits_schema_violation_on_missing_terminal_edge` — dropped edge -> CRITICAL SCHEMA_VIOLATION emitted, `session.plan` unchanged.
- [x] `uv run --extra dev --extra adk pytest -q` -> 501 passed, 38 skipped.
- [x] `uv run ruff check .` -> All checks passed.
