### PR TITLE
Tool-loop drift detector (closes #181)

### DIFF
--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -122,7 +122,7 @@ parts). See `goldfive/drift/reasoning.py` for the detector pipeline.
 
 | Kind | Trigger | Default severity | Recoverable |
 |---|---|---|---|
-| `LOOPING_REASONING` | Consecutive reasoning blocks share the same SHA-256 prefix (always-on) or cosine-similar above `0.9` (opt-in, `goldfive[embedding]`). | `warning` | yes |
+| `LOOPING_REASONING` | Consecutive reasoning blocks share the same SHA-256 prefix (always-on) or cosine-similar above `0.9` (opt-in, `goldfive[embedding]`). Also fired by the tool-call-loop detector in `goldfive.drift.tool_loops` when the ADK plugin's `after_tool_callback` observes repeated `(tool_name, args_hash)` patterns (exact / name / alternating) — see goldfive#181. | `warning` (`info` for the alternating-cycle variant) | yes |
 | `REASONING_CLUSTER_TIGHTENING` | Max cosine similarity between current reasoning and the last N=5 blocks falls in `[0.75, 0.9)` (opt-in, `goldfive[embedding]`). Graduated early-warning tier below the `LOOPING_REASONING` cliff. One-shot per task. | `info` | yes |
 | `CONFUSION` | Reasoning text has ≥ 3 uncertainty markers ("I'm not sure", "wait", "hmm", …). | `info` | yes |
 | `OFF_TOPIC` | Reasoning cosine-distance from the current task description ≥ `0.7` (requires `goldfive[embedding]`). | `warning` | yes |

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -877,6 +877,34 @@ def make_adk_plugin(
             # sub-Runners get their own invocation_id). Each entry is
             # a small dict to keep the payload auditable in tests.
             self._invocation_llm_pending: dict[str, dict[str, Any]] = {}
+            # Tool-loop drift detector (goldfive#181). Observes every
+            # tool call the plugin sees in ``after_tool_callback`` and
+            # fires a ``LOOPING_REASONING`` drift when any of the
+            # three configured patterns (exact / name / alternating)
+            # trips. Thresholds read from ``GOLDFIVE_TOOL_LOOP_*`` env
+            # vars, falling back to the defaults documented in
+            # :mod:`goldfive.drift.tool_loops`. Lazy import so the
+            # plugin module stays importable without the drift helpers
+            # materialised — matches the pattern used for the
+            # confabulation classifier.
+            from goldfive.drift import tool_loops as _tool_loops
+
+            self._tool_loop_tracker = _tool_loops.ToolLoopTracker(
+                **_tool_loops.load_thresholds_from_env()
+            )
+            # Reporting-tool names that indicate forward task progress
+            # and therefore clear the tool-loop tracker's window for
+            # the current (invocation, agent) key. Matches the set
+            # exposed by the adapter's state-transition protocol.
+            self._progress_reporting_tools: frozenset[str] = frozenset(
+                {
+                    "report_task_started",
+                    "report_task_progress",
+                    "report_task_completed",
+                    "report_task_failed",
+                    "report_task_blocked",
+                }
+            )
 
         def set_active_context(self, ctx: SessionContext) -> None:
             """Attach the ``SessionContext`` for the running invocation.
@@ -910,6 +938,10 @@ def make_adk_plugin(
             # ``after_model_callback``; this catches the case where a
             # model turn errored between before/after and never paired.
             self._invocation_llm_pending.clear()
+            # Drop per-(invocation, agent) tool-loop ring buffers so
+            # state from the just-finished dispatch doesn't leak into
+            # the next one on the same plugin instance (goldfive#181).
+            self._tool_loop_tracker.clear()
 
         def set_reconciler(self, reconciler: Any) -> None:
             """Attach a :class:`~goldfive.reconciler.PlanReconciler`.
@@ -1946,6 +1978,121 @@ def make_adk_plugin(
                 await ctx.steerer.observe(observation, ctx.session)
             except Exception as exc:  # noqa: BLE001
                 log.debug("on_tool_error_callback: steerer.observe raised: %s", exc)
+            return None
+
+        # --- Tool-loop drift detection (goldfive#181) ------------------
+
+        async def after_tool_callback(
+            self,
+            *,
+            tool: Any,
+            tool_args: Any,
+            tool_context: Any,
+            result: Any,
+        ) -> None:
+            """Feed the tool-loop tracker and emit any drifts it raises.
+
+            Runs after every tool ADK dispatched (reporting tools,
+            AgentTool delegations, MCP/custom tools) so the detector
+            sees the real function_call stream the agent is emitting.
+            A reporting-tool progress call (``report_task_started`` /
+            ``_progress`` / ``_completed`` / ``_failed`` / ``_blocked``)
+            additionally clears the per-(invocation, agent) window so
+            mode 2's "no task progress" gate is correct.
+
+            The detector is deterministic and O(1) per call modulo the
+            tracker's ``window`` length; any failure is swallowed so a
+            buggy classifier never breaks tool dispatch. Drifts are
+            routed through ``steerer._handle_drift`` when available so
+            the intervention ladder sees them; falls back to
+            ``steerer.observe`` for stubs that don't expose
+            ``_handle_drift``.
+            """
+            ctx = self._resolve_ctx(tool_context)
+            if ctx is None or ctx.steerer is None:
+                return None
+            tool_name = str(_safe_attr(tool, "name", "") or "")
+            if not tool_name:
+                func = _safe_attr(tool, "func", None)
+                tool_name = str(_safe_attr(func, "__name__", "") or "")
+            # Resolve invocation_id + agent_name so the tracker's
+            # per-(invocation, agent) buckets match the reconciler's
+            # isolation model. Missing fields fall back to "" so the
+            # tracker still keys consistently on an ephemeral "unknown"
+            # bucket (tests exercise this path).
+            inv_ctx = _safe_attr(tool_context, "_invocation_context", None) or _safe_attr(
+                tool_context, "invocation_context", None
+            )
+            inv_id = str(_safe_attr(inv_ctx, "invocation_id", "") or "")
+            running_agent = _safe_attr(inv_ctx, "agent", None)
+            agent_name = str(_safe_attr(running_agent, "name", "") or "") or self._host_agent_name
+            task_id = str(_safe_attr(ctx.task, "id", "") or "")
+
+            # Progress-reporting tools reset the window BEFORE we
+            # record the call itself. That way a task-completing
+            # sequence (e.g. the fifth `read_file` that finally
+            # answers the question, followed by report_task_completed)
+            # doesn't leave the completing `report_*` call feeding
+            # a window that's about to be cleared. The progress tool
+            # is not appended at all — its job is to reset, not to
+            # feed the detector.
+            if tool_name in self._progress_reporting_tools:
+                self._tool_loop_tracker.on_task_progress(
+                    invocation_id=inv_id,
+                    agent_name=agent_name,
+                )
+                return None
+
+            try:
+                # tool_args may be None / missing on adapter edge cases;
+                # the tracker's hash helper copes with both.
+                args_payload = tool_args if isinstance(tool_args, Mapping) else {}
+                drifts = self._tool_loop_tracker.observe_tool_call(
+                    invocation_id=inv_id,
+                    agent_name=agent_name,
+                    tool_name=tool_name,
+                    args=dict(args_payload),
+                    task_id=task_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "after_tool_callback: tool-loop tracker raised: %s",
+                    exc,
+                )
+                return None
+
+            if not drifts:
+                return None
+
+            # Prefer ``_handle_drift`` so the intervention ladder
+            # sees the signal. Fall back to ``observe`` for stubs.
+            handle = getattr(ctx.steerer, "_handle_drift", None)
+            for drift in drifts:
+                if handle is not None:
+                    try:
+                        await handle(drift, ctx.session)
+                        continue
+                    except Exception as exc:  # noqa: BLE001
+                        log.debug(
+                            "after_tool_callback: _handle_drift raised: %s",
+                            exc,
+                        )
+                # Fallback path for steerer stubs that don't expose
+                # _handle_drift.
+                observation = _as_observation(
+                    kind="tool_loop_detected",
+                    detail=drift.detail,
+                    raw=drift.raw if isinstance(drift.raw, dict) else {"drift": repr(drift.raw)},
+                    task=ctx.task,
+                    agent_id=agent_name or self._host_agent_name,
+                )
+                try:
+                    await ctx.steerer.observe(observation, ctx.session)
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "after_tool_callback: steerer.observe raised: %s",
+                        exc,
+                    )
             return None
 
     return _GoldfiveADKPlugin()

--- a/goldfive/drift/__init__.py
+++ b/goldfive/drift/__init__.py
@@ -43,6 +43,8 @@ __all__ = [
     "detect_intent_divergence",
     "detect_looping_reasoning",
     "detect_off_topic",
+    "ToolLoopTracker",
+    "load_tool_loop_thresholds_from_env",
 ]
 
 
@@ -66,13 +68,22 @@ _GOALS_EXPORTS = frozenset(
 )
 
 
+_TOOL_LOOP_EXPORTS = frozenset(
+    {
+        "ToolLoopTracker",
+        "load_tool_loop_thresholds_from_env",
+    }
+)
+
+
 def __getattr__(name: str) -> Any:
     """Lazy re-export of the reasoning-drift and goal-drift helpers.
 
     Defers the regex / optional-embedding imports in
     :mod:`goldfive.drift.reasoning` until first access, so
     ``from goldfive.drift import classify_tool_error`` stays cheap.
-    The ``goals`` submodule is also lazy-loaded for parity.
+    The ``goals`` and ``tool_loops`` submodules are also lazy-loaded
+    for parity.
     """
     if name in _REASONING_EXPORTS:
         from goldfive.drift import reasoning as _reasoning
@@ -82,6 +93,12 @@ def __getattr__(name: str) -> Any:
         from goldfive.drift import goals as _goals
 
         return getattr(_goals, name)
+    if name in _TOOL_LOOP_EXPORTS:
+        from goldfive.drift import tool_loops as _tool_loops
+
+        if name == "load_tool_loop_thresholds_from_env":
+            return _tool_loops.load_thresholds_from_env
+        return getattr(_tool_loops, name)
     raise AttributeError(f"module 'goldfive.drift' has no attribute {name!r}")
 
 

--- a/goldfive/drift/tool_loops.py
+++ b/goldfive/drift/tool_loops.py
@@ -1,0 +1,428 @@
+"""Tool-call loop drift detector (goldfive#181).
+
+Post-steer replays on weaker models occasionally degenerate into a
+pattern where the coordinator / sub-agent LLM emits the same
+``function_call`` (or a near-same one) over and over without advancing
+any task. Observed empirically on Qwen runs where a single stuck
+invocation consumed ~30 minutes of wall-clock time before a max-call
+budget tripped the ADK runner. The existing
+:data:`~goldfive.types.DriftKind.LOOPING_REASONING` detector in
+:mod:`goldfive.drift.reasoning` watches LLM *text* output for
+hash / cosine loops -- it does NOT look at the function_call stream,
+so tight tool-loops that never emit the same reasoning text slip
+through.
+
+The existing :class:`goldfive.adapters._tool_loop_guard.ToolLoopGuard`
+IS args-aware but is scoped to **reporting tools** (tools dispatched
+via :func:`~goldfive.adapters._tool_invocation.invoke_tool`). Tool-loops
+on arbitrary agent-visible tools (AgentTool delegations, MCP tools,
+custom adapter-native tools) are not covered there.
+
+This module is the complementary detector: it observes **every** tool
+call the ADK plugin sees (reporting or otherwise), keyed per
+``(invocation_id, agent_name)``, and fires a
+``LOOPING_REASONING``-kind :class:`~goldfive.types.DriftEvent` when
+one of three patterns is detected:
+
+1. **Exact loop** -- same ``(tool_name, args_hash)`` repeats >= the
+   configured ``exact_threshold`` in the last ``window`` calls.
+   WARNING severity.
+2. **Name loop** -- same ``tool_name`` (any args) repeats >= the
+   configured ``name_threshold`` in the last ``window`` calls AND no
+   task-state transition has been recorded in the window. WARNING
+   severity.
+3. **Alternating cycle** -- A,B,A,B,A pattern in the last
+   ``alternating_threshold`` calls. INFO severity.
+
+Mode 2's "no task progress" gate is satisfied by calling
+:meth:`ToolLoopTracker.on_task_progress` whenever a task transitions
+RUNNING -> COMPLETED (or any other meaningful progress signal). That
+clears the per-agent buffer so a legitimate burst of the same tool
+(e.g. a scripted lint + build + test pipeline) is not flagged when
+each call completes its step.
+
+Isolation: trackers are keyed on ``(invocation_id, agent_name)`` so
+each ADK invocation gets its own window, and parallel sub-agents
+within the same invocation (via AgentTool) are also isolated. State
+is intentionally held in a single :class:`ToolLoopTracker` instance
+on the plugin -- we don't need per-session persistence, the whole
+window is ephemeral to one run.
+
+Configuration overrides via environment variables. Defaults chosen
+to balance signal vs noise (see below).
+
+* ``GOLDFIVE_TOOL_LOOP_WINDOW`` -- ring-buffer size (default ``7``).
+  Picked so mode 2's 5-in-7 name-repeat check has two "any-other-tool"
+  slots for variance before firing; a stricter ``5`` window made the
+  detector fire on legitimate pipelines in early manual testing.
+* ``GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD`` -- minimum identical
+  signatures to fire mode 1 (default ``3``). Three identical calls in
+  a row is the smallest number that cannot plausibly be a benign
+  retry.
+* ``GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD`` -- minimum same-name calls to
+  fire mode 2 (default ``5``). Five same-name calls in a 7-call window
+  means at most two distinct tools were invoked -- strong signal the
+  agent is stuck grinding on one capability.
+* ``GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD`` -- pattern length for
+  mode 3 (default ``5``). A,B,A,B,A is the smallest alternating pattern
+  that isn't just "ping once, then ping again" noise.
+
+The detector is intentionally deterministic (no embeddings, no LLM
+calls). O(1) per tool call modulo the `window` length.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from collections import defaultdict, deque
+from typing import Any
+
+from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+
+__all__ = [
+    "DEFAULT_WINDOW",
+    "DEFAULT_EXACT_THRESHOLD",
+    "DEFAULT_NAME_THRESHOLD",
+    "DEFAULT_ALTERNATING_THRESHOLD",
+    "ToolLoopTracker",
+    "args_hash",
+    "load_thresholds_from_env",
+]
+
+
+log = logging.getLogger("goldfive.drift.tool_loops")
+
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+#: Ring-buffer size: how many recent tool calls to retain per
+#: ``(invocation_id, agent_name)`` key. ``7`` is the default so the
+#: 5-in-7 name-repeat check has room for two "other-tool" calls without
+#: firing.
+DEFAULT_WINDOW: int = 7
+
+#: Mode 1 threshold: exact ``(name, args_hash)`` repeats in the window.
+DEFAULT_EXACT_THRESHOLD: int = 3
+
+#: Mode 2 threshold: same ``tool_name`` repeats in the window.
+DEFAULT_NAME_THRESHOLD: int = 5
+
+#: Mode 3 threshold: alternating pattern length (A,B,A,B,A == 5).
+DEFAULT_ALTERNATING_THRESHOLD: int = 5
+
+
+def _read_int_env(name: str, default: int) -> int:
+    """Best-effort integer env override; returns default on parse failure."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        log.debug(
+            "tool-loop detector: ignoring non-integer %s=%r (using default %d)",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if val <= 0:
+        log.debug(
+            "tool-loop detector: ignoring non-positive %s=%d (using default %d)",
+            name,
+            val,
+            default,
+        )
+        return default
+    return val
+
+
+def load_thresholds_from_env() -> dict[str, int]:
+    """Read ``GOLDFIVE_TOOL_LOOP_*`` env vars; return overrides dict.
+
+    Suitable for ``**kwargs``-splatting into :class:`ToolLoopTracker`.
+    Missing / malformed vars fall back to the module defaults. Returned
+    keys match the tracker's constructor kwargs.
+    """
+    return {
+        "window": _read_int_env("GOLDFIVE_TOOL_LOOP_WINDOW", DEFAULT_WINDOW),
+        "exact_threshold": _read_int_env(
+            "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD", DEFAULT_EXACT_THRESHOLD
+        ),
+        "name_threshold": _read_int_env(
+            "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD", DEFAULT_NAME_THRESHOLD
+        ),
+        "alternating_threshold": _read_int_env(
+            "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD", DEFAULT_ALTERNATING_THRESHOLD
+        ),
+    }
+
+
+def args_hash(args: Any) -> str:
+    """Stable 8-char hex hash of a tool-call args payload.
+
+    ``sort_keys=True`` so dict ordering doesn't perturb the hash.
+    ``default=str`` falls back to ``str()`` for non-JSON values (dates,
+    dataclasses, etc.) so we never raise from the hot path. An empty
+    / non-mapping payload hashes deterministically so the mode 1 check
+    still lights up on argument-free tool loops.
+    """
+    try:
+        encoded = json.dumps(args, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        encoded = repr(args)
+    return hashlib.md5(encoded.encode("utf-8")).hexdigest()[:8]
+
+
+# ---------------------------------------------------------------------------
+# Tracker
+# ---------------------------------------------------------------------------
+
+
+class ToolLoopTracker:
+    """Per-(invocation, agent) tool-call ring buffer + loop classifier.
+
+    Instantiate one tracker per plugin instance (session-scoped). Call
+    :meth:`observe_tool_call` on every tool dispatch; the returned list
+    of :class:`~goldfive.types.DriftEvent` is what the plugin should
+    route through the steerer. Call :meth:`on_task_progress` whenever a
+    task on the same invocation transitions to a progress state so mode
+    2's no-progress gate clears.
+
+    The classifier never mutates its buffers after firing -- we do not
+    dedupe drifts here. Upstream (the steerer's intervention ladder)
+    already dedupes by ``(kind, task_id)`` occurrence count, and a
+    repeating loop SHOULD keep emitting so the ladder escalates if the
+    agent doesn't recover.
+    """
+
+    def __init__(
+        self,
+        *,
+        window: int = DEFAULT_WINDOW,
+        exact_threshold: int = DEFAULT_EXACT_THRESHOLD,
+        name_threshold: int = DEFAULT_NAME_THRESHOLD,
+        alternating_threshold: int = DEFAULT_ALTERNATING_THRESHOLD,
+    ) -> None:
+        if window <= 0:
+            raise ValueError(f"window must be positive, got {window}")
+        if exact_threshold <= 0:
+            raise ValueError(f"exact_threshold must be positive, got {exact_threshold}")
+        if name_threshold <= 0:
+            raise ValueError(f"name_threshold must be positive, got {name_threshold}")
+        if alternating_threshold <= 0:
+            raise ValueError(f"alternating_threshold must be positive, got {alternating_threshold}")
+        # Sanity: if the window is too small to hold the thresholds,
+        # the detector can never fire for that mode. We log a debug
+        # warning but still accept the config -- tests pin specific
+        # (window, threshold) tuples and we don't want to reject them.
+        if window < exact_threshold:
+            log.debug(
+                "tool-loop: window=%d < exact_threshold=%d -- mode 1 cannot fire",
+                window,
+                exact_threshold,
+            )
+        if window < name_threshold:
+            log.debug(
+                "tool-loop: window=%d < name_threshold=%d -- mode 2 cannot fire",
+                window,
+                name_threshold,
+            )
+        if window < alternating_threshold:
+            log.debug(
+                "tool-loop: window=%d < alternating_threshold=%d -- mode 3 cannot fire",
+                window,
+                alternating_threshold,
+            )
+
+        self.window = window
+        self.exact_threshold = exact_threshold
+        self.name_threshold = name_threshold
+        self.alternating_threshold = alternating_threshold
+        # Keyed by (invocation_id, agent_name). Value: deque of
+        # (tool_name, args_hash). Uses ``defaultdict`` with a bound
+        # ``maxlen`` so slots auto-size.
+        self._buffers: dict[tuple[str, str], deque[tuple[str, str]]] = defaultdict(
+            lambda: deque(maxlen=self.window)
+        )
+
+    # -- Public API ---------------------------------------------------------
+
+    def observe_tool_call(
+        self,
+        *,
+        invocation_id: str,
+        agent_name: str,
+        tool_name: str,
+        args: Any,
+        task_id: str = "",
+    ) -> list[DriftEvent]:
+        """Record one tool call; return any drift observations it triggers.
+
+        ``task_id`` is stamped onto ``DriftEvent.current_task_id`` so
+        the intervention ladder can scope occurrence counts per task
+        (matches how other drift classifiers populate the field).
+        Passing ``""`` is safe -- sinks just won't associate the drift
+        with a specific task.
+        """
+        key = (invocation_id or "", agent_name or "")
+        signature = (tool_name or "", args_hash(args))
+        self._buffers[key].append(signature)
+        return self._classify(key, current_task_id=task_id)
+
+    def on_task_progress(
+        self,
+        *,
+        invocation_id: str,
+        agent_name: str,
+    ) -> None:
+        """Reset the per-(invocation, agent) buffer after task progress.
+
+        Called whenever a task transitions to a progress state so
+        mode 2's "no task progress in window" gate starts from a clean
+        slate. A legitimate sequence like
+        ``read_file read_file read_file`` that COMPLETES the task is
+        not flagged because the next observation starts from an empty
+        window.
+        """
+        key = (invocation_id or "", agent_name or "")
+        buf = self._buffers.get(key)
+        if buf is not None:
+            buf.clear()
+
+    def clear(self) -> None:
+        """Drop every per-(invocation, agent) buffer.
+
+        Called from the plugin's ``clear_active_context`` so state
+        doesn't leak across sessions when the plugin instance is
+        reused.
+        """
+        self._buffers.clear()
+
+    def buffer_size(self, *, invocation_id: str, agent_name: str) -> int:
+        """Current entry count for the given key (test introspection helper)."""
+        key = (invocation_id or "", agent_name or "")
+        buf = self._buffers.get(key)
+        return 0 if buf is None else len(buf)
+
+    # -- Internal -----------------------------------------------------------
+
+    def _classify(
+        self,
+        key: tuple[str, str],
+        *,
+        current_task_id: str,
+    ) -> list[DriftEvent]:
+        """Return zero or more drift observations for the current window."""
+        buf = list(self._buffers[key])
+        observations: list[DriftEvent] = []
+        invocation_id, agent_name = key
+
+        # --- Mode 1: exact-signature repeat --------------------------------
+        exact_counts: dict[tuple[str, str], int] = {}
+        for sig in buf:
+            exact_counts[sig] = exact_counts.get(sig, 0) + 1
+        fired_exact = False
+        for sig, count in exact_counts.items():
+            if count >= self.exact_threshold:
+                tool_name, sig_hash = sig
+                observations.append(
+                    DriftEvent(
+                        kind=DriftKind.LOOPING_REASONING,
+                        severity=DriftSeverity.WARNING,
+                        detail=(f"tool_loop_exact: {tool_name} x {count} in last {len(buf)} calls"),
+                        current_task_id=current_task_id,
+                        current_agent_id=agent_name,
+                        raw={
+                            "mode": "exact",
+                            "tool_name": tool_name,
+                            "args_hash": sig_hash,
+                            "count": count,
+                            "window_len": len(buf),
+                            "invocation_id": invocation_id,
+                        },
+                    )
+                )
+                fired_exact = True
+                break  # at most one exact drift per classify call
+
+        # --- Mode 2: same-name repeat (only if no task progress) -----------
+        # ``on_task_progress`` clears the window, so if we're here with
+        # a full-enough buffer, no progress has been recorded since the
+        # window started filling. No separate token needed.
+        name_counts: dict[str, int] = {}
+        for sig in buf:
+            name_counts[sig[0]] = name_counts.get(sig[0], 0) + 1
+        fired_name = False
+        for name, count in name_counts.items():
+            if count < self.name_threshold:
+                continue
+            # Suppress mode 2 when mode 1 already fired on the same
+            # tool -- it's the same signal, more specific. Mode 2
+            # still fires independently when mode 1 didn't (args
+            # varied across the burst).
+            if fired_exact and any(
+                sig[0] == name and c >= self.exact_threshold for sig, c in exact_counts.items()
+            ):
+                continue
+            observations.append(
+                DriftEvent(
+                    kind=DriftKind.LOOPING_REASONING,
+                    severity=DriftSeverity.WARNING,
+                    detail=(
+                        f"tool_loop_name: {name} x {count} in last "
+                        f"{len(buf)} calls (no task progress)"
+                    ),
+                    current_task_id=current_task_id,
+                    current_agent_id=agent_name,
+                    raw={
+                        "mode": "name",
+                        "tool_name": name,
+                        "count": count,
+                        "window_len": len(buf),
+                        "invocation_id": invocation_id,
+                    },
+                )
+            )
+            fired_name = True
+            break
+
+        # --- Mode 3: alternating A,B,A,B,A pattern -------------------------
+        if len(buf) >= self.alternating_threshold:
+            tail = buf[-self.alternating_threshold :]
+            names = [sig[0] for sig in tail]
+            if (
+                len(set(names)) == 2
+                and names[0] != names[1]
+                and all(names[i] == names[i % 2] for i in range(len(names)))
+            ):
+                # Don't double-fire if mode 1 or 2 already flagged
+                # this same pair -- the alternating signal is weaker
+                # (INFO) and would be noise on top of a WARNING.
+                if not (fired_exact or fired_name):
+                    a_name, b_name = names[0], names[1]
+                    observations.append(
+                        DriftEvent(
+                            kind=DriftKind.LOOPING_REASONING,
+                            severity=DriftSeverity.INFO,
+                            detail=(
+                                f"tool_loop_alternating: "
+                                f"{a_name} <-> {b_name} "
+                                f"in last {len(tail)} calls"
+                            ),
+                            current_task_id=current_task_id,
+                            current_agent_id=agent_name,
+                            raw={
+                                "mode": "alternating",
+                                "tools": [a_name, b_name],
+                                "window_len": len(tail),
+                                "invocation_id": invocation_id,
+                            },
+                        )
+                    )
+        return observations

--- a/tests/test_drift_classifiers.py
+++ b/tests/test_drift_classifiers.py
@@ -7,9 +7,16 @@ pins the cheaper structural classifiers:
 * :func:`goldfive.drift.classify_confabulation_risk` (issue #128) —
   flags research / verification tasks that finished with zero tool
   calls and non-empty output.
+* :mod:`goldfive.drift.tool_loops` (issue #181) -- deterministic
+  tool-call-loop detector wired into the ADK plugin's
+  ``after_tool_callback``. The unit tests for the classifier live in
+  ``tests/test_tool_loops.py``; here we pin the plugin-level
+  end-to-end wiring.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 import pytest
 
@@ -17,7 +24,7 @@ from goldfive.drift import (
     CONFABULATION_TRIGGER_KEYWORDS,
     classify_confabulation_risk,
 )
-from goldfive.types import DriftKind, DriftSeverity, Task
+from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Session, Task
 
 # ---------------------------------------------------------------------------
 # Keyword-set contract
@@ -260,3 +267,163 @@ def test_detail_message_includes_task_id_and_keyword() -> None:
     assert "t-abc-123" in drift.detail
     assert "verify" in drift.detail
     assert "zero tool calls" in drift.detail
+
+
+# ---------------------------------------------------------------------------
+# Tool-loop drift detector: plugin wiring (goldfive#181)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingToolLoopSteerer:
+    """Steerer stub that captures every drift routed via ``_handle_drift``."""
+
+    def __init__(self) -> None:
+        self.drifts: list[DriftEvent] = []
+        self.observations: list[Any] = []
+        self._sinks: list[Any] = []
+
+    async def observe(self, event: Any, session: Any) -> None:
+        self.observations.append(event)
+
+    async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+        self.drifts.append(drift)
+
+
+def _plugin_with_tool_loop_ctx(task: Task, session: Session, steerer: Any):
+    """Build an ADK plugin + state-context for tool-loop wiring tests.
+
+    Importing deferred so the module stays import-clean when ``google.adk``
+    isn't installed (the integration tests guard on ``importorskip``).
+    """
+    pytest.importorskip("google.adk")
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session,
+            steerer=steerer,
+            task=task,
+            tool_handlers={},
+            host_agent_name="test_agent",
+        )
+    }
+    # Install the context on the plugin directly so _resolve_ctx
+    # returns it without needing the ADK state-dict path.
+    plugin.set_active_context(state[SESSION_CONTEXT_STATE_KEY])
+    return plugin, state
+
+
+class _ToolStub:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _InvCtxStub:
+    def __init__(self, invocation_id: str, agent_name: str) -> None:
+        self.invocation_id = invocation_id
+        self.agent = type("_A", (), {"name": agent_name})()
+
+
+class _ToolCtxStub:
+    """Minimal ADK tool_context shape exposing ``_invocation_context``."""
+
+    def __init__(self, invocation_id: str, agent_name: str) -> None:
+        self._invocation_context = _InvCtxStub(invocation_id, agent_name)
+
+
+async def test_plugin_after_tool_emits_tool_loop_drift() -> None:
+    """Three identical arbitrary tool calls -> LOOPING_REASONING via the plugin."""
+    pytest.importorskip("google.adk")
+    steerer = _RecordingToolLoopSteerer()
+    session = Session(run_id="run-tl-1")
+    task = Task(id="t-loop", title="Something", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_tool_loop_ctx(task, session, steerer)
+
+    tool = _ToolStub("read_file")
+    args = {"path": "doc.md"}
+    tool_ctx = _ToolCtxStub("inv-loop-1", "test_agent")
+
+    # First two calls should not fire.
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result={"ok": True}
+    )
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result={"ok": True}
+    )
+    assert steerer.drifts == []
+
+    # Third identical call trips mode 1.
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result={"ok": True}
+    )
+    assert len(steerer.drifts) == 1
+    drift = steerer.drifts[0]
+    assert drift.kind is DriftKind.LOOPING_REASONING
+    assert drift.severity is DriftSeverity.WARNING
+    assert drift.raw is not None
+    assert drift.raw.get("mode") == "exact"
+    assert drift.raw.get("tool_name") == "read_file"
+    assert drift.current_task_id == "t-loop"
+
+
+async def test_plugin_progress_tool_resets_tool_loop_window() -> None:
+    """A reporting-progress tool call clears the per-(invocation, agent) buffer."""
+    pytest.importorskip("google.adk")
+    steerer = _RecordingToolLoopSteerer()
+    session = Session(run_id="run-tl-2")
+    task = Task(id="t-progress", title="Something", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_tool_loop_ctx(task, session, steerer)
+
+    tool_ctx = _ToolCtxStub("inv-loop-2", "test_agent")
+    tool = _ToolStub("read_file")
+    args = {"path": "doc.md"}
+
+    # Seed two identical calls.
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result={"ok": True}
+    )
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result={"ok": True}
+    )
+    # Progress-reporting tool clears the window.
+    progress_tool = _ToolStub("report_task_progress")
+    await plugin.after_tool_callback(
+        tool=progress_tool,
+        tool_args={"task_id": "t-progress", "fraction": 0.5},
+        tool_context=tool_ctx,
+        result={"acknowledged": True},
+    )
+    # One more identical read_file call should NOT fire because the
+    # buffer was cleared.
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result={"ok": True}
+    )
+    assert steerer.drifts == []
+
+
+async def test_plugin_cross_agent_tool_loop_isolation() -> None:
+    """Same tool, same args, same invocation but different sub-agents -> no drift."""
+    pytest.importorskip("google.adk")
+    steerer = _RecordingToolLoopSteerer()
+    session = Session(run_id="run-tl-3")
+    task = Task(id="t-iso", title="Something", assignee_agent_id="coord")
+    plugin, _state = _plugin_with_tool_loop_ctx(task, session, steerer)
+
+    tool = _ToolStub("read_file")
+    args = {"path": "same.md"}
+
+    # Three identical calls but each attributed to a DIFFERENT sub-agent
+    # (the ADK running_agent.name on ``_invocation_context``).
+    for agent_name in ("researcher", "writer", "reviewer"):
+        await plugin.after_tool_callback(
+            tool=tool,
+            tool_args=args,
+            tool_context=_ToolCtxStub("inv-iso", agent_name),
+            result={"ok": True},
+        )
+    assert steerer.drifts == []

