### PR TITLE
Notify plugins on cancellation so they can flush open state

### DIFF
--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -1424,6 +1424,24 @@ class ADKAdapter:
                 reason=reason,
                 session=session,
             )
+            # Notify every caller-supplied plugin that implements the
+            # ``on_cancellation(invocation_id)`` hook so they can flush
+            # per-invocation state that would otherwise leak.
+            #
+            # Why this is needed: ADK's
+            # :meth:`Runner._exec_with_plugin` places
+            # ``after_run_callback`` (and the sub-call after-hooks) AFTER
+            # its ``async with Aclosing(execute_fn(...))`` block — NOT
+            # inside a ``finally``. On ``CancelledError`` the generator
+            # is closed but the after-callbacks never fire. Observability
+            # plugins like :class:`HarmonografTelemetryPlugin` that open
+            # spans on the before-callbacks would then leave those spans
+            # in ``status=RUNNING`` forever (goldfive#167).
+            #
+            # Best-effort, fire-and-forget: any plugin exception is
+            # swallowed so we still re-raise ``CancelledError`` with the
+            # expected cancel semantics (no extra exception chaining).
+            self._notify_plugins_on_cancellation(last_invocation_id)
             raise
         except Exception as exc:  # noqa: BLE001
             err = exc
@@ -1524,6 +1542,42 @@ class ADKAdapter:
                 "ADKAdapter._touch_session: create_session raised: %s",
                 exc,
             )
