### PR TITLE
Fix PLAN_DIVERGENCE over-firing on legitimate tool calls (closes #178)

### DIFF
--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -375,6 +375,47 @@ Four invariants govern the refine path:
    refine that cannot make progress. The counter resets on a
    successful refine.
 
+## Tool-call drift classification
+
+`GoldfivePlanner.process_planning_response` (see
+`goldfive/planners/goldfive_planner.py`) classifies every
+`function_call` part an LLM emits via a three-stage gate. The gate
+keys on the currently-running agent's own `tools` list (read from
+`callback_context._invocation_context.agent.tools`) combined with the
+tree-wide agent registry plumbed in by `ADKAdapter`. The three stages
+cleanly separate "legitimate tool call", "cross-layer delegation
+attempt", and "hallucinated tool name" — which the single-stage
+registry check in #178 conflated into PLAN_DIVERGENCE and over-fired
+on.
+
+| Input shape | Drift kind | Detector location |
+|---|---|---|
+| `function_call` name in agent's own tools | *(none — legitimate tool call)* | — |
+| `function_call` name in tree agent registry but not in this agent's tools (cross-layer) | `PLAN_DIVERGENCE` | `GoldfivePlanner.process_planning_response` |
+| `function_call` name nowhere (not a tool, not a known agent) | `CONFABULATION_RISK` | `GoldfivePlanner.process_planning_response` |
+| tool returned an error payload or raised | `TOOL_ERROR` | `after_tool_callback` observer |
+| tool called in a tight loop | `LOOPING_TOOL_CALL` / `LOOPING_REASONING` | sequence-based detector in `goldfive/drift/reasoning.py` |
+| tool misaligned with the current task's intent | `INTENT_DIVERGENCE` / `GOAL_DRIFT` | goal classifier (`goldfive/drift/goals.py`, future extension) |
+
+The last row is intentionally not implemented in this classifier — a
+separate work item extends `goldfive/drift/goals.py` to cover it.
+
+`function_call` names prefixed with `report_` (the reporting-tool
+protocol namespace — `report_task_started`, `report_task_finished`,
+etc.) are always treated as legitimate regardless of tool-list
+contents: they're protocol calls goldfive injects and may not be
+reflected in every agent's `tools` list depending on when the
+augmentation ran.
+
+Cancelled function_call ids (from
+`session.state['goldfive.cancelled_function_call_ids']`, populated on
+USER_STEER / REPLAN cascade-cancel) are stripped BEFORE the three-
+stage classifier runs, so a cancelled part never produces a drift
+signal regardless of which stage its name would have fallen in.
+
+All three stages emit signals only — the call is never blocked. The
+steerer's intervention ladder (#142) decides whether to escalate.
+
 ## How drifts become events
 
 Every `DriftEvent` produces exactly one `DriftDetected` event in the

--- a/goldfive/planners/goldfive_planner.py
+++ b/goldfive/planners/goldfive_planner.py
@@ -19,9 +19,19 @@ and performs two structural jobs on every LLM call that agent makes:
      ``session.state['goldfive.cancelled_function_call_ids']`` are
      stripped (the LLM tried to retry a call goldfive already
      cancelled — e.g. on USER_STEER).
-   * ``function_call`` parts to agents outside the adapter's
-     registry emit a ``PLAN_DIVERGENCE`` drift via the steerer.
-     **The call is not blocked** — this is a signal, not a gate.
+   * ``function_call`` parts are classified via a three-stage gate
+     (see :meth:`GoldfivePlanner.process_planning_response`):
+
+     1. **Own tool** — name is in the currently-running agent's
+        ``tools`` list. Legitimate; no drift.
+     2. **Cross-layer agent** — name is in the tree's agent registry
+        but wasn't exposed to this agent. LLM attempted delegation
+        past its layer → ``PLAN_DIVERGENCE`` (WARNING).
+     3. **Nowhere** — name is neither a tool nor a known agent. Pure
+        hallucination → ``CONFABULATION_RISK`` (WARNING).
+
+     **The call is not blocked** in any case — this is a signal, not
+     a gate.
 
 Request-side injection requires a plugin workaround
 -----------------------------------------------------