--- a/tests/test_tool_loops.py
+++ b/tests/test_tool_loops.py
@@ -1,0 +1,443 @@
+"""Unit tests for :mod:`goldfive.drift.tool_loops` (goldfive#181).
+
+Covers the eight contracts named in the PR plan:
+
+1. Exact ``(tool_name, args_hash)`` repeat fires a WARNING.
+2. Same-name (args-varying) repeat fires a WARNING.
+3. Alternating A,B,A,B,A fires an INFO.
+4. ``on_task_progress`` clears the window.
+5. Cross-invocation buffers are isolated.
+6. Cross-agent buffers are isolated.
+7. Below-threshold calls do NOT fire.
+8. Window slides correctly -- old distinct entries age out so three
+   identical calls at the tail still trip mode 1.
+
+Plus small helpers for the env-override config path and the
+deterministic args-hashing helper.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from goldfive.drift.tool_loops import (
+    DEFAULT_ALTERNATING_THRESHOLD,
+    DEFAULT_EXACT_THRESHOLD,
+    DEFAULT_NAME_THRESHOLD,
+    DEFAULT_WINDOW,
+    ToolLoopTracker,
+    args_hash,
+    load_thresholds_from_env,
+)
+from goldfive.types import DriftKind, DriftSeverity
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed(
+    tracker: ToolLoopTracker,
+    calls: list[tuple[str, dict[str, Any]]],
+    *,
+    invocation_id: str = "inv-1",
+    agent_name: str = "agent-a",
+    task_id: str = "t1",
+) -> list[list[Any]]:
+    """Drive ``tracker`` through ``calls`` returning per-call drifts."""
+    out: list[list[Any]] = []
+    for tool_name, args in calls:
+        out.append(
+            tracker.observe_tool_call(
+                invocation_id=invocation_id,
+                agent_name=agent_name,
+                tool_name=tool_name,
+                args=args,
+                task_id=task_id,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# args_hash
+# ---------------------------------------------------------------------------
+
+
+def test_args_hash_is_order_insensitive() -> None:
+    assert args_hash({"a": 1, "b": 2}) == args_hash({"b": 2, "a": 1})
+
+
+def test_args_hash_differs_across_values() -> None:
+    assert args_hash({"a": 1}) != args_hash({"a": 2})
+
+
+def test_args_hash_copes_with_non_json_payloads() -> None:
+    class Widget:
+        def __repr__(self) -> str:
+            return "<widget>"
+
+    # Does not raise; returns an 8-char hex hash.
+    h = args_hash({"w": Widget()})
+    assert isinstance(h, str) and len(h) == 8
+
+
+# ---------------------------------------------------------------------------
+# load_thresholds_from_env
+# ---------------------------------------------------------------------------
+
+
+def test_load_thresholds_defaults_when_unset() -> None:
+    # Strip any active env overrides before the call so the test is
+    # deterministic regardless of the outer shell's environment.
+    with mock.patch.dict(os.environ, {}, clear=False):
+        for var in (
+            "GOLDFIVE_TOOL_LOOP_WINDOW",
+            "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD",
+            "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD",
+            "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD",
+        ):
+            os.environ.pop(var, None)
+        thresholds = load_thresholds_from_env()
+    assert thresholds == {
+        "window": DEFAULT_WINDOW,
+        "exact_threshold": DEFAULT_EXACT_THRESHOLD,
+        "name_threshold": DEFAULT_NAME_THRESHOLD,
+        "alternating_threshold": DEFAULT_ALTERNATING_THRESHOLD,
+    }
+
+
+def test_load_thresholds_respects_env_overrides() -> None:
+    overrides = {
+        "GOLDFIVE_TOOL_LOOP_WINDOW": "11",
+        "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD": "4",
+        "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD": "7",
+        "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD": "6",
+    }
+    with mock.patch.dict(os.environ, overrides, clear=False):
+        thresholds = load_thresholds_from_env()
+    assert thresholds == {
+        "window": 11,
+        "exact_threshold": 4,
+        "name_threshold": 7,
+        "alternating_threshold": 6,
+    }
+
+
+def test_load_thresholds_rejects_bad_values() -> None:
+    # Non-integer and non-positive overrides degrade to defaults.
+    bad = {
+        "GOLDFIVE_TOOL_LOOP_WINDOW": "not-an-int",
+        "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD": "0",
+        "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD": "-3",
+        "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD": "  ",
+    }
+    with mock.patch.dict(os.environ, bad, clear=False):
+        thresholds = load_thresholds_from_env()
+    assert thresholds["window"] == DEFAULT_WINDOW
+    assert thresholds["exact_threshold"] == DEFAULT_EXACT_THRESHOLD
+    assert thresholds["name_threshold"] == DEFAULT_NAME_THRESHOLD
+    assert thresholds["alternating_threshold"] == DEFAULT_ALTERNATING_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"window": 0},
+        {"window": -1},
+        {"exact_threshold": 0},
+        {"name_threshold": 0},
+        {"alternating_threshold": 0},
+    ],
+)
+def test_constructor_rejects_non_positive(kwargs: dict[str, int]) -> None:
+    with pytest.raises(ValueError):
+        ToolLoopTracker(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Mode 1 -- exact repeat
+# ---------------------------------------------------------------------------
+
+
+def test_exact_repeat_fires_warning() -> None:
+    """Mode 1: three identical ``(name, args)`` calls fire WARNING."""
+    tracker = ToolLoopTracker()
+    drifts_per_call = _seed(
+        tracker,
+        [
+            ("read_file", {"path": "a.txt"}),
+            ("read_file", {"path": "a.txt"}),
+            ("read_file", {"path": "a.txt"}),
+        ],
+    )
+    # First two calls below threshold.
+    assert drifts_per_call[0] == []
+    assert drifts_per_call[1] == []
+    assert len(drifts_per_call[2]) == 1
+    drift = drifts_per_call[2][0]
+    assert drift.kind is DriftKind.LOOPING_REASONING
+    assert drift.severity is DriftSeverity.WARNING
+    assert "tool_loop_exact" in drift.detail
+    assert "read_file" in drift.detail
+    assert drift.raw is not None
+    assert drift.raw.get("mode") == "exact"
+    assert drift.raw.get("tool_name") == "read_file"
+    assert drift.raw.get("count") == 3
+    assert drift.current_task_id == "t1"
+    assert drift.current_agent_id == "agent-a"
+
+
+# ---------------------------------------------------------------------------
+# Mode 2 -- name repeat (args-varying)
+# ---------------------------------------------------------------------------
+
+
+def test_name_repeat_fires_warning() -> None:
+    """Mode 2: five same-name, distinct-args calls fire a WARNING."""
+    tracker = ToolLoopTracker()
+    drifts_per_call = _seed(
+        tracker,
+        [("read_file", {"path": f"p{i}.txt"}) for i in range(5)],
+    )
+    # Calls 1-4 below threshold. Call 5 fires mode 2 (and not
+    # mode 1 because each args dict is distinct).
+    for i in range(4):
+        assert drifts_per_call[i] == [], f"unexpected drift at call {i}"
+    assert len(drifts_per_call[4]) == 1
+    drift = drifts_per_call[4][0]
+    assert drift.kind is DriftKind.LOOPING_REASONING
+    assert drift.severity is DriftSeverity.WARNING
+    assert "tool_loop_name" in drift.detail
+    assert drift.raw is not None
+    assert drift.raw.get("mode") == "name"
+    assert drift.raw.get("tool_name") == "read_file"
+    assert drift.raw.get("count") == 5
+
+
+# ---------------------------------------------------------------------------
+# Mode 3 -- alternating cycle
+# ---------------------------------------------------------------------------
+
+
+def test_alternating_pattern_fires_info() -> None:
+    """Mode 3: A,B,A,B,A fires an INFO drift."""
+    tracker = ToolLoopTracker()
+    drifts_per_call = _seed(
+        tracker,
+        [
+            ("A", {"x": 1}),
+            ("B", {"y": 1}),
+            ("A", {"x": 2}),
+            ("B", {"y": 2}),
+            ("A", {"x": 3}),
+        ],
+    )
+    # No mode 1 (args differ), no mode 2 (max per-name count = 3 < 5),
+    # mode 3 fires on the fifth call.
+    assert drifts_per_call[4], "alternating pattern should fire on the 5th call"
+    drift = drifts_per_call[4][0]
+    assert drift.kind is DriftKind.LOOPING_REASONING
+    assert drift.severity is DriftSeverity.INFO
+    assert "tool_loop_alternating" in drift.detail
+    assert drift.raw is not None
+    assert drift.raw.get("mode") == "alternating"
+    assert set(drift.raw.get("tools", [])) == {"A", "B"}
+
+
+def test_alternating_requires_two_distinct_tools() -> None:
+    """A,A,A,A,A is mode 1, NOT mode 3 -- don't double-fire alternating."""
+    tracker = ToolLoopTracker()
+    drifts_per_call = _seed(
+        tracker,
+        [("A", {"x": i}) for i in range(5)],
+    )
+    # Mode 2 should fire by call 5 (5 calls to "A" with distinct args);
+    # mode 3 must NOT also fire -- it would be a false positive.
+    drifts = drifts_per_call[4]
+    assert len(drifts) == 1
+    assert drifts[0].raw.get("mode") == "name"
+
+
+# ---------------------------------------------------------------------------
+# Mode 4 -- progress reset
+# ---------------------------------------------------------------------------
+
+
+def test_task_progress_resets_window() -> None:
+    """on_task_progress clears the per-(inv, agent) buffer."""
+    tracker = ToolLoopTracker()
+    _seed(
+        tracker,
+        [
+            ("read_file", {"path": "a.txt"}),
+            ("read_file", {"path": "a.txt"}),
+        ],
+    )
+    # Reset, then send one more identical call -- should NOT trip
+    # mode 1 because the buffer is empty.
+    tracker.on_task_progress(invocation_id="inv-1", agent_name="agent-a")
+    assert tracker.buffer_size(invocation_id="inv-1", agent_name="agent-a") == 0
+    third = tracker.observe_tool_call(
+        invocation_id="inv-1",
+        agent_name="agent-a",
+        tool_name="read_file",
+        args={"path": "a.txt"},
+        task_id="t1",
+    )
+    assert third == []
+
+
+# ---------------------------------------------------------------------------
+# Cross-invocation isolation
+# ---------------------------------------------------------------------------
+
+
+def test_cross_invocation_isolation() -> None:
+    """Two invocations of the same tool don't share a buffer."""
+    tracker = ToolLoopTracker()
+    a1 = tracker.observe_tool_call(
+        invocation_id="inv-1",
+        agent_name="agent-a",
+        tool_name="read_file",
+        args={"path": "x"},
+        task_id="t1",
+    )
+    a2 = tracker.observe_tool_call(
+        invocation_id="inv-2",
+        agent_name="agent-a",
+        tool_name="read_file",
+        args={"path": "x"},
+        task_id="t1",
+    )
+    a3 = tracker.observe_tool_call(
+        invocation_id="inv-3",
+        agent_name="agent-a",
+        tool_name="read_file",
+        args={"path": "x"},
+        task_id="t1",
+    )
+    # Three identical calls but on THREE different invocations --
+    # each bucket has exactly one entry so no drift fires.
+    assert a1 == a2 == a3 == []
+
+
+# ---------------------------------------------------------------------------
+# Cross-agent isolation
+# ---------------------------------------------------------------------------
+
+
+def test_cross_agent_isolation() -> None:
+    """Same invocation, different agent_name -> independent buckets."""
+    tracker = ToolLoopTracker()
+    for agent in ("coord", "researcher", "writer"):
+        tracker.observe_tool_call(
+            invocation_id="inv-1",
+            agent_name=agent,
+            tool_name="read_file",
+            args={"path": "x"},
+            task_id="t1",
+        )
+    # Only one call per agent-bucket -- no drift.
+    assert tracker.buffer_size(invocation_id="inv-1", agent_name="coord") == 1
+    assert tracker.buffer_size(invocation_id="inv-1", agent_name="researcher") == 1
+    assert tracker.buffer_size(invocation_id="inv-1", agent_name="writer") == 1
+
+
+# ---------------------------------------------------------------------------
+# Below-threshold
+# ---------------------------------------------------------------------------
+
+
+def test_below_threshold_no_drift() -> None:
+    """Two identical calls with exact_threshold=3 -> no drift."""
+    tracker = ToolLoopTracker(exact_threshold=3)
+    drifts = _seed(
+        tracker,
+        [
+            ("read_file", {"path": "x"}),
+            ("read_file", {"path": "x"}),
+        ],
+    )
+    assert drifts[0] == drifts[1] == []
+
+
+# ---------------------------------------------------------------------------
+# Window sliding
+# ---------------------------------------------------------------------------
+
+
+def test_window_slides() -> None:
+    """After ``window`` old calls age out, a fresh burst at the tail fires mode 1.
+
+    Setup: ``window=5, exact_threshold=3``. Seed 5 distinct calls,
+    then 2 identical ``X`` calls (no fire yet -- window is
+    ``[d, e, X, X]`` after the first 4 age-out slots? actually after
+    7 calls the window is the last 5). Then a third identical ``X``
+    fires mode 1 regardless of the aged-out distinct entries.
+    """
+    tracker = ToolLoopTracker(window=5, exact_threshold=3, name_threshold=10)
+    # Fill the window with five distinct tool names.
+    distinct = [(f"tool_{i}", {"i": i}) for i in range(5)]
+    _seed(tracker, distinct)
+    # Now seed three identical calls. By the third, the first three
+    # distinct entries have aged out and the window contains
+    # [tool_3, tool_4, X, X, X] (size=5, maxlen=5).
+    x_calls = [("X", {"arg": 1})] * 3
+    drifts_per_call = _seed(tracker, x_calls)
+    assert drifts_per_call[0] == [] and drifts_per_call[1] == []
+    # Third X call fires mode 1.
+    assert len(drifts_per_call[2]) >= 1
+    drift = drifts_per_call[2][0]
+    assert drift.raw.get("mode") == "exact"
+    assert drift.raw.get("tool_name") == "X"
+    assert drift.raw.get("count") == 3
+
+
+# ---------------------------------------------------------------------------
+# clear() wipes everything
+# ---------------------------------------------------------------------------
+
+
+def test_clear_wipes_all_buckets() -> None:
+    tracker = ToolLoopTracker()
+    for agent in ("a", "b"):
+        for inv in ("i1", "i2"):
+            tracker.observe_tool_call(
+                invocation_id=inv,
+                agent_name=agent,
+                tool_name="read",
+                args={},
+                task_id="t",
+            )
+    tracker.clear()
+    for agent in ("a", "b"):
+        for inv in ("i1", "i2"):
+            assert tracker.buffer_size(invocation_id=inv, agent_name=agent) == 0
+
+
+# ---------------------------------------------------------------------------
+# Suppression: mode 1 preempts mode 2 on the same tool
+# ---------------------------------------------------------------------------
+
+
+def test_exact_mode_preempts_name_mode_on_same_tool() -> None:
+    """If the exact-signature count is also above the name threshold,
+    the tracker emits one exact drift, not both."""
+    tracker = ToolLoopTracker(exact_threshold=3, name_threshold=3)
+    drifts_per_call = _seed(
+        tracker,
+        [("read_file", {"path": "same"})] * 3,
+    )
+    third = drifts_per_call[2]
+    assert len(third) == 1
+    assert third[0].raw.get("mode") == "exact"


