### PR TITLE
docs(guides): refresh guides + .agents skills for current overlay + structural steering

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -22,16 +22,20 @@ action.
 |---|---|
 | wrap my existing agent with goldfive | [use-goldfive.md](use-goldfive.md) |
 | add a feature, adapter, or sink to goldfive | [develop-goldfive.md](develop-goldfive.md) |
-| diagnose a broken run | [debug-goldfive.md](debug-goldfive.md) |
-| understand or implement an `AgentAdapter` | [adapters.md](adapters.md) |
-| understand or implement an `EventSink` | [sinks.md](sinks.md) |
+| diagnose a broken run (overlay + ladder + session id) | [debug-goldfive.md](debug-goldfive.md) |
+| understand or implement an `AgentAdapter` (incl. overlay `invoke_passthrough`) | [adapters.md](adapters.md) |
+| understand or implement an `EventSink` (incl. per-event session_id routing) | [sinks.md](sinks.md) |
 | know what events exist and how to emit one | [events.md](events.md) |
 | write a goldfive test | [testing.md](testing.md) |
 | cut a release | [release.md](release.md) |
 | add a new `AgentAdapter` wrapping a new framework | [how-to-add-a-new-adapter.md](how-to-add-a-new-adapter.md) |
-| debug the "guards defined but not firing" class of bug | [how-to-debug-a-filler-loop.md](how-to-debug-a-filler-loop.md) |
-| add a new `DriftKind` | [how-to-add-a-drift-kind.md](how-to-add-a-drift-kind.md) |
-| drive a goldfive end-to-end run with harmonograf locally | [how-to-run-the-e2e.md](how-to-run-the-e2e.md) |
+| debug a filler loop (tool-loop detector, intervention ladder) | [how-to-debug-a-filler-loop.md](how-to-debug-a-filler-loop.md) |
+| add a new `DriftKind` (proto reservations included) | [how-to-add-a-drift-kind.md](how-to-add-a-drift-kind.md) |
+| drive a goldfive end-to-end run with harmonograf + adk-web + kikuchi + steer.py | [how-to-run-the-e2e.md](how-to-run-the-e2e.md) |
+
+The set is stable. If you think you need a new skill, first check
+whether one of the existing ones should be extended instead — skills
+that overlap are worse than skills that cross-reference.
 
 ## How these get referenced
 

--- a/.agents/adapters.md
+++ b/.agents/adapters.md
@@ -32,9 +32,22 @@ class AgentAdapter(Protocol):
 
     @property
     def available_agents(self) -> list[str]: ...
+
+    # Optional overlay-mode entry point (goldfive#141).
+    async def invoke_passthrough(
+        self,
+        user_message: str,
+        session: Session,
+        *,
+        reconciler: PlanReconciler,
+    ) -> InvocationResult: ...
+
+    # Optional structured tree metadata (goldfive#151).
+    @property
+    def available_agents_tree(self) -> list[dict[str, Any]]: ...
 ```
 
-Three members. That's it.
+Three required members plus two overlay extensions.
 
 - **`register_reporting_tools`** — called once per run, between
   planning and execution. You get the seven canonical reporting tool
@@ -43,9 +56,37 @@ Three members. That's it.
 - **`invoke`** — called per task. Run the agent against `task`, using
   the registered tools to report state changes. Return an
   `InvocationResult` with the final text and/or artifacts.
+- **`invoke_passthrough`** (overlay) — called once per turn with
+  the full user message. The adapter drives the tree naturally; it
+  feeds `before_agent` / `after_agent` / delegation observations
+  into the `PlanReconciler`, which maps them to plan tasks. The
+  `SequentialExecutor(overlay_mode=True)` path uses this when the
+  adapter exposes it. `ADKAdapter` does; `CallableAdapter` and
+  `ClaudeAgentSDKAdapter` do not (they use per-task `invoke`).
 - **`available_agents`** — stable list of agent identifiers this
-  adapter can dispatch to. Planners consult this so they don't generate
-  tasks for non-existent agents.
+  adapter can dispatch to. Planners consult this so they don't
+  generate tasks for non-existent agents. Under the single-Runner
+  model (goldfive#130) this is advisory only; ADK handles actual
+  routing via `AgentTool` / `transfer_to_agent` / `sub_agents`.
+- **`available_agents_tree`** (optional) — list of dicts with
+  `name` / `depth` / `parent` / `role` / `kind`. Consumed by the
+  `GoldfivePlanner`'s orchestration context block and by
+  `LLMPlanner` for structured assignee-hint selection on deep
+  hierarchies. `ADKAdapter._collect_reachable_agent_tree` is the
+  reference implementation.
+
+## Install semantics (goldfive#166)
+
+Callers can pass additional ADK plugins via
+`goldfive.wrap(agent, plugins=[HarmonografTelemetryPlugin(client)])`.
+The adapter dedupes plugins by `name` before handing them to ADK's
+`PluginManager.register_plugin` (which raises on duplicate names). A
+plugin already on `App(plugins=[...])` is not re-installed on wrap.
+
+`ADKAdapter.add_plugin(plugin)` also exists for post-construction
+install — used by `harmonograf_client.observe()` when the caller
+wants to attach telemetry after `goldfive.wrap(...)` has already
+run.
 
 ## Shipped implementations
 

--- a/.agents/debug-goldfive.md
+++ b/.agents/debug-goldfive.md
@@ -104,13 +104,38 @@ When an event goes missing, look at who emits it:
 | Event | Emitted by |
 |---|---|
 | `RunStarted`, `GoalDerived`, `PlanSubmitted`, pre-executor `RunAborted` | `Runner` |
-| `TaskStarted`, `TaskProgress`, `TaskCompleted`, `TaskFailed`, `TaskBlocked`, `TaskCancelled` | `Steerer` (via `mark_task_*`) |
+| `TaskStarted`, `TaskProgress`, `TaskCompleted`, `TaskFailed`, `TaskBlocked`, `TaskCancelled` | `Steerer` (via `mark_task_*`). Under overlay mode, transitions are driven by `PlanReconciler.on_before_agent` / `on_after_agent` which call into the steerer. |
 | `PlanRevised`, terminal `RunCompleted` / `RunAborted` | `Executor` |
 | `DriftDetected` | `Steerer` |
+| `AgentInvocationStarted`, `AgentInvocationCompleted`, `DelegationObserved` | Goldfive ADK plugin via `before_agent` / `after_agent` / `before_tool` callbacks |
+
+Every `Event` carries `session_id` at tag 5 (goldfive#155). Sinks
+that multiplex must route by it, not by client-global state — under
+the adk-web pin (goldfive#161) the id equals `ctx.session.id` for
+the duration of a run, even across sub-Runners spawned by AgentTool.
 
 If your sink never sees `TaskStarted`, the executor never dispatched or
 the steerer is bypassed. If it never sees `RunCompleted`, the executor
 aborted — check `outcome.reason`.
+
+## Intervention ladder — which level fired?
+
+Every drift handled by `DefaultSteerer` routes to exactly one of six
+levels (goldfive#142), dictating what the steerer does next:
+
+| Level | Name | Action |
+|---|---|---|
+| 0 | OBSERVE | Record only; no refine. |
+| 1 | ABSORB | Call `planner.refine`; continue. |
+| 2 | NUDGE | Queue a soft follow-up message on `session.pending_nudges`; overlay loop picks it up at next invocation boundary. |
+| 3 | CANCEL_REINVOKE | Cancel in-flight invoke (`_tag_adapter_cancel_user_steer`), refine, compose corrective message on `session.pending_corrective_message`, overlay loop re-dispatches. |
+| 4 | PAUSE_ESCALATE | Emit `HUMAN_INTERVENTION_REQUIRED`, set `session.paused_for_human_intervention`; executor blocks until CONTROL_RESUME / STEER. |
+| 5 | TERMINATE | Run-level abort (rarely reached directly; actual termination is executor-driven on unhandled Level 4 timeouts). |
+
+The mapping lives in `DefaultSteerer._ladder_level_for` as a
+per-kind table keyed by `(occurrence_count, severity)`. To see which
+level fired, enable DEBUG on `goldfive.steerer` — the
+`_dispatch_ladder_level` routine logs each dispatch.
 
 ## Drift kinds and taxonomy
 

--- a/.agents/events.md
+++ b/.agents/events.md
@@ -47,14 +47,27 @@ Current `main` emits every event (Runner, Executor, Steerer) as a proto
 `goldfive.events.make_event` is still exported as a fallback for
 callers that can't use the `proto` extra; sinks should tolerate both.
 
+The proto envelope carries:
+
+| Field | Tag | What |
+|---|---|---|
+| `event_id` | 1 | Stable ULID per emission. |
+| `run_id` | 2 | Alias for `Session.id`; stable across a run. |
+| `emitted_at` | 3 | Wall-clock time (proto `Timestamp`). |
+| `sequence` | 4 | Monotonic per-run counter. |
+| `session_id` | 5 | Multiplex key (goldfive#155) — under adk-web pin (goldfive#161) equals `ctx.session.id`. |
+| `payload` | oneof | `run_started` / `task_completed` / `drift_detected` / … |
+
 Common idiom for dispatch:
 
 ```python
 if hasattr(event, "DESCRIPTOR"):
     kind = event.WhichOneof("payload")
     payload = getattr(event, kind) if kind else None
+    session_id = event.session_id or event.run_id
 else:
     kind, payload = event["kind"], event["payload"]
+    session_id = event.get("session_id") or event["run_id"]
 ```
 
 ## The seven reporting tools

--- a/.agents/how-to-add-a-drift-kind.md
+++ b/.agents/how-to-add-a-drift-kind.md
@@ -55,6 +55,14 @@ The Python-to-proto bridge is by name: the steerer looks up
 `SequentialExecutor._plan_divergence_drift_event`). The Python
 enum name and the proto enum suffix must match exactly.
 
+**Reserved slots 34-38.** The current highest assigned slot in
+`DriftKind` (proto) is typically in the mid-30s. Check the current
+proto file before picking a number; slots 34-38 are reserved for
+in-flight work (goldfive#181 tool-loop detector; goldfive#142
+intervention-ladder kinds; goldfive#143 `GOAL_DRIFT`). Always append
+to the end of the enum rather than filling gaps — that way two
+concurrent PRs don't collide on the same slot.
+
 ## 3. Regenerate the proto stubs
 
 ```bash

--- a/.agents/how-to-debug-a-filler-loop.md
+++ b/.agents/how-to-debug-a-filler-loop.md
@@ -41,14 +41,57 @@ Check which guard you expected to fire. The goldfive guards are:
 |---|---|---|
 | Schema rejection (missing / unknown `task_id`) | `_tool_invocation.invoke_tool` | `{acknowledged: False, error: "missing_task_id" \| "unknown_task_id"}` |
 | Terminal-task rejection | `_tool_invocation.invoke_tool` | `{acknowledged: False, error: "task_already_terminal"}` |
-| Per-task loop guard | `_tool_loop_guard.detect_loop` | `LOOPING_TOOL_CALL` drift; subsequent calls get `loop_detected` |
+| Per-task loop guard (reporting tools) | `_tool_loop_guard.detect_loop` | `LOOPING_TOOL_CALL` drift; subsequent calls get `loop_detected` |
 | Session-wide volume cap | `_tool_loop_guard.detect_session_loop` | `LOOPING_TOOL_CALL` drift (severity CRITICAL); all further calls hard-rejected |
