### PR TITLE
Reject CANCELLED/FAILED->PENDING edges on plan revision (closes #137)

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -682,8 +682,22 @@ class LLMPlanner:
             "2. Every edge's `from_task_id` and `to_task_id` must "
             "reference either a reserved history id or a new-task id "
             "from your own `tasks` array.\n"
-            "3. Your task ids must be unique within your response.\n"
-            "4. Do not introduce edges that create a cycle."
+            "3. FORBIDDEN EDGES: no edges from history task ids whose "
+            "status is CANCELLED or FAILED to your new PENDING task "
+            "ids. A PENDING task whose predecessor is CANCELLED or "
+            "FAILED is unexecutable: the executor only schedules a "
+            "PENDING task once every predecessor reaches COMPLETED, "
+            "and CANCELLED/FAILED never fire that transition, so "
+            "grafting onto them stalls the whole sub-DAG. New work "
+            "must start fresh — do NOT add edges like "
+            '"cancelled_research -> new_research" to "chain" from '
+            "the prior plan to your new one. Your new tasks must form "
+            "an independent sub-DAG with their own root task (a new "
+            "task whose predecessors, if any, are themselves new "
+            "PENDING tasks from your response or COMPLETED history "
+            "tasks).\n"
+            "4. Your task ids must be unique within your response.\n"
+            "5. Do not introduce edges that create a cycle."
         )
         return (
             f"Goals:\n{goals_block}\n\n"
@@ -770,11 +784,27 @@ class LLMPlanner:
             "validation.",
             f"   Required edges: {tt_edges_json}",
             "",
-            "3. TASK IDS must be unique within `tasks`. Every edge's "
+            "3. FORBIDDEN EDGES: no edges from CANCELLED or FAILED "
+            "tasks to new PENDING tasks. New work must start fresh — "
+            'do NOT add edges like "old_research -> new_research" '
+            "where ``old_research`` is CANCELLED or FAILED. A PENDING "
+            "task whose predecessor is CANCELLED/FAILED is unexecutable "
+            "because the executor only schedules a PENDING task once "
+            "every predecessor reaches COMPLETED, and CANCELLED/FAILED "
+            "states never fire that transition; the whole downstream "
+            "sub-DAG would stall. Your new tasks must form an "
+            "independent sub-DAG with their own root task (a task "
+            "whose `id` appears in no edge's `to_task_id`, or whose "
+            "only predecessors within the new sub-DAG are themselves "
+            "new PENDING tasks). Edges from COMPLETED tasks to new "
+            "PENDING tasks are allowed -- those are immediately "
+            "eligible because the predecessor has already completed.",
+            "",
+            "4. TASK IDS must be unique within `tasks`. Every edge's "
             "`from_task_id` and `to_task_id` must reference a task id "
             "that exists in your `tasks` array.",
             "",
-            "4. The task graph must be ACYCLIC. Do not introduce edges that would create a cycle.",
+            "5. The task graph must be ACYCLIC. Do not introduce edges that would create a cycle.",
         ]
         return "\n".join(lines)
 
@@ -795,8 +825,9 @@ class LLMPlanner:
             f"    {error}\n\n"
             "Re-read the STRUCTURAL INVARIANTS section above. Emit a "
             "corrected JSON plan that preserves every terminal task and "
