### PR TITLE
Tool-loop detector: exempt report_task_* only on acknowledged success (closes #192)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -464,6 +464,44 @@ def _as_observation(
     }
 
 
+def _is_progress_report_success(response: Any) -> bool:
+    """Return ``True`` iff ``response`` indicates a successful progress report.
+
+    Used by the ADK plugin's ``after_tool_callback`` to decide whether a
+    ``report_task_*`` / ``report_awaiting_approval`` call should reset
+    the tool-loop tracker's per-(invocation, agent) window (goldfive#192).
+
+    Previously the exemption triggered on the **call** regardless of
+    outcome: an agent stuck retrying ``report_task_started`` with a
+    bad ``task_id`` would keep getting ``{"acknowledged": false,
+    "error": "missing_task_id"}`` and every one of those errored calls
+    reset the detector window -- masking an obvious tool-loop. This
+    helper tightens the gate so only acknowledged-success responses
+    reset. Everything else (errored, missing field, unknown shape) is
+    conservatively treated as NOT a legitimate progress report so the
+    loop detector gets to count the call.
+
+    Shape contract: the reporting tools return a dict with
+    ``acknowledged`` set to ``True`` on success and ``False`` on
+    failure (with an ``error`` key describing what went wrong); see
+    :mod:`goldfive.adapters._tool_invocation`. Any other shape
+    (``None``, a string, a bare list, etc.) is treated as "unknown"
+    and does NOT reset the window.
+    """
+    if response is None:
+        return False
+    if isinstance(response, Mapping):
+        # Explicit failure wins: even if ``acknowledged`` is somehow
+        # True alongside an ``error`` key, treat it as errored so we
+        # don't silently reset on half-broken shapes.
+        if "error" in response:
+            return False
+        if response.get("acknowledged") is True:
+            return True
+        return False
+    return False  # unknown shape (str, list, bare value) -- conservative no-reset
+
+
 def _tool_requires_confirmation(tool: Any, tool_args: Any) -> bool:
     """Return True if ``tool`` opts into ADK's require_confirmation flag.
 
@@ -893,9 +931,13 @@ def make_adk_plugin(
                 **_tool_loops.load_thresholds_from_env()
             )
             # Reporting-tool names that indicate forward task progress
-            # and therefore clear the tool-loop tracker's window for
-            # the current (invocation, agent) key. Matches the set
-            # exposed by the adapter's state-transition protocol.
+            # and therefore can clear the tool-loop tracker's window
+            # for the current (invocation, agent) key — SUBJECT to the
+            # acknowledged-success gate in ``after_tool_callback``
+            # (goldfive#192). Matches the set exposed by the adapter's
+            # state-transition protocol, plus the approval-gate
+            # reporter which is the other call an agent uses to signal
+            # forward progress on a running task.
             self._progress_reporting_tools: frozenset[str] = frozenset(
                 {
                     "report_task_started",
@@ -903,6 +945,7 @@ def make_adk_plugin(
                     "report_task_completed",
                     "report_task_failed",
                     "report_task_blocked",
+                    "report_awaiting_approval",
                 }
             )
 
@@ -1996,9 +2039,19 @@ def make_adk_plugin(
             AgentTool delegations, MCP/custom tools) so the detector
             sees the real function_call stream the agent is emitting.
             A reporting-tool progress call (``report_task_started`` /
-            ``_progress`` / ``_completed`` / ``_failed`` / ``_blocked``)
-            additionally clears the per-(invocation, agent) window so
-            mode 2's "no task progress" gate is correct.
+            ``_progress`` / ``_completed`` / ``_failed`` / ``_blocked`` /
+            ``report_awaiting_approval``) additionally clears the
+            per-(invocation, agent) window — but ONLY when the call
+            was acknowledged (``result == {"acknowledged": True, ...}``)
+            so mode 2's "no task progress" gate is correct.
+
+            The acknowledged-success gate (goldfive#192) is the
+            tightening over goldfive#181's original behaviour: errored
+            progress reports (``acknowledged=False`` or responses with
+            an ``error`` key) do NOT reset the window, so an agent
+            stuck retrying a failing ``report_task_*`` with a bad
+            ``task_id`` gets caught as a tool-loop at the normal
+            thresholds.
 
             The detector is deterministic and O(1) per call modulo the
             tracker's ``window`` length; any failure is swallowed so a
@@ -2028,21 +2081,18 @@ def make_adk_plugin(
             agent_name = str(_safe_attr(running_agent, "name", "") or "") or self._host_agent_name
             task_id = str(_safe_attr(ctx.task, "id", "") or "")
 
-            # Progress-reporting tools reset the window BEFORE we
-            # record the call itself. That way a task-completing
-            # sequence (e.g. the fifth `read_file` that finally
-            # answers the question, followed by report_task_completed)
-            # doesn't leave the completing `report_*` call feeding
-            # a window that's about to be cleared. The progress tool
-            # is not appended at all — its job is to reset, not to
-            # feed the detector.
-            if tool_name in self._progress_reporting_tools:
-                self._tool_loop_tracker.on_task_progress(
-                    invocation_id=inv_id,
-                    agent_name=agent_name,
-                )
-                return None
-
+            # Every tool call is observed — regardless of kind. For a
+            # progress-reporting tool (``report_task_*`` /
+            # ``report_awaiting_approval``) we THEN look at the
+            # ``result`` payload and reset the per-(invocation, agent)
+            # window only when the call was *acknowledged* successfully
+            # (goldfive#192). Previously the exemption triggered on the
+            # call alone, so an agent stuck retrying a failing
+            # ``report_task_started`` kept resetting the window and the
+            # loop detector never fired. By observing first and resetting
+            # only on acknowledged success, errored report_* calls
+            # accumulate in the ring buffer and trigger loop detection
+            # at the normal thresholds.
             try:
                 # tool_args may be None / missing on adapter edge cases;
                 # the tracker's hash helper copes with both.
@@ -2060,6 +2110,24 @@ def make_adk_plugin(
                     exc,
                 )
                 return None
+
+            # Post-observation: reset the window only on acknowledged
+            # success for progress-reporting tools. An errored report
+            # (``acknowledged=False`` or a response containing an
+            # ``error`` key) falls through to the regular drift
+            # dispatch path so a stuck retry-loop still lights up.
+            if tool_name in self._progress_reporting_tools:
+                if _is_progress_report_success(result):
+                    try:
+                        self._tool_loop_tracker.on_task_progress(
+                            invocation_id=inv_id,
+                            agent_name=agent_name,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        log.debug(
+                            "after_tool_callback: on_task_progress raised: %s",
+                            exc,
+                        )
 
             if not drifts:
                 return None

--- a/goldfive/drift/tool_loops.py
+++ b/goldfive/drift/tool_loops.py
@@ -41,6 +41,24 @@ clears the per-agent buffer so a legitimate burst of the same tool
 (e.g. a scripted lint + build + test pipeline) is not flagged when
 each call completes its step.
 
+.. note::
+
+   The exemption for ``report_task_*`` / ``report_awaiting_approval``
+   calls is **success-conditional**. The ADK plugin's
+   ``after_tool_callback`` only invokes :meth:`on_task_progress` when
+   the tool response indicates an acknowledged success
+   (``{"acknowledged": True, ...}`` with no ``error`` key).
+   Errored progress reports (missing ``task_id``, malformed payload,
+   etc.) are treated as ordinary tool calls and DO count toward
+   loop detection. This closes goldfive#192 where an agent stuck
+   retrying ``report_task_started`` with a bad ``task_id`` received
+   16 consecutive ``missing_task_id`` errors and the detector never
+   fired because the old unconditional-reset behaviour exempted them
+   on the call alone. The classifier here is unchanged; the gate
+   lives in the plugin so ``on_task_progress`` still resets the
+   window unconditionally when called directly (tests and any
+   future direct callers).
+
 Isolation: trackers are keyed on ``(invocation_id, agent_name)`` so
 each ADK invocation gets its own window, and parallel sub-agents
 within the same invocation (via AgentTool) are also isolated. State
@@ -289,6 +307,19 @@ class ToolLoopTracker:
         ``read_file read_file read_file`` that COMPLETES the task is
         not flagged because the next observation starts from an empty
         window.
+
+        .. note::
+
+           This method unconditionally clears the per-key buffer.
+           The **policy** of when to call it lives outside the
+           tracker. In the ADK plugin it is gated on an acknowledged
+           success response from the progress-reporting tool
+           (goldfive#192) so that errored ``report_task_*`` retries
+           accumulate in the ring buffer and trigger loop detection
+           at the configured thresholds. Direct callers (unit tests,
+           alternate adapters) may still invoke this method
+           whenever they have out-of-band knowledge that genuine
+           task progress occurred.
         """
         key = (invocation_id or "", agent_name or "")
         buf = self._buffers.get(key)

