### PR TITLE
Graduated INTENT_DIVERGENCE severity (INFO / WARNING / CRITICAL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
 - #69 Reconciled `HarmonografSink` API docs with the shipped
   `harmonograf_client.HarmonografSink(client)` shape and canonical
   `:7531` port.
+- `INTENT_DIVERGENCE` now fires at **graduated severity**
+  (`INFO` / `WARNING` / `CRITICAL`) based on cosine similarity
+  between the reasoning block and `session.goals` + the current
+  task topic. Bands: `sim >= 0.6` healthy, `>= 0.4` INFO, `>= 0.2`
+  WARNING, `< 0.2` CRITICAL. An unreferenced-keyword mismatch bumps
+  severity one step. The pattern-based fallback (no embeddings)
+  now fires at `WARNING` with the same keyword-mismatch bump. The
+  drift kind is stable; only `severity` changes. See
+  `docs/design/DRIFT.md` for the full table and
+  `goldfive/drift/reasoning.py` for thresholds.
 
 ## 0.1.0 — 2026-04-18
 

--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -124,12 +124,49 @@ parts). See `goldfive/drift/reasoning.py` for the detector pipeline.
 | `LOOPING_REASONING` | Consecutive reasoning blocks share the same SHA-256 prefix (always-on) or cosine-similar above `0.9` (opt-in, `goldfive[embedding]`). | `warning` | yes |
 | `CONFUSION` | Reasoning text has ≥ 3 uncertainty markers ("I'm not sure", "wait", "hmm", …). | `info` | yes |
 | `OFF_TOPIC` | Reasoning cosine-distance from the current task description ≥ `0.7` (requires `goldfive[embedding]`). | `warning` | yes |
-| `INTENT_DIVERGENCE` | Reasoning proposes a new goal that does not overlap with `session.goals`. | `critical` | no |
+| `INTENT_DIVERGENCE` | Reasoning has drifted from `session.goals` + the current task topic. Severity is **graduated** — see table below. | `info` · `warning` · `critical` | depends on severity |
 
 Each observation produces at most one drift (the first match wins) in
 severity order: `INTENT_DIVERGENCE` → `LOOPING_REASONING` → `OFF_TOPIC`
 → `CONFUSION`. Detectors short-circuit so the pipeline cost stays
-bounded regardless of reasoning block size.
+bounded regardless of reasoning block size. `INTENT_DIVERGENCE` runs
+first even when it resolves to `info` severity, because the kind is
+stable — callers that only care about warning-and-up simply filter on
+the `severity` field.
+
+#### Graduated `INTENT_DIVERGENCE` severity
+
+When the `goldfive[embedding]` extra is installed, the detector
+computes cosine similarity between the current reasoning block and
+`session.goals` + the current task's `title + description`, then maps
+the score into a severity band:
+
+| Cosine similarity | Severity | Meaning |
+|---|---|---|
+| `sim >= 0.6` | _(no drift)_ | reasoning aligned with goals |
+| `0.4 <= sim < 0.6` | `info` | minor drift — surface, don't refine |
+| `0.2 <= sim < 0.4` | `warning` | notable drift — refine |
+| `sim < 0.2` | `critical` | far off-goal — refine urgently |
+
+When embeddings are unavailable the detector falls back to the
+pattern path: an explicit "my goal is X / let's focus on Y / pivot to
+Z" phrase whose proposal tokens do not overlap with any goal summary
+fires at `warning`.
+
+Either path may be bumped one step (`info` → `warning` → `critical`,
+saturating at `critical`) when the reasoning text mentions a 5+ char
+non-stopword keyword that is absent from both `session.goals` AND the
+current task's `title / description` — a cheap "talking about
+something unrelated" signal that catches soft divergence the cosine
+score alone may smooth over.
+
+The drift **kind** stays `INTENT_DIVERGENCE` across all severity
+bands: callers filtering by kind see one stable signal; the
+`severity` field differentiates urgency. Thresholds live in
+`goldfive/drift/reasoning.py` as
+`INTENT_DIVERGENCE_HEALTHY_SIMILARITY`,
+`INTENT_DIVERGENCE_MINOR_SIMILARITY`, and
+`INTENT_DIVERGENCE_WARNING_SIMILARITY`.
 
 The reasoning channel is additive: adapters that cannot surface
 chain-of-thought (e.g. classic GPT-4o) simply never call

