### PR TITLE
examples/adk_presentation: minimal wrap-an-agent demo (drop the coordinator tree)

### DIFF
--- a/examples/adk_presentation/README.md
+++ b/examples/adk_presentation/README.md
@@ -1,48 +1,45 @@
-# ADK presentation example
+# Minimal goldfive + ADK example
 
-A reference implementation showing how `goldfive.Runner` wraps a multi-subagent
-Google ADK tree. Ported from harmonograf's `presentation_agent` demo, with the
-orchestration layer swapped from `HarmonografAgent` to
-`goldfive.adapters.adk.ADKAdapter`.
+The smallest possible demo showing how `goldfive.wrap(agent, ...)` plugs a
+plain Google ADK agent into goldfive's planner + executor + steerer stack.
+
+```python
+agent  = <your ADK Agent>                 # any BaseAgent
+runner = goldfive.wrap(                   # goldfive handles decomposition,
+    agent,                                # dispatch, drift, and steering
+    planner=LLMPlanner(call_llm=...),
+    goal_deriver=LLMGoalDeriver(call_llm=...),
+)
+await runner.run("make a presentation about waffles")
+```
+
+One agent, no coordinator, no hand-rolled delegation. If you need a
+multi-specialist reference see the "richer example" section below.
 
 ## What this demonstrates
 
-- **A coordinator that delegates to four specialists** — researcher, web
-  developer, reviewer, and debugger — via `AgentTool`.
-- **One wrap covers the whole tree.** Only the root `coordinator_agent`
-  is handed to `ADKAdapter(...)`. The adapter walks the tree (`sub_agents`,
-  `inner_agent`, and nested `AgentTool.agent`) and attaches goldfive's
-  seven canonical reporting tools to every subagent automatically.
-- **Planner + goal deriver are pluggable.** The example wires
-  `LLMPlanner` and `LLMGoalDeriver` behind a `call_llm` callable so you
-  can swap in any model provider without touching goldfive internals.
-- **Events per subagent.** Goldfive's executor emits `TaskStarted` /
-  `TaskCompleted` events for each of the four specialist tasks, even
-  though the adapter only invokes the coordinator root.
-
-## Agent tree
-
-```
-coordinator_agent
-├── research_agent         (AgentTool)
-├── web_developer_agent    (AgentTool, tool: write_webpage)
-├── reviewer_agent         (AgentTool, tool: read_presentation_files)
-└── debugger_agent         (AgentTool, tool: patch_file)
-```
+- **One ADK `Agent`, goldfive does the rest.** The planner emits a task
+  DAG; the executor invokes the same agent for each task in turn. No
+  subagent tree, no `AgentTool`s, no coordinator with hardcoded routing.
+- **Planner + goal deriver are pluggable.** Wire any model provider
+  behind a `call_llm` callable with signature
+  `(system_prompt, user_prompt, model) -> str`.
+- **Events per task.** Goldfive's executor emits `TaskStarted` /
+  `TaskCompleted` for each planner-generated task. Drop in a
+  `HarmonografSink` to watch the run live in harmonograf's UI.
 
 ## Running
 
-### Mock mode — no credentials required
+### Mock mode — no credentials
 
 ```bash
 uv pip install -e '.[adk]'
 uv run python examples/adk_presentation/agent.py --mock
 ```
 
-In this mode every ADK agent's model is a deterministic in-process
-`BaseLlm` subclass, and the planner / goal deriver use canned JSON. The
-run completes with `success=True` and emits a 13-event stream
-culminating in `run_completed`.
+Canned planner / goal deriver + in-process `_MockLlm` for the agent.
+The run walks three sequential tasks (research → outline → writeup) and
+exits with `success=True`.
 
 ### Live mode — OpenAI
 