### PR DESCRIPTION
## Summary

- New module `goldfive/drift/tool_loops.py`: deterministic per-`(invocation_id, agent_name)` ring-buffer classifier that detects three function_call loop patterns and emits `LOOPING_REASONING` `DriftEvent`s.
- Wired into `_GoldfiveADKPlugin.after_tool_callback` so every tool ADK dispatches (reporting, AgentTool, MCP, custom FunctionTools) feeds the detector. Reporting-progress tools clear the per-`(invocation, agent)` window so legitimate pipelines aren't false-flagged.
- Thresholds are configurable via `GOLDFIVE_TOOL_LOOP_WINDOW` / `_EXACT_THRESHOLD` / `_NAME_THRESHOLD` / `_ALTERNATING_THRESHOLD` (defaults 7 / 3 / 5 / 5).

## Why

Post-steer replays on weaker models (observed on Qwen) can burn 30+ minutes emitting the same `function_call` over and over with no task progress. The existing `LOOPING_REASONING` watches LLM *text*, and `ToolLoopGuard` only covers the eight reporting tools routed through `invoke_tool` -- neither catches tight tool-loops on arbitrary agent-visible tools.

## Failure modes covered

1. Exact `(tool_name, args_hash)` repeat >= `exact_threshold` in window -> WARNING.
2. Same `tool_name` (args-varying) repeat >= `name_threshold` in window with no task-progress reset -> WARNING.
3. Alternating A,B,A,B,A pattern -> INFO.