-            "every terminal->terminal edge verbatim. Respond with JSON "
-            "only; no prose, no markdown fences."
+            "every terminal->terminal edge verbatim, and does NOT add "
+            "any edge from a CANCELLED or FAILED task to a new PENDING "
+            "task. Respond with JSON only; no prose, no markdown fences."
         )
 
     async def _emit_refine_validation_failed(

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -189,6 +189,19 @@ class Plan:
              edge in ``prior.edges`` where both endpoints were terminal
              in ``prior`` must appear in ``self.edges``. Historical
              topology between frozen tasks is frozen.
+        7. No CANCELLED/FAILED→PENDING edges (reachability invariant,
+           goldfive#137). A PENDING task whose predecessor is
+           ``CANCELLED`` or ``FAILED`` is definitionally unexecutable:
+           the executor only schedules a PENDING task when every
+           predecessor reaches ``COMPLETED``, and these absorbing
+           terminal states never fire that transition. Revisions that
+           graft new PENDING tasks onto the graveyard of the prior
+           plan are rejected here -- new work must form an independent
+           sub-DAG with its own root(s) (or chain off a COMPLETED
+           predecessor, which is immediately eligible and therefore
+           safe). ``COMPLETED`` predecessors are *allowed* because
+           that is the natural in-flight DAG shape: a finished stage
+           feeding into a still-PENDING next stage.
 
         This is a pure-data validator: it does not mutate the plan. It
         is intended to be called at plan creation (``LLMPlanner.generate``)
@@ -276,6 +289,52 @@ class Plan:
                         "terminal->terminal edge "
                         f"{e.from_task_id!r} -> {e.to_task_id!r} missing in revision"
                     )
+
+        # 7. reachability invariant (goldfive#137): no edge from an
+        # *absorbing* terminal task (CANCELLED / FAILED) to a PENDING
+        # task. The executor only schedules a PENDING task once every
+        # predecessor has reached COMPLETED; CANCELLED and FAILED
+        # states never transition to COMPLETED, so a PENDING task
+        # hanging off a CANCELLED/FAILED predecessor is definitionally
+        # unexecutable -- the entire sub-DAG stalls. This catches the
+        # shape LLMs emit when they "graft" new work onto the end of
+        # the prior plan (e.g. ``research -> r1`` where ``research`` is
+        # CANCELLED and ``r1`` is the new PENDING root). New tasks must
+        # form an independent sub-DAG starting from no predecessors (or
+        # from predecessors that are PENDING/RUNNING/BLOCKED and can
+        # still progress to COMPLETED).
+        #
+        # COMPLETED predecessors are *explicitly allowed* here because
+        # the executor's eligibility rule is "all predecessors must be
+        # COMPLETED", so a PENDING task whose predecessor is COMPLETED
+        # is immediately eligible. The natural in-flight snapshot of a
+        # running plan -- a done stage feeding into a still-PENDING
+        # stage -- is the archetype the validator must accept.
+        #
+        # This check is safe to run on every plan: the creation path
+        # (``for_revision=False``) already requires all tasks to be
+        # PENDING (step 5) so no CANCELLED/FAILED task exists as a
+        # predecessor.
+        _UNREACHABLE_PREDECESSOR_STATUSES = frozenset({TaskStatus.CANCELLED, TaskStatus.FAILED})
+        tasks_by_id: dict[str, Task] = {t.id: t for t in self.tasks}
+        for e in self.edges:
+            from_task = tasks_by_id.get(e.from_task_id)
+            to_task = tasks_by_id.get(e.to_task_id)
+            if from_task is None or to_task is None:
+                # step 3 guarantees both endpoints resolve; belt-and-braces.
+                continue
+            if (
+                from_task.status in _UNREACHABLE_PREDECESSOR_STATUSES
+                and to_task.status is TaskStatus.PENDING
+            ):
+                raise ValueError(
+                    f"edge {e.from_task_id!r} -> {e.to_task_id!r} would make PENDING "
+                    f"task unexecutable: from-task is {from_task.status.value}. "
+                    f"New tasks must form an independent sub-DAG starting from no "
+                    f"predecessors — do not graft new work onto CANCELLED or "
+                    f"FAILED tasks (their status never transitions to COMPLETED, "
+                    f"so downstream PENDING tasks can never become eligible)."
+                )
 
     def topological_stages(self) -> list[list[Task]]:
         """Return tasks grouped into topological stages (Kahn's algorithm).

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -974,3 +974,271 @@ async def test_refine_rejects_refine_validation_failed_drift() -> None:
 
     assert result is None
     assert scripted.calls == []
+
+
+# ---------------------------------------------------------------------------
+# goldfive#137: CANCELLED/FAILED -> PENDING reachability invariant.
+#
+# The live Qwen run on #137 produced a USER_STEER refinement where the
+# old ``research`` task was CANCELLED but the new plan kept
+# ``research -> r1`` (r1 PENDING). The executor stalled because r1 was
+# never eligible. Part 1 of the fix rejects this shape at validation
+# time; Part 2 teaches the refine prompt to avoid emitting it. These
+# tests cover both.
+# ---------------------------------------------------------------------------
+
+
+def _user_steer_plan_with_cancelled_research() -> Plan:
+    """A plan where ``research`` was CANCELLED by a prior user steer.
+
+    Mirrors the sess_2026-04-21_0021 shape on #137: an operator
+    pivoted away from the original topic, so the research task is
+    terminal-CANCELLED and subsequent tasks were never run.
+    """
+    return Plan(
+        id="plan-steer",
+        run_id="run-steer",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research",
+                title="Research solar panels",
+                assignee_agent_id="researcher",
+                status=TaskStatus.CANCELLED,
+            ),
+            Task(
+                id="old_structure",
+                title="Structure panels presentation",
+                assignee_agent_id="writer",
+                status=TaskStatus.CANCELLED,
+            ),
+        ],
+        edges=[TaskEdge("research", "old_structure")],
+        summary="Solar panels deck (superseded)",
+        revision_index=0,
+    )
+
+
+def _bad_qwen_shape_revision() -> str:
+    """Pre-fix Qwen pathology: graft new ``r1`` onto CANCELLED ``research``.
+
+    The exact shape observed in the live run -- the LLM "chains" the
+    new PENDING root off the prior CANCELLED task, which makes r1
+    unreachable. Step 7 of ``Plan.validate`` rejects this.
+    """
+    return json.dumps(
+        {
+            "summary": "Replanned for solar flares",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research solar panels",
+                    "assignee_agent_id": "researcher",
+                    "status": "CANCELLED",
+                },
+                {
+                    "id": "old_structure",
+                    "title": "Structure panels presentation",
+                    "assignee_agent_id": "writer",
+                    "status": "CANCELLED",
+                },
+                {
+                    "id": "r1",
+                    "title": "Research solar flares",
+                    "assignee_agent_id": "researcher",
+                    "status": "PENDING",
+                },
+                {
+                    "id": "o1",
+                    "title": "Outline solar-flare deck",
+                    "assignee_agent_id": "writer",
+                    "status": "PENDING",
+                },
+            ],
+            "edges": [
+                # Terminal->terminal edge preserved (required).
+                {"from_task_id": "research", "to_task_id": "old_structure"},
+                # BUG: CANCELLED -> PENDING graft. r1 will stall.
+                {"from_task_id": "research", "to_task_id": "r1"},
+                {"from_task_id": "r1", "to_task_id": "o1"},
+            ],
+        }
+    )
+
+
+def _good_post_fix_revision() -> str:
+    """Post-fix shape: new sub-DAG is rooted independently.
+
+    ``r1`` is now a root (no incoming edge from a CANCELLED task);
+    the new sub-DAG is self-contained and executable from the get-go.
+    """
+    return json.dumps(
+        {
+            "summary": "Replanned for solar flares",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research solar panels",
+                    "assignee_agent_id": "researcher",
+                    "status": "CANCELLED",
+                },
+                {
+                    "id": "old_structure",
+                    "title": "Structure panels presentation",
+                    "assignee_agent_id": "writer",
+                    "status": "CANCELLED",
+                },
+                {
+                    "id": "r1",
+                    "title": "Research solar flares",
+                    "assignee_agent_id": "researcher",
+                    "status": "PENDING",
+                },
+                {
+                    "id": "o1",
+                    "title": "Outline solar-flare deck",
+                    "assignee_agent_id": "writer",
+                    "status": "PENDING",
+                },
+            ],
+            "edges": [
+                {"from_task_id": "research", "to_task_id": "old_structure"},
+                {"from_task_id": "r1", "to_task_id": "o1"},
+            ],
+        }
+    )
+
+
+async def test_refine_retry_catches_bad_edges_and_succeeds() -> None:
+    """Attempt 1 emits the live Qwen pathology (CANCELLED->PENDING edge);
+    attempt 2 corrects it. The planner's retry loop must catch the bad
+    edge at validation time, append the error to the prompt, and
+    recover on the second try.
+    """
+    scripted = _ScriptedLLM([_bad_qwen_shape_revision(), _good_post_fix_revision()])
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=2)
+    emitted: list[DriftEvent] = []
+
+    async def capture(drift: DriftEvent) -> None:
+        emitted.append(drift)
+
+    planner.set_drift_emitter(capture)
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="Replan for solar flares",
+        current_task_id="research",
+    )
+
+    revised = await planner.refine(
+        plan=_user_steer_plan_with_cancelled_research(),
+        drift=drift,
+        goals=_goals(),
+    )
+
+    # Recovery succeeds on attempt 2.
+    assert revised is not None
+    assert len(scripted.calls) == 2
+    # No REFINE_VALIDATION_FAILED should fire -- this isn't exhaustion.
+    assert emitted == []
+    # The correction prompt on attempt 2 carries the validator's error
+    # (mentioning the offending edge) so the LLM sees exactly what to fix.
+    _system, second_user_prompt, _model = scripted.calls[1]
+    assert "PREVIOUS ATTEMPT FAILED" in second_user_prompt
+    assert "'research' -> 'r1'" in second_user_prompt
+    assert "PENDING task unexecutable" in second_user_prompt
+    # The final plan has the new PENDING root free of any terminal
+    # predecessor, so the executor can pick it up immediately.
+    by_id = {t.id: t for t in revised.tasks}
+    assert by_id["r1"].status == TaskStatus.PENDING
+    pairs = {(e.from_task_id, e.to_task_id) for e in revised.edges}
+    assert ("research", "r1") not in pairs  # offending edge is gone
+    assert ("r1", "o1") in pairs
+
+
+async def test_refine_prompt_includes_forbidden_edges_section() -> None:
+    """The refine prompt (both the generic and LOOPING variants) must
+    include the FORBIDDEN EDGES guidance so the LLM knows not to graft
+    new PENDING tasks onto CANCELLED/FAILED predecessors. Structural
+    test on the prompt text so the guidance can't silently regress.
+    """
+    # Generic refine path (non-LOOPING, non-USER_STEER).
+    scripted = _ScriptedLLM([_good_post_fix_revision()])
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=2)
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="replan",
+        current_task_id="research",
+    )
+
+    await planner.refine(
+        plan=_user_steer_plan_with_cancelled_research(),
+        drift=drift,
+        goals=_goals(),
+    )
+    _sys, user_prompt, _model = scripted.calls[0]
+    assert "FORBIDDEN EDGES" in user_prompt
+    assert "CANCELLED" in user_prompt and "FAILED" in user_prompt
+    assert "independent sub-DAG" in user_prompt
+
+    # LOOPING_TOOL_CALL refine path.
+    scripted = _ScriptedLLM([_good_looping_revision_json()])
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=2)
+    loop_drift = DriftEvent(
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        severity=DriftSeverity.WARNING,
+        detail="stuck",
+        current_task_id="draft_slides",
+    )
+    await planner.refine(plan=_looping_plan(), drift=loop_drift, goals=_goals())
+    _sys, loop_prompt, _model = scripted.calls[0]
+    assert "FORBIDDEN EDGES" in loop_prompt
+    assert "CANCELLED" in loop_prompt and "FAILED" in loop_prompt
+
+    # USER_STEER refine path has its own inline invariants block.
+    from goldfive.types import Task as _Task  # noqa: PLC0415 -- test-local import
+
+    user_steer_plan = Plan(
+        id="p",
+        run_id="r",
+        goal_ids=["g1"],
+        tasks=[
+            _Task(
+                id="research",
+                title="Research panels",
+                assignee_agent_id="researcher",
+                status=TaskStatus.CANCELLED,
+            ),
+        ],
+        edges=[],
+    )
+    scripted = _ScriptedLLM(
+        [
+            json.dumps(
+                {
+                    "summary": "replan",
+                    "tasks": [
+                        {
+                            "id": "r1",
+                            "title": "Research flares",
+                            "assignee_agent_id": "researcher",
+                            "status": "PENDING",
+                        }
+                    ],
+                    "edges": [],
+                }
+            )
+        ]
+    )
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=1)
+    steer_drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="solar flares",
+        current_task_id="research",
+    )
+    await planner.refine(plan=user_steer_plan, drift=steer_drift, goals=_goals())
+    _sys, steer_prompt, _model = scripted.calls[0]
+    assert "FORBIDDEN EDGES" in steer_prompt
+    assert "CANCELLED" in steer_prompt and "FAILED" in steer_prompt

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -365,7 +365,9 @@ class TestPlanValidate:
         # Raises at creation.
         with pytest.raises(ValueError, match="non-PENDING"):
             plan.validate(for_revision=False)
-        # Allowed at revision.
+        # Allowed at revision. COMPLETED->PENDING edges are fine under
+        # goldfive#137's step-7 check because COMPLETED is exactly the
+        # state that fires PENDING child eligibility.
         plan.validate(for_revision=True)
 
     def test_revision_allows_failed_and_cancelled(self) -> None:
@@ -429,9 +431,7 @@ class TestPlanValidate:
             [Task(id="t2", title="next", status=TaskStatus.PENDING)],
             [],
         )
-        with pytest.raises(
-            ValueError, match=r"terminal task 't1' missing in revision"
-        ):
+        with pytest.raises(ValueError, match=r"terminal task 't1' missing in revision"):
             revision.validate(for_revision=True, prior=prior)
 
     def test_validate_revision_rejects_terminal_task_status_regression(self) -> None:
@@ -444,9 +444,7 @@ class TestPlanValidate:
             [Task(id="t1", title="done", status=TaskStatus.PENDING)],
             [],
         )
-        with pytest.raises(
-            ValueError, match=r"terminal task 't1' regressed to 'PENDING'"
-        ):
+        with pytest.raises(ValueError, match=r"terminal task 't1' regressed to 'PENDING'"):
             revision.validate(for_revision=True, prior=prior)
 
     def test_validate_revision_rejects_terminal_task_status_flip(self) -> None:
@@ -461,9 +459,7 @@ class TestPlanValidate:
             [Task(id="t1", title="done", status=TaskStatus.FAILED)],
             [],
         )
-        with pytest.raises(
-            ValueError, match=r"terminal task 't1' regressed to 'FAILED'"
-        ):
+        with pytest.raises(ValueError, match=r"terminal task 't1' regressed to 'FAILED'"):
             revision.validate(for_revision=True, prior=prior)
 
     def test_validate_revision_accepts_terminal_task_unchanged(self) -> None:
@@ -539,3 +535,131 @@ class TestPlanValidate:
         )
         # No prior supplied -> no terminal-preservation check.
         revision.validate(for_revision=True)
+
+    # ------------------------------------------------------------------
+    # Reachability invariant (goldfive#137). The executor only schedules
+    # a PENDING task once every predecessor reaches COMPLETED; terminal
+    # states (CANCELLED / FAILED / COMPLETED) never fire that
+    # transition, so a PENDING task hanging off a terminal predecessor
+    # is definitionally unexecutable. Step 7 of ``validate`` rejects
+    # these shapes before they reach the executor.
+    # ------------------------------------------------------------------
+
+    def test_validator_rejects_terminal_to_pending_edge(self) -> None:
+        # The exact Qwen pathology observed in the live session on #137:
+        # a CANCELLED task feeding into a fresh PENDING root task. The
+        # executor would stall because ``r1`` can never become eligible.
+        revision = _mk_plan(
+            [
+                Task(id="research", title="R", status=TaskStatus.CANCELLED),
+                Task(id="r1", title="R1", status=TaskStatus.PENDING),
+            ],
+            [TaskEdge("research", "r1")],
+        )
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"edge 'research' -> 'r1' would make PENDING task unexecutable: "
+                r"from-task is CANCELLED"
+            ),
+        ):
+            revision.validate(for_revision=True)
+
+    def test_validator_rejects_failed_to_pending_edge(self) -> None:
+        revision = _mk_plan(
+            [
+                Task(id="bad", title="B", status=TaskStatus.FAILED),
+                Task(id="next", title="N", status=TaskStatus.PENDING),
+            ],
+            [TaskEdge("bad", "next")],
+        )
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"edge 'bad' -> 'next' would make PENDING task unexecutable: "
+                r"from-task is FAILED"
+            ),
+        ):
+            revision.validate(for_revision=True)
+
+    def test_validator_accepts_completed_to_pending_edge(self) -> None:
+        # COMPLETED predecessors are safe for PENDING children: the
+        # executor schedules a PENDING task as soon as every
+        # predecessor reaches COMPLETED, so a COMPLETED->PENDING edge
+        # means the child is *immediately* eligible. This is the
+        # natural in-flight snapshot of a running plan -- a done stage
+        # feeding into a still-PENDING stage. goldfive#137 only
+        # forbids CANCELLED/FAILED->PENDING, where the predecessor's
+        # status is absorbing and the child can never become eligible.
+        revision = _mk_plan(
+            [
+                Task(id="done", title="D", status=TaskStatus.COMPLETED),
+                Task(id="next", title="N", status=TaskStatus.PENDING),
+            ],
+            [TaskEdge("done", "next")],
+        )
+        # Does not raise.
+        revision.validate(for_revision=True)
+
+    def test_validator_accepts_terminal_to_terminal_edge(self) -> None:
+        # Regression guard: the existing §3.2 preservation check is
+        # untouched. Terminal->terminal edges are frozen history and
+        # must continue to validate cleanly in revision mode.
+        prior = _mk_plan(
+            [
+                Task(id="t1", title="1", status=TaskStatus.COMPLETED),
+                Task(id="t2", title="2", status=TaskStatus.COMPLETED),
+            ],
+            [TaskEdge("t1", "t2")],
+        )
+        revision = _mk_plan(
+            [
+                Task(id="t1", title="1", status=TaskStatus.COMPLETED),
+                Task(id="t2", title="2", status=TaskStatus.COMPLETED),
+            ],
+            [TaskEdge("t1", "t2")],
+        )
+        # Does not raise.
+        revision.validate(for_revision=True, prior=prior)
+
+    def test_validator_accepts_new_subdag_with_no_terminal_predecessors(
+        self,
+    ) -> None:
+        # The shape the LLM *should* emit after a post-steer refine:
+        # terminal tasks preserved verbatim, and the new sub-DAG rooted
+        # at a fresh PENDING task with no predecessors from the prior
+        # graveyard. Edges within the new sub-DAG (PENDING->PENDING)
+        # are fine because they can all progress to COMPLETED.
+        prior = _mk_plan(
+            [
+                Task(id="research", title="R", status=TaskStatus.CANCELLED),
+                Task(id="draft", title="D", status=TaskStatus.CANCELLED),
+            ],
+            [TaskEdge("research", "draft")],
+        )
+        revision = _mk_plan(
+            [
+                Task(id="research", title="R", status=TaskStatus.CANCELLED),
+                Task(id="draft", title="D", status=TaskStatus.CANCELLED),
+                Task(id="r1", title="R1", status=TaskStatus.PENDING),
+                Task(id="o1", title="O1", status=TaskStatus.PENDING),
+            ],
+            # §3.2 edge preserved; new sub-DAG is independent.
+            [TaskEdge("research", "draft"), TaskEdge("r1", "o1")],
+        )
+        # Does not raise.
+        revision.validate(for_revision=True, prior=prior)
+
+    def test_validator_accepts_pending_to_pending_edge(self) -> None:
+        # Pure PENDING->PENDING edges are always fine — no reachability
+        # stall is possible because both endpoints can still progress
+        # to COMPLETED.
+        revision = _mk_plan(
+            [
+                Task(id="a", title="A", status=TaskStatus.PENDING),
+                Task(id="b", title="B", status=TaskStatus.PENDING),
+            ],
+            [TaskEdge("a", "b")],
+        )
+        revision.validate(for_revision=True)
+        revision.validate(for_revision=False)


### PR DESCRIPTION
Closes #137.

## Summary

After #136 (#133's retry loop) landed, a live Qwen e2e surfaced the next layer of the same bug: a refined plan that **passed validation but still couldn't execute**. The executor logged `9 task(s) still PENDING with no eligible next task — run ending incomplete` and the run stalled. Root cause: the revision kept `research -> r1` where `research` was CANCELLED and `r1` was the new PENDING root. The executor only schedules a PENDING task once every predecessor reaches COMPLETED; CANCELLED/FAILED are absorbing and never fire that transition, so r1 (and the whole downstream sub-DAG) was unreachable.

Two fixes, both required:

- **Validator side.** `Plan.validate` step 7 rejects any edge where the from-task is CANCELLED/FAILED and the to-task is PENDING. The error message is actionable ("new tasks must form an independent sub-DAG") so the #136 retry loop's correction prompt feeds the LLM a concrete fix. COMPLETED->PENDING is explicitly allowed — that's the natural in-flight DAG shape (a done stage feeding into a still-PENDING next stage).
- **Prompt side.** The shared STRUCTURAL INVARIANTS block (used by the generic + LOOPING_TOOL_CALL refine prompts) and the USER_STEER prompt's inline invariants gain a FORBIDDEN EDGES section that spells out the rule, gives a copy-paste example of the bad shape, and explains *why* (executor eligibility). The correction prompt appended on retry-after-validation-failure also mentions the rule.

## Test plan

- [x] `test_validator_rejects_terminal_to_pending_edge` — exact Qwen shape (CANCELLED research -> PENDING r1)
- [x] `test_validator_rejects_failed_to_pending_edge` — FAILED variant
- [x] `test_validator_accepts_completed_to_pending_edge` — COMPLETED->PENDING is the natural in-flight shape and stays valid
- [x] `test_validator_accepts_terminal_to_terminal_edge` — regression guard for #133's §3.2 preservation
- [x] `test_validator_accepts_new_subdag_with_no_terminal_predecessors` — the fix-compliant shape
- [x] `test_validator_accepts_pending_to_pending_edge`
- [x] `test_refine_retry_catches_bad_edges_and_succeeds` — mocked LLM emits the exact Qwen pathology on attempt 1, recovers on attempt 2 via the retry loop; asserts the correction prompt mentions the offending edge + "PENDING task unexecutable"
- [x] `test_refine_prompt_includes_forbidden_edges_section` — structural test on all three refine paths (generic / LOOPING_TOOL_CALL / USER_STEER)
- [x] `uv run pytest` — 667 passed, 44 skipped

## Out of scope

- Executor behaviour is unchanged ("all predecessors must be COMPLETED" is the correct eligibility rule).
- No new drift kinds — the existing `REFINE_VALIDATION_FAILED` from #133 fires if both retry attempts hit the new check.
- No changes to steerer backoff.