### PR TITLE
Rename max_plan_reinvocations to max_task_invocations; default to unbounded

### DIFF
--- a/.agents/adapters.md
+++ b/.agents/adapters.md
@@ -113,7 +113,8 @@ class MyFrameworkAdapter:
   `report_task_completed` / `_failed` / `_blocked` / `_cancelled`, the
   auto-complete is a no-op. But if the agent transitioned the task
   mid-flight to a non-terminal state without a terminal call, the
-  executor keeps re-invoking until `max_plan_reinvocations`.
+  executor keeps re-invoking until `max_task_invocations` (if set) or
+  the per-task-lineage cap trips.
 - **`invoke` must not crash on well-formed input.** If the underlying
   framework raises, catch and return `InvocationResult(..., error=...)`
   so the executor can surface it as a `TaskFailed`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,19 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
 
 ### Changed
 
+- Renamed `max_plan_reinvocations` to `max_task_invocations` on
+  `SequentialExecutor`, `ParallelDAGExecutor`, `Runner`, and
+  `goldfive.wrap()` / `goldfive.run()`. The default is now
+  `None` (unbounded) — per-task / per-tool caps
+  (`max_retries_per_task_lineage`, adapter-level loop guards) are
+  the primary guards against runaway invocations. The old kwarg is
+  still accepted for one release and emits a
+  `DeprecationWarning` that maps to the new parameter. Callers that
+  relied on the old 32 default should pass `max_task_invocations=32`
+  explicitly, or an appropriate ceiling for their workload.
 - #65 Follow-up cleanup from the Team Lead A drift audit
   (`SequentialExecutor.max_plan_reinvocations` default raised
-  from 3 to 32; minor doc fixes).
+  from 3 to 32; minor doc fixes). Superseded by the rename above.
 - #69 Reconciled `HarmonografSink` API docs with the shipped
   `harmonograf_client.HarmonografSink(client)` shape and canonical
   `:7531` port.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ outcome = await runner.run("make a presentation about waffles")
 
 Every default component is overridable — pass `planner=`,
 `executor=`, `sinks=`, `call_llm=`, `model=`, or
-`max_plan_reinvocations=` as keyword arguments to either function.
+`max_task_invocations=` as keyword arguments to either function.
 
 A runnable demo lives in
 [`examples/hello_callable.py`](examples/hello_callable.py).

--- a/bench/run_100_tasks.py
+++ b/bench/run_100_tasks.py
@@ -88,12 +88,12 @@ async def run_benchmark(jsonl_path: Path) -> tuple[float, int, bool]:
         agent=CallableAdapter(noop_agent, available_agents=["bench-agent"]),
         planner=StaticPlanner(plan),
         executor=SequentialExecutor(
-            max_plan_reinvocations=NUM_TASKS + 1,
+            max_task_invocations=NUM_TASKS + 1,
             fail_fast=True,
         ),
         goal_deriver=PassthroughGoalDeriver("100-task benchmark"),
         sinks=[sink],
-        max_plan_reinvocations=NUM_TASKS + 1,
+        max_task_invocations=NUM_TASKS + 1,
     )
 
     tracemalloc.start()

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -254,7 +254,7 @@ One of three terminal events is emitted:
 - `RunCompleted(run_id, outcome_summary)` — all tasks reached a
   terminal state and the plan is fully realized.
 - `RunAborted(run_id, reason)` — executor surrendered (e.g. hit
-  `max_plan_reinvocations` with tasks still PENDING, planner returned
+  `max_task_invocations` with tasks still PENDING, planner returned
   `None` during refine, unrecoverable drift).
 - Exception propagation — uncaught exceptions surface to
   `runner.run()`'s caller. Sinks still receive a `RunAborted` event

