### PR TITLE
Docs refresh + new .agents/ skills + user guides for telemetry insight

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -27,6 +27,10 @@ action.
 | know what events exist and how to emit one | [events.md](events.md) |
 | write a goldfive test | [testing.md](testing.md) |
 | cut a release | [release.md](release.md) |
+| add a new `AgentAdapter` wrapping a new framework | [how-to-add-a-new-adapter.md](how-to-add-a-new-adapter.md) |
+| debug the "guards defined but not firing" class of bug | [how-to-debug-a-filler-loop.md](how-to-debug-a-filler-loop.md) |
+| add a new `DriftKind` | [how-to-add-a-drift-kind.md](how-to-add-a-drift-kind.md) |
+| drive a goldfive end-to-end run with harmonograf locally | [how-to-run-the-e2e.md](how-to-run-the-e2e.md) |
 
 ## How these get referenced
 

--- a/.agents/debug-goldfive.md
+++ b/.agents/debug-goldfive.md
@@ -267,13 +267,81 @@ project needs.
   downstream-regenerated copy) → `isinstance` fails. See
   `docs/guides/troubleshooting.md` § "Proto and types".
 
+## Inspecting a stuck run
+
+The first thing to check for "the run didn't die but no task is
+moving" is the plan/task state and the guard counters:
+
+```python
+# after await runner.run(...) returns or timed out
+s = outcome.session
+print(f"success={outcome.success} reason={outcome.reason!r}")
+if s.plan is not None:
+    for t in s.plan.tasks:
+        print(f"  {t.status.value:<10} {t.id}  deps={[e.from_task_id for e in s.plan.edges if e.to_task_id == t.id]}")
+print("refine_failure_counts:", dict(s.refine_failure_counts))
+print("current_task:", s.current_task_id)
+print("reasoning_history_len:", len(s.reasoning_history))
+```
+
+Orthogonal bits that accumulate on the session:
+
+- `session.plan.tasks[*].status` — source of truth for what the
+  executor thinks is done / running / stuck.
+- `session.refine_failure_counts` — `(drift_kind, task_id) -> int`
+  incremented every time `planner.refine()` raised or returned
+  `None`. Hitting `DefaultSteerer.REFINE_FAILURE_THRESHOLD` (default
+  `2`) is what should be marking a task FAILED instead of looping.
+- `session.reasoning_history` — last 20 reasoning blocks; what the
+  reasoning-drift detectors run against.
+- `session.pending_approvals` — open APPROVE / REJECT waiters; a
+  non-empty dict after a run ended means some steer never arrived.
+
+For the plan lifecycle (who owns what transition, termination
+predicate, cascade primitive), see
+[docs/design/PLAN-LIFECYCLE.md](../docs/design/PLAN-LIFECYCLE.md) §6.
+
+## Structural vs symptomatic debugging
+
+Postmortem heuristic from this week's filler-loop sprint: every
+time a patch looked correct in isolation but the bug came back
+under a slightly different trigger, the fix was symptomatic (added
+a cap, added a check, lowered a threshold). The real fix was always
+structural — one of:
+
+- **A guard was defined but not wired.** #108: the ADK plugin
+  called `spec.handler` directly from `before_tool_callback` instead
+  of routing through `invoke_tool`, so the terminal-task rejection,
+  idempotency, and loop detection layers never ran even though the
+  code existed.
+- **Two things owned the same state and disagreed.** The pre-#103
+  cascade: `mark_task_cancelled` transitioned one task but
+  `_pick_next_task` required every predecessor COMPLETED — so a
+  CANCELLED predecessor silently orphaned its descendants. Fix was
+  a single shared primitive (`cascade_cancel_downstream`) that both
+  paths use.
+- **A data-path copy broke an invariant.** #116 (local): the ADK
+  plugin was reading `SessionContext` out of `session.state`, which
+  ADK deep-copies between turns. Mutations to the context didn't
+  survive; the fix was plumbing the context through the plugin
+  instance directly.
+
+Decision rule: when a "correct" patch doesn't hold, stop adding
+caps and instead look for the data path where the guard was meant
+to live. If the path touches a copy boundary, a framework-managed
+state store, or a callback registration hook, the structural fix
+is one of those three shapes.
+
 ## Related
 
 - [docs/guides/troubleshooting.md](../docs/guides/troubleshooting.md) — detailed symptom → fix catalogue.
+- [docs/guides/common-failure-modes.md](../docs/guides/common-failure-modes.md) — catalog of observed failure modes with signatures.
+- [docs/design/PLAN-LIFECYCLE.md](../docs/design/PLAN-LIFECYCLE.md) — plan-level state machine; run-termination predicate.
 - [docs/design/CONTROL.md](../docs/design/CONTROL.md) — live-steering protocol, per-kind behaviour, custom dispatcher hook.
 - [docs/design/VOCABULARY.md](../docs/design/VOCABULARY.md) — exhaustive type-system reference (start here when a name is confusing).
 - [docs/design/RATIONALE.md](../docs/design/RATIONALE.md) — design-rationale docs (start here when a choice feels arbitrary).
 - [docs/design/DRIFT.md](../docs/design/DRIFT.md) — drift taxonomy.
 - [docs/design/EVENT-MODEL.md](../docs/design/EVENT-MODEL.md) — event ownership, sequence semantics.
+- [how-to-debug-a-filler-loop.md](how-to-debug-a-filler-loop.md) — filler-loop playbook.
 - [events.md](events.md) — emitting a new event.
 - [sinks.md](sinks.md) — sink contract.

