### PR TITLE
goldfive.* state namespace + steer restart framing + USER_STEER Goal synth

### DIFF
--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -659,3 +659,84 @@ A plan revision emits `PlanRevised(old_plan_id, new_plan_id,
 revision_index, kind, severity, reason)` after
 `_apply_revision` completes. Sinks that cache plan state should
 re-read `session.plan` on every `PlanRevised`.
+
+---
+
+## Appendix: orchestration state namespace (goldfive#152)
+
+`Session.state` is a dict goldfive stamps with keys under the
+`goldfive.*` prefix so downstream consumers (prompt templates,
+refine paths, `GoldfivePlanner`, drift detectors) can read
+orchestration context without walking `session.plan` + the drift
+stream. This is **not** the same surface as the ADK adapter's
+`session.state` (which is the ADK runtime's own dict; see
+[`goldfive/adapters/_adk_state_protocol.py`](../../goldfive/adapters/_adk_state_protocol.py)).
+The orchestration namespace is framework-agnostic — every adapter
+goes through `Session.state`, not just ADK.
+
+Keys:
+
+| Key | Owner | Lifecycle |
+|---|---|---|
+| `goldfive.current_plan_id` | `Runner` on plan submit, `DefaultSteerer._apply_revision` on revision | Set when a plan is installed; persists across the run |
+| `goldfive.current_task_id`, `goldfive.current_task_title` | `PlanReconciler` on before/after_agent; `DefaultSteerer.mark_task_*` on legacy transitions | Set on RUNNING; cleared on terminal transition of the same task and at run end |
+| `goldfive.goals_summary` | `Runner` after goal derivation; `DefaultSteerer._apply_user_steer_state` after USER_STEER | Formatted `"- [id] summary\n..."` block; refreshed whenever `session.goals` changes |
+| `goldfive.active_steer.body`, `goldfive.active_steer.at_turn` | `DefaultSteerer._apply_user_steer_state` on USER_STEER drift | `body` is the raw steer text; `at_turn` is the session sequence value at fire time. Cleared at run end |
+| `goldfive.cancelled_function_call_ids` | `ADKAdapter._heal_pending_tool_calls` | Append-only list of function_call ids that were healed mid-invocation. De-duplicated within the run |
+
+Ownership rules:
+
+1. **Only goldfive writes.** Adapters and agents do not write into
+   this namespace — it's orchestration-owned. Agent-side state
+   lives on the ADK `session.state` dict (see `_adk_state_protocol`)
+   or equivalent per-adapter surface.
+2. **Writers go through `goldfive.orchestration_state`.** The
+   helper module enforces the `goldfive.*` prefix and exposes
+   typed writers / readers so consumers don't hand-roll key
+   strings.
+3. **Steering is always active (no cooldown).** `active_steer.*`
+   is a durable read-back of the most recent USER_STEER, not a
+   cooldown window. The `at_turn` field lets consumers reason
+   about "is this a fresh steer or a stale one?" against the
+   session's monotonic sequence counter; they do the comparison
+   themselves.
+
+USER_STEER flow (`DefaultSteerer._apply_user_steer_state`):
+
+1. Stamp `active_steer.body` / `active_steer.at_turn`.
+2. Call `planner.synthesize_goal_from_steer(body)`. The method
+   returns `(Goal, mode)` where `mode` is `"append"` or
+   `"replace"`. Falls back to a passthrough `Goal(id="steer",
+   summary=body)` when the planner doesn't implement the hook.
+3. Mutate `session.goals` accordingly — `append` adds, `replace`
+   clears and sets the sole goal.
+4. Refresh `goldfive.goals_summary`.
+5. The steerer's normal drift flow (`_handle_drift` continuation)
+   then calls `planner.refine` with `list(session.goals)` — which
+   now contains the synthesized steer goal — so the refined plan
+   sees the pivot as a first-class goal, not just a drift detail
+   string.
+
+Steer restart framing (`SequentialExecutor._compose_steer_restart_message`):
+
+When USER_STEER fires mid-invocation under overlay mode, the
+executor cancels the in-flight invocation (goldfive#149) and
+restarts with the steer body as user input. The body is wrapped in
+a goldfive-authored override header:
+
+```
+[USER STEERING CONTROL — supersedes prior task context]
+
+{steer_body}
+
+Notes:
+- Prior research, partial work, or planned tasks from the pre-steer
+  conversation are superseded unless this message explicitly
+  references them.
+- Proceed with the new direction. Do not continue prior work unless
+  doing so directly serves this steer.
+```
+
+Clean framing without wiping conversation history — the LLM can
+still see earlier turns, but the framing makes it unambiguous that
+the steer is the new north star.

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -1130,6 +1130,7 @@ class ADKAdapter:
                 session_id=session_id,
                 invocation_id=last_invocation_id,
                 reason=reason,
+                session=session,
             )
             raise
         except Exception as exc:  # noqa: BLE001
@@ -1141,6 +1142,7 @@ class ADKAdapter:
                 session_id=session_id,
                 invocation_id=last_invocation_id,
                 reason=f"error:{type(exc).__name__}",
+                session=session,
             )
         finally:
             if not was_cancelled:
@@ -1155,6 +1157,7 @@ class ADKAdapter:
                         session_id=session_id,
                         invocation_id=last_invocation_id,
                         reason="unexpected_orphan_on_normal_exit",
+                        session=session,
                     )
                 # No cancel fired — drop any stale tag so the NEXT
                 # invoke's cancel (if any) doesn't pick up leftover state.
@@ -1237,6 +1240,7 @@ class ADKAdapter:
         session_id: str,
         invocation_id: str,
         reason: str,
+        session: Session | None = None,
     ) -> None:
         """Append synthetic ``function_response`` events for orphan tool calls.
 
@@ -1247,9 +1251,33 @@ class ADKAdapter:
         session via ``session_service.append_event``. Best-effort: logs and
         swallows individual failures so healing one orphan doesn't block
         the others.
+
+        goldfive#152: when ``session`` is provided, the orchestration-state
+        dict at ``session.state`` is stamped with the healed function_call
+        ids under ``goldfive.cancelled_function_call_ids`` (append-only,
+        de-duplicated) so downstream planners / prompt templates can see
+        which tool-call ids were cancelled mid-invocation without poking
+        adapter internals.
         """
         if not self._pending_tool_call_ids:
             return
+        # goldfive#152: snapshot the ids we're about to heal BEFORE we
+        # clear the set so the orchestration-state stamp reflects the
+        # full heal even if an early return fires below.
+        snapshot_ids = sorted(self._pending_tool_call_ids)
+        if session is not None and snapshot_ids:
+            try:
+                from goldfive import orchestration_state as _ostate
+
+                _ostate.append_cancelled_function_call_ids(
+                    session.state, snapshot_ids
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "ADKAdapter._heal_pending_tool_calls: could not stamp "
+                    "goldfive.cancelled_function_call_ids: %s",
+                    exc,
+                )
 
         session_service = getattr(runner, "session_service", None)
         if session_service is None:

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -739,7 +739,11 @@ class SequentialExecutor(Executor):
                     "feeding steerer.observe for USER_STEER drift + refine",
                 )
                 await self._apply_steer(payload, steerer=steerer, session=session)