--- a/docs/design/EVENT-MODEL.md
+++ b/docs/design/EVENT-MODEL.md
@@ -60,7 +60,7 @@ envelope — there is no mixed-shape stream on the sink side.
 |---|---|---|
 | `RunStarted` | `Runner` | At the very top of `run()` before goal derivation. Carries `goal_summary` (the incoming `user_input` or the first goal's summary) and `started_at`. |
 | `RunCompleted` | `Executor` | When every task has reached a terminal state and the plan is fully realized. Carries `outcome_summary`. |
-| `RunAborted` | `Runner`, `Executor` | The `Runner` emits it when setup fails (goal derivation, plan generation, tool registration, steerer bind); the executor emits it when the plan cannot be driven to completion (e.g. `max_plan_reinvocations` exhausted, unrecoverable drift). Carries `reason`. |
+| `RunAborted` | `Runner`, `Executor` | The `Runner` emits it when setup fails (goal derivation, plan generation, tool registration, steerer bind); the executor emits it when the plan cannot be driven to completion (e.g. `max_task_invocations` exhausted, unrecoverable drift). Carries `reason`. |
 
 ### Goal and plan
 

--- a/docs/design/PROTOCOLS.md
+++ b/docs/design/PROTOCOLS.md
@@ -422,8 +422,10 @@ class Executor(Protocol):
     returns.
 - On drift ≥ warning: calls `planner.refine(...)`, swaps the plan,
   emits `PlanRevised`, and restarts the loop.
-- Enforces `max_plan_reinvocations` (typically 3): if the loop runs
-  that many times without net progress, aborts with `RunAborted`.
+- Optionally enforces `max_task_invocations` (default `None` ==
+  unbounded): if a finite integer is configured and the loop runs
+  that many adapter invocations without completing the plan, aborts
+  with `RunAborted`.
 - Emits `RunStarted` at entry and `RunCompleted` / `RunAborted` at
   exit.
 

--- a/docs/design/RATIONALE.md
+++ b/docs/design/RATIONALE.md
@@ -448,7 +448,7 @@ in-place edits and want first-class support, we'd revisit.
 
 **Observation.** `Runner.__init__` requires five named pieces:
 `agent`, `planner`, `executor`, plus the optional `goal_deriver`,
-`steerer`, `sinks`, `control`, `max_plan_reinvocations`. Most callers
+`steerer`, `sinks`, `control`, `max_task_invocations`. Most callers
 have one of {`BaseAgent`, `Client`, `callable`} and want to say "just
 run this with sensible defaults." `goldfive.wrap(agent)` does that in
 one call.
@@ -605,30 +605,44 @@ not — `make_event` is called from several test scenarios and from
 **Related.** [EVENT-MODEL.md §"Forward compatibility"](EVENT-MODEL.md#forward-compatibility),
 [.agents/debug-goldfive.md §"Common pitfalls"](../../.agents/debug-goldfive.md#common-pitfalls).
 
-## Why `max_plan_reinvocations` is a budget, not a time limit
+## Why `max_task_invocations` is a budget, not a time limit
 
-**Observation.** `Runner(..., max_plan_reinvocations=32)` and its
-per-executor equivalent cap the **number** of times the executor may
-re-invoke the planner (or, in the sequential executor, dispatch a
-task) before the run aborts. There is no wall-clock timeout at this
-layer.
+**Observation.** `Runner(..., max_task_invocations=N)` and its
+per-executor equivalent cap the **number** of adapter invocations
+(in the sequential executor) or plan refinements (in the parallel
+executor) that a single run may issue before aborting. The default
+is `None` — unbounded. There is no wall-clock timeout at this layer.
 
 **Intent.** Differentiate **stuck** from **slow**. An agent that takes
 ten minutes per task is slow (fine, maybe). An agent that loops
 through five refines per minute is stuck (not fine). A time budget
 would punish the slow case; an invocation budget only punishes the
-loopy case.
+loopy case. The unbounded default reflects that the primary guards
+against runaway loops live closer to the work: per-task-lineage
+caps (`max_retries_per_task_lineage`), per-tool-loop caps inside
+the adapter, and the adapter's own max-LLM-call ceilings.
 
 **Alternatives considered.**
 
 1. Wall-clock timeout. Rejected: too blunt for mixed workloads.
 2. Exponential-backoff between refines. Rejected: doesn't bound total
    work, just spaces it.
-3. No cap. Rejected: loops happen.
+3. Finite default (historically 32). Rejected: the old name
+   `max_plan_reinvocations` misled callers into thinking the value
+   was a refine-count cap and some set it to the number of expected
+   refinements (e.g. 8), which then tripped on routine large plans.
+   Unbounded-by-default plus explicit opt-in avoids that footgun.
 
-**Tradeoffs.** A stuck agent can still burn 32 refines before we
-notice. The cap is intentionally generous because the signal "we hit
-the cap" is more important than the signal "we hit it fast."
+**Tradeoffs.** Without a configured cap a truly stuck agent keeps
+burning invocations until the per-lineage cap or `fail_fast`
+catches it. Callers who want a belt-and-suspenders ceiling can set
+a finite integer.
+
+**Historical note.** The parameter was formerly called
+`max_plan_reinvocations`; that name implied a refine-count semantic
+that did not match the sequential executor's "total adapter
+invocations" behaviour. The rename is backwards-compatible for one
+release via a deprecation shim.
 
 **Signals this might be wrong.** If callers regularly want wall-clock
 timeouts, we may need a sibling knob. Today none do.

--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -182,12 +182,15 @@ timeout, or the `LOOPING_TOOL_CALL` guard (§5), or a CANCEL on the
 control channel.
 
 **Soundness gap (open):** there is no cap on the number of
-invocations per task. A task can be re-invoked indirectly through a
-refine that produces a `retry_<task>` task; if the retry also loops,
-a new refine is triggered, and so on up to
-`SequentialExecutor.max_plan_reinvocations` (default 32). This
-bounds the blast radius at ~32 × 500 = 16 000 LLM calls per run
-worst case. See §7.
+invocations per task by default. A task can be re-invoked indirectly
+through a refine that produces a `retry_<task>` task; if the retry
+also loops, a new refine is triggered, and so on. Blast radius is
+bounded primarily by `max_retries_per_task_lineage` (default 3,
+see §7.7) and by the per-tool / per-ADK turn caps inside the
+adapter; `SequentialExecutor.max_task_invocations` (default
+`None` == unbounded) can be set to a finite integer as a
+belt-and-suspenders run-wide cap when you want a hard ceiling on
+total adapter invocations. See §7.
 
 ---
 
@@ -240,8 +243,9 @@ rather than hiding it behind a stale plan.
 
 **Soundness gap (open):** refine failures do not themselves
 terminate the run. If the LLM is down entirely, the same drift can
-retrigger → refine fails → drift emitted again. The executor's
-`max_plan_reinvocations` cap eventually stops the loop, but there
+retrigger → refine fails → drift emitted again. The per-lineage
+cap (`max_retries_per_task_lineage`) and the optional
+`max_task_invocations` ceiling eventually stop the loop, but there
 is no per-drift-kind backoff or dedup. See §7.
 
 ---
@@ -513,8 +517,10 @@ impact.
 If the configured LLM is down, the same drift re-fires → refine
 fails → drift re-emitted (now with "refine failed" surface, §4.3)
 → but the underlying condition is unchanged → drift fires again on
-next tick. Eventually bounded by `max_plan_reinvocations`, but the
-budget is burned without forward progress.
+next tick. Eventually bounded by the per-lineage cap
+(`max_retries_per_task_lineage`) or by an explicit
+`max_task_invocations` ceiling when configured, but any budget is
+burned without forward progress.
 
 **Fix direction:** per-`(drift.kind, task_id)` refine-attempt
 counter. After N consecutive failures, mark the task FAILED
@@ -561,13 +567,17 @@ wasted turns is now 49 across the whole session — acceptable.
 ### 7.7 No per-task invocation cap
 
 If a refine produces a `retry_<task>` task and the retry also
-loops, another refine fires — bounded only by
-`max_plan_reinvocations` (default 32). For long runs on flaky
-agents this is ~32 × 500 = 16 000 LLM calls worst case.
+loops, another refine fires. The primary bound on blast radius is
+now the per-lineage cap `max_retries_per_task_lineage` (default 3),
+which refuses to invoke the adapter on the N+1st clone of any
+lineage root. `max_task_invocations` (default `None` == unbounded)
+can be set to a finite integer as an additional run-wide ceiling on
+adapter invocations when a hard budget is desired.
 
-**Fix direction:** add a `max_retries_per_task_id` (default 3) to
-the executor. After N refines that target the same task id's
-lineage, mark the task FAILED and cascade CANCEL downstream.
+**Fix direction:** implemented — `max_retries_per_task_lineage`
+applies the per-lineage cap. After N invocations on the same
+lineage, the next clone is refused and transitioned to FAILED in
+place; downstream tasks then block via dependency cascade.
 
 ### 7.8 CANCELLED cascade to downstream PENDING tasks (closed)
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -77,7 +77,7 @@ DEBUG line explaining the drop.
 
 Every default is overridable via keyword argument — `planner=`,
 `goal_deriver=`, `executor=`, `steerer=`, `sinks=`, and
-`max_plan_reinvocations=` all win over the auto-wiring when passed.
+`max_task_invocations=` all win over the auto-wiring when passed.
 
 ## Mental model in five sentences
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -152,7 +152,7 @@ The full trace is logged at `ERROR` on `goldfive.runner`.
 
 **What you see.** `RunStarted` and `PlanSubmitted` fire, but no
 `TaskStarted` ever does. The run terminates with reason
-`"exhausted max_plan_reinvocations=... with pending task <id>"` or
+`"exhausted max_task_invocations=... with pending task <id>"` or
 completes with zero tasks run.
 
 **Why it happens.** The executor only picks tasks whose predecessors
@@ -179,7 +179,7 @@ assert not missing, f"plan references unknown agents: {missing}"
 
 **What you see.** The adapter calls `report_task_started`, does work,
 returns — but the task never reaches `COMPLETED`. The executor loops
-until `max_plan_reinvocations` trips.
+until `max_task_invocations` trips.
 
 **Why it happens.** `SequentialExecutor` auto-transitions a task to
 `COMPLETED` (or `FAILED` if `InvocationResult.error` is set) only when

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -18,7 +18,7 @@ The benchmark in `bench/run_100_tasks.py` runs:
   no LLM call, no network I/O, and no compute beyond constructing the
   result.
 - The **`SequentialExecutor`** (single-threaded; one task at a time)
-  with `max_plan_reinvocations=101` so the budget cannot trip on the
+  with `max_task_invocations=101` so the budget cannot trip on the
   100-task plan.
 - A single **`JSONLPersistenceSink`** writing proto-encoded events to a
   temporary file. JSONL is the highest-fidelity sink we ship and is the

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -73,7 +73,7 @@ def wrap(
     sinks: Optional[list[EventSink]] = None,
     call_llm: Optional[Callable[[str, str, str], Awaitable[str]]] = None,
     model: Optional[str] = None,
-    max_plan_reinvocations: int = 32,
+    max_task_invocations: Optional[int] = None,
 ) -> Runner: ...
 
 
@@ -151,7 +151,7 @@ class Runner:
         steerer: Optional[Steerer] = None,
         sinks: Optional[list[EventSink]] = None,
         control: Optional[ControlChannel] = None,
-        max_plan_reinvocations: int = 3,
+        max_task_invocations: Optional[int] = None,
     ) -> None: ...
 
     async def run(
@@ -197,7 +197,7 @@ recovered goals. Tracked in issue #15.
 | `steerer` | `DefaultSteerer()` | Optional. |
 | `sinks` | `[]` | Optional. Recommended: at least `InMemorySink` in tests and `JSONLPersistenceSink` in prod. |
 | `control` | `None` | Optional `ControlChannel` for live pause / cancel / steer / rewind / approve / reject. When `None`, the run has no live-steering surface. May also be attached post-construction via the `control` setter; see "Extension API" below. See [../design/CONTROL.md](../design/CONTROL.md). |
-| `max_plan_reinvocations` | `3` | Stamped onto the planner context so executors that honour it can cap refine loops. |
+| `max_task_invocations` | `None` (unbounded) | Optional cap on adapter invocations per run, stamped onto the planner context so executors that honour it can cap refine / task-invocation loops. Accepts the deprecated `max_plan_reinvocations` kwarg for one release with a `DeprecationWarning`. |
 
 ### Extension API
 
@@ -461,7 +461,8 @@ class SequentialExecutor(Executor):
     def __init__(
         self,
         *,
-        max_plan_reinvocations: int = 32,
+        max_task_invocations: Optional[int] = None,  # None = unbounded
+        max_retries_per_task_lineage: int = 3,
         fail_fast: bool = True,
     ) -> None: ...
 
@@ -470,7 +471,7 @@ class ParallelDAGExecutor(Executor):
         self,
         max_concurrency: int = 0,  # 0 = unbounded fan-out
         drift_policy: Literal["cancel_stage", "finish_stage"] = "finish_stage",
-        max_plan_reinvocations: int = 3,
+        max_task_invocations: Optional[int] = None,  # None = unbounded
     ) -> None: ...
 ```
 

--- a/examples/adk_presentation/agent.py
+++ b/examples/adk_presentation/agent.py
@@ -206,7 +206,7 @@ async def run(*, topic: str, mock: bool) -> None:
         _build_agent(agent_model),
         planner=LLMPlanner(call_llm=planner_call_llm, model=model_tag),
         goal_deriver=LLMGoalDeriver(call_llm=goal_call_llm, model=model_tag),
-        executor=SequentialExecutor(max_plan_reinvocations=8),
+        executor=SequentialExecutor(max_task_invocations=8),
         sinks=[LoggingSink()],
     )
 

--- a/examples/drift_refinement.py
+++ b/examples/drift_refinement.py
@@ -163,7 +163,7 @@ async def main() -> None:
     runner = Runner(
         agent=CallableAdapter(worker_agent, available_agents=["worker"]),
         planner=planner,
-        executor=SequentialExecutor(fail_fast=False, max_plan_reinvocations=6),
+        executor=SequentialExecutor(fail_fast=False, max_task_invocations=6),
         goal_deriver=PassthroughGoalDeriver("Produce a report from API data"),
         steerer=steerer,
         sinks=[sink],

--- a/examples/harmonograf_observed/agent.py
+++ b/examples/harmonograf_observed/agent.py
@@ -100,7 +100,7 @@ async def main() -> None:
     runner = Runner(
         agent=CallableAdapter(worker_agent, available_agents=["worker"]),
         planner=StaticPlanner(build_plan()),
-        executor=SequentialExecutor(max_plan_reinvocations=8),
+        executor=SequentialExecutor(max_task_invocations=8),
         goal_deriver=PassthroughGoalDeriver("Research, draft, review, publish"),
         sinks=sinks,
     )

--- a/examples/live_steering.py
+++ b/examples/live_steering.py
@@ -126,7 +126,7 @@ async def main() -> None:
     runner = Runner(
         agent=CallableAdapter(_slow_agent, available_agents=["writer"]),
         planner=LLMPlanner(call_llm=_call_llm, model="stub"),
-        executor=SequentialExecutor(max_plan_reinvocations=10),
+        executor=SequentialExecutor(max_task_invocations=10),
         goal_deriver=PassthroughGoalDeriver("live-steering-demo"),
         steerer=DefaultSteerer(),
         sinks=[sink],

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -22,6 +22,7 @@ keyword argument.
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -60,7 +61,8 @@ def wrap(
     control: ControlChannel | None = None,
     call_llm: CallLLM | None = None,
     model: str | None = None,
-    max_plan_reinvocations: int = 32,
+    max_task_invocations: int | None = None,
+    **legacy_kwargs: Any,
 ) -> Runner:
     """Build a :class:`Runner` that drives ``agent`` with goldfive.
 
@@ -79,7 +81,7 @@ def wrap(
         :class:`LLMGoalDeriver` / :class:`LiteralGoalDeriver`.
     executor:
         Optional :class:`Executor` override. Defaults to
-        :class:`SequentialExecutor(max_plan_reinvocations=...)`.
+        :class:`SequentialExecutor(max_task_invocations=...)`.
     steerer:
         Optional :class:`Steerer` override. Defaults to
         :class:`DefaultSteerer`.
@@ -99,10 +101,12 @@ def wrap(
         Optional model name passed to :class:`LLMPlanner` /
         :class:`LLMGoalDeriver`. Ignored when ``call_llm`` is omitted
         and no LLM is detected on the agent.
-    max_plan_reinvocations:
-        Cap on how many times the executor may re-invoke the planner
-        for refine loops. Default ``32``; flowed into both the
+    max_task_invocations:
+        Optional cap on total adapter invocations per run. Defaults to
+        ``None`` (unbounded); flowed into both the
         :class:`SequentialExecutor` default and the :class:`Runner`.
+        Accepts the deprecated ``max_plan_reinvocations`` kwarg for one
+        release with a :class:`DeprecationWarning`.
 
     Returns
     -------
@@ -159,8 +163,22 @@ def wrap(
         )
         resolved_goal_deriver = LiteralGoalDeriver()
 
+    if "max_plan_reinvocations" in legacy_kwargs:
+        legacy_value = legacy_kwargs.pop("max_plan_reinvocations")
+        warnings.warn(
+            "goldfive.wrap(max_plan_reinvocations=...) is deprecated; use "
+            "max_task_invocations=... instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if max_task_invocations is None:
+            max_task_invocations = legacy_value
+    if legacy_kwargs:
+        unexpected = ", ".join(sorted(legacy_kwargs))
+        raise TypeError(f"goldfive.wrap got unexpected keyword argument(s): {unexpected}")
+
     resolved_executor: Executor = executor or SequentialExecutor(
-        max_plan_reinvocations=max_plan_reinvocations
+        max_task_invocations=max_task_invocations
     )
     resolved_steerer: Steerer = steerer or DefaultSteerer()
     resolved_sinks: list[EventSink] = (
@@ -175,7 +193,7 @@ def wrap(
         steerer=resolved_steerer,
         sinks=resolved_sinks,
         control=control,
-        max_plan_reinvocations=max_plan_reinvocations,
+        max_task_invocations=max_task_invocations,
     )
 
     if is_adk_agent(agent):

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Literal
+import warnings
+from typing import TYPE_CHECKING, Any, Literal
 
 from goldfive.events import (
     emit as emit_event,
@@ -93,28 +94,49 @@ class ParallelDAGExecutor:
           before the next stage.
         * ``"finish_stage"`` (default) — the stage is allowed to
           complete; refinement runs before the next stage.
-    max_plan_reinvocations:
-        Safety cap on the number of times the planner may replace the
-        plan during a single ``run()``. Protects against refine loops.
+    max_task_invocations:
+        Optional safety cap on the number of times the planner may replace
+        the plan during a single ``run()``. Protects against refine loops.
+        Defaults to ``None`` (unbounded); per-task / per-tool caps are the
+        primary guards.
+
+        Note: in the parallel executor this counter increments on plan
+        refinement (not per task invocation as in
+        :class:`SequentialExecutor`); the parameter is unified for naming
+        consistency and backwards compatibility.
     """
 
     def __init__(
         self,
         max_concurrency: int = 0,
         drift_policy: Literal["cancel_stage", "finish_stage"] = "finish_stage",
-        max_plan_reinvocations: int = 3,
+        max_task_invocations: int | None = None,
+        **legacy_kwargs: Any,
     ) -> None:
+        if "max_plan_reinvocations" in legacy_kwargs:
+            legacy_value = legacy_kwargs.pop("max_plan_reinvocations")
+            warnings.warn(
+                "ParallelDAGExecutor(max_plan_reinvocations=...) is deprecated; "
+                "use max_task_invocations=... instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if max_task_invocations is None:
+                max_task_invocations = legacy_value
+        if legacy_kwargs:
+            unexpected = ", ".join(sorted(legacy_kwargs))
+            raise TypeError(f"ParallelDAGExecutor got unexpected keyword argument(s): {unexpected}")
         if max_concurrency < 0:
             raise ValueError("max_concurrency must be >= 0")
         if drift_policy not in ("cancel_stage", "finish_stage"):
             raise ValueError(
                 f"drift_policy must be 'cancel_stage' or 'finish_stage', got {drift_policy!r}"
             )
-        if max_plan_reinvocations < 0:
-            raise ValueError("max_plan_reinvocations must be >= 0")
+        if max_task_invocations is not None and max_task_invocations < 0:
+            raise ValueError("max_task_invocations must be >= 0")
         self.max_concurrency = max_concurrency
         self.drift_policy: Literal["cancel_stage", "finish_stage"] = drift_policy
-        self.max_plan_reinvocations = max_plan_reinvocations
+        self.max_task_invocations: int | None = max_task_invocations
 
     # ------------------------------------------------------------------
     # Executor protocol
@@ -264,15 +286,18 @@ class ParallelDAGExecutor:
                     drift = None
 
                 if drift is not None:
-                    if refinements_used >= self.max_plan_reinvocations:
+                    if (
+                        self.max_task_invocations is not None
+                        and refinements_used >= self.max_task_invocations
+                    ):
                         log.warning(
                             "ParallelDAGExecutor: drift detected but reinvocation "
                             "budget exhausted (%d) — aborting",
-                            self.max_plan_reinvocations,
+                            self.max_task_invocations,
                         )
                         abort_reason = (
                             f"plan reinvocation budget exhausted "
-                            f"({self.max_plan_reinvocations})"
+                            f"({self.max_task_invocations})"
                         )
                         break
 

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -18,8 +18,10 @@ Key behaviors
 * After each invocation, re-read plan state: tasks may have moved to
   ``COMPLETED`` / ``FAILED`` / ``BLOCKED`` via reporting tools; the steerer
   may also have mutated the plan in response to drift (``PlanRevised``).
-* Budget the total number of adapter invocations with ``max_plan_reinvocations``
-  so a stuck agent cannot spin forever.
+* Optionally budget the total number of adapter invocations with
+  ``max_task_invocations`` so a stuck agent cannot spin forever. The
+  default is ``None`` (unbounded); per-task / per-tool caps are the
+  primary guards against runaway loops.
 * Terminate with :class:`RunCompleted` on success or :class:`RunAborted`
   when ``fail_fast`` is set and a task fails fatally.
 
@@ -34,7 +36,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from typing import TYPE_CHECKING
+import warnings
+from typing import TYPE_CHECKING, Any
 
 from goldfive.events import (
     emit,
@@ -63,15 +66,16 @@ class SequentialExecutor(Executor):
 
     Parameters
     ----------
-    max_plan_reinvocations:
-        Upper bound on the number of adapter ``invoke()`` calls a single
-        :meth:`run` may issue. Each eligible task consumes one invocation;
-        when drift triggers a plan revision, the new plan's remaining tasks
-        share the same budget. Defaults to ``32`` — comfortably covers a
-        plan with 10+ tasks plus a few refinement cycles. A stuck agent
-        still aborts via ``fail_fast`` or (in pathological cases) the
-        budget; the old default of ``3`` was tuned to the harmonograf
-        re-invocation cap and surprised callers running realistic plans.
+    max_task_invocations:
+        Optional upper bound on the number of adapter ``invoke()`` calls
+        a single :meth:`run` may issue. Each eligible task consumes one
+        invocation; when drift triggers a plan revision, the new plan's
+        remaining tasks share the same budget. Defaults to ``None``
+        (unbounded) — the run proceeds until every task reaches a
+        terminal state or a drift / ``fail_fast`` / per-task-lineage
+        cap terminates it. Set to an integer to enforce a ceiling on
+        total adapter invocations for defensive, belt-and-suspenders
+        containment.
     max_retries_per_task_lineage:
         Upper bound on the number of adapter ``invoke()`` calls that may
         be spent on any one task "lineage" — the original task plus any
@@ -96,11 +100,32 @@ class SequentialExecutor(Executor):
     def __init__(
         self,
         *,
-        max_plan_reinvocations: int = 32,
+        max_task_invocations: int | None = None,
         max_retries_per_task_lineage: int = 3,
         fail_fast: bool = True,
+        **legacy_kwargs: Any,
     ) -> None:
-        self.max_plan_reinvocations = int(max_plan_reinvocations)
+        # Backwards-compatible alias: accept the old name for one release
+        # and emit a DeprecationWarning mapping it to the new one. Remove
+        # in a future release.
+        if "max_plan_reinvocations" in legacy_kwargs:
+            legacy_value = legacy_kwargs.pop("max_plan_reinvocations")
+            warnings.warn(
+                "SequentialExecutor(max_plan_reinvocations=...) is deprecated; "
+                "use max_task_invocations=... instead. The parameter has been "
+                "renamed for clarity — it caps total adapter invocations per "
+                "run, not plan refinements.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if max_task_invocations is None:
+                max_task_invocations = legacy_value
+        if legacy_kwargs:
+            unexpected = ", ".join(sorted(legacy_kwargs))
+            raise TypeError(f"SequentialExecutor got unexpected keyword argument(s): {unexpected}")
+        self.max_task_invocations: int | None = (
+            None if max_task_invocations is None else int(max_task_invocations)
+        )
         self.max_retries_per_task_lineage = int(max_retries_per_task_lineage)
         self.fail_fast = bool(fail_fast)
 
@@ -153,10 +178,12 @@ class SequentialExecutor(Executor):
         last_plan_id = plan.id
         last_revision_index = plan.revision_index
 
-        # Cap by max_plan_reinvocations: this is the number of adapter
+        # Cap by max_task_invocations: this is the number of adapter
         # invocations we'll allow for the whole run. Each eligible task
-        # burns one; mid-run plan revisions do not refund any.
-        while invocations < self.max_plan_reinvocations:
+        # burns one; mid-run plan revisions do not refund any. ``None``
+        # means unbounded — the loop exits when no eligible task remains
+        # or when ``fail_fast`` / the per-lineage cap trips.
+        while self.max_task_invocations is None or invocations < self.max_task_invocations:
             # ------------------------------------------------------------------
             # Control channel: drain any pending messages before picking
             # the next task. PAUSE here blocks until RESUME arrives.
@@ -262,11 +289,13 @@ class SequentialExecutor(Executor):
             lineage_invocations[lineage_root] = lineage_count + 1
 
             log.debug(
-                "SequentialExecutor: invoking task=%s (invocation %d/%d, "
+                "SequentialExecutor: invoking task=%s (invocation %d/%s, "
                 "lineage_root=%s, lineage_count=%d/%d)",
                 task.id,
                 invocations,
-                self.max_plan_reinvocations,
+                "unbounded"
+                if self.max_task_invocations is None
+                else str(self.max_task_invocations),
                 lineage_root,
                 lineage_count + 1,
                 self.max_retries_per_task_lineage,
@@ -406,11 +435,16 @@ class SequentialExecutor(Executor):
             )
 
         # If we exhausted the invocation budget with work still pending,
-        # that is also a failure (stuck agent).
+        # that is also a failure (stuck agent). Only applies when a
+        # finite cap was configured.
         remaining = _pick_next_task(session.plan or plan)
-        if invocations >= self.max_plan_reinvocations and remaining is not None:
+        if (
+            self.max_task_invocations is not None
+            and invocations >= self.max_task_invocations
+            and remaining is not None
+        ):
             reason = (
-                f"exhausted max_plan_reinvocations={self.max_plan_reinvocations} "
+                f"exhausted max_task_invocations={self.max_task_invocations} "
                 f"with pending task {remaining.id}"
             )
             await emit(

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -36,6 +36,7 @@ and are loaded lazily by callers.
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -99,10 +100,11 @@ class Runner:
         controller (harmonograf UI, CLI, tests). When provided, the
         Runner forwards it into the executor, which polls the channel
         between tasks and races against adapter invocations mid-task.
-    max_plan_reinvocations:
-        Safety cap on plan refinement cycles. Passed through to the
-        executor (via ``context``) so executors that honour it can
-        enforce the cap.
+    max_task_invocations:
+        Optional safety cap on adapter invocations per run. Stamped onto
+        the planner context so executors that honour it can enforce the
+        cap. Defaults to ``None`` (unbounded); per-task / per-tool caps
+        are the primary guards against runaway loops.
     """
 
     def __init__(
@@ -115,9 +117,23 @@ class Runner:
         steerer: Steerer | None = None,
         sinks: list[EventSink] | None = None,
         control: ControlChannel | None = None,
-        max_plan_reinvocations: int = 3,
+        max_task_invocations: int | None = None,
         conversation: Conversation | None = None,
+        **legacy_kwargs: Any,
     ) -> None:
+        if "max_plan_reinvocations" in legacy_kwargs:
+            legacy_value = legacy_kwargs.pop("max_plan_reinvocations")
+            warnings.warn(
+                "Runner(max_plan_reinvocations=...) is deprecated; use "
+                "max_task_invocations=... instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if max_task_invocations is None:
+                max_task_invocations = legacy_value
+        if legacy_kwargs:
+            unexpected = ", ".join(sorted(legacy_kwargs))
+            raise TypeError(f"Runner got unexpected keyword argument(s): {unexpected}")
         self.agent = agent
         self.planner = planner
         self.executor = executor
@@ -127,7 +143,7 @@ class Runner:
         self._control: ControlChannel | None = control
         self._close_hooks: list[Callable[[], Awaitable[None]]] = []
         self._closed: bool = False
-        self.max_plan_reinvocations = max_plan_reinvocations
+        self.max_task_invocations: int | None = max_task_invocations
         self._conversation: Conversation = conversation or Conversation.new()
         # Tracks whether we've emitted the ConversationStarted event for
         # the current Conversation. Flips back to False on new_conversation().
@@ -197,7 +213,7 @@ class Runner:
         # Caller-supplied context wins on key collisions.
         planner_context: dict[str, Any] = {
             "run_id": session.run_id,
-            "max_plan_reinvocations": self.max_plan_reinvocations,
+            "max_task_invocations": self.max_task_invocations,
         }
         planner_context.update(self._conversation.prior_turn_context())
         if context:

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -913,7 +913,7 @@ class DefaultSteerer:
         ``FAILED`` (non-recoverable), and emit a CRITICAL
         ``REPEATED_FAILURE`` drift so sinks see the back-off. This
         bounds the loop that would otherwise re-fire the same drift
-        every tick until ``SequentialExecutor.max_plan_reinvocations``
+        every tick until ``SequentialExecutor.max_task_invocations``
         tripped (see TASK-LIFECYCLE.md §7.3).
         """
         await self._emit_drift_detected(session, drift)

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -348,7 +348,7 @@ class Session:
     # for the given (kind, task) tuple; reset on a successful refine.
     # Consumed by :class:`~goldfive.steerer.DefaultSteerer` to back off
     # and mark the task FAILED after N consecutive failures, preventing
-    # the same drift from looping until ``max_plan_reinvocations`` trips.
+    # the same drift from looping until ``max_task_invocations`` trips.
     refine_failure_counts: dict[tuple[str, str], int] = dataclasses.field(
         default_factory=dict
     )

--- a/tests/test_executor_control.py
+++ b/tests/test_executor_control.py
@@ -229,7 +229,7 @@ async def test_sequential_cancel_mid_task_aborts_run() -> None:
             )
         )
 
-    executor = SequentialExecutor(max_plan_reinvocations=5)
+    executor = SequentialExecutor(max_task_invocations=5)
 
     runner_task = asyncio.create_task(
         executor.run(
@@ -316,7 +316,7 @@ async def test_sequential_steer_mid_task_cancels_and_replans() -> None:
             )
         )
 
-    executor = SequentialExecutor(max_plan_reinvocations=8)
+    executor = SequentialExecutor(max_task_invocations=8)
 
     runner_task = asyncio.create_task(
         executor.run(
@@ -383,7 +383,7 @@ async def test_sequential_pause_blocks_next_task_until_resume() -> None:
     # Send PAUSE before anything starts; pre-task drain picks it up.
     await channel.send(ControlMessage(kind=ControlKind.PAUSE))
 
-    executor = SequentialExecutor(max_plan_reinvocations=8)
+    executor = SequentialExecutor(max_task_invocations=8)
 
     runner_task = asyncio.create_task(
         executor.run(
@@ -455,7 +455,7 @@ async def test_sequential_rewind_between_tasks_re_executes_target() -> None:
 
     adapter = StubAdapter(on_invoke=_handler)
 
-    executor = SequentialExecutor(max_plan_reinvocations=12)
+    executor = SequentialExecutor(max_task_invocations=12)
     outcome = await asyncio.wait_for(
         executor.run(
             plan=plan,
@@ -548,7 +548,7 @@ async def test_sequential_status_query_emits_event_and_acks_success() -> None:
 
     adapter = StubAdapter(on_invoke=_handler)
 
-    executor = SequentialExecutor(max_plan_reinvocations=8)
+    executor = SequentialExecutor(max_task_invocations=8)
     outcome = await asyncio.wait_for(
         executor.run(
             plan=plan,
@@ -609,7 +609,7 @@ async def test_sequential_cancel_abandons_uncooperative_adapter() -> None:
 
     adapter = StubAdapter(on_invoke=_uncooperative)
 
-    executor = SequentialExecutor(max_plan_reinvocations=5)
+    executor = SequentialExecutor(max_task_invocations=5)
 
     # Shrink the grace window via a targeted monkey-patch so the test
     # runs in ~0.3s, not 5s. Grab the original from __dict__ so the

--- a/tests/test_live_steering_e2e.py
+++ b/tests/test_live_steering_e2e.py
@@ -190,7 +190,7 @@ async def test_cancel_mid_task_aborts_run() -> None:
     runner = Runner(
         agent=CallableAdapter(_slow_agent, available_agents=["writer"]),
         planner=planner,
-        executor=SequentialExecutor(max_plan_reinvocations=5),
+        executor=SequentialExecutor(max_task_invocations=5),
         goal_deriver=PassthroughGoalDeriver("cancel-demo"),
         steerer=DefaultSteerer(),
         sinks=[sink],
@@ -274,7 +274,7 @@ async def test_steer_mid_task_triggers_refine_and_continues() -> None:
     runner = Runner(
         agent=CallableAdapter(_agent, available_agents=["writer"]),
         planner=planner,
-        executor=SequentialExecutor(max_plan_reinvocations=10),
+        executor=SequentialExecutor(max_task_invocations=10),
         goal_deriver=PassthroughGoalDeriver("steer-demo"),
         steerer=DefaultSteerer(),
         sinks=[sink],
@@ -353,7 +353,7 @@ async def test_pause_blocks_next_task_until_resume() -> None:
     runner = Runner(
         agent=CallableAdapter(_agent, available_agents=["writer"]),
         planner=planner,
-        executor=SequentialExecutor(max_plan_reinvocations=8),
+        executor=SequentialExecutor(max_task_invocations=8),
         goal_deriver=PassthroughGoalDeriver("pause-demo"),
         steerer=DefaultSteerer(),
         sinks=[sink],
@@ -414,7 +414,7 @@ async def test_rewind_resets_target_and_downstream_tasks() -> None:
     runner = Runner(
         agent=CallableAdapter(_agent, available_agents=["writer"]),
         planner=planner,
-        executor=SequentialExecutor(max_plan_reinvocations=12),
+        executor=SequentialExecutor(max_task_invocations=12),
         goal_deriver=PassthroughGoalDeriver("rewind-demo"),
         steerer=DefaultSteerer(),
         sinks=[sink],
@@ -473,7 +473,7 @@ async def test_status_query_emits_synthetic_report() -> None:
     runner = Runner(
         agent=CallableAdapter(_agent, available_agents=["writer"]),
         planner=planner,
-        executor=SequentialExecutor(max_plan_reinvocations=8),
+        executor=SequentialExecutor(max_task_invocations=8),
         goal_deriver=PassthroughGoalDeriver("status-demo"),
         steerer=DefaultSteerer(),
         sinks=[sink],

--- a/tests/test_parallel_executor.py
+++ b/tests/test_parallel_executor.py
@@ -474,11 +474,11 @@ async def test_info_severity_drift_does_not_trigger_refine() -> None:
 
 @pytest.mark.asyncio
 async def test_reinvocation_budget_exhaustion_aborts() -> None:
-    """After ``max_plan_reinvocations`` refinements the walker aborts.
+    """After ``max_task_invocations`` refinements the walker aborts.
 
     We simulate an adversarial refine loop: each refined plan injects a
     brand-new task that itself drifts, so the planner is asked to refine
-    again. After ``max_plan_reinvocations`` rounds the walker gives up.
+    again. After ``max_task_invocations`` rounds the walker gives up.
     """
 
     def make_plan(round_: int) -> Plan:
@@ -537,7 +537,7 @@ async def test_reinvocation_budget_exhaustion_aborts() -> None:
     planner = AlwaysRefiningPlanner()
     adapter = AlwaysDriftingAdapter(delay=0.005)
     executor = ParallelDAGExecutor(
-        max_concurrency=0, max_plan_reinvocations=2
+        max_concurrency=0, max_task_invocations=2
     )
     outcome = await executor.run(
         plan=make_plan(1),

--- a/tests/test_runner_integration.py
+++ b/tests/test_runner_integration.py
@@ -204,8 +204,8 @@ async def test_runner_accepts_prebuilt_goals_list() -> None:
     assert outcome.session.goals and outcome.session.goals[0].id == "g0"
 
 
-async def test_runner_respects_max_plan_reinvocations() -> None:
-    """``max_plan_reinvocations`` caps refine() calls; after the cap the
+async def test_runner_respects_max_task_invocations() -> None:
+    """``max_task_invocations`` caps refine() calls; after the cap the
     run should terminate rather than loop forever."""
 
     runner_mod = pytest.importorskip("goldfive.runner")
@@ -221,7 +221,7 @@ async def test_runner_respects_max_plan_reinvocations() -> None:
         pytest.skip("Required goldfive modules not yet implemented")
 
     # A planner that always requests a new refine; the runner must still
-    # terminate because max_plan_reinvocations caps the loop.
+    # terminate because max_task_invocations caps the loop.
     class _LoopingPlanner(_DAGPlanner):
         async def refine(self, *, plan, drift, goals):
             self.refine_calls += 1
@@ -244,7 +244,7 @@ async def test_runner_respects_max_plan_reinvocations() -> None:
         executor=SequentialExecutor(),
         steerer=DefaultSteerer(),
         sinks=[],
-        max_plan_reinvocations=2,
+        max_task_invocations=2,
     )
     outcome = await runner.run([types.Goal(id="g1", summary="cap me")])
     # Whatever the final outcome, refine_calls must not exceed the cap.

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -203,8 +203,8 @@ async def test_linear_plan_runs_to_completion() -> None:
 
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_current)
 
-    # Default max_plan_reinvocations=3; allow exactly 3 tasks.
-    executor = SequentialExecutor(max_plan_reinvocations=3)
+    # Default max_task_invocations=3; allow exactly 3 tasks.
+    executor = SequentialExecutor(max_task_invocations=3)
     outcome = await executor.run(
         plan=plan,
         session=session,
@@ -290,7 +290,7 @@ async def test_drift_mid_run_applies_refined_plan() -> None:
 
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_maybe_drift)
 
-    executor = SequentialExecutor(max_plan_reinvocations=5)
+    executor = SequentialExecutor(max_task_invocations=5)
     outcome = await executor.run(
         plan=plan,
         session=session,
@@ -334,7 +334,7 @@ async def test_fail_fast_stops_on_task_failure() -> None:
 
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_fail_middle)
 
-    executor = SequentialExecutor(max_plan_reinvocations=5, fail_fast=True)
+    executor = SequentialExecutor(max_task_invocations=5, fail_fast=True)
     outcome = await executor.run(
         plan=plan,
         session=session,
@@ -379,7 +379,7 @@ async def test_fail_fast_false_continues_past_failure() -> None:
 
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_fail_b)
 
-    executor = SequentialExecutor(max_plan_reinvocations=5, fail_fast=False)
+    executor = SequentialExecutor(max_task_invocations=5, fail_fast=False)
     outcome = await executor.run(
         plan=plan,
         session=session,
@@ -428,7 +428,7 @@ async def test_budget_terminates_stuck_run() -> None:
 
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_stuck)
 
-    executor = SequentialExecutor(max_plan_reinvocations=2, fail_fast=True)
+    executor = SequentialExecutor(max_task_invocations=2, fail_fast=True)
     outcome = await executor.run(
         plan=plan,
         session=session,
@@ -533,7 +533,7 @@ async def test_retry_lineage_cap_fails_task_after_N_retries() -> None:
     # cap=2 -> allow 2 invocations on lineage root "t0"; the 3rd clone
     # is refused before the adapter is called.
     executor = SequentialExecutor(
-        max_plan_reinvocations=32,
+        max_task_invocations=32,
         max_retries_per_task_lineage=2,
         fail_fast=False,
     )
@@ -606,7 +606,7 @@ async def test_retry_lineage_cap_is_per_task_not_global() -> None:
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_fail_first_then_succeed)
 
     executor = SequentialExecutor(
-        max_plan_reinvocations=32,
+        max_task_invocations=32,
         max_retries_per_task_lineage=2,
         fail_fast=False,
     )
@@ -687,7 +687,7 @@ async def test_retry_lineage_cap_passes_on_successful_retry() -> None:
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_fail_then_retry_succeeds)
 
     executor = SequentialExecutor(
-        max_plan_reinvocations=32,
+        max_task_invocations=32,
         max_retries_per_task_lineage=3,
         fail_fast=False,
     )
@@ -750,7 +750,7 @@ async def test_retry_lineage_cap_collapses_nested_retry_prefixes() -> None:
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_task)
 
     executor = SequentialExecutor(
-        max_plan_reinvocations=32,
+        max_task_invocations=32,
         max_retries_per_task_lineage=2,
         fail_fast=False,
     )
@@ -811,7 +811,7 @@ async def test_executor_run_with_orphaned_pending_reports_failure() -> None:
 
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_cancel_t0)
 
-    executor = SequentialExecutor(max_plan_reinvocations=5)
+    executor = SequentialExecutor(max_task_invocations=5)
     outcome = await executor.run(
         plan=plan,
         session=session,
@@ -850,7 +850,7 @@ async def test_executor_emits_plan_divergence_when_pending_orphaned() -> None:
 
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_cancel_t0)
 
-    executor = SequentialExecutor(max_plan_reinvocations=5)
+    executor = SequentialExecutor(max_task_invocations=5)
     await executor.run(
         plan=plan,
         session=session,
@@ -894,7 +894,7 @@ async def test_executor_skips_audit_when_all_tasks_terminal() -> None:
 
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_current)
 
-    executor = SequentialExecutor(max_plan_reinvocations=5)
+    executor = SequentialExecutor(max_task_invocations=5)
     outcome = await executor.run(
         plan=plan,
         session=session,
@@ -954,7 +954,7 @@ async def _run_happy_executor(
         return InvocationResult(task_id=task.id, text="ok")
 
     adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_current)
-    executor = SequentialExecutor(max_plan_reinvocations=5)
+    executor = SequentialExecutor(max_task_invocations=5)
     outcome = await executor.run(
         plan=plan,
         session=session,
@@ -1076,3 +1076,105 @@ async def test_unmet_goal_short_circuits_on_first_false() -> None:
     # Reason names the first goal, not the second.
     assert "first goal" in outcome.reason
     assert "second goal" not in outcome.reason
+
+
+# ---------------------------------------------------------------------------
+# max_task_invocations: rename + unbounded default + deprecation shim.
+# ---------------------------------------------------------------------------
+
+
+async def test_max_task_invocations_unbounded_default_completes_large_plan() -> None:
+    """With the new default (``None`` == unbounded), a plan with more
+    tasks than the old default cap (32) still runs to completion.
+
+    The executor must not abort with "exhausted max_task_invocations=..."
+    when no cap was configured; only the natural plan completion
+    terminates the run.
+    """
+    n = 40  # comfortably above the old default of 32.
+    plan = _linear_plan(n)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _complete_current(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_current)
+
+    # Default: no cap passed. Must still complete all 40 tasks.
+    executor = SequentialExecutor(max_retries_per_task_lineage=n + 1)
+    assert executor.max_task_invocations is None
+
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is True
+    assert len(adapter.invocations) == n
+    for t in plan.tasks:
+        assert t.status == TaskStatus.COMPLETED
+    assert sink.payload_kinds()[-1] == "run_completed"
+
+
+async def test_max_task_invocations_explicit_cap_honored() -> None:
+    """An explicit ``max_task_invocations=3`` aborts the run after
+    exactly 3 adapter invocations when work remains, with a reason
+    that names the new parameter.
+    """
+    plan = _linear_plan(5)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _complete_current(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_current)
+
+    executor = SequentialExecutor(max_task_invocations=3)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is False
+    assert len(adapter.invocations) == 3
+    assert "max_task_invocations=3" in outcome.reason
+    assert sink.payload_kinds()[-1] == "run_aborted"
+
+
+def test_deprecation_warning_fires_for_old_kwarg() -> None:
+    """Passing ``max_plan_reinvocations=`` emits a :class:`DeprecationWarning`
+    and maps to the new attribute name.
+    """
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        executor = SequentialExecutor(max_plan_reinvocations=5)
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, "expected a DeprecationWarning for max_plan_reinvocations"
+    assert "max_task_invocations" in str(deprecations[0].message)
+    # The legacy value is mapped onto the new attribute.
+    assert executor.max_task_invocations == 5
+    # The old attribute is no longer exposed on the instance.
+    assert not hasattr(executor, "max_plan_reinvocations")

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -206,11 +206,11 @@ async def test_wrap_goal_deriver_override_wins() -> None:
 
 
 async def test_wrap_forwards_kwargs_to_runner() -> None:
-    """``max_plan_reinvocations`` flows into the constructed Runner."""
-    runner = goldfive.wrap(_happy_agent, max_plan_reinvocations=7)
-    assert runner.max_plan_reinvocations == 7
+    """``max_task_invocations`` flows into the constructed Runner."""
+    runner = goldfive.wrap(_happy_agent, max_task_invocations=7)
+    assert runner.max_task_invocations == 7
     assert isinstance(runner.executor, SequentialExecutor)
-    assert runner.executor.max_plan_reinvocations == 7
+    assert runner.executor.max_task_invocations == 7
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wrap_adk.py
+++ b/tests/test_wrap_adk.py
@@ -134,7 +134,7 @@ async def test_run_programmatically_returns_outcome(stub_call_llm: Any) -> None:
         return InvocationResult(task_id=task.id, text=f"ok: {task.title}")
 
     wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
-    wrapped.runner.executor = SequentialExecutor(max_plan_reinvocations=3)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
 
     outcome = await wrapped.run(
         [goldfive.Goal(id="g1", summary="say hi")],
@@ -190,7 +190,7 @@ async def test_run_async_yields_events_for_user_turn(stub_call_llm: Any) -> None
         return InvocationResult(task_id=task.id, text=f"ok: {task.title}")
 
     wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
-    wrapped.runner.executor = SequentialExecutor(max_plan_reinvocations=3)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
 
     ctx = _FakeCtx("make a thing")
     events = [evt async for evt in wrapped._run_async_impl(ctx)]


### PR DESCRIPTION
## Summary

- Renames `max_plan_reinvocations` to `max_task_invocations` on `SequentialExecutor`, `ParallelDAGExecutor`, `Runner`, and `goldfive.wrap()` / `goldfive.run()`. The old name implied a refine-count semantic that did not match the sequential executor's actual behaviour (total adapter invocations per run), and a misread of `=8` recently caused a live run to abort at 7 completed tasks when the author thought the value was a refine cap.
- Changes the default from a finite number (sequential: 32, runner: 3) to `None` (unbounded). Per-task / per-tool caps (`max_retries_per_task_lineage`, adapter-level loop guards) are now the primary guards against runaway invocations. Callers that want a run-wide ceiling can pass a finite integer.
- Adds a backwards-compatible deprecation shim: `max_plan_reinvocations=` is still accepted for one release and emits a `DeprecationWarning` mapping it onto the new parameter. Deletable in a later release.

## Flagged divergence worth noting

`Runner` and the executors previously had **independent defaults** for the same logical parameter:

- `Runner.max_plan_reinvocations` defaulted to `3`
- `SequentialExecutor.max_plan_reinvocations` defaulted to `32`
- `ParallelDAGExecutor.max_plan_reinvocations` defaulted to `3`

The Runner stamped its value onto the planner context; the executor read its own attribute. If a caller constructed `Runner(executor=SequentialExecutor())`, the Runner's context advertised `3` while the executor enforced `32`. This is the kind of footgun the task instructions asked me to flag explicitly. Both are now unified at `None` (unbounded).

## Note on parallel executor semantics

In `ParallelDAGExecutor`, the counter increments on **plan refinement** (not per task invocation). The rename follows the user's instruction to unify the name across executors, and the docstring now calls out this semantic difference explicitly. If a follow-up wants to split the concepts (`max_task_invocations` vs `max_plan_refinements`) that should be a separate change.

## Test plan

- [x] `uv run --extra dev --extra adk pytest -q` — 557 passed, 40 skipped, 1 unrelated warning.
- [x] `uv run --extra dev ruff check .` — clean.
- [x] `uv run --extra dev ruff format --check` on my introduced code — clean (pre-existing repo-wide format violations left untouched).
- [x] New unit tests in `tests/test_sequential_executor.py`:
  - `test_max_task_invocations_unbounded_default_completes_large_plan` — 40-task plan runs to completion under the new unbounded default.
  - `test_max_task_invocations_explicit_cap_honored` — explicit cap=3 aborts at 3 with the reason naming `max_task_invocations=3`.
  - `test_deprecation_warning_fires_for_old_kwarg` — old kwarg emits `DeprecationWarning` and maps to the new attribute.
