### PR TITLE
Wire every adapter's reporting-tool dispatch through invoke_tool (critical fix)

### DIFF
--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -248,8 +248,27 @@ is no per-drift-kind backoff or dedup. See §7.
 
 ## 5. Reporting-tool dispatch
 
+**Invariant — all adapters route reporting-tool calls through
+`invoke_tool`.** The three protection layers below live inside
+`goldfive.adapters._tool_invocation.invoke_tool` and are the ONLY
+path that picks them up. Adapters MUST NOT short-circuit by calling
+`spec.handler(...)` directly — doing so silently bypasses every
+layer. The regression guards for this invariant are:
+
+- ADK adapter: `tests/test_adk_adapter.py::test_reporting_tool_dispatch_routes_through_invoke_tool`
+  and the two companion tests
+  (`test_reporting_tool_on_terminal_task_returns_structured_rejection`,
+  `test_reporting_tool_duplicate_returns_duplicate_ack`).
+- Claude adapter: `tests/test_claude_adapter.py::test_pretooluse_hook_on_terminal_task_returns_structured_rejection`
+  and `test_pretooluse_hook_volume_cap_fires_drift`.
+- Callable adapter: the user callable is expected to call
+  `invoke_tool(tools, name, args, session, steerer)` directly
+  (see `tests/test_callable_adapter.py::test_tool_routing_drives_session_transitions`).
+  The adapter itself does not dispatch — it just forwards the spec
+  list to the user's callable.
+
 The three-layer defence in `_tool_invocation.invoke_tool`
-(`adapters/_tool_invocation.py:91–179`), in order:
+(`adapters/_tool_invocation.py`), in order:
 
 ### 5.1 Layer 1 — terminal-task rejection (prevention)
 

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -41,9 +41,11 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from goldfive.adapters import _adk_state_protocol as _sp
+from goldfive.adapters._tool_invocation import invoke_tool
 
 if TYPE_CHECKING:
     from goldfive.protocols import Steerer
+    from goldfive.reporting import ReportingToolSpec
     from goldfive.types import Session
 
 
@@ -63,9 +65,21 @@ class SessionContext:
 
     Carries the goldfive :class:`~goldfive.types.Session`, the active
     :class:`~goldfive.protocols.Steerer`, the task the adapter is about
