### PR TITLE
STEER idempotency + author propagation (closes #171)

### DIFF
--- a/goldfive/conv.py
+++ b/goldfive/conv.py
@@ -411,6 +411,8 @@ def _build_steer(payload: dict[str, Any], pb: Any) -> Any:
     return pb.SteerPayload(
         note=str(payload.get("note", "")),
         suggested_action=str(payload.get("suggested_action", "")),
+        author=str(payload.get("author", "")),
+        annotation_id=str(payload.get("annotation_id", "")),
     )
 
 
@@ -481,6 +483,8 @@ def from_pb_control_event(pb_msg: Any) -> ControlMessage:
         payload = {
             "note": pb_msg.steer.note,
             "suggested_action": pb_msg.steer.suggested_action,
+            "author": pb_msg.steer.author,
+            "annotation_id": pb_msg.steer.annotation_id,
         }
     elif which == "rewind":
         payload = {"task_id": pb_msg.rewind.task_id}

--- a/goldfive/orchestration_state.py
+++ b/goldfive/orchestration_state.py
@@ -54,6 +54,13 @@ Active steer (set by DefaultSteerer on USER_STEER drift):
 * ``goldfive.active_steer.at_turn`` — monotonic sequence value
   captured at steer-fire time. Lets downstream refines know "was this
   steer before or after the observation I'm looking at?".
+* ``goldfive.active_steer.author`` — operator identity from the
+  originating annotation (goldfive#171). Empty string when the bridge
+  doesn't source annotations.
+* ``goldfive.processed_steer_ids`` — bounded FIFO list of
+  already-processed STEER ids (annotation id when available, otherwise
+  the ``ControlMessage.id``). Consulted by DefaultSteerer to drop
+  delivery retries and UI double-fires (goldfive#171).
 
 Heal path (set by adapter ``_heal_pending_tool_calls``):
 
@@ -98,6 +105,13 @@ KEY_GOALS_SUMMARY = "goldfive.goals_summary"
 # Active steer (DefaultSteerer)
 KEY_ACTIVE_STEER_BODY = "goldfive.active_steer.body"
 KEY_ACTIVE_STEER_AT_TURN = "goldfive.active_steer.at_turn"
+KEY_ACTIVE_STEER_AUTHOR = "goldfive.active_steer.author"
+
+# USER_STEER idempotency (goldfive#171). A bounded list of already-
+# processed annotation / control ids. Consulted by DefaultSteerer so a
+# delivery retry or UI double-fire of the same STEER annotation doesn't
+# cascade-cancel + refine twice.
+KEY_PROCESSED_STEER_IDS = "goldfive.processed_steer_ids"
 
 # Heal path (ADKAdapter._heal_pending_tool_calls)
 KEY_CANCELLED_FUNCTION_CALL_IDS = "goldfive.cancelled_function_call_ids"
@@ -109,8 +123,15 @@ ALL_KEYS: tuple[str, ...] = (
     KEY_GOALS_SUMMARY,
     KEY_ACTIVE_STEER_BODY,
     KEY_ACTIVE_STEER_AT_TURN,
+    KEY_ACTIVE_STEER_AUTHOR,
+    KEY_PROCESSED_STEER_IDS,
     KEY_CANCELLED_FUNCTION_CALL_IDS,
 )
+
+# Cap on how many processed steer ids we retain on ``session.state`` so
+# long-lived sessions don't balloon the dedupe set. The oldest entries
+# are evicted FIFO when the cap is reached.
+PROCESSED_STEER_IDS_CAP = 256
 
 
 # ---------------------------------------------------------------------------
@@ -229,16 +250,68 @@ def set_active_steer(
     *,
     body: str,
     at_turn: int,
+    author: str = "",
 ) -> None:
-    """Record the active steer body + turn. See module docstring."""
+    """Record the active steer body + turn (+ optional author).
+
+    See module docstring. ``author`` defaults to the empty string so
+    existing callers that don't know who authored the steer keep
+    working unchanged (goldfive#171).
+    """
     write(state, KEY_ACTIVE_STEER_BODY, str(body or ""))
     write(state, KEY_ACTIVE_STEER_AT_TURN, int(at_turn))
+    write(state, KEY_ACTIVE_STEER_AUTHOR, str(author or ""))
 
 
 def clear_active_steer(state: MutableMapping[str, Any]) -> None:
     """Clear the active-steer keys (e.g. at run start). Idempotent."""
     clear(state, KEY_ACTIVE_STEER_BODY)
     clear(state, KEY_ACTIVE_STEER_AT_TURN)
+    clear(state, KEY_ACTIVE_STEER_AUTHOR)
+
+
+# ---------------------------------------------------------------------------
+# Processed steer ids (goldfive#171)
+# ---------------------------------------------------------------------------
+
+
+def has_processed_steer_id(state: Any, steer_id: str) -> bool:
+    """True when ``steer_id`` is already in the processed set.
+
+    Tolerant of malformed state values: a non-list / missing entry is
+    treated as an empty set.
+    """
+    if not steer_id:
+        return False
+    existing = read(state, KEY_PROCESSED_STEER_IDS, [])
+    if not isinstance(existing, list):
+        return False
+    return str(steer_id) in existing
+
+
+def record_processed_steer_id(
+    state: MutableMapping[str, Any],
+    steer_id: str,
+) -> None:
+    """Append ``steer_id`` to the processed list with FIFO eviction.
+
+    Empty ids are a no-op. Duplicates are silently dropped so the
+    function is safe to call unconditionally after a ``has_`` check.
+    """
+    if not steer_id:
+        return
+    existing = read(state, KEY_PROCESSED_STEER_IDS, [])
+    if not isinstance(existing, list):
+        existing = []
+    merged: list[str] = [str(v) for v in existing if v]
+    sid = str(steer_id)
+    if sid in merged:
+        return
+    merged.append(sid)
+    overflow = len(merged) - PROCESSED_STEER_IDS_CAP
+    if overflow > 0:
+        merged = merged[overflow:]
+    write(state, KEY_PROCESSED_STEER_IDS, merged)
 
 
 # ---------------------------------------------------------------------------
@@ -320,19 +393,24 @@ __all__ = [
     "ALL_KEYS",
     "GOLDFIVE_PREFIX",
     "KEY_ACTIVE_STEER_AT_TURN",
+    "KEY_ACTIVE_STEER_AUTHOR",
     "KEY_ACTIVE_STEER_BODY",
     "KEY_CANCELLED_FUNCTION_CALL_IDS",
     "KEY_CURRENT_PLAN_ID",
     "KEY_CURRENT_TASK_ID",
     "KEY_CURRENT_TASK_TITLE",
     "KEY_GOALS_SUMMARY",
+    "KEY_PROCESSED_STEER_IDS",
+    "PROCESSED_STEER_IDS_CAP",
     "append_cancelled_function_call_ids",
     "clear",
     "clear_active_steer",
     "clear_current_task",
     "format_goals_summary",
+    "has_processed_steer_id",
     "read",
     "read_cancelled_function_call_ids",
+    "record_processed_steer_id",
     "refresh_goals_summary",
     "set_active_steer",
     "set_current_plan",

--- a/goldfive/pb/goldfive/v1/control_pb2.py
+++ b/goldfive/pb/goldfive/v1/control_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x19goldfive/v1/control.proto\x12\x0bgoldfive.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"H\n\rControlTarget\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x0f\n\x07task_id\x18\x02 \x01(\t\x12\x14\n\x0ctool_call_id\x18\x03 \x01(\t\"6\n\x0cSteerPayload\x12\x0c\n\x04note\x18\x01 \x01(\t\x12\x18\n\x10suggested_action\x18\x02 \x01(\t\" \n\rRewindPayload\x12\x0f\n\x07task_id\x18\x01 \x01(\t\"3\n\x0e\x41pprovePayload\x12\x11\n\ttarget_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\"2\n\rRejectPayload\x12\x11\n\ttarget_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\"2\n\x14InjectMessagePayload\x12\x0c\n\x04role\x18\x01 \x01(\t\x12\x0c\n\x04text\x18\x02 \x01(\t\"\x9d\x03\n\x0c\x43ontrolEvent\x12\n\n\x02id\x18\x01 \x01(\t\x12-\n\tissued_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12*\n\x06target\x18\x03 \x01(\x0b\x32\x1a.goldfive.v1.ControlTarget\x12&\n\x04kind\x18\x04 \x01(\x0e\x32\x18.goldfive.v1.ControlKind\x12*\n\x05steer\x18\n \x01(\x0b\x32\x19.goldfive.v1.SteerPayloadH\x00\x12,\n\x06rewind\x18\x0b \x01(\x0b\x32\x1a.goldfive.v1.RewindPayloadH\x00\x12.\n\x07\x61pprove\x18\x0c \x01(\x0b\x32\x1b.goldfive.v1.ApprovePayloadH\x00\x12,\n\x06reject\x18\r \x01(\x0b\x32\x1a.goldfive.v1.RejectPayloadH\x00\x12;\n\x0einject_message\x18\x0e \x01(\x0b\x32!.goldfive.v1.InjectMessagePayloadH\x00\x42\t\n\x07payload\"\x8d\x01\n\nControlAck\x12\x12\n\ncontrol_id\x18\x01 \x01(\t\x12-\n\x06result\x18\x02 \x01(\x0e\x32\x1d.goldfive.v1.ControlAckResult\x12\x0e\n\x06\x64\x65tail\x18\x03 \x01(\t\x12,\n\x08\x61\x63ked_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp*\xc1\x02\n\x0b\x43ontrolKind\x12\x1c\n\x18\x43ONTROL_KIND_UNSPECIFIED\x10\x00\x12\x16\n\x12\x43ONTROL_KIND_PAUSE\x10\x01\x12\x17\n\x13\x43ONTROL_KIND_RESUME\x10\x02\x12\x17\n\x13\x43ONTROL_KIND_CANCEL\x10\x03\x12\x1a\n\x16\x43ONTROL_KIND_REWIND_TO\x10\x04\x12\x16\n\x12\x43ONTROL_KIND_STEER\x10\x05\x12\x18\n\x14\x43ONTROL_KIND_APPROVE\x10\x06\x12\x17\n\x13\x43ONTROL_KIND_REJECT\x10\x07\x12\x1d\n\x19\x43ONTROL_KIND_STATUS_QUERY\x10\x08\x12#\n\x1f\x43ONTROL_KIND_INTERCEPT_TRANSFER\x10\t\x12\x1f\n\x1b\x43ONTROL_KIND_INJECT_MESSAGE\x10\n*\x9a\x01\n\x10\x43ontrolAckResult\x12\"\n\x1e\x43ONTROL_ACK_RESULT_UNSPECIFIED\x10\x00\x12\x1e\n\x1a\x43ONTROL_ACK_RESULT_SUCCESS\x10\x01\x12\x1e\n\x1a\x43ONTROL_ACK_RESULT_FAILURE\x10\x02\x12\"\n\x1e\x43ONTROL_ACK_RESULT_UNSUPPORTED\x10\x03\x42\x39Z7github.com/pedapudi/goldfive/gen/goldfive/v1;goldfivev1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x19goldfive/v1/control.proto\x12\x0bgoldfive.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"H\n\rControlTarget\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x0f\n\x07task_id\x18\x02 \x01(\t\x12\x14\n\x0ctool_call_id\x18\x03 \x01(\t\"]\n\x0cSteerPayload\x12\x0c\n\x04note\x18\x01 \x01(\t\x12\x18\n\x10suggested_action\x18\x02 \x01(\t\x12\x0e\n\x06\x61uthor\x18\x03 \x01(\t\x12\x15\n\rannotation_id\x18\x04 \x01(\t\" \n\rRewindPayload\x12\x0f\n\x07task_id\x18\x01 \x01(\t\"3\n\x0e\x41pprovePayload\x12\x11\n\ttarget_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\"2\n\rRejectPayload\x12\x11\n\ttarget_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\"2\n\x14InjectMessagePayload\x12\x0c\n\x04role\x18\x01 \x01(\t\x12\x0c\n\x04text\x18\x02 \x01(\t\"\x9d\x03\n\x0c\x43ontrolEvent\x12\n\n\x02id\x18\x01 \x01(\t\x12-\n\tissued_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12*\n\x06target\x18\x03 \x01(\x0b\x32\x1a.goldfive.v1.ControlTarget\x12&\n\x04kind\x18\x04 \x01(\x0e\x32\x18.goldfive.v1.ControlKind\x12*\n\x05steer\x18\n \x01(\x0b\x32\x19.goldfive.v1.SteerPayloadH\x00\x12,\n\x06rewind\x18\x0b \x01(\x0b\x32\x1a.goldfive.v1.RewindPayloadH\x00\x12.\n\x07\x61pprove\x18\x0c \x01(\x0b\x32\x1b.goldfive.v1.ApprovePayloadH\x00\x12,\n\x06reject\x18\r \x01(\x0b\x32\x1a.goldfive.v1.RejectPayloadH\x00\x12;\n\x0einject_message\x18\x0e \x01(\x0b\x32!.goldfive.v1.InjectMessagePayloadH\x00\x42\t\n\x07payload\"\x8d\x01\n\nControlAck\x12\x12\n\ncontrol_id\x18\x01 \x01(\t\x12-\n\x06result\x18\x02 \x01(\x0e\x32\x1d.goldfive.v1.ControlAckResult\x12\x0e\n\x06\x64\x65tail\x18\x03 \x01(\t\x12,\n\x08\x61\x63ked_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp*\xc1\x02\n\x0b\x43ontrolKind\x12\x1c\n\x18\x43ONTROL_KIND_UNSPECIFIED\x10\x00\x12\x16\n\x12\x43ONTROL_KIND_PAUSE\x10\x01\x12\x17\n\x13\x43ONTROL_KIND_RESUME\x10\x02\x12\x17\n\x13\x43ONTROL_KIND_CANCEL\x10\x03\x12\x1a\n\x16\x43ONTROL_KIND_REWIND_TO\x10\x04\x12\x16\n\x12\x43ONTROL_KIND_STEER\x10\x05\x12\x18\n\x14\x43ONTROL_KIND_APPROVE\x10\x06\x12\x17\n\x13\x43ONTROL_KIND_REJECT\x10\x07\x12\x1d\n\x19\x43ONTROL_KIND_STATUS_QUERY\x10\x08\x12#\n\x1f\x43ONTROL_KIND_INTERCEPT_TRANSFER\x10\t\x12\x1f\n\x1b\x43ONTROL_KIND_INJECT_MESSAGE\x10\n*\x9a\x01\n\x10\x43ontrolAckResult\x12\"\n\x1e\x43ONTROL_ACK_RESULT_UNSPECIFIED\x10\x00\x12\x1e\n\x1a\x43ONTROL_ACK_RESULT_SUCCESS\x10\x01\x12\x1e\n\x1a\x43ONTROL_ACK_RESULT_FAILURE\x10\x02\x12\"\n\x1e\x43ONTROL_ACK_RESULT_UNSUPPORTED\x10\x03\x42\x39Z7github.com/pedapudi/goldfive/gen/goldfive/v1;goldfivev1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,24 +33,24 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'goldfive.v1.control_pb2', _
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z7github.com/pedapudi/goldfive/gen/goldfive/v1;goldfivev1'
-  _globals['_CONTROLKIND']._serialized_start=957
-  _globals['_CONTROLKIND']._serialized_end=1278
-  _globals['_CONTROLACKRESULT']._serialized_start=1281
-  _globals['_CONTROLACKRESULT']._serialized_end=1435
+  _globals['_CONTROLKIND']._serialized_start=996
+  _globals['_CONTROLKIND']._serialized_end=1317
+  _globals['_CONTROLACKRESULT']._serialized_start=1320
+  _globals['_CONTROLACKRESULT']._serialized_end=1474
   _globals['_CONTROLTARGET']._serialized_start=75
   _globals['_CONTROLTARGET']._serialized_end=147
   _globals['_STEERPAYLOAD']._serialized_start=149
-  _globals['_STEERPAYLOAD']._serialized_end=203
-  _globals['_REWINDPAYLOAD']._serialized_start=205
-  _globals['_REWINDPAYLOAD']._serialized_end=237
-  _globals['_APPROVEPAYLOAD']._serialized_start=239
-  _globals['_APPROVEPAYLOAD']._serialized_end=290
-  _globals['_REJECTPAYLOAD']._serialized_start=292
-  _globals['_REJECTPAYLOAD']._serialized_end=342
-  _globals['_INJECTMESSAGEPAYLOAD']._serialized_start=344
-  _globals['_INJECTMESSAGEPAYLOAD']._serialized_end=394
-  _globals['_CONTROLEVENT']._serialized_start=397
-  _globals['_CONTROLEVENT']._serialized_end=810
-  _globals['_CONTROLACK']._serialized_start=813
-  _globals['_CONTROLACK']._serialized_end=954
+  _globals['_STEERPAYLOAD']._serialized_end=242
+  _globals['_REWINDPAYLOAD']._serialized_start=244
+  _globals['_REWINDPAYLOAD']._serialized_end=276
+  _globals['_APPROVEPAYLOAD']._serialized_start=278
+  _globals['_APPROVEPAYLOAD']._serialized_end=329
+  _globals['_REJECTPAYLOAD']._serialized_start=331
+  _globals['_REJECTPAYLOAD']._serialized_end=381
+  _globals['_INJECTMESSAGEPAYLOAD']._serialized_start=383
+  _globals['_INJECTMESSAGEPAYLOAD']._serialized_end=433
+  _globals['_CONTROLEVENT']._serialized_start=436
+  _globals['_CONTROLEVENT']._serialized_end=849
+  _globals['_CONTROLACK']._serialized_start=852
+  _globals['_CONTROLACK']._serialized_end=993
 # @@protoc_insertion_point(module_scope)

--- a/goldfive/pb/goldfive/v1/control_pb2.pyi
+++ b/goldfive/pb/goldfive/v1/control_pb2.pyi
@@ -56,12 +56,16 @@ class ControlTarget(_message.Message):
     def __init__(self, agent_id: _Optional[str] = ..., task_id: _Optional[str] = ..., tool_call_id: _Optional[str] = ...) -> None: ...
 
 class SteerPayload(_message.Message):
-    __slots__ = ("note", "suggested_action")
+    __slots__ = ("note", "suggested_action", "author", "annotation_id")
     NOTE_FIELD_NUMBER: _ClassVar[int]
     SUGGESTED_ACTION_FIELD_NUMBER: _ClassVar[int]
+    AUTHOR_FIELD_NUMBER: _ClassVar[int]
+    ANNOTATION_ID_FIELD_NUMBER: _ClassVar[int]
     note: str
     suggested_action: str
-    def __init__(self, note: _Optional[str] = ..., suggested_action: _Optional[str] = ...) -> None: ...
+    author: str
+    annotation_id: str
+    def __init__(self, note: _Optional[str] = ..., suggested_action: _Optional[str] = ..., author: _Optional[str] = ..., annotation_id: _Optional[str] = ...) -> None: ...
 
 class RewindPayload(_message.Message):
     __slots__ = ("task_id",)

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -782,7 +782,22 @@ class DefaultSteerer:
         corresponding ``USER_*`` drift kinds without going through the
         heuristic classifiers. Every other event falls through to
         :meth:`detect_drift`.
+
+        STEER ControlMessages are deduped by their source annotation id
+        (goldfive#171): a delivery retry or UI double-fire of the same
+        STEER lands here twice, but cascade-cancel + refine must only
+        happen once. The dedupe set lives on ``session.state`` under
+        :data:`orchestration_state.KEY_PROCESSED_STEER_IDS` with FIFO
+        eviction after :data:`PROCESSED_STEER_IDS_CAP` entries. Content-
+        based drifts (LOOPING_REASONING, tool errors, …) are NOT
+        deduped — they're heuristic signals, not user actions.
         """
+        if self._is_duplicate_steer(event, session):
+            steer_id = self._steer_dedupe_id(event)
+            log.debug(
+                "DefaultSteerer.observe: dropping duplicate STEER id=%s", steer_id
+            )
+            return
         drift = self._drift_from_control(event, session)
         if drift is None:
             drift = self.detect_drift(event, session)
@@ -1210,6 +1225,75 @@ class DefaultSteerer:
         return " | ".join(trimmed)
 
     @staticmethod
+    def _steer_dedupe_id(event: Any) -> str:
+        """Return the dedupe id for a STEER ``ControlMessage``, or ``""``.
+
+        Prefers the source ``annotation_id`` when the bridge forwarded
+        one (goldfive#171), falling back to the ``ControlMessage.id``
+        so callers that don't source annotations still get retry dedupe.
+        Returns ``""`` for non-ControlMessages, non-STEER kinds, or
+        ids the bridge didn't populate — callers treat an empty id as
+        "nothing to dedupe".
+        """
+        from goldfive.control import ControlKind, ControlMessage
+
+        if not isinstance(event, ControlMessage):
+            return ""
+        raw_kind = getattr(event, "kind", None)
+        kind_str = str(getattr(raw_kind, "value", raw_kind) or "").upper()
+        if kind_str != ControlKind.STEER.value:
+            return ""
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        ann_id = str(payload.get("annotation_id", "") or "")
+        if ann_id:
+            return ann_id
+        return str(getattr(event, "id", "") or "")
+
+    @staticmethod
+    def _unpack_steer_context(drift: DriftEvent) -> tuple[str, str, str]:
+        """Extract ``(raw_body, author, dedupe_id)`` from a USER_STEER drift.
+
+        Prefers the originating :class:`ControlMessage` stashed on
+        :attr:`DriftEvent.raw` so the raw body survives the ``"by
+        {author}: {body}"`` rewrite applied to :attr:`DriftEvent.detail`.
+        When ``raw`` is absent (e.g. a test that builds a USER_STEER
+        drift directly), falls back to parsing the detail string — a
+        ``"by X: Y"`` prefix is treated as ``(Y, X, "")``; anything
+        else becomes ``(detail, "", "")``.
+        """
+        from goldfive.control import ControlMessage
+
+        raw = getattr(drift, "raw", None)
+        if isinstance(raw, ControlMessage):
+            payload = raw.payload if isinstance(raw.payload, dict) else {}
+            body = str(payload.get("note", "") or "")
+            author = str(payload.get("author", "") or "").strip()
+            ann_id = str(payload.get("annotation_id", "") or "")
+            dedupe_id = ann_id or str(getattr(raw, "id", "") or "")
+            return body, author, dedupe_id
+        # Fallback: parse "by {author}: {body}" out of detail so the
+        # back-compat DriftEvent-only code path preserves the author in
+        # state writes. No dedupe id is recoverable here.
+        detail = str(getattr(drift, "detail", "") or "")
+        if detail.startswith("by ") and ": " in detail:
+            prefix, _, tail = detail.partition(": ")
+            author = prefix[len("by ") :].strip()
+            return tail, author, ""
+        return detail, "", ""
+
+    @classmethod
+    def _is_duplicate_steer(cls, event: Any, session: Session) -> bool:
+        """True when ``event`` is a STEER ControlMessage already processed.
+
+        See :meth:`_steer_dedupe_id` for the id-selection rules. An
+        empty id always returns ``False`` (nothing to compare against).
+        """
+        steer_id = cls._steer_dedupe_id(event)
+        if not steer_id:
+            return False
+        return _ostate.has_processed_steer_id(session.state, steer_id)
+
+    @staticmethod
     def _drift_from_control(event: Any, session: Session) -> DriftEvent | None:
         """Map a :class:`ControlMessage` to the matching ``USER_*`` drift.
 
@@ -1217,6 +1301,13 @@ class DefaultSteerer:
         the caller can fall through to the classifier pipeline. Unknown
         control kinds return ``None`` as well — they are dispatched by
         the executor, not the steerer.
+
+        For STEER, the operator ``author`` (when the bridge forwarded
+        one) is prefixed onto the drift detail so downstream consumers
+        — prompt templates, sinks, UI — see audit-trail attribution
+        inline without having to peek into ``session.state``
+        (goldfive#171). The raw body still lands on
+        ``goldfive.active_steer.body`` untouched.
         """
         from goldfive.control import ControlKind, ControlMessage
 
@@ -1227,12 +1318,18 @@ class DefaultSteerer:
         payload = event.payload if isinstance(event.payload, dict) else {}
         note = str(payload.get("note", "") or "")
         reason = str(payload.get("reason", "") or "")
+        author = str(payload.get("author", "") or "").strip()
         if kind_str == ControlKind.STEER.value:
+            if author:
+                detail = f"by {author}: {note}"
+            else:
+                detail = note
             return DriftEvent(
                 kind=DriftKind.USER_STEER,
                 severity=DriftSeverity.WARNING,
-                detail=note,
+                detail=detail,
                 current_task_id=session.current_task_id,
+                raw=event,
             )
         if kind_str == ControlKind.CANCEL.value:
             return DriftEvent(
@@ -1840,6 +1937,9 @@ class DefaultSteerer:
            ``session.goals`` BEFORE ``planner.refine`` reads
            ``list(session.goals)``, so the refined plan sees the
            pivot as a goal, not only as a drift detail string.
+        3. The source annotation / control id is appended to
+           ``goldfive.processed_steer_ids`` so a retry or UI double-fire
+           of the same STEER is a no-op (goldfive#171 dedupe).
 
         Never raises: a planner that doesn't implement
         ``synthesize_goal_from_steer`` or a synthesis call that fails
@@ -1847,7 +1947,13 @@ class DefaultSteerer:
         a Goal, mode APPEND). The steerer must never break the run on
         a missing optional hook.
         """
-        body = (drift.detail or "").strip()
+        # Recover the raw body + operator author from the originating
+        # ControlMessage when it's available on drift.raw (goldfive#171).
+        # Falling back to drift.detail preserves back-compat for tests
+        # that synthesize a USER_STEER DriftEvent directly without a
+        # ControlMessage behind it.
+        raw_body, author, steer_id = self._unpack_steer_context(drift)
+        body = raw_body.strip()
         # Stamp the active_steer keys regardless of synthesis outcome
         # so readers see "a steer is active as of turn N" even when
         # the planner can't synthesize. ``at_turn`` uses the session's
@@ -1855,12 +1961,27 @@ class DefaultSteerer:
         # event — a cheap, always-available "turn" proxy.
         at_turn = getattr(session, "_next_sequence", 0) or 0
         try:
-            _ostate.set_active_steer(session.state, body=body, at_turn=at_turn)
+            _ostate.set_active_steer(
+                session.state, body=body, at_turn=at_turn, author=author
+            )
         except Exception as exc:  # noqa: BLE001
             log.debug(
                 "DefaultSteerer._apply_user_steer_state: set_active_steer raised: %s",
                 exc,
             )
+        # Record the dedupe id. Safe to call even with an empty id
+        # (the helper no-ops). Done AFTER the active_steer stamp so a
+        # reader that inspects ``state`` mid-dispatch always sees the
+        # most recent steer is reflected.
+        if steer_id:
+            try:
+                _ostate.record_processed_steer_id(session.state, steer_id)
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "DefaultSteerer._apply_user_steer_state: "
+                    "record_processed_steer_id raised: %s",
+                    exc,
+                )
         if not body:
             # Empty steer body: nothing to synthesize into a goal. The
             # active_steer.* keys still landed (readers may want to know

--- a/proto/goldfive/v1/control.proto
+++ b/proto/goldfive/v1/control.proto
@@ -71,9 +71,18 @@ message ControlTarget {
 
 // STEER: redirect the run. See docs/design/CONTROL.md §5 for the
 // delete-and-replan semantics that follow.
+//
+// ``author`` carries the operator identity from the originating
+// annotation (goldfive#171). Bridges that don't source annotations may
+// leave it empty. ``annotation_id`` carries the source annotation id
+// so goldfive can dedupe retries of the same user action; bridges that
+// don't source annotations may leave it empty and fall back to
+// ``ControlEvent.id``-based dedupe.
 message SteerPayload {
   string note = 1;
   string suggested_action = 2;
+  string author = 3;
+  string annotation_id = 4;
 }
 
 // REWIND_TO: reset ``task_id`` and every downstream task back to

--- a/tests/test_control_proto.py
+++ b/tests/test_control_proto.py
@@ -108,14 +108,38 @@ def test_steer_round_trip() -> None:
     msg = ControlMessage(
         kind=ControlKind.STEER,
         id="ctl-steer",
-        payload={"note": "focus on slide 3", "suggested_action": "narrow scope"},
+        payload={
+            "note": "focus on slide 3",
+            "suggested_action": "narrow scope",
+            "author": "alice",
+            "annotation_id": "ann_abc123",
+        },
     )
     pb_msg = to_pb_control_event(msg)
     assert pb_msg.WhichOneof("payload") == "steer"
     assert pb_msg.steer.note == "focus on slide 3"
+    assert pb_msg.steer.author == "alice"
+    assert pb_msg.steer.annotation_id == "ann_abc123"
     recovered = from_pb_control_event(pb_msg)
     assert recovered.kind == ControlKind.STEER
     assert recovered.payload == msg.payload
+
+
+def test_steer_round_trip_without_author_or_annotation_id() -> None:
+    """Back-compat: callers that don't set author / annotation_id
+    round-trip through empty strings (not missing keys)."""
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        id="ctl-steer-bare",
+        payload={"note": "pivot", "suggested_action": ""},
+    )
+    pb_msg = to_pb_control_event(msg)
+    assert pb_msg.steer.author == ""
+    assert pb_msg.steer.annotation_id == ""
+    recovered = from_pb_control_event(pb_msg)
+    assert recovered.payload["note"] == "pivot"
+    assert recovered.payload["author"] == ""
+    assert recovered.payload["annotation_id"] == ""
 
 
 def test_rewind_round_trip() -> None:
@@ -207,7 +231,12 @@ def test_every_kind_round_trips(kind: ControlKind) -> None:
     without its payload wiring fails loudly in CI."""
     payload: dict[str, object] = {}
     if kind == ControlKind.STEER:
-        payload = {"note": "n", "suggested_action": "s"}
+        payload = {
+            "note": "n",
+            "suggested_action": "s",
+            "author": "",
+            "annotation_id": "",
+        }
     elif kind == ControlKind.REWIND_TO:
         payload = {"task_id": "t"}
     elif kind in (ControlKind.APPROVE, ControlKind.REJECT):

--- a/tests/test_orchestration_state.py
+++ b/tests/test_orchestration_state.py
@@ -427,3 +427,69 @@ async def test_mark_task_running_stamps_orchestration_state() -> None:
 
     await steerer.mark_task_completed("t1", session=session, summary="done")
     assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_ID, "") == ""
+
+
+# ---------------------------------------------------------------------------
+# goldfive#171 — processed_steer_ids helpers + author on set_active_steer
+# ---------------------------------------------------------------------------
+
+
+def test_record_processed_steer_id_appends_and_dedupes() -> None:
+    state: dict[str, Any] = {}
+    _ostate.record_processed_steer_id(state, "ann_1")
+    _ostate.record_processed_steer_id(state, "ann_2")
+    _ostate.record_processed_steer_id(state, "ann_1")  # duplicate — dropped
+    assert state[_ostate.KEY_PROCESSED_STEER_IDS] == ["ann_1", "ann_2"]
+
+
+def test_record_processed_steer_id_empty_is_noop() -> None:
+    state: dict[str, Any] = {}
+    _ostate.record_processed_steer_id(state, "")
+    assert _ostate.KEY_PROCESSED_STEER_IDS not in state
+
+
+def test_has_processed_steer_id_reports_membership() -> None:
+    state: dict[str, Any] = {}
+    assert _ostate.has_processed_steer_id(state, "x") is False
+    _ostate.record_processed_steer_id(state, "x")
+    assert _ostate.has_processed_steer_id(state, "x") is True
+    assert _ostate.has_processed_steer_id(state, "y") is False
+    # Tolerates malformed state.
+    assert (
+        _ostate.has_processed_steer_id({"goldfive.processed_steer_ids": "oops"}, "x")
+        is False
+    )
+    assert _ostate.has_processed_steer_id(state, "") is False
+
+
+def test_record_processed_steer_id_evicts_fifo_at_cap() -> None:
+    state: dict[str, Any] = {}
+    cap = _ostate.PROCESSED_STEER_IDS_CAP
+    for i in range(cap + 2):
+        _ostate.record_processed_steer_id(state, f"id_{i}")
+    ids = state[_ostate.KEY_PROCESSED_STEER_IDS]
+    assert len(ids) == cap
+    assert "id_0" not in ids
+    assert "id_1" not in ids
+    assert ids[0] == "id_2"
+    assert ids[-1] == f"id_{cap + 1}"
+
+
+def test_set_active_steer_writes_author_and_clears_it() -> None:
+    state: dict[str, Any] = {}
+    _ostate.set_active_steer(state, body="pivot", at_turn=7, author="alice")
+    assert state[_ostate.KEY_ACTIVE_STEER_BODY] == "pivot"
+    assert state[_ostate.KEY_ACTIVE_STEER_AT_TURN] == 7
+    assert state[_ostate.KEY_ACTIVE_STEER_AUTHOR] == "alice"
+
+    _ostate.clear_active_steer(state)
+    assert _ostate.KEY_ACTIVE_STEER_BODY not in state
+    assert _ostate.KEY_ACTIVE_STEER_AT_TURN not in state
+    assert _ostate.KEY_ACTIVE_STEER_AUTHOR not in state
+
+
+def test_set_active_steer_author_defaults_to_empty() -> None:
+    """Back-compat: callers that omit author still write an empty key."""
+    state: dict[str, Any] = {}
+    _ostate.set_active_steer(state, body="pivot", at_turn=1)
+    assert state[_ostate.KEY_ACTIVE_STEER_AUTHOR] == ""

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -226,6 +226,191 @@ async def test_observe_non_control_event_still_uses_classifier() -> None:
 
 
 # ---------------------------------------------------------------------------
+# goldfive#171 — STEER idempotency, author propagation
+# ---------------------------------------------------------------------------
+
+
+async def test_observe_steer_dedupes_by_annotation_id() -> None:
+    """Second delivery of the same STEER annotation is a no-op.
+
+    Two ``ControlMessage`` values with different ``id`` but the same
+    ``payload['annotation_id']`` must only trigger one refine. Models
+    the delivery-retry scenario.
+    """
+    steerer, session, _sink, planner = _bind_fresh()
+
+    first = ControlMessage(
+        kind=ControlKind.STEER,
+        id="ctl-retry-1",
+        payload={"note": "pivot", "annotation_id": "ann_abc"},
+    )
+    second = ControlMessage(
+        kind=ControlKind.STEER,
+        id="ctl-retry-2",
+        payload={"note": "pivot", "annotation_id": "ann_abc"},
+    )
+    await steerer.observe(first, session)
+    await steerer.observe(second, session)
+
+    assert len(planner.refine_calls) == 1
+    assert session.state.get("goldfive.processed_steer_ids") == ["ann_abc"]
+
+
+async def test_observe_steer_dedupes_by_control_id_when_annotation_id_absent() -> None:
+    """Bridges that don't source annotations fall back to ControlMessage.id."""
+    steerer, session, _sink, planner = _bind_fresh()
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        id="ctl-noid-1",
+        payload={"note": "pivot"},
+    )
+
+    await steerer.observe(msg, session)
+    # Same id, deliberately re-delivered.
+    await steerer.observe(msg, session)
+
+    assert len(planner.refine_calls) == 1
+    assert session.state.get("goldfive.processed_steer_ids") == ["ctl-noid-1"]
+
+
+async def test_observe_steer_distinct_ids_each_trigger_refine() -> None:
+    """Two distinct STEER annotations each fire refine exactly once."""
+    steerer, session, _sink, planner = _bind_fresh()
+    first = ControlMessage(
+        kind=ControlKind.STEER,
+        id="ctl-a",
+        payload={"note": "one", "annotation_id": "ann_1"},
+    )
+    second = ControlMessage(
+        kind=ControlKind.STEER,
+        id="ctl-b",
+        payload={"note": "two", "annotation_id": "ann_2"},
+    )
+
+    await steerer.observe(first, session)
+    await steerer.observe(second, session)
+
+    assert len(planner.refine_calls) == 2
+    assert session.state.get("goldfive.processed_steer_ids") == ["ann_1", "ann_2"]
+
+
+async def test_observe_dedupe_does_not_affect_heuristic_drifts() -> None:
+    """LOOPING_REASONING-class heuristic drifts are never deduped.
+
+    The dedupe set lives only for user-originated STEER annotations;
+    content-based classifiers (tool errors, refusals, loops) must
+    remain free-running so repeated heuristic signals still escalate.
+    """
+    steerer, session, _sink, planner = _bind_fresh()
+
+    # A steer populates processed_steer_ids.
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        id="ctl-s",
+        payload={"note": "go", "annotation_id": "ann_s"},
+    )
+    await steerer.observe(msg, session)
+    # A tool-error event — classified as TOOL_ERROR, must still emit.
+    await steerer.observe({"error": "boom"}, session)
+    await steerer.observe({"error": "boom"}, session)
+
+    # planner.refine: 1 steer + 2 tool_error observations.
+    assert len(planner.refine_calls) == 3
+
+
+async def test_observe_steer_propagates_author_into_state_and_detail() -> None:
+    """``author`` from SteerPayload lands on state + drift detail prefix."""
+    steerer, session, _sink, planner = _bind_fresh()
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        id="ctl-auth",
+        payload={
+            "note": "focus on clarity",
+            "author": "alice",
+            "annotation_id": "ann_author",
+        },
+    )
+
+    await steerer.observe(msg, session)
+
+    assert session.state.get("goldfive.active_steer.author") == "alice"
+    # Raw body — not the "by alice: ..." rewrite — lands on body.
+    assert session.state.get("goldfive.active_steer.body") == "focus on clarity"
+    # The drift.detail seen by the planner is the prefixed form.
+    assert len(planner.refine_calls) == 1
+    drift: DriftEvent = planner.refine_calls[0]["drift"]
+    assert drift.detail == "by alice: focus on clarity"
+
+
+async def test_observe_steer_without_author_leaves_author_empty() -> None:
+    steerer, session, _sink, planner = _bind_fresh()
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        id="ctl-noauth",
+        payload={"note": "quiet nudge", "annotation_id": "ann_na"},
+    )
+
+    await steerer.observe(msg, session)
+
+    assert session.state.get("goldfive.active_steer.author") == ""
+    assert session.state.get("goldfive.active_steer.body") == "quiet nudge"
+    drift: DriftEvent = planner.refine_calls[0]["drift"]
+    # No "by X: " prefix when author is empty.
+    assert drift.detail == "quiet nudge"
+
+
+async def test_processed_steer_ids_list_evicts_oldest_when_capped() -> None:
+    """The FIFO cap bounds the dedupe list so long sessions stay bounded."""
+    from goldfive import orchestration_state as _ostate
+
+    steerer, session, _sink, _planner = _bind_fresh()
+    cap = _ostate.PROCESSED_STEER_IDS_CAP
+
+    # Fire cap + 3 distinct steers.
+    for i in range(cap + 3):
+        msg = ControlMessage(
+            kind=ControlKind.STEER,
+            id=f"ctl-{i}",
+            payload={"note": f"n{i}", "annotation_id": f"ann_{i}"},
+        )
+        await steerer.observe(msg, session)
+
+    ids = session.state.get("goldfive.processed_steer_ids") or []
+    assert len(ids) == cap
+    # Oldest 3 were evicted.
+    assert "ann_0" not in ids
+    assert "ann_1" not in ids
+    assert "ann_2" not in ids
+    # Newest survives.
+    assert ids[-1] == f"ann_{cap + 2}"
+
+
+async def test_direct_user_steer_drift_event_without_raw_still_writes_state() -> None:
+    """Back-compat: tests that build DriftEvent directly still work.
+
+    Pre-#171 tests fabricate a USER_STEER DriftEvent without a raw
+    ControlMessage behind it. The state writer must fall back to
+    parsing ``detail`` so those tests still round-trip body/author
+    into state.
+    """
+    steerer, session, _sink, _planner = _bind_fresh()
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="by bob: direct call",
+        current_task_id="t2",
+    )
+
+    await steerer._apply_user_steer_state(drift, session)
+
+    assert session.state.get("goldfive.active_steer.body") == "direct call"
+    assert session.state.get("goldfive.active_steer.author") == "bob"
+    # No dedupe id recoverable from a bare DriftEvent → processed list
+    # is not populated.
+    assert session.state.get("goldfive.processed_steer_ids") in (None, [])
+
+
+# ---------------------------------------------------------------------------
 # goldfive#139 — steerer tags the bound adapter's next cancel with a
 # symbolic reason on USER_STEER drift, so the synthetic function_response
 # the adapter appends on cancel carries LLM-actionable content.


### PR DESCRIPTION
## Summary
- `DefaultSteerer.observe` dedupes STEER ControlMessages by source annotation id (or ControlMessage.id fallback) — delivery retries and UI double-fires of the same annotation cascade-cancel + refine exactly once. Bounded FIFO list under `session.state['goldfive.processed_steer_ids']` (cap 256).
- `SteerPayload` proto grows `author` + `annotation_id` fields. Steerer writes `goldfive.active_steer.author` and prefixes drift.detail with `"by {author}: {body}"` for inline audit attribution; raw body still lands untouched on `active_steer.body`.
- Content-based drifts (LOOPING_REASONING, tool errors) are NOT deduped — only user-originated STEER annotations.

## Wire / orchestration-state additions
- `SteerPayload.author` (field 3), `SteerPayload.annotation_id` (field 4) — both additive, empty string is the back-compat default
- `KEY_ACTIVE_STEER_AUTHOR = "goldfive.active_steer.author"`
- `KEY_PROCESSED_STEER_IDS = "goldfive.processed_steer_ids"` (bounded FIFO list)
- `PROCESSED_STEER_IDS_CAP = 256`
- New helpers: `has_processed_steer_id`, `record_processed_steer_id`; `set_active_steer(..., author="")` gains an optional author kwarg

## Paired PR
Harmonograf side plumbs `author` + `annotation_id` through the PostAnnotation server code path and validates body (empty / 8KB cap / control-char scrub) at the client bridge: https://github.com/pedapudi/harmonograf/pull/72

## Test plan
- [x] `uv run pytest -x -q tests/` — 768 passed, 64 skipped
- [x] New tests in `tests/test_steerer_usersteer.py` cover: annotation-id dedupe, control-id fallback dedupe, distinct-ids each refine, heuristic drifts not deduped, author propagates to state + detail, no-author case, FIFO eviction at cap, direct-DriftEvent back-compat
- [x] New tests in `tests/test_orchestration_state.py` unit-test the new helpers
- [x] `tests/test_control_proto.py` round-trips new fields
- [x] `ruff check` clean