### PR TITLE
Post-steer latency instrumentation: per-LLM-call metrics

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -197,6 +198,112 @@ def _session_context_from_callback(ctx: Any) -> SessionContext | None:
     if isinstance(value, SessionContext):
         return value
     return None
+
+
+def _measure_request_chars(llm_request: Any) -> tuple[int, int]:
+    """Return ``(total_chars, messages_count)`` for an ADK ``LlmRequest``.
+
+    Used by the goldfive#172 per-LLM-call instrumentation in
+    :meth:`_GoldfiveADKPlugin.before_model_callback`. We walk
+    ``llm_request.contents`` (a list of ``Content`` whose ``parts`` hold
+    ``text`` / ``function_call`` / ``function_response`` leaves) and
+    sum the character count of each serialised part. The three leaf
+    shapes we care about:
+
+    * ``part.text`` -- plain assistant / user / system text.
+    * ``part.function_call`` -- a model-emitted tool call. We serialise
+      as ``name + json(args)`` because both contribute to the prompt
+      tokens the model pays for.
+    * ``part.function_response`` -- a tool's return payload. Serialised
+      as ``name + json(response)`` for the same reason.
+
+    Unknown part shapes fall through silently (count zero) so a novel
+    ADK part type doesn't break instrumentation. The system instruction
+    on ``llm_request.config.system_instruction`` is counted separately
+    when present, since it's a prompt-prefix the model must process on
+    every call — often the dominant contributor right after a
+    GoldfivePlanner injection.
+
+    Returns ``(0, 0)`` on any failure — instrumentation must never
+    raise into the caller path.
+    """
+    try:
+        contents = _safe_attr(llm_request, "contents", None) or []
+        total_chars = 0
+        messages_count = 0
+        for content in contents:
+            messages_count += 1
+            parts = _safe_attr(content, "parts", None) or []
+            for part in parts:
+                text = _safe_attr(part, "text", "") or ""
+                if text:
+                    total_chars += len(str(text))
+                    continue
+                fc = _safe_attr(part, "function_call", None)
+                if fc is not None:
+                    name = str(_safe_attr(fc, "name", "") or "")
+                    args = _safe_attr(fc, "args", None)
+                    total_chars += len(name)
+                    if args is not None:
+                        try:
+                            total_chars += len(json.dumps(args, default=repr))
+                        except Exception:  # noqa: BLE001
+                            total_chars += len(repr(args))
+                    continue
+                fr = _safe_attr(part, "function_response", None)
+                if fr is not None:
+                    name = str(_safe_attr(fr, "name", "") or "")
+                    resp = _safe_attr(fr, "response", None)
+                    total_chars += len(name)
+                    if resp is not None:
+                        try:
+                            total_chars += len(json.dumps(resp, default=repr))
+                        except Exception:  # noqa: BLE001
+                            total_chars += len(repr(resp))
+                    continue
+        # Include the system instruction — a GoldfivePlanner injection
+        # lands here and typically dominates the prompt prefix.
+        config = _safe_attr(llm_request, "config", None)
+        sys_inst = _safe_attr(config, "system_instruction", "") or ""
+        if isinstance(sys_inst, str):
+            total_chars += len(sys_inst)
+        elif sys_inst is not None:
+            try:
+                total_chars += len(str(sys_inst))
+            except Exception:  # noqa: BLE001
+                pass
+        return total_chars, messages_count
+    except Exception:  # noqa: BLE001 — instrumentation must never raise
+        return 0, 0
+
+
+def _extract_usage_metadata(llm_response: Any) -> dict[str, int]:
+    """Pull prompt / completion / total token counts off an ADK ``LlmResponse``.
+
+    ADK normalises per-provider usage onto
+    ``llm_response.usage_metadata`` (a
+    ``google.genai.types.GenerateContentResponseUsageMetadata`` with
+    ``prompt_token_count`` / ``candidates_token_count`` /
+    ``total_token_count``). Returns an empty dict when the backend
+    didn't report usage (some LiteLLM-fronted providers skip it, some
+    streaming responses defer it to a trailing chunk).
+
+    Returns only fields that are present and non-zero — callers treat
+    missing keys as "not reported".
+    """
+    out: dict[str, int] = {}
+    usage = _safe_attr(llm_response, "usage_metadata", None)
+    if usage is None:
+        return out
+    for src_attr, dst_key in (
+        ("prompt_token_count", "prompt_tokens"),
+        ("candidates_token_count", "completion_tokens"),
+        ("total_token_count", "total_tokens"),
+    ):
+        value = _safe_attr(usage, src_attr, None)
+        if isinstance(value, int) and value > 0:
+            out[dst_key] = value
+    return out
 
 
 def _extract_text_parts(llm_response: Any) -> list[str]:
