### PR TITLE
Inject pinned task_id into report_task_* args when LLM omits it (closes part of #191)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -38,7 +38,7 @@ import asyncio
 import json
 import logging
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any
 
 from goldfive.adapters import _adk_state_protocol as _sp
@@ -198,6 +198,105 @@ def _session_context_from_callback(ctx: Any) -> SessionContext | None:
     if isinstance(value, SessionContext):
         return value
     return None
+
+
+# --------------------------------------------------------------------------
+# goldfive#191 — Layer 3: task_id arg injection for reporting tools
+# --------------------------------------------------------------------------
+#
+# When an LLM emits a report_task_* / report_awaiting_approval call with a
+# missing or obviously-placeholder ``task_id``, we fall back to the pinned
+# ``goldfive.current_task_id`` that ``before_agent_callback`` (Layer 1)
+# stamps into session.state at the start of every agent turn. The reporting-
+# tool handler itself (Layer 2) also defaults from state, so this layer is
+# the outermost safety net: the goal is to have the handler see a valid
+# task_id no matter which dispatch path runs it.
+#
+# We ONLY rewrite when the arg is missing or is a well-known placeholder
+# string. A real-looking task_id (even if it's for the wrong task) is left
+# alone so the handler surfaces the mismatch as a proper terminal-task /
+# not-found failure rather than silently re-targeting the call. Wrong
+# task_ids are better surfaced as failures than masked.
+
+# Reporting-tool names that must always target a specific task. The match
+# is an exact-set test for ``report_awaiting_approval`` plus a prefix test
+# for ``report_task_*`` (see goldfive.reporting for the canonical list).
+_REPORT_AWAITING_APPROVAL = "report_awaiting_approval"
+
+# Case-insensitive set of strings we treat as "the LLM didn't supply a real
+# task_id". Whitespace is stripped before comparison. Keep this list
+# conservative — any real-looking slug should NOT be on it.
+_PLACEHOLDER_TASK_IDS: frozenset[str] = frozenset(
+    {"", "placeholder", "unknown", "todo", "none", "null", "n/a"}
+)
+
+
+def _is_placeholder_task_id(value: Any) -> bool:
+    """Return True if ``value`` is missing or an obvious placeholder.
+
+    Used by :meth:`_GoldfiveADKPlugin.before_tool_callback` to decide
+    whether to overwrite ``tool_args["task_id"]`` with the pinned
+    ``goldfive.current_task_id`` from session.state. Case-insensitive and
+    whitespace-tolerant. Non-string values are treated as placeholders
+    (an int task_id isn't real either).
+    """
+    if value is None:
+        return True
+    if not isinstance(value, str):
+        return True
+    return value.strip().lower() in _PLACEHOLDER_TASK_IDS
+
+
+def _is_reporting_tool_name(tool_name: str) -> bool:
+    """Return True if ``tool_name`` is a reporting-tool that needs a task_id."""
+    if not tool_name:
+        return False
+    return tool_name.startswith("report_task_") or tool_name == _REPORT_AWAITING_APPROVAL
+
+
+def _inject_task_id_from_state(
+    *,
+    tool_name: str,
+    tool_args: Any,
+    tool_context: Any,
+) -> None:
+    """Best-effort: fill in ``tool_args['task_id']`` from pinned state.
+
+    This is the goldfive#191 Layer-3 safety net. Mutates ``tool_args`` in
+    place when:
+
+      * ``tool_name`` is a reporting tool (report_task_* or
+        report_awaiting_approval),
+      * ``tool_args`` is a mutable mapping,
+      * the current ``task_id`` arg is missing / blank / a known
+        placeholder,
+      * session.state has a non-empty ``goldfive.current_task_id``.
+
+    NEVER raises — injection is advisory. If anything goes wrong we log
+    at DEBUG and return, letting Layer 2 (handler default-from-state)
+    handle the fallback or surface the error.
+    """
+    try:
+        if not _is_reporting_tool_name(tool_name):
+            return
+        if not isinstance(tool_args, MutableMapping):
+            return
+        existing = tool_args.get("task_id", "")
+        if not _is_placeholder_task_id(existing):
+            return
+        state = _session_state_from_callback(tool_context)
+        if not isinstance(state, Mapping):
+            return
+        state_tid = state.get(_sp.KEY_CURRENT_TASK_ID, "")
+        if not isinstance(state_tid, str) or not state_tid.strip():
+            return
+        tool_args["task_id"] = state_tid
+    except Exception:  # noqa: BLE001
+        log.debug(
+            "before_tool_callback: task_id injection failed for tool=%s",
+            tool_name,
+            exc_info=True,
+        )
 
 
 def _measure_request_chars(llm_request: Any) -> tuple[int, int]:
@@ -1693,6 +1792,23 @@ def make_adk_plugin(
             #      can intervene.
             #
             # See ``docs/design/TASK-LIFECYCLE.md`` §5 for the contract.
+            #
+            # goldfive#191 Layer 3 — task_id injection. Before we dispatch
+            # a reporting tool, if the LLM omitted ``task_id`` (or passed
+            # an obvious placeholder like "" / "placeholder" / "unknown"
+            # / "TODO") we fall back to the ``goldfive.current_task_id``
+            # pinned into session.state by ``before_agent_callback`` at
+            # the start of the agent turn. The state write fires first in
+            # ADK's callback order (agent-turn → tool-calls-within-turn)
+            # so by the time we reach here the pin is already visible.
+            # Real-looking task_ids are preserved verbatim — we don't
+            # silently rewrite them even if they look wrong (see #191).
+            _inject_task_id_from_state(
+                tool_name=tool_name,
+                tool_args=tool_args,
+                tool_context=tool_context,
+            )
+
             tool_names_registered = {spec.name for spec in ctx.tools}
             if tool_name in tool_names_registered:
                 args_map: dict[str, Any]

--- a/tests/test_before_tool_task_id_injection.py
+++ b/tests/test_before_tool_task_id_injection.py
@@ -1,0 +1,332 @@
+"""Tests for goldfive#191 Layer 3 — ``before_tool_callback`` task_id injection.
+
+The plugin's reporting-tool dispatch path (``_GoldfiveADKPlugin.
+before_tool_callback``) is the outermost safety net that fills in a
+missing / placeholder ``task_id`` from the pinned
+``goldfive.current_task_id`` key on session.state. Layer 1
+(``before_agent_callback``) is responsible for pinning that key at the
+start of every agent turn; Layer 2 (the reporting-tool handler itself)
+also defaults from state. This file pins the Layer-3 contract:
+
+  * empty / placeholder ``task_id`` args are rewritten from state,
+  * real-looking ``task_id`` args are left alone even if state disagrees,
+  * non-reporting tools are never touched,
+  * missing state leaves args unchanged (Layer 2 will handle the error),
+  * a malformed callback_context never raises out of the plugin.
+
+Skipped entirely when ``google.adk`` is not installed (optional dep).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from goldfive.reporting import ReportingToolSpec
+from goldfive.types import Session, Task
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _Ctx:
+    """Minimal ADK-callback-context stub with a mutable state dict.
+
+    Mirrors the ``state_ctx_cls`` fixture from ``test_adk_adapter.py`` but
+    inlined here to avoid cross-file fixture coupling.
+    """
+
+    class _Session:
+        def __init__(self, state: dict) -> None:
+            self.state = state
+
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    @property
+    def session(self) -> Any:
+        return _Ctx._Session(self._state)
+
+
+class _Tool:
+    """Bare tool stub — the plugin only reads ``.name``."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def _make_plugin_with_reporting_spec(tool_name: str):
+    """Return (plugin, state_dict) wired for a single reporting tool.
+
+    The plugin is built via :func:`make_adk_plugin` (the public factory)
+    and wired to a :class:`SessionContext` so the reporting-tool match in
+    ``before_tool_callback`` fires. The handler is a no-op that echoes
+    the args the plugin dispatched with — callers inspect that echo to
+    verify injection.
+    """
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    captured: list[dict[str, Any]] = []
+
+    async def handler(args: Any, session: Any, steerer: Any) -> dict[str, Any]:
+        captured.append(dict(args))
+        return {"acknowledged": True, "echo": dict(args)}
+
+    spec = ReportingToolSpec(
+        name=tool_name,
+        description="",
+        parameters={"type": "object", "properties": {}},
+        handler=handler,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    session_obj = Session(run_id="run-1")
+    task = Task(id="t-ignored", title="x")
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session_obj,
+            steerer=None,
+            task=task,
+            tool_handlers={tool_name: handler},
+            tools=[spec],
+            host_agent_name="test_agent",
+        )
+    }
+    return plugin, state, captured
+
+
+# ---------------------------------------------------------------------------
+# Injection tests — reporting tools
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_arg_replaced_from_state() -> None:
+    """An empty task_id on a report_task_* call is filled from pinned state."""
+    from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
+
+    plugin, state, captured = _make_plugin_with_reporting_spec("report_task_completed")
+    state[KEY_CURRENT_TASK_ID] = "t-1"
+
+    args: dict[str, Any] = {"task_id": "", "summary": "done"}
+    await plugin.before_tool_callback(
+        tool=_Tool("report_task_completed"),
+        tool_args=args,
+        tool_context=_Ctx(state),
+    )
+
+    assert args["task_id"] == "t-1", (
+        "Layer 3 must overwrite an empty task_id with the pinned "
+        "goldfive.current_task_id from state."
+    )
+    # And the handler must have seen the corrected arg.
+    assert captured == [{"task_id": "t-1", "summary": "done"}]
+
+
+async def test_placeholder_arg_replaced() -> None:
+    """Known placeholder strings ('placeholder', 'unknown', 'TODO') are replaced."""
+    from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
+
+    for placeholder in ("placeholder", "unknown", "TODO", "  ", "none", "N/A"):
+        plugin, state, captured = _make_plugin_with_reporting_spec(
+            "report_task_progress"
+        )
+        state[KEY_CURRENT_TASK_ID] = "t-1"
+
+        args: dict[str, Any] = {"task_id": placeholder, "detail": "x"}
+        await plugin.before_tool_callback(
+            tool=_Tool("report_task_progress"),
+            tool_args=args,
+            tool_context=_Ctx(state),
+        )
+
+        assert args["task_id"] == "t-1", (
+            f"placeholder {placeholder!r} must be replaced with the pinned "
+            "task_id from state."
+        )
+
+
+async def test_real_looking_arg_preserved() -> None:
+    """A real-looking task_id is NOT overwritten, even if state disagrees.
+
+    Wrong task_ids must surface as handler errors (terminal-task rejection
+    / not-found) rather than being silently re-targeted. See goldfive#191
+    Layer 3 design note: "Wrong task_ids are better surfaced as failures
+    than masked."
+    """
+    from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
+
+    plugin, state, _ = _make_plugin_with_reporting_spec("report_task_failed")
+    state[KEY_CURRENT_TASK_ID] = "t-1"
+
+    args: dict[str, Any] = {"task_id": "t-42", "error": "boom"}
+    await plugin.before_tool_callback(
+        tool=_Tool("report_task_failed"),
+        tool_args=args,
+        tool_context=_Ctx(state),
+    )
+
+    assert args["task_id"] == "t-42", (
+        "Real-looking task_ids must be preserved verbatim — Layer 3 is a "
+        "safety net for missing/placeholder args, not a rewriter."
+    )
+
+
+async def test_awaiting_approval_also_injected() -> None:
+    """report_awaiting_approval is part of the reporting-tool family."""
+    from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
+
+    plugin, state, _ = _make_plugin_with_reporting_spec("report_awaiting_approval")
+    state[KEY_CURRENT_TASK_ID] = "t-1"
+
+    args: dict[str, Any] = {"task_id": ""}
+    await plugin.before_tool_callback(
+        tool=_Tool("report_awaiting_approval"),
+        tool_args=args,
+        tool_context=_Ctx(state),
+    )
+
+    assert args["task_id"] == "t-1"
+
+
+# ---------------------------------------------------------------------------
+# Non-injection paths
+# ---------------------------------------------------------------------------
+
+
+async def test_non_report_tool_untouched() -> None:
+    """Non-reporting tools must never have their task_id rewritten."""
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+    from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
+
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=Session(run_id="r"),
+            steerer=None,
+            task=Task(id="t", title="x"),
+            tool_handlers={},
+            host_agent_name="test_agent",
+        ),
+        KEY_CURRENT_TASK_ID: "t-1",
+    }
+
+    args: dict[str, Any] = {"task_id": ""}
+    result = await plugin.before_tool_callback(
+        tool=_Tool("write_file"),
+        tool_args=args,
+        tool_context=_Ctx(state),
+    )
+
+    # write_file is not a reporting tool -> plugin passes through with
+    # no rewrite.
+    assert result is None
+    assert args["task_id"] == "", (
+        "Non-reporting tools must be left alone — the injection is scoped "
+        "to report_task_* / report_awaiting_approval only."
+    )
+
+
+async def test_missing_state_leaves_args_unchanged() -> None:
+    """No pinned task_id in state → args untouched; Layer 2 will handle it."""
+    plugin, state, _ = _make_plugin_with_reporting_spec("report_task_started")
+    # Note: NOT setting KEY_CURRENT_TASK_ID.
+
+    args: dict[str, Any] = {"task_id": ""}
+    await plugin.before_tool_callback(
+        tool=_Tool("report_task_started"),
+        tool_args=args,
+        tool_context=_Ctx(state),
+    )
+
+    assert args["task_id"] == "", (
+        "When state has no pinned task_id, Layer 3 must not guess — the "
+        "handler (Layer 2) default-from-state or the eventual error is "
+        "the correct outcome."
+    )
+
+
+async def test_injection_is_best_effort() -> None:
+    """A malformed callback_context (state=None / no .session) must not raise.
+
+    This pins the ``try/except`` in ``_inject_task_id_from_state`` — any
+    exception from state inspection is swallowed at DEBUG level so the
+    plugin's tool-dispatch path cannot be broken by a missing attribute
+    on an odd ADK-context shape.
+    """
+    from goldfive.adapters._adk_plugin import _inject_task_id_from_state
+
+    # Context with no ``.session`` and no ``.state``. The helper must
+    # silently return without touching args.
+    class _BrokenCtx:
+        pass
+
+    args: dict[str, Any] = {"task_id": ""}
+    _inject_task_id_from_state(
+        tool_name="report_task_completed",
+        tool_args=args,
+        tool_context=_BrokenCtx(),
+    )
+    assert args["task_id"] == ""  # unchanged — no state to read from.
+
+    # A context whose ``.state`` attribute raises on access. The helper's
+    # try/except must swallow this.
+    class _RaisingCtx:
+        @property
+        def state(self) -> Any:
+            raise RuntimeError("state access blew up")
+
+        @property
+        def session(self) -> Any:
+            raise RuntimeError("session access blew up")
+
+    args2: dict[str, Any] = {"task_id": ""}
+    _inject_task_id_from_state(
+        tool_name="report_task_completed",
+        tool_args=args2,
+        tool_context=_RaisingCtx(),
+    )
+    assert args2["task_id"] == ""  # unchanged.
+
+
+# ---------------------------------------------------------------------------
+# Ordering: Layer 1 (state stamp) → Layer 3 (injection)
+# ---------------------------------------------------------------------------
+
+
+async def test_injection_sees_layer1_state_stamp() -> None:
+    """Sanity: a state write done BEFORE the tool callback is visible to it.
+
+    This is the ordering contract Layer 3 depends on — Layer 1's
+    ``before_agent_callback`` writes to session.state at agent-turn start,
+    and every ``before_tool_callback`` within that turn sees the write.
+    We simulate that by writing the state key, then dispatching, then
+    asserting the injection happened.
+    """
+    from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
+
+    plugin, state, _ = _make_plugin_with_reporting_spec("report_task_blocked")
+
+    # Layer-1-style write (simulating what before_agent_callback does).
+    state[KEY_CURRENT_TASK_ID] = "t-layer1"
+
+    # Layer-3 tool-call entry.
+    args: dict[str, Any] = {"task_id": "", "blocked_on": "dep-x"}
+    await plugin.before_tool_callback(
+        tool=_Tool("report_task_blocked"),
+        tool_args=args,
+        tool_context=_Ctx(state),
+    )
+
+    assert args["task_id"] == "t-layer1"