+| **`ToolLoopTracker`** (all ADK tool calls, goldfive#181) | `goldfive/drift/tool_loops.py`, fires at `after_tool_callback` | `LOOPING_REASONING` drift with `detail="tool_loop_exact:…"`/`tool_loop_name:…`/`tool_loop_alternating:…` |
 | Per-task retry-lineage cap | `SequentialExecutor._lineage_root` | task marked FAILED without invoking the adapter |
 | Refine-failure threshold | `DefaultSteerer.REFINE_FAILURE_THRESHOLD` | `REPEATED_FAILURE` drift + task FAILED |
+| AgentTool-per-invoke cap | `_GoldfiveADKPlugin.before_tool_callback` | `RUNAWAY_DELEGATION` drift (CRITICAL); further spawns return `{"status": "skipped"}` |
 
 If none of these ACK/drift shapes appear in your sink log, the
 guard never ran. That is the bug — do not patch a new cap; find
 why the existing guard was skipped.
+
+### Step 1.5 — Check the `ToolLoopTracker` coverage (goldfive#181)
+
+The `ToolLoopTracker` is auto-wired into the ADK plugin and observes
+**every** tool call in the ADK tree (not just reporting tools).
+Three modes:
+
+- **Exact** — same `(tool_name, args_hash)` ≥ 3 in last 7 calls.
+- **Name** — same `tool_name` (any args) ≥ 5 in last 7 with no task
+  progress.
+- **Alternating** — A,B,A,B,A pattern in last 5.
+
+Inspect its detection output with:
+
+```python
+import logging
+logging.getLogger("goldfive.drift.tool_loops").setLevel(logging.DEBUG)
+```
+
+The tracker is keyed by `(invocation_id, agent_name)`, so parallel
+sub-agents within one invocation are isolated. Mode 2's "no task
+progress" gate is cleared by calls to
+`ToolLoopTracker.on_task_progress(invocation_id=…, agent_name=…)` —
+the plugin wires this to `mark_task_completed` and friends.
+
+Env-var overrides:
+
+- `GOLDFIVE_TOOL_LOOP_WINDOW` (default 7)
+- `GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD` (default 3)
+- `GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD` (default 5)
+- `GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD` (default 5)
+
+If the tracker isn't firing on a run you know is looping, three
+things to check:
+
+1. The plugin may not be installed. Verify `adapter.add_plugin` /
+   `_register_plugin_on_runner` ran.
+2. The tool names being called may not be reaching the plugin
+   (unusual — ADK routes every tool call through `before_tool_callback`).
+3. The window size may be too small for the loop's phase — try
+   `GOLDFIVE_TOOL_LOOP_WINDOW=15`.
 
 ### Step 2 — Instrument at the guard entry point
 

--- a/.agents/how-to-run-the-e2e.md
+++ b/.agents/how-to-run-the-e2e.md
@@ -37,6 +37,31 @@ The `third_party/adk-python` clone is required even for runs that
 don't go through ADK — the harmonograf `make install` target
 treats it as an editable path dep.
 
+### 3. LLM backend
+
+The canonical e2e uses a local LLM served by kikuchi. Point the
+environment at it before running adk-web:
+
+```bash
+# kikuchi-hosted Qwen on LAN (adjust host as needed)
+export USER_MODEL_NAME=openai/qwen3-coder-30b
+export OPENAI_BASE_URL=http://kikuchi:8000/v1
+export OPENAI_API_KEY=sk-anything   # kikuchi doesn't check
+
+# or OpenAI cloud
+export USER_MODEL_NAME=openai/gpt-4o-mini
+export OPENAI_API_KEY=sk-...
+
+# planner model (defaults to USER_MODEL_NAME via litellm)
+export GOLDFIVE_EXAMPLE_PLANNER_MODEL=gpt-4o-mini
+```
+
+`USER_MODEL_NAME` is the env var the reference agents
+(`presentation_agent_orchestrated` etc.) read. **Do not** leave it
+unset — the default `gemini-2.5-flash` silently breaks without
+`GOOGLE_API_KEY` (see
+[docs/guides/troubleshooting.md §"Run terminates immediately"](../docs/guides/troubleshooting.md)).
+
 ## Driving a run
 
 ### The `/tmp/e2e-*.py` pattern
@@ -92,7 +117,7 @@ few hours and carry local config. Committing them creates churn;
 
 ### Booting the harmonograf stack
 
-Two terminals:
+Three terminals for the canonical e2e (server + frontend + adk-web):
 
 ```bash
 # terminal 1 — gRPC server on :7531 + gRPC-Web on :7532
@@ -102,15 +127,54 @@ make server-run
 # terminal 2 — frontend dev server on :5173
 cd ~/git/harmonograf/frontend
 pnpm dev --port 5173 --strictPort
+
+# terminal 3 — adk-web hosting the reference presentation agent
+cd ~/git/harmonograf/.demo-agents
+export USER_MODEL_NAME=openai/qwen3-coder-30b   # or OpenAI / Gemini
+export OPENAI_BASE_URL=http://kikuchi:8000/v1
+export OPENAI_API_KEY=sk-anything
+export HARMONOGRAF_SERVER=127.0.0.1:7531
+uv run adk web presentation_agent_orchestrated
 ```
 
-Then open `http://127.0.0.1:5173`. Runs started against
-`localhost:7531` appear in the Sessions view as they begin.
+Open `http://127.0.0.1:5173` for the harmonograf UI and
+`http://127.0.0.1:8000` for the adk-web UI.
 
-If you want the full ADK demo rollout (server + frontend + an
-`adk web` process hosting `presentation_agent`), `make demo` in
-the harmonograf repo does all three; skip `make server-run` +
-`pnpm dev` in that case.
+If you want the one-shot demo (server + frontend + adk-web all in
+one command), `make demo` in the harmonograf repo does all three;
+skip the separate terminals in that case.
+
+### Steer flow: `/tmp/steer.py` + browser-use
+
+The canonical driver for STEER end-to-end testing is a small
+script at `/tmp/steer.py` (ephemeral, tuned per session):
+
+```python
+# /tmp/steer.py — submit a prompt to adk-web, wait, then STEER
+import asyncio, json, urllib.request
+
+def post(path, payload):
+    req = urllib.request.Request(
+        f"http://127.0.0.1:8000{path}",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    return urllib.request.urlopen(req).read()
+
+async def main():
+    # 1. submit initial prompt
+    post("/run", {"message": "Make a presentation about waffles"})
+    await asyncio.sleep(10)
+    # 2. steer mid-run
+    post("/steer", {"message": "Switch to raccoons", "author": "e2e"})
+
+asyncio.run(main())
+```
+
+Or drive via `mcp__browser-use__` tools from a parent agent to
+open the adk-web / harmonograf UIs, click Steer buttons, and
+verify PlanRevised events in the UI — same thing, just
+higher-fidelity.
 
 ### Running the reproducer
 

--- a/.agents/sinks.md
+++ b/.agents/sinks.md
@@ -111,6 +111,13 @@ class MySink:
 - **Be prepared for dict envelopes.** At minimum, skip them cleanly.
 - **Ordering.** Events are emitted in sequence order per run. Don't
   reorder within a sink.
+- **Route by `session_id` when multiplexing** (goldfive#155). Every
+  `Event` carries `session_id` at tag 5 — under the adk-web pin
+  (goldfive#161) it equals the outer adk-web session id, which is
+  stable across overlay STEER restarts and nested AgentTool
+  sub-Runners. Sinks that fan out to per-session buffers (e.g.
+  `HarmonografSink`) must key on `event.session_id`, not on any
+  client-global state.
 
 ## Quick reference
 

--- a/.agents/use-goldfive.md
+++ b/.agents/use-goldfive.md
@@ -27,13 +27,33 @@ Optional extras, install only what you need:
   events on the wire or on disk.
 - `goldfive[examples]` — runtime deps for scripts in `examples/`.
 
-## The one-liner (`quickstart`)
+## The one-liner (`goldfive.run` / `goldfive.wrap`)
 
-For callers who just want a runnable `Runner` with sensible defaults:
+For ADK agents and bare callables alike, two convenience helpers:
+
+```python
+import goldfive
+
+# One line: wrap + run, get an ExecutionOutcome back.
+outcome = await goldfive.run(my_agent, "make a presentation about waffles")
+
+# Or, keep the Runner around:
+runner = goldfive.wrap(my_agent, sinks=[my_sink])
+outcome = await runner.run("make a presentation about waffles")
+```
+
+`wrap` auto-detects the adapter from the agent's shape (ADK
+BaseAgent, Claude SDK client factory, async callable, or an existing
+`AgentAdapter` instance); tries to reuse the agent's LLM for the
+planner + goal-deriver; and defaults the executor to
+`SequentialExecutor(overlay_mode=True)` for ADK wrap targets
+(goldfive#141).
+
+For the tightest possible Runner construction with an explicit
+`StaticPlanner`, `goldfive.quickstart` is still available:
 
 ```python
 import asyncio
-
 from goldfive import InvocationResult, quickstart
 
 
@@ -54,9 +74,6 @@ asyncio.run(main())
 `quickstart` wires a `CallableAdapter`, `StaticPlanner` (one task per
 goal), `SequentialExecutor`, and a single `InMemorySink`. Pass
 `planner=` or `sinks=` to override.
-
-> `goldfive.run(agent, "...")` is tracked by issue #66 and not yet
-> merged. Until then, use `quickstart` or construct a `Runner` directly.
 
 ## The explicit form (`Runner`)
 
@@ -105,13 +122,30 @@ asyncio.run(main())
 
 ## Swapping in a real framework
 
-Change one line — the rest of the `Runner` construction stays identical:
+For ADK, use `goldfive.wrap(adk_agent)` directly — it returns a
+`GoldfiveADKAgent` that both satisfies the `BaseAgent` contract (so
+`adk web` loads it) and exposes `Runner.run`:
 
 ```python
-# ADK (requires goldfive[adk])
-from goldfive.adapters.adk import ADKAdapter
-agent = ADKAdapter(root_agent)
+import goldfive
+from google.adk.apps.app import App
+from harmonograf_client import Client, HarmonografSink, HarmonografTelemetryPlugin
 
+client = Client(name="my-agent", server_addr="127.0.0.1:7531")
+wrapped = goldfive.wrap(root_agent, sinks=[HarmonografSink(client)])
+
+app = App(
+    name="my-demo",
+    root_agent=wrapped,
+    plugins=[HarmonografTelemetryPlugin(client)],
+)
+# `adk web agent.py` now loads wrapped; programmatic use:
+#   outcome = await wrapped.run("make a presentation about waffles")
+```
+
+For the Claude Agent SDK:
+
+```python
 # Claude Agent SDK (requires goldfive[claude])
 from goldfive.adapters.claude import ClaudeAgentSDKAdapter
 agent = ClaudeAgentSDKAdapter(

--- a/docs/guides/adk-web-integration.md
+++ b/docs/guides/adk-web-integration.md
@@ -1,47 +1,42 @@
 # Using goldfive with `adk web`
 
 `adk web` is Google ADK's local web UI for driving an agent
-interactively. It expects the module it loads to expose an
+interactively. It loads a Python module that exposes an
 `App(root_agent=...)` whose `root_agent` is a
-`google.adk.agents.BaseAgent`. Before goldfive Phase 2,
-`goldfive.wrap(agent)` always returned a `goldfive.Runner` — great for
-programmatic use, but *not* a `BaseAgent`, so the ADK UI couldn't load
-it.
-
-As of issue [#77], `goldfive.wrap(adk_agent)` returns a polymorphic
-[`GoldfiveADKAgent`](../../goldfive/adapters/adk_wrap.py). The same
-object now works in both contexts:
+`google.adk.agents.BaseAgent`. `goldfive.wrap(adk_agent)` returns a
+polymorphic
+[`GoldfiveADKAgent`](../../goldfive/adapters/adk_wrap.py) — a
+`BaseAgent` subclass that also exposes the Runner surface, so one
+object works in both contexts.
 
 | Call site | Needs | What goldfive returns |
 |---|---|---|
 | `adk web` | `BaseAgent` with `run_async(ctx)` | `GoldfiveADKAgent` — it IS a `BaseAgent`. |
 | Programmatic | `await runner.run(user_input)` | `GoldfiveADKAgent` — same object, same method. |
 
-No new entry points, no second wrap variant — the existing call site
-just works.
-
 ## The any-tree guarantee
 
-`goldfive.wrap(any_adk_tree)` works regardless of tree shape.
-Goldfive builds one `InMemoryRunner` around the tree root; ADK's
-native mechanisms (`AgentTool`, `transfer_to_agent`, `sub_agents`)
-resolve delegation inside the tree. The tree is **respected, never
-rewritten or flattened**:
+`goldfive.wrap(any_adk_tree)` works regardless of tree shape. One
+`InMemoryRunner` around the tree root (single-Runner model,
+goldfive#130); ADK's native mechanisms (`AgentTool`,
+`transfer_to_agent`, `sub_agents`) resolve delegation inside the tree.
+The tree is **respected, never rewritten or flattened**.
 
 | Tree shape | What wrap does |
 |---|---|
-| Single agent — `Agent(name="worker", ...)` | One runner around `worker`; every invoke drives it. |
-| Coordinator with `sub_agents` | One runner around the coordinator. ADK's `transfer_to_agent` handles delegation within a turn. |
-| Coordinator with `AgentTool`-wrapped specialists | One runner around the coordinator. AgentTool calls spawn sub-Runners that inherit the goldfive plugin. |
-| Deep nesting (`inner_agent` wrappers, `AgentTool` inside an agent whose parent is itself an `AgentTool`, …) | One runner at the root; ADK handles arbitrary-depth delegation. `available_agents` walks the tree to expose every reachable name for the planner. |
+| Single `LlmAgent` | One runner around the agent; every turn drives it. |
+| Flat list of specialists under a coordinator via `sub_agents` | One runner around the coordinator. ADK's `transfer_to_agent` handles delegation within a turn. |
+| Coordinator with `AgentTool`-wrapped specialists | One runner around the coordinator. AgentTool calls spawn sub-Runners; ADK propagates the goldfive plugin manager into them automatically. |
+| Deep nesting / wrappers / arbitrary composition | One runner at the root; ADK handles arbitrary-depth delegation. `available_agents_tree` walks the tree once to give the planner a structured map (name / depth / parent / role / kind). |
 
-A writer that has an `editor` sub-agent still has that editor when
-the writer's invocation drives it. A coordinator that has three
-`AgentTool`s as tools still has those tools. `available_agents` is
-an advisory list the planner uses to populate
-`task.assignee_agent_id` as a delegation hint; goldfive does not
-route on it. See
-[ARCHITECTURE.md §"Single-Runner dispatch"](../design/ARCHITECTURE.md#single-runner-dispatch-goldfive-drives-the-root-adk-delegates-within)
+`available_agents` (sorted list of reachable agent names) and the
+richer `available_agents_tree` (structured tree metadata,
+goldfive#151) are advisory inputs to the planner. The planner may
+populate `task.assignee_agent_id` as a delegation hint; goldfive does
+not route on it under the single-Runner model.
+
+See
+[ARCHITECTURE.md §"Single-Runner dispatch"](../design/ARCHITECTURE.md)
 for the underlying model.
 
 ## The recipe
@@ -61,7 +56,6 @@ real_agent = Agent(
     sub_agents=[...],
 )
 
-# Before: root_agent = real_agent
 root_agent = goldfive.wrap(real_agent)
 
 app = App(name="my-demo", root_agent=root_agent)
@@ -75,111 +69,212 @@ adk web agent.py
 ```
 
 Every user turn the UI submits now flows through goldfive's pipeline —
-goal-derive → plan → execute → emit events — and the ADK UI renders a
-short stream of `Event` objects summarising the plan + each completed
-task.
+goal-derive → plan → execute (overlay) → emit events — and the ADK UI
+renders a short stream of `Event` objects summarising the plan + each
+completed task.
 
 A complete runnable file lives at
 [`examples/adk_web_wrapped.py`](../../examples/adk_web_wrapped.py).
 
+## What wrap installs on the tree
+
+`goldfive.wrap(adk_agent)` performs three tree-wide passes at
+construction time:
+
+1. **Reporting-tool augmentation.** Walks `sub_agents` / `inner_agent`
+   / `tool.agent` edges and appends the seven `report_task_*` tools
+   to every agent that carries a mutable `tools` list. Idempotent —
+   agents that already have them are skipped.
+2. **`GoldfivePlanner` attachment.** Every `LlmAgent` gets a
+   `GoldfivePlanner(BasePlanner)` attached as its `planner=` field
+   (goldfive#153). The planner composes with a user-supplied planner
+   if one was already set. Per-agent opt-out via
+   `agent._goldfive_planner_opt_out = True`.
+3. **Plugin install.** Builds one `InMemoryRunner` around the root
+   and installs `_GoldfiveADKPlugin` on it. The plugin is where every
+   structural observation lives — `before_tool_callback`,
+   `after_tool_callback`, `before_model_callback`, `before_agent_callback`,
+   `after_agent_callback`, and the tool-loop detector (goldfive#181).
+
+`goldfive.wrap(agent, plugins=[HarmonografTelemetryPlugin(client)])`
+forwards additional plugins into the same runner, deduped by plugin
+`name` (goldfive#166) so caller-supplied plugins and goldfive's own
+plugin never double-install.
+
+## The per-turn orchestration context block
+
+On every LLM call inside the wrapped tree, the goldfive plugin's
+`before_model_callback` detects that the running agent carries a
+`GoldfivePlanner` and appends a short structural context block to
+`llm_request.config.system_instruction`. The block is tree-agnostic —
+no presentation / research / coordinator vocabulary — and reads
+from `session.state['goldfive.*']` keys the reconciler + steerer
+populate per turn:
+
+- Current task id, title, description, status.
+- Plan summary + every completed task's summary.
+- Goal summaries.
+- Active USER_STEER (when one is in flight) + its author.
+- Cancelled function-call ids to avoid (goldfive#147).
+
+The injection path subclasses `BasePlanner` directly rather than
+`PlanReActPlanner` so goldfive does not inherit ReAct response
+filtering (which would constrain agent output). See
+`goldfive/planners/goldfive_planner.py` for the full contract.
+
 ## What the UI sees each turn
 
-When ADK invokes `root_agent.run_async(ctx)`, goldfive:
+When ADK invokes `root_agent.run_async(ctx)`, `GoldfiveADKAgent`:
 
-1. Extracts the latest user text from `ctx.user_content` (falling back
-   to the session's event history).
-2. Runs one `Runner.run(user_input, context={"adk_ctx": ctx})` pass.
-3. Synthesises an `Event` stream from the resulting
-   [`ExecutionOutcome`](../../goldfive/results.py):
-   - A **plan summary** event (the first message).
+1. Pins `ctx.session.id` (adk-web's outer session id) onto the
+   goldfive `Session.id` and the `ADKAdapter`'s internal session
+   bookkeeping (goldfive#161 + #164). Result: one session in
+   harmonograf per run, and per-event `session_id` stamping
+   (goldfive#155) routes correctly.
+2. Extracts the latest user text from `ctx.user_content` (falling
+   back to `ctx.session.events` for frameworks whose context shape
+   varies).
+3. Runs one `Runner.run(user_input, context={"adk_ctx": ctx},
+   session_id=outer_sid)` pass.
+4. Synthesises an `Event` stream from the resulting
+   `ExecutionOutcome`:
+   - A **plan summary** event.
    - One event per completed task, keyed by `Task.title`.
-   - One line per drift event observed during the turn.
+   - One line per drift observed during the turn.
    - A terminal `turn_complete=True` event closing the turn.
 
-This is deliberately minimal — enough for `adk web` to render a coherent
-turn without duplicating what goldfive emits into its own event sinks.
-Richer views come from attaching a sink to the wrapped runner (see
-below).
+Deliberately minimal — enough for `adk web` to render a coherent turn
+without duplicating goldfive's own sink output. Richer views come from
+attaching a sink to the wrapped runner (see the harmonograf section
+below) or attaching `HarmonografTelemetryPlugin` to the `App`.
+
+## Model setup via `LiteLlm`
+
+ADK sub-agents typically use a LiteLLM model string (`openai/gpt-4o-mini`,
+`anthropic/claude-sonnet-4-5`, etc.) or a Gemini model id. A common
+pattern in the examples:
+
+```python
+from google.adk.agents import Agent
+
+MODEL_NAME = os.environ.get("USER_MODEL_NAME", "openai/gpt-4o-mini")
+agent = Agent(name="writer", model=MODEL_NAME, instruction="...")
+```
+
+Pinning the default matters because of the pitfall below.
+
+### Pitfall: Gemini default without `GOOGLE_API_KEY`
+
+harmonograf's `tests/reference_agents/presentation_agent_orchestrated/agent.py`
+defaults `USER_MODEL_NAME` to `gemini-2.5-flash`. Running that
+module without `export USER_MODEL_NAME=openai/gpt-4o-mini` (or
+setting `GOOGLE_API_KEY`) gets you a coordinator that silently
+instantiates a Gemini client with no credentials. The first LLM call
+raises after goldfive has already run through plan / goal-derive /
+initial dispatch; the stream ends with a bare
+`AttributeError: '_async_httpx_client'` at teardown and the UI shows
+"goldfive run complete." with nothing actually done.
+
+**Signature.** Run terminates almost immediately with a single
+"goldfive run complete." event. Traceback mentions
+`_async_httpx_client`. Coordinator's instruction looked fine. Works
+when you set `USER_MODEL_NAME` to a non-Gemini model.
+
+**Fix.**
+
+```bash
+export USER_MODEL_NAME=openai/gpt-4o-mini
+# or, for the kikuchi local LLM stack:
+export USER_MODEL_NAME=openai/qwen3-coder-30b
+export OPENAI_BASE_URL=http://kikuchi:8000/v1
+export OPENAI_API_KEY=sk-anything   # not validated by kikuchi
+```
+
+Then re-run `adk web ...`. The same env vars feed
+`LLMPlanner.call_llm` when an `OPENAI_API_KEY` is set, so planner +
+subagents land on the same backend.
 
 ## Programmatic use still works
 
 ```python
 root_agent = goldfive.wrap(real_agent)
 
-# Same object. Different call site.
+# Same object, different call site.
 outcome = await root_agent.run("plan a presentation about waffles")
 ```
 
 `GoldfiveADKAgent.run(user_input, **kwargs)` delegates straight to the
-inner `Runner.run(...)`, so every Runner knob — `context=`, cancellation
-via `ControlChannel`, drift handling — behaves as before.
+inner `Runner.run(...)`, so every Runner knob — `context=`,
+cancellation via `ControlChannel`, drift handling — behaves as before.
 
-## Harmonograf observability composes cleanly
+## Attaching harmonograf
 
-The wrapper exposes the inner `Runner`'s sink list as a property, so
-`harmonograf_client.observe()` (which appends a `HarmonografSink`) works
-unchanged:
+Two independent wiring points:
+
+1. **`HarmonografSink`** on the goldfive runner — receives every
+   `Event` (RunStarted / GoalDerived / PlanSubmitted / TaskStarted /
+   TaskCompleted / DriftDetected / PlanRevised / …).
+2. **`HarmonografTelemetryPlugin`** on the ADK `App` — captures
+   per-agent spans (INVOCATION / LLM_CALL / TOOL_CALL), which the UI
+   renders on the Agents timeline with per-agent Gantt rows
+   (goldfive#170 + harmonograf#80).
 
 ```python
 import goldfive
-import harmonograf_client
+from google.adk.apps.app import App
+from harmonograf_client import Client, HarmonografSink, HarmonografTelemetryPlugin
 
-root_agent = harmonograf_client.observe(goldfive.wrap(real_agent))
-# observe() appended a sink to root_agent.sinks — the returned object is
-# still the same GoldfiveADKAgent. adk web will load it just the same.
+client = Client(name="my-agent", server_addr="127.0.0.1:7531")
+wrapped = goldfive.wrap(root_agent, sinks=[HarmonografSink(client)])
 
-app = App(name="observed-demo", root_agent=root_agent)
+app = App(
+    name="my-demo",
+    root_agent=wrapped,
+    plugins=[HarmonografTelemetryPlugin(client)],
+)
 ```
 
-## What is and is not shared with the adk-web session
+Both hooks deduplicate by plugin name (goldfive#166), so if you also
+pass the plugin to `goldfive.wrap(plugins=[...])` only one instance
+ends up installed on the runner.
 
-The goldfive pipeline that runs for each turn uses its own internal
-`InMemoryRunner` (via `ADKAdapter` — see
-[ARCHITECTURE.md §"Single-Runner dispatch"](../design/ARCHITECTURE.md#single-runner-dispatch-goldfive-drives-the-root-adk-delegates-within)).
-That runner is independent of the ADK session that `adk web`
-hosts. In practice this means:
-
-- Per-turn goldfive state (plan, drift history, reporting tool calls)
-  lives in goldfive's `Session` and on goldfive's sinks.
-- The ADK UI sees the synthesised `Event` stream from step 3 above.
-- Cross-turn memory / state shared at the *adk web session* level is on
-  the Phase 3 roadmap (the sibling agent currently wires
-  conversation-level continuity through `run()`; see issue #71).
+`harmonograf_client.observe(wrapped)` is the legacy entry point —
+still works, still appends a `HarmonografSink`. The newer path is
+the explicit `App(plugins=[...])` wire above, because adk-web needs
+the plugin on the App-level runner to see ADK-native spans.
 
 ## Coordinator + AgentTool: delegation happens inside the turn
 
 A common shape: a coordinator whose `tools` list contains
 `AgentTool(specialist_a)`, `AgentTool(specialist_b)`, etc. The
-coordinator's instruction text typically tells it to call the
-appropriate specialist as a tool based on the user request.
+coordinator's instruction typically tells it to call the appropriate
+specialist as a tool based on the user request.
 
 **What goldfive does with this tree.** Builds one `InMemoryRunner`
 around the coordinator with the goldfive plugin installed. Every
-`invoke(task, session)` drives that one runner. The coordinator's
-LLM decides whether to answer directly or delegate via
-`AgentTool(specialist_a)`; ADK spawns a sub-Runner for the
-specialist and propagates the plugin manager into it automatically.
+per-turn invocation drives that one runner. The coordinator's LLM
+decides whether to answer directly or delegate via
+`AgentTool(specialist_a)`; ADK spawns a sub-Runner for the specialist
+and propagates the plugin manager into it automatically.
 
-**What the planner sees.** `available_agents` lists every reachable
-agent name — the planner may populate `task.assignee_agent_id` with
-a specific agent name to hint the coordinator toward a specialist.
-Under the single-Runner model this is advisory only: the hint rides
-in the task context the coordinator reads but does not force
-routing.
+**What the overlay reconciler sees.** `before_agent_callback` fires
+for every agent the tree runs, including sub-Runners. The reconciler
+maps each `(name, invocation_id)` onto the first PENDING plan task
+whose `assignee_agent_id == name` (with a contextual match fallback
+walking the parent chain, goldfive#151). `after_agent_callback`
+moves it to COMPLETED (or FAILED on error). PENDING tasks the tree
+never visited are transitioned to `NOT_NEEDED` at end-of-invocation
+(goldfive#163) — no soft follow-up dispatch, which prevented a class
+of flow-prompted coordinator re-running its whole pipeline on every
+follow-up user message.
 
-**The runaway-delegation cap.** A coordinator whose prompt
-describes a pipeline ("first research, then build, then review…")
-can enter a self-delegating loop. Goldfive cannot require prompt
-cooperation (users bring their own trees), so the plugin enforces
-a per-invocation cap on AgentTool spawns — default 16, configurable
-via `ADKAdapter(agent_tool_cap=N)` (set to 0 to disable). When the
-cap trips, the plugin emits a `RUNAWAY_DELEGATION` drift and
-cancels the invocation; the Steerer's refine hook gets a chance to
-salvage the run. See
-[common-failure-modes §"coordinator+AgentTool loop under real LLM"](common-failure-modes.md#8-coordinatoragenttool-loop-under-real-llm)
-for the detailed signature and
-[RATIONALE.md §"Why single-Runner, not registry-dispatch"](../design/RATIONALE.md#why-single-runner-not-registry-dispatch)
-for the design history.
+**The runaway-delegation cap.** A coordinator whose prompt describes
+a pipeline can enter a self-delegating loop. The plugin enforces a
+per-invocation cap on AgentTool spawns (default 16, configurable via
+`ADKAdapter(agent_tool_cap=N)`; `0` disables). On exceed the plugin
+emits `RUNAWAY_DELEGATION` at CRITICAL severity and short-circuits
+further AgentTool dispatches. The steerer's intervention ladder then
+decides what to do (ABSORB via refine, PAUSE_ESCALATE, etc.).
 
 ### End-to-end example: coordinator + AgentTool under `adk web`
 
@@ -194,9 +289,10 @@ researcher = Agent(
     name="researcher",
     model="gpt-4o-mini",
     instruction=(
-        "You are a researcher. Each message you receive is a single "
-        "task — research the topic and call report_task_completed "
-        "with a concise summary. Do not delegate."
+        "You are a researcher. Each turn, goldfive gives you one "
+        "current task via the orchestration context block at the "
+        "top of your system instruction. Do that task; call "
+        "report_task_completed when done; stop. Do not delegate."
     ),
 )
 
@@ -204,8 +300,9 @@ writer = Agent(
     name="writer",
     model="gpt-4o-mini",
     instruction=(
-        "You are a writer. Each message is a single task — produce "
-        "the requested draft and call report_task_completed."
+        "You are a writer. Same contract as researcher — one task "
+        "per turn from the orchestration context; call "
+        "report_task_completed; stop."
     ),
 )
 
@@ -214,20 +311,14 @@ coordinator = Agent(
     model="gpt-4o-mini",
     tools=[AgentTool(researcher), AgentTool(writer)],
     instruction=(
-        "You coordinate a research + writing pipeline. When asked to "
-        "do multi-step work, call the researcher AgentTool first, "
-        "then the writer AgentTool with the research results."
+        "You coordinate research + writing. Read the current task "
+        "from the orchestration context and call the appropriate "
+        "AgentTool — researcher for research tasks, writer for "
+        "drafting."
     ),
 )
 
-# Wrap the coordinator — goldfive builds one runner around it.
 root_agent = goldfive.wrap(coordinator)
-
-# goldfive.adapters.adk.ADKAdapter.available_agents is
-# ['coordinator', 'researcher', 'writer'] — advisory for the
-# planner. Every task drives the coordinator; delegation to
-# researcher / writer happens via the AgentTool calls the
-# coordinator makes inside its turn.
 
 app = App(name="multi-agent-demo", root_agent=root_agent)
 ```
@@ -239,32 +330,56 @@ uv pip install -e '.[adk]'
 adk web agent.py
 ```
 
-Each user turn, the UI submits a request; goldfive's planner
-produces a two-task plan (research → write) and the executor drives
-the coordinator for each task. The coordinator's AgentTool calls
-delegate to the specialists; the per-invocation cap catches any
-runaway loop.
+Each turn, goldfive's planner produces a multi-task plan; the
+coordinator reads the current task from the context block and
+delegates via AgentTool. The reconciler attributes each sub-Runner's
+`before_agent` / `after_agent` pair to the right plan task.
+
+For the full multi-agent example — coordinator + 4 specialists +
+real file-writing tools — see
+[`examples/presentation_agent/`](../../examples/presentation_agent/).
 
 ## Pre-built Runner degrade mode
 
 If you construct your own `InMemoryRunner` and hand it to
-`goldfive.wrap(...)` (or to `ADKAdapter(...)` directly), goldfive
-uses the runner verbatim. `available_agents` reports just the
-runner's root agent name; the wrap-time plugin-installed integrity
-check is skipped because the caller may have passed a runner shape
-we don't fully control.
+`goldfive.wrap(...)` (or to `ADKAdapter(...)` directly), goldfive uses
+the runner verbatim. `available_agents` reports just the runner's
+root agent name; the wrap-time plugin-installed integrity check is
+skipped because the caller may have passed a runner shape we don't
+fully control.
 
-Every `invoke(task, session)` drives that one runner — which is
-the same behaviour as the non-degraded path under the single-Runner
-model, the only difference being that goldfive didn't construct the
-runner itself.
+Every `invoke(task, session)` drives that one runner — same behaviour
+as the non-degraded path, the only difference being that goldfive
+didn't construct the runner itself.
 
-## Limitations
+## Live steering from harmonograf
 
-- `ControlChannel` steering from a harmonograf UI does not yet reach the
-  adk-web-driven pipeline — Phase 4 follow-up.
-- Only ADK-shaped agents get the polymorphic return. Callable agents and
-  Claude SDK factories still return a plain `Runner`; that's intentional
-  (they can't satisfy `BaseAgent` anyway).
+The harmonograf UI's Steer / Pause / Cancel / Approve buttons drive
+the goldfive `ControlChannel`. Wire it through:
+
+```python
+from goldfive import ControlChannel
+from harmonograf_client import Client, HarmonografSink
+
+channel = ControlChannel()
+client = Client(name="my-agent", server_addr="127.0.0.1:7531")
+
+wrapped = goldfive.wrap(
+    root_agent,
+    control=channel,
+    sinks=[HarmonografSink(client)],
+)
+# ... drain client.observe() into channel.send(bridge(event)) in a
+#     companion task; forward channel.acks() back to the client.
+```
+
+STEER annotations carry an `annotation_id` (goldfive#171) that
+propagates into the drift detail, the refine reason on the revised
+plan, and the resulting `DriftDetected.annotation_id` field. This
+lets harmonograf deduplicate redundant STEER clicks and show the
+author of each refine.
+
+See [../design/CONTROL.md](../design/CONTROL.md) for the full
+protocol.
 
 [#77]: https://github.com/pedapudi/goldfive/issues/77

--- a/docs/guides/common-failure-modes.md
+++ b/docs/guides/common-failure-modes.md
@@ -1,358 +1,308 @@
 # Common failure modes
 
-Catalog of the failure shapes goldfive has observed in the wild,
-with the signature on the event stream, the root cause, and the
-recovery path. Pair with
-[troubleshooting.md](troubleshooting.md) (install + setup
-problems) and [insight-from-logs.md](insight-from-logs.md) (how to
-read the stream itself). For the "it wasn't on this page"
+Catalog of the failure shapes goldfive has observed in the wild, with
+the signature on the event stream, the root cause, and the recovery
+path. Pair with [troubleshooting.md](troubleshooting.md) (install +
+setup problems) and [insight-from-logs.md](insight-from-logs.md) (how
+to read the stream itself). For the "it wasn't on this page"
 catch-all, reach for
 [.agents/debug-goldfive.md](../../.agents/debug-goldfive.md).
 
-## 1. Filler loop
+For the taxonomy of every drift kind, severity rules, and the refine
+policy, see [../design/DRIFT.md](../design/DRIFT.md).
 
-The canonical goldfive failure: the agent loops making no forward
-progress, and the guards — which exist — fail to stop it.
-Pre-#98 / #108 / #109 hardening, this class of bug could ride all
-the way to the framework's own ceiling (ADK 500 calls, Claude
-max_turns) before the run aborted.
+## 1. Tool-call loop — agent stuck calling the same tool
 
-**Signature.** One of:
+The canonical filler loop post-#181: the agent keeps calling the same
+tool over and over without reaching a terminal task state. Covered
+automatically by the **`ToolLoopTracker`** (auto-wired, no user
+config). The detector fires at `after_tool_callback` on three
+patterns:
 
-- `outcome.success=False, reason="exhausted max_task_invocations=N with pending task <id>"`
-  with `id` being the same task every time.
-- `outcome.success=False, reason="adapter.invoke raised ... max_turns_exceeded"`
-  or similar framework-level abort.
-- `sink.events` shows `DRIFT_KIND_LOOPING_TOOL_CALL` (post-guard)
-  or a dominating count of `report_task_*` calls on one task
-  (pre-guard).
-- Task status is `COMPLETED` on the session plan, but reporting
-  tool calls keep arriving for the same `task_id` (returned as
-  `task_already_terminal` acks post-#98).
+- **Exact** — same `(tool_name, args_hash)` repeats ≥ 3 in the last 7
+  calls → `LOOPING_REASONING` / WARNING.
+- **Name** — same `tool_name` (any args) repeats ≥ 5 in the last 7
+  with no task-state progress → `LOOPING_REASONING` / WARNING.
+- **Alternating** — A,B,A,B,A pattern in the last 5 → `LOOPING_REASONING`
+  / INFO (observational; does not trigger refine).
 
-**Root causes (by likelihood).**
-
-1. A new adapter bypassed `invoke_tool`. See
-   [.agents/how-to-debug-a-filler-loop.md](../../.agents/how-to-debug-a-filler-loop.md).
-   This was the #108 root cause in the ADK adapter.
-2. A custom planner produced a task the agent can't actually
-   satisfy (the agent reports "done" but the planner doesn't
-   accept the completion, refine spawns a retry, loop).
-3. The agent's instruction prompt is wrong — it thinks it's
-   driving the whole workflow (see §Agent tree misdesign below).
-
-**Recovery path.**
-
-- Set `SequentialExecutor(max_task_invocations=<finite>)` as a
-  belt-and-suspenders ceiling while investigating.
-- Run [.agents/how-to-debug-a-filler-loop.md](../../.agents/how-to-debug-a-filler-loop.md).
-- If the guard was bypassed, fix the adapter. If the agent is
-  mis-prompted, fix the instruction. Do NOT add another cap.
-
-## 2. Refine failure (truncated JSON, LLM unavailable)
-
-The planner LLM returns something `LLMPlanner` can't parse. Three
-common shapes:
-
-- JSON that got truncated at the token limit — missing closing
-  `}` or `]`.
-- An empty string or a whitespace-only response.
-- Valid JSON but in the wrong shape (no `tasks` field, or tasks
-  missing required keys).
+Reporting-tool calls (`report_task_*`, `report_plan_divergence`, etc.)
+are excluded — they're progress signals, not work.
 
 **Signature.**
 
-- `DriftDetected` with detail starting `refine failed` (or
-  `_refine_user_steer: empty/non-string`).
-- Logger `goldfive.planner` DEBUG line with `failed to parse LLM
-  output`.
-- `session.refine_failure_counts` incrementing for
-  `(drift.kind, current_task_id)` across ticks.
-- Once the counter crosses
-  `DefaultSteerer.REFINE_FAILURE_THRESHOLD` (default `2`),
-  `DriftDetected{kind=REPEATED_FAILURE, severity=CRITICAL}` fires
-  and the task is marked FAILED.
+- `DriftDetected{kind=looping_reasoning, severity=warning}` with
+  `detail` starting `tool_loop_exact:`, `tool_loop_name:`, or
+  `tool_loop_alternating:`.
+- `raw.mode` on the drift identifies which mode fired.
+- Downstream: the steerer escalates through the intervention ladder
+  (Level 1 ABSORB → refine; escalates to Level 3 CANCEL_REINVOKE on
+  repeat).
+
+**Configuration.** Defaults tuned for a 7-call window. Override via
+env vars:
+
+- `GOLDFIVE_TOOL_LOOP_WINDOW` (default 7)
+- `GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD` (default 3)
+- `GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD` (default 5)
+- `GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD` (default 5)
+
+See `goldfive/drift/tool_loops.py` for the full contract.
+
+**Recovery path.**
+
+1. Read the drift detail: identifies the tool being looped.
+2. If the tool is legitimate (scripted pipeline), raise the threshold
+   or clear the buffer with `ToolLoopTracker.on_task_progress(...)`
+   on your own progress signal.
+3. If it's genuine drift, let the intervention ladder handle it —
+   `planner.refine` typically produces a revised task that escapes
+   the loop.
+
+## 2. Plan divergence — agent ran an unplanned agent
+
+The overlay reconciler observed a `before_agent_callback` for an agent
+whose `name` doesn't match any PENDING plan task's `assignee_agent_id`
+(after walking the parent chain for a contextual match,
+goldfive#151). Emitted as `PLAN_DIVERGENCE` / INFO severity —
+observational.
+
+Separately, the three-stage `function_call` gate in
+`GoldfivePlanner.process_planning_response` (goldfive#184) classifies
+LLM-emitted tool calls:
+
+| Input | Classification |
+|---|---|
+| `function_call` name is in the current agent's `tools` | legitimate; no drift |
+| Name is a known agent in the tree registry but not in this agent's tools | cross-layer delegation attempt → `PLAN_DIVERGENCE` / WARNING |
+| Name is nowhere (not a tool, not a known agent) | hallucination → `CONFABULATION_RISK` / WARNING |
+
+`function_call` names prefixed `report_` (the reporting-tool namespace)
+are always legitimate regardless of tool-list contents. Cancelled
+function-call ids from `session.state['goldfive.cancelled_function_call_ids']`
+are stripped before classification runs.
+
+**Signature.**
+
+- `DriftDetected{kind=plan_divergence, severity=warning, detail="function_call ... cross-layer"}`.
+- `DriftDetected{kind=confabulation_risk, severity=warning, detail="function_call ... hallucinated"}`.
+- Never blocks the call — it's a signal, not a gate. The steerer's
+  ladder decides whether to escalate.
+
+**Recovery path.**
+
+- `PLAN_DIVERGENCE` → the refine path typically narrows the tool /
+  agent scope or adjusts assignee hints.
+- `CONFABULATION_RISK` → usually the prompt is wrong. Either (a)
+  narrow the coordinator's instruction to only describe tools it
+  actually has, or (b) add the missing tool / agent to the tree.
+
+## 3. Refine validation failed
+
+`LLMPlanner.refine` exhausted its retry budget — the LLM's response
+couldn't be parsed or couldn't pass `Plan.validate(for_revision=True,
+prior=plan)` after N attempts. The planner falls back to the prior
+plan (or the deterministic fail-the-looper plan when the drift was
+`LOOPING_REASONING`).
+
+**Signature.**
+
+- Logger `goldfive.planner` line: `LLMPlanner._refine_user_steer: attempt 2/2: <error>`.
+- `DriftDetected{kind=refine_validation_failed, severity=critical}`.
+- The steerer deliberately does **not** refine on this drift (infinite
+  loop risk). The ladder escalates to Level 4 PAUSE_ESCALATE →
+  `HUMAN_INTERVENTION_REQUIRED`.
 
 **Root causes.**
 
-- Planner LLM's `max_tokens` too small for the plan size.
-- Planner LLM provider down / rate-limited / returning 500s.
-- Prompt template is wrong (e.g. `{tasks}` literal in output
-  instead of a JSON array — shows up with custom planners).
+- Planner LLM's `max_tokens` too small; output is truncated JSON.
+- LLM returned a revision that drops a terminal task (§3.1 of
+  PLAN-LIFECYCLE) or grafts PENDING tasks onto CANCELLED predecessors
+  (reachability invariant, §7).
+- Planner prompt template is wrong (custom planners).
 
 **Recovery path.**
 
-- Widen `max_tokens` on your planner LLM.
-- Implement retries / backoff inside your `call_llm` callable
-  (not at the goldfive level — the steerer's refine-failure
-  counter is the coarse backoff).
-- Log the raw `call_llm` response before returning so you can
-  see what was actually truncated. See
-  [insight-from-logs.md §Capturing planner reasoning](insight-from-logs.md).
+- Widen `max_tokens`.
+- Log the raw `call_llm` response to see what the LLM produced. See
+  [insight-from-logs.md](insight-from-logs.md).
+- The operator resumes by steering again, cancelling, or accepting
+  the fallback plan.
 
-## 3. Orphaned PENDINGs at run end
+## 4. Runaway delegation — AgentTool cap exceeded
 
-A run ends with `success=False,
-reason="orphaned pending tasks after run: <ids>"`. Pre-#103 this
-could also produce `success=True` with PENDING tasks still on
-the plan — #103 and the reachability audit (§6.4) made that
-impossible.
+The coordinator's prompt describes a pipeline and its LLM keeps
+delegating via `AgentTool`. The goldfive ADK plugin enforces a
+per-invocation cap (default 16, configurable via
+`ADKAdapter(agent_tool_cap=N)`).
 
 **Signature.**
 
-- `outcome.success=False, reason="orphaned pending tasks after run: t4, t5, t6"`.
-- The last event before `RunAborted` is a CRITICAL
-  `DriftDetected{kind=PLAN_DIVERGENCE}` emitted by the
-  reachability audit.
-- Every orphan task is PENDING on the final plan with a
-  predecessor that is CANCELLED or FAILED.
+- `DriftDetected{kind=runaway_delegation, severity=critical}` once the
+  cap trips.
+- Further AgentTool spawns in the same invocation return a "skipped"
+  dict.
+- The current task is marked FAILED (CRITICAL drift flows through the
+  planner's refine path).
 
-**Root causes.**
+**Root cause.** The coordinator's prompt describes a pipeline and the
+LLM keeps re-routing. Goldfive cannot require prompt cooperation
+(users bring their own trees).
 
-- `planner.refine` returned `None` after a USER_STEER or
-  unrecoverable drift, but the cascade didn't fire — pre-#103 bug,
-  should not recur.
-- A custom steerer cancelled a task without calling
-  `cascade_cancel_downstream` — the primitive is the source of
-  truth; any direct `mark_task_cancelled` that skips the
-  downstream walk regresses §6.3.
+**What catches it first, in order.**
+
+1. **`ToolLoopTracker`** (§1) — catches tight AgentTool loops before
+   the cap trips.
+2. **Reasoning-content drift detectors.** `LOOPING_REASONING` (hash-
+   or embedding-based), `INTENT_DIVERGENCE`, `CONFUSION` fire when
+   the coordinator's chain-of-thought shows the pattern.
+3. **Refine-driven recovery.** A WARNING-or-higher drift flows
+   through the ladder into `planner.refine`, which can narrow the
+   assignee hint or split into sub-tasks before the next turn.
+4. **AgentTool cap.** The last-resort safety net.
 
 **Recovery path.**
 
-- Confirm you're on goldfive ≥ #103. If so, file a bug — this
-  shouldn't happen on current `main`.
-- If you have a custom Steerer subclass, audit it for any
-  `mark_task_cancelled` path that doesn't delegate to
-  `cascade_cancel_downstream`.
+- Inspect `adapter.available_agents` after wrap: should list every
+  agent in the tree. A one-entry list means the wrap target was a
+  pre-built `Runner` rather than a `BaseAgent`.
+- Tighten the coordinator's prompt to be task-focused (see the
+  example in [adk-web-integration.md](adk-web-integration.md)).
+- Raise `agent_tool_cap` only if legitimate delegation exceeds 16
+  per turn.
 
-## 4. Agent tree misdesign (coordinator-drives-whole-workflow)
+## 5. Goal drift (opt-in)
 
-Not a framework bug but easy to mistake for one: the agent's
-prompt tells it to run the whole workflow in one turn, instead of
-handling "just the task the orchestrator routed me". The
-`examples/adk_presentation/` example hit this before #111 — a
-hand-rolled coordinator + subagent tree where the coordinator's
-instructions made it `transfer_to_agent` sub-agents in sequence
-regardless of goldfive's task dispatch. Goldfive then marked the
-task complete while the coordinator was still narrating, and the
-coordinator kept calling `require_confirmation=True` tools that
-silently gated on a UI that wasn't watching.
+Periodic trajectory-level check: every N agent turns, an LLM-judge
+looks at the recent activity window and decides whether the tree is
+advancing `session.goals` (goldfive#143). Emits `GOAL_DRIFT` /
+CRITICAL when the judge concludes progress has stalled.
+
+**Feature gate.** Opt-in via `DefaultSteerer(goal_drift_enabled=True,
+goal_drift_call_llm=...)`. Operators who don't configure it never
+trigger it and pay no LLM cost.
 
 **Signature.**
 
-- Multiple agents show up in `available_agents` but every
-  `InvocationResult` originates from one.
-- Plan generated by the LLM planner has one task per
-  sub-workflow, but the agent's output never acknowledges the
-  individual task ids — it just rolls through.
-- Reasoning content (if extracted) mentions the whole workflow
-  not the current task.
-- `report_task_completed` is called with arguments derived from
-  the *plan summary*, not the *current task id* — the agent
-  doesn't know which task it's on.
+- `DriftDetected{kind=goal_drift, severity=critical}`.
+- Routes to Level 4 PAUSE_ESCALATE → `HUMAN_INTERVENTION_REQUIRED`.
 
-**Root causes.**
+## 6. Human intervention required
 
-- The agent's instruction says "execute the plan" rather than
-  "execute the single task the orchestrator gave you."
-- `require_confirmation=True` on sub-agent tools, combined with
-  no UI watching approvals — the tool silently blocks, the
-  framework reports `max_turns_exceeded`.
-- A coordinator that uses `transfer_to_agent` as its primary
-  control-flow mechanism, treating sub-agents as independent
-  processes rather than goldfive-managed workers.
+The steerer escalated a drift to Level 4. Paused the run on
+`session.paused_for_human_intervention`; the executor blocks waiting
+for a `CONTROL_RESUME` or `CONTROL_STEER`. Emitted for:
+
+- Persistent refine failures.
+- `GOAL_DRIFT` (CRITICAL).
+- `REFINE_VALIDATION_FAILED`.
+- `RUNAWAY_DELEGATION` on repeat.
+
+**Signature.**
+
+- `DriftDetected{kind=human_intervention_required, severity=critical}`.
+- Run pauses; no new tasks start.
+- Harmonograf UI's session header shows the pause; the Steer / Resume
+  buttons are armed.
+
+**Recovery path.** A user-initiated `CONTROL_RESUME` or
+`CONTROL_STEER` clears the flag.
+
+## 7. Qwen coordinator hallucinates tool success (model-specific)
+
+Observed on Qwen3-Coder and similar weaker models under the
+`presentation_agent_orchestrated` tree: the coordinator produces
+fluent output claiming it wrote files via `write_webpage` but never
+actually emits the tool call. The tree reports success; the
+filesystem is empty.
+
+**Not a goldfive regression.** The confabulation-risk classifier
+(§2) catches the shape when the task's title/description implies
+external data access (research, lookup, write, verify, …) and the
+agent produced non-empty output without calling a single tool —
+`CONFABULATION_RISK` / INFO. Record-only; does not trigger refine.
 
 **Recovery path.**
 
-- Simplify to one agent + `goldfive.wrap(agent)` first. If the
-  run now succeeds, the agent tree was the problem, not
-  goldfive. See `examples/adk_presentation/agent.py` for the
-  minimal shape post-#111.
-- If you need multiple agents, have each one handle only its
-  assigned task (`task.assignee_agent_id`) and return. Let
-  goldfive do the routing. The harmonograf
-  `tests/reference_agents/presentation_agent` is a worked
-  example with a real multi-agent tree that works with goldfive.
-- Rewrite the instruction to explicitly scope to the current
-  task: "Each message you receive is a single task; complete
-  just that task and stop."
+- Switch to a stronger model (`USER_MODEL_NAME=openai/gpt-4o-mini`
+  works; Gemini + `GOOGLE_API_KEY` works).
+- Tighten the coordinator prompt to say "you MUST call
+  `write_webpage` — do not claim success without the tool call."
+- The INFO drift itself is informational; operators watching the UI
+  can cancel on sight.
 
-## 5. `require_confirmation` silent gating (pre-#111 behaviour)
+## 8. Refine cascade produced no follow-up plan
 
-Specific sub-case of §4 but distinctive enough to call out. ADK
-sub-agents marked `require_confirmation=True` create a tool-call
-that blocks on an APPROVE / REJECT decision. Pre-#83 goldfive
-didn't have an APPROVE / REJECT control channel, so the tool
-call hung forever; #83 added the bridge; #111 dropped the
-unneeded `require_confirmation=True` from the example tree.
+Not a failure per se — "incomplete but not broken". A USER_STEER
+arrives, the current task is CANCELLED, the cascade cancels
+downstream PENDINGs, and then `planner.refine` returns `None`. No
+new work is installed. The run ends cleanly with `success=False`.
 
 **Signature.**
 
-- Agent "goes silent" — no new events after the first
-  `TaskStarted`.
-- `session.pending_approvals` has an entry keyed by an
-  `adk-<uuid>` (ADK Flow B). Non-empty after the run ends is the
-  red flag.
-- After `max_task_invocations` trips, the `RunAborted.reason`
-  blames the task that was waiting on approval, not the approval
-  itself — the failure mode looks like a stuck task.
-
-**Recovery path.**
-
-- Drop `require_confirmation=True` from any ADK tool that doesn't
-  actually need human-in-the-loop approval. This was the #111 fix.
-- If you do need approval, wire up the control channel
-  (`Runner(control=...)`) and route APPROVE / REJECT messages.
-  See [../design/CONTROL.md §Flow B](../design/CONTROL.md) and
-  [../design/APPROVAL.md](../design/APPROVAL.md).
-- Verify harmonograf `observe()` is attached if you expect the UI
-  to drive approvals — it enables HUMAN_IN_LOOP by default since
-  harmonograf #44.
-
-## 6. Cascade ran but refine didn't produce a follow-up plan
-
-Not a failure per se — just "incomplete but not broken". A
-USER_STEER arrives, the current task is CANCELLED, the cascade
-cancels downstream PENDINGs, and then `planner.refine` returns
-`None`. No new work is installed. The run ends cleanly with
-`success=False`.
-
-**Signature.**
-
-- `DriftDetected{kind=USER_STEER, severity=WARNING}`.
+- `DriftDetected{kind=user_steer, severity=warning}`.
 - `TaskCancelled` for the current task, then a flurry of
   `TaskCancelled` events with `reason="cascade from <task_id>"`.
 - No `PlanRevised` follows.
-- `RunAborted` with a reason like "goal '<...>' unmet" or
-  "planner declined refine".
+- `RunAborted` with reason like "goal '<…>' unmet" or "planner
+  declined refine".
 
 **Root causes.**
 
-- The steer message was ambiguous and the planner genuinely
-  couldn't produce a coherent follow-up.
-- The planner's prompt template doesn't know how to handle
-  USER_STEER (most `LLMPlanner` configurations do; custom
-  planners may not).
+- The steer message was ambiguous and the planner genuinely couldn't
+  produce a coherent follow-up.
+- Custom planners whose refine logic doesn't know how to handle
+  `USER_STEER` (the bundled `LLMPlanner` does).
 
 **Recovery path.**
 
-- This is arguably correct behaviour — the planner decided the
-  steer was unrecoverable. Treat the run as failed and start a
-  new one with the steer text folded into the initial input.
-- If you want the planner to always produce something, customise
-  your planner's refine logic to never return `None` (return a
-  trivial one-task plan as a fallback).
+- Arguably correct behaviour — the planner decided the steer was
+  unrecoverable. Start a new run with the steer text folded into
+  the initial input.
+- Customise your planner to never return `None` (return a trivial
+  one-task plan as a fallback).
 
-## 7. Drift kinds firing at unexpected severity
+## 9. Drift severity not what you expected
 
-`INTENT_DIVERGENCE` fires at graduated severity since #114 —
-INFO / WARNING / CRITICAL based on cosine similarity. If you
-were relying on "INTENT_DIVERGENCE always means refine", expect
-more INFO-severity signals that don't trigger refine.
+`INTENT_DIVERGENCE` fires at graduated severity — INFO / WARNING /
+CRITICAL based on cosine similarity against `session.goals` + the
+current task topic. If you were relying on "INTENT_DIVERGENCE always
+means refine", expect more INFO-severity signals that don't trigger
+it.
 
 **Signature.**
 
-- `DriftDetected{kind=INTENT_DIVERGENCE, severity=INFO}` — no
-  refine follows. This is expected and correct.
-- `DriftDetected{kind=INTENT_DIVERGENCE, severity=CRITICAL}` —
+- `DriftDetected{kind=intent_divergence, severity=info}` — no refine
+  follows. Expected.
+- `DriftDetected{kind=intent_divergence, severity=critical}` —
   treated as unrecoverable; cascade fires and the run aborts.
-- `UNCERTAIN_PROGRESS` (INFO) appearing mid-run — this is the
-  opt-in reflective self-progress check from #112 emitting.
-  Informational, no refine.
-- `SELF_REPORTED_STUCK` (WARNING) — refine triggered. Expect a
-  `PlanRevised` follow-up.
-
-**Root causes.**
-
-- Reading the `kind` without the `severity` — now the wrong
-  abstraction.
-- Relying on pre-#114 semantics where INTENT_DIVERGENCE was a
-  single severity.
+- `LOOPING_REASONING` at INFO (the `tool_loop_alternating` variant) —
+  observational, no refine.
 
 **Recovery path.**
 
 - Filter by `severity >= WARNING` if you only care about the
   refine-triggering band.
-- Update any custom `should_refine(drift)` override to inspect
-  severity, not kind.
+- Update custom `should_refine(drift)` overrides to inspect severity,
+  not kind.
 
-## 8. coordinator+AgentTool loop under real LLM
+## 10. Session rows duplicated in harmonograf
 
-Affects `goldfive.wrap(coordinator)` when the coordinator has
-`AgentTool`-wrapped specialists and its instruction describes a
-pipeline ("first research, then build, then review…"). Under a
-real LLM the coordinator may keep re-routing until ADK's 500-call
-ceiling trips.
+Pre-#161 / #164: goldfive's `Session.id`, the `ADKAdapter`'s internal
+`_session_id`, and adk-web's outer `ctx.session.id` were three
+different UUIDs. Goldfive events carried one id; harmonograf spans
+carried another; the UI showed two rows per run with the plan on one
+and the execution on the other.
 
-**Signature.**
+**Current state.** `GoldfiveADKAgent._run_async_impl` pins the outer
+adk-web session id onto both the goldfive Session and the
+ADKAdapter's internal state (`_outer_session_id`, `_session_id`)
+before any sub-agent dispatch runs. Per-event `session_id` stamping
+(goldfive#155) + `HarmonografSink` routing by it means one session
+row per run.
 
-- Plan submitted, at least one `TaskStarted` fires, but tasks hang
-  without reaching a terminal state.
-- The adk log shows repeated AgentTool calls under a single
-  invocation — the coordinator is decoding its own instruction each
-  turn and picking the next specialist.
-- A `drift_detected` event with kind `runaway_delegation` fires at
-  CRITICAL severity once the AgentTool-per-invoke cap trips.
-- The current task is marked `task_failed` (the CRITICAL drift
-  flows through the planner's refine path) with the drift detail
-  naming the exceeded cap.
-
-**Root cause.** The coordinator's prompt describes a pipeline and
-its LLM keeps delegating. Goldfive cannot require prompt
-cooperation (users bring their own trees).
-
-**What catches it.** Three layers, in order of detection:
-
-1. **Reasoning-content drift detectors.** LOOPING_REASONING (hash-
-   or embedding-based), INTENT_DIVERGENCE, CONFUSION — fire when
-   the coordinator's chain-of-thought shows the pattern. Most
-   cases are caught here before the AgentTool cap kicks in.
-2. **Refine-driven recovery.** A WARNING / CRITICAL drift flows
-   through `DefaultSteerer._handle_drift` into `planner.refine`,
-   which can revise the task (e.g. narrow the assignee hint or
-   split into sub-tasks) before the next invocation.
-3. **AgentTool-per-invoke cap (goldfive#130).** The plugin counts
-   AgentTool spawns scoped to the current invocation. Default 16.
-   On exceed the plugin emits `RUNAWAY_DELEGATION` at CRITICAL
-   severity, cancels the invocation, and short-circuits further
-   AgentTool spawns with a "skipped" dict. Tune via
-   `ADKAdapter(agent_tool_cap=N)` (0 disables).
-
-**Recovery path.**
-
-- Inspect `adapter.available_agents` after wrap: it should list
-  every agent in the tree. A one-entry list means the wrap target
-  was a pre-built `Runner` rather than a `BaseAgent` — see the
-  [degrade-mode section in adk-web-integration.md](adk-web-integration.md#pre-built-runner-degrade-mode).
-- Watch the `AgentInvocationStarted` / `AgentInvocationCompleted`
-  / `DelegationObserved` events on sinks to observe the delegation
-  tree (see [EVENT-MODEL.md §"Agent-invocation events"](../design/EVENT-MODEL.md#agent-invocation-events)).
-- If the cap is firing too often, either (a) tighten the
-  coordinator's prompt to be task-focused rather than pipeline-
-  focused, or (b) raise `agent_tool_cap` if the coordinator
-  legitimately delegates more than 16 times per turn.
-
-See
-[ARCHITECTURE.md §"Single-Runner dispatch"](../design/ARCHITECTURE.md#single-runner-dispatch-goldfive-drives-the-root-adk-delegates-within)
-and
-[RATIONALE.md §"Why single-Runner, not registry-dispatch"](../design/RATIONALE.md#why-single-runner-not-registry-dispatch)
-for the design history — including the goldfive#120 registry-
-dispatch experiment that was reverted in #130.
-
-## 9. Deprecation warning: `max_plan_reinvocations`
-
-`DeprecationWarning: SequentialExecutor(max_plan_reinvocations=...)
-is deprecated; use max_task_invocations=... instead.`
-
-**Root cause.** #115 renamed the parameter. The old kwarg is
-still accepted for one release with a `DeprecationWarning`.
-
-**Recovery.** Rename. The default changed from finite (32) to
-`None` (unbounded) in the same PR — if you were relying on the
-old default as a safety cap, set `max_task_invocations=32`
-explicitly. See
-[../design/RATIONALE.md](../design/RATIONALE.md) for why the
-default changed.
+**If you still see duplicates:** verify you're on goldfive ≥ #164
+and harmonograf ≥ #85 (lazy Hello).
 
 ## Related
 
@@ -361,4 +311,5 @@ default changed.
 - [telemetry-with-harmonograf.md](telemetry-with-harmonograf.md) — same diagnostics via the UI.
 - [../../.agents/debug-goldfive.md](../../.agents/debug-goldfive.md) — the triage tree.
 - [../../.agents/how-to-debug-a-filler-loop.md](../../.agents/how-to-debug-a-filler-loop.md) — deep dive on failure mode 1.
+- [../design/DRIFT.md](../design/DRIFT.md) — the drift taxonomy.
 - [../design/PLAN-LIFECYCLE.md](../design/PLAN-LIFECYCLE.md) — run termination predicate and cascade semantics.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -81,20 +81,68 @@ Every default is overridable via keyword argument — `planner=`,
 
 ## Mental model in five sentences
 
-goldfive wraps an agent and runs it against an explicit plan.
+goldfive wraps an agent and **observes** it running against an explicit plan.
 
 1. Your user input becomes one or more **Goals**.
 2. A **Planner** produces a **Plan** (a DAG of **Tasks**) that, if
    executed, satisfies the goals.
-3. An **Executor** walks the plan. For each task, it calls your
-   **AgentAdapter**, which drives whatever underlying framework
-   (Claude, ADK, a bare callable) actually runs the agent.
-4. A **Steerer** watches the execution and classifies **drift** —
-   structured "we're off-track" signals.
-5. On drift, the planner revises the plan; every state change emits a
-   proto **Event** to every configured **EventSink**.
+3. For ADK trees the **Executor** issues ONE invocation with the user
+   request and lets the tree run naturally; a **PlanReconciler** maps
+   the tree's observed `before_agent` / `after_agent` callbacks onto
+   plan tasks (the "overlay" model, goldfive#141). For non-ADK adapters
+   it falls back to the per-task invoke loop.
+4. A **Steerer** watches execution and classifies **drift** — structured
+   "we're off-track" signals — then routes through a six-level
+   intervention ladder (OBSERVE → ABSORB → NUDGE → CANCEL_REINVOKE →
+   PAUSE_ESCALATE → TERMINATE, goldfive#142).
+5. On drift at Level 1+ the planner refines the plan; every state change
+   emits a proto **Event** to every configured **EventSink**.
 
 Six primitives, one `Runner` object, one `await runner.run(...)` call.
+
+## Using goldfive with an ADK agent (the common path)
+
+If you already have a Google ADK agent tree — single `Agent`, flat
+specialists, coordinator+`AgentTool`, or deep hierarchies — the whole
+integration is:
+
+```python
+import goldfive
+from google.adk.apps.app import App
+
+wrapped = goldfive.wrap(root_agent)            # ADK BaseAgent subclass
+app = App(name="my-demo", root_agent=wrapped)  # works in adk web
+```
+
+`goldfive.wrap` on an ADK agent:
+
+1. Builds one `InMemoryRunner` around the tree root (single-Runner
+   model, goldfive#130). ADK handles delegation within the tree via
+   `AgentTool` / `sub_agents` / `transfer_to_agent`.
+2. Walks the tree and attaches the goldfive reporting-tools to every
+   reachable agent (`sub_agents` / `inner_agent` / `tool.agent` edges).
+3. Attaches a `GoldfivePlanner(BasePlanner)` to every `LlmAgent` in
+   the tree (goldfive#153). This injects a per-turn orchestration
+   context block into the LLM's system instruction (current task id /
+   title, plan summary, active user steer, goal summaries) via the
+   goldfive ADK plugin's `before_model_callback`.
+4. Installs the goldfive ADK plugin on the runner. It observes tool
+   calls, function responses, agent transitions, and LLM request /
+   response pairs; routes drift to the steerer; heals orphan tool-call
+   ids on USER_STEER cancellation.
+
+The pipeline runs naturally inside `adk web` — the wrapped object IS
+a `BaseAgent` (`GoldfiveADKAgent`, see
+[adk-web-integration.md](adk-web-integration.md)) — and the same
+object still works programmatically:
+
+```python
+outcome = await wrapped.run("make a presentation about waffles")
+```
+
+See [adk-web-integration.md](adk-web-integration.md) for end-to-end
+setup including environment variables and the `HarmonografTelemetryPlugin`
+pairing.
 
 ## Hello-callable: your first agent in 10 minutes
 

--- a/docs/guides/goals-and-plans.md
+++ b/docs/guides/goals-and-plans.md
@@ -80,10 +80,18 @@ flowchart LR
 
 - `GoalDeriver` runs once, at the top of `Runner.run()`.
 - `Planner.generate` runs once, after goals.
-- `Planner.refine` runs once per warning-or-higher drift.
+- `Planner.refine` runs once per drift escalated to ABSORB (Level 1+)
+  by the steerer's intervention ladder. Same-kind drifts within
+  `DEFAULT_REFINE_THROTTLE_SECONDS` collapse into one refine call;
+  CRITICAL severities bypass the throttle.
 
-Goals never change mid-run in v0.1. Plans change whenever refine
-returns a non-None plan.
+Goals accumulate across USER_STEER interventions (goldfive#154): each
+user steer appends a goal with `source=GOAL_SOURCE_USER_STEER`. These
+are "sticky" — `LLMPlanner.refine` rejects revisions that silently
+drop them, so later drifts cannot unwind an operator's steer by
+merely refining around it.
+
+Plans change whenever refine returns a non-None plan.
 
 ## GoalDerivers
 
@@ -279,20 +287,32 @@ When to write one:
 
 ### The refine contract (important)
 
-`refine(plan, drift, goals)` must:
+`refine(plan, drift, goals, *, observed_actions=None)` must:
 
 1. **Preserve completed tasks verbatim.** The executor will skip any
    task in a terminal state, but the revised plan should still list
    them so downstream plan-diff consumers (sinks, UIs) can see the
-   full history. In practice, copy completed tasks into the new plan
-   unchanged.
-2. **Leave the plan semantically sensible even if the drift is
+   full history. `Plan.validate(for_revision=True, prior=plan)`
+   enforces this (PLAN-LIFECYCLE §3.1 — terminal task preservation;
+   §3.2 — terminal→terminal edge preservation).
+2. **Honor sticky goals.** Goals whose `source == GOAL_SOURCE_USER_STEER`
+   (goldfive#154) must be represented in the revised plan. A refine
+   that silently drops a user-steer goal is rejected by the
+   `LLMPlanner` and triggers a `REFINE_VALIDATION_FAILED` drift.
+3. **Leave the plan semantically sensible even if the drift is
    garbage.** If you can't do anything useful with the drift, return
    `None`. `None` is a legitimate signal that means "I can't revise".
-3. **Increment `revision_index` and stamp `revision_reason`.** The
+4. **Increment `revision_index` and stamp `revision_reason`.** The
    executor stamps these for you after `refine()` returns, but a
    custom planner can pre-populate them if it's doing its own
    tracking.
+5. **Optionally consume `observed_actions`** — the overlay-model
+   reconciler (goldfive#141) builds a list of `ObservedAction`
+   snapshots per invocation and hands them to refine when the drift
+   kind is `PLAN_DIVERGENCE` (goldfive#144). Each entry carries
+   agent name, invocation id, timestamps, status, and a short
+   summary, letting the planner compare planned dispatch against the
+   observed tree execution.
 
 A skeleton refine:
 

--- a/docs/guides/grpc-transport.md
+++ b/docs/guides/grpc-transport.md
@@ -119,6 +119,38 @@ crosses the wire. If a caller (or a custom component) hands a dict
 envelope to the sink, it is silently dropped with a debug log —
 pair with `JSONLPersistenceSink` locally if you need that path.
 
+### Session id stamping
+
+Every `Event` on the wire carries `session_id` (tag 5, goldfive#155).
+Server-side routing uses it as the multiplex key when a single stream
+carries events from multiple Sessions — which matters for consumers
+like `HarmonografSink` where the client-side buffer is process-wide
+but runs are session-scoped.
+
+Under the adk-web integration the outer adk-web session id is pinned
+onto `Session.id` before dispatch (goldfive#161), so the goldfive
+Session, ADKAdapter's internal session, and adk-web's URL session id
+all match. One session row per run; no reconciliation on the
+server side.
+
+### Lazy Hello (harmonograf-specific, harmonograf#85)
+
+The harmonograf client's `Client(name=..., server_addr=...)`
+constructor used to issue a Hello RPC synchronously, which meant the
+session was minted server-side at *client construction* time — before
+the goldfive Session existed. That led to a race where the
+server-side session id and the goldfive-side session id disagreed.
+
+Current harmonograf (≥ #85) defers the Hello until the first event
+emission. The client observes the first goldfive event's `session_id`
+and uses it as the Hello session id. Result: server-side session =
+goldfive Session = adk-web session. No reconciliation needed; no
+duplicate rows in the UI.
+
+If you're building a server that consumes the goldfive gRPC stream,
+mirror the same lazy pattern — defer session creation until the first
+Event's `session_id` is known.
+
 ### Reconnect semantics
 
 With `reconnect=True` (the default) the drain task retries `StreamEvents`

--- a/docs/guides/harmonograf-integration.md
+++ b/docs/guides/harmonograf-integration.md
@@ -179,18 +179,58 @@ Because the proto values mirror harmonograf's existing ones
 = `"new_work_discovered"`, etc.), the frontend needs no changes other
 than pointing at the new messages.
 
-## Bidirectional control (future)
+## Bidirectional control
 
-In v0.1, goldfive is emit-only: the sink receives events but does not
-take control inputs. harmonograf's "steer", "pause", "cancel" control
-actions flow through a separate control channel from frontend → server
-→ client library.
+goldfive's `ControlChannel` is the inbound control surface. Pass one
+to `Runner(control=...)` (or via `goldfive.wrap(control=...)`) and
+the harmonograf UI's Steer / Pause / Cancel / Approve / Reject
+buttons become `ControlMessage` values in a companion task that
+bridges `client.observe()` → `channel.send(...)`. Acks ride back
+through `channel.acks()` → the harmonograf client's ack stream.
 
-A future goldfive version will expose a control-input surface (a way
-for an external system to synthesize a `DriftEvent(kind=USER_STEER)`
-and hand it to the running steerer). When that lands, harmonograf's
-control actions will flow through it. For now, use the per-agent
-control hooks harmonograf already provides.
+STEER messages carry an `annotation_id` (goldfive#171) that
+propagates through to the drift detail, the plan's `revision_reason`,
+and the resulting `DriftDetected.annotation_id` field — letting the
+UI deduplicate redundant clicks and show author metadata on each
+refine. See [../design/CONTROL.md](../design/CONTROL.md) for the
+complete protocol.
+
+## The two harmonograf hooks: sink + telemetry plugin
+
+Full observability of an ADK run needs **both** sides wired:
+
+```python
+import goldfive
+from google.adk.apps.app import App
+from harmonograf_client import Client, HarmonografSink, HarmonografTelemetryPlugin
+
+client = Client(name="my-agent", server_addr="127.0.0.1:7531")
+
+wrapped = goldfive.wrap(root_agent, sinks=[HarmonografSink(client)])
+app = App(
+    name="my-demo",
+    root_agent=wrapped,
+    plugins=[HarmonografTelemetryPlugin(client)],
+)
+```
+
+| Hook | Where | Captures |
+|---|---|---|
+| `HarmonografSink` | goldfive runner `sinks=[...]` | goldfive `Event` proto (RunStarted, PlanSubmitted, TaskStarted, TaskCompleted, DriftDetected, PlanRevised, …) |
+| `HarmonografTelemetryPlugin` | `App(plugins=[...])` or `goldfive.wrap(plugins=[...])` | ADK-native spans: INVOCATION (per-agent), LLM_CALL (per model request), TOOL_CALL (per tool call) |
+
+Both hooks dedupe by plugin `name` (goldfive#166). If you wire the
+plugin both at the App level and the goldfive.wrap level, only one
+instance lands on the runner.
+
+Per-LLM-call instrumentation logs (goldfive#172) ride alongside the
+spans:
+
+- `goldfive.llm.request invocation_id=… agent=… chars=… messages=…`
+- `goldfive.llm.response invocation_id=… agent=… duration_ms=… chars=… usage=…`
+
+These surface in harmonograf's drawer inspector as the LLM call's
+input/output preview.
 
 ## Running the two together
 

--- a/docs/guides/insight-from-logs.md
+++ b/docs/guides/insight-from-logs.md
@@ -152,6 +152,97 @@ print("refine_failure_counts:", dict(s.refine_failure_counts))
 print(f"reasoning_history: {len(s.reasoning_history)} blocks")
 ```
 
+## Log signatures by subsystem
+
+Current `main` emits structured log lines at key orchestration
+decisions. Filter by logger name to drill into one subsystem:
+
+```python
+import logging
+logging.basicConfig(level=logging.INFO)
+for name in (
+    "goldfive.runner",
+    "goldfive.planner",
+    "goldfive.steerer",
+    "goldfive.adapters.adk",
+    "goldfive.drift.tool_loops",
+    "goldfive.reconciler",
+):
+    logging.getLogger(name).setLevel(logging.DEBUG)
+```
+
+### Per-LLM-call instrumentation (goldfive#172)
+
+Every LLM call through the goldfive ADK plugin emits a request +
+response pair:
+
+```
+goldfive.llm.request  invocation_id=<id> agent=<name> chars=<n> messages=<n>
+goldfive.llm.response invocation_id=<id> agent=<name> duration_ms=<ms> chars=<n> usage=<dict>
+```
+
+Useful for:
+
+- Tracing slow turns (grep for `duration_ms=` and sort).
+- Spotting context-window pressure (compare request `chars=` trend).
+- Attributing cost (sum `usage.total_tokens` per agent).
+
+### STEER + refine + orphan heal
+
+When a user steer arrives:
+
+```
+SequentialExecutor._run_overlay: STEER received; cancelling in-flight invoke
+LLMPlanner._refine_user_steer: attempt 1/2: ...
+LLMPlanner._refine_user_steer: attempt 2/2: ...   # only on retry
+goldfive ADKAdapter: healed N orphan tool_call_id(s) after user_steer (pending=...)
+```
+
+The orphan-heal line (ADK-specific, goldfive#139) appends a synthetic
+`function_response` for every `function_call_id` the cancelled
+invocation left hanging, so the LLM sees a well-formed conversation
+on the next turn.
+
+Two consecutive `attempt 2/2` lines that end in an error mean
+`LLMPlanner` exhausted its retry budget; expect a
+`DriftDetected{kind=refine_validation_failed, severity=critical}` to
+follow.
+
+### Tool-loop detector (goldfive#181)
+
+When the `ToolLoopTracker` fires, the drift detail carries the mode:
+
+```jsonc
+{"drift_detected": {
+  "kind": "looping_reasoning",
+  "severity": "warning",
+  "detail": "tool_loop_exact: my_tool x 3 in last 7 calls",
+  "current_task_id": "..."
+}}
+```
+
+`tool_loop_exact:` / `tool_loop_name:` / `tool_loop_alternating:` in
+the detail identify which mode fired; `raw.mode` on the drift
+carries the same tag programmatically.
+
+### Plan reconciler observations
+
+The overlay reconciler emits DEBUG lines at every transition it
+attributes or skips:
+
+```
+PlanReconciler.on_before_agent: agent=writer matched task=t2 (RUNNING)
+PlanReconciler.on_after_agent: agent=writer completed task=t2
+PlanReconciler.get_missed_tasks: marking NOT_NEEDED: [t3, t4]
+```
+
+When an agent runs that has no matching plan task, the reconciler
+emits a `PLAN_DIVERGENCE` at INFO severity and the line reads:
+
+```
+PlanReconciler.on_before_agent: agent=inventor no matching PENDING task; emitted plan_divergence
+```
+
 ## Early warning for the filler-loop class
 
 goldfive has a set of structural guards against filler loops
@@ -167,28 +258,21 @@ sink = InMemorySink()
 
 tool_calls = Counter()
 for e in sink.events:
-    # Reporting-tool dispatch shows up as before_tool_callback in
-    # the underlying framework, not as a dedicated event. Look at
-    # the DriftDetected events of kind LOOPING_TOOL_CALL instead.
     if e.WhichOneof("payload") == "drift_detected":
         d = e.drift_detected
-        if d.kind == "DRIFT_KIND_LOOPING_TOOL_CALL":
+        if d.kind == "DRIFT_KIND_LOOPING_REASONING":
             tool_calls[d.detail] += 1
 
 print(tool_calls.most_common(5))
 ```
 
-If you see the same reporting-tool name dominating the count
-(> 30 calls with identical args, or > 50 calls across varied
-args on the same `task_id`), the guard detected a filler loop
-and cut it off. Cross-reference with
+`LOOPING_REASONING` covers both the reasoning-text loop detector (in
+`goldfive.drift.reasoning`) and the tool-call loop detector (in
+`goldfive.drift.tool_loops`, goldfive#181). The detail prefix
+identifies which — `tool_loop_*` for the tool-call path, `hash=` /
+`cosine=` for the reasoning-text path. Cross-reference with
 [how-to-debug-a-filler-loop.md](../../.agents/how-to-debug-a-filler-loop.md)
 for the postmortem playbook.
-
-For the pre-guard signal — counting raw tool invocations before
-any goldfive guard would fire — instrument the adapter's
-before-tool hook directly or read the harmonograf DB (next
-section).
 
 ## Capturing planner reasoning
 

--- a/docs/guides/multi-turn.md
+++ b/docs/guides/multi-turn.md
@@ -172,6 +172,28 @@ stable conversation identifier is inside the payload.
 - **Multi-user conversation routing.** One Runner, one Conversation.
   Multi-user systems should build a per-user Runner pool.
 
+## Overlay model + multi-turn under adk-web
+
+Under `adk web`, each user turn in the UI is a fresh
+`GoldfiveADKAgent._run_async_impl` call, which translates to one
+`runner.run(user_text, session_id=outer_sid)` pass. The outer
+adk-web session id (`ctx.session.id`) is stable across turns on the
+same URL, so:
+
+- Goldfive Session.id stays constant (pinned to outer id,
+  goldfive#161) — one harmonograf session row carries every turn.
+- Goldfive Conversation state accumulates normally: turn N sees
+  turn N-1's `completed_results` rendered into the planner prompt.
+- Each turn's plan is independent — different `plan.id`,
+  `revision_index` restarts at 0 — but harmonograf's UI shows them
+  all on the same session timeline.
+
+Overlay STEER mid-turn is an **in-turn restart** (the executor
+cancels the in-flight invoke and re-dispatches with the corrective
+message composed by the steerer). It does not create a new turn
+from the user-facing perspective — the harmonograf UI sees one
+continuous span with a PlanRevised marker partway through.
+
 ## Summary
 
 | Question                                     | Answer                                            |

--- a/docs/guides/observability-with-harmonograf.md
+++ b/docs/guides/observability-with-harmonograf.md
@@ -316,6 +316,12 @@ reuses the ADK agent's `.model` to configure `LLMPlanner` and
 `LLMGoalDeriver`. Override any default (`planner=`, `executor=`,
 `call_llm=`, `model=`, ...) by passing it as a keyword argument.
 
+For the full ADK + `adk web` pairing — including the
+`HarmonografTelemetryPlugin` that captures per-agent spans so the
+Gantt shows one row per sub-agent (goldfive#170 + harmonograf#80) —
+see [adk-web-integration.md](adk-web-integration.md) and
+[harmonograf-integration.md §"The two harmonograf hooks"](harmonograf-integration.md#the-two-harmonograf-hooks-sink--telemetry-plugin).
+
 The lower-level `goldfive.quickstart()` factory is still available
 for callers who want a ready-to-run `StaticPlanner` with one task per
 goal — see the source of `goldfive/quickstart.py`.

--- a/docs/guides/persistence-and-recovery.md
+++ b/docs/guides/persistence-and-recovery.md
@@ -384,6 +384,44 @@ SQLitePersistenceSink("./shared.db", table="harmonograf_events")
 
 `replay_from_sqlite` and `list_runs` take the same `table=` argument.
 
+## Session id stability
+
+Under the adk-web integration, goldfive's `Session.id` is pinned to
+`ctx.session.id` (the adk-web URL session) before sub-agent dispatch
+runs (goldfive#161). adk-web keeps the same session id across
+reloads of the same URL, so JSONL logs keyed on `run_id` can reuse
+the same file across browser refreshes without producing duplicate
+session rows in harmonograf.
+
+In practice:
+
+- **Single file per URL session** — `./runs/{session_id}.jsonl`
+  append-mode tracks every turn on one conversation.
+- **Separate files per "new conversation" click** — after
+  `runner.new_conversation()` the adk-web session id stays the same
+  but the underlying Conversation resets, so downstream consumers
+  see a `ConversationEnded` / `ConversationStarted` boundary in the
+  stream.
+
+## Plan + goldfive state persistence
+
+`reconstruct_session` replays every `TaskStarted` / `TaskCompleted`
+/ `TaskFailed` / `TaskBlocked` / `TaskCancelled` to rebuild the
+plan's per-task status. It also:
+
+- Replays `PlanRevised` in order so the final `session.plan` matches
+  the last revision.
+- Replays `DriftDetected` into `session.history` so post-run analysis
+  can count per-kind occurrences.
+- Rebuilds `session.completed_results` from `TaskCompleted.summary`.
+- Does **not** rebuild `session.reasoning_history`,
+  `session.recent_agent_activity`, `session.refine_failure_counts`,
+  or `session.pending_approvals` — those live only in-process and
+  are reset on resume.
+
+If you need any of those across restarts, log them separately or
+extend `reconstruct_session` with your own replay hook.
+
 ## What's explicitly not in v0.1
 
 - **Live replay** — feeding JSONL back through sinks in real time.

--- a/docs/guides/telemetry-with-harmonograf.md
+++ b/docs/guides/telemetry-with-harmonograf.md
@@ -23,19 +23,37 @@ Four pieces:
 
    ```python
    import goldfive
-   from harmonograf_client import HarmonografClient
+   from google.adk.apps.app import App
+   from harmonograf_client import Client, HarmonografSink, HarmonografTelemetryPlugin
 
-   hg = HarmonografClient("localhost:7531")
-   runner = hg.observe(goldfive.wrap(my_agent))
+   client = Client(name="my-agent", server_addr="127.0.0.1:7531")
+
+   wrapped = goldfive.wrap(root_agent, sinks=[HarmonografSink(client)])
+   app = App(
+       name="my-demo",
+       root_agent=wrapped,
+       plugins=[HarmonografTelemetryPlugin(client)],
+   )
    ```
 
-   `observe()` as of harmonograf #44 attaches a `HarmonografSink`
-   and enables the STEERING + HUMAN_IN_LOOP capabilities by
-   default — you can steer, pause, and approve from the UI without
-   extra wiring.
+   Two hooks. `HarmonografSink` carries the goldfive `Event` stream
+   (run / plan / task / drift); `HarmonografTelemetryPlugin` carries
+   per-agent spans. Both route by `session_id` (goldfive#155 stamps
+   each event; goldfive#161 pins adk-web's session id onto the
+   goldfive Session so there's one row per run in harmonograf).
 
-Runnable example:
-[`examples/harmonograf_observed/agent.py`](../../examples/harmonograf_observed/agent.py).
+   `harmonograf_client.observe(wrapped)` is the legacy entry point —
+   still works, appends a `HarmonografSink`, enables STEERING +
+   HUMAN_IN_LOOP capabilities — but the newer path attaches the
+   telemetry plugin explicitly at the `App` level so adk-web's
+   runner sees it.
+
+Runnable examples:
+
+- [`examples/harmonograf_observed/agent.py`](../../examples/harmonograf_observed/agent.py)
+  — minimal CallableAdapter + sink.
+- [`examples/presentation_agent/agent.py`](../../examples/presentation_agent/agent.py)
+  — full ADK tree + both hooks.
 
 ## What you'll see in the UI
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -282,6 +282,123 @@ finally:
     await runner.close()
 ```
 
+## adk-web integration
+
+### Symptom: Run terminates immediately with "goldfive run complete."
+
+**What you see.** You open adk-web, submit a prompt, and the stream
+shows a plan summary followed instantly by "goldfive run complete."
+— nothing actually ran. Sometimes a bare `AttributeError:
+'_async_httpx_client'` shows up in the server log at teardown.
+
+**Why it happens.** Almost always the model is misconfigured. Two
+common shapes:
+
+1. **Gemini default with no `GOOGLE_API_KEY`.** `presentation_agent_orchestrated`
+   and similar examples default `USER_MODEL_NAME` to `gemini-2.5-flash`;
+   without credentials the first LLM call raises after goldfive has
+   already emitted RunStarted / PlanSubmitted, so the stream looks
+   short but ended.
+2. **Custom planner returned `None` from `generate`** — e.g.
+   `LLMPlanner` with a `call_llm` that raised on first use. The
+   Runner emits `RunAborted` with `reason="no plan generated"` and
+   the UI renders it as "goldfive run complete." with no tasks.
+
+**Fix.**
+
+```bash
+export USER_MODEL_NAME=openai/gpt-4o-mini
+export OPENAI_API_KEY=sk-...
+# or for local LLMs:
+export USER_MODEL_NAME=openai/qwen3-coder-30b
+export OPENAI_BASE_URL=http://localhost:8000/v1
+export OPENAI_API_KEY=sk-anything
+```
+
+Then inspect the underlying issue:
+
+```python
+import logging
+logging.getLogger("goldfive.runner").setLevel(logging.DEBUG)
+logging.getLogger("goldfive.planner").setLevel(logging.DEBUG)
+```
+
+The full exception trace is logged at `ERROR` on `goldfive.runner`.
+
+### Symptom: Spans don't appear per-agent in the harmonograf Gantt
+
+**What you see.** The Gantt timeline shows one big bar per turn
+instead of a row per sub-agent.
+
+**Why it happens.** You're on a goldfive / harmonograf combination
+that predates per-agent span stamping (goldfive#170 +
+harmonograf#80). Or the `HarmonografTelemetryPlugin` didn't install
+on the App-level runner — goldfive's in-process plugin sees its own
+observations but not the ADK-native spans the telemetry plugin adds.
+
+**Fix.**
+
+```python
+from google.adk.apps.app import App
+from harmonograf_client import Client, HarmonografTelemetryPlugin
+
+client = Client(name="my-agent", server_addr="127.0.0.1:7531")
+app = App(
+    name="my-demo",
+    root_agent=goldfive.wrap(root_agent),
+    plugins=[HarmonografTelemetryPlugin(client)],  # <— this line
+)
+```
+
+The plugin must be on the `App`; putting it on `goldfive.wrap(plugins=...)`
+also works but the App-level path is idempotent and doesn't require
+that goldfive construct the runner.
+
+### Symptom: Steer doesn't take effect
+
+**What you see.** You click Steer in the harmonograf UI, the
+`DriftDetected{kind=user_steer}` event appears, but no `PlanRevised`
+follows and the run keeps running against the old plan.
+
+**Possible causes.**
+
+1. **`planner.refine` silently failed.** Look for
+   `DriftDetected{kind=refine_validation_failed, severity=critical}`
+   — that's the terminal signal from `LLMPlanner` when it exhausts
+   its retry budget. See [common-failure-modes.md §3](common-failure-modes.md).
+2. **Annotation not propagated.** STEER annotations are deduped by
+   `annotation_id` (goldfive#171). If two clicks have the same id
+   the second is a no-op. Check the harmonograf client's bridge is
+   forwarding a fresh id per click.
+3. **Author missing.** The refine's revised plan should carry the
+   steering author in `revision_reason`. If it's empty the bridge
+   didn't forward `ControlMessage.steer.author`.
+
+**Fix.** Enable DEBUG on `goldfive.planner` and re-steer; the
+`LLMPlanner._refine_user_steer: attempt X/2: <error>` log line tells
+you exactly which attempt failed and why.
+
+### Symptom: Multiple session rows in harmonograf per run
+
+**What you see.** Every goldfive run produces two (or three) rows in
+the harmonograf Sessions picker — one has the plan, another has the
+spans, and they refer to the same underlying run.
+
+**Why it happens.** Pre-goldfive#161 / #164 + pre-harmonograf#85
+(lazy Hello). Goldfive's `Session.id` and the ADKAdapter's internal
+session id disagreed with adk-web's outer `ctx.session.id`; per-event
+routing split the stream across multiple sessions.
+
+**Fix.** Upgrade both goldfive (≥ #164) and harmonograf (≥ #85). In
+current `main` `GoldfiveADKAgent._run_async_impl` pins the outer
+session id onto both goldfive and the adapter before sub-agent
+dispatch runs, and harmonograf's client defers the Hello RPC until
+the first event — so every span + event carries the same session id.
+
+If you're still seeing duplicates on current code, check for a
+pre-built `Runner` constructed outside `goldfive.wrap` (degrade mode)
+— the pin only works when the wrap path built the runner.
+
 ## harmonograf integration
 
 ### Symptom: `HarmonografSink` — connection refused

--- a/docs/guides/writing-an-agent-adapter.md
+++ b/docs/guides/writing-an-agent-adapter.md
@@ -5,16 +5,23 @@ the system that knows about a specific framework — ADK, Claude Agent
 SDK, LangGraph, an MCP server, a bare async callable, anything.
 
 This guide walks through writing a new `AgentAdapter` for a framework
-goldfive doesn't ship. Reference v0.1 adapters:
+goldfive doesn't ship. Reference adapters:
 
 - `goldfive.adapters.callable.CallableAdapter` — the simplest form.
   Start here when prototyping a new adapter.
-- `goldfive.adapters.adk.ADKAdapter` — ports harmonograf's ADK plugin.
+- `goldfive.adapters.adk.ADKAdapter` — the overlay-model flagship.
+  Implements `invoke_passthrough` for the single-Runner overlay
+  execution path (goldfive#141) plus the per-task `invoke` fallback.
+  Installs the goldfive ADK plugin once per runner
+  (`_register_plugin_on_runner` is idempotent by plugin name,
+  goldfive#166). Exposes `available_agents_tree` for structural
+  steering (goldfive#151).
 - `goldfive.adapters.claude.ClaudeAgentSDKAdapter` — wraps Anthropic's
-  Claude Agent SDK.
+  Claude Agent SDK. Uses the per-task `invoke` path.
 
 Related: [PROTOCOLS.md](../design/PROTOCOLS.md#agentadapter),
-[tool-protocol.md](../reference/tool-protocol.md).
+[tool-protocol.md](../reference/tool-protocol.md),
+[ARCHITECTURE.md](../design/ARCHITECTURE.md).
 
 ## The protocol
 
@@ -34,24 +41,49 @@ class AgentAdapter(Protocol):
 
     @property
     def available_agents(self) -> list[str]: ...
+
+    # Optional (overlay model, goldfive#141):
+    async def invoke_passthrough(
+        self,
+        user_message: str,
+        session: Session,
+        *,
+        reconciler: PlanReconciler,
+    ) -> InvocationResult: ...
+
+    # Optional (structural steering, goldfive#151):
+    @property
+    def available_agents_tree(self) -> list[dict[str, Any]]: ...
 ```
 
-Three responsibilities:
+Three required members plus two overlay extensions.
+
+Responsibilities:
 
 1. **Register reporting tools.** The steerer hands you a list of
    `ReportingToolSpec`s (see [tool-protocol.md](../reference/tool-protocol.md)).
    Translate each spec into the tool shape your framework expects and
    install a hook that routes calls to the spec's handler.
-2. **Invoke the agent for one task.** Render current-task context,
-   run the agent, stream observed events to the steerer, return an
-   `InvocationResult`. How delegation works inside the framework is
-   the framework's business — goldfive's single-Runner contract
-   says the adapter drives one agent per invoke and the framework
-   resolves anything deeper.
-3. **Expose `available_agents`.** The names the planner may
-   populate `task.assignee_agent_id` with — advisory hints for
-   delegation, not routing keys under the single-Runner model.
-   Must be sorted and unique.
+2. **Invoke the agent.** Two shapes:
+   - **Per-task `invoke(task, session)`** (classic path) — render
+     task context, run the agent, feed observed events to the
+     steerer, return an `InvocationResult`.
+   - **`invoke_passthrough(user_message, session, *, reconciler)`**
+     (overlay model) — the executor passes the full user message
+     once and observes the tree running naturally. The adapter feeds
+     `before_agent` / `after_agent` / delegation observations into
+     the `PlanReconciler`; the reconciler maps them to plan tasks.
+     This is the path `SequentialExecutor(overlay_mode=True)` uses
+     for adapters that expose the method (`ADKAdapter` does,
+     `ClaudeAgentSDKAdapter` does not). `goldfive.wrap(adk_agent)`
+     defaults to overlay mode.
+3. **Expose `available_agents`.** The names the planner may populate
+   `task.assignee_agent_id` with — advisory hints for delegation,
+   not routing keys under the single-Runner model. Must be sorted
+   and unique. Optionally also expose `available_agents_tree` —
+   structured metadata (name / depth / parent / role / kind) per
+   agent — which the planner uses to constrain `assignee_agent_id`
+   selection for deep hierarchies (goldfive#151).
 
 ### The `available_agents` contract
 

--- a/docs/guides/writing-an-event-sink.md
+++ b/docs/guides/writing-an-event-sink.md
@@ -48,6 +48,28 @@ envelopes — a sink only needs to handle that one shape. Dispatch on
 callers who want the simpler shape without proto, but no shipped
 goldfive component feeds dicts to sinks today.
 
+### Per-event `session_id` (field 5, goldfive#155)
+
+Every proto `Event` carries a `session_id` field (tag 5) populated
+from `Session.id` at emission time. `Session.id` aliases `run_id`,
+but under the adk-web integration it's **pinned** to the outer
+adk-web session id before sub-agent dispatch runs (goldfive#161), so
+every event in a run shares one id regardless of how many
+sub-Runners the tree spawned.
+
+Sinks that multiplex across sessions (the `HarmonografSink` reference
+is the canonical example) must route by `event.session_id`, not by
+client-global state:
+
+```python
+async def emit(self, event: Any) -> None:
+    session_id = getattr(event, "session_id", "") or event.run_id
+    await self._route_to_session(session_id, event)
+```
+
+This is what makes "one session row per run in harmonograf" work
+across overlay STEER restarts and nested AgentTool sub-Runners.
+
 ## A minimal stdout sink
 
 ```python

--- a/examples/adk_presentation/README.md
+++ b/examples/adk_presentation/README.md
@@ -1,26 +1,36 @@
 # Minimal goldfive + ADK example
 
-The smallest possible demo showing how `goldfive.wrap(agent, ...)` plugs a
-plain Google ADK agent into goldfive's planner + executor + steerer stack.
+The smallest possible demo showing how `goldfive.wrap(agent, ...)`
+plugs a plain Google ADK agent into goldfive's planner + reconciler
++ steerer stack.
 
 ```python
 agent  = <your ADK Agent>                 # any BaseAgent
 runner = goldfive.wrap(                   # goldfive handles decomposition,
-    agent,                                # dispatch, drift, and steering
+    agent,                                # overlay dispatch, drift, and steering
     planner=LLMPlanner(call_llm=...),
     goal_deriver=LLMGoalDeriver(call_llm=...),
 )
 await runner.run("make a presentation about waffles")
 ```
 
-One agent, no coordinator, no hand-rolled delegation. If you need a
-multi-specialist reference see the "richer example" section below.
+One agent, no coordinator, no hand-rolled delegation. `goldfive.wrap`
+returns a `GoldfiveADKAgent` — a `BaseAgent` subclass that also
+exposes `Runner.run`, so the same object works under `adk web` and
+programmatically.
 
 ## What this demonstrates
 
-- **One ADK `Agent`, goldfive does the rest.** The planner emits a task
-  DAG; the executor invokes the same agent for each task in turn. No
-  subagent tree, no `AgentTool`s, no coordinator with hardcoded routing.
+- **One ADK `Agent`, goldfive does the rest.** The planner emits a
+  task DAG; the overlay reconciler observes the agent running via
+  `before_agent` / `after_agent` callbacks and maps invocations to
+  plan tasks. No subagent tree, no `AgentTool`s, no coordinator with
+  hardcoded routing.
+- **`GoldfivePlanner` auto-attached** to the agent's `LlmAgent`
+  (goldfive#153). A per-turn orchestration context block is injected
+  into the LLM's system instruction so the agent reads the current
+  task from `session.state['goldfive.*']` without the caller wiring
+  prompts manually.
 - **Planner + goal deriver are pluggable.** Wire any model provider
   behind a `call_llm` callable with signature
   `(system_prompt, user_prompt, model) -> str`.

--- a/examples/harmonograf_observed/README.md
+++ b/examples/harmonograf_observed/README.md
@@ -2,8 +2,12 @@
 
 Minimal `CallableAdapter` agent wired to both an `InMemorySink` and a
 `HarmonografSink` so every goldfive event lands in the harmonograf UI.
-No LLM, no ADK, no Claude SDK — just a four-task `StaticPlanner` and a
-canned-reply callable.
+No LLM, no ADK, no Claude SDK — just a four-task `StaticPlanner` and
+a canned-reply callable.
+
+This is the smallest thing that puts real events on the harmonograf
+wire. For the full ADK + `HarmonografTelemetryPlugin` pairing see
+[`../presentation_agent/`](../presentation_agent/).
 
 ## What this shows
 
@@ -12,10 +16,15 @@ canned-reply callable.
   `harmonograf-client` and the paired `runner.close()` +
   `client.shutdown(flush_timeout=5.0)` teardown.
 - Graceful fallback: if `harmonograf_client` is not installed the
-  example still runs end-to-end with `InMemorySink` + `LoggingSink` and
-  prints a pointer to the observability guide.
-- The event counts reported by `InMemorySink` match what the harmonograf
-  console renders — useful as a sanity check when debugging the sink.
+  example still runs end-to-end with `InMemorySink` + `LoggingSink`
+  and prints a pointer to the observability guide.
+- Per-event `session_id` (goldfive#155) — every event carries the
+  same id since `CallableAdapter` runs have a single Session per
+  `runner.run()`. Server-side this gives one session row in
+  harmonograf.
+- The event counts reported by `InMemorySink` match what the
+  harmonograf console renders — useful as a sanity check when
+  debugging the sink.
 
 ## Prerequisites
 

--- a/examples/presentation_agent/README.md
+++ b/examples/presentation_agent/README.md
@@ -3,17 +3,36 @@
 A production-shaped goldfive + ADK example: a coordinator plus four
 specialists (research, web_developer, reviewer, debugger) with real
 `write_webpage` / `read_presentation_files` / `patch_file` tools. The
-coordinator tree is plain ADK; goldfive handles planning, task dispatch,
-drift detection, and steering. Optional harmonograf telemetry watches
-the run.
+coordinator tree is plain ADK; goldfive handles goal derivation,
+planning, overlay-mode dispatch, drift detection, and steering.
+Optional harmonograf telemetry watches the run per-agent.
 
 This tree is the canonical source for harmonograf's
 `tests/reference_agents/presentation_agent/` — harmonograf re-exports
 these agents so the two repos share a single definition.
 
 For the minimal "how do I wrap a single agent" lesson, see
-[`../adk_presentation`](../adk_presentation/). This example assumes you
-already understand that pattern.
+[`../adk_presentation`](../adk_presentation/). This example assumes
+you already understand that pattern.
+
+## What this demonstrates
+
+- **`goldfive.wrap(root_agent)` on a full tree.** One
+  `InMemoryRunner` around the coordinator; ADK's `AgentTool`
+  delegation routes to specialists; goldfive observes via the
+  overlay `PlanReconciler` (goldfive#141).
+- **`GoldfivePlanner(BasePlanner)` auto-attached to every
+  `LlmAgent`** (goldfive#153). Per-turn orchestration context block
+  (current task id/title, goals, active steer, cancelled
+  function-call ids) is injected into each LLM's system
+  instruction.
+- **`HarmonografTelemetryPlugin` on the `App`.** Per-agent spans
+  land in the harmonograf Gantt (one row per sub-agent, goldfive#170
+  + harmonograf#80).
+- **`HarmonografSink` on the runner.** Goldfive events (run / plan
+  / task / drift / PlanRevised) stream to harmonograf.
+- **Mock mode for CI.** Zero network; canned planner / goal-deriver
+  / `_MockLlm`.
 
 ## Running
 
@@ -38,22 +57,46 @@ uv run python examples/presentation_agent/agent.py --topic "the Voyager missions
 ```
 
 The subagents hit `openai/gpt-4o-mini` (override with
-`GOLDFIVE_EXAMPLE_MODEL`); the planner + goal-deriver use the `openai`
-SDK directly (override with `GOLDFIVE_EXAMPLE_PLANNER_MODEL`). The
-`web_developer_agent` writes files under `output/<topic>/`.
+`GOLDFIVE_EXAMPLE_MODEL`); the planner + goal-deriver use the
+`openai` SDK directly (override with
+`GOLDFIVE_EXAMPLE_PLANNER_MODEL`). The `web_developer_agent` writes
+files under `output/<topic>/`.
+
+### Live mode — local LLM via kikuchi / Qwen
+
+```bash
+export GOLDFIVE_EXAMPLE_MODEL=openai/qwen3-coder-30b
+export OPENAI_BASE_URL=http://kikuchi:8000/v1
+export OPENAI_API_KEY=sk-anything   # not validated
+export GOLDFIVE_EXAMPLE_PLANNER_MODEL=qwen3-coder-30b
+uv run python examples/presentation_agent/agent.py --topic waffles
+```
+
+Qwen sometimes hallucinates `write_webpage` success without calling
+the tool. The goldfive `CONFABULATION_RISK` classifier catches this
+at INFO severity — record-only, does not trigger refine. See
+[docs/guides/common-failure-modes.md §7](../../docs/guides/common-failure-modes.md).
 
 ### Under `adk web`
 
 ```bash
 uv pip install -e '.[adk]'
+export USER_MODEL_NAME=openai/gpt-4o-mini  # or qwen, etc.
+export OPENAI_API_KEY=sk-...
 adk web examples/presentation_agent
 ```
 
-The module exposes `app` lazily (PEP 562 `__getattr__`), so importing
-it is side-effect free. On first access `app` builds a
-`goldfive.wrap(root_agent, ...)` root agent and hands it to ADK's
-`App`. If `OPENAI_API_KEY` is unset the `App` falls back to mock mode
-so `adk web` still loads offline.
+The module exposes `app` lazily (PEP 562 `__getattr__`), so
+importing it is side-effect free. On first access `app` builds the
+goldfive-wrapped tree and hands it to ADK's `App`. If
+`OPENAI_API_KEY` is unset the `App` falls back to mock mode so `adk
+web` still loads offline.
+
+**Don't skip `USER_MODEL_NAME`** when hitting a non-Gemini backend.
+The default is `gemini-2.5-flash`; without `GOOGLE_API_KEY` every
+run terminates instantly with "goldfive run complete." and an
+`AttributeError: '_async_httpx_client'` at teardown. See
+[docs/guides/troubleshooting.md](../../docs/guides/troubleshooting.md).
 
 ### With harmonograf telemetry
 
@@ -63,11 +106,27 @@ uv run python examples/presentation_agent/agent.py --topic waffles
 ```
 
 Attaches a `HarmonografSink` to the runner and a
-`HarmonografTelemetryPlugin` to the `App` so per-span TOOL_CALL /
-LLM_CALL events land in the harmonograf UI. Install harmonograf's
-client extra (`pip install harmonograf-client`) first. Both hooks are
-optional — unset `HARMONOGRAF_SERVER` or skip the package and the
-example runs silently.
+`HarmonografTelemetryPlugin` to the `App` so per-span INVOCATION /
+LLM_CALL / TOOL_CALL spans land in harmonograf with one Gantt row
+per sub-agent. Install harmonograf's client extra
+(`pip install harmonograf-client`) first. Both hooks are optional —
+unset `HARMONOGRAF_SERVER` or skip the package and the example runs
+silently.
+
+## What to expect in the harmonograf UI
+
+- One session row per run (session id pinned to the outer adk-web
+  session, goldfive#161).
+- Plan: four tasks (research / build / review / debug) in a
+  sequential DAG. Each transitions PENDING → RUNNING → COMPLETED
+  as the overlay reconciler credits tree invocations to tasks.
+- Agents timeline: one Gantt row per sub-agent, children showing
+  LLM_CALL and TOOL_CALL spans. AgentTool delegations show as
+  dashed edges.
+- Drifts panel: on a clean run, empty. Under Qwen, occasional
+  `CONFABULATION_RISK` / INFO.
+- Plan revisions panel: empty on a clean run; populated if you
+  click Steer in the UI.
 
 ## Flags
 


### PR DESCRIPTION
## Summary

Refresh user guides and `.agents/` sub-agent skills to match the current state of goldfive's orchestration contracts. Target surface: every file under `docs/guides/`, every file under `.agents/`, and the `examples/*/README.md` files for `adk_presentation`, `harmonograf_observed`, and `presentation_agent`.

## What changed per subsystem

**Overlay execution model (goldfive#141).**
- `getting-started.md`, `adk-web-integration.md`, `writing-an-agent-adapter.md`, `.agents/adapters.md` now describe `goldfive.wrap(any_adk_tree)` producing a `GoldfiveADKAgent` that IS a `BaseAgent`, the single `InMemoryRunner`, the `PlanReconciler` observing tree invocations via before_agent/after_agent, and the optional `invoke_passthrough` adapter method.

**Structural steering (goldfive#153).**
- `adk-web-integration.md` explains `GoldfivePlanner(BasePlanner)` auto-attachment and per-turn orchestration context block injection through the goldfive ADK plugin's `before_model_callback`. Tree-agnostic; no presentation vocabulary.

**Drift taxonomy.**
- `common-failure-modes.md` rewritten around current drift kinds: CONFABULATION_RISK, RUNAWAY_DELEGATION, REFINE_VALIDATION_FAILED, HUMAN_INTERVENTION_REQUIRED, GOAL_DRIFT. Three-stage function_call gate (goldfive#184) documented: own-tool, cross-layer PLAN_DIVERGENCE, hallucinated CONFABULATION_RISK. Dropped outdated per-task-driving and coordinator-flow-looping-as-current references.

**Tool-loop detector (goldfive#181).**
- `common-failure-modes.md` and `how-to-debug-a-filler-loop.md` document the `ToolLoopTracker`: three modes (exact / name / alternating), env var overrides, and when it fires vs. `LOOPING_TOOL_CALL` (reporting-tool guard).

**Session unification (goldfive#155/#161/#164).**
- `writing-an-event-sink.md`, `grpc-transport.md`, `.agents/sinks.md`, `.agents/events.md` document per-event `session_id` (tag 5) and the adk-web pin. `troubleshooting.md` adds the multiple-session-rows diagnostic.

**Per-LLM-call instrumentation (goldfive#172).**
- `insight-from-logs.md` and `harmonograf-integration.md` document `goldfive.llm.request` / `goldfive.llm.response` log lines.

**STEER idempotency (goldfive#171).**
- `adk-web-integration.md`, `troubleshooting.md`, `harmonograf-integration.md` document `annotation_id` propagation from ControlMessage through drift, revision reason, and DriftDetected.annotation_id.

**Intervention ladder (goldfive#142).**
- `.agents/debug-goldfive.md` adds a level-by-level table (OBSERVE / ABSORB / NUDGE / CANCEL_REINVOKE / PAUSE_ESCALATE / TERMINATE) with what the steerer does at each.

**adk-web + harmonograf wiring.**
- `telemetry-with-harmonograf.md`, `observability-with-harmonograf.md`, `harmonograf-integration.md`, `adk-web-integration.md` consolidate on the two-hook pattern: `HarmonografSink` on the runner + `HarmonografTelemetryPlugin` on the `App(plugins=[...])`, with dedup by plugin name (goldfive#166).

**USER_MODEL_NAME pitfall.**
- `adk-web-integration.md`, `troubleshooting.md`, `examples/presentation_agent/README.md`, `.agents/how-to-run-the-e2e.md` call out the Gemini default without GOOGLE_API_KEY — coordinator silently instantiates a Gemini client and the run terminates instantly with "goldfive run complete." and AttributeError on _async_httpx_client.

**e2e flow.**
- `.agents/how-to-run-the-e2e.md` adds the kikuchi/Qwen env setup and the `/tmp/steer.py` + browser-use STEER driving pattern.

## Files touched (15 guides + 10 skills + 3 READMEs)

- `docs/guides/*.md` (15 files)
- `.agents/*.md` (9 skills modified; README.md index refreshed)
- `examples/adk_presentation/README.md`
- `examples/harmonograf_observed/README.md`
- `examples/presentation_agent/README.md`

## Test plan

- [x] All snippets use helpers / API surfaces that exist on current main (verified against `goldfive/__init__.py`, `goldfive/convenience.py`, `goldfive/adapters/adk_wrap.py`, `goldfive/types.py`, `goldfive/drift/tool_loops.py`, `goldfive/planners/goldfive_planner.py`, `goldfive/steerer.py`, `goldfive/reconciler.py`).
- [x] No stale references to per-task driving as "current".
- [x] `LOOPING_TOOL_CALL` vs `LOOPING_REASONING` distinction accurate (both exist; tool-loop detector emits `LOOPING_REASONING`).
- [x] Markdown renders (tables, code fences, nested lists all valid).
- [ ] CI green.