@@ -53,25 +50,34 @@ export OPENAI_API_KEY=sk-...
 uv run python examples/adk_presentation/agent.py --topic "the Voyager missions"
 ```
 
-Live mode uses the `openai` Python SDK for the planner / goal deriver
-and a LiteLLM model string (default `openai/gpt-4o-mini`) for the ADK
-subagents. Override the models via:
+Live mode uses the `openai` SDK for planner + goal deriver and a LiteLLM
+model string (default `openai/gpt-4o-mini`) for the ADK agent. Overrides:
 
-- `GOLDFIVE_EXAMPLE_MODEL` — ADK agent model (LiteLLM format, e.g.
-  `openai/gpt-4o-mini`).
-- `GOLDFIVE_EXAMPLE_PLANNER_MODEL` — model id passed to the planner's
-  `call_llm`. Defaults to `gpt-4o-mini`.
-- `GOLDFIVE_EXAMPLE_GOAL_MODEL` — model id for the goal deriver.
-  Defaults to `gpt-4o-mini`.
-
-Generated slideshow files land under
-`examples/adk_presentation/output/<topic>/` (`index.html`,
-`styles.css`, `script.js`).
+| Env var | What it controls |
+|---|---|
+| `GOLDFIVE_EXAMPLE_MODEL` | ADK agent model (LiteLLM format) |
+| `GOLDFIVE_EXAMPLE_PLANNER_MODEL` | Planner `call_llm` model id |
 
 ## Flags
 
 | Flag | Effect |
 |---|---|
 | `--mock` | Replace every LLM with an in-process mock. No network. |
-| `--topic TEXT` | Override the presentation topic. |
-| `--verbose`, `-v` | Enable INFO logging from goldfive's `LoggingSink`. |
+| `--topic TEXT` | Override the presentation topic. Default: `waffles`. |
+| `--verbose`, `-v` | INFO-level logs from goldfive's `LoggingSink`. |
+
+## A richer example
+
+For a production-shaped multi-agent ADK tree (coordinator + research /
+developer / reviewer / debugger specialists with real file tools) see
+**harmonograf's `presentation_agent`** at
+`tests/reference_agents/presentation_agent/agent.py` in the
+[harmonograf repo](https://github.com/pedapudi/harmonograf). That module
+already exports a `build_goldfive_runner` helper that assembles the same
+goldfive `Runner` shape as this example, but over the full subagent
+tree, so you can compare the two side-by-side.
+
+The split is deliberate: this repo's example shows you *how to wrap*;
+harmonograf's example shows you *how to structure a real multi-agent
+ADK tree*. The two concerns compose but live in different files so
+neither obscures the other.

--- a/examples/adk_presentation/agent.py
+++ b/examples/adk_presentation/agent.py
@@ -1,22 +1,37 @@
-"""ADK presentation reference example — goldfive wrapping a multi-subagent tree.
+"""Minimal goldfive + ADK example.
 
-Ports harmonograf's ``presentation_agent`` demo to goldfive. The ADK tree
-is unchanged: a ``coordinator_agent`` exposes four specialists as
-``AgentTool`` s (researcher, web developer, reviewer, debugger). The
-whole tree is wrapped with :class:`goldfive.adapters.adk.ADKAdapter`
-and driven by a :class:`goldfive.Runner` with an ``LLMPlanner`` and
-``LLMGoalDeriver``.
+The whole point of goldfive is that *you bring an agent and goldfive
+orchestrates around it*. This example is the smallest thing that
+demonstrates that shape:
+
+    agent  = <your ADK agent>                        # one ``BaseAgent``.
+    runner = goldfive.wrap(agent, planner=...)       # goldfive plans + dispatches.
+    await runner.run("make a presentation about waffles")
+
+No hand-rolled coordinator, no subagent tree, no file tools wired up
+across specialists. ``LLMPlanner`` receives the user prompt, emits a
+task DAG, and the same agent handles each task in sequence. This is the
+baseline a user should copy when they are integrating goldfive for the
+first time.
+
+For a realistic multi-agent reference — coordinator + research /
+developer / reviewer / debugger subagents with real tools — see
+``tests/reference_agents/presentation_agent/agent.py`` in
+`harmonograf <https://github.com/pedapudi/harmonograf>`_. That module
+exports ``root_agent`` plus a ``build_goldfive_runner`` helper that
+assembles the same ``goldfive.Runner`` as this example, but with the
+full four-specialist tree. The point of keeping the goldfive-side
+example minimal is that a user reading this file learns *how to wrap*,
+not *how to structure a multi-agent ADK tree* — those are orthogonal
+concerns.
 
 Two run modes:
 
-* ``--mock`` — no network. Every ADK agent's model is replaced with an
-  in-process ``_MockLlm`` that returns canned text, and the planner /
-  goal-deriver use mock ``call_llm`` callables that emit deterministic
-  JSON. Verifies goldfive wiring end-to-end without credentials.
+* ``--mock`` — no network. Canned JSON for planner / goal-deriver and a
+  single ``_MockLlm`` for the ADK agent itself. Good for CI.
 * Default — uses ``OPENAI_API_KEY`` via the ``openai`` Python SDK for
