### PR TITLE
Bridge orchestration state to ADK session.state (#170)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -879,6 +879,24 @@ def make_adk_plugin(
                 except Exception as exc:  # noqa: BLE001
                     log.debug("before_run_callback: state write failed: %s", exc)
 
+                # goldfive#170: bridge orchestration-level state
+                # (goldfive.Session.state — written by DefaultSteerer,
+                # PlanReconciler, and the heal path) onto the live ADK
+                # session.state so GoldfivePlanner's request-side
+                # injection renders real values instead of ``(none)``.
+                # Tree-agnostic: fires on every invocation, including
+                # AgentTool-spawned sub-Runners whose own
+                # ``before_run_callback`` will repeat this bridge on
+                # their own live session. No separate propagation path
+                # needed.
+                try:
+                    self._bridge_orchestration_state(ctx.session, state)
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "before_run_callback: orchestration-state bridge failed: %s",
+                        exc,
+                    )
+
             # Emit AgentInvocationStarted. Best-effort: observability
             # only, so a sink / proto issue must not block the run.
             agent_name = str(_safe_attr(ctx, "host_agent_name", "") or "") or self._host_agent_name
@@ -1084,6 +1102,87 @@ def make_adk_plugin(
                     except Exception as exc:  # noqa: BLE001
                         log.debug("after_run_callback: note_agent_turn raised: %s", exc)
             return None
+
+        def _bridge_orchestration_state(
+            self,
+            gf_session: Any,
+            adk_state: Any,
+        ) -> None:
+            """Copy ``goldfive.Session.state`` orchestration keys onto the
+            ADK session.state (goldfive#170).
+
+            The orchestration dict is the framework-agnostic source of
+            truth for active-steer body / turn, formatted goals summary,
+            and the list of cancelled function-call ids (written by the
+            DefaultSteerer USER_STEER path, PlanReconciler goals-refresh
+            path, and the adapter's heal path respectively).
+            :class:`GoldfivePlanner.build_planning_instruction` reads
+            the same logical keys off the ADK session.state — so this
+            bridge is the missing data path between the orchestration
+            writes and the per-turn instruction injection.
+
+            Called from :meth:`before_run_callback` against the live
+            invocation session so the bridge runs on every root invoke
+            AND every AgentTool-spawned sub-Runner invoke (which has
+            its own ``before_run_callback`` firing against its own
+            live session). Sub-Runner propagation is therefore
+            automatic — no separate handoff path required.
+
+            Silent on any individual key that can't be read: the
+            planner's placeholders default to ``(none)`` so a degraded
+            bridge never breaks the run.
+            """
+            # Lazy import: orchestration_state is framework-agnostic
+            # and cheap, but the adapter module shouldn't assume at
+            # import time that the orchestration module is loaded.
+            from goldfive import orchestration_state as _ostate
+
+            gf_state = _safe_attr(gf_session, "state", None)
+            if gf_state is None:
+                return
+            # Active steer body + turn. The ADK-side helper clears
+            # both keys when body is empty, so a steer-then-clear
+            # sequence correctly renders as ``(none)`` on the next
+            # turn instead of retaining the old body.
+            body = _ostate.read(gf_state, _ostate.KEY_ACTIVE_STEER_BODY, "")
+            at_turn = _ostate.read(gf_state, _ostate.KEY_ACTIVE_STEER_AT_TURN, None)
+            try:
+                _sp.set_active_steer_on_adk_state(
+                    adk_state,
+                    body=str(body) if body else "",
+                    at_turn=at_turn,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_bridge_orchestration_state: active_steer bridge failed: %s",
+                    exc,
+                )
+            # Goals summary.
+            summary = _ostate.read(gf_state, _ostate.KEY_GOALS_SUMMARY, "")
+            try:
+                _sp.set_goals_summary_on_adk_state(
+                    adk_state,
+                    str(summary) if summary else "",
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_bridge_orchestration_state: goals_summary bridge failed: %s",
+                    exc,
+                )
+            # Cancelled function-call ids. Use the orchestration-state
+            # reader so the list-shape guard (non-list → []) is
+            # centralised in one place.
+            cancelled = _ostate.read_cancelled_function_call_ids(gf_state)
+            try:
+                _sp.set_cancelled_function_call_ids_on_adk_state(
+                    adk_state,
+                    cancelled,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_bridge_orchestration_state: cancelled_ids bridge failed: %s",
+                    exc,
+                )
 
         async def _maybe_emit_confabulation_risk(
             self,

--- a/goldfive/adapters/_adk_state_protocol.py
+++ b/goldfive/adapters/_adk_state_protocol.py
@@ -49,6 +49,20 @@ KEY_TASK_OUTCOME = "goldfive.task_outcome"
 KEY_AGENT_NOTE = "goldfive.agent_note"
 KEY_DIVERGENCE_FLAG = "goldfive.divergence_flag"
 
+# Orchestration -> Agents (goldfive#170 — bridged from
+# ``goldfive.Session.state`` into the live ADK session.state so
+# :class:`~goldfive.planners.goldfive_planner.GoldfivePlanner` sees them
+# on its request-side injection path. Writers live in
+# :mod:`goldfive.orchestration_state`; this module owns the ADK-side key
+# names so the adapter's plugin can stamp them without importing the
+# orchestration module for key constants. The string values are
+# intentionally identical to the orchestration-state module's keys —
+# same logical field, two readers.
+KEY_ACTIVE_STEER_BODY = "goldfive.active_steer.body"
+KEY_ACTIVE_STEER_AT_TURN = "goldfive.active_steer.at_turn"
+KEY_GOALS_SUMMARY = "goldfive.goals_summary"
+KEY_CANCELLED_FUNCTION_CALL_IDS = "goldfive.cancelled_function_call_ids"
+
 _CURRENT_TASK_KEYS: tuple[str, ...] = (
     KEY_CURRENT_TASK_ID,
     KEY_CURRENT_TASK_TITLE,
@@ -71,6 +85,10 @@ ALL_KEYS: tuple[str, ...] = (
     KEY_TASK_OUTCOME,
     KEY_AGENT_NOTE,
     KEY_DIVERGENCE_FLAG,
+    KEY_ACTIVE_STEER_BODY,
+    KEY_ACTIVE_STEER_AT_TURN,
+    KEY_GOALS_SUMMARY,
+    KEY_CANCELLED_FUNCTION_CALL_IDS,
 )
 
 
@@ -295,6 +313,81 @@ def write_tools_available(
         KEY_TOOLS_AVAILABLE,
         [name for name in tool_names if isinstance(name, str)],
     )
+
+
+# ---------------------------------------------------------------------------
+# Bridge writers (goldfive#170)
+#
+# The four helpers below stamp orchestration-state values onto the ADK
+# session.state dict. They exist so the adapter plugin's
+# ``before_run_callback`` can copy values from ``goldfive.Session.state``
+# (orchestration-level, written by DefaultSteerer / reconciler / heal
+# paths) into the ADK session.state (per-agent view, read by
+# :class:`~goldfive.planners.goldfive_planner.GoldfivePlanner`).
+#
+# A missing / empty value is cleared rather than stamped so a prior
+# bridged write from an earlier invocation doesn't linger past its
+# orchestration-state clear.
+# ---------------------------------------------------------------------------
+
+
+def set_active_steer_on_adk_state(
+    state: MutableMapping[str, Any],
+    *,
+    body: str | None,
+    at_turn: int | None,
+) -> None:
+    """Bridge ``goldfive.active_steer.*`` onto ADK session.state.
+
+    Clears both keys when ``body`` is falsy / ``at_turn`` is None so a
+    later invocation after a steer clear never renders a stale body.
+    """
+    if not body:
+        state.pop(KEY_ACTIVE_STEER_BODY, None)
+        state.pop(KEY_ACTIVE_STEER_AT_TURN, None)
+        return
+    _set(state, KEY_ACTIVE_STEER_BODY, _safe_str(body))
+    try:
+        _set(state, KEY_ACTIVE_STEER_AT_TURN, int(at_turn) if at_turn is not None else 0)
+    except (TypeError, ValueError):
+        _set(state, KEY_ACTIVE_STEER_AT_TURN, 0)
+
+
+def set_goals_summary_on_adk_state(
+    state: MutableMapping[str, Any],
+    summary: str | None,
+) -> None:
+    """Bridge ``goldfive.goals_summary`` onto ADK session.state.
+
+    An empty / None summary clears the key so a planner that re-reads
+    after ``session.goals`` was itself cleared doesn't see the stale
+    rendering.
+    """
+    if not summary:
+        state.pop(KEY_GOALS_SUMMARY, None)
+        return
+    _set(state, KEY_GOALS_SUMMARY, _safe_str(summary))
+
+
+def set_cancelled_function_call_ids_on_adk_state(
+    state: MutableMapping[str, Any],
+    ids: Iterable[str] | None,
+) -> None:
+    """Bridge ``goldfive.cancelled_function_call_ids`` onto ADK session.state.
+
+    Rewrites the whole list on each call (the orchestration-state owner
+    is append-only within a run, but the bridge's job is just to mirror
+    whatever the orchestration dict currently holds). Empty / None
+    input clears the key.
+    """
+    if not ids:
+        state.pop(KEY_CANCELLED_FUNCTION_CALL_IDS, None)
+        return
+    cleaned = [str(v) for v in ids if v]
+    if not cleaned:
+        state.pop(KEY_CANCELLED_FUNCTION_CALL_IDS, None)
+        return
+    _set(state, KEY_CANCELLED_FUNCTION_CALL_IDS, cleaned)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_state_protocol_propagation.py
+++ b/tests/test_state_protocol_propagation.py
@@ -473,3 +473,419 @@ async def test_top_level_invocation_id_pinned_then_released() -> None:
     # Top-level after_run RELEASES.
     await plugin.after_run_callback(invocation_context=top)
     assert plugin._top_invocation_id == ""
+
+
+# ---------------------------------------------------------------------------
+# Orchestration-state bridge (goldfive#170)
+#
+# DefaultSteerer (#152) writes active_steer / goals_summary /
+# cancelled_function_call_ids onto ``goldfive.Session.state`` —
+# framework-agnostic orchestration dict. GoldfivePlanner (#153) reads
+# the same logical keys off the ADK session.state for its per-turn
+# injection. Before #170 there was no bridge between the two
+# surfaces, so the planner always rendered ``(none)``.
+#
+# The bridge lives in :meth:`_GoldfiveADKPlugin.before_run_callback`
+# and fires on every invocation — including AgentTool sub-Runners
+# whose own ``before_run_callback`` repeats the bridge against their
+# own live session. These tests pin the contract.
+# ---------------------------------------------------------------------------
+
+
+async def test_bridge_active_steer_copies_from_orchestration_state_to_adk_state() -> None:
+    """When goldfive.Session.state carries an active steer, the plugin's
+    ``before_run_callback`` bridges it onto the live ADK session.state.
+    """
+    from goldfive import orchestration_state as _ostate
+    from goldfive.adapters._adk_plugin import SessionContext, make_adk_plugin
+    from goldfive.adapters._adk_state_protocol import (
+        KEY_ACTIVE_STEER_AT_TURN,
+        KEY_ACTIVE_STEER_BODY,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="agent_a")
+    session = Session(run_id="run-42")
+    # Stamp the orchestration-level active_steer as DefaultSteerer would.
+    _ostate.set_active_steer(
+        session.state,
+        body="focus on the cost angle",
+        at_turn=7,
+    )
+
+    task = Task(id="t1", title="x", assignee_agent_id="agent_a")
+    ctx = SessionContext(
+        session=session,
+        steerer=None,
+        task=task,
+        tool_handlers={},
+        host_agent_name="agent_a",
+    )
+    plugin.set_active_context(ctx)
+
+    class _Session:
+        def __init__(self) -> None:
+            self.state: dict[str, Any] = {}
+
+    class _InvCtx:
+        def __init__(self) -> None:
+            self.session = _Session()
+            self.invocation_id = "inv-1"
+            self.agent = type("A", (), {"name": "agent_a"})()
+
+    inv_ctx = _InvCtx()
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+
+    assert inv_ctx.session.state[KEY_ACTIVE_STEER_BODY] == "focus on the cost angle"
+    assert inv_ctx.session.state[KEY_ACTIVE_STEER_AT_TURN] == 7
+
+
+async def test_bridge_goals_summary_copies_from_orchestration_state_to_adk_state() -> None:
+    """``goldfive.goals_summary`` crosses the bridge."""
+    from goldfive import orchestration_state as _ostate
+    from goldfive.adapters._adk_plugin import SessionContext, make_adk_plugin
+    from goldfive.adapters._adk_state_protocol import KEY_GOALS_SUMMARY
+    from goldfive.types import Goal
+
+    plugin = make_adk_plugin(host_agent_name="agent_a")
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="ship the widget")],
+    )
+    _ostate.refresh_goals_summary(session.state, session.goals)
+
+    task = Task(id="t1", title="x")
+    ctx = SessionContext(
+        session=session,
+        steerer=None,
+        task=task,
+        tool_handlers={},
+        host_agent_name="agent_a",
+    )
+    plugin.set_active_context(ctx)
+
+    class _Session:
+        def __init__(self) -> None:
+            self.state: dict[str, Any] = {}
+
+    class _InvCtx:
+        def __init__(self) -> None:
+            self.session = _Session()
+            self.invocation_id = "inv-1"
+            self.agent = type("A", (), {"name": "agent_a"})()
+
+    inv_ctx = _InvCtx()
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+
+    adk_summary = inv_ctx.session.state[KEY_GOALS_SUMMARY]
+    assert "g1" in adk_summary
+    assert "ship the widget" in adk_summary
+
+
+async def test_bridge_cancelled_function_call_ids_copies_to_adk_state() -> None:
+    """``goldfive.cancelled_function_call_ids`` crosses the bridge."""
+    from goldfive import orchestration_state as _ostate
+    from goldfive.adapters._adk_plugin import SessionContext, make_adk_plugin
+    from goldfive.adapters._adk_state_protocol import (
+        KEY_CANCELLED_FUNCTION_CALL_IDS,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="agent_a")
+    session = Session(run_id="r1")
+    _ostate.append_cancelled_function_call_ids(session.state, ["fc-a", "fc-b"])
+
+    task = Task(id="t1", title="x")
+    ctx = SessionContext(
+        session=session,
+        steerer=None,
+        task=task,
+        tool_handlers={},
+        host_agent_name="agent_a",
+    )
+    plugin.set_active_context(ctx)
+
+    class _Session:
+        def __init__(self) -> None:
+            self.state: dict[str, Any] = {}
+
+    class _InvCtx:
+        def __init__(self) -> None:
+            self.session = _Session()
+            self.invocation_id = "inv-1"
+            self.agent = type("A", (), {"name": "agent_a"})()
+
+    inv_ctx = _InvCtx()
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+
+    assert inv_ctx.session.state[KEY_CANCELLED_FUNCTION_CALL_IDS] == ["fc-a", "fc-b"]
+
+
+async def test_bridge_clears_stale_active_steer_when_orchestration_state_empty() -> None:
+    """An earlier bridged write does NOT linger across a subsequent
+    invocation whose orchestration-state has no active steer.
+    """
+    from goldfive.adapters._adk_plugin import SessionContext, make_adk_plugin
+    from goldfive.adapters._adk_state_protocol import (
+        KEY_ACTIVE_STEER_AT_TURN,
+        KEY_ACTIVE_STEER_BODY,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="agent_a")
+    session = Session(run_id="r1")
+    # No orchestration-level active steer.
+
+    task = Task(id="t1", title="x")
+    ctx = SessionContext(
+        session=session,
+        steerer=None,
+        task=task,
+        tool_handlers={},
+        host_agent_name="agent_a",
+    )
+    plugin.set_active_context(ctx)
+
+    class _Session:
+        def __init__(self) -> None:
+            # Start with a stale active_steer on ADK state (e.g. from an
+            # earlier turn that has since been cleared).
+            self.state: dict[str, Any] = {
+                KEY_ACTIVE_STEER_BODY: "stale steer",
+                KEY_ACTIVE_STEER_AT_TURN: 3,
+            }
+
+    class _InvCtx:
+        def __init__(self) -> None:
+            self.session = _Session()
+            self.invocation_id = "inv-1"
+            self.agent = type("A", (), {"name": "agent_a"})()
+
+    inv_ctx = _InvCtx()
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+
+    # Both keys were cleared because orchestration-state had no active steer.
+    assert KEY_ACTIVE_STEER_BODY not in inv_ctx.session.state
+    assert KEY_ACTIVE_STEER_AT_TURN not in inv_ctx.session.state
+
+
+async def test_bridge_preserves_legacy_state_keys_regression() -> None:
+    """Regression: adding the orchestration bridge MUST NOT regress the
+    legacy-key writes (run_id, plan context, current_task, tools).
+    """
+    from goldfive import orchestration_state as _ostate
+    from goldfive.adapters._adk_plugin import SessionContext, make_adk_plugin
+    from goldfive.adapters._adk_state_protocol import (
+        KEY_ACTIVE_STEER_BODY,
+        KEY_CURRENT_TASK_ID,
+        KEY_CURRENT_TASK_TITLE,
+        KEY_PLAN_ID,
+        KEY_RUN_ID,
+        KEY_TOOLS_AVAILABLE,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="agent_a")
+    session = Session(
+        run_id="run-42",
+        plan=Plan(
+            id="plan-42",
+            run_id="run-42",
+            goal_ids=[],
+            tasks=[Task(id="t1", title="xyz")],
+            edges=[],
+            summary="summary",
+        ),
+    )
+    _ostate.set_active_steer(session.state, body="steer it", at_turn=1)
+
+    task = Task(id="t1", title="xyz")
+    ctx = SessionContext(
+        session=session,
+        steerer=None,
+        task=task,
+        tool_handlers={"report_task_started": lambda *a, **kw: None},
+        host_agent_name="agent_a",
+    )
+    plugin.set_active_context(ctx)
+
+    class _Session:
+        def __init__(self) -> None:
+            self.state: dict[str, Any] = {}
+
+    class _InvCtx:
+        def __init__(self) -> None:
+            self.session = _Session()
+            self.invocation_id = "inv-1"
+            self.agent = type("A", (), {"name": "agent_a"})()
+
+    inv_ctx = _InvCtx()
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+
+    # Legacy keys still land.
+    assert inv_ctx.session.state[KEY_RUN_ID] == "run-42"
+    assert inv_ctx.session.state[KEY_PLAN_ID] == "plan-42"
+    assert inv_ctx.session.state[KEY_CURRENT_TASK_ID] == "t1"
+    assert inv_ctx.session.state[KEY_CURRENT_TASK_TITLE] == "xyz"
+    assert "report_task_started" in (inv_ctx.session.state[KEY_TOOLS_AVAILABLE] or [])
+    # Bridged key lands too.
+    assert inv_ctx.session.state[KEY_ACTIVE_STEER_BODY] == "steer it"
+
+
+async def test_bridge_active_steer_visible_in_sub_runner() -> None:
+    """Steer body bridged via DefaultSteerer is visible on the sub-Runner
+    session.state during its own ``before_model_callback`` — i.e. the
+    bridge runs automatically across AgentTool boundaries via each
+    sub-Runner's ``before_run_callback``.
+    """
+    from google.adk.agents import Agent
+    from google.adk.tools.agent_tool import AgentTool
+
+    from goldfive import orchestration_state as _ostate
+    from goldfive.adapters._adk_state_protocol import KEY_ACTIVE_STEER_BODY
+    from goldfive.adapters.adk import ADKAdapter
+
+    observed_steer: dict[str, Any] = {}
+
+    def _snapshot_steer(callback_context: Any, llm_request: Any) -> None:  # noqa: ARG001
+        inv_ctx = getattr(callback_context, "_invocation_context", None)
+        state = None
+        if inv_ctx is not None:
+            sess = getattr(inv_ctx, "session", None)
+            state = getattr(sess, "state", None)
+        if state is None:
+            return None
+        # Only snapshot the sub-Runner's first before_model.
+        if observed_steer:
+            return None
+        try:
+            observed_steer["body"] = state.get(KEY_ACTIVE_STEER_BODY)
+            observed_steer["agent_name"] = getattr(
+                getattr(inv_ctx, "agent", None), "name", ""
+            )
+        except Exception:
+            observed_steer["body"] = None
+        return None
+
+    agent_b = Agent(
+        name="agent_b",
+        model=_make_agent_b_llm()(),
+        instruction="",
+        before_model_callback=_snapshot_steer,
+    )
+    agent_a = Agent(
+        name="agent_a",
+        model=_make_agent_a("agent_b")(),
+        instruction="",
+        tools=[AgentTool(agent_b)],
+    )
+    adapter = ADKAdapter(agent_a)
+    adapter.bind_steerer(_StubSteerer())
+
+    task = Task(id="t1", title="compound", assignee_agent_id="agent_a")
+    plan = Plan(id="p1", run_id="r1", goal_ids=[], tasks=[task], edges=[])
+    session = Session(run_id="r1", plan=plan)
+    # Fire an orchestration-level active steer before invoking. The
+    # plugin's before_run_callback will bridge this onto BOTH the top
+    # invocation's session AND the sub-Runner's session.
+    _ostate.set_active_steer(
+        session.state,
+        body="bridge this to sub-runner",
+        at_turn=1,
+    )
+    await adapter.invoke(task=task, session=session)
+
+    assert observed_steer, (
+        "sub-Runner's before_model_callback never ran — AgentTool dispatch broke"
+    )
+    assert observed_steer.get("body") == "bridge this to sub-runner", (
+        f"sub-Runner saw active_steer.body={observed_steer.get('body')!r}; "
+        "orchestration-state bridge did not propagate through AgentTool."
+    )
+    # Sanity: the sub-Runner observation came from agent_b's callback
+    # (not agent_a's), so this is genuinely the nested sub-Runner.
+    assert observed_steer.get("agent_name") == "agent_b"
+
+
+async def test_bridge_end_to_end_steerer_to_goldfive_planner_instruction() -> None:
+    """Fire USER_STEER through DefaultSteerer; start an ADK invocation;
+    assert GoldfivePlanner's injected instruction contains the steer
+    body (not ``(none)``).
+
+    This is the highest-level assertion for #170: the data path from
+    operator-authored steer → DefaultSteerer._apply_user_steer_state
+    → goldfive.Session.state → bridge (before_run_callback) → ADK
+    session.state → GoldfivePlanner.build_planning_instruction.
+    """
+    from google.adk.agents import Agent
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_response import LlmResponse
+    from google.genai import types as genai_types
+
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.control import ControlKind, ControlMessage
+    from goldfive.steerer import DefaultSteerer
+
+    # Capture the system_instruction the LLM sees so we can assert
+    # GoldfivePlanner's orchestration block landed with the real
+    # steer body rather than ``(none)``.
+    captured_instructions: list[str] = []
+
+    class _ScriptedLLM(BaseLlm):
+        model: str = "fake-model"
+
+        async def generate_content_async(self, llm_request: Any, stream: bool = False):  # noqa: ARG002
+            # Pull the system instruction for assertion. ADK stashes it
+            # under ``config.system_instruction``.
+            config = getattr(llm_request, "config", None)
+            si = getattr(config, "system_instruction", "") if config is not None else ""
+            if isinstance(si, str):
+                captured_instructions.append(si)
+            else:
+                # Some ADK versions wrap it in a Content or list of parts.
+                captured_instructions.append(str(si))
+            yield LlmResponse(
+                content=genai_types.Content(
+                    role="model",
+                    parts=[genai_types.Part(text="ok")],
+                ),
+                turn_complete=True,
+            )
+
+    agent = Agent(
+        name="agent_a",
+        model=_ScriptedLLM(),
+        instruction="",
+    )
+    adapter = ADKAdapter(agent)
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[], planner=None)  # type: ignore[arg-type]
+    steerer.bind_adapter(adapter)
+    adapter.bind_steerer(steerer)
+
+    task = Task(id="t1", title="ship it", assignee_agent_id="agent_a")
+    plan = Plan(id="p1", run_id="r1", goal_ids=[], tasks=[task], edges=[])
+    session = Session(run_id="r1", plan=plan)
+
+    # Fire a USER_STEER via the steerer — same path a control-channel
+    # STEER takes in production. This writes the active_steer onto
+    # goldfive.Session.state via _apply_user_steer_state.
+    await steerer.observe(
+        ControlMessage(
+            kind=ControlKind.STEER,
+            payload={"note": "pivot toward reliability"},
+        ),
+        session,
+    )
+
+    await adapter.invoke(task=task, session=session)
+
+    assert captured_instructions, (
+        "LLM generate_content_async never ran — invocation did not dispatch"
+    )
+    first = captured_instructions[0]
+    assert "[GOLDFIVE ORCHESTRATION CONTEXT]" in first, (
+        "GoldfivePlanner's orchestration block missing from the system instruction"
+    )
+    assert "pivot toward reliability" in first, (
+        f"Steer body missing from injected instruction; saw:\n{first}"
+    )
+    assert "Active user steer (if any): (none)" not in first, (
+        "Active steer rendered as (none) — bridge did not propagate the body"
+    )


