### PR TITLE
Goal-aware plan refine (closes #154)

### DIFF
--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -44,6 +44,7 @@ from goldfive.sinks import (
 )
 from goldfive.steerer import DefaultSteerer
 from goldfive.types import (
+    GOAL_SOURCE_USER_STEER,
     DriftEvent,
     DriftKind,
     DriftSeverity,
@@ -74,6 +75,7 @@ __all__ = [
     "EventSink",
     "ExecutionOutcome",
     "Executor",
+    "GOAL_SOURCE_USER_STEER",
     "GRPCSink",
     "Goal",
     "GoalDeriver",

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -29,6 +29,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
 from goldfive.types import (
+    GOAL_SOURCE_USER_STEER,
     DriftEvent,
     DriftKind,
     DriftSeverity,
@@ -236,19 +237,22 @@ You will receive:
 Decide between two outcomes:
 
 A. ABSORB. If the observed activity plausibly moves the run toward
-   the declared GOALS, emit a revised plan that REFLECTS the observed
-   activity. Existing tasks that correspond to completed invocations
-   should be marked COMPLETED; in-flight invocations may be marked
-   RUNNING. Invocations that do not correspond to any existing task
-   should be added as new tasks (with fresh stable ids) so the Gantt
-   view can show them.
+   the declared GOALS *and* preserves every STICKY goal (goals marked
+   ``[STICKY — from USER_STEER]`` — the operator has already steered
+   the plan toward them, so they cannot be silently dropped), emit a
+   revised plan that REFLECTS the observed activity. Existing tasks
+   that correspond to completed invocations should be marked
+   COMPLETED; in-flight invocations may be marked RUNNING. Invocations
+   that do not correspond to any existing task should be added as new
+   tasks (with fresh stable ids) so the Gantt view can show them.
 
-B. REJECT. If the observed activity is clearly off-goal — the tree
-   has wandered into work that doesn't advance any goal — return a
-   JSON object of the form ``{"reject": true, "reason": "..."}`` and
-   NOTHING else. The caller will escalate to human intervention. Only
-   reject when the divergence cannot be squared with the goals; when
-   in doubt, absorb.
+B. REJECT. If the observed activity CONTRADICTS the goals — the tree
+   has wandered into work that doesn't advance any goal, or (most
+   importantly) is actively undoing a STICKY goal the operator just
+   steered toward — return a JSON object of the form
+   ``{"reject": true, "reason": "..."}`` and NOTHING else. The caller
+   will escalate to human intervention. Only reject when the divergence
+   cannot be squared with the goals; when in doubt, absorb.
 
 Structural invariants (apply to the ABSORB path; REJECT bypasses
 validation):
@@ -628,14 +632,38 @@ class LLMPlanner:
 
     @staticmethod
     def _render_goals_block(goals: list[Goal]) -> str:
+        """Render goals for prompt consumption.
+
+        Goals sourced from a USER_STEER directive
+        (``source == GOAL_SOURCE_USER_STEER``) are annotated ``[STICKY —
+        from USER_STEER]`` so the planner-LLM sees them as operator-
+        authored and knows the refine validator (goldfive#154) will
+        reject revisions that silently drop them. Goals without an
+        explicit source render unchanged so legacy callers see the
+        exact same prompt shape.
+        """
         if not goals:
             return "- (no goals provided)"
         lines: list[str] = []
         for g in goals:
             gid = g.id or "(no-id)"
             summary = g.summary or "(no summary)"
-            lines.append(f"- [{gid}] {summary}")
+            if g.source == GOAL_SOURCE_USER_STEER:
+                lines.append(f"- [{gid}] {summary}  [STICKY — from USER_STEER]")
+            else:
+                lines.append(f"- [{gid}] {summary}")
         return "\n".join(lines)
+
+    @staticmethod
+    def _user_steer_goals(goals: list[Goal]) -> list[Goal]:
+        """Return the subset of ``goals`` added by a prior ``USER_STEER``.
+
+        Used by the refine validator (goldfive#154) to enforce the
+        "sticky goal" contract: a USER_STEER-sourced goal must remain
+        addressed by the revised plan, so a later drift cannot silently
+        unwind an operator steer by refining around it.
+        """
+        return [g for g in goals if g.source == GOAL_SOURCE_USER_STEER]
 
     @staticmethod
     def _render_agents_block(available_agents: list[str]) -> str:
@@ -779,6 +807,7 @@ class LLMPlanner:
         history_json = json.dumps(history, default=str)
         history_ids = json.dumps([t.id for t in completed])
         goals_block = self._render_goals_block(goals)
+        sticky_block = self._render_sticky_goals_block(goals)
         note = drift.detail or "(no steering note provided)"
         invariants = (
             "STRUCTURAL INVARIANTS (the validator will REJECT any response "
@@ -806,7 +835,10 @@ class LLMPlanner:
             "5. Do not introduce edges that create a cycle."
         )
         return (
-            f"Goals:\n{goals_block}\n\n"
+            f"CURRENT GOALS (the new PENDING tasks must still advance "
+            f"every goal, and MUST NOT silently drop any [STICKY] "
+            f"goal carried from a prior USER_STEER):\n{goals_block}\n\n"
+            f"{sticky_block}"
             f"Completed/Failed/Cancelled tasks (READ-ONLY CONTEXT — "
             "preserve these verbatim at the start of the returned plan; "
             f"do NOT repeat them in your response):\n{history_json}\n\n"
@@ -913,6 +945,129 @@ class LLMPlanner:
             "5. The task graph must be ACYCLIC. Do not introduce edges that would create a cycle.",
         ]
         return "\n".join(lines)
+
+    _GOAL_REFERENCE_STOPWORDS: frozenset[str] = frozenset(
+        {
+            "the",
+            "and",
+            "with",
+            "from",
+            "that",
+            "this",
+            "have",
+            "will",
+            "into",
+            "your",
+            "about",
+            "also",
+            "ensure",
+            "make",
+            "keep",
+            "should",
+            "must",
+            "while",
+            "their",
+            "there",
+            "them",
+            "then",
+            "than",
+            "when",
+            "what",
+            "which",
+            "some",
+            "goal",
+            "goals",
+            "task",
+            "tasks",
+            "plan",
+            "plans",
+            "focus",
+            "draft",
+            "review",
+            "final",
+            "work",
+            "round",
+        }
+    )
+
+    @classmethod
+    def _goal_summary_tokens(cls, goal: Goal) -> set[str]:
+        """Tokenise a goal summary into lowercase words of length >= 4
+        that aren't trivial stopwords. A heuristic by design — see
+        :meth:`_check_user_steer_goals_preserved` for the rationale.
+        """
+        tokens: set[str] = set()
+        summary = goal.summary or ""
+        for raw in re.split(r"[^A-Za-z0-9_]+", summary):
+            w = raw.lower().strip()
+            if len(w) >= 4 and w not in cls._GOAL_REFERENCE_STOPWORDS:
+                tokens.add(w)
+        return tokens
+
+    @classmethod
+    def _check_user_steer_goals_preserved(
+        cls,
+        revised: Plan,
+        goals: list[Goal],
+    ) -> str:
+        """Ensure USER_STEER-sourced goals still appear in the revision.
+
+        Returns ``""`` when every USER_STEER goal is referenced by the
+        revised plan's task titles / descriptions (or is present in
+        ``revised.goal_ids``), and a non-empty error string otherwise.
+        The retry loop feeds that string back into the correction
+        prompt so the LLM gets a precise diagnosis of which goal it
+        silently dropped. See goldfive#154.
+
+        The "reference" check is token-based and uses *discriminative*
+        tokens only: a token from a sticky goal's summary that also
+        appears in a non-sticky goal's summary is too generic to be a
+        signal (e.g. "goldfish" in a post-about-goldfish session is
+        present in every goal and so cannot tell you whether the
+        sticky goal was addressed). Discriminative tokens are summary
+        tokens that DO NOT appear in any non-sticky goal. If a sticky
+        goal has no discriminative tokens (the operator steered in a
+        way indistinguishable from the base goals), we fall back to a
+        lenient "goal id in revised.goal_ids" check -- better to let
+        the revision through than to reject forever on ambiguous text.
+        """
+        sticky = cls._user_steer_goals(goals)
+        if not sticky:
+            return ""
+        non_sticky_tokens: set[str] = set()
+        for g in goals:
+            if g.source == GOAL_SOURCE_USER_STEER:
+                continue
+            non_sticky_tokens |= cls._goal_summary_tokens(g)
+        plan_text = " ".join(f"{t.id} {t.title} {t.description}".lower() for t in revised.tasks)
+        revised_goal_ids = {gid.lower() for gid in revised.goal_ids if gid}
+        dropped: list[str] = []
+        for g in sticky:
+            # Goal-id match on the revised plan envelope is a strong,
+            # unambiguous signal — respect it first.
+            if g.id and g.id.lower() in revised_goal_ids and g.id.lower() in plan_text:
+                continue
+            discriminative = cls._goal_summary_tokens(g) - non_sticky_tokens
+            # Fallback 1: the goal id itself is discriminative.
+            if g.id and g.id.lower() not in non_sticky_tokens:
+                discriminative.add(g.id.lower())
+            if not discriminative:
+                # No tokens unique to this sticky goal; we cannot
+                # distinguish it from the base goals via text alone.
+                # Be lenient and accept the revision.
+                continue
+            if any(tok in plan_text for tok in discriminative):
+                continue
+            dropped.append(f"[{g.id or '(no-id)'}] {g.summary}")
+        if not dropped:
+            return ""
+        joined = "; ".join(dropped)
+        return (
+            "revision silently drops USER_STEER goal(s) (no task "
+            f"references them): {joined}. Operator steers are sticky — "
+            "add PENDING tasks that explicitly advance these goals, "
+            "or emit the reject sentinel if they cannot be reconciled."
+        )
 
     @staticmethod
     def _build_correction_prompt(base_prompt: str, error: str) -> str:
@@ -1106,6 +1261,26 @@ class LLMPlanner:
                 if attempt < attempts:
                     user_prompt = self._build_correction_prompt(base_user_prompt, last_error)
                 continue
+            # Goal-awareness check (#154): any USER_STEER-sourced goals
+            # that the prior plan was carrying must still be addressed
+            # by the revised plan. Silently dropping them would let a
+            # later drift unwind an operator steer -- the very failure
+            # mode this issue was filed against. Treat a drop as a
+            # validator failure so the retry loop feeds the LLM an
+            # explicit correction message.
+            goal_error = self._check_user_steer_goals_preserved(revised, goals)
+            if goal_error:
+                last_error = goal_error
+                log.warning(
+                    "%s: attempt %d/%d: %s",
+                    log_prefix,
+                    attempt,
+                    attempts,
+                    last_error,
+                )
+                if attempt < attempts:
+                    user_prompt = self._build_correction_prompt(base_user_prompt, last_error)
+                continue
             return revised, "", False
         return None, last_error, False
 
@@ -1146,22 +1321,27 @@ class LLMPlanner:
         drift_json = json.dumps(drift_payload, default=str)
         goals_block = self._render_goals_block(goals)
         invariants_block = self._render_structural_invariants_block(plan)
+        sticky_block = self._render_sticky_goals_block(goals)
         observed_block = ""
         if observed_actions is not None:
             observed_block = (
                 f"{self._render_observed_actions_block(observed_actions)}\n\n"
                 "The tree may have diverged from the planned dispatch because it "
                 "found a better path. Decide:\n"
-                "- If the observed activity moves toward the goals: produce a "
-                "revised plan that REFLECTS the observed activity (mark matching "
-                "tasks COMPLETED/RUNNING, add new tasks for agent invocations "
-                "not already in the plan).\n"
-                "- If the observed activity does NOT move toward the goals: "
+                "- ABSORB: if the observed activity moves toward the GOALS "
+                "(and preserves every STICKY goal), produce a revised plan "
+                "that REFLECTS the observed activity (mark matching tasks "
+                "COMPLETED/RUNNING, add new tasks for agent invocations not "
+                "already in the plan).\n"
+                "- REJECT: if the observed activity CONTRADICTS any goal -- "
+                "especially any STICKY goal added by a prior USER_STEER -- "
                 'return a JSON object of the form {"reject": true, "reason": '
                 '"..."} (the caller will escalate to human intervention).\n\n'
             )
         return (
-            f"Goals:\n{goals_block}\n\n"
+            f"CURRENT GOALS (the revision must still advance every goal, "
+            f"and MUST NOT silently drop any [STICKY] goal):\n{goals_block}\n\n"
+            f"{sticky_block}"
             f"Current plan:\n{plan_json}\n\n"
             f"Drift event:\n{drift_json}\n\n"
             f"{observed_block}"
@@ -1171,6 +1351,31 @@ class LLMPlanner:
             "is warranted, respond with the current plan unchanged. Respond "
             "with JSON only."
         )
+
+    @classmethod
+    def _render_sticky_goals_block(cls, goals: list[Goal]) -> str:
+        """Render a dedicated STICKY GOALS block when sticky goals exist.
+
+        Returns ``""`` when there are no USER_STEER-sourced goals, so
+        legacy prompts for non-steered sessions are unchanged. When at
+        least one sticky goal is present, surface an explicit section
+        naming them so the LLM cannot "forget" that dropping them will
+        fail validation (goldfive#154).
+        """
+        sticky = cls._user_steer_goals(goals)
+        if not sticky:
+            return ""
+        lines = [
+            "STICKY GOALS (added by USER_STEER — the refine validator will "
+            "REJECT any revision that does not include at least one task "
+            "advancing each of these; if the drift IRRECONCILABLY "
+            'contradicts a sticky goal, emit {"reject": true, "reason": '
+            '"..."} instead of silently dropping it):'
+        ]
+        for g in sticky:
+            gid = g.id or "(no-id)"
+            lines.append(f"- [{gid}] {g.summary}")
+        return "\n".join(lines) + "\n\n"
 
     # ---- Planner protocol ------------------------------------------------
 
@@ -1285,13 +1490,24 @@ class LLMPlanner:
             if use_divergence_prompt
             else self._refine_system_prompt
         )
+        # Allow the reject sentinel whenever the LLM might legitimately
+        # conclude the drift cannot be reconciled with the current goals
+        # (goldfive#154). That's always true on the PLAN_DIVERGENCE +
+        # observed_actions path (it's the reconciler's explicit
+        # ABSORB/REJECT contract from #144), and also true whenever the
+        # session carries a sticky USER_STEER goal -- an unrelated drift
+        # might surface work that irreconcilably contradicts the
+        # operator's steer, and escalating via reject is cleaner than
+        # exhausting retries. Other callers keep the legacy "parse or
+        # bust" semantics.
+        allow_reject = use_divergence_prompt or bool(self._user_steer_goals(goals))
         revised, last_error, rejected = await self._call_and_validate_refine(
             system_prompt=system_prompt,
             base_user_prompt=base_user_prompt,
             prior_plan=plan,
             goals=goals,
             log_prefix="LLMPlanner.refine",
-            allow_reject=use_divergence_prompt,
+            allow_reject=allow_reject,
         )
         if rejected:
             # LLM judged the divergence off-goal. Return None so the
@@ -1372,9 +1588,13 @@ class LLMPlanner:
             else json.dumps({"id": loop_id})
         )
         goals_block = self._render_goals_block(goals)
+        sticky_block = self._render_sticky_goals_block(goals)
         invariants_block = self._render_structural_invariants_block(plan)
         return (
-            f"Goals:\n{goals_block}\n\n"
+            f"CURRENT GOALS (the revised plan must still advance every "
+            f"goal, and MUST NOT silently drop any [STICKY] goal):\n"
+            f"{goals_block}\n\n"
+            f"{sticky_block}"
             f"Already-finished tasks (preserve verbatim):\n"
             f"{json.dumps(history, default=str)}\n\n"
             f"LOOPING task (must appear in the returned plan with "
@@ -1667,6 +1887,15 @@ class LLMPlanner:
             merged_plan.validate(for_revision=True, prior=plan)
         except ValueError as exc:
             return None, f"validator rejected revision: {exc}"
+        # Preserve earlier USER_STEER goals through successive steers
+        # (goldfive#154). The current steer's note is handed in via
+        # ``drift.detail``; any *prior* USER_STEER goals still on
+        # ``session.goals`` must still be addressed by the new PENDING
+        # tasks, otherwise a later steer would silently unwind an
+        # earlier one.
+        goal_error = self._check_user_steer_goals_preserved(merged_plan, goals)
+        if goal_error:
+            return None, goal_error
         return merged_plan, ""
 
 

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -407,12 +407,26 @@ class Plan:
         return stages
 
 
+#: Conventional value for :attr:`Goal.source` indicating a goal was added
+#: by a ``USER_STEER`` directive (goldfive#152 / #154). Goals carrying
+#: this source are treated as "sticky": ``LLMPlanner.refine`` will
+#: reject any revision whose tasks silently drop the goal, so later
+#: drifts cannot unwind an operator steer by merely refining around it.
+GOAL_SOURCE_USER_STEER: str = "USER_STEER"
+
+
 @dataclasses.dataclass
 class Goal:
     id: str
     summary: str
     success_predicate: Callable[[Session], bool] | None = None
     metadata: dict[str, str] = dataclasses.field(default_factory=dict)
+    #: Provenance of the goal. Empty string for goals derived from the
+    #: original user input; :data:`GOAL_SOURCE_USER_STEER` for goals
+    #: added by a ``USER_STEER`` (operator steer) -- these are "sticky"
+    #: and the planner will reject refines that silently drop them
+    #: (goldfive#154).
+    source: str = ""
 
 
 @dataclasses.dataclass

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -378,8 +378,11 @@ async def test_llm_planner_refine_preserves_completed_tasks() -> None:
     assert revised.revision_index == 1
 
     # The prompt included goals, the current plan JSON, and the drift.
+    # The goals section header was renamed from "Goals:" to
+    # "CURRENT GOALS" by goldfive#154 so the planner-LLM treats the
+    # section as operator-authored rather than informational.
     _system, user_prompt, _model = stub.calls[0]
-    assert "Goals:" in user_prompt
+    assert "CURRENT GOALS" in user_prompt
     assert "Current plan:" in user_prompt
     assert "Drift event:" in user_prompt
     assert "new_work_discovered" in user_prompt

--- a/tests/test_planner_goal_aware_refine.py
+++ b/tests/test_planner_goal_aware_refine.py
@@ -1,0 +1,664 @@
+"""Tests for goal-aware ``LLMPlanner.refine`` (goldfive#154).
+
+Scope:
+
+* Every refine kind's prompt includes a ``CURRENT GOALS`` section that
+  enumerates ``session.goals`` (dependency on #152 which populates them).
+* ``PLAN_DIVERGENCE`` refine with ``observed_actions`` that contradict
+  the current goals takes the reject path (``refine()`` returns ``None``
+  so the steerer escalates via the intervention ladder, goldfive#142).
+* ``PLAN_DIVERGENCE`` refine with ``observed_actions`` that align with
+  the goals absorbs normally into a revised plan.
+* Successive ``USER_STEER`` refines do NOT silently drop goals added by
+  earlier USER_STEERs (sticky-goal contract; the planner validator
+  catches a drop and the retry loop re-prompts).
+* A missing USER_STEER goal in the refined plan triggers the retry loop
+  and is corrected on the second attempt.
+* NO COOLDOWN: PLAN_DIVERGENCE refine fired milliseconds after a
+  USER_STEER still runs normally and absorbs a goal-aligned
+  ``observed_actions`` batch. This is a regression-test-worthy
+  constraint per the issue's explicit user directive — steering is
+  always active, never time-suppressed.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from goldfive.planner import LLMPlanner
+from goldfive.types import (
+    GOAL_SOURCE_USER_STEER,
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    ObservedAction,
+    Plan,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_goals() -> list[Goal]:
+    """Original session goals (from the user's first message)."""
+    return [
+        Goal(id="g1", summary="Draft a blog post about goldfish."),
+        Goal(id="g2", summary="Get one round of editorial review."),
+    ]
+
+
+def _goals_with_user_steer() -> list[Goal]:
+    """Session goals after a USER_STEER ("focus on tropical habitats")."""
+    return [
+        Goal(id="g1", summary="Draft a blog post about goldfish."),
+        Goal(id="g2", summary="Get one round of editorial review."),
+        Goal(
+            id="steer1",
+            summary="Focus the draft on tropical goldfish habitats.",
+            source=GOAL_SOURCE_USER_STEER,
+        ),
+    ]
+
+
+def _running_plan() -> Plan:
+    """Plan with one COMPLETED, one RUNNING, one PENDING task."""
+    return Plan(
+        id="plan-1",
+        run_id="run-1",
+        goal_ids=["g1", "g2"],
+        tasks=[
+            Task(
+                id="research",
+                title="Research goldfish facts",
+                description="Gather facts about goldfish.",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="draft",
+                title="Draft the post",
+                description="Write a 500-word draft.",
+                assignee_agent_id="writer",
+                status=TaskStatus.RUNNING,
+            ),
+            Task(
+                id="review",
+                title="Review the draft",
+                description="Produce reviewer comments.",
+                assignee_agent_id="editor",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft"),
+            TaskEdge(from_task_id="draft", to_task_id="review"),
+        ],
+        summary="Draft and review a goldfish blog post.",
+        revision_index=0,
+    )
+
+
+def _aligned_observed_actions() -> list[ObservedAction]:
+    """Tree activity consistent with goals and sticky USER_STEER goal."""
+    base = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+    return [
+        ObservedAction(
+            agent_name="researcher",
+            invocation_id="inv-1",
+            parent_invocation_id="",
+            started_at=base,
+            completed_at=base + timedelta(seconds=30),
+            status="completed",
+            summary="Gathered facts about tropical goldfish habitats.",
+        ),
+        ObservedAction(
+            agent_name="writer",
+            invocation_id="inv-2",
+            parent_invocation_id="",
+            started_at=base + timedelta(seconds=31),
+            completed_at=None,
+            status="running",
+            summary="Drafting the tropical-habitat section.",
+        ),
+    ]
+
+
+def _contradicting_observed_actions() -> list[ObservedAction]:
+    """Tree activity contradicting the USER_STEER goal.
+
+    Operator steered toward tropical habitats; tree is instead writing
+    about arctic environments (observable contradiction the LLM should
+    catch via the reject sentinel).
+    """
+    base = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+    return [
+        ObservedAction(
+            agent_name="writer",
+            invocation_id="inv-x",
+            parent_invocation_id="",
+            started_at=base,
+            completed_at=base + timedelta(seconds=10),
+            status="completed",
+            summary=("Drafted section on arctic fish habitats and cold-water survival strategies."),
+        ),
+    ]
+
+
+def _absorb_revision_preserving_sticky() -> str:
+    """A revision that absorbs observed activity AND preserves the
+    USER_STEER goal (tasks reference "tropical")."""
+    return json.dumps(
+        {
+            "summary": "Draft the tropical-habitat-focused goldfish post.",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research goldfish facts",
+                    "description": "Gather facts about tropical goldfish.",
+                    "assignee_agent_id": "researcher",
+                    "status": "COMPLETED",
+                },
+                {
+                    "id": "draft",
+                    "title": "Draft the post",
+                    "description": "Write the tropical-habitat section.",
+                    "assignee_agent_id": "writer",
+                    "status": "RUNNING",
+                },
+                {
+                    "id": "review",
+                    "title": "Review the draft",
+                    "description": "Produce reviewer comments on tropical focus.",
+                    "assignee_agent_id": "editor",
+                    "status": "PENDING",
+                },
+            ],
+            "edges": [
+                {"from_task_id": "research", "to_task_id": "draft"},
+                {"from_task_id": "draft", "to_task_id": "review"},
+            ],
+        }
+    )
+
+
+def _absorb_revision_dropping_sticky() -> str:
+    """A revision that absorbs observed activity BUT silently drops the
+    USER_STEER goal (no task references "tropical" / "habitats"/
+    "steer1")."""
+    return json.dumps(
+        {
+            "summary": "Draft a generic goldfish post.",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research goldfish facts",
+                    "description": "Gather generic facts about goldfish.",
+                    "assignee_agent_id": "researcher",
+                    "status": "COMPLETED",
+                },
+                {
+                    "id": "draft",
+                    "title": "Draft the post",
+                    "description": "Write a 500-word draft.",
+                    "assignee_agent_id": "writer",
+                    "status": "RUNNING",
+                },
+                {
+                    "id": "review",
+                    "title": "Review the draft",
+                    "description": "Produce reviewer comments.",
+                    "assignee_agent_id": "editor",
+                    "status": "PENDING",
+                },
+            ],
+            "edges": [
+                {"from_task_id": "research", "to_task_id": "draft"},
+                {"from_task_id": "draft", "to_task_id": "review"},
+            ],
+        }
+    )
+
+
+class _StubLLM:
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        self.calls.append((system, user, model))
+        return self.response
+
+
+class _ScriptedLLM:
+    def __init__(self, responses: list[str]) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        self.calls.append((system, user, model))
+        if not self.responses:
+            raise AssertionError("scripted LLM called more times than expected")
+        return self.responses.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# 1. Prompt structure: CURRENT GOALS section
+# ---------------------------------------------------------------------------
+
+
+async def test_refine_prompt_includes_goals_section() -> None:
+    """Every refine kind's user prompt must include a CURRENT GOALS
+    section enumerating session.goals. Without this, goal-aware refine
+    decisions are ungrounded."""
+    kinds = [
+        DriftKind.PLAN_DIVERGENCE,
+        DriftKind.TOOL_ERROR,
+        DriftKind.AGENT_REFUSAL,
+        DriftKind.NEW_WORK_DISCOVERED,
+        DriftKind.LOOPING_TOOL_CALL,
+        DriftKind.USER_STEER,
+    ]
+    for kind in kinds:
+        stub = _StubLLM(_absorb_revision_preserving_sticky())
+        planner = LLMPlanner(call_llm=stub)
+        drift = DriftEvent(
+            kind=kind,
+            severity=DriftSeverity.WARNING,
+            detail="test drift",
+            current_task_id="draft",
+        )
+        await planner.refine(
+            plan=_running_plan(),
+            drift=drift,
+            goals=_goals_with_user_steer(),
+        )
+        # At least one call happened; inspect the first user prompt.
+        assert stub.calls, f"LLM not called for drift kind {kind.value}"
+        _system, user_prompt, _model = stub.calls[0]
+        # Every goal is enumerated by id+summary.
+        assert "g1" in user_prompt, f"goal g1 missing from prompt for {kind.value}"
+        assert "g2" in user_prompt, f"goal g2 missing from prompt for {kind.value}"
+        assert "steer1" in user_prompt, f"steer1 goal missing for {kind.value}"
+        # The dedicated CURRENT GOALS header is present (capitalised by
+        # convention so it's easy to spot in logs).
+        assert "CURRENT GOALS" in user_prompt, (
+            f"CURRENT GOALS section missing from prompt for {kind.value}"
+        )
+        # Sticky goals are flagged so the LLM cannot miss them.
+        assert "STICKY" in user_prompt, f"STICKY marker missing for USER_STEER goal on {kind.value}"
+
+
+# ---------------------------------------------------------------------------
+# 2. PLAN_DIVERGENCE reject path on goal contradiction
+# ---------------------------------------------------------------------------
+
+
+async def test_plan_divergence_refine_rejects_on_goal_contradiction() -> None:
+    """When observed activity contradicts a sticky USER_STEER goal, the
+    LLM emits the reject sentinel and refine returns None (the steerer
+    escalates to Level 4 via the intervention ladder, #142)."""
+    stub = _StubLLM(
+        json.dumps(
+            {
+                "reject": True,
+                "reason": (
+                    "tree is writing about arctic habitats; USER_STEER "
+                    "sticky goal steer1 demands tropical focus"
+                ),
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=stub)
+
+    emitted: list[DriftEvent] = []
+
+    async def capture(d: DriftEvent) -> None:
+        emitted.append(d)
+
+    planner.set_drift_emitter(capture)
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="tree wandered off-steer",
+        current_task_id="draft",
+    )
+    revised = await planner.refine(
+        plan=_running_plan(),
+        drift=drift,
+        goals=_goals_with_user_steer(),
+        observed_actions=_contradicting_observed_actions(),
+    )
+    assert revised is None
+    # Reject is a successful decision, not a validation failure -- no
+    # REFINE_VALIDATION_FAILED drift emitted.
+    assert emitted == []
+    # Exactly one LLM call; no retry on a valid reject.
+    assert len(stub.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. PLAN_DIVERGENCE absorb path on goal alignment
+# ---------------------------------------------------------------------------
+
+
+async def test_plan_divergence_refine_absorbs_on_goal_alignment() -> None:
+    """When observed activity aligns with goals (including sticky
+    USER_STEER goals), the LLM absorbs it into a revised plan and
+    refine() returns the revision with updated revision metadata."""
+    stub = _StubLLM(_absorb_revision_preserving_sticky())
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="tree executing extra invocations",
+        current_task_id="draft",
+    )
+    revised = await planner.refine(
+        plan=_running_plan(),
+        drift=drift,
+        goals=_goals_with_user_steer(),
+        observed_actions=_aligned_observed_actions(),
+    )
+    assert revised is not None
+    assert revised.revision_index == 1
+    assert revised.revision_kind == DriftKind.PLAN_DIVERGENCE.value
+    # Sticky goal is addressed: at least one task description mentions
+    # "tropical" (the operator's steer keyword).
+    plan_text = " ".join(f"{t.title} {t.description}".lower() for t in revised.tasks)
+    assert "tropical" in plan_text
+
+
+# ---------------------------------------------------------------------------
+# 4. USER_STEER refine preserves prior USER_STEER goals
+# ---------------------------------------------------------------------------
+
+
+async def test_user_steer_refine_preserves_prior_user_steer_goals() -> None:
+    """A second USER_STEER ("add a code example") must not silently drop
+    the first steer's sticky goal ("focus on tropical habitats"). The
+    validator checks each prior USER_STEER goal is still referenced."""
+    # First steer has already been applied and recorded as a sticky goal
+    # on session.goals. A new steer fires now, adding new pending work.
+    goals_after_first_steer = _goals_with_user_steer()
+
+    # The LLM emits a plan that preserves "tropical" (prior steer) and
+    # adds a "code_example" task (the new steer). Sticky check passes.
+    good_response = json.dumps(
+        {
+            "summary": "Add a code example to the tropical-habitat post.",
+            "tasks": [
+                {
+                    "id": "code_example",
+                    "title": "Add a code example about tropical goldfish tank setup",
+                    "description": (
+                        "Include a runnable snippet showing tropical tank temperature control."
+                    ),
+                    "assignee_agent_id": "writer",
+                },
+                {
+                    "id": "review_new",
+                    "title": "Review the new section",
+                    "description": "Verify the code example and tropical framing.",
+                    "assignee_agent_id": "editor",
+                },
+            ],
+            "edges": [
+                {"from_task_id": "code_example", "to_task_id": "review_new"},
+            ],
+        }
+    )
+    stub = _StubLLM(good_response)
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="also add a code example",
+        current_task_id="draft",
+    )
+    # Start from a plan where draft is COMPLETED so the USER_STEER
+    # merge path has something to preserve.
+    plan = _running_plan()
+    plan.tasks[1].status = TaskStatus.COMPLETED  # draft done
+    plan.tasks[2].status = TaskStatus.COMPLETED  # review done
+
+    revised = await planner.refine(
+        plan=plan,
+        drift=drift,
+        goals=goals_after_first_steer,
+    )
+    assert revised is not None
+    # New PENDING tasks reference the prior steer (tropical).
+    new_pending_text = " ".join(
+        f"{t.title} {t.description}".lower()
+        for t in revised.tasks
+        if t.status is TaskStatus.PENDING
+    )
+    assert "tropical" in new_pending_text
+    # And the new steer's work is there.
+    assert "code" in new_pending_text or "example" in new_pending_text
+
+
+# ---------------------------------------------------------------------------
+# 5. Silently-dropped USER_STEER goal triggers retry loop
+# ---------------------------------------------------------------------------
+
+
+async def test_refine_output_missing_user_steer_goal_triggers_retry() -> None:
+    """If the LLM's first revision silently drops the sticky USER_STEER
+    goal, the validator feeds a correction message into the prompt and
+    the second attempt (which honours the sticky goal) succeeds."""
+    scripted = _ScriptedLLM(
+        [
+            _absorb_revision_dropping_sticky(),  # no reference to tropical
+            _absorb_revision_preserving_sticky(),  # tasks mention tropical
+        ]
+    )
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=2)
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="tree diverged",
+        current_task_id="draft",
+    )
+    revised = await planner.refine(
+        plan=_running_plan(),
+        drift=drift,
+        goals=_goals_with_user_steer(),
+        observed_actions=_aligned_observed_actions(),
+    )
+    assert revised is not None
+    assert len(scripted.calls) == 2
+    _sys1, _first_user, _m1 = scripted.calls[0]
+    _sys2, second_user, _m2 = scripted.calls[1]
+    # The retry prompt tells the LLM exactly what it missed.
+    assert "PREVIOUS ATTEMPT FAILED" in second_user
+    # And diagnoses the sticky-goal drop specifically.
+    assert "USER_STEER" in second_user or "sticky" in second_user.lower()
+    # Second-attempt plan references tropical.
+    plan_text = " ".join(f"{t.title} {t.description}".lower() for t in revised.tasks)
+    assert "tropical" in plan_text
+
+
+async def test_refine_exhausted_retries_on_sticky_goal_drop_emits_validation_drift() -> None:
+    """If the LLM NEVER respects the sticky goal, retries exhaust and a
+    REFINE_VALIDATION_FAILED drift is emitted (so the ladder can
+    escalate to human intervention). Refine returns None."""
+    scripted = _ScriptedLLM(
+        [
+            _absorb_revision_dropping_sticky(),
+            _absorb_revision_dropping_sticky(),
+        ]
+    )
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=2)
+    emitted: list[DriftEvent] = []
+
+    async def capture(d: DriftEvent) -> None:
+        emitted.append(d)
+
+    planner.set_drift_emitter(capture)
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="diverged",
+        current_task_id="draft",
+    )
+    revised = await planner.refine(
+        plan=_running_plan(),
+        drift=drift,
+        goals=_goals_with_user_steer(),
+        observed_actions=_aligned_observed_actions(),
+    )
+    assert revised is None
+    assert len(emitted) == 1
+    assert emitted[0].kind is DriftKind.REFINE_VALIDATION_FAILED
+
+
+# ---------------------------------------------------------------------------
+# 6. NO cooldown: refine fires immediately post-USER_STEER (regression)
+# ---------------------------------------------------------------------------
+
+
+async def test_no_cooldown_refine_fires_immediately_post_user_steer() -> None:
+    """Explicit regression test for the "NO cooldown" user directive
+    (goldfive#154). A PLAN_DIVERGENCE refine triggered one second after
+    a USER_STEER must run normally — no time-windowing, no suppression.
+
+    The durability mechanism is goal-aware refine rejecting
+    contradictions, not a time-based mute. Steering should always be
+    active."""
+    # Scenario: USER_STEER was applied at t0. One second later the
+    # reconciler flags PLAN_DIVERGENCE with aligned observed activity.
+    # The refine must absorb normally -- no "too soon after a steer"
+    # suppression.
+    stub = _StubLLM(_absorb_revision_preserving_sticky())
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="tree executing extra invocations (1s after USER_STEER)",
+        current_task_id="draft",
+    )
+    revised = await planner.refine(
+        plan=_running_plan(),
+        drift=drift,
+        goals=_goals_with_user_steer(),  # sticky USER_STEER goal present
+        observed_actions=_aligned_observed_actions(),
+    )
+    # Refine ran (one LLM call), returned a revised plan, not None.
+    assert revised is not None
+    assert revised.revision_index == 1
+    assert len(stub.calls) == 1
+    # Regression sentinel: no attribute on the planner that would let a
+    # future maintainer reintroduce cooldown by accident.
+    assert not hasattr(planner, "_steer_refine_cooldown_seconds")
+    assert not hasattr(planner, "_last_user_steer_at")
+    assert not hasattr(planner, "STEER_REFINE_COOLDOWN_SECONDS")
+
+
+# ---------------------------------------------------------------------------
+# 7. No sticky goals -> legacy behaviour unchanged
+# ---------------------------------------------------------------------------
+
+
+async def test_refine_without_sticky_goals_behaves_as_before() -> None:
+    """When there are no USER_STEER goals, sticky-goal checks are
+    inactive and the legacy PLAN_DIVERGENCE refine behaviour holds.
+    Also the STICKY GOALS section must NOT appear in the prompt --
+    legacy callers see the exact same prompt shape."""
+    stub = _StubLLM(_absorb_revision_preserving_sticky())
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="divergence",
+        current_task_id="draft",
+    )
+    revised = await planner.refine(
+        plan=_running_plan(),
+        drift=drift,
+        goals=_base_goals(),
+        observed_actions=_aligned_observed_actions(),
+    )
+    assert revised is not None
+    # Legacy callers must not see the STICKY GOALS block.
+    _system, user_prompt, _model = stub.calls[0]
+    assert "STICKY GOALS" not in user_prompt
+    # But the CURRENT GOALS header is still present on goal-aware
+    # refine prompts (goldfive#154 lands that for everyone).
+    assert "CURRENT GOALS" in user_prompt
+
+
+# ---------------------------------------------------------------------------
+# 8. Goal dataclass wiring
+# ---------------------------------------------------------------------------
+
+
+def test_goal_source_defaults_empty() -> None:
+    """Back-compat: ``Goal`` without an explicit source defaults to ``""``."""
+    g = Goal(id="g", summary="s")
+    assert g.source == ""
+
+
+def test_goal_source_user_steer_marker() -> None:
+    """The ``GOAL_SOURCE_USER_STEER`` marker is the documented value
+    for goals added by a USER_STEER directive."""
+    g = Goal(id="g", summary="s", source=GOAL_SOURCE_USER_STEER)
+    assert g.source == "USER_STEER"
+
+
+# ---------------------------------------------------------------------------
+# 9. Reject sentinel honoured for non-PLAN_DIVERGENCE refine when sticky
+# ---------------------------------------------------------------------------
+
+
+async def test_non_divergence_refine_honours_reject_sentinel_when_sticky() -> None:
+    """When a sticky USER_STEER goal is present, even non-divergence
+    refine kinds (e.g. TOOL_ERROR) can escalate via the reject sentinel
+    if the LLM determines the drift irreconcilably contradicts the
+    operator's steer. This is the extended reject path from #154."""
+    stub = _StubLLM(
+        json.dumps(
+            {
+                "reject": True,
+                "reason": "tool error forces cold-water pivot; contradicts steer",
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.WARNING,
+        detail="tool timeout; fallback path would abandon tropical focus",
+        current_task_id="research",
+    )
+    revised = await planner.refine(
+        plan=_running_plan(),
+        drift=drift,
+        goals=_goals_with_user_steer(),
+    )
+    assert revised is None  # reject -> escalate
+    # Exactly one call -- reject is terminal.
+    assert len(stub.calls) == 1
+
+
+async def test_non_divergence_refine_ignores_reject_sentinel_without_sticky() -> None:
+    """Back-compat: without sticky goals, non-divergence refine does NOT
+    honour the reject sentinel (preserves legacy behaviour — the reject
+    path was originally only for PLAN_DIVERGENCE + observed_actions).
+    A reject-shaped JSON is treated as a malformed plan."""
+    stub = _StubLLM(json.dumps({"reject": True, "reason": "x"}))
+    planner = LLMPlanner(call_llm=stub, max_refine_attempts=1)
+    drift = DriftEvent(
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.WARNING,
+        detail="tool error",
+        current_task_id="research",
+    )
+    revised = await planner.refine(plan=_running_plan(), drift=drift, goals=_base_goals())
+    assert revised is None  # but via "no usable plan" exhaustion, not reject


### PR DESCRIPTION
Closes #154. Extends LLMPlanner.refine so it consistently respects session.goals across every drift kind, closing the silent-undo-steer bug where a post-USER_STEER PLAN_DIVERGENCE could absorb pre-steer tree activity back into the plan and effectively revert the operator's steer.

## Summary

- `Goal` dataclass gains a `source` field; the `GOAL_SOURCE_USER_STEER` marker flags goals added by a USER_STEER directive. Default `""` preserves back-compat (#152 will populate this when it lands).
- Every refine prompt renders a dedicated `CURRENT GOALS` section with sticky goals flagged `[STICKY]` inline plus a separate `STICKY GOALS` block so the LLM cannot miss them.
- The `PLAN_DIVERGENCE` system prompt's ABSORB/REJECT contract (from #144) now explicitly calls out sticky goals as a REJECT trigger when observed activity contradicts them.
- The reject sentinel path added in #145 is extended: any refine kind can emit `{"reject": true, ...}` whenever the session carries a sticky goal, so unrelated drifts that irreconcilably contradict the steer escalate via the #142 intervention ladder rather than burning retries.
- A `_check_user_steer_goals_preserved` validator rejects revisions whose task titles/descriptions don't reference any sticky goal. Reference is checked via *discriminative* summary tokens (tokens NOT also in non-sticky goals) so generic session vocabulary ("goldfish") can't mask a silent drop. On drop the retry loop receives a precise correction message; on exhaustion a `REFINE_VALIDATION_FAILED` drift is emitted exactly like existing validator failures.

## NO cooldown — deliberate constraint

Per the explicit user directive in #154, **no time-windowing** of PLAN_DIVERGENCE refines post-USER_STEER, no `STEER_REFINE_COOLDOWN_SECONDS` constant, no suppression logic based on time since last USER_STEER. Steering is always active and updates instantly. Durability comes from:

1. `session.goals` persisting the steer as a sticky Goal (populated by #152 when it lands).
2. Goal-aware refine rejecting contradictions (this PR).
3. #153 GoldfivePlanner injecting active_steer + goals into every LLM call so the tree naturally aligns.

`test_no_cooldown_refine_fires_immediately_post_user_steer` is a regression sentinel: it asserts the planner has **no** cooldown attributes (`_steer_refine_cooldown_seconds`, `_last_user_steer_at`, `STEER_REFINE_COOLDOWN_SECONDS`) so a future maintainer can't reintroduce the behaviour without failing the test.

## Orthogonality with #151 / #152 / #153 / #155

- **#144** (`observed_actions` + `allow_reject`) is extended, not reimplemented. Existing PLAN_DIVERGENCE reject path unchanged; new sticky-goal reject path layered on top.
- **#152** (session.goals update on USER_STEER) is a consumer: goals with `source == GOAL_SOURCE_USER_STEER` trigger the sticky-goal path here. Works whether or not #152 has merged.
- **#151** (tree-aware `available_agents`) is orthogonal — only affects generate(), not refine().
- **#153** GoldfivePlanner and **#155** proto are orthogonal (no shared edits).
- **#137/#138** edge validator, **#133/#136** retry loop, **#142** ladder all preserved.

## Test plan

- [x] 12 new tests in `tests/test_planner_goal_aware_refine.py` cover every requirement from the issue (prompt includes goals; reject on contradiction; absorb on alignment; sticky-goal preservation; retry correction; retry exhaustion; no-cooldown; back-compat; Goal dataclass wiring; extended reject path).
- [x] `uv run pytest -x -v` → 714 pass, 61 skipped.
- [x] `uv run ruff check goldfive/ tests/` → clean.
- [x] Back-compat: no sticky goals → no STICKY GOALS block in the prompt, legacy PLAN_DIVERGENCE reject ignored on non-divergence paths, existing USER_STEER / looping-tool-call refine paths unchanged.