### PR TITLE
Share one outer ADK session id across per-agent runners (#123)

### DIFF
--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -442,7 +442,18 @@ class ADKAdapter:
         ``"goldfive_user"`` which is fine for local / single-user runs.
     session_id:
         Optional stable session id. When omitted the adapter mints a
-        fresh session id on first :meth:`invoke`.
+        fresh session id on first :meth:`invoke`. When set, the same id
+        is broadcast to every per-agent runner so telemetry / span
+        session-id stamping rolls up under one logical session (see
+        ``outer_session_id`` for the preferred spelling).
+    outer_session_id:
+        Optional preferred-spelling alias for ``session_id``. When
+        provided, pins the SHARED session id used for every per-agent
+        runner this adapter builds. Callers that want to anchor a full
+        adk-web run's telemetry under one harmonograf session id pass
+        the outer runner's session id here. Exactly one of
+        ``session_id`` / ``outer_session_id`` should be set; if both
+        are, ``outer_session_id`` wins.
     app_name:
         Optional ADK app_name override. Defaults to the runner's own
         ``app_name`` or the agent's ``name``.
@@ -463,6 +474,7 @@ class ADKAdapter:
         *,
         user_id: str = "goldfive_user",
         session_id: str | None = None,
+        outer_session_id: str | None = None,
         app_name: str | None = None,
         plugins: list[Any] | None = None,
     ) -> None:
@@ -480,6 +492,17 @@ class ADKAdapter:
         # its AgentTool calls looped forever.
         # ------------------------------------------------------------------
         self._user_id = user_id
+        # Caller-pinned outer session id, if any. ``outer_session_id``
+        # wins over the legacy ``session_id`` spelling when both are
+        # set. This id — or one minted lazily on first
+        # ``_ensure_session_for`` — is broadcast to every per-agent
+        # runner so telemetry rolls up under a single harmonograf
+        # session id (goldfive#123). Previously each per-agent runner
+        # got its OWN ``uuid.uuid4()`` session id, which the
+        # HarmonografTelemetryPlugin stamped onto spans — scattering
+        # one adk-web run's spans across 3+ UI sessions.
+        pinned_outer = outer_session_id if outer_session_id is not None else session_id
+        self._outer_session_id: str | None = pinned_outer
         self._session_id = session_id  # legacy single-runner id; per-runner ids below
         self._degraded_prebuilt_runner = False
         # Caller-supplied ADK plugins (e.g. HarmonografTelemetryPlugin).
@@ -1001,27 +1024,53 @@ class ADKAdapter:
     async def _ensure_session_for(self, agent_name: str) -> str:
         """Return the ADK session id for ``agent_name``'s runner.
 
-        Per-runner session ids because each :class:`InMemoryRunner`
-        carries its own :class:`InMemorySessionService`. Built on
-        demand so agents that never get dispatched to never get an
-        empty ADK session created for them.
+        All per-agent runners share ONE logical session id string
+        (goldfive#123). Each :class:`InMemoryRunner` still carries its
+        own :class:`InMemorySessionService`, so session objects remain
+        distinct per service — they just share an id string. This is
+        safe because ADK looks sessions up as
+        ``(app_name, user_id, session_id)`` against a single
+        per-runner service; sharing the id across runners does NOT
+        create cross-service collisions.
 
-        Legacy back-compat: callers (older tests) that set
-        ``adapter._session_id = "stub-session"`` before the first
-        invoke() pin a session id. We map that single id to every
-        requested agent on first access so the legacy assignment still
-        drives the dispatch target's session. Once an agent has its
-        own entry in ``_session_ids`` it is authoritative.
+        Why uniform: :class:`HarmonografTelemetryPlugin` (and similar
+        telemetry plugins) stamp ``ctx.session.id`` onto every span.
+        When sub-agent runners each minted their own ``uuid.uuid4()``
+        id, a single adk-web run's spans scattered across 3+ UI
+        session ids — breaking the Gantt roll-up. With a shared id,
+        all of a run's spans land under one harmonograf session.
+
+        The shared id is resolved in this order:
+
+        1. A caller-pinned ``outer_session_id`` / legacy
+           ``session_id`` (``self._outer_session_id``) — used as-is.
+        2. Otherwise, lazily mint ONE ``uuid.uuid4()`` on first call
+           and cache it on ``self._outer_session_id``. Subsequent
+           ``_ensure_session_for(...)`` calls reuse it.
+
+        For each distinct ``agent_name``, we still call
+        ``create_session`` once on that runner's session service
+        (which is what ADK's ``run_async`` needs for a successful
+        dispatch). We just pass the SHARED id as the ``session_id``
+        kwarg.
         """
         existing = self._session_ids.get(agent_name)
         if existing:
             return existing
 