-  both planner / deriver and a ``LiteLLM`` model string (e.g.
-  ``openai/gpt-4o-mini``) for the ADK subagents. Requires the
-  ``openai`` and ``litellm`` packages.
+  the planner + goal-deriver, and a LiteLLM model string for the ADK
+  agent.
 
 Gated on the ``adk`` extra::
 
@@ -38,223 +53,44 @@ try:
     from google.adk.models.base_llm import BaseLlm
     from google.adk.models.llm_request import LlmRequest
     from google.adk.models.llm_response import LlmResponse
-    from google.adk.tools import AgentTool, FunctionTool
     from google.genai import types as genai_types
 except ImportError as _adk_err:  # pragma: no cover
     raise SystemExit("install goldfive[adk] to run this example") from _adk_err
 
-from goldfive import (
-    InMemorySink,
-    LLMGoalDeriver,
-    LLMPlanner,
-    Runner,
-    SequentialExecutor,
-)
-from goldfive.adapters.adk import ADKAdapter
+import goldfive
+from goldfive import LLMGoalDeriver, LLMPlanner, SequentialExecutor
 from goldfive.sinks import LoggingSink
 
-log = logging.getLogger("examples.adk_presentation")
-
-
 # ---------------------------------------------------------------------------
-# ADK tools — mirror harmonograf's presentation_agent tool surface.
-# ---------------------------------------------------------------------------
-
-
-# All three file tools share one canonical directory so the writer, the
-# reviewer, and the debugger always agree on which presentation they are
-# operating on. The previous design threaded a ``topic`` string through
-# each call and derived the directory name by slugifying it — but the
-# writer, reviewer, and debugger each invented their own ``topic`` string
-# from local context, and the slugs rarely matched. The reviewer would
-# look in ``output/pandas/`` while the writer had saved to
-# ``output/giant_pandas:_icons_of_conservation/``; ``read_presentation_files``
-# returned error strings, the reviewer reported the task blocked, the
-# planner refined, and the loop repeated. Root-caused during a live-run
-# investigation; see ``docs/design/PLAN-LIFECYCLE.md`` §6.1 for the
-# termination predicate this bug was exposing.
-#
-# Canonical path keeps the demo single-run-at-a-time (each run overwrites
-# the prior). For multi-run isolation, a future enhancement can scope the
-# path by ``session_id``.
-_PRESENTATION_DIR = os.path.join(os.path.dirname(__file__), "output", "current")
-
-
-def write_webpage(html_content: str, css_content: str, js_content: str) -> str:
-    """Write the interactive webpage (HTML + CSS + JS) into the canonical
-    presentation directory. Overwrites any prior files there.
-
-    The reviewer and debugger read from the same canonical directory, so
-    ``write_webpage`` does not accept a topic argument — the agent tree
-    operates on exactly one presentation at a time per run.
-    """
-    os.makedirs(_PRESENTATION_DIR, exist_ok=True)
-    try:
-        with open(os.path.join(_PRESENTATION_DIR, "index.html"), "w") as f:
-            f.write(html_content)
-        with open(os.path.join(_PRESENTATION_DIR, "styles.css"), "w") as f:
-            f.write(css_content)
-        with open(os.path.join(_PRESENTATION_DIR, "script.js"), "w") as f:
-            f.write(js_content)
-        return f"Successfully wrote presentation to {_PRESENTATION_DIR}"
-    except OSError as e:
-        return f"Error writing file: {e}"
-
-
-def read_presentation_files() -> dict[str, str]:
-    """Read the current presentation files and return a name → content map.
-
-    Reads from the canonical presentation directory that ``write_webpage``
-    populated. No topic argument — writer and reader share one location so
-    the reviewer cannot miss the file the writer just produced.
-
-    If the writer hasn't run yet, each value carries a ``<not yet written>``
-    marker so the reviewer can detect that state cleanly and report the
-    task blocked (rather than silently "reviewing" an empty presentation).
-    """
-    files: dict[str, str] = {}
-    for name in ("index.html", "styles.css", "script.js"):
-        path = os.path.join(_PRESENTATION_DIR, name)
-        try:
-            with open(path) as f:
-                files[name] = f.read()
-        except FileNotFoundError:
-            files[name] = "<not yet written>"
-        except OSError as e:
-            files[name] = f"<error reading {path}: {e}>"
-    return files
-
-
-def patch_file(filename: str, new_content: str) -> str:
-    """Overwrite ``filename`` inside the canonical presentation directory.
-
-    ``filename`` is the base name (e.g. ``index.html``); paths are always
-    rooted at the canonical presentation directory so the debugger cannot
-    write outside it or target a presentation the reviewer never saw.
-    """
-    safe_name = os.path.basename(filename)
-    if not safe_name:
-        return "Error: filename is empty"
-    path = os.path.join(_PRESENTATION_DIR, safe_name)
-    try:
-        os.makedirs(_PRESENTATION_DIR, exist_ok=True)
-        with open(path, "w") as f:
-            f.write(new_content)
-        return f"Successfully patched {path}"
-    except OSError as e:
-        return f"Error patching file: {e}"
-
-
-write_webpage_tool = FunctionTool(write_webpage)
-read_presentation_files_tool = FunctionTool(read_presentation_files)
-patch_file_tool = FunctionTool(patch_file)
-
-
-# ---------------------------------------------------------------------------
-# Agent tree construction
+# The agent. One ADK ``Agent``; goldfive's planner breaks the user prompt
+# into tasks and invokes this same agent for each. No coordinator, no
+# subagents. For a richer multi-agent example, see
+# harmonograf/tests/reference_agents/presentation_agent/agent.py.
 # ---------------------------------------------------------------------------
 
 
