### PR TITLE
GoldfivePlanner (BasePlanner subclass) + plugin-side instruction injection

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -533,6 +533,140 @@ def _tool_approval_prompt(tool: Any, tool_name: str, tool_args: Any) -> str:
     return f"Run {tool_name}()?"
 
 
+async def _inject_goldfive_planner_instruction(
+    *,
+    callback_context: Any,
+    llm_request: Any,
+) -> None:
+    """Append :class:`GoldfivePlanner` output to ``llm_request.config.system_instruction``.
+
+    ADK's ``flows/llm_flows/_nl_planning.py`` request-side processor
+    gates instruction injection on ``isinstance(planner,
+    PlanReActPlanner)`` — so a ``BasePlanner`` subclass that is NOT a
+    PlanReAct subclass gets its ``build_planning_instruction`` called
+    on the RESPONSE side (via ``process_planning_response``) but never
+    on the REQUEST side. That's fine for response filtering but it
+    starves the model of goldfive's orchestration context block on
+    the turn that matters.
+
+    This helper is the workaround: it detects when the running
+    agent's ``.planner`` is a :class:`~goldfive.planners.goldfive_planner.GoldfivePlanner`
+    (NOT a ``PlanReActPlanner`` or ``BuiltInPlanner`` — ADK handles
+    those on its own via ``_nl_planning``) and appends the planner's
+    :meth:`build_planning_instruction` output to the request's system
+    instruction using ADK's own ``append_instructions`` method.
+
+    Silent fall-throughs in priority order:
+
+    * ADK not installed or ``BasePlanner`` import fails → skip.
+    * Running agent has no ``planner`` attribute or planner is None
+      → skip (plain ADK LlmAgent with no goldfive attachment).
+    * Planner is a ``PlanReActPlanner`` / ``BuiltInPlanner`` subclass
+      → skip (ADK will handle it natively).
+    * ``build_planning_instruction`` returns ``None`` / empty →
+      skip (planner opted out for this turn).
+    * ``llm_request`` lacks ``append_instructions`` → skip (unit-test
+      request stubs).
+    """
+    try:
+        from goldfive.planners.goldfive_planner import GoldfivePlanner
+    except ImportError:  # pragma: no cover — ADK not installed
+        return
+    try:
+        from google.adk.planners.base_planner import BasePlanner  # type: ignore
+        from google.adk.planners.built_in_planner import BuiltInPlanner  # type: ignore
+        from google.adk.planners.plan_re_act_planner import (  # type: ignore
+            PlanReActPlanner,
+        )
+    except ImportError:  # pragma: no cover — ADK not installed
+        return
+
+    # Find the running agent on the callback_context. ADK exposes it
+    # through the invocation context; tests may supply a context that
+    # carries ``.agent`` directly.
+    inv_ctx = _safe_attr(callback_context, "_invocation_context", None) or _safe_attr(
+        callback_context, "invocation_context", None
+    )
+    agent = _safe_attr(inv_ctx, "agent", None)
+    if agent is None:
+        agent = _safe_attr(callback_context, "agent", None)
+    if agent is None:
+        return
+
+    planner = _safe_attr(agent, "planner", None)
+    if planner is None:
+        return
+    # If ADK itself will inject for this planner type, skip. ``BuiltInPlanner``
+    # never emits a text instruction (it configures thinking on the
+    # request instead), ``PlanReActPlanner`` is the one ADK gates on.
+    if isinstance(planner, (PlanReActPlanner, BuiltInPlanner)):
+        return
+    if not isinstance(planner, BasePlanner):
+        return
+    # Narrow further: the adapter attaches GoldfivePlanner specifically.
+    # A custom BasePlanner subclass that is not GoldfivePlanner should
+    # be respected by ADK's own (response-side) dispatch only, not
+    # re-injected here. This keeps the hook behaviour predictable for
+    # users who subclass BasePlanner themselves.
+    if not isinstance(planner, GoldfivePlanner):
+        return
+
+    # Build the ReadonlyContext ADK expects. When invocation_context
+    # is available we use ADK's real class; otherwise we fall back to
+    # ``callback_context`` itself (test stubs carrying ``.state`` work
+    # through GoldfivePlanner's tolerant _extract_state).
+    readonly = callback_context
+    try:
+        from google.adk.agents.readonly_context import ReadonlyContext  # type: ignore
+
+        if inv_ctx is not None:
+            readonly = ReadonlyContext(inv_ctx)
+    except Exception as exc:  # noqa: BLE001 — use fallback
+        log.debug(
+            "_inject_goldfive_planner_instruction: ReadonlyContext unavailable: %s",
+            exc,
+        )
+
+    instruction = planner.build_planning_instruction(readonly, llm_request)
+    if not instruction:
+        return
+
+    append = getattr(llm_request, "append_instructions", None)
+    if not callable(append):
+        # Best-effort write directly into ``config.system_instruction``
+        # when the test stub doesn't carry the helper. Preserves the
+        # existing value if it's a string.
+        config = getattr(llm_request, "config", None)
+        if config is None:
+            return
+        existing = getattr(config, "system_instruction", None)
+        if not existing:
+            try:
+                config.system_instruction = instruction
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_inject_goldfive_planner_instruction: could not set system_instruction: %s",
+                    exc,
+                )
+        elif isinstance(existing, str):
+            try:
+                config.system_instruction = existing + "\n\n" + instruction
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_inject_goldfive_planner_instruction: could not append system_instruction: %s",
+                    exc,
+                )
+        return
+
+    try:
+        append([instruction])
+    except Exception as exc:  # noqa: BLE001
+        log.debug(
+            "_inject_goldfive_planner_instruction: append_instructions raised: %s",
+            exc,
+        )
+
+
 def make_adk_plugin(
     *,
     name: str = "goldfive_adk_plugin",
@@ -1123,7 +1257,8 @@ def make_adk_plugin(
         # --- Plan + current-task context -------------------------------
 
         async def before_model_callback(self, *, callback_context: Any, llm_request: Any) -> None:
-            """Best-effort re-seed goldfive.* state for legacy test harnesses.
+            """Best-effort re-seed goldfive.* state for legacy test harnesses
+            + GoldfivePlanner request-side instruction injection.
 
             The authoritative state write happens in
             :meth:`before_run_callback` against the live invocation
@@ -1131,6 +1266,17 @@ def make_adk_plugin(
             for unit tests that drive the plugin with a minimal
             callback-context stub without a matching ``before_run``
             lifecycle (see ``tests/test_adk_adapter.py``).
+
+            It ALSO performs GoldfivePlanner request-side instruction
+            injection (goldfive#153): ADK's ``_nl_planning.py``
+            request-side gate fires only for ``PlanReActPlanner``
+            subclasses, not every ``BasePlanner``. Since goldfive
+            deliberately subclasses ``BasePlanner`` directly (we don't
+            want PlanReAct's response filtering), we invoke
+            :meth:`GoldfivePlanner.build_planning_instruction` ourselves
+            here and append the returned string to
+            ``llm_request.config.system_instruction`` via the same
+            ``append_instructions`` helper ADK uses internally.
             """
             ctx = self._resolve_ctx(callback_context)
             if ctx is None:
@@ -1155,6 +1301,22 @@ def make_adk_plugin(
                 _sp.write_tools_available(state, ctx.tool_handlers.keys())
             except Exception as exc:  # noqa: BLE001
                 log.debug("before_model_callback: state write failed: %s", exc)
+
+            # GoldfivePlanner request-side injection (goldfive#153).
+            # Best-effort: never raise from this path; injection failure
+            # degrades to "LLM runs without goldfive's orchestration
+            # context block" which is safe — ADK state still carries
+            # the same keys via the write above.
+            try:
+                await _inject_goldfive_planner_instruction(
+                    callback_context=callback_context,
+                    llm_request=llm_request,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "before_model_callback: goldfive planner injection raised: %s",
+                    exc,
+                )
             return None
 
         # --- Reporting-tool interception + tool-confirmation bridge ---

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -223,6 +223,165 @@ def _collect_reachable_agent_names(root_agent: Any) -> list[str]:
     return sorted(names)
 
 
+GOLDFIVE_PLANNER_OPT_OUT_ATTR = "_goldfive_planner_opt_out"
+"""Attribute users can set on an agent to skip GoldfivePlanner attachment.
+
+When ``getattr(agent, "_goldfive_planner_opt_out", False)`` is truthy
+the auto-attachment pass leaves that agent's ``planner`` untouched.
+Applies per-agent — a sibling in the same tree without the marker
+still gets a GoldfivePlanner. Rarely needed; the planner is designed
+to be compose-safe with any user-supplied ``BasePlanner``, so the
+opt-out is reserved for cases where even the additive injection is
+undesired (e.g. a highly constrained research agent that must emit
+only tool calls in a specific shape).
+"""
+
+
+def _attach_goldfive_planner_to_tree(root_agent: Any) -> int:
+    """Attach :class:`~goldfive.planners.goldfive_planner.GoldfivePlanner`
+    to every ``LlmAgent`` reachable from ``root_agent``.
+
+    Traverses the same three edges :func:`_augment_subtree_with_reporting`
+    uses (``sub_agents`` / ``inner_agent`` / ``AgentTool.agent``). For
+    every node that looks like an ``LlmAgent`` (duck-typed via the
+    presence of a ``planner`` attribute — LlmAgents have it as an
+    optional pydantic field):
+
+    * If :data:`GOLDFIVE_PLANNER_OPT_OUT_ATTR` is set and truthy on
+      the agent, skip.
+    * If ``agent.planner`` is ``None``: attach a fresh
+      :class:`GoldfivePlanner`.
+    * If ``agent.planner`` is already a :class:`GoldfivePlanner`: skip
+      (idempotent — re-wrap on a re-binded adapter should not stack).
+    * Otherwise compose: replace with
+      ``GoldfivePlanner(user_planner=agent.planner)``.
+
+    Non-LlmAgents (``SequentialAgent``, ``ParallelAgent``, custom
+    ``BaseAgent`` subclasses without a ``planner`` field) have no
+    ``planner`` attribute and are skipped silently.
+
+    Returns the number of agents where an attachment happened (not
+    counting opt-outs / already-goldfive cases).
+
+    Deliberately silent on individual failures: assigning to
+    ``agent.planner`` may raise if the agent's pydantic model has
+    frozen configuration; in that case we log and continue so one
+    bad agent doesn't block the rest of the tree.
+    """
+    if root_agent is None:
+        return 0
+    try:
+        from goldfive.planners.goldfive_planner import GoldfivePlanner
+    except ImportError:  # pragma: no cover
+        return 0
+
+    touched = 0
+    seen: set[int] = set()
+    stack: list[Any] = [root_agent]
+    while stack:
+        cur = stack.pop()
+        if cur is None or id(cur) in seen:
+            continue
+        seen.add(id(cur))
+
+        # Push children BEFORE the skip-checks so opted-out / non-LlmAgent
+        # nodes still propagate the walk to their children.
+        for sub in getattr(cur, "sub_agents", None) or ():
+            stack.append(sub)
+        inner = getattr(cur, "inner_agent", None)
+        if inner is not None:
+            stack.append(inner)
+        for t in getattr(cur, "tools", None) or ():
+            nested = getattr(t, "agent", None)
+            if nested is not None:
+                stack.append(nested)
+
+        if getattr(cur, GOLDFIVE_PLANNER_OPT_OUT_ATTR, False):
+            continue
+        # LlmAgent carries a ``planner: Optional[BasePlanner]`` field;
+        # other BaseAgent subclasses (Sequential/Parallel/custom) do
+        # not expose one. Duck-type by presence + settability.
+        if not hasattr(cur, "planner"):
+            continue
+        existing = getattr(cur, "planner", None)
+        if isinstance(existing, GoldfivePlanner):
+            # Idempotent: a re-wrap on the same tree (e.g. a test that
+            # constructs two adapters over the same agent) should not
+            # stack GoldfivePlanners on top of each other.
+            continue
+        try:
+            if existing is None:
+                cur.planner = GoldfivePlanner()
+            else:
+                cur.planner = GoldfivePlanner(user_planner=existing)
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "could not attach GoldfivePlanner to %s: %s",
+                getattr(cur, "name", "?"),
+                exc,
+            )
+            continue
+        touched += 1
+
+    if touched:
+        log.debug("goldfive: attached GoldfivePlanner to %d agent(s)", touched)
+    return touched
+
+
+def _rebind_goldfive_planners(
+    root_agent: Any,
+    *,
+    agent_registry: list[str],
+    steerer: Any,
+    session: Any,
+) -> None:
+    """Rebind every :class:`GoldfivePlanner` in the tree to the live collaborators.
+
+    Called from :meth:`ADKAdapter._invoke_internal` right before
+    ``runner.run_async`` so the planner sees the current steerer,
+    session, and the authoritative agent registry. Cheap walk — the
+    tree is small and this runs once per invocation.
+    """
+    if root_agent is None:
+        return
+    try:
+        from goldfive.planners.goldfive_planner import GoldfivePlanner
+    except ImportError:  # pragma: no cover
+        return
+
+    seen: set[int] = set()
+    stack: list[Any] = [root_agent]
+    while stack:
+        cur = stack.pop()
+        if cur is None or id(cur) in seen:
+            continue
+        seen.add(id(cur))
+        for sub in getattr(cur, "sub_agents", None) or ():
+            stack.append(sub)
+        inner = getattr(cur, "inner_agent", None)
+        if inner is not None:
+            stack.append(inner)
+        for t in getattr(cur, "tools", None) or ():
+            nested = getattr(t, "agent", None)
+            if nested is not None:
+                stack.append(nested)
+
+        planner = getattr(cur, "planner", None)
+        if isinstance(planner, GoldfivePlanner):
+            try:
+                planner.bind(
+                    agent_registry=agent_registry,
+                    steerer=steerer,
+                    session=session,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "could not rebind GoldfivePlanner on %s: %s",
+                    getattr(cur, "name", "?"),
+                    exc,
+                )
+
+
 def _register_plugin_on_runner(runner: Any, plugin: Any) -> bool:
     """Install ``plugin`` on ``runner``'s plugin manager if one exists.
 
@@ -701,6 +860,18 @@ class ADKAdapter:
         else:
             self._available_agents = _collect_reachable_agent_names(self._agent)
 
+        # Auto-attach GoldfivePlanner to every LlmAgent in the tree
+        # (goldfive#153). Idempotent: skipped for agents already
+        # carrying a GoldfivePlanner, and for agents opting out via
+        # the ``_goldfive_planner_opt_out = True`` marker. A pre-existing
+        # user-supplied planner is COMPOSED (wrapped as
+        # ``user_planner=...``) rather than replaced. Skipped in
+        # degraded mode because the caller has taken over runner
+        # construction and may have its own planner conventions we
+        # don't want to stomp on.
+        if not self._degraded_prebuilt_runner:
+            _attach_goldfive_planner_to_tree(self._agent)
+
         # tool_name -> handler. Populated by register_reporting_tools.
         self._tool_handlers: dict[str, Any] = {}
         # Full reporting-tool specs, in registration order. The plugin's
@@ -1057,6 +1228,17 @@ class ADKAdapter:
                 set_rec = getattr(self._plugin, "set_reconciler", None)
                 if callable(set_rec):
                     set_rec(reconciler)
+
+        # Rebind every GoldfivePlanner in the tree to the live
+        # collaborators for this invocation (goldfive#153). Cheap walk
+        # — the tree is small and this lets the structural filters
+        # emit PLAN_DIVERGENCE drifts through the bound steerer.
+        _rebind_goldfive_planners(
+            self._agent,
+            agent_registry=list(self._available_agents),
+            steerer=self._steerer,
+            session=session,
+        )
 
         # Mirror into ADK state as a best-effort fallback for legacy
         # unit tests that construct a plain ``tool_context`` holding a

--- a/goldfive/planners/__init__.py
+++ b/goldfive/planners/__init__.py
@@ -1,0 +1,30 @@
+"""Goldfive ADK ``BasePlanner`` subclasses.
+
+This is the structural steering layer (goldfive#153). The module
+:mod:`~goldfive.planners.goldfive_planner` ships
+:class:`~goldfive.planners.goldfive_planner.GoldfivePlanner` — an ADK
+``BasePlanner`` subclass that injects a tree-agnostic orchestration
+context block on every LLM call and performs structural
+post-processing on the response.
+
+The planner is auto-attached to every ``LlmAgent`` reachable from the
+wrapped root by :func:`goldfive.wrap`. Agents carrying an explicit
+``_goldfive_planner_opt_out = True`` marker are skipped. When a user
+has already set a planner on an agent, :class:`GoldfivePlanner` wraps
+it via ``user_planner=`` and delegates for composition — goldfive's
+instruction is appended to the user planner's, and the user planner's
+response post-processing runs after goldfive's structural filters.
+
+Kept as a package (``goldfive.planners``) rather than a flat module so
+future work (#154 goal-aware refine, any subsequent planner family)
+can drop siblings here without reshuffling imports.
+"""
+
+from __future__ import annotations
+
+try:
+    from goldfive.planners.goldfive_planner import GoldfivePlanner
+except ImportError:  # pragma: no cover — optional dep (ADK) missing
+    GoldfivePlanner = None  # type: ignore[assignment,misc]
+
+__all__ = ["GoldfivePlanner"]

--- a/goldfive/planners/goldfive_planner.py
+++ b/goldfive/planners/goldfive_planner.py
@@ -1,0 +1,565 @@
+"""Goldfive's structural-steering ``BasePlanner`` (goldfive#153).
+
+The :class:`GoldfivePlanner` is an ADK ``BasePlanner`` subclass that
+attaches to every ``LlmAgent`` in a tree wrapped by :func:`goldfive.wrap`
+and performs two structural jobs on every LLM call that agent makes:
+
+1. **Request side.** Builds a short orchestration context block
+   assembled from ``session.state['goldfive.*']`` keys (see
+   :mod:`goldfive.adapters._adk_state_protocol`) and asks the agent
+   to read the current plan task / goals / active user steer from it.
+   The block is tree-agnostic — no presentation-layer or
+   domain-specific vocabulary — so the same planner works for single
+   LlmAgent, flat specialists, or deep hierarchies alike.
+
+2. **Response side.** Filters the LLM's response parts for two
+   structural signals:
+
+   * ``function_call`` parts whose ``id`` appears in
+     ``session.state['goldfive.cancelled_function_call_ids']`` are
+     stripped (the LLM tried to retry a call goldfive already
+     cancelled — e.g. on USER_STEER).
+   * ``function_call`` parts to agents outside the adapter's
+     registry emit a ``PLAN_DIVERGENCE`` drift via the steerer.
+     **The call is not blocked** — this is a signal, not a gate.
+
+Request-side injection requires a plugin workaround
+-----------------------------------------------------
+
+ADK's ``flows/llm_flows/_nl_planning.py`` gates request-side
+instruction injection on ``isinstance(planner, PlanReActPlanner)``
+(see ``_NlPlanningRequestProcessor.run_async``). Subclassing
+``PlanReActPlanner`` would inherit its ReAct response filtering —
+which constrains the agent's output to a tag-based shape we don't
+want to impose. So :class:`GoldfivePlanner` subclasses ``BasePlanner``
+directly, and :class:`~goldfive.adapters._adk_plugin._GoldfiveADKPlugin`'s
+``before_model_callback`` takes over the injection: it detects when
+the running agent carries a :class:`GoldfivePlanner`, calls
+:meth:`build_planning_instruction`, and appends the result to
+``llm_request.config.system_instruction`` via ``append_instructions``.
+
+The response-side gate in ``_nl_planning.py`` is permissive — it
+fires for any ``BasePlanner`` subclass other than ``BuiltInPlanner``
+— so :meth:`process_planning_response` runs natively without a
+workaround.
+
+Compose-with-user-planner
+-------------------------
+
+If the user attaches their own ``BasePlanner`` to an agent before
+``goldfive.wrap`` runs, the auto-attachment path preserves it by
+passing it in as :attr:`user_planner`. On the request side goldfive
+calls the user planner's ``build_planning_instruction`` first and
+**prepends** that result ahead of goldfive's orchestration context
+block (the user planner's framing lands above goldfive's, since the
+user planner's context is typically more general — meta-instructions
+— and goldfive's is per-turn ambient state). On the response side
+goldfive's structural filters run first (strip cancelled calls;
+signal divergence); then whatever parts remain are passed to the
+user planner's ``process_planning_response`` so it can apply its
+own transformations on top.
+
+Tree-agnostic, no domain content
+--------------------------------
+
+Every placeholder in the orchestration block reads from session
+state. The planner refuses to hard-code any presentation / research
+/ coordinator / specialist vocabulary. Tree shape (flat, nested,
+deep) is irrelevant — every agent in the tree receives the same
+block format, with the state values differing only when the
+goldfive driver has populated them.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Any
+
+from goldfive.adapters._adk_state_protocol import (
+    KEY_CURRENT_TASK_ID,
+    KEY_CURRENT_TASK_TITLE,
+)
+
+if TYPE_CHECKING:  # pragma: no cover — type-check only
+    from google.adk.agents.callback_context import CallbackContext  # type: ignore
+    from google.adk.agents.readonly_context import ReadonlyContext  # type: ignore
+    from google.adk.models.llm_request import LlmRequest  # type: ignore
+    from google.genai import types  # type: ignore
+
+
+log = logging.getLogger("goldfive.planners.goldfive_planner")
+
+
+# --- Additional state keys owned by this module --------------------------
+#
+# These keys are READ by GoldfivePlanner. They are populated by other
+# layers (#152 state namespace expansion, the adapter/cancel path, the
+# user-steer path) and default-safe — missing keys just render as
+# ``(none)`` in the instruction block or are treated as empty sets in
+# the response filters. Writing is scoped to the owning layer, not to
+# this module.
+
+KEY_GOALS_SUMMARY = "goldfive.goals_summary"
+"""Comma-joined summary of ``session.goals`` maintained by the runner."""
+
+KEY_ACTIVE_STEER_BODY = "goldfive.active_steer.body"
+"""Text of the most recent user steering command, if any."""
+
+KEY_CANCELLED_FUNCTION_CALL_IDS = "goldfive.cancelled_function_call_ids"
+"""List of ADK ``function_call`` ids the adapter cancelled mid-invoke.
+
+Written by the USER_STEER / REPLAN cancel paths and consumed by
+:meth:`GoldfivePlanner.process_planning_response` to strip any
+retry attempts the LLM emits for the same ids on the next turn.
+"""
+
+
+# Sentinel rendered into the orchestration block when a state key is
+# missing or empty. Kept intentionally short so the block stays compact
+# when the driver has not yet populated state.
+_NONE_MARKER = "(none)"
+
+
+def _state_get(state: Any, key: str, default: str = "") -> str:
+    """Tolerant mapping read for ``state`` — returns ``default`` on any failure."""
+    if not isinstance(state, Mapping):
+        return default
+    try:
+        value = state.get(key, default)
+    except Exception:  # noqa: BLE001 -- best-effort state access
+        return default
+    if value is None:
+        return default
+    return str(value)
+
+
+def _state_list(state: Any, key: str) -> list[str]:
+    """Tolerant list-of-strings read for ``state``."""
+    if not isinstance(state, Mapping):
+        return []
+    try:
+        value = state.get(key, None)
+    except Exception:  # noqa: BLE001
+        return []
+    if not isinstance(value, Iterable) or isinstance(value, str | bytes):
+        return []
+    out: list[str] = []
+    for v in value:
+        if isinstance(v, str) and v:
+            out.append(v)
+    return out
+
+
+# Lazily import ``BasePlanner`` so importing this module without ADK
+# installed fails with the same "requires 'pip install goldfive[adk]'"
+# shape the rest of the adapters use.
+try:
+    from google.adk.planners.base_planner import BasePlanner  # type: ignore
+except ImportError as exc:  # pragma: no cover — covered via importorskip in tests
+    raise ImportError(
+        "goldfive.planners.goldfive_planner requires 'pip install goldfive[adk]'"
+    ) from exc
+
+
+class GoldfivePlanner(BasePlanner):
+    """Structural ``BasePlanner`` auto-attached by :func:`goldfive.wrap`.
+
+    Parameters
+    ----------
+    user_planner:
+        Optional pre-existing ``BasePlanner`` the user already attached
+        to an agent. When provided :class:`GoldfivePlanner` composes
+        with it:
+
+        * **Request side** — calls
+          ``user_planner.build_planning_instruction(...)`` first; the
+          result is **prepended** ahead of goldfive's orchestration
+          context block in the returned string.
+        * **Response side** — goldfive's structural filters (strip
+          cancelled ``function_call`` ids, signal PLAN_DIVERGENCE on
+          off-registry agent calls) run first; the remaining parts
+          are passed to ``user_planner.process_planning_response(...)``
+          so the user planner can apply its own transformations on
+          top.
+    agent_registry:
+        Optional iterable of agent names that are considered "on the
+        registry" — function_calls to agents whose name is not in
+        this set emit a ``PLAN_DIVERGENCE`` drift when
+        :meth:`process_planning_response` runs. When ``None`` the
+        divergence check is disabled (no registry → nothing to
+        diverge from). The adapter's auto-attachment pass fills this
+        in with :attr:`~goldfive.adapters.adk.ADKAdapter.available_agents`.
+    steerer:
+        Optional :class:`~goldfive.protocols.Steerer` used to emit the
+        PLAN_DIVERGENCE drift. When ``None`` the divergence-signal
+        path is silent (but the off-registry count is still tracked
+        via log.debug).
+    session:
+        Optional :class:`~goldfive.types.Session` passed to
+        ``steerer._handle_drift``. Same binding contract as
+        ``steerer`` — set by the adapter when it auto-attaches.
+    """
+
+    def __init__(
+        self,
+        *,
+        user_planner: BasePlanner | None = None,
+        agent_registry: Iterable[str] | None = None,
+        steerer: Any = None,
+        session: Any = None,
+    ) -> None:
+        # ``BasePlanner`` is an ABC with no ``__init__`` state of its own
+        # beyond the abstract method contract; invoking super() is still
+        # correct for the MRO but we have no base fields to initialise.
+        super().__init__()
+        self._user_planner = user_planner
+        self._agent_registry: set[str] | None = (
+            {str(n) for n in agent_registry if isinstance(n, str) and n}
+            if agent_registry is not None
+            else None
+        )
+        self._steerer = steerer
+        self._session = session
+
+    # ------------------------------------------------------------------
+    # Public rebinding — called by the adapter once it knows the
+    # registry / steerer / session for the current invocation.
+    # ------------------------------------------------------------------
+
+    def bind(
+        self,
+        *,
+        agent_registry: Iterable[str] | None = None,
+        steerer: Any = None,
+        session: Any = None,
+    ) -> None:
+        """Rebind the per-invocation collaborators.
+
+        Called by :class:`~goldfive.adapters.adk.ADKAdapter` after
+        :func:`goldfive.wrap` attaches the planner to each agent but
+        before ``runner.run_async`` fires. Any argument set to a
+        non-``None`` value replaces the prior binding; ``None`` leaves
+        the existing value intact so partial rebinding works.
+        """
+        if agent_registry is not None:
+            self._agent_registry = {str(n) for n in agent_registry if isinstance(n, str) and n}
+        if steerer is not None:
+            self._steerer = steerer
+        if session is not None:
+            self._session = session
+
+    @property
+    def user_planner(self) -> BasePlanner | None:
+        """The composed user-supplied planner, if any (see class docstring)."""
+        return self._user_planner
+
+    # ------------------------------------------------------------------
+    # BasePlanner: build_planning_instruction
+    # ------------------------------------------------------------------
+
+    def build_planning_instruction(
+        self,
+        readonly_context: ReadonlyContext,
+        llm_request: LlmRequest,
+    ) -> str | None:
+        """Return the orchestration context block for this LLM turn.
+
+        Reads ``session.state['goldfive.*']`` off ``readonly_context``
+        and emits a short, tree-agnostic block. When a
+        :attr:`user_planner` is set its own ``build_planning_instruction``
+        is called first and **prepended** so the user planner's framing
+        lands above goldfive's per-turn state block.
+
+        Returns ``None`` only when an internal error prevents building
+        any instruction — never returns an empty string (empty would
+        cause ADK to skip the append, hiding the bug).
+        """
+        state = _extract_state(readonly_context)
+
+        # Collect the placeholders off state. All keys default to the
+        # ``(none)`` marker so the block still renders when state is
+        # sparse — e.g. before #152 populates the new keys — making
+        # this module a soft dependency.
+        task_id = _state_get(state, KEY_CURRENT_TASK_ID) or _NONE_MARKER
+        task_title = _state_get(state, KEY_CURRENT_TASK_TITLE) or _NONE_MARKER
+        goals_summary = _state_get(state, KEY_GOALS_SUMMARY) or _NONE_MARKER
+        steer_body = _state_get(state, KEY_ACTIVE_STEER_BODY) or _NONE_MARKER
+
+        goldfive_block = (
+            "[GOLDFIVE ORCHESTRATION CONTEXT]\n"
+            "\n"
+            f"Plan task (if any): {task_id}\n"
+            f"  title: {task_title}\n"
+            f"Current goals: {goals_summary}\n"
+            f"Active user steer (if any): {steer_body}\n"
+            "\n"
+            "Notes:\n"
+            "- The steering direction above supersedes prior context "
+            "unless your response explicitly references prior work.\n"
+            "- Do not retry cancelled tool calls (their ids are in "
+            "state['goldfive.cancelled_function_call_ids'])."
+        )
+
+        # Compose with any user-supplied planner. Prepend the user
+        # planner's result: user-authored meta-instructions typically
+        # describe "how to think", goldfive's block is per-turn ambient
+        # state, and LLMs parse a two-section instruction more
+        # reliably when the more-general section comes first.
+        if self._user_planner is not None:
+            try:
+                user_out = self._user_planner.build_planning_instruction(
+                    readonly_context, llm_request
+                )
+            except Exception as exc:  # noqa: BLE001 — user code; don't propagate
+                log.debug(
+                    "GoldfivePlanner: user_planner.build_planning_instruction raised: %s",
+                    exc,
+                )
+                user_out = None
+            if user_out:
+                return f"{user_out}\n\n{goldfive_block}"
+
+        return goldfive_block
+
+    # ------------------------------------------------------------------
+    # BasePlanner: process_planning_response
+    # ------------------------------------------------------------------
+
+    def process_planning_response(
+        self,
+        callback_context: CallbackContext,
+        response_parts: list[types.Part],
+    ) -> list[types.Part] | None:
+        """Apply structural filters to the LLM's response parts.
+
+        Two independent filters run in order:
+
+        1. Strip ``function_call`` parts whose ``function_call.id`` is
+           in ``session.state['goldfive.cancelled_function_call_ids']``.
+           Keeps the rest of the parts intact.
+        2. For every retained ``function_call`` whose ``name`` is not
+           in :attr:`_agent_registry` (when the registry is set),
+           emit a ``PLAN_DIVERGENCE`` drift at INFO severity via
+           ``steerer._handle_drift``. The call is NOT blocked; this
+           is signal-only so the steerer can decide policy.
+
+        After goldfive's filters run, if a :attr:`user_planner` is set
+        its own ``process_planning_response`` is called on the
+        remaining parts so it can layer its own transformations.
+        """
+        state = _extract_state(callback_context)
+        cancelled_ids = {s for s in _state_list(state, KEY_CANCELLED_FUNCTION_CALL_IDS)}
+
+        # Filter 1: strip cancelled function_call ids.
+        kept: list[Any] = []
+        stripped_count = 0
+        for part in response_parts or []:
+            fc = getattr(part, "function_call", None)
+            if fc is not None and cancelled_ids:
+                fc_id = getattr(fc, "id", None)
+                if fc_id and str(fc_id) in cancelled_ids:
+                    stripped_count += 1
+                    continue
+            kept.append(part)
+
+        if stripped_count:
+            log.debug(
+                "GoldfivePlanner: stripped %d cancelled function_call part(s)",
+                stripped_count,
+            )
+
+        # Filter 2: signal PLAN_DIVERGENCE on function_calls to agents
+        # outside the registry. We emit best-effort and never block;
+        # the steerer decides whether to escalate.
+        if self._agent_registry is not None and self._steerer is not None:
+            off_registry: list[str] = []
+            for part in kept:
+                fc = getattr(part, "function_call", None)
+                if fc is None:
+                    continue
+                name = getattr(fc, "name", "") or ""
+                if not name:
+                    continue
+                # Only call names that LOOK like agent delegation
+                # targets are checked — goldfive cannot distinguish
+                # an AgentTool name from any other tool name purely
+                # from the Part, so we rely on the registry being
+                # authoritative: if the tool name is in
+                # _agent_registry it's on-plan; if not, it MAY be a
+                # regular tool (fine) OR an off-registry agent call
+                # (divergence). We emit on not-in-registry only when
+                # the name matches the delegation shape we care about
+                # — today that's "not a known agent and not prefixed
+                # with the reporting-tool 'report_' namespace".
+                if name in self._agent_registry:
+                    continue
+                if name.startswith("report_"):
+                    # Reporting tools (report_task_started, etc.) are
+                    # protocol calls, not agent delegation. Skip.
+                    continue
+                # Heuristic: genuine ADK tool names usually include
+                # verbs (web_search, read_file) and rarely coincide
+                # with agent names. We keep the signal permissive —
+                # over-reporting once is fine; the steerer's INFO
+                # severity is absorbable.
+                off_registry.append(name)
+
+            for name in off_registry:
+                self._emit_divergence_signal(name, callback_context)
+
+        # Compose with user planner: their filter runs AFTER goldfive's
+        # so they see the structurally-clean parts.
+        if self._user_planner is not None:
+            try:
+                user_out = self._user_planner.process_planning_response(callback_context, kept)
+            except Exception as exc:  # noqa: BLE001 — user code; don't propagate
+                log.debug(
+                    "GoldfivePlanner: user_planner.process_planning_response raised: %s",
+                    exc,
+                )
+                user_out = None
+            if user_out is not None:
+                return list(user_out)
+
+        # Return ``kept`` when we modified the list; return ``None`` —
+        # ADK's "leave response untouched" signal — when we kept
+        # everything AND did not emit any divergence signals. The
+        # latter gate keeps this a no-op in the common case where no
+        # cancelled-ids / off-registry calls exist.
+        if stripped_count or (
+            self._agent_registry is not None
+            and self._steerer is not None
+            and any(getattr(p, "function_call", None) is not None for p in kept)
+        ):
+            return kept
+        return None
+
+    # ------------------------------------------------------------------
+    # Drift emission — plumbed through steerer._handle_drift to hit
+    # the same pipeline PlanReconciler / RUNAWAY_DELEGATION use.
+    # ------------------------------------------------------------------
+
+    def _emit_divergence_signal(self, off_registry_name: str, callback_context: Any) -> None:
+        """Emit a ``PLAN_DIVERGENCE`` drift for an off-registry function_call.
+
+        Non-blocking: the call still reaches ADK's dispatcher and is
+        executed (or fails naturally if the tool name is unknown). We
+        only SIGNAL the divergence so the steerer's policy can decide
+        whether to escalate via the intervention ladder (#142) or let
+        it ride.
+
+        Routed through ``steerer._handle_drift`` (pre-built
+        :class:`DriftEvent` path) matching the reconciler's
+        convention — :meth:`observe` would round-trip the event back
+        through classification and drop it.
+        """
+        steerer = self._steerer
+        if steerer is None:
+            return
+        try:
+            from goldfive.types import (  # noqa: PLC0415 — lazy
+                DriftEvent,
+                DriftKind,
+                DriftSeverity,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "GoldfivePlanner._emit_divergence_signal: cannot import DriftEvent: %s",
+                exc,
+            )
+            return
+
+        # Prefer state-derived current_task_id; fall back to empty.
+        state = _extract_state(callback_context)
+        current_task_id = _state_get(state, KEY_CURRENT_TASK_ID, "")
+
+        drift = DriftEvent(
+            kind=DriftKind.PLAN_DIVERGENCE,
+            severity=DriftSeverity.INFO,
+            detail=(
+                f"LLM emitted function_call to off-registry agent "
+                f"{off_registry_name!r} — call not blocked, signal only"
+            ),
+            current_task_id=current_task_id,
+            current_agent_id=off_registry_name,
+        )
+        handle = getattr(steerer, "_handle_drift", None)
+        if not callable(handle):
+            log.debug("GoldfivePlanner: steerer has no _handle_drift; divergence signal dropped")
+            return
+
+        session = self._session
+        # The steerer handler is async; since
+        # ``process_planning_response`` is SYNC by ADK's contract, we
+        # schedule on the running event loop. When no loop is running
+        # (hypothetical tests calling the method synchronously) fall
+        # through silently — the divergence signal is best-effort.
+        try:
+            import asyncio  # noqa: PLC0415 — lazy
+
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            log.debug(
+                "GoldfivePlanner: no running loop; divergence signal for %s dropped",
+                off_registry_name,
+            )
+            return
+
+        coro = handle(drift, session)
+        # Create a task; do not await (we are sync). The loop will
+        # drive the coroutine to completion; we attach a done-callback
+        # that swallows exceptions to keep the signal fire-and-forget.
+        task = loop.create_task(coro)
+
+        def _swallow(t: Any) -> None:
+            try:
+                t.result()
+            except Exception as exc:  # noqa: BLE001
+                log.debug("GoldfivePlanner: _handle_drift task raised: %s", exc)
+
+        task.add_done_callback(_swallow)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_state(ctx: Any) -> Any:
+    """Return the state mapping from a readonly or callback context.
+
+    ADK's :class:`ReadonlyContext` exposes ``.state`` as a
+    MappingProxyType; :class:`CallbackContext` exposes a ``State``
+    object (which also supports ``.get`` / ``__getitem__``). In both
+    cases treating the object as a Mapping works for our read-only
+    needs. For robustness against test stubs we also try
+    ``.session.state`` and ``._invocation_context.session.state``.
+    """
+    for attr_chain in (
+        ("state",),
+        ("session", "state"),
+        ("_invocation_context", "session", "state"),
+        ("invocation_context", "session", "state"),
+    ):
+        cur: Any = ctx
+        ok = True
+        for part in attr_chain:
+            try:
+                cur = getattr(cur, part, None)
+            except Exception:  # noqa: BLE001
+                cur = None
+            if cur is None:
+                ok = False
+                break
+        if ok and cur is not None:
+            return cur
+    return {}
+
+
+__all__ = [
+    "KEY_ACTIVE_STEER_BODY",
+    "KEY_CANCELLED_FUNCTION_CALL_IDS",
+    "KEY_GOALS_SUMMARY",
+    "GoldfivePlanner",
+]

--- a/tests/test_goldfive_planner.py
+++ b/tests/test_goldfive_planner.py
@@ -1,0 +1,697 @@
+"""Tests for :class:`goldfive.planners.goldfive_planner.GoldfivePlanner`
+and the plugin-side request-side instruction injection (goldfive#153).
+
+Skipped entirely when ``google.adk`` is not installed (optional dep).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    SESSION_CONTEXT_STATE_KEY,
+    SessionContext,
+    _inject_goldfive_planner_instruction,
+    make_adk_plugin,
+)
+from goldfive.adapters._adk_state_protocol import (  # noqa: E402
+    KEY_CURRENT_TASK_ID,
+    KEY_CURRENT_TASK_TITLE,
+)
+from goldfive.adapters.adk import (  # noqa: E402
+    GOLDFIVE_PLANNER_OPT_OUT_ATTR,
+    ADKAdapter,
+    _attach_goldfive_planner_to_tree,
+    _rebind_goldfive_planners,
+)
+from goldfive.planners.goldfive_planner import (  # noqa: E402
+    KEY_ACTIVE_STEER_BODY,
+    KEY_CANCELLED_FUNCTION_CALL_IDS,
+    KEY_GOALS_SUMMARY,
+    GoldfivePlanner,
+)
+from goldfive.types import DriftEvent, DriftKind, Session, Task  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_llm_agent(name: str = "agent_under_test") -> Any:
+    """Construct a bare ADK ``LlmAgent`` for planner attachment tests."""
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(
+        name=name,
+        model="fake-model",
+        description="Test agent",
+        instruction="Test.",
+    )
+
+
+@dataclass
+class _FakeReadonlyContext:
+    """Minimal ReadonlyContext stand-in — only needs ``.state`` for our planner."""
+
+    state: dict
+
+
+class _FakeFunctionCall:
+    """Duck-type of ``types.FunctionCall`` carrying id + name."""
+
+    def __init__(self, *, id: str, name: str, args: dict | None = None) -> None:
+        self.id = id
+        self.name = name
+        self.args = args or {}
+
+
+class _FakePart:
+    """Duck-type of ``types.Part`` with either ``function_call`` or ``text``."""
+
+    def __init__(
+        self,
+        *,
+        function_call: _FakeFunctionCall | None = None,
+        text: str = "",
+    ) -> None:
+        self.function_call = function_call
+        self.text = text
+
+
+class _RecordingSteerer:
+    """Async-capable steerer stub that records _handle_drift calls."""
+
+    def __init__(self) -> None:
+        self.drifts: list[DriftEvent] = []
+        self._sinks: list = []
+
+    async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+        self.drifts.append(drift)
+
+    async def observe(self, event: Any, session: Any) -> None:
+        pass
+
+
+class _RecordingUserPlanner:
+    """Test double for a user-supplied BasePlanner.
+
+    Records the calls and returns canned values so composition
+    order is observable.
+    """
+
+    def __init__(
+        self,
+        *,
+        build_return: str | None = "USER_BLOCK",
+        process_return: list[_FakePart] | None = None,
+    ) -> None:
+        # Import here so non-ADK test collection doesn't break.
+        from google.adk.planners.base_planner import BasePlanner  # type: ignore
+
+        # We intentionally DON'T inherit from BasePlanner as a class so we
+        # can be duck-typed; but to make isinstance(...) checks work we
+        # ALSO register via a tiny BasePlanner subclass wrapper.
+        self._BasePlanner = BasePlanner
+        self.build_calls: list[tuple] = []
+        self.process_calls: list[tuple] = []
+        self._build_return = build_return
+        self._process_return = process_return
+
+    def build_planning_instruction(self, readonly_context, llm_request):
+        self.build_calls.append((readonly_context, llm_request))
+        return self._build_return
+
+    def process_planning_response(self, callback_context, response_parts):
+        self.process_calls.append((callback_context, list(response_parts)))
+        return self._process_return
+
+
+def _make_user_planner(**kwargs) -> Any:
+    """Build a BasePlanner-subclass wrapper around :class:`_RecordingUserPlanner`."""
+    from google.adk.planners.base_planner import BasePlanner  # type: ignore
+
+    rec = _RecordingUserPlanner(**kwargs)
+
+    class _BPShim(BasePlanner):
+        def build_planning_instruction(self, readonly_context, llm_request):
+            return rec.build_planning_instruction(readonly_context, llm_request)
+
+        def process_planning_response(self, callback_context, response_parts):
+            return rec.process_planning_response(callback_context, response_parts)
+
+    shim = _BPShim()
+    # Stick the recorder on the shim so tests can read its call log.
+    shim.recorder = rec  # type: ignore[attr-defined]
+    return shim
+
+
+# ---------------------------------------------------------------------------
+# build_planning_instruction
+# ---------------------------------------------------------------------------
+
+
+def test_goldfive_planner_build_instruction_reads_state() -> None:
+    """State values render into the emitted orchestration block."""
+    planner = GoldfivePlanner()
+    state = {
+        KEY_CURRENT_TASK_ID: "task-42",
+        KEY_CURRENT_TASK_TITLE: "Summarise findings",
+        KEY_GOALS_SUMMARY: "deliver a 500-word brief",
+        KEY_ACTIVE_STEER_BODY: "focus on the cost angle",
+    }
+    ctx = _FakeReadonlyContext(state=state)
+    out = planner.build_planning_instruction(ctx, llm_request=None)
+
+    assert out is not None
+    assert "[GOLDFIVE ORCHESTRATION CONTEXT]" in out
+    assert "task-42" in out
+    assert "Summarise findings" in out
+    assert "deliver a 500-word brief" in out
+    assert "focus on the cost angle" in out
+
+
+def test_goldfive_planner_build_instruction_defaults_when_state_empty() -> None:
+    """Missing state keys render as ``(none)`` so the block is never empty."""
+    planner = GoldfivePlanner()
+    ctx = _FakeReadonlyContext(state={})
+    out = planner.build_planning_instruction(ctx, llm_request=None)
+
+    assert out is not None
+    assert "[GOLDFIVE ORCHESTRATION CONTEXT]" in out
+    # Every placeholder defaults to ``(none)`` when state is empty.
+    assert out.count("(none)") >= 3
+
+
+def test_goldfive_planner_build_instruction_tree_agnostic() -> None:
+    """No domain / presentation-agent vocabulary in the emitted block."""
+    planner = GoldfivePlanner()
+    state = {
+        KEY_CURRENT_TASK_ID: "t1",
+        KEY_CURRENT_TASK_TITLE: "Do research",
+        KEY_GOALS_SUMMARY: "investigate widgets",
+    }
+    out = (
+        planner.build_planning_instruction(_FakeReadonlyContext(state=state), llm_request=None)
+        or ""
+    )
+
+    banned = (
+        "presentation",
+        "presenter",
+        "slide",
+        "deck",
+        "researcher",
+        "coordinator",
+        "specialist",
+    )
+    low = out.lower()
+    for term in banned:
+        assert term not in low, (
+            f"tree-agnostic contract violated: emitted block contains {term!r}\nblock:\n{out}"
+        )
+
+
+def test_goldfive_planner_composes_with_user_planner_build() -> None:
+    """User planner's result is prepended ahead of goldfive's block."""
+    user_planner = _make_user_planner(build_return="USER_META_INSTRUCTION")
+    planner = GoldfivePlanner(user_planner=user_planner)
+    state = {KEY_CURRENT_TASK_ID: "t1", KEY_CURRENT_TASK_TITLE: "Step 1"}
+
+    out = (
+        planner.build_planning_instruction(_FakeReadonlyContext(state=state), llm_request=None)
+        or ""
+    )
+
+    assert "USER_META_INSTRUCTION" in out
+    assert "[GOLDFIVE ORCHESTRATION CONTEXT]" in out
+    # User block is prepended — its text appears before goldfive's.
+    assert out.index("USER_META_INSTRUCTION") < out.index("[GOLDFIVE ORCHESTRATION CONTEXT]")
+    # Composition called through.
+    assert len(user_planner.recorder.build_calls) == 1
+
+
+def test_goldfive_planner_handles_user_planner_raising() -> None:
+    """A raising user planner's error is swallowed; goldfive block still emits."""
+    from google.adk.planners.base_planner import BasePlanner  # type: ignore
+
+    class _Boom(BasePlanner):
+        def build_planning_instruction(self, *a, **kw):
+            raise RuntimeError("boom")
+
+        def process_planning_response(self, *a, **kw):
+            return None
+
+    planner = GoldfivePlanner(user_planner=_Boom())
+    out = planner.build_planning_instruction(_FakeReadonlyContext(state={}), llm_request=None) or ""
+    assert "[GOLDFIVE ORCHESTRATION CONTEXT]" in out
+
+
+# ---------------------------------------------------------------------------
+# process_planning_response
+# ---------------------------------------------------------------------------
+
+
+async def test_goldfive_planner_process_response_strips_cancelled_call_ids() -> None:
+    """function_call parts with cancelled ids are filtered out."""
+    planner = GoldfivePlanner()
+    state = {KEY_CANCELLED_FUNCTION_CALL_IDS: ["fc-x", "fc-y"]}
+    parts = [
+        _FakePart(function_call=_FakeFunctionCall(id="fc-x", name="do_a")),
+        _FakePart(text="some text"),
+        _FakePart(function_call=_FakeFunctionCall(id="fc-ok", name="do_b")),
+        _FakePart(function_call=_FakeFunctionCall(id="fc-y", name="do_c")),
+    ]
+    ctx = _FakeReadonlyContext(state=state)
+
+    out = planner.process_planning_response(ctx, parts)
+
+    assert out is not None
+    ids = [p.function_call.id for p in out if p.function_call is not None]
+    assert ids == ["fc-ok"]
+    # Non-function_call parts preserved.
+    assert any(p.text == "some text" for p in out)
+
+
+def test_goldfive_planner_process_response_noop_when_no_filters_fire() -> None:
+    """Return ``None`` when no cancels and no divergence signal — ADK skip-flag."""
+    planner = GoldfivePlanner()
+    ctx = _FakeReadonlyContext(state={})
+    parts = [_FakePart(text="hello")]
+    out = planner.process_planning_response(ctx, parts)
+    assert out is None
+
+
+async def test_goldfive_planner_process_response_emits_divergence_on_off_registry_agent() -> None:
+    """A function_call to an unknown agent name triggers PLAN_DIVERGENCE."""
+    steerer = _RecordingSteerer()
+    session = Session(run_id="r")
+    planner = GoldfivePlanner(
+        agent_registry=["researcher", "writer"],
+        steerer=steerer,
+        session=session,
+    )
+    parts = [
+        _FakePart(
+            function_call=_FakeFunctionCall(id="fc-1", name="researcher", args={}),
+        ),
+        _FakePart(
+            function_call=_FakeFunctionCall(id="fc-2", name="rogue_agent", args={}),
+        ),
+        # Reporting tool — must not trigger divergence.
+        _FakePart(
+            function_call=_FakeFunctionCall(
+                id="fc-3", name="report_task_started", args={"task_id": "t"}
+            ),
+        ),
+    ]
+    ctx = _FakeReadonlyContext(state={})
+
+    out = planner.process_planning_response(ctx, parts)
+
+    # All three parts retained; divergence is signal-only.
+    assert out is not None
+    names = [p.function_call.name for p in out]
+    assert names == ["researcher", "rogue_agent", "report_task_started"]
+
+    # Yield once so the scheduled _handle_drift task runs.
+    await asyncio.sleep(0)
+
+    assert len(steerer.drifts) == 1
+    drift = steerer.drifts[0]
+    assert drift.kind is DriftKind.PLAN_DIVERGENCE
+    assert "rogue_agent" in drift.detail
+    assert drift.current_agent_id == "rogue_agent"
+
+
+async def test_goldfive_planner_process_response_composes_user_planner() -> None:
+    """User planner's process runs after goldfive's structural filtering."""
+    transformed = [_FakePart(text="transformed_by_user")]
+    user_planner = _make_user_planner(process_return=transformed)
+
+    planner = GoldfivePlanner(user_planner=user_planner)
+    state = {KEY_CANCELLED_FUNCTION_CALL_IDS: ["fc-bad"]}
+    parts = [
+        _FakePart(function_call=_FakeFunctionCall(id="fc-bad", name="x")),
+        _FakePart(function_call=_FakeFunctionCall(id="fc-ok", name="y")),
+    ]
+    ctx = _FakeReadonlyContext(state=state)
+
+    out = planner.process_planning_response(ctx, parts)
+
+    # User planner saw the already-filtered list (fc-bad removed).
+    assert len(user_planner.recorder.process_calls) == 1
+    call_ctx, call_parts = user_planner.recorder.process_calls[0]
+    ids_passed_to_user = [p.function_call.id for p in call_parts if p.function_call]
+    assert ids_passed_to_user == ["fc-ok"]
+
+    # User planner's return wins the final output.
+    assert list(out) == list(transformed)
+    assert out[0].text == "transformed_by_user"
+
+
+# ---------------------------------------------------------------------------
+# Auto-attachment in goldfive.wrap (via ADKAdapter construction)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_attachment_attaches_goldfive_planner_to_single_agent() -> None:
+    """Single LlmAgent gets a GoldfivePlanner by default."""
+    agent = _make_llm_agent()
+    assert agent.planner is None
+    _attach_goldfive_planner_to_tree(agent)
+    assert isinstance(agent.planner, GoldfivePlanner)
+    assert agent.planner.user_planner is None
+
+
+def test_auto_attachment_composes_when_user_planner_already_set() -> None:
+    """Existing user planner is preserved via ``user_planner=`` composition."""
+    agent = _make_llm_agent()
+    user_planner = _make_user_planner()
+    agent.planner = user_planner
+    _attach_goldfive_planner_to_tree(agent)
+    assert isinstance(agent.planner, GoldfivePlanner)
+    assert agent.planner.user_planner is user_planner
+
+
+def test_auto_attachment_is_idempotent() -> None:
+    """Re-running attachment does not re-wrap a GoldfivePlanner."""
+    agent = _make_llm_agent()
+    _attach_goldfive_planner_to_tree(agent)
+    first = agent.planner
+    _attach_goldfive_planner_to_tree(agent)
+    assert agent.planner is first
+    # The second pass didn't wrap the first-pass planner as a user_planner.
+    assert agent.planner.user_planner is None
+
+
+def test_opt_out_marker_skips_attachment() -> None:
+    """Agents with ``_goldfive_planner_opt_out = True`` stay untouched."""
+    agent = _make_llm_agent()
+    setattr(agent, GOLDFIVE_PLANNER_OPT_OUT_ATTR, True)
+    _attach_goldfive_planner_to_tree(agent)
+    assert agent.planner is None
+
+
+def test_auto_attachment_covers_flat_specialists_tree() -> None:
+    """Every LlmAgent in a flat specialists tree gets a GoldfivePlanner."""
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    a = _make_llm_agent("a")
+    b = _make_llm_agent("b")
+    c = _make_llm_agent("c")
+    root = LlmAgent(
+        name="root",
+        model="fake-model",
+        description="root",
+        instruction="root",
+        sub_agents=[a, b, c],
+    )
+    _attach_goldfive_planner_to_tree(root)
+    for node in (root, a, b, c):
+        assert isinstance(node.planner, GoldfivePlanner), (
+            f"{node.name} did not receive a GoldfivePlanner"
+        )
+
+
+def test_auto_attachment_covers_deep_hierarchy() -> None:
+    """LlmAgents nested at depth 3+ get a GoldfivePlanner."""
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    leaf = _make_llm_agent("leaf")
+    mid = LlmAgent(
+        name="mid",
+        model="fake-model",
+        description="mid",
+        instruction="mid",
+        sub_agents=[leaf],
+    )
+    inner = LlmAgent(
+        name="inner",
+        model="fake-model",
+        description="inner",
+        instruction="inner",
+        sub_agents=[mid],
+    )
+    root = LlmAgent(
+        name="root",
+        model="fake-model",
+        description="root",
+        instruction="root",
+        sub_agents=[inner],
+    )
+    _attach_goldfive_planner_to_tree(root)
+    for node in (root, inner, mid, leaf):
+        assert isinstance(node.planner, GoldfivePlanner)
+
+
+def test_auto_attachment_skips_opt_out_but_walks_subtree() -> None:
+    """Opt-out marker skips only the marked agent; children still get attached."""
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    child = _make_llm_agent("child")
+    marked = LlmAgent(
+        name="marked",
+        model="fake-model",
+        description="marked",
+        instruction="marked",
+        sub_agents=[child],
+    )
+    setattr(marked, GOLDFIVE_PLANNER_OPT_OUT_ATTR, True)
+    _attach_goldfive_planner_to_tree(marked)
+    assert marked.planner is None
+    assert isinstance(child.planner, GoldfivePlanner)
+
+
+def test_rebind_populates_agent_registry_and_steerer() -> None:
+    """``_rebind_goldfive_planners`` flows the runtime collaborators in."""
+    agent = _make_llm_agent()
+    _attach_goldfive_planner_to_tree(agent)
+    planner = agent.planner
+    assert isinstance(planner, GoldfivePlanner)
+    assert planner._agent_registry is None
+    assert planner._steerer is None
+
+    steerer = _RecordingSteerer()
+    session = Session(run_id="r")
+    _rebind_goldfive_planners(
+        agent,
+        agent_registry=["agent_under_test", "helper"],
+        steerer=steerer,
+        session=session,
+    )
+    assert planner._agent_registry == {"agent_under_test", "helper"}
+    assert planner._steerer is steerer
+    assert planner._session is session
+
+
+def test_adk_adapter_init_attaches_goldfive_planner_to_tree() -> None:
+    """Constructing ``ADKAdapter`` auto-attaches GoldfivePlanner (non-degraded)."""
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    leaf = _make_llm_agent("leaf")
+    root = LlmAgent(
+        name="root",
+        model="fake-model",
+        description="root",
+        instruction="root",
+        sub_agents=[leaf],
+    )
+    ADKAdapter(root)
+    assert isinstance(root.planner, GoldfivePlanner)
+    assert isinstance(leaf.planner, GoldfivePlanner)
+
+
+# ---------------------------------------------------------------------------
+# Plugin-side request injection
+# ---------------------------------------------------------------------------
+
+
+class _FakeLlmRequestConfig:
+    def __init__(self) -> None:
+        self.system_instruction: str | None = None
+
+
+class _FakeLlmRequest:
+    """Minimal LlmRequest stub exposing ``append_instructions`` + ``config``."""
+
+    def __init__(self) -> None:
+        self.config = _FakeLlmRequestConfig()
+        self.calls: list[list[str]] = []
+
+    def append_instructions(self, instructions: list[str]) -> list:
+        self.calls.append(list(instructions))
+        if not self.config.system_instruction:
+            self.config.system_instruction = "\n\n".join(instructions)
+        else:
+            self.config.system_instruction += "\n\n" + "\n\n".join(instructions)
+        return []
+
+
+class _FakeInvocationContext:
+    def __init__(self, *, agent: Any, state: dict) -> None:
+        self.agent = agent
+
+        class _S:
+            def __init__(self, st):
+                self.state = st
+
+        self.session = _S(state)
+        self.invocation_id = "inv-1"
+        self.user_content = None
+        self.user_id = "u"
+        self.branch = None
+        self.run_config = None
+
+
+class _FakeCallbackContext:
+    """Stand-in for ADK's CallbackContext carrying ``_invocation_context``."""
+
+    def __init__(self, *, inv_ctx: _FakeInvocationContext) -> None:
+        self._invocation_context = inv_ctx
+        self.session = inv_ctx.session
+
+
+async def test_plugin_before_model_callback_injects_system_instruction() -> None:
+    """The plugin's ``before_model_callback`` appends GoldfivePlanner output."""
+    agent = _make_llm_agent()
+    _attach_goldfive_planner_to_tree(agent)
+
+    state = {
+        KEY_CURRENT_TASK_ID: "t-42",
+        KEY_CURRENT_TASK_TITLE: "Prepare brief",
+    }
+    inv_ctx = _FakeInvocationContext(agent=agent, state=state)
+    cb = _FakeCallbackContext(inv_ctx=inv_ctx)
+    llm_request = _FakeLlmRequest()
+
+    await _inject_goldfive_planner_instruction(
+        callback_context=cb,
+        llm_request=llm_request,
+    )
+
+    assert llm_request.config.system_instruction is not None
+    assert "[GOLDFIVE ORCHESTRATION CONTEXT]" in llm_request.config.system_instruction
+    assert "t-42" in llm_request.config.system_instruction
+    assert "Prepare brief" in llm_request.config.system_instruction
+
+
+async def test_plugin_skips_injection_for_plan_re_act_planner() -> None:
+    """Agent carrying a PlanReActPlanner is NOT double-injected by the plugin."""
+    from google.adk.planners.plan_re_act_planner import PlanReActPlanner  # type: ignore
+
+    agent = _make_llm_agent()
+    agent.planner = PlanReActPlanner()
+    # NOTE: we do NOT run _attach_goldfive_planner_to_tree — this test
+    # asks the plugin to skip even when the planner is NOT a
+    # GoldfivePlanner. ADK handles PlanReActPlanner natively via
+    # _nl_planning.py — the plugin's hook must be a no-op so the
+    # instruction isn't injected twice.
+
+    inv_ctx = _FakeInvocationContext(agent=agent, state={})
+    cb = _FakeCallbackContext(inv_ctx=inv_ctx)
+    llm_request = _FakeLlmRequest()
+
+    await _inject_goldfive_planner_instruction(
+        callback_context=cb,
+        llm_request=llm_request,
+    )
+
+    assert llm_request.config.system_instruction is None
+    assert llm_request.calls == []
+
+
+async def test_plugin_skips_injection_when_no_planner() -> None:
+    """Agent with no planner attached — plugin no-ops."""
+    agent = _make_llm_agent()
+    assert agent.planner is None
+
+    inv_ctx = _FakeInvocationContext(agent=agent, state={})
+    cb = _FakeCallbackContext(inv_ctx=inv_ctx)
+    llm_request = _FakeLlmRequest()
+
+    await _inject_goldfive_planner_instruction(
+        callback_context=cb,
+        llm_request=llm_request,
+    )
+    assert llm_request.config.system_instruction is None
+
+
+async def test_plugin_skips_injection_for_custom_base_planner_subclass() -> None:
+    """A user BasePlanner subclass (not GoldfivePlanner) is skipped by the hook.
+
+    Rationale: the hook is the GoldfivePlanner-specific workaround for
+    ADK's PlanReActPlanner-only request gate. Custom BasePlanner
+    subclasses are expected to work via ADK's response-side dispatch
+    only; the plugin must not unilaterally inject for them.
+    """
+    from google.adk.planners.base_planner import BasePlanner  # type: ignore
+
+    class _MyPlanner(BasePlanner):
+        def build_planning_instruction(self, ro, req):
+            return "USER_BLOCK"
+
+        def process_planning_response(self, cb, parts):
+            return None
+
+    agent = _make_llm_agent()
+    agent.planner = _MyPlanner()
+
+    inv_ctx = _FakeInvocationContext(agent=agent, state={})
+    cb = _FakeCallbackContext(inv_ctx=inv_ctx)
+    llm_request = _FakeLlmRequest()
+    await _inject_goldfive_planner_instruction(callback_context=cb, llm_request=llm_request)
+    assert llm_request.config.system_instruction is None
+
+
+async def test_plugin_injection_via_full_before_model_callback() -> None:
+    """End-to-end: running the plugin's real ``before_model_callback`` injects."""
+    plugin = make_adk_plugin(host_agent_name="h")
+    agent = _make_llm_agent()
+    _attach_goldfive_planner_to_tree(agent)
+
+    session = Session(run_id="r")
+    state = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session,
+            steerer=None,
+            task=Task(id="t-99", title="Build the thing"),
+            tool_handlers={},
+            host_agent_name="h",
+        )
+    }
+
+    inv_ctx = _FakeInvocationContext(agent=agent, state=state)
+    cb = _FakeCallbackContext(inv_ctx=inv_ctx)
+    llm_request = _FakeLlmRequest()
+
+    await plugin.before_model_callback(
+        callback_context=cb,
+        llm_request=llm_request,
+    )
+
+    # before_model_callback also re-seeds current_task via the state protocol;
+    # assert the instruction injection picked the new state up.
+    assert llm_request.config.system_instruction is not None
+    assert "t-99" in llm_request.config.system_instruction
+    assert "Build the thing" in llm_request.config.system_instruction
+
+
+async def test_plugin_injection_skips_built_in_planner() -> None:
+    """BuiltInPlanner (thinking-config only) is not injected for by the plugin."""
+    from google.adk.planners.built_in_planner import BuiltInPlanner  # type: ignore
+    from google.genai import types  # type: ignore
+
+    agent = _make_llm_agent()
+    agent.planner = BuiltInPlanner(thinking_config=types.ThinkingConfig())
+
+    inv_ctx = _FakeInvocationContext(agent=agent, state={})
+    cb = _FakeCallbackContext(inv_ctx=inv_ctx)
+    llm_request = _FakeLlmRequest()
+    await _inject_goldfive_planner_instruction(callback_context=cb, llm_request=llm_request)
+    assert llm_request.config.system_instruction is None


### PR DESCRIPTION
Closes #153.

## Summary

- Replaces user-message-injection steering with a **structural** BasePlanner subclass (`GoldfivePlanner`) auto-attached to every `LlmAgent` in the wrapped tree. Emits a tree-agnostic `[GOLDFIVE ORCHESTRATION CONTEXT]` block on every LLM call, built from `goldfive.*` session-state keys only (no domain vocabulary).
- **Subclasses `BasePlanner` directly, not `PlanReActPlanner`** — we don't want ReAct response filtering. ADK's `_nl_planning.py` gates request-side injection on `PlanReActPlanner` only, so the adapter's plugin `before_model_callback` takes over the injection: it detects GoldfivePlanner attachment, calls `build_planning_instruction`, and appends via `llm_request.append_instructions([...])`. Response-side `process_planning_response` runs natively via ADK's permissive response gate.
- Response-side structural filters: strip `function_call` parts whose ids are in `goldfive.cancelled_function_call_ids`; emit INFO-severity `PLAN_DIVERGENCE` drift (signal-only, non-blocking) on `function_call`s to agents outside the adapter's registry.
- **Composition with user-supplied planners** — if an agent already has a `BasePlanner`, `GoldfivePlanner(user_planner=...)` wraps it: user's `build_planning_instruction` is called first and **prepended** above goldfive's block; user's `process_planning_response` runs **after** goldfive's structural filters so the user planner sees a cleaned part list.
- **Per-agent opt-out**: `setattr(agent, '_goldfive_planner_opt_out', True)` skips attachment.

## Coordination

- **#152 state keys** — reads everything defaulted via `state.get(key, "")`; empty values render as `(none)`. No hard dependency.
- **#151 available_agents_tree** — uses the existing `ADKAdapter._available_agents` list for the off-registry check.
- **#154 / #155** — orthogonal.

## Test plan

- [x] `test_goldfive_planner.py` — 24 new tests covering:
  - `build_planning_instruction` reads state, defaults to `(none)`, tree-agnostic (banned-vocabulary assertion)
  - `process_planning_response` strips cancelled ids, emits PLAN_DIVERGENCE drift on off-registry agent calls (non-blocking), no-ops when no filter fires
  - Composition — user-planner called first on build, last on process; raising user planner is swallowed
  - Auto-attachment on single / flat-specialists / deep-hierarchy trees; opt-out skips a node but walks its subtree; idempotent on re-attach
  - Rebind flows steerer/session/registry into every GoldfivePlanner in the tree
  - Plugin injection end-to-end via real `before_model_callback`; skipped for PlanReActPlanner / BuiltInPlanner / custom BasePlanner / no-planner
- [x] Full existing suite: `818 passed, 46 skipped`
- [x] `ruff check` + `ruff format` clean