### PR TITLE
Fire on_run_end teardown on GoldfiveADKAgent exit (closes #196)

### DIFF
--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -284,15 +284,78 @@ class GoldfiveADKAgent(BaseAgent):
             )
             return
 
-        outcome = await self._runner.run(
-            user_input,
-            context={"adk_ctx": ctx},
-            session_id=outer_sid or None,
-        )
-        async for adk_event in _outcome_to_adk_events(
-            outcome, ctx, author=self.name
-        ):
-            yield adk_event
+        # try/finally wraps the entire run so ``_notify_plugins_on_run_end``
+        # fires on ALL exit paths — normal completion, adapter raise,
+        # upstream ``CancelledError`` (adk-web disconnect mid-stream), or
+        # ``GeneratorExit`` when the caller ``aclose()``s this generator
+        # early. Observability plugins rely on this hook to close any
+        # INVOCATION spans their own ``before_run_callback`` opened but
+        # whose matching ``after_run_callback`` never fired — see
+        # goldfive#196. ADK's plugin-manager ``after_run_callback`` is
+        # placed AFTER an ``async with Aclosing(execute_fn(...))`` block
+        # in :meth:`Runner._exec_with_plugin`, NOT inside a ``finally``,
+        # so a cancelled or early-closed generator leaks open spans. The
+        # teardown hook here is the goldfive-side guarantee that orphan
+        # INVOCATION spans get flushed regardless of ADK's gap.
+        try:
+            outcome = await self._runner.run(
+                user_input,
+                context={"adk_ctx": ctx},
+                session_id=outer_sid or None,
+            )
+            async for adk_event in _outcome_to_adk_events(
+                outcome, ctx, author=self.name
+            ):
+                yield adk_event
+        finally:
+            self._notify_plugins_on_run_end()
+
+    def _notify_plugins_on_run_end(self) -> None:
+        """Fire ``on_run_end()`` on every adapter plugin that defines it.
+
+        Fire-and-forget: any plugin exception is swallowed so a faulty
+        observability hook cannot mask the real outcome of the run.
+        Duck-typed — plugins without the hook (older builds, plugins
+        that don't track per-invocation spans) fall through cleanly.
+
+        Why this exists (goldfive#196):
+        The harmonograf telemetry plugin opens an INVOCATION span on
+        every ``before_run_callback``, keyed by the sub-Runner's ADK
+        ``invocation_id``. On normal completion the matching
+        ``after_run_callback`` closes it. But when the outer
+        :class:`GoldfiveADKAgent` run is cancelled mid-flight (adk-web
+        client disconnect, STEER during an AgentTool sub-Runner, crash
+        in a sibling sub-Runner), ADK's plugin-manager does NOT fire
+        ``after_run_callback`` — it's placed after
+        ``async with Aclosing(execute_fn(...))`` in
+        :meth:`Runner._exec_with_plugin`, outside any ``finally``. The
+        sub-Runner's span then leaks ``status=RUNNING`` in the
+        harmonograf DB forever, and the frontend's Live Activity panel
+        shows a stuck "N RUNNING" header.
+
+        ADKAdapter.invoke already calls ``on_cancellation`` on the
+        OUTER invocation on ``CancelledError``. This hook is the
+        broader sweep that fires on EVERY exit path and lets plugins
+        close every span they opened during the run — including
+        orphaned sub-Runner spans the outer cancel path cannot reach.
+        """
+        adapter = getattr(self._runner, "agent", None)
+        plugins = getattr(adapter, "_plugins", None)
+        if not plugins:
+            return
+        for plugin in plugins:
+            hook = getattr(plugin, "on_run_end", None)
+            if hook is None:
+                continue
+            try:
+                hook()
+            except Exception as exc:  # noqa: BLE001 — defensive
+                log.debug(
+                    "GoldfiveADKAgent: plugin %r on_run_end raised "
+                    "(swallowed): %s",
+                    plugin,
+                    exc,
+                )
 
     @staticmethod
     def _outer_session_id_from_ctx(ctx: InvocationContext) -> str:

--- a/tests/test_wrap_adk.py
+++ b/tests/test_wrap_adk.py
@@ -253,6 +253,172 @@ async def test_sinks_mutation_propagates_to_inner_runner() -> None:
 
 
 # ---------------------------------------------------------------------------