--- a/.agents/how-to-add-a-drift-kind.md
+++ b/.agents/how-to-add-a-drift-kind.md
@@ -1,0 +1,195 @@
+---
+name: how-to-add-a-drift-kind
+description: Checklist for adding a new DriftKind to goldfive. Covers the Python enum, the proto enum, codegen, classifier wiring, the steerer dispatch, tests, and the docs/design/DRIFT.md taxonomy row.
+applies-when: ["add drift kind", "new drift signal", "DriftKind enum", "drift taxonomy"]
+---
+
+# Add a new `DriftKind`
+
+Every drift signal goldfive understands is a `DriftKind` enum
+value. Adding one is a six-step walk across Python, proto, the
+classifier, the steerer, tests, and the taxonomy doc.
+
+Worked example this week: #112 added `UNCERTAIN_PROGRESS` /
+`SELF_REPORTED_STUCK` for the opt-in reflective self-progress
+check. Follow its diff if the code shape below is ambiguous.
+
+## 1. Add the Python enum value
+
+`goldfive/types.py::DriftKind` — add a new `StrEnum` member. Place
+it with other members of the same category (error, divergence,
+structural, discovery, user, goal, reasoning, reflective, escape)
+so code-readers navigating the enum find it where they expect.
+
+```python
+class DriftKind(StrEnum):
+    ...
+    # Opt-in reflective self-progress check: agent said it *is*
+    # making progress but with low confidence (< 0.5). INFO severity.
+    UNCERTAIN_PROGRESS = "uncertain_progress"
+```
+
+Include a short docstring-style comment explaining default
+severity, trigger, and any feature gate. If the kind fires at a
+**variable** severity (like `INTENT_DIVERGENCE`), say so
+explicitly — callers filtering by kind shouldn't assume severity
+is fixed.
+
+## 2. Mirror the value in the proto enum
+
+`proto/goldfive/v1/types.proto` — add `DRIFT_KIND_<NAME>` to the
+`DriftKind` enum. Preserve existing numbering; append. Proto3
+requires stable numbering for forward compatibility.
+
+```proto
+enum DriftKind {
+  ...
+  DRIFT_KIND_UNCERTAIN_PROGRESS = 30;
+  DRIFT_KIND_SELF_REPORTED_STUCK = 31;
+}
+```
+
+The Python-to-proto bridge is by name: the steerer looks up
+`getattr(types_pb2, f"DRIFT_KIND_{kind.name}")` at emission time
+(see `DefaultSteerer._emit_drift_detected` and
+`SequentialExecutor._plan_divergence_drift_event`). The Python
+enum name and the proto enum suffix must match exactly.
+
+## 3. Regenerate the proto stubs
+
+```bash
+uv sync --extra proto
+make proto
+```
+
+This regenerates `goldfive/pb/goldfive/v1/types_pb2.py` and
+`types_pb2.pyi`. Verify the new value is listed:
+
+```bash
+uv run python -c "from goldfive.pb.goldfive.v1 import types_pb2; print([n for n in dir(types_pb2) if 'DRIFT_KIND' in n])"
+```
+
+## 4. Wire a classifier (if the detection is pattern-based)
+
+For drifts whose detection is non-trivial (pattern match, regex,
+embedding cosine, LLM call, threshold on session state), add a
+classifier helper. Two homes:
+
+- **Upstream / tool-facing drifts** — `goldfive/drift/__init__.py`
+  alongside `classify_tool_error`, `classify_refusal`,
+  `classify_stop_reason`. Signature:
+  ```python
+  def classify_my_new_thing(event: Any) -> DriftEvent | None: ...
+  ```
+  Pure function. Returns `DriftEvent` or `None`.
+
+- **Reasoning-channel drifts** —
+  `goldfive/drift/reasoning.py`. Follow the pattern of
+  `detect_intent_divergence`: pattern-first fallback, optional
+  embedding path when `goldfive[embedding]` is installed, any
+  tunable thresholds as module-level constants prefixed with the
+  drift kind name
+  (e.g. `INTENT_DIVERGENCE_WARNING_SIMILARITY`,
+  `LOOPING_REASONING_SIMILARITY_THRESHOLD`).
+
+For drifts that fire directly from a reporting-tool handler
+(`report_plan_divergence`, `report_new_work_discovered`,
+`report_task_blocked`), there's no separate classifier — the
+handler emits the `DriftEvent` inline.
+
+## 5. Wire the steerer dispatch
+
+`goldfive/steerer.py::DefaultSteerer.detect_drift` (for passive
+classification on adapter events) or a direct call site in the
+reporting-tool handler / post-invoke hook (for signals that
+originate from a specific entry point).
+
+For reflective / periodic checks — the #112 pattern — add a new
+public method to `DefaultSteerer` that the adapter invokes on
+its own schedule (e.g. once per LLM turn). Gate behind a ctor
+flag so operators who don't enable it pay zero cost:
+
+```python
+def __init__(self, *, my_check_interval: int = 0, my_call_llm=None):
+    self._my_check_interval = my_check_interval
+    self._my_call_llm = my_call_llm
+
+async def note_llm_call(self, session):
+    if self._my_check_interval <= 0 or self._my_call_llm is None:
+        return
+    session._llm_calls_since_check += 1
+    if session._llm_calls_since_check < self._my_check_interval:
+        return
+    session._llm_calls_since_check = 0
+    drift = await self._run_my_check(session)
+    if drift is not None:
+        await self._handle_drift(drift, session)
+```
+
+If the drift fires at graduated severity (like `INTENT_DIVERGENCE`
+does after #114), the classifier decides severity based on the
+observation; the kind stays stable and only the
+`DriftEvent.severity` varies. Callers filtering by kind then see
+one signal; severity differentiates urgency.
+
+## 6. Add taxonomy tests
+
+`tests/test_drift_taxonomy.py` is the canonical home. At minimum:
+
+- **The enum value exists** — no ImportError, `DriftKind.MY_NEW` resolves.
+- **Proto mirror** — `types_pb2.DRIFT_KIND_MY_NEW` exists with a non-zero value.
+- **Severity round-trips** — `DriftEvent(kind=MY_NEW, severity=WARNING)`
+  serialises through `drift_detected_event` and deserialises without
+  collapsing to `UNSPECIFIED`.
+- **Classifier returns the right shape** — feed an in-class event,
+  assert the returned `DriftEvent.kind` / `severity` match.
+
+If the drift fires with graduated severity, add a severity-band
+test per band (INFO / WARNING / CRITICAL) with representative
+inputs.
+
+For reasoning-channel drifts, the reasoning-specific test suite is
+`tests/test_drift_reasoning.py`. Add band / threshold tests there.
+
+## 7. Update `docs/design/DRIFT.md`
+
+Add a row to the taxonomy table under the appropriate category
+(Error / Divergence / Structural / Discovery / User / Goal /
+Reasoning / Reflective). Include:
+
+- Trigger — one line naming the event / tool / threshold that fires it.
+- Default severity — `info`, `warning`, `critical`, or "graduated".
+- Recoverable — yes / no / sometimes.
+
+If the drift is graduated-severity, add a sub-section below the
+table with the band boundaries and rationale, mirroring the
+`INTENT_DIVERGENCE` treatment in DRIFT.md.
+
+## 8. (Optional) UI metadata in harmonograf
+
+Harmonograf's front-end renders per-kind icons and colors. If the
+new kind should not fall through to the generic drift badge, file
+an issue / PR on harmonograf to add the icon/color mapping. Not
+required for the kind to function — the UI degrades gracefully.
+
+## Checklist (copy-paste)
+
+```
+[ ] goldfive/types.py::DriftKind — enum value + comment
+[ ] proto/goldfive/v1/types.proto — DRIFT_KIND_<NAME>
+[ ] make proto — regenerate types_pb2
+[ ] goldfive/drift/__init__.py or drift/reasoning.py — classifier
+[ ] goldfive/steerer.py — detect_drift dispatch OR new public method
+[ ] tests/test_drift_taxonomy.py — enum + proto + severity
+[ ] tests/test_drift_reasoning.py — if reasoning-channel
+[ ] docs/design/DRIFT.md — taxonomy row + optional sub-section
+[ ] CHANGELOG.md — Added / Changed entry
+[ ] (harmonograf) UI metadata
+```
+
+## Related
+
+- [docs/design/DRIFT.md](../docs/design/DRIFT.md) — full taxonomy + refine policy.
+- [docs/design/VOCABULARY.md §5](../docs/design/VOCABULARY.md#5-driftkind-taxonomy) — enum-value-by-enum-value reference.
+- [events.md](events.md) — proto event factories.
+- `goldfive/drift/reasoning.py` — reference implementation for a reasoning-channel drift (with both pattern and embedding paths).

--- a/.agents/how-to-add-a-new-adapter.md
+++ b/.agents/how-to-add-a-new-adapter.md
@@ -1,0 +1,238 @@
+---
+name: how-to-add-a-new-adapter
+description: Step-by-step for wrapping a new agent framework as a goldfive AgentAdapter — the protocol, the invoke_tool dispatch contract, and the architectural invariants that must hold.
+applies-when: ["add adapter", "wrap framework", "new agent runtime", "AgentAdapter"]
+---
+
+# Add a new `AgentAdapter`
+
+goldfive is framework-agnostic. The adapter is the one place that
+knows about a specific framework (ADK, Claude SDK, a bare callable,
+LangGraph, MCP, anything). This skill is the checklist for writing
+a new one. See the longer-form guide at
+[docs/guides/writing-an-agent-adapter.md](../docs/guides/writing-an-agent-adapter.md)
+for the full worked example; this file is the terse checklist.
+
+## The protocol contract
+
+Live definition: `goldfive/protocols.py::AgentAdapter`.
+
+```python
+@runtime_checkable
+class AgentAdapter(Protocol):
+    async def register_reporting_tools(
+        self, tools: list[ReportingToolSpec]
+    ) -> None: ...
+    async def invoke(
+        self, task: Task, session: Session
+    ) -> InvocationResult: ...
+    async def emit_reasoning(
+        self,
+        text: str,
+        *,
+        task: Task | None = None,
+        session: Session,
+        provider: str = "",
+        call_id: str = "",
+    ) -> None: ...
+    @property
+    def available_agents(self) -> list[str]: ...
+```
+
+The protocol is `@runtime_checkable`; a duck-typed implementation
+passes `isinstance(x, AgentAdapter)`.
+
+## Checklist
+
+### 1. Register reporting tools
+
+Store the full list of `ReportingToolSpec` on the adapter instance.
+**Do not** translate to just a name-to-handler map — you need the
+full specs to feed `invoke_tool`, which runs the guard layers.
+
+```python
+async def register_reporting_tools(self, tools):
+    self._tools: list[ReportingToolSpec] = list(tools)
+    # Translate each spec into the framework's tool shape (ADK
+    # FunctionTool, Claude SDK inline tool, MCP tool, …).
+    ...
+```
+
+Reference impls:
+
+- ADK: `goldfive/adapters/adk.py::ADKAdapter.register_reporting_tools` — plus `_augment_subtree_with_reporting` walks `sub_agents` / `inner_agent` / `tool.agent` so every descendant is wired.
+- Claude SDK: `goldfive/adapters/claude.py::ClaudeAgentSDKAdapter.register_reporting_tools`.
+- Callable: `goldfive/adapters/callable.py::CallableAdapter.register_reporting_tools`.
+
+### 2. Route every tool call through `invoke_tool`
+
+This is the non-negotiable. The adapter's tool-invocation hook
+(ADK `before_tool_callback`, Claude SDK handler wrapper, your
+framework's equivalent) MUST route through:
+
+```python
+from goldfive.adapters._tool_invocation import invoke_tool
+
+ack = await invoke_tool(
+    self._tools, name, args, session, self._steerer
+)
+```
+
+`invoke_tool` runs four guard layers before calling
+`spec.handler`:
+
+1. **Schema rejection** — missing / unknown `task_id` for a
+   task-scoped tool is rejected with a structured error before
+   any counter update.
+2. **Terminal-task rejection** — calls on COMPLETED / FAILED /
+   CANCELLED tasks return `task_already_terminal`.
+3. **Per-task loop guard** — duplicate-args returns `duplicate`;
+   sustained bursts or volume caps flip the `(task, tool)` bucket
+   into a hard-reject state.
+4. **Session-wide volume cap** — > 50 calls of the same tool name
+   across all tasks in a session flags the tool session-wide.
+
+Calling `spec.handler` directly bypasses all four. Pre-#108 that
+was the root cause of the filler-loop class of bugs: the state
+machine advanced to COMPLETED, but the adapter kept re-invoking
+the agent until the framework's own ceiling tripped.
+
+### 3. Hook drift observation
+
+Non-reporting-tool events — LLM text, transfer events, stop
+reasons, tool errors — are fed to the steerer as raw observations:
+
+```python
+if self._steerer is not None:
+    await self._steerer.observe(event, session)
+```
+
+The steerer classifies; you forward. `DefaultSteerer.detect_drift`
+is the classifier.
+
+For chain-of-thought surfaces (OpenAI `reasoning_content`,
+Anthropic `thinking` blocks, Google thought parts), implement
+`emit_reasoning` and call the steerer:
+
+```python
+async def emit_reasoning(
+    self, text, *, task=None, session, provider="", call_id=""
+):
+    if self._steerer is None or not text.strip():
+        return
+    await self._steerer.observe_reasoning(
+        text, task=task, session=session, provider=provider
+    )
+```
+
+Adapters that cannot surface reasoning simply never call this; the
+reasoning-drift pipeline degrades to pattern-only detectors.
+
+### 4. Render current-task context for the agent
+
+Frameworks differ:
+
+- **ADK** — write `session.state["goldfive.current_task_id"]`
+  etc. in `before_model_callback`; the agent reads them.
+- **Claude SDK** — inject task context into the first user
+  message or the system prompt. See
+  `goldfive/adapters/_claude_prompt.py`.
+- **Custom callable** — pass as a function argument.
+
+Either approach works; pick whichever matches the framework's idiom.
+Required bits: `task.id`, `task.title`, `task.description`, the plan
+summary, and the summary of every completed task
+(`session.completed_results`).
+
+### 5. Return an `InvocationResult`
+
+```python
+return InvocationResult(
+    task_id=task.id,
+    text=final_assistant_text,
+    stop_reason=framework_stop_reason,  # "end_turn", "max_tokens", …
+    error=exc_if_the_framework_raised_else_None,
+    raw=the_raw_framework_response_object,
+)
+```
+
+The executor uses `stop_reason` for `CONTEXT_PRESSURE` /
+`TOO_MANY_STEPS` classification. It uses `error` to route through
+`steerer.mark_task_failed` when the agent didn't report a terminal
+state itself.
+
+### 6. Expose `available_agents`
+
+A property that lists every agent the adapter can dispatch to.
+Consumed by the planner to populate `task.assignee_agent_id`. For
+nested-agent trees (ADK `sub_agents`, agent-as-tool wrappers), walk
+the tree and return every name.
+
+## The architectural invariant
+
+**Framework-to-framework handoff must not cross an SDK-managed
+state boundary without the SDK's own copy semantics being taken
+into account.** The concrete failures this rule prevents:
+
+- Storing `SessionContext` on `session.state` in ADK and expecting
+  it to survive the turn. ADK deep-copies its session state between
+  turns; mutations are silently dropped. The fix is to bind state
+  to the adapter/plugin instance (a Python reference that survives),
+  not to `session.state` (an SDK-owned copy).
+- Relying on a `ContextVar` set in one coroutine being visible in
+  another coroutine that the SDK dispatched via
+  `loop.run_in_executor` / `asyncio.to_thread`. Every framework
+  handles this differently; don't assume.
+- Assuming the handler registered with the SDK at construction
+  time is the handler that runs when the tool is called. Some
+  frameworks bind by name, not by reference.
+
+If you are writing an adapter for a framework that offers more
+than one way to install a tool-dispatch hook, pick the one that
+(a) survives the SDK's own state-copy boundary and (b) exposes the
+raw tool name + args payload, not a pre-parsed surface.
+
+See the "structural vs symptomatic" heuristic in
+[debug-goldfive.md §"Structural vs symptomatic debugging"](debug-goldfive.md)
+for the postmortem that extracted this invariant.
+
+## `InvocationStateStore` (tracked)
+
+Issue #117 proposes a shared `InvocationStateStore` primitive on
+the adapter base — a small object owned by the adapter that
+bundles (session, steerer, task, tool_specs, pending call-ids) for
+one `invoke()` call and is explicitly thread-agnostic. When that
+lands, new adapters will inherit the store rather than re-rolling
+the ContextVar / plugin-instance dance each time. Until then,
+every adapter handles its own wiring; follow the existing adapters'
+pattern of keeping a reference on `self` that the hook closes over.
+
+## Multi-agent trees
+
+When the framework supports nested agents, wrap the root and walk
+the tree yourself — do not require callers to attach reporting
+tools to every child. Reference: `ADKAdapter` walks
+`agent.sub_agents`, `agent.inner_agent`, and every `tool.agent`
+for `tool in agent.tools`. Idempotent: agents that already carry
+the canonical reporting-tool names are skipped.
+
+## Testing
+
+Reference tests: `tests/test_callable_adapter.py`,
+`tests/test_claude_adapter.py`, `tests/test_adk_adapter.py`. At
+minimum assert:
+
+- `isinstance(adapter, AgentAdapter)` — protocol-compliant.
+- `register_reporting_tools` accepts an empty list without crashing.
+- `invoke` calls the spec's `handler` via `invoke_tool` (a
+  terminal-status task must receive `task_already_terminal`).
+- Exceptions from the wrapped agent surface as
+  `InvocationResult.error`, not as raises out of `invoke`.
+
+## Related
+
+- [docs/guides/writing-an-agent-adapter.md](../docs/guides/writing-an-agent-adapter.md) — long-form walkthrough with worked 50-line example.
+- [docs/design/PROTOCOLS.md §AgentAdapter](../docs/design/PROTOCOLS.md#agentadapter) — contract.
+- [docs/reference/tool-protocol.md](../docs/reference/tool-protocol.md) — the seven reporting tools.
+- [adapters.md](adapters.md) — the existing adapters skill.
+- [debug-goldfive.md](debug-goldfive.md) — triage when an adapter misbehaves.

--- a/.agents/how-to-debug-a-filler-loop.md
+++ b/.agents/how-to-debug-a-filler-loop.md
@@ -1,0 +1,156 @@
+---
+name: how-to-debug-a-filler-loop
+description: Diagnostic playbook for the "guards are defined but aren't firing" class of filler-loop bugs. Based on the postmortem from #98 / #108 / #109 / #116 / harmonograf #45.
+applies-when: ["filler loop", "report_task_completed called repeatedly", "500-call ceiling", "guard not firing"]
+---
+
+# How to debug a filler loop
+
+A **filler loop** is the class of bug where the agent makes no
+forward progress and goldfive's guards — which exist — fail to
+stop it. The five bugs the spring 2026 sprint found all fit this
+mold: the guard was written correctly and had tests, but the data
+path never reached it.
+
+## Symptom signatures
+
+Any of these is a high-confidence filler-loop signal:
+
+- The run terminates on the adapter framework's own ceiling (ADK
+  500-call, Claude max-turns) rather than on any goldfive
+  guard.
+- `sink.events` shows the same reporting tool called more than
+  ~20 times in a single `invoke()` with the same or near-identical
+  args, yet no `LOOPING_TOOL_CALL` drift fires.
+- `outcome.success=True` but a large fraction of tasks are still
+  `PENDING` after the run.
+- `outcome.success=False` with `reason="adapter.invoke raised ...
+  max_turns_exceeded"` or similar framework-level error.
+- The `RunAborted.reason` mentions exhausting `max_task_invocations`
+  with one specific `task_id` pending every time.
+- `task.status` sits at `COMPLETED` but new reporting-tool calls
+  keep arriving for the same `task_id`.
+
+## The diagnostic playbook
+
+### Step 1 — Confirm it's structural, not symptomatic
+
+Check which guard you expected to fire. The goldfive guards are:
+
+| Guard | Where | Expected drift or ack |
+|---|---|---|
+| Schema rejection (missing / unknown `task_id`) | `_tool_invocation.invoke_tool` | `{acknowledged: False, error: "missing_task_id" \| "unknown_task_id"}` |
+| Terminal-task rejection | `_tool_invocation.invoke_tool` | `{acknowledged: False, error: "task_already_terminal"}` |
+| Per-task loop guard | `_tool_loop_guard.detect_loop` | `LOOPING_TOOL_CALL` drift; subsequent calls get `loop_detected` |
+| Session-wide volume cap | `_tool_loop_guard.detect_session_loop` | `LOOPING_TOOL_CALL` drift (severity CRITICAL); all further calls hard-rejected |
+| Per-task retry-lineage cap | `SequentialExecutor._lineage_root` | task marked FAILED without invoking the adapter |
+| Refine-failure threshold | `DefaultSteerer.REFINE_FAILURE_THRESHOLD` | `REPEATED_FAILURE` drift + task FAILED |
+
+If none of these ACK/drift shapes appear in your sink log, the
+guard never ran. That is the bug — do not patch a new cap; find
+why the existing guard was skipped.
+
+### Step 2 — Instrument at the guard entry point
+
+Add a single line at the top of `invoke_tool`:
+
+```python
+# goldfive/adapters/_tool_invocation.py
+async def invoke_tool(tools, name, args, session, steerer):
+    import logging; logging.getLogger("goldfive").warning(
+        "invoke_tool entry: tool=%s task_id=%r session=%s",
+        name, args.get("task_id"), id(session),
+    )
+    ...
+```
+
+Run the reproducer. If the line doesn't print for the looping
+tool, `invoke_tool` is never called — the adapter is dispatching
+`spec.handler` directly. This was the #108 bug.
+
+If the line prints but the guard decisions look wrong, the
+counters / keys / session are inconsistent. Proceed to step 3.
+
+### Step 3 — Verify `invoke_tool` is actually wired
+
+Check each adapter's tool-invocation hook:
+
+- **ADK.** `goldfive/adapters/_adk_plugin.py::before_tool_callback`
+  — the dispatch line should be
+  `return await invoke_tool(self._adapter._tool_specs, name, args, session, steerer)`.
+  Historically it was `return await spec.handler(args, session, steerer)`,
+  which bypassed every guard. #108 fixed this.
+- **Claude SDK.**
+  `goldfive/adapters/claude.py::ClaudeAgentSDKAdapter._handle_tool_use`
+  — look for `await invoke_tool(self._tools, name, args, ...)`.
+- **Callable.** `CallableAdapter` hands the spec list to the
+  callable; the callable is responsible for routing through
+  `invoke_tool` if it wants guard coverage. Most don't, because
+  most callables are test harnesses.
+- **Custom.** Search the adapter for `spec.handler(` — every call
+  is a bypass candidate.
+
+### Step 4 — Check `ContextVar` propagation
+
+If the adapter uses a `ContextVar` to carry per-invoke state
+(session, steerer, task) into its callbacks:
+
+- The `ContextVar` must be set in the coroutine that calls
+  `adapter.invoke(...)`, not in the hook registration site.
+- `asyncio.to_thread` / `loop.run_in_executor` does NOT propagate
+  context vars across the thread boundary by default. Frameworks
+  that dispatch callbacks through a thread pool will see `None`.
+- `asyncio.gather` with `copy_context=True` (the default in
+  3.11+) copies the current context into each child; mutations to
+  a `ContextVar` inside a child task are invisible to the parent.
+
+The fix, as landed in this week's #116 (local) for the ADK
+plugin: stop routing state through `ContextVar` / `session.state`
+and bind the state to the adapter/plugin instance directly. A
+Python reference held by the adapter survives every SDK-internal
+copy boundary.
+
+### Step 5 — Check `session.state` copy semantics
+
+If handoff between an adapter hook and a framework callback uses
+the SDK's own session-state object (ADK's
+`InvocationContext.session.state`, Claude's conversation state,
+etc.), verify that the SDK does not copy state between turns.
+
+ADK deep-copies `session.state` between every turn. Anything
+written into it in turn N is **not** the same object in turn
+N+1. Mutating it after turn boundaries has no effect from the
+agent's perspective. The symptoms: the guard counter you see in
+one callback is consistently different from the one the next
+callback reads.
+
+The reference memory note
+(`~/.claude/.../memory/feedback_callback_context_handoff.md`
+for the agent-local copy; on-repo analogue: the postmortem in
+TASK-LIFECYCLE.md §7.5 and the rationale in ARCHITECTURE.md's
+"architectural invariant" section) documents this class of bug
+and the fix pattern: bind state to the adapter / plugin instance
+(a Python object reference), not to the SDK's state store.
+
+## The five bugs — what was actually broken
+
+| PR | Symptom | Actual cause |
+|---|---|---|
+| #98 | Adapter kept invoking agent past `COMPLETED`; 500-call ADK ceiling | The invoke-loop didn't early-break on terminal status. Reporting-tool dispatch didn't reject calls on terminal tasks. |
+| #108 | All guards "correctly defined", none firing under load | ADK plugin called `spec.handler` direct, bypassing `invoke_tool` and the four guard layers. |
+| #109 | Guard fired once per task; agents that invented fresh `task_id` each call defeated it | No session-wide cap, and the per-task guard's "flag and continue" ack looked like a pass to the model, which then kept calling. |
+| #116 (local) | Post-#108 regression under ADK load; SessionContext kept vanishing | The plugin was reading its context out of `session.state`, which ADK copied between turns. Rebinding to the plugin instance fixed it. |
+| harmonograf #45 | Reasoning content not appearing on spans despite #43 wiring | The span attribute name mismatch: server wrote `llm.reasoning`, client read `reasoning`. Not a goldfive bug but the same "two sides of the same wire" pattern. |
+
+Common thread: each "fix" before the real structural fix added
+another cap or threshold. The real fix was always finding the one
+data path that should have been routing through the guard and
+wasn't.
+
+## Related
+
+- [docs/guides/common-failure-modes.md](../docs/guides/common-failure-modes.md) — each failure mode in detail with its recovery path.
+- [docs/design/TASK-LIFECYCLE.md §5](../docs/design/TASK-LIFECYCLE.md) — the four guard layers and their ordering.
+- [docs/design/TASK-LIFECYCLE.md §7.3 / §7.4](../docs/design/TASK-LIFECYCLE.md) — refine-failure threshold and ADK session heal.
+- [debug-goldfive.md](debug-goldfive.md) — general debugging playbook; "structural vs symptomatic" heuristic.
+- [how-to-add-a-new-adapter.md](how-to-add-a-new-adapter.md) — the `invoke_tool` wiring contract for new adapters.

--- a/.agents/how-to-run-the-e2e.md
+++ b/.agents/how-to-run-the-e2e.md
@@ -1,0 +1,214 @@
+---
+name: how-to-run-the-e2e
+description: How to drive a goldfive run end-to-end locally with harmonograf observability — submodule setup, server spin-up, monitor scripts, success validation.
+applies-when: ["run e2e", "local stack", "harmonograf server", "reproduce a bug", "full rollout"]
+---
+
+# Run a goldfive end-to-end run locally
+
+This is the canonical loop for reproducing a real goldfive run
+against harmonograf — the same loop we used all week to chase
+filler-loop regressions. It assumes `~/git/goldfive` and
+`~/git/harmonograf` are sibling checkouts.
+
+## One-time setup
+
+### 1. goldfive
+
+```bash
+cd ~/git/goldfive
+uv sync --extra adk --extra claude --extra proto --extra dev
+uv run pytest -q        # sanity check
+```
+
+The `adk` extra is required for the ADK examples; `claude` for
+the Claude SDK adapter; `proto` for the event protobufs; `dev`
+for pytest / ruff / mypy.
+
+### 2. harmonograf
+
+```bash
+cd ~/git/harmonograf
+git clone https://github.com/google/adk-python.git third_party/adk-python
+make install        # installs server + client + frontend deps
+```
+
+The `third_party/adk-python` clone is required even for runs that
+don't go through ADK — the harmonograf `make install` target
+treats it as an editable path dep.
+
+## Driving a run
+
+### The `/tmp/e2e-*.py` pattern
+
+The reproducer scripts land in `/tmp/e2e-<topic>.py` — never
+committed, ephemeral, one per investigation. Shape:
+
+```python
+# /tmp/e2e-plain-waffles.py — reproducer for issue #XXX
+import asyncio, logging
+
+import goldfive
+from goldfive.sinks import LoggingSink
+from harmonograf_client import HarmonografClient, HarmonografSink
+# ... imports for the specific agent you're driving ...
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("goldfive").setLevel(logging.DEBUG)
+
+async def main():
+    # 1. harmonograf client + sink.
+    hg = HarmonografClient("localhost:7531")
+    hg_sink = HarmonografSink(hg)
+
+    # 2. wrap your agent (ADK / Claude / callable; see
+    #    /tmp/e2e-*.py in your shell history for references).
+    agent = ...  # your Agent / client factory / callable
+    runner = goldfive.wrap(
+        agent,
+        sinks=[LoggingSink(), hg_sink],
+    )
+
+    # 3. or observe() for live-steering as well.
+    # runner = hg.observe(runner)
+
+    try:
+        outcome = await runner.run("make a presentation about waffles")
+    finally:
+        await runner.close()
+        await hg.close()
+
+    print(f"success={outcome.success} reason={outcome.reason!r}")
+    if outcome.session.plan is not None:
+        for t in outcome.session.plan.tasks:
+            print(f"  {t.status.value:<10} {t.id}  {t.title}")
+
+asyncio.run(main())
+```
+
+Why `/tmp/` and not `examples/`: these scripts change shape every
+few hours and carry local config. Committing them creates churn;
+`examples/` should stay stable and runnable by readers.
+
+### Booting the harmonograf stack
+
+Two terminals:
+
+```bash
+# terminal 1 — gRPC server on :7531 + gRPC-Web on :7532
+cd ~/git/harmonograf
+make server-run
+
+# terminal 2 — frontend dev server on :5173
+cd ~/git/harmonograf/frontend
+pnpm dev --port 5173 --strictPort
+```
+
+Then open `http://127.0.0.1:5173`. Runs started against
+`localhost:7531` appear in the Sessions view as they begin.
+
+If you want the full ADK demo rollout (server + frontend + an
+`adk web` process hosting `presentation_agent`), `make demo` in
+the harmonograf repo does all three; skip `make server-run` +
+`pnpm dev` in that case.
+
+### Running the reproducer
+
+```bash
+cd ~/git/goldfive
+uv run python /tmp/e2e-plain-waffles.py
+```
+
+The run writes events to harmonograf as it executes; watch the
+Sessions view update live. The stdout of the reproducer gives
+you `success` / `reason` / per-task final status for a quick
+pass/fail check.
+
+## Monitor scripts
+
+Two patterns show up repeatedly:
+
+### Live tail against a specific run
+
+```python
+# /tmp/monitor-latest.py
+import asyncio
+from harmonograf_client import HarmonografClient
+
+async def main():
+    hg = HarmonografClient("localhost:7531")
+    sess = await hg.get_latest_session()
+    async for event in hg.stream_events(sess.run_id):
+        kind = event.WhichOneof("payload")
+        print(f"[{event.sequence:4d}] {kind}")
+    await hg.close()
+
+asyncio.run(main())
+```
+
+### SQLite drill-down after the fact
+
+Harmonograf persists every received event to
+`~/git/harmonograf/data/harmonograf.db`. Direct SQL for
+post-mortem drilling:
+
+```bash
+sqlite3 ~/git/harmonograf/data/harmonograf.db \
+  "SELECT sequence, event_type, payload FROM events \
+   WHERE run_id = '<run_id>' ORDER BY sequence" \
+  | less
+```
+
+This is the pattern the postmortem used to reconstruct the
+filler-loop sequence events when the UI truncated them.
+
+## Validating success
+
+A run is healthy when **all four** hold:
+
+1. `outcome.success == True`.
+2. Every task in `outcome.session.plan.tasks` has status `COMPLETED`.
+3. No `DriftDetected` events of severity CRITICAL appear in the
+   event stream.
+4. The `RunCompleted` event is the last event on the run's stream.
+
+Failure shapes you'll see in this order of likelihood, and what
+each means:
+
+- `success=False, reason="orphaned pending tasks after run"` —
+  cascade didn't fire cleanly; see PLAN-LIFECYCLE §6.4.
+- `success=False, reason="exhausted max_task_invocations=N with pending task ..."` —
+  agent stuck in a loop; a finite `max_task_invocations` caught
+  it. Drop to the filler-loop playbook
+  ([how-to-debug-a-filler-loop.md](how-to-debug-a-filler-loop.md)).
+- `success=False, reason="goal '<summary>' unmet"` — the
+  `Goal.success_predicate` returned False; the tasks completed
+  but the semantic goal wasn't met. #104.
+- `success=False, reason="adapter.invoke raised ..."` — the
+  underlying framework crashed. Look at the LoggingSink output;
+  the traceback is in the preceding ERROR line.
+- `success=True` but a task is `PENDING`/`FAILED` — can't happen
+  post-#98 / #104; if it does, that's a regression worth filing.
+
+## Tips
+
+- Run with `logging.getLogger("goldfive").setLevel(logging.DEBUG)` —
+  every planner call, every refine, every cascade step logs at
+  DEBUG. Volume is manageable for a single run.
+- Set `GOLDFIVE_EXAMPLE_MODEL=openai/gpt-4o-mini` (or whatever)
+  to pin the model in examples that default to something expensive.
+- Use `--mock` (in `examples/adk_presentation/agent.py` and
+  similar) to run without any network. That isolates goldfive
+  orchestration bugs from LLM / API flakiness.
+- `outcome.session.plan.tasks` after the run tells you where the
+  run ended. `outcome.session.reasoning_history` is the last 20
+  reasoning blocks, useful for post-hoc reasoning-drift diagnosis.
+
+## Related
+
+- [docs/guides/observability-with-harmonograf.md](../docs/guides/observability-with-harmonograf.md) — the user-facing end-to-end walkthrough.
+- [docs/guides/telemetry-with-harmonograf.md](../docs/guides/telemetry-with-harmonograf.md) — deriving insight from the UI.
+- [docs/guides/harmonograf-integration.md](../docs/guides/harmonograf-integration.md) — the sink wiring and protocol.
+- [docs/guides/common-failure-modes.md](../docs/guides/common-failure-modes.md) — catalog of failure shapes.
+- [how-to-debug-a-filler-loop.md](how-to-debug-a-filler-loop.md) — what to do when the run doesn't progress.
+- [debug-goldfive.md](debug-goldfive.md) — the triage tree.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,128 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
   `LLMGoalDeriver` by default. `goldfive.adapters.auto.auto_adapter`
   exposes the dispatch standalone.
 - #68 `.agents/` — agent-facing skill folder.
+- #98 Task-lifecycle soundness: adapter invoke-loop breaks on
+  terminal task status, reporting-tool dispatch rejects calls on
+  terminal tasks with a structured `task_already_terminal` ack, the
+  per-task reporting-tool volume cap got the first full pass
+  (50 calls, same `(task, tool)` bucket), and refine failures now
+  surface as a CRITICAL follow-up `DriftDetected` so sinks do not
+  lose a silently-swallowed refine. Closes the filler-loop class.
+- #99 Per-`(drift_kind, task)` refine-failure counter
+  (`session.refine_failure_counts`) + back-off. Two consecutive
+  refine failures for the same key now mark the task FAILED and
+  emit a CRITICAL `REPEATED_FAILURE` drift rather than looping
+  until `max_task_invocations` trips. Threshold is tunable via the
+  class attribute `DefaultSteerer.REFINE_FAILURE_THRESHOLD`.
+- #100 `Plan.validate(for_revision=..., prior=...)` runs at plan
+  creation (`LLMPlanner.generate`) and revision
+  (`LLMPlanner.refine`, `DefaultSteerer._apply_revision`). Enforces
+  unique task ids, edge referential integrity, acyclicity, PENDING
+  status on creation, and (post-#105) terminal-task and
+  terminal→terminal-edge preservation on revision. Malformed plans
+  are rejected before being installed on the session.
+- #101 ADK session conversation history is healed on mid-invocation
+  cancel. The adapter tracks pending `function_call_id`s inside an
+  invoke and synthesises `{"cancelled": true}` function responses
+  for any tool-call that never got a matching response, so the
+  next turn does not see an orphaned `function_call` that upsets
+  the model.
+- #102 `SequentialExecutor(max_retries_per_task_lineage=3)` per-task
+  retry-lineage cap. A "lineage root" strips `retry_` / `retryN_` /
+  `retry_retry_` prefixes so `t0`, `retry_t0`, and
+  `retry2_retry_t0` all share the same budget. When a lineage
+  reaches the cap the next task in that lineage is marked FAILED in
+  place without invoking the adapter. Bounds blast-radius of a
+  runaway refine-spawning-retry-tasks loop.
+- #103 Cancellation cascade: any `mark_task_cancelled` (via control
+  CANCEL, reporting tool, or `_apply_steer`) BFS-walks
+  `plan.edges` forward from the cancelled task and cancels every
+  reachable non-terminal PENDING / RUNNING / BLOCKED task with
+  `reason="cascade from <task_id>"`. Closes the orphaned-PENDING
+  soundness gap. See `PLAN-LIFECYCLE.md` §6.3.
+- #104 `Goal.success_predicate: Callable[[Session], bool] | None`
+  is now evaluated at run termination by
+  `goldfive.results.evaluate_goal_predicates`. A predicate that
+  returns False or raises produces `Outcome.success=False` with
+  `reason="goal '<summary>' unmet"` (or `"goal '<summary>'
+  predicate raised: <exc>"`). Predicates evaluate in
+  `session.goals` order; a raise is logged WARNING and treated as
+  unmet. See `PLAN-LIFECYCLE.md` §6.1.
+- #105 `Plan.validate(for_revision=True, prior=...)` enforces
+  terminal-task and terminal→terminal-edge preservation across
+  revisions (PLAN-LIFECYCLE §3.1 + §3.2). A revision that drops a
+  terminal task, regresses one to PENDING, or deletes a frozen
+  terminal edge now raises `ValueError` before the plan is
+  installed.
+- #106 `PlanRevised` now carries a `PlanRevisionDiff` sidecar
+  (`added_task_ids`, `removed_task_ids`, `modified_task_ids`,
+  `added_edges`, `removed_edges`) so sinks can render "what
+  changed" without re-fetching the prior plan. Populated by
+  `DefaultSteerer._emit_plan_revised`.
+- #107 `DefaultSteerer.mark_task_failed(recoverable=False)` and the
+  cancellation cascade now fan out through **one** shared
+  primitive — `Steerer.cascade_cancel_downstream(session,
+  task_id)` on `goldfive/protocols.py`. Sinks see the same
+  `TaskCancelled` event stream for downstream cancellations
+  regardless of whether the cascade was seeded by a fatal FAILED
+  or a CANCEL.
+- #109 Tool-loop guard hardening. Schema layer rejects calls with
+  missing / unknown `task_id` (so malformed-spam can't poison
+  session counters); per-task loop guard flips the `(task, tool)`
+  bucket into a hard-reject once a burst is detected so continued
+  spam gets `loop_detected` instead of silent pass-through; new
+  session-wide volume cap (> 50 calls of the same tool name across
+  ALL tasks) catches adversarial callers that invent a fresh
+  `task_id` every call.
+- #110 `examples/adk_presentation/` (new canonical path); the
+  pre-existing `examples/adk_agent.py` keeps running unchanged.
+- #112 Opt-in **reflective self-progress check**. When operators
+  enable it via
+  `DefaultSteerer(reflective_check_interval=15, reflective_call_llm=...)`,
+  every N LLM turns the steerer asks the model "are you making
+  forward progress on task X?" and classifies the reply as either
+  `UNCERTAIN_PROGRESS` (yes, but `confidence < 0.5`, INFO) or
+  `SELF_REPORTED_STUCK` (no, WARNING → refine). Off by default:
+  operators that don't supply `reflective_call_llm` pay no LLM
+  cost. A parse / LLM failure emits an INFO `CUSTOM` drift
+  prefixed `reflective_check_failed:` — the run is never broken
+  by a bad reflective call.
+- Extended `Runner` extension API (#87) with the post-construction
+  `control` setter for late `ControlChannel` attachment.
+- Shared `Steerer.cascade_cancel_downstream` primitive added to
+  `goldfive/protocols.py`; reference impl on `DefaultSteerer`.
 
 ### Changed
 
-- Renamed `max_plan_reinvocations` to `max_task_invocations` on
+- #108 **Critical fix.** Every adapter's reporting-tool dispatch is
+  now routed through the central
+  `goldfive.adapters._tool_invocation.invoke_tool` helper, which
+  runs the four-layer guard stack (schema rejection, terminal-task
+  rejection, per-task loop guard, session-wide volume cap) before
+  calling `spec.handler`. Pre-#108 the ADK plugin called
+  `spec.handler` directly from `before_tool_callback`, bypassing
+  the idempotency and terminal-rejection layers — which is the
+  root cause of the "guard defined but not firing" class of
+  filler-loop bugs. No public API change; behaviour only.
+- #111 `examples/adk_presentation/agent.py` simplified to a single
+  `Agent` + `goldfive.wrap(...)` call. The previous hand-rolled
+  coordinator+subagents tree was agent-design, not framework, and
+  was hiding a root cause of the week's filler-loop investigation
+  (`require_confirmation` combined with a bad coordinator prompt
+  kept the agent silently gated instead of executing the task).
+  The multi-agent reference moved to
+  `harmonograf/tests/reference_agents/presentation_agent/`.
+- #114 `INTENT_DIVERGENCE` now fires at **graduated severity**
+  (`INFO` / `WARNING` / `CRITICAL`) based on cosine similarity
+  between the reasoning block and `session.goals` + the current
+  task topic. Bands: `sim >= 0.6` healthy, `>= 0.4` INFO, `>= 0.2`
+  WARNING, `< 0.2` CRITICAL. An unreferenced-keyword mismatch bumps
+  severity one step. The pattern-based fallback (no embeddings)
+  now fires at `WARNING` with the same keyword-mismatch bump. The
+  drift kind is stable; only `severity` changes. See
+  `docs/design/DRIFT.md` for the full table and
+  `goldfive/drift/reasoning.py` for thresholds.
+- #115 Renamed `max_plan_reinvocations` to `max_task_invocations` on
   `SequentialExecutor`, `ParallelDAGExecutor`, `Runner`, and
   `goldfive.wrap()` / `goldfive.run()`. The default is now
   `None` (unbounded) — per-task / per-tool caps
@@ -56,16 +174,20 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
 - #69 Reconciled `HarmonografSink` API docs with the shipped
   `harmonograf_client.HarmonografSink(client)` shape and canonical
   `:7531` port.
-- `INTENT_DIVERGENCE` now fires at **graduated severity**
-  (`INFO` / `WARNING` / `CRITICAL`) based on cosine similarity
-  between the reasoning block and `session.goals` + the current
-  task topic. Bands: `sim >= 0.6` healthy, `>= 0.4` INFO, `>= 0.2`
-  WARNING, `< 0.2` CRITICAL. An unreferenced-keyword mismatch bumps
-  severity one step. The pattern-based fallback (no embeddings)
-  now fires at `WARNING` with the same keyword-mismatch bump. The
-  drift kind is stable; only `severity` changes. See
-  `docs/design/DRIFT.md` for the full table and
-  `goldfive/drift/reasoning.py` for thresholds.
+
+### Fixed
+
+- #98 Filler-loop ceiling regressions: adapters that ignored the
+  terminal-task status post-`report_task_completed` could keep
+  invoking and hit the ADK 500-call ceiling. The adapter invoke
+  loop now breaks early on terminal status, and the steerer rejects
+  terminal-task reporting calls at the dispatch boundary.
+- #108 See **Changed**. Reporting-tool dispatch that skipped the
+  guard layers was the class of bug that caused every filler-loop
+  patch before this to look correct in isolation but ineffective
+  in practice.
+- #109 `report_task_completed(task_id="")` and other empty / unknown
+  `task_id` payloads no longer reach the guard state counters.
 
 ## 0.1.0 — 2026-04-18
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,12 @@ inspect the event stream. Concrete and runnable.
 - [`docs/design/ARCHITECTURE.md`](docs/design/ARCHITECTURE.md) — overview of the six primitives, how they compose, full lifecycle.
 - [`docs/design/PROTOCOLS.md`](docs/design/PROTOCOLS.md) — the six protocol contracts with minimal implementations.
 - [`docs/design/STATE-MACHINE.md`](docs/design/STATE-MACHINE.md) — task lifecycle state diagram, transition rules, invariants.
+- [`docs/design/TASK-LIFECYCLE.md`](docs/design/TASK-LIFECYCLE.md) — per-task lifecycle, reporting-tool dispatch layering, cancellation protocol.
+- [`docs/design/PLAN-LIFECYCLE.md`](docs/design/PLAN-LIFECYCLE.md) — plan-level state machine: revision modes, run-termination predicate, cascade semantics.
 - [`docs/design/DRIFT.md`](docs/design/DRIFT.md) — full drift-kind taxonomy (25+), classification rules, refine policy.
 - [`docs/design/EVENT-MODEL.md`](docs/design/EVENT-MODEL.md) — proto event taxonomy, sequence semantics, `EventSink` contract.
+- [`docs/design/CONTROL.md`](docs/design/CONTROL.md) — live-steering control channel protocol (PAUSE / RESUME / CANCEL / STEER / REWIND_TO / APPROVE / REJECT).
+- [`docs/design/APPROVAL.md`](docs/design/APPROVAL.md) — human-in-the-loop approval flows (Flow A: goldfive-native; Flow B: ADK tool confirmation).
 
 ### Further reading — the "why" docs
 
@@ -106,6 +110,9 @@ inspect the event stream. Concrete and runnable.
 
 - [`docs/guides/getting-started.md`](docs/guides/getting-started.md) — install + first agent.
 - [`docs/guides/observability-with-harmonograf.md`](docs/guides/observability-with-harmonograf.md) — ten-minute end-to-end with the harmonograf UI.
+- [`docs/guides/telemetry-with-harmonograf.md`](docs/guides/telemetry-with-harmonograf.md) — reading the UI: Gantt, span popovers, Inspector Drawer, live steering, plan revisions.
+- [`docs/guides/insight-from-logs.md`](docs/guides/insight-from-logs.md) — operators without the UI: raw event stream, session state after a run, post-mortem from JSONL / SQLite.
+- [`docs/guides/common-failure-modes.md`](docs/guides/common-failure-modes.md) — catalog of observed failure shapes, each with its signature and recovery path.
 - [`docs/guides/writing-an-agent-adapter.md`](docs/guides/writing-an-agent-adapter.md) — wrap a new framework.
 - [`docs/guides/writing-an-event-sink.md`](docs/guides/writing-an-event-sink.md) — build a custom sink.
 - [`docs/guides/choosing-a-sink.md`](docs/guides/choosing-a-sink.md) — decision matrix across the five shipped sinks.

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -81,8 +81,14 @@ crosses a severity threshold it invokes `planner.refine(...)`.
 agent framework (ADK, Claude Agent SDK, a bare callable, ...). It
 registers reporting tools, renders current-task context into whatever
 form the framework expects (shared session state, a system prompt,
-whatever), invokes the agent, and routes intercepted tool calls and
-observed events back to the steerer.
+whatever), invokes the agent, and routes tool calls and observed
+events back to the steerer. All adapters funnel reporting-tool
+dispatch through the shared
+`goldfive.adapters._tool_invocation.invoke_tool` helper, which runs
+four guard layers (schema rejection, terminal-task rejection,
+per-task loop detection, session-wide volume cap) before calling the
+`ReportingToolSpec.handler` — see [TASK-LIFECYCLE.md §5](TASK-LIFECYCLE.md)
+for the layering.
 
 **EventSink** — consumes the proto-encoded event stream. goldfive
 ships five sinks: `InMemorySink` for tests, `LoggingSink` for dev,
@@ -231,16 +237,29 @@ while session.plan has unfinished tasks:
         if any dep of task is not COMPLETED: skip
         steerer.transition(task.id, RUNNING, session=session)
         result = await adapter.invoke(task, session)    # agent runs here
-        # adapter has been forwarding reporting-tool calls
-        # to steerer throughout the invocation
+        # adapter has been forwarding reporting-tool calls through
+        # invoke_tool (four-layer guard) to the steerer throughout.
         drift = steerer.detect_drift(result, session)
         if drift and drift.severity >= WARNING:
             revised = await planner.refine(plan=session.plan, drift=drift, goals=session.goals)
             if revised:
+                # PlanRevised carries a PlanRevisionDiff sidecar
+                # (added / removed / modified task ids + edges).
                 session.plan = revised
-                emit PlanRevised(plan=revised, revision_metadata=...)
+                emit PlanRevised(plan=revised, diff=<PlanRevisionDiff>, …)
                 break to outer loop  # restart walk with revised plan
+            else:
+                # register (drift_kind, task_id) refine failure;
+                # 2 consecutive failures → mark task FAILED and emit
+                # CRITICAL REPEATED_FAILURE drift. See PLAN-LIFECYCLE.md §4.5.
 ```
+
+Cancellation and unrecoverable drift fan out to downstream tasks
+through the shared `Steerer.cascade_cancel_downstream(session, id)`
+primitive — both cascades emit the same `TaskCancelled` event
+stream for the downstream set. See
+[PLAN-LIFECYCLE.md §6.2 / §6.3](PLAN-LIFECYCLE.md) and
+[STATE-MACHINE.md §"Cascade semantics"](STATE-MACHINE.md).
 
 ParallelDAGExecutor differs only in that each topological *stage* is
 an `asyncio.gather` over the stage's tasks; refine runs between
@@ -292,14 +311,17 @@ Four invariants hold across every `Runner.run(...)` invocation:
 - **CLI.** goldfive is a library. Callers build CLIs on top.
 - **Multi-run coordination.** One `Runner.run()` = one `run_id`. For
   resuming a crashed run, see [persistence-and-recovery.md](../guides/persistence-and-recovery.md).
-- **Human-in-the-loop mid-run steering.** Control actions (pause,
-  resume, external steer) are on the roadmap but not implemented in
-  v0.1. External systems can emit drift by synthesizing a
-  `DriftEvent(kind=USER_STEER)` and handing it to the steerer, but
-  there is no in-box protocol yet.
 - **Streaming to the caller.** `Runner.run()` is a batch call.
   Streaming live progress is expected to happen through a caller-
   supplied `EventSink`, not through an async generator.
+
+**Live steering is in-box.** Human-in-the-loop mid-run steering
+(PAUSE, RESUME, CANCEL, STEER, REWIND_TO, APPROVE, REJECT) is
+implemented. Pass a `ControlChannel` to `Runner(control=...)` and
+an external process can drive the run through it. See
+[CONTROL.md](CONTROL.md) for the wire format and
+[`examples/live_steering.py`](../../examples/live_steering.py) for
+a runnable demo.
 
 ## Layering: goldfive inside, harmonograf outside
 

--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -272,11 +272,13 @@ flowchart TD
     C9 -->|no| R9[AGENT_TRANSFER / info]
 ```
 
-The helper classifiers live in `goldfive/drift.py`:
+The helper classifiers live in `goldfive/drift/__init__.py` (the
+`goldfive.drift` package; the reasoning-drift pipeline lives in
+`goldfive/drift/reasoning.py`):
 
 ```python
 # pseudo-code: signature-only view. Live definitions are in
-# ``goldfive/drift.py``.
+# ``goldfive/drift/__init__.py``.
 def classify_tool_error(event: Any) -> DriftEvent | None: ...
 def classify_refusal(text: Any) -> DriftEvent | None: ...
 def classify_stop_reason(reason: Any) -> DriftEvent | None: ...
@@ -322,16 +324,30 @@ session.plan = revised
 await emit_plan_revised(sinks, plan=revised, drift=drift, session=session)
 ```
 
-Three invariants govern the refine path:
+Four invariants govern the refine path:
 
 1. **Completed tasks are preserved.** `planner.refine()` implementations
-   must not return a plan that deletes or re-runs completed tasks.
+   must not return a plan that deletes or re-runs completed tasks. The
+   terminal-task and terminal→terminal-edge preservation rules
+   (PLAN-LIFECYCLE §3.1–§3.2) are enforced by `Plan.validate()` on
+   every revision install.
 2. **Revision metadata is stamped.** The revised plan's
    `revision_reason`, `revision_kind`, `revision_severity`, and
    `revision_index` fields are set by the executor before emission.
+   The emitted `PlanRevised` event also carries a `PlanRevisionDiff`
+   sidecar (added / removed / modified task ids + edges) so sinks can
+   render "what changed" without re-fetching the prior plan.
 3. **Refine is throttled.** Multiple drifts of the same kind within
    `DEFAULT_REFINE_THROTTLE_SECONDS` (2s) collapse into one refine
    call. `critical` drifts bypass the throttle.
+4. **Refine failures back off.** `session.refine_failure_counts`
+   tracks consecutive `planner.refine()` failures per
+   `(drift.kind, current_task_id)`. Once the counter crosses
+   `DefaultSteerer.REFINE_FAILURE_THRESHOLD` (default `2`), the
+   steerer marks the current task FAILED and emits a CRITICAL
+   `REPEATED_FAILURE` drift — the run does not loop forever on a
+   refine that cannot make progress. The counter resets on a
+   successful refine.
 
 ## How drifts become events
 

--- a/docs/design/PROTOCOLS.md
+++ b/docs/design/PROTOCOLS.md
@@ -135,10 +135,23 @@ class Planner(Protocol):
 
 1. Generated plans are acyclic. `Plan.topological_stages()` raises on
    a cycle; planners are responsible for producing valid DAGs.
+   `Plan.validate()` is called on every installed plan (creation and
+   revision) and will reject cyclic / dangling / duplicate-id plans
+   before they land on the session.
 2. `plan.goal_ids` lists every goal the plan intends to satisfy.
-3. `refine()` preserves `Task.id` for completed tasks; it may add,
-   remove, or edit `PENDING` tasks freely.
+3. `refine()` preserves `Task.id` AND terminal status for every
+   terminal task in the outgoing plan (PLAN-LIFECYCLE §3.1). It may
+   add, remove, or edit `PENDING` tasks freely, and it may re-draw
+   edges that touch at least one mutable endpoint, but every
+   terminal→terminal edge in the outgoing plan must reappear verbatim
+   in the revision (PLAN-LIFECYCLE §3.2).
 4. `refine()` monotonically increments `plan.revision_index`.
+5. When `refine()` returns `None` twice consecutively for the same
+   `(drift.kind, current_task_id)` pair, the steerer marks the task
+   FAILED and emits a CRITICAL `REPEATED_FAILURE` drift — the run
+   does not loop forever on a refine that cannot make progress. The
+   threshold is the class attribute
+   `DefaultSteerer.REFINE_FAILURE_THRESHOLD` (default `2`).
 
 ### Minimal implementation
 
@@ -192,6 +205,15 @@ response, see `goldfive/planner.py` or
 class Steerer(Protocol):
     async def observe(self, event: Any, session: Session) -> None: ...
 
+    async def observe_reasoning(
+        self,
+        text: str,
+        *,
+        task: Task | None = None,
+        session: Session,
+        provider: str = "",
+    ) -> None: ...
+
     async def transition(
         self,
         task_id: str,
@@ -199,6 +221,12 @@ class Steerer(Protocol):
         *,
         detail: str = "",
         session: Session,
+    ) -> None: ...
+
+    async def cascade_cancel_downstream(
+        self,
+        session: Session,
+        cancelled_id: str,
     ) -> None: ...
 
     def detect_drift(self, event: Any, session: Session) -> Optional[DriftEvent]: ...
@@ -217,10 +245,26 @@ class Steerer(Protocol):
   events (LLM text, tool calls, stream chunks) here. The steerer may
   classify drift, update per-task progress, or no-op. Must not mutate
   `event`.
+- `observe_reasoning(text, *, task=, session, provider="")` — called
+  once per LLM response that carries chain-of-thought (OpenAI
+  `reasoning_content`, Anthropic `thinking`, Google thought parts).
+  Feeds `Session.reasoning_history` and the reasoning-drift pipeline
+  (`LOOPING_REASONING`, `CONFUSION`, `OFF_TOPIC`, `INTENT_DIVERGENCE`).
+  Adapters that cannot surface reasoning simply never call this.
 - `transition(task_id, to, session)` — the single source-of-truth
   state-mutating method. Enforces monotonicity (see
   [STATE-MACHINE.md](STATE-MACHINE.md)) and emits one event per
   successful transition.
+- `cascade_cancel_downstream(session, cancelled_id)` — shared
+  cancellation-fanout primitive. BFS-walks `session.plan.edges`
+  forward from `cancelled_id`, transitions every reachable
+  non-terminal task to CANCELLED, and emits exactly one
+  `TaskCancelled` per transitioned task. De-duplicates diamond-DAG
+  reachability and skips already-terminal downstream tasks. Used by
+  both the unrecoverable-failure cascade
+  (`mark_task_failed(recoverable=False)`) and the
+  cancellation-cascade path. The initiator itself is *not*
+  transitioned by this method; callers own that.
 - `detect_drift(event, session)` — pure classifier. Returns a
   `DriftEvent` or `None`. No state mutation, no event emission.
 - `bind(sinks, planner)` — called once by the executor before the
@@ -310,6 +354,16 @@ class AgentAdapter(Protocol):
         session: Session,
     ) -> InvocationResult: ...
 
