### PR TITLE
Drop overlay soft follow-up; PENDING → NOT_NEEDED (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
 
 ## Unreleased
 
+### Changed
+
+- #163 Overlay executor no longer dispatches soft follow-ups. When
+  `SequentialExecutor._run_overlay` finishes its single
+  `invoke_passthrough` invocation, any still-PENDING plan tasks are
+  transitioned to `TaskStatus.NOT_NEEDED` instead of being
+  re-dispatched as per-task `invoke_follow_up` calls. Evidence from
+  a flow-prompted coordinator: a tree that plain-ADK completes in
+  ~10 min was taking 40+ min under `goldfive.wrap` because each
+  follow-up user message re-triggered the coordinator's full
+  research → web_dev → reviewer → debugger pipeline. Follow-up was
+  intended as a safety net for genuinely missed tasks but fired for
+  tasks the tree's flow simply did not specifically exercise by
+  agent invocation — which is most of them when the tree is
+  flow-prompted. Users who want uncovered tasks exercised
+  explicitly can STEER. `ADKAdapter.invoke_follow_up` is retained
+  for external callers but is no longer invoked by the overlay
+  executor. The `SequentialExecutor(max_follow_up_rounds=...)`
+  kwarg is accepted for one release with a `DeprecationWarning`
+  and has no effect.
+
 ### Added
 
 - #141 Overlay execution model — `goldfive.wrap(...)` no longer drives

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -1264,13 +1264,22 @@ class ADKAdapter:
     async def invoke_follow_up(self, task: Task, session: Session) -> InvocationResult:
         """Drive a gentle follow-up for a plan ``task`` missed during passthrough.
 
-        Used by the overlay-model executor (goldfive#141) after
-        :meth:`invoke_passthrough` finishes and the
-        :class:`PlanReconciler` reports PENDING tasks the tree did
-        not exercise. Sends a natural-language "Also, please: ..."
-        user turn on top of the existing conversation so the tree
-        picks up the missed work without re-running its full
-        pipeline.
+        .. note::
+           As of goldfive#163 this method is **no longer called by the
+           overlay-mode** :class:`~goldfive.executors.sequential.SequentialExecutor`.
+           The overlay now marks PENDING tasks ``NOT_NEEDED`` at the
+           end of the passthrough invocation instead of dispatching
+           follow-ups — flow-prompted coordinators were re-running
+           their full pipeline on every follow-up user message,
+           amplifying a ~10 min run into 40+ min. STEER is the
+           supported user-driven path for exercising uncovered work.
+
+        The method is retained for external callers that want to
+        manually nudge a single task on top of an existing
+        conversation (e.g. custom executors, interactive tooling).
+        It sends a natural-language "Also, please: ..." user turn
+        on top of the existing conversation so the tree picks up
+        the missed work without re-running its full pipeline.
         """
         return await self._invoke_internal(
             task=task,

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -130,7 +130,6 @@ class SequentialExecutor(Executor):
         max_retries_per_task_lineage: int = 3,
         fail_fast: bool = True,
         overlay_mode: bool = False,
-        max_follow_up_rounds: int = 3,
         **legacy_kwargs: Any,
     ) -> None:
         # Backwards-compatible alias: accept the old name for one release
@@ -148,6 +147,25 @@ class SequentialExecutor(Executor):
             )
             if max_task_invocations is None:
                 max_task_invocations = legacy_value
+        # ``max_follow_up_rounds`` was the cap on the overlay's soft
+        # follow-up loop. goldfive#163 removed that loop entirely
+        # (flow-prompted coordinators were re-running their full
+        # pipeline on every follow-up, amplifying a ~10min run into
+        # 40+ minutes). The kwarg is accepted here for back-compat
+        # with a DeprecationWarning; it has no effect. Remove in a
+        # future release.
+        if "max_follow_up_rounds" in legacy_kwargs:
+            legacy_kwargs.pop("max_follow_up_rounds")
+            warnings.warn(
+                "SequentialExecutor(max_follow_up_rounds=...) is deprecated "
+                "and has no effect; the overlay's soft follow-up loop was "
+                "removed in goldfive#163. PENDING tasks at the end of the "
+                "passthrough invocation are transitioned to NOT_NEEDED "
+                "instead of being re-dispatched. STEER remains the user-"
+                "driven path for exercising uncovered tasks.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if legacy_kwargs:
             unexpected = ", ".join(sorted(legacy_kwargs))
             raise TypeError(f"SequentialExecutor got unexpected keyword argument(s): {unexpected}")
@@ -156,22 +174,22 @@ class SequentialExecutor(Executor):
         )
         self.max_retries_per_task_lineage = int(max_retries_per_task_lineage)
         self.fail_fast = bool(fail_fast)
-        # Overlay model (goldfive#141). When ``overlay_mode`` is True:
+        # Overlay model (goldfive#141, refined in goldfive#163). When
+        # ``overlay_mode`` is True:
         #   1. Call ``adapter.invoke_passthrough(goal_text)`` ONCE
         #      with the user's original request and a plugin-attached
         #      :class:`~goldfive.reconciler.PlanReconciler` watching
         #      the agent tree run its natural flow.
-        #   2. After the invocation ends, ask the reconciler for
-        #      PENDING tasks the tree missed and fire one
-        #      ``adapter.invoke_follow_up(task)`` per missed task.
-        #   3. Repeat up to ``max_follow_up_rounds`` times or until
-        #      every task reaches a terminal status.
+        #   2. When the invocation ends, mark any PENDING tasks as
+        #      NOT_NEEDED. The tree did what it naturally does; the
+        #      reconciler recorded the coverage; goldfive does not
+        #      drive per-task. Users who want uncovered tasks
+        #      exercised explicitly can STEER.
         # When False (default for direct SequentialExecutor() callers)
         # we keep the legacy per-task loop so tests and callers that
         # already encode that model keep working. The ``goldfive.wrap``
         # convenience flips this to True by default.
         self.overlay_mode = bool(overlay_mode)
-        self.max_follow_up_rounds = int(max_follow_up_rounds)
 
     # ------------------------------------------------------------------
     # Executor protocol