### PR DESCRIPTION
## Summary

Layer 3 of the goldfive#191 three-layer fix for the 100% failure rate on reporting-tool calls in orchestrated runs. When an LLM emits a `report_task_*` or `report_awaiting_approval` call with a missing or obviously-placeholder `task_id`, the ADK plugin's `before_tool_callback` now injects the `goldfive.current_task_id` pinned into session.state by Layer 1 (`before_agent_callback`).

- New helper `_inject_task_id_from_state` (best-effort; never raises) + a small placeholder set.
- Hooked into `before_tool_callback` just before the reporting-tool dispatch routes through `invoke_tool`, so the corrected `task_id` flows through the terminal-rejection / idempotency / loop-guard layers unchanged.
- Real-looking `task_id` values are preserved verbatim — wrong task_ids are better surfaced as handler errors than silently re-targeted.

Scope: only `before_tool_callback` + one helper in `_adk_plugin.py` plus a new standalone test file. Does not touch `before_agent_callback`, `goldfive/reporting.py`, or `_adk_state_protocol.py` (sibling's territory for Layers 1+2).

This PR does NOT close #191 — sibling's Layers 1+2 land separately.

## Test plan

- [x] `tests/test_before_tool_task_id_injection.py` — 8 new tests covering empty/placeholder replacement, real-looking preservation, non-reporting pass-through, missing-state pass-through, best-effort malformed-context tolerance, and Layer-1 → Layer-3 ordering.
- [x] Full adapter suite (`test_adk_adapter.py`, `test_adk_adapter_overlay.py`, `test_state_protocol_propagation.py`, `test_approval_flow.py`, `test_wrap_adk.py`) — 102 tests pass.
- [x] Full test suite — 965 passed, 46 skipped, 0 failures.
- [x] `ruff check` clean on changed files.