### PR TITLE
Harden tool-loop guard against empty/unknown task_ids, flag pass-through, and session-wide flooding

### DIFF
--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -249,16 +249,17 @@ is no per-drift-kind backoff or dedup. See §7.
 ## 5. Reporting-tool dispatch
 
 **Invariant — all adapters route reporting-tool calls through
-`invoke_tool`.** The three protection layers below live inside
+`invoke_tool`.** The four protection layers below live inside
 `goldfive.adapters._tool_invocation.invoke_tool` and are the ONLY
 path that picks them up. Adapters MUST NOT short-circuit by calling
 `spec.handler(...)` directly — doing so silently bypasses every
 layer. The regression guards for this invariant are:
 
 - ADK adapter: `tests/test_adk_adapter.py::test_reporting_tool_dispatch_routes_through_invoke_tool`
-  and the two companion tests
+  and the companion tests
   (`test_reporting_tool_on_terminal_task_returns_structured_rejection`,
-  `test_reporting_tool_duplicate_returns_duplicate_ack`).
+  `test_reporting_tool_duplicate_returns_duplicate_ack`,
+  `test_adversarial_agent_with_varying_task_ids_is_stopped_at_session_cap`).
 - Claude adapter: `tests/test_claude_adapter.py::test_pretooluse_hook_on_terminal_task_returns_structured_rejection`
   and `test_pretooluse_hook_volume_cap_fires_drift`.
 - Callable adapter: the user callable is expected to call
@@ -267,14 +268,35 @@ layer. The regression guards for this invariant are:
   The adapter itself does not dispatch — it just forwards the spec
   list to the user's callable.
 
-The three-layer defence in `_tool_invocation.invoke_tool`
+The four-layer defence in `_tool_invocation.invoke_tool`
 (`adapters/_tool_invocation.py`), in order:
 
-### 5.1 Layer 1 — terminal-task rejection (prevention)
+### 5.1 Layer 1 — schema + terminal-task rejection (prevention)
 