-def _build_agent_tree(model: str | BaseLlm) -> Any:
-    """Build the coordinator + four specialist subagents and return the root."""
-    research_agent = Agent(
-        name="research_agent",
+def _build_agent(model: str | BaseLlm) -> Any:
+    return Agent(
+        name="presenter",
         model=model,
         instruction=(
-            "You are a researcher. Gather key facts about the topic the user "
-            "provides and synthesise them into concise bullet points suitable "
-            "for a short presentation."
+            "You are a helpful writing assistant working through one task "
+            "at a time. Each message you receive is a single task from an "
+            "orchestrator: complete *just that task*, write a short clear "
+            "answer, and stop. Do not attempt to run the whole workflow "
+            "in one turn — the orchestrator routes you through each step."
         ),
-        description=("Agent that synthesises research bullet points for a topic."),
-        tools=[],
+        description="Writing assistant for short presentation tasks.",
     )
-
-    web_developer_agent = Agent(
-        name="web_developer_agent",
-        model=model,
-        instruction=(
-            "You are an expert frontend developer. Given research notes, "
-            "generate a single-page HTML slideshow plus CSS and JavaScript, "
-            "then call the write_webpage tool to save the files. "
-            "write_webpage takes ONLY (html_content, css_content, js_content) "
-            "— there is no topic argument. All presentations are written "
-            "to a shared canonical location that the reviewer and debugger "
-            "read from."
-        ),
-        description=(
-            "Frontend agent that produces and saves an interactive HTML/CSS/JS slideshow."
-        ),
-        tools=[write_webpage_tool],
-    )
-
-    reviewer_agent = Agent(
-        name="reviewer_agent",
-        model=model,
-        instruction=(
-            "You are a senior frontend reviewer. Call read_presentation_files() "
-            "(no arguments — it reads from the canonical location the web "
-            "developer wrote to) and return a structured list of issues "
-            "(each with a severity of critical / major / minor) or an empty "
-            "list if the output looks clean. If any file returns "
-            "'<not yet written>', the web developer hasn't produced the "
-            "presentation yet; report that as a blocker instead of reviewing "
-            "an empty presentation."
-        ),
-        description=("Reviewer agent that critiques the generated presentation files."),
-        tools=[read_presentation_files_tool],
-    )
-
-    debugger_agent = Agent(
-        name="debugger_agent",
-        model=model,
-        instruction=(
-            "You are a debugging agent. Given a list of issues flagged by "
-            "the reviewer, call patch_file(filename, new_content) with "
-            "the corrected contents for each affected file. "
-            "filename is the base name only (index.html, styles.css, or "
-            "script.js); paths are always rooted at the canonical "
-            "presentation directory."
-        ),
-        description=("Debugger agent that patches presentation files flagged by the reviewer."),
-        tools=[patch_file_tool],
-    )
-
-    coordinator_agent = Agent(
-        name="coordinator_agent",
-        model=model,
-        instruction=(
-            "You are the Coordinator. Drive a presentation workflow by "
-            "delegating to research_agent, then web_developer_agent, then "
-            "reviewer_agent, and finally debugger_agent if the reviewer "
-            "flagged critical issues."
-        ),
-        description=(
-            "Coordinator that delegates research / build / review / debug "
-            "steps to specialist subagents."
-        ),
-        tools=[
-            AgentTool(research_agent),
-            AgentTool(web_developer_agent),
-            AgentTool(reviewer_agent),
-            AgentTool(debugger_agent),
-        ],
-    )
-    return coordinator_agent
 
 
 # ---------------------------------------------------------------------------
-# Mock LLM — used by --mock mode so the demo runs without credentials.
+# Mock mode — deterministic, network-free demo path for CI.
 # ---------------------------------------------------------------------------
 
 
 class _MockLlm(BaseLlm):
-    """Minimal BaseLlm that returns a single canned text response.
-
-    Short-circuits ADK's model layer so the coordinator and every
-    subagent produce a deterministic reply in ``--mock`` mode. The
-    executor's auto-complete behaviour (goldfive #37) then marks each
-    task COMPLETED based on the wrapped adapter returning cleanly.
-    """
+    """Minimal ``BaseLlm`` that returns a one-line deterministic reply."""
 
     @classmethod
     def supported_models(cls) -> list[str]:
@@ -263,108 +99,65 @@ class _MockLlm(BaseLlm):
     async def generate_content_async(
         self, llm_request: LlmRequest, stream: bool = False
     ) -> AsyncGenerator[LlmResponse, None]:
-        text = f"[mock:{self.model}] acknowledged task and deferred real work to a production run."
         yield LlmResponse(
             content=genai_types.Content(
                 role="model",
-                parts=[genai_types.Part(text=text)],
+                parts=[genai_types.Part(text=f"[mock:{self.model}] task done.")],
             ),
             partial=False,
             turn_complete=True,
         )
 
 
-# ---------------------------------------------------------------------------
-# Mock call_llm callables — used by LLMPlanner / LLMGoalDeriver under --mock.
-# ---------------------------------------------------------------------------
-
-
-def _make_mock_planner_llm(topic: str) -> Any:
-    """Return an async ``call_llm`` that produces a canned presentation plan.
-
-    Matches ``LLMPlanner``'s ``(system_prompt, user_prompt, model) -> str``
-    signature and returns a plan with one task per specialist subagent so
-    the executor emits ``TaskStarted`` / ``TaskCompleted`` for each.
-    """
-
-    plan_json = {
-        "summary": f"Build a slideshow presentation on '{topic}'.",
+def _mock_planner_call_llm(topic: str):
+    """Canned ``LLMPlanner.call_llm``: three sequential tasks on the agent."""
+    plan = {
+        "summary": f"Short presentation about {topic}.",
         "tasks": [
             {
                 "id": "research",
-                "title": "Gather research bullet points on the topic",
-                "description": "Summarise key facts about the topic.",
-                "assignee_agent_id": "research_agent",
+                "title": f"Research key facts about {topic}",
+                "assignee_agent_id": "presenter",
             },
             {
-                "id": "build",
-                "title": "Generate HTML/CSS/JS slideshow",
-                "description": "Produce the presentation files and save them.",
-                "assignee_agent_id": "web_developer_agent",
+                "id": "outline",
+                "title": "Draft a 5-slide outline from the research",
+                "assignee_agent_id": "presenter",
             },
             {
-                "id": "review",
-                "title": "Review the generated presentation",
-                "description": "Critique the generated slideshow for issues.",
-                "assignee_agent_id": "reviewer_agent",
-            },
-            {
-                "id": "debug",
-                "title": "Patch any critical issues the reviewer flagged",
-                "description": "Apply fixes to the presentation files.",
-                "assignee_agent_id": "debugger_agent",
+                "id": "writeup",
+                "title": "Expand each outline bullet into a slide-ready paragraph",
+                "assignee_agent_id": "presenter",
             },
         ],
         "edges": [
-            {"from_task_id": "research", "to_task_id": "build"},
-            {"from_task_id": "build", "to_task_id": "review"},
-            {"from_task_id": "review", "to_task_id": "debug"},
+            {"from_task_id": "research", "to_task_id": "outline"},
+            {"from_task_id": "outline", "to_task_id": "writeup"},
         ],
     }
 
     async def _call(system: str, prompt: str, model: str) -> str:
-        return json.dumps(plan_json)
+        return json.dumps(plan)
 
     return _call
 
 
-def _make_mock_goal_llm(topic: str) -> Any:
-    """Return an async ``call_llm`` that produces a single canned goal."""
-
-    goals_json = {
-        "goals": [
-            {
-                "id": "g1",
-                "summary": f"Produce an interactive slideshow on '{topic}'.",
-            }
-        ]
-    }
+def _mock_goal_call_llm(topic: str):
+    """Canned ``LLMGoalDeriver.call_llm``: one goal for the run."""
+    goals = {"goals": [{"id": "g1", "summary": f"Produce a short presentation about {topic}."}]}
 
     async def _call(system: str, prompt: str, model: str) -> str:
-        return json.dumps(goals_json)
+        return json.dumps(goals)
 
     return _call
 
 
 # ---------------------------------------------------------------------------
-# Real call_llm — OpenAI via the official SDK.
+# Real mode — openai-backed planner + goal deriver.
 # ---------------------------------------------------------------------------
 
 
-def _make_openai_call_llm() -> Any:
-    """Return an async ``call_llm`` backed by the OpenAI Python SDK.
-
-    Used when ``--mock`` is not passed. Requires ``OPENAI_API_KEY`` and
-    ``pip install openai``. Model identifiers default to
-    ``gpt-4o-mini`` but can be overridden via
-    ``GOLDFIVE_EXAMPLE_PLANNER_MODEL``.
-
-    The returned callable carries an async ``close`` attribute that
-    shuts down the underlying ``aiohttp`` session. Goldfive's
-    :class:`Runner.close` discovers and awaits it via the duck-typed
-    :class:`goldfive._llm.ClosableCallLLM` protocol, so callers don't
-    need to register a separate close hook.
-    """
+def _openai_call_llm():
     try:
         from openai import AsyncOpenAI  # type: ignore
     except ImportError as exc:  # pragma: no cover
@@ -392,84 +185,48 @@ def _make_openai_call_llm() -> Any:
 
 
 # ---------------------------------------------------------------------------
-# Entry point
+# Entry point. This is the whole "wrap an agent with goldfive" pattern.
 # ---------------------------------------------------------------------------
 
 
-async def run(
-    *,
-    topic: str,
-    mock: bool,
-) -> None:
-    """Drive one end-to-end presentation generation."""
-
+async def run(*, topic: str, mock: bool) -> None:
     if mock:
-        model: str | BaseLlm = _MockLlm(model="mock/presentation-agent")
-        planner_call_llm = _make_mock_planner_llm(topic)
-        goal_call_llm = _make_mock_goal_llm(topic)
-        planner_model = "mock/planner"
-        goal_model = "mock/goal-deriver"
+        agent_model: str | BaseLlm = _MockLlm(model="mock/presenter")
+        planner_call_llm = _mock_planner_call_llm(topic)
+        goal_call_llm = _mock_goal_call_llm(topic)
+        model_tag = "mock/planner"
     else:
-        model = os.environ.get("GOLDFIVE_EXAMPLE_MODEL", "openai/gpt-4o-mini")
-        openai_call_llm = _make_openai_call_llm()
-        planner_call_llm = openai_call_llm
-        goal_call_llm = openai_call_llm
-        planner_model = os.environ.get("GOLDFIVE_EXAMPLE_PLANNER_MODEL", "gpt-4o-mini")
-        goal_model = os.environ.get("GOLDFIVE_EXAMPLE_GOAL_MODEL", "gpt-4o-mini")
+        agent_model = os.environ.get("GOLDFIVE_EXAMPLE_MODEL", "openai/gpt-4o-mini")
+        planner_call_llm = _openai_call_llm()
+        goal_call_llm = planner_call_llm
+        model_tag = os.environ.get("GOLDFIVE_EXAMPLE_PLANNER_MODEL", "gpt-4o-mini")
 
-    root_agent = _build_agent_tree(model)
-    adapter = ADKAdapter(root_agent)
-
-    memory_sink = InMemorySink()
-    logging_sink = LoggingSink()
-    runner = Runner(
-        agent=adapter,
-        planner=LLMPlanner(call_llm=planner_call_llm, model=planner_model),
+    # --- the whole wrap, in five lines. ---
+    runner = goldfive.wrap(
+        _build_agent(agent_model),
+        planner=LLMPlanner(call_llm=planner_call_llm, model=model_tag),
+        goal_deriver=LLMGoalDeriver(call_llm=goal_call_llm, model=model_tag),
         executor=SequentialExecutor(max_plan_reinvocations=8),
-        goal_deriver=LLMGoalDeriver(call_llm=goal_call_llm, model=goal_model),
-        sinks=[memory_sink, logging_sink],
-        max_plan_reinvocations=8,
+        sinks=[LoggingSink()],
     )
 
-    outcome = await runner.run(f"Create a short interactive slideshow presentation on {topic}.")
-    await runner.close()
-
-    print(f"\nsuccess={outcome.success}  reason={outcome.reason!r}")
-    print(f"events emitted: {len(memory_sink.events)}")
-    for evt in memory_sink.events:
-        if isinstance(evt, dict):
-            kind = evt.get("kind", "?")
-            run_id = evt.get("run_id", "")
-            seq = evt.get("sequence", 0)
-        else:
-            kind = getattr(evt, "WhichOneof", lambda _: None)("payload") or "?"
-            run_id = getattr(evt, "run_id", "")
-            seq = getattr(evt, "sequence", 0)
-        print(f"  seq={seq:>3}  run={run_id[:8]:<8}  {kind}")
+    try:
+        outcome = await runner.run(f"Make a short presentation about {topic}.")
+        print(f"\nsuccess={outcome.success}  reason={outcome.reason!r}")
+        if outcome.session.plan is not None:
+            for task in outcome.session.plan.tasks:
+                print(f"  {task.status.value:<10} {task.id}  {task.title}")
+    finally:
+        await runner.close()
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--topic", default="waffles", help="Presentation topic.")
     parser.add_argument(
-        "--topic",
-        default="the history of the espresso machine",
-        help="Topic for the slideshow presentation.",
+        "--mock", action="store_true", help="Run without network — canned planner + MockLlm."
     )
-    parser.add_argument(
-        "--mock",
-        action="store_true",
-        help=(
-            "Run without network calls — uses an in-process MockLlm for "
-            "every ADK agent and canned JSON for the goldfive planner and "
-            "goal deriver."
-        ),
-    )
-    parser.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
-        help="Enable INFO-level logging from goldfive sinks.",
-    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="INFO-level logs from sinks.")
     args = parser.parse_args()
 
     logging.basicConfig(


### PR DESCRIPTION
## Summary

Simplify the adk_presentation example to the smallest thing that answers "how do I use goldfive?": one ADK ``Agent``, ``goldfive.wrap(...)``, three sequential tasks. No coordinator, no subagent tree, no file tools, no hand-rolled delegation logic.

**Before:** 483 lines, a 4-specialist coordinator tree with hand-crafted "delegate to X then Y then Z" instructions, ``write_webpage`` / ``read_presentation_files`` / ``patch_file`` tools with a shared (implicit) topic convention. That's the shape of an application, not a demo of the framework.

**After:** 227 lines, one ``Agent`` with a task-scoped instruction. ``LLMPlanner`` emits a 3-step DAG; executor invokes the same agent per task. Mock mode runs offline, live mode uses OpenAI.

The richer multi-agent reference already exists in harmonograf's ``tests/reference_agents/presentation_agent``, which exports ``build_goldfive_runner`` for the full coordinator + 4-specialist tree. README now points there for users who want that shape.

## Why this matters

The prior example conflated "how to structure a multi-agent ADK tree" with "how to plug goldfive into your existing agent." A user reading it had to understand both at once, and in practice the coordinator-and-specialists shape introduced coordination bugs (#110) that are invisible when you're just wrapping a simple agent.

## Test plan

- [x] Mock mode: ``uv run python examples/adk_presentation/agent.py --mock`` → ``success=True`` with 3 tasks COMPLETED.
- [x] Full suite: ``uv run --extra dev --extra adk pytest -q`` → 535 passed, 38 skipped.
- [x] Ruff clean.