+# on_run_end teardown fan-out (goldfive#196)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_async_impl_fires_on_run_end_on_normal_exit(stub_call_llm: Any) -> None:
+    """On clean ``_run_async_impl`` completion, every adapter plugin
+    that defines ``on_run_end`` must have it called exactly once.
+
+    Observability plugins (e.g. harmonograf's telemetry plugin) use
+    this hook to sweep orphan INVOCATION spans left open because ADK's
+    ``after_run_callback`` is placed after an ``async with
+    Aclosing(...)`` block — not inside a ``finally`` — so cancelled or
+    early-closed sub-Runners leak their spans. See goldfive#196.
+    """
+    from unittest.mock import AsyncMock
+
+    from goldfive import InvocationResult, SequentialExecutor
+
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    class _RecordingPlugin:
+        def __init__(self) -> None:
+            self.on_run_end_calls = 0
+
+        def on_run_end(self) -> None:
+            self.on_run_end_calls += 1
+
+    plugin = _RecordingPlugin()
+    wrapped.runner.agent._plugins.append(plugin)
+
+    ctx = _FakeCtx("do a thing")
+    events = [evt async for evt in wrapped._run_async_impl(ctx)]
+    assert len(events) >= 1
+
+    assert plugin.on_run_end_calls == 1
+
+
+async def test_run_async_impl_fires_on_run_end_on_generator_close(
+    stub_call_llm: Any,
+) -> None:
+    """If the caller ``aclose()``s the generator early (the adk-web
+    disconnect path), ``on_run_end`` still fires via the ``finally``
+    block. This is the specific orphan-span scenario goldfive#196
+    closes: outer adk-web cancel leaves sub-Runner spans open, so the
+    teardown hook MUST run even when the generator doesn't exhaust
+    naturally.
+    """
+    from unittest.mock import AsyncMock
+
+    from goldfive import InvocationResult, SequentialExecutor
+
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    class _RecordingPlugin:
+        def __init__(self) -> None:
+            self.on_run_end_calls = 0
+
+        def on_run_end(self) -> None:
+            self.on_run_end_calls += 1
+
+    plugin = _RecordingPlugin()
+    wrapped.runner.agent._plugins.append(plugin)
+
+    ctx = _FakeCtx("do a thing")
+    agen = wrapped._run_async_impl(ctx)
+    # Pull one event then bail — mimics adk-web disconnecting mid-stream.
+    first = await agen.__anext__()
+    assert first is not None
+    await agen.aclose()
+
+    assert plugin.on_run_end_calls == 1
+
+
+async def test_run_async_impl_swallows_plugin_on_run_end_exceptions(
+    stub_call_llm: Any,
+) -> None:
+    """A faulty ``on_run_end`` hook must not break the main run path.
+    Any plugin exception is swallowed with a debug log so one bad
+    plugin can't crash the outer generator's finalize sequence.
+    """
+    from unittest.mock import AsyncMock
+
+    from goldfive import InvocationResult, SequentialExecutor
+
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    class _BrokenPlugin:
+        def on_run_end(self) -> None:
+            raise RuntimeError("plugin boom")
+
+    wrapped.runner.agent._plugins.append(_BrokenPlugin())
+
+    ctx = _FakeCtx("do a thing")
+    # Must not raise even though the plugin does.
+    events = [evt async for evt in wrapped._run_async_impl(ctx)]
+    assert events
+
+
+async def test_run_async_impl_without_on_run_end_plugins_still_works(
+    stub_call_llm: Any,
+) -> None:
+    """Plugins that do NOT define ``on_run_end`` fall through cleanly —
+    this is the back-compat path for older ADK plugins that don't
+    know about the teardown hook.
+    """
+    from unittest.mock import AsyncMock
+
+    from goldfive import InvocationResult, SequentialExecutor
+
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    class _NoHookPlugin:
+        pass
+
+    wrapped.runner.agent._plugins.append(_NoHookPlugin())
+
+    ctx = _FakeCtx("do a thing")
+    events = [evt async for evt in wrapped._run_async_impl(ctx)]
+    assert events
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- ADK places \`after_run_callback\` outside a \`finally\` in \`Runner._exec_with_plugin\` — after \`async with Aclosing(execute_fn(...))\`. Any invocation cancelled mid-flight (adk-web disconnect, STEER in a sub-Runner, sibling crash) leaks every span its matching \`before_*\` opened. \`ADKAdapter.invoke\`'s existing \`on_cancellation(invocation_id)\` hook only reaches spans keyed by the OUTER invocation; sub-Runner INVOCATION spans spawned via \`AgentTool\` have their own invocation_id and leak forever.
- This PR wraps \`GoldfiveADKAgent._run_async_impl\`'s inner body in a \`try/finally\` and fires a new \`on_run_end()\` hook on every plugin on ALL exit paths (normal return, CancelledError, GeneratorExit on early \`aclose\`). Plugins that define \`on_run_end\` close the orphans; plugins that don't fall through cleanly (back-compat).
- Paired with [harmonograf#96](https://github.com/pedapudi/harmonograf/pull/96), which (a) makes \`HarmonografTelemetryPlugin\` implement \`on_run_end\` to sweep leftover INVOCATION / model / tool spans, and (b) wires \`_on_run_completed\` / \`_on_run_aborted\` in the server's ingest pipeline to flip \`sessions.status\` terminal + close orphan INVOCATION spans as belt-and-suspenders — so the frontend's "LIVE ACTIVITY · N RUNNING" header clears when a run completes.

## Root cause (DB evidence from session \`post_fix_1776870546\`)

\`\`\`
-- Session stuck LIVE forever
SELECT id, status, ended_at FROM sessions;
-- post_fix_1776870546 | LIVE | NULL

-- Three INVOCATION spans stuck RUNNING after normal completion
SELECT name, status, end_time FROM spans WHERE end_time IS NULL;
-- web_developer_agent | RUNNING | NULL
-- openai/Qwen.../gguf | RUNNING | NULL
-- coordinator_agent   | RUNNING | NULL
\`\`\`

Each stuck INVOCATION span was a sub-Runner's \`before_run_callback\`-opened span whose sibling \`after_run_callback\` never fired (ADK cancel gap). The outer run's \`on_cancellation(invocation_id)\` hook can't reach sub-Runner invocations because they have different invocation_ids.

## Test plan

- [x] 4 new unit tests in \`tests/test_wrap_adk.py\` covering normal exit, generator \`aclose()\` (adk-web disconnect), plugin-exception swallow, and no-hook back-compat.
- [x] Full goldfive test suite: 994 passed, 46 skipped.
- [x] E2E with the orchestrated presentation_agent against Qwen on kikuchi (see PR description below).