### PR TITLE
docs(design): refresh design docs for overlay + structural steering + drift taxonomy

### DIFF
--- a/docs/design/APPROVAL.md
+++ b/docs/design/APPROVAL.md
@@ -1,9 +1,18 @@
-# Human-in-the-loop approval
+# Human-in-the-loop approval & escalation
 
-Two scenarios require a human yes/no before the run proceeds. Both terminate in
-the same two control kinds — `ControlKind.APPROVE` and `ControlKind.REJECT` —
-and both surface through the same three proto events, so a single UI affordance
-(approve/reject buttons on a queued "awaiting" card) works for either.
+Three scenarios require a human action before the run proceeds. Two of
+them are **approval flows** (A / B below) — the agent explicitly waits
+for yes/no — and terminate in `ControlKind.APPROVE` /
+`ControlKind.REJECT`. The third is **escalation** — goldfive detects
+unrecoverable drift and pauses until the operator steers or resumes,
+terminating in `HUMAN_INTERVENTION_REQUIRED` drift (Level 4 of the
+intervention ladder).
+
+All three surface through proto events the harmonograf UI (or any
+sink) can render. Approvals use `ApprovalRequested` / `ApprovalGranted`
+/ `ApprovalRejected`; escalation uses `DriftDetected` with kind
+`HUMAN_INTERVENTION_REQUIRED` plus the session's
+`paused_for_human_intervention` flag.
 
 ## Flow A — Task-level approval (framework-agnostic)
 