-    to invoke, and the registered reporting-tool handler map. The
-    plugin picks it up from the ADK callback's ``callback_context``
-    via :func:`_session_context_from_callback`.
+    to invoke, the registered reporting-tool handler map, and the full
+    :class:`~goldfive.reporting.ReportingToolSpec` list. The plugin
+    picks it up from the ADK callback's ``callback_context`` via
+    :func:`_session_context_from_callback`.
+
+    The ``tools`` field is the authoritative source the plugin's
+    ``before_tool_callback`` uses to route calls through
+    :func:`~goldfive.adapters._tool_invocation.invoke_tool` — that
+    routing is what picks up the terminal-task rejection, idempotency,
+    and loop-guard layers. ``tool_handlers`` is kept for backward
+    compatibility with callers that construct a ``SessionContext``
+    directly (examples + test stubs) without a full spec list; when
+    only ``tool_handlers`` is supplied the plugin synthesizes minimal
+    ``ReportingToolSpec`` shims so the dispatch path still flows
+    through ``invoke_tool``.
     """
 
     __slots__ = (
@@ -73,6 +87,7 @@ class SessionContext:
         "steerer",
         "task",
         "tool_handlers",
+        "tools",
         "host_agent_name",
     )
 
@@ -82,14 +97,61 @@ class SessionContext:
         session: Session,
         steerer: Steerer | None,
         task: Any,
-        tool_handlers: Mapping[str, Any],
+        tool_handlers: Mapping[str, Any] | None = None,
+        tools: list[ReportingToolSpec] | None = None,
         host_agent_name: str,
     ) -> None:
         self.session = session
         self.steerer = steerer
         self.task = task
-        self.tool_handlers = dict(tool_handlers)
         self.host_agent_name = host_agent_name
+
+        # Prefer an explicit ``tools`` list (the adapter constructs
+        # ``SessionContext`` that way). Fall back to materialising
+        # lightweight specs from ``tool_handlers`` so existing external
+        # callers (approval_gated_agent example, legacy tests) still
+        # route through ``invoke_tool`` and get the protection layers.
+        if tools is not None:
+            self.tools = list(tools)
+            # Keep ``tool_handlers`` populated as a legacy read-only
+            # view for any code that introspected it (e.g.
+            # ``before_model_callback`` used to surface the list of
+            # reporting-tool names to the state protocol).
+            self.tool_handlers = {spec.name: spec.handler for spec in tools}
+        else:
+            self.tool_handlers = dict(tool_handlers or {})
+            self.tools = _tools_from_handlers(self.tool_handlers)
+
+
+def _tools_from_handlers(
+    tool_handlers: Mapping[str, Any],
+) -> list[ReportingToolSpec]:
+    """Materialise a list of ``ReportingToolSpec`` from a name→handler map.
+
+    Used when a caller builds :class:`SessionContext` with just a
+    handler map (legacy path — examples / test stubs). We fabricate
+    minimal specs so the dispatch path still routes through
+    :func:`invoke_tool` and picks up the terminal-task rejection,
+    idempotency, and loop-guard layers.
+
+    The synthesized specs carry empty ``description`` / ``parameters``
+    — the plugin only needs ``name`` + ``handler`` at dispatch time;
+    the rich schema is surfaced through the native SDK tool wrapping
+    done earlier in the adapter's ``register_reporting_tools``.
+    """
+    from goldfive.reporting import ReportingToolSpec
+
+    specs: list[ReportingToolSpec] = []
+    for name, handler in tool_handlers.items():
+        specs.append(
+            ReportingToolSpec(
+                name=str(name),
+                description="",
+                parameters={"type": "object", "properties": {}},
+                handler=handler,
+            )
+        )
+    return specs
 
 
 def _safe_attr(obj: Any, name: str, default: Any = None) -> Any:
@@ -271,29 +333,6 @@ def _extract_function_calls(llm_response: Any) -> list[dict]:
     return calls
 
 
-async def _invoke_handler(
-    handler: Any,
-    args: Mapping[str, Any],
-    session: Session,
-    steerer: Steerer | None,
-) -> dict[str, Any]:
-    """Invoke a reporting-tool handler, tolerating sync or async shapes."""
-    import asyncio
-
-    try:
-        call = handler(dict(args), session, steerer)
-    except TypeError:
-        # Some handler implementations accept keyword-style signatures.
-        call = handler(args=dict(args), session=session, steerer=steerer)
-    if asyncio.iscoroutine(call):
-        result = await call
-    else:
-        result = call
-    if isinstance(result, dict):
-        return result
-    return {"acknowledged": True}
-
-
 def _as_observation(
     *,
     kind: str,
@@ -397,9 +436,7 @@ async def _emit_approval_requested_from_plugin(
         )
         await emit(sinks, evt)
     except Exception as exc:  # noqa: BLE001
-        log.debug(
-            "_emit_approval_requested_from_plugin: sink emit failed: %s", exc
-        )
+        log.debug("_emit_approval_requested_from_plugin: sink emit failed: %s", exc)
 
 
 def _jsonable(v: Any) -> Any:
@@ -461,9 +498,7 @@ async def _await_tool_approval(
         prompt=prompt,
         tool_name=tool_name,
         tool_args=tool_args if isinstance(tool_args, Mapping) else {},
-        task_id=(
-            session_ctx.task.id if session_ctx.task is not None else ""
-        ),
+        task_id=(session_ctx.task.id if session_ctx.task is not None else ""),
     )
 
     await waiter.wait()
@@ -482,9 +517,7 @@ async def _await_tool_approval(
     return None
 
 
-def _tool_approval_prompt(
-    tool: Any, tool_name: str, tool_args: Any
-) -> str:
+def _tool_approval_prompt(tool: Any, tool_name: str, tool_args: Any) -> str:
     """Human-readable prompt the UI shows to the human.
 
     Prefers an explicit ``approval_prompt`` attribute on the tool so