--- a/tests/test_tool_loop_exemption_tightening.py
+++ b/tests/test_tool_loop_exemption_tightening.py
@@ -1,0 +1,405 @@
+"""Tool-loop detector exemption tightening (goldfive#192).
+
+Defense-in-depth for the tool-loop drift detector (#181/#186). The
+previous behaviour exempted ``report_task_*`` calls from loop
+detection on the **call** alone -- ``on_task_progress`` cleared the
+per-(invocation, agent) ring buffer unconditionally whenever one of
+those tools was dispatched. In the wild this meant an agent stuck
+retrying ``report_task_started`` with a bad ``task_id`` kept
+receiving ``{"acknowledged": false, "error": "missing_task_id"}``
+and every one of those errored calls reset the detector. The
+tool-loop never fired; the reasoning-loop detector caught it
+eventually but only after the agent had chewed through 8 plan
+revisions.
+
+The fix moves the reset decision into
+``ADKAdapter._GoldfiveADKPlugin.after_tool_callback`` and gates it on
+the response shape. Only an acknowledged-success response
+(``{"acknowledged": True, ...}`` with no ``error`` key) resets the
+window. Every other shape -- including errored reports, unknown
+response types, and ``None`` -- falls through to the detector's
+normal ``observe_tool_call`` path so the errored calls accumulate in
+the ring buffer and fire at the usual thresholds.
+
+Contracts pinned here:
+
+1. Successful ``report_task_progress`` calls reset the window on
+   each dispatch -- a long burst of legitimate progress reports
+   never fires the detector.
+2. Errored ``report_task_started`` calls count as ordinary tool
+   calls -- three identical errored retries trip mode 1 at the
+   default exact-threshold of 3.
+3. Mixed traffic (success + error) resets on the successes only;
+   the errored calls can still trip mode 1 when they land back-to-back.
+4. Non-reporting tools are unaffected by the gate -- existing #181
+   behaviour preserved.
+5. Unknown response shapes (string, ``None``, bare list) are
+   conservatively treated as "not a successful progress report";
+   the window does not reset and the call counts toward loop
+   detection.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Session, Task
+
+# ---------------------------------------------------------------------------
+# Stubs -- mirror the shapes used in ``tests/test_drift_classifiers.py`` so
+# the plugin wiring looks identical to operators cross-referencing tests.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingToolLoopSteerer:
+    """Steerer stub that captures every drift routed via ``_handle_drift``."""
+
+    def __init__(self) -> None:
+        self.drifts: list[DriftEvent] = []
+        self.observations: list[Any] = []
+        self._sinks: list[Any] = []
+
+    async def observe(self, event: Any, session: Any) -> None:
+        self.observations.append(event)
+
+    async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+        self.drifts.append(drift)
+
+
+def _plugin_with_tool_loop_ctx(task: Task, session: Session, steerer: Any):
+    """Build an ADK plugin + state-context for tool-loop wiring tests.
+
+    Importing deferred so the module stays import-clean when
+    ``google.adk`` isn't installed (the integration tests guard on
+    ``importorskip``). Mirrors the fixture in
+    ``test_drift_classifiers.py`` so both test suites exercise the
+    exact same plugin entry point.
+    """
+    pytest.importorskip("google.adk")
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session,
+            steerer=steerer,
+            task=task,
+            tool_handlers={},
+            host_agent_name="test_agent",
+        )
+    }
+    plugin.set_active_context(state[SESSION_CONTEXT_STATE_KEY])
+    return plugin, state
+
+
+class _ToolStub:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _InvCtxStub:
+    def __init__(self, invocation_id: str, agent_name: str) -> None:
+        self.invocation_id = invocation_id
+        self.agent = type("_A", (), {"name": agent_name})()
+
+
+class _ToolCtxStub:
+    """Minimal ADK tool_context shape exposing ``_invocation_context``."""
+
+    def __init__(self, invocation_id: str, agent_name: str) -> None:
+        self._invocation_context = _InvCtxStub(invocation_id, agent_name)
+
+
+# ---------------------------------------------------------------------------
+# Helper: the ``_is_progress_report_success`` predicate -- unit-pinned so
+# regressions on the success-detection heuristic fail loudly without
+# requiring the full plugin harness.
+# ---------------------------------------------------------------------------
+
+
+def test_is_progress_report_success_true_when_acknowledged_true() -> None:
+    from goldfive.adapters._adk_plugin import _is_progress_report_success
+
+    assert _is_progress_report_success({"acknowledged": True}) is True
+    assert _is_progress_report_success({"acknowledged": True, "task_id": "t1"}) is True
+
+
+def test_is_progress_report_success_false_when_acknowledged_false() -> None:
+    from goldfive.adapters._adk_plugin import _is_progress_report_success
+
+    assert _is_progress_report_success({"acknowledged": False}) is False
+
+
+def test_is_progress_report_success_false_when_error_present() -> None:
+    """Explicit ``error`` key wins even if ``acknowledged`` is missing / True."""
+    from goldfive.adapters._adk_plugin import _is_progress_report_success
+
+    assert _is_progress_report_success({"acknowledged": False, "error": "missing_task_id"}) is False
+    # Half-broken shape: ``acknowledged=True`` AND ``error`` set. The error
+    # wins so we don't silently reset on contradictory payloads.
+    assert _is_progress_report_success({"acknowledged": True, "error": "something"}) is False
+
+
+def test_is_progress_report_success_false_on_unknown_shapes() -> None:
+    """None, strings, lists, bare values -> conservative False."""
+    from goldfive.adapters._adk_plugin import _is_progress_report_success
+
+    assert _is_progress_report_success(None) is False
+    assert _is_progress_report_success("ok") is False
+    assert _is_progress_report_success([{"acknowledged": True}]) is False
+    assert _is_progress_report_success(42) is False
+    # A dict that doesn't carry ``acknowledged`` at all -> False.
+    assert _is_progress_report_success({"task_id": "t1"}) is False
+
+
+# ---------------------------------------------------------------------------
+# Plugin-level wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_successful_report_task_progress_resets_window() -> None:
+    """Five acknowledged-true progress reports in a row -> no drift.
+
+    Pins the legitimate path: a long-running task that regularly
+    reports progress must NEVER trip the detector even though it's
+    calling the same ``(tool_name, args)`` repeatedly. The gate is
+    ``acknowledged=True`` on every call, so each observation is
+    followed by a window reset.
+    """
+    pytest.importorskip("google.adk")
+    steerer = _RecordingToolLoopSteerer()
+    session = Session(run_id="run-192-1")
+    task = Task(id="t-success", title="Long task", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_tool_loop_ctx(task, session, steerer)
+
+    tool = _ToolStub("report_task_progress")
+    tool_ctx = _ToolCtxStub("inv-success", "test_agent")
+    args = {"task_id": "t-success", "fraction": 0.25}
+    ack = {"acknowledged": True, "task_id": "t-success"}
+
+    for _ in range(5):
+        await plugin.after_tool_callback(
+            tool=tool, tool_args=args, tool_context=tool_ctx, result=ack
+        )
+
+    assert steerer.drifts == []
+    # Window should be empty after the final reset.
+    assert (
+        plugin._tool_loop_tracker.buffer_size(invocation_id="inv-success", agent_name="test_agent")
+        == 0
+    )
+
+
+async def test_errored_report_task_started_counts_as_loop() -> None:
+    """Identical errored ``report_task_started`` retries must trip mode 1.
+
+    This is the #192 regression shape from session
+    ``e2e_final_1776866766``: 17 consecutive
+    ``{"acknowledged": false, "error": "missing_task_id"}`` responses
+    were previously exempt from loop detection. With the tightening,
+    the third identical errored retry fires mode 1 at the default
+    exact-threshold of 3.
+    """
+    pytest.importorskip("google.adk")
+    steerer = _RecordingToolLoopSteerer()
+    session = Session(run_id="run-192-2")
+    task = Task(id="t-err", title="Task", assignee_agent_id="debugger_agent")
+    plugin, _state = _plugin_with_tool_loop_ctx(task, session, steerer)
+
+    tool = _ToolStub("report_task_started")
+    tool_ctx = _ToolCtxStub("inv-err", "test_agent")
+    args = {"task_id": "bogus-task-id"}
+    nack = {"acknowledged": False, "error": "missing_task_id", "task_id": "bogus-task-id"}
+
+    # Calls 1 and 2: buffer fills but mode 1 needs count >= 3.
+    await plugin.after_tool_callback(tool=tool, tool_args=args, tool_context=tool_ctx, result=nack)
+    await plugin.after_tool_callback(tool=tool, tool_args=args, tool_context=tool_ctx, result=nack)
+    assert steerer.drifts == []
+
+    # Call 3: exact-threshold hit -> WARNING drift fires.
+    await plugin.after_tool_callback(tool=tool, tool_args=args, tool_context=tool_ctx, result=nack)
+    assert len(steerer.drifts) == 1
+    drift = steerer.drifts[0]
+    assert drift.kind is DriftKind.LOOPING_REASONING
+    assert drift.severity is DriftSeverity.WARNING
+    assert drift.raw is not None
+    assert drift.raw.get("mode") == "exact"
+    assert drift.raw.get("tool_name") == "report_task_started"
+    assert drift.current_task_id == "t-err"
+
+    # The errored call must NOT have reset the window -- subsequent
+    # identical retries keep the mode-1 signal hot.
+    await plugin.after_tool_callback(tool=tool, tool_args=args, tool_context=tool_ctx, result=nack)
+    assert len(steerer.drifts) == 2
+
+
+async def test_mixed_success_and_error_counts_only_errors() -> None:
+    """Mixed traffic: successes reset, errors accumulate.
+
+    With default thresholds (window=7, exact_threshold=3) the sequence
+
+        success, error, error, success, error, error, error
+
+    should fire mode 1 at the final error. The two successes each
+    clear the buffer, so between them the detector sees
+    ``[error, error]`` (count 2, no fire). After the second success
+    resets, the detector sees ``[error, error, error]`` -> mode 1
+    fires on the third consecutive error.
+    """
+    pytest.importorskip("google.adk")
+    steerer = _RecordingToolLoopSteerer()
+    session = Session(run_id="run-192-3")
+    task = Task(id="t-mixed", title="Task", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_tool_loop_ctx(task, session, steerer)
+
+    started = _ToolStub("report_task_started")
+    progress = _ToolStub("report_task_progress")
+    tool_ctx = _ToolCtxStub("inv-mixed", "test_agent")
+    err_args = {"task_id": "bogus"}
+    ok_args = {"task_id": "t-mixed", "fraction": 0.1}
+    nack = {"acknowledged": False, "error": "missing_task_id"}
+    ack = {"acknowledged": True}
+
+    async def _call(tool: _ToolStub, args: dict[str, Any], result: dict[str, Any]) -> None:
+        await plugin.after_tool_callback(
+            tool=tool, tool_args=args, tool_context=tool_ctx, result=result
+        )
+
+    # 1. success -> buffer cleared, no drift.
+    await _call(progress, ok_args, ack)
+    assert steerer.drifts == []
+    # 2. error -> buffer = [started@err]. count=1 < 3.
+    await _call(started, err_args, nack)
+    # 3. error -> buffer = [started@err, started@err]. count=2 < 3.
+    await _call(started, err_args, nack)
+    assert steerer.drifts == []
+    # 4. success -> window reset, buffer empty.
+    await _call(progress, ok_args, ack)
+    assert steerer.drifts == []
+    assert (
+        plugin._tool_loop_tracker.buffer_size(invocation_id="inv-mixed", agent_name="test_agent")
+        == 0
+    )
+    # 5, 6. two errors after the reset -- count climbing, still < 3.
+    await _call(started, err_args, nack)
+    await _call(started, err_args, nack)
+    assert steerer.drifts == []
+    # 7. third errored-in-a-row -> mode 1 fires.
+    await _call(started, err_args, nack)
+    assert len(steerer.drifts) == 1
+    drift = steerer.drifts[0]
+    assert drift.raw is not None
+    assert drift.raw.get("mode") == "exact"
+    assert drift.raw.get("tool_name") == "report_task_started"
+
+
+async def test_non_report_tool_unaffected() -> None:
+    """A non-reporting tool called 3 times trips mode 1 exactly as before.
+
+    #192 changes the report_* exemption semantics only; ordinary
+    tool-loop detection on arbitrary tools must be unchanged. This
+    pins that the new success-gate logic does not disturb the #181
+    baseline for non-reporting tools.
+    """
+    pytest.importorskip("google.adk")
+    steerer = _RecordingToolLoopSteerer()
+    session = Session(run_id="run-192-4")
+    task = Task(id="t-wf", title="Task", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_tool_loop_ctx(task, session, steerer)
+
+    tool = _ToolStub("write_file")
+    tool_ctx = _ToolCtxStub("inv-wf", "test_agent")
+    args = {"path": "out.txt", "content": "hi"}
+    # Any ``result`` shape -- the non-report path never looks at it.
+    result = {"bytes_written": 2}
+
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result=result
+    )
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result=result
+    )
+    assert steerer.drifts == []
+
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result=result
+    )
+    assert len(steerer.drifts) == 1
+    drift = steerer.drifts[0]
+    assert drift.kind is DriftKind.LOOPING_REASONING
+    assert drift.severity is DriftSeverity.WARNING
+    assert drift.raw is not None
+    assert drift.raw.get("mode") == "exact"
+    assert drift.raw.get("tool_name") == "write_file"
+
+
+async def test_unknown_response_shape_does_not_reset() -> None:
+    """Progress tool + weird response -> conservative no-reset, call counts.
+
+    The exemption rationale is "agent successfully reported forward
+    progress". If we can't prove the call succeeded (response is
+    ``None``, a bare string, a list, anything other than an
+    acknowledged-success dict), we do NOT reset -- the call counts
+    toward the loop detector like any other. This closes the
+    half-broken-adapter hole where a buggy reporter that returned
+    ``None`` could silently mask tool-loops.
+    """
+    pytest.importorskip("google.adk")
+    steerer = _RecordingToolLoopSteerer()
+    session = Session(run_id="run-192-5")
+    task = Task(id="t-unknown", title="Task", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_tool_loop_ctx(task, session, steerer)
+
+    tool = _ToolStub("report_task_started")
+    tool_ctx = _ToolCtxStub("inv-unknown", "test_agent")
+    args = {"task_id": "t-unknown"}
+
+    # Three identical calls, each returning ``None`` (or a string).
+    # None must not reset; mode 1 fires at call 3.
+    await plugin.after_tool_callback(tool=tool, tool_args=args, tool_context=tool_ctx, result=None)
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result="weird-bare-string"
+    )
+    assert steerer.drifts == []
+
+    await plugin.after_tool_callback(tool=tool, tool_args=args, tool_context=tool_ctx, result=None)
+    assert len(steerer.drifts) == 1
+    drift = steerer.drifts[0]
+    assert drift.raw is not None
+    assert drift.raw.get("mode") == "exact"
+    assert drift.raw.get("tool_name") == "report_task_started"
+
+
+async def test_report_awaiting_approval_respects_success_gate() -> None:
+    """``report_awaiting_approval`` follows the same success-conditional gate.
+
+    The approval-gate reporter is in the progress-reporting set
+    (goldfive#192). An acknowledged success resets the window; an
+    errored call does not. Pins the symmetry with the
+    ``report_task_*`` tools.
+    """
+    pytest.importorskip("google.adk")
+    steerer = _RecordingToolLoopSteerer()
+    session = Session(run_id="run-192-6")
+    task = Task(id="t-approval", title="Task", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_tool_loop_ctx(task, session, steerer)
+
+    tool = _ToolStub("report_awaiting_approval")
+    tool_ctx = _ToolCtxStub("inv-approval", "test_agent")
+    args = {"task_id": "t-approval", "reason": "needs human"}
+
+    # Three errored approval reports -> mode 1 fires on call 3.
+    nack = {"acknowledged": False, "error": "missing_task_id"}
+    for _ in range(3):
+        await plugin.after_tool_callback(
+            tool=tool, tool_args=args, tool_context=tool_ctx, result=nack
+        )
+    assert len(steerer.drifts) == 1
+    assert steerer.drifts[0].raw is not None
+    assert steerer.drifts[0].raw.get("tool_name") == "report_awaiting_approval"


### PR DESCRIPTION
## Summary

Defense-in-depth for the tool-loop drift detector (#181/#186). Previously `on_task_progress` was called on every `report_task_*` / `report_awaiting_approval` dispatch regardless of outcome, so an agent stuck retrying `report_task_started` with a bad `task_id` reset the detector window on every errored retry. The loop detector never fired.

Fix moves the reset decision to `_GoldfiveADKPlugin.after_tool_callback`: every tool call is observed first, and the window reset fires only when the response is an acknowledged-success dict (`{\"acknowledged\": True, ...}` with no `error` key). Errored reports, unknown shapes, `None`, and bare strings all fall through to the detector's normal `observe_tool_call` path, so retries accumulate and trip mode 1 at the usual exact-threshold of 3.

- `goldfive/adapters/_adk_plugin.py`: add `_is_progress_report_success` helper; rewire `after_tool_callback` to observe-then-gate; extend `_progress_reporting_tools` set to include `report_awaiting_approval`.
- `goldfive/drift/tool_loops.py`: module + `on_task_progress` docstrings note that the exemption is success-conditional (the gate lives in the plugin; tracker API is unchanged).
- `tests/test_tool_loop_exemption_tightening.py`: 10 new tests covering the predicate unit contract and plugin-level wiring for success, errored, mixed, non-report, unknown-shape, and approval-gate paths.

Closes #192. Sibling agents are targeting #191's root cause in parallel; this tightening means even if an errored `report_*` slips through, the detector catches it.

## Test plan

- [x] `uv run --extra dev --extra adk pytest tests/test_tool_loop_exemption_tightening.py -v` (10 passed)
- [x] `uv run --extra dev --extra adk pytest tests/test_tool_loops.py tests/test_drift_classifiers.py tests/test_tool_loop_guard.py` (all #181 tests still green: 41 + 22)
- [x] `uv run --extra dev --extra adk pytest tests/` (967 passed, 46 skipped — the skips are the same pre-existing skips)
- [x] `uv run --extra dev ruff check goldfive/adapters/_adk_plugin.py goldfive/drift/tool_loops.py tests/test_tool_loop_exemption_tightening.py`
- [x] `uv run --extra dev ruff format --check` (all formatted)