@@ -197,10 +215,14 @@ class SequentialExecutor(Executor):
 
         When :attr:`overlay_mode` is True the executor switches to the
         goldfive#141 overlay path: one
-        :meth:`AgentAdapter.invoke_passthrough` with ``user_input``
-        followed by :meth:`AgentAdapter.invoke_follow_up` for each
-        task the reconciler flags as missed. Falls through to the
-        legacy per-task loop when ``overlay_mode`` is False.
+        :meth:`AgentAdapter.invoke_passthrough` with ``user_input``.
+        When the invocation ends any PENDING tasks are transitioned to
+        ``NOT_NEEDED`` — goldfive#163 removed the soft follow-up loop
+        that used to re-dispatch missed tasks (it amplified slow
+        flow-prompted coordinators into rework loops). STEER remains
+        the user-driven path for exercising uncovered work. Falls
+        through to the legacy per-task loop when ``overlay_mode`` is
+        False.
         """
         # Pin the plan onto the session so the steerer / reporting handlers
         # see the same object the executor is iterating.
@@ -647,7 +669,7 @@ class SequentialExecutor(Executor):
         control: ControlChannel | None,
         user_input: str,
     ) -> ExecutionOutcome:
-        """Overlay-model run loop: single passthrough + reconciled follow-ups.
+        """Overlay-model run loop: single passthrough, no soft follow-ups.
 
         See :meth:`run` for the high-level contract. In order:
 
@@ -657,16 +679,21 @@ class SequentialExecutor(Executor):
            reconciler=...)`` ONCE. While the generator runs, the
            plugin forwards before/after_agent observations to the
            reconciler, which transitions plan tasks.
-        3. When the invocation ends, ask the reconciler for missed
-           PENDING tasks. For each missed task, fire
-           ``adapter.invoke_follow_up(task, session)`` and let the
-           plugin's legacy per-task attribution path close it out.
-        4. Repeat missed-task discovery up to
-           :attr:`max_follow_up_rounds` times.
-        5. If any tasks remain PENDING after the last round, mark
-           them NOT_NEEDED (not CANCELLED — the tree intentionally
-           did not run them and a re-invoke would not help).
-        6. Emit terminal RunCompleted / RunAborted.
+        3. When the invocation ends, mark any PENDING tasks as
+           ``NOT_NEEDED``. The tree did what it naturally does;
+           goldfive does not drive per-task. See goldfive#163:
+           the previous soft follow-up loop re-dispatched each
+           PENDING task as a new user message, and flow-prompted
+           coordinators re-ran their full pipeline on every such
+           message — turning a ~10 min run into 40+ min. Users who
+           want uncovered tasks exercised explicitly can STEER.
+        4. Emit terminal RunCompleted / RunAborted.
+
+        STEER handling inside the passthrough loop is preserved
+        (goldfive#149): a steer cancels the in-flight invocation,
+        feeds the message to the steerer for USER_STEER drift +
+        refine, then restarts ``invoke_passthrough`` with the steer
+        body as the new user input.
         """
         from goldfive.reconciler import PlanReconciler
 
@@ -696,7 +723,7 @@ class SequentialExecutor(Executor):
         # the tree runs the revised plan. This is why the loop is a
         # ``while True`` — a steer restarts the invocation against
         # the new plan; ``cancelled`` / ``adapter_error`` terminates
-        # the run; ``result`` falls through to the follow-up rounds.
+        # the run; ``result`` falls through to the NOT_NEEDED sweep.
         # See goldfive#149 for the regression this guards against.
         current_user_input = user_input
         failure_reason = ""
@@ -740,9 +767,10 @@ class SequentialExecutor(Executor):
                 # Feed the STEER through the steerer so USER_STEER
                 # drift fires → cascade-cancel + planner.refine runs
                 # → session.plan is replaced with the revised plan.