@@ -202,6 +211,54 @@ ControlMessage(kind=ControlKind.REJECT,  payload={"target_id": "...", "detail": 
 
 The target_id routes to the same `session.pending_approvals` map regardless of
 whether it was a task-level or tool-level request.
+
+## Flow C — `HUMAN_INTERVENTION_REQUIRED` escalation (goldfive#142)
+
+Unlike flows A and B — which are agent-initiated approvals — flow C is
+**goldfive-initiated**. When the intervention ladder
+(`DefaultSteerer._ladder_level_for`) routes a drift to Level 4
+(`PAUSE_ESCALATE`), the steerer:
+
+1. Sets `session.paused_for_human_intervention = True`.
+2. Emits a `DriftDetected` event of kind
+   `HUMAN_INTERVENTION_REQUIRED` (proto enum value 37, CRITICAL
+   severity) carrying `detail="escalated from {orig_kind}: {orig_detail}"`.
+
+Typical Level-4 triggers:
+
+- `GOAL_DRIFT` at CRITICAL (every occurrence — the trajectory LLM
+  judge says the tree is no longer advancing goals).
+- `REFINE_VALIDATION_FAILED` at CRITICAL (planner exhausted its
+  retry budget; steerer deliberately does NOT re-refine to avoid an
+  infinite loop).
+- `INTENT_DIVERGENCE` at CRITICAL (or at WARNING on repeat).
+- `RUNAWAY_DELEGATION` on repeat.
+- Any `CRITICAL` drift whose first-occurrence Level-3 CANCEL_REINVOKE
+  didn't resolve and it repeats.
+
+The Runner's overlay loop blocks before picking up the next step
+when `session.paused_for_human_intervention` is set. To unpause, the
+operator sends one of:
+
+- **`ControlKind.RESUME`** — clear the flag and continue (if the
+  operator believes the drift was spurious).
+- **`ControlKind.STEER`** — provide a new direction. The refine runs,
+  the plan is revised, and the overlay restarts with the steer body.
+- **`ControlKind.CANCEL`** — abort the run cleanly.
+
+If the pause never resolves and the same `HUMAN_INTERVENTION_REQUIRED`
+drift fires a second time (rare — would require the operator to
+send a STEER that re-triggers the same escalation), the ladder
+escalates to Level 5 (`TERMINATE`) — a run-level abort.
+
+Sinks should render the pause as a visible state (badge + paused
+Gantt) and surface the approve/reject-style buttons as Resume /
+Steer / Cancel affordances. The UI path mirrors flow A's
+"awaiting" card shape but with a distinct drift source and a
+different control verb set.
+
+See [DRIFT.md §"Intervention ladder"](DRIFT.md#intervention-ladder-levels-0-5)
+for the full per-drift-kind level mapping.
 
 ## harmonograf follow-up (out of scope for this PR)
 

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -66,11 +66,15 @@ revises it on drift via `refine(plan, drift, goals)`. The planner is
 the only component that ever decides *what* tasks exist. Executors and
 steerers just mechanically walk whatever plan the planner hands them.
 
-**Executor** — walks the plan. Two executors ship in v0.1:
-`SequentialExecutor` runs tasks one at a time in topological order;
-`ParallelDAGExecutor` batches independent tasks per topological stage
-and runs the stage with `asyncio.gather`. The executor is the only
-component that calls `adapter.invoke(task, session)`.
+**Executor** — drives the run. Two executors ship:
+`SequentialExecutor` (the default; supports both the overlay model
+and a legacy per-task loop behind `overlay_mode=False`) and
+`ParallelDAGExecutor` (per-task; batches independent tasks per
+topological stage and runs the stage with `asyncio.gather`). Under
+the overlay model the executor calls `adapter.invoke_passthrough(user_input)`
+ONCE per run / turn; under the legacy per-task loop it calls
+`adapter.invoke(task, session)` per eligible task. See §"Overlay
+execution model" below for the overlay flow.
 
 **Steerer** — owns the task state machine. It reacts to reporting tool
 calls (from the adapter) and to adapter-observed events, transitions
@@ -289,6 +293,165 @@ caller captures the same information.
   flushes buffered writes and releases the file lock. See the
   [persistence guide](../guides/persistence-and-recovery.md).
 
+## Overlay execution model
+
+Since the 2026-04 overlay refactor (goldfive#141, PR #148, refined by
+#163, #149, #152, #160, #170) goldfive **no longer drives per-task**
+for the default code path. The model is observation-driven with soft
+intervention:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Default path (goldfive.wrap → SequentialExecutor(overlay_mode=1))│
+│                                                                  │
+│ 1. Single invocation:                                            │
+│    adapter.invoke_passthrough(user_input)                        │
+│                                                                  │
+│ 2. While the tree runs, the ADK plugin emits                     │
+│    before_agent / after_agent / before_tool / after_tool         │
+│    events. A PlanReconciler consumes the before/after_agent      │
+│    pair and maps observed agent transitions onto plan tasks:     │
+│      coordinator → (no task claim, host lifecycle marker)         │
+│      researcher  → claim first PENDING task assigned to this name │
+│      writer      → same, contextual match via invocation chain    │
+│      (goldfive#151) if a direct assignee match fails              │
+│                                                                  │
+│ 3. The GoldfivePlanner (BasePlanner) attached to every LlmAgent  │
+│    in the tree injects a per-turn orchestration block into the   │
+│    LLM system prompt and classifies every function_call via the  │
+│    three-stage gate (own-tool / cross-layer / confabulation).    │
+│                                                                  │
+│ 4. Drift signals (PLAN_DIVERGENCE, CONFABULATION_RISK,           │
+│    LOOPING_REASONING from reasoning + tool_loops detectors,      │
+│    INTENT_DIVERGENCE, GOAL_DRIFT, ...) feed the intervention     │
+│    ladder (Levels 0-5) in DefaultSteerer._handle_drift.          │
+│                                                                  │
+│ 5. On USER_STEER:                                                │
+│      a. dedup by annotation_id (goldfive#171)                    │
+│      b. refine under USER_STEER drift (delete-and-replan)        │
+│      c. cancel in-flight adapter.invoke_passthrough              │
+│      d. restart invoke_passthrough with framed steer message     │
+│         (`_compose_steer_restart_message`, goldfive#152)          │
+│                                                                  │
+│ 6. Invocation-end sweep:                                         │
+│    Any PENDING task the tree never exercised → NOT_NEEDED        │
+│    (goldfive#163). No soft follow-up — flow-coordinators         │
+│    re-ran their full pipeline on every follow-up user message.   │
+│    STEER is the user-driven path for exercising uncovered work. │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Per-task driving is gone** from the default code path. The legacy
+per-task loop still lives in `SequentialExecutor.run` behind
+`overlay_mode=False` for backward compatibility with direct
+`SequentialExecutor(...)` callers and tests.
+
+**Key modules.**
+
+- `goldfive/executors/sequential.py::SequentialExecutor._run_overlay`
+  — the overlay loop.
+- `goldfive/reconciler.py::PlanReconciler` — observation → task
+  transition mapping.
+- `goldfive/steerer.py::DefaultSteerer` — the intervention ladder
+  (`InterventionLevel.OBSERVE`, `ABSORB`, `NUDGE`,
+  `CANCEL_REINVOKE`, `PAUSE_ESCALATE`, `TERMINATE`) plus
+  `compose_corrective_user_message` used by Level 3.
+- `goldfive/planners/goldfive_planner.py::GoldfivePlanner` —
+  `BasePlanner` subclass auto-attached to every LlmAgent.
+- `goldfive/adapters/_adk_plugin.py::_GoldfiveADKPlugin` — installs
+  once per `InMemoryRunner`, propagates into AgentTool sub-Runners,
+  plumbs the plan reconciler's observation hooks and instruments
+  `goldfive.llm.request` / `goldfive.llm.response` per-LLM-call
+  logs (goldfive#172).
+
+### GoldfivePlanner: structural steering via plugin injection
+
+`GoldfivePlanner` subclasses ADK's `BasePlanner` directly (NOT
+`PlanReActPlanner` — see [RATIONALE.md](RATIONALE.md#why-goldfiveplanner-subclasses-baseplanner-not-planreactplanner)).
+It has two structural jobs on every LLM call:
+
+1. **Request side** — build a short tree-agnostic orchestration
+   block assembled from `session.state["goldfive.*"]` keys (plan
+   task, goals, active user steer) and inject it into the
+   `llm_request.config.system_instruction`. Because ADK gates native
+   request-side instruction injection on
+   `isinstance(planner, PlanReActPlanner)`, the `_GoldfiveADKPlugin`'s
+   `before_model_callback` takes over the injection whenever it
+   detects a `GoldfivePlanner` on the running agent.
+
+2. **Response side** — run the three-stage `function_call`
+   classifier (own-tool / cross-layer / confabulation) and strip
+   any parts whose id is in
+   `session.state["goldfive.cancelled_function_call_ids"]` (post-
+   STEER retry suppression). ADK's response-side
+   `_NlPlanningResponseProcessor` fires for any `BasePlanner`
+   subclass, so this side runs natively.
+
+`goldfive.wrap` auto-attaches a `GoldfivePlanner` instance to every
+LlmAgent reachable in the tree (#153/#156). Pre-existing user
+planners are preserved via `GoldfivePlanner(user_planner=...)`
+composition — the user planner's request-side output is **prepended**
+ahead of goldfive's block, and goldfive's response-side filters run
+first (cancelled-id strip + divergence signal) before the user
+planner sees the remaining parts.
+
+### Orchestration state namespace (goldfive.*)
+
+`Session.state` is a dict goldfive stamps under the `goldfive.*`
+prefix (see `goldfive/orchestration_state.py`). It is the framework-
+agnostic orchestration surface; the ADK-specific
+`_adk_state_protocol` bridges it onto the ADK runtime session.state
+so the `GoldfivePlanner` reading from `state["goldfive.current_task_id"]`
+sees what the reconciler just wrote.
+
+Key names:
+
+| Key | Owner | Lifecycle |
+|---|---|---|
+| `goldfive.current_plan_id` | Runner / `_apply_revision` | Set on plan install; persists across the run. |
+| `goldfive.current_task_id`, `goldfive.current_task_title` | `PlanReconciler` | Set on RUNNING; cleared on terminal transition + run end. |
+| `goldfive.goals_summary` | Runner post-derivation; `_apply_user_steer_state` | Refreshed whenever `session.goals` changes. |
+| `goldfive.active_steer.body`, `.at_turn`, `.author` | `DefaultSteerer._apply_user_steer_state` | Durable read-back of the most recent USER_STEER — NOT a cooldown. No-cooldown is a user directive (goldfive#152). |
+| `goldfive.processed_steer_ids` | `DefaultSteerer` | Bounded FIFO of processed STEER ids; drives idempotency (goldfive#171). |
+| `goldfive.cancelled_function_call_ids` | `ADKAdapter._heal_pending_tool_calls` | Append-only list of function_call ids healed mid-invocation. Consumed by `GoldfivePlanner.process_planning_response` to strip retry attempts. |
+
+**Writers only go through** `goldfive.orchestration_state.write(...)`
+which enforces the `goldfive.*` prefix.
+
+### Session unification (three-session alignment, goldfive#161)
+
+Three session ids used to float independently; post-#161 / #164 they
+are pinned together:
+
+```
+┌──────────────────────────┐    ┌──────────────────────────┐
+│ adk-web                  │    │ harmonograf              │
+│   InvocationContext      │    │   home session (client)  │
+│   .session.id = S        │    │   Hello: session_id=S    │
+└─────────┬────────────────┘    └─────────┬────────────────┘
+          │                               │
+          ▼                               ▼
+┌──────────────────────────────────────────────────────────┐
+│ goldfive                                                 │
+│   Session.id (= run_id) = S   ← pinned by Runner(        │
+│                                   session_id=ctx.session.id)│
+│                                                           │
+│   Every emitted Event carries Event.session_id = S       │
+│   (goldfive#155 field 5)                                 │
+│                                                           │
+│   ADK-side session (_adk_state_protocol) runs in the     │
+│   same runtime session; state.goldfive.* writes land on  │
+│   the live session the plugin sees.                      │
+└──────────────────────────────────────────────────────────┘
+```
+
+The `HarmonografSink` routes spans by `ctx.session.id` and goldfive
+events by `Event.session_id` (field 5). All three layers reference
+the same id, so "plan view / Gantt / event log" line up.
+
+See [RATIONALE.md §"Session unification"](RATIONALE.md#why-session-unification-over-multi-session-rollup)
+for the design reasoning.
+
 ## Single-Runner dispatch: goldfive drives the root, ADK delegates within
 
 The `AgentAdapter.invoke(task, session)` boundary is deliberately
@@ -449,10 +612,16 @@ Four invariants hold across every `Runner.run(...)` invocation:
   supplied `EventSink`, not through an async generator.
 
 **Live steering is in-box.** Human-in-the-loop mid-run steering
-(PAUSE, RESUME, CANCEL, STEER, REWIND_TO, APPROVE, REJECT) is
-implemented. Pass a `ControlChannel` to `Runner(control=...)` and
-an external process can drive the run through it. See
-[CONTROL.md](CONTROL.md) for the wire format and
+(PAUSE, RESUME, CANCEL, STEER, REWIND_TO, APPROVE, REJECT,
+STATUS_QUERY, INTERCEPT_TRANSFER, INJECT_MESSAGE) is implemented.
+Pass a `ControlChannel` to `Runner(control=...)` and an external
+process can drive the run through it. STEER is idempotent by
+`annotation_id` (goldfive#171). The intervention ladder
+(`DefaultSteerer`) classifies drift into one of six levels (OBSERVE /
+ABSORB / NUDGE / CANCEL_REINVOKE / PAUSE_ESCALATE / TERMINATE) so
+"when does goldfive interrupt the tree" is a single table. See
+[CONTROL.md](CONTROL.md) for the wire format, [DRIFT.md](DRIFT.md)
+for the ladder, and
 [`examples/live_steering.py`](../../examples/live_steering.py) for
 a runnable demo.
 

--- a/docs/design/CONTROL.md
+++ b/docs/design/CONTROL.md
@@ -69,6 +69,43 @@ that carries data has a dedicated message (`SteerPayload`,
 `payload: dict[str, Any]` for Python-side ergonomics; the converter is
 the boundary that maps `dict` → oneof branch and back.
 
+### 1.b `SteerPayload` fields (goldfive#171)
+
+`SteerPayload` (`proto/goldfive/v1/control.proto`) carries four
+strings:
+
+| Field | # | Meaning |
+|---|---|---|
+| `note` | 1 | The free-text steering instruction the operator authored. |
+| `suggested_action` | 2 | Optional short verb the UI may surface as a hint (e.g. "drop research phase"). |
+| `author` | 3 | Operator identity from the originating annotation. Empty when the bridge doesn't source annotations. Used for audit trails and prompt attribution (appears in the USER_STEER drift detail as `"by {author}: {note}"`). |
+| `annotation_id` | 4 | Source annotation id. Used for idempotency (see §1.c) and for stamping `DriftDetected.annotation_id` on the resulting USER_STEER drift so sinks can dedup against the annotation row. |
+
+Bridges that don't source annotations may leave `author` and
+`annotation_id` empty — the in-process dedupe falls back to
+`ControlEvent.id` / `ControlMessage.id`.
+
+### 1.c STEER idempotency contract (goldfive#171)
+
+Every STEER carries a dedupe id: `annotation_id` when the bridge
+populated one, otherwise the `ControlMessage.id`. `DefaultSteerer`
+records processed ids on
+`session.state["goldfive.processed_steer_ids"]` (a bounded FIFO) and
+drops retries before they reach `steerer._handle_drift`:
+
+- **Retries of the same STEER** (same annotation, repeated
+  `channel.send`) — dropped silently; the steerer does not cascade-
+  cancel or call `planner.refine` a second time.
+- **New STEER with a fresh id** — processed normally; emits
+  USER_STEER drift, cancels the in-flight invocation, runs refine.
+- **Bridge that doesn't source annotation_id** — falls back to the
+  `ControlMessage.id`; retries at the transport layer still dedupe
+  because the bridge re-uses the same message id.
+
+Dispatcher and ack still fire on every delivery (so the bridge sees
+an `AckResult.SUCCESS` back) — only the side-effects (drift + refine)
+are suppressed for duplicates.
+
 ## 2. The `ControlChannel` primitive
 
 One class, two queues, a dozen lines of interface. Lives at
@@ -500,6 +537,38 @@ acks iterator or on events captured by an `InMemorySink`. Patterns:
 `tests/test_live_steering_e2e.py`. A runnable demo covering PAUSE /
 STEER / CANCEL against an offline canned-LLM planner lives at
 `examples/live_steering.py`.
+
+## 7.d Intervention ladder (goldfive#142)
+
+A STEER control message is the user-initiated entry into a broader
+intervention story. Goldfive-internal drift detectors (loop, refusal,
+goal drift, ...) enter the same pipeline via synthesized drifts, and
+both paths route through `DefaultSteerer._handle_drift` which maps
+`(drift_kind, severity, occurrence_count)` to one of six levels:
+
+| Level | Name | What happens |
+|---|---|---|
+| **0** | `OBSERVE` | Emit `DriftDetected`; no further action. |
+| **1** | `ABSORB` | Call `planner.refine`; install revised plan; continue. This is where USER_STEER lands. |
+| **2** | `NUDGE` | Queue a corrective user message on `session.pending_nudges`. Not on the default table today; reserved for future policies. |
+| **3** | `CANCEL_REINVOKE` | Cancel the in-flight invocation; refine; compose a corrective user message for overlay re-invoke. |
+| **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; set `session.paused_for_human_intervention = True`; runner blocks for user input. |
+| **5** | `TERMINATE` | Run-level abort. Only reached on repeat Level-4 that didn't resolve. |
+
+The per-`(drift_kind, severity)` mapping lives in
+`DefaultSteerer._LADDER` (see `goldfive/steerer.py`). A subclass can
+override `_ladder_level_for` to tune the table.
+
+USER_STEER specifically maps to **Level 1 (ABSORB)** at WARNING (the
+default severity) — refine runs synchronously, the revised plan
+installs, and the overlay loop restarts with the steer body as the
+new user input (framed via `_compose_steer_restart_message`, see
+goldfive#152). USER_CANCEL is special-cased to short-circuit the
+ladder into an unconditional `RunAborted`.
+
+See [DRIFT.md §"Intervention ladder (Levels 0-5)"](DRIFT.md#intervention-ladder-levels-0-5)
+for the full per-drift-kind mapping and the corresponding code
+path in `goldfive/steerer.py`.
 
 ## 8. What ControlChannel is *not*
 

--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -102,8 +102,18 @@ kinds group naturally into six categories.
 
 | Kind | Trigger | Default severity | Recoverable |
 |---|---|---|---|
-| `USER_STEER` | Caller synthesized a `DriftEvent` to redirect the run. | `warning` | yes |
-| `USER_CANCEL` | Caller cancelled the run. | `critical` | no |
+| `USER_STEER` | Caller synthesized a `DriftEvent` to redirect the run. Carries `annotation_id` on the emitted `DriftDetected` event (#177) for sink-side dedupe with the source annotation. Idempotent by `annotation_id` (#171) — duplicate deliveries of the same STEER are dropped by `DefaultSteerer._is_duplicate_steer`. | `warning` | yes |
+| `USER_CANCEL` | Caller cancelled the run. `annotation_id` stamped on the emitted event. | `critical` | no |
+
+### Delegation & planning category — the tree routed work into a shape the plan doesn't endorse
+
+| Kind | Enum value | Trigger | Default severity | Detector location | Steerer response |
+|---|---|---|---|---|---|
+| `RUNAWAY_DELEGATION` | `35` | ADK coordinator delegated via `AgentTool` more than `ADKAdapter(agent_tool_cap=N)` allows (default 16). | `critical` | `_GoldfiveADKPlugin._emit_runaway_delegation_drift` | Level 3 → Level 4 (cancel + refine; escalate on repeat) |
+| `CONFABULATION_RISK` | `34` | Two sources: (a) `GoldfivePlanner.process_planning_response` sees a `function_call` whose name is neither in the running agent's own tools nor in the tree agent registry (pure hallucination, three-stage gate #178); (b) `goldfive.drift.classify_confabulation_risk` spots the cheap structural pattern "task title implies external data access but the agent produced output without calling any tool." | `warning` (three-stage gate) / `info` (structural) | `GoldfivePlanner` or `after_run_callback` | Level 1 → Level 3 on repeat |
+| `REFINE_VALIDATION_FAILED` | `36` | `LLMPlanner` exhausted its refine retry budget (attempts 1 & 2 both rejected by the structural validator). Terminal signal. | `critical` | `LLMPlanner._emit_refine_validation_failed` | Level 4 (PAUSE_ESCALATE — steerer deliberately does NOT re-refine) |
+| `HUMAN_INTERVENTION_REQUIRED` | `37` | Escalation target emitted by the intervention ladder when Level 4 fires (persistent refine failures, goal drift, repeated critical drift). | `critical` | `DefaultSteerer._dispatch_pause_escalate` | Level 4; repeat → Level 5 (TERMINATE) |
+| `GOAL_DRIFT` | `38` | Periodic trajectory-level LLM-judge: every N invocations, classify whether accumulated activity advances `session.goals`. Gated behind `Runner(goal_drift_enabled=...)` + a `goal_drift_call_llm` callable on the steerer. | `critical` | `goldfive.drift.goals.classify_goal_drift` | Level 4 both on first and repeat (refine cannot recover from trajectory-level drift) |
 
 ### Goal category — we will not be able to finish
 
@@ -129,13 +139,12 @@ parts). See `goldfive/drift/reasoning.py` for the detector pipeline.
 | `INTENT_DIVERGENCE` | Reasoning has drifted from `session.goals` + the current task topic. Severity is **graduated** — see table below. | `info` · `warning` · `critical` | depends on severity |
 
 Each observation produces at most one drift (the first match wins) in
-severity order: `INTENT_DIVERGENCE` → `LOOPING_REASONING` → `OFF_TOPIC`
-<<<<<<< HEAD
-→ `CONFUSION`. Detectors short-circuit so the pipeline cost stays
-bounded regardless of reasoning block size. `INTENT_DIVERGENCE` runs
-first even when it resolves to `info` severity, because the kind is
-stable — callers that only care about warning-and-up simply filter on
-the `severity` field.
+severity order: `INTENT_DIVERGENCE` → `LOOPING_REASONING` →
+`REASONING_CLUSTER_TIGHTENING` → `OFF_TOPIC` → `CONFUSION`. Detectors
+short-circuit so the pipeline cost stays bounded regardless of
+reasoning block size. `INTENT_DIVERGENCE` runs first even when it
+resolves to `info` severity, because the kind is stable — callers that
+only care about warning-and-up simply filter on the `severity` field.
 
 #### Graduated `INTENT_DIVERGENCE` severity
 
@@ -170,14 +179,12 @@ bands: callers filtering by kind see one stable signal; the
 `INTENT_DIVERGENCE_HEALTHY_SIMILARITY`,
 `INTENT_DIVERGENCE_MINOR_SIMILARITY`, and
 `INTENT_DIVERGENCE_WARNING_SIMILARITY`.
-=======
-→ `REASONING_CLUSTER_TIGHTENING` → `CONFUSION`. Detectors short-circuit
-so the pipeline cost stays bounded regardless of reasoning block size.
 
-**Graduated reasoning-similarity ladder.** `LOOPING_REASONING` and
-`REASONING_CLUSTER_TIGHTENING` together form a two-rung early-warning
-ladder on the same underlying signal (cosine similarity of the current
-reasoning block against recent history):
+#### Graduated reasoning-similarity ladder
+
+`LOOPING_REASONING` and `REASONING_CLUSTER_TIGHTENING` together form
+a two-rung early-warning ladder on the same underlying signal (cosine
+similarity of the current reasoning block against recent history):
 
 | Max cosine | Tier | Fires what |
 |---|---|---|
@@ -192,7 +199,6 @@ the planner is only woken up once the cliff fires. The INFO tier is
 skipped entirely when the current observation would also trip the
 cliff (i.e., `LOOPING_REASONING` runs first in the pipeline), so the
 two tiers never double-fire on the same observation.
->>>>>>> f6d3daf (Add REASONING_CLUSTER_TIGHTENING graduated drift signal)
 
 The reasoning channel is additive: adapters that cannot surface
 chain-of-thought (e.g. classic GPT-4o) simply never call
@@ -379,14 +385,15 @@ Four invariants govern the refine path:
 
 `GoldfivePlanner.process_planning_response` (see
 `goldfive/planners/goldfive_planner.py`) classifies every
-`function_call` part an LLM emits via a three-stage gate. The gate
-keys on the currently-running agent's own `tools` list (read from
+`function_call` part an LLM emits via a three-stage gate (PR #184 /
+goldfive#178). The gate keys on the currently-running agent's own
+`tools` list (read from
 `callback_context._invocation_context.agent.tools`) combined with the
 tree-wide agent registry plumbed in by `ADKAdapter`. The three stages
 cleanly separate "legitimate tool call", "cross-layer delegation
-attempt", and "hallucinated tool name" — which the single-stage
-registry check in #178 conflated into PLAN_DIVERGENCE and over-fired
-on.
+attempt", and "hallucinated tool name" — which the pre-#184
+single-stage registry check conflated into `PLAN_DIVERGENCE` and
+over-fired on for every legitimate non-registry tool.
 
 | Input shape | Drift kind | Detector location |
 |---|---|---|
@@ -394,43 +401,134 @@ on.
 | `function_call` name in tree agent registry but not in this agent's tools (cross-layer) | `PLAN_DIVERGENCE` | `GoldfivePlanner.process_planning_response` |
 | `function_call` name nowhere (not a tool, not a known agent) | `CONFABULATION_RISK` | `GoldfivePlanner.process_planning_response` |
 | tool returned an error payload or raised | `TOOL_ERROR` | `after_tool_callback` observer |
-| tool called in a tight loop | `LOOPING_TOOL_CALL` / `LOOPING_REASONING` | sequence-based detector in `goldfive/drift/reasoning.py` |
-| tool misaligned with the current task's intent | `INTENT_DIVERGENCE` / `GOAL_DRIFT` | goal classifier (`goldfive/drift/goals.py`, future extension) |
-
-The last row is intentionally not implemented in this classifier — a
-separate work item extends `goldfive/drift/goals.py` to cover it.
+| tool called in a tight loop | `LOOPING_REASONING` (modes exact/name/alternating) | `goldfive/drift/tool_loops.py::ToolLoopTracker` (PR #186) |
+| reasoning-content loop (chain-of-thought identical / similar across blocks) | `LOOPING_REASONING` | `goldfive/drift/reasoning.py` |
+| tool misaligned with the current task's intent | `INTENT_DIVERGENCE` / `GOAL_DRIFT` | goal classifier (`goldfive/drift/goals.py`) |
 
 `function_call` names prefixed with `report_` (the reporting-tool
-protocol namespace — `report_task_started`, `report_task_finished`,
+protocol namespace — `report_task_started`, `report_task_completed`,
 etc.) are always treated as legitimate regardless of tool-list
 contents: they're protocol calls goldfive injects and may not be
 reflected in every agent's `tools` list depending on when the
 augmentation ran.
 
-Cancelled function_call ids (from
+Cancelled `function_call` ids (from
 `session.state['goldfive.cancelled_function_call_ids']`, populated on
 USER_STEER / REPLAN cascade-cancel) are stripped BEFORE the three-
 stage classifier runs, so a cancelled part never produces a drift
 signal regardless of which stage its name would have fallen in.
 
 All three stages emit signals only — the call is never blocked. The
-steerer's intervention ladder (#142) decides whether to escalate.
+steerer's intervention ladder (§"Intervention ladder") decides
+whether to escalate.
+
+## Tool-call loop detection (`ToolLoopTracker`)
+
+Per-invocation tool-call loop detector in
+`goldfive/drift/tool_loops.py` (goldfive#181, landed in PR #186). The
+ADK plugin's `after_tool_callback` forwards every tool dispatch —
+reporting tools, AgentTool delegations, MCP tools, custom adapter-
+native tools — into a `ToolLoopTracker` keyed on `(invocation_id,
+agent_name)`. Three patterns fire a `LOOPING_REASONING` drift
+(severity depends on mode):
+
+| Mode | Trigger | Severity | `raw["mode"]` |
+|---|---|---|---|
+| **Exact loop** | Same `(tool_name, args_hash)` ≥ `exact_threshold=3` times in the last `window=7` calls. | `warning` | `"exact"` |
+| **Name loop** | Same `tool_name` (any args) ≥ `name_threshold=5` times in the window AND no task progress recorded since the window started filling. | `warning` | `"name"` |
+| **Alternating cycle** | A,B,A,B,A pattern over the last `alternating_threshold=5` calls. Suppressed when exact or name mode already fired on the same pair. | `info` | `"alternating"` |
+
+Thresholds tunable via `GOLDFIVE_TOOL_LOOP_WINDOW` /
+`GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD` /
+`GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD` /
+`GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD` env vars;
+`load_thresholds_from_env()` reads them.
+
+**Task-progress gate.** Mode 2 requires "no task progress in window";
+`ToolLoopTracker.on_task_progress(invocation_id, agent_name)` clears
+the per-agent buffer whenever a task transitions to a progress state.
+A legitimate repeating tool that *completes* its task (e.g.
+`read_file read_file read_file → report_task_completed`) is not
+flagged because the next observation starts from an empty window.
+
+**Isolation.** Each `(invocation_id, agent_name)` gets its own ring
+buffer, so parallel AgentTool sub-invocations within one outer
+invocation do not cross-contaminate. State is ephemeral to a run —
+`clear()` is called from the plugin's `clear_active_context`.
+
+This is complementary to the reporting-tool-scoped
+`ToolLoopGuard` (`goldfive/adapters/_tool_loop_guard.py`, TASK-
+LIFECYCLE §5) which only covers calls routed through
+`invoke_tool`. The `ToolLoopTracker` sees every tool call the ADK
+plugin observes.
+
+## Intervention ladder (Levels 0-5)
+
+Drift handling routes through an explicit six-level ladder
+(goldfive#142) so "when does goldfive interrupt the tree" is a single
+table, not a tangle of conditionals. The live mapping from
+`(drift_kind, severity, occurrence_count)` to level is
+`DefaultSteerer._LADDER` plus the fallback in
+`DefaultSteerer._ladder_level_for`. See `goldfive/steerer.py` for
+the authoritative table.
+
+| Level | Name | Action | Typical triggers |
+|---|---|---|---|
+| **0** | `OBSERVE` | Emit `DriftDetected`; no further action. | Every `INFO` drift. |
+| **1** | `ABSORB` | Call `planner.refine`; install the revised plan; continue. | `WARNING` drifts with a known kind (`LOOPING_REASONING`, `LOOPING_TOOL_CALL`, `PLAN_DIVERGENCE`, `TOOL_ERROR`, `AGENT_REFUSAL`, `INTENT_DIVERGENCE`, etc.); CRITICAL first-occurrence of most kinds. |
+| **2** | `NUDGE` | Queue a short corrective user message on `session.pending_nudges` for the Runner's overlay loop to pick up at the next invocation boundary. (Not used by default — table entries prefer Level 1 or Level 3. Reserved for future policies.) | Caller overrides. |
+| **3** | `CANCEL_REINVOKE` | Cancel in-flight invocation; refine; compose a corrective user message via `compose_corrective_user_message` for the overlay loop to re-invoke with. | CRITICAL first-occurrence for most refinable kinds (`LOOPING_REASONING`, `PLAN_DIVERGENCE`, `TOOL_ERROR`, `RUNAWAY_DELEGATION`, ...). |
+| **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; set `session.paused_for_human_intervention = True`; do NOT call `planner.refine`. Runner blocks until a user `RESUME` / `STEER` arrives. | `GOAL_DRIFT` (first & repeat); `REFINE_VALIDATION_FAILED`; `HUMAN_INTERVENTION_REQUIRED`; `INTENT_DIVERGENCE` at CRITICAL; CRITICAL-repeat of almost every kind. |
+| **5** | `TERMINATE` | Run-level abort. Currently only reachable when a Level-4-initiated pause times out and `HUMAN_INTERVENTION_REQUIRED` re-fires as a repeat CRITICAL. | Repeat `HUMAN_INTERVENTION_REQUIRED`. |
+
+**Repeat detection.** Occurrence count per `(drift.kind, task_id)` is
+tracked on the session; a drift crosses "repeat" once
+`occurrence_count >= DefaultSteerer.REFINE_FAILURE_THRESHOLD`
+(default `2`). Most CRITICAL entries have a `(first, repeat)` level
+pair so the first critical fire refines, the second escalates.
+
+**Severity-to-level quick map (fallback).** Drifts with no explicit
+table entry fall through to:
+
+- `INFO` → `OBSERVE`
+- `WARNING` → `ABSORB`
+- `CRITICAL` first → `ABSORB`; repeat → `PAUSE_ESCALATE`
+
+Subclasses of `DefaultSteerer` override `_ladder_level_for` to tune
+the table without re-implementing `_handle_drift`.
+
+See goldfive#179 (umbrella) for future detection work — additional
+detectors will register new rows on `_LADDER` rather than editing the
+handler.
 
 ## How drifts become events
 
 Every `DriftEvent` produces exactly one `DriftDetected` event in the
-proto stream. The event envelope carries:
+proto stream. The event envelope (`goldfive.v1.DriftDetected`)
+carries:
 
-- `kind` — the `DriftKind` string value.
-- `severity` — the `DriftSeverity` string value.
-- `detail` — human-readable note.
-- `current_task_id`, `current_agent_id` — from the session at
-  emission time.
-- `recoverable` — derived from severity and kind.
-- `raw_summary` — a short stringification of `raw` (the full
-  untouched trigger is not serialized into the proto to avoid
-  bloating the wire; sinks that need the raw trigger should snapshot
-  it in-process).
+- `kind` (field 1) — the `DriftKind` enum value.
+- `severity` (field 2) — the `DriftSeverity` enum value.
+- `detail` (field 3) — human-readable note.
+- `current_task_id` (field 4), `current_agent_id` (field 5) — from
+  the session at emission time.
+- `annotation_id` (field 6, goldfive#177) — for `USER_STEER` /
+  `USER_CANCEL` drifts that rode in on a `ControlMessage` with a
+  bridge-supplied annotation id. Empty for drifts goldfive minted
+  itself (loop detection, `GOAL_DRIFT`, `CONFABULATION_RISK`, etc.).
+  Sinks use this to dedup the drift row against the source annotation
+  — without it a single user STEER surfaces as three cards
+  (annotation row, `user_steer` drift row, `plan_revised` row) in
+  harmonograf's Intervention view.
+
+Per-event `session_id` (#155) is stamped on the outer `Event`
+envelope, not inside the drift payload — see
+[EVENT-MODEL.md §"Event envelope"](EVENT-MODEL.md#event-envelope).
+
+Note: `recoverable` and `raw_summary` are in-memory fields on the
+Python `DriftEvent` dataclass; they are NOT serialized onto the
+proto event. The full untouched trigger (`raw`) is not emitted; sinks
+that need it should snapshot in-process.
 
 If refine runs and succeeds, the next event in the stream is
 `PlanRevised`, whose `revision_kind` / `revision_severity` / `revision_index`

--- a/docs/design/EVENT-MODEL.md
+++ b/docs/design/EVENT-MODEL.md
@@ -23,17 +23,30 @@ and the [writing-an-event-sink guide](../guides/writing-an-event-sink.md).
 
 Every event, regardless of kind, carries a common envelope:
 
-| Field | Type | Meaning |
-|---|---|---|
-| `event_id` | `string` | UUIDv7, unique per event. |
-| `run_id` | `string` | The owning `Session.run_id`. |
-| `emitted_at` | `google.protobuf.Timestamp` | Wall-clock time of emission. |
-| `sequence` | `uint64` | Monotonic per-run counter from `Session.next_sequence()`. |
-| `payload` | `oneof` | The event-specific body; see the taxonomy. |
+| Field | # | Type | Meaning |
+|---|---|---|---|
+| `event_id` | 1 | `string` | UUIDv7, unique per event. |
+| `run_id` | 2 | `string` | The owning `Session.run_id`. |
+| `sequence` | 3 | `uint64` | Monotonic per-run counter from `Session.next_sequence()`. |
+| `emitted_at` | 4 | `google.protobuf.Timestamp` | Wall-clock time of emission. |
+| `session_id` | 5 | `string` | The `Session.id` this event belongs to. Stable across all events one turn produces. Empty string means "route via the stream's Hello session" (pre-#155 behaviour); populated by Runner / Steerer / Executor emitters so a harmonograf stream can multiplex multiple goldfive sessions onto one client connection. Added in goldfive#155 (PR #157). |
+| `payload` | 10+ | `oneof` | The event-specific body; see the taxonomy. |
 
 The envelope is defined in `proto/goldfive/v1/events.proto` (see
 [issue #3](https://github.com/pedapudi/goldfive/issues/3)). Generated
 Python lives under `goldfive/pb/goldfive/v1/events_pb2.py`.
+
+### `session_id` vs `run_id`
+
+These are the same value today under the three-session-unification
+work (goldfive#161 / #164) — `Runner(session_id=...)` pins
+`Session.run_id = session_id`, so every `Event.run_id == Event.session_id`
+for runs that flow through an outer session (adk-web, harmonograf
+client, kikuchi). The distinction matters at the proto layer because
+`run_id` is the logical "run lineage" (surviving conversation turns
+if we ever decouple them) while `session_id` is the routing key
+downstream sinks multiplex on. Both fields are always populated for
+goldfive-emitted events post-#155.
 
 Helpers in `goldfive/events.py` produce envelopes:
 
@@ -91,9 +104,21 @@ string, and an optional `artifacts` map for `TaskCompleted`.
 
 | Event | Fired by | When |
 |---|---|---|
-| `DriftDetected` | `Steerer` | Whenever `detect_drift()` returns a non-None `DriftEvent`. Always fired before the corresponding `PlanRevised` (if refine runs). Carries `kind`, `severity`, `detail`, `current_task_id`, and a summarized `raw` trigger. |
+| `DriftDetected` | `Steerer` | Whenever a drift is produced (via `detect_drift`, `observe`, `_handle_drift` from a reporting-tool handler, or synthesized by a plugin). Always fired before the corresponding `PlanRevised` (if refine runs). |
 
-See [DRIFT.md](DRIFT.md) for the full drift-kind taxonomy.
+**`DriftDetected` fields** (`goldfive.v1.DriftDetected`):
+
+| Field | # | Meaning |
+|---|---|---|
+| `kind` | 1 | `DriftKind` enum. |
+| `severity` | 2 | `DriftSeverity` enum. |
+| `detail` | 3 | Human-readable note. For USER_STEER this is prefixed `"by {author}: {note}"` when the bridge forwarded an author. |
+| `current_task_id` | 4 | Task id current at emission. |
+| `current_agent_id` | 5 | Agent id current at emission. |
+| `annotation_id` | 6 | Source annotation id for user-control drifts (USER_STEER / USER_CANCEL) when the bridge forwarded one. Empty for goldfive-minted drifts. Added in goldfive#177. Sinks use this to dedup the drift row against the source annotation — without it a single user STEER surfaces as three cards (annotation row, `user_steer` drift row, `plan_revised` row) in harmonograf's Intervention view. |
+
+See [DRIFT.md](DRIFT.md) for the full drift-kind taxonomy and the
+intervention ladder mapping.
 
 ### Agent-invocation events
 
@@ -191,6 +216,77 @@ given a task assigned to the coordinator:
 Emission is best-effort: a failure in the plugin's observability
 path is swallowed and logged at DEBUG — the run never blocks on
 observability.
+
+### Per-LLM-call instrumentation logs (goldfive#172)
+
+In addition to proto events, the `_GoldfiveADKPlugin` emits two
+`logging.INFO`-level log lines per LLM invocation (one before, one
+after) so operators running a live run can tail stderr and correlate
+context growth / cost against a specific task + invocation.
+
+**`goldfive.llm.request`** — emitted from `before_model_callback`
+after `GoldfivePlanner.build_planning_instruction` has appended its
+block, so the reported chars reflect what the model actually sees:
+
+```
+goldfive.llm.request invocation_id=<inv_id>
+  llm.request.chars=<int>
+  llm.request.messages_count=<int>
+  task_id=<str or ?>
+  agent=<str or ?>
+```
+
+**`goldfive.llm.response`** — emitted from `after_model_callback`
+paired with the matching request by `invocation_id`:
+
+```
+goldfive.llm.response invocation_id=<inv_id>
+  llm.call.duration_ms=<int>
+  llm.request.chars=<int>
+  llm.request.messages_count=<int>
+  llm.usage.prompt_tokens=<int or ?>
+  llm.usage.completion_tokens=<int or ?>
+  llm.usage.total_tokens=<int or ?>
+  task_id=<str or ?>
+  agent=<str or ?>
+```
+
+Usage extraction is best-effort via `_extract_usage_metadata` off the
+`LlmResponse`; models that don't surface usage leave those fields as
+`?`. Duration is wall-clock (time.monotonic) between the two
+callbacks.
+
+The same metrics (plus any extras) are also stashed onto the
+`observation.raw["metrics"]` passed to `steerer.observe` so custom
+steerer sinks can surface the numbers alongside the LLM response
+event without parsing logs.
+
+### `SteerPayload` fields (proto `goldfive.v1.SteerPayload`)
+
+STEER control messages carry a typed payload:
+
+| Field | # | Meaning |
+|---|---|---|
+| `note` | 1 | Free-text steering instruction. |
+| `suggested_action` | 2 | Optional short verb for the UI to surface as a hint. |
+| `author` | 3 | Operator identity from the originating annotation (goldfive#171). Empty when the bridge doesn't source annotations. |
+| `annotation_id` | 4 | Source annotation id. Used for idempotency — see [CONTROL.md §1.c](CONTROL.md#1c-steer-idempotency-contract-goldfive171). |
+
+### HarmonografSink routing contract
+
+`HarmonografSink` (the canonical external sink, implemented in
+harmonograf) routes per-event using two keys:
+
+1. **Spans** (otel-style traces from adapter / plugin code) are
+   routed by `ctx.session.id` — the live ADK / runtime session they
+   were emitted against.
+2. **Goldfive events** are routed by `Event.session_id` (field 5).
+
+Post-#161 / #164 / #155 the two keys align: `Runner(session_id=ctx.session.id)`
+pins `Session.id` onto the outer session id, and every
+goldfive-emitted Event stamps that id on field 5. The sink therefore
+renders "plan view / Gantt / event log" in one consistent session
+on the UI side. See [ARCHITECTURE.md §"Session unification"](ARCHITECTURE.md#session-unification-three-session-alignment-goldfive161).
 
 ## Sequence semantics
 

--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -191,6 +191,47 @@ Different drifts demand different rewrites of the DAG. The current
 planner implements three modes, each with its own preservation
 contract layered on top of the §3 invariants.
 
+### 4.0 Refine inputs and goal-awareness
+
+`Planner.refine(*, plan, drift, goals, observed_actions=None, available_agents=None) -> Plan | None`
+is the contract. Beyond `drift` + `plan` the refine receives:
+
+- **`goals`** (`list[Goal]`) — the run's active goals. Goal-aware
+  refine (goldfive#154) surfaces them in the LLM prompt AND enforces
+  a "every sticky USER_STEER goal must have at least one advancing
+  task" validator check. A USER_STEER synthesizes a new `Goal` via
+  `planner.synthesize_goal_from_steer(body)` which returns
+  `(Goal, mode)` where mode is `"append"` or `"replace"` (see
+  `goldfive/steerer.py::DefaultSteerer._apply_user_steer_state`).
+  Sticky goals are marked via `Goal.metadata["source"] == "user_steer"`
+  and cannot be silently dropped by subsequent refines.
+- **`observed_actions`** (`list[ObservedAction] | None`, goldfive#144)
+  — only consulted on `drift.kind is DriftKind.PLAN_DIVERGENCE`. The
+  reconciler (`PlanReconciler`) builds the list from observed tool
+  calls / agent transitions so the planner can either ABSORB the
+  observed activity into a revised plan or REJECT by emitting
+  `{"reject": true, "reason": "..."}`. A reject collapses to
+  `None` — the steerer then escalates via the intervention ladder.
+- **`available_agents`** — either a flat `list[str]` (legacy) or a
+  structured tree (`list[dict]` with `{name, depth, parent, role,
+  kind}` per entry, goldfive#151). On the tree form the planner
+  renders an "AGENT TREE" section in its prompt and the validator
+  rejects off-registry assignees.
+
+The drift's `kind` + `severity` plus the `DriftEvent.detail` string
+is how refine derives its "reason". Conventional reasons:
+
+| Reason origin | Typical `drift.kind` |
+|---|---|
+| `USER_STEER` | `ControlKind.STEER` → `DriftKind.USER_STEER` |
+| `PLAN_DIVERGENCE` | Three-stage gate cross-layer delegation, reconciler off-plan agent, or `report_plan_divergence` |
+| `DRIFT_ESCALATION` (umbrella term; no literal enum) | Any other drift that reached Level 1 (ABSORB) or Level 3 (CANCEL_REINVOKE) — `TOOL_ERROR`, `LOOPING_REASONING`, `LOOPING_TOOL_CALL`, `AGENT_REFUSAL`, `INTENT_DIVERGENCE`, `RUNAWAY_DELEGATION`, etc. Generic refine path. |
+
+`REFINE_VALIDATION_FAILED` is **not** a refine input — it's the
+terminal output when the planner's own retry budget is exhausted.
+The steerer deliberately does NOT feed it back into another refine
+(infinite-loop risk); it routes to Level 4 (PAUSE_ESCALATE).
+
 ### 4.1 Inline-edit (default)
 
 **Triggers:** `TOOL_ERROR`, `AGENT_REFUSAL`, `PLAN_DIVERGENCE`,
@@ -314,18 +355,57 @@ Called by `LLMPlanner.generate` (creation) and
   `PENDING`. At revision (`for_revision=True`), terminal tasks are
   allowed (expected, per §3.1).
 - **At revision with a `prior` plan supplied**
-  (`for_revision=True, prior=old_plan`): every terminal task in
-  `prior` appears in the revision with the same id and the same
-  terminal status (no regression, no drop) — §3.1 — and every
-  terminal→terminal edge in `prior` appears in the revision — §3.2.
-  The steerer calls `validate(for_revision=True, prior=session.plan)`
-  in `_apply_revision`, and `LLMPlanner.refine` / `_refine_user_steer`
-  / `_refine_looping_tool_call` likewise thread `prior=plan` so the
-  planner catches its own violations before the steerer does.
+  (`for_revision=True, prior=old_plan`):
+    - Every terminal task in `prior` appears in the revision with
+      the same id and the same terminal status (no regression, no
+      drop) — §3.1.
+    - Every terminal→terminal edge in `prior` appears in the
+      revision — §3.2.
+    - **Re-animation rejected (goldfive#138):** a task that was
+      terminal (`COMPLETED` / `FAILED` / `CANCELLED` / `NOT_NEEDED`)
+      in the prior plan cannot be re-emitted as `PENDING` in the
+      revision. This prevents the planner from "retrying" a
+      terminal task by resetting its status — the planner must
+      emit a NEW task id (optionally with a `retry_` prefix) if it
+      wants a fresh attempt.
+- **Off-registry assignees rejected (goldfive#151):** when
+  `available_agents` is supplied as a tree, every task's
+  `assignee_agent_id` must be a reachable name in the registry.
+  An unknown assignee is rejected and fed back to the LLM as a
+  validator-correction message for the retry loop.
+- **Sticky USER_STEER goal coverage (goldfive#154):** when any
+  goal on the session carries
+  `Goal.metadata["source"] == "user_steer"`, the revision must
+  include at least one PENDING task advancing it. Planner-side
+  escape: emit `{"reject": true, "reason": "..."}` instead of
+  silently dropping the goal.
+
+`LLMPlanner.refine` / `_refine_user_steer` / `_refine_looping_tool_call`
+thread `prior=plan` so the planner catches its own violations before
+the steerer does. The retry loop feeds the validator's error message
+back to the LLM on attempt N+1 (up to `max_refine_attempts`, default
+2). If both attempts fail the planner emits a CRITICAL
+`REFINE_VALIDATION_FAILED` drift and returns `None` — see §4.0.
 
 On failure: `ValueError` with a descriptive message. `generate`
 returns `None`; `_apply_revision` rejects the revision and emits
 `SCHEMA_VIOLATION`.
+
+### 5.1 Revision metadata
+
+Every revision carries, besides the plan structure itself:
+
+| Field | Source | Meaning |
+|---|---|---|
+| `revision_index` | Monotonic from `prior.revision_index + 1` | Ordering key across revisions; stamped by `_apply_revision` if the planner didn't. |
+| `revision_kind` | `drift.kind` | Which drift triggered the refine. |
+| `revision_severity` | `drift.severity` | Drift severity at the time. |
+| `revision_reason` | `drift.detail` | Human-readable reason. |
+
+All four are surfaced on the `PlanRevised` event so sinks can render
+revision timelines without walking back through the drift stream.
+The accompanying `PlanRevisionDiff` sidecar (§2.1) tells the sink
+what specifically changed.
 
 ---
 

--- a/docs/design/PROTOCOLS.md
+++ b/docs/design/PROTOCOLS.md
@@ -98,7 +98,9 @@ class Planner(Protocol):
         self,
         *,
         goals: list[Goal],
-        available_agents: list[str],
+        # Either a flat list[str] (legacy) or a structured tree of
+        # {name, depth, parent, role, kind} dicts (goldfive#151).
+        available_agents: list[str] | list[dict[str, Any]] | None,
         context: Optional[Mapping[str, Any]] = None,
     ) -> Optional[Plan]: ...
 
@@ -108,6 +110,11 @@ class Planner(Protocol):
         plan: Plan,
         drift: DriftEvent,
         goals: list[Goal],
+        # PLAN_DIVERGENCE path — reconciler-observed actions to
+        # reconcile into the revised plan (goldfive#144).
+        observed_actions: list[ObservedAction] | None = None,
+        # Tree-aware assignee validation (goldfive#151).
+        available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> Optional[Plan]: ...
 ```
 
@@ -631,6 +638,64 @@ class NullSink:
     async def close(self):
         return
 ```
+
+## Proto changes (summary)
+
+Recent additions to the `goldfive.v1` proto set. Fields are
+non-breaking additions (proto3 defaults apply).
+
+### `Event.session_id` (goldfive#155, PR #157)
+
+`Event.session_id` (field 5) — stable id for the goldfive
+`Session` that emitted the event. Populated by every Runner /
+Executor / Steerer emission site. Empty string means "route via
+the stream's Hello session" for back-compat. See
+[EVENT-MODEL.md §"Event envelope"](EVENT-MODEL.md#event-envelope).
+
+### `DriftDetected.annotation_id` (goldfive#177)
+
+`DriftDetected.annotation_id` (field 6) — source annotation id for
+`USER_STEER` / `USER_CANCEL` drifts that rode in on a
+`ControlMessage` with a bridge-populated annotation id. Empty for
+drifts goldfive minted itself. Sinks use it to dedup the drift row
+against the annotation-source row. See
+[DRIFT.md §"How drifts become events"](DRIFT.md#how-drifts-become-events).
+
+### `SteerPayload.author`, `.annotation_id` (goldfive#171)
+
+`SteerPayload.author` (field 3) — operator identity from the
+originating annotation. `SteerPayload.annotation_id` (field 4) —
+source annotation id used for idempotency. Both empty when the
+bridge doesn't source annotations. See
+[CONTROL.md §1.b](CONTROL.md#1b-steerpayload-fields-goldfive171).
+
+### Control messages
+
+The full `ControlKind` set is unchanged:
+`PAUSE`, `RESUME`, `CANCEL`, `REWIND_TO`, `STEER`, `APPROVE`,
+`REJECT`, `STATUS_QUERY`, `INTERCEPT_TRANSFER`, `INJECT_MESSAGE`.
+Per-kind typed payloads live in `control.proto` as `SteerPayload`,
+`RewindPayload`, `ApprovePayload`, `RejectPayload`,
+`InjectMessagePayload`. See [CONTROL.md](CONTROL.md).
+
+### `TaskStatus.NOT_NEEDED` (goldfive#141)
+
+`TaskStatus.TASK_STATUS_NOT_NEEDED` (enum value 7) — terminal
+status the PlanReconciler stamps on PENDING tasks the tree never
+exercised. Distinct from `CANCELLED`. See
+[STATE-MACHINE.md](STATE-MACHINE.md).
+
+### New `DriftKind` values
+
+| Value | # | Added in |
+|---|---|---|
+| `CONFABULATION_RISK` | 34 | goldfive#128 (hallucination classifier) + #178 (three-stage gate) |
+| `RUNAWAY_DELEGATION` | 35 | goldfive#130 (AgentTool cap) |
+| `REFINE_VALIDATION_FAILED` | 36 | goldfive#133 |
+| `HUMAN_INTERVENTION_REQUIRED` | 37 | goldfive#142 (intervention ladder Level 4) |
+| `GOAL_DRIFT` | 38 | goldfive#143 (trajectory-level goal judge) |
+
+See [DRIFT.md](DRIFT.md) for per-kind semantics.
 
 ## Composition example
 

--- a/docs/design/RATIONALE.md
+++ b/docs/design/RATIONALE.md
@@ -354,10 +354,6 @@ consolidating back to proto-only.
 **Related.** [EVENT-MODEL.md](EVENT-MODEL.md),
 [.agents/debug-goldfive.md §"Common pitfalls"](../../.agents/debug-goldfive.md#common-pitfalls).
 
-<!-- TODO: once docs/design/CONTROL.md lands, cross-link from the
-ControlChannel, STEER "delete-and-replan", and "Phase 1 mid-task cancel"
-entries below. -->
-
 ## Why `ControlChannel` is a primitive rather than methods on Runner
 
 **Observation.** `Runner.pause()` / `Runner.cancel()` / `Runner.steer()`
@@ -950,6 +946,314 @@ enough.
 
 **Related.** `goldfive/steerer.py::DefaultSteerer._handle_drift`,
 [STATE-MACHINE.md](STATE-MACHINE.md).
+
+## Why the overlay model over per-task driving
+
+**Observation.** The default `SequentialExecutor(overlay_mode=True)`
+— reached through `goldfive.wrap` — calls
+`adapter.invoke_passthrough(user_input)` exactly ONCE per run / turn
+and observes the tree's natural flow via a `PlanReconciler`. Per-
+task driving (`adapter.invoke(task, session)` in a loop) still lives
+behind `overlay_mode=False` for back-compat but is no longer the
+default code path.
+
+**Intent.** ADK coordinators whose prompts describe a pipeline
+(goldfive#130's coordinator-flow-looping regression) fan out one
+AgentTool call per task goldfive drove. Each per-task drive then
+re-entered the coordinator's instruction text, which re-routed the
+pipeline, which re-invoked the specialists. A ~10 min run amplified
+into 40+ min of redundant work. The overlay model breaks the
+feedback loop:
+
+- **ONE invocation.** The tree runs its natural flow once; the
+  reconciler maps observed agent transitions onto plan tasks
+  post-hoc.
+- **Drift catches divergence.** The three-stage gate
+  (`GoldfivePlanner.process_planning_response`), the tool-loop
+  tracker (`ToolLoopTracker`), and the reasoning detectors classify
+  observed behaviour into drift kinds. The intervention ladder
+  escalates via refine (Level 1) or cancel-reinvoke (Level 3) when
+  divergence is non-trivial.
+- **PENDING → NOT_NEEDED.** Tasks the tree didn't exercise at
+  invocation end are marked `NOT_NEEDED` (goldfive#163). No soft
+  follow-up was tried (goldfive#141 pre-#163 did; it re-amplified
+  the regression). STEER is the user-driven path for exercising
+  uncovered work.
+
+**Alternatives considered.**
+
+1. **Keep per-task driving + cap coordinators.** Rejected: the cap
+   catches symptoms, not the root cause. Tree shape is user-owned
+   (goldfive.wrap contract — don't blame the coordinator), so the
+   fix has to respect coordinator prompts as written.
+2. **Registry-dispatch (PR #120).** Walk the tree, build one runner
+   per agent, route directly to the leaf. Broke the "one tree, one
+   Runner" invariant harmonograf / adk-web / span-rollup all relied
+   on. Reverted via PR #130. See §"Why single-Runner, not
+   registry-dispatch".
+3. **Keep a soft follow-up loop (pre-#163 overlay).** Re-dispatch
+   each missed task as a new user message. Flow-prompted
+   coordinators re-ran their full pipeline per follow-up,
+   amplifying the very regression the overlay was supposed to fix.
+
+**Tradeoffs.**
+
+- Refine semantics shift: `PlanReconciler` is now the primary
+  driver of `PENDING → RUNNING` under the default path; the
+  executor no longer picks tasks.
+- Missed-task handling is by terminal `NOT_NEEDED` rather than
+  iterative re-dispatch. A user who wants uncovered tasks
+  exercised must STEER.
+- The three-stage gate has to distinguish "legitimate tool call on
+  this agent" from "cross-layer delegation" from "hallucination,"
+  which is more code than the pre-#184 single-stage PLAN_DIVERGENCE
+  check. The payoff is no false-PLAN_DIVERGENCE firing on every
+  legitimate tool call (the regression that PR #184 closed).
+
+**Signals this might be wrong.** If a large class of users wants
+goldfive to drive per-task for structural reasons (stepwise human
+approval, per-task logging boundaries, etc.), the default could
+flip back — but the overlay mode already supports STEER-per-task
+manually, and the NOT_NEEDED signal is richer than
+per-task-dispatch visibility would be.
+
+**Related.** [ARCHITECTURE.md §"Overlay execution model"](ARCHITECTURE.md#overlay-execution-model),
+`goldfive/executors/sequential.py::SequentialExecutor._run_overlay`,
+`goldfive/reconciler.py::PlanReconciler`.
+
+## Why `GoldfivePlanner` subclasses `BasePlanner`, not `PlanReActPlanner`
+
+**Observation.** `goldfive/planners/goldfive_planner.py` imports
+`google.adk.planners.base_planner.BasePlanner` and subclasses it
+directly. It does NOT subclass the concrete
+`google.adk.planners.plan_re_act_planner.PlanReActPlanner`. The
+`_GoldfiveADKPlugin.before_model_callback` contains a bespoke
+workaround that detects a `GoldfivePlanner` on the running agent
+and manually appends `build_planning_instruction`'s output to the
+LLM request's system instruction.
+
+**Intent.** ADK's `flows/llm_flows/_nl_planning.py` gates
+request-side instruction injection on
+`isinstance(planner, PlanReActPlanner)`. If we subclassed
+`PlanReActPlanner` we would:
+
+- get the request-side injection for free (the gate matches),
+- BUT inherit the ReAct response filter that constrains agent
+  output to the `<think>...</think>` / `<tool>...</tool>` tag
+  shape, which we explicitly don't want to impose on callers'
+  trees. Many ADK agents aren't ReAct-shaped; forcing the ReAct
+  output contract would break them.
+
+Subclassing `BasePlanner` directly gives us:
+
+- The response-side gate (`_NlPlanningResponseProcessor`) fires for
+  any `BasePlanner` subclass other than `BuiltInPlanner`, so
+  `process_planning_response` runs natively without a workaround.
+- The request-side gate is bypassed, so we handle it in the plugin:
+  `_GoldfiveADKPlugin.before_model_callback` detects
+  `isinstance(agent.planner, GoldfivePlanner)` and appends via
+  `append_instructions`.
+
+**Alternatives considered.**
+
+1. **Subclass `PlanReActPlanner`.** Rejected: imposes ReAct
+   output on callers' agents.
+2. **File a patch against ADK to generalize the gate.** Future
+   work; the plugin workaround is the pragmatic fix in the
+   meantime.
+3. **Use a custom `before_model_callback` PER agent instead of
+   auto-attaching a planner.** Rejected: planners are the ADK-
+   native surface for "structural reasoning extensions," and
+   composing with user-attached planners (per the
+   `GoldfivePlanner(user_planner=...)` compose contract) falls out
+   of the planner subclass naturally.
+
+**Tradeoffs.** The plugin workaround is a small amount of extra
+code tied to a specific ADK version. If ADK's gate changes shape,
+the plugin may need a follow-up.
+
+**Signals this might be wrong.** If ADK generalises the
+`_nl_planning` gate to accept any `BasePlanner` subclass, we can
+drop the plugin workaround. If callers want full ReAct shape, they
+should compose their own ReAct planner UNDER the
+`GoldfivePlanner(user_planner=...)` layer rather than swapping the
+base.
+
+**Related.** `goldfive/planners/goldfive_planner.py` module docstring
+("Request-side injection requires a plugin workaround"),
+`goldfive/adapters/_adk_plugin.py::_inject_goldfive_planner_instruction`.
+
+## Why there's no STEER cooldown
+
+**Observation.** `DefaultSteerer._apply_user_steer_state` stamps
+`session.state["goldfive.active_steer.body"]` and `.at_turn` on every
+USER_STEER — but there is no "reject subsequent steers for N seconds"
+cooldown window. Every STEER that arrives (and passes the
+`annotation_id` dedupe, goldfive#171) runs a full drift → refine →
+cancel-reinvoke cycle.
+
+**Intent.** User directive (goldfive#154): steering must always be
+responsive. An operator who clicks Steer twice in a row because the
+first steer wasn't precise enough expects both to land. A cooldown
+would silently drop the second click and erode trust.
+
+Idempotency is handled differently — by `annotation_id` or
+`ControlMessage.id` dedupe in
+`DefaultSteerer._is_duplicate_steer`. That's "same steer delivered
+twice by the transport," not "two distinct steers within N seconds."
+
+**Alternatives considered.**
+
+1. **Time-based cooldown (1s / 5s).** Rejected per the user
+   directive above.
+2. **Queue steers; process one at a time.** The underlying
+   `_handle_drift` is async and sequential per session, so two
+   STEERs arriving back-to-back are serialized naturally. No extra
+   queue is needed.
+
+**Tradeoffs.** A misbehaving external bridge that fires distinct
+message ids for the "same" user action (broken idempotency on the
+bridge side) can cause duplicate refines. The dedupe on
+`annotation_id` was added to prevent this when the bridge sources
+annotations; bridges that don't source annotations should ensure
+they dedupe by `ControlMessage.id` at their layer.
+
+**Signals this might be wrong.** If operators report "double
+refines" after a single click, check the bridge's annotation-
+sourcing; if cooldowns are actually requested, expose them as an
+opt-in rather than changing the default.
+
+**Related.** `goldfive/steerer.py::_is_duplicate_steer`,
+`goldfive/orchestration_state.py::KEY_PROCESSED_STEER_IDS`.
+
+## Why session unification over multi-session rollup
+
+**Observation.** Post-goldfive#161 / #164 all three session layers
+(adk-web outer session, `goldfive.Session.id`, harmonograf home
+session) share the same id. The Runner's
+`run(session_id=ctx.session.id)` pins it explicitly. Every
+`Event.session_id` stamps it on field 5. `HarmonografSink` routes
+spans and events by that one key.
+
+**Intent.** The alternative — goldfive mints its own session id,
+harmonograf mints its own, adk-web mints its own, and downstream
+"rollup" code stitches them together — was the original design
+through the registry-dispatch rabbit hole (#121–#126). Each fix
+closed one seam but introduced another:
+
+- #121 propagated the plugin to sub-agent runners.
+- #122 followed up with additional propagation.
+- #123 shared one outer session id across runners.
+- #124 exposed `outer_session_id=` as a constructor kwarg.
+- #125 propagated outer adk-web session_id into sub-runners.
+- #126 added `_pin_outer_session_from_ctx` for the adk_wrap seam.
+
+Even after all of the above, `TelemetryUp.goldfive_event` had no
+per-event session id. Plan / drift events landed on the client's
+home session regardless of what spans did. The rollup approach
+was drowning in seams.
+
+Unifying the session id (one id = one session, everywhere)
+eliminates the rollup problem entirely. Harmonograf's
+`HarmonografSink` reads `ctx.session.id` for spans and
+`Event.session_id` for events, and the two match — no stitching
+needed.
+
+**Alternatives considered.**
+
+1. **Keep rollup, fix one more seam.** Rejected: tried; each fix
+   exposed the next. The structural fix was to unify upstream.
+2. **Unify only at the sink boundary.** Rejected: the problem
+   wasn't just the sink; goldfive-internal code also needed to
+   know "what session am I in" at drift-emission time, and the
+   per-event session id field is what lets sinks multiplex.
+
+**Tradeoffs.**
+
+- Callers who want goldfive to run *independent* of an outer
+  session must either accept a freshly-minted id (default) or
+  explicitly route events somewhere else. Bridges that want
+  per-goldfive-session routing can no longer distinguish
+  "goldfive run A" from "goldfive run B" when both share an outer
+  session (if they did share one — they shouldn't).
+- The `Session.run_id` field no longer implies a *new* id for
+  every run when an outer session pins it. This is deliberate:
+  `run_id` is the run-lineage identifier for a logical
+  conversation; a turn (one `Runner.run()`) is still one run, but
+  the id may be shared across turns that share an outer session.
+
+**Signals this might be wrong.** If a caller legitimately wants
+separate ids per turn within one outer session, expose a
+`per_turn_session_id` toggle. Today none do.
+
+**Related.** [ARCHITECTURE.md §"Session unification"](ARCHITECTURE.md#session-unification-three-session-alignment-goldfive161),
+`goldfive/runner.py::Runner.run`, harmonograf#61 / #63.
+
+## Why the three-stage drift gate
+
+**Observation.** `GoldfivePlanner.process_planning_response`
+classifies every LLM-emitted `function_call` via a three-stage
+gate: (1) own-tool, (2) cross-layer agent, (3) confabulation. The
+pre-#184 single-stage registry check treated any non-registry
+function_call as `PLAN_DIVERGENCE`, which over-fired on every
+legitimate tool call.
+
+**Intent.** The drift signal needs to distinguish three distinct
+conditions because they demand different responses:
+
+- **Own-tool call.** Agent calls a tool in its own `tools` list.
+  Legitimate; no drift.
+- **Cross-layer delegation attempt.** Agent calls by name an agent
+  that exists elsewhere in the tree but wasn't exposed to this
+  agent. This is a `PLAN_DIVERGENCE` — the LLM tried to
+  transfer_to_agent past its layer.
+- **Pure hallucination.** Agent calls a name that is neither a
+  tool nor a known agent. This is `CONFABULATION_RISK` — the LLM
+  invented the target.
+
+A single-stage check collapsing all three into `PLAN_DIVERGENCE`
+would make the refine prompt meaningless ("divergence from what?")
+and would over-fire on every legitimate tool call whose name isn't
+coincidentally in the agent registry. The three-stage gate gives
+each drift kind a clean meaning and keeps response-side filters
+from blocking legitimate traffic.
+
+**Key detail:** the gate NEVER blocks the call. It only signals.
+The steerer's intervention ladder decides whether to escalate.
+Blocking would break agent authorship — a coordinator that calls
+a legitimate utility tool happens to share a name with a tree
+agent, and blocking would prevent the tool from running.
+
+**Alternatives considered.**
+
+1. **Block cross-layer delegation structurally.** Rejected: breaks
+   trees where the coordinator's prompt legitimately references a
+   specialist by name (the LLM just uses the wrong call shape).
+2. **Single-stage (pre-#184 behaviour).** Rejected: over-fires on
+   legitimate tool calls because the registry-only check can't
+   tell a tool from an unknown name.
+3. **Classify during response emission rather than during
+   `process_planning_response`.** Rejected: the classification
+   needs the agent's `tools` list, which is only available via
+   `callback_context._invocation_context.agent.tools` — precisely
+   the context ADK gives to `process_planning_response`.
+
+**Tradeoffs.** The classifier's source of truth is the ADK
+`callback_context` + `ADKAdapter.available_agents` (tree
+registry). A subtree whose tools were attached *after* the
+registry was snapshotted may see its tools classified as
+confabulation. The adapter always re-augments on wrap, so this
+window is narrow; tests in `test_goldfive_planner.py` cover the
+common edge cases.
+
+**Signals this might be wrong.** If users report frequent
+false-`CONFABULATION_RISK` signals on legitimate tool calls, the
+own-tool detection probably has a gap (tool names on Python
+callables vs on the FunctionTool wrapper; see
+`_extract_own_tool_names`).
+
+**Related.** `goldfive/planners/goldfive_planner.py::process_planning_response`,
+[DRIFT.md §"Tool-call drift classification"](DRIFT.md#tool-call-drift-classification).
 
 ## Why reasoning-based drift detection is its own channel
 

--- a/docs/design/STATE-MACHINE.md
+++ b/docs/design/STATE-MACHINE.md
@@ -26,6 +26,7 @@ class TaskStatus(StrEnum):
     FAILED = "FAILED"
     CANCELLED = "CANCELLED"
     BLOCKED = "BLOCKED"
+    NOT_NEEDED = "NOT_NEEDED"
 ```
 
 | State | Meaning |
@@ -36,6 +37,7 @@ class TaskStatus(StrEnum):
 | `FAILED` | Terminal failure. `report_task_failed(...)` was called, or the adapter returned an exception, or the executor aborted the task. |
 | `CANCELLED` | Terminal. Executor-driven; e.g. after an unrecoverable upstream failure cascaded down to this task. |
 | `BLOCKED` | Non-terminal. An external condition prevents progress; the task may return to `RUNNING` once the blocker resolves. |
+| `NOT_NEEDED` | Terminal (overlay-model only, goldfive#141/#163). PENDING task the tree never exercised during an overlay invocation; stamped when the passthrough invocation ends. Distinct from `CANCELLED` so sinks render "tree chose not to run" vs "user/system cancelled" differently. |
 
 ## The diagram
 
@@ -43,12 +45,13 @@ class TaskStatus(StrEnum):
 stateDiagram-v2
     [*] --> PENDING : task added to plan
 
-    PENDING --> RUNNING : executor invokes adapter\n(emits TaskStarted)
+    PENDING --> RUNNING : executor invokes adapter OR\nreconciler observes RUNNING\n(emits TaskStarted)
     PENDING --> CANCELLED : upstream cancellation cascade\n(emits TaskCancelled)
+    PENDING --> NOT_NEEDED : overlay invocation end\n(tree did not exercise)
 
     RUNNING --> RUNNING : report_task_progress\n(emits TaskProgress; no transition)
-    RUNNING --> COMPLETED : report_task_completed\n(emits TaskCompleted)
-    RUNNING --> FAILED : report_task_failed or adapter error\n(emits TaskFailed)
+    RUNNING --> COMPLETED : report_task_completed OR\nreconciler observes after_agent success\n(emits TaskCompleted)
+    RUNNING --> FAILED : report_task_failed, adapter error, OR\nreconciler observes after_agent error\n(emits TaskFailed)
     RUNNING --> BLOCKED : report_task_blocked (structural)\n(emits TaskBlocked)
     RUNNING --> CANCELLED : executor cancel\n(emits TaskCancelled)
 
@@ -59,6 +62,7 @@ stateDiagram-v2
     COMPLETED --> [*]
     FAILED --> [*]
     CANCELLED --> [*]
+    NOT_NEEDED --> [*]
 ```
 
 ## Transition rules
@@ -67,9 +71,11 @@ Every transition obeys three invariants.
 
 ### Invariant 1 — Terminal states absorb
 
-Once a task is in `COMPLETED`, `FAILED`, or `CANCELLED`, no further
-transition is legal. `Steerer.transition()` rejects attempts to leave a
-terminal state:
+Once a task is in `COMPLETED`, `FAILED`, `CANCELLED`, or `NOT_NEEDED`,
+no further transition is legal. `Steerer.transition()` rejects
+attempts to leave a terminal state. `TERMINAL_TASK_STATUSES` in
+`goldfive/types.py` is the authoritative set, imported by every
+module that gates on terminality.
 
 ```python
 # pseudo-code: illustrative of the absorbing-terminal-state guard.
@@ -90,17 +96,27 @@ This is the single most load-bearing invariant in goldfive. Every
 feature downstream (progress reporting, refine, crash recovery,
 harmonograf integration) assumes it.
 
-### Invariant 2 — Reporting tools drive the machine
+### Invariant 2 — Transitions have two canonical entry points
 
-In v0.1, the canonical path into the state machine is through
-**reporting tools** (see [tool-protocol.md](../reference/tool-protocol.md)).
-When an agent calls `report_task_started("t3")`, the adapter routes
-the call through `goldfive.adapters._tool_invocation.invoke_tool`
-(which runs the schema / terminal / loop / volume guards), the
-spec's handler fires, and the steerer applies `PENDING → RUNNING`
-for task `t3`.
+Under the **overlay model (default)**, the primary driver is the
+`PlanReconciler` (`goldfive/reconciler.py`). The ADK plugin's
+`before_agent_callback` / `after_agent_callback` pairs are forwarded
+to `PlanReconciler.on_before_agent` / `.on_after_agent`, which claim
+the first PENDING task assigned to the observed agent name (direct
+match, or contextual match via the invocation-parent chain,
+goldfive#151/#160) and drive `steerer.transition(..., RUNNING)` then
+`steerer.transition(..., COMPLETED | FAILED)`.
 
-There are four non-reporting-tool paths in:
+Under both overlay and legacy modes, agents may also call
+**reporting tools** (`report_task_started`, `report_task_completed`,
+etc.) to report state directly. The adapter routes those calls
+through `goldfive.adapters._tool_invocation.invoke_tool` (which runs
+the schema / terminal / loop / volume guards), the spec's handler
+fires, and the steerer applies the transition. This is redundant
+with the reconciler's observation but harmless — the steerer's
+terminal-absorption guard drops duplicate transitions.
+
+Non-reconciler, non-reporting-tool paths in:
 
 - **Executor-driven transitions.** When the executor first picks up a
   `PENDING` task, it calls `steerer.transition(task_id, RUNNING, ...)`
@@ -135,6 +151,7 @@ Every successful transition in `Steerer.transition()` emits one event:
 | `RUNNING → BLOCKED` | `TaskBlocked` |
 | `RUNNING → CANCELLED` | `TaskCancelled` |
 | `PENDING → CANCELLED` | `TaskCancelled` |
+| `PENDING → NOT_NEEDED` | `TaskCancelled` (overlay-only; reason `"not needed (tree did not exercise)"`; task status in the plan is `NOT_NEEDED`) |
 | `BLOCKED → RUNNING` | `TaskStarted` (with `detail="resumed"`) |
 | `BLOCKED → *` | same as the `RUNNING → *` case |
 

--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -79,10 +79,47 @@ See §7.
 
 ## 2. Assignment protocol
 
-Once a Plan exists, tasks move from `PENDING` to `RUNNING` via one of
-two entry points, and execution is driven by the Executor.
+Once a Plan exists, tasks move from `PENDING` to one of two active
+states (`RUNNING` under the overlay model, via a
+`PlanReconciler` observation; or `PENDING → NOT_NEEDED` at invocation
+end if the tree never exercised it). Under the legacy per-task loop
+the executor drives `PENDING → RUNNING` directly.
 
-### 2.1 Who picks the next task
+### Overlay-model assignment
+
+Under the default overlay mode (goldfive#141, refined by #163 /
+#149 / #152) the executor issues ONE
+`adapter.invoke_passthrough(user_input)` per run / turn. While the
+tree runs:
+
+1. ADK plugin's `before_agent_callback` fires → the plugin calls
+   `PlanReconciler.on_before_agent(name, invocation_id, parent_invocation_id)`
+   → the reconciler picks the first PENDING task assigned to that
+   agent (or a contextual match via the invocation-parent chain,
+   goldfive#151) and transitions it `PENDING → RUNNING` via
+   `steerer.transition`.
+2. `after_agent_callback` fires with an optional error → the
+   reconciler transitions `RUNNING → COMPLETED` (no error) or
+   `RUNNING → FAILED` (error).
+3. Drift signals (PLAN_DIVERGENCE from three-stage gate,
+   LOOPING_REASONING from tool-loop and reasoning detectors, ...)
+   ride the ADK plugin → steerer.observe / steerer._handle_drift
+   → intervention ladder.
+
+### Invocation-end `PENDING → NOT_NEEDED` sweep (goldfive#163)
+
+When the passthrough invocation generator ends cleanly (tree
+finished its natural flow), `SequentialExecutor._run_overlay`
+walks the live plan and transitions every still-PENDING task to
+`NOT_NEEDED`. The previous behaviour (goldfive#141 pre-#163)
+dispatched a soft follow-up per missed task; flow-prompted
+coordinators re-ran their full pipeline on every follow-up,
+amplifying a ~10 min run into 40+ min. STEER remains the user-
+driven path for exercising uncovered work.
+
+### Legacy per-task assignment (overlay_mode=False)
+
+### 2.1 Who picks the next task (legacy per-task mode)
 
 `SequentialExecutor._pick_next_task` (`executors/sequential.py:~624`)
 walks topological stages and returns the first task that is `PENDING`

--- a/docs/design/VOCABULARY.md
+++ b/docs/design/VOCABULARY.md
@@ -61,8 +61,6 @@ The symmetry: a `ControlKind` (external verb) is often *bridged* into a
 `DriftKind` (internal observation) before it acts on the plan. The
 next section walks one such bridge end-to-end.
 
-<!-- TODO: once docs/design/CONTROL.md lands, add cross-links in §2 and §3. -->
-
 ## 2. `ControlKind` vs `DriftKind` — a worked example
 
 The subtlest distinction in goldfive is between the five `ControlKind`
@@ -235,11 +233,12 @@ enum reference.
 | State | String | Terminal? | Meaning |
 |---|---|---|---|
 | `PENDING` | `"PENDING"` | no | Task exists in the plan, has not been started. Default on every new task in a fresh plan. |
-| `RUNNING` | `"RUNNING"` | no | Executor has dispatched `adapter.invoke(task, session)`. Agent is working. |
-| `COMPLETED` | `"COMPLETED"` | **yes** | Terminal success. Output is in `session.completed_results[task_id]`. Reached via `report_task_completed` or the executor's default-complete path. |
-| `FAILED` | `"FAILED"` | **yes** | Terminal failure. Reached via `report_task_failed`, adapter exception, or executor-driven failure. |
+| `RUNNING` | `"RUNNING"` | no | Executor has dispatched `adapter.invoke(task, session)` OR the `PlanReconciler` observed an agent running for this task. Agent is working. |
+| `COMPLETED` | `"COMPLETED"` | **yes** | Terminal success. Output is in `session.completed_results[task_id]`. Reached via `report_task_completed` or reconciler-observed `after_agent`. |
+| `FAILED` | `"FAILED"` | **yes** | Terminal failure. Reached via `report_task_failed`, adapter exception, reconciler-observed `after_agent` with error, or executor-driven failure. |
 | `CANCELLED` | `"CANCELLED"` | **yes** | Terminal. Reached via executor cancellation cascade or `report_task_cancelled`. |
 | `BLOCKED` | `"BLOCKED"` | no | External condition prevents progress. Task can return to `RUNNING` if the planner resolves the blocker, or convert to `FAILED`/`CANCELLED`. |
+| `NOT_NEEDED` | `"NOT_NEEDED"` | **yes** | Overlay-only (goldfive#141/#163). PENDING task the tree never exercised during the single passthrough invocation; stamped at invocation end. Distinct from `CANCELLED` so sinks can render "tree chose not to run" vs "user/system cancelled" differently. Proto enum value 7. |
 
 ### State diagram
 
@@ -388,8 +387,8 @@ the full bridge table.
 
 | `DriftKind` | Value | Default severity | Bridges from |
 |---|---|---|---|
-| `USER_STEER` | `"user_steer"` | `WARNING` | `ControlKind.STEER` (via `steerer.observe(ControlMessage)`). |
-| `USER_CANCEL` | `"user_cancel"` | `CRITICAL` | `ControlKind.CANCEL` (synthesized in `control_received_event` for audit; executor short-circuits to `RunAborted`). |
+| `USER_STEER` | `"user_steer"` | `WARNING` | `ControlKind.STEER` (via `steerer.observe(ControlMessage)`). Idempotent by `annotation_id` or `ControlMessage.id` (goldfive#171); emitted `DriftDetected` carries `annotation_id` (field 6) so sinks can dedup against the source annotation row. |
+| `USER_CANCEL` | `"user_cancel"` | `CRITICAL` | `ControlKind.CANCEL` (synthesized in `control_received_event` for audit; executor short-circuits to `RunAborted`). Emitted `DriftDetected` carries `annotation_id` when the bridge sourced one. |
 | `USER_PAUSE` | `"user_pause"` | `INFO` | `ControlKind.PAUSE` (synthesized for audit; executor blocks on next poll). |
 
 ### 5.e Transfer — the wrong agent picked something up
@@ -415,15 +414,17 @@ session-state mutation, not drift synthesis.
 
 ### Count check
 
-The table above covers the core trigger-driven kinds. The live
+The tables above cover the core trigger-driven kinds. The live
 `DriftKind` in `goldfive/types.py` also carries the reasoning-category
 kinds (`LOOPING_REASONING`, `REASONING_CLUSTER_TIGHTENING`, `CONFUSION`,
-`OFF_TOPIC`, `INTENT_DIVERGENCE`) and the reflective/confabulation
+`OFF_TOPIC`, `INTENT_DIVERGENCE`), the reflective / confabulation
 signals (`UNCERTAIN_PROGRESS`, `SELF_REPORTED_STUCK`,
-`CONFABULATION_RISK`) documented in [DRIFT.md](DRIFT.md), plus the
-looping-signal kinds (`LOOPING_TOOL_CALL`) and `USER_PAUSE`. The
-authoritative per-kind reference lives in [DRIFT.md](DRIFT.md); this
-section groups the kinds by what triggers them in production code.
+`CONFABULATION_RISK`), the looping-signal kinds (`LOOPING_TOOL_CALL`),
+`USER_PAUSE`, and the post-overlay additions
+(`RUNAWAY_DELEGATION` #35, `REFINE_VALIDATION_FAILED` #36,
+`HUMAN_INTERVENTION_REQUIRED` #37, `GOAL_DRIFT` #38).
+See `proto/goldfive/v1/types.proto::DriftKind` for the authoritative
+enum values and [DRIFT.md](DRIFT.md) for per-kind semantics.
 
 ## 6. Event payload kinds
 
@@ -554,3 +555,25 @@ compare string values directly — use the helpers.
 - [EVENT-MODEL.md](EVENT-MODEL.md) for the envelope spec.
 - [RATIONALE.md](RATIONALE.md) for why each of these shapes is the way
   it is.
+
+## 8. Overlay-era glossary
+
+New terms introduced by the 2026-04 overlay refactor and structural-
+steering work. Each has a load-bearing meaning distinct from its
+plain-English reading.
+
+| Term | Defined in | Meaning |
+|---|---|---|
+| **Overlay model** | `goldfive/executors/sequential.py::SequentialExecutor._run_overlay` | The default execution model. Single `adapter.invoke_passthrough(user_input)` per run / turn; plan tasks are transitioned by a `PlanReconciler` observing the tree's natural flow rather than by the executor driving one task at a time. Counterpart: "per-task driving," the legacy `overlay_mode=False` path. |
+| **PlanReconciler** | `goldfive/reconciler.py::PlanReconciler` | Overlay-mode component that maps observed agent transitions (`before_agent` / `after_agent` pairs from the ADK plugin) onto plan-task state transitions via `steerer.transition`. One instance per invocation. |
+| **Intervention ladder** | `goldfive/steerer.py::InterventionLevel` | Six-level policy table (0–5: OBSERVE / ABSORB / NUDGE / CANCEL_REINVOKE / PAUSE_ESCALATE / TERMINATE) that maps `(drift_kind, severity, occurrence_count)` to an action. Single source of truth for "when does goldfive interrupt the tree." See [DRIFT.md §"Intervention ladder"](DRIFT.md#intervention-ladder-levels-0-5). |
+| **Drift kind** | `goldfive/types.py::DriftKind` | The categorized observation; see §5. "Adding a drift kind" means proto + Python enum + classifier + (optional) ladder entry. |
+| **Orchestration state** | `goldfive/orchestration_state.py` | Framework-agnostic dict of `goldfive.*`-prefixed keys on `Session.state`. Bridges via `_adk_state_protocol` to the ADK runtime session state. |
+| **Tree-agnostic** | N/A | A component behaves the same regardless of tree shape (flat, nested, deep). `GoldfivePlanner`'s orchestration block is tree-agnostic; plan divergence classification is tree-aware (consults the registry). |
+| **Annotation id** | `proto/goldfive/v1/control.proto::SteerPayload.annotation_id`, `goldfive.v1.DriftDetected.annotation_id` | Source identifier for a user-control message, used for (a) STEER idempotency in `DefaultSteerer._is_duplicate_steer` and (b) sink-side dedup of a drift row against the annotation row. |
+| **Session unification** | goldfive#161 | The convention that `adk-web.ctx.session.id == goldfive.Session.id == harmonograf home session id`. All three layers reference the same id; `Event.session_id` stamps it per-event. |
+| **Three-stage gate** | `GoldfivePlanner.process_planning_response` | The classifier that splits an LLM-emitted `function_call` into "own tool" (no drift), "cross-layer agent" (`PLAN_DIVERGENCE`), or "nowhere" (`CONFABULATION_RISK`). Replaces the pre-#184 single-stage registry check. |
+| **Tool-loop tracker** | `goldfive/drift/tool_loops.py::ToolLoopTracker` | Per-`(invocation_id, agent_name)` ring buffer + loop classifier. Detects exact / name / alternating tool-call patterns (#186). |
+| **Structural steering** | goldfive#151-#155 | Umbrella for tree-aware planner constraints, orchestration state namespace, `GoldfivePlanner(BasePlanner)`, goal-aware refine. |
+| **Reporting tools** | `goldfive/reporting.py::ReportingToolSpec` | The agent-facing protocol tools (`report_task_started`, `report_task_completed`, `report_task_failed`, `report_task_blocked`, `report_task_progress`, `report_task_cancelled`, `report_plan_divergence`, `report_new_work_discovered`, `report_awaiting_approval`). Still present; agents can call them to drive state directly. Under overlay the reconciler is usually faster, but the two paths converge at `steerer.transition` (terminal absorption dedupes). |
+| **`NOT_NEEDED`** | `TaskStatus.NOT_NEEDED` | Terminal status stamped on PENDING tasks at overlay-invocation end. |


### PR DESCRIPTION
## Summary

Refreshes `docs/design/*.md` to reflect the current state of goldfive
after the 2026-04 overlay refactor and the structural-steering /
drift-taxonomy work that followed.

Key coverage:

- **Overlay execution model** (goldfive#141 → #148, #149, #152, #163,
  #160, #170). Per-task driving is gone from the default path;
  observation-driven `PlanReconciler` maps tree activity onto plan
  tasks; `PENDING → NOT_NEEDED` at invocation end; soft follow-up was
  dropped to avoid flow-coordinator rework amplification.
- **Structural steering** — `GoldfivePlanner(BasePlanner)` auto-attach
  (#153/#156), plugin-based request-side instruction injection,
  tree-aware assignee constraints (#151), orchestration state
  namespace (#152/#159/#170), goal-aware refine (#154), STEER
  idempotency (#171), annotation_id on DriftDetected (#177),
  three-stage drift gate (#178/#184).
- **Drift taxonomy** — documents `CONFABULATION_RISK` (#34),
  `RUNAWAY_DELEGATION` (#35), `REFINE_VALIDATION_FAILED` (#36),
  `HUMAN_INTERVENTION_REQUIRED` (#37), `GOAL_DRIFT` (#38), and the
  `ToolLoopTracker` (#181/#186) with modes exact/name/alternating.
  Adds the full Levels 0-5 intervention ladder with drift-severity
  mapping.
- **Per-event session_id** (#155/#157) and session unification
  (#161/#164) — all three layers (adk-web / goldfive.Session /
  harmonograf home) now share one id; `HarmonografSink` routes
  accordingly.
- **Per-LLM-call instrumentation** (#172) — documents
  `goldfive.llm.request` / `goldfive.llm.response` INFO log format
  and the `observation.raw["metrics"]` enrichment.
- **Human-in-the-loop escalation** (#142 Level 4) — adds Flow C to
  APPROVAL.md alongside the existing task-level (Flow A) and ADK
  tool-confirmation (Flow B) approval flows.
- **Rationale** — adds "why overlay over per-task driving," "why
  `GoldfivePlanner` subclasses `BasePlanner` not `PlanReActPlanner`,"
  "why no STEER cooldown" (user directive), "why session
  unification over rollup," "why the three-stage drift gate."

Also resolves a lingering merge conflict in `DRIFT.md` around the
reasoning-similarity ladder section.

## Per-file changes

- `ARCHITECTURE.md` — Overlay execution model section, GoldfivePlanner
  + plugin injection, orchestration state namespace, three-session
  alignment diagram.
- `CONTROL.md` — SteerPayload fields, STEER idempotency contract,
  intervention ladder cross-ref.
- `DRIFT.md` — resolves merge conflict; new drift-kind table for
  delegation & planning category; `ToolLoopTracker` section; full
  intervention-ladder (Levels 0-5) section; three-stage gate clarified;
  annotation_id added to DriftDetected fields.
- `EVENT-MODEL.md` — `Event.session_id` field 5;
  `DriftDetected.annotation_id` field 6; `SteerPayload` fields;
  per-LLM-call instrumentation logs; HarmonografSink routing contract.
- `PLAN-LIFECYCLE.md` — refine inputs (goal-aware, observed_actions,
  available_agents tree); validator rules (#138/#151/#154); revision
  metadata table.
- `PROTOCOLS.md` — Planner.refine signature updated; Proto changes
  summary section.
- `RATIONALE.md` — 5 new rationale entries (overlay, GoldfivePlanner,
  no STEER cooldown, session unification, three-stage gate).
- `STATE-MACHINE.md` — `NOT_NEEDED` terminal; reconciler-driven
  transitions in diagram; updated transition/event table.
- `TASK-LIFECYCLE.md` — overlay-model assignment section;
  PENDING → NOT_NEEDED invocation-end sweep.
- `VOCABULARY.md` — NOT_NEEDED in TaskStatus table; USER_STEER /
  USER_CANCEL annotated with annotation_id; overlay-era glossary.
- `APPROVAL.md` — title includes escalation; Flow C
  (HUMAN_INTERVENTION_REQUIRED).

## Test plan

- [ ] CI green (markdown lints / broken-link check where applicable).
- [ ] Sibling docs in `.agents/`, `docs/guides/`, and top-level
  (README / CHANGELOG / reference) are owned by other agents and not
  modified here.