### PR TITLE
Pin current_task_id at delegation + default from state in reporting tools (closes part of #191)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1084,20 +1084,39 @@ def make_adk_plugin(
             return None
 
         async def before_agent_callback(self, *, agent: Any, callback_context: Any) -> None:
-            """Forward an agent-turn start to the overlay reconciler.
+            """Pin ``goldfive.current_task_id`` for the starting sub-agent and
+            forward an agent-turn start to the overlay reconciler.
 
             Fires once per agent invocation (including sub-agents
-            inside AgentTool sub-Runners). When a
-            :class:`~goldfive.reconciler.PlanReconciler` is attached,
-            we forward ``agent.name``, the invocation id, and the
-            parent_invocation_id (the outer runner's id, when the
-            current invocation is nested inside an ``AgentTool``
-            sub-Runner) so the reconciler can resolve parent chains
-            for contextual matching (goldfive#151).
+            inside AgentTool sub-Runners). Two jobs:
+
+            1. **Task-id pinning (goldfive#191 Layer 1).** At delegation
+               time, find the unique plan task whose
+               ``assignee_agent_id == agent.name`` and whose status is
+               PENDING or RUNNING, and stamp its id onto both the live
+               ADK ``session.state`` and the goldfive orchestration
+               ``session.state`` under the ``goldfive.current_task_id``
+               key. Sub-agents' reporting-tool handlers read this key
+               as a fallback when the model's tool call omits
+               ``task_id``, so delegated work doesn't retry-loop on
+               the structured ``missing_task_id`` error.
+
+               Zero matches (off-plan agent) and multiple matches
+               (ambiguous — a coordinator with two pending siblings
+               for the same assignee) intentionally leave the state
+               unset. The ``missing_task_id`` error path still fires
+               in those cases — better an explicit rejection than a
+               mis-attributed report.
+
+            2. **Overlay reconciler forward.** When a
+               :class:`~goldfive.reconciler.PlanReconciler` is
+               attached, we forward ``agent.name``, the invocation
+               id, and the parent_invocation_id (the outer runner's
+               id, when the current invocation is nested inside an
+               ``AgentTool`` sub-Runner) so the reconciler can
+               resolve parent chains for contextual matching
+               (goldfive#151).
             """
-            reconciler = self._reconciler
-            if reconciler is None:
-                return None
             agent_name = str(_safe_attr(agent, "name", "") or "")
             inv_ctx = _safe_attr(callback_context, "_invocation_context", None) or _safe_attr(
                 callback_context, "invocation_context", None
@@ -1106,6 +1125,25 @@ def make_adk_plugin(
             parent_inv_id = ""
             if inv_id and self._top_invocation_id and inv_id != self._top_invocation_id:
                 parent_inv_id = self._top_invocation_id
+
+            # Layer 1: pin the starting sub-agent's task_id so its
+            # reporting-tool calls can default the arg from state
+            # (goldfive#191). Best-effort: a raise here must never
+            # break the invocation.
+            try:
+                self._pin_current_task_id_for_agent(
+                    agent_name=agent_name,
+                    callback_context=callback_context,
+                )
+            except Exception as exc:  # noqa: BLE001 — pinning must never raise
+                log.debug(
+                    "before_agent_callback: current_task_id pin raised: %s",
+                    exc,
+                )
+
+            reconciler = self._reconciler
+            if reconciler is None:
+                return None
             try:
                 await reconciler.on_before_agent(
                     agent_name=agent_name,
@@ -1131,6 +1169,106 @@ def make_adk_plugin(
                     exc,
                 )
             return None
+
+        def _pin_current_task_id_for_agent(
+            self,
+            *,
+            agent_name: str,
+            callback_context: Any,
+        ) -> None:
+            """Stamp ``goldfive.current_task_id`` for ``agent_name`` if unambiguous.
+
+            Matching rule: the plan task whose ``assignee_agent_id``
+            equals ``agent_name`` and whose status is PENDING or
+            RUNNING. Exactly-one matches stamp the id onto both the
+            live ADK ``session.state`` (agent-side reads via
+            ``tool_ctx.state``) and the goldfive orchestration
+            ``session.state`` (handler fallback in
+            :mod:`goldfive.reporting` + :mod:`goldfive.adapters._tool_invocation`).
+
+            Zero / multiple matches leave state unset — the handler
+            path will surface the existing ``missing_task_id`` error
+            rather than guess, which is the correct signal for an
+            off-plan agent or an ambiguous coordinator assignment.
+
+            Silent on every failure mode (no agent name, no ctx, no
+            plan, state not a mapping). Instrumentation-class path:
+            a mistake here degrades to the pre-#191 behaviour where
+            the model sees ``missing_task_id`` and retry-loops — bad,
+            but strictly no worse than the baseline.
+            """
+            if not agent_name:
+                return
+            ctx = self._resolve_ctx(callback_context)
+            if ctx is None:
+                return
+            plan = _safe_attr(ctx.session, "plan", None)
+            if plan is None:
+                return
+            tasks = _safe_attr(plan, "tasks", None) or ()
+            # Import here so the type is available without forcing a
+            # top-level import for a rarely-hot-path enum compare.
+            from goldfive.types import TaskStatus
+
+            matches: list[Any] = []
+            for task in tasks:
+                assignee = str(_safe_attr(task, "assignee_agent_id", "") or "")
+                if assignee != agent_name:
+                    continue
+                status = _safe_attr(task, "status", None)
+                if status is TaskStatus.PENDING or status is TaskStatus.RUNNING:
+                    matches.append(task)
+                    if len(matches) > 1:
+                        break  # ambiguous — no need to count further
+
+            if len(matches) != 1:
+                # Zero matches (off-plan) or >1 matches (ambiguous).
+                # Leave state unset; the existing ``missing_task_id``
+                # error path remains the explicit signal.
+                log.debug(
+                    "before_agent_callback: not pinning current_task_id for %s "
+                    "(%d PENDING/RUNNING task matches)",
+                    agent_name,
+                    len(matches),
+                )
+                return
+            task = matches[0]
+            task_id = str(_safe_attr(task, "id", "") or "")
+            if not task_id:
+                return
+
+            # Stamp the goldfive orchestration-state key first — the
+            # reporting-tool handler fallback in ``invoke_tool`` +
+            # ``reporting.py`` reads from here.
+            gf_state = _safe_attr(ctx.session, "state", None)
+            if isinstance(gf_state, dict):
+                try:
+                    gf_state[_sp.KEY_CURRENT_TASK_ID] = task_id
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "before_agent_callback: goldfive session.state pin failed: %s",
+                        exc,
+                    )
+
+            # Stamp the ADK session.state key — the sibling's Layer 3
+            # (before_tool_callback arg-injection) reads from here and
+            # any agent that inspects ``tool_ctx.state`` directly picks
+            # up the same value.
+            adk_state = _session_state_from_callback(callback_context)
+            if isinstance(adk_state, Mapping):
+                try:
+                    _sp.write_current_task_id(adk_state, task_id)
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "before_agent_callback: ADK session.state pin failed: %s",
+                        exc,
+                    )
+
+            log.info(
+                "goldfive: pinned current_task_id=%s for sub-agent %s",
+                task_id,
+                agent_name,
+            )
 
         async def after_agent_callback(self, *, agent: Any, callback_context: Any) -> None:
             """Forward an agent-turn end to the overlay reconciler."""

--- a/goldfive/adapters/_adk_state_protocol.py
+++ b/goldfive/adapters/_adk_state_protocol.py
@@ -203,6 +203,24 @@ def read_divergence_flag(state: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def write_current_task_id(state: MutableMapping[str, Any], task_id: str) -> None:
+    """Stamp just ``goldfive.current_task_id`` onto ``state``.
+
+    Narrower than :func:`write_current_task` which rewrites all four
+    ``current_task_*`` keys from a :class:`Task`. Used by the adapter's
+    ``before_agent_callback`` pin path (goldfive#191 Layer 1) where the
+    plugin only knows the id at delegation time and doesn't want to
+    overwrite the title/description/assignee written earlier by the
+    reconciler.
+
+    Empty / None ``task_id`` is a no-op — callers that want to clear
+    the key should use :func:`clear_current_task`.
+    """
+    if not task_id:
+        return
+    _set(state, KEY_CURRENT_TASK_ID, _safe_str(task_id))
+
+
 def write_current_task(state: MutableMapping[str, Any], task: Any) -> None:
     """Mutate state with current_task_* fields from a :class:`goldfive.types.Task`.
 
@@ -223,9 +241,7 @@ def write_current_task(state: MutableMapping[str, Any], task: Any) -> None:
         tid = getattr(task, "id", "")
         title = getattr(task, "title", "")
         description = getattr(task, "description", "")
-        assignee = getattr(task, "assignee_agent_id", "") or getattr(
-            task, "assignee", ""
-        )
+        assignee = getattr(task, "assignee_agent_id", "") or getattr(task, "assignee", "")
 
     _set(state, KEY_CURRENT_TASK_ID, _safe_str(tid))
     _set(state, KEY_CURRENT_TASK_TITLE, _safe_str(title))
@@ -281,9 +297,7 @@ def write_plan_context(
             {
                 "id": tid,
                 "title": _safe_str(getattr(task, "title", "")),
-                "assignee": _safe_str(
-                    getattr(task, "assignee_agent_id", "") or host_agent
-                ),
+                "assignee": _safe_str(getattr(task, "assignee_agent_id", "") or host_agent),
                 "status": status_str,
                 "deps": list(deps_by_task.get(tid, [])),
             }
@@ -305,9 +319,7 @@ def write_run_id(state: MutableMapping[str, Any], run_id: str) -> None:
     _set(state, KEY_RUN_ID, _safe_str(run_id))
 
 
-def write_tools_available(
-    state: MutableMapping[str, Any], tool_names: Iterable[str]
-) -> None:
+def write_tools_available(state: MutableMapping[str, Any], tool_names: Iterable[str]) -> None:
     _set(
         state,
         KEY_TOOLS_AVAILABLE,
@@ -406,14 +418,10 @@ def extract_agent_writes(before: Any, after: Any) -> dict:
     after_map: Mapping[str, Any] = after if isinstance(after, Mapping) else {}
 
     before_g = {
-        k: v
-        for k, v in before_map.items()
-        if isinstance(k, str) and k.startswith(GOLDFIVE_PREFIX)
+        k: v for k, v in before_map.items() if isinstance(k, str) and k.startswith(GOLDFIVE_PREFIX)
     }
     after_g = {
-        k: v
-        for k, v in after_map.items()
-        if isinstance(k, str) and k.startswith(GOLDFIVE_PREFIX)
+        k: v for k, v in after_map.items() if isinstance(k, str) and k.startswith(GOLDFIVE_PREFIX)
     }
 
     changes: dict[str, Any] = {}

--- a/goldfive/adapters/_tool_invocation.py
+++ b/goldfive/adapters/_tool_invocation.py
@@ -77,6 +77,33 @@ def find_tool(
     return None
 
 
+# Orchestration-state key the adapter stamps at delegation time
+# (goldfive#191). Duplicated here rather than imported from
+# :mod:`goldfive.orchestration_state` to avoid forcing every adapter
+# to pull in the orchestration module just to resolve a fallback.
+_STATE_KEY_CURRENT_TASK_ID = "goldfive.current_task_id"
+
+
+def _resolve_state_task_id(session: Session) -> str:
+    """Return ``session.state["goldfive.current_task_id"]`` or ``""``.
+
+    Tolerant of a missing ``state`` attribute and a non-mapping /
+    non-string value — any degenerate shape yields the empty string
+    so the caller's existing ``missing_task_id`` rejection still
+    fires. Strips whitespace to match the ``task_id`` normalisation
+    :func:`invoke_tool` already applies to the arg.
+    """
+    state = getattr(session, "state", None)
+    if not isinstance(state, dict):
+        return ""
+    raw = state.get(_STATE_KEY_CURRENT_TASK_ID, "")
+    if isinstance(raw, str):
+        return raw.strip()
+    if raw is None:
+        return ""
+    return str(raw).strip()
+
+
 async def invoke_tool(
     tools: Iterable[ReportingToolSpec],
     name: str,
@@ -113,6 +140,19 @@ async def invoke_tool(
         return await tool.handler(args, session, steerer)
 
     task_id = str(args.get("task_id") or "").strip()
+    # goldfive#191 Layer 2: fall back to the orchestration-state pin
+    # when the model's tool call omits ``task_id``. The adapter's
+    # ``before_agent_callback`` stamps ``goldfive.current_task_id`` at
+    # delegation time when the starting sub-agent has an unambiguous
+    # plan task assignment. Mutating ``args`` here (rather than just
+    # using a local) makes the resolved id visible to the handler too,
+    # so all downstream paths (idempotency signature, terminal-task
+    # lookup, handler body) see a single consistent value.
+    if not task_id:
+        fallback = _resolve_state_task_id(session)
+        if fallback:
+            task_id = fallback
+            args["task_id"] = fallback
     guard_key = task_id or "__plan__"
     is_plan_level = name in _PLAN_LEVEL_TOOLS
     sig = (name, args_signature(args))

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -78,6 +78,66 @@ REPORTING_TOOL_NAMES: tuple[str, ...] = (
 
 _ACK: dict[str, Any] = {"acknowledged": True}
 
+# Orchestration-state key the adapter stamps at delegation time
+# (goldfive#191). Handlers fall back to this value when the model's
+# tool call omits ``task_id``. Re-declared here rather than imported
+# from :mod:`goldfive.orchestration_state` to avoid a circular import
+# — the string is a stable contract shared between the adapter's
+# :mod:`._adk_state_protocol`, :mod:`orchestration_state`, and this
+# handler module.
+_STATE_KEY_CURRENT_TASK_ID = "goldfive.current_task_id"
+
+
+def _resolve_task_id(args: dict[str, Any], session: Session) -> str:
+    """Return the task_id to act on, falling back to session state.
+
+    Order of precedence (goldfive#191):
+
+    1. ``args["task_id"]`` — explicit model-provided id always wins.
+    2. ``session.state["goldfive.current_task_id"]`` — the id pinned
+       by the adapter's ``before_agent_callback`` when the current
+       sub-agent has exactly one PENDING/RUNNING task assigned to
+       it. Closes the loop where the LLM's tool call omits the
+       arg but the orchestration layer knew the answer.
+
+    Empty string when neither source supplies a value — caller
+    should short-circuit with the canonical ``missing_task_id``
+    error in that case.
+    """
+    raw = args.get("task_id")
+    if raw is not None:
+        task_id = str(raw).strip()
+        if task_id:
+            return task_id
+    state = getattr(session, "state", None)
+    if isinstance(state, dict):
+        fallback = state.get(_STATE_KEY_CURRENT_TASK_ID, "")
+        if isinstance(fallback, str):
+            return fallback.strip()
+        if fallback is not None:
+            return str(fallback).strip()
+    return ""
+
+
+def _missing_task_id_response(tool_name: str) -> dict[str, Any]:
+    """Return the canonical ``missing_task_id`` rejection shape.
+
+    Mirrors the shape :mod:`goldfive.adapters._tool_invocation`
+    returns so adapters that call the handler directly (legacy paths,
+    custom adapters) surface the same structured error the
+    ``invoke_tool`` dispatcher would.
+    """
+    return {
+        "acknowledged": False,
+        "error": "missing_task_id",
+        "tool": tool_name,
+        "message": (
+            f"Tool {tool_name!r} requires a task_id; call it with the id "
+            "of the task you're reporting on, or ensure the adapter "
+            "has pinned goldfive.current_task_id on session state."
+        ),
+    }
+
 
 def _str(args: dict[str, Any], key: str, default: str = "") -> str:
     v = args.get(key, default)
@@ -114,28 +174,30 @@ def _int(args: dict[str, Any], key: str, default: int = 0) -> int:
 async def _handle_task_started(
     args: dict[str, Any], session: Session, steerer: Steerer
 ) -> dict[str, Any]:
-    task_id = _str(args, "task_id")
+    task_id = _resolve_task_id(args, session)
     detail = _str(args, "detail")
-    if task_id:
-        await steerer.mark_task_running(task_id, session=session, detail=detail)
+    if not task_id:
+        return _missing_task_id_response("report_task_started")
+    await steerer.mark_task_running(task_id, session=session, detail=detail)
     return dict(_ACK)
 
 
 async def _handle_task_progress(
     args: dict[str, Any], session: Session, steerer: Steerer
 ) -> dict[str, Any]:
-    task_id = _str(args, "task_id")
+    task_id = _resolve_task_id(args, session)
     fraction = _float(args, "fraction")
     detail = _str(args, "detail")
-    if task_id:
-        await steerer.mark_task_progress(task_id, session=session, fraction=fraction, detail=detail)
+    if not task_id:
+        return _missing_task_id_response("report_task_progress")
+    await steerer.mark_task_progress(task_id, session=session, fraction=fraction, detail=detail)
     return dict(_ACK)
 
 
 async def _handle_task_completed(
     args: dict[str, Any], session: Session, steerer: Steerer
 ) -> dict[str, Any]:
-    task_id = _str(args, "task_id")
+    task_id = _resolve_task_id(args, session)
     summary = _str(args, "summary")
     artifacts_raw = args.get("artifacts")
     artifacts = (
@@ -143,37 +205,40 @@ async def _handle_task_completed(
         if isinstance(artifacts_raw, dict)
         else {}
     )
-    if task_id:
-        await steerer.mark_task_completed(
-            task_id, session=session, summary=summary, artifacts=artifacts
-        )
+    if not task_id:
+        return _missing_task_id_response("report_task_completed")
+    await steerer.mark_task_completed(
+        task_id, session=session, summary=summary, artifacts=artifacts
+    )
     return dict(_ACK)
 
 
 async def _handle_task_failed(
     args: dict[str, Any], session: Session, steerer: Steerer
 ) -> dict[str, Any]:
-    task_id = _str(args, "task_id")
+    task_id = _resolve_task_id(args, session)
     reason = _str(args, "reason")
     recoverable = _bool(args, "recoverable", default=True)
-    if task_id:
-        await steerer.mark_task_failed(
-            task_id,
-            session=session,
-            reason=reason,
-            recoverable=recoverable,
-        )
+    if not task_id:
+        return _missing_task_id_response("report_task_failed")
+    await steerer.mark_task_failed(
+        task_id,
+        session=session,
+        reason=reason,
+        recoverable=recoverable,
+    )
     return dict(_ACK)
 
 
 async def _handle_task_blocked(
     args: dict[str, Any], session: Session, steerer: Steerer
 ) -> dict[str, Any]:
-    task_id = _str(args, "task_id")
+    task_id = _resolve_task_id(args, session)
     blocker = _str(args, "blocker")
     needed = _str(args, "needed")
-    if task_id:
-        await steerer.mark_task_blocked(task_id, session=session, blocker=blocker, needed=needed)
+    if not task_id:
+        return _missing_task_id_response("report_task_blocked")
+    await steerer.mark_task_blocked(task_id, session=session, blocker=blocker, needed=needed)
     return dict(_ACK)
 
 
@@ -223,11 +288,11 @@ async def _handle_awaiting_approval(
     decision lands returns ``{"decision": "timeout", "detail": ...}``
     and leaves the task blocked (the caller may re-prompt or fail).
     """
-    task_id = _str(args, "task_id")
+    task_id = _resolve_task_id(args, session)
     prompt = _str(args, "prompt")
     timeout_ms = _int(args, "timeout_ms", 0)
     if not task_id:
-        return {"acknowledged": False, "error": "task_id is required"}
+        return _missing_task_id_response("report_awaiting_approval")
 
     # Idempotency: reuse an existing waiter if one is already pending.
     waiter = session.pending_approvals.get(task_id)
@@ -330,8 +395,16 @@ def _object_schema(*, required: list[str], properties: dict[str, dict[str, Any]]
     }
 
 
+# NOTE: ``task_id`` is intentionally omitted from every schema's
+# ``required`` list (goldfive#191). The adapter stamps
+# ``goldfive.current_task_id`` onto session state at delegation time
+# so the handler can default from state when the model doesn't supply
+# the arg. Handlers still reject with the canonical
+# ``missing_task_id`` shape when neither source resolves a value —
+# so strictness is enforced at the handler layer, not the schema.
+
 _SCHEMA_TASK_STARTED = _object_schema(
-    required=["task_id"],
+    required=[],
     properties={
         "task_id": {"type": "string"},
         "detail": {"type": "string"},
@@ -339,7 +412,7 @@ _SCHEMA_TASK_STARTED = _object_schema(
 )
 
 _SCHEMA_TASK_PROGRESS = _object_schema(
-    required=["task_id"],
+    required=[],
     properties={
         "task_id": {"type": "string"},
         "fraction": {"type": "number", "minimum": 0.0, "maximum": 1.0},
@@ -348,7 +421,7 @@ _SCHEMA_TASK_PROGRESS = _object_schema(
 )
 
 _SCHEMA_TASK_COMPLETED = _object_schema(
-    required=["task_id", "summary"],
+    required=["summary"],
     properties={
         "task_id": {"type": "string"},
         "summary": {"type": "string"},
@@ -360,7 +433,7 @@ _SCHEMA_TASK_COMPLETED = _object_schema(
 )
 
 _SCHEMA_TASK_FAILED = _object_schema(
-    required=["task_id", "reason"],
+    required=["reason"],
     properties={
         "task_id": {"type": "string"},
         "reason": {"type": "string"},
@@ -369,7 +442,7 @@ _SCHEMA_TASK_FAILED = _object_schema(
 )
 
 _SCHEMA_TASK_BLOCKED = _object_schema(
-    required=["task_id", "blocker"],
+    required=["blocker"],
     properties={
         "task_id": {"type": "string"},
         "blocker": {"type": "string"},
@@ -396,7 +469,7 @@ _SCHEMA_PLAN_DIVERGENCE = _object_schema(
 )
 
 _SCHEMA_AWAITING_APPROVAL = _object_schema(
-    required=["task_id", "prompt"],
+    required=["prompt"],
     properties={
         "task_id": {"type": "string"},
         "prompt": {"type": "string"},

--- a/tests/test_task_id_wiring.py
+++ b/tests/test_task_id_wiring.py
@@ -1,0 +1,448 @@
+"""Tests for task_id wiring (goldfive#191 Layers 1 + 2).
+
+Covers:
+
+* Layer 1 — ``_GoldfiveADKPlugin.before_agent_callback`` pins
+  ``goldfive.current_task_id`` onto BOTH the ADK session.state and the
+  goldfive orchestration session.state when the starting sub-agent has
+  exactly one PENDING / RUNNING task assigned to it. Ambiguous
+  (multiple) and absent (zero) matches leave state unset so the
+  ``missing_task_id`` error path still fires.
+* Layer 2 — reporting-tool handlers fall back to
+  ``session.state["goldfive.current_task_id"]`` when the model's tool
+  call omits the ``task_id`` arg, yield the canonical
+  ``missing_task_id`` error when neither source supplies a value, and
+  honour an explicit arg over the state fallback.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    SESSION_CONTEXT_STATE_KEY,
+    SessionContext,
+    make_adk_plugin,
+)
+from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID  # noqa: E402
+from goldfive.adapters._tool_invocation import invoke_tool  # noqa: E402
+from goldfive.reporting import (  # noqa: E402
+    BUILTIN_REPORTING_TOOLS,
+    ReportingToolSpec,
+)
+from goldfive.types import (  # noqa: E402
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StateCtx:
+    """Minimal ADK-callback-context stub with a ``session.state`` dict."""
+
+    class _Session:
+        def __init__(self, state: dict) -> None:
+            self.state = state
+
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    @property
+    def session(self) -> Any:
+        return _StateCtx._Session(self._state)
+
+
+class _Agent:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _RecordingSteerer:
+    """Steerer stub that records transitions + drifts for assertions."""
+
+    def __init__(self) -> None:
+        self.transitions: list[tuple[str, Any, str]] = []
+        self.drifts: list[Any] = []
+
+    async def mark_task_running(self, task_id: str, *, session: Any, detail: str = "") -> None:
+        self.transitions.append((task_id, "RUNNING", detail))
+
+    async def mark_task_progress(
+        self, task_id: str, *, session: Any, fraction: float = 0.0, detail: str = ""
+    ) -> None:
+        self.transitions.append((task_id, "PROGRESS", detail))
+
+    async def mark_task_completed(
+        self, task_id: str, *, session: Any, summary: str = "", artifacts: Any = None
+    ) -> None:
+        self.transitions.append((task_id, "COMPLETED", summary))
+
+    async def mark_task_failed(
+        self,
+        task_id: str,
+        *,
+        session: Any,
+        reason: str = "",
+        recoverable: bool = True,
+    ) -> None:
+        self.transitions.append((task_id, "FAILED", reason))
+
+    async def mark_task_blocked(
+        self, task_id: str, *, session: Any, blocker: str = "", needed: str = ""
+    ) -> None:
+        self.transitions.append((task_id, "BLOCKED", blocker))
+
+    async def report_new_work_discovered(self, **kwargs: Any) -> None:
+        pass
+
+    async def report_plan_divergence(self, **kwargs: Any) -> None:
+        pass
+
+    async def observe(self, event: Any, session: Any) -> None:
+        self.drifts.append(event)
+
+    async def transition(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    def detect_drift(self, event: Any, session: Any) -> Any:
+        return None
+
+    def bind(self, **kw: Any) -> None:
+        pass
+
+
+def _plan_with(*tasks: Task, edges: list[TaskEdge] | None = None) -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=[],
+        tasks=list(tasks),
+        edges=list(edges or []),
+        summary="",
+    )
+
+
+def _session_with(plan: Plan | None) -> Session:
+    return Session(run_id="r1", plan=plan)
+
+
+def _ctx_for(session: Session, agent_name: str) -> tuple[dict, Any]:
+    """Build a ({adk_state}, callback_context) pair for plugin callbacks."""
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session,
+            steerer=None,
+            task=None,
+            tool_handlers={spec.name: spec.handler for spec in BUILTIN_REPORTING_TOOLS},
+            host_agent_name=agent_name,
+        ),
+    }
+    return state, _StateCtx(state)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — before_agent_callback pins current_task_id
+# ---------------------------------------------------------------------------
+
+
+async def test_before_agent_callback_pins_unambiguous_task() -> None:
+    """Exactly one PENDING task assigned to the starting agent → state pinned."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="research", assignee_agent_id="research_agent"),
+            Task(id="t2", title="code", assignee_agent_id="web_developer"),
+        )
+    )
+    state, ctx = _ctx_for(session, "coord")
+
+    await plugin.before_agent_callback(
+        agent=_Agent("research_agent"),
+        callback_context=ctx,
+    )
+
+    # ADK session.state side (sub-agent-visible).
+    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    # Goldfive orchestration-state side (handler fallback).
+    assert session.state["goldfive.current_task_id"] == "t1"
+
+
+async def test_before_agent_callback_ambiguous_match_leaves_unset() -> None:
+    """Two PENDING tasks for the same agent → no stamp."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="first", assignee_agent_id="research_agent"),
+            Task(id="t2", title="second", assignee_agent_id="research_agent"),
+        )
+    )
+    state, ctx = _ctx_for(session, "coord")
+
+    await plugin.before_agent_callback(
+        agent=_Agent("research_agent"),
+        callback_context=ctx,
+    )
+
+    assert KEY_CURRENT_TASK_ID not in state
+    assert "goldfive.current_task_id" not in session.state
+
+
+async def test_before_agent_callback_no_match_leaves_unset() -> None:
+    """Zero PENDING tasks for the agent (off-plan agent) → no stamp."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="first", assignee_agent_id="research_agent"),
+        )
+    )
+    state, ctx = _ctx_for(session, "coord")
+
+    # Agent name doesn't match any assignee in the plan.
+    await plugin.before_agent_callback(
+        agent=_Agent("rogue_agent"),
+        callback_context=ctx,
+    )
+
+    assert KEY_CURRENT_TASK_ID not in state
+    assert "goldfive.current_task_id" not in session.state
+
+
+async def test_before_agent_callback_includes_running_tasks() -> None:
+    """A RUNNING task for the agent also counts (re-entry / re-spawn path)."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    running_task = Task(
+        id="t1",
+        title="research",
+        assignee_agent_id="research_agent",
+        status=TaskStatus.RUNNING,
+    )
+    session = _session_with(_plan_with(running_task))
+    state, ctx = _ctx_for(session, "coord")
+
+    await plugin.before_agent_callback(
+        agent=_Agent("research_agent"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state["goldfive.current_task_id"] == "t1"
+
+
+async def test_before_agent_callback_skips_terminal_tasks() -> None:
+    """A COMPLETED task does not count; if it's the only match, state stays unset."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(
+        _plan_with(
+            Task(
+                id="t1",
+                title="already done",
+                assignee_agent_id="research_agent",
+                status=TaskStatus.COMPLETED,
+            ),
+        )
+    )
+    state, ctx = _ctx_for(session, "coord")
+
+    await plugin.before_agent_callback(
+        agent=_Agent("research_agent"),
+        callback_context=ctx,
+    )
+
+    assert KEY_CURRENT_TASK_ID not in state
+    assert "goldfive.current_task_id" not in session.state
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — reporting-tool handlers default task_id from state
+# ---------------------------------------------------------------------------
+
+
+def _get_spec(name: str) -> ReportingToolSpec:
+    for spec in BUILTIN_REPORTING_TOOLS:
+        if spec.name == name:
+            return spec
+    raise AssertionError(f"builtin tool {name!r} missing")
+
+
+async def test_reporting_tool_uses_state_task_id_when_arg_missing() -> None:
+    """State fallback reaches the handler via ``invoke_tool``."""
+    steerer = _RecordingSteerer()
+    session = _session_with(_plan_with(Task(id="t-1", title="do", assignee_agent_id="a")))
+    session.state["goldfive.current_task_id"] = "t-1"
+
+    spec = _get_spec("report_task_started")
+    result = await invoke_tool(
+        [spec],
+        "report_task_started",
+        {"detail": "starting"},  # no task_id
+        session,
+        steerer,
+    )
+
+    assert result == {"acknowledged": True}
+    # The handler ran with the state-derived id.
+    assert steerer.transitions == [("t-1", "RUNNING", "starting")]
+
+
+async def test_reporting_tool_honors_explicit_arg_over_state() -> None:
+    """An explicit ``task_id`` wins against the session-state fallback."""
+    steerer = _RecordingSteerer()
+    # Plan carries both ids so the ``unknown_task_id`` guard doesn't mask
+    # the behavior we're trying to observe.
+    session = _session_with(
+        _plan_with(
+            Task(id="t-1", title="a", assignee_agent_id="a"),
+            Task(id="t-2", title="b", assignee_agent_id="b"),
+        )
+    )
+    session.state["goldfive.current_task_id"] = "t-1"
+
+    spec = _get_spec("report_task_started")
+    result = await invoke_tool(
+        [spec],
+        "report_task_started",
+        {"task_id": "t-2", "detail": "explicit wins"},
+        session,
+        steerer,
+    )
+
+    assert result == {"acknowledged": True}
+    # Explicit arg is what reached the handler.
+    assert steerer.transitions == [("t-2", "RUNNING", "explicit wins")]
+
+
+async def test_reporting_tool_errors_when_neither_arg_nor_state() -> None:
+    """Neither arg nor state → canonical ``missing_task_id`` rejection."""
+    steerer = _RecordingSteerer()
+    session = _session_with(_plan_with(Task(id="t-1", title="do", assignee_agent_id="a")))
+    # session.state intentionally empty — no fallback.
+
+    spec = _get_spec("report_task_started")
+    result = await invoke_tool(
+        [spec],
+        "report_task_started",
+        {"detail": "starting"},
+        session,
+        steerer,
+    )
+
+    assert result["acknowledged"] is False
+    assert result["error"] == "missing_task_id"
+    assert result["tool"] == "report_task_started"
+    # No transition — handler must not run.
+    assert steerer.transitions == []
+
+
+@pytest.mark.parametrize(
+    "tool_name,extra_args",
+    [
+        ("report_task_started", {}),
+        ("report_task_progress", {"fraction": 0.5}),
+        ("report_task_completed", {"summary": "done"}),
+        ("report_task_failed", {"reason": "oops", "recoverable": True}),
+        ("report_task_blocked", {"blocker": "missing input"}),
+    ],
+)
+async def test_all_task_scoped_reporting_tools_default_task_id(
+    tool_name: str, extra_args: dict[str, Any]
+) -> None:
+    """Every task-scoped reporting tool defaults ``task_id`` from state.
+
+    Parameterized over the five task-scoped tools in
+    :data:`BUILTIN_REPORTING_TOOLS`. The remaining three (the plan-level
+    ``report_plan_divergence`` + ``report_new_work_discovered`` and the
+    waiter-based ``report_awaiting_approval``) are not task-id-gated by
+    the invoke_tool schema layer (``report_plan_divergence`` is
+    plan-level; ``report_new_work_discovered`` takes ``parent_task_id``;
+    ``report_awaiting_approval`` blocks on a waiter this test won't set
+    up), so they follow a different shape — covered separately.
+    """
+    steerer = _RecordingSteerer()
+    session = _session_with(_plan_with(Task(id="t-1", title="do", assignee_agent_id="a")))
+    session.state["goldfive.current_task_id"] = "t-1"
+
+    spec = _get_spec(tool_name)
+    args: dict[str, Any] = dict(extra_args)  # no task_id supplied
+    result = await invoke_tool([spec], tool_name, args, session, steerer)
+
+    # Each tool either ACKs or passes through to the handler with the
+    # state-derived id; neither should produce a ``missing_task_id``.
+    assert result.get("error") != "missing_task_id", (
+        f"{tool_name} did not default task_id from state: {result!r}"
+    )
+    # Handler ran with the resolved id.
+    assert any(t[0] == "t-1" for t in steerer.transitions), (
+        f"{tool_name} did not invoke the handler with t-1: transitions={steerer.transitions!r}"
+    )
+
+
+async def test_report_awaiting_approval_accepts_state_task_id() -> None:
+    """``report_awaiting_approval`` also resolves task_id from state.
+
+    Unlike the other tools, it fails at the ``prompt`` schema check if
+    absent, but we're testing the state-fallback behavior specifically.
+    We don't drive the waiter to completion — we just verify the
+    handler does NOT return ``missing_task_id`` when state supplies
+    the id.
+    """
+    import asyncio
+
+    steerer = _RecordingSteerer()
+    session = _session_with(_plan_with(Task(id="t-1", title="do", assignee_agent_id="a")))
+    session.state["goldfive.current_task_id"] = "t-1"
+
+    spec = _get_spec("report_awaiting_approval")
+    # Set the waiter in advance so the handler doesn't block forever.
+    waiter = asyncio.Event()
+    session.pending_approvals["t-1"] = waiter
+    session.pending_approvals_meta["t-1"] = {
+        "kind": "task",
+        "prompt": "ok?",
+        "task_id": "t-1",
+        "decision": "approve",
+        "detail": "",
+    }
+    waiter.set()
+
+    result = await invoke_tool(
+        [spec],
+        "report_awaiting_approval",
+        {"prompt": "approve this?"},  # no task_id
+        session,
+        steerer,
+    )
+
+    assert result.get("error") != "missing_task_id"
+    assert result.get("decision") == "approve"
+
+
+async def test_missing_task_id_still_rejects_when_state_empty() -> None:
+    """Regression guard: the existing ``missing_task_id`` rejection path
+    still fires when neither ``args.task_id`` nor session-state supplies
+    a value. The fallback must not degrade the schema guard."""
+    steerer = _RecordingSteerer()
+    session = _session_with(_plan_with(Task(id="t-1", title="do", assignee_agent_id="a")))
+
+    spec = _get_spec("report_task_failed")
+    for bad_args in (
+        {},
+        {"task_id": ""},
+        {"task_id": "   "},
+        {"task_id": None, "reason": "x"},
+        {"reason": "x"},
+    ):
+        result = await invoke_tool([spec], "report_task_failed", dict(bad_args), session, steerer)
+        assert result["acknowledged"] is False, bad_args
+        assert result["error"] == "missing_task_id", bad_args
+    # No handler runs → no transitions.
+    assert steerer.transitions == []


### PR DESCRIPTION
## Summary

Fixes the 100% reporting-tool failure rate for orchestrated sub-agents (#191). Sub-agents (research / web_developer / reviewer / debugger) were calling `report_task_*` without a `task_id` and getting back `{"acknowledged": false, "error": "missing_task_id"}`, then retry-looping.

Two layers:

- **Layer 1 — pin at delegation time.** `_GoldfiveADKPlugin.before_agent_callback` now looks up the starting sub-agent's unique PENDING/RUNNING plan task and stamps `goldfive.current_task_id` onto both the ADK `session.state` (sub-agent read surface) and the goldfive orchestration `session.state` (handler fallback surface). Zero / multiple matches leave state unset so the `missing_task_id` signal still fires when the answer is genuinely ambiguous.
- **Layer 2 — default from state.** `reporting.py` handlers and `_tool_invocation.invoke_tool` now resolve `task_id` as `args["task_id"] or session.state["goldfive.current_task_id"]`. Explicit arg wins. Neither source → canonical `missing_task_id` rejection (error shape preserved). JSON schemas drop `task_id` from `required` since the handler resolves it.

Sibling agent is landing Layer 3 (`before_tool_callback` arg-injection) in parallel; this PR intentionally does not touch `before_tool_callback`.

## Files touched

- `goldfive/adapters/_adk_plugin.py` — `before_agent_callback` + new `_pin_current_task_id_for_agent` helper.
- `goldfive/adapters/_adk_state_protocol.py` — new `write_current_task_id` helper.
- `goldfive/adapters/_tool_invocation.py` — state fallback before `missing_task_id` rejection.
- `goldfive/reporting.py` — handlers use shared `_resolve_task_id(args, session)` + `_missing_task_id_response(name)`; schemas drop `task_id` from `required`.
- `tests/test_task_id_wiring.py` — 15 new tests covering both layers.

## Test plan

- [x] `pytest tests/test_task_id_wiring.py` — 15 passed.
- [x] `pytest tests/test_reporting.py tests/test_tool_loop_guard.py tests/test_adk_adapter.py tests/test_plan_reconciler.py tests/test_callable_adapter.py tests/test_claude_adapter.py tests/test_approval_flow.py` — 139 passed, 1 skipped.
- [x] Full suite: `pytest -q` — 972 passed, 46 skipped.
- [x] `ruff check` + `ruff format --check` — clean.

## Followups

- Layer 3 (sibling agent): `before_tool_callback` arg-injection from ADK `tool_context.state`.
- #191 stays open pending Layer 3.