### PR TITLE
Pin outer adk-web session id onto goldfive Session.id (closes #161)

### DIFF
--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -237,24 +237,43 @@ class GoldfiveADKAgent(BaseAgent):
         :meth:`BaseAgent.run_async` is ``@final`` — overriding this
         protected hook is ADK's documented extension seam.
         """
-        # Pin the outer adk-web session id onto the ADKAdapter BEFORE
-        # any sub-agent dispatch kicks in (goldfive#125). adk-web creates
-        # its own session ``X`` and invokes us via this hook; without
-        # pinning, ``ADKAdapter._ensure_session_for`` would lazily mint
-        # a fresh uuid ``Y`` that all per-agent runners share — but
-        # ``Y != X``, so :class:`HarmonografTelemetryPlugin` stamps the
-        # coordinator's spans under ``X`` (adk-web's own runner) and
-        # every sub-agent span under ``Y`` (the adapter's internal
-        # shared id). Users see two harmonograf sessions per run.
+        # Pin the outer adk-web session id onto the goldfive Session
+        # AND the ADKAdapter BEFORE any sub-agent dispatch kicks in
+        # (goldfive#161). Three layers of session identity exist under
+        # overlay + AgentTool:
         #
-        # Pinning here anchors the adapter's shared outer id to
-        # adk-web's real session id so coordinator + sub-agent spans
-        # roll up to ONE harmonograf session. Idempotent: we only set
-        # it if nothing has been pinned yet (constructor path, prior
-        # invocation), and we skip entirely when the context lacks a
-        # usable string session id (bare-Runner / test-harness ctx
-        # shapes fall back to the lazy-uuid path from goldfive#123).
-        self._pin_outer_session_from_ctx(ctx)
+        #   1. adk-web's outer ``ctx.session.id`` (the URL session id
+        #      users see in the harmonograf UI)
+        #   2. goldfive ``Session.id`` (== ``run_id``, minted uuid4
+        #      from :class:`Conversation.next_turn_session`)
+        #   3. the ADKAdapter's internal ``_session_id`` (minted uuid4
+        #      in :meth:`ADKAdapter._ensure_session`)
+        #
+        # If we let each layer pick its own id, goldfive Event
+        # envelopes stamp ``Session.id`` (layer 2) via the #155
+        # per-event session routing field, but harmonograf spans carry
+        # ``ctx.session.id`` (layer 1). The plan view then shows an
+        # empty Gantt: the spans are on the adk-web session, but the
+        # plan / task rows are on the goldfive session. See goldfive#161.
+        #
+        # Pinning layer 1's id onto layer 2 (via the ``session_id=``
+        # override on :meth:`Runner.run`) and layer 3 (via the
+        # adapter's ``_session_id`` / ``_outer_session_id``) makes all
+        # three equal. Harmonograf's plugin (per goldfive#162) caches
+        # the same id for every span it stamps. Result: plan +
+        # execution co-locate on one harmonograf session.
+        #
+        # Idempotent / safe fallback:
+        # * Empty ``ctx.session.id`` (bare contexts, test harnesses
+        #   that skip ``ctx.session``) falls through to the legacy
+        #   uuid4 mint from :meth:`Conversation.next_turn_session` +
+        #   :meth:`ADKAdapter._ensure_session`, preserving back-compat.
+        # * Subsequent invocations (overlay STEER restart, follow-up
+        #   turns) receive the SAME ``ctx.session.id`` from adk-web
+        #   because adk-web keeps the session stable across turns on
+        #   the same URL, so the pin stays consistent.
+        outer_sid = self._outer_session_id_from_ctx(ctx)
+        self._pin_outer_session_on_adapter(outer_sid)
 
         user_input = _extract_user_input(ctx)
         if not user_input:
@@ -266,49 +285,61 @@ class GoldfiveADKAgent(BaseAgent):
             return
 
         outcome = await self._runner.run(
-            user_input, context={"adk_ctx": ctx}
+            user_input,
+            context={"adk_ctx": ctx},
+            session_id=outer_sid or None,
         )
         async for adk_event in _outcome_to_adk_events(
             outcome, ctx, author=self.name
         ):
             yield adk_event
 
-    def _pin_outer_session_from_ctx(self, ctx: InvocationContext) -> None:
-        """Adopt ``ctx.session.id`` as the ADKAdapter's outer session id.
+    @staticmethod
+    def _outer_session_id_from_ctx(ctx: InvocationContext) -> str:
+        """Return ``ctx.session.id`` when usable, ``""`` otherwise.
 
-        On the first adk-web invocation, ``ctx`` carries adk-web's own
-        session id (the one users see in the harmonograf UI). Pinning
-        it onto :attr:`ADKAdapter._outer_session_id` makes every
-        per-agent runner's ``_ensure_session_for`` return that same id,
-        so :class:`HarmonografTelemetryPlugin` stamps the SAME
-        ``ctx.session.id`` onto coordinator AND sub-agent spans. See
-        goldfive#125.
-
-        No-op when:
-
-        * The adapter already has a pinned outer id (constructor
-          ``outer_session_id=`` / ``session_id=``, or a previous
-          invocation already pinned one). We never OVERWRITE — the
-          caller's constructor value is authoritative.
-        * The context does not carry a usable string session id (bare
-          ``Runner`` callers, fake contexts in tests that skip
-          ``ctx.session``). The lazy-uuid4 fallback from goldfive#123
-          then still kicks in on the next ``_ensure_session_for``.
+        Defensive: ADK contexts in tests may omit ``session`` or
+        substitute it with a value whose ``id`` is ``None`` / empty.
+        Centralises the guard so the pin path and the Runner handoff
+        stay in sync.
         """
+        session = getattr(ctx, "session", None)
+        if session is None:
+            return ""
+        sid = getattr(session, "id", None)
+        if not isinstance(sid, str):
+            return ""
+        return sid
+
+    def _pin_outer_session_on_adapter(self, outer_sid: str) -> None:
+        """Adopt ``outer_sid`` on the ADKAdapter's session bookkeeping.
+
+        Pins both ``_outer_session_id`` (for structural consumers that
+        want the raw outer id for logging) and ``_session_id`` (used
+        by :meth:`ADKAdapter._ensure_session` and
+        :meth:`ADKAdapter._heal_pending_tool_calls`). The goal is for
+        the adapter's internal ADK session creation to use the SAME id
+        as the outer adk-web session so the harmonograf plugin sees
+        one session id across both layers.
+
+        No-op when ``outer_sid`` is empty — the adapter's lazy-uuid
+        mint still runs and the legacy behaviour is preserved.
+
+        Never overwrites an adapter that already carries a pinned
+        ``_session_id`` (constructor ``session_id=`` is authoritative).
+        """
+        if not outer_sid:
+            return
         adapter = getattr(self._runner, "agent", None)
         if adapter is None:
             return
-        # Guard against non-ADKAdapter adapters (custom AgentAdapter
-        # implementations under the same wrap path) that don't carry
-        # the shared-outer-session attribute.
-        if not hasattr(adapter, "_outer_session_id"):
-            return
-        if adapter._outer_session_id:
-            return
-        sid = getattr(getattr(ctx, "session", None), "id", None)
-        if not isinstance(sid, str) or not sid:
-            return
-        adapter._outer_session_id = sid
+        # Pin the forensic-only outer id when the attribute exists.
+        if hasattr(adapter, "_outer_session_id") and not adapter._outer_session_id:
+            adapter._outer_session_id = outer_sid
+        # Pin the adapter's effective ADK session id. Constructor
+        # ``session_id=`` wins; we only set when it was empty.
+        if hasattr(adapter, "_session_id") and not adapter._session_id:
+            adapter._session_id = outer_sid
 
     # ------------------------------------------------------------------
     # Runner passthrough — keeps the programmatic entry point working.

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -187,14 +187,36 @@ class Runner:
         user_input: str | list[Goal],
         *,
         context: Mapping[str, Any] | None = None,
+        session_id: str | None = None,
     ) -> ExecutionOutcome:
-        """Execute one end-to-end goldfive run and return the outcome."""
+        """Execute one end-to-end goldfive run and return the outcome.
+
+        ``session_id`` optionally overrides the ``Session.run_id`` /
+        ``Session.id`` that :class:`Conversation.next_turn_session`
+        would otherwise mint. Used by :class:`GoldfiveADKAgent` to
+        adopt the outer adk-web ``InvocationContext.session.id`` so
+        every goldfive Event emitted through sinks stamps the same
+        session id that harmonograf spans carry (goldfive#161). Empty
+        / ``None`` preserves the legacy uuid4 mint so bare programmatic
+        Runner callers see no behaviour change.
+        """
 
         # 1. Build Session seeded by the Conversation. The Session's
         #    run_id is fresh for this turn; conversation_id is stable
         #    across turns; goals / completed_results are pre-populated
         #    with prior-turn state.
         session = self._conversation.next_turn_session()
+        # Outer-session pin (goldfive#161): when the caller supplies a
+        # non-empty ``session_id`` (typically ``ctx.session.id`` from
+        # adk-web), override the freshly-minted ``run_id`` so every
+        # Event emitted this turn carries that id. Sinks stamp
+        # ``Event.session_id`` from ``Session.id`` (= ``run_id``), so
+        # this aligns goldfive events with the ADK session that
+        # harmonograf spans already target — resolving the
+        # "plan view has empty Gantt" regression from the overlay
+        # architecture.
+        if session_id:
+            session.run_id = session_id
         self._last_session = session
 
         # 2. Announce the Conversation on the first turn.

