### PR TITLE
Unify cascade codepaths between recoverable and unrecoverable drift (closes PLAN-LIFECYCLE.md §8 gap #3)

### DIFF
--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -351,22 +351,26 @@ predicate that raises is logged at WARNING and treated as unmet.
 
 When a drift fires with `recoverable=False` — today only
 `TASK_FAILED_FATAL`, `USER_CANCEL`, and `INTENT_DIVERGENCE` — the
-executor runs the unrecoverable cascade (STATE-MACHINE.md
-§"Cascade semantics"):
+unrecoverable cascade runs (STATE-MACHINE.md §"Cascade semantics"):
 
-1. Mark the current task FAILED (if not already terminal).
-2. Mark every RUNNING task FAILED.
+1. Mark the current task FAILED (if not already terminal). Owned by
+   `Steerer.mark_task_failed(..., recoverable=False)`.
+2. Mark every RUNNING task FAILED. Sequential executors have at most
+   one RUNNING task so this step is vacuous for them; parallel
+   executors own this step explicitly.
 3. BFS downstream from each just-FAILED task; every reachable
-   PENDING → CANCELLED.
+   non-terminal task → CANCELLED. **This step funnels through the
+   same shared primitive as §6.3** —
+   `Steerer.cascade_cancel_downstream(session, task_id)` — so both
+   cascades emit the same `TaskCancelled` event stream and share the
+   terminal-skip / diamond-dedup guards. `mark_task_failed` calls the
+   primitive itself when `recoverable=False`.
 4. Clear adapter-bound task context.
 5. Emit `RunAborted(reason=drift.kind, drift=drift)`.
 
 Outcome: `success=False`, reason carries the triggering drift.
 
 ### 6.3 Cancellation cascade (recoverable path)
-
-Previously undocumented; implemented by the cascade worker
-(fix/cancel-cascade PR).
 
 When a task transitions to CANCELLED by any means —
 `mark_task_cancelled` from the executor, `mark_task_cancelled` from
@@ -375,6 +379,14 @@ steerer walks the plan's edges forward from the cancelled task and
 cancels every reachable PENDING task with
 `reason="cascade from <original_task_id>"`. Already-terminal
 downstream tasks are left alone.
+
+The downstream walk is the shared primitive
+`Steerer.cascade_cancel_downstream(session, task_id)`: the same
+method the unrecoverable path (§6.2) invokes from
+`mark_task_failed(..., recoverable=False)`. Both cascades therefore
+produce the same `TaskCancelled` event stream for the downstream
+set, share the terminal-skip / diamond-dedup guards, and share
+observability.
 
 This makes the CANCEL the primitive that delete-and-replan relies
 on (§4.2): the cancel alone gets the plan to a terminal-only shape;
@@ -430,4 +442,4 @@ Violating any of them is a bug in goldfive.
 
 ## 8. Known gaps (open)
 
-- **Unrecoverable cascade (§6.2) does not currently use the same cascade primitive as §6.3** — they're two different code paths that happen to do similar work. Unify once both are implemented.
+(All previously-listed gaps have been closed: §7.1 terminal-status unification by #98, §7.2 plan validation by #100, §7.3 refine-failure backoff by #99, §7.4 ADK session heal by #101, §7.7 per-task retry cap by #102, cascade cascade by #103, goal predicates by #104, terminal edge preservation by #105, revision-diff sidecar by #106, and cascade codepath unification by #107. Any new gaps discovered during maintenance should be added to this list.)

--- a/docs/design/STATE-MACHINE.md
+++ b/docs/design/STATE-MACHINE.md
@@ -167,14 +167,14 @@ detected via elapsed time, not via progress gaps).
 
 ## Cascade semantics on unrecoverable drift
 
-When a drift carries `recoverable=False`, the executor runs the
-**unrecoverable cascade**:
+When a drift carries `recoverable=False`, the **unrecoverable
+cascade** runs:
 
 ```
 1. Mark the current task FAILED (if not already terminal).
 2. Mark every RUNNING task FAILED.
 3. BFS downstream from each just-FAILED task and mark every
-   reachable PENDING task CANCELLED.
+   reachable non-terminal task CANCELLED.
 4. Clear any adapter-bound task context (ContextVars).
 5. Emit RunAborted(reason=drift.kind, drift=drift).
 ```
@@ -196,6 +196,30 @@ would cancel the current task but leave downstream PENDING tasks
 silently orphaned (they never satisfy `_pick_next_task`'s "all
 predecessors COMPLETED" check). See
 [TASK-LIFECYCLE.md §6.1 — Cancellation cascade](TASK-LIFECYCLE.md#61-cancellation-cascade).
+
+### Shared downstream-CANCEL primitive
+
+Both cascades (the unrecoverable case above and the cancel-cascade
+below) fan out to downstream tasks through **one shared primitive**:
+`Steerer.cascade_cancel_downstream(session, cancelled_id)` on
+`goldfive/protocols.py` (reference impl on
+`DefaultSteerer.cascade_cancel_downstream` in
+`goldfive/steerer.py`). The primitive:
+
+- walks `session.plan.edges` forward from the initiator,
+- transitions every reachable non-terminal task to `CANCELLED`,
+- emits exactly one `TaskCancelled` event per transition with
+  reason `"cascade from <cancelled_id>"`,
+- skips already-terminal tasks (diamond-DAG-safe).
+
+Having a single primitive means the §6.2 and §6.3 downstream event
+streams are identical — sinks (and harmonograf's UI) see the same
+shape regardless of whether the cascade was seeded by a CANCEL or a
+fatal FAILED. The "mark every RUNNING task FAILED" step of the
+unrecoverable cascade is *not* part of this primitive; that stays
+separate because the unrecoverable path explicitly wants `FAILED`
+status (not `CANCELLED`) on running work that the fatal drift
+invalidated.
 
 ## Implementation notes
 

--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -338,13 +338,20 @@ things on every legal cancel:
    `FAILED` / already-`CANCELLED`) are preserved verbatim and not
    traversed past — a diamond DAG does not double-cancel.
 
-This mirrors the "unrecoverable drift" cascade documented in
-[STATE-MACHINE.md §"Cascade semantics on unrecoverable drift"](STATE-MACHINE.md#cascade-semantics-on-unrecoverable-drift).
+Both this cascade and the "unrecoverable drift" cascade share the
+same downstream-CANCEL primitive —
+`Steerer.cascade_cancel_downstream(session, task_id)` — so they
+emit identical `TaskCancelled` event streams for the same downstream
+set. The unrecoverable path differs only in the *initiator*
+transition (FAILED instead of CANCELLED); the fan-out is identical.
+See [STATE-MACHINE.md §"Cascade semantics on unrecoverable drift"](STATE-MACHINE.md#cascade-semantics-on-unrecoverable-drift)
+and [STATE-MACHINE.md §"Shared downstream-CANCEL primitive"](STATE-MACHINE.md#shared-downstream-cancel-primitive).
 Whether the cancel arrives via (a) a control-channel `CANCEL`,
 (b) a `USER_STEER` whose refine returns no new plan (so the executor
-preserves the CANCELLED current task without replacing it), or
-(c) an explicit `mark_task_cancelled` call, the cascade fires at the
-same boundary in the steerer.
+preserves the CANCELLED current task without replacing it),
+(c) an explicit `mark_task_cancelled` call, or
+(d) a `mark_task_failed(..., recoverable=False)` fatal failure,
+the cascade fans out through the same steerer primitive.
 
 The `SequentialExecutor` additionally runs a **reachability audit**
 at loop exit: if `_pick_next_task` returns None but some tasks are

--- a/goldfive/protocols.py
+++ b/goldfive/protocols.py
@@ -73,6 +73,32 @@ class Steerer(Protocol):
         session: Session,
     ) -> None: ...
 
+    async def cascade_cancel_downstream(
+        self,
+        session: Session,
+        cancelled_id: str,
+    ) -> None:
+        """BFS-cancel every downstream non-terminal task of ``cancelled_id``.
+
+        Shared cancellation-fanout primitive for both PLAN-LIFECYCLE.md
+        §6.2 (unrecoverable cascade) and §6.3 (cancel cascade). A
+        conforming Steerer MUST:
+
+        - Walk the current plan's forward edges from ``cancelled_id``.
+        - Transition every reachable non-terminal task to CANCELLED.
+        - Emit exactly one ``TaskCancelled`` event per transitioned
+          task, with a reason that identifies ``cancelled_id`` as the
+          cascade source.
+        - Skip tasks already in a terminal status (no re-cancellation,
+          no event re-emission).
+        - De-duplicate diamond-DAG reachability (emit at most one event
+          per downstream task per call).
+
+        The initiator (``cancelled_id``) itself is *not* transitioned
+        or emitted here — callers own that transition before invoking
+        this primitive.
+        """
+
     def detect_drift(
         self,
         event: Any,

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -208,6 +208,19 @@ class DefaultSteerer:
         ``TASK_FAILED_FATAL``. The drift event is dispatched through the
         same drift pipeline as observer-detected drift: if severity is
         ``>= WARNING`` (both of these are) we invoke ``planner.refine``.
+
+        When ``recoverable=False`` the failure is fatal for this task
+        lineage: **cascade-cancel every reachable downstream non-terminal
+        task** via :meth:`cascade_cancel_downstream`, so the plan lands
+        in a consistent terminal-only shape instead of orphaning
+        dependents that would sit PENDING forever. This is the
+        implementation of PLAN-LIFECYCLE.md §6.2 step 3 and it shares
+        its primitive with the §6.3 cancel cascade path
+        (:meth:`mark_task_cancelled`). The downstream cascade fires
+        *before* we dispatch the fatal drift through ``_handle_drift``
+        so that planner.refine sees the post-cascade plan shape and a
+        refine-failure back-off does not leave orphans behind. See
+        ``STATE-MACHINE.md §"Cascade semantics on unrecoverable drift"``.
         """
         task = self._find_task(session, task_id)
         if task is None:
@@ -216,6 +229,11 @@ class DefaultSteerer:
             return
         task.status = TaskStatus.FAILED
         await self._emit_task_failed(session, task_id, reason, recoverable)
+        # Fatal failures cascade downstream via the same primitive used
+        # by mark_task_cancelled, so both §6.2 and §6.3 produce the
+        # same TaskCancelled event stream and share rejection guards.
+        if not recoverable:
+            await self.cascade_cancel_downstream(session, task_id)
         kind = DriftKind.TASK_FAILED_RECOVERABLE if recoverable else DriftKind.TASK_FAILED_FATAL
         severity = DriftSeverity.WARNING if recoverable else DriftSeverity.CRITICAL
         drift = DriftEvent(
@@ -290,14 +308,31 @@ class DefaultSteerer:
             return
         task.status = TaskStatus.CANCELLED
         await self._emit_task_cancelled(session, task_id, reason)
-        await self._cascade_cancel_downstream(session, task_id)
+        await self.cascade_cancel_downstream(session, task_id)
 
-    async def _cascade_cancel_downstream(
+    async def cascade_cancel_downstream(
         self,
         session: Session,
         cancelled_id: str,
     ) -> None:
         """BFS-cancel every downstream non-terminal task of ``cancelled_id``.
+
+        Shared primitive for both cascade codepaths
+        (PLAN-LIFECYCLE.md §6.2 unrecoverable cascade and §6.3
+        cancellation cascade):
+
+        - The recoverable path
+          (:meth:`mark_task_cancelled`) calls it after transitioning
+          the initiator to ``CANCELLED``.
+        - The unrecoverable path
+          (:meth:`mark_task_failed` with ``recoverable=False``) calls
+          it after transitioning the initiator to ``FAILED``.
+
+        Both paths therefore produce the same ``TaskCancelled`` event
+        stream for the downstream set and share the rejection guards
+        (terminal tasks are skipped; diamond DAGs are de-duplicated).
+        The initiator's own transition-emission is caller-controlled —
+        this method only emits for the *downstream* set.
 
         Walks ``session.plan.edges`` forward from ``cancelled_id`` and
         transitions every reachable non-terminal task to ``CANCELLED``

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -82,6 +82,9 @@ class _SteererStub:
     ) -> None:
         return None
 
+    async def cascade_cancel_downstream(self, session: Any, cancelled_id: str) -> None:
+        return None
+
     def detect_drift(self, event: Any, session: Any) -> Any | None:
         return None
 

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -239,7 +239,19 @@ async def test_mark_task_failed_recoverable_fires_drift() -> None:
 async def test_mark_task_failed_fatal_fires_critical_drift() -> None:
     steerer, session, sink, _planner = _fresh()
     await steerer.mark_task_failed("t1", session=session, reason="unrecoverable", recoverable=False)
-    drift_evt = sink.events[1]
+    # Event order: TaskFailed(t1) → TaskCancelled(t2, cascade) → DriftDetected(TASK_FAILED_FATAL) →
+    # refine-failure DriftDetected (stub planner returns None). The
+    # cascade fires before the fatal drift so planner.refine (if it ran)
+    # would see the post-cascade plan shape.
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert kinds == ["task_failed", "task_cancelled", "drift_detected", "drift_detected"]
+    assert sink.events[0].task_failed.task_id == "t1"
+    assert sink.events[0].task_failed.recoverable is False
+    # Downstream cascade picked up t2 via the shared primitive.
+    assert sink.events[1].task_cancelled.task_id == "t2"
+    assert "cascade" in sink.events[1].task_cancelled.reason
+    assert "t1" in sink.events[1].task_cancelled.reason
+    drift_evt = sink.events[2]
     from goldfive.pb.goldfive.v1 import types_pb2
 
     assert drift_evt.drift_detected.kind == types_pb2.DRIFT_KIND_TASK_FAILED_FATAL
@@ -564,10 +576,14 @@ async def test_two_consecutive_refine_failures_marks_task_failed() -> None:
     from goldfive.pb.goldfive.v1 import types_pb2
 
     kinds = [e.WhichOneof("payload") for e in sink.events]
-    # Expected stream across both ticks:
+    # Expected stream across both ticks (inclusive of the unrecoverable
+    # downstream cascade — PLAN-LIFECYCLE.md §6.2 step 3 — that
+    # mark_task_failed(recoverable=False) now drives through the shared
+    # cascade_cancel_downstream primitive):
     #   tick 1: drift_detected (TOOL_ERROR)
     #   tick 2: drift_detected (TOOL_ERROR),
-    #           task_failed,
+    #           task_failed(t1),
+    #           task_cancelled(t2, cascade from t1),
     #           drift_detected (TASK_FAILED_FATAL — from mark_task_failed),
     #           drift_detected (REPEATED_FAILURE).
     assert "task_failed" in kinds
@@ -1154,3 +1170,83 @@ async def test_mark_task_cancelled_does_not_re_cancel() -> None:
     assert len(sink.events) == first_event_count
     assert _task(session, "t1").status is TaskStatus.CANCELLED
     assert _task(session, "t2").status is TaskStatus.CANCELLED
+
+
+async def test_cascade_primitive_shared_between_recoverable_and_unrecoverable_paths() -> None:
+    """Both cascade paths fan out CANCELs through the same primitive.
+
+    Closes PLAN-LIFECYCLE.md §8 gap #3: the recoverable cascade (§6.3 —
+    driven by ``mark_task_cancelled``) and the unrecoverable cascade
+    (§6.2 — driven by ``mark_task_failed(recoverable=False)``) share
+    :meth:`DefaultSteerer.cascade_cancel_downstream`. Both paths must
+    therefore emit ``TaskCancelled`` events for the same downstream set
+    with identical reasons.
+
+    This is the regression guard against future divergence: if somebody
+    adds a second BFS-cancel implementation (e.g. an "unrecoverable
+    cascade" method on the executor that mutates status directly), the
+    downstream event stream for the two paths will drift and this test
+    will flag it.
+    """
+
+    # Diamond DAG t1 -> {t2, t3} -> t4 so the test exercises both
+    # forward-BFS and the dedup-across-paths guarantee on both paths.
+    def _build() -> tuple[DefaultSteerer, Session, ListSink]:
+        plan = Plan(
+            id="p-cascade-parity",
+            run_id="r1",
+            goal_ids=["g1"],
+            tasks=[Task(id=tid, title=tid.upper()) for tid in ("t1", "t2", "t3", "t4")],
+            edges=[
+                TaskEdge(from_task_id="t1", to_task_id="t2"),
+                TaskEdge(from_task_id="t1", to_task_id="t3"),
+                TaskEdge(from_task_id="t2", to_task_id="t4"),
+                TaskEdge(from_task_id="t3", to_task_id="t4"),
+            ],
+        )
+        session = _make_session(plan)
+        sink = ListSink()
+        steerer = DefaultSteerer()
+        steerer.bind(sinks=[sink], planner=StubPlanner())
+        return steerer, session, sink
+
+    # --- Recoverable path: mark_task_cancelled("t1") -------------------
+    rec_steerer, rec_session, rec_sink = _build()
+    await rec_steerer.mark_task_cancelled("t1", session=rec_session, reason="steer")
+    rec_cancelled = [
+        e.task_cancelled for e in rec_sink.events if e.WhichOneof("payload") == "task_cancelled"
+    ]
+    # Initiator t1 + downstream {t2, t3, t4} = 4 TaskCancelled events.
+    assert [c.task_id for c in rec_cancelled][0] == "t1"
+    rec_downstream_ids = sorted(c.task_id for c in rec_cancelled[1:])
+    assert rec_downstream_ids == ["t2", "t3", "t4"]
+    rec_downstream_reasons = {c.task_id: c.reason for c in rec_cancelled[1:]}
+
+    # --- Unrecoverable path: mark_task_failed("t1", recoverable=False) -
+    fat_steerer, fat_session, fat_sink = _build()
+    await fat_steerer.mark_task_failed("t1", session=fat_session, reason="fatal", recoverable=False)
+    fat_cancelled = [
+        e.task_cancelled for e in fat_sink.events if e.WhichOneof("payload") == "task_cancelled"
+    ]
+    # Initiator t1 is FAILED (not CANCELLED), so only the *downstream*
+    # set shows up as TaskCancelled events — same three tasks as the
+    # recoverable path produced downstream.
+    fat_downstream_ids = sorted(c.task_id for c in fat_cancelled)
+    assert fat_downstream_ids == ["t2", "t3", "t4"]
+    fat_downstream_reasons = {c.task_id: c.reason for c in fat_cancelled}
+
+    # Core parity assertion: the downstream TaskCancelled events emitted
+    # by the two paths carry the same reason strings ("cascade from t1"
+    # shape), proving both paths funnel through cascade_cancel_downstream.
+    assert rec_downstream_reasons == fat_downstream_reasons
+    for tid, reason in fat_downstream_reasons.items():
+        assert "cascade" in reason, (tid, reason)
+        assert "t1" in reason, (tid, reason)
+
+    # Final plan shape parity on the downstream set (initiator differs:
+    # CANCELLED on the recoverable path, FAILED on the unrecoverable).
+    for tid in ("t2", "t3", "t4"):
+        assert _task(rec_session, tid).status is TaskStatus.CANCELLED, tid
+        assert _task(fat_session, tid).status is TaskStatus.CANCELLED, tid
+    assert _task(rec_session, "t1").status is TaskStatus.CANCELLED
+    assert _task(fat_session, "t1").status is TaskStatus.FAILED


### PR DESCRIPTION
## Summary

Closes PLAN-LIFECYCLE.md §8 gap #3: the recoverable cascade
(`mark_task_cancelled`, §6.3) and the unrecoverable cascade
(`mark_task_failed(recoverable=False)`, §6.2) now share the downstream
fan-out primitive `Steerer.cascade_cancel_downstream(session, task_id)`.
Both paths produce the same `TaskCancelled` event stream for the
downstream set, share the terminal-skip / diamond-dedup guards, and
share observability.

## Investigation findings

Before refactoring, I traced both codepaths and found that the
**unrecoverable cascade step 3 was never implemented in code** — only
documented. The STATE-MACHINE.md §"Cascade semantics on unrecoverable
drift" and PLAN-LIFECYCLE.md §6.2 both specify:

> 1. Mark the current task FAILED.
> 2. Mark every RUNNING task FAILED.
> 3. BFS downstream from each just-FAILED task; every reachable
>    PENDING → CANCELLED.

Today (before this PR), `mark_task_failed(recoverable=False)` only does
step 1 and fires a `TASK_FAILED_FATAL` drift. The
`SequentialExecutor.run` loop then catches `tracked_status == FAILED`
and (with `fail_fast=True`) emits `RunAborted` immediately — leaving
downstream tasks stuck at `PENDING`. You can see this in the existing
`test_fail_fast_stops_on_task_failure` at
`tests/test_sequential_executor.py:351`:

```python
assert plan.tasks[2].status == TaskStatus.PENDING
```

The framework gets away with this today because:

- With `fail_fast=False`, `_pick_next_task` returns None (FAILED dep),
  and the **reachability audit** at `sequential.py:452` cancels orphan
  PENDINGs — but via `steerer.transition(..., CANCELLED)`, which now
  routes through `mark_task_cancelled` and does trigger the §6.3
  cascade. So the audit's first `transition(CANCELLED)` fans out to
  downstream PENDINGs via the same primitive.
- With `fail_fast=True`, downstream PENDINGs are simply left as-is
  when the run ends — they never cause a bug because nobody reads them
  after `RunAborted`.

So the gap was both a **doc/code inconsistency** (doc says step 3
happens, code doesn't do it) and a **unification gap** (two cascades
described but only one implemented).

This PR closes both at once: it promotes `cascade_cancel_downstream`
to a public Steerer-protocol method, and has `mark_task_failed(...,
recoverable=False)` call it so §6.2 step 3 actually runs.

## Key changes

- `DefaultSteerer.cascade_cancel_downstream` is renamed from
  previously-private `_cascade_cancel_downstream`, with an expanded
  docstring noting it is the shared primitive for both §6.2 and §6.3.
- `Steerer` protocol (`goldfive/protocols.py`) gains
  `cascade_cancel_downstream` as a required method with a documented
  contract (walk forward edges, transition non-terminal reachables to
  CANCELLED, dedup diamonds, skip already-terminal tasks, one
  TaskCancelled event per transition).
- `mark_task_failed(..., recoverable=False)` invokes the shared
  primitive **after** transitioning the initiator to FAILED and
  **before** dispatching `TASK_FAILED_FATAL` through `_handle_drift`,
  so planner.refine (if it runs) sees the post-cascade plan shape and
  a refine-failure back-off cannot leave orphans behind. The "mark
  every RUNNING FAILED" step (§6.2 step 2) stays separate — it wants
  FAILED status, not CANCELLED, and is owned by the executor (vacuous
  for sequential, explicit for parallel).
- Existing `test_mark_task_failed_fatal_fires_critical_drift` updated
  to assert the new post-cascade event stream
  (`TaskFailed + TaskCancelled(downstream) + DriftDetected + DriftDetected`).
  This is the one test whose event shape changed; the assertion change
  is noted in the commit.
- New `test_cascade_primitive_shared_between_recoverable_and_unrecoverable_paths`
  is a parity regression guard: it runs both paths over the same
  diamond DAG `t1 → {t2, t3} → t4` and asserts both emit identical
  downstream TaskCancelled events (same task set, same reason strings
  of shape `"cascade from t1"`). Future divergence between the
  codepaths fails this test.
- `_SteererStub` in `tests/test_protocols.py` gains the new method so
  the Protocol runtime-check still passes.
- Docs updated: PLAN-LIFECYCLE.md §6.2 / §6.3 (both now mention the
  shared primitive), §8 gap #3 removed. STATE-MACHINE.md §"Cascade
  semantics" gains a new "Shared downstream-CANCEL primitive"
  subsection making the parity contract explicit. TASK-LIFECYCLE.md
  §6.1 updated to mention the fatal-failed cascade route.

## Test plan

- [x] `uv run --extra dev --extra adk pytest -q` — 493 passed, 38
      skipped, 0 failures.
- [x] `make lint` — All checks passed.
- [x] Investigation: confirmed the unrecoverable cascade step 3 was
      not previously implemented; confirmed the recoverable cascade
      tests remain green verbatim.
- [x] New parity test
      `test_cascade_primitive_shared_between_recoverable_and_unrecoverable_paths`
      passes and guards against future divergence.