-                current_user_input = self._extract_steer_body(
+                # goldfive#152: wrap the steer body in a goldfive-authored
+                # override header so the LLM sees it as a USER STEERING
+                # CONTROL directive, not a fresh user turn. Supersedes
+                # goldfive#149's raw-body handoff.
+                current_user_input = self._compose_steer_restart_message(
                     payload, fallback=current_user_input
                 )
                 # Reset reconciler bookkeeping so the revised plan's
@@ -1223,8 +1227,8 @@ class SequentialExecutor(Executor):
             log.warning("SequentialExecutor: steerer.observe(STEER) raised: %s", exc)
 
     @staticmethod
-    def _extract_steer_body(msg: object, *, fallback: str) -> str:
-        """Pull the user-authored steer text out of a STEER ControlMessage.
+    def _compose_steer_restart_message(msg: object, *, fallback: str) -> str:
+        """Wrap a STEER body in a goldfive-authored override header.
 
         The STEER payload shape on the goldfive side is
         ``{"note": str, "suggested_action": str}`` — the harmonograf
@@ -1236,15 +1240,41 @@ class SequentialExecutor(Executor):
         ``payload["body"]`` as a courtesy for callers building STEER
         messages directly from annotation shapes, so either key works.
 
+        Replaces goldfive#149's ``_extract_steer_body`` which handed
+        the raw body to the adapter. Post-#152 we wrap the body in an
+        ``[USER STEERING CONTROL — supersedes prior task context]``
+        header plus a notes block so the LLM has an explicit signal
+        that: (a) this is an operator override, not a fresh user turn,
+        and (b) prior research / partial work / pending tasks are
+        superseded unless the steer references them. Clean framing
+        without wiping conversation history — the LLM can still see
+        earlier turns, but the framing makes it unambiguous that the
+        steer is the new north star.
+
         Falls back to ``fallback`` when the extracted text is empty,
-        so the re-invocation after a USER_STEER refine still has a
-        non-empty user message to work from.
+        then wraps that fallback in the same header so the re-invocation
+        always shows the override semantics.
         """
         payload = getattr(msg, "payload", None)
-        if not isinstance(payload, dict):
-            return fallback
-        body = str(payload.get("note", "") or payload.get("body", "") or "")
-        return body or fallback
+        body = ""
+        if isinstance(payload, dict):
+            body = str(payload.get("note", "") or payload.get("body", "") or "")
+        effective = body or fallback
+        # Build the override-framing message. Keep the header line
+        # short and machine-readable so prompt templates / tests can
+        # match on the prefix ("[USER STEERING CONTROL").
+        return (
+            "[USER STEERING CONTROL — supersedes prior task context]\n"
+            "\n"
+            f"{effective}\n"
+            "\n"
+            "Notes:\n"
+            "- Prior research, partial work, or planned tasks from the pre-steer "
+            "conversation are superseded unless this message explicitly "
+            "references them.\n"
+            "- Proceed with the new direction. Do not continue prior work unless "
+            "doing so directly serves this steer."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/goldfive/orchestration_state.py
+++ b/goldfive/orchestration_state.py
@@ -1,0 +1,342 @@
+"""Goldfive orchestration-level session-state namespace (goldfive#152).
+
+This module owns the key names goldfive writes into
+``goldfive.types.Session.state`` — the framework-agnostic orchestration
+dict that the PlanReconciler, DefaultSteerer, executor heal paths, and
+downstream planners (goldfive#153) all read and write.
+
+**This is NOT the same surface as the ADK ``session.state``** dict the
+ADK adapter writes to for agent-side reads (see
+:mod:`goldfive.adapters._adk_state_protocol`). The ADK state protocol
+is a per-adapter bridge between goldfive and the LLM's view; this
+module is a cross-cutting orchestration convention that:
+
+* Any goldfive component can read without pulling in ADK.
+* Any planner or drift detector can consult for "what's the current
+  plan, current task, recent steer, healed function_calls?" without
+  having to crawl ``session.plan`` + drift stream + adapter internals.
+* Downstream components (goldfive#153's GoldfivePlanner, goldfive#154's
+  goal-aware refine) consume as a stable contract.
+
+Keys live under :data:`GOLDFIVE_PREFIX`. Values are always JSON-serialisable
+where practical so sinks can round-trip the dict if they want to
+persist it; readers tolerate missing / malformed entries and return
+typed defaults.
+
+Namespace
+---------
+Plan lifecycle:
+
+* ``goldfive.current_plan_id`` — plan id of the currently-installed
+  :class:`Plan` on ``session.plan``. Stamped by plan_submitted and
+  plan_revised flows.
+
+Task lifecycle (set by PlanReconciler on RUNNING/COMPLETED):
+
+* ``goldfive.current_task_id`` — task id most recently transitioned
+  to RUNNING. Cleared when the task terminates and no new task has
+  opened, and on run end.
+* ``goldfive.current_task_title`` — the title of the same task.
+
+Goals:
+
+* ``goldfive.goals_summary`` — human-readable, formatted one-per-line
+  summary of :attr:`Session.goals`. Refreshed whenever goals change
+  (goldfive#152 USER_STEER path; goldfive#154 goal-aware refine).
+  Prompt templates read this so they never need to walk
+  ``session.goals`` themselves.
+
+Active steer (set by DefaultSteerer on USER_STEER drift):
+
+* ``goldfive.active_steer.body`` — the steer body as authored by the
+  operator (post-``_compose_steer_restart_message`` UNWRAPPING; i.e.
+  the raw steer text, not the framed restart message).
+* ``goldfive.active_steer.at_turn`` — monotonic sequence value
+  captured at steer-fire time. Lets downstream refines know "was this
+  steer before or after the observation I'm looking at?".
+
+Heal path (set by adapter ``_heal_pending_tool_calls``):
+
+* ``goldfive.cancelled_function_call_ids`` — list of function_call
+  ids that were healed mid-invocation. Append-only within a run; a
+  later heal simply extends the list. Downstream prompt templates /
+  refine paths may consult to reference "the cancelled tool call"
+  without poking adapter internals.
+
+Design notes
+-------------
+* **No cooldown.** Per the goldfive#152 directive, steering is always
+  active — so ``goldfive.active_steer.*`` is just a durable read-back
+  of the most recent USER_STEER, not a cooldown window. Consumers
+  that want "has the steer expired?" compare the recorded ``at_turn``
+  against the current session sequence themselves.
+* **Tree-agnostic.** No presentation-specific or domain keys. The
+  namespace is pure orchestration state.
+* **Writers only under the prefix.** :func:`write` refuses non-goldfive
+  keys so accidental clobbers are caught early.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, MutableMapping
+from typing import Any
+
+from goldfive.types import Goal, Plan, Task, TaskStatus
+
+GOLDFIVE_PREFIX = "goldfive."
+
+# Plan lifecycle
+KEY_CURRENT_PLAN_ID = "goldfive.current_plan_id"
+
+# Task lifecycle (PlanReconciler)
+KEY_CURRENT_TASK_ID = "goldfive.current_task_id"
+KEY_CURRENT_TASK_TITLE = "goldfive.current_task_title"
+
+# Goals
+KEY_GOALS_SUMMARY = "goldfive.goals_summary"
+
+# Active steer (DefaultSteerer)
+KEY_ACTIVE_STEER_BODY = "goldfive.active_steer.body"
+KEY_ACTIVE_STEER_AT_TURN = "goldfive.active_steer.at_turn"
+
+# Heal path (ADKAdapter._heal_pending_tool_calls)
+KEY_CANCELLED_FUNCTION_CALL_IDS = "goldfive.cancelled_function_call_ids"
+
+ALL_KEYS: tuple[str, ...] = (
+    KEY_CURRENT_PLAN_ID,
+    KEY_CURRENT_TASK_ID,
+    KEY_CURRENT_TASK_TITLE,
+    KEY_GOALS_SUMMARY,
+    KEY_ACTIVE_STEER_BODY,
+    KEY_ACTIVE_STEER_AT_TURN,
+    KEY_CANCELLED_FUNCTION_CALL_IDS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Primitive writers / readers
+# ---------------------------------------------------------------------------
+
+
+def _assert_goldfive_key(key: str) -> None:
+    if not key.startswith(GOLDFIVE_PREFIX):
+        raise ValueError(
+            f"goldfive.orchestration_state refuses to write non-goldfive key: {key!r}"
+        )
+
+
+def write(state: MutableMapping[str, Any], key: str, value: Any) -> None:
+    """Stamp ``key`` under the goldfive namespace.
+
+    Rejects non-``goldfive.*`` keys defensively — this module is the
+    single source of truth for orchestration-level state, and a
+    mis-namespaced write is almost always a typo or a leaky abstraction.
+    """
+    _assert_goldfive_key(key)
+    state[key] = value
+
+
+def clear(state: MutableMapping[str, Any], key: str) -> None:
+    """Remove ``key`` from ``state`` if present. Refuses non-goldfive keys."""
+    _assert_goldfive_key(key)
+    state.pop(key, None)
+
+
+def read(state: Any, key: str, default: Any = None) -> Any:
+    """Return ``state[key]`` or ``default`` when absent / malformed."""
+    if not isinstance(state, Mapping):
+        return default
+    try:
+        value = state.get(key, default)
+    except Exception:
+        return default
+    return value if value is not None else default
+
+
+# ---------------------------------------------------------------------------
+# Plan / task helpers
+# ---------------------------------------------------------------------------
+
+
+def set_current_plan(state: MutableMapping[str, Any], plan: Plan | None) -> None:
+    """Record the plan id (or clear it when ``plan`` is None)."""
+    if plan is None:
+        clear(state, KEY_CURRENT_PLAN_ID)
+        return
+    write(state, KEY_CURRENT_PLAN_ID, str(getattr(plan, "id", "") or ""))
+
+
+def set_current_task(state: MutableMapping[str, Any], task: Task | None) -> None:
+    """Record the active task id + title, or clear when ``task`` is None."""
+    if task is None:
+        clear(state, KEY_CURRENT_TASK_ID)
+        clear(state, KEY_CURRENT_TASK_TITLE)
+        return
+    write(state, KEY_CURRENT_TASK_ID, str(getattr(task, "id", "") or ""))
+    write(state, KEY_CURRENT_TASK_TITLE, str(getattr(task, "title", "") or ""))
+
+
+def clear_current_task(state: MutableMapping[str, Any]) -> None:
+    """Remove the current-task keys. Cheap alias used at run end."""
+    clear(state, KEY_CURRENT_TASK_ID)
+    clear(state, KEY_CURRENT_TASK_TITLE)
+
+
+# ---------------------------------------------------------------------------
+# Goals summary
+# ---------------------------------------------------------------------------
+
+
+def format_goals_summary(goals: Iterable[Goal] | None) -> str:
+    """Return a human-readable one-per-line summary of goals.
+
+    Shape::
+
+        - [g1] first goal summary
+        - [g2] second goal summary
+
+    Empty / None input renders as the single line ``"(no goals)"`` so
+    prompt templates can interpolate unconditionally without
+    worrying about the empty case.
+    """
+    if not goals:
+        return "(no goals)"
+    lines: list[str] = []
+    for goal in goals:
+        gid = getattr(goal, "id", "") or "(no-id)"
+        summary = getattr(goal, "summary", "") or "(no summary)"
+        lines.append(f"- [{gid}] {summary}")
+    if not lines:
+        return "(no goals)"
+    return "\n".join(lines)
+
+
+def refresh_goals_summary(
+    state: MutableMapping[str, Any],
+    goals: Iterable[Goal] | None,
+) -> None:
+    """Recompute and stamp ``goldfive.goals_summary`` from ``goals``."""
+    write(state, KEY_GOALS_SUMMARY, format_goals_summary(goals))
+
+
+# ---------------------------------------------------------------------------
+# Active steer
+# ---------------------------------------------------------------------------
+
+
+def set_active_steer(
+    state: MutableMapping[str, Any],
+    *,
+    body: str,
+    at_turn: int,
+) -> None:
+    """Record the active steer body + turn. See module docstring."""
+    write(state, KEY_ACTIVE_STEER_BODY, str(body or ""))
+    write(state, KEY_ACTIVE_STEER_AT_TURN, int(at_turn))
+
+
+def clear_active_steer(state: MutableMapping[str, Any]) -> None:
+    """Clear the active-steer keys (e.g. at run start). Idempotent."""
+    clear(state, KEY_ACTIVE_STEER_BODY)
+    clear(state, KEY_ACTIVE_STEER_AT_TURN)
+
+
+# ---------------------------------------------------------------------------
+# Cancelled function_call ids
+# ---------------------------------------------------------------------------
+
+
+def append_cancelled_function_call_ids(
+    state: MutableMapping[str, Any],
+    call_ids: Iterable[str],
+) -> None:
+    """Append ``call_ids`` to ``goldfive.cancelled_function_call_ids``.
+
+    Creates the list on first call; extends idempotently on subsequent
+    calls. De-duplicates while preserving order so a heal that fires
+    twice for the same id (defensive) doesn't balloon the list.
+    """
+    ids = [str(c) for c in call_ids if c]
+    if not ids:
+        return
+    existing = read(state, KEY_CANCELLED_FUNCTION_CALL_IDS, [])
+    if not isinstance(existing, list):
+        existing = []
+    merged: list[str] = list(existing)
+    seen = set(merged)
+    for cid in ids:
+        if cid in seen:
+            continue
+        seen.add(cid)
+        merged.append(cid)
+    write(state, KEY_CANCELLED_FUNCTION_CALL_IDS, merged)
+
+
+def read_cancelled_function_call_ids(state: Any) -> list[str]:
+    value = read(state, KEY_CANCELLED_FUNCTION_CALL_IDS, [])
+    if not isinstance(value, list):
+        return []
+    return [str(v) for v in value if v]
+
+
+# ---------------------------------------------------------------------------
+# Convenience: task-status-aware current-task sync
+# ---------------------------------------------------------------------------
+
+
+def sync_current_task_from_transition(
+    state: MutableMapping[str, Any],
+    task: Task | None,
+    to: TaskStatus,
+) -> None:
+    """Stamp or clear current_task_* based on a transition target.
+
+    Called by PlanReconciler (and the DefaultSteerer's overlay path) on
+    every task transition. Rules:
+
+    * RUNNING → stamp the task's id + title.
+    * COMPLETED / FAILED / CANCELLED / NOT_NEEDED → clear if the
+      task is the currently-pinned one (another task may have opened
+      before this one's terminal write; don't steal its stamp).
+    * Any other status is a no-op.
+    """
+    if task is None:
+        return
+    if to is TaskStatus.RUNNING:
+        set_current_task(state, task)
+        return
+    if to in (
+        TaskStatus.COMPLETED,
+        TaskStatus.FAILED,
+        TaskStatus.CANCELLED,
+        TaskStatus.NOT_NEEDED,
+    ):
+        current = read(state, KEY_CURRENT_TASK_ID, "")
+        if current == str(getattr(task, "id", "") or ""):
+            clear_current_task(state)
+
+
+__all__ = [
+    "ALL_KEYS",
+    "GOLDFIVE_PREFIX",
+    "KEY_ACTIVE_STEER_AT_TURN",
+    "KEY_ACTIVE_STEER_BODY",
+    "KEY_CANCELLED_FUNCTION_CALL_IDS",
+    "KEY_CURRENT_PLAN_ID",
+    "KEY_CURRENT_TASK_ID",
+    "KEY_CURRENT_TASK_TITLE",
+    "KEY_GOALS_SUMMARY",
+    "append_cancelled_function_call_ids",
+    "clear",
+    "clear_active_steer",
+    "clear_current_task",
+    "format_goals_summary",
+    "read",
+    "read_cancelled_function_call_ids",
+    "refresh_goals_summary",
+    "set_active_steer",
+    "set_current_plan",
+    "set_current_task",
+    "sync_current_task_from_transition",
+    "write",
+]

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -1669,6 +1669,118 @@ class LLMPlanner:
             return None, f"validator rejected revision: {exc}"
         return merged_plan, ""
 
+    # ------------------------------------------------------------------
+    # Goal synthesis from USER_STEER body (goldfive#152)
+    # ------------------------------------------------------------------
+
+    #: System prompt for :meth:`synthesize_goal_from_steer`. Asks the
+    #: LLM to turn a free-form steer body into a durable Goal and
+    #: classify whether the steer is additive (APPEND) or a
+    #: scrap-and-pivot (REPLACE). Keep the shape tight so a minimal
+    #: response is enough.
+    _SYNTHESIZE_GOAL_SYSTEM_PROMPT: str = (
+        "You are a goal extractor for a multi-agent orchestration system. "
+        "A human operator has just issued a STEERING directive mid-run. "
+        "Convert the directive into a single durable Goal and decide "
+        "whether it REPLACES the existing goals (scrap-and-pivot) or is "
+        "ADDITIVE (append alongside existing goals).\n\n"
+        "Reply with a single JSON object and NOTHING ELSE:\n"
+        '{"goal": {"id": "<short-id>", "summary": "<one-sentence>"}, '
+        '"mode": "append" | "replace", '
+        '"reason": "<one-sentence why>"}\n\n'
+        "Guidelines:\n"
+        "- Use 'replace' when the steer contradicts or supersedes prior "
+        "goals (e.g. 'actually, just do X instead', 'skip the rest', "
+        "'change direction to Y').\n"
+        "- Use 'append' when the steer adds a new concern alongside "
+        "existing goals (e.g. 'also include X', 'while you're at it, Y').\n"
+        "- The id should be short (<=16 chars) and unique-looking; "
+        "'steer' is an acceptable default when no better label fits."
+    )
+
+    async def synthesize_goal_from_steer(
+        self,
+        steer_body: str,
+    ) -> tuple[Goal, str] | None:
+        """Synthesize a ``Goal`` from a USER_STEER body via one LLM call.
+
+        Returns ``(goal, mode)`` where ``mode`` is ``"append"`` or
+        ``"replace"``. Returns ``None`` on LLM error / parse failure so
+        the caller can fall back to a passthrough Goal. The steerer
+        handles the fallback (see
+        :meth:`goldfive.steerer.DefaultSteerer._synthesize_goal_from_steer`);
+        this method is deliberately strict so a misbehaving LLM doesn't
+        silently append nonsense goals.
+
+        One-shot: no retry loop (unlike refine), because the failure
+        mode of a bad synthesis is recoverable by the caller's
+        fallback, whereas a bad refine leaves the plan mis-shaped.
+        """
+        body = (steer_body or "").strip()
+        if not body:
+            return None
+        user_prompt = (
+            f"STEERING DIRECTIVE:\n{body}\n\n"
+            "Extract the durable Goal and classify the mode. Reply JSON only."
+        )
+        try:
+            raw = await self._call_llm(
+                self._SYNTHESIZE_GOAL_SYSTEM_PROMPT,
+                user_prompt,
+                self._model,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "LLMPlanner.synthesize_goal_from_steer: call_llm raised %s",
+                exc,
+            )
+            return None
+        if not isinstance(raw, str) or not raw.strip():
+            log.warning(
+                "LLMPlanner.synthesize_goal_from_steer: empty / non-str response"
+            )
+            return None
+        cleaned = _strip_code_fences(raw).strip()
+        try:
+            parsed = json.loads(cleaned)
+        except (ValueError, TypeError) as exc:
+            log.warning(
+                "LLMPlanner.synthesize_goal_from_steer: JSON parse failed: %s",
+                exc,
+            )
+            return None
+        if not isinstance(parsed, dict):
+            log.warning(
+                "LLMPlanner.synthesize_goal_from_steer: response was not an "
+                "object; got %r",
+                type(parsed),
+            )
+            return None
+        goal_raw = parsed.get("goal")
+        if not isinstance(goal_raw, dict):
+            log.warning(
+                "LLMPlanner.synthesize_goal_from_steer: missing 'goal' object"
+            )
+            return None
+        summary = goal_raw.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            log.warning(
+                "LLMPlanner.synthesize_goal_from_steer: goal missing non-empty "
+                "'summary'"
+            )
+            return None
+        gid = goal_raw.get("id")
+        if not isinstance(gid, str) or not gid.strip():
+            gid = "steer"
+        mode = parsed.get("mode")
+        if not isinstance(mode, str) or mode.strip().lower() not in (
+            "append",
+            "replace",
+        ):
+            mode = "append"
+        goal = Goal(id=gid.strip(), summary=summary.strip())
+        return goal, mode.strip().lower()
+
 
 __all__ = [
     "LLMPlanner",

--- a/goldfive/reconciler.py
+++ b/goldfive/reconciler.py
@@ -69,6 +69,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from goldfive import orchestration_state as _ostate
 from goldfive.types import (
     TERMINAL_TASK_STATUSES,
     DriftEvent,
@@ -192,6 +193,15 @@ class PlanReconciler:
                 "PlanReconciler.on_before_agent: transition(RUNNING) raised: %s",
                 exc,
             )
+        # goldfive#152: stamp the orchestration-state current_task_*
+        # keys so downstream refine paths / prompt templates /
+        # sinks see a single source of truth for the active task.
+        # Done AFTER the steerer transition so a steerer stub that
+        # refuses the transition (e.g. test doubles) doesn't leak
+        # into these reads.
+        _ostate.sync_current_task_from_transition(
+            self._session.state, task, TaskStatus.RUNNING
+        )
 
     async def on_after_agent(
         self,
@@ -228,6 +238,13 @@ class PlanReconciler:
                     "PlanReconciler.on_after_agent: transition(FAILED) raised: %s",
                     exc,
                 )
+            # goldfive#152: clear the current_task_* stamp if it was
+            # pointing at this task. A FAILED transition retires the
+            # task even if a follow-up refine re-spawns it under a
+            # different id.
+            _ostate.sync_current_task_from_transition(
+                self._session.state, task, TaskStatus.FAILED
+            )
             return
         try:
             await self._steerer.transition(
@@ -241,6 +258,11 @@ class PlanReconciler:
                 "PlanReconciler.on_after_agent: transition(COMPLETED) raised: %s",
                 exc,
             )
+        # goldfive#152: clear the current_task_* stamp when the active
+        # task terminates. A later before_agent will repopulate.
+        _ostate.sync_current_task_from_transition(
+            self._session.state, task, TaskStatus.COMPLETED
+        )
 
     async def on_delegation_observed(
         self,

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -41,6 +41,7 @@ import warnings
 from collections.abc import Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from goldfive import orchestration_state as _ostate
 from goldfive._llm import maybe_close_call_llm
 from goldfive.conversation import Conversation
 from goldfive.events import (
@@ -229,6 +230,11 @@ class Runner:
             if g.id:
                 existing_ids.add(g.id)
 
+        # goldfive#152: refresh the orchestration-state goals summary
+        # so prompt templates / refine paths / downstream planners
+        # see an up-to-date ``goldfive.goals_summary``.
+        _ostate.refresh_goals_summary(session.state, session.goals)
+
         await self._emit_goal_derived(session)
 
         # Build the context passed to the planner. Stamp run_id (so LLM
@@ -275,6 +281,12 @@ class Runner:
         if not plan.run_id:
             plan.run_id = session.run_id
         session.plan = plan
+
+        # goldfive#152: record the installed plan id on the
+        # orchestration-state dict so downstream components don't
+        # need to reach into ``session.plan`` to read the current
+        # plan id.
+        _ostate.set_current_plan(session.state, plan)
 
         await self._emit_plan_submitted(session, plan)
 
@@ -372,6 +384,12 @@ class Runner:
                 aborted, user_input_summary=_initial_goal_summary(user_input)
             )
             return aborted
+
+        # goldfive#152: clear the current_task_* stamp at run end.
+        # The plan id + goals summary stay (they remain meaningful
+        # cross-turn on the owning Conversation).
+        _ostate.clear_current_task(session.state)
+        _ostate.clear_active_steer(session.state)
 
         self._conversation.absorb_turn(
             outcome, user_input_summary=_initial_goal_summary(user_input)

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -50,6 +50,7 @@ import re
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
+from goldfive import orchestration_state as _ostate
 from goldfive.drift import (
     classify_refusal,
     classify_stop_reason,
@@ -60,6 +61,7 @@ from goldfive.types import (
     DriftEvent,
     DriftKind,
     DriftSeverity,
+    Goal,
     Plan,
     Session,
     Task,
@@ -437,6 +439,11 @@ class DefaultSteerer:
         session.current_task_id = task_id
         if detail:
             session.agent_notes[task_id] = detail
+        # goldfive#152: stamp current_task_* on the orchestration-state
+        # dict so downstream prompt templates / refine paths see it.
+        _ostate.sync_current_task_from_transition(
+            session.state, task, TaskStatus.RUNNING
+        )
         await self._emit_task_started(session, task_id, detail)
 
     async def mark_task_progress(
@@ -482,6 +489,10 @@ class DefaultSteerer:
         task.status = TaskStatus.COMPLETED
         if summary:
             session.completed_results[task_id] = summary
+        # goldfive#152: clear current_task_* if we were the active task.
+        _ostate.sync_current_task_from_transition(
+            session.state, task, TaskStatus.COMPLETED
+        )
         await self._emit_task_completed(session, task_id, summary, artifacts or {})
 
     async def mark_task_failed(
@@ -518,6 +529,9 @@ class DefaultSteerer:
         if task.status in _TERMINAL_TASK_STATUSES:
             return
         task.status = TaskStatus.FAILED
+        _ostate.sync_current_task_from_transition(
+            session.state, task, TaskStatus.FAILED
+        )
         await self._emit_task_failed(session, task_id, reason, recoverable)
         # Fatal failures cascade downstream via the same primitive used
         # by mark_task_cancelled, so both §6.2 and §6.3 produce the
@@ -597,6 +611,9 @@ class DefaultSteerer:
             # TaskCancelled events for downstream tasks on every call.
             return
         task.status = TaskStatus.CANCELLED
+        _ostate.sync_current_task_from_transition(
+            session.state, task, TaskStatus.CANCELLED
+        )
         await self._emit_task_cancelled(session, task_id, reason)
         await self.cascade_cancel_downstream(session, task_id)
 
@@ -629,6 +646,9 @@ class DefaultSteerer:
         if task.status in _TERMINAL_TASK_STATUSES:
             return
         task.status = TaskStatus.NOT_NEEDED
+        _ostate.sync_current_task_from_transition(
+            session.state, task, TaskStatus.NOT_NEEDED
+        )
         # There is no dedicated ``TaskNotNeeded`` proto message;
         # reuse TaskCancelled with the reason prefix so sinks that
         # inspect reason can differentiate if they wish. The live
@@ -1326,6 +1346,17 @@ class DefaultSteerer:
         # goldfive#139 and
         # :func:`goldfive.adapters.adk._build_cancelled_response_event`.
         self._tag_adapter_cancel_reason(drift)
+        # goldfive#152: USER_STEER-specific side effects -- write the
+        # active-steer bookkeeping onto the orchestration-state dict
+        # and synthesize a durable Goal from the steer body so
+        # subsequent refines see the pivot as a first-class goal,
+        # not a one-shot user message. Done BEFORE the drift event
+        # is emitted (the state writes are cheap) and BEFORE the
+        # ladder dispatches to planner.refine (which reads
+        # ``session.goals`` we just mutated) so the refine sees the
+        # new goal shape in the same dispatch.
+        if drift.kind is DriftKind.USER_STEER:
+            await self._apply_user_steer_state(drift, session)
         await self._emit_drift_detected(session, drift)
         # Route through the intervention ladder. The per-(kind, task)
         # occurrence count drives the "first vs repeat" distinction in
@@ -1730,6 +1761,134 @@ class DefaultSteerer:
                 exc,
             )
 
+    # ------------------------------------------------------------------
+    # USER_STEER state handler (goldfive#152)
+    # ------------------------------------------------------------------
+
+    async def _apply_user_steer_state(
+        self,
+        drift: DriftEvent,
+        session: Session,
+    ) -> None:
+        """Side-effects for USER_STEER drift that aren't refine: state
+        bookkeeping + goal synthesis.
+
+        Called from :meth:`_handle_drift` just before ``_emit_drift_detected``
+        and well before ``planner.refine`` runs, so:
+
+        1. The ``goldfive.active_steer.*`` keys are set so downstream
+           observers see the steer before the drift event.
+        2. The synthesized Goal is appended / replaced onto
+           ``session.goals`` BEFORE ``planner.refine`` reads
+           ``list(session.goals)``, so the refined plan sees the
+           pivot as a goal, not only as a drift detail string.
+
+        Never raises: a planner that doesn't implement
+        ``synthesize_goal_from_steer`` or a synthesis call that fails
+        falls through to a minimal passthrough (wrap the steer body as
+        a Goal, mode APPEND). The steerer must never break the run on
+        a missing optional hook.
+        """
+        body = (drift.detail or "").strip()
+        # Stamp the active_steer keys regardless of synthesis outcome
+        # so readers see "a steer is active as of turn N" even when
+        # the planner can't synthesize. ``at_turn`` uses the session's
+        # monotonic sequence counter which increments on every emitted
+        # event — a cheap, always-available "turn" proxy.
+        at_turn = getattr(session, "_next_sequence", 0) or 0
+        try:
+            _ostate.set_active_steer(session.state, body=body, at_turn=at_turn)
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "DefaultSteerer._apply_user_steer_state: set_active_steer raised: %s",
+                exc,
+            )
+        if not body:
+            # Empty steer body: nothing to synthesize into a goal. The
+            # active_steer.* keys still landed (readers may want to know
+            # "a steer was fired even if empty"). Keep goals as-is.
+            return
+        synth_goal, mode = await self._synthesize_goal_from_steer(body)
+        if synth_goal is None:
+            return
+        mode_norm = (mode or "append").strip().lower()
+        if mode_norm == "replace":
+            session.goals.clear()
+            session.goals.append(synth_goal)
+        else:
+            # Default / "append" mode: add unless an id collision
+            # exists (belt-and-braces if the synthesizer reuses an id).
+            existing = {g.id for g in session.goals if g.id}
+            if synth_goal.id and synth_goal.id in existing:
+                # Replace the colliding goal in-place so the synthesizer
+                # can refine a previously-appended steer goal.
+                for i, g in enumerate(session.goals):
+                    if g.id == synth_goal.id:
+                        session.goals[i] = synth_goal
+                        break
+            else:
+                session.goals.append(synth_goal)
+        # Refresh the goals_summary so downstream consumers (refine
+        # prompt templates, GoldfivePlanner in goldfive#153) see the
+        # new shape immediately.
+        try:
+            _ostate.refresh_goals_summary(session.state, session.goals)
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "DefaultSteerer._apply_user_steer_state: refresh_goals_summary raised: %s",
+                exc,
+            )
+
+    async def _synthesize_goal_from_steer(
+        self,
+        steer_body: str,
+    ) -> tuple[Goal | None, str]:
+        """Call ``planner.synthesize_goal_from_steer`` if available.
+
+        Returns ``(goal, mode)`` where ``mode`` is ``"append"`` or
+        ``"replace"``. Falls back to a passthrough goal (APPEND) when
+        the planner doesn't implement the hook or the call fails.
+        The fallback keeps the steer body durable on
+        ``session.goals`` even when the planner is a minimal stub
+        (PassthroughPlanner / StaticPlanner / tests).
+        """
+        planner = self._planner
+        synth = getattr(planner, "synthesize_goal_from_steer", None)
+        if not callable(synth):
+            return Goal(id="steer", summary=steer_body), "append"
+        try:
+            result = await synth(steer_body)
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "DefaultSteerer: planner.synthesize_goal_from_steer raised "
+                "%s; falling back to passthrough append",
+                exc,
+            )
+            return Goal(id="steer", summary=steer_body), "append"
+        if result is None:
+            return Goal(id="steer", summary=steer_body), "append"
+        # Accept two shapes: a bare Goal (mode defaults to "append") or
+        # a ``(Goal, mode)`` tuple. The tuple shape is what the
+        # synthesizer should emit in the common case; the bare form is
+        # a courtesy for callers / tests that only care about the goal.
+        if isinstance(result, tuple) and len(result) == 2:
+            goal, mode = result
+            if not isinstance(goal, Goal):
+                log.warning(
+                    "DefaultSteerer: synthesize_goal_from_steer returned "
+                    "tuple without Goal; falling back"
+                )
+                return Goal(id="steer", summary=steer_body), "append"
+            return goal, str(mode or "append")
+        if isinstance(result, Goal):
+            return result, "append"
+        log.warning(
+            "DefaultSteerer: synthesize_goal_from_steer returned "
+            "unrecognised shape %r; falling back",
+            type(result),
+        )
+        return Goal(id="steer", summary=steer_body), "append"
+
     # Consecutive refine failures tolerated per (drift_kind, task_id)
     # before we give up and mark the task FAILED. Class attribute so
     # subclasses / tests can tune it without poking at instance state.
@@ -1818,6 +1977,9 @@ class DefaultSteerer:
         if not revised.revision_reason:
             revised.revision_reason = drift.detail
         session.plan = revised
+        # goldfive#152: refresh the orchestration-state current plan id
+        # so downstream reads see the revised id, not the stale one.
+        _ostate.set_current_plan(session.state, revised)
 
     # --- Event construction ------------------------------------------
 

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -577,6 +577,19 @@ class Session:
     # than a queue) is deliberate: a second Level 3 while one is pending
     # overwrites the first -- the more-recent directive wins.
     pending_corrective_message: str | None = None
+    # Orchestration-level session state dict (goldfive#152). Goldfive
+    # owns keys under the ``goldfive.*`` namespace — see
+    # :mod:`goldfive.orchestration_state` for the documented key names
+    # and helpers. This is NOT the same surface as the ADK
+    # ``session.state`` dict the ADK adapter writes to for agent-side
+    # reads (that lives on the ADK ``Session`` object; see
+    # :mod:`goldfive.adapters._adk_state_protocol`). This dict is
+    # goldfive-orchestration-internal: the PlanReconciler stamps the
+    # current task id/title here, the steerer writes active-steer
+    # bookkeeping, and the ADK heal path records cancelled function
+    # call ids so prompt templates / refine paths / downstream planners
+    # can read a single, framework-agnostic source of truth.
+    state: dict[str, Any] = dataclasses.field(default_factory=dict)
     # monotonic event sequence counter for sinks
     _next_sequence: int = 0
 

--- a/tests/test_orchestration_state.py
+++ b/tests/test_orchestration_state.py
@@ -1,0 +1,429 @@
+"""Tests for the goldfive.* session-state namespace (goldfive#152).
+
+Covers the six pieces of the issue:
+
+1. ``PlanReconciler`` stamps / clears ``goldfive.current_task_*`` on
+   RUNNING / terminal transitions.
+2. ``DefaultSteerer`` USER_STEER handler writes ``goldfive.active_steer.*``.
+3. USER_STEER synthesizes a Goal via the planner and appends it.
+4. USER_STEER synthesize returning ``mode=replace`` clears goals.
+5. ``_compose_steer_restart_message`` produces the override-framed body.
+6. ``_heal_pending_tool_calls`` stamps
+   ``goldfive.cancelled_function_call_ids`` on session.state.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive import orchestration_state as _ostate  # noqa: E402
+from goldfive.control import ControlKind, ControlMessage  # noqa: E402
+from goldfive.executors.sequential import SequentialExecutor  # noqa: E402
+from goldfive.reconciler import PlanReconciler  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / stubs
+# ---------------------------------------------------------------------------
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class _StubPlanner:
+    """Minimal planner: records refine + synthesize calls."""
+
+    def __init__(
+        self,
+        *,
+        synth_result: Any = None,
+        revised_plan: Plan | None = None,
+    ) -> None:
+        self.synth_result = synth_result
+        self.revised_plan = revised_plan
+        self.refine_calls: list[dict[str, Any]] = []
+        self.synth_calls: list[str] = []
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Any | None = None,
+    ) -> Plan | None:
+        return None
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        self.refine_calls.append({"plan": plan, "drift": drift, "goals": list(goals)})
+        return self.revised_plan
+
+    async def synthesize_goal_from_steer(self, body: str) -> Any:
+        self.synth_calls.append(body)
+        return self.synth_result
+
+
+def _plan_two_running() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="First", assignee_agent_id="agent_a"),
+            Task(id="t2", title="Second", assignee_agent_id="agent_b"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+
+
+def _make_session_with_plan() -> Session:
+    plan = _plan_two_running()
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="original goal")],
+        plan=plan,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. PlanReconciler stamps and clears goldfive.current_task_*
+# ---------------------------------------------------------------------------
+
+
+async def test_orchestration_state_keys_lifecycle() -> None:
+    """Reconciler stamps current_task_* on RUNNING, clears on COMPLETED.
+
+    Exercises the full lifecycle: initial state empty, stamped on
+    before_agent, cleared on after_agent once the task terminates.
+    """
+    session = _make_session_with_plan()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[_ListSink()], planner=_StubPlanner())
+
+    reconciler = PlanReconciler(session=session, steerer=steerer)
+
+    # Pre-flight: no current_task_* keys yet.
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_ID, "") == ""
+
+    # Claim t1.
+    await reconciler.on_before_agent(agent_name="agent_a", invocation_id="inv1")
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_ID) == "t1"
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_TITLE) == "First"
+
+    # Close t1.
+    await reconciler.on_after_agent(agent_name="agent_a", invocation_id="inv1")
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_ID, "") == ""
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_TITLE, "") == ""
+
+    # Claim t2.
+    await reconciler.on_before_agent(agent_name="agent_b", invocation_id="inv2")
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_ID) == "t2"
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_TITLE) == "Second"
+
+    # Close t2 → cleared again.
+    await reconciler.on_after_agent(agent_name="agent_b", invocation_id="inv2")
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_ID, "") == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. DefaultSteerer USER_STEER writes goldfive.active_steer.*
+# ---------------------------------------------------------------------------
+
+
+async def test_user_steer_writes_active_steer_state() -> None:
+    """STEER ControlMessage → USER_STEER drift → active_steer.* stamped."""
+    session = _make_session_with_plan()
+    planner = _StubPlanner(revised_plan=None)
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[_ListSink()], planner=planner)
+
+    # Baseline: no active steer state.
+    assert _ostate.read(session.state, _ostate.KEY_ACTIVE_STEER_BODY, "") == ""
+
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        payload={"note": "focus on the writing instead"},
+    )
+    await steerer.observe(msg, session)
+
+    body = _ostate.read(session.state, _ostate.KEY_ACTIVE_STEER_BODY, "")
+    assert body == "focus on the writing instead"
+    # at_turn is an int and should be > 0 (emit_drift_detected bumped
+    # the sequence counter).
+    at_turn = _ostate.read(session.state, _ostate.KEY_ACTIVE_STEER_AT_TURN, 0)
+    assert isinstance(at_turn, int)
+
+
+# ---------------------------------------------------------------------------
+# 3. USER_STEER synthesizes and appends a Goal (default mode).
+# ---------------------------------------------------------------------------
+
+
+async def test_user_steer_synthesizes_and_appends_goal() -> None:
+    """Planner returns (Goal, 'append') → session.goals grows by one."""
+    session = _make_session_with_plan()
+    synth_goal = Goal(id="steer", summary="focus on the writing instead")
+    planner = _StubPlanner(synth_result=(synth_goal, "append"))
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[_ListSink()], planner=planner)
+
+    assert [g.id for g in session.goals] == ["g1"]
+
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        payload={"note": "focus on the writing instead"},
+    )
+    await steerer.observe(msg, session)
+
+    # Planner was asked to synthesize.
+    assert planner.synth_calls == ["focus on the writing instead"]
+    # Goal was appended.
+    assert [g.id for g in session.goals] == ["g1", "steer"]
+    assert session.goals[-1].summary == "focus on the writing instead"
+    # goals_summary on the state dict refreshed.
+    summary = _ostate.read(session.state, _ostate.KEY_GOALS_SUMMARY, "")
+    assert "[g1]" in summary
+    assert "[steer]" in summary
+    assert "focus on the writing" in summary
+
+
+# ---------------------------------------------------------------------------
+# 4. USER_STEER synthesize decides REPLACE → goals cleared + replaced.
+# ---------------------------------------------------------------------------
+
+
+async def test_user_steer_synthesizes_replace_when_scrap_steer() -> None:
+    """Planner returns mode='replace' → session.goals collapses to one."""
+    session = _make_session_with_plan()
+    # Seed two prior goals so we can prove replace clears BOTH.
+    session.goals.append(Goal(id="g2", summary="secondary"))
+    assert len(session.goals) == 2
+
+    replacement = Goal(id="new", summary="actually, do this instead")
+    planner = _StubPlanner(synth_result=(replacement, "replace"))
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[_ListSink()], planner=planner)
+
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        payload={"note": "actually, do this instead"},
+    )
+    await steerer.observe(msg, session)
+
+    assert [g.id for g in session.goals] == ["new"]
+    assert session.goals[0].summary == "actually, do this instead"
+    summary = _ostate.read(session.state, _ostate.KEY_GOALS_SUMMARY, "")
+    # Prior goal ids are gone from the summary.
+    assert "g1" not in summary
+    assert "g2" not in summary
+    assert "[new]" in summary
+
+
+async def test_user_steer_falls_back_when_planner_lacks_synthesize() -> None:
+    """Planner without ``synthesize_goal_from_steer`` → passthrough append."""
+
+    class _MinimalPlanner:
+        refine_calls: list[dict[str, Any]] = []  # noqa: RUF012
+
+        async def generate(self, **kwargs: Any) -> Plan | None:
+            return None
+
+        async def refine(self, **kwargs: Any) -> Plan | None:
+            self.refine_calls.append(kwargs)
+            return None
+
+    session = _make_session_with_plan()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[_ListSink()], planner=_MinimalPlanner())
+
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        payload={"note": "tangential aside"},
+    )
+    await steerer.observe(msg, session)
+
+    # Passthrough goal appended with id 'steer'.
+    assert len(session.goals) == 2
+    assert session.goals[-1].id == "steer"
+    assert session.goals[-1].summary == "tangential aside"
+
+
+# ---------------------------------------------------------------------------
+# 5. _compose_steer_restart_message shape
+# ---------------------------------------------------------------------------
+
+
+def test_compose_steer_restart_message_shape() -> None:
+    """Override header + body + notes block all present in the output."""
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        payload={"note": "refactor the intro paragraph"},
+    )
+    composed = SequentialExecutor._compose_steer_restart_message(
+        msg, fallback="prior input"
+    )
+    # Header present (leading line).
+    assert composed.startswith("[USER STEERING CONTROL — supersedes prior task context]")
+    # Body interpolated verbatim.
+    assert "refactor the intro paragraph" in composed
+    # Notes block present.
+    assert "Notes:" in composed
+    assert "superseded unless this message explicitly" in composed
+    assert "Proceed with the new direction" in composed
+
+
+def test_compose_steer_restart_message_empty_uses_fallback() -> None:
+    """Empty steer body falls back to ``fallback`` (still wrapped)."""
+    msg = ControlMessage(kind=ControlKind.STEER, payload={"note": ""})
+    composed = SequentialExecutor._compose_steer_restart_message(
+        msg, fallback="the original request"
+    )
+    assert composed.startswith("[USER STEERING CONTROL")
+    assert "the original request" in composed
+
+
+def test_compose_steer_restart_message_accepts_body_key() -> None:
+    """``payload['body']`` is accepted as a courtesy key."""
+    msg = ControlMessage(kind=ControlKind.STEER, payload={"body": "switch gears"})
+    composed = SequentialExecutor._compose_steer_restart_message(
+        msg, fallback="fallback"
+    )
+    assert "switch gears" in composed
+
+
+# ---------------------------------------------------------------------------
+# 6. _heal_pending_tool_calls stamps cancelled_function_call_ids
+# ---------------------------------------------------------------------------
+
+
+async def test_cancelled_function_call_ids_populated_on_heal() -> None:
+    """Heal path records healed function_call ids on session.state."""
+    # Avoid requiring the ADK optional dependency by unit-testing the
+    # state-stamp helper the heal path uses. The adapter-integration
+    # side is covered by tests/test_cancel_propagation.py + the
+    # existing ADK heal tests; here we verify the orchestration-state
+    # stamp semantics.
+    session = _make_session_with_plan()
+
+    # Baseline: empty list.
+    assert _ostate.read_cancelled_function_call_ids(session.state) == []
+
+    _ostate.append_cancelled_function_call_ids(session.state, ["call-1", "call-2"])
+    assert _ostate.read_cancelled_function_call_ids(session.state) == [
+        "call-1",
+        "call-2",
+    ]
+
+    # Second heal with overlap → de-duplicated, order preserved.
+    _ostate.append_cancelled_function_call_ids(session.state, ["call-2", "call-3"])
+    assert _ostate.read_cancelled_function_call_ids(session.state) == [
+        "call-1",
+        "call-2",
+        "call-3",
+    ]
+
+
+async def test_cancelled_function_call_ids_populated_on_adk_heal() -> None:
+    """End-to-end: trigger the ADK adapter's heal path and verify the stamp.
+
+    Skipped when the optional ADK dependency is not installed.
+    """
+    try:
+        from google.adk.events import Event  # noqa: F401
+    except ImportError:
+        pytest.skip("google-adk not installed")
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    # Build a minimal ADKAdapter and drive _heal_pending_tool_calls
+    # directly with a session. No actual ADK runner; we stub the
+    # pieces the heal helper touches (session_service, append_event).
+    class _StubSessionService:
+        def __init__(self) -> None:
+            self.appended: list[Any] = []
+
+        async def create_session(self, **kwargs: Any) -> Any:
+            return object()
+
+        async def get_session(self, **kwargs: Any) -> Any:
+            return object()
+
+        async def append_event(self, *, session: Any, event: Any) -> None:  # noqa: ARG002
+            self.appended.append(event)
+
+    class _StubRunner:
+        app_name = "test"
+        session_service = _StubSessionService()
+
+    class _StubAgent:
+        name = "host"
+
+    adapter = ADKAdapter.__new__(ADKAdapter)
+    adapter._runner = _StubRunner()
+    adapter._agent = _StubAgent()
+    adapter._user_id = "u1"
+    adapter._app_name = "test"
+    adapter._pending_tool_call_ids = {"call-a", "call-b"}
+    adapter._pending_tool_call_names = {"call-a": "tool1", "call-b": "tool2"}
+
+    session = _make_session_with_plan()
+
+    await adapter._heal_pending_tool_calls(
+        runner=adapter._runner,
+        session_id="s1",
+        invocation_id="inv-1",
+        reason="cancelled_mid_invocation",
+        session=session,
+    )
+
+    healed = _ostate.read_cancelled_function_call_ids(session.state)
+    assert set(healed) == {"call-a", "call-b"}
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: DefaultSteerer.mark_task_running also stamps state
+# ---------------------------------------------------------------------------
+
+
+async def test_mark_task_running_stamps_orchestration_state() -> None:
+    """Legacy (non-overlay) path: transitions still stamp state keys."""
+    session = _make_session_with_plan()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[_ListSink()], planner=_StubPlanner())
+
+    await steerer.mark_task_running("t1", session=session, detail="starting")
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_ID) == "t1"
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_TITLE) == "First"
+
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+    assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_ID, "") == ""

--- a/tests/test_overlay_steer.py
+++ b/tests/test_overlay_steer.py
@@ -419,7 +419,12 @@ async def test_overlay_steer_restarts_invocation_with_steer_body() -> None:
         f"expected 2 invoke_passthrough calls, got {adapter.passthrough_calls}"
     )
     assert adapter.passthrough_calls[0] == "original user input"
-    assert adapter.passthrough_calls[1] == steer_body
+    # goldfive#152: the post-steer user input is now wrapped in a
+    # goldfive-authored override header instead of handed raw. The
+    # steer body still appears verbatim inside the framed message.
+    second = adapter.passthrough_calls[1]
+    assert second.startswith("[USER STEERING CONTROL"), second
+    assert steer_body in second
 
 
 # ---------------------------------------------------------------------------
@@ -480,7 +485,13 @@ async def test_overlay_steer_empty_body_falls_back_to_previous_input() -> None:
     outcome = await asyncio.wait_for(runner_task, timeout=5.0)
 
     assert outcome.success is True
-    assert adapter.passthrough_calls == ["the original", "the original"]
+    # goldfive#152: empty-body steer still wraps the fallback in the
+    # override header so the LLM sees the override semantics even
+    # when the operator's note is empty.
+    assert adapter.passthrough_calls[0] == "the original"
+    second = adapter.passthrough_calls[1]
+    assert second.startswith("[USER STEERING CONTROL"), second
+    assert "the original" in second
 
 
 # ---------------------------------------------------------------------------
@@ -630,7 +641,12 @@ async def test_overlay_steer_after_steer() -> None:
 
     assert outcome.success is True
     # Three invocations: v0 (steered), v1 (steered), v2 (completed).
-    assert adapter.passthrough_calls == ["v0", "pivot to v1", "now pivot to v2"]
+    # goldfive#152: post-steer inputs wrapped in the override header.
+    assert adapter.passthrough_calls[0] == "v0"
+    assert adapter.passthrough_calls[1].startswith("[USER STEERING CONTROL")
+    assert "pivot to v1" in adapter.passthrough_calls[1]
+    assert adapter.passthrough_calls[2].startswith("[USER STEERING CONTROL")
+    assert "now pivot to v2" in adapter.passthrough_calls[2]
     # Two USER_STEER drift events, two refine calls.
     user_steer_drifts = [
         d for d in steerer.drift_events if d.kind is DriftKind.USER_STEER

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1242,3 +1242,125 @@ async def test_refine_prompt_includes_forbidden_edges_section() -> None:
     _sys, steer_prompt, _model = scripted.calls[0]
     assert "FORBIDDEN EDGES" in steer_prompt
     assert "CANCELLED" in steer_prompt and "FAILED" in steer_prompt
+
+
+# ---------------------------------------------------------------------------
+# synthesize_goal_from_steer (goldfive#152)
+# ---------------------------------------------------------------------------
+
+
+class _SynthLLM:
+    """Minimal call_llm stub for the synthesize_goal_from_steer tests.
+
+    Named distinctly from the file's existing ``_ScriptedLLM`` (which
+    accepts a list of responses and pops per-call) because the
+    synthesize API is one-shot: a single canned string response.
+    """
+
+    def __init__(self, response: str) -> None:
+        self._response = response
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        self.calls.append((system, user, model))
+        return self._response
+
+
+async def test_synthesize_goal_from_steer_returns_goal_and_append_mode() -> None:
+    """Minimal well-formed response → (Goal, 'append')."""
+    scripted = _SynthLLM(
+        json.dumps(
+            {
+                "goal": {"id": "steer1", "summary": "also include a summary slide"},
+                "mode": "append",
+                "reason": "additive request",
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    result = await planner.synthesize_goal_from_steer(
+        "also include a summary slide"
+    )
+    assert result is not None
+    goal, mode = result
+    assert goal.id == "steer1"
+    assert goal.summary == "also include a summary slide"
+    assert mode == "append"
+    # The system prompt asks for JSON + mode.
+    _sys, user_prompt, _model = scripted.calls[0]
+    assert "STEERING DIRECTIVE" in user_prompt
+    assert "also include a summary slide" in user_prompt
+
+
+async def test_synthesize_goal_from_steer_returns_replace_mode() -> None:
+    """``mode: replace`` propagates through to the caller."""
+    scripted = _SynthLLM(
+        json.dumps(
+            {
+                "goal": {"id": "pivot", "summary": "scrap everything and do Y"},
+                "mode": "replace",
+                "reason": "scrap-and-pivot",
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    result = await planner.synthesize_goal_from_steer(
+        "forget everything — just do Y"
+    )
+    assert result is not None
+    _goal, mode = result
+    assert mode == "replace"
+
+
+async def test_synthesize_goal_from_steer_handles_markdown_fences() -> None:
+    """LLM response wrapped in ```json fences parses correctly."""
+    scripted = _SynthLLM(
+        "```json\n"
+        + json.dumps(
+            {
+                "goal": {"id": "g", "summary": "do the thing"},
+                "mode": "append",
+            }
+        )
+        + "\n```"
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    result = await planner.synthesize_goal_from_steer("do the thing")
+    assert result is not None
+    goal, mode = result
+    assert goal.summary == "do the thing"
+    assert mode == "append"
+
+
+async def test_synthesize_goal_from_steer_returns_none_on_empty_body() -> None:
+    """Empty steer body short-circuits before the LLM is called."""
+    scripted = _SynthLLM("should not be called")
+    planner = LLMPlanner(call_llm=scripted)
+    result = await planner.synthesize_goal_from_steer("")
+    assert result is None
+    assert scripted.calls == []
+
+
+async def test_synthesize_goal_from_steer_returns_none_on_malformed_json() -> None:
+    """Unparseable LLM response → None (caller falls back to passthrough)."""
+    scripted = _SynthLLM("not json at all {[")
+    planner = LLMPlanner(call_llm=scripted)
+    result = await planner.synthesize_goal_from_steer("some steer")
+    assert result is None
+
+
+async def test_synthesize_goal_from_steer_defaults_mode_when_invalid() -> None:
+    """Invalid ``mode`` falls back to 'append'."""
+    scripted = _SynthLLM(
+        json.dumps(
+            {
+                "goal": {"id": "g", "summary": "x"},
+                "mode": "nonsense",
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    result = await planner.synthesize_goal_from_steer("some steer")
+    assert result is not None
+    _goal, mode = result
+    assert mode == "append"


### PR DESCRIPTION
Closes #152. Part of a 5-stream parallel refactor; coordinates with #151 / #153 / #154 / #155.

## Summary

- **`goldfive.*` session-state namespace**: new `goldfive/orchestration_state.py` owns keys on `Session.state` (`current_plan_id`, `current_task_id`, `current_task_title`, `goals_summary`, `active_steer.body/at_turn`, `cancelled_function_call_ids`). Typed writers enforce the prefix. Distinct from ADK `session.state` (which is the agent-side surface); this is cross-cutting orchestration state any adapter/planner can consume.
- **`PlanReconciler` + `DefaultSteerer` stamp current_task_***: both execution paths (overlay observation, legacy `mark_task_*`) publish the active task so the orchestration contract is uniform.
- **USER_STEER handler updates state + synthesizes a Goal**: `DefaultSteerer._apply_user_steer_state` runs on USER_STEER drift BEFORE `planner.refine`: writes `active_steer.*`, calls `LLMPlanner.synthesize_goal_from_steer(body)`, appends / replaces the synthesized Goal on `session.goals`, refreshes `goals_summary`. Refine sees the new goals and aligns the revised plan to the steer as a first-class goal.
- **`_compose_steer_restart_message`** (replaces #149's `_extract_steer_body`): wraps the steer body in `[USER STEERING CONTROL — supersedes prior task context]` framing + notes block. Tree-agnostic; no domain content.
- **`_heal_pending_tool_calls` stamps `goldfive.cancelled_function_call_ids`**: append-only, de-duplicated list of healed function_call ids across the run.
- **Docs**: TASK-LIFECYCLE.md appendix documents the namespace, ownership rules, USER_STEER flow, and steer-restart framing.

No cooldown (per issue directive). Steering always active; the new Goal IS the durable mechanism.

## Test plan

- [x] `test_orchestration_state_keys_lifecycle` — reconciler stamps / clears current_task_* on transitions
- [x] `test_user_steer_writes_active_steer_state` — active_steer.* on drift
- [x] `test_user_steer_synthesizes_and_appends_goal` — goals grows by one via planner stub
- [x] `test_user_steer_synthesizes_replace_when_scrap_steer` — mode=replace clears prior goals
- [x] `test_user_steer_falls_back_when_planner_lacks_synthesize` — passthrough
- [x] `test_compose_steer_restart_message_shape` — override header + body + notes block
- [x] `test_compose_steer_restart_message_empty_uses_fallback`
- [x] `test_compose_steer_restart_message_accepts_body_key`
- [x] `test_cancelled_function_call_ids_populated_on_heal` — helper + ADK E2E
- [x] `test_mark_task_running_stamps_orchestration_state` — legacy path
- [x] `test_synthesize_goal_from_steer_*` — LLMPlanner unit suite (6 cases incl. fences, malformed JSON, empty body)
- [x] `uv run pytest -x` — 817 passed / 46 skipped
- [x] `uv run ruff check .` — clean

## Out of scope (sibling PRs)

- #151 tree-aware planner (separate; doesn't touch available_agents)
- #153 GoldfivePlanner (will consume these state keys)
- #154 goal-aware refine (will consume `session.goals` which this PR updates on USER_STEER)
- #155 proto fix (orthogonal)