### PR TITLE
Dedupe duplicate HarmonografTelemetryPlugin install in ADKAdapter (closes #166)

### DIFF
--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -462,15 +462,57 @@ def _collect_reachable_agent_tree(root_agent: Any) -> list[dict[str, Any]]:
     return [visited[k] for k in order]
 
 
+def _plugin_already_installed(runner: Any, plugin_name: str) -> bool:
+    """Return True when a plugin of ``plugin_name`` is already on ``runner``.
+
+    Under ``App(plugins=[...])`` the ADK runner already carries the
+    caller-supplied plugin list by the time goldfive's wrap path tries
+    to install anything. Asking the runner before appending is cheap
+    (a walk over a short list) and prevents the duplicate-registration
+    cascade that caused goldfive #166 (every harmonograf span appearing
+    twice).
+
+    Tolerates missing plugin managers and unusual ``plugins`` shapes —
+    returns ``False`` on any lookup error so the caller falls through to
+    the normal install path without masking real errors.
+    """
+    if runner is None or not plugin_name:
+        return False
+    pm = getattr(runner, "plugin_manager", None)
+    plugins = getattr(pm, "plugins", None) if pm is not None else None
+    if plugins is None:
+        plugins = getattr(runner, "plugins", None)
+    if not isinstance(plugins, list):
+        return False
+    return any(getattr(p, "name", None) == plugin_name for p in plugins)
+
+
 def _register_plugin_on_runner(runner: Any, plugin: Any) -> bool:
     """Install ``plugin`` on ``runner``'s plugin manager if one exists.
 
     Tolerates both ``runner.plugin_manager.register(plugin)`` and the
     newer ``runner.plugins.append(plugin)`` shapes. Returns True if the
-    plugin was installed.
+    plugin was installed (or was already present under the same name).
+
+    Idempotent on plugin ``name`` (goldfive #166). When the runner
+    already carries a plugin with the same ``name``, returns ``True``
+    without appending a second instance — ADK's own ``register_plugin``
+    raises on duplicate names and the silent-append fallback path we
+    used to keep as a last resort was precisely what let the duplicate
+    slip through. The dedup is primary; the fallback is belt-and-braces
+    and preserved only for runner shapes without a working
+    ``register_plugin``.
     """
     if runner is None:
         return False
+    plugin_name = getattr(plugin, "name", None)
+    if plugin_name and _plugin_already_installed(runner, plugin_name):
+        log.info(
+            "goldfive.adapters.adk: plugin %r already installed on runner; "
+            "skipping duplicate install (see goldfive #166)",
+            plugin_name,
+        )
+        return True
     pm = getattr(runner, "plugin_manager", None)
     if pm is not None:
         for meth in ("register", "register_plugin", "add"):
@@ -492,6 +534,38 @@ def _register_plugin_on_runner(runner: Any, plugin: Any) -> bool:
     return False
 
 
+def _dedupe_plugins_by_name(plugins: list[Any]) -> list[Any]:
+    """Return ``plugins`` with later same-``name`` instances removed.
+
+    Caller-supplied plugin lists can land duplicates in subtle ways
+    (``App(plugins=[p])`` followed by ``observe()`` or ``add_plugin(p)``
+    both referencing the same plugin class). ADK's own
+    :class:`PluginManager.register_plugin` raises on same-name collisions
+    with a terse ``ValueError`` that is easy to miss in a stack trace —
+    we'd rather normalise the list up front so every downstream install
+    path sees a single instance per name.
+
+    Preserves order: the first plugin at each name wins. Plugins without
+    a ``name`` attribute pass through unfiltered (they can't collide by
+    name). See goldfive #166.
+    """
+    seen: set[str] = set()
+    out: list[Any] = []
+    for plugin in plugins:
+        name = getattr(plugin, "name", None)
+        if isinstance(name, str) and name:
+            if name in seen:
+                log.info(
+                    "goldfive.adapters.adk: dropping duplicate plugin %r from "
+                    "caller-supplied plugins (first instance wins; see goldfive #166)",
+                    name,
+                )
+                continue
+            seen.add(name)
+        out.append(plugin)
+    return out
+
+
 def _build_runner(agent: Any, plugins: list[Any] | None = None) -> Any:
     """Construct an ADK ``InMemoryRunner`` around a ``BaseAgent``.
 
@@ -500,18 +574,20 @@ def _build_runner(agent: Any, plugins: list[Any] | None = None) -> Any:
     session-service bookkeeping.
 
     When ``plugins`` is a non-empty iterable, the plugin list is forwarded
-    to :class:`InMemoryRunner` via its ``plugins=`` kwarg. Under the
-    single-Runner model there is exactly one runner, and ADK propagates
-    its plugin manager into any AgentTool-spawned sub-Runners
-    automatically — so installing the plugin here is sufficient for the
-    whole tree.
+    to :class:`InMemoryRunner` via its ``plugins=`` kwarg. Duplicates by
+    ``name`` are collapsed via :func:`_dedupe_plugins_by_name` so ADK's
+    ``PluginManager.register_plugin`` (which raises on same-name
+    collisions) never sees them. Under the single-Runner model there is
+    exactly one runner, and ADK propagates its plugin manager into any
+    AgentTool-spawned sub-Runners automatically — so installing the
+    plugin here is sufficient for the whole tree.
     """
     from google.adk.runners import InMemoryRunner  # type: ignore
 
     app_name = str(getattr(agent, "name", "") or "goldfive")
     kwargs: dict[str, Any] = {"agent": agent, "app_name": app_name}
     if plugins:
-        kwargs["plugins"] = list(plugins)
+        kwargs["plugins"] = _dedupe_plugins_by_name(list(plugins))
     return InMemoryRunner(**kwargs)
 
 

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -2865,3 +2865,180 @@ async def test_caller_plugin_fires_on_sub_agent_invocation_via_agent_tool() -> N
         "plugin_manager propagation broke. Saw: "
         f"{plugin.agents_seen!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-plugin dedup (goldfive#166)
+# ---------------------------------------------------------------------------
+
+
+def test_dedupe_plugins_by_name_drops_later_duplicates() -> None:
+    """``_dedupe_plugins_by_name`` keeps the first occurrence and drops
+    later instances sharing a ``name``. Plugins without a ``name`` pass
+    through unchanged — only identically-named duplicates are a problem.
+    """
+    from dataclasses import dataclass
+
+    from goldfive.adapters import adk as adk_mod
+
+    @dataclass
+    class _NamedPlugin:
+        name: str
+
+    class _NamelessPlugin:
+        pass
+
+    a = _NamedPlugin(name="telemetry")
+    b = _NamedPlugin(name="telemetry")  # same name -> duplicate
+    c = _NamedPlugin(name="goldfive_adk_plugin")
+    d = _NamelessPlugin()  # no name attribute
+    e = _NamelessPlugin()
+
+    deduped = adk_mod._dedupe_plugins_by_name([a, b, c, d, e])
+
+    assert deduped == [a, c, d, e]
+
+
+def test_build_runner_dedupes_plugins_before_inmemoryrunner() -> None:
+    """``_build_runner`` must collapse same-``name`` duplicates before
+    forwarding to :class:`InMemoryRunner`.
+
+    Without this, ADK's ``PluginManager.register_plugin`` raises
+    ``ValueError`` for the duplicate and the caller's intent (install
+    one telemetry plugin) is lost. See goldfive #166.
+    """
+    from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+
+    from goldfive.adapters import adk as adk_mod
+
+    class _StubPlugin(BasePlugin):
+        def __init__(self) -> None:
+            super().__init__(name="duplicate-stub")
+
+    captured: dict[str, Any] = {}
+
+    class _FakeRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    first = _StubPlugin()
+    second = _StubPlugin()  # same name — should be dropped
+    import google.adk.runners as adk_runners  # type: ignore
+
+    orig = adk_runners.InMemoryRunner
+    adk_runners.InMemoryRunner = _FakeRunner  # type: ignore[assignment]
+    try:
+        adk_mod._build_runner(_make_agent(), plugins=[first, second])
+    finally:
+        adk_runners.InMemoryRunner = orig  # type: ignore[assignment]
+
+    passed = captured.get("plugins")
+    assert passed == [first], (
+        "duplicate plugin instance must be dropped before reaching InMemoryRunner; "
+        f"got {passed!r}"
+    )
+
+
+def test_register_plugin_on_runner_is_idempotent_by_name() -> None:
+    """When the runner already carries a plugin with the same name, the
+    helper must skip the install rather than appending a second copy.
+
+    This is the belt-and-braces guard for goldfive #166: the harmonograf
+    plugin's own dedup is primary, but goldfive's install path must also
+    refuse to stack two instances of the same name. Regression test for
+    the pre-fix behaviour where a ``register_plugin`` ValueError was
+    caught and the helper fell through to ``plugins.append(plugin)``.
+    """
+    from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+
+    from goldfive.adapters.adk import _register_plugin_on_runner
+
+    class _Stub(BasePlugin):
+        def __init__(self, name: str) -> None:
+            super().__init__(name=name)
+
+    first = _Stub("telemetry")
+    second = _Stub("telemetry")  # same name
+
+    class _FakeRunner:
+        class plugin_manager:  # type: ignore[misc]
+            plugins: list[Any] = []
+
+            @classmethod
+            def register_plugin(cls, plugin: Any) -> None:
+                # Mirror ADK's PluginManager: raise on duplicate name.
+                if any(p.name == plugin.name for p in cls.plugins):
+                    raise ValueError(
+                        f"Plugin with name '{plugin.name}' already registered."
+                    )
+                cls.plugins.append(plugin)
+
+    runner = _FakeRunner()
+    assert _register_plugin_on_runner(runner, first) is True
+    assert _register_plugin_on_runner(runner, second) is True
+    assert runner.plugin_manager.plugins == [first], (
+        "dedup guard must short-circuit; got "
+        f"{runner.plugin_manager.plugins!r}"
+    )
+
+
+async def test_wrap_skips_duplicate_plugin_on_same_tree() -> None:
+    """``ADKAdapter(tree, plugins=[p, p'])`` where both plugins share a
+    name must install only one of them on the runner.
+
+    Exercises the integration path end-to-end: pass two instances of the
+    same-named plugin and assert the runner's plugin list carries just
+    one. Goldfive #166 regression.
+    """
+    from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    class _Stub(BasePlugin):
+        def __init__(self) -> None:
+            super().__init__(name="tele-stub")
+
+    p1 = _Stub()
+    p2 = _Stub()  # same name
+    adapter = ADKAdapter(_make_agent(), plugins=[p1, p2])
+
+    installed = list(getattr(adapter._runner.plugin_manager, "plugins", []))
+    tele = [p for p in installed if getattr(p, "name", "") == "tele-stub"]
+    assert len(tele) == 1, (
+        f"expected a single telemetry-stub plugin after dedup, got {tele!r}"
+    )
+    # First instance wins.
+    assert tele[0] is p1
+
+
+async def test_add_plugin_skips_when_same_name_already_installed() -> None:
+    """``ADKAdapter.add_plugin`` must not stack a second instance when a
+    plugin of the same name already sits on the runner.
+
+    Under ``goldfive.wrap`` + ``adk web``, the outer App carries the
+    telemetry plugin and a downstream call (``observe()``,
+    ``add_plugin``) can end up trying to attach a second instance. The
+    guard prevents the duplicate span-doubling pathology (goldfive #166)
+    even when the harmonograf plugin's own dedup is disabled or absent.
+    """
+    from google.adk.plugins.base_plugin import BasePlugin  # type: ignore
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    class _Stub(BasePlugin):
+        def __init__(self) -> None:
+            super().__init__(name="observability")
+
+    adapter = ADKAdapter(_make_agent(), plugins=[_Stub()])
+    before = list(getattr(adapter._runner.plugin_manager, "plugins", []))
+    before_count = sum(1 for p in before if getattr(p, "name", "") == "observability")
+    assert before_count == 1
+
+    # User / library tries to install a second same-named instance.
+    adapter.add_plugin(_Stub())
+
+    after = list(getattr(adapter._runner.plugin_manager, "plugins", []))
+    after_count = sum(1 for p in after if getattr(p, "name", "") == "observability")
+    assert after_count == 1, (
+        f"add_plugin installed a duplicate; counts before={before_count} after={after_count}"
+    )


### PR DESCRIPTION
## Summary

- Under `goldfive.wrap` + `adk web` + `App(plugins=[HarmonografTelemetryPlugin(client)])` the telemetry plugin could end up registered twice on the same ADK `PluginManager` — once from `App.plugins`, once from a downstream `observe()` / `add_plugin`. Each instance fired every lifecycle callback → every agent / model / tool span appeared twice in harmonograf's Gantt.
- Goldfive-side guard: `_dedupe_plugins_by_name` collapses same-`name` duplicates before `_build_runner` forwards the list to `InMemoryRunner`. `_register_plugin_on_runner` now checks the manager for a same-name plugin before appending, so post-construction `add_plugin` stays idempotent too.
- Primary fix is at the plugin layer (harmonograf#68 — plugin detects duplicate install at first-callback time and disables the later instance). This PR is the belt-and-braces counterpart on the goldfive side so a plugin without its own dedup still can't get double-registered.

## Test plan

- [x] `uv run pytest tests/test_adk_adapter.py -x -v` — 55 tests pass (5 new dedup tests + existing plugin-propagation tests still green)
- [x] `uv run pytest` — full suite: 892 passed, 46 skipped, no regressions
- [x] `_register_plugin_on_runner` is idempotent by name even when the underlying manager's `register_plugin` raises `ValueError`
- [x] `_build_runner(plugins=[p, p_same_name])` forwards only one instance to `InMemoryRunner`

Pair PR: https://github.com/pedapudi/harmonograf/pull/68

closes #166