--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -349,9 +349,12 @@ predicate that raises is logged at WARNING and treated as unmet.
 
 ### 6.2 Unrecoverable cascade (ABORTED)
 
-When a drift fires with `recoverable=False` — today only
-`TASK_FAILED_FATAL`, `USER_CANCEL`, and `INTENT_DIVERGENCE` — the
-unrecoverable cascade runs (STATE-MACHINE.md §"Cascade semantics"):
+When a drift fires with `recoverable=False` — today
+`TASK_FAILED_FATAL`, `USER_CANCEL`, and `INTENT_DIVERGENCE` **at
+`CRITICAL` severity** (see DRIFT.md for the graduated
+`INTENT_DIVERGENCE` bands; `INFO` / `WARNING` intent-divergence
+drifts are recoverable and refine normally) — the unrecoverable
+cascade runs (STATE-MACHINE.md §"Cascade semantics"):
 
 1. Mark the current task FAILED (if not already terminal). Owned by
    `Steerer.mark_task_failed(..., recoverable=False)`.

--- a/docs/design/RATIONALE.md
+++ b/docs/design/RATIONALE.md
@@ -847,15 +847,22 @@ on models that are merely verbose about their process (GPT-4o's
 contexts). We mitigate by leaving it at `INFO` severity so it does
 not trigger refine by default — callers that want action can
 subclass `DefaultSteerer` and override `should_refine`.
-`INTENT_DIVERGENCE` is `CRITICAL`, so its detector is intentionally
-conservative (requires an explicit "let's change goals" phrasing
-*and* a token-overlap check against `session.goals`) to avoid
-false-positive run aborts.
+`INTENT_DIVERGENCE` uses *graduated* severity
+(`INFO` / `WARNING` / `CRITICAL`) based on cosine similarity to the
+goals + task topic. That keeps the kind stable (callers that filter
+by kind see one signal) while letting refine policy hinge on
+`severity` — a 0.5 similarity is worth surfacing but not worth
+aborting over, whereas a 0.1 similarity plus an unrelated-keyword
+hit is. The pattern fallback still requires an explicit "let's
+change goals" phrasing *and* a token-overlap check against
+`session.goals`, so false-positive run aborts remain rare without
+embeddings.
 
 **Signals this might be wrong.** If users report