-        # Honor a pre-seeded legacy id exactly once per agent. After
-        # that, each agent's entry is authoritative and independent.
-        if self._session_id and not self._session_ids:
-            self._session_ids[agent_name] = self._session_id
-            return self._session_id
+        # Resolve the shared outer session id exactly once per adapter.
+        # After this block ``self._outer_session_id`` is non-empty.
+        #
+        # Legacy back-compat: older tests set
+        # ``adapter._session_id = "stub-session"`` AFTER construction,
+        # before the first invoke(). Honor that post-ctor mutation
+        # when no outer id has been resolved yet.
+        if not self._outer_session_id:
+            if self._session_id:
+                self._outer_session_id = self._session_id
+            else:
+                self._outer_session_id = str(uuid.uuid4())
+        shared_id = self._outer_session_id
 
         runner = self._runners.get(agent_name, self._runner)
         # IMPORTANT: use the per-runner app_name for session creation,
@@ -1035,18 +1084,16 @@ class ADKAdapter:
         app_name = str(getattr(runner, "app_name", "") or "") or self._app_name
         session_service = getattr(runner, "session_service", None)
         if session_service is None:
-            new_id = str(uuid.uuid4())
-            self._session_ids[agent_name] = new_id
-            return new_id
+            self._session_ids[agent_name] = shared_id
+            return shared_id
 
-        new_id = str(uuid.uuid4())
         try:
             create = getattr(session_service, "create_session", None)
             if callable(create):
                 coro = create(
                     app_name=app_name,
                     user_id=self._user_id,
-                    session_id=new_id,
+                    session_id=shared_id,
                 )
                 if hasattr(coro, "__await__"):
                     await coro
@@ -1056,8 +1103,8 @@ class ADKAdapter:
                 agent_name,
                 exc,
             )
-        self._session_ids[agent_name] = new_id
-        return new_id
+        self._session_ids[agent_name] = shared_id
+        return shared_id
 
     # Legacy shim for tests that called ``_ensure_session()`` directly
     # before the registry-dispatch refactor. Maps to the root agent's

--- a/tests/test_dispatch_by_assignee.py
+++ b/tests/test_dispatch_by_assignee.py
@@ -246,9 +246,18 @@ async def test_sequential_dispatch_plugin_active_ctx_cleared_between_invokes() -
     assert adapter._plugin._top_invocation_id == ""
 
 
