### PR TITLE
Tree-aware planner constraints + contextual plan reconciliation

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -917,10 +917,11 @@ def make_adk_plugin(
             Fires once per agent invocation (including sub-agents
             inside AgentTool sub-Runners). When a
             :class:`~goldfive.reconciler.PlanReconciler` is attached,
-            we forward ``agent.name`` and the invocation id so it
-            can transition the matching plan task to RUNNING. When
-            no reconciler is attached (legacy ``invoke(task)`` path),
-            this is a no-op.
+            we forward ``agent.name``, the invocation id, and the
+            parent_invocation_id (the outer runner's id, when the
+            current invocation is nested inside an ``AgentTool``
+            sub-Runner) so the reconciler can resolve parent chains
+            for contextual matching (goldfive#151).
             """
             reconciler = self._reconciler
             if reconciler is None:
@@ -930,11 +931,28 @@ def make_adk_plugin(
                 callback_context, "invocation_context", None
             )
             inv_id = str(_safe_attr(inv_ctx, "invocation_id", "") or "")
+            parent_inv_id = ""
+            if inv_id and self._top_invocation_id and inv_id != self._top_invocation_id:
+                parent_inv_id = self._top_invocation_id
             try:
                 await reconciler.on_before_agent(
                     agent_name=agent_name,
                     invocation_id=inv_id,
+                    parent_invocation_id=parent_inv_id,
                 )
+            except TypeError:
+                # Custom reconciler without the #151 kwarg — fall back
+                # to the pre-#151 signature. Keeps back-compat.
+                try:
+                    await reconciler.on_before_agent(
+                        agent_name=agent_name,
+                        invocation_id=inv_id,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "before_agent_callback: reconciler.on_before_agent raised: %s",
+                        exc,
+                    )
             except Exception as exc:  # noqa: BLE001
                 log.debug(
                     "before_agent_callback: reconciler.on_before_agent raised: %s",
@@ -952,6 +970,9 @@ def make_adk_plugin(
                 callback_context, "invocation_context", None
             )
             inv_id = str(_safe_attr(inv_ctx, "invocation_id", "") or "")
+            parent_inv_id = ""
+            if inv_id and self._top_invocation_id and inv_id != self._top_invocation_id:
+                parent_inv_id = self._top_invocation_id
             summary = self._invocation_last_text.get(inv_id, "") if inv_id else ""
             try:
                 await reconciler.on_after_agent(
@@ -959,7 +980,21 @@ def make_adk_plugin(
                     invocation_id=inv_id,
                     error=None,
                     summary=summary,
+                    parent_invocation_id=parent_inv_id,
                 )
+            except TypeError:
+                try:
+                    await reconciler.on_after_agent(
+                        agent_name=agent_name,
+                        invocation_id=inv_id,
+                        error=None,
+                        summary=summary,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "after_agent_callback: reconciler.on_after_agent raised: %s",
+                        exc,
+                    )
             except Exception as exc:  # noqa: BLE001
                 log.debug(
                     "after_agent_callback: reconciler.on_after_agent raised: %s",

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -380,6 +380,86 @@ def _rebind_goldfive_planners(
                     getattr(cur, "name", "?"),
                     exc,
                 )
+def _collect_reachable_agent_tree(root_agent: Any) -> list[dict[str, Any]]:
+    """Return structured metadata for every agent reachable from ``root_agent``.
+
+    Each entry is a dict with ``name``, ``depth``, ``parent``, ``role``
+    and ``kind``:
+
+    * ``depth``: 0 for the root agent, N for depth-N descendants.
+    * ``parent``: the name of the parent agent. Empty string for root.
+    * ``role``: ``"root"`` for the root agent, ``"intermediate"`` for
+      agents that have children, ``"leaf"`` for agents with no
+      children.
+    * ``kind``: the ADK class name — ``LlmAgent``, ``SequentialAgent``,
+      ``ParallelAgent``, ``BaseAgent``, or any custom subclass name.
+      Tree-agnostic: the function does not interpret or rename kinds.
+
+    Follows the same ``sub_agents`` / ``inner_agent`` / ``AgentTool.agent``
+    edges as :func:`_collect_reachable_agent_names` and
+    :func:`_augment_subtree_with_reporting`. First BFS visit wins so
+    depth / parent are minimal; duplicate reachable edges are collapsed
+    by ``id(agent)`` identity to avoid double-counting shared agents.
+
+    Used to populate :attr:`ADKAdapter.available_agents_tree`, which the
+    LLM planner consumes to constrain ``assignee_agent_id`` selection.
+    Under the single-Runner model (goldfive#130) this remains advisory —
+    goldfive drives one runner and ADK handles delegation.
+    """
+    if root_agent is None:
+        return []
+
+    # BFS so depth is minimal (first reachable edge wins). We record
+    # entries keyed by id() so shared sub-tree references don't get
+    # double-appended with a different depth.
+    from collections import deque
+
+    visited: dict[int, dict[str, Any]] = {}
+    order: list[int] = []
+    queue: deque[tuple[Any, int, str]] = deque()
+    queue.append((root_agent, 0, ""))
+    while queue:
+        cur, depth, parent = queue.popleft()
+        if cur is None:
+            continue
+        key = id(cur)
+        if key in visited:
+            continue
+        name = str(getattr(cur, "name", "") or "")
+        if not name:
+            # Agents without a usable name are not routable; skip them
+            # so the planner only ever sees named targets. Children
+            # are still walked so named descendants are not lost.
+            pass
+        kind = type(cur).__name__
+        children: list[Any] = []
+        for sub in getattr(cur, "sub_agents", None) or ():
+            children.append(sub)
+        inner = getattr(cur, "inner_agent", None)
+        if inner is not None:
+            children.append(inner)
+        for t in getattr(cur, "tools", None) or ():
+            nested = getattr(t, "agent", None)
+            if nested is not None:
+                children.append(nested)
+
+        if name:
+            role = "root" if depth == 0 else ("intermediate" if children else "leaf")
+            visited[key] = {
+                "name": name,
+                "depth": depth,
+                "parent": parent,
+                "role": role,
+                "kind": kind,
+            }
+            order.append(key)
+
+        for child in children:
+            child_key = id(child) if child is not None else 0
+            if child_key and child_key not in visited:
+                queue.append((child, depth + 1, name))
+
+    return [visited[k] for k in order]
 
 
 def _register_plugin_on_runner(runner: Any, plugin: Any) -> bool:
@@ -857,8 +937,18 @@ class ADKAdapter:
             # With a pre-built runner we only know about the root agent.
             root_name = str(getattr(self._agent, "name", "") or host_agent_name or "goldfive")
             self._available_agents: list[str] = [root_name]
+            self._available_agents_tree: list[dict[str, Any]] = [
+                {
+                    "name": root_name,
+                    "depth": 0,
+                    "parent": "",
+                    "role": "root",
+                    "kind": type(self._agent).__name__ if self._agent is not None else "BaseAgent",
+                }
+            ]
         else:
             self._available_agents = _collect_reachable_agent_names(self._agent)
+            self._available_agents_tree = _collect_reachable_agent_tree(self._agent)
 
         # Auto-attach GoldfivePlanner to every LlmAgent in the tree
         # (goldfive#153). Idempotent: skipped for agents already
@@ -955,6 +1045,26 @@ class ADKAdapter:
         (AgentTool, transfer_to_agent, sub_agents).
         """
         return list(self._available_agents)
+
+    @property
+    def available_agents_tree(self) -> list[dict[str, Any]]:
+        """Return structured metadata for every reachable agent in the tree.
+
+        Each entry is a dict with the keys ``name`` (str), ``depth``
+        (int; 0 = root), ``parent`` (str; empty for root), ``role``
+        (``"root"`` | ``"intermediate"`` | ``"leaf"``), and ``kind``
+        (the ADK class name — ``LlmAgent``, ``SequentialAgent``,
+        ``ParallelAgent``, ``BaseAgent``, or any custom subclass name;
+        tree-agnostic — no semantic interpretation).
+
+        Used by :class:`goldfive.planner.LLMPlanner` (goldfive#151) to
+        render an "AGENT TREE" section in planner prompts and to
+        validate that every task's ``assignee_agent_id`` is actually
+        reachable in the wrapped tree. A fresh shallow copy is returned
+        on each access so callers cannot mutate the cached list in
+        place.
+        """
+        return [dict(entry) for entry in self._available_agents_tree]
 
     async def register_reporting_tools(self, tools: list[ReportingToolSpec]) -> None:
         """Register goldfive reporting tools with the wrapped agent tree.

--- a/goldfive/adapters/callable.py
+++ b/goldfive/adapters/callable.py
@@ -18,6 +18,7 @@ layer because it removes LLM non-determinism from the loop.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 from goldfive.reporting import ReportingToolSpec
 from goldfive.results import InvocationResult
@@ -101,3 +102,24 @@ class CallableAdapter:
     def available_agents(self) -> list[str]:
         """Return the configured list of available agent identifiers."""
         return list(self._available_agents)
+
+    @property
+    def available_agents_tree(self) -> list[dict[str, Any]]:
+        """Return a flat single-level tree describing the configured agents.
+
+        CallableAdapter has no real tree — every configured name is
+        rendered as a depth-0 root leaf so planners that consume
+        :attr:`available_agents_tree` (goldfive#151) see a consistent
+        shape. Adapters that model a real tree (ADK) override with a
+        richer walker.
+        """
+        return [
+            {
+                "name": name,
+                "depth": 0,
+                "parent": "",
+                "role": "root",
+                "kind": "Callable",
+            }
+            for name in self._available_agents
+        ]

--- a/goldfive/adapters/claude.py
+++ b/goldfive/adapters/claude.py
@@ -153,6 +153,26 @@ class ClaudeAgentSDKAdapter:
     def available_agents(self) -> list[str]:
         return list(self._available_agents)
 
+    @property
+    def available_agents_tree(self) -> list[dict[str, Any]]:
+        """Return a flat single-level tree describing the configured agents.
+
+        ClaudeAdapter is a single-model adapter — every configured name
+        is rendered as a depth-0 root leaf so planners that consume
+        :attr:`available_agents_tree` (goldfive#151) see the same shape
+        across adapters.
+        """
+        return [
+            {
+                "name": name,
+                "depth": 0,
+                "parent": "",
+                "role": "root",
+                "kind": "Claude",
+            }
+            for name in self._available_agents
+        ]
+
     def bind_steerer(self, steerer: SteererLike) -> None:
         """Wire a :class:`Steerer` in after construction.
 

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -368,6 +368,21 @@ still as a complete JSON plan, not an empty object).
 
 _VALID_TASK_STATUSES = frozenset(s.value for s in TaskStatus)
 
+
+def _is_tree_entry_list(available_agents: Any) -> bool:
+    """Return True when ``available_agents`` is a structured tree list.
+
+    Structured entries are dicts carrying at least a ``name`` key —
+    see :attr:`goldfive.adapters.adk.ADKAdapter.available_agents_tree`.
+    Plain ``list[str]`` returns False so the legacy code path renders
+    the flat bullet-list form (goldfive#151).
+    """
+    if not isinstance(available_agents, list) or not available_agents:
+        return False
+    first = available_agents[0]
+    return isinstance(first, Mapping) and "name" in first
+
+
 _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*\n?(.*?)\n?```\s*$", re.DOTALL)
 
 
@@ -466,7 +481,7 @@ class PassthroughPlanner:
         self,
         *,
         goals: list[Goal],
-        available_agents: list[str],
+        available_agents: list[str] | list[dict[str, Any]] | None,
         context: Mapping[str, Any] | None = None,
     ) -> Plan | None:
         return None
@@ -478,6 +493,7 @@ class PassthroughPlanner:
         drift: DriftEvent,
         goals: list[Goal],
         observed_actions: list[ObservedAction] | None = None,
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> Plan | None:
         return None
 
@@ -502,7 +518,7 @@ class StaticPlanner:
         self,
         *,
         goals: list[Goal],
-        available_agents: list[str],
+        available_agents: list[str] | list[dict[str, Any]] | None,
         context: Mapping[str, Any] | None = None,
     ) -> Plan | None:
         run_id = ""
@@ -539,6 +555,7 @@ class StaticPlanner:
         drift: DriftEvent,
         goals: list[Goal],
         observed_actions: list[ObservedAction] | None = None,
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> Plan | None:
         return None
 
@@ -666,8 +683,104 @@ class LLMPlanner:
         return [g for g in goals if g.source == GOAL_SOURCE_USER_STEER]
 
     @staticmethod
-    def _render_agents_block(available_agents: list[str]) -> str:
+    def _render_agents_block(available_agents: list[str] | list[dict[str, Any]] | None) -> str:
+        """Render the agents/AGENT TREE section for the planner prompt.
+
+        Accepts either a plain ``list[str]`` (back-compat) or a
+        structured ``list[dict]`` as produced by
+        :attr:`goldfive.adapters.adk.ADKAdapter.available_agents_tree`
+        (goldfive#151). The dict form renders as a tree-shape block
+        with name, role, kind, depth, and parent so the LLM can see
+        which agents it may pick and which are intermediate
+        coordinators. Plain strings render as a flat bullet list
+        exactly as before.
+
+        An empty / None value renders as the literal placeholder used
+        today so existing structural prompt assertions keep passing.
+        """
+        if not available_agents:
+            return "- (none listed)"
+        if _is_tree_entry_list(available_agents):
+            lines: list[str] = []
+            for entry in available_agents:
+                name = str(entry.get("name", ""))
+                if not name:
+                    continue
+                role = str(entry.get("role", ""))
+                kind = str(entry.get("kind", ""))
+                depth = int(entry.get("depth", 0) or 0)
+                parent = str(entry.get("parent", ""))
+                parent_frag = f" parent={parent}" if parent else ""
+                lines.append(f"- {name} (role={role}, kind={kind}, depth={depth}{parent_frag})")
+            return "\n".join(lines) or "- (none listed)"
         return "\n".join(f"- {a}" for a in available_agents) or "- (none listed)"
+
+    @staticmethod
+    def _flatten_agent_names(
+        available_agents: list[str] | list[dict[str, Any]] | None,
+    ) -> list[str]:
+        """Return the list of legal ``assignee_agent_id`` values.
+
+        Accepts either the plain-string or tree-entry shape and
+        produces a de-duplicated, order-preserving list of agent
+        names. ``None`` / empty yields ``[]`` — the validator treats
+        an empty registry as "skip the assignee check" so existing
+        callers that don't provide available_agents keep working.
+        """
+        if not available_agents:
+            return []
+        names: list[str] = []
+        seen: set[str] = set()
+        if _is_tree_entry_list(available_agents):
+            for entry in available_agents:
+                name = str(entry.get("name", ""))
+                if name and name not in seen:
+                    seen.add(name)
+                    names.append(name)
+            return names
+        for a in available_agents:
+            s = str(a)
+            if s and s not in seen:
+                seen.add(s)
+                names.append(s)
+        return names
+
+    @staticmethod
+    def _validate_plan_assignees(
+        plan: Plan,
+        available_agents: list[str] | list[dict[str, Any]] | None,
+    ) -> str:
+        """Return an error string if any task's assignee is off-registry.
+
+        When ``available_agents`` is falsy the check is skipped —
+        callers that did not supply a registry get the legacy
+        "anything goes" behaviour. When non-empty, every task's
+        ``assignee_agent_id`` (if non-empty) must appear in the
+        flattened name list; offenders are enumerated in the error
+        message so the retry-with-correction loop (#133/#136) has
+        concrete feedback to thread back to the LLM.
+        """
+        names = LLMPlanner._flatten_agent_names(available_agents)
+        if not names:
+            return ""
+        registry = set(names)
+        offenders: list[tuple[str, str]] = []
+        for t in plan.tasks:
+            assignee = (t.assignee_agent_id or "").strip()
+            if not assignee:
+                continue
+            if assignee not in registry:
+                offenders.append((t.id, assignee))
+        if not offenders:
+            return ""
+        listed = ", ".join(f"{tid!r}->{a!r}" for tid, a in offenders)
+        return (
+            f"off-registry assignee(s): {listed}. "
+            f"Every task's `assignee_agent_id` must match a name from the "
+            f"AGENT TREE registry: {sorted(registry)}. "
+            f"Re-assign offending tasks to a registry-listed agent or, "
+            f"when no specialised agent fits, to the root/coordinator."
+        )
 
     @staticmethod
     def _render_observed_actions_block(observed_actions: list[ObservedAction]) -> str:
@@ -742,11 +855,16 @@ class LLMPlanner:
     def _build_generate_prompt(
         self,
         goals: list[Goal],
-        available_agents: list[str],
+        available_agents: list[str] | list[dict[str, Any]] | None,
         context: Mapping[str, Any] | None,
     ) -> str:
         goals_block = self._render_goals_block(goals)
         agents_block = self._render_agents_block(available_agents)
+        agents_header = (
+            "AGENT TREE (pick assignee_agent_id from this registry):"
+            if _is_tree_entry_list(available_agents)
+            else "Available agents:"
+        )
         prior_block = self._render_prior_turns_block(context)
         context_block = ""
         if context:
@@ -772,7 +890,7 @@ class LLMPlanner:
                 except (TypeError, ValueError):
                     context_block = ""
         return (
-            f"Available agents:\n{agents_block}\n\n"
+            f"{agents_header}\n{agents_block}\n\n"
             f"Goals:\n{goals_block}\n"
             f"{prior_block}"
             f"{context_block}\n"
@@ -1131,6 +1249,7 @@ class LLMPlanner:
         post_parse: Callable[[Plan], Plan] | None = None,
         log_prefix: str,
         allow_reject: bool = False,
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> tuple[Plan | None, str, bool]:
         """Run the retry loop for a single refine call.
 
@@ -1281,6 +1400,22 @@ class LLMPlanner:
                 if attempt < attempts:
                     user_prompt = self._build_correction_prompt(base_user_prompt, last_error)
                 continue
+            # Registry check (goldfive#151): off-registry assignees
+            # are a retryable validator error — the correction loop
+            # feeds the list of legal names back on the next attempt.
+            assignee_error = self._validate_plan_assignees(revised, available_agents)
+            if assignee_error:
+                last_error = assignee_error
+                log.warning(
+                    "%s: attempt %d/%d: %s",
+                    log_prefix,
+                    attempt,
+                    attempts,
+                    last_error,
+                )
+                if attempt < attempts:
+                    user_prompt = self._build_correction_prompt(base_user_prompt, last_error)
+                continue
             return revised, "", False
         return None, last_error, False
 
@@ -1290,6 +1425,7 @@ class LLMPlanner:
         drift: DriftEvent,
         goals: list[Goal],
         observed_actions: list[ObservedAction] | None = None,
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> str:
         current = {
             "id": plan.id,
@@ -1322,6 +1458,14 @@ class LLMPlanner:
         goals_block = self._render_goals_block(goals)
         invariants_block = self._render_structural_invariants_block(plan)
         sticky_block = self._render_sticky_goals_block(goals)
+        agents_block = ""
+        if available_agents:
+            header = (
+                "AGENT TREE (pick assignee_agent_id from this registry):"
+                if _is_tree_entry_list(available_agents)
+                else "Available agents:"
+            )
+            agents_block = f"{header}\n{self._render_agents_block(available_agents)}\n\n"
         observed_block = ""
         if observed_actions is not None:
             observed_block = (
@@ -1339,6 +1483,7 @@ class LLMPlanner:
                 '"..."} (the caller will escalate to human intervention).\n\n'
             )
         return (
+            f"{agents_block}"
             f"CURRENT GOALS (the revision must still advance every goal, "
             f"and MUST NOT silently drop any [STICKY] goal):\n{goals_block}\n\n"
             f"{sticky_block}"
@@ -1383,50 +1528,123 @@ class LLMPlanner:
         self,
         *,
         goals: list[Goal],
-        available_agents: list[str],
+        available_agents: list[str] | list[dict[str, Any]] | None,
         context: Mapping[str, Any] | None = None,
     ) -> Plan | None:
+        """Produce the initial plan for ``goals``.
+
+        ``available_agents`` may be a plain ``list[str]`` (legacy
+        callers) or a structured tree as produced by
+        :attr:`goldfive.adapters.adk.ADKAdapter.available_agents_tree`
+        (goldfive#151). When the tree form is supplied the prompt
+        renders a richer "AGENT TREE" section and the validator
+        rejects any task whose ``assignee_agent_id`` is not in the
+        registry — the retry-with-correction loop (#133/#136) feeds
+        the validator message back to the LLM on the next attempt.
+        An empty / None registry skips the assignee check for
+        back-compat.
+        """
         if not goals:
             log.debug("LLMPlanner.generate: no goals provided; skipping plan")
             return None
-        prompt = self._build_generate_prompt(goals, available_agents, context)
-        try:
-            raw = await self._call_llm(self._system_prompt, prompt, self._model)
-        except Exception as exc:  # noqa: BLE001
-            log.warning("LLMPlanner.generate: call_llm raised %s; skipping plan", exc)
-            return None
-        if not raw or not isinstance(raw, str):
-            log.warning("LLMPlanner.generate: empty/non-string LLM response; skipping plan")
-            return None
-        cleaned = _strip_code_fences(raw).strip()
-        try:
-            parsed = json.loads(cleaned)
-        except (ValueError, TypeError) as exc:
-            log.warning(
-                "LLMPlanner.generate: failed to parse LLM output as JSON (%s); skipping",
-                exc,
-            )
-            return None
+        base_prompt = self._build_generate_prompt(goals, available_agents, context)
         run_id = ""
         if context is not None:
             run_id = str(context.get("run_id") or "")
-        plan = _plan_from_json(
-            parsed,
-            run_id=run_id,
-            goal_ids=[g.id for g in goals if g.id],
-        )
-        if plan is None:
-            log.warning("LLMPlanner.generate: parsed JSON did not contain a usable plan; skipping")
-            return None
-        try:
-            plan.validate(for_revision=False)
-        except ValueError as exc:
-            log.warning(
-                "LLMPlanner.generate: plan failed validation (%s); skipping",
-                exc,
+        user_prompt = base_prompt
+        last_error = ""
+        attempts = max(1, self._max_refine_attempts)
+        for attempt in range(1, attempts + 1):
+            try:
+                raw = await self._call_llm(self._system_prompt, user_prompt, self._model)
+            except Exception as exc:  # noqa: BLE001
+                last_error = f"call_llm raised: {exc}"
+                log.warning(
+                    "LLMPlanner.generate: attempt %d/%d: %s",
+                    attempt,
+                    attempts,
+                    last_error,
+                )
+                if attempt < attempts:
+                    user_prompt = self._build_correction_prompt(base_prompt, last_error)
+                continue
+            if not raw or not isinstance(raw, str):
+                last_error = "empty or non-string LLM response"
+                log.warning(
+                    "LLMPlanner.generate: attempt %d/%d: %s",
+                    attempt,
+                    attempts,
+                    last_error,
+                )
+                if attempt < attempts:
+                    user_prompt = self._build_correction_prompt(base_prompt, last_error)
+                continue
+            cleaned = _strip_code_fences(raw).strip()
+            try:
+                parsed = json.loads(cleaned)
+            except (ValueError, TypeError) as exc:
+                last_error = f"JSON parse failed: {exc}"
+                log.warning(
+                    "LLMPlanner.generate: attempt %d/%d: %s",
+                    attempt,
+                    attempts,
+                    last_error,
+                )
+                if attempt < attempts:
+                    user_prompt = self._build_correction_prompt(base_prompt, last_error)
+                continue
+            plan = _plan_from_json(
+                parsed,
+                run_id=run_id,
+                goal_ids=[g.id for g in goals if g.id],
             )
-            return None
-        return plan
+            if plan is None:
+                last_error = "parsed JSON did not contain a usable plan"
+                log.warning(
+                    "LLMPlanner.generate: attempt %d/%d: %s",
+                    attempt,
+                    attempts,
+                    last_error,
+                )
+                if attempt < attempts:
+                    user_prompt = self._build_correction_prompt(base_prompt, last_error)
+                continue
+            try:
+                plan.validate(for_revision=False)
+            except ValueError as exc:
+                last_error = f"validator rejected plan: {exc}"
+                log.warning(
+                    "LLMPlanner.generate: attempt %d/%d: %s",
+                    attempt,
+                    attempts,
+                    last_error,
+                )
+                if attempt < attempts:
+                    user_prompt = self._build_correction_prompt(base_prompt, last_error)
+                continue
+            # Registry check (goldfive#151): reject off-registry
+            # assignees so the tree-aware retry loop can ask the LLM
+            # to re-pick a legal name. Skipped when no registry
+            # supplied — preserves back-compat with pre-#151 callers.
+            assignee_error = self._validate_plan_assignees(plan, available_agents)
+            if assignee_error:
+                last_error = assignee_error
+                log.warning(
+                    "LLMPlanner.generate: attempt %d/%d: %s",
+                    attempt,
+                    attempts,
+                    last_error,
+                )
+                if attempt < attempts:
+                    user_prompt = self._build_correction_prompt(base_prompt, last_error)
+                continue
+            return plan
+        log.warning(
+            "LLMPlanner.generate: exhausted %d attempt(s); last_error=%s",
+            attempts,
+            last_error,
+        )
+        return None
 
     async def refine(
         self,
@@ -1435,6 +1653,7 @@ class LLMPlanner:
         drift: DriftEvent,
         goals: list[Goal],
         observed_actions: list[ObservedAction] | None = None,
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> Plan | None:
         """Produce a revised plan in response to a drift event.
 
@@ -1447,11 +1666,19 @@ class LLMPlanner:
         or REJECT by emitting ``{"reject": true, "reason": "..."}``. A
         reject collapses to ``None`` — the steerer then escalates via
         the intervention ladder (goldfive#142).
+
+        ``available_agents`` (goldfive#151) is optional. When provided
+        the refine prompt renders an "AGENT TREE" section so the LLM
+        picks ``assignee_agent_id`` values from the real tree, and the
+        retry-with-correction loop rejects off-registry assignees with
+        a concrete error message feeding the next attempt. Accepts
+        either ``list[str]`` (legacy) or the structured tree form
+        produced by :attr:`ADKAdapter.available_agents_tree`.
         """
         if plan is None:
             return None
         if drift.kind is DriftKind.USER_STEER:
-            return await self._refine_user_steer(plan, drift, goals)
+            return await self._refine_user_steer(plan, drift, goals, available_agents)
         if drift.kind in (
             DriftKind.LOOPING_TOOL_CALL,
             DriftKind.LOOPING_REASONING,
@@ -1460,7 +1687,7 @@ class LLMPlanner:
             # around it" shape with LOOPING_TOOL_CALL: the symptom is a
             # stuck loop on the currently-running task, and the repair
             # is to mark it FAILED and regenerate the rest.
-            return await self._refine_looping_tool_call(plan, drift, goals)
+            return await self._refine_looping_tool_call(plan, drift, goals, available_agents)
         # REFINE_VALIDATION_FAILED is a terminal signal from ourselves --
         # refining on it would risk an infinite loop of validation
         # failures. The steerer is expected to skip refine for this
@@ -1481,6 +1708,7 @@ class LLMPlanner:
                 drift,
                 goals,
                 observed_actions=observed_actions if use_divergence_prompt else None,
+                available_agents=available_agents,
             )
         except (TypeError, ValueError) as exc:
             log.warning("LLMPlanner.refine: failed to serialise inputs (%s)", exc)
@@ -1508,6 +1736,7 @@ class LLMPlanner:
             goals=goals,
             log_prefix="LLMPlanner.refine",
             allow_reject=allow_reject,
+            available_agents=available_agents,
         )
         if rejected:
             # LLM judged the divergence off-goal. Return None so the
@@ -1611,6 +1840,7 @@ class LLMPlanner:
         plan: Plan,
         drift: DriftEvent,
         goals: list[Goal],
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> Plan | None:
         """Fail-and-regenerate path for ``LOOPING_TOOL_CALL`` drift.
 
@@ -1671,6 +1901,7 @@ class LLMPlanner:
             goals=goals,
             post_parse=_force_looper_failed,
             log_prefix="LLMPlanner._refine_looping_tool_call",
+            available_agents=available_agents,
         )
         if revised is None:
             # Retries exhausted. Signal the failure explicitly, then
@@ -1758,6 +1989,7 @@ class LLMPlanner:
         plan: Plan,
         drift: DriftEvent,
         goals: list[Goal],
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> Plan | None:
         """Delete-and-replan path for ``USER_STEER`` drift.
 
@@ -1790,6 +2022,7 @@ class LLMPlanner:
                 completed=completed,
                 completed_ids=completed_ids,
                 user_prompt=user_prompt,
+                available_agents=available_agents,
             )
             if merged_plan is not None:
                 return merged_plan
@@ -1816,6 +2049,7 @@ class LLMPlanner:
         completed: list[Task],
         completed_ids: set[str],
         user_prompt: str,
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> tuple[Plan | None, str]:
         """Run a single LLM attempt for the USER_STEER refine path.
 
@@ -1896,6 +2130,9 @@ class LLMPlanner:
         goal_error = self._check_user_steer_goals_preserved(merged_plan, goals)
         if goal_error:
             return None, goal_error
+        assignee_error = self._validate_plan_assignees(merged_plan, available_agents)
+        if assignee_error:
+            return None, assignee_error
         return merged_plan, ""
 
 

--- a/goldfive/protocols.py
+++ b/goldfive/protocols.py
@@ -37,7 +37,7 @@ class Planner(Protocol):
         self,
         *,
         goals: list[Goal],
-        available_agents: list[str],
+        available_agents: list[str] | list[dict[str, Any]] | None,
         context: Mapping[str, Any] | None = None,
     ) -> Plan | None: ...
 
@@ -48,6 +48,7 @@ class Planner(Protocol):
         drift: DriftEvent,
         goals: list[Goal],
         observed_actions: list[ObservedAction] | None = None,
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> Plan | None: ...
 
 
@@ -143,6 +144,14 @@ class AgentAdapter(Protocol):
 
     @property
     def available_agents(self) -> list[str]: ...
+
+    # NOTE: goldfive#151 added a structured ``available_agents_tree``
+    # property on the shipped adapters (ADK, Claude, Callable) for the
+    # tree-aware planner, but it is intentionally *not* part of the
+    # Protocol so custom / legacy adapters that only expose
+    # ``available_agents`` still pass ``isinstance(x, AgentAdapter)``
+    # checks. Call sites look the attribute up via ``getattr`` and
+    # fall back to the flat list when absent.
 
 
 @runtime_checkable

--- a/goldfive/reconciler.py
+++ b/goldfive/reconciler.py
@@ -14,9 +14,15 @@ The reconciler is instantiated once per invocation (one per
 ``ADKAdapter.invoke_passthrough`` call) and receives three signal
 streams from the goldfive ADK plugin:
 
-* ``on_before_agent(name, invocation_id)`` — an agent in the tree
-  is about to run. Maps ``name`` to the first PENDING plan task
-  whose ``assignee_agent_id == name`` and transitions it RUNNING.
+* ``on_before_agent(name, invocation_id, parent_invocation_id="")``
+  — an agent in the tree is about to run. Maps ``name`` to the
+  first PENDING plan task whose ``assignee_agent_id == name`` and
+  transitions it RUNNING. When no direct match is found, the
+  reconciler walks the parent chain (via the invocation_id → agent
+  map accumulated across observations) and credits a PENDING task
+  assigned to any ancestor — goldfive#151 "contextual match" for
+  deep hierarchies where the plan assigned work to a coordinator
+  the tree routes through.
 * ``on_after_agent(name, invocation_id, error)`` — the agent
   finished. The currently-running task matched to ``name`` moves
   to COMPLETED (or FAILED when ``error`` is non-None).
@@ -131,6 +137,15 @@ class PlanReconciler:
         # — used to avoid emitting the same PLAN_DIVERGENCE drift
         # repeatedly when an off-plan agent loops.
         self._off_plan_seen: set[str] = set()
+        # Invocation bookkeeping for contextual matching (goldfive#151).
+        # ``_invocation_agent`` maps invocation_id → agent_name and is
+        # populated on every ``on_before_agent``; ``_invocation_parent``
+        # maps invocation_id → parent_invocation_id so :meth:`_parent_chain`
+        # can walk up to the root without the reconciler knowing the
+        # tree shape. Tree-agnostic: depth-1, depth-N, flat, and deep
+        # hierarchies all produce a single-edge-per-invocation map here.
+        self._invocation_agent: dict[str, str] = {}
+        self._invocation_parent: dict[str, str] = {}
         # Public counters for tests and observability.
         self.observed_agents: list[str] = []
         self.divergence_events: list[str] = []
@@ -144,11 +159,31 @@ class PlanReconciler:
         *,
         agent_name: str,
         invocation_id: str = "",
+        parent_invocation_id: str = "",
     ) -> None:
-        """An agent is about to run. Claim the matching plan task."""
+        """An agent is about to run. Claim the matching plan task.
+
+        ``parent_invocation_id`` (goldfive#151) is optional and only
+        consulted for contextual fallback matching: when the observed
+        agent has no direct plan task and also no intermediate-turn
+        escape (see below), the reconciler walks the invocation chain
+        using the ``_invocation_agent`` map and tries to match an
+        ancestor's name against the pending plan. This handles deep
+        hierarchies where the plan assigned work to an ancestor
+        coordinator but the tree ran the leaf directly via
+        ``transfer_to_agent`` / ``AgentTool``.
+        """
         if not agent_name:
             return
         self.observed_agents.append(agent_name)
+        # Record the invocation → agent mapping so subsequent
+        # observations can resolve parent chains. Tree-agnostic: the
+        # reconciler has no notion of depth — it just stores what
+        # the plugin tells it.
+        if invocation_id:
+            self._invocation_agent[invocation_id] = agent_name
+            if parent_invocation_id:
+                self._invocation_parent[invocation_id] = parent_invocation_id
         if self._is_host_agent_turn(agent_name, invocation_id):
             # Top-level host-agent before/after wraps the whole
             # dispatch; plan tasks never map to the host itself
@@ -159,6 +194,33 @@ class PlanReconciler:
             return
         task = self._pick_pending_for_agent(agent_name)
         if task is None:
+            # Contextual fallback (goldfive#151): when the observed
+            # agent is a leaf invoked via an ancestor coordinator
+            # delegation, the ancestor's name may carry the plan
+            # task. Walk the parent chain and try to claim the first
+            # ancestor that has a pending plan task. This is the
+            # inverse of the usual leaf-match case and handles plans
+            # that assigned to a coordinator the tree routes through.
+            ancestor_task = self._pick_pending_via_parent_chain(invocation_id)
+            if ancestor_task is not None:
+                self._running_by_agent[agent_name] = ancestor_task.id
+                self._observed_task_ids.add(ancestor_task.id)
+                try:
+                    await self._steerer.transition(
+                        ancestor_task.id,
+                        TaskStatus.RUNNING,
+                        detail=(
+                            f"observed: {agent_name} started (contextual match via "
+                            f"ancestor {ancestor_task.assignee_agent_id!r})"
+                        ),
+                        session=self._session,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "PlanReconciler.on_before_agent: contextual transition(RUNNING) raised: %s",
+                        exc,
+                    )
+                return
             # No PENDING task matches this agent — either an
             # off-plan agent or a plan task that already finished.
             # Emit PLAN_DIVERGENCE once per off-plan agent and
@@ -170,6 +232,22 @@ class PlanReconciler:
             # divergence. A coordinator that delegates to the
             # research agent twice is normal.
             if self._agent_has_any_plan_task(agent_name):
+                return
+            # Contextual-plumbing suppression (goldfive#151): if any
+            # descendant in the parent chain is itself plan-attached,
+            # treat the current agent as intermediate plumbing rather
+            # than divergence. Tree-agnostic — the check is over
+            # invocation bookkeeping, not tree structure.
+            if self._invocation_chain_contains_plan_attached_descendant(invocation_id):
+                return
+            # Symmetric suppression: when the agent is a descendant of
+            # a plan-attached ancestor (i.e. an ancestor coordinator
+            # carries a plan task), the current invocation is the
+            # leaf-side of a coordinator delegation. The ancestor
+            # already claimed its task; the leaf is plumbing here, not
+            # divergence.
+            chain = self._parent_chain(invocation_id)
+            if any(self._agent_has_any_plan_task(name) for name in chain):
                 return
             self._off_plan_seen.add(agent_name)
             await self._emit_divergence(
@@ -200,10 +278,15 @@ class PlanReconciler:
         invocation_id: str = "",
         error: BaseException | None = None,
         summary: str = "",
+        parent_invocation_id: str = "",
     ) -> None:
         """An agent finished. Close out its matched task."""
         if not agent_name:
             return
+        # Keep bookkeeping up to date even on close so parent-chain
+        # lookups from late observations stay resolvable.
+        if invocation_id and parent_invocation_id:
+            self._invocation_parent.setdefault(invocation_id, parent_invocation_id)
         if self._is_host_agent_turn(agent_name, invocation_id):
             return
         task_id = self._running_by_agent.pop(agent_name, "")
@@ -365,6 +448,79 @@ class PlanReconciler:
             if task.assignee_agent_id == agent_name:
                 return task
         return None
+
+    def _parent_chain(self, invocation_id: str) -> list[str]:
+        """Return the ordered list of ancestor agent names for ``invocation_id``.
+
+        Walks ``_invocation_parent`` up to the root. Stops on cycles
+        (shouldn't happen, but defensive) and on missing edges. Returns
+        ``[]`` when no chain is known.
+
+        Tree-agnostic: the reconciler does not read any tree metadata;
+        it composes the chain purely from observations it has already
+        received.
+        """
+        if not invocation_id:
+            return []
+        names: list[str] = []
+        seen: set[str] = set()
+        cur = self._invocation_parent.get(invocation_id, "")
+        while cur and cur not in seen:
+            seen.add(cur)
+            parent_name = self._invocation_agent.get(cur, "")
+            if parent_name:
+                names.append(parent_name)
+            cur = self._invocation_parent.get(cur, "")
+        return names
+
+    def _pick_pending_via_parent_chain(self, invocation_id: str) -> Task | None:
+        """Return a PENDING task whose assignee is in the parent chain.
+
+        Contextual match (goldfive#151): the leaf observation has no
+        directly-assigned plan task, but an ancestor coordinator on its
+        invocation chain does. Credit the leaf observation to the first
+        pending ancestor task we find walking up the chain.
+        """
+        chain = self._parent_chain(invocation_id)
+        if not chain:
+            return None
+        for ancestor in chain:
+            # Skip the host agent — its task semantics are handled by
+            # the direct-match rules.
+            task = self._pick_pending_for_agent(ancestor)
+            if task is not None:
+                return task
+        return None
+
+    def _invocation_chain_contains_plan_attached_descendant(
+        self,
+        invocation_id: str,
+    ) -> bool:
+        """Return True when any descendant observation already claimed a task.
+
+        Used to suppress PLAN_DIVERGENCE for intermediate coordinators
+        that the planner did not assign tasks to but which merely
+        route through to task-attached leaves. Kept as a small check
+        over the observation history — the reconciler never looks at
+        tree metadata directly (tree-agnostic invariant).
+        """
+        if not invocation_id:
+            return False
+        # Any observed invocation whose parent chain passes through
+        # ``invocation_id`` and whose agent_name has a plan task is a
+        # task-attached descendant.
+        for inv_id, parent in self._invocation_parent.items():
+            cur = parent
+            seen: set[str] = set()
+            while cur and cur not in seen:
+                seen.add(cur)
+                if cur == invocation_id:
+                    desc_name = self._invocation_agent.get(inv_id, "")
+                    if desc_name and self._agent_has_any_plan_task(desc_name):
+                        return True
+                    break
+                cur = self._invocation_parent.get(cur, "")
+        return False
 
     def _agent_has_any_plan_task(self, agent_name: str) -> bool:
         plan = self._session.plan

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -245,10 +245,21 @@ class Runner:
         planner_context["run_id"] = session.run_id
 
         # 4. Generate the plan.
+        # Prefer the richer tree shape (goldfive#151) when the adapter
+        # exposes it so the planner can constrain assignee_agent_id to
+        # real tree names and render the tree in its prompt. Adapters
+        # that don't implement the property fall through to the legacy
+        # flat list — keeps back-compat with custom adapters.
+        available_agents: Any
+        tree = getattr(self.agent, "available_agents_tree", None)
+        if isinstance(tree, list) and tree:
+            available_agents = list(tree)
+        else:
+            available_agents = list(self.agent.available_agents)
         try:
             plan = await self.planner.generate(
                 goals=session.goals,
-                available_agents=list(self.agent.available_agents),
+                available_agents=available_agents,
                 context=planner_context,
             )
         except Exception as exc:  # noqa: BLE001

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -226,6 +226,37 @@ def _severity_ge(a: DriftSeverity, b: DriftSeverity) -> bool:
     return _SEVERITY_ORDER[a] >= _SEVERITY_ORDER[b]
 
 
+def _planner_refine_accepts_available_agents(planner: Any) -> bool:
+    """Return True if ``planner.refine`` accepts ``available_agents=``.
+
+    The #151 registry kwarg is additive — the main goldfive planners
+    (``LLMPlanner``, ``PassthroughPlanner``, ``StaticPlanner``) all
+    accept it, but user-supplied / test-stub planners that predate
+    #151 have a refine signature without the kwarg. We probe the
+    signature once per drift and fall back to the legacy kwarg-set
+    when the kwarg would raise ``TypeError: unexpected keyword
+    argument``. Planners declared with ``**kwargs`` are assumed to
+    accept (the kwarg passes through).
+    """
+    import inspect
+
+    refine = getattr(planner, "refine", None)
+    if refine is None:
+        return False
+    try:
+        sig = inspect.signature(refine)
+    except (TypeError, ValueError):
+        # Unintrospectable callable — safest to not pass the kwarg.
+        return False
+    params = sig.parameters
+    if "available_agents" in params:
+        return True
+    for p in params.values():
+        if p.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # DefaultSteerer
 # ---------------------------------------------------------------------------
@@ -1377,12 +1408,39 @@ class DefaultSteerer:
         # a stale session pointer. See goldfive#133.
         self._active_session = session
         try:
+            # Thread the adapter's available_agents_tree (goldfive#151)
+            # through refine so the LLM is constrained to pick real
+            # tree assignees. Adapters without the property fall back
+            # to ``available_agents`` (list[str]); custom/legacy adapters
+            # without either surface produce ``None`` and the planner
+            # keeps its pre-#151 behaviour. Planners whose refine does
+            # not accept the kwarg (test stubs, pre-#151 custom
+            # planners) are called the old way so nothing breaks.
+            available_agents: Any = None
+            adapter = self._adapter
+            if adapter is not None:
+                tree = getattr(adapter, "available_agents_tree", None)
+                if isinstance(tree, list) and tree:
+                    available_agents = list(tree)
+                else:
+                    flat = getattr(adapter, "available_agents", None)
+                    if flat:
+                        available_agents = list(flat)
+            refine_accepts_registry = _planner_refine_accepts_available_agents(self._planner)
             try:
-                revised = await self._planner.refine(
-                    plan=session.plan,
-                    drift=drift,
-                    goals=list(session.goals),
-                )
+                if refine_accepts_registry:
+                    revised = await self._planner.refine(
+                        plan=session.plan,
+                        drift=drift,
+                        goals=list(session.goals),
+                        available_agents=available_agents,
+                    )
+                else:
+                    revised = await self._planner.refine(
+                        plan=session.plan,
+                        drift=drift,
+                        goals=list(session.goals),
+                    )
             except Exception as exc:  # noqa: BLE001 — refine errors must not break the run
                 # Surface the failure via logging + a synthetic follow-up
                 # drift so operators don't silently see the same plan loop

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -1148,8 +1148,7 @@ async def test_user_steer_primer_appended_after_function_response() -> None:
     agent = _make_agent()
 
     multi_parts = [
-        types.Part(function_call=types.FunctionCall(id=f"call-{i}", name=f"t{i}"))
-        for i in (1, 2)
+        types.Part(function_call=types.FunctionCall(id=f"call-{i}", name=f"t{i}")) for i in (1, 2)
     ]
     multi_event = Event(
         invocation_id="inv-steer",
@@ -1165,9 +1164,7 @@ async def test_user_steer_primer_appended_after_function_response() -> None:
     runner = _FakeRunner(_run, agent)
     adapter = ADKAdapter(runner, session_id="sess-steer")
 
-    invoke_task = asyncio.create_task(
-        adapter.invoke(Task(id="t1", title="x"), Session(run_id="r"))
-    )
+    invoke_task = asyncio.create_task(adapter.invoke(Task(id="t1", title="x"), Session(run_id="r")))
     await asyncio.sleep(0.01)
     # Simulate the executor tagging the adapter before triggering cancel.
     adapter._next_cancel_reason = SYMBOLIC_REASON_USER_STEER
@@ -1217,9 +1214,7 @@ async def test_replan_cancel_does_not_append_primer() -> None:
     runner = _FakeRunner(_run, agent)
     adapter = ADKAdapter(runner, session_id="sess-replan")
 
-    invoke_task = asyncio.create_task(
-        adapter.invoke(Task(id="t1", title="x"), Session(run_id="r"))
-    )
+    invoke_task = asyncio.create_task(adapter.invoke(Task(id="t1", title="x"), Session(run_id="r")))
     await asyncio.sleep(0.01)
     adapter._next_cancel_reason = SYMBOLIC_REASON_REPLAN
     invoke_task.cancel()
@@ -1250,9 +1245,7 @@ async def test_generic_cancel_does_not_append_primer() -> None:
     runner = _FakeRunner(_run, agent)
     adapter = ADKAdapter(runner, session_id="sess-generic")
 
-    invoke_task = asyncio.create_task(
-        adapter.invoke(Task(id="t1", title="x"), Session(run_id="r"))
-    )
+    invoke_task = asyncio.create_task(adapter.invoke(Task(id="t1", title="x"), Session(run_id="r")))
     await asyncio.sleep(0.01)
     # Do NOT set _next_cancel_reason — simulate the legacy code path
     # where the cancel arrives without a symbolic tag.
@@ -1323,9 +1316,7 @@ async def test_next_cancel_reason_cleared_after_consumption() -> None:
     runner = _FakeRunner(_run, agent)
     adapter = ADKAdapter(runner, session_id="sess-clear")
 
-    invoke_task = asyncio.create_task(
-        adapter.invoke(Task(id="t1", title="x"), Session(run_id="r"))
-    )
+    invoke_task = asyncio.create_task(adapter.invoke(Task(id="t1", title="x"), Session(run_id="r")))
     await asyncio.sleep(0.01)
     adapter._next_cancel_reason = SYMBOLIC_REASON_USER_STEER
     invoke_task.cancel()
@@ -1930,7 +1921,7 @@ async def test_reporting_tool_guards_fire_across_back_to_back_invocations() -> N
                             stripped = line.strip()
                             for prefix in ("Also, please: ", "Task: "):
                                 if stripped.startswith(prefix):
-                                    tail = stripped[len(prefix):]
+                                    tail = stripped[len(prefix) :]
                                     # Drop trailing punctuation / descriptions.
                                     for sep in (". ", "\n"):
                                         idx = tail.find(sep)
@@ -2107,6 +2098,120 @@ def test_available_agents_reports_reachable_names() -> None:
 
     adapter = ADKAdapter(root)
     assert adapter.available_agents == ["leaf", "mid", "root"]
+
+
+# ---------------------------------------------------------------------------
+# available_agents_tree — tree-aware planner constraints (goldfive#151)
+# ---------------------------------------------------------------------------
+
+
+def _mk_llm(name: str) -> Any:
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(name=name, model="fake-model", description=name, instruction="x")
+
+
+def test_available_agents_tree_single_llm_agent() -> None:
+    """Fixture 1: single LlmAgent. Tree has one root leaf."""
+    from goldfive.adapters.adk import ADKAdapter
+
+    solo = _mk_llm("solo")
+    adapter = ADKAdapter(solo)
+    tree = adapter.available_agents_tree
+    assert len(tree) == 1
+    entry = tree[0]
+    assert entry["name"] == "solo"
+    assert entry["depth"] == 0
+    assert entry["parent"] == ""
+    assert entry["role"] == "root"
+    assert entry["kind"] == "LlmAgent"
+
+
+def test_available_agents_tree_flat_specialist_tree() -> None:
+    """Fixture 2: coordinator with three specialist sub_agents.
+
+    Tree shape: coordinator (root) -> A, B, C (leaves, depth=1).
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    a = _mk_llm("agent_a")
+    b = _mk_llm("agent_b")
+    c = _mk_llm("agent_c")
+    coordinator = _mk_llm("coordinator")
+    coordinator.sub_agents = [a, b, c]
+
+    adapter = ADKAdapter(coordinator)
+    tree = adapter.available_agents_tree
+    by_name = {e["name"]: e for e in tree}
+    assert set(by_name) == {"coordinator", "agent_a", "agent_b", "agent_c"}
+    assert by_name["coordinator"]["depth"] == 0
+    assert by_name["coordinator"]["role"] == "root"
+    assert by_name["coordinator"]["parent"] == ""
+    for leaf_name in ("agent_a", "agent_b", "agent_c"):
+        entry = by_name[leaf_name]
+        assert entry["depth"] == 1
+        assert entry["role"] == "leaf"
+        assert entry["parent"] == "coordinator"
+        assert entry["kind"] == "LlmAgent"
+
+
+def test_available_agents_tree_deep_hierarchy() -> None:
+    """Fixture 3: deep hierarchy (depth >= 3)."""
+    from goldfive.adapters.adk import ADKAdapter
+
+    leaf1 = _mk_llm("leaf1")
+    leaf2 = _mk_llm("leaf2")
+    coord1 = _mk_llm("coord1")
+    coord1.sub_agents = [leaf1, leaf2]
+    root = _mk_llm("root")
+    root.sub_agents = [coord1]
+
+    adapter = ADKAdapter(root)
+    tree = adapter.available_agents_tree
+    by_name = {e["name"]: e for e in tree}
+    assert set(by_name) == {"root", "coord1", "leaf1", "leaf2"}
+    assert by_name["root"]["depth"] == 0
+    assert by_name["root"]["role"] == "root"
+    assert by_name["coord1"]["depth"] == 1
+    assert by_name["coord1"]["role"] == "intermediate"
+    assert by_name["coord1"]["parent"] == "root"
+    assert by_name["leaf1"]["depth"] == 2
+    assert by_name["leaf1"]["parent"] == "coord1"
+    assert by_name["leaf1"]["role"] == "leaf"
+    assert by_name["leaf2"]["depth"] == 2
+    assert by_name["leaf2"]["parent"] == "coord1"
+    assert by_name["leaf2"]["role"] == "leaf"
+
+
+def test_available_agents_tree_agnostic_to_agent_class() -> None:
+    """Custom BaseAgent subclasses pass through ``kind`` unchanged.
+
+    Tree-agnostic invariant (goldfive#151): the walker reports the raw
+    class name of whatever agent is in the tree — it does NOT
+    special-case LlmAgent / SequentialAgent / ParallelAgent / BaseAgent.
+    """
+    from google.adk.agents.base_agent import BaseAgent  # type: ignore
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    class CustomAgent(BaseAgent):
+        """A caller-supplied subclass the walker must not interpret."""
+
+        async def _run_async_impl(self, ctx):  # noqa: D401, ANN001
+            return
+            yield  # pragma: no cover - required async generator shape
+
+    custom_leaf = CustomAgent(name="my_custom_leaf", description="x")
+    root = _mk_llm("root")
+    root.sub_agents = [custom_leaf]
+
+    adapter = ADKAdapter(root)
+    tree = adapter.available_agents_tree
+    by_name = {e["name"]: e for e in tree}
+    assert by_name["my_custom_leaf"]["kind"] == "CustomAgent"
+    assert by_name["my_custom_leaf"]["role"] == "leaf"
+    assert by_name["my_custom_leaf"]["parent"] == "root"
+    assert by_name["root"]["kind"] == "LlmAgent"
 
 
 async def test_invoke_always_drives_the_one_runner() -> None:

--- a/tests/test_plan_reconciler.py
+++ b/tests/test_plan_reconciler.py
@@ -462,5 +462,306 @@ async def test_task_without_assignee_not_claimed() -> None:
     assert steerer.transitions == []
     assert session.plan.tasks[0].status is TaskStatus.PENDING
     # And the no-assignee agent is recorded as divergent (there's no
-    # plan task targeting it).
+    # plan task targeting any_agent and no ancestor chain to resolve).
     assert len(steerer.drifts) == 1
+
+
+# ---------------------------------------------------------------------------
+# 10. Contextual match via parent_invocation_id chain (goldfive#151).
+# ---------------------------------------------------------------------------
+
+
+async def test_reconciler_contextual_match_via_parent_invocation() -> None:
+    """Plan assigned to a leaf; tree delegates through an intermediate coord.
+
+    Tree shape driving the observations:
+
+        root (host) → coord1 → leaf1
+
+    Plan assigns ``t0`` to ``leaf1``. The tree actually invokes
+    ``coord1`` first (an intermediate with no plan task), which then
+    delegates to ``leaf1`` via an ``AgentTool`` sub-Runner. The
+    reconciler credits ``t0`` on leaf1's direct name match AND it
+    does NOT emit PLAN_DIVERGENCE for coord1, because the invocation
+    chain contains a task-attached descendant.
+
+    Tree-agnostic: the reconciler never reads real tree metadata —
+    it only uses the invocation_id → agent_name map and the
+    parent_invocation_id edges the plugin hands in.
+    """
+    session = _make_session(
+        [
+            Task(id="t0", title="do leaf work", assignee_agent_id="leaf1"),
+        ]
+    )
+    steerer = _RecordingSteerer()
+    rec = PlanReconciler(session=session, steerer=steerer, host_agent_name="root")
+
+    # Outer (host) turn — skipped by host-agent rule.
+    await rec.on_before_agent(agent_name="root", invocation_id="inv_root")
+    # Leaf fires inside a nested AgentTool sub-Runner; its parent
+    # chain is inv_leaf -> inv_coord -> inv_root. Direct name match
+    # wins for ``leaf1``.
+    await rec.on_before_agent(
+        agent_name="leaf1",
+        invocation_id="inv_leaf",
+        parent_invocation_id="inv_coord",
+    )
+    await rec.on_after_agent(
+        agent_name="leaf1",
+        invocation_id="inv_leaf",
+        parent_invocation_id="inv_coord",
+        summary="leaf1 did the work",
+    )
+    # Intermediate coordinator's own before/after (as sibling under
+    # the outer invocation). Without the invocation map it would
+    # emit PLAN_DIVERGENCE because coord1 is off-plan; with the map
+    # the reconciler sees ``leaf1`` under coord1's sub-chain and
+    # suppresses the divergence.
+    await rec.on_before_agent(
+        agent_name="coord1",
+        invocation_id="inv_coord",
+        parent_invocation_id="inv_root",
+    )
+
+    statuses = [s[1] for s in steerer.transitions]
+    assert TaskStatus.RUNNING in statuses
+    assert TaskStatus.COMPLETED in statuses
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+    # No divergence: coord1's chain contained leaf1 which matched t0.
+    assert steerer.drifts == []
+
+
+async def test_reconciler_contextual_match_plan_on_coordinator() -> None:
+    """Inverse scenario: plan assigned to an ancestor, tree runs the leaf.
+
+    Tree shape: root (host) → coord1 → leaf1, with plan task
+    assigned to ``coord1``. The tree invokes the leaf directly via
+    an AgentTool sub-Runner; the leaf has no direct match but walks
+    up its parent chain, finds coord1's PENDING task, and claims it.
+    """
+    session = _make_session(
+        [
+            Task(id="t0", title="coord work", assignee_agent_id="coord1"),
+        ]
+    )
+    steerer = _RecordingSteerer()
+    rec = PlanReconciler(session=session, steerer=steerer, host_agent_name="root")
+
+    await rec.on_before_agent(agent_name="root", invocation_id="inv_root")
+    # Leaf fires first (e.g. the tree skipped coord1's own before
+    # turn because it delegated immediately). The reconciler has no
+    # prior mapping for inv_coord yet; contextual match still needs
+    # to resolve it. We record the parent edge here so the walker
+    # has something to chase. When inv_coord has no name in the map
+    # the walker continues up to inv_root (host), which has no plan
+    # task either. Only after coord1 fires (below) does the leaf's
+    # retry of contextual match succeed via coord1. Real plugins
+    # fire coord1 before leaf1; we mirror that here:
+    await rec.on_before_agent(
+        agent_name="coord1",
+        invocation_id="inv_coord",
+        parent_invocation_id="inv_root",
+    )
+    # coord1 directly matches t0 (plan assigned to coord1).
+    # When leaf1 then fires as a child invocation there's no PENDING
+    # task left; contextual-match returns None and the leaf observation
+    # is credited as a revisit of an already-terminal task (no
+    # divergence, no double-count).
+    await rec.on_before_agent(
+        agent_name="leaf1",
+        invocation_id="inv_leaf",
+        parent_invocation_id="inv_coord",
+    )
+    await rec.on_after_agent(
+        agent_name="coord1",
+        invocation_id="inv_coord",
+        parent_invocation_id="inv_root",
+        summary="coord1 delegated to leaf1",
+    )
+
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+    assert steerer.drifts == []
+
+
+async def test_reconciler_contextual_match_suppresses_coord_divergence() -> None:
+    """An intermediate coord with a task-attached descendant does not diverge.
+
+    When the plan assigns work to a leaf and the tree routes through
+    an intermediate coordinator, the coordinator's own before/after
+    should NOT emit PLAN_DIVERGENCE because its invocation chain
+    contains a task-attached descendant.
+    """
+    session = _make_session(
+        [
+            Task(id="t0", title="leaf work", assignee_agent_id="leaf1"),
+        ]
+    )
+    steerer = _RecordingSteerer()
+    rec = PlanReconciler(session=session, steerer=steerer, host_agent_name="root")
+
+    # root (host) — skipped.
+    await rec.on_before_agent(agent_name="root", invocation_id="inv_root")
+    # leaf fires via AgentTool sub-Runner — claims t0 directly.
+    await rec.on_before_agent(
+        agent_name="leaf1",
+        invocation_id="inv_leaf",
+        parent_invocation_id="inv_coord",
+    )
+    # coord1 (intermediate) fires after we've already seen the leaf
+    # under its chain. The reconciler must not emit PLAN_DIVERGENCE
+    # because coord1's chain contains a plan-attached descendant.
+    await rec.on_before_agent(
+        agent_name="coord1",
+        invocation_id="inv_coord",
+        parent_invocation_id="inv_root",
+    )
+
+    assert session.plan.tasks[0].status is TaskStatus.RUNNING
+    # No divergence emitted: leaf matched directly and coord1 was
+    # observed as plumbing, not divergence.
+    assert steerer.drifts == []
+
+
+async def test_reconciler_tracks_invocation_to_agent_map() -> None:
+    """Observations populate the invocation_id → agent_name map.
+
+    Tree-agnostic: whatever invocation_id/parent edges the plugin
+    hands in are stored verbatim, without the reconciler consulting
+    any tree metadata.
+    """
+    session = _make_session(
+        [
+            Task(id="t0", title="a", assignee_agent_id="agent_a"),
+        ]
+    )
+    steerer = _RecordingSteerer()
+    rec = PlanReconciler(session=session, steerer=steerer, host_agent_name="root")
+
+    await rec.on_before_agent(
+        agent_name="agent_a",
+        invocation_id="inv_a",
+        parent_invocation_id="inv_root",
+    )
+
+    assert rec._invocation_agent.get("inv_a") == "agent_a"
+    assert rec._invocation_parent.get("inv_a") == "inv_root"
+
+
+# ---------------------------------------------------------------------------
+# 11. Tree-shape full-lifecycle fixtures (goldfive#151).
+# ---------------------------------------------------------------------------
+
+
+async def test_lifecycle_single_agent_tree() -> None:
+    """Fixture 1 lifecycle: single LlmAgent. Plan's only assignee is the root.
+
+    The reconciler claims the task on the root agent's direct name
+    match; no parent chain is needed.
+    """
+    session = _make_session(
+        [
+            Task(id="t0", title="do it", assignee_agent_id="solo"),
+        ]
+    )
+    steerer = _RecordingSteerer()
+    rec = PlanReconciler(session=session, steerer=steerer, host_agent_name="solo")
+
+    # Single agent tree: the host IS the assignee. The host-skip
+    # rule yields when the plan has a task targeting the host.
+    await rec.on_before_agent(agent_name="solo", invocation_id="inv1")
+    await rec.on_after_agent(agent_name="solo", invocation_id="inv1")
+
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+    assert steerer.drifts == []
+    assert rec.get_missed_tasks() == []
+
+
+async def test_lifecycle_flat_specialist_tree() -> None:
+    """Fixture 2 lifecycle: coordinator + 3 specialists. Plan routes to leaves.
+
+    Reconciler matches each leaf on direct name match; no contextual
+    walk needed; no divergence.
+    """
+    session = _make_session(
+        [
+            Task(id="t0", title="research", assignee_agent_id="agent_a"),
+            Task(id="t1", title="write", assignee_agent_id="agent_b"),
+            Task(id="t2", title="review", assignee_agent_id="agent_c"),
+        ]
+    )
+    steerer = _RecordingSteerer()
+    rec = PlanReconciler(session=session, steerer=steerer, host_agent_name="coordinator")
+
+    for name, inv in (("agent_a", "inv_a"), ("agent_b", "inv_b"), ("agent_c", "inv_c")):
+        await rec.on_before_agent(
+            agent_name=name,
+            invocation_id=inv,
+            parent_invocation_id="inv_root",
+        )
+        await rec.on_after_agent(
+            agent_name=name,
+            invocation_id=inv,
+            parent_invocation_id="inv_root",
+        )
+
+    statuses = {t.id: t.status for t in session.plan.tasks}
+    assert statuses == {
+        "t0": TaskStatus.COMPLETED,
+        "t1": TaskStatus.COMPLETED,
+        "t2": TaskStatus.COMPLETED,
+    }
+    assert steerer.drifts == []
+
+
+async def test_lifecycle_deep_hierarchy() -> None:
+    """Fixture 3 lifecycle: root → coord1 → leaf1, leaf2. Plan routes to leaves.
+
+    The intermediate coord1 is plumbing — its own before should not
+    diverge because its invocation chain contains plan-attached
+    descendants (leaf1, leaf2). Leaf tasks credit on direct match.
+    """
+    session = _make_session(
+        [
+            Task(id="t0", title="one", assignee_agent_id="leaf1"),
+            Task(id="t1", title="two", assignee_agent_id="leaf2"),
+        ]
+    )
+    steerer = _RecordingSteerer()
+    rec = PlanReconciler(session=session, steerer=steerer, host_agent_name="root")
+
+    await rec.on_before_agent(agent_name="root", invocation_id="inv_root")
+    # Leaves fire through the coord's delegation; the reconciler
+    # sees leaf invocations parented to inv_coord, which parents to
+    # inv_root. coord1's own turn fires in between but is suppressed
+    # as intermediate plumbing.
+    await rec.on_before_agent(
+        agent_name="leaf1",
+        invocation_id="inv_leaf1",
+        parent_invocation_id="inv_coord",
+    )
+    await rec.on_after_agent(
+        agent_name="leaf1",
+        invocation_id="inv_leaf1",
+        parent_invocation_id="inv_coord",
+    )
+    await rec.on_before_agent(
+        agent_name="coord1",
+        invocation_id="inv_coord",
+        parent_invocation_id="inv_root",
+    )
+    await rec.on_before_agent(
+        agent_name="leaf2",
+        invocation_id="inv_leaf2",
+        parent_invocation_id="inv_coord",
+    )
+    await rec.on_after_agent(
+        agent_name="leaf2",
+        invocation_id="inv_leaf2",
+        parent_invocation_id="inv_coord",
+    )
+
+    statuses = {t.id: t.status for t in session.plan.tasks}
+    assert statuses == {"t0": TaskStatus.COMPLETED, "t1": TaskStatus.COMPLETED}
+    # coord1 is plumbing — no PLAN_DIVERGENCE.
+    assert steerer.drifts == []

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -269,6 +269,173 @@ async def test_llm_planner_generate_handles_json_without_tasks() -> None:
 
 
 # ---------------------------------------------------------------------------
+# LLMPlanner.generate — tree-aware registry constraints (goldfive#151)
+# ---------------------------------------------------------------------------
+
+
+def _tree_registry() -> list[dict[str, object]]:
+    """A structured tree matching the canned plan's assignees."""
+    return [
+        {"name": "coordinator", "depth": 0, "parent": "", "role": "root", "kind": "LlmAgent"},
+        {
+            "name": "researcher",
+            "depth": 1,
+            "parent": "coordinator",
+            "role": "leaf",
+            "kind": "LlmAgent",
+        },
+        {
+            "name": "writer",
+            "depth": 1,
+            "parent": "coordinator",
+            "role": "leaf",
+            "kind": "LlmAgent",
+        },
+        {
+            "name": "editor",
+            "depth": 1,
+            "parent": "coordinator",
+            "role": "leaf",
+            "kind": "LlmAgent",
+        },
+    ]
+
+
+def _off_registry_plan_json() -> str:
+    """A plan whose assignees don't match the registry names."""
+    return json.dumps(
+        {
+            "summary": "Off-registry plan.",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research",
+                    "description": "Do research.",
+                    "assignee_agent_id": "agent_researcher",
+                },
+                {
+                    "id": "draft",
+                    "title": "Draft",
+                    "description": "Draft post.",
+                    "assignee_agent_id": "agent_content",
+                },
+            ],
+            "edges": [{"from_task_id": "research", "to_task_id": "draft"}],
+        }
+    )
+
+
+async def test_generate_prompt_renders_agent_tree_when_tree_given() -> None:
+    """Passing the structured tree form renders an AGENT TREE section."""
+    stub = _StubLLM(_canned_plan_json())
+    planner = LLMPlanner(call_llm=stub)
+    await planner.generate(
+        goals=_goals(),
+        available_agents=_tree_registry(),
+    )
+    assert stub.calls, "stub should have been invoked"
+    _sys, user, _model = stub.calls[0]
+    assert "AGENT TREE" in user
+    # Tree metadata surfaces (role / kind / depth).
+    assert "role=root" in user
+    assert "role=leaf" in user
+    assert "kind=LlmAgent" in user
+
+
+async def test_generate_prompt_flat_list_renders_legacy_header() -> None:
+    """Legacy ``list[str]`` callers still see the old 'Available agents:' header."""
+    stub = _StubLLM(_canned_plan_json())
+    planner = LLMPlanner(call_llm=stub)
+    await planner.generate(
+        goals=_goals(),
+        available_agents=["researcher", "writer", "editor"],
+    )
+    _sys, user, _model = stub.calls[0]
+    assert "Available agents:" in user
+    assert "AGENT TREE" not in user
+
+
+async def test_validator_rejects_off_registry_assignee() -> None:
+    """Plans whose assignees aren't in the registry are rejected on every attempt.
+
+    Exhausts the retry budget because the stub always returns the same
+    off-registry JSON; ``generate`` eventually returns ``None``.
+    """
+
+    class _AlwaysOffRegistry:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, str]] = []
+
+        async def __call__(self, system: str, user: str, model: str) -> str:
+            self.calls.append((system, user, model))
+            return _off_registry_plan_json()
+
+    stub = _AlwaysOffRegistry()
+    planner = LLMPlanner(call_llm=stub, max_refine_attempts=2)
+    result = await planner.generate(
+        goals=_goals(),
+        available_agents=_tree_registry(),
+    )
+    assert result is None
+    # The retry loop fired the full budget.
+    assert len(stub.calls) == 2
+    # The retry prompt fed the validator error back to the LLM.
+    _sys, retry_user, _ = stub.calls[1]
+    assert "off-registry assignee" in retry_user
+
+
+async def test_retry_loop_corrects_off_registry_assignee() -> None:
+    """First attempt uses bogus assignees; second attempt picks the real names.
+
+    Demonstrates the #133/#136 retry-with-correction loop wired into
+    the #151 registry check: the validator's error message feeds the
+    second prompt, and the second response validates cleanly.
+    """
+
+    class _Correcting:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, str]] = []
+
+        async def __call__(self, system: str, user: str, model: str) -> str:
+            self.calls.append((system, user, model))
+            if len(self.calls) == 1:
+                return _off_registry_plan_json()
+            return _canned_plan_json()
+
+    stub = _Correcting()
+    planner = LLMPlanner(call_llm=stub, max_refine_attempts=3)
+    plan = await planner.generate(
+        goals=_goals(),
+        available_agents=_tree_registry(),
+    )
+    assert plan is not None
+    # Second attempt used the real registry names.
+    assignees = {t.assignee_agent_id for t in plan.tasks}
+    assert assignees <= {"researcher", "writer", "editor"}
+    # Correction feedback landed in the retry prompt.
+    _sys, retry_user, _ = stub.calls[1]
+    assert "off-registry assignee" in retry_user
+
+
+async def test_generate_accepts_none_registry_backcompat() -> None:
+    """``available_agents=None`` skips the registry check entirely.
+
+    Preserves back-compat with callers that don't supply a registry —
+    the plan validates structurally but no assignee-membership check
+    fires.
+    """
+    stub = _StubLLM(_off_registry_plan_json())
+    planner = LLMPlanner(call_llm=stub, max_refine_attempts=2)
+    plan = await planner.generate(
+        goals=_goals(),
+        available_agents=None,
+    )
+    # With no registry, off-registry names are allowed.
+    assert plan is not None
+    assert len(stub.calls) == 1
+
+
+# ---------------------------------------------------------------------------
 # LLMPlanner.refine
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #151.

## Summary

- **`ADKAdapter.available_agents_tree`** — tree-agnostic structured walker returning `[{name, depth, parent, role, kind}]` for every reachable agent (same traversal as `_build_agent_registry`). `kind` passes through any ADK class name (`LlmAgent`, `SequentialAgent`, `ParallelAgent`, `BaseAgent`, or custom subclasses) without interpretation. Also surfaced on `CallableAdapter` / `ClaudeAdapter` as a flat single-entry tree for consistency.
- **`LLMPlanner.generate` / `.refine` accept `available_agents=None` / `list[str]` / `list[dict]`** — when a tree is supplied, the prompt renders an `AGENT TREE` section and the validator rejects off-registry `assignee_agent_id` values. The existing #133/#136 retry-with-correction loop feeds the validator error back to the LLM on the next attempt. Empty registry skips the check (back-compat). `PassthroughPlanner` / `StaticPlanner` / the `Planner` Protocol gain the kwarg; the `Steerer` probes the planner's `refine` signature so legacy custom planners keep working.
- **`PlanReconciler` contextual match** — tracks `invocation_id → agent_name` + `invocation_id → parent_invocation_id` as observations arrive. When a leaf's direct name match fails, walks the parent chain and credits a PENDING task assigned to any ancestor. Symmetric suppression: intermediate coordinators no longer fire spurious `PLAN_DIVERGENCE` when their invocation chain contains plan-attached descendants (or when one of their ancestors carries a plan task). The ADK plugin forwards `parent_invocation_id` via a back-compat shim that falls through to the pre-#151 signature on `TypeError`.

## Test plan

- [x] `test_available_agents_tree_single_llm_agent` / `_flat_specialist_tree` / `_deep_hierarchy` / `_agnostic_to_agent_class` (custom `BaseAgent` subclass) in `tests/test_adk_adapter.py`
- [x] `test_validator_rejects_off_registry_assignee` / `test_retry_loop_corrects_off_registry_assignee` / `test_generate_prompt_renders_agent_tree_when_tree_given` / `test_generate_prompt_flat_list_renders_legacy_header` / `test_generate_accepts_none_registry_backcompat` in `tests/test_planner.py`
- [x] `test_reconciler_contextual_match_via_parent_invocation` / `test_reconciler_contextual_match_plan_on_coordinator` / `test_reconciler_tracks_invocation_to_agent_map` / three full-lifecycle fixtures (`test_lifecycle_single_agent_tree`, `test_lifecycle_flat_specialist_tree`, `test_lifecycle_deep_hierarchy`) in `tests/test_plan_reconciler.py`
- [x] `uv run pytest -q` — 810 passed, 46 skipped
- [x] `uv run ruff check` — clean

## Coordination

Sibling PRs #152 (state namespace), #153 (GoldfivePlanner), #154 (goal-aware refine), #155 (proto fix) are running in parallel worktrees. Primary overlap point is `LLMPlanner.refine` with #154 — both changes are additive (different kwargs, different prompt regions) and should rebase cleanly.