@@ -333,16 +343,30 @@ class GoldfivePlanner(BasePlanner):
     ) -> list[types.Part] | None:
         """Apply structural filters to the LLM's response parts.
 
-        Two independent filters run in order:
+        Two independent concerns run in order:
 
-        1. Strip ``function_call`` parts whose ``function_call.id`` is
-           in ``session.state['goldfive.cancelled_function_call_ids']``.
-           Keeps the rest of the parts intact.
-        2. For every retained ``function_call`` whose ``name`` is not
-           in :attr:`_agent_registry` (when the registry is set),
-           emit a ``PLAN_DIVERGENCE`` drift at INFO severity via
-           ``steerer._handle_drift``. The call is NOT blocked; this
-           is signal-only so the steerer can decide policy.
+        1. **Cancelled-id filter.** Strip ``function_call`` parts
+           whose ``function_call.id`` is in
+           ``session.state['goldfive.cancelled_function_call_ids']``.
+           Keeps the rest of the parts intact. This runs on EVERY part
+           regardless of which drift-stage its name falls in.
+        2. **Three-stage drift classification** (for each retained
+           ``function_call`` part):
+
+           - *Stage 1 — own tool.* Name appears in the currently-
+             running agent's ``tools`` list (read from
+             ``callback_context._invocation_context.agent.tools``).
+             Legitimate; no drift.
+           - *Stage 2 — cross-layer agent.* Name matches an agent in
+             :attr:`_agent_registry` but is not in the running agent's
+             tools. The LLM attempted to delegate past its exposed
+             layer. Emit :data:`DriftKind.PLAN_DIVERGENCE` at WARNING.
+           - *Stage 3 — nowhere.* Name is neither a tool nor a known
+             agent. Emit :data:`DriftKind.CONFABULATION_RISK` at
+             WARNING.
+
+           Calls are NEVER blocked — this is signal-only; the steerer
+           decides whether to escalate.
 
         After goldfive's filters run, if a :attr:`user_planner` is set
         its own ``process_planning_response`` is called on the
@@ -351,7 +375,8 @@ class GoldfivePlanner(BasePlanner):
         state = _extract_state(callback_context)
         cancelled_ids = {s for s in _state_list(state, KEY_CANCELLED_FUNCTION_CALL_IDS)}
 
-        # Filter 1: strip cancelled function_call ids.
+        # Filter 1: strip cancelled function_call ids. Runs on every
+        # part regardless of which drift-stage its name would fall in.
         kept: list[Any] = []
         stripped_count = 0
         for part in response_parts or []:
@@ -369,11 +394,13 @@ class GoldfivePlanner(BasePlanner):
                 stripped_count,
             )
 
-        # Filter 2: signal PLAN_DIVERGENCE on function_calls to agents
-        # outside the registry. We emit best-effort and never block;
-        # the steerer decides whether to escalate.
-        if self._agent_registry is not None and self._steerer is not None:
-            off_registry: list[str] = []
+        # Filter 2: three-stage tool-call drift classification. We
+        # need the currently-running agent's own tool set to
+        # distinguish legitimate tool calls (stage 1) from cross-layer
+        # delegation (stage 2) and hallucination (stage 3).
+        own_tool_names = _extract_own_tool_names(callback_context)
+        divergence_fired = False
+        if self._steerer is not None:
             for part in kept:
                 fc = getattr(part, "function_call", None)
                 if fc is None:
@@ -381,32 +408,50 @@ class GoldfivePlanner(BasePlanner):
                 name = getattr(fc, "name", "") or ""
                 if not name:
                     continue
-                # Only call names that LOOK like agent delegation
-                # targets are checked — goldfive cannot distinguish
-                # an AgentTool name from any other tool name purely
-                # from the Part, so we rely on the registry being
-                # authoritative: if the tool name is in
-                # _agent_registry it's on-plan; if not, it MAY be a
-                # regular tool (fine) OR an off-registry agent call
-                # (divergence). We emit on not-in-registry only when
-                # the name matches the delegation shape we care about
-                # — today that's "not a known agent and not prefixed
-                # with the reporting-tool 'report_' namespace".
-                if name in self._agent_registry:
-                    continue
-                if name.startswith("report_"):
-                    # Reporting tools (report_task_started, etc.) are
-                    # protocol calls, not agent delegation. Skip.
-                    continue
-                # Heuristic: genuine ADK tool names usually include
-                # verbs (web_search, read_file) and rarely coincide
-                # with agent names. We keep the signal permissive —
-                # over-reporting once is fine; the steerer's INFO
-                # severity is absorbable.
-                off_registry.append(name)
 
-            for name in off_registry:
-                self._emit_divergence_signal(name, callback_context)
+                # Stage 1 — agent's own tool. Always legitimate.
+                if name in own_tool_names:
+                    continue
+                # Reporting tools (report_task_started, etc.) are
+                # protocol calls. They may be injected onto the agent
+                # tree post-construction; treat the ``report_`` prefix
+                # as an always-legitimate protocol namespace even if
+                # the tool list didn't reflect it.
+                if name.startswith("report_"):
+                    continue
+
+                # Stage 2 — name matches an agent in the registry but
+                # wasn't exposed to this agent. Cross-layer delegation.
+                if self._agent_registry is not None and name in self._agent_registry:
+                    self._emit_tool_call_drift(
+                        name,
+                        callback_context,
+                        kind_name="PLAN_DIVERGENCE",
+                        detail=(
+                            f"LLM emitted function_call to agent "
+                            f"{name!r} which is in the tree registry "
+                            f"but was not exposed as a tool to the "
+                            f"currently-running agent — cross-layer "
+                            f"delegation attempt, call not blocked"
+                        ),
+                    )
+                    divergence_fired = True
+                    continue
+
+                # Stage 3 — name is neither a tool nor a known agent.
+                # Pure hallucination.
+                self._emit_tool_call_drift(
+                    name,
+                    callback_context,
+                    kind_name="CONFABULATION_RISK",
+                    detail=(
+                        f"LLM emitted function_call to {name!r} which "
+                        f"is neither one of the current agent's tools "
+                        f"nor a known agent in the tree registry — "
+                        f"hallucinated tool, call not blocked"
+                    ),
+                )
+                divergence_fired = True
 
         # Compose with user planner: their filter runs AFTER goldfive's
         # so they see the structurally-clean parts.
@@ -426,12 +471,8 @@ class GoldfivePlanner(BasePlanner):
         # ADK's "leave response untouched" signal — when we kept
         # everything AND did not emit any divergence signals. The
         # latter gate keeps this a no-op in the common case where no
-        # cancelled-ids / off-registry calls exist.
-        if stripped_count or (
-            self._agent_registry is not None
-            and self._steerer is not None
-            and any(getattr(p, "function_call", None) is not None for p in kept)
-        ):
+        # cancelled-ids / divergence classifications fired.
+        if stripped_count or divergence_fired:
             return kept
         return None
 
@@ -440,12 +481,24 @@ class GoldfivePlanner(BasePlanner):
     # the same pipeline PlanReconciler / RUNAWAY_DELEGATION use.
     # ------------------------------------------------------------------
 
-    def _emit_divergence_signal(self, off_registry_name: str, callback_context: Any) -> None:
-        """Emit a ``PLAN_DIVERGENCE`` drift for an off-registry function_call.
+    def _emit_tool_call_drift(
+        self,
+        function_call_name: str,
+        callback_context: Any,
+        *,
+        kind_name: str,
+        detail: str,
+    ) -> None:
+        """Emit a structural tool-call drift via ``steerer._handle_drift``.
+
+        ``kind_name`` selects which :class:`DriftKind` member to fire
+        — one of ``"PLAN_DIVERGENCE"`` (cross-layer delegation) or
+        ``"CONFABULATION_RISK"`` (hallucinated tool) per the three-
+        stage classification in :meth:`process_planning_response`.
 
         Non-blocking: the call still reaches ADK's dispatcher and is
         executed (or fails naturally if the tool name is unknown). We
-        only SIGNAL the divergence so the steerer's policy can decide
+        only SIGNAL the drift so the steerer's policy can decide
         whether to escalate via the intervention ladder (#142) or let
         it ride.
 
@@ -465,8 +518,16 @@ class GoldfivePlanner(BasePlanner):
             )
         except Exception as exc:  # noqa: BLE001
             log.debug(
-                "GoldfivePlanner._emit_divergence_signal: cannot import DriftEvent: %s",
+                "GoldfivePlanner._emit_tool_call_drift: cannot import DriftEvent: %s",
                 exc,
+            )
+            return
+
+        kind = getattr(DriftKind, kind_name, None)
+        if kind is None:
+            log.debug(
+                "GoldfivePlanner._emit_tool_call_drift: unknown DriftKind %r; signal dropped",
+                kind_name,
             )
             return
 
@@ -475,18 +536,18 @@ class GoldfivePlanner(BasePlanner):
         current_task_id = _state_get(state, KEY_CURRENT_TASK_ID, "")
 
         drift = DriftEvent(
-            kind=DriftKind.PLAN_DIVERGENCE,
-            severity=DriftSeverity.INFO,
-            detail=(
-                f"LLM emitted function_call to off-registry agent "
-                f"{off_registry_name!r} — call not blocked, signal only"
-            ),
+            kind=kind,
+            severity=DriftSeverity.WARNING,
+            detail=detail,
             current_task_id=current_task_id,
-            current_agent_id=off_registry_name,
+            current_agent_id=function_call_name,
         )
         handle = getattr(steerer, "_handle_drift", None)
         if not callable(handle):
-            log.debug("GoldfivePlanner: steerer has no _handle_drift; divergence signal dropped")
+            log.debug(
+                "GoldfivePlanner: steerer has no _handle_drift; %s signal dropped",
+                kind_name,
+            )
             return
 
         session = self._session
@@ -494,15 +555,16 @@ class GoldfivePlanner(BasePlanner):
         # ``process_planning_response`` is SYNC by ADK's contract, we
         # schedule on the running event loop. When no loop is running
         # (hypothetical tests calling the method synchronously) fall
-        # through silently — the divergence signal is best-effort.
+        # through silently — the drift signal is best-effort.
         try:
             import asyncio  # noqa: PLC0415 — lazy
 
             loop = asyncio.get_running_loop()
         except RuntimeError:
             log.debug(
-                "GoldfivePlanner: no running loop; divergence signal for %s dropped",
-                off_registry_name,
+                "GoldfivePlanner: no running loop; %s signal for %s dropped",
+                kind_name,
+                function_call_name,
             )
             return
 
@@ -555,6 +617,63 @@ def _extract_state(ctx: Any) -> Any:
         if ok and cur is not None:
             return cur
     return {}
+
+
+def _extract_own_tool_names(callback_context: Any) -> set[str]:
+    """Return the set of tool names exposed to the currently-running agent.
+
+    Reads ``callback_context._invocation_context.agent.tools`` and
+    collects each tool's ``.name`` attribute (falling back to the
+    underlying function's ``__name__`` for ``FunctionTool`` wrappers
+    that don't carry an explicit ``name``). Tools that expose neither
+    are skipped silently.
+
+    Returns an empty set when the attribute chain is missing (e.g.
+    test stubs that don't plumb an invocation_context) — the three-
+    stage classifier treats every function_call as either stage 2 or
+    stage 3 in that case, which is the safe fallback (we err toward
+    reporting rather than suppressing).
+    """
+    # Prefer the standard chain CallbackContext exposes in ADK:
+    # ``_invocation_context.agent`` → the agent whose LLM turn we're
+    # processing.
+    agent = None
+    for attr_chain in (
+        ("_invocation_context", "agent"),
+        ("invocation_context", "agent"),
+        ("agent",),
+    ):
+        cur: Any = callback_context
+        ok = True
+        for part in attr_chain:
+            try:
+                cur = getattr(cur, part, None)
+            except Exception:  # noqa: BLE001 — best-effort
+                cur = None
+            if cur is None:
+                ok = False
+                break
+        if ok and cur is not None:
+            agent = cur
+            break
+    if agent is None:
+        return set()
+
+    tools = getattr(agent, "tools", None)
+    if not tools:
+        return set()
+
+    names: set[str] = set()
+    for tool in tools:
+        name = getattr(tool, "name", None)
+        if not name:
+            # FunctionTool sometimes carries its name on the
+            # wrapped function rather than on the tool object.
+            func = getattr(tool, "func", None)
+            name = getattr(func, "__name__", None) if func is not None else None
+        if isinstance(name, str) and name:
+            names.add(name)
+    return names
 
 
 __all__ = [

--- a/tests/test_goldfive_planner.py
+++ b/tests/test_goldfive_planner.py
@@ -288,7 +288,14 @@ def test_goldfive_planner_process_response_noop_when_no_filters_fire() -> None:
 
 
 async def test_goldfive_planner_process_response_emits_divergence_on_off_registry_agent() -> None:
-    """A function_call to an unknown agent name triggers PLAN_DIVERGENCE."""
+    """Three-stage classification: cross-layer → PLAN_DIVERGENCE;
+    hallucinated → CONFABULATION_RISK; report_ prefix → skipped.
+
+    Ctx has no ``_invocation_context`` so ``_extract_own_tool_names``
+    returns an empty set — every function_call falls through stage 1
+    and is classified against the registry (stage 2) or as
+    hallucination (stage 3).
+    """
     steerer = _RecordingSteerer()
     session = Session(run_id="r")
     planner = GoldfivePlanner(
@@ -297,13 +304,17 @@ async def test_goldfive_planner_process_response_emits_divergence_on_off_registr
         session=session,
     )
     parts = [
+        # Stage 2 — name matches a registry agent but wasn't exposed
+        # as a tool to this agent: PLAN_DIVERGENCE.
         _FakePart(
             function_call=_FakeFunctionCall(id="fc-1", name="researcher", args={}),
         ),
+        # Stage 3 — name is neither a tool nor a known agent:
+        # CONFABULATION_RISK.
         _FakePart(
             function_call=_FakeFunctionCall(id="fc-2", name="rogue_agent", args={}),
         ),
-        # Reporting tool — must not trigger divergence.
+        # Reporting tool — must not trigger any drift.
         _FakePart(
             function_call=_FakeFunctionCall(
                 id="fc-3", name="report_task_started", args={"task_id": "t"}
@@ -314,19 +325,250 @@ async def test_goldfive_planner_process_response_emits_divergence_on_off_registr
 
     out = planner.process_planning_response(ctx, parts)
 
-    # All three parts retained; divergence is signal-only.
+    # All three parts retained; classification is signal-only.
     assert out is not None
     names = [p.function_call.name for p in out]
     assert names == ["researcher", "rogue_agent", "report_task_started"]
 
-    # Yield once so the scheduled _handle_drift task runs.
+    # Yield once so the scheduled _handle_drift tasks run.
     await asyncio.sleep(0)
 
-    assert len(steerer.drifts) == 1
+    # Two drifts: stage 2 (PLAN_DIVERGENCE) + stage 3 (CONFABULATION_RISK).
+    by_kind = {d.kind: d for d in steerer.drifts}
+    assert DriftKind.PLAN_DIVERGENCE in by_kind, (
+        f"expected PLAN_DIVERGENCE drift, got {steerer.drifts!r}"
+    )
+    assert DriftKind.CONFABULATION_RISK in by_kind, (
+        f"expected CONFABULATION_RISK drift, got {steerer.drifts!r}"
+    )
+    div = by_kind[DriftKind.PLAN_DIVERGENCE]
+    assert "researcher" in div.detail
+    assert div.current_agent_id == "researcher"
+    assert div.severity.value == "warning"
+
+    conf = by_kind[DriftKind.CONFABULATION_RISK]
+    assert "rogue_agent" in conf.detail
+    assert conf.current_agent_id == "rogue_agent"
+    assert conf.severity.value == "warning"
+
+
+class _FakeTool:
+    """Duck-typed ADK tool exposing a ``.name`` attribute."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeAgent:
+    """Duck-typed ADK agent exposing ``.tools`` for the planner's own-tool lookup."""
+
+    def __init__(self, *, name: str, tool_names: list[str]) -> None:
+        self.name = name
+        self.tools = [_FakeTool(n) for n in tool_names]
+
+
+class _FakeInvocationContextAgent:
+    """Stand-in for ``CallbackContext._invocation_context`` carrying an agent."""
+
+    def __init__(self, *, agent: _FakeAgent, state: dict) -> None:
+        self.agent = agent
+
+        class _S:
+            def __init__(self, st):
+                self.state = st
+
+        self.session = _S(state)
+
+
+class _FakeCallbackContextWithAgent:
+    """CallbackContext stand-in wiring ``_invocation_context.agent.tools``.
+
+    Also satisfies the state-extraction contract via
+    ``._invocation_context.session.state`` so the cancelled-id filter
+    still exercises the real chain.
+    """
+
+    def __init__(self, *, agent: _FakeAgent, state: dict | None = None) -> None:
+        self._invocation_context = _FakeInvocationContextAgent(agent=agent, state=state or {})
+        # Mirror ADK CallbackContext behaviour: a direct ``.state`` alias
+        # for simple readers.
+        self.state = state or {}
+
+
+async def test_own_tool_call_no_drift() -> None:
+    """Stage 1: function_call name in agent's own tools → no drift, part retained.
+
+    A ``web_developer_agent`` exposes ``write_webpage`` directly on its
+    tool list. An LLM turn emitting ``function_call(name="write_webpage")``
+    must NOT fire any drift — this is the over-firing bug #178 fixed.
+    """
+    steerer = _RecordingSteerer()
+    session = Session(run_id="r")
+    planner = GoldfivePlanner(
+        agent_registry=["web_developer_agent", "research_agent", "coordinator_agent"],
+        steerer=steerer,
+        session=session,
+    )
+    agent = _FakeAgent(
+        name="web_developer_agent",
+        tool_names=["write_webpage", "read_presentation_files", "patch_file"],
+    )
+    ctx = _FakeCallbackContextWithAgent(agent=agent)
+    parts = [
+        _FakePart(function_call=_FakeFunctionCall(id="fc-1", name="write_webpage")),
+        _FakePart(function_call=_FakeFunctionCall(id="fc-2", name="patch_file")),
+    ]
+
+    out = planner.process_planning_response(ctx, parts)
+
+    # No drift fired — all function_calls are the agent's own tools.
+    await asyncio.sleep(0)
+    assert steerer.drifts == [], f"expected no drifts for own-tool calls, got {steerer.drifts!r}"
+
+    # Parts retained verbatim. When no cancellations and no drift
+    # classification fired, the planner returns ``None`` (ADK skip-flag)
+    # to preserve the original response untouched.
+    assert out is None
+
+
+async def test_cross_layer_agent_call_fires_plan_divergence() -> None:
+    """Stage 2: name matches a registry agent but is not in this agent's tools.
+
+    ``research_agent`` (the current agent) has its own tools list
+    without ``coordinator_agent``. The coordinator IS in the tree's
+    registry — so emitting ``function_call(name="coordinator_agent")``
+    from research_agent's LLM is a cross-layer delegation attempt →
+    PLAN_DIVERGENCE (WARNING).
+    """
+    steerer = _RecordingSteerer()
+    session = Session(run_id="r")
+    planner = GoldfivePlanner(
+        agent_registry=["research_agent", "coordinator_agent", "writer_agent"],
+        steerer=steerer,
+        session=session,
+    )
+    agent = _FakeAgent(
+        name="research_agent",
+        tool_names=["web_search", "read_file"],  # NOT coordinator_agent
+    )
+    ctx = _FakeCallbackContextWithAgent(agent=agent)
+    parts = [
+        _FakePart(function_call=_FakeFunctionCall(id="fc-1", name="coordinator_agent")),
+    ]
+
+    out = planner.process_planning_response(ctx, parts)
+
+    await asyncio.sleep(0)
+    assert len(steerer.drifts) == 1, f"expected exactly 1 drift, got {steerer.drifts!r}"
     drift = steerer.drifts[0]
     assert drift.kind is DriftKind.PLAN_DIVERGENCE
-    assert "rogue_agent" in drift.detail
-    assert drift.current_agent_id == "rogue_agent"
+    assert drift.severity.value == "warning"
+    assert "coordinator_agent" in drift.detail
+    assert drift.current_agent_id == "coordinator_agent"
+
+    # Part retained; classification is signal-only.
+    assert out is not None
+    assert [p.function_call.name for p in out if p.function_call] == ["coordinator_agent"]
+
+
+async def test_hallucinated_tool_fires_confabulation_risk() -> None:
+    """Stage 3: name is neither a tool nor a known agent → CONFABULATION_RISK.
+
+    ``flux_capacitor_42`` is in no agent's tool list and not in the
+    tree's registry — pure hallucination. Fire CONFABULATION_RISK at
+    WARNING.
+    """
+    steerer = _RecordingSteerer()
+    session = Session(run_id="r")
+    planner = GoldfivePlanner(
+        agent_registry=["research_agent", "writer_agent"],
+        steerer=steerer,
+        session=session,
+    )
+    agent = _FakeAgent(
+        name="writer_agent",
+        tool_names=["write_text", "read_text"],
+    )
+    ctx = _FakeCallbackContextWithAgent(agent=agent)
+    parts = [
+        _FakePart(function_call=_FakeFunctionCall(id="fc-1", name="flux_capacitor_42")),
+    ]
+
+    out = planner.process_planning_response(ctx, parts)
+
+    await asyncio.sleep(0)
+    assert len(steerer.drifts) == 1, f"expected exactly 1 drift, got {steerer.drifts!r}"
+    drift = steerer.drifts[0]
+    assert drift.kind is DriftKind.CONFABULATION_RISK
+    assert drift.severity.value == "warning"
+    assert "flux_capacitor_42" in drift.detail
+    assert drift.current_agent_id == "flux_capacitor_42"
+
+    # Part retained.
+    assert out is not None
+    assert [p.function_call.name for p in out if p.function_call] == ["flux_capacitor_42"]
+
+
+async def test_cancelled_id_stripped_across_all_stages() -> None:
+    """Cancelled-id filter runs regardless of drift stage.
+
+    Mix parts that would fall in stages 1/2/3 AND carry cancelled ids;
+    verify every cancelled id is stripped and the remaining parts flow
+    into the drift classifier exactly once each.
+    """
+    steerer = _RecordingSteerer()
+    session = Session(run_id="r")
+    planner = GoldfivePlanner(
+        agent_registry=["coordinator_agent", "web_developer_agent"],
+        steerer=steerer,
+        session=session,
+    )
+    agent = _FakeAgent(
+        name="web_developer_agent",
+        tool_names=["write_webpage"],
+    )
+    state = {
+        KEY_CANCELLED_FUNCTION_CALL_IDS: [
+            "fc-cancel-stage1",
+            "fc-cancel-stage2",
+            "fc-cancel-stage3",
+        ],
+    }
+    ctx = _FakeCallbackContextWithAgent(agent=agent, state=state)
+
+    parts = [
+        # Cancelled stage-1 (own tool) — stripped.
+        _FakePart(function_call=_FakeFunctionCall(id="fc-cancel-stage1", name="write_webpage")),
+        # Retained stage-1 (own tool) — no drift.
+        _FakePart(function_call=_FakeFunctionCall(id="fc-ok-1", name="write_webpage")),
+        # Cancelled stage-2 (cross-layer agent) — stripped before classification.
+        _FakePart(function_call=_FakeFunctionCall(id="fc-cancel-stage2", name="coordinator_agent")),
+        # Retained stage-2 — PLAN_DIVERGENCE.
+        _FakePart(function_call=_FakeFunctionCall(id="fc-ok-2", name="coordinator_agent")),
+        # Cancelled stage-3 (hallucination) — stripped before classification.
+        _FakePart(function_call=_FakeFunctionCall(id="fc-cancel-stage3", name="made_up_tool")),
+        # Retained stage-3 — CONFABULATION_RISK.
+        _FakePart(function_call=_FakeFunctionCall(id="fc-ok-3", name="made_up_tool")),
+    ]
+
+    out = planner.process_planning_response(ctx, parts)
+
+    # Every cancelled id removed from the output across all three stages.
+    assert out is not None
+    remaining_ids = [p.function_call.id for p in out if p.function_call]
+    assert remaining_ids == ["fc-ok-1", "fc-ok-2", "fc-ok-3"]
+    assert "fc-cancel-stage1" not in remaining_ids
+    assert "fc-cancel-stage2" not in remaining_ids
+    assert "fc-cancel-stage3" not in remaining_ids
+
+    # Drifts fired only for the retained cross-layer + hallucinated
+    # parts — the cancelled ones never reach classification because
+    # the cancelled-id filter runs first.
+    await asyncio.sleep(0)
+    kinds = sorted(d.kind.value for d in steerer.drifts)
+    assert kinds == ["confabulation_risk", "plan_divergence"], (
+        f"expected one PLAN_DIVERGENCE + one CONFABULATION_RISK, got {steerer.drifts!r}"
+    )
 
 
 async def test_goldfive_planner_process_response_composes_user_planner() -> None:


### PR DESCRIPTION
## Summary

- `GoldfivePlanner.process_planning_response` was firing PLAN_DIVERGENCE on every `function_call` whose name wasn't in `_agent_registry` — producing ~5 spurious drifts per run in `presentation_agent_orchestrated` e2e for legitimate tool calls (`write_webpage`, `read_presentation_files`, `patch_file`). Validated live on session `final_1776826449`.
- Replace with a three-stage classifier keyed off the currently-running agent's own `tools` list:
  1. Name in agent's tools → legitimate, no drift.
  2. Name in tree registry but not in this agent's tools → `PLAN_DIVERGENCE` (cross-layer delegation, WARNING).
  3. Name nowhere → `CONFABULATION_RISK` (hallucinated tool, WARNING, reusing drift enum 34).
- Cancelled-function_call-id filter runs BEFORE classification and covers all three stages — verified by dedicated test.
- New "Tool-call drift classification" section in `docs/design/DRIFT.md` with the detector-location table.

Closes #178.

## Test plan

- [x] `tests/test_goldfive_planner.py::test_own_tool_call_no_drift` — stage 1 path.
- [x] `tests/test_goldfive_planner.py::test_cross_layer_agent_call_fires_plan_divergence` — stage 2 path.
- [x] `tests/test_goldfive_planner.py::test_hallucinated_tool_fires_confabulation_risk` — stage 3 path.
- [x] `tests/test_goldfive_planner.py::test_cancelled_id_stripped_across_all_stages` — cancelled-id filter unaffected.
- [x] Full suite: `932 passed, 46 skipped` on `tests/`.
- [x] Ruff + format + mypy clean on the touched files.
- [ ] Post-merge e2e: rerun orchestrated presentation_agent against kikuchi/Qwen with a steer pivot; expect 0 spurious PLAN_DIVERGENCE (new CONFABULATION_RISK signal is legitimate, not a regression).