@@ -760,6 +867,16 @@ def make_adk_plugin(
             # this to break out of ``run_async`` cleanly — the drift
             # event has already been emitted.
             self.runaway_delegation_tripped: bool = False
+            # Per-LLM-call instrumentation (goldfive#172). Keyed by
+            # ADK ``invocation_id`` — ``before_model_callback`` stashes
+            # the start time + request chars + message count here and
+            # ``after_model_callback`` pops it to compute
+            # ``llm.call.duration_ms``. Since ADK fires before/after
+            # pairs synchronously for a single invocation, a single
+            # slot per invocation_id is sufficient (nested AgentTool
+            # sub-Runners get their own invocation_id). Each entry is
+            # a small dict to keep the payload auditable in tests.
+            self._invocation_llm_pending: dict[str, dict[str, Any]] = {}
 
         def set_active_context(self, ctx: SessionContext) -> None:
             """Attach the ``SessionContext`` for the running invocation.
@@ -788,6 +905,11 @@ def make_adk_plugin(
             self._agent_tool_spawn_count = 0
             self.runaway_delegation_tripped = False
             self._reconciler = None
+            # Drop any straggling per-LLM-call metrics entries
+            # (goldfive#172). Normal operation pops each entry in
+            # ``after_model_callback``; this catches the case where a
+            # model turn errored between before/after and never paired.
+            self._invocation_llm_pending.clear()
 
         def set_reconciler(self, reconciler: Any) -> None:
             """Attach a :class:`~goldfive.reconciler.PlanReconciler`.
@@ -1300,7 +1422,8 @@ def make_adk_plugin(
 
         async def before_model_callback(self, *, callback_context: Any, llm_request: Any) -> None:
             """Best-effort re-seed goldfive.* state for legacy test harnesses
-            + GoldfivePlanner request-side instruction injection.
+            + GoldfivePlanner request-side instruction injection
+            + per-LLM-call instrumentation (goldfive#172).
 
             The authoritative state write happens in
             :meth:`before_run_callback` against the live invocation
@@ -1319,6 +1442,15 @@ def make_adk_plugin(
             here and append the returned string to
             ``llm_request.config.system_instruction`` via the same
             ``append_instructions`` helper ADK uses internally.
+
+            Finally, it stamps per-LLM-call metrics (goldfive#172):
+            counts ``llm_request.contents`` chars and message count,
+            stashes a start-time on the plugin keyed by invocation_id
+            so the paired ``after_model_callback`` can compute call
+            duration, and logs the measurements at INFO with
+            structured fields so operators running the live kikuchi
+            endpoint can correlate post-steer slowdowns to context
+            growth (see issue #172, hypothesis 1).
             """
             ctx = self._resolve_ctx(callback_context)
             if ctx is None:
@@ -1357,6 +1489,43 @@ def make_adk_plugin(
             except Exception as exc:  # noqa: BLE001
                 log.debug(
                     "before_model_callback: goldfive planner injection raised: %s",
+                    exc,
+                )
+
+            # Per-LLM-call instrumentation (goldfive#172). Measure the
+            # request AFTER GoldfivePlanner has appended its
+            # instruction so the reported chars reflect what the
+            # model actually sees. Stash a start-time so the paired
+            # after_model_callback can compute duration.
+            try:
+                chars, messages_count = _measure_request_chars(llm_request)
+                inv_ctx = _safe_attr(callback_context, "_invocation_context", None) or _safe_attr(
+                    callback_context, "invocation_context", None
+                )
+                inv_id = str(_safe_attr(inv_ctx, "invocation_id", "") or "")
+                start_mono = time.monotonic()
+                if inv_id:
+                    self._invocation_llm_pending[inv_id] = {
+                        "start_mono": start_mono,
+                        "chars": chars,
+                        "messages_count": messages_count,
+                    }
+                # INFO log so an operator running a live e2e (kikuchi)
+                # can tail stderr and correlate context growth against
+                # the subsequent duration line.
+                log.info(
+                    "goldfive.llm.request invocation_id=%s "
+                    "llm.request.chars=%d llm.request.messages_count=%d "
+                    "task_id=%s agent=%s",
+                    inv_id or "?",
+                    chars,
+                    messages_count,
+                    str(_safe_attr(ctx.task, "id", "") or "") or "?",
+                    self._host_agent_name or "?",
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "before_model_callback: LLM-call instrumentation raised: %s",
                     exc,
                 )
             return None
@@ -1542,15 +1711,60 @@ def make_adk_plugin(
                     joined = " ".join(texts).strip()
                     if joined:
                         self._invocation_last_text[inv_id] = joined
+            # Per-LLM-call instrumentation (goldfive#172). Pair with the
+            # before_model_callback stash to compute duration, extract
+            # token usage, log the result, and enrich the observation
+            # raw dict so custom steerer sinks can surface the metrics
+            # alongside each LLM turn. Any failure in this block is
+            # swallowed — instrumentation must not shadow a real LLM
+            # response from the steerer.
+            metrics: dict[str, Any] = {}
+            try:
+                pending = self._invocation_llm_pending.pop(inv_id, None) if inv_id else None
+                if pending is not None:
+                    duration_ms = int((time.monotonic() - pending["start_mono"]) * 1000)
+                    metrics["llm.call.duration_ms"] = duration_ms
+                    metrics["llm.request.chars"] = int(pending.get("chars", 0))
+                    metrics["llm.request.messages_count"] = int(pending.get("messages_count", 0))
+                usage = _extract_usage_metadata(llm_response)
+                for key, value in usage.items():
+                    metrics[f"llm.usage.{key}"] = value
+                if metrics:
+                    log.info(
+                        "goldfive.llm.response invocation_id=%s "
+                        "llm.call.duration_ms=%s llm.request.chars=%s "
+                        "llm.request.messages_count=%s "
+                        "llm.usage.prompt_tokens=%s "
+                        "llm.usage.completion_tokens=%s "
+                        "llm.usage.total_tokens=%s "
+                        "task_id=%s agent=%s",
+                        inv_id or "?",
+                        metrics.get("llm.call.duration_ms", "?"),
+                        metrics.get("llm.request.chars", "?"),
+                        metrics.get("llm.request.messages_count", "?"),
+                        metrics.get("llm.usage.prompt_tokens", "?"),
+                        metrics.get("llm.usage.completion_tokens", "?"),
+                        metrics.get("llm.usage.total_tokens", "?"),
+                        str(_safe_attr(ctx.task, "id", "") or "") or "?",
+                        self._host_agent_name or "?",
+                    )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "after_model_callback: LLM-call instrumentation raised: %s",
+                    exc,
+                )
+            raw: dict[str, Any] = {
+                "texts": texts,
+                "function_calls": calls,
+                "reasoning": reasoning,
+                "finish_reason": str(finish) if finish is not None else "",
+            }
+            if metrics:
+                raw["metrics"] = metrics
             observation = _as_observation(
                 kind="llm_response",
                 detail=" ".join(texts)[:500],
-                raw={
-                    "texts": texts,
-                    "function_calls": calls,
-                    "reasoning": reasoning,
-                    "finish_reason": str(finish) if finish is not None else "",
-                },
+                raw=raw,
                 task=ctx.task,
                 agent_id=self._host_agent_name,
             )

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -504,6 +504,324 @@ async def test_after_run_no_confabulation_when_tool_was_called(state_ctx_cls) ->
     assert steerer.drifts == [], f"no drift expected when a tool was called; got {steerer.drifts!r}"
 
 
+# ---------------------------------------------------------------------------
+# Per-LLM-call instrumentation (goldfive#172)
+# ---------------------------------------------------------------------------
+
+
+async def test_llm_call_instrumentation_emits_chars_and_duration(state_ctx_cls, caplog) -> None:
+    """before/after_model_callback pair yields chars + duration metrics.
+
+    goldfive#172 Phase 1: instrumentation. Drives the callback pair
+    by hand with a minimal LlmRequest / LlmResponse stub and asserts:
+
+    * ``before_model_callback`` logs ``llm.request.chars`` +
+      ``llm.request.messages_count`` at INFO with a matching
+      invocation_id.
+    * ``after_model_callback`` logs ``llm.call.duration_ms`` at INFO
+      and writes a ``metrics`` entry into the steerer observation's
+      raw dict so downstream sinks can surface the numbers without
+      re-parsing the log.
+    * Token usage from ``llm_response.usage_metadata`` flows into
+      ``llm.usage.prompt_tokens`` / ``completion_tokens`` /
+      ``total_tokens``.
+    """
+    import logging
+
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="coord")
+    steerer = _RecordingSteerer()
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=Session(run_id="run-instr"),
+            steerer=steerer,
+            task=Task(id="t-instr", title="Instrumentation smoke"),
+            tool_handlers={},
+            host_agent_name="coord",
+        )
+    }
+
+    class _InvContext:
+        def __init__(self, invocation_id: str) -> None:
+            self.invocation_id = invocation_id
+
+    class _CbContext:
+        def __init__(self, state: dict, invocation_id: str) -> None:
+            self._state = state
+            self._invocation_context = _InvContext(invocation_id)
+
+        @property
+        def session(self) -> Any:
+            return state_ctx_cls(self._state).session
+
+    # Request stub: three messages, known character counts. A user
+    # turn with text, an assistant turn with a function_call, and a
+    # tool turn with a function_response.
+    class _Part:
+        def __init__(
+            self,
+            text: str = "",
+            function_call: Any = None,
+            function_response: Any = None,
+        ) -> None:
+            self.text = text
+            self.function_call = function_call
+            self.function_response = function_response
+            self.thought = False
+
+    class _FC:
+        def __init__(self, name: str, args: dict) -> None:
+            self.name = name
+            self.args = args
+
+    class _FR:
+        def __init__(self, name: str, response: dict) -> None:
+            self.name = name
+            self.response = response
+
+    class _Content:
+        def __init__(self, role: str, parts: list[_Part]) -> None:
+            self.role = role
+            self.parts = parts
+
+    class _Config:
+        system_instruction = "goldfive planner context: focus on t-instr"
+
+    class _LlmRequest:
+        contents = [
+            _Content("user", [_Part(text="research solar panels")]),
+            _Content(
+                "model",
+                [_Part(function_call=_FC("web_search", {"q": "solar panels"}))],
+            ),
+            _Content(
+                "tool",
+                [_Part(function_response=_FR("web_search", {"results": ["panel"]}))],
+            ),
+        ]
+        config = _Config()
+
+    class _Usage:
+        prompt_token_count = 421
+        candidates_token_count = 97
+        total_token_count = 518
+
+    class _LlmResponseContent:
+        parts = [_Part(text="Solar panels convert sunlight to electricity.")]
+
+    class _LlmResponse:
+        content = _LlmResponseContent()
+        finish_reason = None
+        usage_metadata = _Usage()
+
+    inv_id = "inv-instr-1"
+    caplog.set_level(logging.INFO, logger="goldfive.adapters.adk")
+
+    await plugin.before_model_callback(
+        callback_context=_CbContext(state, inv_id),
+        llm_request=_LlmRequest(),
+    )
+    # The pending entry must be stamped with the chars we measured.
+    pending = plugin._invocation_llm_pending.get(inv_id)
+    assert pending is not None
+    assert pending["messages_count"] == 3
+    # Rough bound: the three contents + system_instruction are at
+    # least ~80 chars combined; we avoid brittle exact asserts but
+    # require it saw something meaningful.
+    assert pending["chars"] > 50
+
+    # Tiny delay so duration_ms is > 0.
+    import asyncio as _asyncio
+
+    await _asyncio.sleep(0.005)
+
+    await plugin.after_model_callback(
+        callback_context=_CbContext(state, inv_id),
+        llm_response=_LlmResponse(),
+    )
+
+    # The pending entry must be popped after the pair completes.
+    assert plugin._invocation_llm_pending.get(inv_id) is None
+
+    # The steerer observed the turn. The raw payload must carry the
+    # metrics dict so custom sinks can surface the numbers alongside
+    # each LLM turn without re-parsing the log output.
+    assert len(steerer.events) == 1
+    raw = steerer.events[0]["raw"]
+    assert "metrics" in raw, f"expected metrics key in raw dict; got {raw!r}"
+    metrics = raw["metrics"]
+    assert metrics["llm.request.chars"] > 50
+    assert metrics["llm.request.messages_count"] == 3
+    assert metrics["llm.call.duration_ms"] >= 0
+    assert metrics["llm.usage.prompt_tokens"] == 421
+    assert metrics["llm.usage.completion_tokens"] == 97
+    assert metrics["llm.usage.total_tokens"] == 518
+
+    # INFO log records carry the structured fields.
+    request_logs = [
+        r.getMessage() for r in caplog.records if "goldfive.llm.request" in r.getMessage()
+    ]
+    response_logs = [
+        r.getMessage() for r in caplog.records if "goldfive.llm.response" in r.getMessage()
+    ]
+    assert any(inv_id in msg for msg in request_logs), (
+        f"expected goldfive.llm.request log for {inv_id}; saw {request_logs!r}"
+    )
+    assert any("llm.call.duration_ms=" in msg and inv_id in msg for msg in response_logs), (
+        f"expected goldfive.llm.response log with duration for {inv_id}; saw {response_logs!r}"
+    )
+
+
+async def test_llm_call_instrumentation_tolerates_missing_usage(
+    state_ctx_cls,
+) -> None:
+    """LLM responses without ``usage_metadata`` still yield duration + chars.
+
+    Some LiteLLM-fronted providers omit usage (especially on the first
+    streaming chunk). The instrumentation must degrade gracefully —
+    duration + char counts are still reported; usage keys are simply
+    absent.
+    """
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="coord")
+    steerer = _RecordingSteerer()
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=Session(run_id="run-instr-2"),
+            steerer=steerer,
+            task=Task(id="t-instr-2", title="No usage"),
+            tool_handlers={},
+            host_agent_name="coord",
+        )
+    }
+
+    class _InvContext:
+        def __init__(self, invocation_id: str) -> None:
+            self.invocation_id = invocation_id
+
+    class _CbContext:
+        def __init__(self, state: dict, invocation_id: str) -> None:
+            self._state = state
+            self._invocation_context = _InvContext(invocation_id)
+
+        @property
+        def session(self) -> Any:
+            return state_ctx_cls(self._state).session
+
+    class _Part:
+        def __init__(self, text: str = "") -> None:
+            self.text = text
+            self.thought = False
+            self.function_call = None
+            self.function_response = None
+
+    class _Content:
+        def __init__(self, parts: list[_Part]) -> None:
+            self.role = "user"
+            self.parts = parts
+
+    class _LlmRequest:
+        contents = [_Content([_Part(text="hello")])]
+        config = None
+
+    class _RespContent:
+        parts = [_Part(text="hi")]
+
+    class _LlmResponse:
+        content = _RespContent()
+        finish_reason = None
+        # No usage_metadata attribute at all.
+
+    inv_id = "inv-instr-2"
+    await plugin.before_model_callback(
+        callback_context=_CbContext(state, inv_id),
+        llm_request=_LlmRequest(),
+    )
+    await plugin.after_model_callback(
+        callback_context=_CbContext(state, inv_id),
+        llm_response=_LlmResponse(),
+    )
+
+    assert len(steerer.events) == 1
+    metrics = steerer.events[0]["raw"].get("metrics", {})
+    assert "llm.call.duration_ms" in metrics
+    assert "llm.request.chars" in metrics
+    assert "llm.request.messages_count" in metrics
+    # Usage omitted on this response — keys must be absent, not zero.
+    assert "llm.usage.prompt_tokens" not in metrics
+    assert "llm.usage.completion_tokens" not in metrics
+
+
+def test_measure_request_chars_counts_text_and_tool_payloads() -> None:
+    """_measure_request_chars sums text, function_call, function_response."""
+    from goldfive.adapters._adk_plugin import _measure_request_chars
+
+    class _Part:
+        def __init__(
+            self,
+            text: str = "",
+            function_call: Any = None,
+            function_response: Any = None,
+        ) -> None:
+            self.text = text
+            self.function_call = function_call
+            self.function_response = function_response
+            self.thought = False
+
+    class _FC:
+        def __init__(self, name: str, args: dict) -> None:
+            self.name = name
+            self.args = args
+
+    class _FR:
+        def __init__(self, name: str, response: dict) -> None:
+            self.name = name
+            self.response = response
+
+    class _Content:
+        def __init__(self, parts: list[_Part]) -> None:
+            self.parts = parts
+
+    class _Config:
+        system_instruction = "SYS"
+
+    class _LlmRequest:
+        contents = [
+            _Content([_Part(text="hello world")]),
+            _Content([_Part(function_call=_FC("tool", {"a": 1}))]),
+            _Content([_Part(function_response=_FR("tool", {"ok": True}))]),
+        ]
+        config = _Config()
+
+    chars, messages = _measure_request_chars(_LlmRequest())
+    assert messages == 3
+    # "hello world" is 11 chars; "SYS" is 3; plus tool name + json
+    # blobs each contribute a few more. Bound loosely but require
+    # meaningful content.
+    assert chars >= len("hello world") + len("SYS")
+    # Must also pick up the function_call + function_response
+    # serialisation (so more than just text + sys).
+    assert chars > len("hello world") + len("SYS") + 4
+
+
+def test_measure_request_chars_safe_on_garbage() -> None:
+    """_measure_request_chars returns (0, 0) for non-ADK inputs."""
+    from goldfive.adapters._adk_plugin import _measure_request_chars
+
+    assert _measure_request_chars(None) == (0, 0)
+    assert _measure_request_chars(object()) == (0, 0)
+
+
 async def test_on_event_transfer_calls_steerer_observe(state_ctx_cls) -> None:
     from goldfive.adapters._adk_plugin import (
         SESSION_CONTEXT_STATE_KEY,


### PR DESCRIPTION
Closes #172 (Phase 1: instrumentation). Diagnosis (Phase 2) follow-up will be commented on the issue after sufficient data is collected from a live e2e.

## Summary

Adds per-LLM-call instrumentation to `_GoldfiveADKPlugin` so the post-steer latency blow-up observed on Qwen via kikuchi (pre-steer ~16 min -> post-steer 35+ min with LiteLLM timeout) can be diagnosed empirically. Pure instrumentation — no semantic changes.

## Measurements

On every LLM call the plugin now captures:

- `llm.request.chars` — total character count of `llm_request.contents` (text, function_call, function_response payloads) plus `config.system_instruction`, so GoldfivePlanner's request-side injection shows up in the chars budget
- `llm.request.messages_count` — number of `Content` entries
- `llm.call.duration_ms` — timer spanning `before_model_callback` -> `after_model_callback`, keyed by ADK `invocation_id` (AgentTool sub-Runners get their own slot)
- `llm.usage.prompt_tokens` / `completion_tokens` / `total_tokens` — pulled from `llm_response.usage_metadata` when the backend reports them; keys simply absent when a provider skips usage (some LiteLLM-fronted chunks)

## Surfaces

1. **INFO logs** on the `goldfive.adapters.adk` logger — two records per LLM call (`goldfive.llm.request` at begin, `goldfive.llm.response` at end) with space-separated `key=value` fields. An operator tailing stderr during a live kikuchi e2e can correlate context growth against duration without additional tooling.
2. **Steerer observation raw dict** — same metrics land under a new `metrics` key on the existing `llm_response` observation so custom steerer sinks pick them up without re-parsing logs. The existing `texts` / `function_calls` / `reasoning` / `finish_reason` fields are unchanged.

## Safety

Every instrumentation path is best-effort: any failure is swallowed with a debug log so a novel ADK response shape never blocks a real LLM turn from reaching the steerer. `clear_active_context` now drops straggling pending entries left by mid-turn errors.

## Test plan

- [x] `test_llm_call_instrumentation_emits_chars_and_duration` — full before/after pair asserts metrics dict on observation + log lines
- [x] `test_llm_call_instrumentation_tolerates_missing_usage` — response without `usage_metadata` still yields duration + chars; usage keys absent
- [x] `test_measure_request_chars_counts_text_and_tool_payloads` — helper sums text + function_call + function_response + system_instruction
- [x] `test_measure_request_chars_safe_on_garbage` — helper returns `(0, 0)` for non-ADK inputs
- [x] `uv run pytest -x` — full suite 891 passed, 46 skipped
- [x] `uv run ruff check` + `ruff format` clean

## Follow-ups

- **Phase 2 (diagnosis)**: run one e2e on kikuchi with the 2-slide solar-panels -> solar-flares steer and tabulate pre-vs-post-steer chars / duration / tokens distributions. Will comment on #172 once collected.
- **Phase 3 (fix)**: scope depends on Phase 2 findings — likely the "shorter synthetic function_response on cascade-cancel" + "surface pre-steer summary via `goldfive.*` state keys" fixes described in the issue, in a separate PR.