### PR TITLE
Harden drift-recovery path against silent fallbacks (closes #134)

### DIFF
--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -53,6 +53,7 @@ from goldfive.protocols import (
 from goldfive.results import ExecutionOutcome, InvocationResult, evaluate_goal_predicates
 from goldfive.types import (
     DriftEvent,
+    DriftKind,
     DriftSeverity,
     Plan,
     Session,
@@ -301,11 +302,21 @@ class ParallelDAGExecutor:
                         )
                         break
 
-                    refined = await self._refine(plan=session.plan or plan,
-                                                 drift=drift, planner=planner,
-                                                 session=session)
+                    refined = await self._refine(
+                        plan=session.plan or plan,
+                        drift=drift,
+                        planner=planner,
+                        session=session,
+                        sinks=sinks,
+                    )
                     if refined is not None and refined is not (session.plan or plan):
                         refinements_used += 1
+                        # Refine succeeded: clear any per-(kind, task)
+                        # failure history so a future drift of the same
+                        # kind on the same task starts fresh.
+                        session.refine_failure_counts.pop(
+                            (drift.kind.value, drift.current_task_id), None
+                        )
                         session.plan = refined
                         await emit_event(
                             sinks,
@@ -319,7 +330,32 @@ class ParallelDAGExecutor:
                         # Falls through to loop top: stages recomputed.
                         continue
 
-                # No drift (or no refinement): continue to next stage.
+                    # Refine returned None: _refine has already emitted a
+                    # CRITICAL follow-up DriftDetected. Bump the per-(kind,
+                    # task) counter and abort the run if we've exceeded
+                    # the threshold — silently re-entering the same stage
+                    # with the same plan is the exact stall goldfive#134
+                    # targets.
+                    if refined is None:
+                        failure_count = self._bump_refine_failure(
+                            session=session, drift=drift
+                        )
+                        if failure_count >= self.REFINE_FAILURE_THRESHOLD:
+                            abort_reason = (
+                                f"refine failed {failure_count} consecutive "
+                                f"times for {drift.kind.value} "
+                                f"(task {drift.current_task_id or 'n/a'}); "
+                                f"aborting to avoid silent loop"
+                            )
+                            log.warning(
+                                "ParallelDAGExecutor: %s", abort_reason
+                            )
+                            break
+                        # Below threshold: fall through to the next stage
+                        # and give the planner another chance on the next
+                        # drift of the same kind.
+
+                # No drift (or refine below threshold): continue to next stage.
         except BaseException as exc:  # noqa: BLE001 — propagate reason, then re-raise
             abort_reason = f"{type(exc).__name__}: {exc}"
             await emit_event(
@@ -431,9 +467,25 @@ class ParallelDAGExecutor:
                 except asyncio.CancelledError:
                     raise
                 except Exception as detect_exc:  # noqa: BLE001
-                    log.debug(
-                        "ParallelDAGExecutor: steerer.detect_drift raised: %s",
+                    # Plumbing failure inside the drift pipeline: surface
+                    # it so sinks see a signal, instead of silently
+                    # treating the task's output as benign. An INFO
+                    # CUSTOM drift mirrors the pattern
+                    # ``DefaultSteerer._emit_reflective_failure`` uses
+                    # for the reflective-check plumbing: the run
+                    # continues but operators can see the failure in
+                    # the event stream. See goldfive#134.
+                    log.warning(
+                        "ParallelDAGExecutor: steerer.observe/detect_drift "
+                        "raised for task=%s: %s",
+                        task.id,
                         detect_exc,
+                    )
+                    await _emit_pipeline_failure_drift(
+                        session=session,
+                        sinks=sinks,
+                        task_id=task.id,
+                        reason=f"drift_pipeline_failed: {detect_exc}",
                     )
                     drift = None
 
@@ -589,6 +641,13 @@ class ParallelDAGExecutor:
     # Plan refinement
     # ------------------------------------------------------------------
 
+    # Consecutive refine failures tolerated per (drift_kind, task_id)
+    # before the parallel executor gives up and aborts the run. Mirrors
+    # ``DefaultSteerer.REFINE_FAILURE_THRESHOLD`` so a stage-level refine
+    # that fails validation or raises does not loop silently. See
+    # goldfive#134.
+    REFINE_FAILURE_THRESHOLD: int = 2
+
     async def _refine(
         self,
         *,
@@ -596,15 +655,107 @@ class ParallelDAGExecutor:
         drift: DriftEvent,
         planner: Planner,
         session: Session,
+        sinks: list[EventSink],
     ) -> Plan | None:
+        """Ask ``planner.refine`` for a revision; validate and signal failures.
+
+        Unlike the previous quiet-null version, every failure mode
+        (``refine`` raises, returns ``None``, or returns a plan that
+        fails structural validation) emits a CRITICAL follow-up
+        ``DriftDetected`` event so sinks see "refine failed" instead of
+        silently observing the old plan. A per-``(kind, task_id)``
+        failure counter is bumped on ``session.refine_failure_counts``
+        and mirrors the steerer's back-off threshold. Returns the
+        validated revised plan on success or ``None`` on any failure;
+        callers should fall through to the next stage when ``None`` is
+        returned (downstream tasks that depended on a replacement still
+        block via ``_pick_next_task`` and the reachability audit).
+
+        See goldfive#134.
+        """
         try:
             refined = await planner.refine(
                 plan=plan, drift=drift, goals=list(session.goals)
             )
         except Exception as exc:  # noqa: BLE001
             log.warning("ParallelDAGExecutor: planner.refine raised: %s", exc)
+            await self._emit_refine_failure(
+                session=session,
+                sinks=sinks,
+                source=drift,
+                reason=f"refine raised: {exc}",
+            )
+            return None
+        if refined is None:
+            log.warning(
+                "ParallelDAGExecutor: planner.refine(kind=%s) returned None; "
+                "plan unchanged",
+                drift.kind.value,
+            )
+            await self._emit_refine_failure(
+                session=session,
+                sinks=sinks,
+                source=drift,
+                reason="planner returned no revised plan",
+            )
+            return None
+        try:
+            refined.validate(for_revision=True, prior=plan)
+        except ValueError as exc:
+            log.warning(
+                "ParallelDAGExecutor: revised plan failed validation (%s); "
+                "keeping prior plan",
+                exc,
+            )
+            await self._emit_refine_failure(
+                session=session,
+                sinks=sinks,
+                source=drift,
+                reason=f"plan validation failed: {exc}",
+            )
             return None
         return refined
+
+    async def _emit_refine_failure(
+        self,
+        *,
+        session: Session,
+        sinks: list[EventSink],
+        source: DriftEvent,
+        reason: str,
+    ) -> None:
+        """Surface a failed refine as a CRITICAL follow-up ``DriftDetected``.
+
+        Mirrors ``DefaultSteerer._emit_refine_failure`` so the parallel
+        executor's direct refine path produces the same sink-level
+        signal the sequential path does. Without this, a planner.refine
+        that raises or returns a garbage plan leaves the session pinned
+        to the stale plan and the next stage re-enters the same state.
+        See goldfive#134.
+        """
+        failure = DriftEvent(
+            kind=source.kind,
+            severity=DriftSeverity.CRITICAL,
+            detail=f"refine failed ({source.kind.value}): {reason}",
+            current_task_id=source.current_task_id,
+            current_agent_id=source.current_agent_id,
+        )
+        await _emit_drift_event(session=session, sinks=sinks, drift=failure)
+
+    def _bump_refine_failure(
+        self, *, session: Session, drift: DriftEvent
+    ) -> int:
+        """Bump the per-``(kind, task_id)`` refine-failure counter.
+
+        Returns the new count. Callers compare against
+        :attr:`REFINE_FAILURE_THRESHOLD` to decide whether to abort the
+        run. Uses ``session.refine_failure_counts`` so the counter is
+        shared with :class:`~goldfive.steerer.DefaultSteerer`.
+        """
+        key = (drift.kind.value, drift.current_task_id)
+        count = session.refine_failure_counts.get(key, 0) + 1
+        session.refine_failure_counts[key] = count
+        return count
 
     # ------------------------------------------------------------------
     # Control helpers
@@ -727,6 +878,68 @@ class ParallelDAGExecutor:
 
 def _outcome_summary(completed_task_ids: set[str]) -> str:
     return f"{len(completed_task_ids)} tasks completed"
+
+
+async def _emit_pipeline_failure_drift(
+    *,
+    session: Session,
+    sinks: list[EventSink],
+    task_id: str,
+    reason: str,
+) -> None:
+    """Emit an INFO ``CUSTOM`` drift when the drift pipeline itself raised.
+
+    Surfaces plumbing failures in ``steerer.observe`` / ``detect_drift``
+    that would otherwise be swallowed. INFO severity so this is
+    record-only and does not trigger another refine. Sinks that care
+    can filter on the ``drift_pipeline_failed:`` detail prefix. See
+    goldfive#134.
+    """
+    drift = DriftEvent(
+        kind=DriftKind.CUSTOM,
+        severity=DriftSeverity.INFO,
+        detail=reason,
+        current_task_id=task_id or "",
+    )
+    await _emit_drift_event(session=session, sinks=sinks, drift=drift)
+
+
+async def _emit_drift_event(
+    *,
+    session: Session,
+    sinks: list[EventSink],
+    drift: DriftEvent,
+) -> None:
+    """Build a DriftDetected envelope with proto enum mapping, then emit.
+
+    Uses the same enum-mapping shape
+    :meth:`DefaultSteerer._emit_drift_detected` uses — the
+    :func:`drift_detected_event` helper in :mod:`goldfive.events` does
+    a best-effort name lookup that silently fails for StrEnum-style
+    kind/severity names (stored as lowercase like ``critical``), which
+    would leave the event with enum value ``0`` (UNSPECIFIED).
+    """
+    from goldfive.events import new_event
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    evt = new_event(session.run_id, session.next_sequence())
+    evt.drift_detected.kind = getattr(
+        types_pb2,
+        f"DRIFT_KIND_{drift.kind.name}",
+        getattr(types_pb2, "DRIFT_KIND_CUSTOM", 0),
+    )
+    evt.drift_detected.severity = getattr(
+        types_pb2,
+        f"DRIFT_SEVERITY_{drift.severity.name}",
+        getattr(types_pb2, "DRIFT_SEVERITY_UNSPECIFIED", 0),
+    )
+    evt.drift_detected.detail = drift.detail
+    evt.drift_detected.current_task_id = drift.current_task_id or ""
+    evt.drift_detected.current_agent_id = drift.current_agent_id or ""
+    try:
+        await emit_event(sinks, evt)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("_emit_drift_event: sink emit raised: %s", exc)
 
 
 # Runtime conformance check — the class must satisfy the Executor protocol.

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -373,9 +373,22 @@ class SequentialExecutor(Executor):
                 try:
                     await steerer.observe(result, session)
                 except Exception as observe_exc:  # noqa: BLE001
-                    log.debug(
-                        "SequentialExecutor: steerer.observe raised: %s",
+                    # Plumbing failure inside the drift pipeline: surface
+                    # it so sinks see a signal, rather than silently
+                    # treating the task's output as benign. INFO CUSTOM
+                    # so the run continues but the failure is durably
+                    # recorded. See goldfive#134.
+                    log.warning(
+                        "SequentialExecutor: steerer.observe raised for "
+                        "task=%s: %s",
+                        task.id,
                         observe_exc,
+                    )
+                    await _emit_pipeline_failure_drift(
+                        session=session,
+                        sinks=sinks,
+                        task_id=task.id,
+                        reason=f"drift_pipeline_failed: {observe_exc}",
                     )
 
             # Re-read the task's tracked status after the invocation.
@@ -850,6 +863,49 @@ def _pending_task_ids(plan: Plan) -> list[str]:
     sinks see a coherent plan-end state instead of "stuck PENDING forever."
     """
     return [t.id for t in plan.tasks if t.status == TaskStatus.PENDING and t.id]
+
+
+async def _emit_pipeline_failure_drift(
+    *,
+    session: Session,
+    sinks: list[EventSink],
+    task_id: str,
+    reason: str,
+) -> None:
+    """Emit an INFO ``CUSTOM`` drift when the drift pipeline itself raised.
+
+    Mirrors the helper in
+    :mod:`goldfive.executors.parallel`: a bug in the steerer's observe
+    path must not silently disappear. INFO severity so the run does not
+    trigger another refine — the goal is to make the plumbing failure
+    visible, not to recover from it. Sinks that care can filter on
+    the ``drift_pipeline_failed:`` detail prefix. See goldfive#134.
+
+    Uses the steerer's proto-enum mapping shape
+    (``DRIFT_KIND_<NAME>``) so the emitted envelope carries a real
+    enum value rather than UNSPECIFIED — the
+    :func:`goldfive.events.drift_detected_event` helper does a
+    best-effort lookup that silently drops StrEnum-style values.
+    """
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    evt = new_event(session.run_id, session.next_sequence())
+    evt.drift_detected.kind = getattr(
+        types_pb2,
+        f"DRIFT_KIND_{DriftKind.CUSTOM.name}",
+        0,
+    )
+    evt.drift_detected.severity = getattr(
+        types_pb2,
+        f"DRIFT_SEVERITY_{DriftSeverity.INFO.name}",
+        0,
+    )
+    evt.drift_detected.detail = reason
+    evt.drift_detected.current_task_id = task_id or ""
+    try:
+        await emit(sinks, evt)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("_emit_pipeline_failure_drift: sink emit raised: %s", exc)
 
 
 def _plan_divergence_drift_event(session: Session, detail: str) -> object:

--- a/tests/test_parallel_executor.py
+++ b/tests/test_parallel_executor.py
@@ -676,3 +676,255 @@ async def test_parallel_all_goals_met_returns_success() -> None:
     assert calls == ["a", "b"]
     kinds = _proto_kinds(sink.events)
     assert kinds[-1] == "RunCompleted"
+
+
+# ---------------------------------------------------------------------------
+# Recovery-path hardening (goldfive#134)
+#
+# These tests pin the "silent-fallback no more" contract: when
+# ``planner.refine`` raises, returns None, or returns a plan that fails
+# structural validation, the parallel executor must emit a CRITICAL
+# follow-up DriftDetected and (after REFINE_FAILURE_THRESHOLD
+# consecutive failures for the same (kind, task)) abort the run instead
+# of silently re-entering the next stage with the unchanged plan. A
+# failure inside the steerer's observe path must likewise emit an INFO
+# CUSTOM drift instead of being swallowed.
+# ---------------------------------------------------------------------------
+
+
+def _drift_detected_events(sink: NoopSink) -> list[Any]:
+    return [
+        e
+        for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "drift_detected"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refine_raise_emits_critical_follow_up_drift() -> None:
+    """planner.refine raising must emit a CRITICAL ``refine failed`` drift."""
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="C diverged",
+        current_task_id="C",
+    )
+    adapter = TracingAdapter(delay=0.005, drift_for={"C": drift})
+
+    class RaisingPlanner(RecordingPlanner):
+        async def refine(self, *, plan: Plan, drift: DriftEvent, goals) -> Plan | None:
+            self.refine_calls.append(drift)
+            raise RuntimeError("LLM transient failure")
+
+    planner = RaisingPlanner()
+    sink = NoopSink()
+    executor = ParallelDAGExecutor(max_concurrency=0, drift_policy="finish_stage")
+    outcome = await executor.run(
+        plan=_diamond_plan(),
+        session=_new_session(),
+        adapter=adapter,
+        steerer=RecordingSteerer(),
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # Drift surfaced (WARNING) -> refine raised -> follow-up CRITICAL
+    # DriftDetected should be on the sink.
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    drifts = _drift_detected_events(sink)
+    assert drifts, "expected at least one DriftDetected event"
+    critical = [
+        e
+        for e in drifts
+        if e.drift_detected.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+        and "refine failed" in e.drift_detected.detail
+    ]
+    assert critical, (
+        "expected a CRITICAL 'refine failed' DriftDetected after "
+        "planner.refine raised; got details="
+        f"{[e.drift_detected.detail for e in drifts]}"
+    )
+    assert "LLM transient failure" in critical[-1].drift_detected.detail
+    # Run itself proceeded (the refine failure did not cascade into an
+    # abort because the threshold wasn't exceeded).
+    assert outcome is not None
+
+
+@pytest.mark.asyncio
+async def test_refine_returns_invalid_plan_emits_follow_up_drift() -> None:
+    """planner.refine returning a garbage plan must not be silently applied.
+
+    Mirrors the exact failure mode #133 describes (validation rejects
+    the LLM's revised plan, steerer falls back silently) but at the
+    parallel executor layer, which previously skipped validation
+    entirely.
+    """
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="C diverged",
+        current_task_id="C",
+    )
+    adapter = TracingAdapter(delay=0.005, drift_for={"C": drift})
+
+    # A structurally broken plan: an edge pointing at an id that
+    # doesn't exist in ``tasks``. ``Plan.validate`` rejects this.
+    bad_plan = Plan(
+        id="plan-bad",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[Task(id="A", title="A", status=TaskStatus.COMPLETED)],
+        edges=[TaskEdge(from_task_id="A", to_task_id="does-not-exist")],
+        revision_index=1,
+    )
+    planner = RecordingPlanner(refined_plan=bad_plan)
+    sink = NoopSink()
+    executor = ParallelDAGExecutor(max_concurrency=0, drift_policy="finish_stage")
+
+    await executor.run(
+        plan=_diamond_plan(),
+        session=_new_session(),
+        adapter=adapter,
+        steerer=RecordingSteerer(),
+        planner=planner,
+        sinks=[sink],
+    )
+
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    drifts = _drift_detected_events(sink)
+    critical = [
+        e
+        for e in drifts
+        if e.drift_detected.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+        and "refine failed" in e.drift_detected.detail
+        and "validation" in e.drift_detected.detail.lower()
+    ]
+    assert critical, (
+        "expected a CRITICAL 'refine failed: plan validation failed' drift; "
+        f"got details={[e.drift_detected.detail for e in drifts]}"
+    )
+    # The executor did NOT install the garbage plan.
+    kinds = _proto_kinds(sink.events)
+    assert "PlanRevised" not in kinds
+
+
+@pytest.mark.asyncio
+async def test_repeated_refine_failure_aborts_run() -> None:
+    """After REFINE_FAILURE_THRESHOLD consecutive raises, the run aborts.
+
+    Every task in the plan drifts with the same (kind, task_id=""),
+    the planner always raises, so each stage's drift adds another
+    consecutive failure to the counter. After the threshold the
+    executor must break out with an explicit ``RunAborted`` rather
+    than silently looping through the remaining stages.
+    """
+    # Same drift kind for every task, no current_task_id so the
+    # counter key is stable across tasks. This keeps the "consecutive
+    # failures for the same (kind, task)" invariant honoured.
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="always drift",
+        current_task_id="",
+    )
+
+    class AlwaysDriftingAdapter(TracingAdapter):
+        async def invoke(self, task: Task, session: Session) -> InvocationResult:
+            async with self._lock:
+                self.in_flight += 1
+                self.peak_in_flight = max(self.peak_in_flight, self.in_flight)
+                self.order.append(task.id)
+            try:
+                await asyncio.sleep(self.delay)
+            finally:
+                async with self._lock:
+                    self.in_flight -= 1
+                    self.completed.append(task.id)
+            return InvocationResult(
+                task_id=task.id,
+                text=f"result:{task.id}",
+                raw={"_drift_to_surface": drift},
+            )
+
+    class AlwaysRaisingPlanner(RecordingPlanner):
+        async def refine(self, *, plan: Plan, drift: DriftEvent, goals) -> Plan | None:
+            self.refine_calls.append(drift)
+            raise RuntimeError("refine keeps raising")
+
+    adapter = AlwaysDriftingAdapter(delay=0.005)
+    planner = AlwaysRaisingPlanner()
+    sink = NoopSink()
+    executor = ParallelDAGExecutor(
+        max_concurrency=0, drift_policy="finish_stage"
+    )
+    outcome = await executor.run(
+        plan=_diamond_plan(),
+        session=_new_session(),
+        adapter=adapter,
+        steerer=RecordingSteerer(),
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # After REFINE_FAILURE_THRESHOLD consecutive refine failures for
+    # the same (kind, task_id), the run must abort.
+    assert outcome.success is False
+    assert "refine failed" in outcome.reason
+    assert "aborting" in outcome.reason
+    kinds = _proto_kinds(sink.events)
+    assert kinds[-1] == "RunAborted"
+    # The planner was called up to the threshold (exclusive bound: on
+    # crossing the threshold we break before calling again).
+    assert len(planner.refine_calls) == executor.REFINE_FAILURE_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_observer_exception_emits_pipeline_failure_drift() -> None:
+    """``steerer.observe`` raising must emit an INFO ``CUSTOM`` drift.
+
+    Previously the executor would ``log.debug`` and set ``drift = None``,
+    leaving sinks unaware the drift pipeline had silently failed for
+    the task. goldfive#134: an INFO ``CUSTOM`` drift with a
+    ``drift_pipeline_failed:`` detail prefix is now emitted so the
+    plumbing failure is durably visible.
+    """
+
+    class RaisingSteerer(RecordingSteerer):
+        async def observe(self, event: Any, session: Session) -> None:
+            raise RuntimeError("classifier exploded")
+
+        def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
+            return None  # pragma: no cover - never reached; observe raises
+
+    adapter = TracingAdapter(delay=0.005)
+    sink = NoopSink()
+    executor = ParallelDAGExecutor(max_concurrency=0)
+    await executor.run(
+        plan=_diamond_plan(),
+        session=_new_session(),
+        adapter=adapter,
+        steerer=RaisingSteerer(),
+        planner=RecordingPlanner(),
+        sinks=[sink],
+    )
+
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    drifts = _drift_detected_events(sink)
+    pipeline_failures = [
+        e
+        for e in drifts
+        if e.drift_detected.kind == types_pb2.DRIFT_KIND_CUSTOM
+        and "drift_pipeline_failed" in e.drift_detected.detail
+    ]
+    assert pipeline_failures, (
+        "expected at least one INFO CUSTOM drift with "
+        "'drift_pipeline_failed:' prefix after steerer.observe raised"
+    )
+    assert (
+        pipeline_failures[0].drift_detected.severity
+        == types_pb2.DRIFT_SEVERITY_INFO
+    )
+    assert "classifier exploded" in pipeline_failures[0].drift_detected.detail

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -1161,6 +1161,70 @@ async def test_max_task_invocations_explicit_cap_honored() -> None:
     assert sink.payload_kinds()[-1] == "run_aborted"
 
 
+async def test_observer_exception_emits_pipeline_failure_drift() -> None:
+    """``steerer.observe`` raising must emit an INFO ``CUSTOM`` drift.
+
+    goldfive#134: a bug in the drift pipeline used to be swallowed at
+    ``log.debug`` level. The run now surfaces an INFO ``CUSTOM`` drift
+    with a ``drift_pipeline_failed:`` detail prefix so sinks see the
+    plumbing failure instead of silently accepting the task's output
+    as benign.
+    """
+    plan = _linear_plan(1)
+    session = _fresh_session()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    class RaisingSteerer(StubSteerer):
+        async def observe(self, event: Any, session: Session) -> None:
+            raise RuntimeError("classifier exploded")
+
+    steerer = RaisingSteerer()
+
+    async def _complete_current(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_complete_current)
+    executor = SequentialExecutor(max_task_invocations=5)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    # The run completed (the plumbing failure is record-only), but a
+    # DriftDetected(kind=CUSTOM, severity=INFO) was emitted.
+    assert outcome.success is True
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    drift_events = [
+        e
+        for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "drift_detected"
+    ]
+    pipeline_failures = [
+        e
+        for e in drift_events
+        if e.drift_detected.kind == types_pb2.DRIFT_KIND_CUSTOM
+        and "drift_pipeline_failed" in e.drift_detected.detail
+    ]
+    assert pipeline_failures, (
+        "expected an INFO CUSTOM 'drift_pipeline_failed' drift after "
+        "steerer.observe raised"
+    )
+    assert (
+        pipeline_failures[0].drift_detected.severity
+        == types_pb2.DRIFT_SEVERITY_INFO
+    )
+    assert "classifier exploded" in pipeline_failures[0].drift_detected.detail
+
+
 def test_deprecation_warning_fires_for_old_kwarg() -> None:
     """Passing ``max_plan_reinvocations=`` emits a :class:`DeprecationWarning`
     and maps to the new attribute name.


### PR DESCRIPTION
## Summary

Sibling to #133. Where #133 fixes the silent-fallback pattern inside `LLMPlanner._refine_looping_tool_call`, the audit surfaced the same shape in the **executor layer** and the **observer path**. This PR hardens both so a drift to refine to stall scenario can't happen silently any more.

### Seams fixed

1. **`ParallelDAGExecutor._refine`** swallowed `planner.refine` exceptions and None returns with only `log.warning`, and never validated the returned plan. A raised refine meant the stage loop silently re-entered with the same plan; a garbage plan installed with no schema check.
   - Now: every failure path (raise / None / validation failure) emits a CRITICAL follow-up `DriftDetected` with `refine failed (<kind>): <reason>` detail, same shape `DefaultSteerer._emit_refine_failure` uses.
   - A per-(kind, task_id) counter on `session.refine_failure_counts` (shared with the steerer) aborts the run after `REFINE_FAILURE_THRESHOLD=2` consecutive failures, so a stuck refine cannot loop silently through remaining stages.

2. **Observer exceptions** in both `SequentialExecutor` (sequential.py:373) and `ParallelDAGExecutor._run_stage` (parallel.py:433) used to `log.debug` and drop drift.
   - Now: an INFO `CUSTOM` drift with `drift_pipeline_failed:` prefix is emitted. INFO so the run still progresses, the goal is visibility, not recovery.

## Why this is parallel to #133

#133 is adding a retry loop + `REFINE_VALIDATION_FAILED` drift kind for the planner's LLM-level refine failures. My findings sit **one layer up**, at the executor's direct `planner.refine` call (the parallel executor bypasses the steerer's refine path) and at the steerer's observer hook. Both are sibling patterns, same "detect, silently fallback, stall" shape. Once #133 lands with its new `REFINE_VALIDATION_FAILED` drift kind, a follow-up can swap my source-drift-kind reuse over to it; the emission plumbing doesn't need to change.

## Test plan

- [x] `tests/test_parallel_executor.py`: four new tests covering refine raise, refine returns invalid plan, threshold-crossing abort, observer exception.
- [x] `tests/test_sequential_executor.py`: observer-exception pipeline-failure test.
- [x] Full `pytest` suite green: 652 passed, 43 skipped (no regressions).
- [x] `ruff check` clean.
- [x] `mypy` no new errors beyond the 6 pre-existing ones.

## Scope carefully respected

- Did NOT touch `LLMPlanner._refine_looping_tool_call` or any `_refine_*` method, #133's surface.
- Did NOT add a new `DriftKind`, reused the source drift's kind for refine-failure follow-ups (matches the steerer's existing `_emit_refine_failure` shape).
- Did NOT touch adapters.