-If the tool carries a `task_id` and the task is already in a
-terminal state (`COMPLETED` / `FAILED` / `CANCELLED`), the
-dispatcher returns a structured error:
+**Schema rejections.** For task-scoped tools (every canonical tool
+except `report_plan_divergence`), the dispatcher first validates
+the call carries a usable `task_id`:
+
+- **Missing task_id** — if `task_id` is absent / empty / whitespace:
+  ```python
+  {"acknowledged": False, "error": "missing_task_id", "tool": "<name>",
+   "message": "Tool '<name>' requires a task_id; ..."}
+  ```
+- **Unknown task_id** — if the id doesn't appear in the current
+  `session.plan.tasks`:
+  ```python
+  {"acknowledged": False, "error": "unknown_task_id", "tool": "<name>",
+   "task_id": "<id>",
+   "message": "Task with id '<id>' does not exist in the current plan ..."}
+  ```
+
+These rejections fire **before** the session counter (Layer 4)
+increments — so a malformed-call flood cannot poison session-wide
+state or create a false session drift against the next legitimate
+call.
+
+**Terminal-task rejection.** If the task exists and is already
+terminal (`COMPLETED` / `FAILED` / `CANCELLED`):
 
 ```python
 {
@@ -305,22 +327,73 @@ without invoking the handler.
 `report_awaiting_approval` is exempt — polling the same approval
 arguments is expected behaviour.
 
-### 5.3 Layer 3 — loop guard (safety net)
+### 5.3 Layer 3 — per-task loop guard (safety net)
 
 Two triggers, either one fires a one-shot `LOOPING_TOOL_CALL` drift:
 
 - **Exact-signature burst** — the same `(name, args_hash)` appears
   ≥ 6 times in the last 8 dispatches for this task.
-- **Per-tool volume cap** — cumulative calls to the same tool name
+- **Per-task volume cap** — cumulative calls to the same tool name
   for this task cross 15. Catches loops where the agent varies
   `reason` / `detail` strings on every call (defeating the
   signature match).
 
-`report_awaiting_approval` is exempt from the volume cap because
-polling is its design.
+`report_awaiting_approval` is exempt from the per-task volume cap
+because polling is its design.
 
-Once fired, `state.loop_flagged = True` prevents re-firing for the
-same task until refine resets the guard state.
+Once fired, the `(task, tool)` bucket is flagged and every
+subsequent call is **hard-rejected** with a structured error:
+
+```python
+{"acknowledged": False, "error": "loop_detected",
+ "task_id": "<id>", "tool": "<name>",
+ "reason": "exact_signature_burst" | "per_task_volume_cap",
+ "scope": "per_task",
+ "message": "Repeated calls to '<name>' ... Do not retry; wait for "
+            "the orchestrator to route you to the next task."}
+```
+
+Pre-hardening this layer was a one-shot: the drift fired on first
+crossing, then `detect_loop` returned False forever after and the
+dispatcher silently fell through to the handler on every subsequent
+call. A misbehaving agent could burn through ADK's 500-LLM-call
+ceiling with 100+ plain ACKs. The hard-reject behaviour keeps the
+rejection loud on every single call until a refine resets the
+bucket via `ToolLoopGuard.reset_task`.
+
+### 5.4 Layer 4 — session-wide volume cap
+
+A final safety net against adversarial callers that invent a fresh
+`task_id` on every call — a pattern which distributes 1-2 calls per
+per-task bucket and defeats Layer 3 entirely (the live-run failure
+that motivated this layer: 237 consecutive `report_task_failed`
+calls all returned plain ACK).
+
+The guard maintains a per-session, per-tool-name counter across
+ALL task_ids. Once a tool is called **50+ times** across the whole
+session, it is flagged session-wide and every subsequent call is
+hard-rejected with the same `loop_detected` response shape —
+`scope` is `"session"` and the drift detail identifies the
+session-wide trigger:
+
+```python
+{"acknowledged": False, "error": "loop_detected",
+ "tool": "<name>", "reason": "session_volume_cap",
+ "scope": "session",
+ "message": "Tool '<name>' has been called too many times across "
+            "all tasks in this session ..."}
+```
+
+One `LOOPING_TOOL_CALL` drift is emitted on the crossing call; the
+rejection continues silently for the rest of the session.
+
+`report_awaiting_approval` is exempt (polling by design).
+
+**Why 50.** The per-task cap is 15; a legitimate multi-task run
+making ~15 calls per task on three tasks in a row would hit ~45.
+Setting the session cap at 50 leaves just enough headroom for
+normal use while catching the 200+-call pathologies observed in
+live runs well before ADK's 500-LLM-call ceiling bites.
 
 ---
 
@@ -472,17 +545,18 @@ plan (after a USER_STEER delete-and-replan).
 flag on the executor/adapter that trims the ADK session history at
 revision boundaries. Medium effort, medium impact.
 
-### 7.6 Soft reject vs hard stop on terminal-task reporting
+### 7.6 Soft reject vs hard stop on terminal-task reporting (narrowed)
 
 Layer 1 (§5.1) returns a structured error, but does not actively
 prevent the agent from calling again. A misbehaving agent can
 ignore the error and call `report_task_failed` 100 times; each call
 is cheap (no handler, no drift) but still consumes an ADK turn. The
-loop guard (§5.3) catches this at the 15-call threshold, so the
-worst-case wasted turns is bounded at 14 — acceptable.
+per-task cap (§5.3, 15 calls) bounds this for single-task spam; the
+session-wide cap (§5.4, 50 calls) bounds the adversarial
+varying-`task_id` pattern that defeats the per-task cap. Worst-case
+wasted turns is now 49 across the whole session — acceptable.
 
-**Fix direction:** none required in the short term; the observed
-worst case is bounded.
+**Fix direction:** none required; bounded by Layer 3 + Layer 4.
 
 ### 7.7 No per-task invocation cap
 

--- a/goldfive/adapters/_tool_invocation.py
+++ b/goldfive/adapters/_tool_invocation.py
@@ -6,18 +6,31 @@ handler with ``(args, session, steerer)``. This helper centralises that
 lookup so that every adapter (CallableAdapter, ADK, Claude) routes through
 the same code path — keeping behaviour and error messages consistent.
 
-The dispatcher also threads every reporting-tool call through a per-task
+The dispatcher threads every reporting-tool call through a four-layer
 guard (see :mod:`goldfive.adapters._tool_loop_guard`) so that:
 
-* a duplicate call (same task, tool, args) returns a cheap ACK without
-  re-invoking the underlying handler / Steerer transition; and
-* a sustained burst of identical calls within a short window emits a
-  ``LOOPING_TOOL_CALL`` drift so the planner can intervene.
+* **Layer 1 — schema rejections.** A call with no ``task_id`` for a
+  task-scoped tool, or an unknown ``task_id`` not present in the
+  current plan, is rejected with a structured error **before** any
+  other layer runs (so malformed calls can't poison the session
+  counter).
+* **Layer 2 — terminal-task rejection.** A call on a task already in
+  ``COMPLETED`` / ``FAILED`` / ``CANCELLED`` is rejected with
+  ``task_already_terminal`` so the agent sees a clear stop signal.
+* **Layer 3 — per-task loop guard.** Duplicate-args calls return a
+  cheap ``duplicate`` ACK; a sustained burst (same signature) or
+  volume cap (same tool name, varying args) emits a
+  ``LOOPING_TOOL_CALL`` drift and flips that ``(task, tool)`` bucket
+  into a hard-reject state so subsequent spam gets
+  ``loop_detected`` instead of pass-through.
+* **Layer 4 — session-wide volume cap.** A final safety net against
+  adversarial callers that invent a fresh ``task_id`` every call,
+  which would distribute one call per per-task bucket and defeat the
+  per-task cap. Once a tool is called > 50 times across ALL tasks in
+  a session, it is flagged session-wide and every subsequent call is
+  hard-rejected.
 
-The guard is applied to **all** reporting-tool calls — the eight
-canonical reporting tools all carry an explicit ``task_id`` argument
-(except ``report_plan_divergence``, which we exempt below). Plan-level
-calls without a task scope are passed through unchanged.
+See ``docs/design/TASK-LIFECYCLE.md`` §5 for the layering rationale.
 """
 
 from __future__ import annotations
@@ -28,6 +41,7 @@ from typing import TYPE_CHECKING, Any
 from goldfive.adapters._tool_loop_guard import (
     args_signature,
     detect_loop,
+    detect_session_loop,
     emit_loop_drift,
     guard_for,
 )
@@ -76,16 +90,17 @@ async def invoke_tool(
     mirrors the behaviour a real SDK would exhibit when an agent hallucinates
     a tool name, and lets adapters surface a clean error to the agent.
 
-    Idempotency: if this ``(task_id, name, args)`` has already been
-    dispatched for this Session, the handler is skipped and the dispatcher
-    returns ``{"acknowledged": true, "duplicate": true}`` instead of
-    re-running the underlying Steerer transition. The first call still
-    drives the UI; subsequent ones are a no-op + ACK.
+    See the module docstring for the layer ordering. In brief, the layers
+    fire in this order and any rejection short-circuits the rest:
 
-    Loop detection: every call updates a per-task sliding window. Once
-    enough recent calls match the same ``(name, args)`` signature, a
-    one-shot ``LOOPING_TOOL_CALL`` drift is emitted (CRITICAL severity)
-    so the planner can either fail the looping task or replan around it.
+    1. Schema validation (missing / unknown ``task_id``) — malformed
+       calls never reach the counters so an adversarial flood can't
+       poison session-wide state.
+    2. Terminal-task rejection — structured ``task_already_terminal``.
+    3. Per-task loop guard — duplicate ACK, or ``loop_detected`` once
+       the bucket is flagged.
+    4. Session-wide volume cap — ``loop_detected`` once the tool is
+       flagged session-wide.
     """
     tool = find_tool(tools, name)
     if tool is None:
@@ -102,33 +117,86 @@ async def invoke_tool(
     is_plan_level = name in _PLAN_LEVEL_TOOLS
     sig = (name, args_signature(args))
 
-    # Terminal-task rejection (root-cause prevention). Models that have
-    # already reported a task as COMPLETED/FAILED/CANCELLED sometimes
-    # keep calling reporting tools for that task — the first call moved
-    # the task to a terminal status (the Steerer's ``mark_task_*``
-    # guards make subsequent transitions no-ops), but a bland ``ACK``
-    # back to the agent doesn't communicate "stop." Without this check,
-    # a model can burn dozens of reporting calls after the task is
-    # already done. We return a structured error response so the model
-    # has clear, actionable feedback to stop reporting against that
-    # task. Plan-level tools (no ``task_id``) bypass this path.
-    if not is_plan_level and task_id:
-        task = _find_task(session, task_id)
-        if task is not None and task.status in TERMINAL_TASK_STATUSES:
+    # ------------------------------------------------------------------
+    # Layer 1 — schema rejections. These MUST run before any counter
+    # updates so a malformed-call spam can't poison session state.
+    # ------------------------------------------------------------------
+    if not is_plan_level:
+        if not task_id:
             return {
                 "acknowledged": False,
-                "error": "task_already_terminal",
-                "task_id": task_id,
-                "current_status": task.status.value,
+                "error": "missing_task_id",
+                "tool": name,
                 "message": (
-                    f"Task {task_id!r} is already {task.status.value}. Do not "
-                    "call further reporting tools for this task; wait for the "
-                    "orchestrator to route you to the next task."
+                    f"Tool {name!r} requires a task_id; call it with the id "
+                    "of the task you're reporting on."
                 ),
             }
+        # The unknown-task and terminal-task checks are only meaningful
+        # when the session has an installed plan to look the id up in.
+        # Plan-less sessions do occur (early bootstrap, minimal test
+        # harnesses) and we don't want to spuriously reject a call
+        # that the adapter has legitimately dispatched.
+        if session.plan is not None:
+            task = _find_task(session, task_id)
+            if task is None:
+                return {
+                    "acknowledged": False,
+                    "error": "unknown_task_id",
+                    "tool": name,
+                    "task_id": task_id,
+                    "message": (
+                        f"Task with id {task_id!r} does not exist in the "
+                        "current plan. Re-check the current plan via session "
+                        "state and use an id that appears in it."
+                    ),
+                }
 
+            # Layer 2 — terminal-task rejection. Models that have
+            # already reported a task as COMPLETED/FAILED/CANCELLED
+            # sometimes keep calling reporting tools for that task —
+            # the first call moved the task to a terminal status (the
+            # Steerer's ``mark_task_*`` guards make subsequent
+            # transitions no-ops), but a bland ``ACK`` back to the
+            # agent doesn't communicate "stop." Without this check, a
+            # model can burn dozens of reporting calls after the task
+            # is already done. Structured error response so the model
+            # has clear, actionable feedback to stop reporting.
+            if task.status in TERMINAL_TASK_STATUSES:
+                return {
+                    "acknowledged": False,
+                    "error": "task_already_terminal",
+                    "task_id": task_id,
+                    "current_status": task.status.value,
+                    "message": (
+                        f"Task {task_id!r} is already {task.status.value}. "
+                        "Do not call further reporting tools for this task; "
+                        "wait for the orchestrator to route you to the next "
+                        "task."
+                    ),
+                }
+
+    # ------------------------------------------------------------------
+    # Layer 3 — per-task loop guard.
+    # ------------------------------------------------------------------
     guard = guard_for(session)
     state = guard.state_for(guard_key)
+
+    # If this (task, tool) bucket is already flagged, hard-reject
+    # without updating the sliding window or incrementing counters
+    # further. This is the fix for "one-shot loop flag lets subsequent
+    # calls pass through": after the drift fires once, every future
+    # call to that tool on that task gets a structured
+    # ``loop_detected`` error instead of silently falling through to
+    # the handler (which was the live-run failure).
+    if state.loop_flagged and state.loop_tool == name:
+        return _loop_rejection(
+            task_id=task_id,
+            tool_name=name,
+            reason=state.loop_reason or "per_task_loop",
+            scope="per_task",
+        )
+
     state.window.append(sig)
 
     if detect_loop(state, sig):
@@ -137,13 +205,103 @@ async def invoke_tool(
             steerer=steerer,
             task_id=task_id,
             tool_name=name,
+            reason=_human_reason(state.loop_reason),
+        )
+        # The call that trips the guard is itself rejected — there's
+        # no forward progress to preserve (the agent is already
+        # spamming) and letting it through would be our 16th+ handler
+        # invocation on a confirmed-looping task.
+        return _loop_rejection(
+            task_id=task_id,
+            tool_name=name,
+            reason=state.loop_reason,
+            scope="per_task",
         )
 
     if not is_plan_level and name not in _NON_IDEMPOTENT_TOOLS and task_id and sig in state.seen:
         return {"acknowledged": True, "duplicate": True}
 
+    # ------------------------------------------------------------------
+    # Layer 4 — session-wide volume cap. Runs AFTER Layer 1 (so
+    # malformed calls don't count) but before we invoke the handler,
+    # so the flood is cut off at its 51st call, not its 500th.
+    # ------------------------------------------------------------------
+    if detect_session_loop(guard, name):
+        await emit_loop_drift(
+            session=session,
+            steerer=steerer,
+            task_id=task_id or "(session)",
+            tool_name=name,
+            reason=(
+                f"session-wide volume cap ({guard.session_tool_count[name]} "
+                "calls across all tasks, no forward progress)"
+            ),
+        )
+        return _loop_rejection(
+            task_id=task_id,
+            tool_name=name,
+            reason="session_volume_cap",
+            scope="session",
+        )
+    if name in guard.session_tool_flagged:
+        # Tool was already session-flagged on a prior call; keep
+        # rejecting without re-firing drift.
+        return _loop_rejection(
+            task_id=task_id,
+            tool_name=name,
+            reason="session_volume_cap",
+            scope="session",
+        )
+
     state.seen.add(sig)
     return await tool.handler(args, session, steerer)
+
+
+def _loop_rejection(*, task_id: str, tool_name: str, reason: str, scope: str) -> dict[str, Any]:
+    """Build the structured ``loop_detected`` response.
+
+    All rejection paths funnel through this helper so the response
+    shape stays consistent and the agent sees the same error key
+    (``loop_detected``) regardless of which trigger fired. ``scope``
+    is ``"per_task"`` or ``"session"``; ``reason`` is a machine-
+    readable classifier (``exact_signature_burst``,
+    ``per_task_volume_cap``, ``session_volume_cap``).
+    """
+    message: str
+    if scope == "session":
+        message = (
+            f"Tool {tool_name!r} has been called too many times across all "
+            "tasks in this session without forward progress. Do not retry; "
+            "wait for the orchestrator to route you to the next task."
+        )
+    else:
+        message = (
+            f"Repeated calls to {tool_name!r} without forward progress "
+            f"detected (reason: {reason}). Do not retry; wait for the "
+            "orchestrator to route you to the next task."
+        )
+    payload: dict[str, Any] = {
+        "acknowledged": False,
+        "error": "loop_detected",
+        "tool": tool_name,
+        "reason": reason,
+        "scope": scope,
+        "message": message,
+    }
+    if task_id:
+        payload["task_id"] = task_id
+    return payload
+
+
+def _human_reason(machine_reason: str) -> str:
+    """Map a machine classifier to a human-readable drift detail fragment."""
+    if machine_reason == "exact_signature_burst":
+        return (
+            "exact-signature burst: same (tool, args) seen repeatedly in the recent sliding window"
+        )
+    if machine_reason == "per_task_volume_cap":
+        return "per-task volume cap: too many total calls to this tool on this task"
+    return machine_reason or "repeated calls without forward progress"
 
 
 def _find_task(session: Session, task_id: str) -> Task | None:

--- a/goldfive/adapters/_tool_loop_guard.py
+++ b/goldfive/adapters/_tool_loop_guard.py
@@ -6,7 +6,7 @@ with the same arguments instead of making forward progress. The eventual
 failure mode is the host LLM's max-call budget, which surfaces as a
 :class:`ResourceExhausted` outside goldfive — diagnostically useless.
 
-This module gives the adapter dispatch layer two protections:
+This module gives the adapter dispatch layer several protections:
 
 1. **Idempotency table** — a per-(task_id, tool_name, args_hash) memo.
    The first matching call goes through to the handler; subsequent
@@ -16,12 +16,21 @@ This module gives the adapter dispatch layer two protections:
    but the dispatch is cheaper and the agent gets a clear "duplicate"
    signal in the tool result).
 
-2. **Loop detector** — a per-task sliding window of the last
-   :data:`_LOOP_WINDOW` tool-call signatures. Once
-   :data:`_LOOP_THRESHOLD` of those signatures share a single
-   ``(tool_name, args_hash)``, we emit a single
-   :class:`DriftKind.LOOPING_TOOL_CALL` event and arm a one-shot
-   suppressor so the planner sees the loop at most once per task.
+2. **Per-task loop detector** — a per-task sliding window of the last
+   :data:`_LOOP_WINDOW` tool-call signatures plus a per-tool volume
+   counter. Once either threshold is crossed, the guard flags the
+   ``(task_id, tool_name)`` bucket and *hard-rejects* every subsequent
+   call to that tool on that task with a structured
+   ``loop_detected`` error — replacing the previous behaviour where
+   subsequent calls silently fell through to the handler.
+
+3. **Session-wide volume cap** — a per-tool counter that spans every
+   task in the session. Catches adversarial patterns where a
+   malformed agent invents a fresh ``task_id`` on every call and
+   distributes one or two calls per per-task bucket — defeating the
+   per-task volume cap entirely. After the threshold is crossed the
+   tool is flagged session-wide and all further calls to it are
+   hard-rejected regardless of which task_id they name.
 
 The guard intentionally lives at the adapter dispatch boundary
 (``invoke_tool``) rather than inside individual handlers — that way every
@@ -42,15 +51,15 @@ if TYPE_CHECKING:  # pragma: no cover - type-only
     from goldfive.types import Session
 
 
-# Loop-detector tuning. A window of 8 with a threshold of 6 means the
-# guard fires after the agent has issued the same call ~6 times in the
-# last 8 attempts — enough signal that the model is stuck, not just
-# being slightly redundant.
+# Per-task exact-signature loop tuning. A window of 8 with a threshold
+# of 6 means the guard fires after the agent has issued the same call
+# ~6 times in the last 8 attempts — enough signal that the model is
+# stuck, not just being slightly redundant.
 _LOOP_WINDOW = 8
 _LOOP_THRESHOLD = 6
 
-# Volume-based fallback: fire a loop drift once a single reporting tool
-# has been invoked this many times within one task, regardless of
+# Per-task volume fallback: fire a loop drift once a single reporting
+# tool has been invoked this many times within one task, regardless of
 # whether the args repeat. Catches args-varying spam (e.g. a model
 # looping on ``report_task_failed`` with a fresh ``reason`` each call) —
 # the signature-based window misses this because every call hashes to a
@@ -60,9 +69,18 @@ _LOOP_THRESHOLD = 6
 # burn out the whole task.
 _VOLUME_THRESHOLD = 15
 
+# Session-wide volume cap: final safety net against adversarial agents
+# that invent a fresh ``task_id`` on every call, which would otherwise
+# defeat the per-task volume cap (each bucket stays at 1–2 calls). Set
+# above the per-task cap so legitimate multi-task runs that make ~15
+# calls per task on several tasks in a row don't trip it, but low
+# enough to catch the 200+-call pathologies observed in live runs well
+# before ADK's 500-LLM-call ceiling bites.
+_SESSION_VOLUME_THRESHOLD = 50
+
 # Reporting tools that are expected to be polled — the agent legitimately
 # re-invokes them while waiting for an external decision, and the volume
-# cap would falsely fire on normal use. The exact-signature guard still
+# caps would falsely fire on normal use. The exact-signature guard still
 # applies.
 _VOLUME_EXEMPT_TOOLS: frozenset[str] = frozenset({"report_awaiting_approval"})
 
@@ -87,6 +105,17 @@ class _TaskGuardState:
     # so we don't pile on identical drifts every subsequent call. Cleared
     # by the planner when it refines/fails the task.
     loop_flagged: bool = False
+    # Human-readable classification of why the guard flipped to
+    # ``loop_flagged`` — surfaced in the hard-rejection payload so the
+    # agent gets a specific reason ("exact-signature burst" vs
+    # "per-task volume cap") in its tool result.
+    loop_reason: str = ""
+    # The tool name whose spam tripped the flag. Subsequent calls to a
+    # DIFFERENT tool on the same task are still allowed to proceed —
+    # the rejection is per-(task, tool), not blanket per-task, so a
+    # legitimate follow-up like ``report_task_failed`` after a looping
+    # ``report_task_progress`` can still transition the task.
+    loop_tool: str = ""
 
 
 @dataclass
@@ -99,6 +128,15 @@ class ToolLoopGuard:
     """
 
     _by_task: dict[str, _TaskGuardState] = field(default_factory=dict)
+    # Session-wide cumulative count of every reporting tool invoked,
+    # regardless of which task_id the call named. Final safety net for
+    # adversarial callers that invent a fresh task_id every call so the
+    # per-task volume cap never trips.
+    session_tool_count: dict[str, int] = field(default_factory=dict)
+    # Tool names that have already tripped the session-wide cap. Once
+    # listed, every subsequent call to that tool is hard-rejected
+    # without firing a new drift.
+    session_tool_flagged: set[str] = field(default_factory=set)
 
     def state_for(self, task_id: str) -> _TaskGuardState:
         """Return (and lazily create) the per-task state row."""
@@ -151,22 +189,27 @@ def guard_for(session: Session) -> ToolLoopGuard:
 
 
 def detect_loop(state: _TaskGuardState, signature: tuple[str, str]) -> bool:
-    """Return True iff the current call should fire a loop drift.
+    """Return True iff this call just tripped the per-task loop guard.
 
     Two independent triggers, either one fires the one-shot drift:
 
     * **Exact-signature burst** — the same ``(name, args_hash)`` appears
       at least :data:`_LOOP_THRESHOLD` times within the last
       :data:`_LOOP_WINDOW` calls. Catches byte-identical loops quickly.
-    * **Per-tool volume cap** — cumulative calls to the same tool name
+    * **Per-task volume cap** — cumulative calls to the same tool name
       for this task cross :data:`_VOLUME_THRESHOLD`. Catches loops that
       vary their args on every call (a fresh ``reason`` / ``detail``
       string etc.) which never collide in the signature window but
       equally indicate no forward progress.
 
     Callers have already appended ``signature`` to ``state.window``.
-    Sets :attr:`_TaskGuardState.loop_flagged` so subsequent calls don't
-    re-fire the drift for the same task.
+    Sets :attr:`_TaskGuardState.loop_flagged` / ``loop_reason`` /
+    ``loop_tool`` so the dispatcher can (a) skip re-firing the drift
+    and (b) hard-reject subsequent calls with a specific reason.
+
+    Returns ``False`` on every call after the first threshold crossing
+    — the "already flagged" case is distinguished by the flag itself
+    on :class:`_TaskGuardState`, which the dispatcher reads directly.
     """
     name = signature[0]
     state.per_tool_count[name] = state.per_tool_count.get(name, 0) + 1
@@ -178,6 +221,8 @@ def detect_loop(state: _TaskGuardState, signature: tuple[str, str]) -> bool:
     # below misses these because every call hashes differently).
     if name not in _VOLUME_EXEMPT_TOOLS and state.per_tool_count[name] >= _VOLUME_THRESHOLD:
         state.loop_flagged = True
+        state.loop_reason = "per_task_volume_cap"
+        state.loop_tool = name
         return True
 
     # Exact-signature burst: fastest path for byte-identical loops.
@@ -185,8 +230,35 @@ def detect_loop(state: _TaskGuardState, signature: tuple[str, str]) -> bool:
         matching = sum(1 for s in state.window if s == signature)
         if matching >= _LOOP_THRESHOLD:
             state.loop_flagged = True
+            state.loop_reason = "exact_signature_burst"
+            state.loop_tool = name
             return True
 
+    return False
+
+
+def detect_session_loop(guard: ToolLoopGuard, tool_name: str) -> bool:
+    """Return True iff ``tool_name`` just tripped the session-wide cap.
+
+    Increments the session-wide counter for ``tool_name`` and returns
+    ``True`` exactly once — on the call that crosses
+    :data:`_SESSION_VOLUME_THRESHOLD`. On subsequent calls the
+    dispatcher sees ``tool_name in guard.session_tool_flagged`` and
+    hard-rejects without re-firing drift.
+
+    Exempt tools (``_VOLUME_EXEMPT_TOOLS``) never flag. Their counter
+    is still maintained for observability but never crosses the
+    threshold check.
+    """
+    guard.session_tool_count[tool_name] = guard.session_tool_count.get(tool_name, 0) + 1
+
+    if tool_name in _VOLUME_EXEMPT_TOOLS:
+        return False
+    if tool_name in guard.session_tool_flagged:
+        return False
+    if guard.session_tool_count[tool_name] >= _SESSION_VOLUME_THRESHOLD:
+        guard.session_tool_flagged.add(tool_name)
+        return True
     return False
 
 
@@ -196,24 +268,33 @@ async def emit_loop_drift(
     steerer: Steerer,
     task_id: str,
     tool_name: str,
+    reason: str = "",
 ) -> None:
     """Push a CRITICAL ``LOOPING_TOOL_CALL`` drift through the steerer.
 
     Falls back silently if the steerer doesn't expose the private
     ``_handle_drift`` hook (e.g., test stubs) — losing the signal is
     less disruptive than crashing the tool dispatch.
+
+    ``reason`` distinguishes per-task ("exact-signature burst",
+    "per-task volume cap") and session-wide ("session-wide volume cap")
+    triggers so sinks can separate the two patterns.
     """
     from goldfive.types import DriftEvent, DriftKind, DriftSeverity
 
-    drift = DriftEvent(
-        kind=DriftKind.LOOPING_TOOL_CALL,
-        severity=DriftSeverity.CRITICAL,
-        detail=(
+    if reason:
+        detail = f"task {task_id} kept calling {tool_name!r} without forward progress ({reason})"
+    else:
+        detail = (
             f"task {task_id} kept calling {tool_name!r} without forward "
             f"progress (either {_LOOP_THRESHOLD}+ identical signatures in "
             f"the last {_LOOP_WINDOW} calls, or {_VOLUME_THRESHOLD}+ total "
             "calls to this tool within the task)"
-        ),
+        )
+    drift = DriftEvent(
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        severity=DriftSeverity.CRITICAL,
+        detail=detail,
         current_task_id=task_id,
     )
     handler = getattr(steerer, "_handle_drift", None)
@@ -229,6 +310,7 @@ __all__ = [
     "ToolLoopGuard",
     "args_signature",
     "detect_loop",
+    "detect_session_loop",
     "emit_loop_drift",
     "guard_for",
 ]

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -1092,3 +1092,102 @@ async def test_reporting_tool_duplicate_returns_duplicate_ack(state_ctx_cls) -> 
         "bypassed (before_tool_callback is routing around invoke_tool)."
     )
     assert len(handler_calls) == 1
+
+
+async def test_adversarial_agent_with_varying_task_ids_is_stopped_at_session_cap(
+    state_ctx_cls,
+) -> None:
+    """Live-run regression: an adversarial agent fires
+    ``report_task_failed`` over and over, inventing a FRESH
+    ``task_id`` each time so the per-task volume cap never trips
+    (each per-task bucket stays at 1 call). The session-wide volume
+    cap (Layer 4 in ``docs/design/TASK-LIFECYCLE.md`` §5) must catch
+    this before ADK's 500-LLM-call ceiling bites — observed in the
+    wild as 237 consecutive plain ACKs and no intervention.
+    """
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+    )
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.reporting import BUILTIN_REPORTING_TOOLS
+    from goldfive.types import DriftEvent, DriftKind, Plan
+
+    handler_calls: list[dict[str, Any]] = []
+
+    # Use a permissive handler (not the built-in that would need a
+    # functioning Steerer) so we can count invocations directly.
+    async def _recording_handler(args, session, steerer):
+        handler_calls.append(dict(args))
+        return {"acknowledged": True}
+
+    template = next(t for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_failed")
+    spec = ReportingToolSpec(
+        name=template.name,
+        description=template.description,
+        parameters=template.parameters,
+        handler=_recording_handler,
+    )
+
+    class _Steerer:
+        def __init__(self) -> None:
+            self.drifts: list[DriftEvent] = []
+
+        async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+            self.drifts.append(drift)
+
+    agent = _make_agent()
+    adapter = ADKAdapter(agent)
+    await adapter.register_reporting_tools([spec])
+    steerer = _Steerer()
+
+    # 60 distinct tasks pre-populated so the ``unknown_task_id`` check
+    # doesn't short-circuit before the session counter increments.
+    tasks = [Task(id=f"t{i}", title=f"task-{i}") for i in range(60)]
+    session = Session(
+        run_id="r1",
+        plan=Plan(id="p1", run_id="r1", goal_ids=[], tasks=tasks, edges=[]),
+    )
+
+    ctx = SessionContext(
+        session=session,
+        steerer=steerer,
+        task=tasks[0],
+        tools=[spec],
+        host_agent_name="test_agent",
+    )
+    state = {SESSION_CONTEXT_STATE_KEY: ctx}
+
+    class _Tool:
+        name = "report_task_failed"
+
+    results: list[dict[str, Any]] = []
+    for i in range(60):
+        result = await adapter._plugin.before_tool_callback(
+            tool=_Tool(),
+            tool_args={"task_id": f"t{i}", "reason": f"fresh #{i}"},
+            tool_context=state_ctx_cls(state),
+        )
+        assert isinstance(result, dict)
+        results.append(result)
+
+    # The session-wide cap fires exactly one drift — not ADK's 500-call
+    # ceiling, and not per-task drifts (each per-task bucket stayed at 1).
+    assert len(steerer.drifts) == 1, (
+        f"expected session-wide LOOPING_TOOL_CALL drift; got {len(steerer.drifts)}. "
+        "If this fails, the session-wide volume cap is not wired through "
+        "invoke_tool (the live-run failure from 237 passes of report_task_failed)."
+    )
+    assert steerer.drifts[0].kind is DriftKind.LOOPING_TOOL_CALL
+    assert "session-wide" in steerer.drifts[0].detail.lower()
+
+    # Handler runs for the first 49 (below the 50 threshold); call 50
+    # trips the drift and is itself rejected; calls 51..60 stay rejected.
+    assert len(handler_calls) == 49
+    for r in results[:49]:
+        assert r == {"acknowledged": True}
+    for r in results[49:]:
+        assert r["acknowledged"] is False
+        assert r["error"] == "loop_detected"
+        assert r["scope"] == "session"
+        assert r["tool"] == "report_task_failed"

--- a/tests/test_tool_loop_guard.py
+++ b/tests/test_tool_loop_guard.py
@@ -195,20 +195,42 @@ async def test_progress_with_distinct_args_is_not_duplicate() -> None:
 
 
 async def test_eight_identical_calls_fires_drift_exactly_once() -> None:
-    """6+/8 identical calls → one CRITICAL LOOPING_TOOL_CALL drift."""
+    """6+/8 identical calls → one CRITICAL LOOPING_TOOL_CALL drift, and
+    calls 7-8 are hard-rejected with ``loop_detected`` (new behaviour).
+
+    Pre-hardening, the sixth call fired the one-shot drift and then
+    subsequent calls fell through to the handler with a plain
+    duplicate ACK — giving the agent no signal to stop. Now every
+    call after the flag flips gets the structured ``loop_detected``
+    error so a misbehaving agent gets a clear stop signal on EVERY
+    further attempt.
+    """
     steerer = _RecordingSteerer()
     session = _session_with_task()
     tools = [_spec("report_task_progress")]
 
     args = {"task_id": "t1", "fraction": 0.5, "detail": "stuck"}
+    results: list[dict[str, Any]] = []
     for _ in range(8):
-        await invoke_tool(tools, "report_task_progress", args, session, steerer)
+        results.append(await invoke_tool(tools, "report_task_progress", args, session, steerer))
 
     assert len(steerer.drifts) == 1
     drift = steerer.drifts[0]
     assert drift.kind is DriftKind.LOOPING_TOOL_CALL
     assert drift.current_task_id == "t1"
     assert "report_task_progress" in drift.detail
+
+    # Call 1 = fresh ACK; calls 2..5 = duplicate ACK; call 6 triggers
+    # the drift and is itself rejected; calls 7-8 are rejected without
+    # re-firing drift.
+    assert results[0] == {"acknowledged": True}
+    for r in results[1:5]:
+        assert r == {"acknowledged": True, "duplicate": True}
+    for r in results[5:]:
+        assert r["acknowledged"] is False
+        assert r["error"] == "loop_detected"
+        assert r["tool"] == "report_task_progress"
+        assert r["scope"] == "per_task"
 
 
 async def test_loop_drift_does_not_re_fire_after_first_emission() -> None:
@@ -467,6 +489,338 @@ async def test_frontier_style_progression_does_not_fire_drift() -> None:
 
     assert steerer.drifts == []
     assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Schema rejections (Layer 1) and hardening against adversarial agents
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_task_id_is_rejected() -> None:
+    """A task-scoped reporting call with no ``task_id`` must be rejected
+    with the structured ``missing_task_id`` error, and MUST NOT reach
+    the underlying handler.
+
+    Pre-hardening, ``invoke_tool`` silently skipped the terminal-task
+    layer whenever ``task_id`` was empty and then passed the call
+    straight through to the handler — which would quietly do nothing
+    (the handler's own ``if not task_id`` short-circuit kicks in). The
+    agent received a bland ``{"acknowledged": True}`` back and
+    cheerfully kept hammering the tool.
+    """
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+    spec_template = _spec("report_task_failed")
+
+    # Spec the handler to raise so a regression immediately fails this
+    # test — if the rejection is skipped, we hit this handler.
+    async def _boom(args, session, steerer):
+        raise AssertionError("handler must not run when task_id is missing")
+
+    spec = ReportingToolSpec(
+        name=spec_template.name,
+        description=spec_template.description,
+        parameters=spec_template.parameters,
+        handler=_boom,
+    )
+
+    # Try a variety of "no task_id" shapes to cover every bypass route.
+    for bad_args in (
+        {},
+        {"task_id": ""},
+        {"task_id": "   "},  # whitespace → stripped to empty
+        {"task_id": None, "reason": "x"},
+        {"reason": "x"},
+    ):
+        result = await invoke_tool([spec], "report_task_failed", bad_args, session, steerer)
+        assert result["acknowledged"] is False
+        assert result["error"] == "missing_task_id"
+        assert result["tool"] == "report_task_failed"
+        assert "task_id" in result["message"].lower()
+
+    # No drift fires for this class of error — it's a schema problem,
+    # not a loop.
+    assert steerer.drifts == []
+    assert steerer.transitions == []
+
+
+async def test_unknown_task_id_is_rejected() -> None:
+    """A reporting call that names a ``task_id`` not present in the plan
+    must be rejected with ``unknown_task_id``; handler must not run.
+    """
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+
+    async def _boom(args, session, steerer):
+        raise AssertionError("handler must not run when task_id is unknown")
+
+    template = _spec("report_task_failed")
+    spec = ReportingToolSpec(
+        name=template.name,
+        description=template.description,
+        parameters=template.parameters,
+        handler=_boom,
+    )
+
+    result = await invoke_tool(
+        [spec],
+        "report_task_failed",
+        {"task_id": "bogus_does_not_exist", "reason": "lost in space"},
+        session,
+        steerer,
+    )
+    assert result["acknowledged"] is False
+    assert result["error"] == "unknown_task_id"
+    assert result["task_id"] == "bogus_does_not_exist"
+    assert result["tool"] == "report_task_failed"
+    # No drift — it's a schema problem, not a loop.
+    assert steerer.drifts == []
+    assert steerer.transitions == []
+
+
+async def test_plan_level_tools_still_work_without_task_id() -> None:
+    """``report_plan_divergence`` is plan-level and MUST NOT be
+    rejected for missing task_id — the Layer 1 schema check is
+    scoped to task-level tools only.
+    """
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+    tools = [_spec("report_plan_divergence")]
+
+    result = await invoke_tool(
+        tools,
+        "report_plan_divergence",
+        {"note": "the plan drifted", "suggested_action": "replan"},
+        session,
+        steerer,
+    )
+    # The plan-level handler runs successfully → plain ACK.
+    assert result == {"acknowledged": True}
+    assert any(t[1] == "DIVERGENCE" for t in steerer.transitions)
+
+
+async def test_loop_flagged_short_circuits_subsequent_calls() -> None:
+    """After the per-task loop guard trips, every subsequent call to
+    the SAME tool on the SAME task is hard-rejected with
+    ``loop_detected``.
+
+    This is the direct fix for the live-run failure: pre-hardening,
+    ``detect_loop`` set ``loop_flagged=True`` on the first crossing
+    and returned False forever after — so the dispatcher fell through
+    to the idempotency check (which misses when args vary) and on to
+    the handler. With the fix, the ``(task, tool)`` bucket stays
+    hard-rejecting until refine resets it.
+    """
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+    tools = [_spec("report_task_progress")]
+
+    args = {"task_id": "t1", "fraction": 0.5, "detail": "stuck"}
+    results: list[dict[str, Any]] = []
+    for _ in range(20):
+        results.append(await invoke_tool(tools, "report_task_progress", args, session, steerer))
+
+    # Drift fires exactly once — the bucket is flagged on call 6 and
+    # every call after that is hard-rejected without re-firing.
+    assert len(steerer.drifts) == 1
+
+    # Handler is invoked EXACTLY once (first call); the rest are a
+    # mix of duplicate ACKs and hard rejections — none reach the
+    # handler / steerer transition.
+    progress_transitions = [t for t in steerer.transitions if t[1] == "PROGRESS"]
+    assert len(progress_transitions) == 1
+
+    # Call 1 → fresh ACK.
+    assert results[0] == {"acknowledged": True}
+    # Calls 2..5 → duplicate ACK (under threshold, seen in table).
+    for r in results[1:5]:
+        assert r == {"acknowledged": True, "duplicate": True}
+    # Calls 6..20 → all hard-rejected with ``loop_detected``.
+    for r in results[5:]:
+        assert r["acknowledged"] is False
+        assert r["error"] == "loop_detected"
+        assert r["task_id"] == "t1"
+        assert r["tool"] == "report_task_progress"
+        assert r["scope"] == "per_task"
+
+
+async def test_session_wide_volume_cap_fires_on_varying_task_ids() -> None:
+    """An adversarial agent that invents a FRESH task_id on every
+    call distributes 1 call per per-task bucket — the per-task volume
+    cap (15) never fires. The session-wide cap (50) is the safety net
+    for this pattern.
+
+    This is the exact live-run failure scenario (237 calls to
+    ``report_task_failed`` that all returned plain ACK).
+    """
+    steerer = _RecordingSteerer()
+
+    # Build a plan with 60 pre-existing task ids so ``unknown_task_id``
+    # doesn't short-circuit before the session counter increments.
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id=f"t{i}", title=f"task-{i}") for i in range(60)],
+        edges=[],
+    )
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do it")],
+        plan=plan,
+    )
+    tools = [_spec("report_task_failed")]
+
+    results: list[dict[str, Any]] = []
+    for i in range(60):
+        results.append(
+            await invoke_tool(
+                tools,
+                "report_task_failed",
+                {"task_id": f"t{i}", "reason": f"fresh reason #{i}"},
+                session,
+                steerer,
+            )
+        )
+
+    # Exactly one drift — the session-wide cap fired on call 50 and
+    # did not re-fire afterwards.
+    assert len(steerer.drifts) == 1
+    assert steerer.drifts[0].kind is DriftKind.LOOPING_TOOL_CALL
+    assert "session-wide" in steerer.drifts[0].detail.lower()
+
+    # Calls 1..49 → handler runs (marks each distinct task as FAILED).
+    failed_transitions = [t for t in steerer.transitions if t[1] == "FAILED"]
+    assert len(failed_transitions) == 49
+
+    # Calls 50..60 → all rejected with loop_detected (scope=session).
+    for r in results[:49]:
+        assert r == {"acknowledged": True}
+    for r in results[49:]:
+        assert r["acknowledged"] is False
+        assert r["error"] == "loop_detected"
+        assert r["scope"] == "session"
+        assert r["tool"] == "report_task_failed"
+
+
+async def test_session_wide_cap_is_per_tool_not_cross_tool() -> None:
+    """The session-wide cap counts per tool name. 30 progress + 30
+    blocked = 60 total calls, but neither tool alone crosses the 50
+    threshold, so nothing is flagged.
+    """
+    steerer = _RecordingSteerer()
+
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id=f"t{i}", title=f"task-{i}") for i in range(30)],
+        edges=[],
+    )
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do it")],
+        plan=plan,
+    )
+    tools = [_spec("report_task_progress"), _spec("report_task_blocked")]
+
+    for i in range(30):
+        r = await invoke_tool(
+            tools,
+            "report_task_progress",
+            {"task_id": f"t{i}", "fraction": 0.1, "detail": f"p{i}"},
+            session,
+            steerer,
+        )
+        assert r == {"acknowledged": True}
+        r = await invoke_tool(
+            tools,
+            "report_task_blocked",
+            {"task_id": f"t{i}", "blocked_on": f"dep-{i}"},
+            session,
+            steerer,
+        )
+        assert r == {"acknowledged": True}
+
+    # Neither tool crossed its own 50-call threshold → no drift.
+    assert steerer.drifts == []
+
+
+async def test_missing_task_id_does_not_count_toward_session_cap() -> None:
+    """Rejections at the missing/unknown task_id layer MUST happen
+    BEFORE the session counter increments — otherwise an adversarial
+    spam of malformed calls would poison the session counter and
+    trigger a false session-wide drift against the next legitimate
+    call.
+    """
+    from goldfive.adapters._tool_loop_guard import guard_for
+
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+    tools = [_spec("report_task_failed")]
+
+    # 200 calls with no task_id — way above the session threshold.
+    for _ in range(200):
+        r = await invoke_tool(tools, "report_task_failed", {}, session, steerer)
+        assert r["error"] == "missing_task_id"
+
+    # 200 calls with unknown task_id.
+    for _ in range(200):
+        r = await invoke_tool(
+            tools,
+            "report_task_failed",
+            {"task_id": "no_such_task", "reason": "spam"},
+            session,
+            steerer,
+        )
+        assert r["error"] == "unknown_task_id"
+
+    # Neither path touched the session counter.
+    guard = guard_for(session)
+    assert guard.session_tool_count.get("report_task_failed", 0) == 0
+    assert "report_task_failed" not in guard.session_tool_flagged
+    # No drift was emitted for schema errors.
+    assert steerer.drifts == []
+
+
+async def test_session_wide_cap_exempts_awaiting_approval() -> None:
+    """``report_awaiting_approval`` polls by design — the session-wide
+    cap must not fire for it no matter how many times it's invoked.
+    """
+    from goldfive.adapters._tool_loop_guard import guard_for
+
+    steerer = _RecordingSteerer()
+    session = _session_with_task()
+
+    # ``report_awaiting_approval`` is a builtin that blocks on a
+    # control-channel waiter, which we don't want to drive in this
+    # test — swap in a stub spec that just ACKs.
+    async def _ack_handler(args, session, steerer):
+        return {"acknowledged": True}
+
+    template = _spec("report_awaiting_approval")
+    spec = ReportingToolSpec(
+        name=template.name,
+        description=template.description,
+        parameters=template.parameters,
+        handler=_ack_handler,
+    )
+
+    # 200 polls with varying prompts — well above the session cap.
+    for i in range(200):
+        r = await invoke_tool(
+            [spec],
+            "report_awaiting_approval",
+            {"task_id": "t1", "prompt": f"check #{i}"},
+            session,
+            steerer,
+        )
+        assert r == {"acknowledged": True}
+
+    # The counter does tick (for observability) but the flag never trips.
+    guard = guard_for(session)
+    assert "report_awaiting_approval" not in guard.session_tool_flagged
+    assert steerer.drifts == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Live e2e run exposed three gaps in the reporting-tool guard that let a malformed / adversarial agent burn through ADK's 500-LLM-call ceiling:
237 consecutive calls to `report_task_failed` all returned `{"acknowledged": true}` with no rejections, no duplicate ACKs, and no effective stopping. Drift fired once, then every subsequent call passed through.

- **Gap 1 — empty/unknown `task_id` bypassed the rejection layer.** The terminal-task check was gated on `if not is_plan_level and task_id`, so calls with empty string or a task_id not present in the plan fell straight through to the handler (no-op) and returned bland ACK.
- **Gap 2 — one-shot `loop_flagged` let subsequent calls pass through.** After the first threshold crossing, `detect_loop` returned False forever; the dispatcher fell through idempotency (which misses when args vary) and on to the handler. The drift was one-shot; the spam was unbounded.
- **Gap 3 — per-task volume cap was defeated by varying `task_id`.** An agent inventing a fresh task_id on every call distributed 1–2 calls per per-task bucket, never crossing the 15-call per-task cap.

## Fix

Re-architected `_tool_invocation.invoke_tool` + `_tool_loop_guard` into four layers (full spec: `docs/design/TASK-LIFECYCLE.md` §5):

- **Layer 1 (schema + terminal).** Rejects missing/empty/whitespace/None `task_id` with `error="missing_task_id"` and unknown `task_id` (not in plan) with `error="unknown_task_id"`, **before** incrementing the session counter so malformed floods can't poison state. Plan-level tools (`report_plan_divergence`) and plan-less sessions are exempt.
- **Layer 2.** Idempotency — unchanged.
- **Layer 3 (per-task loop guard).** After the flag flips, every call to the same tool on the same task is hard-rejected with `error="loop_detected"` (`scope="per_task"`). Calls to a **different** tool on the same task still flow — rejection is per-`(task, tool)`, so a legitimate `report_task_failed` after a looping `report_task_progress` can still transition the task.
- **Layer 4 (new — session-wide volume cap).** 50 calls to the same tool across ALL task_ids in the session fires one `LOOPING_TOOL_CALL` drift and hard-rejects further calls (`scope="session"`). `report_awaiting_approval` is exempt (polls by design).

All rejection paths funnel through a single `_loop_rejection` helper so the response shape is consistent.

## Test coverage (every new rejection path has a test)

`tests/test_tool_loop_guard.py`:
- `test_missing_task_id_is_rejected` — five "no task_id" shapes rejected; handler never runs.
- `test_unknown_task_id_is_rejected` — task_id not in plan rejected; handler never runs.
- `test_plan_level_tools_still_work_without_task_id` — plan-level tools unaffected.
- `test_loop_flagged_short_circuits_subsequent_calls` — 20 identical calls; handler runs exactly once; calls 6-20 get `loop_detected`. (Gap 2.)
- `test_session_wide_volume_cap_fires_on_varying_task_ids` — 60 distinct task_ids; session cap fires at call 50; calls 50-60 rejected with `scope=session`. (Gap 3 — the live-run reproducer.)
- `test_session_wide_cap_is_per_tool_not_cross_tool` — 30 progress + 30 blocked stay under cap.
- `test_missing_task_id_does_not_count_toward_session_cap` — 400 malformed calls don't touch the session counter.
- `test_session_wide_cap_exempts_awaiting_approval` — polling tool exempt.
- `test_eight_identical_calls_fires_drift_exactly_once` (**updated**) — now also asserts calls 6-8 return `loop_detected` rejection, not the plain duplicate ACK (documents the new semantics).

`tests/test_adk_adapter.py`:
- `test_adversarial_agent_with_varying_task_ids_is_stopped_at_session_cap` — end-to-end ADK regression for the exact field-failure pattern.

## Docs

`docs/design/TASK-LIFECYCLE.md` §5 rewritten:
- §5.1 now covers Layer 1 (schema + terminal-task rejection) with `missing_task_id` / `unknown_task_id` / `task_already_terminal` payloads documented.
- §5.3 renamed to "per-task loop guard"; hard-reject-after-flag behaviour spelled out.
- §5.4 is new — session-wide volume cap with rationale for the 50 threshold.
- §7.6 narrowed (soft-reject gap now bounded by Layer 3 + Layer 4).

## Existing tests updated

Only `test_eight_identical_calls_fires_drift_exactly_once`: calls 7-8 now return `loop_detected` rejection instead of passing through to the handler. Every other existing test continues to pass unchanged (535 passed, 38 skipped).

## Test plan

- [x] `uv run --extra dev --extra adk pytest -q` — 535 passed, 38 skipped (all skips are optional-dep gates).
- [x] `uv run --extra dev ruff check .` — all checks passed.
- [x] `uv run --extra dev ruff format --check` on touched files — all formatted.
- [ ] Merge gating: confirm next live e2e run shows the adversarial pattern bounces at the rejection layer rather than ADK's 500-call ceiling.
