### PR TITLE
docs: refresh README + CHANGELOG + reference for current state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,151 @@
 
 All notable changes to goldfive are documented in this file. Dates are ISO-8601.
 
-## Unreleased
+## Unreleased — 2026-04-21
 
-### Changed
+Overview of the arc since the last doc refresh: **goldfive stopped driving
+per-task and became an overlay.** `goldfive.wrap` now hands the user's
+original request to the tree once, observes via ADK callbacks, and steers
+structurally through `GoldfivePlanner` + a drift ladder rather than
+rewriting each turn. The supporting work — session-state namespace,
+per-event session_id, steer idempotency, tool-loop detector, LLM-call
+instrumentation — lands alongside.
+
+### Execution-model refactor (overlay)
+
+- [#135](https://github.com/pedapudi/goldfive/pull/135) **Single-Runner revert.**
+  Rolled back the #120 N-runners registry-dispatch. Goldfive now wraps one
+  `InMemoryRunner` around the caller-supplied root agent and drives it via
+  `ADKAdapter.invoke(_passthrough|_follow_up)`. Delegation happens natively
+  through ADK (`AgentTool`, `transfer_to_agent`, `sub_agents`). `#120`'s
+  state-protocol, reporting-tool augmentation, and sink-event coverage are
+  preserved; per-invocation AgentTool-spawn cap added as a backstop
+  (`ADKAdapter(agent_tool_cap=16)` by default; `RUNAWAY_DELEGATION` drift
+  on exceed).
+- [#140](https://github.com/pedapudi/goldfive/pull/140) **Contextual plan
+  reconciliation.** `PlanReconciler` matches observed agent activity via
+  `parent_invocation_id` so nested `AgentTool` runs no longer trip
+  cross-task attribution.
+- [#148](https://github.com/pedapudi/goldfive/pull/148) **Overlay execution
+  model.** Merged on #141-#144. One `invoke_passthrough` per run; the
+  `PlanReconciler` observes via ADK callbacks. Drop per-task driving
+  entirely for overlay-mode executors. `SequentialExecutor(overlay_mode=True)`
+  is the default for `goldfive.wrap`.
+- [#147](https://github.com/pedapudi/goldfive/pull/147) **Intervention ladder**
+  Levels 0-5: OBSERVE / ABSORB / NUDGE / CANCEL_REINVOKE / PAUSE_ESCALATE /
+  TERMINATE. `DefaultSteerer._ladder_level_for` maps
+  `(kind, severity, occurrence_count)` to a level.
+- [#150](https://github.com/pedapudi/goldfive/pull/150) **Feed STEER through
+  the overlay loop.** STEER cancels in-flight, runs refine, restarts
+  `invoke_passthrough` with a composed steer-restart message. Closes the
+  regression where STEER under overlay landed on the original (pre-refine)
+  plan.
+- [#165](https://github.com/pedapudi/goldfive/pull/165) **Drop overlay soft
+  follow-up** (#163). When the passthrough invocation ends, PENDING plan
+  tasks are transitioned to `TaskStatus.NOT_NEEDED` instead of being
+  re-dispatched as per-task follow-up user messages. Closes the
+  ~10 min → 40+ min amplification on flow-prompted coordinators.
+
+### Structural steering
+
+- [#156](https://github.com/pedapudi/goldfive/pull/156) **GoldfivePlanner.**
+  `BasePlanner` subclass auto-attached by `goldfive.wrap` to every
+  `LlmAgent` in the tree. Injects a tree-agnostic
+  `[GOLDFIVE ORCHESTRATION CONTEXT]` block per turn via plugin-side
+  `before_model_callback` (ADK's `_nl_planning.py` gates request-side
+  injection on `isinstance(..., PlanReActPlanner)`; we bypass via the
+  plugin). Composes with user-supplied `BasePlanner` on both sides. Filters
+  cancelled `function_call` ids; signals off-registry agent calls.
+- [#158](https://github.com/pedapudi/goldfive/pull/158) **Goal-aware refine**
+  (#154). `LLMPlanner.refine` includes `goals` in the divergence prompt;
+  rejects revisions whose observed activity contradicts the goals. **No
+  steer cooldown** per user directive — `goldfive.active_steer.*` is a
+  durable read-back, not a cooldown window.
+- [#159](https://github.com/pedapudi/goldfive/pull/159) **`goldfive.*`
+  session-state namespace** (#152). Owned keys under
+  `goldfive.orchestration_state`: `current_plan_id`, `current_task_id`,
+  `current_task_title`, `goals_summary`, `active_steer.body`,
+  `active_steer.at_turn`, `active_steer.author`,
+  `cancelled_function_call_ids`, `processed_steer_ids`. Also adds
+  USER_STEER Goal synthesis with `Goal.source = GOAL_SOURCE_USER_STEER`
+  and a steer-restart framing header.
+- [#160](https://github.com/pedapudi/goldfive/pull/160) **Tree-aware planner
+  constraints** (#151). `LLMPlanner.plan(available_agents=)` and
+  `refine(available_agents=)` accept either a plain `list[str]` or the
+  structured walker from `ADKAdapter.available_agents_tree`. Validator
+  rejects off-registry assignees with a retry-with-correction loop.
+- [#164](https://github.com/pedapudi/goldfive/pull/164) **Session unification**
+  (#161). `goldfive.adapters.adk_wrap.GoldfiveADKAgent` pins the outer
+  adk-web session id onto `ADKAdapter._session_id` so all three session
+  layers (adk-web, ADKAdapter ADK session, goldfive `Session.id`) align.
+  `Session.id` aliases `run_id`.
+- [#173](https://github.com/pedapudi/goldfive/pull/173) **Bridge
+  orchestration state → ADK session.state** (#170). `_adk_state_protocol`
+  writers for `active_steer.body`, `goals_summary`,
+  `cancelled_function_call_ids`; `_GoldfiveADKPlugin.before_run_callback`
+  bridges per invocation so GoldfivePlanner's request-side read sees the
+  live orchestration-state.
+- [#175](https://github.com/pedapudi/goldfive/pull/175) **STEER idempotency +
+  author propagation** (#171). `DefaultSteerer.observe` dedupes STEER
+  messages by source `annotation_id` (or `ControlMessage.id` when the
+  bridge doesn't source annotations). New proto fields
+  `SteerPayload.author = 3` and `SteerPayload.annotation_id = 4`.
+
+### Observability
+
+- [#157](https://github.com/pedapudi/goldfive/pull/157) **Per-event
+  `session_id`** (#155). `goldfive.v1.Event` gains field 5 `session_id`.
+  Populated by Runner / Steerer / Executors so downstream consumers
+  (harmonograf) can multiplex multiple `Session`s on a single stream
+  without the Hello envelope.
+- [#168](https://github.com/pedapudi/goldfive/pull/168) **On-cancellation
+  plugin notify** (#167). `ADKAdapter` invokes `plugin.on_cancellation(invocation_id)`
+  on every plugin that defines the method before re-raising
+  `CancelledError`, so observability plugins (`HarmonografTelemetryPlugin`)
+  can close open spans with `status=CANCELLED`.
+- [#169](https://github.com/pedapudi/goldfive/pull/169) **Dedupe plugin
+  install** (#166). `_dedupe_plugins_by_name` silent no-ops on duplicate
+  instances of the same plugin name in `ADKAdapter`. Fixes double-install
+  of `HarmonografTelemetryPlugin` when the caller wires it into both
+  `App(plugins=...)` and `goldfive.wrap(plugins=...)`.
+- [#174](https://github.com/pedapudi/goldfive/pull/174) **Per-LLM-call
+  instrumentation** (#172). `_GoldfiveADKPlugin.before_model_callback`
+  emits a structured `goldfive.llm.request` log with `chars` /
+  `messages_count`; `after_model_callback` emits `goldfive.llm.response`
+  with `duration_ms` / `usage`. The `llm_response` observation dict is
+  enriched with a `metrics` key for downstream consumers.
+
+### Drift taxonomy
+
+- [#138](https://github.com/pedapudi/goldfive/pull/138) **Plan validator
+  hardening.** `LLMPlanner.refine` rejects CANCELLED/FAILED → PENDING
+  status regressions and off-registry assignees up-front.
+- [#177](https://github.com/pedapudi/goldfive/pull/177) **`DriftDetected.annotation_id`**
+  (proto field 6). User-control drifts (USER_STEER / USER_CANCEL) carry
+  the source annotation id for server-side dedup against the originating
+  annotation card.
+- [#184](https://github.com/pedapudi/goldfive/pull/184) **Three-stage drift
+  gate** (#178). `GoldfivePlanner.process_planning_response` classifies
+  each `function_call` part: (1) own-tool → skip; (2) cross-layer agent
+  name in the tree registry → `PLAN_DIVERGENCE` (WARNING); (3)
+  hallucinated name → `CONFABULATION_RISK` (WARNING). Calls are never
+  blocked — signal-only. Reporting-tool prefix (`report_*`) always passes
+  as stage 1.
+- [#186](https://github.com/pedapudi/goldfive/pull/186) **Tool-loop detector**
+  (#181). New `goldfive/drift/tool_loops.py::ToolLoopTracker` plumbed via
+  `after_tool_callback`. Three modes:
+  - **Exact** — same `(tool_name, args_hash)` ≥ 3 in last 7 calls (WARNING)
+  - **Name** — same `tool_name` ≥ 5 in last 7 with no task progress (WARNING)
+  - **Alternating** — A,B,A,B,A pattern in last 5 (INFO)
+
+  Progress-reporting calls (`report_task_*`) reset the per-(invocation,
+  agent) window. Tunable via `GOLDFIVE_TOOL_LOOP_{WINDOW,EXACT_THRESHOLD,NAME_THRESHOLD,ALTERNATING_THRESHOLD}`.
+  Follow-up umbrella tracked in #179; specific items in [#182](https://github.com/pedapudi/goldfive/issues/182)
+  (args-quality classification), [#183](https://github.com/pedapudi/goldfive/issues/183)
+  (silent tool success / no-progress), [#185](https://github.com/pedapudi/goldfive/issues/185)
+  (wrong-tool-for-job).
+
+### Earlier
 
 - #163 Overlay executor no longer dispatches soft follow-ups. When
   `SequentialExecutor._run_overlay` finishes its single

--- a/README.md
+++ b/README.md
@@ -3,23 +3,92 @@
 **Stay on target.**
 
 goldfive is a small, framework-agnostic Python library that wraps an agent
-with the orchestration scaffolding most agents quietly need: an explicit
-**goal**, a **plan** broken into tasks, per-turn **drift analysis**, and a
-**steering** loop that nudges the agent back on course when it wanders.
+tree with the orchestration scaffolding most agents quietly need: an
+explicit **goal**, a **plan** broken into tasks, per-turn **drift analysis**,
+and a **steering** loop that nudges the agent back on course when it wanders
+— without driving the tree per-task.
+
+Execution model (since goldfive#141): **overlay, not controller.**
+`goldfive.wrap(tree)` hands the caller's original request verbatim to the
+tree exactly once, observes via ADK callbacks, and intervenes structurally
+through an intervention ladder (Levels 0-5) rather than rewriting every
+turn. The tree runs its natural flow; goldfive watches, steers on drift,
+and reconciles a plan view alongside.
 
 It does not ship an LLM client, a prompt DSL, or a tool registry. It wraps
 whatever agent runtime you already use (Google ADK, the Anthropic SDK, a
 plain callable, ...) behind a narrow `AgentAdapter` protocol and gives you:
 
-- a `Runner` (or one-line `goldfive.wrap` / `goldfive.run`) that drives
-  the agent turn by turn against a `Goal`
-- pluggable `GoalDeriver`, `Planner`, `Executor`, and `Steerer` components
+- a `Runner` (or one-line `goldfive.wrap` / `goldfive.run`) that overlays
+  goldfive's goal / plan / drift machinery on top of a live tree
+- pluggable `GoalDeriver`, `Planner`, `Executor`, `Steerer` components
+  plus an ADK `BasePlanner` subclass (`GoldfivePlanner`) auto-attached per
+  `LlmAgent` for per-turn structural steering
+- an observation-driven `PlanReconciler` that maps before/after-agent
+  callbacks to plan-task transitions
 - an `EventSink` stream of proto-encoded events you can log, persist, or
   ship to an observability console
 
 goldfive is the orchestration half of
 [harmonograf](https://github.com/pedapudi/harmonograf), extracted so you
 can use the control loop without the console.
+
+## Architecture at a glance
+
+```
+           caller's agent tree (any shape)
+           ┌──────────────────────────────┐
+           │  LlmAgent / Coordinator      │
+           │    ├─ AgentTool(Specialist)  │
+           │    └─ sub_agents=[...]       │
+           └──────────────────────────────┘
+                         │
+                         ▼
+            goldfive.wrap(tree, ...)
+                         │
+                         ▼
+     ┌─────────────────────────────────────────────┐
+     │         GoldfiveADKAgent (BaseAgent)        │
+     │  (adk-web sees a root_agent; Runner inside) │
+     └─────────────────────────────────────────────┘
+                         │
+                         ▼
+     ┌─────────────────────────────────────────────┐
+     │   Runner                                    │
+     │     SequentialExecutor(overlay_mode=True)   │
+     │       ──► one adapter.invoke_passthrough    │
+     │                                             │
+     │   auto-attached per LlmAgent:               │
+     │     GoldfivePlanner (BasePlanner subclass)  │
+     │                                             │
+     │   observation:                              │
+     │     PlanReconciler (before/after_agent)     │
+     │     ToolLoopTracker (after_tool)            │
+     │                                             │
+     │   control:                                  │
+     │     DefaultSteerer + intervention ladder    │
+     │     LLMPlanner.{plan,refine}                │
+     └─────────────────────────────────────────────┘
+                         │
+                         ▼
+        EventSink stream (proto goldfive.v1.Event)
+            InMemory / Logging / JSONL / SQLite /
+                   GRPC / HarmonografSink
+                         │
+                         ▼
+              harmonograf server + UI
+```
+
+Key properties:
+
+| Property | Shape |
+|---|---|
+| Tree shape | any — single `LlmAgent`, coordinator + `AgentTool` specialists, deep `sub_agents` nesting |
+| Tree rewriting | none; `goldfive.wrap` walks once to build a `name → BaseAgent` registry |
+| Per-task driving | no (since #141) — one invocation, natural flow |
+| Planning | LLM-driven by default (detects ADK's LLM); falls back to `PassthroughPlanner` when no LLM |
+| Drift signals | tool errors, refusals, tool-loops, reasoning similarity, goal drift (opt-in), cross-layer delegation, hallucinated tools |
+| Intervention | six-level ladder (OBSERVE / ABSORB / NUDGE / CANCEL_REINVOKE / PAUSE_ESCALATE / TERMINATE) in `DefaultSteerer` |
 
 ## Get running in 10 minutes
 
@@ -62,9 +131,9 @@ the agent's LLM when it can detect one, and returns an
 import asyncio
 import goldfive
 
-# `agent` is any of: an ADK BaseAgent, a Claude SDK client factory,
-# an async (task, session, tools) -> InvocationResult callable, or
-# anything implementing goldfive.AgentAdapter.
+# `agent` is any of: an ADK BaseAgent (or pre-built Runner), a Claude
+# SDK client factory, an async (task, session, tools) -> InvocationResult
+# callable, or anything implementing goldfive.AgentAdapter.
 outcome = await goldfive.run(agent, "make a presentation about waffles")
 ```
 
@@ -72,28 +141,76 @@ Prefer to keep the runner around (for `.resume()`, custom sinks, or
 multiple runs)? Use `goldfive.wrap`:
 
 ```python
-runner = goldfive.wrap(agent, sinks=[my_sink])
+runner = goldfive.wrap(
+    agent,
+    sinks=[my_sink],
+    # Common overrides (all optional):
+    # planner=LLMPlanner(call_llm=..., model=...),
+    # goal_deriver=LLMGoalDeriver(call_llm=..., model=...),
+    # steerer=DefaultSteerer(),
+    # plugins=[HarmonografTelemetryPlugin(...)],
+    # control=ControlChannel(),
+)
 outcome = await runner.run("make a presentation about waffles")
 ```
 
-Every default component is overridable — pass `planner=`,
-`executor=`, `sinks=`, `call_llm=`, `model=`, or
-`max_task_invocations=` as keyword arguments to either function.
+Every default component is overridable. Keyword arguments accepted by
+both `wrap` and `run`:
 
-`goldfive.wrap(any_adk_tree)` works regardless of tree shape —
-single agent, coordinator with `AgentTool`-wrapped specialists,
-deep `sub_agents` nesting, `inner_agent` wrappers. goldfive walks
-the tree once at wrap time, builds a `name -> BaseAgent` registry,
-and dispatches each task to the per-agent runner for its
-`task.assignee_agent_id`. The tree is **respected, never rewritten
-or flattened**. See
-[`docs/design/ARCHITECTURE.md §"Registry dispatch"`](docs/design/ARCHITECTURE.md#registry-dispatch-goldfive-drives-adk-executes)
-for the model and
+| Keyword | Default | Notes |
+|---|---|---|
+| `planner=` | `LLMPlanner` when an LLM is detectable, else `PassthroughPlanner` | Any `Planner` |
+| `goal_deriver=` | `LLMGoalDeriver` / `LiteralGoalDeriver` by the same rule | Any `GoalDeriver` |
+| `executor=` | `SequentialExecutor(overlay_mode=True)` | Any `Executor` |
+| `steerer=` | `DefaultSteerer()` | |
+| `sinks=` | `[LoggingSink()]` | Pass `[]` to suppress |
+| `call_llm=` | auto-detected from ADK trees; none otherwise | Async `(system, user, model) -> str` |
+| `model=` | auto-detected from ADK; else empty string | |
+| `max_task_invocations=` | `None` (unbounded) | Cap on adapter invocations per run |
+| `plugins=` | `None` | List of ADK `BasePlugin` instances installed on the runner |
+| `control=` | `None` | `ControlChannel` for live PAUSE / STEER / CANCEL / etc. |
+
+`goldfive.wrap(any_adk_tree)` works regardless of tree shape — single
+agent, coordinator with `AgentTool`-wrapped specialists, deep
+`sub_agents` nesting, `inner_agent` wrappers. Under the **single-Runner,
+overlay-mode** model (since goldfive#141):
+
+- goldfive walks the tree once at wrap time, builds a
+  `name → BaseAgent` registry, and **attaches `GoldfivePlanner`** to
+  every `LlmAgent` so per-turn structural context is injected.
+- `goldfive.wrap` builds **one** `InMemoryRunner` around the root; the
+  tree runs its natural flow (coordinator delegates, specialists report
+  back, etc.).
+- `adapter.invoke_passthrough(user_input)` sends the caller's request
+  verbatim — no `"Task: X"` framing, no goldfive jargon — and the
+  `PlanReconciler` maps observed agent turns back to plan-task
+  transitions via ADK callbacks.
+- The tree is **respected, never rewritten or flattened.**
+
+See
+[`docs/design/ARCHITECTURE.md`](docs/design/ARCHITECTURE.md)
+for the full model and
 [`docs/guides/adk-web-integration.md`](docs/guides/adk-web-integration.md)
 for a coordinator+AgentTool example under `adk web`.
 
 A runnable demo lives in
 [`examples/hello_callable.py`](examples/hello_callable.py).
+
+## What's new in this version
+
+Arc since the last stable doc refresh, in rough order of impact:
+
+- **Overlay execution model** (#141-#148) — one invocation per run, observation-driven reconciliation, per-task driving is retired.
+- **Intervention ladder** (#142/#147) — Levels 0-5 uniformly map `(drift_kind, severity, occurrence_count)` to the right response.
+- **GoldfivePlanner** (#153/#156) — `BasePlanner` subclass auto-attached per `LlmAgent`, injects tree-agnostic orchestration context + structural drift gate.
+- **Tree-aware planner** (#151/#160) — `LLMPlanner` plans + refines against a structured agent registry.
+- **`goldfive.*` session-state namespace** (#152/#159) — documented keys
+  on ADK session state bridged from `goldfive.orchestration_state`.
+- **STEER idempotency + author propagation** (#171/#175) — `DefaultSteerer.observe` dedupes by source `annotation_id`.
+- **Tool-loop detector** (#181/#186) — three-mode args-aware detector on every tool call, not just reporting tools.
+- **Per-LLM-call instrumentation** (#172/#174) — structured request/response logs with `chars`/`messages_count`/`duration`/`usage`.
+
+Full list: [CHANGELOG.md](CHANGELOG.md).
 
 ## Docs
 
@@ -137,7 +254,8 @@ inspect the event stream. Concrete and runnable.
 ### Reference
 
 - [`docs/reference/api.md`](docs/reference/api.md) — public API surface.
-- [`docs/reference/tool-protocol.md`](docs/reference/tool-protocol.md) — the seven reporting tools.
+- [`docs/reference/tool-protocol.md`](docs/reference/tool-protocol.md) — the eight reporting tools.
+- [`docs/performance.md`](docs/performance.md) — orchestration-overhead baseline.
 
 ## License
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -41,10 +41,36 @@ proto event messages. The script prints a single block of measurements
 to stdout and unlinks its temp file before exiting. Total runtime is
 well under a second on commodity hardware.
 
-## Recorded baseline (v0.1.0)
+## Recorded baselines
 
-Median of five consecutive runs on **2026-04-18**, commodity Linux
-laptop, single core, no parallelism, CPython 3.12.13:
+### 2026-04-21 (current)
+
+Median of five consecutive runs, commodity Linux laptop, single
+core, no parallelism, CPython 3.12.13, post-overlay + tool-loop
+detector.
+
+| Metric             | Value          |
+| ------------------ | -------------- |
+| Wall time          | **0.104 s**    |
+| Throughput         | **962 tasks/s** |
+| Peak memory        | **0.33 MiB**   |
+| JSONL file size    | **61.59 KiB**  |
+| Python             | 3.12.13        |
+| goldfive           | 0.1.0          |
+
+JSONL file size grew ~20 % vs the 2026-04-18 baseline because the
+proto `Event` envelope gained the `session_id` field (goldfive#155)
+and `DriftDetected` gained `annotation_id` (goldfive#177). These
+are per-event string fields stamped by the Runner / Steerer, not
+per-turn overhead. Peak memory and wall time held flat relative to
+baseline — the overlay execution model (goldfive#141) removes the
+per-task re-invocation overhead, offsetting the new per-call
+instrumentation (`goldfive.llm.request` / `goldfive.llm.response`
+logs, goldfive#172/#174).
+
+### 2026-04-18 (v0.1.0 release snapshot)
+
+Median of five consecutive runs on the same hardware:
 
 | Metric             | Value          |
 | ------------------ | -------------- |
@@ -55,7 +81,7 @@ laptop, single core, no parallelism, CPython 3.12.13:
 | Python             | 3.12.13        |
 | goldfive           | 0.1.0          |
 
-Run-to-run variance over the five samples was roughly ±10 % on
+Run-to-run variance over the five samples is roughly ±10 % on
 wall-time and effectively zero on peak memory and JSONL size.
 
 ## Methodology notes
@@ -76,6 +102,36 @@ wall-time and effectively zero on peak memory and JSONL size.
   only**. Real workloads will be dominated by LLM and tool latency,
   which goldfive does not control.
 
+## Shape of the performance profile
+
+The 2026-04-18 baseline measures a **legacy per-task** executor path
+(`SequentialExecutor(overlay_mode=False)` + `StaticPlanner`, no LLM
+in the loop). Real `goldfive.wrap`-driven runs have a different
+profile:
+
+- **LLM call count** scales with `tree_depth × task_count` in the
+  per-task model; under the overlay model (goldfive#141, default for
+  `goldfive.wrap`) it scales with whatever the wrapped tree does
+  naturally for the single passthrough invocation. Goldfive adds
+  one additional LLM call per refine, bounded by
+  `LLMPlanner.DEFAULT_MAX_REFINE_ATTEMPTS=2`.
+- **Tool-loop detector** (`ToolLoopTracker`) is **O(1) per tool call**
+  modulo the ring-buffer window (default 7). Pure Python dict /
+  deque ops; no embeddings, no LLM.
+- **Reasoning-similarity detectors** are O(1) when embeddings are
+  unavailable (hash-only path). With `goldfive[embedding]`
+  installed, each reasoning block costs one embedding lookup against
+  the last N=5 blocks in `session.reasoning_history`.
+- **Per-LLM-call instrumentation** (goldfive#172/#174) adds a
+  constant-time log line before and after each model call. No
+  measurable overhead at this scale.
+- **GoldfivePlanner** runs request-side and response-side on every
+  LLM turn; both are O(parts_in_response) for the three-stage
+  classifier. No allocations per call in the common case.
+- **Session state bridge** (goldfive#170/#173) writes ~5 goldfive
+  keys onto ADK `session.state` at `before_run_callback`; one dict
+  copy per invocation, not per turn.
+
 ## Known limitations
 
 - **Single-threaded**: `SequentialExecutor` walks one task at a time.
@@ -89,18 +145,23 @@ wall-time and effectively zero on peak memory and JSONL size.
   own serialisation cost.
 - **Linear plan**: a 100-stage chain stresses sequential walking but
   not the topological-sort path that wide DAGs exercise.
+- **Per-task executor**: the benchmark still runs the legacy per-task
+  loop because the overlay path needs an adapter that implements
+  `invoke_passthrough`. An overlay-mode baseline should be added
+  once the benchmark is migrated.
 - **CPython only**: numbers measured under CPython 3.12; PyPy and
   newer CPython releases may differ.
 
 ## Regression policy
 
-If a future change pushes wall-time past **2× baseline** (~0.21 s) or
-peak memory past **2× baseline** (~0.58 MiB) on this exact workload,
-that warrants investigation before merge. We do **not** gate CI on the
-benchmark — it is a tripwire for human reviewers, not infrastructure.
+If a future change pushes wall-time past **2× current baseline**
+(~0.21 s) or peak memory past **2× current baseline** (~0.66 MiB) on
+this exact workload, that warrants investigation before merge. We do
+**not** gate CI on the benchmark — it is a tripwire for human
+reviewers, not infrastructure.
 
 To check after a change, simply re-run the benchmark a handful of times
-and compare the medians against the table above. If the workload
+and compare the medians against the tables above. If the workload
 itself changes (different sink, different plan shape, different
-adapter), record a new baseline rather than comparing apples to
-oranges.
+adapter, overlay-mode path), record a new baseline rather than
+comparing apples to oranges.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,11 +1,12 @@
 # Public API surface
 
-Hand-maintained reference for goldfive's public API as of v0.1. When
+Hand-maintained reference for goldfive's public API. When
 this doc disagrees with the code, trust the code and file a patch to
 fix the doc.
 
 Related: [PROTOCOLS.md](../design/PROTOCOLS.md),
-[ARCHITECTURE.md](../design/ARCHITECTURE.md).
+[ARCHITECTURE.md](../design/ARCHITECTURE.md),
+[DRIFT.md](../design/DRIFT.md).
 
 ## Top-level imports
 
@@ -66,14 +67,16 @@ call.
 def wrap(
     agent: Any,
     *,
-    planner: Optional[Planner] = None,
-    goal_deriver: Optional[GoalDeriver] = None,
-    executor: Optional[Executor] = None,
-    steerer: Optional[Steerer] = None,
-    sinks: Optional[list[EventSink]] = None,
-    call_llm: Optional[Callable[[str, str, str], Awaitable[str]]] = None,
-    model: Optional[str] = None,
-    max_task_invocations: Optional[int] = None,
+    planner: Planner | None = None,
+    goal_deriver: GoalDeriver | None = None,
+    executor: Executor | None = None,
+    steerer: Steerer | None = None,
+    sinks: list[EventSink] | None = None,
+    control: ControlChannel | None = None,
+    call_llm: Callable[[str, str, str], Awaitable[str]] | None = None,
+    model: str | None = None,
+    max_task_invocations: int | None = None,
+    plugins: list[Any] | None = None,
 ) -> Runner: ...
 
 
@@ -81,7 +84,7 @@ async def run(
     agent: Any,
     user_input: str | list[Goal],
     *,
-    context: Optional[Mapping[str, Any]] = None,
+    context: Mapping[str, Any] | None = None,
     **wrap_kwargs: Any,
 ) -> ExecutionOutcome: ...
 ```
@@ -97,10 +100,27 @@ Adapter dispatch favours ADK over the async-callable path so ADK
 agents are not misrouted to `CallableAdapter`. Unknown shapes raise
 `TypeError` with a pointer to the supported options.
 
+Default `executor` is `SequentialExecutor(overlay_mode=True,
+max_task_invocations=max_task_invocations)`; callers who supply their
+own `executor=` retain full control of the execution model.
+
 When no `call_llm` is supplied and the agent does not expose an LLM
 surface `wrap` can detect (currently only ADK), `wrap` falls back to
 `PassthroughPlanner` + `LiteralGoalDeriver` and emits a `DEBUG`
 log line on the `goldfive.wrap` logger.
+
+`plugins=` is forwarded to `ADKAdapter(plugins=...)` and installed on
+the one runner. ADK propagates the plugin manager into any
+`AgentTool`-spawned sub-Runner so delegation inherits the same plugin
+surface. Duplicate plugin instances (same `plugin.name`) are
+silently deduped (#166/#169).
+
+When the wrap target is an ADK `BaseAgent`, the returned object is a
+`GoldfiveADKAgent` — a `BaseAgent` subclass that *also* exposes the
+`Runner` surface, so the same call site works programmatically and as
+the `root_agent` of an `adk web` app. `GoldfiveADKAgent` pins the
+outer adk-web session id onto the inner `ADKAdapter` so all three
+session layers align (#161/#164).
 
 Direct `auto_adapter` access is available for callers who want the
 dispatch logic without the Runner defaults:
@@ -235,7 +255,10 @@ class TaskStatus(StrEnum):
     FAILED
     CANCELLED
     BLOCKED
+    NOT_NEEDED   # terminal; overlay-mode sweep at invocation end (#141/#163)
 ```
+
+`TERMINAL_TASK_STATUSES = {COMPLETED, FAILED, CANCELLED, NOT_NEEDED}`.
 
 ### `DriftSeverity`
 
@@ -248,16 +271,56 @@ class DriftSeverity(StrEnum):
 
 ### `DriftKind`
 
-25 values. See [DRIFT.md](../design/DRIFT.md) for the full
-taxonomy. Examples:
+Full taxonomy. Proto numbers are the authoritative wire values from
+`proto/goldfive/v1/types.proto::DriftKind`. Python `StrEnum` values
+use snake_case for forward compatibility with sinks.
 
-```python
-class DriftKind(StrEnum):
-    TOOL_ERROR, AGENT_REFUSAL, NEW_WORK_DISCOVERED, PLAN_DIVERGENCE,
-    USER_STEER, USER_CANCEL, TASK_FAILED_RECOVERABLE,
-    TASK_FAILED_FATAL, CONTEXT_PRESSURE, BLOCKED, WRONG_AGENT, ...
-    CUSTOM
-```
+| Proto # | Name | Python value | Meaning |
+|---|---|---|---|
+| 1 | TOOL_ERROR | `"tool_error"` | A tool invocation raised or returned a structured error. |
+| 2 | AGENT_REFUSAL | `"agent_refusal"` | Agent declined to perform; graduated severity via `classify_refusal`. |
+| 3 | NEW_WORK_DISCOVERED | `"new_work_discovered"` | `report_new_work_discovered` called; refine expected. |
+| 4 | PLAN_DIVERGENCE | `"plan_divergence"` | `report_plan_divergence`; cross-layer `AgentTool` call from `GoldfivePlanner`. |
+| 5 | USER_STEER | `"user_steer"` | `ControlKind.STEER` arrived; cascade-cancel + refine. |
+| 6 | USER_CANCEL | `"user_cancel"` | `ControlKind.CANCEL` arrived. |
+| 7 | TASK_FAILED_RECOVERABLE | `"task_failed_recoverable"` | `report_task_failed(recoverable=True)`; WARNING. |
+| 8 | TASK_FAILED_FATAL | `"task_failed_fatal"` | `report_task_failed(recoverable=False)`; CRITICAL. |
+| 9 | CONTEXT_PRESSURE | `"context_pressure"` | Stop-reason implied context / token pressure. |
+| 10 | BLOCKED | `"blocked"` | `report_task_blocked`; awaits external input. |
+| 11 | WRONG_AGENT | `"wrong_agent"` | Agent-transfer landed at the wrong target. |
+| 12 | AGENT_TRANSFER | `"agent_transfer"` | Transfer observed; informational. |
+| 13 | MODEL_REFUSAL | `"model_refusal"` | Provider-level refusal. |
+| 14 | STOPPED_EARLY | `"stopped_early"` | Response truncated before the task completed. |
+| 15 | TOO_MANY_STEPS | `"too_many_steps"` | Per-task / per-lineage step cap exceeded. |
+| 16 | GOAL_UNREACHABLE | `"goal_unreachable"` | Planner concluded no plan can satisfy the goal. |
+| 17 | TASK_TIMEOUT | `"task_timeout"` | Task exceeded `predicted_duration_ms` by threshold. |
+| 18 | REPEATED_FAILURE | `"repeated_failure"` | N consecutive refine failures for the same `(kind, task)` pair. |
+| 19 | UNEXPECTED_OUTPUT | `"unexpected_output"` | Output shape violates declared schema. |
+| 20 | SCHEMA_VIOLATION | `"schema_violation"` | Hard JSON / schema parse failure. |
+| 21 | HALLUCINATION_SUSPECTED | `"hallucination_suspected"` | Content inconsistent with the session's facts. |
+| 22 | SAFETY_CONCERN | `"safety_concern"` | Policy / safety signal. |
+| 23 | RESOURCE_EXHAUSTED | `"resource_exhausted"` | Rate limits, quota, etc. |
+| 24 | AMBIGUOUS_INTENT | `"ambiguous_intent"` | Signals the planner needs clarification. |
+| 25 | CUSTOM | `"custom"` | Escape hatch paired with `DriftDetected.detail`. |
+| 26 | LOOPING_TOOL_CALL | `"looping_tool_call"` | Reporting-tool loop guard tripped. |
+| 27 | LOOPING_REASONING | `"looping_reasoning"` | Reasoning-content loop (hash/embedding) **or** tool-loop detector (#181). |
+| 28 | CONFUSION | `"confusion"` | Reasoning expresses uncertainty; INFO. |
+| 29 | OFF_TOPIC | `"off_topic"` | Reasoning topic distant from task description (embedding). |
+| 30 | INTENT_DIVERGENCE | `"intent_divergence"` | Reasoning mentions a non-session goal; graduated severity. |
+| 31 | UNCERTAIN_PROGRESS | `"uncertain_progress"` | Opt-in reflective check: yes-but-low-confidence. |
+| 32 | SELF_REPORTED_STUCK | `"self_reported_stuck"` | Opt-in reflective check: agent says no progress. |
+| 33 | REASONING_CLUSTER_TIGHTENING | `"reasoning_cluster_tightening"` | Embedding-only early-warning below the LOOPING_REASONING cliff. |
+| 34 | CONFABULATION_RISK | `"confabulation_risk"` | Task implies external data but no tool was called; hallucinated `function_call` name (from `GoldfivePlanner`). |
+| 35 | RUNAWAY_DELEGATION | `"runaway_delegation"` | `ADKAdapter(agent_tool_cap=N)` exceeded; CRITICAL. |
+| 36 | REFINE_VALIDATION_FAILED | `"refine_validation_failed"` | `LLMPlanner.refine` exhausted retries; CRITICAL terminal signal. |
+| 37 | HUMAN_INTERVENTION_REQUIRED | `"human_intervention_required"` | Ladder Level 4 escalation; CRITICAL. |
+| 38 | GOAL_DRIFT | `"goal_drift"` | Periodic trajectory-level goal-alignment check; CRITICAL. |
+
+`DriftKind.USER_PAUSE` also exists on the Python side (no proto
+member) for in-process PAUSE bookkeeping.
+
+See [DRIFT.md](../design/DRIFT.md) for severity bands, classifier
+pipelines, and the intervention ladder's level-mapping table.
 
 ### `Task`
 
@@ -329,12 +392,17 @@ class DriftEvent:
 
 ### `Session`
 
+Abbreviated shape (see `goldfive.types.Session` for the full
+dataclass including reflective-check counters and ladder-handoff
+slots):
+
 ```python
 @dataclass
 class Session:
     run_id: str
+    conversation_id: str = ""
     goals: list[Goal] = field(default_factory=list)
-    plan: Optional[Plan] = None
+    plan: Plan | None = None
     current_task_id: str = ""
     completed_results: dict[str, str] = field(default_factory=dict)
     task_progress: dict[str, float] = field(default_factory=dict)
@@ -343,9 +411,45 @@ class Session:
     history: list[Any] = field(default_factory=list)
     started_at_ms: int = 0
 
+    # Reasoning-drift pipeline (goldfive#96)
+    reasoning_history: list[str] = field(default_factory=list)
+    reasoning_history_max: int = 20
+
+    # Intervention-ladder handoffs (goldfive#142)
+    paused_for_human_intervention: bool = False
+    pending_nudges: list[str] = field(default_factory=list)
+    pending_corrective_message: str | None = None
+
+    # Goldfive-orchestration session state (goldfive#152). Owned key
+    # names live in ``goldfive.orchestration_state``; see below.
+    state: dict[str, Any] = field(default_factory=dict)
+
     def next_sequence(self) -> int:
         """Monotonic event sequence counter."""
+
+    @property
+    def id(self) -> str:
+        """Alias for ``run_id``; used as ``Event.session_id`` (goldfive#155)."""
 ```
+
+`goldfive.orchestration_state` owns these keys under `goldfive.*`:
+
+| Key | Written by | Read by |
+|---|---|---|
+| `goldfive.current_plan_id` | plan-submitted / plan-revised paths | planners, sinks |
+| `goldfive.current_task_id` | `PlanReconciler` on RUNNING | `GoldfivePlanner`, sinks |
+| `goldfive.current_task_title` | same | same |
+| `goldfive.goals_summary` | Runner (on goals change / USER_STEER) | `GoldfivePlanner` |
+| `goldfive.active_steer.body` | `DefaultSteerer` on USER_STEER | `GoldfivePlanner` |
+| `goldfive.active_steer.at_turn` | same | refine / drift |
+| `goldfive.active_steer.author` | same | sinks |
+| `goldfive.processed_steer_ids` | `DefaultSteerer.observe` dedupe | self |
+| `goldfive.cancelled_function_call_ids` | adapter `_heal_pending_tool_calls` | `GoldfivePlanner` response filter |
+
+`_GoldfiveADKPlugin.before_run_callback` bridges a subset of these
+from `goldfive.Session.state` onto the live ADK `session.state` so
+`GoldfivePlanner` sees them on its request-side read
+(goldfive#170/#173).
 
 ## Results (`goldfive.results`)
 
@@ -384,11 +488,21 @@ marked otherwise below. Full contracts in
 | Protocol | Methods |
 |---|---|
 | `GoalDeriver` | `derive(user_input, *, context=None) -> list[Goal]` |
-| `Planner` | `generate(*, goals, available_agents, context=None) -> Optional[Plan]` · `refine(*, plan, drift, goals) -> Optional[Plan]` |
-| `Steerer` | `observe(event, session)` · `transition(task_id, to, *, detail="", session)` · `detect_drift(event, session) -> Optional[DriftEvent]` (sync) · `bind(*, sinks, planner)` (sync) |
-| `AgentAdapter` | `register_reporting_tools(tools)` · `invoke(task, session) -> InvocationResult` · property `available_agents: list[str]` (sync) |
-| `Executor` | `run(*, plan, session, adapter, steerer, planner, sinks) -> ExecutionOutcome` |
+| `Planner` | `generate(*, goals, available_agents, context=None) -> Plan \| None` · `refine(*, plan, drift, goals, observed_actions=None, available_agents=None) -> Plan \| None` |
+| `Steerer` | `observe(event, session)` · `transition(task_id, to, *, detail="", session)` · `detect_drift(event, session) -> DriftEvent \| None` (sync) · `bind(*, sinks, planner)` (sync) |
+| `AgentAdapter` | `register_reporting_tools(tools)` · `invoke(task, session) -> InvocationResult` · `emit_reasoning(text, *, task=None, session, provider="", call_id="")` · property `available_agents: list[str]` (sync) |
+| `Executor` | `run(*, plan, session, adapter, steerer, planner, sinks, control=None, user_input="")` — overlay-mode executors honour `user_input`; legacy per-task executors ignore it. |
 | `EventSink` | `emit(event_pb)` · `close()` |
+
+Overlay-specific adapter methods are **duck-typed**, not in the
+`AgentAdapter` protocol: `invoke_passthrough(user_message, *, session,
+reconciler=None, ctx=None)` and `invoke_follow_up(task, session)` are
+defined on `ADKAdapter`. Custom adapters that want to participate in
+the overlay execution path implement them; callers look them up via
+`getattr` and fall back to `invoke` when absent. Similarly,
+`available_agents_tree` (goldfive#151) is a duck-typed property
+shipped on `ADKAdapter` / `CallableAdapter` / `ClaudeAgentSDKAdapter`
+but not part of the Protocol contract.
 
 ## Default implementations
 
@@ -429,22 +543,70 @@ class StaticPlanner(Planner):
     # always returns None.
 
 class LLMPlanner(Planner):
+    DEFAULT_MAX_REFINE_ATTEMPTS: int = 2
+
     def __init__(
         self,
         *,
         call_llm: Callable[[str, str, str], Awaitable[str]],
         model: str = "",
-        system_prompt: Optional[str] = None,
-        refine_system_prompt: Optional[str] = None,
+        system_prompt: str | None = None,
+        refine_system_prompt: str | None = None,
+        user_steer_system_prompt: str | None = None,
+        looping_tool_call_system_prompt: str | None = None,
+        plan_divergence_system_prompt: str | None = None,
+        max_refine_attempts: int | None = None,
     ) -> None: ...
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str] | list[dict[str, Any]] | None,
+        context: Mapping[str, Any] | None = None,
+    ) -> Plan | None: ...
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+        observed_actions: list[ObservedAction] | None = None,
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
+    ) -> Plan | None: ...
 ```
+
+`available_agents` may be a plain `list[str]` (legacy callers) or the
+structured walker produced by
+`ADKAdapter.available_agents_tree` (goldfive#151). When the tree form
+is supplied the prompt renders an `AGENT TREE` section and the
+validator rejects any task whose `assignee_agent_id` is not in the
+registry, feeding the validator message back into a
+retry-with-correction loop. An empty / `None` registry skips the
+assignee check for back-compat.
+
+`refine` behaviour by drift kind:
+
+| `drift.kind` | Prompt used | Uses `observed_actions`? | Uses `available_agents`? |
+|---|---|---|---|
+| `USER_STEER` | user-steer system prompt | no | yes |
+| `LOOPING_TOOL_CALL` / `LOOPING_REASONING` | looping-tool-call prompt | no | yes |
+| `PLAN_DIVERGENCE` with `observed_actions` | divergence / reconciler prompt | yes — ABSORB or `{"reject": true, ...}` | yes |
+| `REFINE_VALIDATION_FAILED` | — | — | — (returns `None`; terminal) |
+| everything else | generic refine prompt | no | yes |
+
+Goal-aware refine (#154): `goals` are included in the divergence
+prompt; USER_STEER-sourced goals render with `[STICKY]`, and the
+validator rejects revisions that silently drop them.
 
 ### Steerer (`goldfive.steerer`)
 
 ```python
 class DefaultSteerer(Steerer):
     # Implements the full state machine + drift classifier from
-    # DRIFT.md and STATE-MACHINE.md. No required constructor args.
+    # DRIFT.md and STATE-MACHINE.md plus the six-level intervention
+    # ladder. No required constructor args.
 ```
 
 In addition to the `Steerer` protocol methods, `DefaultSteerer`
@@ -454,6 +616,147 @@ exposes `mark_task_running`, `mark_task_progress`,
 `report_plan_divergence` for the canonical reporting-tool handlers to
 call into.
 
+STEER idempotency (goldfive#171): `observe(event, session)` dedupes
+`ControlMessage`s of kind `STEER` by source annotation id. The
+dedupe key is taken from the `ControlMessage.payload["annotation_id"]`
+when the bridge supplied one; otherwise the `ControlMessage.id` is
+used as the fallback. Processed ids are stored in
+`session.state[goldfive.processed_steer_ids]` with FIFO eviction at
+`DefaultSteerer.PROCESSED_STEER_IDS_CAP`. Content-based drifts
+(`LOOPING_REASONING`, tool errors, etc.) are **not** deduped — they
+are heuristic signals, not user actions.
+
+Intervention ladder (goldfive#142):
+
+| Level | Name | Action |
+|---|---|---|
+| 0 | OBSERVE | Emit `DriftDetected`; no further action. |
+| 1 | ABSORB | Call `planner.refine`; continue. |
+| 2 | NUDGE | Queue a soft follow-up on `session.pending_nudges`; overlay loop picks it up at the next invocation boundary. |
+| 3 | CANCEL_REINVOKE | Cancel in-flight, refine, stash a corrective message on `session.pending_corrective_message`. |
+| 4 | PAUSE_ESCALATE | Emit `HUMAN_INTERVENTION_REQUIRED`; set `session.paused_for_human_intervention`. |
+| 5 | TERMINATE | Run-level abort (reserved for unhandled Level 4 timeouts). |
+
+Mapping from `(drift_kind, severity, occurrence_count)` to level lives
+in `DefaultSteerer._ladder_level_for`.
+
+### `GoldfivePlanner` (`goldfive.planners.goldfive_planner`)
+
+ADK `BasePlanner` subclass auto-attached by `goldfive.wrap` to every
+`LlmAgent` in the tree (goldfive#153/#156). Two jobs:
+
+1. **Request side** — `build_planning_instruction` returns a
+   tree-agnostic `[GOLDFIVE ORCHESTRATION CONTEXT]` block assembled
+   from `session.state[goldfive.*]` keys. Request-side injection is
+   performed by `_GoldfiveADKPlugin.before_model_callback`
+   (workaround for ADK's `isinstance(planner, PlanReActPlanner)` gate
+   in `_nl_planning.py`).
+2. **Response side** — `process_planning_response` filters response
+   parts:
+   - strips `function_call` parts whose id is in
+     `session.state[goldfive.cancelled_function_call_ids]`
+   - classifies each remaining `function_call` via a three-stage
+     gate (goldfive#178/#184): own-tool → skip; cross-layer agent
+     name in the tree registry → `PLAN_DIVERGENCE` (WARNING);
+     hallucinated name → `CONFABULATION_RISK` (WARNING). Calls are
+     **never blocked**.
+
+```python
+class GoldfivePlanner(BasePlanner):
+    def __init__(
+        self,
+        *,
+        user_planner: BasePlanner | None = None,
+        agent_registry: Iterable[str] | None = None,
+        steerer: Any = None,
+        session: Any = None,
+    ) -> None: ...
+
+    def bind(
+        self,
+        *,
+        agent_registry: Iterable[str] | None = None,
+        steerer: Any = None,
+        session: Any = None,
+    ) -> None: ...
+
+    def build_planning_instruction(
+        self, readonly_context, llm_request
+    ) -> str | None: ...
+
+    def process_planning_response(
+        self, callback_context, response_parts
+    ) -> list[Part] | None: ...
+```
+
+Composes with a user-supplied `BasePlanner` via `user_planner=`: the
+user's `build_planning_instruction` is called first and **prepended**
+ahead of goldfive's block; on the response side goldfive's filters
+run first and the cleaned parts flow through the user planner's
+`process_planning_response`.
+
+### `ToolLoopTracker` (`goldfive.drift.tool_loops`)
+
+Tool-call loop detector (goldfive#181/#186) plumbed on every
+`after_tool_callback` dispatch in `_GoldfiveADKPlugin`. Per-
+`(invocation_id, agent_name)` ring buffer; emits
+`DriftEvent(kind=LOOPING_REASONING, ...)` on three patterns.
+
+```python
+class ToolLoopTracker:
+    def __init__(
+        self,
+        *,
+        window: int = 7,                   # DEFAULT_WINDOW
+        exact_threshold: int = 3,          # DEFAULT_EXACT_THRESHOLD
+        name_threshold: int = 5,           # DEFAULT_NAME_THRESHOLD
+        alternating_threshold: int = 5,    # DEFAULT_ALTERNATING_THRESHOLD
+    ) -> None: ...
+
+    def observe_tool_call(
+        self,
+        *,
+        invocation_id: str,
+        agent_name: str,
+        tool_name: str,
+        args: Any,
+        task_id: str = "",
+    ) -> list[DriftEvent]: ...
+
+    def on_task_progress(
+        self, *, invocation_id: str, agent_name: str
+    ) -> None: ...
+
+    def clear(self) -> None: ...
+
+    def buffer_size(self, *, invocation_id: str, agent_name: str) -> int: ...
+
+
+def args_hash(args: Any) -> str: ...          # 8-char md5 hex of sorted-keys JSON
+def load_thresholds_from_env() -> dict[str, int]: ...
+```
+
+Detection modes:
+
+| Mode | Pattern | Default | Severity |
+|---|---|---|---|
+| Exact | same `(tool_name, args_hash)` ≥ threshold in last `window` | 3 / 7 | WARNING |
+| Name | same `tool_name` ≥ threshold in last `window`, no task progress | 5 / 7 | WARNING |
+| Alternating | A,B,A,B,A pattern in last `alternating_threshold` | 5 | INFO |
+
+Progress-reporting tools (`report_task_*`) call
+`on_task_progress(...)` which clears the per-(invocation, agent)
+window, so legitimate scripted sequences aren't flagged.
+
+Env-var overrides:
+`GOLDFIVE_TOOL_LOOP_WINDOW`,
+`GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD`,
+`GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD`,
+`GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD`.
+
+Follow-ups tracked: #179 (umbrella), #182 (args-quality),
+#183 (silent-success), #185 (wrong-tool).
+
 ### Executors (`goldfive.executors`)
 
 ```python
@@ -461,9 +764,10 @@ class SequentialExecutor(Executor):
     def __init__(
         self,
         *,
-        max_task_invocations: Optional[int] = None,  # None = unbounded
+        max_task_invocations: int | None = None,       # None = unbounded
         max_retries_per_task_lineage: int = 3,
         fail_fast: bool = True,
+        overlay_mode: bool = False,                     # goldfive#141
     ) -> None: ...
 
 class ParallelDAGExecutor(Executor):
@@ -471,9 +775,19 @@ class ParallelDAGExecutor(Executor):
         self,
         max_concurrency: int = 0,  # 0 = unbounded fan-out
         drift_policy: Literal["cancel_stage", "finish_stage"] = "finish_stage",
-        max_task_invocations: Optional[int] = None,  # None = unbounded
+        max_task_invocations: int | None = None,  # None = unbounded
     ) -> None: ...
 ```
+
+`overlay_mode=True` (set by `goldfive.wrap` by default) swaps the
+executor's per-task loop for a single
+`adapter.invoke_passthrough(user_input)` invocation. Observation
+happens via the plugin callback surface and `PlanReconciler` maps
+observed agent turns to plan-task transitions. STEER control
+messages cancel the in-flight invocation and restart `invoke_passthrough`
+with the composed steer-restart message as the new user input. At
+invocation end any task still PENDING lands in
+`TaskStatus.NOT_NEEDED` (no soft follow-up, goldfive#163).
 
 ### Adapters (`goldfive.adapters`)
 
@@ -497,11 +811,40 @@ class ADKAdapter(AgentAdapter):
         agent_or_runner: Any,  # google.adk.BaseAgent OR an existing Runner
         *,
         user_id: str = "goldfive_user",
-        session_id: Optional[str] = None,
-        app_name: Optional[str] = None,
-        plugins: Optional[list[Any]] = None,
-        agent_tool_cap: Optional[int] = None,  # default 16; 0 disables
+        session_id: str | None = None,
+        app_name: str | None = None,
+        plugins: list[Any] | None = None,
+        agent_tool_cap: int | None = None,  # default 16; 0 disables
     ) -> None: ...
+
+    # Overlay-model entry points (goldfive#141). `goldfive.wrap` uses
+    # ``invoke_passthrough`` exclusively; ``invoke`` and
+    # ``invoke_follow_up`` are kept for external callers.
+
+    async def invoke_passthrough(
+        self,
+        user_message: str,
+        *,
+        session: Session,
+        reconciler: Any = None,
+        ctx: Any = None,
+    ) -> InvocationResult:
+        """Drive ONE ADK turn with the user's original request verbatim."""
+
+    async def invoke_follow_up(
+        self, task: Task, session: Session
+    ) -> InvocationResult:
+        """Gentle ``Also, please: {title}.`` for a missed task.
+
+        Not called by the overlay executor since goldfive#163 —
+        PENDING tasks land in ``TaskStatus.NOT_NEEDED`` at invocation
+        end. Retained for external callers.
+        """
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:
+        """DEPRECATED — per-task drive. Uses ``invoke_follow_up`` phrasing."""
+
+    def add_plugin(self, plugin: Any) -> None: ...
 
     @property
     def available_agents(self) -> list[str]:
@@ -512,6 +855,15 @@ class ADKAdapter(AgentAdapter):
         populates ``task.assignee_agent_id`` as a delegation hint;
         goldfive does not route on the assignee under the single-
         Runner model (goldfive#130).
+        """
+
+    @property
+    def available_agents_tree(self) -> list[dict[str, Any]]:
+        """Structured walker of the tree: one dict per reachable agent
+        with ``name`` / ``depth`` / ``parent`` / ``role`` / ``kind``.
+        Passed to ``LLMPlanner.generate(available_agents=...)`` so the
+        prompt and validator can enforce on-registry assignees
+        (goldfive#151).
         """
 
 # Requires `goldfive[claude]`
@@ -530,12 +882,21 @@ class ClaudeAgentSDKAdapter(AgentAdapter):
         """Wire a :class:`Steerer` in after construction."""
 ```
 
-`ADKAdapter.invoke(task, session)` drives the one runner regardless
-of `task.assignee_agent_id` — the assignee is a planner hint, not
-a routing key. The plugin enforces a per-invocation cap on
-AgentTool spawns (default 16, `agent_tool_cap=0` disables); on
-exceed the plugin emits a `RUNAWAY_DELEGATION` drift at CRITICAL
-severity and cancels the invocation.
+`ADKAdapter.invoke_passthrough(user_message, session=..., reconciler=...)`
+drives the one runner regardless of `task.assignee_agent_id` — the
+assignee is a planner hint, not a routing key. The plugin enforces a
+per-invocation cap on AgentTool spawns (default 16,
+`agent_tool_cap=0` disables); on exceed the plugin emits a
+`RUNAWAY_DELEGATION` drift at CRITICAL severity and cancels the
+invocation.
+
+When the caller or the executor cancels an in-flight invocation,
+`ADKAdapter` invokes `plugin.on_cancellation(invocation_id)` on every
+plugin that defines the method (goldfive#167/#168). Observability
+plugins like `HarmonografTelemetryPlugin` use this to close open
+spans with `status=CANCELLED` before the `CancelledError` is
+re-raised. Exceptions in the hook are swallowed — cancel semantics
+take precedence.
 
 See [ARCHITECTURE.md §"Single-Runner dispatch"](../design/ARCHITECTURE.md#single-runner-dispatch-goldfive-drives-the-root-adk-delegates-within)
 for the model and [adk-web-integration.md §"Pre-built Runner degrade mode"](../guides/adk-web-integration.md#pre-built-runner-degrade-mode)
@@ -856,11 +1217,42 @@ Event, RunStarted, GoalDerived, PlanSubmitted, PlanRevised,
 TaskStarted, TaskProgress, TaskCompleted, TaskFailed,
 TaskBlocked, TaskCancelled, DriftDetected, RunCompleted, RunAborted,
 AgentInvocationStarted, AgentInvocationCompleted, DelegationObserved
+
+# control_pb2
+ControlEvent, ControlAck, ControlKind, ControlAckResult, ControlTarget,
+SteerPayload, RewindPayload, ApprovePayload, RejectPayload,
+InjectMessagePayload
 ```
 
 The `Event` envelope has a `oneof payload` with one field per
 per-event message. See [EVENT-MODEL.md](../design/EVENT-MODEL.md) for
 the full catalog.
+
+Envelope fields worth knowing about:
+
+| # | Field | Added | Purpose |
+|---|---|---|---|
+| 1 | `event_id` | v0.1 | UUIDv7 recommended for sink dedupe. |
+| 2 | `run_id` | v0.1 | Stable across every event in a run. |
+| 3 | `sequence` | v0.1 | Per-run monotonic, gap-free starting at 0. |
+| 4 | `emitted_at` | v0.1 | Wall clock; advisory only. |
+| 5 | `session_id` | goldfive#155/#157 | Per-event `Session.id` for stream-multiplexed consumers. Empty means "route via stream Hello". |
+
+Drift-side augmentations:
+
+- `DriftDetected.annotation_id` (field 6, goldfive#176/#177) — source
+  annotation id for USER_STEER / USER_CANCEL drifts minted from a
+  `ControlMessage`; empty for goldfive-minted drifts. Sinks dedupe
+  against the annotation card.
+
+Control-side augmentations (`SteerPayload`, goldfive#171/#175):
+
+| # | Field | Purpose |
+|---|---|---|
+| 1 | `note` | Steer body text. |
+| 2 | `suggested_action` | Optional hint to the planner. |
+| 3 | `author` | Operator identity from the originating annotation; empty when the bridge doesn't source annotations. |
+| 4 | `annotation_id` | Source annotation id used for idempotent delivery in `DefaultSteerer.observe`. |
 
 ## Convenience helpers (`goldfive.conv`)
 

--- a/docs/reference/tool-protocol.md
+++ b/docs/reference/tool-protocol.md
@@ -11,9 +11,28 @@ interception path: when the agent calls `report_task_completed(...)`,
 the adapter routes it through the spec's handler, which invokes the
 steerer, which applies the state transition and emits an event.
 
+Canonical list of tool names lives in
+`goldfive.reporting.REPORTING_TOOL_NAMES`:
+
+```python
+REPORTING_TOOL_NAMES: tuple[str, ...] = (
+    "report_task_started",
+    "report_task_progress",
+    "report_task_completed",
+    "report_task_failed",
+    "report_task_blocked",
+    "report_new_work_discovered",
+    "report_plan_divergence",
+    "report_awaiting_approval",
+)
+```
+
+Pre-built specs live in `goldfive.reporting.BUILTIN_REPORTING_TOOLS`.
+
 Related: [STATE-MACHINE.md](../design/STATE-MACHINE.md),
 [PROTOCOLS.md](../design/PROTOCOLS.md#agentadapter),
-[writing-an-agent-adapter.md](../guides/writing-an-agent-adapter.md).
+[writing-an-agent-adapter.md](../guides/writing-an-agent-adapter.md),
+[APPROVAL.md](../design/APPROVAL.md) (report_awaiting_approval).
 
 ## The `ReportingToolSpec` shape
 
@@ -53,10 +72,13 @@ The current `task_id` is made available to the agent by the adapter —
 either in a shared session-state dict (ADK), a system prompt (Claude
 SDK), or as a direct argument (CallableAdapter).
 
-## The seven tools
+## The eight tools
 
 Names are stable contract — do not rename. Mirrors harmonograf's
 canonical reporting tools; goldfive owns the list from v0.1 forward.
+`report_awaiting_approval` is documented at the end of this file —
+it's the task-level half of the human-in-the-loop approval flow
+(see [APPROVAL.md](../design/APPROVAL.md)).
 
 ### 1. `report_task_started`
 
@@ -286,6 +308,45 @@ await report_plan_divergence(
 Use sparingly. Most drift should route through the more specific
 tools above; `report_plan_divergence` is the catch-all.
 
+### 8. `report_awaiting_approval`
+
+```python
+report_awaiting_approval(
+    task_id: str,
+    target_id: str = "",
+    detail: str = "",
+) -> dict
+```
+
+**Call when:** a task needs a human decision before it can proceed.
+Blocks the calling tool-call until an `APPROVE` or `REJECT`
+`ControlMessage` targeting the same id lands on the runner's
+`ControlChannel`.
+
+**Side effects:**
+
+- Registers an `asyncio.Event` on
+  `session.pending_approvals[target_id]` (defaults to `task_id`).
+- Emits `ApprovalRequested(task_id, target_id, detail)`.
+- Blocks until the control dispatcher sets the event, then returns
+  `{"acknowledged": True, "decision": "approve"|"reject",
+  "detail": "..."}`.
+
+**Example:**
+
+```python
+outcome = await report_awaiting_approval(
+    task_id="t5",
+    detail="about to commit destructive changes to production",
+)
+if outcome["decision"] == "reject":
+    await report_task_failed(task_id="t5", reason="operator rejected")
+```
+
+See [APPROVAL.md](../design/APPROVAL.md) for the full Flow A
+semantics (goldfive-native) and Flow B (ADK require_confirmation /
+tool-call id).
+
 ## Summary table
 
 | Tool | Signature | Transition | Drift kind |
@@ -297,6 +358,50 @@ tools above; `report_plan_divergence` is the catch-all.
 | `report_task_blocked` | `(task_id, blocker, needed="")` | RUNNING → BLOCKED | `BLOCKED` |
 | `report_new_work_discovered` | `(parent_task_id, title, description, assignee="")` | none | `NEW_WORK_DISCOVERED` |
 | `report_plan_divergence` | `(note, suggested_action="")` | none | `PLAN_DIVERGENCE` |
+| `report_awaiting_approval` | `(task_id, target_id="", detail="")` | none (blocks caller) | — |
+
+## Interaction with goldfive orchestration
+
+### Tool-loop detector (goldfive#181/#186)
+
+Every tool call the ADK plugin dispatches is observed by
+`ToolLoopTracker` at `after_tool_callback`. **Calls to any
+`report_task_*` tool bypass the detector's counters and instead call
+`ToolLoopTracker.on_task_progress(...)` which clears the per-
+`(invocation_id, agent_name)` ring buffer.** This means:
+
+- A legitimate loop like `read_file → read_file → read_file → report_task_completed`
+  is not flagged.
+- A busted loop that keeps emitting `search → search → search` without
+  ever calling `report_task_progress` / `report_task_completed` will
+  fire `LOOPING_REASONING` (`mode=name`, WARNING) after five same-name
+  calls in seven.
+
+Agents should call `report_task_progress` / `report_task_completed`
+at natural step boundaries so the detector's window clears
+deterministically.
+
+### Session state written by reporting tools
+
+Reporting-tool handlers live in `goldfive.reporting` and write
+through the bound `Steerer`. The ADK plugin bridges a subset onto
+the live ADK `session.state` via `_adk_state_protocol` so the
+agent's next turn sees them:
+
+| Tool | Key(s) stamped on ADK `session.state` |
+|---|---|
+| `report_task_started` | `goldfive.current_task_id`, `goldfive.current_task_title`, `goldfive.current_task_description`, `goldfive.current_task_assignee` |
+| `report_task_progress` | `goldfive.task_progress` |
+| `report_task_completed` | `goldfive.task_outcome`, `goldfive.completed_task_results` |
+| `report_task_failed` | `goldfive.task_outcome` |
+| `report_plan_divergence` | `goldfive.divergence_flag` |
+
+Orchestration-owned keys under `goldfive.*` (see
+`goldfive.orchestration_state`) — `current_plan_id`,
+`goals_summary`, `active_steer.*`, `cancelled_function_call_ids`,
+`processed_steer_ids` — are written by goldfive itself (Runner,
+Steerer, adapter heal path) and read by `GoldfivePlanner` at
+request-side injection time.
 
 ## How the interception works
 


### PR DESCRIPTION
## Summary

Refreshes the top-level and reference documentation to reflect the
current state of goldfive post-overlay execution model.

- **README**: overlay-first project description, ASCII architecture diagram (tree → `goldfive.wrap` → overlay executor → planner/reconciler/steerer → sink), refreshed `wrap()` parameter table, "What's new" section.
- **CHANGELOG**: entries for #135 / #138 / #140 / #147 / #148 / #150 / #156 / #157 / #158 / #159 / #160 / #164 / #165 / #168 / #169 / #173 / #174 / #175 / #177 / #184 / #186 grouped by theme (execution model, structural steering, observability, drift taxonomy).
- **api.md**:
  - Full 38-value `DriftKind` taxonomy with proto numbers and descriptions.
  - Overlay adapter entry points (`invoke_passthrough` / `invoke_follow_up` / on-cancellation hook).
  - `GoldfivePlanner` and `ToolLoopTracker` public API.
  - STEER idempotency, per-event `session_id`, `SteerPayload` + `DriftDetected.annotation_id` proto fields.
  - Orchestration-state key table (`goldfive.*`).
  - Revised `LLMPlanner` / `SequentialExecutor` signatures (including `overlay_mode`, `max_refine_attempts`).
  - Note on duck-typed overlay contract (`invoke_passthrough`, `available_agents_tree`).
- **tool-protocol.md**: documents `report_awaiting_approval` (the 8th tool), tool-loop detector interaction (`report_task_*` resets the window), and the ADK `session.state` keys each reporting tool stamps.
- **performance.md**: re-baselined on current HEAD (median 0.104 s, 962 t/s, 0.33 MiB, 61.59 KiB) and added a qualitative O(...) profile section covering the new detectors and instrumentation.

## Discovered inconsistencies corrected

- Tool-protocol doc called out "seven tools" while the code ships eight (`REPORTING_TOOL_NAMES` in `goldfive/reporting.py`).
- `TaskStatus` doc was missing `NOT_NEEDED` — added from proto `TASK_STATUS_NOT_NEEDED = 7`.
- `Planner.refine` protocol signature in api.md was missing `observed_actions=` and `available_agents=` kwargs.
- `DriftKind` doc listed ~25 values; code has 38 + USER_PAUSE.
- `Session` dataclass doc missed `state`, `id` property, `pending_nudges`, `pending_corrective_message`, `paused_for_human_intervention`, reasoning-history fields.

## Test plan
- [x] `uv run --extra proto --extra dev python bench/run_100_tasks.py` (5× runs, recorded the median in `docs/performance.md`)
- [x] `uv run --extra proto --extra dev --extra adk python -m pytest tests/test_goldfive_planner.py tests/test_drift_taxonomy.py -x -q` — 68 passed.
- [x] `uv run python -c "import goldfive; ..."` sanity check on `ToolLoopTracker`, `GoldfivePlanner`, `DriftKind`, `TaskStatus.NOT_NEEDED`.
- [ ] Rendered markdown review (reviewer)