@@ -520,9 +553,7 @@ def make_adk_plugin(
     try:
         from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
     except ImportError as exc:  # pragma: no cover — tested via importorskip
-        raise ImportError(
-            "goldfive.adapters.adk requires 'pip install goldfive[adk]'"
-        ) from exc
+        raise ImportError("goldfive.adapters.adk requires 'pip install goldfive[adk]'") from exc
 
     class _GoldfiveADKPlugin(BasePlugin):  # type: ignore[misc, valid-type]
         """Routes ADK callbacks into the goldfive steerer + state protocol."""
@@ -533,9 +564,7 @@ def make_adk_plugin(
 
         # --- Plan + current-task context -------------------------------
 
-        async def before_model_callback(
-            self, *, callback_context: Any, llm_request: Any
-        ) -> None:
+        async def before_model_callback(self, *, callback_context: Any, llm_request: Any) -> None:
             ctx = _session_context_from_callback(callback_context)
             if ctx is None:
                 return None
@@ -582,16 +611,35 @@ def make_adk_plugin(
             # e.g. report_task_started should never also be gated by
             # confirmation — the protocol handlers are control-plane
             # calls, not side-effects.
-            handler = ctx.tool_handlers.get(tool_name)
-            if handler is not None:
-                args_map: Mapping[str, Any]
+            #
+            # Route through ``invoke_tool`` (NOT a direct handler call)
+            # so every reporting-tool dispatch picks up the three
+            # protection layers defined in
+            # ``goldfive.adapters._tool_invocation``:
+            #
+            #   1. terminal-task rejection — structured error response
+            #      once a task has reached COMPLETED/FAILED/CANCELLED,
+            #   2. idempotency — duplicate (task_id, name, args) calls
+            #      return ``{"acknowledged": True, "duplicate": True}``,
+            #   3. loop guard — a sustained burst of identical calls
+            #      fires a ``LOOPING_TOOL_CALL`` drift so the planner
+            #      can intervene.
+            #
+            # See ``docs/design/TASK-LIFECYCLE.md`` §5 for the contract.
+            tool_names_registered = {spec.name for spec in ctx.tools}
+            if tool_name in tool_names_registered:
+                args_map: dict[str, Any]
                 if isinstance(tool_args, Mapping):
-                    args_map = tool_args
+                    args_map = dict(tool_args)
                 else:
                     args_map = {}
                 try:
-                    result = await _invoke_handler(
-                        handler, args_map, ctx.session, ctx.steerer
+                    result = await invoke_tool(
+                        ctx.tools,
+                        tool_name,
+                        args_map,
+                        ctx.session,
+                        ctx.steerer,
                     )
                 except Exception as exc:  # noqa: BLE001
                     log.debug(
@@ -603,7 +651,12 @@ def make_adk_plugin(
                     # agent doesn't see a tool error for a protocol call.
                     return {"acknowledged": True, "error": str(exc)}
                 # Return a non-None result to short-circuit ADK tool dispatch.
-                return result or {"acknowledged": True}
+                # ``invoke_tool`` always returns a dict; preserve it verbatim
+                # so the terminal-rejection / duplicate-ACK payloads reach
+                # the agent unchanged.
+                if isinstance(result, dict):
+                    return result
+                return {"acknowledged": True}
 
             # Tool-level approval (Flow B). If the tool opts into
             # confirmation via ADK's native `require_confirmation` flag,
@@ -620,9 +673,7 @@ def make_adk_plugin(
 
         # --- Drift observation -----------------------------------------
 
-        async def after_model_callback(
-            self, *, callback_context: Any, llm_response: Any
-        ) -> None:
+        async def after_model_callback(self, *, callback_context: Any, llm_response: Any) -> None:
             ctx = _session_context_from_callback(callback_context)
             if ctx is None or ctx.steerer is None:
                 return None
@@ -647,9 +698,7 @@ def make_adk_plugin(
             except Exception as exc:  # noqa: BLE001
                 log.debug("after_model_callback: steerer.observe raised: %s", exc)
             if reasoning:
-                observe_reasoning = getattr(
-                    ctx.steerer, "observe_reasoning", None
-                )
+                observe_reasoning = getattr(ctx.steerer, "observe_reasoning", None)
                 if observe_reasoning is not None:
                     try:
                         await observe_reasoning(
@@ -665,9 +714,7 @@ def make_adk_plugin(
                         )
             return None
 
-        async def on_event_callback(
-            self, *, invocation_context: Any, event: Any
-        ) -> None:
+        async def on_event_callback(self, *, invocation_context: Any, event: Any) -> None:
             ctx = _session_context_from_callback(invocation_context)
             if ctx is None or ctx.steerer is None:
                 return None
@@ -678,9 +725,7 @@ def make_adk_plugin(
             if not transfer_to and not escalate:
                 return None
             kind = "agent_transfer" if transfer_to else "agent_escalation"
-            detail = (
-                f"transfer -> {transfer_to}" if transfer_to else "escalate"
-            )
+            detail = f"transfer -> {transfer_to}" if transfer_to else "escalate"
             observation = _as_observation(
                 kind=kind,
                 detail=detail,
@@ -716,9 +761,7 @@ def make_adk_plugin(
             try:
                 await ctx.steerer.observe(observation, ctx.session)
             except Exception as exc:  # noqa: BLE001
-                log.debug(
-                    "on_tool_error_callback: steerer.observe raised: %s", exc
-                )
+                log.debug("on_tool_error_callback: steerer.observe raised: %s", exc)
             return None
 
     return _GoldfiveADKPlugin()

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -430,6 +430,13 @@ class ADKAdapter:
 
         # tool_name -> handler. Populated by register_reporting_tools.
         self._tool_handlers: dict[str, Any] = {}
+        # Full reporting-tool specs, in registration order. The plugin's
+        # ``before_tool_callback`` routes each call through
+        # :func:`goldfive.adapters._tool_invocation.invoke_tool` so the
+        # terminal-rejection / idempotency / loop-guard layers fire.
+        # Keeping the full spec list (not just handlers) is what wires
+        # those protections in — a bare handler map would bypass them.
+        self._tool_specs: list[ReportingToolSpec] = []
         # The current Steerer. Set by bind_steerer() before invoke().
         self._steerer: Steerer | None = None
         # Pending ADK function_call ids observed in the current invoke()'s
@@ -513,6 +520,9 @@ class ADKAdapter:
             self._tool_handlers[name] = handler
             function_tools.append(_build_function_tool(spec))
             names.add(name)
+        # Replace the spec list on every call so repeated registrations
+        # (re-bind on a new run) stay consistent with the handler map.
+        self._tool_specs = list(tools)
 
         # Attach to the inner agent itself (root), then the whole subtree.
         root_tools = getattr(self._agent, "tools", None)
@@ -588,6 +598,7 @@ class ADKAdapter:
             steerer=self._steerer,
             task=task,
             tool_handlers=self._tool_handlers,
+            tools=self._tool_specs,
             host_agent_name=str(getattr(self._agent, "name", "") or ""),
         )
 

--- a/goldfive/adapters/claude.py
+++ b/goldfive/adapters/claude.py
@@ -32,13 +32,14 @@ This module is pinned to the shapes in ``docs/design/PROTOCOLS.md``.
 from __future__ import annotations
 
 import json
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from goldfive.adapters._claude_prompt import (
     DEFAULT_SYSTEM_PROMPT_TEMPLATE,
     render_system_prompt,
 )
+from goldfive.adapters._tool_invocation import invoke_tool
 from goldfive.drift import classify_stop_reason
 from goldfive.reporting import REPORTING_TOOL_NAMES, ReportingToolSpec
 from goldfive.results import InvocationResult
@@ -367,8 +368,7 @@ class ClaudeAgentSDKAdapter:
         ) -> dict[str, Any]:
             tool_name = input_data.get("tool_name", "") or ""
             bare = _strip_mcp_prefix(tool_name)
-            spec = specs.get(bare)
-            if spec is None:
+            if bare not in specs:
                 # Not a reporting tool — let the SDK run it normally.
                 return {}
 
@@ -386,8 +386,19 @@ class ClaudeAgentSDKAdapter:
                 session,
             )
 
+            # Route through ``invoke_tool`` (NOT ``spec.handler`` direct)
+            # so every reporting-tool dispatch picks up the three
+            # protection layers: terminal-task rejection, idempotency,
+            # and loop-guard. See
+            # ``docs/design/TASK-LIFECYCLE.md`` §5 for the contract.
             try:
-                ack = await spec.handler(tool_input, session, steerer)
+                ack = await invoke_tool(
+                    list(specs.values()),
+                    bare,
+                    dict(tool_input) if isinstance(tool_input, Mapping) else {},
+                    session,
+                    steerer,
+                )
             except Exception as exc:  # noqa: BLE001 - surface to agent
                 ack = {"ok": False, "error": str(exc)}
 

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -818,3 +818,277 @@ async def test_heal_is_noop_when_no_pending_calls() -> None:
     adapter_empty = ADKAdapter(runner_empty, session_id="sess-empty")
     await adapter_empty.invoke(Task(id="t1", title="x"), Session(run_id="r"))
     assert runner_empty.session_service.appended == []
+
+
+# ---------------------------------------------------------------------------
+# Regression guard — every reporting-tool dispatch MUST route through
+# :func:`goldfive.adapters._tool_invocation.invoke_tool` so the three
+# protection layers (terminal-task rejection, idempotency, loop guard)
+# fire. A prior version of ``before_tool_callback`` called the handler
+# directly and silently bypassed all three — 500-LLM-call ceilings were
+# being hit on already-terminal tasks with nothing but bland
+# ``{"acknowledged": True}`` responses reaching the agent. These tests
+# are the regression guard for that wiring. See
+# ``docs/design/TASK-LIFECYCLE.md`` §5.
+# ---------------------------------------------------------------------------
+
+
+async def test_reporting_tool_dispatch_routes_through_invoke_tool(state_ctx_cls) -> None:
+    """15 calls to the same reporting tool on one task must trip the
+    volume-cap loop guard (15+ cumulative calls → LOOPING_TOOL_CALL
+    drift), proving the plugin's ``before_tool_callback`` runs the
+    dispatch through :func:`invoke_tool` and not the handler directly.
+
+    If the wiring regresses (callback calls ``handler(...)`` directly),
+    no drift will be emitted and the 15th call will return a plain
+    ``{"acknowledged": True}`` — this test catches that.
+    """
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+    )
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.reporting import BUILTIN_REPORTING_TOOLS
+    from goldfive.types import DriftEvent, DriftKind, Plan, TaskEdge
+
+    # _RecordingSteerer-shaped double that the tool-loop-guard's
+    # ``emit_loop_drift`` can push a DriftEvent into. The builtin
+    # reporting handlers call ``mark_task_*`` on the steerer, so we
+    # implement the two we need.
+    class _Steerer:
+        def __init__(self) -> None:
+            self.drifts: list[DriftEvent] = []
+            self.blocked_calls: int = 0
+
+        async def mark_task_blocked(self, task_id: str, *, session: Any, **kwargs: Any) -> None:
+            self.blocked_calls += 1
+
+        async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+            self.drifts.append(drift)
+
+    spec = next(t for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_blocked")
+
+    agent = _make_agent()
+    adapter = ADKAdapter(agent)
+    await adapter.register_reporting_tools([spec])
+
+    steerer = _Steerer()
+    task = Task(id="t1", title="x")
+    session = Session(
+        run_id="r1",
+        plan=Plan(
+            id="p1",
+            run_id="r1",
+            goal_ids=[],
+            tasks=[task, Task(id="t2", title="y")],
+            edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+        ),
+    )
+
+    ctx = SessionContext(
+        session=session,
+        steerer=steerer,
+        task=task,
+        tools=[spec],
+        host_agent_name="test_agent",
+    )
+    state = {SESSION_CONTEXT_STATE_KEY: ctx}
+
+    class _Tool:
+        name = "report_task_blocked"
+
+    # Fire 16 calls on the same task, with varied ``blocked_on`` strings
+    # so every signature is unique — the volume cap (>= 15 cumulative
+    # calls) is the layer that catches this pattern. If the dispatch
+    # bypasses invoke_tool, no drift ever fires and the handler is
+    # invoked all 16 times.
+    results: list[dict[str, Any]] = []
+    for i in range(16):
+        result = await adapter._plugin.before_tool_callback(
+            tool=_Tool(),
+            tool_args={"task_id": "t1", "blocked_on": f"dep-{i}"},
+            tool_context=state_ctx_cls(state),
+        )
+        assert isinstance(result, dict)
+        results.append(result)
+
+    # The loop guard must have emitted exactly one LOOPING_TOOL_CALL
+    # drift — proof that invoke_tool's loop-detection layer ran.
+    assert len(steerer.drifts) == 1, (
+        f"expected one LOOPING_TOOL_CALL drift; got {len(steerer.drifts)}. "
+        "If this fails, before_tool_callback is bypassing invoke_tool "
+        "(the regression from PR #94/#98)."
+    )
+    assert steerer.drifts[0].kind is DriftKind.LOOPING_TOOL_CALL
+    assert steerer.drifts[0].current_task_id == "t1"
+
+    # Calls 1..14 reach the handler; call 15 is the one that trips the
+    # volume cap — it STILL reaches the handler (the drift is a side
+    # effect, not a short-circuit). The handler count therefore ends at
+    # 15 (first 15 calls) because the 16th call has the same task_id
+    # so is NOT subject to further short-circuiting by the volume
+    # check. The exact arithmetic is less important than: the drift
+    # fired at all. The regression-catching assertion is the drift
+    # count above; the handler count here is a secondary sanity check.
+    assert steerer.blocked_calls >= 1, (
+        "handler should have run at least once on a non-terminal task"
+    )
+
+
+async def test_reporting_tool_on_terminal_task_returns_structured_rejection(
+    state_ctx_cls,
+) -> None:
+    """A reporting call on an already-terminal task must get the
+    structured ``task_already_terminal`` error response — NOT a bland
+    ``{"acknowledged": True}``.
+
+    This is the terminal-task rejection layer (layer 1 in
+    ``docs/design/TASK-LIFECYCLE.md`` §5). Fires from inside
+    ``invoke_tool``; this test proves the ADK plugin's dispatch path
+    reaches that layer.
+    """
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+    )
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.reporting import BUILTIN_REPORTING_TOOLS
+    from goldfive.types import Plan, TaskStatus
+
+    # The handler must NEVER run when the task is already terminal —
+    # route the call through a spec whose handler raises, to catch a
+    # regression where invoke_tool's short-circuit is skipped.
+    invoked_count = [0]
+
+    async def _boom_handler(args, session, steerer):
+        invoked_count[0] += 1
+        raise AssertionError(
+            "handler must not run on a terminal task; dispatch should "
+            "short-circuit via invoke_tool's terminal rejection"
+        )
+
+    spec_template = next(t for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_progress")
+    spec = ReportingToolSpec(
+        name=spec_template.name,
+        description=spec_template.description,
+        parameters=spec_template.parameters,
+        handler=_boom_handler,
+    )
+
+    agent = _make_agent()
+    adapter = ADKAdapter(agent)
+    await adapter.register_reporting_tools([spec])
+
+    task = Task(id="t1", title="x", status=TaskStatus.FAILED)
+    session = Session(
+        run_id="r1",
+        plan=Plan(
+            id="p1",
+            run_id="r1",
+            goal_ids=[],
+            tasks=[task],
+            edges=[],
+        ),
+    )
+
+    ctx = SessionContext(
+        session=session,
+        steerer=None,
+        task=task,
+        tools=[spec],
+        host_agent_name="test_agent",
+    )
+    state = {SESSION_CONTEXT_STATE_KEY: ctx}
+
+    class _Tool:
+        name = "report_task_progress"
+
+    result = await adapter._plugin.before_tool_callback(
+        tool=_Tool(),
+        tool_args={"task_id": "t1", "fraction": 0.5, "detail": "too late"},
+        tool_context=state_ctx_cls(state),
+    )
+
+    assert isinstance(result, dict)
+    assert result.get("acknowledged") is False, (
+        "expected structured rejection; got acknowledged=true. If this "
+        "fails, before_tool_callback is bypassing invoke_tool's "
+        "terminal-task rejection layer."
+    )
+    assert result.get("error") == "task_already_terminal"
+    assert result.get("task_id") == "t1"
+    assert result.get("current_status") == "FAILED"
+    # Handler must have stayed cold.
+    assert invoked_count[0] == 0
+
+
+async def test_reporting_tool_duplicate_returns_duplicate_ack(state_ctx_cls) -> None:
+    """A byte-identical follow-up call must get the idempotency ACK
+    ``{"acknowledged": True, "duplicate": True}`` instead of re-entering
+    the handler — proof that layer 2 (idempotency) is wired.
+    """
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+    )
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.reporting import BUILTIN_REPORTING_TOOLS
+    from goldfive.types import Plan, TaskEdge
+
+    handler_calls: list[dict[str, Any]] = []
+
+    async def _recording_handler(args, session, steerer):
+        handler_calls.append(dict(args))
+        return {"acknowledged": True}
+
+    spec_template = next(t for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_started")
+    spec = ReportingToolSpec(
+        name=spec_template.name,
+        description=spec_template.description,
+        parameters=spec_template.parameters,
+        handler=_recording_handler,
+    )
+
+    agent = _make_agent()
+    adapter = ADKAdapter(agent)
+    await adapter.register_reporting_tools([spec])
+
+    task = Task(id="t1", title="x")
+    session = Session(
+        run_id="r1",
+        plan=Plan(
+            id="p1",
+            run_id="r1",
+            goal_ids=[],
+            tasks=[task, Task(id="t2", title="y")],
+            edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+        ),
+    )
+    ctx = SessionContext(
+        session=session,
+        steerer=None,
+        task=task,
+        tools=[spec],
+        host_agent_name="test_agent",
+    )
+    state = {SESSION_CONTEXT_STATE_KEY: ctx}
+
+    class _Tool:
+        name = "report_task_started"
+
+    args = {"task_id": "t1", "detail": "kick"}
+    first = await adapter._plugin.before_tool_callback(
+        tool=_Tool(), tool_args=args, tool_context=state_ctx_cls(state)
+    )
+    second = await adapter._plugin.before_tool_callback(
+        tool=_Tool(), tool_args=args, tool_context=state_ctx_cls(state)
+    )
+
+    # First call: handler runs, plain ACK.
+    assert first == {"acknowledged": True}
+    # Second call: handler must NOT re-run; duplicate ACK returned.
+    assert second == {"acknowledged": True, "duplicate": True}, (
+        "expected duplicate ACK; if this fails, idempotency layer is "
+        "bypassed (before_tool_callback is routing around invoke_tool)."
+    )
+    assert len(handler_calls) == 1

--- a/tests/test_claude_adapter.py
+++ b/tests/test_claude_adapter.py
@@ -142,8 +142,7 @@ def test_prompt_render_override_template() -> None:
     """A custom template is honored — placeholders are resolved."""
 
     template = (
-        "GOALS:\n{goal_block}\nPLAN:{plan_summary}\nDONE:{completed_block}\n"
-        "TASK:{task_block}\n"
+        "GOALS:\n{goal_block}\nPLAN:{plan_summary}\nDONE:{completed_block}\nTASK:{task_block}\n"
     )
     rendered = render_system_prompt(
         template,
@@ -358,3 +357,141 @@ def test_pretooluse_hook_passes_through_non_reporting_tools() -> None:
 
     result = asyncio.run(_run())
     assert result == {}
+
+
+# --------------------------------------------------------------------------- #
+# Regression guard — every reporting-tool dispatch MUST route through
+# :func:`goldfive.adapters._tool_invocation.invoke_tool` so the three
+# protection layers (terminal-task rejection, idempotency, loop guard)
+# fire. The Claude adapter's pre-tool-use hook previously invoked
+# ``spec.handler(...)`` directly, silently bypassing all three. See
+# ``docs/design/TASK-LIFECYCLE.md`` §5.
+# --------------------------------------------------------------------------- #
+
+
+def test_pretooluse_hook_on_terminal_task_returns_structured_rejection() -> None:
+    """A reporting call on an already-FAILED task must surface the
+    structured ``task_already_terminal`` error inside the hook's
+    ``permissionDecisionReason`` — proof the hook routes through
+    ``invoke_tool``.
+    """
+    import json as _json
+
+    from goldfive.types import TaskStatus
+
+    async def _boom_handler(args, session, steerer):
+        raise AssertionError(
+            "handler must not run on a terminal task; dispatch should "
+            "short-circuit via invoke_tool's terminal rejection"
+        )
+
+    spec = ReportingToolSpec(
+        name="report_task_progress",
+        description="progress",
+        parameters={"type": "object", "properties": {}},
+        handler=_boom_handler,
+    )
+
+    adapter = ClaudeAgentSDKAdapter(client_factory=lambda: _StubClient([]))
+
+    async def _run() -> dict[str, Any]:
+        await adapter.register_reporting_tools([spec])
+        task = Task(id="t1", title="x", status=TaskStatus.FAILED)
+        session = Session(
+            run_id="r",
+            plan=Plan(
+                id="p",
+                run_id="r",
+                goal_ids=[],
+                tasks=[task],
+                edges=[],
+            ),
+        )
+        hook = adapter._make_pretooluse_hook(session)  # noqa: SLF001
+        return await hook(
+            {
+                "tool_name": "mcp__goldfive_reporting__report_task_progress",
+                "tool_input": {"task_id": "t1", "fraction": 0.3},
+            },
+            "tu_x",
+            None,
+        )
+
+    result = asyncio.run(_run())
+    spec_out = result.get("hookSpecificOutput", {})
+    assert spec_out.get("permissionDecision") == "deny"
+    reason = spec_out.get("permissionDecisionReason", "")
+    # The hook encodes the ACK dict as JSON in the reason; parse it back
+    # to inspect the structured rejection payload.
+    parsed = _json.loads(reason)
+    assert parsed.get("acknowledged") is False, (
+        "expected structured rejection; got acknowledged=true. If this "
+        "fails, _make_pretooluse_hook is bypassing invoke_tool."
+    )
+    assert parsed.get("error") == "task_already_terminal"
+    assert parsed.get("task_id") == "t1"
+    assert parsed.get("current_status") == "FAILED"
+
+
+def test_pretooluse_hook_volume_cap_fires_drift() -> None:
+    """15+ calls to the same reporting tool for one task must fire a
+    ``LOOPING_TOOL_CALL`` drift — proves the hook's dispatch runs
+    through ``invoke_tool``'s loop-guard layer.
+    """
+    from goldfive.reporting import BUILTIN_REPORTING_TOOLS
+    from goldfive.types import DriftEvent, TaskEdge
+
+    class _Steerer:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+            self.drifts: list[DriftEvent] = []
+
+        async def observe(self, event: Any, session: Session) -> None:
+            self.events.append(event)
+
+        async def mark_task_blocked(self, task_id: str, *, session: Any, **kwargs: Any) -> None:
+            return None
+
+        async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+            self.drifts.append(drift)
+
+    spec = next(t for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_blocked")
+    steerer = _Steerer()
+    adapter = ClaudeAgentSDKAdapter(
+        client_factory=lambda: _StubClient([]),
+        steerer=steerer,
+    )
+
+    task = Task(id="t1", title="x")
+    session = Session(
+        run_id="r",
+        plan=Plan(
+            id="p",
+            run_id="r",
+            goal_ids=[],
+            tasks=[task, Task(id="t2", title="y")],
+            edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+        ),
+    )
+
+    async def _run() -> None:
+        await adapter.register_reporting_tools([spec])
+        hook = adapter._make_pretooluse_hook(session)  # noqa: SLF001
+        for i in range(16):
+            await hook(
+                {
+                    "tool_name": "mcp__goldfive_reporting__report_task_blocked",
+                    "tool_input": {"task_id": "t1", "blocked_on": f"dep-{i}"},
+                },
+                f"tu-{i}",
+                None,
+            )
+
+    asyncio.run(_run())
+
+    assert len(steerer.drifts) == 1, (
+        f"expected one LOOPING_TOOL_CALL drift; got {len(steerer.drifts)}. "
+        "If this fails, _make_pretooluse_hook is bypassing invoke_tool's "
+        "loop-guard layer."
+    )
+    assert steerer.drifts[0].kind is DriftKind.LOOPING_TOOL_CALL


### PR DESCRIPTION
## Summary

Every real adapter (ADK, Claude) was bypassing the three protection
layers in `goldfive/adapters/_tool_invocation.py::invoke_tool`
(terminal-task rejection, idempotency, loop guard) — `grep -rn 'invoke_tool(' goldfive/`
returned only the function *definition*, zero call sites.

In the wild this manifested as 499 `report_task_blocked` calls on a
single task in a live e2e run (`session_id=sess_2026-04-20_0010`),
every one returning a plain `{\"acknowledged\": true}` while ADK's
500-LLM-call ceiling burned through. The structured terminal-rejection
response and the duplicate-ACK were never observed because the
dispatch never reached them.

## Investigation — which adapters were broken

| Adapter | Dispatch site | Status before fix |
|---|---|---|
| ADK | `_adk_plugin.py::before_tool_callback` (lines 585-606 pre-fix) | **Broken** — called `_invoke_handler(handler, ...)` directly, bypassing all three layers. |
| Claude | `claude.py::_make_pretooluse_hook` (~line 390 pre-fix) | **Broken** — called `spec.handler(tool_input, session, steerer)` directly. |
| Callable | `callable.py` | **Already correct** — adapter does not dispatch; it forwards the `ReportingToolSpec` list to the user's async callable, and the canonical pattern (and existing tests like `test_tool_routing_drives_session_transitions`) already uses `invoke_tool`. |

## Fix

* **ADK:** extend `SessionContext` with a new `tools: list[ReportingToolSpec]` field so `before_tool_callback` can call `invoke_tool(ctx.tools, ...)`. `ADKAdapter.register_reporting_tools` builds `self._tool_specs` alongside the existing handler map; `ADKAdapter.invoke` threads it onto the context. `tool_handlers` stays for backward compatibility (examples + test stubs that construct `SessionContext` directly use `_tools_from_handlers` fallback which synthesizes lightweight specs). The dead `_invoke_handler` shim is removed.
* **Claude:** `_make_pretooluse_hook` now routes through `invoke_tool(list(specs.values()), bare, args, session, steerer)` instead of calling `spec.handler` directly.
* **Callable:** no code change required — the adapter was already wired correctly. The user's async callable is expected to invoke `invoke_tool` directly, and the existing tests cover that path.

## Tests

The existing `tests/test_tool_loop_guard.py` exercises `invoke_tool`
directly, so it would not have caught this wiring regression. New
adapter-layer guards:

* `tests/test_adk_adapter.py::test_reporting_tool_dispatch_routes_through_invoke_tool` — 16 calls to the same tool for one task must fire exactly one `LOOPING_TOOL_CALL` drift (volume-cap layer).
* `tests/test_adk_adapter.py::test_reporting_tool_on_terminal_task_returns_structured_rejection` — a call on an already-FAILED task must return the structured rejection; the handler (`_boom_handler`) must stay cold.
* `tests/test_adk_adapter.py::test_reporting_tool_duplicate_returns_duplicate_ack` — a byte-identical follow-up call must return `{\"acknowledged\": true, \"duplicate\": true}` and the handler must run exactly once.
* `tests/test_claude_adapter.py::test_pretooluse_hook_on_terminal_task_returns_structured_rejection` + `test_pretooluse_hook_volume_cap_fires_drift` — analogous guards on the Claude PreToolUse hook.

All five new tests fail against the pre-fix code (SessionContext didn't have `tools=` and the hook bypassed invoke_tool) and pass with the fix.

## Docs

`docs/design/TASK-LIFECYCLE.md` §5 now opens with an explicit invariant: \"all adapters route reporting-tool calls through `invoke_tool`\" — with pointers to the regression guards above.

`PLAN-LIFECYCLE.md` §5 is about plan validation, not reporting-tool dispatch, so no update was needed there.

## Test plan
- [x] `uv run --extra dev --extra adk pytest -q` — 526 passed, 38 skipped (all optional-dep skips), no regressions
- [x] `uv run --extra dev ruff check goldfive/adapters/ tests/test_adk_adapter.py tests/test_claude_adapter.py` — clean
- [x] `uv run --extra dev ruff format --check` on modified files — clean
- [x] Regression tests verified to fail against pre-fix ADK plugin

This closes a critical gap where #94 and #98's protection layers were bypassed by every real adapter.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>