-async def test_sequential_dispatch_creates_separate_session_ids_per_agent() -> None:
-    """Per-agent runners each get their own ADK session id on first
-    dispatch — no session bleed between runners.
+async def test_sequential_dispatch_shares_one_session_id_across_agents() -> None:
+    """Per-agent runners all share the SAME ADK session id string
+    (goldfive#123). The HarmonografTelemetryPlugin stamps
+    ``ctx.session.id`` onto every span, so a uniform id across runners
+    rolls an adk-web run's spans up under one harmonograf session
+    (before the fix, sub-agent runners minted their own uuids and the
+    UI scattered one run across 3+ sessions).
+
+    Safety: each :class:`InMemoryRunner` has its own
+    :class:`InMemorySessionService`; ADK looks sessions up as
+    ``(app_name, user_id, session_id)`` on the PER-RUNNER service, so
+    sharing the id string across runners does NOT collide.
     """
     from google.adk.tools.agent_tool import AgentTool
 
@@ -267,6 +276,7 @@ async def test_sequential_dispatch_creates_separate_session_ids_per_agent() -> N
     # on first dispatch (exercising the real _ensure_session_for flow
     # against our recording runners, which have no session_service).
     adapter._session_ids = {}
+    adapter._outer_session_id = None
 
     session = Session(
         run_id="r1",
@@ -285,11 +295,13 @@ async def test_sequential_dispatch_creates_separate_session_ids_per_agent() -> N
     for task in session.plan.tasks:
         await adapter.invoke(task=task, session=session)
 
-    # Each agent got its own session id.
+    # Both agents got the SAME shared session id.
     assert "a" in adapter._session_ids
     assert "b" in adapter._session_ids
-    assert adapter._session_ids["a"] != adapter._session_ids["b"], (
-        "per-agent session ids collided — ADK would look sessions up "
-        "by the wrong app_name/session_id combo and pick the other "
-        "agent's conversation history"
+    assert adapter._session_ids["a"] == adapter._session_ids["b"], (
+        "per-agent session ids must share ONE outer id so telemetry "
+        "plugins that stamp ctx.session.id onto spans roll up under a "
+        "single harmonograf session (goldfive#123)"
     )
+    # And that id is cached on the adapter for reuse.
+    assert adapter._outer_session_id == adapter._session_ids["a"]

--- a/tests/test_per_agent_runners.py
+++ b/tests/test_per_agent_runners.py
@@ -227,3 +227,137 @@ def test_degraded_prebuilt_runner_yields_single_entry_registry() -> None:
     assert adapter._degraded_prebuilt_runner is True
     assert set(adapter._runners) == {"solo_inner"}
     assert adapter._runners["solo_inner"] is prebuilt
+
+
+# ---------------------------------------------------------------------------
+# Shared outer session id (goldfive#123)
+# ---------------------------------------------------------------------------
+#
+# Before goldfive#123 each per-agent ``InMemoryRunner`` minted its own
+# ``uuid.uuid4()`` session id on first ``_ensure_session_for(...)`` call.
+# :class:`HarmonografTelemetryPlugin` stamps ``ctx.session.id`` onto every
+# span, so a single adk-web run's spans landed under 3+ distinct
+# harmonograf session ids in the UI — the Gantt for the outer coordinator
+# session only showed the coordinator row, and the sub-agent rows lived
+# under sibling ids the user had to hunt for.
+#
+# The fix: one shared outer session id string, broadcast to every
+# per-agent runner. Each runner still has its own
+# ``InMemorySessionService`` so there is no cross-service collision.
+
+
+async def test_ensure_session_for_shares_one_id_across_all_agents() -> None:
+    """``_ensure_session_for(...)`` returns the SAME string for every agent.
+
+    Regression guard for goldfive#123: sub-agent runners must not
+    mint their own uuids — all dispatches of a single adapter roll up
+    under one harmonograf session.
+    """
+    from google.adk.tools.agent_tool import AgentTool
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    a = _mk("a")
+    b = _mk("b")
+    c = _mk("c")
+    coord = _mk("coord")
+    coord.sub_agents = [b]
+    coord.tools = [AgentTool(a), AgentTool(c)]
+
+    adapter = ADKAdapter(coord)
+
+    sid_a = await adapter._ensure_session_for("a")
+    sid_b = await adapter._ensure_session_for("b")
+    sid_c = await adapter._ensure_session_for("c")
+    sid_coord = await adapter._ensure_session_for("coord")
+
+    assert sid_a == sid_b == sid_c == sid_coord, (
+        "per-agent runners must share ONE outer session id so "
+        "telemetry plugins (HarmonografTelemetryPlugin) stamp the "
+        "SAME ctx.session.id on every span — the adk-web UI then "
+        "rolls coordinator + sub-agent rows into a single Gantt."
+    )
+    # And the id is cached on the adapter for stable reuse.
+    assert adapter._outer_session_id == sid_a
+
+
+async def test_ensure_session_for_is_idempotent_per_agent() -> None:
+    """Calling ``_ensure_session_for(name)`` twice yields the same id
+    (both for the same agent AND across agents)."""
+    from google.adk.tools.agent_tool import AgentTool
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    a = _mk("a")
+    coord = _mk("coord")
+    coord.tools = [AgentTool(a)]
+
+    adapter = ADKAdapter(coord)
+
+    first = await adapter._ensure_session_for("a")
+    second = await adapter._ensure_session_for("a")
+    third = await adapter._ensure_session_for("coord")
+    fourth = await adapter._ensure_session_for("a")
+
+    assert first == second == third == fourth
+
+
+async def test_outer_session_id_kwarg_pins_shared_id() -> None:
+    """``ADKAdapter(..., outer_session_id="pinned")`` pins the shared id.
+
+    Callers that want to anchor an adk-web run's telemetry under a
+    specific harmonograf session id pass the outer runner's id here.
+    """
+    from google.adk.tools.agent_tool import AgentTool
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    a = _mk("a")
+    b = _mk("b")
+    coord = _mk("coord")
+    coord.tools = [AgentTool(a), AgentTool(b)]
+
+    adapter = ADKAdapter(coord, outer_session_id="pinned-outer-abc")
+    assert adapter._outer_session_id == "pinned-outer-abc"
+
+    sid_a = await adapter._ensure_session_for("a")
+    sid_b = await adapter._ensure_session_for("b")
+    sid_coord = await adapter._ensure_session_for("coord")
+
+    assert sid_a == sid_b == sid_coord == "pinned-outer-abc"
+
+
+async def test_legacy_session_id_kwarg_pins_shared_id() -> None:
+    """Legacy ``session_id=...`` kwarg still works and now broadcasts
+    to every per-agent runner (previously only the first-touched agent
+    honored it).
+    """
+    from google.adk.tools.agent_tool import AgentTool
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    a = _mk("a")
+    b = _mk("b")
+    coord = _mk("coord")
+    coord.tools = [AgentTool(a), AgentTool(b)]
+
+    adapter = ADKAdapter(coord, session_id="legacy-outer-xyz")
+
+    sid_a = await adapter._ensure_session_for("a")
+    sid_b = await adapter._ensure_session_for("b")
+    sid_coord = await adapter._ensure_session_for("coord")
+
+    assert sid_a == sid_b == sid_coord == "legacy-outer-xyz"
+
+
+async def test_outer_session_id_wins_over_legacy_session_id() -> None:
+    """When both are set, ``outer_session_id`` beats ``session_id``."""
+    from goldfive.adapters.adk import ADKAdapter
+
+    adapter = ADKAdapter(
+        _mk("solo"),
+        session_id="legacy",
+        outer_session_id="outer-wins",
+    )
+    assert adapter._outer_session_id == "outer-wins"
+    assert await adapter._ensure_session_for("solo") == "outer-wins"


### PR DESCRIPTION
## Summary

Closes #123

`ADKAdapter._ensure_session_for` minted a fresh `uuid.uuid4()` per
sub-agent runner. `HarmonografTelemetryPlugin` stamps `ctx.session.id`
onto every span, so a single adk-web run produced spans scattered
across 3+ harmonograf session ids in the UI — the outer coordinator
Gantt only showed the coordinator row, and sub-agent rows (research,
web_developer, reviewer, debugger) lived under sibling ids users had
to hunt for.

### Fix

- Resolve ONE shared outer session id per adapter (pinned via a new
  `outer_session_id=` kwarg, or lazily minted on first
  `_ensure_session_for`), cached on `self._outer_session_id`.
- Broadcast that id to every per-agent runner's `create_session` call
  and cache entry. Each `InMemoryRunner` still has its own
  `InMemorySessionService`, so sharing the id string across runners
  does not collide — ADK looks sessions up as
  `(app_name, user_id, session_id)` on the per-runner service.
- Legacy `session_id=` kwarg now broadcasts too; `outer_session_id`
  wins when both are passed.

### Tests

- New regression coverage in `tests/test_per_agent_runners.py`:
  shared-id across agents, idempotence, `outer_session_id` pin,
  legacy-kwarg pin, and `outer_session_id`-wins-over-legacy.
- Flipped the now-incorrect
  `test_sequential_dispatch_creates_separate_session_ids_per_agent`
  (which encoded the buggy "distinct ids per runner" contract) into
  `test_sequential_dispatch_shares_one_session_id_across_agents`.

## Test plan

- [x] `uv run pytest tests/test_per_agent_runners.py tests/test_dispatch_by_assignee.py tests/test_adk_adapter.py -x -v` (57 passed)
- [x] Full suite: `uv run pytest` (644 passed, 41 skipped)
- [x] `uv run ruff check goldfive/adapters/adk.py tests/test_per_agent_runners.py tests/test_dispatch_by_assignee.py` (clean)
- [x] Manual verification: `_ensure_session_for("a")` and `_ensure_session_for("b")` return the same string; `_outer_session_id` is set on the adapter.