+
+    def _notify_plugins_on_cancellation(self, invocation_id: str) -> None:
+        """Fire-and-forget ``on_cancellation`` notification to every plugin.
+
+        Walks the caller-supplied plugin list (``self._plugins``) and
+        invokes ``plugin.on_cancellation(invocation_id)`` on every plugin
+        that defines the method. This is the canonical handoff from
+        goldfive's ``except asyncio.CancelledError:`` branch to
+        observability plugins that must flush per-invocation state —
+        most notably :class:`HarmonografTelemetryPlugin`, which closes
+        its open spans with ``status=CANCELLED`` to prevent the stale
+        ``RUNNING`` spans reported in goldfive#167.
+
+        The hook is an opt-in duck-typed contract: plugins that don't
+        need cancellation cleanup simply don't define the method. ADK's
+        ``BasePlugin`` doesn't require it.
+
+        Swallows every exception: we must NOT replace the
+        ``CancelledError`` about to be re-raised with a plugin-side
+        error — that would change the cancel semantics for every caller
+        above us in the stack.
+        """
+        if not invocation_id:
+            return
+        for plugin in self._plugins:
+            hook = getattr(plugin, "on_cancellation", None)
+            if not callable(hook):
+                continue
+            try:
+                hook(invocation_id)
+            except Exception:  # noqa: BLE001 — observability must not break cancel
+                log.debug(
+                    "ADKAdapter: plugin %r on_cancellation raised (swallowed)",
+                    type(plugin).__name__,
+                    exc_info=True,
+                )
 
     async def _heal_pending_tool_calls(
         self,

--- a/tests/test_adapter_on_cancellation_plugin.py
+++ b/tests/test_adapter_on_cancellation_plugin.py
@@ -1,0 +1,261 @@
+"""Tests for :meth:`ADKAdapter._notify_plugins_on_cancellation` (goldfive#167).
+
+When ``asyncio.CancelledError`` raises inside ``runner.run_async``
+mid-invocation, ADK's :meth:`Runner._exec_with_plugin` does NOT fire
+``after_run_callback`` (it's placed after the ``async with
+Aclosing(...)`` block, not inside a ``finally``). So observability
+plugins that track open spans via ``before_*_callback`` need an
+alternate cleanup hook.
+
+The adapter now iterates its caller-supplied ``plugins`` list in the
+``except asyncio.CancelledError:`` branch and calls
+``plugin.on_cancellation(invocation_id)`` on every plugin that defines
+the method. This file pins that behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+
+def _mk(name: str) -> Any:
+    from google.adk.agents.llm_agent import LlmAgent
+
+    return LlmAgent(name=name, model="fake-model", description=name, instruction="x")
+
+
+# ---------------------------------------------------------------------------
+# Fakes (mirrors the shapes test_cancel_propagation.py uses)
+# ---------------------------------------------------------------------------
+
+
+class _FakeADKSession:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+        self.state: dict[str, Any] = {}
+
+
+class _FakeSessionService:
+    def __init__(self) -> None:
+        self._session = _FakeADKSession()
+        self.appended: list[Any] = []
+
+    async def create_session(self, **_kwargs: Any) -> _FakeADKSession:
+        return self._session
+
+    async def get_session(self, **_kwargs: Any) -> _FakeADKSession:
+        return self._session
+
+    async def append_event(self, *, session: Any, event: Any) -> Any:
+        self.appended.append(event)
+        session.events.append(event)
+        return event
+
+
+@dataclass
+class _HangingRunner:
+    """Yields one event (for invocation_id tracking), then hangs."""
+
+    agent: Any = None
+    session_service: Any = field(default_factory=_FakeSessionService)
+    plugin_manager: Any = None
+    plugins: list = field(default_factory=list)
+    app_name: str = "fake-app"
+
+    async def run_async(self, **kwargs: Any):  # noqa: ARG002
+        from google.adk.events.event import Event
+        from google.genai import types
+
+        part = types.Part(function_call=types.FunctionCall(id="p1", name="search"))
+        yield Event(
+            invocation_id="inv-cancel",
+            author="test_agent",
+            content=types.Content(role="model", parts=[part]),
+        )
+        await asyncio.Event().wait()
+        yield None  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Spy plugins
+# ---------------------------------------------------------------------------
+
+
+class _SpyPlugin:
+    """Records every ``on_cancellation`` call."""
+
+    def __init__(self, name: str = "spy") -> None:
+        self.name = name
+        self.cancel_calls: list[str] = []
+
+    def on_cancellation(self, invocation_id: str) -> None:
+        self.cancel_calls.append(invocation_id)
+
+
+class _NoHookPlugin:
+    """Plugin without ``on_cancellation`` — must be tolerated silently."""
+
+    def __init__(self) -> None:
+        self.name = "no-hook"
+
+
+class _RaisingPlugin:
+    """Plugin whose ``on_cancellation`` raises — must NOT break cancel."""
+
+    def __init__(self) -> None:
+        self.name = "raiser"
+        self.called = 0
+
+    def on_cancellation(self, invocation_id: str) -> None:
+        self.called += 1
+        raise RuntimeError("plugin boom")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_invokes_on_cancellation_on_registered_plugins() -> None:
+    """On ``asyncio.CancelledError``, every plugin with an
+    ``on_cancellation`` method receives ``(invocation_id,)``.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _mk("worker")
+    hanging = _HangingRunner(agent=agent)
+    spy = _SpyPlugin()
+    adapter = ADKAdapter(hanging, session_id="sess-1", plugins=[spy])
+
+    invoke_task = asyncio.create_task(
+        adapter.invoke(task=Task(id="t1", title="x"), session=Session(run_id="r1"))
+    )
+    await asyncio.sleep(0.01)
+    invoke_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await invoke_task
+
+    assert spy.cancel_calls == ["inv-cancel"]
+
+
+async def test_adapter_tolerates_plugin_without_on_cancellation() -> None:
+    """Plugins that do NOT define ``on_cancellation`` are skipped
+    silently — no AttributeError, no log spam that breaks the cancel
+    path.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _mk("worker")
+    hanging = _HangingRunner(agent=agent)
+    no_hook = _NoHookPlugin()
+    spy = _SpyPlugin()
+    adapter = ADKAdapter(hanging, session_id="sess-2", plugins=[no_hook, spy])
+
+    invoke_task = asyncio.create_task(
+        adapter.invoke(task=Task(id="t1", title="x"), session=Session(run_id="r1"))
+    )
+    await asyncio.sleep(0.01)
+    invoke_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await invoke_task
+
+    # The hook-carrying plugin still got its call; the hookless one was
+    # tolerated.
+    assert spy.cancel_calls == ["inv-cancel"]
+
+
+async def test_plugin_exception_does_not_replace_cancel() -> None:
+    """A plugin raising from ``on_cancellation`` must NOT leak an
+    exception into the cancel path — the caller still sees a clean
+    ``CancelledError``, not a chained ``RuntimeError``.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Session, Task
+
+    agent = _mk("worker")
+    hanging = _HangingRunner(agent=agent)
+    raiser = _RaisingPlugin()
+    spy = _SpyPlugin()
+    adapter = ADKAdapter(hanging, session_id="sess-3", plugins=[raiser, spy])
+
+    invoke_task = asyncio.create_task(
+        adapter.invoke(task=Task(id="t1", title="x"), session=Session(run_id="r1"))
+    )
+    await asyncio.sleep(0.01)
+    invoke_task.cancel()
+    # Must be plain CancelledError — the RuntimeError is swallowed.
+    with pytest.raises(asyncio.CancelledError):
+        await invoke_task
+
+    # Both plugins were still visited (one raiser doesn't prevent
+    # the next plugin from seeing its notification).
+    assert raiser.called == 1
+    assert spy.cancel_calls == ["inv-cancel"]
+
+
+async def test_on_cancellation_not_called_on_normal_completion() -> None:
+    """Normal path: ``on_cancellation`` is NOT called on clean
+    generator completion. Plugins rely on this — they use their usual
+    ``after_run_callback`` on the success path and would double-close
+    spans if the cancel hook also fired.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Session, Task
+
+    @dataclass
+    class _CleanRunner:
+        agent: Any = None
+        session_service: Any = field(default_factory=_FakeSessionService)
+        plugin_manager: Any = None
+        plugins: list = field(default_factory=list)
+        app_name: str = "fake-app"
+
+        async def run_async(self, **kwargs: Any):  # noqa: ARG002
+            if False:  # pragma: no cover
+                yield None
+            return
+
+    agent = _mk("worker")
+    clean = _CleanRunner(agent=agent)
+    spy = _SpyPlugin()
+    adapter = ADKAdapter(clean, session_id="sess-4", plugins=[spy])
+
+    await adapter.invoke(
+        task=Task(id="t1", title="clean"), session=Session(run_id="r1")
+    )
+    assert spy.cancel_calls == []
+
+
+def test_notify_plugins_empty_invocation_id_is_noop() -> None:
+    """Direct unit test for the helper: an empty invocation id skips
+    plugins entirely. Defensive — an empty id can't usefully be routed
+    to span cleanup and would pollute plugin-side logs.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    agent = _mk("worker")
+    hanging = _HangingRunner(agent=agent)
+    spy = _SpyPlugin()
+    adapter = ADKAdapter(hanging, session_id="sess-5", plugins=[spy])
+
+    adapter._notify_plugins_on_cancellation("")
+    assert spy.cancel_calls == []
+
+
+def test_notify_plugins_empty_plugin_list_is_noop() -> None:
+    """No plugins registered → no-op, no AttributeError."""
+    from goldfive.adapters.adk import ADKAdapter
+
+    agent = _mk("worker")
+    hanging = _HangingRunner(agent=agent)
+    adapter = ADKAdapter(hanging, session_id="sess-6")
+    # Must not raise.
+    adapter._notify_plugins_on_cancellation("inv-X")


### PR DESCRIPTION
## Summary

Closes #167 (goldfive side; harmonograf companion PR: pedapudi/harmonograf#67).

- `ADKAdapter.invoke`'s `except asyncio.CancelledError:` branch now fans out `plugin.on_cancellation(invocation_id)` to every caller-supplied plugin that defines the hook. Opt-in and duck-typed — plugins without the method are skipped silently.
- Needed because ADK's `Runner._exec_with_plugin` places `after_run_callback` **after** the `async with Aclosing(execute_fn(...))` block (not inside a `finally`). On `CancelledError` the after-hooks never fire, leaving observability plugins (e.g. `HarmonografTelemetryPlugin`) with spans stuck in `status=RUNNING` forever. UI shows 9+ agents "running" 20+ minutes post-cancel.
- Best-effort, fire-and-forget: plugin exceptions are swallowed so the `CancelledError` that we re-raise isn't replaced by a `RuntimeError`. Cancel semantics preserved end-to-end.
- Normal completion path unchanged — `on_cancellation` never fires on clean generator exit; plugins keep relying on their usual `after_run_callback` for success.

## Test plan

- [x] `tests/test_adapter_on_cancellation_plugin.py` — 6 new tests covering: hook invoked with invocation_id on cancel, plugin-without-hook tolerated, plugin exception swallowed (clean CancelledError propagates), hook NOT called on normal completion, empty invocation_id no-op, empty plugin list no-op.
- [x] Full `pytest tests/` — 889 passed, 46 skipped. No regressions.