### PR DESCRIPTION
Closes #170.

## Problem

Post-merge of #152 + #153, structural steering was inert at the data layer:

- `DefaultSteerer._apply_user_steer_state` (#152) writes `goldfive.active_steer.body/at_turn`, `goldfive.goals_summary`, `goldfive.cancelled_function_call_ids` onto **`goldfive.Session.state`** (framework-agnostic orchestration dict).
- `GoldfivePlanner.build_planning_instruction` (#153) reads the same logical keys off **ADK `session.state`** for its per-turn system-instruction injection.
- `_adk_state_protocol.ALL_KEYS` only bridged the legacy keys (`current_task_id`, `plan_id`, `tools_available`, etc.).

Consequence: the planner always rendered `Active user steer (if any): (none)` on every LLM call — structural steering had no effect until the next heal-composed user-turn framing.

## Fix

1. **`_adk_state_protocol.py`** — added `KEY_ACTIVE_STEER_BODY` / `KEY_ACTIVE_STEER_AT_TURN` / `KEY_GOALS_SUMMARY` / `KEY_CANCELLED_FUNCTION_CALL_IDS` (same strings as the orchestration-state module owns) and `set_active_steer_on_adk_state` / `set_goals_summary_on_adk_state` / `set_cancelled_function_call_ids_on_adk_state` writer helpers.
2. **`_adk_plugin.py::_GoldfiveADKPlugin.before_run_callback`** — after the existing legacy-key writes, the new `_bridge_orchestration_state` helper reads the orchestration-level values off `ctx.session.state` via the `goldfive.orchestration_state` readers and copies them onto the live ADK `session.state` via the new helpers.

**Tree-agnostic.** The bridge fires on every invocation — including AgentTool-spawned sub-Runners whose own `before_run_callback` runs against their own live session. Sub-Runner propagation is automatic; no separate handoff path.

**Back-compat.** Legacy-key writes are unchanged; the bridge is additive.

## Test plan

- [x] Unit: `before_run_callback` bridges active_steer, goals_summary, and cancelled_ids onto a hand-constructed ADK session
- [x] Unit: bridge clears stale active_steer when orchestration-state has none
- [x] Regression: legacy keys still land alongside the new bridged keys
- [x] Integration: steer body visible on sub-Runner session.state when a goldfive.wrap-style tree dispatches through AgentTool
- [x] End-to-end: `DefaultSteerer.observe(ControlMessage(STEER))` -> `adapter.invoke` -> assert the captured `llm_request.config.system_instruction` contains the steer body (not `(none)`)
- [x] `uv run pytest -x -v` → 894 passed, 46 skipped