### PR TITLE
Propagate plugins into ADKAdapter sub-agent runners (closes #121)

### DIFF
--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -225,17 +225,28 @@ def _register_plugin_on_runner(runner: Any, plugin: Any) -> bool:
     return False
 
 
-def _build_runner(agent: Any) -> Any:
+def _build_runner(agent: Any, plugins: list[Any] | None = None) -> Any:
     """Construct an ADK ``InMemoryRunner`` around a ``BaseAgent``.
 
     Used by :class:`ADKAdapter` when the caller passes an agent rather
     than a runner. ``app_name`` defaults to the agent's name for tidy
     session-service bookkeeping.
+
+    When ``plugins`` is a non-empty iterable, the plugin list is forwarded
+    to :class:`InMemoryRunner` via its ``plugins=`` kwarg. This is the
+    path goldfive uses to propagate caller-supplied observability plugins
+    (e.g. ``HarmonografTelemetryPlugin``) onto every per-agent sub-runner,
+    not just the coordinator — goldfive#121. Passing ``None`` or an empty
+    list omits the kwarg so we stay compatible with ADK versions that
+    constructed ``InMemoryRunner`` without a ``plugins`` parameter.
     """
     from google.adk.runners import InMemoryRunner  # type: ignore
 
     app_name = str(getattr(agent, "name", "") or "goldfive")
-    return InMemoryRunner(agent=agent, app_name=app_name)
+    kwargs: dict[str, Any] = {"agent": agent, "app_name": app_name}
+    if plugins:
+        kwargs["plugins"] = list(plugins)
+    return InMemoryRunner(**kwargs)
 
 
 def _looks_like_runner(obj: Any) -> bool:
@@ -435,6 +446,15 @@ class ADKAdapter:
     app_name:
         Optional ADK app_name override. Defaults to the runner's own
         ``app_name`` or the agent's ``name``.
+    plugins:
+        Optional list of ADK ``BasePlugin`` instances to install on
+        every per-agent ``InMemoryRunner`` built by this adapter.
+        Observability plugins (e.g. ``HarmonografTelemetryPlugin``)
+        must land on sub-agent runners too — the top-level
+        ``App(plugins=[...])`` only covers the root runner, so
+        coordinator + ``AgentTool`` trees would otherwise emit
+        telemetry only for the coordinator's own invocations. See
+        goldfive#121.
     """
 
     def __init__(
@@ -444,6 +464,7 @@ class ADKAdapter:
         user_id: str = "goldfive_user",
         session_id: str | None = None,
         app_name: str | None = None,
+        plugins: list[Any] | None = None,
     ) -> None:
         # ------------------------------------------------------------------
         # Registry-dispatch model (see docs/design/DISPATCH.md and the
@@ -461,6 +482,14 @@ class ADKAdapter:
         self._user_id = user_id
         self._session_id = session_id  # legacy single-runner id; per-runner ids below
         self._degraded_prebuilt_runner = False
+        # Caller-supplied ADK plugins (e.g. HarmonografTelemetryPlugin).
+        # Stored so EVERY per-agent runner constructed by this adapter
+        # receives them at ``InMemoryRunner`` construction time. Without
+        # this, the ADK ``App(plugins=[...])`` level only covers the
+        # coordinator's root runner and sub-agent dispatches (via
+        # ``AgentTool``) run through bare ``InMemoryRunner`` instances
+        # with no plugins attached — goldfive#121.
+        self._plugins: list[Any] = list(plugins) if plugins else []
 
         if _looks_like_runner(agent_or_runner):
             # Caller handed us an already-built Runner. We cannot derive
@@ -478,7 +507,7 @@ class ADKAdapter:
             )
         else:
             self._agent = agent_or_runner
-            self._runner = _build_runner(agent_or_runner)
+            self._runner = _build_runner(agent_or_runner, plugins=self._plugins)
 
         self._app_name = (
             app_name
@@ -513,7 +542,9 @@ class ADKAdapter:
                 if agent_name == root_name and agent_ref is self._agent:
                     self._runners[agent_name] = self._runner
                 else:
-                    self._runners[agent_name] = _build_runner(agent_ref)
+                    self._runners[agent_name] = _build_runner(
+                        agent_ref, plugins=self._plugins
+                    )
 
         # Install the goldfive plugin on EVERY runner. The plugin is a
         # single shared instance — set_active_context() handoff works

--- a/goldfive/adapters/auto.py
+++ b/goldfive/adapters/auto.py
@@ -114,7 +114,7 @@ def _looks_like_async_agent_callable(agent: Any) -> bool:
     return asyncio.iscoroutinefunction(call_attr)
 
 
-def auto_adapter(agent: Any) -> AgentAdapter:
+def auto_adapter(agent: Any, *, plugins: list[Any] | None = None) -> AgentAdapter:
     """Return a concrete :class:`AgentAdapter` for ``agent``.
 
     Dispatch order:
@@ -130,6 +130,11 @@ def auto_adapter(agent: Any) -> AgentAdapter:
        :class:`~goldfive.adapters.callable.CallableAdapter`.
     5. Otherwise, raise :class:`TypeError` with a list of the shapes
        goldfive recognises.
+
+    ``plugins`` is forwarded to :class:`ADKAdapter` when the dispatch
+    target is an ADK agent/runner. It is ignored for the other shapes —
+    there is no analogous plugin surface in the Claude SDK or callable
+    adapters today. See goldfive#121.
     """
     if isinstance(agent, AgentAdapter):
         return agent
@@ -137,7 +142,7 @@ def auto_adapter(agent: Any) -> AgentAdapter:
     if _looks_like_adk_agent(agent) or _looks_like_adk_runner(agent):
         from goldfive.adapters.adk import ADKAdapter  # lazy: requires extra
 
-        return ADKAdapter(agent)
+        return ADKAdapter(agent, plugins=plugins)
 
     if _looks_like_claude_client_factory(agent):
         from goldfive.adapters.claude import ClaudeAgentSDKAdapter  # lazy

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -62,6 +62,7 @@ def wrap(
     call_llm: CallLLM | None = None,
     model: str | None = None,
     max_task_invocations: int | None = None,
+    plugins: list[Any] | None = None,
     **legacy_kwargs: Any,
 ) -> Runner:
     """Build a :class:`Runner` that drives ``agent`` with goldfive.
@@ -107,6 +108,14 @@ def wrap(
         :class:`SequentialExecutor` default and the :class:`Runner`.
         Accepts the deprecated ``max_plan_reinvocations`` kwarg for one
         release with a :class:`DeprecationWarning`.
+    plugins:
+        Optional list of ADK ``BasePlugin`` instances to install on
+        every per-agent runner built for an ADK wrap target. Forwards
+        to :class:`~goldfive.adapters.adk.ADKAdapter` so sub-agent
+        dispatches (``AgentTool(...)``, ``sub_agents``) observe the
+        same plugins as the coordinator — not just the
+        ``App(plugins=[...])``-level root runner. Ignored for
+        non-ADK agents. See goldfive#121.
 
     Returns
     -------
@@ -123,7 +132,7 @@ def wrap(
         ``BaseAgent`` side can annotate
         ``cast(GoldfiveADKAgent, goldfive.wrap(...))`` themselves.
     """
-    adapter = auto_adapter(agent)
+    adapter = auto_adapter(agent, plugins=plugins)
 
     resolved_call_llm: CallLLM | None = call_llm
     resolved_model: str = model or ""

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -2064,3 +2064,228 @@ async def test_delegation_observed_emitted_on_agent_tool_call() -> None:
     assert first.from_agent == "agent_a"
     assert first.to_agent == "agent_b"
     assert first.task_id == "t1"
+
+
+# ---------------------------------------------------------------------------
+# Caller-supplied plugin propagation (goldfive#121)
+# ---------------------------------------------------------------------------
+
+
+def test_build_runner_without_plugins() -> None:
+    """``_build_runner(agent)`` must not pass a ``plugins`` kwarg to
+    ``InMemoryRunner`` when the caller didn't supply any.
+
+    Without the ``if plugins:`` guard, callers would always pay for a
+    ``plugins=[]`` kwarg which also masks ADK versions that omit the
+    parameter from their ``__init__``.
+    """
+    from goldfive.adapters import adk as adk_mod
+
+    captured: dict[str, Any] = {}
+
+    class _FakeRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    import google.adk.runners as adk_runners  # type: ignore
+
+    orig = adk_runners.InMemoryRunner
+    adk_runners.InMemoryRunner = _FakeRunner  # type: ignore[assignment]
+    try:
+        adk_mod._build_runner(_make_agent())
+    finally:
+        adk_runners.InMemoryRunner = orig  # type: ignore[assignment]
+
+    assert "plugins" not in captured, (
+        "no plugins supplied — _build_runner must omit the kwarg entirely"
+    )
+    assert captured["app_name"] == "test_agent"
+
+
+def test_build_runner_with_plugins() -> None:
+    """``_build_runner(agent, plugins=[...])`` must forward the plugin
+    list into :class:`InMemoryRunner` via the ``plugins=`` kwarg.
+    """
+    from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+
+    from goldfive.adapters import adk as adk_mod
+
+    class _StubPlugin(BasePlugin):
+        def __init__(self) -> None:
+            super().__init__(name="stub")
+
+    captured: dict[str, Any] = {}
+
+    class _FakeRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    plugin = _StubPlugin()
+    import google.adk.runners as adk_runners  # type: ignore
+
+    orig = adk_runners.InMemoryRunner
+    adk_runners.InMemoryRunner = _FakeRunner  # type: ignore[assignment]
+    try:
+        adk_mod._build_runner(_make_agent(), plugins=[plugin])
+    finally:
+        adk_runners.InMemoryRunner = orig  # type: ignore[assignment]
+
+    assert captured.get("plugins") == [plugin]
+
+
+def test_adk_adapter_init_accepts_plugins() -> None:
+    """``ADKAdapter(tree, plugins=[...])`` stores the plugin list and
+    propagates it onto EVERY per-agent runner's plugin manager.
+
+    This is the goldfive#121 fix: without this, caller-supplied
+    observability plugins only land on the coordinator's runner because
+    the ADK ``App(plugins=[...])`` surface only covers the root.
+    """
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+    from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+    from google.adk.tools.agent_tool import AgentTool  # type: ignore
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    class _StubPlugin(BasePlugin):
+        def __init__(self) -> None:
+            super().__init__(name="adapter_init_stub")
+
+    def _mk(name: str) -> Any:
+        return LlmAgent(name=name, model="fake-model", description=name, instruction="x")
+
+    research = _mk("research")
+    web = _mk("web")
+    coordinator = _mk("coordinator")
+    coordinator.tools = [AgentTool(research), AgentTool(web)]
+
+    plugin = _StubPlugin()
+    adapter = ADKAdapter(coordinator, plugins=[plugin])
+
+    assert adapter._plugins == [plugin]
+    # Every per-agent runner — not just the coordinator — must carry
+    # the caller-supplied plugin on its plugin_manager.
+    for agent_name, runner in adapter._runners.items():
+        installed = list(getattr(runner.plugin_manager, "plugins", []))
+        assert plugin in installed, (
+            f"caller-supplied plugin did not land on runner for {agent_name!r}; "
+            f"goldfive#121 regression"
+        )
+
+
+def test_wrap_accepts_plugins() -> None:
+    """``goldfive.wrap(tree, plugins=[...])`` must forward the plugin
+    list through to the underlying :class:`ADKAdapter`.
+    """
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+    from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+    from google.adk.tools.agent_tool import AgentTool  # type: ignore
+
+    import goldfive
+    from goldfive.adapters.adk_wrap import GoldfiveADKAgent
+
+    class _StubPlugin(BasePlugin):
+        def __init__(self) -> None:
+            super().__init__(name="wrap_stub")
+
+    def _mk(name: str) -> Any:
+        return LlmAgent(name=name, model="fake-model", description=name, instruction="x")
+
+    sub = _mk("sub")
+    coordinator = _mk("coordinator")
+    coordinator.tools = [AgentTool(sub)]
+
+    plugin = _StubPlugin()
+    wrapped = goldfive.wrap(coordinator, plugins=[plugin])
+    assert isinstance(wrapped, GoldfiveADKAgent)
+
+    adapter = wrapped._runner.agent
+    assert adapter._plugins == [plugin]
+    for agent_name, runner in adapter._runners.items():
+        installed = list(getattr(runner.plugin_manager, "plugins", []))
+        assert plugin in installed, (
+            f"wrap(plugins=[...]) did not propagate onto runner for {agent_name!r}"
+        )
+
+
+async def test_dispatch_uses_plugins_in_sub_agent_runner() -> None:
+    """Dispatching to a sub-agent must exercise caller-supplied plugins.
+
+    Regression guard for goldfive#121: previously only the coordinator's
+    runner received ``App(plugins=[...])`` plugins; sub-agent dispatches
+    (via ``AgentTool``/registry lookup) ran through a bare
+    ``InMemoryRunner`` with no plugins, so harmonograf only saw
+    telemetry for the outermost coordinator.
+    """
+    from google.adk.agents import Agent  # type: ignore
+    from google.adk.models.base_llm import BaseLlm  # type: ignore
+    from google.adk.models.llm_response import LlmResponse  # type: ignore
+    from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+    from google.adk.tools.agent_tool import AgentTool  # type: ignore
+    from google.genai import types as genai_types  # type: ignore
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    class _RecordingPlugin(BasePlugin):
+        def __init__(self) -> None:
+            super().__init__(name="recording")
+            self.agents_seen: list[str] = []
+
+        async def before_run_callback(self, *, invocation_context: Any) -> None:  # noqa: ARG002
+            agent = getattr(invocation_context, "agent", None)
+            name = getattr(agent, "name", "") if agent is not None else ""
+            self.agents_seen.append(str(name))
+
+    class _ScriptedLlm(BaseLlm):
+        model: str = "fake-model"
+
+        async def generate_content_async(self, llm_request: Any, stream: bool = False):  # noqa: ARG002
+            yield LlmResponse(
+                content=genai_types.Content(
+                    role="model",
+                    parts=[genai_types.Part(text="ok")],
+                ),
+                turn_complete=True,
+            )
+
+    # Coordinator with an AgentTool(sub) so both agents are reachable
+    # in the registry and can be dispatched to independently.
+    sub = Agent(name="sub_agent", model=_ScriptedLlm(), instruction="")
+    coordinator = Agent(
+        name="coordinator",
+        model=_ScriptedLlm(),
+        instruction="",
+        tools=[AgentTool(sub)],
+    )
+
+    plugin = _RecordingPlugin()
+    adapter = ADKAdapter(coordinator, plugins=[plugin])
+
+    class _StubSteerer:
+        async def observe(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        async def transition(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        def detect_drift(self, *a: Any, **kw: Any) -> None:
+            return None
+
+        def bind(self, **kw: Any) -> None:
+            pass
+
+    adapter.bind_steerer(_StubSteerer())
+
+    # Dispatch directly to the sub-agent. Before the fix, the sub
+    # agent's runner had no plugin manager entries so the recording
+    # plugin's before_run_callback would never fire for this invoke().
+    task = Task(id="t1", title="do it", assignee_agent_id="sub_agent")
+    plan = Plan(id="p1", run_id="r1", goal_ids=[], tasks=[task], edges=[])
+    session = Session(run_id="r1", plan=plan)
+    await adapter.invoke(task=task, session=session)
+
+    assert "sub_agent" in plugin.agents_seen, (
+        "caller-supplied plugin was never invoked when dispatching to the "
+        "sub-agent; goldfive#121 regression — plugins must propagate "
+        f"onto the sub-agent runner. Saw: {plugin.agents_seen!r}"
+    )


### PR DESCRIPTION
## Summary

- Caller-supplied ADK plugins (e.g. `HarmonografTelemetryPlugin` set via `App(plugins=[...])`) previously only landed on the coordinator's top-level runner. Sub-agent dispatches routed through `ADKAdapter._build_runner` constructed bare `InMemoryRunner` instances with no plugins, so telemetry from every `AgentTool` / `sub_agents` invocation was silently dropped (goldfive#121).
- Thread a `plugins` kwarg through `_build_runner` -> `ADKAdapter.__init__` -> `auto_adapter` -> `goldfive.wrap`. Every per-agent runner built by the adapter now receives the caller's plugin list at construction time.
- Non-ADK adapters (Claude SDK, callable) ignore the kwarg; there is no analogous plugin surface there today.

## Design notes

- Went with explicit propagation (option A in the design discussion): the caller passes `plugins=` to `goldfive.wrap(tree, plugins=[...])`. The harmonograf demo will need a follow-up to pass its plugin through — tracked separately, not part of this PR.
- `_build_runner` only forwards the `plugins` kwarg to `InMemoryRunner` when the list is non-empty, so ADK builds that omit the parameter still construct cleanly.

## Test plan

- [x] `test_build_runner_without_plugins` — no plugins -> `InMemoryRunner` called without the `plugins` kwarg.
- [x] `test_build_runner_with_plugins` — plugin list is forwarded verbatim.
- [x] `test_adk_adapter_init_accepts_plugins` — `ADKAdapter(tree, plugins=[...])` lands the plugin on every per-agent runner in a 3-agent `AgentTool` tree.
- [x] `test_wrap_accepts_plugins` — `goldfive.wrap(tree, plugins=[...])` forwards through to the adapter.
- [x] `test_dispatch_uses_plugins_in_sub_agent_runner` — a recording plugin's `before_run_callback` fires on a direct sub-agent dispatch (before this fix, the callback never ran).
- [x] Full suite: `uv run pytest` -> 639 passed, 41 skipped.