-`INTENT_DIVERGENCE` false positives we should tighten the marker
-regex. If `LOOPING_REASONING` fires on models whose reasoning is
-legitimately iterative (e.g. chain-of-thought enumerating
+`INTENT_DIVERGENCE` false positives at `CRITICAL` we should raise
+the `INTENT_DIVERGENCE_WARNING_SIMILARITY` floor or tighten the
+marker regex. If `LOOPING_REASONING` fires on models whose reasoning
+is legitimately iterative (e.g. chain-of-thought enumerating
 hypotheses), we should increase the hash-window or add a
 "distinct-tokens" guard before firing.
 

--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -16,11 +16,16 @@ Four drift kinds live in this module:
 * :data:`~goldfive.types.DriftKind.OFF_TOPIC` -- reasoning topic is
   far from the task description (requires the ``embedding`` extra).
 * :data:`~goldfive.types.DriftKind.INTENT_DIVERGENCE` -- reasoning
-  mentions goals that are not in ``session.goals``.
+  has drifted away from ``session.goals`` + the current task. Severity
+  is graduated by cosine distance when embeddings are available and
+  falls back to a pattern-based WARNING when they are not.
 
 The pipeline emits at most one drift per call to keep cost bounded.
-Detectors run in severity order: INTENT_DIVERGENCE (CRITICAL) ->
+Detectors run in severity order: INTENT_DIVERGENCE (up to CRITICAL) ->
 LOOPING_REASONING (WARNING) -> OFF_TOPIC (WARNING) -> CONFUSION (INFO).
+When INTENT_DIVERGENCE resolves to a non-CRITICAL severity (INFO /
+WARNING), the pipeline still returns it first -- the kind is stable,
+severity differentiates.
 """
 
 from __future__ import annotations
@@ -39,6 +44,9 @@ if TYPE_CHECKING:
 __all__ = [
     "CONFUSION_MARKERS",
     "CONFUSION_MIN_HITS",
+    "INTENT_DIVERGENCE_HEALTHY_SIMILARITY",
+    "INTENT_DIVERGENCE_MINOR_SIMILARITY",
+    "INTENT_DIVERGENCE_WARNING_SIMILARITY",
     "LOOPING_REASONING_HASH_WINDOW",
     "LOOPING_REASONING_SIMILARITY_THRESHOLD",
     "OFF_TOPIC_DISTANCE_THRESHOLD",
@@ -91,8 +99,9 @@ LOOPING_REASONING_SIMILARITY_THRESHOLD: float = 0.9
 OFF_TOPIC_DISTANCE_THRESHOLD: float = 0.7
 
 # Regex looking for explicit "my goal is / let me change goals / new
-# objective" style phrasing. Proof-by-wording only; embedding coverage
-# is deferred to a follow-up.
+# objective" style phrasing. Used by the pattern-based fallback path
+# when embeddings are unavailable, and also to surface off-goal
+# proposals the embedding path may dilute over a long reasoning block.
 _INTENT_DIVERGENCE_MARKERS: re.Pattern[str] = re.compile(
     r"\b("
     r"my (?:real )?goal (?:is|should be)|"
@@ -105,6 +114,18 @@ _INTENT_DIVERGENCE_MARKERS: re.Pattern[str] = re.compile(
     r")",
     re.IGNORECASE,
 )
+
+
+# Cosine-similarity bands for graduated INTENT_DIVERGENCE severity.
+# Similarity is measured between the reasoning block and the goals +
+# current task topic text.
+#   sim >= HEALTHY            -> no drift
+#   MINOR <= sim < HEALTHY    -> INFO
+#   WARNING <= sim < MINOR    -> WARNING
+#   sim < WARNING             -> CRITICAL
+INTENT_DIVERGENCE_HEALTHY_SIMILARITY: float = 0.6
+INTENT_DIVERGENCE_MINOR_SIMILARITY: float = 0.4
+INTENT_DIVERGENCE_WARNING_SIMILARITY: float = 0.2
 
 
 # ---------------------------------------------------------------------------
@@ -156,22 +177,88 @@ def detect_intent_divergence(
     text: str, session: Session
 ) -> DriftEvent | None:
     """Return :data:`DriftKind.INTENT_DIVERGENCE` when the reasoning
-    text proposes a goal that is not in ``session.goals``.
+    text has drifted from ``session.goals`` + the current task topic.
 
-    Pattern-based only: looks for explicit "my goal is X / let's focus
-    on Y" phrases and confirms that the mentioned focus does not
-    overlap with any existing goal summary token. Conservative by
-    design -- false positives here are costly (CRITICAL severity).
+    Graduated severity by cosine similarity (embedding path):
+
+    =====================  ===========
+    similarity             severity
+    =====================  ===========
+    >= 0.6                 no drift
+    0.4 <= sim < 0.6       INFO
+    0.2 <= sim < 0.4       WARNING
+    < 0.2                  CRITICAL
+    =====================  ===========
+
+    When embeddings are unavailable we fall back to the pattern path:
+    an explicit "my goal is / let's focus on" phrase whose proposal
+    tokens do not overlap with any goal summary fires at WARNING.
+
+    Either path may be bumped one step (INFO -> WARNING -> CRITICAL)
+    when the reasoning text mentions a significant noun / keyword that
+    does not appear in ``session.goals`` OR in the current task's
+    title / description -- a cheap "talking about something unrelated"
+    signal that catches soft divergence the cosine score alone may
+    smooth over.
+
+    The kind is stable. Severity differentiates -- callers that filter
+    by kind see one signal, callers that care about urgency read the
+    ``severity`` field.
     """
     if not text:
         return None
+
+    goals_text = _goals_text(session)
+    task_topic = _task_topic(_current_task(session))
+    reference = " ".join(p for p in (goals_text, task_topic) if p).strip()
+    if not reference:
+        # No goals or task to compare against -- cannot determine
+        # divergence with any confidence.
+        return None
+
+    # Embedding path -- graduated similarity bands. Only engage when the
+    # encoder is loadable; otherwise fall through to the pattern path.
+    if _embed.available():
+        sim = _embed.max_similarity(text, [reference])
+        severity = _severity_from_similarity(sim)
+        if severity is None:
+            return None
+        if _has_unreferenced_keyword(text, goals_text, task_topic):
+            severity = _bump_severity(severity)
+        detail = (
+            f"reasoning diverged from goals (cosine={sim:.2f}): "
+            f"reference={reference[:80]!r}"
+        )
+        return DriftEvent(
+            kind=DriftKind.INTENT_DIVERGENCE,
+            severity=severity,
+            detail=detail,
+            current_task_id=session.current_task_id,
+            raw=text,
+        )
+
+    # Pattern-based fallback (no embeddings).
+    return _pattern_intent_divergence(text, session, goals_text, task_topic)
+
+
+def _pattern_intent_divergence(
+    text: str,
+    session: Session,
+    goals_text: str,
+    task_topic: str,
+) -> DriftEvent | None:
+    """Return an INTENT_DIVERGENCE drift from regex-only signals.
+
+    Fires at WARNING by default when an off-goal "focus on X" phrase
+    sits next to tokens that do not appear in the goal summary. An
+    unreferenced-keyword mismatch elsewhere in the text bumps severity
+    to CRITICAL.
+    """
     match = _INTENT_DIVERGENCE_MARKERS.search(text)
     if match is None:
         return None
-    goals_text = _goals_text(session).lower()
-    if not goals_text:
-        # No goals to compare against -- cannot determine divergence
-        # with any confidence. Skip rather than fire a CRITICAL.
+    goals_lower = goals_text.lower()
+    if not goals_lower:
         return None
     # Use the 120 chars after the marker as a cheap proxy for the
     # proposed new goal. If any significant token (>=4 chars) also
@@ -186,16 +273,71 @@ def detect_intent_divergence(
     }
     if not tokens:
         return None
-    if any(tok in goals_text for tok in tokens):
+    if any(tok in goals_lower for tok in tokens):
         return None
+    severity = DriftSeverity.WARNING
+    if _has_unreferenced_keyword(text, goals_text, task_topic):
+        severity = _bump_severity(severity)
     snippet = (text[max(0, match.start() - 40) : match.end() + 80]).strip()
     return DriftEvent(
         kind=DriftKind.INTENT_DIVERGENCE,
-        severity=DriftSeverity.CRITICAL,
+        severity=severity,
         detail=f"reasoning proposes off-goal focus: {snippet!r}",
         current_task_id=session.current_task_id,
         raw=text,
     )
+
+
+def _severity_from_similarity(sim: float) -> DriftSeverity | None:
+    """Map a cosine-similarity score to an INTENT_DIVERGENCE severity.
+
+    Returns ``None`` for "healthy" scores (>= ``HEALTHY``) so the
+    caller can suppress the drift entirely.
+    """
+    if sim >= INTENT_DIVERGENCE_HEALTHY_SIMILARITY:
+        return None
+    if sim >= INTENT_DIVERGENCE_MINOR_SIMILARITY:
+        return DriftSeverity.INFO
+    if sim >= INTENT_DIVERGENCE_WARNING_SIMILARITY:
+        return DriftSeverity.WARNING
+    return DriftSeverity.CRITICAL
+
+
+def _bump_severity(sev: DriftSeverity) -> DriftSeverity:
+    """Return the next-higher severity, saturating at CRITICAL."""
+    if sev is DriftSeverity.INFO:
+        return DriftSeverity.WARNING
+    if sev is DriftSeverity.WARNING:
+        return DriftSeverity.CRITICAL
+    return DriftSeverity.CRITICAL
+
+
+def _has_unreferenced_keyword(
+    text: str, goals_text: str, task_topic: str
+) -> bool:
+    """Return True if the reasoning mentions a keyword not in goals or task.
+
+    A "keyword" is any 5+ char alphabetic token from ``text`` that is
+    not a stopword. If at least one such keyword is absent from both
+    ``goals_text`` and ``task_topic`` (lower-cased, substring match),
+    we treat the reasoning as talking about something unrelated.
+
+    We require a 5-char minimum to avoid matching on generic English
+    (``with``, ``from``); stopwords strip the common connectives that
+    slip past the length gate. The check is deliberately conservative
+    -- one odd token can bump severity by one step, never more.
+    """
+    if not text:
+        return False
+    reference = (goals_text + " " + task_topic).lower()
+    if not reference.strip():
+        return False
+    for tok in re.findall(r"[a-z]{5,}", text.lower()):
+        if tok in _STOPWORDS:
+            continue
+        if tok not in reference:
+            return True
+    return False
 
 
 def detect_looping_reasoning(
@@ -300,10 +442,13 @@ def detect_confusion(text: str, session: Session) -> DriftEvent | None:
 def analyze_reasoning(text: str, session: Session) -> DriftEvent | None:
     """Run the reasoning-drift pipeline against ``text``.
 
-    Emits at most one drift per call. Detectors are tried in severity
-    order so the worst signal wins: INTENT_DIVERGENCE (CRITICAL) ->
+    Emits at most one drift per call. Detectors are tried in the order
+    that preserves the worst-signal-wins invariant:
+    INTENT_DIVERGENCE (graduated INFO/WARNING/CRITICAL) ->
     LOOPING_REASONING (WARNING) -> OFF_TOPIC (WARNING) -> CONFUSION
-    (INFO).
+    (INFO). INTENT_DIVERGENCE runs first even at INFO severity so its
+    kind is stable; callers that only care about warning-and-up simply
+    filter by ``severity``.
     """
     if not text:
         return None

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -65,6 +65,13 @@ class DriftKind(StrEnum):
     LOOPING_REASONING = "looping_reasoning"
     CONFUSION = "confusion"
     OFF_TOPIC = "off_topic"
+    # INTENT_DIVERGENCE fires at a *variable* severity
+    # (INFO / WARNING / CRITICAL) based on how far the reasoning has
+    # drifted from ``session.goals`` + the current task topic. The
+    # kind is stable so callers filtering by kind see one signal;
+    # severity differentiates. See
+    # ``goldfive/drift/reasoning.py::detect_intent_divergence`` and
+    # ``docs/design/DRIFT.md`` for the graduated similarity bands.
     INTENT_DIVERGENCE = "intent_divergence"
     # Opt-in reflective self-progress check: agent said it *is* making
     # progress but with low confidence (< 0.5). INFO severity.

--- a/tests/test_drift_reasoning.py
+++ b/tests/test_drift_reasoning.py
@@ -102,10 +102,21 @@ def _session_with_task(
 
 @pytest.fixture(autouse=True)
 def _clear_embedding_model() -> Any:
-    """Ensure each test starts with no custom encoder installed."""
+    """Ensure each test starts with embeddings *unavailable*.
+
+    ``set_model(None)`` clears any cached encoder, and flipping
+    ``_MODEL_UNAVAILABLE`` true short-circuits the lazy import in
+    :func:`goldfive.drift._embed._get_model`. Tests that want the
+    embedding path install a stub via ``set_model(<encoder>)``, which
+    resets the flag.
+    """
+    from goldfive.drift import _embed as _embed_mod
+
     set_model(None)
+    _embed_mod._MODEL_UNAVAILABLE = True
     yield
     set_model(None)
+    _embed_mod._MODEL_UNAVAILABLE = True
 
 
 # ---------------------------------------------------------------------------
@@ -134,11 +145,16 @@ def test_confusion_suppressed_below_threshold() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Pattern-based INTENT_DIVERGENCE
+# Pattern-based INTENT_DIVERGENCE (fallback path, no embedding model)
 # ---------------------------------------------------------------------------
 
 
-def test_intent_divergence_fires_when_goal_proposes_unrelated_focus() -> None:
+def test_intent_divergence_pattern_path_fires_when_goal_proposes_unrelated_focus() -> None:
+    # No embedding model -> pattern-based fallback. Default severity is
+    # WARNING; a keyword mismatch elsewhere in the text bumps it to
+    # CRITICAL (covered in the dedicated test below). The "cryptocurrency
+    # trading dashboard" text here has several 5+ char tokens absent
+    # from the goal summary, so severity bumps to CRITICAL.
     session = _session_with_task(
         goals=[Goal(id="g1", summary="write a slide review report")]
     )
@@ -149,7 +165,29 @@ def test_intent_divergence_fires_when_goal_proposes_unrelated_focus() -> None:
     drift = dreason.detect_intent_divergence(text, session)
     assert drift is not None
     assert drift.kind is DriftKind.INTENT_DIVERGENCE
+    # Proposal tokens disjoint AND unrelated keywords present -> bumped
+    # from WARNING up to CRITICAL.
     assert drift.severity is DriftSeverity.CRITICAL
+
+
+def test_intent_divergence_pattern_path_warning_without_keyword_mismatch() -> None:
+    # The unreferenced-keyword bump only fires on 5+ char non-stopword
+    # tokens that appear in the reasoning but not in goals+task. Here
+    # every 5+ char token in the reasoning also shows up in the task
+    # description, so the bump is suppressed and severity stays at
+    # WARNING. Meanwhile the proposal tokens ("tactics", "champion",
+    # "shortly") are disjoint from the goal summary, so the pattern
+    # detector still fires.
+    session = _session_with_task(
+        title="pivot actually focus report",
+        description="pivot actually focus report tactics champion shortly goal",
+        goals=[Goal(id="g1", summary="write a slide review report")],
+    )
+    text = "pivot to tactics champion shortly"
+    drift = dreason.detect_intent_divergence(text, session)
+    assert drift is not None
+    assert drift.kind is DriftKind.INTENT_DIVERGENCE
+    assert drift.severity is DriftSeverity.WARNING
 
 
 def test_intent_divergence_suppressed_when_focus_overlaps_goals() -> None:
@@ -264,12 +302,178 @@ def test_embedding_based_off_topic_no_fire_when_on_topic() -> None:
 
 
 def test_embedding_based_off_topic_silent_without_model() -> None:
-    # No model installed; graceful degradation.
+    # No model installed; graceful degradation. The autouse fixture
+    # already forces embeddings unavailable, but we re-assert here so
+    # the intent of the test is explicit: ``set_model(None)`` alone
+    # is not sufficient because it resets the lazy-load gate, which
+    # then allows the real sentence-transformers model to load when
+    # the ``embedding`` extra is installed.
+    from goldfive.drift import _embed as _embed_mod
+
     set_model(None)
+    _embed_mod._MODEL_UNAVAILABLE = True
     session = _session_with_task()
     text = "wildly unrelated reasoning content goes here"
     drift = dreason.detect_off_topic(text, session)
     assert drift is None
+
+
+# ---------------------------------------------------------------------------
+# Graduated INTENT_DIVERGENCE (embedding path)
+#
+# We use a fixed-similarity encoder so cosine(text, reference) is exactly
+# ``cos(angle_text - angle_reference)``. This keeps the tests independent
+# of the hash-bucket distribution in ``_StubEncoder``.
+# ---------------------------------------------------------------------------
+
+
+class _FixedSimilarityEncoder:
+    """Encoder that maps registered texts to pre-chosen unit vectors.
+
+    All vectors live on a 2-D unit circle so cosine between two texts
+    equals ``cos(theta_a - theta_b)``. Unregistered texts land at angle
+    0 (cosine 1 against each other). Use ``set(text, angle_rad)`` to
+    control the angle per text.
+    """
+
+    def __init__(self) -> None:
+        import math
+
+        self._math = math
+        self._by_text: dict[str, tuple[float, float]] = {}
+
+    def set(self, text: str, angle_rad: float) -> None:
+        self._by_text[text] = (self._math.cos(angle_rad), self._math.sin(angle_rad))
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        return [list(self._by_text.get(t, (1.0, 0.0))) for t in texts]
+
+
+def _intent_session(
+    *,
+    reasoning_text: str,
+    reasoning_angle: float,
+    goals_summary: str = "alpha bravo charlie delta",
+    task_title: str = "echo foxtrot",
+    task_description: str = "golf hotel india juliet",
+) -> Session:
+    """Build a session whose reference-text vector sits at angle 0 and
+    whose reasoning vector sits at ``reasoning_angle``. Cosine becomes
+    ``cos(reasoning_angle)``.
+
+    Default goals / task topic use NATO-style placeholder tokens so
+    tests can craft a reasoning text whose 5+ char tokens all appear
+    in the reference (suppressing the unreferenced-keyword bump) and
+    dial severity purely through the encoder angle. Tests that want
+    the keyword bump should override the defaults with a reasoning
+    text that includes an off-reference token.
+    """
+    import math
+
+    encoder = _FixedSimilarityEncoder()
+    # The detector concatenates goals_summary + task_title + task_description
+    # with single spaces (see ``reasoning._goals_text`` + ``_task_topic``).
+    # We register the exact concatenation at angle 0.
+    reference = " ".join(
+        p for p in (goals_summary, f"{task_title} {task_description}") if p
+    ).strip()
+    encoder.set(reference, 0.0)
+    encoder.set(reasoning_text, reasoning_angle)
+    set_model(encoder)
+    session = _session_with_task(
+        title=task_title,
+        description=task_description,
+        goals=[Goal(id="g1", summary=goals_summary)],
+    )
+    # Sanity: make sure our calibration matches what the detector will
+    # see. If this assert ever trips a reviewer has changed the
+    # _goals_text / _task_topic concatenation contract.
+    assert math.isclose(
+        math.cos(reasoning_angle),
+        dreason._embed.max_similarity(reasoning_text, [reference]),
+        abs_tol=1e-6,
+    )
+    return session
+
+
+def test_intent_divergence_healthy_above_0_6() -> None:
+    import math
+
+    # cos(theta) = 0.8 -> healthy, no drift. Every 5+ char token in
+    # ``reasoning_text`` already appears in the reference, so the
+    # keyword-mismatch bump cannot fire.
+    reasoning_text = "alpha bravo charlie"
+    session = _intent_session(
+        reasoning_text=reasoning_text,
+        reasoning_angle=math.acos(0.8),
+    )
+    drift = dreason.detect_intent_divergence(reasoning_text, session)
+    assert drift is None
+
+
+def test_intent_divergence_minor_fires_info_at_0_4_0_6() -> None:
+    import math
+
+    # cos(theta) = 0.5 -> in [0.4, 0.6) -> INFO.
+    reasoning_text = "alpha bravo charlie"
+    session = _intent_session(
+        reasoning_text=reasoning_text,
+        reasoning_angle=math.acos(0.5),
+    )
+    drift = dreason.detect_intent_divergence(reasoning_text, session)
+    assert drift is not None
+    assert drift.kind is DriftKind.INTENT_DIVERGENCE
+    assert drift.severity is DriftSeverity.INFO
+
+
+def test_intent_divergence_warning_at_0_2_0_4() -> None:
+    import math
+
+    # cos(theta) = 0.3 -> in [0.2, 0.4) -> WARNING.
+    reasoning_text = "alpha bravo charlie"
+    session = _intent_session(
+        reasoning_text=reasoning_text,
+        reasoning_angle=math.acos(0.3),
+    )
+    drift = dreason.detect_intent_divergence(reasoning_text, session)
+    assert drift is not None
+    assert drift.kind is DriftKind.INTENT_DIVERGENCE
+    assert drift.severity is DriftSeverity.WARNING
+
+
+def test_intent_divergence_critical_below_0_2() -> None:
+    import math
+
+    # cos(theta) = 0.0 -> < 0.2 -> CRITICAL.
+    reasoning_text = "alpha bravo charlie"
+    session = _intent_session(
+        reasoning_text=reasoning_text,
+        reasoning_angle=math.acos(0.0),
+    )
+    drift = dreason.detect_intent_divergence(reasoning_text, session)
+    assert drift is not None
+    assert drift.kind is DriftKind.INTENT_DIVERGENCE
+    assert drift.severity is DriftSeverity.CRITICAL
+
+
+def test_intent_divergence_keyword_mismatch_upgrades_severity() -> None:
+    import math
+
+    # Cosine sits in the INFO band (0.5). The reasoning text mentions
+    # "blockchain" -- a 5+ char non-stopword absent from both the goal
+    # summary and the task topic -> severity bumps INFO -> WARNING.
+    # All other 5+ char reasoning tokens DO appear in the reference, so
+    # only the off-topic keyword drives the bump.
+    reasoning_text = "alpha bravo blockchain charlie"
+    session = _intent_session(
+        reasoning_text=reasoning_text,
+        reasoning_angle=math.acos(0.5),
+    )
+    drift = dreason.detect_intent_divergence(reasoning_text, session)
+    assert drift is not None
+    assert drift.kind is DriftKind.INTENT_DIVERGENCE
+    # INFO (cosine band) + unreferenced keyword "blockchain" -> WARNING.
+    assert drift.severity is DriftSeverity.WARNING
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace the hard-CRITICAL pattern-only `INTENT_DIVERGENCE` detector with a graduated signal whose severity scales with cosine similarity to `session.goals` + the current task topic. Bands: `>= 0.6` healthy, `>= 0.4` INFO, `>= 0.2` WARNING, `< 0.2` CRITICAL.
- An unreferenced-keyword mismatch (a 5+ char non-stopword token in the reasoning absent from both the goal summary and the current task's title/description) bumps severity one step, saturating at CRITICAL. Applies to both the embedding path and the pattern fallback.
- Pattern-only fallback (no `goldfive[embedding]`) now fires at `WARNING` by default with the same bump rule, replacing the prior hard-CRITICAL behavior.
- The `DriftKind` stays `INTENT_DIVERGENCE` across all severity bands — kind is stable, severity differentiates. `DriftKind.INTENT_DIVERGENCE` gains an enum-level comment documenting this design decision.
- Pre-existing `test_embedding_based_off_topic_silent_without_model` was latently broken under `uv run --extra embedding` because `set_model(None)` alone resets the lazy-load gate and lets `sentence-transformers` load. Fixed by also flipping `_embed._MODEL_UNAVAILABLE = True` in the autouse fixture (and in the test's explicit setup for clarity).
- Docs: `DRIFT.md` gains the graduated-severity table; `RATIONALE.md` explains the kind-stable / severity-variable tradeoff; `PLAN-LIFECYCLE.md` §6.2 narrows "INTENT_DIVERGENCE" to "INTENT_DIVERGENCE at CRITICAL".

## Background

PR #97 landed `INTENT_DIVERGENCE` as a real (not stub) **pattern-based** detector that always fired at CRITICAL. The embedding-based graduation was flagged as the next iteration. This PR delivers that: real cosine-similarity detection with graduated severity, while preserving the pattern fallback for zero-dependency installs.

## Test plan

- [x] `uv run --extra dev --extra embedding pytest -q` — 518 passed, 47 skipped.
- [x] `uv run --extra dev ruff check goldfive tests` — all checks passed.
- [x] New tests in `tests/test_drift_reasoning.py`:
  - `test_intent_divergence_healthy_above_0_6` — cosine 0.8 → no drift.
  - `test_intent_divergence_minor_fires_info_at_0_4_0_6` — cosine 0.5 → INFO.
  - `test_intent_divergence_warning_at_0_2_0_4` — cosine 0.3 → WARNING.
  - `test_intent_divergence_critical_below_0_2` — cosine 0.0 → CRITICAL.
  - `test_intent_divergence_keyword_mismatch_upgrades_severity` — INFO + unreferenced keyword → WARNING.
  - `test_intent_divergence_pattern_path_warning_without_keyword_mismatch` — pattern-only fallback fires at WARNING when reasoning tokens all appear in the reference.
- [x] Tests use a `_FixedSimilarityEncoder` stub so cosine is exactly `cos(angle)` between two 2-D unit vectors — no hash-bucket collision noise.
