### PR TITLE
Rewrite mid-invoke cancel response content for LLMs (closes #139)

### DIFF
--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -389,6 +389,74 @@ def _function_response_ids_in_event(event: Any) -> list[str]:
     return out
 
 
+# ---------------------------------------------------------------------------
+# Symbolic reasons for mid-invocation tool-call cancellation.
+#
+# These are the semantic tags the synthetic ``function_response`` content is
+# differentiated on. The content below each variant is written for the LLM
+# that will read this history on the next turn — NOT for a human reading
+# goldfive's logs. Qwen and similar small/quantized models choke on the
+# prior "goldfive_cancelled / preserve session history well-formedness"
+# phrasing and either retry the cancelled call or enter a reasoning loop
+# trying to reconcile the jargon. See goldfive#139.
+# ---------------------------------------------------------------------------
+
+SYMBOLIC_REASON_USER_STEER = "user_steer"
+"""Cancel was caused by a user steering command (USER_STEER drift)."""
+
+SYMBOLIC_REASON_REPLAN = "replan"
+"""Cancel was caused by goldfive updating the plan mid-flight."""
+
+SYMBOLIC_REASON_ERROR = "error"
+"""Cancel / heal was caused by an unexpected error / disconnect."""
+
+
+_USER_STEER_RESPONSE_CONTENT: dict[str, str] = {
+    "status": "cancelled_by_user_steering",
+    "instruction": (
+        "The user issued a steering command during this tool call. "
+        "The prior task has been ABANDONED. Do NOT retry this call. "
+        "Do NOT continue the prior plan. The next user message "
+        "contains your new task — respond to it fresh."
+    ),
+}
+
+_REPLAN_RESPONSE_CONTENT: dict[str, str] = {
+    "status": "cancelled_by_replan",
+    "instruction": (
+        "The plan was updated by goldfive. This tool call is no longer "
+        "part of the plan. Do NOT retry. Await the next task message."
+    ),
+}
+
+_GENERIC_RESPONSE_CONTENT: dict[str, str] = {
+    "status": "cancelled",
+    "instruction": "This call was cancelled. Do NOT retry. Await next instruction.",
+}
+
+
+_USER_STEER_PRIMER_TEXT = (
+    "\u26a0 STEERING NOTICE: Your prior task was cancelled by user steering. "
+    "The task below supersedes all prior work. Do not retry or reference "
+    "the cancelled tool call."
+)
+
+
+def _resolve_response_content(reason: str) -> dict[str, str]:
+    """Map ``reason`` onto one of the three content variants.
+
+    Unknown or legacy reasons (``"cancelled_mid_invocation"``,
+    ``"error:<ExceptionName>"``, ``"unexpected_orphan_on_normal_exit"``)
+    fall through to the generic bucket — the earlier callers didn't
+    differentiate, and the content there is neutral and LLM-actionable.
+    """
+    if reason == SYMBOLIC_REASON_USER_STEER:
+        return dict(_USER_STEER_RESPONSE_CONTENT)
+    if reason == SYMBOLIC_REASON_REPLAN:
+        return dict(_REPLAN_RESPONSE_CONTENT)
+    return dict(_GENERIC_RESPONSE_CONTENT)
+
+
 def _build_cancelled_response_event(
     *,
     function_call_id: str,
@@ -405,22 +473,20 @@ def _build_cancelled_response_event(
     turns (the "Missing tool results for tool_call_id(s): [...]" symptom in
     driver logs). This builder produces a minimally-shaped response event
     that the next turn's request assembler will pair with the orphan call.
+
+    The response payload is reason-differentiated (see goldfive#139): the
+    prior generic "goldfive_cancelled" jargon caused Qwen and similar
+    smaller models to either retry the cancelled call or enter a
+    reasoning loop. The new content is short, model-actionable, and
+    selected based on the symbolic ``reason`` (USER_STEER / REPLAN /
+    generic) passed from the cancel trigger.
     """
     from google.adk.events.event import Event  # type: ignore
     from google.genai import types  # type: ignore
 
     part = types.Part.from_function_response(
         name=tool_name or "unknown_tool",
-        response={
-            "goldfive_cancelled": True,
-            "reason": reason,
-            "detail": (
-                "Tool call was cancelled mid-invocation by goldfive "
-                "(USER_STEER / USER_CANCEL control). This synthetic "
-                "response was appended to preserve session history "
-                "well-formedness."
-            ),
-        },
+        response=_resolve_response_content(reason),
     )
     # Preserve the pairing so ADK's find_event_by_function_call_id
     # correctly matches this response to the orphan function_call.
@@ -431,6 +497,32 @@ def _build_cancelled_response_event(
     return Event(
         invocation_id=invocation_id or "",
         author=author or "user",
+        content=content,
+    )
+
+
+def _build_user_steer_primer_event(
+    *,
+    invocation_id: str,
+) -> Any:
+    """Synthesize a user-role primer event reinforcing the USER_STEER pivot.
+
+    Appended after the per-tool ``function_response`` heals when the
+    cancel reason is ``user_steer``. Belt-and-braces: even if the LLM
+    skims the function_response content, the subsequent user-role
+    message with the ⚠ STEERING NOTICE is impossible to miss on the
+    next turn. See goldfive#139.
+    """
+    from google.adk.events.event import Event  # type: ignore
+    from google.genai import types  # type: ignore
+
+    content = types.Content(
+        role="user",
+        parts=[types.Part(text=_USER_STEER_PRIMER_TEXT)],
+    )
+    return Event(
+        invocation_id=invocation_id or "",
+        author="user",
         content=content,
     )
 
@@ -589,6 +681,15 @@ class ADKAdapter:
         # the synthetic response can name its tool.
         self._pending_tool_call_ids: set[str] = set()
         self._pending_tool_call_names: dict[str, str] = {}
+        # Short-lived tag for the NEXT mid-invocation cancel. Set by the
+        # Steerer (on USER_STEER drift) or by refine-triggered paths
+        # BEFORE they cancel the in-flight invoke so
+        # _heal_pending_tool_calls knows which content variant to emit
+        # in the synthetic function_response. Cleared after consumption
+        # so a stale tag can't bleed into the next cancel. See
+        # goldfive#139 and
+        # :func:`_build_cancelled_response_event` for the content map.
+        self._next_cancel_reason: str = ""
 
         # Wrap-time integrity check: the one runner must carry the
         # goldfive plugin. In degraded mode we skip because the caller
@@ -882,11 +983,17 @@ class ADKAdapter:
         except asyncio.CancelledError:
             was_cancelled = True
             stop_reason = "cancelled"
+            # Consume the tag the steerer / executor stashed on us before
+            # triggering the cancel (see goldfive#139). An unset tag
+            # falls through to the legacy generic reason so existing
+            # heal paths keep the neutral content variant.
+            reason = self._next_cancel_reason or "cancelled_mid_invocation"
+            self._next_cancel_reason = ""
             await self._heal_pending_tool_calls(
                 runner=self._runner,
                 session_id=session_id,
                 invocation_id=last_invocation_id,
-                reason="cancelled_mid_invocation",
+                reason=reason,
             )
             raise
         except Exception as exc:  # noqa: BLE001
@@ -913,6 +1020,9 @@ class ADKAdapter:
                         invocation_id=last_invocation_id,
                         reason="unexpected_orphan_on_normal_exit",
                     )
+                # No cancel fired — drop any stale tag so the NEXT
+                # invoke's cancel (if any) doesn't pick up leftover state.
+                self._next_cancel_reason = ""
             if self._plugin is not None:
                 self._plugin.clear_active_context()
             if isinstance(state, Mapping):
@@ -1080,6 +1190,34 @@ class ADKAdapter:
                     fc_id,
                     exc,
                 )
+
+        # After the per-call function_response heals, append a user-role
+        # primer event for USER_STEER cancels only. Belt-and-braces so
+        # the next LLM turn sees the pivot reinforced even if the model
+        # skims the function_response content. REPLAN and generic
+        # cancels keep the function_response content as the sole signal
+        # — those pivots are less jolting and don't need the extra
+        # framing (see goldfive#139).
+        if healed and reason == SYMBOLIC_REASON_USER_STEER:
+            try:
+                primer = _build_user_steer_primer_event(invocation_id=invocation_id)
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "ADKAdapter._heal_pending_tool_calls: could not build "
+                    "user_steer primer event: %s",
+                    exc,
+                )
+            else:
+                try:
+                    coro = append(session=adk_session, event=primer)
+                    if hasattr(coro, "__await__"):
+                        await coro
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "ADKAdapter._heal_pending_tool_calls: append_event "
+                        "for user_steer primer raised: %s",
+                        exc,
+                    )
 
         if healed:
             log.info(

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -79,6 +79,32 @@ _TERMINAL_TASK_STATUSES: frozenset[TaskStatus] = frozenset(
 _StageResult = tuple[Task, InvocationResult | None, DriftEvent | None, BaseException | None]
 
 
+# Symbolic cancel-reason for USER_STEER. Mirrors
+# :data:`goldfive.adapters.adk.SYMBOLIC_REASON_USER_STEER` but duplicated
+# as a plain string to avoid importing the optional ADK adapter module
+# from the provider-agnostic executor. Keep in sync. See goldfive#139.
+_CANCEL_REASON_USER_STEER: str = "user_steer"
+
+
+def _tag_adapter_cancel_user_steer(adapter: Any) -> None:
+    """Tag ``adapter._next_cancel_reason`` with the USER_STEER symbolic reason.
+
+    Called just before the executor triggers ``task.cancel()`` on any
+    in-flight stage invoke task so the adapter's mid-invocation cancel
+    handler picks up the tag and appends an LLM-actionable synthetic
+    ``function_response`` (instead of the legacy generic jargon).
+    Adapters that don't expose ``_next_cancel_reason`` are tolerated
+    via a duck-typed write. See goldfive#139.
+    """
+    try:
+        adapter._next_cancel_reason = _CANCEL_REASON_USER_STEER
+    except Exception as exc:  # noqa: BLE001
+        log.debug(
+            "ParallelDAGExecutor: could not tag adapter cancel reason: %s",
+            exc,
+        )
+
+
 class ParallelDAGExecutor:
     """Parallel rigid-DAG executor.
 
@@ -585,6 +611,14 @@ class ParallelDAGExecutor:
                                 except BaseException as exc:  # noqa: BLE001
                                     results[task.id] = (task, None, None, exc)
                             stage_control_outcome = outcome
+                            # Tag the adapter's next mid-invocation
+                            # cancel with USER_STEER when that's the
+                            # control cause, so the synthetic
+                            # function_response carries LLM-actionable
+                            # content instead of the legacy generic
+                            # jargon. See goldfive#139.
+                            if outcome.steer_message is not None:
+                                _tag_adapter_cancel_user_steer(adapter)
                             await _cancel_stage_tasks()
                             break
                         # Non-interrupting control (PAUSE/RESUME/

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -61,6 +61,32 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+# Symbolic cancel-reason for USER_STEER. Mirrors
+# :data:`goldfive.adapters.adk.SYMBOLIC_REASON_USER_STEER` but duplicated
+# as a plain string to avoid importing the optional ADK adapter module
+# from the provider-agnostic executor. Keep in sync. See goldfive#139.
+_CANCEL_REASON_USER_STEER: str = "user_steer"
+
+
+def _tag_adapter_cancel_user_steer(adapter: Any) -> None:
+    """Tag ``adapter._next_cancel_reason`` with the USER_STEER symbolic reason.
+
+    Called just before the executor triggers ``task.cancel()`` on the
+    in-flight invoke task so the adapter's mid-invocation cancel
+    handler picks up the tag and appends an LLM-actionable synthetic
+    ``function_response`` (instead of the legacy generic jargon). Adapters
+    that don't expose ``_next_cancel_reason`` are tolerated via a
+    duck-typed write. See goldfive#139.
+    """
+    try:
+        adapter._next_cancel_reason = _CANCEL_REASON_USER_STEER
+    except Exception as exc:  # noqa: BLE001
+        log.debug(
+            "SequentialExecutor: could not tag adapter cancel reason: %s",
+            exc,
+        )
+
+
 class SequentialExecutor(Executor):
     """Single-threaded executor that drives one task at a time.
 
@@ -708,6 +734,13 @@ class SequentialExecutor(Executor):
                 return ("cancelled", outcome.cancel_reason or "cancelled by control")
 
             if outcome.steer_message is not None:
+                # Tag the adapter's next mid-invocation cancel with the
+                # USER_STEER symbolic reason BEFORE triggering the
+                # actual cancel, so the adapter's CancelledError
+                # handler (and the synthetic function_response it
+                # appends) carries LLM-actionable content instead of
+                # the legacy generic jargon. See goldfive#139.
+                _tag_adapter_cancel_user_steer(adapter)
                 await self._cancel_invoke_task(invoke_task)
                 return ("steer", outcome.steer_message)
 

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -304,6 +304,20 @@ class Runner:
                 )
                 return outcome
 
+        # 6c. Wire the adapter back into the steerer. Optional hook
+        # (goldfive#139) the steerer uses to tag the adapter's next
+        # mid-invocation cancel with a symbolic reason on USER_STEER
+        # drift, so the synthetic function_response the adapter appends
+        # on cancel carries LLM-actionable content. Duck-typed on
+        # purpose — custom Steerers that don't implement
+        # ``bind_adapter`` skip this silently.
+        bind_steerer_adapter = getattr(self.steerer, "bind_adapter", None)
+        if callable(bind_steerer_adapter):
+            try:
+                bind_steerer_adapter(self.agent)
+            except Exception as exc:  # noqa: BLE001
+                log.debug("steerer.bind_adapter raised: %s", exc)
+
         # 7. Hand off to the executor.
         try:
             executor_kwargs: dict[str, Any] = dict(

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -125,6 +125,12 @@ class DefaultSteerer:
         """
         self._sinks: list[Any] = []
         self._planner: Any | None = None
+        # Optional adapter back-reference. Wired via :meth:`bind_adapter`
+        # so the steerer can tag the next mid-invocation cancel with a
+        # symbolic reason (``user_steer``) before the executor triggers
+        # ``task.cancel()`` on the invoke task. See goldfive#139 and
+        # :attr:`goldfive.adapters.adk.ADKAdapter._next_cancel_reason`.
+        self._adapter: Any | None = None
         # Per-session, per-kind last-refine bookkeeping. Purely advisory:
         # callers can subclass to throttle on top of this if needed.
         self._last_refine_kind: dict[tuple[str, DriftKind], int] = {}
@@ -157,6 +163,20 @@ class DefaultSteerer:
         setter = getattr(planner, "set_drift_emitter", None)
         if callable(setter):
             setter(self._emit_planner_refine_validation_failed)
+
+    def bind_adapter(self, adapter: Any) -> None:
+        """Attach the active adapter for cancel-reason tagging.
+
+        Optional wiring (goldfive#139). When set, the steerer tags the
+        adapter's next mid-invocation cancel with a symbolic reason
+        (``user_steer``) so the synthetic ``function_response`` event
+        the adapter appends on cancel carries LLM-actionable content
+        instead of the legacy goldfive-internal jargon. Adapters that
+        don't expose ``_next_cancel_reason`` are tolerated: the setter
+        is a no-op and the cancel falls through to the generic content
+        variant.
+        """
+        self._adapter = adapter
 
     async def _emit_planner_refine_validation_failed(self, drift: DriftEvent) -> None:
         """Emit a planner-side drift through the DriftDetected pipeline.
@@ -956,6 +976,15 @@ class DefaultSteerer:
         every tick until ``SequentialExecutor.max_task_invocations``
         tripped (see TASK-LIFECYCLE.md §7.3).
         """
+        # Tag the bound adapter's next cancel with a symbolic reason so
+        # the synthetic function_response the adapter appends on cancel
+        # carries LLM-actionable content. Done BEFORE the drift event
+        # is emitted so a sink that reacts by cancelling the invoke
+        # sees the tag. Harmless if the adapter doesn't expose the
+        # attribute (duck-typed) or no adapter is bound. See
+        # goldfive#139 and
+        # :func:`goldfive.adapters.adk._build_cancelled_response_event`.
+        self._tag_adapter_cancel_reason(drift)
         await self._emit_drift_detected(session, drift)
         if not _severity_ge(drift.severity, DriftSeverity.WARNING):
             return
@@ -1048,6 +1077,38 @@ class DefaultSteerer:
         prev_plan = session.plan
         self._apply_revision(session, revised, drift)
         await self._emit_plan_revised(session, revised, drift, prev_plan=prev_plan)
+
+    # Symbolic cancel-reason tags — mirror
+    # :mod:`goldfive.adapters.adk` constants but duplicated as plain
+    # strings here to avoid a hard import of the optional ADK adapter
+    # module from the provider-agnostic steerer. Keep in sync with
+    # :data:`goldfive.adapters.adk.SYMBOLIC_REASON_USER_STEER` etc.
+    _ADAPTER_CANCEL_REASON_USER_STEER: str = "user_steer"
+
+    def _tag_adapter_cancel_reason(self, drift: DriftEvent) -> None:
+        """Set ``adapter._next_cancel_reason`` based on ``drift.kind``.
+
+        USER_STEER drift -> ``"user_steer"``. Other kinds currently leave
+        the tag unset so the adapter falls through to the generic
+        content variant. Tolerates adapters that don't carry the
+        attribute (no-op) and an unbound adapter (no-op). See
+        goldfive#139.
+        """
+        adapter = self._adapter
+        if adapter is None:
+            return
+        if drift.kind is DriftKind.USER_STEER:
+            reason = self._ADAPTER_CANCEL_REASON_USER_STEER
+        else:
+            return
+        try:
+            adapter._next_cancel_reason = reason
+        except Exception as exc:  # noqa: BLE001
+            # Adapter doesn't expose the attribute — tolerated.
+            log.debug(
+                "DefaultSteerer: could not tag adapter cancel reason: %s",
+                exc,
+            )
 
     # Consecutive refine failures tolerated per (drift_kind, task_id)
     # before we give up and mark the task FAILED. Class attribute so

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -936,9 +936,13 @@ async def test_cancel_mid_tool_call_heals_session() -> None:
     responses = synth.get_function_responses()
     assert len(responses) == 1
     assert responses[0].id == "call-1"
-    # The payload flags this as goldfive-synthesized so downstream tools can
-    # tell it apart from a real tool return.
-    assert responses[0].response.get("goldfive_cancelled") is True
+    # Reason-differentiated content (goldfive#139). A bare
+    # task.cancel() without a steerer-set _next_cancel_reason falls
+    # through to the generic content variant — LLM-actionable, not
+    # goldfive-internal jargon.
+    payload = responses[0].response
+    assert payload.get("status") == "cancelled"
+    assert "Do NOT retry" in payload.get("instruction", "")
 
 
 async def test_multiple_pending_tool_calls_all_healed() -> None:
@@ -1029,6 +1033,333 @@ async def test_heal_is_noop_when_no_pending_calls() -> None:
     adapter_empty = ADKAdapter(runner_empty, session_id="sess-empty")
     await adapter_empty.invoke(Task(id="t1", title="x"), Session(run_id="r"))
     assert runner_empty.session_service.appended == []
+
+
+# ---------------------------------------------------------------------------
+# goldfive#139 — reason-differentiated synthetic response content +
+# USER_STEER user-role primer event. The prior generic content shape
+# ("goldfive_cancelled" / "preserve session history well-formedness")
+# was written for human log viewers and confused Qwen + other smaller
+# LLMs reading it on the next turn, triggering retry loops and
+# reasoning spirals. These tests pin the new content variants and the
+# primer-event append behaviour.
+# ---------------------------------------------------------------------------
+
+
+def test_build_cancelled_response_event_user_steer_content() -> None:
+    """``reason=user_steer`` → status/instruction aimed at the next LLM turn.
+
+    The content must carry the "prior task abandoned" instruction and
+    not leak goldfive-internal jargon ("goldfive_cancelled",
+    "preserve session history well-formedness", etc.) the prior
+    generic shape emitted. See goldfive#139.
+    """
+    from goldfive.adapters.adk import (
+        SYMBOLIC_REASON_USER_STEER,
+        _build_cancelled_response_event,
+    )
+
+    event = _build_cancelled_response_event(
+        function_call_id="call-x",
+        tool_name="search",
+        author="agent",
+        invocation_id="inv-1",
+        reason=SYMBOLIC_REASON_USER_STEER,
+    )
+    responses = event.get_function_responses()
+    assert len(responses) == 1
+    fr = responses[0]
+    assert fr.id == "call-x"
+    payload = fr.response
+    assert payload.get("status") == "cancelled_by_user_steering"
+    instruction = payload.get("instruction", "")
+    assert "ABANDONED" in instruction
+    assert "Do NOT retry" in instruction
+    # No goldfive-internal jargon leaks into the LLM-visible payload.
+    assert "goldfive_cancelled" not in payload
+    assert "session history" not in instruction
+
+
+def test_build_cancelled_response_event_replan_content() -> None:
+    """``reason=replan`` → status/instruction describing a plan update.
+
+    Milder wording than USER_STEER — a replan is expected to reference
+    prior context the agent may still need.
+    """
+    from goldfive.adapters.adk import (
+        SYMBOLIC_REASON_REPLAN,
+        _build_cancelled_response_event,
+    )
+
+    event = _build_cancelled_response_event(
+        function_call_id="call-x",
+        tool_name="search",
+        author="agent",
+        invocation_id="inv-1",
+        reason=SYMBOLIC_REASON_REPLAN,
+    )
+    fr = event.get_function_responses()[0]
+    assert fr.response.get("status") == "cancelled_by_replan"
+    instruction = fr.response.get("instruction", "")
+    assert "plan was updated" in instruction.lower()
+    assert "Do NOT retry" in instruction
+
+
+def test_build_cancelled_response_event_generic_content() -> None:
+    """Legacy / unknown reasons fall through to the neutral variant."""
+    from goldfive.adapters.adk import _build_cancelled_response_event
+
+    for legacy_reason in (
+        "cancelled_mid_invocation",
+        "error:ConnectionError",
+        "unexpected_orphan_on_normal_exit",
+        "",
+    ):
+        event = _build_cancelled_response_event(
+            function_call_id="call-x",
+            tool_name="search",
+            author="agent",
+            invocation_id="inv-1",
+            reason=legacy_reason,
+        )
+        fr = event.get_function_responses()[0]
+        assert fr.response.get("status") == "cancelled", (
+            f"reason {legacy_reason!r} should resolve to generic content"
+        )
+        assert "Do NOT retry" in fr.response.get("instruction", "")
+
+
+async def test_user_steer_primer_appended_after_function_response() -> None:
+    """USER_STEER cancel with 2 orphan calls → 2 function_response + 1 primer.
+
+    Covers the belt-and-braces primer-event append that reinforces the
+    pivot for the next LLM turn. Primer must come AFTER the
+    function_response events (ordering matters for ADK's chronological
+    replay).
+    """
+    import asyncio
+
+    from google.adk.events.event import Event  # type: ignore
+    from google.genai import types  # type: ignore
+
+    from goldfive.adapters.adk import SYMBOLIC_REASON_USER_STEER, ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _make_agent()
+
+    multi_parts = [
+        types.Part(function_call=types.FunctionCall(id=f"call-{i}", name=f"t{i}"))
+        for i in (1, 2)
+    ]
+    multi_event = Event(
+        invocation_id="inv-steer",
+        author="test_agent",
+        content=types.Content(role="model", parts=multi_parts),
+    )
+
+    async def _run():
+        yield multi_event
+        await asyncio.Event().wait()
+        yield None  # pragma: no cover
+
+    runner = _FakeRunner(_run, agent)
+    adapter = ADKAdapter(runner, session_id="sess-steer")
+
+    invoke_task = asyncio.create_task(
+        adapter.invoke(Task(id="t1", title="x"), Session(run_id="r"))
+    )
+    await asyncio.sleep(0.01)
+    # Simulate the executor tagging the adapter before triggering cancel.
+    adapter._next_cancel_reason = SYMBOLIC_REASON_USER_STEER
+    invoke_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await invoke_task
+
+    appended = runner.session_service.appended
+    # Exactly 3 events: 2 function_response + 1 user-role primer, in that order.
+    assert len(appended) == 3, f"expected 3 events; got {len(appended)}"
+    # First two events are function_response pairings for the orphans.
+    fr_ids = set()
+    for ev in appended[:2]:
+        for fr in ev.get_function_responses():
+            fr_ids.add(fr.id)
+    assert fr_ids == {"call-1", "call-2"}
+    # Third event is the user-role primer reinforcing the pivot.
+    primer = appended[2]
+    assert primer.content is not None
+    assert primer.content.role == "user"
+    # Primer is plain text, not a function_response.
+    assert primer.get_function_responses() == []
+    text = "".join((p.text or "") for p in (primer.content.parts or []))
+    assert "STEERING NOTICE" in text
+    assert "cancelled by user steering" in text
+    assert "supersedes" in text.lower()
+
+
+async def test_replan_cancel_does_not_append_primer() -> None:
+    """REPLAN cancel heals orphans but does NOT append a primer event.
+
+    The replan variant is a less-jolting pivot — the function_response
+    content is sufficient signal; adding a primer would be noise.
+    """
+    import asyncio
+
+    from goldfive.adapters.adk import SYMBOLIC_REASON_REPLAN, ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _make_agent()
+
+    async def _run():
+        yield _mk_function_call_event(call_id="call-r", name="search")
+        await asyncio.Event().wait()
+        yield None  # pragma: no cover
+
+    runner = _FakeRunner(_run, agent)
+    adapter = ADKAdapter(runner, session_id="sess-replan")
+
+    invoke_task = asyncio.create_task(
+        adapter.invoke(Task(id="t1", title="x"), Session(run_id="r"))
+    )
+    await asyncio.sleep(0.01)
+    adapter._next_cancel_reason = SYMBOLIC_REASON_REPLAN
+    invoke_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await invoke_task
+
+    appended = runner.session_service.appended
+    # Exactly 1 event — the function_response pairing. No primer.
+    assert len(appended) == 1
+    fr = appended[0].get_function_responses()[0]
+    assert fr.response.get("status") == "cancelled_by_replan"
+
+
+async def test_generic_cancel_does_not_append_primer() -> None:
+    """A bare (untagged) cancel also gets no primer event."""
+    import asyncio
+
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _make_agent()
+
+    async def _run():
+        yield _mk_function_call_event(call_id="call-g", name="search")
+        await asyncio.Event().wait()
+        yield None  # pragma: no cover
+
+    runner = _FakeRunner(_run, agent)
+    adapter = ADKAdapter(runner, session_id="sess-generic")
+
+    invoke_task = asyncio.create_task(
+        adapter.invoke(Task(id="t1", title="x"), Session(run_id="r"))
+    )
+    await asyncio.sleep(0.01)
+    # Do NOT set _next_cancel_reason — simulate the legacy code path
+    # where the cancel arrives without a symbolic tag.
+    invoke_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await invoke_task
+
+    appended = runner.session_service.appended
+    # Exactly 1 event — the function_response pairing. No primer.
+    assert len(appended) == 1
+    fr = appended[0].get_function_responses()[0]
+    assert fr.response.get("status") == "cancelled"
+
+
+async def test_pending_tool_call_pairing_preserved_under_new_content() -> None:
+    """Regression: the function_response.id MUST still match the
+    orphan function_call.id across all content variants.
+
+    ADK's ``find_event_by_function_call_id`` pairs on the id, not the
+    content; if we ever broke the pairing the next turn would still
+    see "Missing tool results for tool_call_id". Pin the invariant
+    across USER_STEER, REPLAN, and generic reasons.
+    """
+    from goldfive.adapters.adk import (
+        SYMBOLIC_REASON_REPLAN,
+        SYMBOLIC_REASON_USER_STEER,
+        _build_cancelled_response_event,
+    )
+
+    for reason in (
+        SYMBOLIC_REASON_USER_STEER,
+        SYMBOLIC_REASON_REPLAN,
+        "cancelled_mid_invocation",
+        "error:SomeError",
+    ):
+        event = _build_cancelled_response_event(
+            function_call_id="call-paired",
+            tool_name="whatever",
+            author="agent",
+            invocation_id="inv-1",
+            reason=reason,
+        )
+        fr = event.get_function_responses()[0]
+        assert fr.id == "call-paired", (
+            f"reason {reason!r} broke the function_call/function_response "
+            f"pairing — ADK would see an orphan call on next turn"
+        )
+
+
+async def test_next_cancel_reason_cleared_after_consumption() -> None:
+    """After a cancel fires, ``_next_cancel_reason`` is cleared.
+
+    A stale tag would bleed into the NEXT cancel (of a different
+    invocation), causing the wrong content variant to be emitted.
+    """
+    import asyncio
+
+    from goldfive.adapters.adk import SYMBOLIC_REASON_USER_STEER, ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _make_agent()
+
+    async def _run():
+        yield _mk_function_call_event(call_id="call-c", name="search")
+        await asyncio.Event().wait()
+        yield None  # pragma: no cover
+
+    runner = _FakeRunner(_run, agent)
+    adapter = ADKAdapter(runner, session_id="sess-clear")
+
+    invoke_task = asyncio.create_task(
+        adapter.invoke(Task(id="t1", title="x"), Session(run_id="r"))
+    )
+    await asyncio.sleep(0.01)
+    adapter._next_cancel_reason = SYMBOLIC_REASON_USER_STEER
+    invoke_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await invoke_task
+
+    # Tag was consumed during _heal_pending_tool_calls and cleared.
+    assert adapter._next_cancel_reason == ""
+
+
+async def test_next_cancel_reason_cleared_on_clean_exit() -> None:
+    """A clean (non-cancelled) exit also clears any stale tag.
+
+    Defensive: if someone sets the tag speculatively and the invoke
+    then finishes normally, we don't want the tag to leak into the
+    next cancel.
+    """
+    from goldfive.adapters.adk import SYMBOLIC_REASON_USER_STEER, ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _make_agent()
+
+    async def _run_clean():
+        if False:  # pragma: no cover
+            yield None
+        return
+
+    runner_clean = _FakeRunner(_run_clean, agent)
+    adapter = ADKAdapter(runner_clean, session_id="sess-clean-clear")
+    adapter._next_cancel_reason = SYMBOLIC_REASON_USER_STEER
+
+    await adapter.invoke(Task(id="t1", title="x"), Session(run_id="r"))
+
+    assert adapter._next_cancel_reason == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cancel_propagation.py
+++ b/tests/test_cancel_propagation.py
@@ -125,7 +125,12 @@ async def test_cancel_invoke_raises_cancelled_and_heals_orphan_tool_calls() -> N
     responses = appended[0].get_function_responses()
     assert len(responses) == 1
     assert responses[0].id == "pending-1"
-    assert responses[0].response.get("goldfive_cancelled") is True
+    # Reason-differentiated content (goldfive#139). A bare task.cancel()
+    # without a steerer-set _next_cancel_reason resolves to the generic
+    # content variant.
+    payload = responses[0].response
+    assert payload.get("status") == "cancelled"
+    assert "Do NOT retry" in payload.get("instruction", "")
 
 
 async def test_after_cancel_pending_tool_call_bookkeeping_is_empty() -> None:

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -226,6 +226,89 @@ async def test_observe_non_control_event_still_uses_classifier() -> None:
 
 
 # ---------------------------------------------------------------------------
+# goldfive#139 — steerer tags the bound adapter's next cancel with a
+# symbolic reason on USER_STEER drift, so the synthetic function_response
+# the adapter appends on cancel carries LLM-actionable content.
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    """Minimal adapter stub that exposes ``_next_cancel_reason``.
+
+    The real ``ADKAdapter`` carries the same attribute; this stub
+    avoids pulling in the ADK optional dep just to verify the steerer
+    side of the wiring.
+    """
+
+    def __init__(self) -> None:
+        self._next_cancel_reason: str = ""
+
+
+async def test_steerer_sets_adapter_next_cancel_reason_on_user_steer() -> None:
+    """USER_STEER drift via ``observe`` → adapter gets tagged ``"user_steer"``.
+
+    Regression for goldfive#139: the steerer must stash the symbolic
+    reason on the bound adapter BEFORE the drift_detected event is
+    emitted, so whatever downstream component reacts by cancelling
+    the in-flight invoke sees a tagged adapter and the adapter's
+    cancel handler picks up the LLM-actionable content variant.
+    """
+    steerer, session, _sink, _planner = _bind_fresh()
+    adapter = _FakeAdapter()
+    steerer.bind_adapter(adapter)
+
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        payload={"note": "pivot to security posture"},
+    )
+    await steerer.observe(msg, session)
+
+    assert adapter._next_cancel_reason == "user_steer"
+
+
+async def test_steerer_does_not_tag_adapter_on_non_user_steer_drift() -> None:
+    """Non-USER_STEER drift leaves the adapter tag untouched.
+
+    Pause (USER_PAUSE, INFO) and other drift kinds must not set the
+    tag — only USER_STEER maps to the explicit content variant. Other
+    cancels fall through to the neutral content.
+    """
+    steerer, session, _sink, _planner = _bind_fresh()
+    adapter = _FakeAdapter()
+    steerer.bind_adapter(adapter)
+
+    # PAUSE → USER_PAUSE drift (INFO severity, no refine).
+    pause_msg = ControlMessage(kind=ControlKind.PAUSE, payload={"note": "wait"})
+    await steerer.observe(pause_msg, session)
+    assert adapter._next_cancel_reason == ""
+
+    # A raw tool-error event also should not tag the adapter.
+    await steerer.observe({"error": "boom"}, session)
+    assert adapter._next_cancel_reason == ""
+
+
+async def test_steerer_bind_adapter_tolerates_adapter_without_attr() -> None:
+    """A third-party adapter that doesn't carry ``_next_cancel_reason``
+    must not break the USER_STEER drift path.
+
+    The steerer's tagging helper swallows the AttributeError / similar
+    and logs at DEBUG. The drift still flows through ``_handle_drift``
+    (refine etc.) normally.
+    """
+    class _FrozenAdapter:
+        __slots__ = ()  # no attributes, no __dict__ — assignment raises.
+
+    steerer, session, _sink, planner = _bind_fresh()
+    steerer.bind_adapter(_FrozenAdapter())
+
+    msg = ControlMessage(kind=ControlKind.STEER, payload={"note": "x"})
+    # Must not raise.
+    await steerer.observe(msg, session)
+    # Refine still ran.
+    assert len(planner.refine_calls) == 1
+
+
+# ---------------------------------------------------------------------------
 # LLMPlanner.refine — USER_STEER delete-and-replan
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #139.

## Root cause

When a USER_STEER cancels a mid-flight invoke, `_heal_pending_tool_calls` appends a synthetic `function_response` whose content was written for **humans reading logs**, not for the **LLM that reads the session history on the next turn**:

```python
response={
    "goldfive_cancelled": True,
    "reason": "cancelled_mid_invocation",
    "detail": "Tool call was cancelled mid-invocation by goldfive "
              "(USER_STEER / USER_CANCEL control). This synthetic "
              "response was appended to preserve session history "
              "well-formedness.",
}
```

Qwen3.5 (and likely other small/quantized models) reading that on the next turn couldn't parse the goldfive-internal jargon, treated it as a generic tool error, and either retried the cancelled call or entered a reasoning loop trying to reconcile it with the task. Observed live on `sess_2026-04-21_0023` as 140 LLM calls over 30 minutes with no progress after a USER_STEER.

## Fix — append-only, three parts

**Part 1 — reason-differentiated response content.** `_build_cancelled_response_event` now branches on a symbolic reason:

- `user_steer` → `status=cancelled_by_user_steering` with an "ABANDONED / do NOT retry / next user message contains your new task" instruction.
- `replan` → `status=cancelled_by_replan` with a "plan was updated / await next task" instruction.
- Anything else (legacy `cancelled_mid_invocation`, `error:<ExceptionName>`, `unexpected_orphan_on_normal_exit`) → neutral `status=cancelled` with "Do NOT retry. Await next instruction."

`function_response.id` pairing with the orphan `function_call.id` is preserved across all variants.

**Part 2 — plumb the real cancel reason.** `ADKAdapter` gains a short-lived `_next_cancel_reason: str` attr, consumed and cleared by the `CancelledError` handler inside `invoke`. Two writers set it before `task.cancel()`:

- `SequentialExecutor` / `ParallelDAGExecutor` tag the adapter with `"user_steer"` before `_cancel_invoke_task` on a STEER control. This is the load-bearing live path — the steerer's `observe` runs *after* the cancel, by which point heal has already fired.
- `DefaultSteerer` gains `bind_adapter(adapter)` and tags on USER_STEER drift in `_handle_drift`. Covers direct-`observe` callers and makes the semantics observable at the steerer level. Both writers are idempotent.

Runner wires the reverse binding after `adapter.bind_steerer`, duck-typed so custom steerers skip silently.

**Part 3 — USER_STEER user-role primer.** After the per-call function_response heals, if reason is `user_steer`, append a single user-role event with a short "STEERING NOTICE" text. Belt-and-braces: even if the LLM skims the function_response content, the subsequent user-role message is hard to miss on the next turn. REPLAN and generic cancels do NOT get a primer — those pivots are less jolting and the function_response's instruction is sufficient signal.

## Non-goals (preserved)

- Append-only architecture — no event deletion, no session rebuild, no rewinding.
- `_heal_pending_tool_calls`'s pairing logic unchanged.
- Single-Runner architecture unchanged.
- No new DriftKinds.
- The user can still reference prior events in their steer — only the cancel-point's own synthetic response changes shape.

## Test plan

- [x] 10 new cases in `tests/test_adk_adapter.py` covering each content variant, primer behaviour, pairing preservation, and tag lifecycle.
- [x] 3 new cases in `tests/test_steerer_usersteer.py` covering `bind_adapter`, USER_STEER-only tagging, and adapter-without-attr tolerance.
- [x] 2 pre-existing tests updated (they asserted on the deprecated `goldfive_cancelled` key).
- [x] Full suite: 679 passed, 44 skipped, 0 failures locally.
- [x] `uv run ruff check .` passes.