### PR TITLE
Graduate classify_refusal severity into tiered INFO/WARNING/CRITICAL (#127)

### DIFF
--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -63,7 +63,7 @@ kinds group naturally into six categories.
 | Kind | Trigger | Default severity | Recoverable |
 |---|---|---|---|
 | `TOOL_ERROR` | Adapter observed a tool raising an exception or returning an error payload. | `warning` | yes |
-| `AGENT_REFUSAL` | LLM refused to proceed with polite language ("I can't help with that"). | `warning` | yes |
+| `AGENT_REFUSAL` | LLM refused to proceed; severity graded by tier — `info` for hedging ("I'm not confident"), `warning` for capability refusals ("I can't help with that"), `critical` for policy/safety refusals ("I must decline"). | tiered (`info`/`warning`/`critical`) | usually (INFO is observational, WARNING retries via refine, CRITICAL typically not) |
 | `MODEL_REFUSAL` | Hard refusal — safety-filter style. | `critical` | no |
 | `SAFETY_CONCERN` | Detected content policy / safety trigger from the model. | `critical` | no |
 | `TASK_FAILED_RECOVERABLE` | `report_task_failed(task_id, reason, recoverable=True)` | `warning` | yes |

--- a/docs/design/VOCABULARY.md
+++ b/docs/design/VOCABULARY.md
@@ -344,7 +344,7 @@ Kinds synthesized from signals coming out of the model or adapter layer.
 | `DriftKind` | Value | Default severity | Trigger |
 |---|---|---|---|
 | `TOOL_ERROR` | `"tool_error"` | `WARNING` | `classify_tool_error(event)` matched a tool-result shape with a truthy error / `status=FAILED`/`ok=False`. |
-| `AGENT_REFUSAL` | `"agent_refusal"` | `WARNING` | `classify_refusal(text)` found an `LLM_REFUSAL_MARKERS` substring ("I cannot", "I refuse", ...). |
+| `AGENT_REFUSAL` | `"agent_refusal"` | tier-graded (`INFO` / `WARNING` / `CRITICAL`) | `classify_refusal(text)` matched a marker in one of `LLM_REFUSAL_MARKERS_CRITICAL` (policy/safety, e.g. "I must decline"), `LLM_REFUSAL_MARKERS_WARNING` (capability, e.g. "I cannot"), or `LLM_REFUSAL_MARKERS_INFO` (hedging, e.g. "I'm not confident"). Scan order is CRITICAL -> WARNING -> INFO, first match wins. |
 | `MODEL_REFUSAL` | `"model_refusal"` | `CRITICAL` | Adapter-specific hard refusal path (safety-filter style). Not classified by default; adapters synthesize directly. |
 | `HALLUCINATION_SUSPECTED` | `"hallucination_suspected"` | `WARNING` | Output references entities the session never produced. Caller-supplied heuristic; no default classifier. |
 | `STOPPED_EARLY` | `"stopped_early"` | `WARNING` | Agent emitted nothing before exiting its turn. Adapter-detected. |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -914,9 +914,27 @@ def classify_stop_reason(reason: Any) -> Optional[DriftEvent]: ...
 
 Each returns `None` when the input does not match the classifier's
 signal; callers compose them into a steerer's `detect_drift`
-pipeline. The module also exposes the marker tables
-`LLM_REFUSAL_MARKERS: tuple[str, ...]` and
-`CONTEXT_PRESSURE_STOP_REASONS: tuple[str, ...]` for downstream reuse.
+pipeline.
+
+`classify_refusal` grades severity by matching tier:
+
+| Tier       | Tuple                            | Severity    | Example marker          |
+| ---------- | -------------------------------- | ----------- | ----------------------- |
+| Policy     | `LLM_REFUSAL_MARKERS_CRITICAL`   | `CRITICAL`  | `"i must decline"`      |
+| Capability | `LLM_REFUSAL_MARKERS_WARNING`    | `WARNING`   | `"i cannot"`            |
+| Hedging    | `LLM_REFUSAL_MARKERS_INFO`       | `INFO`      | `"i'm not confident"`   |
+
+The scan order is `CRITICAL -> WARNING -> INFO`; first match wins, so
+a policy/safety refusal is never downgraded when the same text also
+contains a capability or hedging marker. `DefaultSteerer` only
+triggers `planner.refine` for `WARNING`/`CRITICAL` drift; INFO
+matches are emitted to sinks for observability only.
+
+The module also exposes the context-pressure table
+`CONTEXT_PRESSURE_STOP_REASONS: tuple[str, ...]` for downstream
+reuse. The flat `LLM_REFUSAL_MARKERS` tuple is retained as the
+concatenation of the three tiered tuples for back-compat; new code
+should import the tiered names directly.
 
 ## Version compatibility
 

--- a/goldfive/drift/__init__.py
+++ b/goldfive/drift/__init__.py
@@ -26,6 +26,9 @@ __all__ = [
     "DriftSeverity",
     "DriftEvent",
     "LLM_REFUSAL_MARKERS",
+    "LLM_REFUSAL_MARKERS_INFO",
+    "LLM_REFUSAL_MARKERS_WARNING",
+    "LLM_REFUSAL_MARKERS_CRITICAL",
     "CONTEXT_PRESSURE_STOP_REASONS",
     "classify_tool_error",
     "classify_refusal",
@@ -68,8 +71,27 @@ def __getattr__(name: str) -> Any:
 # ---------------------------------------------------------------------------
 
 
-# Substrings that indicate an LLM-level refusal in free-form text.
-LLM_REFUSAL_MARKERS: tuple[str, ...] = (
+# Tiered refusal markers. ``classify_refusal`` scans the tiers in
+# CRITICAL -> WARNING -> INFO order and returns a ``DriftEvent`` with
+# the matching ``DriftSeverity``. First-match-wins: a substring match
+# in a higher tier short-circuits scans of the lower tiers, so
+# policy/safety refusals never get downgraded to hedging.
+#
+# INFO — hedging / deferral. The model is expressing low confidence
+# but has not refused outright. Emitted as observational drift only;
+# the default steerer does not trigger ``planner.refine`` for INFO.
+LLM_REFUSAL_MARKERS_INFO: tuple[str, ...] = (
+    "i may not be the best fit",
+    "i think this might",
+    "not particularly well suited",
+    "i'm not confident",
+    "i am not confident",
+)
+
+# WARNING — the model has stated it cannot or will not proceed but
+# without invoking a safety policy. Historically the only severity for
+# ``AGENT_REFUSAL``; still the most common tier. Triggers refine.
+LLM_REFUSAL_MARKERS_WARNING: tuple[str, ...] = (
     "i cannot",
     "i can't",
     "i won't",
@@ -77,11 +99,39 @@ LLM_REFUSAL_MARKERS: tuple[str, ...] = (
     "i'm unable",
     "i am unable",
     "i refuse",
-    "i must decline",
     "i'm not able to",
     "i am not able to",
-    "cannot assist",
     "can't help with",
+    "beyond my capabilities",
+    "outside my scope",
+    "cannot proceed",
+    "no viable approach",
+    "unable to locate",
+    "this is not something i can",
+    "i was unable to",
+)
+
+# CRITICAL — policy / safety refusals. These usually mean the model
+# will not produce the requested output no matter how the plan is
+# refined; surface the highest severity so operators see the refusal
+# clearly in sinks.
+LLM_REFUSAL_MARKERS_CRITICAL: tuple[str, ...] = (
+    "i must decline",
+    "cannot assist with",
+    "against my guidelines",
+    "for safety reasons",
+    "i will not proceed",
+)
+
+#: Deprecated: kept for back-compat with external callers that
+#: imported the flat marker tuple. Prefer the tiered tables above
+#: (:data:`LLM_REFUSAL_MARKERS_INFO`, :data:`LLM_REFUSAL_MARKERS_WARNING`,
+#: :data:`LLM_REFUSAL_MARKERS_CRITICAL`) and scan via
+#: :func:`classify_refusal`, which graduates severity per tier.
+LLM_REFUSAL_MARKERS: tuple[str, ...] = (
+    LLM_REFUSAL_MARKERS_CRITICAL
+    + LLM_REFUSAL_MARKERS_WARNING
+    + LLM_REFUSAL_MARKERS_INFO
 )
 
 # Stop-reason / finish-reason values that indicate the model hit a length
@@ -200,23 +250,37 @@ def classify_tool_error(event: Any) -> DriftEvent | None:
 
 
 def classify_refusal(text: Any) -> DriftEvent | None:
-    """Return a ``DriftEvent`` of kind ``AGENT_REFUSAL`` if the text
-    contains any of :data:`LLM_REFUSAL_MARKERS`.
+    """Return a ``DriftEvent`` of kind ``AGENT_REFUSAL`` with a severity
+    graduated from the matching tier.
 
-    ``text`` may be a raw string or any object from which
-    :func:`_extract_text` can pull a text payload. Case-insensitive.
+    Scans :data:`LLM_REFUSAL_MARKERS_CRITICAL`,
+    :data:`LLM_REFUSAL_MARKERS_WARNING`, then
+    :data:`LLM_REFUSAL_MARKERS_INFO` in that order and returns on the
+    first match. This guarantees a policy/safety refusal is never
+    downgraded to a WARNING or INFO just because the text also
+    contains a hedging phrase. ``text`` may be a raw string or any
+    object from which :func:`_extract_text` can pull a text payload.
+    Case-insensitive.
     """
     s = text if isinstance(text, str) else _extract_text(text)
-    marker = _first_marker(s, LLM_REFUSAL_MARKERS)
-    if marker is None:
+    if not s:
         return None
-    snippet = s[:140]
-    return DriftEvent(
-        kind=DriftKind.AGENT_REFUSAL,
-        severity=DriftSeverity.WARNING,
-        detail=f"refusal marker {marker!r}: {snippet!r}",
-        raw=text,
-    )
+    for tier_markers, severity in (
+        (LLM_REFUSAL_MARKERS_CRITICAL, DriftSeverity.CRITICAL),
+        (LLM_REFUSAL_MARKERS_WARNING, DriftSeverity.WARNING),
+        (LLM_REFUSAL_MARKERS_INFO, DriftSeverity.INFO),
+    ):
+        marker = _first_marker(s, tier_markers)
+        if marker is None:
+            continue
+        snippet = s[:140]
+        return DriftEvent(
+            kind=DriftKind.AGENT_REFUSAL,
+            severity=severity,
+            detail=f"refusal marker {marker!r}: {snippet!r}",
+            raw=text,
+        )
+    return None
 
 
 def classify_stop_reason(reason: Any) -> DriftEvent | None:

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -343,6 +343,83 @@ def test_classify_refusal_none_on_normal_text() -> None:
     assert classify_refusal("OK, I will do that.") is None
 
 
+@pytest.mark.parametrize(
+    ("text", "expected_severity"),
+    [
+        # CRITICAL — policy / safety refusals.
+        ("I must decline to answer this.", DriftSeverity.CRITICAL),
+        ("I cannot assist with that request.", DriftSeverity.CRITICAL),
+        ("That request is against my guidelines.", DriftSeverity.CRITICAL),
+        ("For safety reasons, I won't elaborate.", DriftSeverity.CRITICAL),
+        ("I will not proceed with this task.", DriftSeverity.CRITICAL),
+        # WARNING — capability / scope refusals.
+        ("I cannot help with that, sorry.", DriftSeverity.WARNING),
+        ("That is beyond my capabilities right now.", DriftSeverity.WARNING),
+        ("That's outside my scope as a planner.", DriftSeverity.WARNING),
+        ("I was unable to find the file.", DriftSeverity.WARNING),
+        ("No viable approach presents itself.", DriftSeverity.WARNING),
+        ("This is not something I can do.", DriftSeverity.WARNING),
+        # INFO — hedging / deferral.
+        ("I may not be the best fit for this.", DriftSeverity.INFO),
+        ("I think this might be the wrong approach.", DriftSeverity.INFO),
+        ("I'm not particularly well suited for image work.", DriftSeverity.INFO),
+        ("I'm not confident this will succeed.", DriftSeverity.INFO),
+    ],
+)
+def test_classify_refusal_severity_tiers(
+    text: str, expected_severity: DriftSeverity
+) -> None:
+    """Each tier maps to its documented ``DriftSeverity``."""
+    d = classify_refusal(text)
+    assert d is not None
+    assert d.kind is DriftKind.AGENT_REFUSAL
+    assert d.severity is expected_severity
+
+
+def test_classify_refusal_critical_wins_over_warning_substring() -> None:
+    """First-match-wins across tiers: a CRITICAL marker in the same
+    text must not be downgraded because a WARNING marker also
+    happens to appear.
+    """
+    # "i cannot" (WARNING) appears before "i must decline" (CRITICAL)
+    # in the raw string, but the scan order is tier-first, not
+    # position-first, so CRITICAL must win.
+    text = "I cannot continue here; I must decline on policy grounds."
+    d = classify_refusal(text)
+    assert d is not None
+    assert d.kind is DriftKind.AGENT_REFUSAL
+    assert d.severity is DriftSeverity.CRITICAL
+
+
+def test_classify_refusal_warning_wins_over_info_substring() -> None:
+    """WARNING tier beats INFO when both markers coexist."""
+    text = "I'm not confident, and in fact I cannot do this."
+    d = classify_refusal(text)
+    assert d is not None
+    assert d.kind is DriftKind.AGENT_REFUSAL
+    assert d.severity is DriftSeverity.WARNING
+
+
+def test_classify_refusal_flat_markers_back_compat() -> None:
+    """The deprecated flat ``LLM_REFUSAL_MARKERS`` tuple still exposes
+    every tiered marker so external callers that imported the name
+    continue to work.
+    """
+    from goldfive.drift import (
+        LLM_REFUSAL_MARKERS,
+        LLM_REFUSAL_MARKERS_CRITICAL,
+        LLM_REFUSAL_MARKERS_INFO,
+        LLM_REFUSAL_MARKERS_WARNING,
+    )
+
+    expected = set(
+        LLM_REFUSAL_MARKERS_CRITICAL
+        + LLM_REFUSAL_MARKERS_WARNING
+        + LLM_REFUSAL_MARKERS_INFO
+    )
+    assert set(LLM_REFUSAL_MARKERS) == expected
+
+
 def test_classify_stop_reason_max_tokens() -> None:
     d = classify_stop_reason("MAX_TOKENS")
     assert d is not None and d.kind is DriftKind.CONTEXT_PRESSURE


### PR DESCRIPTION
Closes #127

## Summary
- Split the flat `LLM_REFUSAL_MARKERS` tuple into three tiered tables (`_INFO`, `_WARNING`, `_CRITICAL`) covering hedging, capability refusals, and policy/safety refusals respectively.
- `classify_refusal` now scans CRITICAL -> WARNING -> INFO (first match wins) and returns a `DriftEvent` whose `severity` reflects the matching tier, so hedging never triggers `planner.refine` and policy refusals never get downgraded.
- Kept `LLM_REFUSAL_MARKERS` as the concatenation of all three tiers for back-compat (marked Deprecated in the docstring) and extended the exports accordingly.
- Verified `DefaultSteerer._handle_drift` already gates refine on `>= WARNING`, so INFO refusals become observational automatically; no Steerer-side change needed for the #99 concern raised in the issue.
- Updated `docs/reference/api.md`, `docs/design/VOCABULARY.md`, and `docs/design/DRIFT.md` to describe the graduated severities.

## Test plan
- [x] `uv run pytest -x -v` (662 passed, 41 skipped) — full suite green.
- [x] New parameterised `test_classify_refusal_severity_tiers` covers >=2 markers per tier (5 CRITICAL, 6 WARNING, 4 INFO).
- [x] `test_classify_refusal_critical_wins_over_warning_substring` asserts tier order short-circuits position order.
- [x] `test_classify_refusal_warning_wins_over_info_substring` covers the WARNING > INFO case.
- [x] `test_classify_refusal_flat_markers_back_compat` asserts the deprecated flat tuple is still the union of all tiers.
- [x] Existing `test_classify_refusal_detects_markers` / `_on_dict_content` / `_none_on_normal_text` still pass unchanged.