### PR TITLE
Add PlanRevisionDiff payload to PlanRevised event (closes PLAN-LIFECYCLE.md §8 gap #4)

### DIFF
--- a/docs/design/EVENT-MODEL.md
+++ b/docs/design/EVENT-MODEL.md
@@ -68,7 +68,7 @@ envelope — there is no mixed-shape stream on the sink side.
 |---|---|---|
 | `GoalDerived` | `Runner` | After `goal_deriver.derive()` returns. Carries the `list[Goal]`. Fired once per run. |
 | `PlanSubmitted` | `Runner` | After initial `planner.generate()` succeeds. Carries the full `Plan`. |
-| `PlanRevised` | `Executor` | After a successful `planner.refine()` swap. Carries the revised `Plan`, the `revision_reason`, the triggering `DriftKind`, severity, and a monotonically increasing `revision_index`. |
+| `PlanRevised` | `Executor` | After a successful `planner.refine()` swap. Carries the revised `Plan`, the `revision_reason`, the triggering `DriftKind`, severity, a monotonically increasing `revision_index`, and a `PlanRevisionDiff` sidecar (`added_task_ids`, `removed_task_ids`, `modified_task_ids`, `added_edges`, `removed_edges`) so sinks can render "what changed" without re-fetching the prior plan. See PLAN-LIFECYCLE.md §2.1. |
 
 ### Task lifecycle
 

--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -72,7 +72,33 @@ A `Plan` (see `types.py::Plan`) carries revision metadata:
 - `new.revision_index ≥ old.revision_index + 1` (bumps if the planner returned a smaller number).
 - `revision_kind` / `revision_severity` / `revision_reason` default to the triggering drift's values if the planner didn't set them.
 
-**Observability.** Every revision emits one `PlanRevised(old_id=..., new_id=..., revision_index=..., kind=..., severity=..., reason=...)` event on the sink channel. Sinks that cache plan structure MUST re-read `session.plan` on every `PlanRevised`.
+**Observability.** Every revision emits one `PlanRevised(plan=..., revision_index=..., drift_kind=..., severity=..., reason=..., diff=...)` event on the sink channel. Sinks that cache plan structure MUST re-read `session.plan` on every `PlanRevised`.
+
+### 2.1 Cross-revision diff sidecar (`PlanRevisionDiff`)
+
+`PlanRevised.diff` (proto `goldfive.v1.PlanRevisionDiff`) is a minimal
+change-set attached to every `PlanRevised` event so sinks that want to
+render "what changed" don't have to re-fetch and diff the two plans
+client-side. It carries:
+
+- `added_task_ids: list[str]` — tasks present in the new plan but not
+  the old plan, in new-plan order.
+- `removed_task_ids: list[str]` — tasks present in the old plan but
+  not the new plan, in old-plan order.
+- `modified_task_ids: list[str]` — tasks present in both plans where
+  at least one of `title`, `description`, `assignee_agent_id`, or
+  `status` changed. (Pure status-only transitions are *also* covered by
+  the `Task*` events on the stream; `modified_task_ids` is the
+  authoritative per-revision set keyed by id.)
+- `added_edges: list[TaskEdge]` / `removed_edges: list[TaskEdge]` —
+  edges keyed by the `(from_task_id, to_task_id)` pair. An edge
+  re-target shows up as one removed + one added entry.
+
+Identity rules match §3.0: tasks are keyed by `id`, edges by the pair
+of endpoints. The diff is built by `goldfive.events.build_plan_revision_diff(old, new)`
+and populated in `DefaultSteerer._emit_plan_revised` before the event is
+fanned out. `diff` is optional at the proto layer (proto3 default) so
+older sinks that haven't updated yet continue to ignore it.
 
 ---
 
@@ -405,4 +431,3 @@ Violating any of them is a bug in goldfive.
 ## 8. Known gaps (open)
 
 - **Unrecoverable cascade (§6.2) does not currently use the same cascade primitive as §6.3** — they're two different code paths that happen to do similar work. Unify once both are implemented.
-- **No cross-revision lineage view.** Sinks receive `PlanRevised` events but the proto doesn't carry the full diff. Harmonograf's UI currently has to stitch revisions by plan_id + revision_index. A dedicated `revision_diff` sidecar would simplify the UI.

--- a/goldfive/events.py
+++ b/goldfive/events.py
@@ -389,6 +389,87 @@ def approval_rejected_event(
     return evt
 
 
+def build_plan_revision_diff(old_plan: Any, new_plan: Any) -> Any:
+    """Build a ``PlanRevisionDiff`` pb comparing ``old_plan`` to ``new_plan``.
+
+    Both arguments are :class:`goldfive.types.Plan` dataclasses (not pb
+    messages). Either may be ``None`` — a ``None`` old plan treats every
+    task/edge in ``new_plan`` as added, and vice versa — so this helper
+    is safe to call even before the first revision.
+
+    Identity rules (PLAN-LIFECYCLE.md §3.0):
+
+    * Tasks are identified by ``id``. ``added_task_ids`` / ``removed_task_ids``
+      are set difference on id sets. ``modified_task_ids`` is the id-
+      intersection with at least one differing tracked metadata field
+      (title, description, assignee_agent_id, status).
+    * Edges are identified by the ``(from_task_id, to_task_id)`` pair.
+
+    The returned message is a bare ``PlanRevisionDiff`` (not wrapped in
+    an ``Event`` envelope). Callers splice it into
+    ``plan_revised.diff.CopyFrom(...)`` themselves — this keeps the
+    helper usable in tests without constructing a full envelope.
+    """
+    pb = _events_pb_module()
+    diff = pb.PlanRevisionDiff()
+
+    old_tasks = list(getattr(old_plan, "tasks", []) or []) if old_plan is not None else []
+    new_tasks = list(getattr(new_plan, "tasks", []) or []) if new_plan is not None else []
+    old_by_id = {t.id: t for t in old_tasks if getattr(t, "id", "")}
+    new_by_id = {t.id: t for t in new_tasks if getattr(t, "id", "")}
+
+    old_ids = set(old_by_id.keys())
+    new_ids = set(new_by_id.keys())
+
+    # Preserve the order tasks appear in new_plan / old_plan respectively —
+    # sinks that render added-first, removed-next benefit from stable order
+    # matching the authoritative plan layout.
+    added = [t.id for t in new_tasks if t.id in (new_ids - old_ids)]
+    removed = [t.id for t in old_tasks if t.id in (old_ids - new_ids)]
+    modified: list[str] = []
+    for tid in (t.id for t in new_tasks if t.id in (old_ids & new_ids)):
+        old_t = old_by_id[tid]
+        new_t = new_by_id[tid]
+        if (
+            getattr(old_t, "title", "") != getattr(new_t, "title", "")
+            or getattr(old_t, "description", "") != getattr(new_t, "description", "")
+            or getattr(old_t, "assignee_agent_id", "")
+            != getattr(new_t, "assignee_agent_id", "")
+            or str(getattr(old_t, "status", "")) != str(getattr(new_t, "status", ""))
+        ):
+            modified.append(tid)
+
+    diff.added_task_ids.extend(added)
+    diff.removed_task_ids.extend(removed)
+    diff.modified_task_ids.extend(modified)
+
+    def _edge_key(e: Any) -> tuple[str, str]:
+        return (getattr(e, "from_task_id", ""), getattr(e, "to_task_id", ""))
+
+    old_edges = list(getattr(old_plan, "edges", []) or []) if old_plan is not None else []
+    new_edges = list(getattr(new_plan, "edges", []) or []) if new_plan is not None else []
+    old_edge_keys = {_edge_key(e) for e in old_edges}
+    new_edge_keys = {_edge_key(e) for e in new_edges}
+
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    for e in new_edges:
+        if _edge_key(e) not in old_edge_keys:
+            diff.added_edges.append(
+                types_pb2.TaskEdge(
+                    from_task_id=e.from_task_id, to_task_id=e.to_task_id
+                )
+            )
+    for e in old_edges:
+        if _edge_key(e) not in new_edge_keys:
+            diff.removed_edges.append(
+                types_pb2.TaskEdge(
+                    from_task_id=e.from_task_id, to_task_id=e.to_task_id
+                )
+            )
+    return diff
+
+
 def drift_detected_event(run_id: str, sequence: int, drift: Any) -> Any:
     pb = _events_pb_module()
     evt = new_event(run_id, sequence)

--- a/goldfive/pb/goldfive/v1/events_pb2.py
+++ b/goldfive/pb/goldfive/v1/events_pb2.py
@@ -26,7 +26,7 @@ from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__
 from goldfive.v1 import types_pb2 as goldfive_dot_v1_dot_types__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18goldfive/v1/events.proto\x12\x0bgoldfive.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17goldfive/v1/types.proto\"\xc2\x08\n\x05\x45vent\x12\x10\n\x08\x65vent_id\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08sequence\x18\x03 \x01(\x04\x12.\n\nemitted_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12.\n\x0brun_started\x18\n \x01(\x0b\x32\x17.goldfive.v1.RunStartedH\x00\x12\x30\n\x0cgoal_derived\x18\x0b \x01(\x0b\x32\x18.goldfive.v1.GoalDerivedH\x00\x12\x34\n\x0eplan_submitted\x18\x0c \x01(\x0b\x32\x1a.goldfive.v1.PlanSubmittedH\x00\x12\x30\n\x0cplan_revised\x18\r \x01(\x0b\x32\x18.goldfive.v1.PlanRevisedH\x00\x12\x30\n\x0ctask_started\x18\x0e \x01(\x0b\x32\x18.goldfive.v1.TaskStartedH\x00\x12\x32\n\rtask_progress\x18\x0f \x01(\x0b\x32\x19.goldfive.v1.TaskProgressH\x00\x12\x34\n\x0etask_completed\x18\x10 \x01(\x0b\x32\x1a.goldfive.v1.TaskCompletedH\x00\x12.\n\x0btask_failed\x18\x11 \x01(\x0b\x32\x17.goldfive.v1.TaskFailedH\x00\x12\x30\n\x0ctask_blocked\x18\x12 \x01(\x0b\x32\x18.goldfive.v1.TaskBlockedH\x00\x12\x34\n\x0etask_cancelled\x18\x13 \x01(\x0b\x32\x1a.goldfive.v1.TaskCancelledH\x00\x12\x34\n\x0e\x64rift_detected\x18\x14 \x01(\x0b\x32\x1a.goldfive.v1.DriftDetectedH\x00\x12\x32\n\rrun_completed\x18\x15 \x01(\x0b\x32\x19.goldfive.v1.RunCompletedH\x00\x12.\n\x0brun_aborted\x18\x16 \x01(\x0b\x32\x17.goldfive.v1.RunAbortedH\x00\x12@\n\x14\x63onversation_started\x18\x17 \x01(\x0b\x32 .goldfive.v1.ConversationStartedH\x00\x12<\n\x12\x63onversation_ended\x18\x18 \x01(\x0b\x32\x1e.goldfive.v1.ConversationEndedH\x00\x12<\n\x12\x61pproval_requested\x18\x19 \x01(\x0b\x32\x1e.goldfive.v1.ApprovalRequestedH\x00\x12\x38\n\x10\x61pproval_granted\x18\x1a \x01(\x0b\x32\x1c.goldfive.v1.ApprovalGrantedH\x00\x12:\n\x11\x61pproval_rejected\x18\x1b \x01(\x0b\x32\x1d.goldfive.v1.ApprovalRejectedH\x00\x42\t\n\x07payload\"b\n\nRunStarted\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x14\n\x0cgoal_summary\x18\x02 \x01(\t\x12.\n\nstarted_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"/\n\x0bGoalDerived\x12 \n\x05goals\x18\x01 \x03(\x0b\x32\x11.goldfive.v1.Goal\"0\n\rPlanSubmitted\x12\x1f\n\x04plan\x18\x01 \x01(\x0b\x32\x11.goldfive.v1.Plan\"\xb0\x01\n\x0bPlanRevised\x12\x1f\n\x04plan\x18\x01 \x01(\x0b\x32\x11.goldfive.v1.Plan\x12*\n\ndrift_kind\x18\x02 \x01(\x0e\x32\x16.goldfive.v1.DriftKind\x12,\n\x08severity\x18\x03 \x01(\x0e\x32\x1a.goldfive.v1.DriftSeverity\x12\x0e\n\x06reason\x18\x04 \x01(\t\x12\x16\n\x0erevision_index\x18\x05 \x01(\r\".\n\x0bTaskStarted\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\"A\n\x0cTaskProgress\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x10\n\x08\x66raction\x18\x02 \x01(\x02\x12\x0e\n\x06\x64\x65tail\x18\x03 \x01(\t\"\xa1\x01\n\rTaskCompleted\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0f\n\x07summary\x18\x02 \x01(\t\x12<\n\tartifacts\x18\x03 \x03(\x0b\x32).goldfive.v1.TaskCompleted.ArtifactsEntry\x1a\x30\n\x0e\x41rtifactsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"B\n\nTaskFailed\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06reason\x18\x02 \x01(\t\x12\x13\n\x0brecoverable\x18\x03 \x01(\x08\"?\n\x0bTaskBlocked\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0f\n\x07\x62locker\x18\x02 \x01(\t\x12\x0e\n\x06needed\x18\x03 \x01(\t\"0\n\rTaskCancelled\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06reason\x18\x02 \x01(\t\"\xa6\x01\n\rDriftDetected\x12$\n\x04kind\x18\x01 \x01(\x0e\x32\x16.goldfive.v1.DriftKind\x12,\n\x08severity\x18\x02 \x01(\x0e\x32\x1a.goldfive.v1.DriftSeverity\x12\x0e\n\x06\x64\x65tail\x18\x03 \x01(\t\x12\x17\n\x0f\x63urrent_task_id\x18\x04 \x01(\t\x12\x18\n\x10\x63urrent_agent_id\x18\x05 \x01(\t\"\'\n\x0cRunCompleted\x12\x17\n\x0foutcome_summary\x18\x01 \x01(\t\"\x1c\n\nRunAborted\x12\x0e\n\x06reason\x18\x01 \x01(\t\"^\n\x13\x43onversationStarted\x12\x17\n\x0f\x63onversation_id\x18\x01 \x01(\t\x12.\n\nstarted_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"P\n\x11\x43onversationEnded\x12\x17\n\x0f\x63onversation_id\x18\x01 \x01(\t\x12\x12\n\nturn_count\x18\x02 \x01(\r\x12\x0e\n\x06reason\x18\x03 \x01(\t\"\xc6\x01\n\x11\x41pprovalRequested\x12\x11\n\ttarget_id\x18\x01 \x01(\t\x12\x0c\n\x04kind\x18\x02 \x01(\t\x12\x0e\n\x06prompt\x18\x03 \x01(\t\x12\x0f\n\x07task_id\x18\x04 \x01(\t\x12>\n\x08metadata\x18\x05 \x03(\x0b\x32,.goldfive.v1.ApprovalRequested.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"4\n\x0f\x41pprovalGranted\x12\x11\n\ttarget_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\"5\n\x10\x41pprovalRejected\x12\x11\n\ttarget_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\tB9Z7github.com/pedapudi/goldfive/gen/goldfive/v1;goldfivev1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18goldfive/v1/events.proto\x12\x0bgoldfive.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17goldfive/v1/types.proto\"\xc2\x08\n\x05\x45vent\x12\x10\n\x08\x65vent_id\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08sequence\x18\x03 \x01(\x04\x12.\n\nemitted_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12.\n\x0brun_started\x18\n \x01(\x0b\x32\x17.goldfive.v1.RunStartedH\x00\x12\x30\n\x0cgoal_derived\x18\x0b \x01(\x0b\x32\x18.goldfive.v1.GoalDerivedH\x00\x12\x34\n\x0eplan_submitted\x18\x0c \x01(\x0b\x32\x1a.goldfive.v1.PlanSubmittedH\x00\x12\x30\n\x0cplan_revised\x18\r \x01(\x0b\x32\x18.goldfive.v1.PlanRevisedH\x00\x12\x30\n\x0ctask_started\x18\x0e \x01(\x0b\x32\x18.goldfive.v1.TaskStartedH\x00\x12\x32\n\rtask_progress\x18\x0f \x01(\x0b\x32\x19.goldfive.v1.TaskProgressH\x00\x12\x34\n\x0etask_completed\x18\x10 \x01(\x0b\x32\x1a.goldfive.v1.TaskCompletedH\x00\x12.\n\x0btask_failed\x18\x11 \x01(\x0b\x32\x17.goldfive.v1.TaskFailedH\x00\x12\x30\n\x0ctask_blocked\x18\x12 \x01(\x0b\x32\x18.goldfive.v1.TaskBlockedH\x00\x12\x34\n\x0etask_cancelled\x18\x13 \x01(\x0b\x32\x1a.goldfive.v1.TaskCancelledH\x00\x12\x34\n\x0e\x64rift_detected\x18\x14 \x01(\x0b\x32\x1a.goldfive.v1.DriftDetectedH\x00\x12\x32\n\rrun_completed\x18\x15 \x01(\x0b\x32\x19.goldfive.v1.RunCompletedH\x00\x12.\n\x0brun_aborted\x18\x16 \x01(\x0b\x32\x17.goldfive.v1.RunAbortedH\x00\x12@\n\x14\x63onversation_started\x18\x17 \x01(\x0b\x32 .goldfive.v1.ConversationStartedH\x00\x12<\n\x12\x63onversation_ended\x18\x18 \x01(\x0b\x32\x1e.goldfive.v1.ConversationEndedH\x00\x12<\n\x12\x61pproval_requested\x18\x19 \x01(\x0b\x32\x1e.goldfive.v1.ApprovalRequestedH\x00\x12\x38\n\x10\x61pproval_granted\x18\x1a \x01(\x0b\x32\x1c.goldfive.v1.ApprovalGrantedH\x00\x12:\n\x11\x61pproval_rejected\x18\x1b \x01(\x0b\x32\x1d.goldfive.v1.ApprovalRejectedH\x00\x42\t\n\x07payload\"b\n\nRunStarted\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x14\n\x0cgoal_summary\x18\x02 \x01(\t\x12.\n\nstarted_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"/\n\x0bGoalDerived\x12 \n\x05goals\x18\x01 \x03(\x0b\x32\x11.goldfive.v1.Goal\"0\n\rPlanSubmitted\x12\x1f\n\x04plan\x18\x01 \x01(\x0b\x32\x11.goldfive.v1.Plan\"\xb9\x01\n\x10PlanRevisionDiff\x12\x16\n\x0e\x61\x64\x64\x65\x64_task_ids\x18\x01 \x03(\t\x12\x18\n\x10removed_task_ids\x18\x02 \x03(\t\x12\x19\n\x11modified_task_ids\x18\x03 \x03(\t\x12*\n\x0b\x61\x64\x64\x65\x64_edges\x18\x04 \x03(\x0b\x32\x15.goldfive.v1.TaskEdge\x12,\n\rremoved_edges\x18\x05 \x03(\x0b\x32\x15.goldfive.v1.TaskEdge\"\xdd\x01\n\x0bPlanRevised\x12\x1f\n\x04plan\x18\x01 \x01(\x0b\x32\x11.goldfive.v1.Plan\x12*\n\ndrift_kind\x18\x02 \x01(\x0e\x32\x16.goldfive.v1.DriftKind\x12,\n\x08severity\x18\x03 \x01(\x0e\x32\x1a.goldfive.v1.DriftSeverity\x12\x0e\n\x06reason\x18\x04 \x01(\t\x12\x16\n\x0erevision_index\x18\x05 \x01(\r\x12+\n\x04\x64iff\x18\x06 \x01(\x0b\x32\x1d.goldfive.v1.PlanRevisionDiff\".\n\x0bTaskStarted\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\"A\n\x0cTaskProgress\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x10\n\x08\x66raction\x18\x02 \x01(\x02\x12\x0e\n\x06\x64\x65tail\x18\x03 \x01(\t\"\xa1\x01\n\rTaskCompleted\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0f\n\x07summary\x18\x02 \x01(\t\x12<\n\tartifacts\x18\x03 \x03(\x0b\x32).goldfive.v1.TaskCompleted.ArtifactsEntry\x1a\x30\n\x0e\x41rtifactsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"B\n\nTaskFailed\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06reason\x18\x02 \x01(\t\x12\x13\n\x0brecoverable\x18\x03 \x01(\x08\"?\n\x0bTaskBlocked\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0f\n\x07\x62locker\x18\x02 \x01(\t\x12\x0e\n\x06needed\x18\x03 \x01(\t\"0\n\rTaskCancelled\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x0e\n\x06reason\x18\x02 \x01(\t\"\xa6\x01\n\rDriftDetected\x12$\n\x04kind\x18\x01 \x01(\x0e\x32\x16.goldfive.v1.DriftKind\x12,\n\x08severity\x18\x02 \x01(\x0e\x32\x1a.goldfive.v1.DriftSeverity\x12\x0e\n\x06\x64\x65tail\x18\x03 \x01(\t\x12\x17\n\x0f\x63urrent_task_id\x18\x04 \x01(\t\x12\x18\n\x10\x63urrent_agent_id\x18\x05 \x01(\t\"\'\n\x0cRunCompleted\x12\x17\n\x0foutcome_summary\x18\x01 \x01(\t\"\x1c\n\nRunAborted\x12\x0e\n\x06reason\x18\x01 \x01(\t\"^\n\x13\x43onversationStarted\x12\x17\n\x0f\x63onversation_id\x18\x01 \x01(\t\x12.\n\nstarted_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"P\n\x11\x43onversationEnded\x12\x17\n\x0f\x63onversation_id\x18\x01 \x01(\t\x12\x12\n\nturn_count\x18\x02 \x01(\r\x12\x0e\n\x06reason\x18\x03 \x01(\t\"\xc6\x01\n\x11\x41pprovalRequested\x12\x11\n\ttarget_id\x18\x01 \x01(\t\x12\x0c\n\x04kind\x18\x02 \x01(\t\x12\x0e\n\x06prompt\x18\x03 \x01(\t\x12\x0f\n\x07task_id\x18\x04 \x01(\t\x12>\n\x08metadata\x18\x05 \x03(\x0b\x32,.goldfive.v1.ApprovalRequested.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"4\n\x0f\x41pprovalGranted\x12\x11\n\ttarget_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\"5\n\x10\x41pprovalRejected\x12\x11\n\ttarget_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\tB9Z7github.com/pedapudi/goldfive/gen/goldfive/v1;goldfivev1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -46,38 +46,40 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_GOALDERIVED']._serialized_end=1339
   _globals['_PLANSUBMITTED']._serialized_start=1341
   _globals['_PLANSUBMITTED']._serialized_end=1389
-  _globals['_PLANREVISED']._serialized_start=1392
-  _globals['_PLANREVISED']._serialized_end=1568
-  _globals['_TASKSTARTED']._serialized_start=1570
-  _globals['_TASKSTARTED']._serialized_end=1616
-  _globals['_TASKPROGRESS']._serialized_start=1618
-  _globals['_TASKPROGRESS']._serialized_end=1683
-  _globals['_TASKCOMPLETED']._serialized_start=1686
-  _globals['_TASKCOMPLETED']._serialized_end=1847
-  _globals['_TASKCOMPLETED_ARTIFACTSENTRY']._serialized_start=1799
-  _globals['_TASKCOMPLETED_ARTIFACTSENTRY']._serialized_end=1847
-  _globals['_TASKFAILED']._serialized_start=1849
-  _globals['_TASKFAILED']._serialized_end=1915
-  _globals['_TASKBLOCKED']._serialized_start=1917
-  _globals['_TASKBLOCKED']._serialized_end=1980
-  _globals['_TASKCANCELLED']._serialized_start=1982
-  _globals['_TASKCANCELLED']._serialized_end=2030
-  _globals['_DRIFTDETECTED']._serialized_start=2033
-  _globals['_DRIFTDETECTED']._serialized_end=2199
-  _globals['_RUNCOMPLETED']._serialized_start=2201
-  _globals['_RUNCOMPLETED']._serialized_end=2240
-  _globals['_RUNABORTED']._serialized_start=2242
-  _globals['_RUNABORTED']._serialized_end=2270
-  _globals['_CONVERSATIONSTARTED']._serialized_start=2272
-  _globals['_CONVERSATIONSTARTED']._serialized_end=2366
-  _globals['_CONVERSATIONENDED']._serialized_start=2368
-  _globals['_CONVERSATIONENDED']._serialized_end=2448
-  _globals['_APPROVALREQUESTED']._serialized_start=2451
-  _globals['_APPROVALREQUESTED']._serialized_end=2649
-  _globals['_APPROVALREQUESTED_METADATAENTRY']._serialized_start=2602
-  _globals['_APPROVALREQUESTED_METADATAENTRY']._serialized_end=2649
-  _globals['_APPROVALGRANTED']._serialized_start=2651
-  _globals['_APPROVALGRANTED']._serialized_end=2703
-  _globals['_APPROVALREJECTED']._serialized_start=2705
-  _globals['_APPROVALREJECTED']._serialized_end=2758
+  _globals['_PLANREVISIONDIFF']._serialized_start=1392
+  _globals['_PLANREVISIONDIFF']._serialized_end=1577
+  _globals['_PLANREVISED']._serialized_start=1580
+  _globals['_PLANREVISED']._serialized_end=1801
+  _globals['_TASKSTARTED']._serialized_start=1803
+  _globals['_TASKSTARTED']._serialized_end=1849
+  _globals['_TASKPROGRESS']._serialized_start=1851
+  _globals['_TASKPROGRESS']._serialized_end=1916
+  _globals['_TASKCOMPLETED']._serialized_start=1919
+  _globals['_TASKCOMPLETED']._serialized_end=2080
+  _globals['_TASKCOMPLETED_ARTIFACTSENTRY']._serialized_start=2032
+  _globals['_TASKCOMPLETED_ARTIFACTSENTRY']._serialized_end=2080
+  _globals['_TASKFAILED']._serialized_start=2082
+  _globals['_TASKFAILED']._serialized_end=2148
+  _globals['_TASKBLOCKED']._serialized_start=2150
+  _globals['_TASKBLOCKED']._serialized_end=2213
+  _globals['_TASKCANCELLED']._serialized_start=2215
+  _globals['_TASKCANCELLED']._serialized_end=2263
+  _globals['_DRIFTDETECTED']._serialized_start=2266
+  _globals['_DRIFTDETECTED']._serialized_end=2432
+  _globals['_RUNCOMPLETED']._serialized_start=2434
+  _globals['_RUNCOMPLETED']._serialized_end=2473
+  _globals['_RUNABORTED']._serialized_start=2475
+  _globals['_RUNABORTED']._serialized_end=2503
+  _globals['_CONVERSATIONSTARTED']._serialized_start=2505
+  _globals['_CONVERSATIONSTARTED']._serialized_end=2599
+  _globals['_CONVERSATIONENDED']._serialized_start=2601
+  _globals['_CONVERSATIONENDED']._serialized_end=2681
+  _globals['_APPROVALREQUESTED']._serialized_start=2684
+  _globals['_APPROVALREQUESTED']._serialized_end=2882
+  _globals['_APPROVALREQUESTED_METADATAENTRY']._serialized_start=2835
+  _globals['_APPROVALREQUESTED_METADATAENTRY']._serialized_end=2882
+  _globals['_APPROVALGRANTED']._serialized_start=2884
+  _globals['_APPROVALGRANTED']._serialized_end=2936
+  _globals['_APPROVALREJECTED']._serialized_start=2938
+  _globals['_APPROVALREJECTED']._serialized_end=2991
 # @@protoc_insertion_point(module_scope)

--- a/goldfive/pb/goldfive/v1/events_pb2.pyi
+++ b/goldfive/pb/goldfive/v1/events_pb2.pyi
@@ -80,19 +80,35 @@ class PlanSubmitted(_message.Message):
     plan: _types_pb2.Plan
     def __init__(self, plan: _Optional[_Union[_types_pb2.Plan, _Mapping]] = ...) -> None: ...
 
+class PlanRevisionDiff(_message.Message):
+    __slots__ = ("added_task_ids", "removed_task_ids", "modified_task_ids", "added_edges", "removed_edges")
+    ADDED_TASK_IDS_FIELD_NUMBER: _ClassVar[int]
+    REMOVED_TASK_IDS_FIELD_NUMBER: _ClassVar[int]
+    MODIFIED_TASK_IDS_FIELD_NUMBER: _ClassVar[int]
+    ADDED_EDGES_FIELD_NUMBER: _ClassVar[int]
+    REMOVED_EDGES_FIELD_NUMBER: _ClassVar[int]
+    added_task_ids: _containers.RepeatedScalarFieldContainer[str]
+    removed_task_ids: _containers.RepeatedScalarFieldContainer[str]
+    modified_task_ids: _containers.RepeatedScalarFieldContainer[str]
+    added_edges: _containers.RepeatedCompositeFieldContainer[_types_pb2.TaskEdge]
+    removed_edges: _containers.RepeatedCompositeFieldContainer[_types_pb2.TaskEdge]
+    def __init__(self, added_task_ids: _Optional[_Iterable[str]] = ..., removed_task_ids: _Optional[_Iterable[str]] = ..., modified_task_ids: _Optional[_Iterable[str]] = ..., added_edges: _Optional[_Iterable[_Union[_types_pb2.TaskEdge, _Mapping]]] = ..., removed_edges: _Optional[_Iterable[_Union[_types_pb2.TaskEdge, _Mapping]]] = ...) -> None: ...
+
 class PlanRevised(_message.Message):
-    __slots__ = ("plan", "drift_kind", "severity", "reason", "revision_index")
+    __slots__ = ("plan", "drift_kind", "severity", "reason", "revision_index", "diff")
     PLAN_FIELD_NUMBER: _ClassVar[int]
     DRIFT_KIND_FIELD_NUMBER: _ClassVar[int]
     SEVERITY_FIELD_NUMBER: _ClassVar[int]
     REASON_FIELD_NUMBER: _ClassVar[int]
     REVISION_INDEX_FIELD_NUMBER: _ClassVar[int]
+    DIFF_FIELD_NUMBER: _ClassVar[int]
     plan: _types_pb2.Plan
     drift_kind: _types_pb2.DriftKind
     severity: _types_pb2.DriftSeverity
     reason: str
     revision_index: int
-    def __init__(self, plan: _Optional[_Union[_types_pb2.Plan, _Mapping]] = ..., drift_kind: _Optional[_Union[_types_pb2.DriftKind, str]] = ..., severity: _Optional[_Union[_types_pb2.DriftSeverity, str]] = ..., reason: _Optional[str] = ..., revision_index: _Optional[int] = ...) -> None: ...
+    diff: PlanRevisionDiff
+    def __init__(self, plan: _Optional[_Union[_types_pb2.Plan, _Mapping]] = ..., drift_kind: _Optional[_Union[_types_pb2.DriftKind, str]] = ..., severity: _Optional[_Union[_types_pb2.DriftSeverity, str]] = ..., reason: _Optional[str] = ..., revision_index: _Optional[int] = ..., diff: _Optional[_Union[PlanRevisionDiff, _Mapping]] = ...) -> None: ...
 
 class TaskStarted(_message.Message):
     __slots__ = ("task_id", "detail")

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -631,8 +631,12 @@ class DefaultSteerer:
         # Successful refine — reset the back-off counter for this key
         # so a future drift of the same kind starts fresh.
         session.refine_failure_counts.pop(counter_key, None)
+        # Capture the outgoing plan BEFORE _apply_revision installs the
+        # revised one; _emit_plan_revised diffs the two to populate the
+        # PlanRevisionDiff sidecar (PLAN-LIFECYCLE.md §2, §8 gap #4).
+        prev_plan = session.plan
         self._apply_revision(session, revised, drift)
-        await self._emit_plan_revised(session, revised, drift)
+        await self._emit_plan_revised(session, revised, drift, prev_plan=prev_plan)
 
     # Consecutive refine failures tolerated per (drift_kind, task_id)
     # before we give up and mark the task FAILED. Class attribute so
@@ -814,8 +818,16 @@ class DefaultSteerer:
         evt.drift_detected.current_agent_id = drift.current_agent_id
         await self._emit(evt)
 
-    async def _emit_plan_revised(self, session: Session, revised: Plan, drift: DriftEvent) -> None:
+    async def _emit_plan_revised(
+        self,
+        session: Session,
+        revised: Plan,
+        drift: DriftEvent,
+        *,
+        prev_plan: Plan | None = None,
+    ) -> None:
         from goldfive.conv import to_pb_plan
+        from goldfive.events import build_plan_revision_diff
 
         evt = self._new_envelope(session)
         evt.plan_revised.plan.CopyFrom(to_pb_plan(revised))
@@ -823,4 +835,10 @@ class DefaultSteerer:
         evt.plan_revised.severity = self._drift_severity_pb_value(drift.severity)
         evt.plan_revised.reason = drift.detail
         evt.plan_revised.revision_index = revised.revision_index
+        # Populate the minimal cross-revision diff so sinks that want a
+        # "what changed" view don't have to re-fetch and diff the two
+        # plans client-side. prev_plan may be None on the first revision
+        # of a run that never received an initial plan — the helper
+        # treats that as "everything in revised is newly added".
+        evt.plan_revised.diff.CopyFrom(build_plan_revision_diff(prev_plan, revised))
         await self._emit(evt)

--- a/proto/goldfive/v1/events.proto
+++ b/proto/goldfive/v1/events.proto
@@ -88,6 +88,33 @@ message PlanSubmitted {
   Plan plan = 1;
 }
 
+// Minimal cross-revision diff payload attached to `PlanRevised` so
+// sinks that render "what changed" can do so without re-fetching and
+// diff'ing the two plans client-side. Closes PLAN-LIFECYCLE.md §8
+// gap #4.
+//
+// Identity rules mirror PLAN-LIFECYCLE.md §3.0: a task/edge is identified
+// by its id (tasks) or its (from_task_id, to_task_id) pair (edges). The
+// diff is advisory — the authoritative plan lives in the enclosing
+// `PlanRevised.plan` field; `diff` just saves consumers the work of
+// computing the delta themselves.
+message PlanRevisionDiff {
+  // Task ids present in the new plan but not in the old plan.
+  repeated string added_task_ids = 1;
+  // Task ids present in the old plan but not in the new plan.
+  repeated string removed_task_ids = 2;
+  // Task ids present in both plans where at least one tracked
+  // metadata field changed (title, description, assignee, status).
+  // Pure status-only transitions that are already covered by the
+  // Task* events are still listed here so sinks have a single
+  // authoritative "modified" set keyed by task id.
+  repeated string modified_task_ids = 3;
+  // Edges present in the new plan but not in the old plan.
+  repeated TaskEdge added_edges = 4;
+  // Edges present in the old plan but not in the new plan.
+  repeated TaskEdge removed_edges = 5;
+}
+
 // A revised plan, emitted by the observer in response to drift. The
 // plan's `revision_index` is monotonically greater than the previous
 // plan on this run. `drift_kind`, `severity`, and `reason` duplicate
@@ -99,6 +126,11 @@ message PlanRevised {
   DriftSeverity severity = 3;
   string reason = 4;
   uint32 revision_index = 5;
+  // Minimal diff between the previous plan and `plan`. Optional for
+  // back-compat with older producers; sinks that don't need the diff
+  // can ignore it. Consumers that want a no-fetch "what changed" view
+  // should read this field. See :class:`PlanRevisionDiff` above.
+  PlanRevisionDiff diff = 6;
 }
 
 // Task transitioned PENDING -> RUNNING.

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,221 @@
+"""Unit tests for goldfive.events helpers.
+
+Focused on :func:`goldfive.events.build_plan_revision_diff`, the helper
+that powers the ``PlanRevisionDiff`` sidecar attached to every
+``PlanRevised`` event (closes PLAN-LIFECYCLE.md §8 gap #4). The helper
+is deliberately small and pure so these tests pin its identity rules
+(PLAN-LIFECYCLE.md §3.0) in isolation — full end-to-end wiring is
+exercised in ``tests/test_steerer.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.events import build_plan_revision_diff  # noqa: E402
+from goldfive.types import Plan, Task, TaskEdge, TaskStatus  # noqa: E402
+
+
+def _plan(
+    tasks: list[Task] | None = None,
+    edges: list[TaskEdge] | None = None,
+    *,
+    plan_id: str = "p1",
+    run_id: str = "r1",
+) -> Plan:
+    return Plan(
+        id=plan_id,
+        run_id=run_id,
+        goal_ids=["g1"],
+        tasks=list(tasks or []),
+        edges=list(edges or []),
+    )
+
+
+def test_plan_revision_diff_detects_added_task() -> None:
+    """Tasks present in new but not old land in ``added_task_ids``."""
+    old = _plan(tasks=[Task(id="t1", title="T1")])
+    new = _plan(
+        tasks=[
+            Task(id="t1", title="T1"),
+            Task(id="t2", title="T2"),
+        ]
+    )
+    diff = build_plan_revision_diff(old, new)
+    assert list(diff.added_task_ids) == ["t2"]
+    assert list(diff.removed_task_ids) == []
+    assert list(diff.modified_task_ids) == []
+    assert list(diff.added_edges) == []
+    assert list(diff.removed_edges) == []
+
+
+def test_plan_revision_diff_detects_removed_task() -> None:
+    """Tasks present in old but not new land in ``removed_task_ids``."""
+    old = _plan(
+        tasks=[
+            Task(id="t1", title="T1"),
+            Task(id="t2", title="T2"),
+        ]
+    )
+    new = _plan(tasks=[Task(id="t1", title="T1")])
+    diff = build_plan_revision_diff(old, new)
+    assert list(diff.added_task_ids) == []
+    assert list(diff.removed_task_ids) == ["t2"]
+    assert list(diff.modified_task_ids) == []
+
+
+def test_plan_revision_diff_detects_modified_task() -> None:
+    """Same id, differing tracked metadata → ``modified_task_ids``.
+
+    Tracked fields are ``title``, ``description``, ``assignee_agent_id``,
+    ``status``. A change to any one of them is enough to surface the
+    task as modified.
+    """
+    old = _plan(
+        tasks=[
+            Task(id="t1", title="old title", description="d", assignee_agent_id="a1"),
+            Task(id="t2", title="T2"),
+            Task(id="t3", title="T3", status=TaskStatus.PENDING),
+        ]
+    )
+    new = _plan(
+        tasks=[
+            # title changed
+            Task(id="t1", title="new title", description="d", assignee_agent_id="a1"),
+            # assignee changed
+            Task(id="t2", title="T2", assignee_agent_id="a2"),
+            # status changed
+            Task(id="t3", title="T3", status=TaskStatus.COMPLETED),
+        ]
+    )
+    diff = build_plan_revision_diff(old, new)
+    # All three modified; preserve new-plan order for deterministic UI.
+    assert list(diff.modified_task_ids) == ["t1", "t2", "t3"]
+    assert list(diff.added_task_ids) == []
+    assert list(diff.removed_task_ids) == []
+
+
+def test_plan_revision_diff_unchanged_task_not_modified() -> None:
+    """Identical metadata → task must NOT appear in ``modified_task_ids``."""
+    old = _plan(
+        tasks=[
+            Task(id="t1", title="T1", description="d", assignee_agent_id="a1"),
+            Task(id="t2", title="T2"),
+        ]
+    )
+    new = _plan(
+        tasks=[
+            Task(id="t1", title="T1", description="d", assignee_agent_id="a1"),
+            Task(id="t2", title="T2"),
+        ]
+    )
+    diff = build_plan_revision_diff(old, new)
+    assert list(diff.modified_task_ids) == []
+    assert list(diff.added_task_ids) == []
+    assert list(diff.removed_task_ids) == []
+
+
+def test_plan_revision_diff_detects_added_edge() -> None:
+    """An edge present in new but not old lands in ``added_edges``."""
+    old = _plan(
+        tasks=[Task(id="t1", title="T1"), Task(id="t2", title="T2")],
+        edges=[],
+    )
+    new = _plan(
+        tasks=[Task(id="t1", title="T1"), Task(id="t2", title="T2")],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    diff = build_plan_revision_diff(old, new)
+    assert len(diff.added_edges) == 1
+    assert diff.added_edges[0].from_task_id == "t1"
+    assert diff.added_edges[0].to_task_id == "t2"
+    assert list(diff.removed_edges) == []
+
+
+def test_plan_revision_diff_detects_removed_edge() -> None:
+    """An edge present in old but not new lands in ``removed_edges``."""
+    old = _plan(
+        tasks=[Task(id="t1", title="T1"), Task(id="t2", title="T2")],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    new = _plan(
+        tasks=[Task(id="t1", title="T1"), Task(id="t2", title="T2")],
+        edges=[],
+    )
+    diff = build_plan_revision_diff(old, new)
+    assert list(diff.added_edges) == []
+    assert len(diff.removed_edges) == 1
+    assert diff.removed_edges[0].from_task_id == "t1"
+    assert diff.removed_edges[0].to_task_id == "t2"
+
+
+def test_plan_revision_diff_edge_re_target_surfaces_both_added_and_removed() -> None:
+    """Re-targeting an edge is modelled as (removed old, added new)."""
+    old = _plan(
+        tasks=[
+            Task(id="t1", title="T1"),
+            Task(id="t2", title="T2"),
+            Task(id="t3", title="T3"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    new = _plan(
+        tasks=[
+            Task(id="t1", title="T1"),
+            Task(id="t2", title="T2"),
+            Task(id="t3", title="T3"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t3")],
+    )
+    diff = build_plan_revision_diff(old, new)
+    added = [(e.from_task_id, e.to_task_id) for e in diff.added_edges]
+    removed = [(e.from_task_id, e.to_task_id) for e in diff.removed_edges]
+    assert added == [("t1", "t3")]
+    assert removed == [("t1", "t2")]
+
+
+def test_plan_revision_diff_old_plan_none_treats_all_as_added() -> None:
+    """An absent old plan means every task/edge in new is a fresh add."""
+    new = _plan(
+        tasks=[Task(id="t1", title="T1"), Task(id="t2", title="T2")],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    diff = build_plan_revision_diff(None, new)
+    assert list(diff.added_task_ids) == ["t1", "t2"]
+    assert list(diff.removed_task_ids) == []
+    assert list(diff.modified_task_ids) == []
+    assert [(e.from_task_id, e.to_task_id) for e in diff.added_edges] == [("t1", "t2")]
+    assert list(diff.removed_edges) == []
+
+
+def test_plan_revision_diff_identity_revision_is_empty() -> None:
+    """Pathological case: new plan deep-equal to old plan → empty diff."""
+    plan = _plan(
+        tasks=[
+            Task(id="t1", title="T1", description="d", assignee_agent_id="a"),
+            Task(id="t2", title="T2", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    # Build a second plan with the same contents (distinct objects; the
+    # helper must not short-circuit on identity).
+    other = _plan(
+        tasks=[
+            Task(id="t1", title="T1", description="d", assignee_agent_id="a"),
+            Task(id="t2", title="T2", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    diff = build_plan_revision_diff(plan, other)
+    assert list(diff.added_task_ids) == []
+    assert list(diff.removed_task_ids) == []
+    assert list(diff.modified_task_ids) == []
+    assert list(diff.added_edges) == []
+    assert list(diff.removed_edges) == []

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -921,6 +921,96 @@ async def test_apply_revision_emits_schema_violation_on_missing_terminal_edge() 
     assert "terminal->terminal edge 't1' -> 't2'" in second.detail
 
 
+async def test_plan_revised_carries_diff() -> None:
+    """The ``PlanRevised`` event populates ``diff`` with add/remove/modify deltas.
+
+    Closes PLAN-LIFECYCLE.md §8 gap #4: sinks should not have to re-fetch
+    the old plan to render "what changed". The steerer's
+    ``_emit_plan_revised`` captures the outgoing plan before
+    ``_apply_revision`` swaps it in, so the emitted event carries a
+    populated ``PlanRevisionDiff`` covering tasks added, removed,
+    modified, and edges added / removed.
+    """
+    # Outgoing plan: t1 -> t2, with t2's title about to change.
+    old = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1"),
+            Task(id="t2", title="old title"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    # Revised plan: t1 preserved; t2 re-titled (modified); t3 added;
+    # original t1->t2 edge dropped in favour of t1->t3.
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1"),
+            Task(id="t2", title="new title"),
+            Task(id="t3", title="T3"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t3")],
+    )
+    planner = StubPlanner(revised=revised)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session(old)
+
+    await steerer.observe({"error": "trigger refine"}, session)
+
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["drift_detected", "plan_revised"]
+    pr = sink.events[1].plan_revised
+    assert list(pr.diff.added_task_ids) == ["t3"]
+    assert list(pr.diff.removed_task_ids) == []
+    assert list(pr.diff.modified_task_ids) == ["t2"]
+    added = [(e.from_task_id, e.to_task_id) for e in pr.diff.added_edges]
+    removed = [(e.from_task_id, e.to_task_id) for e in pr.diff.removed_edges]
+    assert added == [("t1", "t3")]
+    assert removed == [("t1", "t2")]
+
+
+async def test_plan_revised_diff_empty_on_identity_revision() -> None:
+    """Revised plan structurally identical to the old → all diff lists empty.
+
+    The steerer still emits the ``PlanRevised`` event (because
+    ``planner.refine`` returned a non-None plan that passed validation),
+    but its ``diff`` fields must all be empty so sinks render a
+    no-op revision without a spurious "what changed" row.
+    """
+    # Build the "revised" plan so it is structurally equal to the
+    # outgoing plan but is a distinct object (so the helper doesn't
+    # short-circuit on identity).
+    tasks_a = [Task(id="t1", title="T1"), Task(id="t2", title="T2")]
+    tasks_b = [Task(id="t1", title="T1"), Task(id="t2", title="T2")]
+    edges_a = [TaskEdge(from_task_id="t1", to_task_id="t2")]
+    edges_b = [TaskEdge(from_task_id="t1", to_task_id="t2")]
+    old = Plan(id="p1", run_id="r1", goal_ids=["g1"], tasks=tasks_a, edges=edges_a)
+    revised = Plan(id="p1", run_id="r1", goal_ids=["g1"], tasks=tasks_b, edges=edges_b)
+
+    planner = StubPlanner(revised=revised)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session(old)
+
+    await steerer.observe({"error": "trigger refine"}, session)
+
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["drift_detected", "plan_revised"]
+    pr = sink.events[1].plan_revised
+    assert list(pr.diff.added_task_ids) == []
+    assert list(pr.diff.removed_task_ids) == []
+    assert list(pr.diff.modified_task_ids) == []
+    assert list(pr.diff.added_edges) == []
+    assert list(pr.diff.removed_edges) == []
+
+
 async def test_bind_replaces_sinks() -> None:
     steerer = DefaultSteerer()
     planner = StubPlanner()


### PR DESCRIPTION
## Summary

- Adds a new `PlanRevisionDiff` message (added/removed/modified task ids + added/removed edges) and attaches it as an optional `diff` field on `PlanRevised`, so sinks that want to render "what changed" don't have to re-fetch and diff the two plans client-side.
- Wires it in at `DefaultSteerer._emit_plan_revised`: capture the outgoing `session.plan` before `_apply_revision` swaps it in, then populate `diff` via a new `goldfive.events.build_plan_revision_diff` helper that applies the identity rules from `PLAN-LIFECYCLE.md §3.0` (tasks by id, edges by endpoint pair).
- Docs: `PLAN-LIFECYCLE.md` gains a §2.1 describing the sidecar, `EVENT-MODEL.md`'s `PlanRevised` row is updated, and the corresponding §8 gap #4 bullet is removed.

### Back-compat

The new field is `proto3` optional (field number 6 — `diff`), so existing harmonograf (and any other) consumers that haven't updated their stubs silently ignore it. This is an additive change only. No proto major bump needed.

## Test plan

- [x] `uv run --extra dev --extra adk pytest -q` — 503 passed, 38 skipped (baseline)
- [x] `make lint` — clean
- [x] `make proto` — stubs regenerate cleanly with the new `PlanRevisionDiff` class
- [x] New `tests/test_events.py` — six unit tests covering the diff helper (added / removed / modified tasks, added / removed edges, edge re-target, null-old, identity revision)
- [x] New `tests/test_steerer.py::test_plan_revised_carries_diff` — end-to-end via `observe` → `_handle_drift` → `_emit_plan_revised`, verifying the emitted event's `diff` fields populate correctly
- [x] New `tests/test_steerer.py::test_plan_revised_diff_empty_on_identity_revision` — pathological case where the revised plan is structurally equal to the old plan; all diff lists empty