--- a/tests/test_goldfive_session_pin_outer.py
+++ b/tests/test_goldfive_session_pin_outer.py
@@ -1,0 +1,352 @@
+"""Tests for outer-session pinning on :class:`GoldfiveADKAgent` (goldfive#161).
+
+When adk-web drives a wrapped goldfive tree, the outer
+``InvocationContext.session.id`` is the session id users see in the
+harmonograf UI. goldfive's ``Session.run_id`` is minted independently by
+:class:`Conversation.next_turn_session` (a uuid4), and the ADKAdapter's
+internal ADK session id is minted by :meth:`ADKAdapter._ensure_session`
+(another uuid4). Three layers of identity — three different session ids
+stamped on different pieces of the stream — produce a harmonograf UI
+where the plan view is empty and the span view has no plan.
+
+The fix: ``GoldfiveADKAgent._run_async_impl`` reads ``ctx.session.id``
+and pins it onto BOTH the goldfive ``Session.run_id`` (via
+``Runner.run(session_id=...)``) AND the adapter's ``_session_id`` /
+``_outer_session_id``. That way every goldfive Event and every
+harmonograf span stamp the same id.
+
+Back-compat: bare ``Runner.run`` callers (no adk-web ctx) keep seeing
+minted uuid4 ``run_id`` s — nothing about the programmatic entry point
+changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+import goldfive
+from goldfive import (
+    InMemorySink,
+    InvocationResult,
+    Runner,
+    SequentialExecutor,
+    StaticPlanner,
+)
+from goldfive.types import Plan, Task
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — minimal fakes for the InvocationContext shape the wrapper reads.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """Mirrors ``InvocationContext.session`` — exposes ``id`` + ``events``."""
+
+    def __init__(self, sid: str = "") -> None:
+        self.id = sid
+        self.events: list[Any] = []
+
+
+class _FakeCtx:
+    """Stand-in for an ADK ``InvocationContext`` carrying a user turn.
+
+    The wrapper only reads ``user_content``, ``invocation_id`` and
+    ``session`` off the context.
+    """
+
+    def __init__(self, text: str, session_id: str = "") -> None:
+        from google.genai.types import Content, Part  # type: ignore
+
+        self.user_content = Content(role="user", parts=[Part(text=text)])
+        self.session = _FakeSession(session_id)
+        self.invocation_id = "invocation-test-1"
+        self.end_invocation = False
+
+
+def _mk_inner(name: str = "inner_agent") -> Any:
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(
+        name=name,
+        model="fake-model",
+        description="a wrapped agent",
+        instruction="follow",
+    )
+
+
+def _mk_wrapped() -> Any:
+    """Build a wrapped ADK agent whose adapter.invoke is mocked.
+
+    The mock short-circuits the real InMemoryRunner event loop so each
+    test case can observe the final Session state without spinning up
+    a live LLM.
+    """
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=StaticPlanner(
+            Plan(
+                id="p1",
+                run_id="",
+                goal_ids=["g1"],
+                tasks=[
+                    Task(
+                        id="t1",
+                        title="the task",
+                        description="x",
+                        assignee_agent_id="inner_agent",
+                    )
+                ],
+                edges=[],
+                summary="one-task plan",
+            )
+        ),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+    return wrapped
+
+
+# ---------------------------------------------------------------------------
+# Part A tests — Session.id picks up ctx.session.id on first run.
+# ---------------------------------------------------------------------------
+
+
+async def test_goldfive_session_pins_outer_ctx_session_id() -> None:
+    """``Session.id`` adopts ``ctx.session.id`` on the first invocation.
+
+    Every Event emitted through the sink carries the same session_id as
+    the outer adk-web session — not the uuid4 that
+    ``Conversation.next_turn_session`` would have minted. This is the
+    #161 fix: goldfive events now co-locate with harmonograf spans on
+    the same UI session.
+    """
+    sink = InMemorySink()
+    wrapped = _mk_wrapped()
+    wrapped.sinks.append(sink)
+
+    ctx = _FakeCtx("go", session_id="adk-outer-X")
+    # Drive the ADK hook directly so we exercise the pin path without
+    # requiring a real adk-web runner.
+    events = [evt async for evt in wrapped._run_async_impl(ctx)]
+    assert events, "wrapper produced no events"
+
+    proto_events = [e for e in sink.events if hasattr(e, "session_id")]
+    assert proto_events, "sink saw no proto envelopes"
+    mismatches = [
+        (e.WhichOneof("payload"), e.session_id, e.run_id)
+        for e in proto_events
+        if e.session_id != "adk-outer-X"
+    ]
+    assert not mismatches, f"events not pinned to outer session: {mismatches!r}"
+    # run_id aliases session.id — confirm the Session itself carries it.
+    assert all(e.run_id == "adk-outer-X" for e in proto_events)
+
+
+async def test_goldfive_adapter_session_id_pins_to_outer() -> None:
+    """The ADKAdapter's internal ``_session_id`` aligns with the outer id.
+
+    ``ADKAdapter._ensure_session`` caches ``_session_id`` and reuses it
+    across invoke calls — pinning the outer session id here means the
+    internal ADK runner creates its InMemorySessionService session with
+    the same id as adk-web, so ``_heal_pending_tool_calls`` and
+    ``_touch_session`` also operate on the matched id.
+    """
+    wrapped = _mk_wrapped()
+    adapter = wrapped.runner.agent
+    # Precondition: no constructor-pinned id.
+    assert adapter._session_id is None
+    assert adapter._outer_session_id is None
+
+    ctx = _FakeCtx("go", session_id="adk-outer-Y")
+    _ = [evt async for evt in wrapped._run_async_impl(ctx)]
+
+    assert adapter._session_id == "adk-outer-Y", (
+        "adapter _session_id must adopt the outer ctx session id "
+        "so _ensure_session / _heal_pending_tool_calls target the "
+        "same ADK session that adk-web is driving"
+    )
+    assert adapter._outer_session_id == "adk-outer-Y"
+
+
+async def test_goldfive_session_preserved_across_steer_restart() -> None:
+    """A second invocation on the same ctx keeps the pinned session id.
+
+    The overlay loop restarts ``invoke_passthrough`` with the same
+    in-memory ``Session`` object, so ``Session.id`` cannot drift
+    mid-turn. The cross-turn check verifies subsequent top-level
+    ``_run_async_impl`` calls — the equivalent of a follow-up turn
+    from the same adk-web tab — also re-pin to the same id (adk-web
+    keeps the session stable across turns).
+    """
+    sink = InMemorySink()
+    wrapped = _mk_wrapped()
+    wrapped.sinks.append(sink)
+
+    ctx = _FakeCtx("go", session_id="adk-outer-Z")
+
+    # First invocation.
+    _ = [evt async for evt in wrapped._run_async_impl(ctx)]
+    # Second invocation with the SAME session id (adk-web's stable URL session).
+    _ = [evt async for evt in wrapped._run_async_impl(ctx)]
+
+    proto_events = [e for e in sink.events if hasattr(e, "session_id")]
+    assert proto_events
+    ids = {e.session_id for e in proto_events}
+    assert ids == {"adk-outer-Z"}, (
+        f"expected every event pinned to adk-outer-Z; saw ids={ids!r}"
+    )
+
+
+async def test_goldfive_session_falls_back_to_uuid_when_ctx_missing() -> None:
+    """Bare programmatic ``Runner.run`` callers still mint a uuid4.
+
+    Back-compat: users who never touch the ADK wrap path keep getting
+    a freshly-minted ``Session.run_id`` per turn — the legacy contract
+    from :meth:`Conversation.next_turn_session`.
+    """
+    import re
+
+    from goldfive import CallableAdapter, PassthroughGoalDeriver
+
+    async def _agent(task: Task, session: Any, tools: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_agent, available_agents=["w"]),
+        planner=StaticPlanner(
+            Plan(
+                id="p1",
+                run_id="",
+                goal_ids=["g1"],
+                tasks=[Task(id="t1", title="T1", assignee_agent_id="w")],
+                edges=[],
+                summary="",
+            )
+        ),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("go"),
+        sinks=[sink],
+    )
+
+    outcome = await runner.run("go")
+    await runner.close()
+    assert outcome.success
+
+    # uuid4 hex is 32 lowercase hex chars — the shape
+    # Conversation.next_turn_session produces.
+    sid = outcome.session.id
+    assert re.fullmatch(r"[0-9a-f]{32}", sid), (
+        f"expected uuid4 hex run_id when ctx is absent; got {sid!r}"
+    )
+
+
+async def test_goldfive_session_falls_back_to_uuid_when_ctx_session_empty() -> None:
+    """Empty ``ctx.session.id`` leaves the legacy uuid4 path intact.
+
+    Live adk-web always populates a real session id, but test harnesses
+    and future ADK shapes might pass a context whose ``session.id`` is
+    ``""`` or ``None``. The pin path must skip cleanly in that case.
+    """
+    import re
+
+    sink = InMemorySink()
+    wrapped = _mk_wrapped()
+    wrapped.sinks.append(sink)
+
+    ctx = _FakeCtx("go", session_id="")
+    _ = [evt async for evt in wrapped._run_async_impl(ctx)]
+
+    proto_events = [e for e in sink.events if hasattr(e, "session_id")]
+    assert proto_events
+    # Every event still carries SOME session id (the minted uuid4), and
+    # the run_id should be a uuid4 hex.
+    ids = {e.session_id for e in proto_events}
+    assert len(ids) == 1, f"expected one minted id; saw {ids!r}"
+    minted = next(iter(ids))
+    assert re.fullmatch(r"[0-9a-f]{32}", minted), (
+        f"expected uuid4 hex for empty-ctx path; got {minted!r}"
+    )
+
+
+async def test_runner_run_accepts_session_id_override() -> None:
+    """Direct programmatic callers can pass ``session_id`` to pin themselves.
+
+    Primarily a contract test so third-party embedders that don't use
+    the ADK wrap path can still align their Session.id with whatever
+    external id they care about (e.g. a webhook correlation id).
+    """
+    from goldfive import CallableAdapter, PassthroughGoalDeriver
+
+    async def _agent(task: Task, session: Any, tools: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_agent, available_agents=["w"]),
+        planner=StaticPlanner(
+            Plan(
+                id="p1",
+                run_id="",
+                goal_ids=["g1"],
+                tasks=[Task(id="t1", title="T1", assignee_agent_id="w")],
+                edges=[],
+                summary="",
+            )
+        ),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("go"),
+        sinks=[sink],
+    )
+
+    outcome = await runner.run("go", session_id="external-correlation-42")
+    await runner.close()
+    assert outcome.success
+    assert outcome.session.id == "external-correlation-42"
+
+    proto_events = [e for e in sink.events if hasattr(e, "session_id")]
+    assert proto_events
+    assert all(e.session_id == "external-correlation-42" for e in proto_events)
+
+
+async def test_runner_run_empty_session_id_is_minted_uuid() -> None:
+    """``session_id=None`` / ``""`` preserves the legacy uuid4 mint."""
+    import re
+
+    from goldfive import CallableAdapter, PassthroughGoalDeriver
+
+    async def _agent(task: Task, session: Any, tools: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    runner = Runner(
+        agent=CallableAdapter(_agent, available_agents=["w"]),
+        planner=StaticPlanner(
+            Plan(
+                id="p1",
+                run_id="",
+                goal_ids=["g1"],
+                tasks=[Task(id="t1", title="T1", assignee_agent_id="w")],
+                edges=[],
+                summary="",
+            )
+        ),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("go"),
+    )
+
+    outcome = await runner.run("go", session_id="")
+    await runner.close()
+    assert outcome.success
+    assert re.fullmatch(r"[0-9a-f]{32}", outcome.session.id)

--- a/tests/test_goldfive_session_pin_outer.py
+++ b/tests/test_goldfive_session_pin_outer.py
@@ -39,7 +39,6 @@ from goldfive import (
 )
 from goldfive.types import Plan, Task
 
-
 # ---------------------------------------------------------------------------
 # Fixtures — minimal fakes for the InvocationContext shape the wrapper reads.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three session-id layers were unaligned under overlay + AgentTool:

1. adk-web's outer `ctx.session.id` — what users see in the harmonograf UI
2. goldfive's `Session.run_id` — minted uuid4 by `Conversation.next_turn_session`
3. `ADKAdapter._session_id` — minted uuid4 by `_ensure_session`

Goldfive Events stamp (2) via proto #155's per-event session routing; harmonograf spans stamp (1). Three different ids meant the plan view had an empty Gantt (spans routed elsewhere) and span views lacked plan context.

On the first `GoldfiveADKAgent._run_async_impl` call, read `ctx.session.id` and pin it onto all three layers via:
- new `session_id=` override on `Runner.run()`
- adapter's `_session_id` (consulted by `_ensure_session` and `_heal_pending_tool_calls`)
- adapter's `_outer_session_id` (forensic)

`_pin_outer_session_from_ctx` from #125 previously wrote only to `_outer_session_id` (dead — nothing read it). Replaced with `_pin_outer_session_on_adapter` that writes both plus the Runner override.

Back-compat: empty ctx session, bare `Runner`, constructor `session_id=`, empty `Runner.run(session_id="")` all preserve the legacy uuid4 mint.

## Test plan

- [x] `tests/test_goldfive_session_pin_outer.py` — 7 new tests
  - pins `Session.id` to `ctx.session.id`
  - pins adapter `_session_id` to the same
  - preserves pin across steer restart / follow-up turn
  - falls back to uuid4 for bare Runner / empty ctx
  - `Runner.run(session_id=...)` override and empty-string passthrough
- [x] Full suite: 850 passed, 46 skipped

Pair with harmonograf PR for #162 (plugin caches outer session for span stamping + per-ADK-session control subscription for steer routing).