+    async def emit_reasoning(
+        self,
+        text: str,
+        *,
+        task: Task | None = None,
+        session: Session,
+        provider: str = "",
+        call_id: str = "",
+    ) -> None: ...
+
     @property
     def available_agents(self) -> list[str]: ...
 ```
@@ -319,8 +373,18 @@ class AgentAdapter(Protocol):
 - `register_reporting_tools(tools)` — called once before the first
   invoke. Adapter translates `ReportingToolSpec` into whatever form
   its framework uses (ADK `FunctionTool`, Claude SDK inline tool,
-  etc.) and wires a hook that intercepts calls and routes them
-  through the steerer.
+  etc.), stores the full spec list, and wires a hook that routes
+  calls through
+  `goldfive.adapters._tool_invocation.invoke_tool(specs, name, args, session, steerer)`.
+  The `invoke_tool` helper runs four guard layers — schema
+  rejection (missing / unknown `task_id`), terminal-task rejection,
+  per-task loop detection, session-wide volume cap — and then
+  dispatches to the spec's `handler`. All in-tree adapters
+  (`CallableAdapter`, `ADKAdapter`, `ClaudeAgentSDKAdapter`) funnel
+  dispatch through this helper; any new adapter MUST do the same,
+  or the filler-loop / duplicate-ack / terminal-task protections
+  won't fire for calls it forwards. See
+  [TASK-LIFECYCLE.md §5](TASK-LIFECYCLE.md).
 - `invoke(task, session)` — runs the wrapped agent for one task.
   Must render current-task context (task id, description, completed
   results) into the agent's input channel. Returns an

--- a/docs/design/STATE-MACHINE.md
+++ b/docs/design/STATE-MACHINE.md
@@ -94,11 +94,13 @@ harmonograf integration) assumes it.
 
 In v0.1, the canonical path into the state machine is through
 **reporting tools** (see [tool-protocol.md](../reference/tool-protocol.md)).
-When an agent calls `report_task_started("t3")`, the adapter
-intercepts, and the steerer applies `PENDING → RUNNING` for task
-`t3`.
+When an agent calls `report_task_started("t3")`, the adapter routes
+the call through `goldfive.adapters._tool_invocation.invoke_tool`
+(which runs the schema / terminal / loop / volume guards), the
+spec's handler fires, and the steerer applies `PENDING → RUNNING`
+for task `t3`.
 
-There are three non-reporting-tool paths in:
+There are four non-reporting-tool paths in:
 
 - **Executor-driven transitions.** When the executor first picks up a
   `PENDING` task, it calls `steerer.transition(task_id, RUNNING, ...)`
@@ -107,9 +109,18 @@ There are three non-reporting-tool paths in:
 - **Adapter-observed failures.** If `adapter.invoke()` raises, the
   executor catches, classifies the error as `TOOL_ERROR` or
   `TASK_FAILED_FATAL`, and calls `steerer.transition(task_id, FAILED, ...)`.
-- **Cascade cancellations.** On an unrecoverable drift, the executor
-  walks downstream PENDING tasks via `Plan.topological_stages()` and
-  transitions each to `CANCELLED`.
+- **Cascade cancellations.** `Steerer.cascade_cancel_downstream(session, id)`
+  BFS-walks forward along `plan.edges` from a cancelled or fatally-failed
+  task and transitions every reachable non-terminal task to `CANCELLED`.
+  Used by both the unrecoverable-failure cascade
+  (`mark_task_failed(recoverable=False)`) and the cancellation
+  cascade on `mark_task_cancelled`. See §"Cascade semantics" below.
+- **Reachability audit on executor exit.** If the executor loop
+  exits with PENDING tasks still remaining and `_pick_next_task`
+  returns `None` (orphans whose every predecessor path crosses a
+  terminal task), the executor cancels them in place and emits a
+  CRITICAL `PLAN_DIVERGENCE` drift. See
+  [PLAN-LIFECYCLE.md §6.4](PLAN-LIFECYCLE.md).
 
 ### Invariant 3 — Transitions emit exactly one event
 

--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -498,45 +498,36 @@ lockstep. No automated check enforces it.
 `goldfive.types._constants`) and import from it. Low effort, high
 impact.
 
-### 7.2 Weak plan validation at creation and revision
+### 7.2 Plan validation at creation and revision (closed)
 
-`Plan.__post_init__` / `_apply_revision` do not check for:
+Closed by #100 and #105. `Plan.validate(for_revision=..., prior=...)`
+runs at plan creation (`LLMPlanner.generate`) and on every plan
+revision (`DefaultSteerer._apply_revision` and `LLMPlanner.refine`).
+Checks duplicate task ids, edge referential integrity, acyclicity,
+PENDING-only tasks on creation, and — when a `prior` plan is
+supplied — terminal-task and terminal→terminal-edge preservation
+(PLAN-LIFECYCLE §3.1–§3.2). Malformed plans are rejected with
+`ValueError` before they are installed on the session.
 
-- duplicate task IDs,
-- edges referencing missing tasks,
-- cycles (topological_stages silently appends leftover tasks),
-- `TaskStatus` values that are not `PENDING` at creation time.
+### 7.3 Refine failure retry backoff (closed)
 
-**Fix direction:** add `Plan.validate()` called from
-`LLMPlanner.generate` before return and from
-`DefaultSteerer._apply_revision` before install. Emit a
-`PLAN_DIVERGENCE` drift (severity CRITICAL) if validation fails.
+Closed by #99. `session.refine_failure_counts: dict[(kind, task),
+int]` tracks consecutive `planner.refine()` failures per drift
+key. When the counter crosses
+`DefaultSteerer.REFINE_FAILURE_THRESHOLD` (default `2`), the
+steerer marks the task FAILED, emits a CRITICAL `REPEATED_FAILURE`
+drift, and resets the counter. A successful refine also resets the
+counter so a future drift of the same kind starts fresh.
 
-### 7.3 Refine failure retry backoff
+### 7.4 Orphaned tool_call_ids on mid-invocation cancel (closed)
 
-If the configured LLM is down, the same drift re-fires → refine
-fails → drift re-emitted (now with "refine failed" surface, §4.3)
-→ but the underlying condition is unchanged → drift fires again on
-next tick. Eventually bounded by the per-lineage cap
-(`max_retries_per_task_lineage`) or by an explicit
-`max_task_invocations` ceiling when configured, but any budget is
-burned without forward progress.
-
-**Fix direction:** per-`(drift.kind, task_id)` refine-attempt
-counter. After N consecutive failures, mark the task FAILED
-directly (skip refine entirely) and emit a CRITICAL
-`REPEATED_FAILURE` drift. 2–3 attempts is probably right.
-
-### 7.4 Orphaned tool_call_ids on mid-invocation cancel
-
-Cancelling ADK mid-tool-call leaves the assistant message with
-`tool_calls` unmatched by `tool_result` messages. Described in §6.1.
-
-**Fix direction:** `ADKAdapter._cancel_and_heal(task_id,
-tool_call_ids)` — after `task.cancel()`, append synthetic
-`tool_result` messages (status="cancelled") for each pending
-tool_call_id. Requires ADK internals knowledge; medium-high effort,
-high impact for live-steering scenarios.
+Closed by #101. `ADKAdapter` tracks pending `function_call_id`s
+observed in the current `invoke()`'s event stream in
+`self._pending_tool_call_ids` / `self._pending_tool_call_names`.
+On mid-invocation cancel (or unexpected exception), the adapter
+synthesises `{"cancelled": true}` function-response messages for
+every pending id so the ADK session history stays well-formed and
+the next turn does not see an orphaned `function_call`.
 
 ### 7.5 Cross-task ADK session history pollution
 

--- a/docs/guides/common-failure-modes.md
+++ b/docs/guides/common-failure-modes.md
@@ -1,0 +1,301 @@
+# Common failure modes
+
+Catalog of the failure shapes goldfive has observed in the wild,
+with the signature on the event stream, the root cause, and the
+recovery path. Pair with
+[troubleshooting.md](troubleshooting.md) (install + setup
+problems) and [insight-from-logs.md](insight-from-logs.md) (how to
+read the stream itself). For the "it wasn't on this page"
+catch-all, reach for
+[.agents/debug-goldfive.md](../../.agents/debug-goldfive.md).
+
+## 1. Filler loop
+
+The canonical goldfive failure: the agent loops making no forward
+progress, and the guards — which exist — fail to stop it.
+Pre-#98 / #108 / #109 hardening, this class of bug could ride all
+the way to the framework's own ceiling (ADK 500 calls, Claude
+max_turns) before the run aborted.
+
+**Signature.** One of:
+
+- `outcome.success=False, reason="exhausted max_task_invocations=N with pending task <id>"`
+  with `id` being the same task every time.
+- `outcome.success=False, reason="adapter.invoke raised ... max_turns_exceeded"`
+  or similar framework-level abort.
+- `sink.events` shows `DRIFT_KIND_LOOPING_TOOL_CALL` (post-guard)
+  or a dominating count of `report_task_*` calls on one task
+  (pre-guard).
+- Task status is `COMPLETED` on the session plan, but reporting
+  tool calls keep arriving for the same `task_id` (returned as
+  `task_already_terminal` acks post-#98).
+
+**Root causes (by likelihood).**
+
+1. A new adapter bypassed `invoke_tool`. See
+   [.agents/how-to-debug-a-filler-loop.md](../../.agents/how-to-debug-a-filler-loop.md).
+   This was the #108 root cause in the ADK adapter.
+2. A custom planner produced a task the agent can't actually
+   satisfy (the agent reports "done" but the planner doesn't
+   accept the completion, refine spawns a retry, loop).
+3. The agent's instruction prompt is wrong — it thinks it's
+   driving the whole workflow (see §Agent tree misdesign below).
+
+**Recovery path.**
+
+- Set `SequentialExecutor(max_task_invocations=<finite>)` as a
+  belt-and-suspenders ceiling while investigating.
+- Run [.agents/how-to-debug-a-filler-loop.md](../../.agents/how-to-debug-a-filler-loop.md).
+- If the guard was bypassed, fix the adapter. If the agent is
+  mis-prompted, fix the instruction. Do NOT add another cap.
+
+## 2. Refine failure (truncated JSON, LLM unavailable)
+
+The planner LLM returns something `LLMPlanner` can't parse. Three
+common shapes:
+
+- JSON that got truncated at the token limit — missing closing
+  `}` or `]`.
+- An empty string or a whitespace-only response.
+- Valid JSON but in the wrong shape (no `tasks` field, or tasks
+  missing required keys).
+
+**Signature.**
+
+- `DriftDetected` with detail starting `refine failed` (or
+  `_refine_user_steer: empty/non-string`).
+- Logger `goldfive.planner` DEBUG line with `failed to parse LLM
+  output`.
+- `session.refine_failure_counts` incrementing for
+  `(drift.kind, current_task_id)` across ticks.
+- Once the counter crosses
+  `DefaultSteerer.REFINE_FAILURE_THRESHOLD` (default `2`),
+  `DriftDetected{kind=REPEATED_FAILURE, severity=CRITICAL}` fires
+  and the task is marked FAILED.
+
+**Root causes.**
+
+- Planner LLM's `max_tokens` too small for the plan size.
+- Planner LLM provider down / rate-limited / returning 500s.
+- Prompt template is wrong (e.g. `{tasks}` literal in output
+  instead of a JSON array — shows up with custom planners).
+
+**Recovery path.**
+
+- Widen `max_tokens` on your planner LLM.
+- Implement retries / backoff inside your `call_llm` callable
+  (not at the goldfive level — the steerer's refine-failure
+  counter is the coarse backoff).
+- Log the raw `call_llm` response before returning so you can
+  see what was actually truncated. See
+  [insight-from-logs.md §Capturing planner reasoning](insight-from-logs.md).
+
+## 3. Orphaned PENDINGs at run end
+
+A run ends with `success=False,
+reason="orphaned pending tasks after run: <ids>"`. Pre-#103 this
+could also produce `success=True` with PENDING tasks still on
+the plan — #103 and the reachability audit (§6.4) made that
+impossible.
+
+**Signature.**
+
+- `outcome.success=False, reason="orphaned pending tasks after run: t4, t5, t6"`.
+- The last event before `RunAborted` is a CRITICAL
+  `DriftDetected{kind=PLAN_DIVERGENCE}` emitted by the
+  reachability audit.
+- Every orphan task is PENDING on the final plan with a
+  predecessor that is CANCELLED or FAILED.
+
+**Root causes.**
+
+- `planner.refine` returned `None` after a USER_STEER or
+  unrecoverable drift, but the cascade didn't fire — pre-#103 bug,
+  should not recur.
+- A custom steerer cancelled a task without calling
+  `cascade_cancel_downstream` — the primitive is the source of
+  truth; any direct `mark_task_cancelled` that skips the
+  downstream walk regresses §6.3.
+
+**Recovery path.**
+
+- Confirm you're on goldfive ≥ #103. If so, file a bug — this
+  shouldn't happen on current `main`.
+- If you have a custom Steerer subclass, audit it for any
+  `mark_task_cancelled` path that doesn't delegate to
+  `cascade_cancel_downstream`.
+
+## 4. Agent tree misdesign (coordinator-drives-whole-workflow)
+
+Not a framework bug but easy to mistake for one: the agent's
+prompt tells it to run the whole workflow in one turn, instead of
+handling "just the task the orchestrator routed me". The
+`examples/adk_presentation/` example hit this before #111 — a
+hand-rolled coordinator + subagent tree where the coordinator's
+instructions made it `transfer_to_agent` sub-agents in sequence
+regardless of goldfive's task dispatch. Goldfive then marked the
+task complete while the coordinator was still narrating, and the
+coordinator kept calling `require_confirmation=True` tools that
+silently gated on a UI that wasn't watching.
+
+**Signature.**
+
+- Multiple agents show up in `available_agents` but every
+  `InvocationResult` originates from one.
+- Plan generated by the LLM planner has one task per
+  sub-workflow, but the agent's output never acknowledges the
+  individual task ids — it just rolls through.
+- Reasoning content (if extracted) mentions the whole workflow
+  not the current task.
+- `report_task_completed` is called with arguments derived from
+  the *plan summary*, not the *current task id* — the agent
+  doesn't know which task it's on.
+
+**Root causes.**
+
+- The agent's instruction says "execute the plan" rather than
+  "execute the single task the orchestrator gave you."
+- `require_confirmation=True` on sub-agent tools, combined with
+  no UI watching approvals — the tool silently blocks, the
+  framework reports `max_turns_exceeded`.
+- A coordinator that uses `transfer_to_agent` as its primary
+  control-flow mechanism, treating sub-agents as independent
+  processes rather than goldfive-managed workers.
+
+**Recovery path.**
+
+- Simplify to one agent + `goldfive.wrap(agent)` first. If the
+  run now succeeds, the agent tree was the problem, not
+  goldfive. See `examples/adk_presentation/agent.py` for the
+  minimal shape post-#111.
+- If you need multiple agents, have each one handle only its
+  assigned task (`task.assignee_agent_id`) and return. Let
+  goldfive do the routing. The harmonograf
+  `tests/reference_agents/presentation_agent` is a worked
+  example with a real multi-agent tree that works with goldfive.
+- Rewrite the instruction to explicitly scope to the current
+  task: "Each message you receive is a single task; complete
+  just that task and stop."
+
+## 5. `require_confirmation` silent gating (pre-#111 behaviour)
+
+Specific sub-case of §4 but distinctive enough to call out. ADK
+sub-agents marked `require_confirmation=True` create a tool-call
+that blocks on an APPROVE / REJECT decision. Pre-#83 goldfive
+didn't have an APPROVE / REJECT control channel, so the tool
+call hung forever; #83 added the bridge; #111 dropped the
+unneeded `require_confirmation=True` from the example tree.
+
+**Signature.**
+
+- Agent "goes silent" — no new events after the first
+  `TaskStarted`.
+- `session.pending_approvals` has an entry keyed by an
+  `adk-<uuid>` (ADK Flow B). Non-empty after the run ends is the
+  red flag.
+- After `max_task_invocations` trips, the `RunAborted.reason`
+  blames the task that was waiting on approval, not the approval
+  itself — the failure mode looks like a stuck task.
+
+**Recovery path.**
+
+- Drop `require_confirmation=True` from any ADK tool that doesn't
+  actually need human-in-the-loop approval. This was the #111 fix.
+- If you do need approval, wire up the control channel
+  (`Runner(control=...)`) and route APPROVE / REJECT messages.
+  See [../design/CONTROL.md §Flow B](../design/CONTROL.md) and
+  [../design/APPROVAL.md](../design/APPROVAL.md).
+- Verify harmonograf `observe()` is attached if you expect the UI
+  to drive approvals — it enables HUMAN_IN_LOOP by default since
+  harmonograf #44.
+
+## 6. Cascade ran but refine didn't produce a follow-up plan
+
+Not a failure per se — just "incomplete but not broken". A
+USER_STEER arrives, the current task is CANCELLED, the cascade
+cancels downstream PENDINGs, and then `planner.refine` returns
+`None`. No new work is installed. The run ends cleanly with
+`success=False`.
+
+**Signature.**
+
+- `DriftDetected{kind=USER_STEER, severity=WARNING}`.
+- `TaskCancelled` for the current task, then a flurry of
+  `TaskCancelled` events with `reason="cascade from <task_id>"`.
+- No `PlanRevised` follows.
+- `RunAborted` with a reason like "goal '<...>' unmet" or
+  "planner declined refine".
+
+**Root causes.**
+
+- The steer message was ambiguous and the planner genuinely
+  couldn't produce a coherent follow-up.
+- The planner's prompt template doesn't know how to handle
+  USER_STEER (most `LLMPlanner` configurations do; custom
+  planners may not).
+
+**Recovery path.**
+
+- This is arguably correct behaviour — the planner decided the
+  steer was unrecoverable. Treat the run as failed and start a
+  new one with the steer text folded into the initial input.
+- If you want the planner to always produce something, customise
+  your planner's refine logic to never return `None` (return a
+  trivial one-task plan as a fallback).
+
+## 7. Drift kinds firing at unexpected severity
+
+`INTENT_DIVERGENCE` fires at graduated severity since #114 —
+INFO / WARNING / CRITICAL based on cosine similarity. If you
+were relying on "INTENT_DIVERGENCE always means refine", expect
+more INFO-severity signals that don't trigger refine.
+
+**Signature.**
+
+- `DriftDetected{kind=INTENT_DIVERGENCE, severity=INFO}` — no
+  refine follows. This is expected and correct.
+- `DriftDetected{kind=INTENT_DIVERGENCE, severity=CRITICAL}` —
+  treated as unrecoverable; cascade fires and the run aborts.
+- `UNCERTAIN_PROGRESS` (INFO) appearing mid-run — this is the
+  opt-in reflective self-progress check from #112 emitting.
+  Informational, no refine.
+- `SELF_REPORTED_STUCK` (WARNING) — refine triggered. Expect a
+  `PlanRevised` follow-up.
+
+**Root causes.**
+
+- Reading the `kind` without the `severity` — now the wrong
+  abstraction.
+- Relying on pre-#114 semantics where INTENT_DIVERGENCE was a
+  single severity.
+
+**Recovery path.**
+
+- Filter by `severity >= WARNING` if you only care about the
+  refine-triggering band.
+- Update any custom `should_refine(drift)` override to inspect
+  severity, not kind.
+
+## 8. Deprecation warning: `max_plan_reinvocations`
+
+`DeprecationWarning: SequentialExecutor(max_plan_reinvocations=...)
+is deprecated; use max_task_invocations=... instead.`
+
+**Root cause.** #115 renamed the parameter. The old kwarg is
+still accepted for one release with a `DeprecationWarning`.
+
+**Recovery.** Rename. The default changed from finite (32) to
+`None` (unbounded) in the same PR — if you were relying on the
+old default as a safety cap, set `max_task_invocations=32`
+explicitly. See
+[../design/RATIONALE.md](../design/RATIONALE.md) for why the
+default changed.
+
+## Related
+
+- [troubleshooting.md](troubleshooting.md) — install + setup problems (distinct from these run-time failure modes).
+- [insight-from-logs.md](insight-from-logs.md) — how to read the event stream to identify which failure mode you're in.
+- [telemetry-with-harmonograf.md](telemetry-with-harmonograf.md) — same diagnostics via the UI.
+- [../../.agents/debug-goldfive.md](../../.agents/debug-goldfive.md) — the triage tree.
+- [../../.agents/how-to-debug-a-filler-loop.md](../../.agents/how-to-debug-a-filler-loop.md) — deep dive on failure mode 1.
+- [../design/PLAN-LIFECYCLE.md](../design/PLAN-LIFECYCLE.md) — run termination predicate and cascade semantics.

--- a/docs/guides/insight-from-logs.md
+++ b/docs/guides/insight-from-logs.md
@@ -1,0 +1,320 @@
+# Insight from logs
+
+Guide for operators who don't have (or don't want) the harmonograf
+UI but need to read goldfive's raw event stream to understand a
+run. Covers what `LoggingSink` emits, how to inspect
+`outcome.session.plan` after a run, early-warning signals for the
+common failure modes, and post-mortem patterns from raw SQLite
+dumps.
+
+If you want the UI view of the same data, see
+[telemetry-with-harmonograf.md](telemetry-with-harmonograf.md).
+
+## `LoggingSink` output
+
+`goldfive.sinks.LoggingSink` logs every event as one JSON line via
+`google.protobuf.json_format.MessageToJson(..., preserving_proto_field_name=True)`.
+The log record's message is the JSON; the logger is configurable
+so you can route to a file, stdout, or a structured-logging
+backend.
+
+Minimal wiring:
+
+```python
+import logging
+from goldfive import wrap
+from goldfive.sinks import LoggingSink
+
+logging.basicConfig(level=logging.INFO)
+runner = wrap(my_agent, sinks=[LoggingSink()])
+outcome = await runner.run("make a presentation about waffles")
+```
+
+### What each event kind looks like
+
+Twelve event payloads ship in v0.1. The envelope is common —
+`event_id`, `run_id`, `emitted_at`, `sequence`, plus one
+`oneof payload`. The following shows just the payload
+(abbreviated) for each kind.
+
+```jsonc
+// RunStarted — fires once; sequence=0.
+{"run_started": {
+  "goal_summary": "make a presentation about waffles",
+  "started_at_ms": 1713600000000
+}}
+
+// GoalDerived — the goal_deriver's output.
+{"goal_derived": {
+  "goals": [{"id": "g1", "summary": "presentation about waffles"}]
+}}
+
+// PlanSubmitted — the first plan.
+{"plan_submitted": {
+  "plan": {"id": "p1", "tasks": [...], "edges": [...]}
+}}
+
+// TaskStarted — PENDING → RUNNING transition.
+{"task_started": {"task_id": "research", "detail": ""}}
+
+// TaskProgress — RUNNING → RUNNING; agent reporting forward motion.
+{"task_progress": {"task_id": "research", "fraction": 0.6, "detail": "found 3 sources"}}
+
+// TaskCompleted — RUNNING → COMPLETED.
+{"task_completed": {"task_id": "research", "summary": "...", "artifacts": {}}}
+
+// TaskFailed — RUNNING → FAILED.
+{"task_failed": {"task_id": "research", "reason": "LLM timeout", "recoverable": true}}
+
+// TaskBlocked — RUNNING → BLOCKED.
+{"task_blocked": {"task_id": "publish", "blocker": "awaiting approval"}}
+
+// TaskCancelled — PENDING/RUNNING → CANCELLED.
+{"task_cancelled": {"task_id": "review", "reason": "cascade from research"}}
+
+// DriftDetected — fires whenever detect_drift returns non-None.
+{"drift_detected": {
+  "kind": "DRIFT_KIND_LOOPING_TOOL_CALL",
+  "severity": "DRIFT_SEVERITY_WARNING",
+  "detail": "report_task_completed called 7 times with identical args",
+  "current_task_id": "draft"
+}}
+
+// PlanRevised — fires after a successful planner.refine.
+// Includes the PlanRevisionDiff sidecar (goldfive #106).
+{"plan_revised": {
+  "plan": {...},
+  "revision_reason": "redirect: focus on vegan waffles",
+  "revision_kind": "user_steer",
+  "revision_severity": "warning",
+  "revision_index": 1,
+  "diff": {
+    "added_task_ids": ["research_vegan", "draft_vegan"],
+    "removed_task_ids": ["research"],
+    "modified_task_ids": [],
+    "added_edges": [{"from_task_id": "research_vegan", "to_task_id": "draft_vegan"}],
+    "removed_edges": []
+  }
+}}
+
+// RunCompleted — last event on a successful run.
+{"run_completed": {"outcome_summary": "4/4 tasks completed"}}
+
+// RunAborted — last event on a failed run.
+{"run_aborted": {"reason": "orphaned pending tasks after run"}}
+```
+
+### The monotone rules
+
+- `sequence` increases by one per event within a run. Gaps mean
+  events were lost between emission and ingestion; this should
+  never happen for in-process sinks. Gaps in a JSONL file mean
+  the sink wasn't flushed — see
+  [persistence-and-recovery.md](persistence-and-recovery.md).
+- `RunStarted` has the lowest sequence; `RunCompleted` /
+  `RunAborted` has the highest. Anything after a terminal event
+  is a bug.
+- `DriftDetected(kind=X)` that produces a refine is followed by
+  `PlanRevised(revision_kind=X)` before the next `TaskStarted`.
+  If they don't pair, refine returned `None` (or raised).
+
+## Inspecting the plan state after a run
+
+`Runner.run` returns an `ExecutionOutcome` with the full
+`session` attached. Five fields to read:
+
+```python
+outcome = await runner.run("...")
+await runner.close()
+
+s = outcome.session
+print(f"success={outcome.success}  reason={outcome.reason!r}")
+print(f"goals:         {[g.summary for g in s.goals]}")
+print(f"current_task:  {s.current_task_id!r}")
+
+if s.plan is not None:
+    print(f"plan.id={s.plan.id}  revision={s.plan.revision_index}")
+    for t in s.plan.tasks:
+        print(f"  {t.status.value:<10} {t.id:>20}  {t.title}")
+
+# Outcome summaries per-task.
+for task_id, summary in s.completed_results.items():
+    print(f"  {task_id}: {summary[:80]}")
+
+# Approvals still open (non-empty is a red flag after a run ends).
+print("pending_approvals:", list(s.pending_approvals))
+
+# Per-(drift_kind, task_id) refine failure counters.
+# Non-zero means refine couldn't recover from that drift.
+print("refine_failure_counts:", dict(s.refine_failure_counts))
+
+# Last 20 reasoning blocks. Useful for post-hoc reasoning-drift.
+print(f"reasoning_history: {len(s.reasoning_history)} blocks")
+```
+
+## Early warning for the filler-loop class
+
+goldfive has a set of structural guards against filler loops
+(TASK-LIFECYCLE.md §5), but the **earliest** signal from the
+logs alone is the tool-call name distribution within one
+`invoke()`:
+
+```python
+from collections import Counter
+
+sink = InMemorySink()
+# ... run ...
+
+tool_calls = Counter()
+for e in sink.events:
+    # Reporting-tool dispatch shows up as before_tool_callback in
+    # the underlying framework, not as a dedicated event. Look at
+    # the DriftDetected events of kind LOOPING_TOOL_CALL instead.
+    if e.WhichOneof("payload") == "drift_detected":
+        d = e.drift_detected
+        if d.kind == "DRIFT_KIND_LOOPING_TOOL_CALL":
+            tool_calls[d.detail] += 1
+
+print(tool_calls.most_common(5))
+```
+
+If you see the same reporting-tool name dominating the count
+(> 30 calls with identical args, or > 50 calls across varied
+args on the same `task_id`), the guard detected a filler loop
+and cut it off. Cross-reference with
+[how-to-debug-a-filler-loop.md](../../.agents/how-to-debug-a-filler-loop.md)
+for the postmortem playbook.
+
+For the pre-guard signal — counting raw tool invocations before
+any goldfive guard would fire — instrument the adapter's
+before-tool hook directly or read the harmonograf DB (next
+section).
+
+## Capturing planner reasoning
+
+When you're running LLM-backed planning, the planner's own
+reasoning can reveal drift before the first task executes. A
+pattern used by `/tmp/e2e-raccoons.py` and similar reproducers:
+wrap the `call_llm` callable and log both the prompt and the raw
+response:
+
+```python
+import json
+
+async def logging_call_llm(system, prompt, model):
+    resp = await real_call_llm(system, prompt, model)
+    logging.getLogger("goldfive.planner").debug(
+        "call_llm response model=%s len=%d\nfirst 500 chars: %s",
+        model, len(resp), resp[:500]
+    )
+    # For OpenAI / Claude models that return structured reasoning,
+    # pull the reasoning_content / thinking field out here too.
+    return resp
+
+runner = goldfive.wrap(
+    my_agent,
+    call_llm=logging_call_llm,
+    model="gpt-4o-mini",
+)
+```
+
+What to look for in the response body:
+
+- Truncated JSON (missing closing `}`) — the planner LLM hit a
+  token limit. Often a silent cause of refine failures. Manifests
+  as `outcome.reason` containing "failed to parse LLM output" or
+  the `DriftDetected.detail` containing `_refine_user_steer:
+  empty/non-string`.
+- An empty `tasks` array — the planner decided no further work
+  is needed. Legitimate for some refine cases, disastrous when
+  you expected replanning.
+- Reasoning that doesn't match the plan — the LLM's
+  chain-of-thought says it will do A, but the emitted JSON says
+  B. The `INTENT_DIVERGENCE` detector catches the agent-side
+  version of this; for planner-side, read the logs.
+
+## Post-mortem from a harmonograf SQLite dump
+
+When a run goes wrong in production, the JSONL file or harmonograf
+SQLite DB is the ground truth. The DB schema (harmonograf's
+`server/db.sql`) has one row per event:
+
+```sql
+CREATE TABLE events (
+  run_id      TEXT NOT NULL,
+  sequence    INTEGER NOT NULL,
+  event_type  TEXT NOT NULL,
+  payload     TEXT NOT NULL,   -- JSON
+  ts          INTEGER NOT NULL,
+  PRIMARY KEY (run_id, sequence)
+);
+```
+
+Useful queries:
+
+```sql
+-- List runs with their start time and end state.
+SELECT run_id,
+       MIN(ts) AS started_at,
+       MAX(CASE WHEN event_type IN ('RunCompleted', 'RunAborted')
+                THEN event_type ELSE NULL END) AS ended_as
+  FROM events GROUP BY run_id ORDER BY started_at DESC LIMIT 20;
+
+-- Every DriftDetected in one run.
+SELECT sequence, json_extract(payload, '$.kind') AS kind,
+       json_extract(payload, '$.severity') AS sev,
+       json_extract(payload, '$.detail') AS detail
+  FROM events
+ WHERE run_id = '<run_id>' AND event_type = 'DriftDetected'
+ ORDER BY sequence;
+
+-- Final task statuses.
+SELECT json_extract(payload, '$.plan.tasks') AS tasks
+  FROM events
+ WHERE run_id = '<run_id>' AND event_type IN ('PlanSubmitted', 'PlanRevised')
+ ORDER BY sequence DESC LIMIT 1;
+
+-- Tool call frequency by name — the filler-loop signal.
+SELECT json_extract(payload, '$.detail'), COUNT(*)
+  FROM events
+ WHERE run_id = '<run_id>'
+   AND event_type = 'DriftDetected'
+   AND json_extract(payload, '$.kind') = 'DRIFT_KIND_LOOPING_TOOL_CALL'
+ GROUP BY 1 ORDER BY 2 DESC;
+```
+
+This is the pattern the week's postmortem used when the UI
+truncated long reasoning blocks — direct SQL on the JSON payload
+surfaced the full detail strings that the UI was eliding.
+
+## Replay from JSONL
+
+If you persisted with `JSONLPersistenceSink`, the full event
+stream is replayable:
+
+```python
+from goldfive.sinks.persistence import replay_from_jsonl
+
+for event in replay_from_jsonl("./runs/my-run.jsonl"):
+    kind = event.WhichOneof("payload")
+    # ... same inspection as sink.events ...
+```
+
+`JSONLPersistenceSink.close()` flushes before returning, so a
+cleanly-terminated run produces a complete file. A crash mid-run
+leaves a truncated last line; the replay skips it and logs a
+warning.
+
+For cross-run SQL queries, the `SQLitePersistenceSink` produces
+the same schema as the harmonograf DB (minus the harmonograf
+server-side augmentation). See
+[choosing-a-sink.md](choosing-a-sink.md) for the matrix.
+
+## Related
+
+- [telemetry-with-harmonograf.md](telemetry-with-harmonograf.md) — UI-side view of the same data.
+- [common-failure-modes.md](common-failure-modes.md) — reason → root cause.
+- [choosing-a-sink.md](choosing-a-sink.md) — JSONL vs SQLite vs Logging vs GRPC.
+- [persistence-and-recovery.md](persistence-and-recovery.md) — durable event storage.
+- [../design/EVENT-MODEL.md](../design/EVENT-MODEL.md) — the proto event taxonomy.
+- [troubleshooting.md](troubleshooting.md) — symptom → fix catalogue for the common problems.

--- a/docs/guides/telemetry-with-harmonograf.md
+++ b/docs/guides/telemetry-with-harmonograf.md
@@ -1,0 +1,240 @@
+# Telemetry with harmonograf
+
+This guide is for the person staring at the harmonograf UI, asking
+"what is my agent actually doing and why did that happen?" It is
+the companion to
+[observability-with-harmonograf.md](observability-with-harmonograf.md) —
+that guide gets you to the point of seeing events on the wire;
+this one walks through how to read what the wire is saying.
+
+If you already have harmonograf running and your run is flowing
+through, skip to [§What you'll see](#what-youll-see-in-the-ui).
+
+## Minimum setup
+
+Four pieces:
+
+1. `uv sync --extra proto` in `~/git/goldfive` (or wherever).
+2. `make server-run` in `~/git/harmonograf` (Python gRPC server on
+   `127.0.0.1:7531`).
+3. `pnpm dev --port 5173 --strictPort` in `~/git/harmonograf/frontend`
+   (the React UI).
+4. Wrap your runner:
+
+   ```python
+   import goldfive
+   from harmonograf_client import HarmonografClient
+
+   hg = HarmonografClient("localhost:7531")
+   runner = hg.observe(goldfive.wrap(my_agent))
+   ```
+
+   `observe()` as of harmonograf #44 attaches a `HarmonografSink`
+   and enables the STEERING + HUMAN_IN_LOOP capabilities by
+   default — you can steer, pause, and approve from the UI without
+   extra wiring.
+
+Runnable example:
+[`examples/harmonograf_observed/agent.py`](../../examples/harmonograf_observed/agent.py).
+
+## What you'll see in the UI
+
+Open `http://127.0.0.1:5173`. The chrome is four panels:
+
+- **Sessions** (top-left) — every `run_id` harmonograf has seen.
+  Newest first. Click one to focus the other views on it.
+- **Agents timeline** — Gantt chart of agent invocations across
+  the run. Each bar is an `INVOCATION` span; children are
+  `LLM_CALL` and `TOOL_CALL` spans.
+- **DAG** — the current plan, rendered as the topological DAG.
+  Tasks show status badges (PENDING / RUNNING / COMPLETED /
+  FAILED / CANCELLED / BLOCKED) and colour-code by severity. When
+  the plan revises mid-run, the DAG morphs in place; the revision
+  history is accessible via the "revisions" picker.
+- **Task list** — every task in the current plan, with status,
+  duration, and a preview of the final outcome text. Sortable.
+- **Live Activity** — stream of events as they land. Useful for
+  "watch the agent think" during a live run.
+
+Four secondary panels live in the right rail:
+
+- **Notes** — any `TaskProgress` notes and agent annotations.
+- **Drifts** — every `DriftDetected` event on this session, with
+  kind, severity, and `detail`.
+- **Plan revisions** — when the plan has been revised, a timeline
+  showing what was added / removed / modified at each revision
+  (populated from the `PlanRevisionDiff` sidecar — goldfive #106).
+- **Approvals** — open `ApprovalRequested` waiters with
+  Approve / Reject buttons.
+
+## Reading the Gantt view
+
+The Agents timeline is the densest surface. Three things to look
+for:
+
+**Span hierarchy.** Each top-level bar is one call to
+`adapter.invoke(task, session)` — the `INVOCATION` span. Its
+children are `LLM_CALL` spans (one per round-trip to the model)
+and `TOOL_CALL` spans (one per tool the model called, including
+the goldfive reporting tools). Clicking a parent expands its
+children.
+
+**Duration columns.** Hover any span for the exact
+start / end / duration. The column widths are proportional to
+wall-clock duration — a fat `LLM_CALL` is typically where your
+latency is, not the orchestration overhead (which is usually
+< 1 ms per transition; see [performance.md](../performance.md)).
+
+**Cancellation strikethroughs.** A span that was cancelled
+mid-flight (CANCEL control, unrecoverable drift cascade, STEER
+re-route) renders struck-through. You'll see this on every
+downstream task after a cascade — each one is one
+`TaskCancelled` event from the
+`cascade_cancel_downstream` primitive (goldfive #103 + #107).
+
+**Revision markers.** Each time the plan is revised, a vertical
+marker appears across the timeline at the `PlanRevised` event's
+timestamp. Hover it to see the triggering drift (kind + severity
++ detail) and the diff summary.
+
+## Clicking on a span
+
+Left-click opens a popover with four actions:
+
+| Action | When to use it |
+|---|---|
+| **Steer** | The run is live and you want to redirect it — add guidance, pivot to a different approach, or nudge it back on goal. Sends a `ControlKind.STEER` with the free-text message you type. Deletes any downstream PENDING tasks and refines. |
+| **Annotate** | You want to leave a note (for yourself or a reviewer) on this span without affecting the run. Notes are persisted and show up in the Notes panel. |
+| **Copy id** | Grab the `span_id` / `event_id` / `run_id` for pasting into a ticket or SQL query. |
+| **Open drawer** | Open the full Inspector Drawer for this span. See next section. |
+
+"Steer" is the destructive one — use it when the run is still
+live and you've decided the current direction is wrong. "Annotate"
+is cheap and reversible; reach for it first when you're still
+deciding.
+
+## The Inspector Drawer
+
+Click "Open drawer" (or double-click a span) to open the right-side
+Inspector. Five tabs:
+
+- **Reasoning.** Chain-of-thought blocks extracted by the
+  adapter: OpenAI `reasoning_content`, Anthropic `thinking`
+  blocks, Google thought parts. Surfaced via
+  `Steerer.observe_reasoning` and stored in the
+  `llm.reasoning` span attribute (harmonograf #43 + #45). This is
+  the first place to look when asking "why did the agent make
+  that choice" — the reasoning often reveals intent that didn't
+  surface in the visible output.
+- **Tool input / output.** The exact `args` payload the model
+  sent and the `result` the tool returned. For goldfive reporting
+  tools (`report_task_*`, `report_plan_divergence`, etc.), the
+  result is the ACK dict — an `{"acknowledged": False, "error":
+  "task_already_terminal"}` here is the signal that a guard
+  layer rejected the call (see [common-failure-modes.md](common-failure-modes.md)).
+- **Context window.** Preview of the messages goldfive rendered
+  for this task — the task context, the completed-results
+  summary, the goal summary.
+- **Span links.** Forward / back navigation to parent and child
+  spans. Useful for walking a deep tree.
+- **Raw.** The proto event JSON. Last resort when the cooked
+  views are hiding something.
+
+## Live steering from the UI
+
+With `observe()` attached (which enables STEERING +
+HUMAN_IN_LOOP capabilities since harmonograf #44), the UI shows
+two always-on controls in the run header:
+
+- **Pause / Resume** — sends `ControlKind.PAUSE` / `RESUME`. The
+  current in-flight task finishes, then the executor blocks on
+  the control channel until a RESUME arrives. Useful when you
+  want to pause a run, read the reasoning carefully, and decide
+  what to do.
+- **Cancel** — sends `ControlKind.CANCEL`. The current task is
+  cancelled (adapter is signalled; has 5 s grace), the cascade
+  fires, and the run ends with
+  `outcome.reason="cancelled by control"`.
+
+Plus the context-sensitive actions on every span:
+
+- **Steer** (from the span popover) — `ControlKind.STEER` with
+  the user text as the message. The steerer handles it as a
+  `USER_STEER` drift: the current task is CANCELLED, the
+  cascade cancels downstream PENDINGs, and `planner.refine` is
+  called with the steer as the drift payload. If the refine
+  returns a new plan, it is installed on the session and
+  execution continues against the new plan.
+- **Cancel & redirect** — shorthand for CANCEL + STEER. Current
+  task stops immediately; the steer text redirects the
+  replanner.
+- **Add to queue** — when you want the steer to apply at the
+  next task boundary, not mid-task. Enqueues the steer without
+  cancelling the current task.
+
+Verifying a steer took effect: watch the Drifts panel for a new
+`USER_STEER` event (severity WARNING); the Plan revisions panel
+for a new revision carrying the `added_task_ids` from the
+refine; the DAG for the morphed plan. If the drift arrives but
+no revision follows, `planner.refine` declined (returned
+`None`); the task CANCEL still fired, and the run ends cleanly
+as "incomplete but not broken."
+
+## Diagnosing "why did my run fail"
+
+Three places to look, in order:
+
+1. **`outcome.success` + `outcome.reason`.** Printed by the
+   reproducer or visible in the UI's session header. See
+   [common-failure-modes.md](common-failure-modes.md) for the
+   reason → root cause table.
+2. **The last `DriftDetected` event.** Filter the Drifts panel
+   by severity CRITICAL; the last one is almost always the one
+   that cascaded into `RunAborted`. Its `kind` tells you what
+   class of failure; its `detail` usually names the specific
+   task.
+3. **The reasoning of the last `LLM_CALL` before the abort.**
+   Open the drawer on the last span before the `RunAborted`
+   marker; read the Reasoning tab. The model will often narrate
+   that it gave up, got confused, or decided the task was
+   unreachable — which `detect_drift` then classified.
+
+When the three disagree (e.g. reason says "orphaned pending",
+last drift is INFO `OFF_TOPIC`, reasoning is unremarkable),
+look at [insight-from-logs.md](insight-from-logs.md) — the raw
+log-level view is what you want.
+
+## Plan revisions in the UI
+
+When `planner.refine` produces a new plan, harmonograf renders
+the revision with three affordances:
+
+- **Diff summary on the revision marker.** Hover shows
+  "+2 tasks, -1 task, 3 edges modified" — sourced from the
+  `PlanRevisionDiff` sidecar on the `PlanRevised` event
+  (goldfive #106).
+- **Diff detail in the Plan revisions panel.** Expanded, you
+  see the exact `added_task_ids`, `removed_task_ids`,
+  `modified_task_ids`, `added_edges`, `removed_edges`. No need
+  to fetch the prior plan to figure out what changed.
+- **Morphed DAG.** The current-state DAG switches to the new
+  plan. Terminal tasks from the prior plan are preserved
+  (PLAN-LIFECYCLE §3.1 — goldfive #105), so a COMPLETED task
+  in revision N shows up COMPLETED in revision N+1 and you
+  don't lose history.
+
+A cascade visualised: when a task FAILED-fatal or CANCELLED
+triggers the cascade, you'll see exactly one `TaskCancelled`
+event per downstream task on the Live Activity stream, all
+within a few ms of each other, each with
+`reason="cascade from <task_id>"`. That's
+`cascade_cancel_downstream` (goldfive #107) doing its BFS walk.
+
+## Related
+
+- [observability-with-harmonograf.md](observability-with-harmonograf.md) — one-time setup walkthrough.
+- [harmonograf-integration.md](harmonograf-integration.md) — sink protocol + client factory.
+- [insight-from-logs.md](insight-from-logs.md) — same diagnostics without the UI.
+- [common-failure-modes.md](common-failure-modes.md) — catalog of failure shapes + recovery path.
+- [../design/CONTROL.md](../design/CONTROL.md) — the live-steering protocol the UI speaks.
+- [../design/EVENT-MODEL.md](../design/EVENT-MODEL.md) — what each event on the wire carries.

--- a/docs/guides/writing-an-agent-adapter.md
+++ b/docs/guides/writing-an-agent-adapter.md
@@ -76,11 +76,23 @@ your adapter must:
 
 1. Recognize the tool name (it's in `REPORTING_TOOL_NAMES`).
 2. Parse the arguments.
-3. Invoke the spec's `handler(args, session, steerer)`.
-4. Return the handler's return value as the tool result.
+3. Route through
+   `goldfive.adapters._tool_invocation.invoke_tool(specs, name, args, session, steerer)`
+   — **not** `spec.handler` directly. `invoke_tool` runs four guard
+   layers (schema / terminal-task / per-task loop / session-wide
+   volume cap) before dispatching the spec's handler. Skipping this
+   is the root cause of the filler-loop class of bugs (#108): the
+   handler runs, the state updates, but the adapter keeps
+   re-invoking the agent past a task that already completed.
+4. Return the helper's return value as the tool result.
 
 The handler is where the steerer applies the state transition.
-`{"acknowledged": True}` is the conventional response body.
+`{"acknowledged": True}` is the conventional response body; the
+guard layers may instead return `{"acknowledged": False, "error":
+"task_already_terminal" | "loop_detected" | "missing_task_id" |
+"unknown_task_id", ...}` — return those payloads verbatim to the
+agent as the tool response. They are designed to be model-readable
+so the agent can course-correct.
 
 ### Forward observed events to the steerer
 
@@ -150,6 +162,7 @@ from typing import Any
 
 from awesome_agent_sdk import AwesomeClient, ToolDef  # fictional
 
+from goldfive.adapters._tool_invocation import invoke_tool
 from goldfive.protocols import AgentAdapter
 from goldfive.reporting import ReportingToolSpec
 from goldfive.results import InvocationResult
@@ -223,7 +236,12 @@ class AwesomeAdapter:
 
     def _wrap_tool(self, spec: ReportingToolSpec, session: Session):
         async def handler(args: dict[str, Any]) -> dict[str, Any]:
-            return await spec.handler(args, session, self._steerer)
+            # Route through ``invoke_tool`` — NOT ``spec.handler`` direct —
+            # so the schema / terminal / loop / volume-cap guards fire.
+            # Skipping this is the pre-#108 bug class.
+            return await invoke_tool(
+                self._tools, spec.name, args, session, self._steerer
+            )
 
         return ToolDef(
             name=spec.name,


### PR DESCRIPTION
## Summary

Brings goldfive's documentation up to date with the sprint's 20-odd
landed PRs (#97 through #115), adds four new `.agents/` skills to
cover development workflows that came out of the postmortem, and
adds three user-facing guides on deriving insight from goldfive's
telemetry.

Scope is docs-only — no code changes. Commits are one-per-doc for
reviewability.

## Part A — design-doc audit + refresh

| File | Commit | Why |
|---|---|---|
| `CHANGELOG.md` | `b4c66bc` | Missing entries for #97 – #115; added complete run covering added / changed / fixed. |
| `docs/design/ARCHITECTURE.md` | `32b69cb` | Clarified `invoke_tool` dispatch (post-#108); referenced `PlanRevisionDiff` sidecar (#106) and shared cascade primitive (#107); moved live-steering out of "out of scope for v0.1" (CONTROL.md now exists). |
| `docs/design/PROTOCOLS.md` | `ca43d55` | Added missing protocol methods (`Steerer.observe_reasoning`, `Steerer.cascade_cancel_downstream`, `AgentAdapter.emit_reasoning`); documented `invoke_tool` routing and `REFINE_FAILURE_THRESHOLD`. |
| `docs/design/STATE-MACHINE.md` | `53bc93d` | Routed reporting-tool dispatch description through `invoke_tool`; added reachability audit as fourth non-tool entry point; linked PLAN-LIFECYCLE.md §6. |
| `docs/design/DRIFT.md` | `a26677b` | Fixed `goldfive/drift.py` → `goldfive/drift/__init__.py` package path; documented refine-failure threshold + `PlanRevisionDiff` in refine invariants. |
| `docs/design/TASK-LIFECYCLE.md` | `9f7bb8b` | Marked §7.2 / §7.3 / §7.4 closed by #100 / #105, #99, #101 (PLAN-LIFECYCLE.md §8 already lists these as closed; TASK-LIFECYCLE lagged). |
| `docs/guides/writing-an-agent-adapter.md` | `e0eac63` | Replaced `spec.handler(...)` direct-dispatch pattern with `invoke_tool(...)` — the pre-#108 pattern was the root-cause shape of the filler-loop bugs. |

### Verified-accurate (no changes needed)

These docs were checked against the source and found to already
track current behaviour — no rewrite needed:

- `docs/design/EVENT-MODEL.md` — already references `PlanRevisionDiff` sidecar (#106).
- `docs/design/PLAN-LIFECYCLE.md` — §8 already lists the closed gaps.
- `docs/design/CONTROL.md` — accurate; "ADK plugin intercepts in `before_tool_callback`" language is still correct post-#108 (it describes the plugin callback registration, which hasn't changed).
- `docs/design/APPROVAL.md` — Flow A / Flow B descriptions accurate.
- `docs/design/RATIONALE.md` — documents the rename historically; accurate.
- `docs/design/VOCABULARY.md` — authoritative type-system reference; spot-checked, aligned with current enum values.
- `docs/reference/api.md` — already uses `max_task_invocations`; accurate.
- `docs/reference/tool-protocol.md` — unchanged semantics.
- `docs/guides/getting-started.md` — uses `max_task_invocations`; snippets align with current API.
- `docs/guides/observability-with-harmonograf.md` — setup walkthrough accurate.
- `docs/guides/harmonograf-integration.md`, `docs/guides/grpc-transport.md`, `docs/guides/choosing-a-sink.md`, `docs/guides/writing-an-event-sink.md`, `docs/guides/goals-and-plans.md`, `docs/guides/persistence-and-recovery.md`, `docs/guides/troubleshooting.md`, `docs/guides/multi-turn.md`, `docs/guides/adk-web-integration.md` — spot-checked, accurate.
- `docs/performance.md` — v0.1 baseline; unchanged.
- `README.md` — hello snippet uses `max_task_invocations`; accurate (but gained new doc links in the final indexing commit).

## Part B — new `.agents/` skills

| File | Commit | Covers |
|---|---|---|
| `.agents/how-to-add-a-new-adapter.md` | `7f1d45e` | Protocol contract, `invoke_tool` dispatch requirement, drift observation hook, framework-to-framework handoff invariant (references `InvocationStateStore` tracked in #117). |
| `.agents/how-to-debug-a-filler-loop.md` | `b3ac003` | Symptom signatures for the class; step-by-step instrumentation; the five bugs (#98 / #108 / #109 / #116 / harmonograf #45); the postmortem's structural-vs-symptomatic heuristic. |
| `.agents/how-to-add-a-drift-kind.md` | `8a8e0f2` | Python enum + proto enum + pb regen + classifier + steerer dispatch + tests + DRIFT.md; worked against #112 (UNCERTAIN_PROGRESS / SELF_REPORTED_STUCK) as the in-flight example. |
| `.agents/how-to-run-the-e2e.md` | `51166a1` | Submodule setup, harmonograf server boot, `/tmp/e2e-*.py` pattern, monitor + SQLite drill-down, success validation. |
| `.agents/debug-goldfive.md` | `dd80a4c` | Extended the existing skill with "Inspecting a stuck run" (session state after `run()`) + the structural-vs-symptomatic heuristic + cross-links to the new skills. |

## Part C — user guides for telemetry insight

| File | Commit | Covers |
|---|---|---|
| `docs/guides/telemetry-with-harmonograf.md` | `997718b` | Minimum setup with harmonograf #44's default `observe()` caps; Sessions / Agents-Gantt / DAG / Task-list / Live-Activity; span popovers (Steer / Annotate / Copy id / Open drawer); Inspector Drawer (Reasoning tab from harmonograf #43 + #45); live steering; plan revisions rendered from `PlanRevisionDiff` (#106); diagnosing "why did my run fail". |
| `docs/guides/insight-from-logs.md` | `0e3ba56` | Raw `LoggingSink` output per event kind; reading `outcome.session.plan` / `refine_failure_counts` / `reasoning_history`; filler-loop early warning via tool-call name distribution; planner reasoning capture; SQLite drill-down queries from the postmortem. |
| `docs/guides/common-failure-modes.md` | `b4e5c0a` | Eight failure modes with signature + root cause + recovery: filler loop (§1), refine failure / truncated JSON (§2), orphaned PENDINGs (§3), agent-tree misdesign (§4), `require_confirmation` silent gating (§5 — pre-#111), cascade-without-refine (§6), graduated-severity drift surprises (§7), `max_plan_reinvocations` deprecation (§8). |

## Final indexing commit

`ac17796` updates `.agents/README.md` + `README.md` Docs section
to link the new files.

## Follow-up items (code-level observations, not fixed here)

- `TASK-LIFECYCLE.md §7.1` still describes three duplicate definitions of `_TERMINAL_TASK_STATUSES` (steerer, `_tool_invocation`, adk). `goldfive/types.py::TERMINAL_TASK_STATUSES` was added as the canonical definition but not every call site imports from there; some still re-declare. Low-effort cleanup.
- `#117 InvocationStateStore` — referenced in `how-to-add-a-new-adapter.md` as tracked-but-not-landed; when it lands the skill should be updated to use the new primitive as the recommended handoff path.
- `#113 REASONING_CLUSTER_TIGHTENING` and `#116 filler-loop regression fix` are on local branches but haven't merged to `origin/main`; docs reflect what's on `main`. If/when they land, DRIFT.md and the filler-loop skill should gain entries.

## Test plan

- [ ] Review each commit's diff in isolation.
- [ ] Confirm the six verified-accurate files listed above still hold after any last-minute changes.
- [ ] `uv run pytest -q` still passes (docs-only; shouldn't touch tests).
- [ ] Skim the new `.agents/` files for the "under 200 lines, terse" voice the `.agents/README.md` describes.