### PR TITLE
Fix filler loop regression after plan revision (invariant repair)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -561,11 +561,64 @@ def make_adk_plugin(
         def __init__(self) -> None:
             super().__init__(name=name)
             self._host_agent_name = host_agent_name
+            # Active :class:`SessionContext` for the invocation that is
+            # currently driving this plugin's runner. Set by
+            # :meth:`ADKAdapter.invoke` before ``run_async`` and cleared
+            # in its ``finally`` block. Callbacks prefer this field over
+            # the ADK-state lookup because ADK's
+            # :class:`~google.adk.sessions.in_memory_session_service.InMemorySessionService`
+            # returns a **shallow copy** of the stored session on every
+            # ``get_session`` call (see ``_light_copy`` /
+            # ``copy.copy(session.state)``) — so a SessionContext written
+            # into the adapter's own ``get_session`` copy never reaches
+            # the fresh copy that ``runner.run_async`` materialises for
+            # the invocation, and the callbacks would see an empty state
+            # and silently fall through to the ACK shim.
+            #
+            # A module-level fallback path (``_session_context_from_callback``)
+            # is kept so unit tests that stash a ``SessionContext`` in a
+            # plain dict they control still work — the state-based lookup
+            # there is authoritative for those synthetic harnesses.
+            self._active_ctx: SessionContext | None = None
+
+        def set_active_context(self, ctx: SessionContext) -> None:
+            """Attach the ``SessionContext`` for the running invocation.
+
+            Called once per :meth:`ADKAdapter.invoke` before
+            ``runner.run_async``. The plugin's five callback methods
+            prefer this context over any value stashed in ADK session
+            state (which is an unreliable channel because InMemorySessionService
+            copies state on every get). Overwriting a non-``None`` value
+            is accepted — sequential invocations reuse the adapter.
+            """
+            self._active_ctx = ctx
+
+        def clear_active_context(self) -> None:
+            """Release the active ``SessionContext`` reference.
+
+            Called from ``ADKAdapter.invoke``'s ``finally`` block. Safe
+            to call when no context is active.
+            """
+            self._active_ctx = None
+
+        def _resolve_ctx(self, adk_ctx: Any) -> SessionContext | None:
+            """Return the live ``SessionContext`` or ``None`` if unbound.
+
+            Prefers the plugin-local ``_active_ctx`` (authoritative for
+            real ADK runs) but falls through to the state-dict lookup
+            for unit tests that drive the plugin with a hand-built
+            ``tool_context`` holding a populated state mapping. The two
+            paths are never inconsistent in production — only one is
+            populated at a time.
+            """
+            if self._active_ctx is not None:
+                return self._active_ctx
+            return _session_context_from_callback(adk_ctx)
 
         # --- Plan + current-task context -------------------------------
 
         async def before_model_callback(self, *, callback_context: Any, llm_request: Any) -> None:
-            ctx = _session_context_from_callback(callback_context)
+            ctx = self._resolve_ctx(callback_context)
             if ctx is None:
                 return None
             state = _session_state_from_callback(callback_context)
@@ -599,7 +652,7 @@ def make_adk_plugin(
         async def before_tool_callback(
             self, *, tool: Any, tool_args: Any, tool_context: Any
         ) -> dict[str, Any] | None:
-            ctx = _session_context_from_callback(tool_context)
+            ctx = self._resolve_ctx(tool_context)
             if ctx is None:
                 return None
             tool_name = str(_safe_attr(tool, "name", "") or "")
@@ -674,7 +727,7 @@ def make_adk_plugin(
         # --- Drift observation -----------------------------------------
 
         async def after_model_callback(self, *, callback_context: Any, llm_response: Any) -> None:
-            ctx = _session_context_from_callback(callback_context)
+            ctx = self._resolve_ctx(callback_context)
             if ctx is None or ctx.steerer is None:
                 return None
             texts = _extract_text_parts(llm_response)
@@ -725,7 +778,7 @@ def make_adk_plugin(
             return None
 
         async def on_event_callback(self, *, invocation_context: Any, event: Any) -> None:
-            ctx = _session_context_from_callback(invocation_context)
+            ctx = self._resolve_ctx(invocation_context)
             if ctx is None or ctx.steerer is None:
                 return None
             # Detect transfer / escalation actions on the event payload.
@@ -757,7 +810,7 @@ def make_adk_plugin(
             tool_context: Any,
             error: Any,
         ) -> None:
-            ctx = _session_context_from_callback(tool_context)
+            ctx = self._resolve_ctx(tool_context)
             if ctx is None or ctx.steerer is None:
                 return None
             tool_name = str(_safe_attr(tool, "name", "") or "")

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -602,9 +602,38 @@ class ADKAdapter:
             host_agent_name=str(getattr(self._agent, "name", "") or ""),
         )
 
-        # Stash the per-invocation context on ADK state so plugin
-        # callbacks can pick it up. Written directly rather than via
-        # the state protocol because this is an adapter-internal handoff.
+        # Hand the per-invocation context to the goldfive plugin. This
+        # is the AUTHORITATIVE handoff for real ADK runs — the plugin's
+        # callbacks read the active context off its own instance, not
+        # from ADK session state.
+        #
+        # Historical note: earlier versions stashed the context in ADK
+        # session state under :data:`SESSION_CONTEXT_STATE_KEY` and let
+        # ``before_tool_callback`` fish it back out of
+        # ``tool_context.session.state``. That silently broke every real
+        # run: ``InMemorySessionService.get_session`` returns a shallow
+        # copy of the stored session (see ``_light_copy`` in
+        # ``in_memory_session_service.py``), so this adapter's
+        # ``_get_session_state`` returned a fresh copy whose
+        # ``[SESSION_CONTEXT_STATE_KEY] = ctx`` assignment never reached
+        # the *second* copy the ADK runner materialised for the
+        # invocation via its own ``get_session`` call. Callbacks then
+        # saw an empty state, returned ``None`` from
+        # ``before_tool_callback``, and every reporting-tool call fell
+        # through to the ``_build_ack_shim`` — producing 500+ plain
+        # ``{"acknowledged": true}`` ACKs per run with every protection
+        # layer bypassed. The plugin-instance handoff below sidesteps
+        # the copy entirely: the plugin is a direct reference and the
+        # adapter owns its lifecycle, so the active context is always
+        # exactly the one the invocation is driving.
+        if self._plugin is not None:
+            self._plugin.set_active_context(ctx)
+
+        # Also mirror into ADK state as a best-effort fallback for
+        # legacy unit tests that construct a plain ``tool_context``
+        # holding a populated state dict and drive the plugin directly
+        # (see ``tests/test_adk_adapter.py``). The live-run path does
+        # not depend on this write succeeding.
         try:
             state[SESSION_CONTEXT_STATE_KEY] = ctx  # type: ignore[index]
         except Exception:
@@ -717,6 +746,12 @@ class ADKAdapter:
                         invocation_id=last_invocation_id,
                         reason="unexpected_orphan_on_normal_exit",
                     )
+            # Release the plugin-instance handoff so a subsequent
+            # ``invoke`` on a different task gets a clean setup and a
+            # stray callback arriving after the generator closes does
+            # not see a stale ctx. Mirrors the state-dict cleanup below.
+            if self._plugin is not None:
+                self._plugin.clear_active_context()
             if isinstance(state, Mapping):
                 try:
                     state.pop(SESSION_CONTEXT_STATE_KEY, None)  # type: ignore[attr-defined]

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -1191,3 +1191,311 @@ async def test_adversarial_agent_with_varying_task_ids_is_stopped_at_session_cap
         assert r["error"] == "loop_detected"
         assert r["scope"] == "session"
         assert r["tool"] == "report_task_failed"
+
+
+# ---------------------------------------------------------------------------
+# Live-run regression: the SessionContext handoff must survive ADK's
+# ``InMemorySessionService`` state-copying semantics.
+# ---------------------------------------------------------------------------
+
+
+async def test_reporting_tool_guards_fire_under_real_adk_runner() -> None:
+    """Drive a REAL ``google.adk.runners.InMemoryRunner`` end-to-end and
+    verify the reporting-tool handler (and therefore every guard layer)
+    is actually invoked.
+
+    This is the regression test for the filler-loop outage: every
+    reporting-tool call in a live ADK run was silently falling through
+    to the :func:`_build_ack_shim` because the adapter's session-context
+    handoff relied on mutating the dict returned by
+    ``InMemorySessionService.get_session`` — which returns a shallow
+    *copy* of the stored session state on every call. The copy the
+    adapter wrote to was discarded; the runner's own
+    ``get_session`` produced a second, empty copy for the invocation;
+    ``before_tool_callback`` saw no goldfive SessionContext and returned
+    ``None``; ADK then called the shim which returned
+    ``{"acknowledged": true}`` — bypassing terminal rejection,
+    idempotency, per-task and session-wide loop guards entirely.
+
+    The fix hands the context to the goldfive plugin instance directly,
+    sidestepping ADK state. This test exercises that path by running
+    the *actual* ADK runner with a scripted LLM so the copy-state
+    behaviour is real, not simulated. A regression here would once again
+    produce 500+ plain ACKs per run with every protection layer silent.
+    """
+    from google.adk.agents import Agent
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_response import LlmResponse
+    from google.genai import types as genai_types
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    # A scripted LLM that: turn 1 — emits a report_task_completed
+    # function call with concrete args; turn 2 — responds "done" and
+    # ends. If the guards were bypassed, step 1 would still return an
+    # ACK but the handler below would never be called.
+    class _ScriptedLLM(BaseLlm):
+        model: str = "fake-model"
+        _step: int = 0
+
+        async def generate_content_async(self, llm_request: Any, stream: bool = False):  # noqa: ARG002
+            self._step += 1
+            if self._step == 1:
+                yield LlmResponse(
+                    content=genai_types.Content(
+                        role="model",
+                        parts=[
+                            genai_types.Part(
+                                function_call=genai_types.FunctionCall(
+                                    id="call_1",
+                                    name="report_task_completed",
+                                    args={
+                                        "task_id": "raccoon_research",
+                                        "summary": "done",
+                                    },
+                                )
+                            ),
+                        ],
+                    ),
+                )
+            else:
+                yield LlmResponse(
+                    content=genai_types.Content(
+                        role="model",
+                        parts=[genai_types.Part(text="ok")],
+                    ),
+                    turn_complete=True,
+                )
+
+    agent = Agent(name="presenter", model=_ScriptedLLM(), instruction="")
+    adapter = ADKAdapter(agent)
+
+    handler_calls: list[dict[str, Any]] = []
+
+    async def _handler(args: dict[str, Any], session: Any, steerer: Any) -> dict:
+        handler_calls.append(dict(args))
+        # Mirror what the real handler does: mark the task COMPLETED so
+        # the adapter's post-event check tears the run-loop down cleanly.
+        from goldfive.types import TaskStatus
+
+        for t in session.plan.tasks:
+            if t.id == args.get("task_id"):
+                t.status = TaskStatus.COMPLETED
+        return {"acknowledged": True, "routed_via_invoke_tool": True}
+
+    spec = ReportingToolSpec(
+        name="report_task_completed",
+        description="Mark a task completed.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string"},
+                "summary": {"type": "string"},
+            },
+        },
+        handler=_handler,
+    )
+    await adapter.register_reporting_tools([spec])
+
+    class _StubSteerer:
+        async def observe(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        async def transition(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        def detect_drift(self, *a: Any, **kw: Any) -> None:
+            return None
+
+        def bind(self, **kw: Any) -> None:
+            pass
+
+    adapter.bind_steerer(_StubSteerer())
+
+    task = Task(id="raccoon_research", title="research raccoons")
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[task],
+        edges=[],
+    )
+    session = Session(run_id="r1", plan=plan)
+
+    result = await adapter.invoke(task=task, session=session)
+
+    # If the fix regresses, handler_calls stays empty (the shim swallows
+    # the call) and the task status never flips to COMPLETED.
+    assert handler_calls == [{"task_id": "raccoon_research", "summary": "done"}], (
+        "handler never ran: reporting-tool dispatch fell through to the "
+        "ACK shim, so every guard layer (terminal rejection, idempotency, "
+        "per-task loop cap, session volume cap) was silently bypassed. "
+        "This is the regression from the live run that produced 500+ "
+        "plain ACKs on a single task."
+    )
+    assert result.stop_reason in {"final_response", "task_terminal"}
+
+
+async def test_reporting_tool_guards_fire_across_back_to_back_invocations() -> None:
+    """Two sequential ``adapter.invoke`` calls must BOTH route through
+    the handler — the plugin-instance handoff must be correctly reset
+    between invocations so the second invocation gets its own ctx.
+
+    Specifically covers the filler-loop pattern from the live outage:
+    after a mid-run STEER cancels the first invocation and the
+    sequential executor starts a fresh invocation on the refined plan,
+    the NEW invocation's reporting-tool calls must still reach the
+    real handler (not the ACK shim). A regression where
+    ``clear_active_context`` is called too aggressively — or where the
+    second ``invoke`` fails to re-set the active ctx — would look
+    identical in the sink stream: first task healthy, second task
+    emits N plain ACKs with no handler invocation.
+    """
+    from google.adk.agents import Agent
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_response import LlmResponse
+    from google.genai import types as genai_types
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    class _ScriptedLLM(BaseLlm):
+        model: str = "fake-model"
+
+        async def generate_content_async(self, llm_request: Any, stream: bool = False):  # noqa: ARG002
+            # Inspect the LAST event in the conversation to decide:
+            # * If the last event is a user turn with a "Task: X" nudge
+            #   we haven't acted on yet (no matching function_response
+            #   after it), emit a function_call for that task id.
+            # * Otherwise (the last event is a function_response, meaning
+            #   the handler just acked), close out with ``turn_complete``.
+            contents = getattr(llm_request, "contents", None) or []
+            last_user_task_id = ""
+            last_was_function_response_for_task: str | None = None
+            for c in contents:
+                role = getattr(c, "role", "")
+                parts = getattr(c, "parts", None) or []
+                for p in parts:
+                    text = getattr(p, "text", None)
+                    fr = getattr(p, "function_response", None)
+                    if text and role == "user":
+                        # Extract "Task: <id>" from the adapter's nudge.
+                        for line in text.splitlines():
+                            stripped = line.strip()
+                            if stripped.startswith("Task: "):
+                                last_user_task_id = (
+                                    stripped.split("Task: ", 1)[1].split("\n", 1)[0].strip()
+                                )
+                        last_was_function_response_for_task = None
+                    if fr is not None:
+                        last_was_function_response_for_task = getattr(fr, "name", "") or ""
+            if last_was_function_response_for_task is None and last_user_task_id:
+                # Map the nudge title back to the task id we expect. The
+                # adapter's nudge text is "Task: <title>" — our test
+                # creates tasks whose title spells out the topic.
+                task_id = {
+                    "waffles": "waffle_research",
+                    "raccoons": "raccoon_research",
+                }.get(last_user_task_id, last_user_task_id)
+                yield LlmResponse(
+                    content=genai_types.Content(
+                        role="model",
+                        parts=[
+                            genai_types.Part(
+                                function_call=genai_types.FunctionCall(
+                                    id="call_" + task_id,
+                                    name="report_task_completed",
+                                    args={
+                                        "task_id": task_id,
+                                        "summary": "done",
+                                    },
+                                )
+                            ),
+                        ],
+                    ),
+                )
+            else:
+                yield LlmResponse(
+                    content=genai_types.Content(
+                        role="model",
+                        parts=[genai_types.Part(text="ok")],
+                    ),
+                    turn_complete=True,
+                )
+
+    agent = Agent(name="presenter", model=_ScriptedLLM(), instruction="")
+    adapter = ADKAdapter(agent)
+
+    handler_calls: list[dict[str, Any]] = []
+
+    async def _handler(args: dict[str, Any], session: Any, steerer: Any) -> dict:
+        handler_calls.append(dict(args))
+        from goldfive.types import TaskStatus
+
+        for t in session.plan.tasks:
+            if t.id == args.get("task_id"):
+                t.status = TaskStatus.COMPLETED
+        return {"acknowledged": True}
+
+    spec = ReportingToolSpec(
+        name="report_task_completed",
+        description="Mark a task completed.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string"},
+                "summary": {"type": "string"},
+            },
+        },
+        handler=_handler,
+    )
+    await adapter.register_reporting_tools([spec])
+
+    class _StubSteerer:
+        async def observe(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        async def transition(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        def detect_drift(self, *a: Any, **kw: Any) -> None:
+            return None
+
+        def bind(self, **kw: Any) -> None:
+            pass
+
+    adapter.bind_steerer(_StubSteerer())
+
+    # First invocation: the "pre-STEER" task.
+    t_waffle = Task(id="waffle_research", title="waffles")
+    plan_rev0 = Plan(id="p0", run_id="r1", goal_ids=[], tasks=[t_waffle], edges=[])
+    session = Session(run_id="r1", plan=plan_rev0)
+    await adapter.invoke(task=t_waffle, session=session)
+    assert len(handler_calls) == 1
+    assert handler_calls[0]["task_id"] == "waffle_research"
+
+    # Simulate the STEER-driven plan revision: swap the plan on the
+    # session to rev 1 with a new task, which is exactly what
+    # ``steerer._apply_revision`` does mid-run.
+    t_raccoon = Task(id="raccoon_research", title="raccoons")
+    plan_rev1 = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[t_raccoon],
+        edges=[],
+        revision_index=1,
+    )
+    session.plan = plan_rev1
+
+    # Second invocation: the "post-STEER" task. This is the one the
+    # live run filler-looped on because the plugin-instance handoff
+    # was previously via ADK state, which the session-service copy
+    # discarded.
+    await adapter.invoke(task=t_raccoon, session=session)
+
+    assert len(handler_calls) == 2, (
+        "second invocation's reporting-tool call never reached the "
+        "handler — the plugin-instance handoff is not being re-set "
+        "across back-to-back invocations (the filler-loop regression)."
+    )
+    assert handler_calls[1]["task_id"] == "raccoon_research"


### PR DESCRIPTION
## Summary

Live ADK runs were silently bypassing every reporting-tool protection layer — terminal-task rejection (#98), missing/unknown task_id rejection (#109), and per-task + session-wide loop caps (#108/#109). The symptom in session `sess_2026-04-20_0018`: 545 consecutive `report_task_completed` calls on one task, all returning plain `{\"acknowledged\": true}`, zero structured rejections.

## Root cause (single point, not a guard-stack gap)

The guards and `invoke_tool` dispatch are all correct; they just weren't being reached.

`ADKAdapter.invoke` handed the per-invocation `SessionContext` to the plugin by writing `state[SESSION_CONTEXT_STATE_KEY] = ctx` on the dict it got from `session_service.get_session`. ADK's `InMemorySessionService.get_session` returns a session whose `.state` is a **shallow copy** (`_light_copy` → `copy.copy(session.state)`) on every call. The adapter's write landed on copy A; `runner.run_async` then called `get_session` again, producing copy B — which the callback's `tool_context.session.state` exposes. Copy B never received the context. `before_tool_callback` saw empty state, returned `None`, and ADK fell through to the tool's `_build_ack_shim` (which returns `{\"acknowledged\": true}` — exactly matching the sink payload digest).

Pre-STEER tasks looked healthy only because `SequentialExecutor.run` auto-completes tasks on adapter return; the post-STEER task filler-looped because the agent never returned.

## Fix

Stop using ADK session state for the handoff. The adapter owns the plugin instance (`self._plugin`); hand the context through `plugin.set_active_context(ctx)` before `run_async` and clear it in `finally`. Callbacks read from `self._active_ctx` first with a state-dict fallback for synthetic unit-test `tool_context` objects. **One targeted fix — no new layer, no defensive stacking.**

## Test plan

- [x] New `test_reporting_tool_guards_fire_under_real_adk_runner` — drives a real `InMemoryRunner` with a scripted LLM; confirms the handler is reached. Fails against pre-fix adapter, passes after.
- [x] New `test_reporting_tool_guards_fire_across_back_to_back_invocations` — simulates the exact STEER scenario (invoke on plan rev 0, swap `session.plan` to rev 1, invoke again); both invocations must route to the handler. Fails pre-fix, passes post-fix.
- [x] Full suite: `uv run --extra dev --extra adk pytest -q` → 559 passed, 40 skipped.
- [x] `ruff check` + `ruff format --check` clean on all three touched files.