## Test plan

- [x] 22 unit tests in `tests/test_tool_loops.py` (all eight contracts + env-config + args-hash + constructor validation + mode-preemption).
- [x] 3 plugin-level integration tests in `tests/test_drift_classifiers.py` (drift emission, progress-reset, cross-agent isolation).
- [x] Full 953-test suite green (`uv run --frozen pytest`).
- [x] `uv run --frozen ruff check .` clean.
- [x] E2E validation: drove the plugin through a synthetic `fetch_url` loop end-to-end with a real `DefaultSteerer` + `SQLitePersistenceSink` and confirmed the first drift row in `goldfive_events` is `kind=DRIFT_KIND_LOOPING_REASONING severity=WARNING detail="tool_loop_exact: fetch_url x 3 in last 3 calls"`.

## Design notes on threshold choices

* `window=7` -- must hold `name_threshold=5` with two "other-tool" slots of slack; a tighter 5-call window tripped on legitimate pipelines in manual testing.
* `exact_threshold=3` -- smallest identical-call count that cannot plausibly be a benign retry.
* `name_threshold=5` -- five same-name calls in a 7-call window means at most two distinct tools ran; strong "agent is grinding" signal.
* `alternating_threshold=5` (A,B,A,B,A) -- smallest pattern that isn't just two unrelated pings.
* No embeddings, no LLM calls -- O(1) per call modulo `window` length. Safe for the hot path.

## Scope

Shares `before_tool_callback` territory with the sibling tool-intent classifier (#182) and the silent-tool-success detector (#183) -- this PR only touches `after_tool_callback`, leaves the existing `before_tool_callback` and the PLAN_DIVERGENCE three-stage gate (#178) untouched.