-                # Without this call the overlay would just re-enter
-                # the missed-task follow-up loop on the ORIGINAL plan,
-                # which is the goldfive#149 regression.
+                # Without this call the overlay would just mark the
+                # pre-steer plan's tasks NOT_NEEDED on the ORIGINAL
+                # plan and miss the steer entirely (the goldfive#149
+                # regression, preserved here post-#163).
                 log.info(
                     "SequentialExecutor._run_overlay: STEER received; "
                     "feeding steerer.observe for USER_STEER drift + refine",
@@ -762,101 +790,36 @@ class SequentialExecutor(Executor):
                 # Restart the invocation with the steer body as the
                 # new user input.
                 continue
-            # kind == "result": fall through to the follow-up rounds.
+            # kind == "result": invocation ended normally; fall
+            # through to the NOT_NEEDED sweep.
             break
 
-        # --- Missed-task follow-up rounds. -------------------------
-        rounds = 0
-        while rounds < self.max_follow_up_rounds:
-            missed = reconciler.get_missed_tasks(session.plan)
-            if not missed:
-                break
-            rounds += 1
+        # --- PENDING → NOT_NEEDED on invocation end (goldfive#163). ----
+        # The tree finished its natural flow. Any task still PENDING
+        # was not exercised by the tree. Mark terminal so sinks do not
+        # see stale PENDING entries and downstream runs do not wedge.
+        # We deliberately do NOT dispatch a follow-up: flow-prompted
+        # coordinators re-run their full pipeline on every new user
+        # message, which amplifies a ~10 min run into 40+ min. STEER
+        # is the user-driven path for exercising uncovered work.
+        live_plan = session.plan or plan
+        pending_ids = [
+            t.id
+            for t in list(getattr(live_plan, "tasks", None) or ())
+            if t.status is TaskStatus.PENDING and t.id
+        ]
+        if pending_ids:
             log.info(
-                "SequentialExecutor._run_overlay: round %d follow-up for %d missed task(s): %s",
-                rounds,
-                len(missed),
-                ", ".join(t.id for t in missed),
+                "SequentialExecutor._run_overlay: marking %d PENDING task(s) "
+                "NOT_NEEDED at invocation end (no soft follow-up per #163): %s",
+                len(pending_ids),
+                ", ".join(pending_ids),
             )
-            for task in missed:
-                # Re-check: a previous follow-up in this round may have
-                # pulled the task through a dependency side effect.
-                live = _find_task(session.plan or plan, task.id)
-                if live is None or live.status is not TaskStatus.PENDING:
-                    continue
-                # Announce the task as RUNNING before the follow-up
-                # invocation so TaskStarted lands in the sink stream
-                # exactly like the legacy per-task path. Idempotent
-                # via the steerer's terminal-status guard.
+            for tid in pending_ids:
                 await steerer.transition(
-                    task.id,
-                    TaskStatus.RUNNING,
-                    session=session,
-                )
-                # Attempt a gentle follow-up. We tolerate adapters that
-                # don't expose ``invoke_follow_up`` by falling back to
-                # the legacy ``invoke`` (same gentle phrasing now).
-                invoke_fn = getattr(adapter, "invoke_follow_up", None) or adapter.invoke
-                try:
-                    result = await invoke_fn(task, session)
-                except asyncio.CancelledError:
-                    failure_reason = "cancelled during follow-up"
-                    await emit(
-                        sinks,
-                        run_aborted_event(
-                            run_id=session.run_id,
-                            sequence=session.next_sequence(),
-                            reason=failure_reason,
-                            session_id=session.id,
-                        ),
-                    )
-                    return ExecutionOutcome(success=False, session=session, reason=failure_reason)
-                except Exception as exc:  # noqa: BLE001
-                    log.warning(
-                        "SequentialExecutor._run_overlay: follow-up for %s raised: %s",
-                        task.id,
-                        exc,
-                    )
-                    await steerer.transition(
-                        task.id,
-                        TaskStatus.FAILED,
-                        detail=f"follow-up adapter raised: {exc}",
-                        session=session,
-                    )
-                    continue
-                # If the follow-up didn't complete the task, let the
-                # auto-transition logic decide: invocation error →
-                # FAILED, otherwise COMPLETED. Idempotent on already-
-                # terminal tasks.
-                live_after = _find_task(session.plan or plan, task.id)
-                live_status = live_after.status if live_after is not None else TaskStatus.PENDING
-                if live_status in (TaskStatus.PENDING, TaskStatus.RUNNING):
-                    if result is not None and getattr(result, "error", None) is not None:
-                        await steerer.transition(
-                            task.id,
-                            TaskStatus.FAILED,
-                            detail=str(result.error),
-                            session=session,
-                        )
-                    else:
-                        summary = (result.text if result is not None else "") or ""
-                        await steerer.transition(
-                            task.id,
-                            TaskStatus.COMPLETED,
-                            detail=summary,
-                            session=session,
-                        )
-
-        # --- Any remaining PENDING tasks are "not needed". --------
-        # The tree legitimately did not run them, the follow-up
-        # rounds didn't resurrect them; mark terminal so sinks don't
-        # see stale PENDING entries and downstream runs don't wedge.
-        for t in list(getattr(session.plan, "tasks", None) or ()):
-            if t.status is TaskStatus.PENDING:
-                await steerer.transition(
-                    t.id,
+                    tid,
                     TaskStatus.NOT_NEEDED,
-                    detail="overlay: tree did not exercise; no follow-up needed",
+                    detail="overlay: tree did not exercise; no follow-up dispatched (goldfive#163)",
                     session=session,
                 )
 

--- a/goldfive/reconciler.py
+++ b/goldfive/reconciler.py
@@ -32,8 +32,13 @@ streams from the goldfive ADK plugin:
 
 After the invocation completes the runner / executor calls
 :meth:`get_missed_tasks` to find PENDING tasks the tree never
-exercised. Those become candidates for soft follow-up via
-``ADKAdapter.invoke_follow_up``.
+exercised. As of goldfive#163 the overlay executor transitions
+those to ``TaskStatus.NOT_NEEDED`` and does NOT dispatch soft
+follow-ups — flow-prompted coordinators were re-running their
+full pipeline on every follow-up user message. The method is
+kept available for external callers that want to surface the
+coverage gap in their own way (logging, custom nudge prompts,
+etc.).
 
 Tolerance
 ---------
@@ -406,8 +411,11 @@ class PlanReconciler:
         """Return PENDING tasks the tree never exercised.
 
         Called by the executor's overlay-mode loop after the single
-        invocation ends. Each returned task is a candidate for a
-        soft follow-up via :meth:`ADKAdapter.invoke_follow_up`.
+        invocation ends. As of goldfive#163 the overlay transitions
+        these tasks to ``TaskStatus.NOT_NEEDED`` rather than
+        re-dispatching them; the method is retained for external
+        callers (custom executors, telemetry) that want to surface
+        the coverage gap.
 
         If ``plan`` is ``None`` the reconciler reads the session's
         live plan — which may differ from the plan at the start of

--- a/tests/examples/test_presentation_agent_adk_web.py
+++ b/tests/examples/test_presentation_agent_adk_web.py
@@ -15,10 +15,14 @@ loads ``examples/presentation_agent`` in mock mode, POSTs a prompt via
 ``/run_sse``, and asserts:
 
 * a single ``plan_submitted`` with the expected four-task plan,
-* one ``task_started`` + one terminal (``task_completed``) per task,
-* at least one ``task_completed`` fires (proving dispatch progressed —
-  the specific pathology we're guarding against was "plan submitted,
-  but no task ever completes"),
+* every planned task reaches a terminal state
+  (``task_completed`` / ``task_failed`` / ``task_cancelled`` — the
+  last covers both real cancellations and NOT_NEEDED tasks, which
+  emit ``task_cancelled`` with a ``not_needed:`` reason prefix per
+  ``Steerer.mark_task_not_needed``),
+* at least one task progressed to a non-NOT_NEEDED terminal state
+  (proving dispatch actually worked — the specific pathology we're
+  guarding against was "plan submitted, but no task ever completes"),
 * per-task dispatch hits the right assignee — ``AgentInvocationStarted``
   for task ``research`` carries ``agent_name == "research_agent"``, not
   the coordinator (the "coordinator-always-runs" regression the Phase 1
@@ -156,8 +160,7 @@ def _consume_sse(client: Any, body: dict[str, Any]) -> tuple[int, float]:
     lines = 0
     with client.stream("POST", "/run_sse", json=body) as s:
         assert s.status_code == 200, (
-            f"/run_sse returned {s.status_code} — expected 200. "
-            f"Body preview: {s.read()[:400]!r}"
+            f"/run_sse returned {s.status_code} — expected 200. Body preview: {s.read()[:400]!r}"
         )
         for _line in s.iter_lines():
             lines += 1
@@ -224,8 +227,7 @@ def test_presentation_agent_e2e_under_adk_web(
     from google.adk.apps.app import App
 
     assert isinstance(agent_or_app, App), (
-        f"expected an adk.App from mock-mode lazy build, got "
-        f"{type(agent_or_app).__name__}"
+        f"expected an adk.App from mock-mode lazy build, got {type(agent_or_app).__name__}"
     )
     root_agent = agent_or_app.root_agent
 
@@ -285,13 +287,10 @@ def test_presentation_agent_e2e_under_adk_web(
     # 1. Exactly one plan_submitted, with all four expected tasks.
     plan_events = [e for e, k in zip(events, kinds, strict=True) if k == "plan_submitted"]
     assert len(plan_events) == 1, (
-        f"expected exactly one plan_submitted; got {len(plan_events)} "
-        f"(kinds: {kinds})"
+        f"expected exactly one plan_submitted; got {len(plan_events)} (kinds: {kinds})"
     )
     plan_pb = plan_events[0].plan_submitted.plan
-    planned_tasks = {
-        t.id: t.assignee_agent_id for t in plan_pb.tasks
-    }
+    planned_tasks = {t.id: t.assignee_agent_id for t in plan_pb.tasks}
     assert planned_tasks == {
         "research": "research_agent",
         "build": "web_developer_agent",
@@ -300,7 +299,16 @@ def test_presentation_agent_e2e_under_adk_web(
     }, f"unexpected plan shape: {planned_tasks}"
 
     # 2. Every planned task must reach a terminal state. Goldfive's
-    # terminal task events are task_completed / task_failed / task_cancelled.
+    # terminal task events are task_completed / task_failed /
+    # task_cancelled. NOT_NEEDED tasks (goldfive#141) emit
+    # task_cancelled with a ``not_needed:`` reason prefix (no
+    # dedicated proto event) — see ``Steerer.mark_task_not_needed``.
+    #
+    # Under the goldfive#163 overlay model, tasks the tree did not
+    # naturally exercise are transitioned PENDING → NOT_NEEDED
+    # directly (without going through RUNNING first), so we do NOT
+    # require a task_started event for every planned task — only
+    # that every planned task reaches SOME terminal state.
     started_ids = {
         e.task_started.task_id for e, k in zip(events, kinds, strict=True) if k == "task_started"
     }
@@ -312,31 +320,62 @@ def test_presentation_agent_e2e_under_adk_web(
     failed_ids = {
         e.task_failed.task_id for e, k in zip(events, kinds, strict=True) if k == "task_failed"
     }
-    cancelled_ids = {
+    # task_cancelled covers both "actually cancelled" and
+    # "NOT_NEEDED" (the latter carries a ``not_needed:`` reason
+    # prefix on the event's reason field).
+    cancelled_events = [e for e, k in zip(events, kinds, strict=True) if k == "task_cancelled"]
+    cancelled_ids = {e.task_cancelled.task_id for e in cancelled_events}
+    not_needed_ids = {
         e.task_cancelled.task_id
-        for e, k in zip(events, kinds, strict=True)
-        if k == "task_cancelled"
+        for e in cancelled_events
+        if str(getattr(e.task_cancelled, "reason", "")).startswith("not_needed")
     }
+    real_cancelled_ids = cancelled_ids - not_needed_ids
     terminal_ids = completed_ids | failed_ids | cancelled_ids
 
-    assert started_ids == set(planned_tasks), (
-        f"task_started missing for some planned tasks. "
-        f"planned={set(planned_tasks)} started={started_ids}"
+    # task_started events only fire for tasks the reconciler
+    # matched to an observed sub-agent invocation. Unmatched tasks
+    # land in NOT_NEEDED without a RUNNING announcement (#163). The
+    # only invariant is: any id with a task_started must also be in
+    # terminal_ids (no dangling RUNNING).
+    assert started_ids <= terminal_ids, (
+        f"some task_started events had no matching terminal event. "
+        f"started={started_ids} terminal={terminal_ids}"
     )
     assert set(planned_tasks) <= terminal_ids, (
         f"some planned tasks never reached terminal state. "
         f"planned={set(planned_tasks)} terminal={terminal_ids}"
     )
 
-    # 3. At least one task_completed. If every task failed/cancelled
-    # that would satisfy "reached terminal state" but not "dispatch
-    # actually progressed" — which is the specific regression we're
-    # guarding against.
-    assert completed_ids, (
-        "no task_completed event fired — plan was submitted but no "
-        "task progressed. This is the coordinator-loop pathology the "
-        "registry-dispatch refactor was supposed to eliminate."
-    )
+    # 3. Per-task progression check — informational under mock mode.
+    # The original test required "at least one task_completed" to
+    # guard against the plan-submitted-but-no-task-completes
+    # pathology. Under the goldfive#163 overlay model that guard
+    # is softened for mock-mode trees: a ``_MockLlm`` coordinator
+    # that returns a one-line "task done" without actually
+    # invoking any AgentTools produces ZERO sub-agent observations
+    # for the reconciler, so every planned task legitimately ends
+    # in NOT_NEEDED. Before #163 the same tree produced synthetic
+    # task_completed events because the follow-up loop force-
+    # dispatched ``invoke_follow_up(task)`` for each missed task.
+    # That was the exact "goldfive drives per-task" behaviour #163
+    # removed.
+    #
+    # The hang bug the test exists to guard against is now covered
+    # by (a) the plan_submitted assertion above, (b) the terminal-
+    # state assertion above, and (c) the run_completed + wall-
+    # clock assertions below. If the coordinator loop re-appears,
+    # the run would not complete within 30s and /run_sse would
+    # hang — both are caught without needing a per-task
+    # completed/cancelled signal.
+    progressed_ids = completed_ids | failed_ids | real_cancelled_ids
+    if not progressed_ids:
+        # Informational log; not a test failure. A real LLM run
+        # WILL produce task_completed events because the
+        # coordinator actually invokes its AgentTools; mock mode
+        # is the only path where NOT_NEEDED is the expected
+        # terminal status for every task.
+        pass
 
     # 4. Top-level dispatch drives the root (coordinator_agent) under the
     # single-Runner model (goldfive#130). Goldfive does not route tasks
@@ -345,6 +384,16 @@ def test_presentation_agent_e2e_under_adk_web(
     # mechanisms inside the coordinator's turn. The top-level
     # ``AgentInvocationStarted`` (parent_invocation_id empty) always
     # carries the root agent's name.
+    #
+    # Under the goldfive#163 overlay model, per-task top-level
+    # AgentInvocationStarted events only fire for tasks the
+    # reconciler matched — unmatched tasks go directly to
+    # NOT_NEEDED without a dispatch. So we no longer require a
+    # top-level event PER planned task; instead we assert the
+    # weaker "whenever a top-level invocation carries a task_id,
+    # the agent is coordinator_agent". This still catches the
+    # "coordinator-always-runs"-inverse regression (a specialist
+    # agent running at top level without the coordinator).
     inv_events_by_task: dict[str, str] = {}
     for event, kind in zip(events, kinds, strict=True):
         if kind != "agent_invocation_started":
@@ -354,9 +403,11 @@ def test_presentation_agent_e2e_under_adk_web(
             continue
         if inv.task_id and inv.task_id not in inv_events_by_task:
             inv_events_by_task[inv.task_id] = inv.agent_name
-    # Every task's top-level invocation is the coordinator.
-    for task_id in ("research", "build", "review", "debug"):
-        actual = inv_events_by_task.get(task_id)
+    # Whenever a top-level invocation is tagged with a task_id, it
+    # must name the coordinator (never a specialist). Empty dict
+    # is also acceptable under mock mode (overlay dispatched the
+    # single passthrough invocation off task — see #163).
+    for task_id, actual in inv_events_by_task.items():
         assert actual == "coordinator_agent", (
             f"task {task_id!r} top-level dispatch went to {actual!r}, "
             f"expected the single-Runner root 'coordinator_agent'. "
@@ -387,9 +438,7 @@ def test_presentation_agent_e2e_under_adk_web(
 
     # 6. run_completed must fire — proves the outer pipeline terminated
     # cleanly rather than hanging.
-    assert "run_completed" in kinds, (
-        f"run_completed not emitted; kinds={kinds}"
-    )
+    assert "run_completed" in kinds, f"run_completed not emitted; kinds={kinds}"
 
     # 7. Bounded wall-clock for the whole test body.
     total_elapsed = time.monotonic() - wall_clock_start

--- a/tests/test_sequential_executor_overlay.py
+++ b/tests/test_sequential_executor_overlay.py
@@ -1,18 +1,24 @@
 """Unit tests for :class:`SequentialExecutor`'s overlay-mode branch.
 
-The overlay path (goldfive#141) flips execution from "loop over plan
-tasks calling adapter.invoke(task)" to:
+The overlay path (goldfive#141, refined in goldfive#163) flips
+execution from "loop over plan tasks calling adapter.invoke(task)" to:
 
 1. ONE call to ``adapter.invoke_passthrough(user_input, reconciler=...)``.
-2. After that completes, ask the reconciler for missed tasks.
-3. Fire ``adapter.invoke_follow_up(task)`` for each missed task.
-4. Mark any still-PENDING tasks NOT_NEEDED at end-of-run.
+2. When the invocation ends, mark any PENDING tasks as ``NOT_NEEDED``.
+
+goldfive#163 specifically **removed** the old "fire
+``adapter.invoke_follow_up(task)`` for each missed task" loop — it
+was amplifying slow flow-prompted coordinators into 4-5x rework
+loops. The tests below encode the new contract: no follow-up
+dispatch, PENDING → NOT_NEEDED at invocation end, STEER and CANCEL
+paths preserved.
 
 These tests use stub adapters — no ADK, no LLM, no network.
 """
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -61,6 +67,7 @@ class StubSteerer:
         self._sinks: list[EventSink] = []
         self._planner: Any = None
         self.observed: list[Any] = []
+        self.transitions: list[tuple[str, TaskStatus]] = []
 
     def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
         self._sinks = sinks
@@ -80,6 +87,7 @@ class StubSteerer:
         detail: str = "",  # noqa: ARG002
         session: Session,
     ) -> None:
+        self.transitions.append((task_id, to))
         if session.plan is None:
             return
         for t in session.plan.tasks:
@@ -105,8 +113,12 @@ class OverlayStubAdapter:
     ``passthrough_effect`` is called on ``invoke_passthrough`` with
     the (user_input, session, reconciler) and may transition tasks
     through the reconciler to simulate the agent tree's natural
-    activity. ``follow_up_effect`` is called on ``invoke_follow_up``
-    with (task, session).
+    activity.
+
+    The adapter also exposes ``invoke_follow_up`` so the tests can
+    **assert it is never called** under the goldfive#163 contract.
+    If the overlay ever re-introduces follow-up dispatch, these
+    tests catch it via ``follow_up_calls``.
     """
 
     def __init__(
@@ -181,13 +193,13 @@ def _three_task_plan() -> Plan:
 
 
 # ---------------------------------------------------------------------------
-# Overlay ON: one passthrough call + follow-ups for missed tasks.
+# Overlay ON: single passthrough, no follow-ups under any circumstance.
 # ---------------------------------------------------------------------------
 
 
 async def test_overlay_mode_single_passthrough_no_missed_tasks() -> None:
     """If the passthrough transitions every task COMPLETED via the
-    reconciler, no follow-ups should fire.
+    reconciler, the overlay exits cleanly and no follow-ups fire.
     """
     plan = _three_task_plan()
     session = Session(run_id="r1")
@@ -217,15 +229,18 @@ async def test_overlay_mode_single_passthrough_no_missed_tasks() -> None:
 
     assert outcome.success is True
     assert adapter.passthrough_calls == ["make it"]
-    assert adapter.follow_up_calls == [], "no tasks were missed"
+    assert adapter.follow_up_calls == [], "no follow-ups should ever fire under #163"
     for t in plan.tasks:
         assert t.status is TaskStatus.COMPLETED
     assert sink.payload_kinds()[-1] == "run_completed"
 
 
-async def test_overlay_mode_fires_follow_up_for_missed_tasks() -> None:
-    """If the passthrough only completes t0, follow-ups should fire
-    for t1 and t2.
+async def test_overlay_does_not_dispatch_follow_ups() -> None:
+    """goldfive#163: even when the reconciler reports missed PENDING
+    tasks, the overlay MUST NOT dispatch ``invoke_follow_up``. The
+    missed tasks end up ``NOT_NEEDED`` instead.
+
+    Regression guard: this is the core contract #163 added.
     """
     plan = _three_task_plan()
     session = Session(run_id="r1")
@@ -237,6 +252,7 @@ async def test_overlay_mode_fires_follow_up_for_missed_tasks() -> None:
         session: Session,
         reconciler: Any,  # noqa: ARG001
     ) -> InvocationResult:
+        # Only t0 is exercised by the tree. t1 and t2 stay PENDING.
         await reconciler.on_before_agent(agent_name="agent_a", invocation_id="inv_t0")
         await reconciler.on_after_agent(agent_name="agent_a", invocation_id="inv_t0")
         return InvocationResult(task_id="", text="")
@@ -254,88 +270,32 @@ async def test_overlay_mode_fires_follow_up_for_missed_tasks() -> None:
     )
 
     assert outcome.success is True
+    # Passthrough ran exactly once.
     assert adapter.passthrough_calls == ["do it"]
-    # Both t1 and t2 were missed — follow-up fired for each.
-    assert set(adapter.follow_up_calls) == {"t1", "t2"}
-    for t in plan.tasks:
-        assert t.status is TaskStatus.COMPLETED
-
-
-async def test_overlay_mode_marks_stubborn_pending_as_not_needed() -> None:
-    """If a task stays PENDING after every follow-up round, the
-    executor marks it NOT_NEEDED (the tree chose not to run it).
-    """
-    plan = _three_task_plan()
-    session = Session(run_id="r1")
-    steerer = StubSteerer()
-    sink = RecordingSink()
-
-    async def _passthrough(
-        user_message: str,
-        session: Session,
-        reconciler: Any,  # noqa: ARG001
-    ) -> InvocationResult:
-        # Complete t0 only.
-        await reconciler.on_before_agent(agent_name="agent_a", invocation_id="inv_t0")
-        await reconciler.on_after_agent(agent_name="agent_a", invocation_id="inv_t0")
-        return InvocationResult(task_id="", text="")
-
-    async def _follow_up_noop(task: Task, session: Session) -> InvocationResult:  # noqa: ARG001
-        # Stay PENDING — follow-up did nothing. But the executor's
-        # auto-transition will move to COMPLETED on a clean result.
-        # Simulate a genuinely "not actionable" task by returning an
-        # error-free result and then immediately back to PENDING via
-        # direct mutation.
-        return InvocationResult(task_id=task.id, text="")
-
-    async def _follow_up_stubborn(task: Task, session: Session) -> InvocationResult:
-        # Simulate the tree ignoring the follow-up: don't run, don't
-        # complete, just return an empty result. BUT set status back
-        # to PENDING after the executor's auto-transition so the next
-        # round sees it missed again — mimicking an agent that refuses.
-        # Simplest way: return with error=None but the executor
-        # still auto-completes. To force a NOT_NEEDED outcome, use a
-        # task the adapter's follow-up can't resolve: the assignee is
-        # unreachable and we want the adapter to *raise*.
-        raise RuntimeError("tree cannot run this task")
-
-    # Replace with an effect that raises for t2 to exercise the failed
-    # path; t1 succeeds via follow-up.
-    async def _mixed(task: Task, session: Session) -> InvocationResult:  # noqa: ARG001
-        if task.id == "t2":
-            raise RuntimeError("unreachable")
-        return InvocationResult(task_id=task.id, text=f"done:{task.id}")
-
-    adapter = OverlayStubAdapter(passthrough_effect=_passthrough, follow_up_effect=_mixed)
-    executor = SequentialExecutor(overlay_mode=True, fail_fast=False)
-    outcome = await executor.run(
-        plan=plan,
-        session=session,
-        adapter=adapter,
-        steerer=steerer,
-        planner=StubPlanner(),
-        sinks=[sink],
-        user_input="try",
+    # CRITICAL: no follow-up dispatch under any circumstance.
+    assert adapter.follow_up_calls == [], (
+        f"overlay must not dispatch follow-ups (goldfive#163); got {adapter.follow_up_calls!r}"
     )
-
-    # fail_fast=False: run completes with t2 failed.
+    # t0 completed via the reconciler; t1 and t2 are NOT_NEEDED (not
+    # PENDING, not COMPLETED-via-follow-up, not FAILED).
     by_id = {t.id: t.status for t in plan.tasks}
     assert by_id["t0"] is TaskStatus.COMPLETED
-    assert by_id["t1"] is TaskStatus.COMPLETED
-    assert by_id["t2"] is TaskStatus.FAILED
-    # t2 went through follow-up path, raised → transitioned FAILED.
-    assert outcome.success is True or outcome.success is False
-    assert "t1" in adapter.follow_up_calls
-    assert "t2" in adapter.follow_up_calls
+    assert by_id["t1"] is TaskStatus.NOT_NEEDED, (
+        f"missed task t1 should be NOT_NEEDED, got {by_id['t1']}"
+    )
+    assert by_id["t2"] is TaskStatus.NOT_NEEDED, (
+        f"missed task t2 should be NOT_NEEDED, got {by_id['t2']}"
+    )
 
 
-async def test_overlay_mode_respects_max_follow_up_rounds() -> None:
-    """The follow-up loop should terminate after ``max_follow_up_rounds``
-    even if the tasks keep staying PENDING.
+async def test_overlay_pending_to_not_needed_on_invocation_end() -> None:
+    """Explicit transition test: every PENDING task at the end of
+    ``invoke_passthrough`` is transitioned via
+    ``steerer.transition(..., TaskStatus.NOT_NEEDED, ...)``.
 
-    We simulate that by making every follow-up put the task BACK to
-    PENDING after the executor's auto-transition. This is a torture
-    test for the loop boundary — a real adapter would succeed or fail.
+    Verifies the exact transition API call (not just the terminal
+    status), so future refactors can't silently mutate task.status
+    without going through the steerer.
     """
     plan = _three_task_plan()
     session = Session(run_id="r1")
@@ -343,27 +303,15 @@ async def test_overlay_mode_respects_max_follow_up_rounds() -> None:
     sink = RecordingSink()
 
     async def _passthrough(
-        user_message: str,
-        session: Session,
+        user_message: str,  # noqa: ARG001
+        session: Session,  # noqa: ARG001
         reconciler: Any,  # noqa: ARG001
     ) -> InvocationResult:
+        # Tree does nothing — all three tasks stay PENDING.
         return InvocationResult(task_id="", text="")
 
-    call_counts: dict[str, int] = {}
-
-    async def _stuck(task: Task, session: Session) -> InvocationResult:
-        call_counts[task.id] = call_counts.get(task.id, 0) + 1
-        # Return a benign result; the executor will auto-COMPLETE.
-        # To force a second round we'd need to re-PENDING the task,
-        # but the terminal guard prevents that via the steerer. So
-        # instead: just return and let auto-COMPLETE happen — the
-        # loop then sees no missed tasks and exits. This test
-        # confirms the loop CAP works even when follow-ups do
-        # succeed.
-        return InvocationResult(task_id=task.id, text="ok")
-
-    adapter = OverlayStubAdapter(passthrough_effect=_passthrough, follow_up_effect=_stuck)
-    executor = SequentialExecutor(overlay_mode=True, max_follow_up_rounds=1)
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    executor = SequentialExecutor(overlay_mode=True)
     outcome = await executor.run(
         plan=plan,
         session=session,
@@ -371,12 +319,243 @@ async def test_overlay_mode_respects_max_follow_up_rounds() -> None:
         steerer=steerer,
         planner=StubPlanner(),
         sinks=[sink],
-        user_input="x",
+        user_input="anything",
     )
 
     assert outcome.success is True
-    # All three tasks touched in exactly one round (not more).
-    assert sum(call_counts.values()) == 3
+    # Exactly three NOT_NEEDED transitions (one per PENDING task).
+    not_needed_transitions = [tid for tid, to in steerer.transitions if to is TaskStatus.NOT_NEEDED]
+    assert set(not_needed_transitions) == {"t0", "t1", "t2"}, (
+        f"expected NOT_NEEDED transitions for t0/t1/t2, got {not_needed_transitions!r}"
+    )
+    # All tasks terminal.
+    for t in plan.tasks:
+        assert t.status is TaskStatus.NOT_NEEDED
+    # And of course: no follow-up dispatch.
+    assert adapter.follow_up_calls == []
+
+
+async def test_overlay_no_pending_tasks_no_not_needed_transitions() -> None:
+    """When every task is already terminal when the passthrough
+    ends, the overlay does NOT emit spurious NOT_NEEDED transitions.
+    """
+    plan = _three_task_plan()
+    session = Session(run_id="r1")
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    async def _passthrough(
+        user_message: str,  # noqa: ARG001
+        session: Session,
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        # Simulate the tree completing every task directly.
+        if session.plan is not None:
+            for t in session.plan.tasks:
+                t.status = TaskStatus.COMPLETED
+        return InvocationResult(task_id="", text="")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    executor = SequentialExecutor(overlay_mode=True)
+    await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="go",
+    )
+
+    # No NOT_NEEDED transitions when nothing was pending.
+    assert [tid for tid, to in steerer.transitions if to is TaskStatus.NOT_NEEDED] == []
+
+
+# ---------------------------------------------------------------------------
+# Deprecation: max_follow_up_rounds kwarg is accepted but warns + ignored.
+# ---------------------------------------------------------------------------
+
+
+def test_max_follow_up_rounds_kwarg_is_deprecated_and_ignored() -> None:
+    """Back-compat: ``max_follow_up_rounds=`` on the executor is
+    accepted but emits a ``DeprecationWarning`` and has no effect.
+
+    goldfive#163 removed the follow-up loop; the parameter is
+    retained for one release so external callers don't break on
+    upgrade.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        executor = SequentialExecutor(overlay_mode=True, max_follow_up_rounds=5)
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, "expected a DeprecationWarning for max_follow_up_rounds"
+    assert "max_follow_up_rounds" in str(deprecations[0].message)
+    # And the attribute is NOT stored on the instance (there's no
+    # follow-up loop to parameterise).
+    assert not hasattr(executor, "max_follow_up_rounds")
+
+
+# ---------------------------------------------------------------------------
+# Regression guards: STEER / CANCEL / adapter-error paths preserved.
+# ---------------------------------------------------------------------------
+
+
+async def test_overlay_steer_restart_still_works() -> None:
+    """Regression: ``kind == "steer"`` from the passthrough control
+    loop still restarts the invocation with the steer body. The
+    goldfive#163 change only touched the post-result NOT_NEEDED
+    sweep; the STEER branch must behave identically.
+
+    Uses a simple stub that delivers a synthetic STEER by raising
+    a sentinel and then completing on the second call. The full
+    control-channel integration is covered in
+    ``tests/test_overlay_steer.py``; this test is a belt-and-
+    suspenders check that the restart loop in ``_run_overlay``
+    still routes STEERs to ``steerer.observe`` and re-invokes
+    passthrough.
+    """
+    # We exercise the STEER branch through the real
+    # ``_invoke_passthrough_with_control`` code path by monkey-
+    # patching a version that returns (kind, payload) directly.
+    plan = _three_task_plan()
+    session = Session(run_id="r1")
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    class SteerOnceAdapter(OverlayStubAdapter):
+        def __init__(self) -> None:
+            super().__init__()
+
+    adapter = SteerOnceAdapter()
+    executor = SequentialExecutor(overlay_mode=True)
+
+    call_idx = {"n": 0}
+
+    async def _fake_invoke_passthrough_with_control(
+        *, adapter, session, steerer, sinks, control, reconciler, user_input
+    ):  # noqa: ARG001
+        call_idx["n"] += 1
+        adapter.passthrough_calls.append(user_input)
+        if call_idx["n"] == 1:
+            # Emulate a STEER arriving mid-invocation.
+            msg = type(
+                "StubSteerMsg",
+                (),
+                {"kind": type("K", (), {"value": "STEER"})(), "payload": {"note": "switch focus"}},
+            )()
+            return ("steer", msg)
+        # Second invocation: mark every task COMPLETED directly.
+        if session.plan is not None:
+            for t in session.plan.tasks:
+                t.status = TaskStatus.COMPLETED
+        return ("result", InvocationResult(task_id="", text="done"))
+
+    executor._invoke_passthrough_with_control = _fake_invoke_passthrough_with_control  # type: ignore[assignment]
+
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="v0",
+    )
+
+    assert outcome.success is True
+    # Two passthrough invocations: v0 (steered), then the steer
+    # body (wrapped in the goldfive#152 "USER STEERING CONTROL"
+    # header). We assert on the body substring rather than exact
+    # equality so the header wording can evolve without flaking
+    # this test.
+    assert len(adapter.passthrough_calls) == 2
+    assert adapter.passthrough_calls[0] == "v0"
+    assert "switch focus" in adapter.passthrough_calls[1]
+    # Steerer observed the STEER message.
+    assert any(
+        str(getattr(getattr(o, "kind", None), "value", "")).upper() == "STEER"
+        for o in steerer.observed
+    ), "steerer.observe was not called with the STEER message"
+    # No follow-up dispatch (even though we had a steer in the middle).
+    assert adapter.follow_up_calls == []
+
+
+async def test_overlay_cancel_still_works() -> None:
+    """Regression: ``kind == "cancelled"`` terminates the run with
+    ``ExecutionOutcome(success=False)`` and a ``RunAborted`` sink
+    event. The goldfive#163 change did not touch this branch.
+    """
+    plan = _three_task_plan()
+    session = Session(run_id="r1")
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    async def _fake_invoke_passthrough_with_control(
+        *, adapter, session, steerer, sinks, control, reconciler, user_input
+    ):  # noqa: ARG001
+        adapter.passthrough_calls.append(user_input)
+        return ("cancelled", "user aborted")
+
+    adapter = OverlayStubAdapter()
+    executor = SequentialExecutor(overlay_mode=True)
+    executor._invoke_passthrough_with_control = _fake_invoke_passthrough_with_control  # type: ignore[assignment]
+
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="go",
+    )
+
+    assert outcome.success is False
+    assert "aborted" in (outcome.reason or "")
+    assert sink.payload_kinds()[-1] == "run_aborted"
+    # No follow-ups, no NOT_NEEDED sweep on cancel — we exit early.
+    assert adapter.follow_up_calls == []
+    # Tasks remain PENDING (we aborted; didn't reach the sweep).
+    for t in plan.tasks:
+        assert t.status is TaskStatus.PENDING
+
+
+async def test_overlay_adapter_error_still_works() -> None:
+    """Regression: ``kind == "adapter_error"`` terminates the run
+    with a ``RunAborted`` event and a descriptive reason.
+    """
+    plan = _three_task_plan()
+    session = Session(run_id="r1")
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    boom = RuntimeError("adapter exploded")
+
+    async def _fake_invoke_passthrough_with_control(
+        *, adapter, session, steerer, sinks, control, reconciler, user_input
+    ):  # noqa: ARG001
+        adapter.passthrough_calls.append(user_input)
+        return ("adapter_error", boom)
+
+    adapter = OverlayStubAdapter()
+    executor = SequentialExecutor(overlay_mode=True)
+    executor._invoke_passthrough_with_control = _fake_invoke_passthrough_with_control  # type: ignore[assignment]
+
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="go",
+    )
+
+    assert outcome.success is False
+    assert "adapter exploded" in (outcome.reason or "")
+    assert sink.payload_kinds()[-1] == "run_aborted"
+    assert adapter.follow_up_calls == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #163.

## Summary

The overlay executor's soft follow-up loop was amplifying slow
flow-prompted coordinators into 4-5x rework loops. A tree that
plain-ADK completes in ~10 min was taking 40+ min under
`goldfive.wrap` because `_run_overlay` re-dispatched each PENDING
task as a new user message via `adapter.invoke_follow_up(task)`,
and flow-prompted coordinators re-ran their full
research → web_dev → reviewer → debugger pipeline on every such
message.

Fix: remove the follow-up rounds loop. When
`adapter.invoke_passthrough` returns, any still-PENDING tasks are
transitioned to `TaskStatus.NOT_NEEDED` via the steerer. The tree
did what it naturally does; the reconciler recorded coverage;
goldfive does not drive per-task. Users who want uncovered tasks
exercised explicitly can STEER.

- `SequentialExecutor(max_follow_up_rounds=...)` is accepted for
  one release with a `DeprecationWarning` and has no effect
- `ADKAdapter.invoke_follow_up` kept for external callers but no
  longer invoked by the overlay executor (docstring updated)
- STEER restart path preserved (goldfive#149 regression guard)
- CANCEL / adapter_error paths preserved

## Test plan

- [x] `test_overlay_does_not_dispatch_follow_ups` — core contract
- [x] `test_overlay_pending_to_not_needed_on_invocation_end` —
  explicit transition call check
- [x] `test_overlay_no_pending_tasks_no_not_needed_transitions`
- [x] `test_max_follow_up_rounds_kwarg_is_deprecated_and_ignored`
- [x] `test_overlay_steer_restart_still_works`
- [x] `test_overlay_cancel_still_works`
- [x] `test_overlay_adapter_error_still_works`
- [x] `tests/test_overlay_steer.py` (unchanged, still green) —
  end-to-end STEER path through real control channel
- [x] Full suite: 725 passed, 62 skipped