### PR TITLE
Post-refine forward progress: fail_fast respects replacements, Level 2 nudge wired

### DIFF
--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -87,6 +87,9 @@ def _tag_adapter_cancel_user_steer(adapter: Any) -> None:
         )
 
 
+_DEFAULT_MAX_NUDGE_REPLAYS: int = 3
+
+
 class SequentialExecutor(Executor):
     """Single-threaded executor that drives one task at a time.
 
@@ -190,6 +193,13 @@ class SequentialExecutor(Executor):
         # already encode that model keep working. The ``goldfive.wrap``
         # convenience flips this to True by default.
         self.overlay_mode = bool(overlay_mode)
+
+    # goldfive#202: cap on the overlay's nudge-driven re-invoke loop.
+    # Each pass that the steerer queues a Level 2 nudge burns one.
+    # Class attribute (not a constructor kwarg) so subclasses can tune
+    # it without expanding the public constructor surface; also keeps
+    # it out of ``legacy_kwargs`` handling above.
+    _MAX_NUDGE_REPLAYS: int = _DEFAULT_MAX_NUDGE_REPLAYS
 
     # ------------------------------------------------------------------
     # Executor protocol
@@ -515,8 +525,26 @@ class SequentialExecutor(Executor):
             if tracked_status == TaskStatus.FAILED:
                 failure_reason = f"task {task.id} failed"
                 if self.fail_fast:
-                    run_failed = True
-                    break
+                    # goldfive#202: a FAILED task with a live replacement
+                    # in the current plan (refine-spawned successor, e.g.
+                    # ``retry_<id>`` or ``<id>_v2``) is NOT fatal — the
+                    # replacement is the forward-progress path. Only
+                    # abort when no replacement exists.
+                    live_plan = session.plan or current_plan
+                    failed_task = _find_task(live_plan, task.id)
+                    has_replacement = failed_task is not None and _has_live_replacement(
+                        live_plan, failed_task
+                    )
+                    if has_replacement:
+                        log.info(
+                            "SequentialExecutor: fail_fast skipped for task=%s — "
+                            "live replacement present in current plan revision",
+                            task.id,
+                        )
+                        failure_reason = ""  # not actually fatal
+                    else:
+                        run_failed = True
+                        break
                 # else: continue to next eligible task.
 
             # Session.current_task_id gets reset by the next iteration.
@@ -563,12 +591,17 @@ class SequentialExecutor(Executor):
             )
             return ExecutionOutcome(success=False, session=session, reason=reason)
 
-        # If fail_fast=False and some task ended FAILED, the run is only
-        # "successful" in the best-effort sense. Match harmonograf: report
-        # success=False with a reason when any task is terminal-failed.
-        any_failed = _any_failed(session.plan or plan)
-        if any_failed and not self.fail_fast:
-            reason = "one or more tasks failed (fail_fast=False)"
+        # If fail_fast=False and some task ended FAILED with no live
+        # replacement, the run is only "successful" in the best-effort
+        # sense. Match harmonograf: report success=False with a reason
+        # when any task is truly terminal-failed (goldfive#202: a FAILED
+        # task whose refine-spawned successor is live is not fatal).
+        fatally_failed = _fatally_failed_task_ids(session.plan or plan)
+        if fatally_failed and not self.fail_fast:
+            reason = (
+                "one or more tasks failed without a live replacement "
+                f"(fail_fast=False): {', '.join(tid for tid in fatally_failed if tid)}"
+            )
             await emit(
                 sinks,
                 run_aborted_event(
@@ -723,10 +756,28 @@ class SequentialExecutor(Executor):
         # the tree runs the revised plan. This is why the loop is a
         # ``while True`` — a steer restarts the invocation against
         # the new plan; ``cancelled`` / ``adapter_error`` terminates
-        # the run; ``result`` falls through to the NOT_NEEDED sweep.
+        # the run; ``result`` falls through to a (scoped) nudge-replay
+        # check (goldfive#202) and then the NOT_NEEDED sweep.
         # See goldfive#149 for the regression this guards against.
+        #
+        # goldfive#202 re-introduces — in a narrowly scoped form — a
+        # post-invocation re-invoke that #163 removed wholesale. The
+        # #163 removal was correct for the "every PENDING at invocation
+        # end triggers a follow-up" case (flow-prompted coordinators
+        # re-ran their entire pipeline on every such message, turning
+        # a 10-min run into 40+ min). But when the steerer explicitly
+        # queues a nudge via ``session.pending_nudges`` in response to
+        # an autonomous drift + plan revision (e.g. LOOPING_REASONING
+        # → refine spawned ``<task>_v2``), the coordinator has no way
+        # to know its plan changed; without a follow-up it keeps
+        # retrying the superseded task. The nudge-replay path below
+        # fires ONLY when the steerer explicitly asked for it (a nudge
+        # is queued) AND there is still live work to do; capped at
+        # ``_MAX_NUDGE_REPLAYS`` so a pathological nudge-queueing drift
+        # cannot re-introduce the #163 amplification.
         current_user_input = user_input
         failure_reason = ""
+        nudge_replays = 0
         while True:
             kind, payload = await self._invoke_passthrough_with_control(
                 adapter=adapter,
@@ -790,8 +841,39 @@ class SequentialExecutor(Executor):
                 # Restart the invocation with the steer body as the
                 # new user input.
                 continue
-            # kind == "result": invocation ended normally; fall
-            # through to the NOT_NEEDED sweep.
+            # kind == "result": invocation ended normally. Before
+            # falling through to the NOT_NEEDED sweep, check whether
+            # the steerer queued a Level 2 nudge during this invocation
+            # (e.g. LOOPING_REASONING drift → refine spawned a
+            # replacement task → nudge queued describing the pivot).
+            # If so, and there is still live work for the tree to do,
+            # consume the queued nudge(s) as the next user message
+            # and re-invoke. Bounded by ``_MAX_NUDGE_REPLAYS`` to
+            # prevent the #163-style amplification: a coordinator
+            # whose tree keeps producing nudge-eligible drift on every
+            # turn must eventually stop triggering re-invokes.
+            pending = list(session.pending_nudges)
+            if (
+                pending
+                and nudge_replays < self._MAX_NUDGE_REPLAYS
+                and _has_live_pending_or_running(session.plan or plan)
+            ):
+                session.pending_nudges.clear()
+                nudge_replays += 1
+                current_user_input = self._compose_nudge_replay_message(pending)
+                log.info(
+                    "SequentialExecutor._run_overlay: nudge replay %d/%d "
+                    "(nudges=%d) — re-invoking passthrough with queued nudge",
+                    nudge_replays,
+                    self._MAX_NUDGE_REPLAYS,
+                    len(pending),
+                )
+                # Reset reconciler bookkeeping so the revised plan's
+                # tasks map fresh. The refine that queued the nudge
+                # likely added new PENDING tasks that reconciler-side
+                # agent claims should re-match against.
+                reconciler.reset_for_new_plan(session.plan)
+                continue
             break
 
         # --- PENDING → NOT_NEEDED on invocation end (goldfive#163). ----
@@ -824,8 +906,17 @@ class SequentialExecutor(Executor):
                 )
 
         # --- Terminal emission: success if no failures. -----------
-        if _any_failed(session.plan or plan) and self.fail_fast:
-            reason = "one or more tasks failed"
+        # goldfive#202: a FAILED task with a live replacement (refine
+        # spawned a successor like ``retry_<id>`` / ``<id>_v2``) is not
+        # fatal — the replacement is the forward-progress path. Only
+        # abort when at least one FAILED task has no live replacement
+        # in the current plan revision.
+        fatally_failed = _fatally_failed_task_ids(session.plan or plan)
+        if fatally_failed and self.fail_fast:
+            reason = (
+                "one or more tasks failed without a live replacement: "
+                f"{', '.join(tid for tid in fatally_failed if tid)}"
+            )
             await emit(
                 sinks,
                 run_aborted_event(
@@ -1203,6 +1294,46 @@ class SequentialExecutor(Executor):
             log.warning("SequentialExecutor: steerer.observe(STEER) raised: %s", exc)
 
     @staticmethod
+    def _compose_nudge_replay_message(nudges: list[str]) -> str:
+        """Wrap queued nudges in a goldfive-authored framing header.
+
+        Mirrors :meth:`_compose_steer_restart_message` but for the
+        autonomous-nudge path (goldfive#202). The LLM sees:
+
+        * A header distinguishing this from a fresh user turn: the
+          operator did not intervene; goldfive detected drift (e.g.
+          repeated ``report_task_completed`` calls), revised the plan,
+          and is directing the coordinator to the new next task.
+        * Each queued nudge verbatim (short, action-focused strings
+          composed by :func:`compose_corrective_user_message`).
+        * A brief instruction to continue with the revised plan.
+
+        The scoped replay path is the carefully-narrowed successor to
+        the blanket follow-up loop that goldfive#163 removed. #163's
+        removal was correct when every PENDING task triggered a
+        follow-up; this path only fires when the STEERER explicitly
+        queued a nudge in response to a tracked drift + plan
+        revision — not on every PENDING-at-invocation-end.
+        """
+        body = "\n".join(f"- {n}" for n in nudges if n)
+        return (
+            "[GOLDFIVE PLAN REVISION — replace superseded task(s)]\n"
+            "\n"
+            "Goldfive detected drift during the prior turn and revised "
+            "the active plan. The task you were last working on has "
+            "been superseded by a replacement. Proceed with the "
+            "replacement; do NOT retry the prior task.\n"
+            "\n"
+            f"{body}\n"
+            "\n"
+            "Notes:\n"
+            "- Continue the run with the revised plan. Resume with the "
+            "next unfinished task — the replacement mentioned above, "
+            "or any other PENDING task your tree still owns.\n"
+            "- Do not re-invoke reporting tools for the superseded task."
+        )
+
+    @staticmethod
     def _compose_steer_restart_message(msg: object, *, fallback: str) -> str:
         """Wrap a STEER body in a goldfive-authored override header.
 
@@ -1325,6 +1456,112 @@ def _lineage_root(task_id: str) -> str:
 
 def _any_failed(plan: Plan) -> bool:
     return any(t.status == TaskStatus.FAILED for t in plan.tasks)
+
+
+def _has_live_pending_or_running(plan: Plan) -> bool:
+    """Return True if the plan has any PENDING or RUNNING task left.
+
+    Used by the overlay's nudge-replay gate (goldfive#202): a queued
+    nudge should only trigger a re-invoke when there is actually
+    outstanding work for the coordinator to do. Guards against replaying
+    against a terminated plan.
+    """
+    return any(t.status in (TaskStatus.PENDING, TaskStatus.RUNNING) for t in plan.tasks)
+
+
+def _has_live_replacement(plan: Plan, failed: Task) -> bool:
+    """Return True iff ``failed`` has a *live* replacement task in ``plan``.
+
+    A replacement task is one the planner spawned to supersede
+    ``failed`` — a forward-progress successor, not a predecessor. We
+    require it to be PENDING or RUNNING (never COMPLETED) so a
+    COMPLETED sibling lineage peer (``t0`` when ``retry_retry_t0`` is
+    the failure) does NOT mask the failure — that's a predecessor, not
+    a replacement. See goldfive#202.
+
+    Matched via one of two id conventions goldfive's refine path
+    produces (structural inference; no proto ``replaces`` field):
+
+    * Shared retry lineage: ``_lineage_root(R.id) == _lineage_root(failed.id)``.
+      Catches ``retry_<id>``, ``retry2_<id>`` etc. — the pattern the
+      refine system prompt historically emitted (see PLAN-LIFECYCLE.md
+      §7.3).
+    * Versioned replacement: ``R.id`` starts with ``<failed.id>_``
+      (``define_structure`` → ``define_structure_v2``, ``..._retry``,
+      etc.). Empirically the shape LLM planners emit when the refine
+      prompt does NOT encode a ``retry_`` convention.
+
+    Additionally require ``R.assignee_agent_id == failed.assignee_agent_id``
+    when both are populated, so a task owned by a different agent doesn't
+    accidentally mask a genuine failure.
+
+    Lives in the executor (not a proto field on :class:`Task`) to avoid
+    a cross-cutting contract change through planner JSON shapes and
+    prompt templates. Structural inference is adequate: the refine
+    output is always validated against :meth:`Plan.validate`, so the
+    shapes here are the shapes the planner actually emits.
+    """
+    failed_root = _lineage_root(failed.id)
+    for r in plan.tasks:
+        if r.id == failed.id or not r.id:
+            continue
+        # FAILED / CANCELLED are obviously not replacements.
+        if r.status in (TaskStatus.FAILED, TaskStatus.CANCELLED):
+            continue
+        # Convention match. The two patterns have different chronological
+        # semantics w.r.t. the FAILED task:
+        # * Versioned pattern (``<failed_id>_<suffix>`` like
+        #   ``define_structure_v2``) is conventionally a SUCCESSOR — a
+        #   planner would not emit ``..._v2`` before ``v1`` had run —
+        #   so PENDING / RUNNING / COMPLETED all count as a live
+        #   replacement.
+        # * Shared retry lineage (``retry_<id>``, ``retry2_<id>``)
+        #   is CHRONOLOGY-AMBIGUOUS — ``t0`` COMPLETED + ``retry_t0``
+        #   COMPLETED + ``retry_retry_t0`` FAILED describes predecessors
+        #   of the FAILED task, not replacements. So retry-lineage peers
+        #   only count when PENDING / RUNNING (clear "still to run").
+        versioned = r.id.startswith(f"{failed.id}_")
+        same_lineage = (
+            not versioned  # don't double-count versioned-and-lineage
+            and _lineage_root(r.id) == failed_root
+            and r.id != failed.id
+        )
+        if versioned:
+            pass  # any non-FAILED / non-CANCELLED state counts
+        elif same_lineage:
+            if r.status not in (TaskStatus.PENDING, TaskStatus.RUNNING):
+                continue
+        else:
+            continue
+        # Assignee scoping when both are populated — narrow false positives.
+        if (
+            failed.assignee_agent_id
+            and r.assignee_agent_id
+            and r.assignee_agent_id != failed.assignee_agent_id
+        ):
+            continue
+        return True
+    return False
+
+
+def _fatally_failed_task_ids(plan: Plan) -> list[str]:
+    """Return FAILED task ids with NO live replacement in ``plan``.
+
+    Used by :class:`SequentialExecutor`'s ``fail_fast`` gate so a FAILED
+    task whose refine-time replacement is still live (PENDING / RUNNING
+    / COMPLETED) does not abort the run. Without this check,
+    ``fail_fast=True`` would see the refine's FAILED mark and abort
+    before the replacement gets a chance to execute — defeating the
+    point of the refine. See goldfive#202.
+    """
+    fatal: list[str] = []
+    for t in plan.tasks:
+        if t.status != TaskStatus.FAILED:
+            continue
+        if _has_live_replacement(plan, t):
+            continue
+        fatal.append(t.id or "")
+    return fatal
 
 
 def _pending_task_ids(plan: Plan) -> list[str]:

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -104,6 +104,23 @@ class InterventionLevel(enum.IntEnum):
     TERMINATE = 5
 
 
+# goldfive#202: drift kinds for which a successful ABSORB (Level 1
+# refine) also queues a Level 2 nudge onto ``session.pending_nudges``.
+# The executor's overlay loop consumes the nudge at invocation end and
+# re-invokes the passthrough with a synthesized user message describing
+# the plan revision — the only way for a coordinator that is still
+# mid-invocation (retrying the superseded task) to learn its plan
+# changed. Scoped to "coordinator-stuck" shapes; other ABSORB kinds
+# recover at the next task boundary or via Level 3 CANCEL_REINVOKE.
+_ABSORB_NUDGE_KINDS: frozenset[DriftKind] = frozenset(
+    {
+        DriftKind.LOOPING_REASONING,
+        DriftKind.LOOPING_TOOL_CALL,
+        DriftKind.SELF_REPORTED_STUCK,
+    }
+)
+
+
 # Default drift messages per kind, used by
 # :func:`compose_corrective_user_message` when the drift carries no
 # kind-specific override. Keep SHORT, action-focused; no goldfive jargon
@@ -472,9 +489,7 @@ class DefaultSteerer:
             session.agent_notes[task_id] = detail
         # goldfive#152: stamp current_task_* on the orchestration-state
         # dict so downstream prompt templates / refine paths see it.
-        _ostate.sync_current_task_from_transition(
-            session.state, task, TaskStatus.RUNNING
-        )
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.RUNNING)
         await self._emit_task_started(session, task_id, detail)
 
     async def mark_task_progress(
@@ -521,9 +536,7 @@ class DefaultSteerer:
         if summary:
             session.completed_results[task_id] = summary
         # goldfive#152: clear current_task_* if we were the active task.
-        _ostate.sync_current_task_from_transition(
-            session.state, task, TaskStatus.COMPLETED
-        )
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.COMPLETED)
         await self._emit_task_completed(session, task_id, summary, artifacts or {})
 
     async def mark_task_failed(
@@ -560,9 +573,7 @@ class DefaultSteerer:
         if task.status in _TERMINAL_TASK_STATUSES:
             return
         task.status = TaskStatus.FAILED
-        _ostate.sync_current_task_from_transition(
-            session.state, task, TaskStatus.FAILED
-        )
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.FAILED)
         await self._emit_task_failed(session, task_id, reason, recoverable)
         # Fatal failures cascade downstream via the same primitive used
         # by mark_task_cancelled, so both §6.2 and §6.3 produce the
@@ -642,9 +653,7 @@ class DefaultSteerer:
             # TaskCancelled events for downstream tasks on every call.
             return
         task.status = TaskStatus.CANCELLED
-        _ostate.sync_current_task_from_transition(
-            session.state, task, TaskStatus.CANCELLED
-        )
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.CANCELLED)
         await self._emit_task_cancelled(session, task_id, reason)
         await self.cascade_cancel_downstream(session, task_id)
 
@@ -677,9 +686,7 @@ class DefaultSteerer:
         if task.status in _TERMINAL_TASK_STATUSES:
             return
         task.status = TaskStatus.NOT_NEEDED
-        _ostate.sync_current_task_from_transition(
-            session.state, task, TaskStatus.NOT_NEEDED
-        )
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.NOT_NEEDED)
         # There is no dedicated ``TaskNotNeeded`` proto message;
         # reuse TaskCancelled with the reason prefix so sinks that
         # inspect reason can differentiate if they wish. The live
@@ -794,9 +801,7 @@ class DefaultSteerer:
         """
         if self._is_duplicate_steer(event, session):
             steer_id = self._steer_dedupe_id(event)
-            log.debug(
-                "DefaultSteerer.observe: dropping duplicate STEER id=%s", steer_id
-            )
+            log.debug("DefaultSteerer.observe: dropping duplicate STEER id=%s", steer_id)
             return
         drift = self._drift_from_control(event, session)
         if drift is None:
@@ -1644,6 +1649,35 @@ class DefaultSteerer:
                 drift=drift,
                 refined_plan=session.plan,
             )
+        # goldfive#202: for drifts where the coordinator has no way to
+        # observe the plan revision on its own (it is still mid-
+        # invocation, retrying the superseded task), ALSO queue a
+        # Level 2 nudge after a successful ABSORB. The overlay loop's
+        # scoped nudge-replay path (see SequentialExecutor._run_overlay)
+        # picks this up at invocation end and re-invokes the
+        # passthrough with the nudge as the next user message — the
+        # only way for the coordinator to learn its plan changed.
+        #
+        # Scoped to drift kinds whose mid-invocation signature is
+        # "coordinator is stuck on a task goldfive just replaced":
+        # LOOPING_REASONING / LOOPING_TOOL_CALL (detector fires while
+        # the coordinator retries the same tool call), SELF_REPORTED_STUCK
+        # (reflective self-check reports no progress). Other ABSORB
+        # kinds (CONFUSION, CONFABULATION_RISK, etc.) do not need
+        # mid-invocation rescue — their corrective path fires at the
+        # next task boundary or via Level 3 CANCEL_REINVOKE.
+        if level is InterventionLevel.ABSORB and drift.kind in _ABSORB_NUDGE_KINDS:
+            nudge_msg = compose_corrective_user_message(
+                drift=drift,
+                refined_plan=session.plan,
+            )
+            session.pending_nudges.append(nudge_msg)
+            log.debug(
+                "DefaultSteerer._handle_drift: queued post-ABSORB nudge for kind=%s task=%s: %s",
+                drift.kind.value,
+                drift.current_task_id or "-",
+                nudge_msg,
+            )
 
     # --- Intervention ladder -----------------------------------------
     #
@@ -1963,9 +1997,7 @@ class DefaultSteerer:
         # event — a cheap, always-available "turn" proxy.
         at_turn = getattr(session, "_next_sequence", 0) or 0
         try:
-            _ostate.set_active_steer(
-                session.state, body=body, at_turn=at_turn, author=author
-            )
+            _ostate.set_active_steer(session.state, body=body, at_turn=at_turn, author=author)
         except Exception as exc:  # noqa: BLE001
             log.debug(
                 "DefaultSteerer._apply_user_steer_state: set_active_steer raised: %s",
@@ -1980,8 +2012,7 @@ class DefaultSteerer:
                 _ostate.record_processed_steer_id(session.state, steer_id)
             except Exception as exc:  # noqa: BLE001
                 log.debug(
-                    "DefaultSteerer._apply_user_steer_state: "
-                    "record_processed_steer_id raised: %s",
+                    "DefaultSteerer._apply_user_steer_state: record_processed_steer_id raised: %s",
                     exc,
                 )
         if not body:

--- a/tests/test_overlay_forward_progress.py
+++ b/tests/test_overlay_forward_progress.py
@@ -1,0 +1,665 @@
+"""Post-refine forward-progress tests (goldfive#202).
+
+Two structural fixes land together:
+
+1. ``fail_fast`` respects replacement tasks: a FAILED task with a live
+   replacement in the current plan revision (refine-spawned successor
+   like ``retry_<id>`` or ``<id>_v2``) does not abort the run — the
+   replacement is the forward-progress path.
+2. The steerer's ABSORB dispatch queues a Level 2 nudge on
+   ``session.pending_nudges`` for coordinator-stuck drift kinds
+   (LOOPING_REASONING / LOOPING_TOOL_CALL / SELF_REPORTED_STUCK), and
+   the overlay's scoped nudge-replay consumes it between invocations
+   to tell the coordinator its plan changed.
+
+Plus: the ``run_aborted_event`` reason names the fatally-failed task(s)
+when fail_fast truly fires.
+
+These tests use lightweight stubs — no ADK, no LLM, no network.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from goldfive.executors.sequential import (
+    SequentialExecutor,
+    _fatally_failed_task_ids,
+    _has_live_replacement,
+)
+from goldfive.protocols import EventSink
+from goldfive.results import InvocationResult
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs (mirrors tests/test_sequential_executor_overlay.py shapes).
+# ---------------------------------------------------------------------------
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        return None
+
+    def last_run_aborted_reason(self) -> str | None:
+        for e in reversed(self.events):
+            if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "run_aborted":
+                return e.run_aborted.reason
+        return None
+
+
+class StubSteerer:
+    def __init__(self) -> None:
+        self._sinks: list[EventSink] = []
+        self._planner: Any = None
+        self.observed: list[Any] = []
+        self.transitions: list[tuple[str, TaskStatus]] = []
+
+    def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
+        self._sinks = sinks
+        self._planner = planner
+
+    async def observe(self, event: Any, session: Session) -> None:  # noqa: ARG002
+        self.observed.append(event)
+
+    async def _handle_drift(self, drift: DriftEvent, session: Session) -> None:  # noqa: ARG002
+        self.observed.append(drift)
+
+    async def transition(
+        self,
+        task_id: str,
+        to: TaskStatus,
+        *,
+        detail: str = "",  # noqa: ARG002
+        session: Session,
+    ) -> None:
+        self.transitions.append((task_id, to))
+        if session.plan is None:
+            return
+        for t in session.plan.tasks:
+            if t.id == task_id:
+                t.status = to
+                return
+
+    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:  # noqa: ARG002
+        return None
+
+
+class StubPlanner:
+    async def generate(self, **kwargs: Any) -> None:  # noqa: ARG002
+        return None
+
+    async def refine(self, **kwargs: Any) -> None:  # noqa: ARG002
+        return None
+
+
+class StubAdapter:
+    """Minimal legacy-path adapter (used by fail_fast tests).
+
+    The ``on_invoke`` callback drives task state for the invoked task.
+    """
+
+    def __init__(
+        self,
+        *,
+        on_invoke: Callable[[Task, Session], Awaitable[InvocationResult]],
+    ) -> None:
+        self._on_invoke = on_invoke
+        self.invocations: list[str] = []
+
+    async def register_reporting_tools(self, tools: list[Any]) -> None:  # noqa: ARG002
+        return None
+
+    @property
+    def available_agents(self) -> list[str]:
+        return ["stub"]
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:
+        self.invocations.append(task.id)
+        return await self._on_invoke(task, session)
+
+
+class OverlayStubAdapter:
+    """Overlay-path adapter. ``passthrough_effect`` can mutate the plan
+    via the steerer and queue nudges directly to simulate the real
+    steerer's ABSORB-nudge behaviour.
+    """
+
+    def __init__(
+        self,
+        *,
+        passthrough_effect: Callable[[str, Session, Any], Awaitable[InvocationResult | None]]
+        | None = None,
+    ) -> None:
+        self._passthrough_effect = passthrough_effect
+        self.passthrough_calls: list[str] = []
+
+    @property
+    def available_agents(self) -> list[str]:
+        return ["stub"]
+
+    async def register_reporting_tools(self, tools: list[Any]) -> None:  # noqa: ARG002
+        return None
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:  # noqa: ARG002
+        return InvocationResult(task_id=task.id, text="")
+
+    async def invoke_passthrough(
+        self,
+        user_message: str,
+        *,
+        session: Session,
+        reconciler: Any = None,
+        ctx: Any = None,  # noqa: ARG002
+    ) -> InvocationResult:
+        self.passthrough_calls.append(user_message)
+        if self._passthrough_effect is not None:
+            result = await self._passthrough_effect(user_message, session, reconciler)
+            if result is not None:
+                return result
+        return InvocationResult(task_id="", text="")
+
+
+# ---------------------------------------------------------------------------
+# Helper: inline reconciler stub the overlay uses.
+# ---------------------------------------------------------------------------
+
+
+def _fresh_session(run_id: str = "run-1") -> Session:
+    return Session(run_id=run_id)
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests for the replacement predicate.
+# ---------------------------------------------------------------------------
+
+
+def test_has_live_replacement_lineage_pending_replacement() -> None:
+    """A PENDING ``retry_<id>`` is a live replacement for FAILED ``<id>``."""
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="t0", title="a", status=TaskStatus.FAILED, assignee_agent_id="a"),
+            Task(
+                id="retry_t0",
+                title="a retry",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="a",
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is True
+
+
+def test_has_live_replacement_versioned_pending_replacement() -> None:
+    """A PENDING ``<id>_v2`` is a live replacement for FAILED ``<id>``."""
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="define_structure",
+                title="define",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="planner",
+            ),
+            Task(
+                id="define_structure_v2",
+                title="define (v2)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="planner",
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is True
+
+
+def test_has_live_replacement_requires_pending_or_running_not_completed() -> None:
+    """A COMPLETED lineage peer is a predecessor, not a replacement.
+
+    Regression guard for the lineage-cap scenario: ``t0`` (COMPLETED)
+    and ``retry_t0`` (COMPLETED) are predecessors of a FAILED
+    ``retry_retry_t0`` — they ran BEFORE it. Marking them as a
+    "replacement" would hide a genuine exhausted-retries failure.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="t0", title="a", status=TaskStatus.COMPLETED),
+            Task(id="retry_t0", title="a retry", status=TaskStatus.COMPLETED),
+            Task(
+                id="retry_retry_t0",
+                title="a retry retry",
+                status=TaskStatus.FAILED,
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[2]
+    assert _has_live_replacement(plan, failed) is False
+
+
+def test_has_live_replacement_assignee_mismatch_rejected() -> None:
+    """A candidate with a DIFFERENT assignee is not a replacement."""
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="t0", title="a", status=TaskStatus.FAILED, assignee_agent_id="a"),
+            Task(
+                id="retry_t0",
+                title="a retry",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="b",  # different agent
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is False
+
+
+def test_fatally_failed_task_ids_filters_replaced() -> None:
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            # Replaced (PENDING successor with same lineage root): not fatal.
+            Task(id="ta", title="a", status=TaskStatus.FAILED, assignee_agent_id="a"),
+            Task(
+                id="retry_ta",
+                title="a retry",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="a",
+            ),
+            # No replacement: fatal.
+            Task(id="tb", title="b", status=TaskStatus.FAILED, assignee_agent_id="b"),
+            Task(id="tc", title="c", status=TaskStatus.COMPLETED),
+        ],
+        edges=[],
+    )
+    assert _fatally_failed_task_ids(plan) == ["tb"]
+
+
+# ---------------------------------------------------------------------------
+# Legacy run() path: fail_fast respects replacement.
+# ---------------------------------------------------------------------------
+
+
+async def test_fail_fast_ignores_replaced_task() -> None:
+    """Rev-0 plan has FAILED ``ta``; rev-1 has PENDING ``retry_ta`` on the
+    same assignee. ``fail_fast=True`` must NOT abort — the replacement is
+    live forward progress.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="ta",
+                title="original",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="agent_a",
+            ),
+            Task(
+                id="retry_ta",
+                title="retry of original",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="agent_a",
+            ),
+        ],
+        edges=[],
+    )
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _complete_task(task: Task, session: Session) -> InvocationResult:
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter = StubAdapter(on_invoke=_complete_task)
+
+    executor = SequentialExecutor(max_task_invocations=8, fail_fast=True)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is True, outcome.reason
+    # The executor should have invoked retry_ta (the replacement); the
+    # pre-existing FAILED ta must not have caused an abort.
+    assert adapter.invocations == ["retry_ta"]
+    assert sink.last_run_aborted_reason() is None
+
+
+async def test_fail_fast_aborts_on_truly_fatal_failure() -> None:
+    """A FAILED task with no replacement aborts under fail_fast=True, and
+    the aborted event names the offending task.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[
+            Task(id="ta", title="a"),
+            Task(id="tb", title="b"),
+        ],
+        edges=[TaskEdge(from_task_id="ta", to_task_id="tb")],
+    )
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _fail_ta(task: Task, session: Session) -> InvocationResult:
+        await steerer.transition(task.id, TaskStatus.FAILED, session=session)
+        return InvocationResult(task_id=task.id, text="", error="boom")
+
+    adapter = StubAdapter(on_invoke=_fail_ta)
+
+    executor = SequentialExecutor(max_task_invocations=8, fail_fast=True)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is False
+    reason = sink.last_run_aborted_reason() or ""
+    assert "ta" in reason, reason
+
+
+async def test_run_aborted_event_carries_reason_with_task_id() -> None:
+    """fail_fast=False + FAILED-without-replacement path: reason names the task."""
+    plan = Plan(
+        id="p0",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[
+            Task(id="t0", title="t0"),
+            Task(id="t1", title="t1"),
+        ],
+        edges=[TaskEdge(from_task_id="t0", to_task_id="t1")],
+    )
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _fail(task: Task, session: Session) -> InvocationResult:
+        await steerer.transition(task.id, TaskStatus.FAILED, session=session)
+        return InvocationResult(task_id=task.id, text="", error="x")
+
+    adapter = StubAdapter(on_invoke=_fail)
+
+    executor = SequentialExecutor(max_task_invocations=8, fail_fast=False)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is False
+    reason = sink.last_run_aborted_reason() or ""
+    # The reason should name at least one failed task id.
+    assert "t0" in reason, reason
+
+
+# ---------------------------------------------------------------------------
+# Overlay path: Level 2 nudge wired.
+# ---------------------------------------------------------------------------
+
+
+async def test_level_2_nudge_triggers_overlay_replay() -> None:
+    """Overlay path: when the passthrough enqueues a nudge onto
+    ``session.pending_nudges`` (mirroring the real steerer's post-ABSORB
+    handling for LOOPING_REASONING), the overlay re-invokes passthrough
+    with a synthesized framing message and proceeds with the replacement.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="define_structure",
+                title="define",
+                assignee_agent_id="planner",
+            ),
+            Task(
+                id="draft_slide_1",
+                title="draft",
+                assignee_agent_id="writer",
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="define_structure", to_task_id="draft_slide_1")],
+    )
+    session = _fresh_session()
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    replay_count = 0
+
+    async def _passthrough(
+        user_message: str, session: Session, reconciler: Any
+    ) -> InvocationResult:
+        nonlocal replay_count
+        # First invocation: simulate the LOOPING_REASONING + refine path.
+        # Mark ``define_structure`` FAILED, add a PENDING ``define_structure_v2``
+        # replacement, and queue a nudge.
+        if replay_count == 0:
+            replay_count += 1
+            session.plan.tasks[0].status = TaskStatus.FAILED
+            session.plan.tasks.append(
+                Task(
+                    id="define_structure_v2",
+                    title="define (v2)",
+                    status=TaskStatus.PENDING,
+                    assignee_agent_id="planner",
+                )
+            )
+            # Wire replacement into the DAG so draft_slide_1 depends on it.
+            session.plan.edges.append(
+                TaskEdge(from_task_id="define_structure_v2", to_task_id="draft_slide_1")
+            )
+            session.pending_nudges.append(
+                "The prior attempt looped on define_structure. Refined plan: "
+                "define (v2). Please try a different approach."
+            )
+            return InvocationResult(task_id="", text="")
+        # Second invocation (nudge replay): coordinator sees the framing
+        # message, proceeds with the replacement + downstream.
+        await steerer.transition("define_structure_v2", TaskStatus.COMPLETED, session=session)
+        await steerer.transition("draft_slide_1", TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id="", text="done")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    executor = SequentialExecutor(overlay_mode=True)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="make the deck",
+    )
+
+    # Two passthrough calls: first is the original user message, second is
+    # the overlay's synthesized nudge-replay message.
+    assert len(adapter.passthrough_calls) == 2, adapter.passthrough_calls
+    assert adapter.passthrough_calls[0] == "make the deck"
+    replay_msg = adapter.passthrough_calls[1]
+    assert replay_msg.startswith("[GOLDFIVE PLAN REVISION"), replay_msg
+    assert "define (v2)" in replay_msg or "define_structure" in replay_msg
+
+    # Nudges were consumed.
+    assert session.pending_nudges == []
+
+    # Run completed cleanly — the FAILED define_structure is NOT fatal
+    # because its replacement (COMPLETED define_structure_v2) was live
+    # when fail_fast evaluated.
+    assert outcome.success is True, outcome.reason
+    assert sink.last_run_aborted_reason() is None
+
+
+async def test_overlay_nudge_replay_cap_is_bounded() -> None:
+    """A pathological steerer that keeps re-queueing a nudge every turn
+    must not loop forever — the overlay caps replays at
+    ``_MAX_NUDGE_REPLAYS`` and exits cleanly.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[Task(id="ta", title="a", assignee_agent_id="agent_a")],
+        edges=[],
+    )
+    session = _fresh_session()
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    async def _passthrough(
+        user_message: str,  # noqa: ARG001
+        session: Session,
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        # Always keep a pending nudge; never complete the task.
+        session.pending_nudges.append("still stuck")
+        return InvocationResult(task_id="", text="")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    executor = SequentialExecutor(overlay_mode=True, fail_fast=False)
+    await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="go",
+    )
+
+    # 1 initial invocation + _MAX_NUDGE_REPLAYS replay invocations.
+    max_replays = SequentialExecutor._MAX_NUDGE_REPLAYS
+    assert len(adapter.passthrough_calls) == 1 + max_replays, adapter.passthrough_calls
+
+
+# ---------------------------------------------------------------------------
+# Steerer-level test: ABSORB on LOOPING_REASONING queues a nudge.
+# ---------------------------------------------------------------------------
+
+
+async def test_absorb_on_looping_reasoning_queues_nudge() -> None:
+    """When DefaultSteerer absorbs a LOOPING_REASONING drift (Level 1
+    refine), it also queues a Level 2 nudge on ``session.pending_nudges``
+    so the overlay's replay path has something to consume.
+    """
+    from goldfive.steerer import DefaultSteerer
+    from goldfive.types import Goal
+
+    # Seed: a plan where the refine-spawned replacement is already live.
+    # The refine stub returns this revised plan.
+    revised = Plan(
+        id="p1",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="define_structure",
+                title="define",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="planner",
+            ),
+            Task(
+                id="define_structure_v2",
+                title="define (v2)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="planner",
+            ),
+        ],
+        edges=[],
+        revision_index=1,
+    )
+
+    class _StubPlanner:
+        async def generate(self, **kwargs: Any) -> None:  # noqa: ARG002
+            return None
+
+        async def refine(self, **kwargs: Any) -> Plan:  # noqa: ARG002
+            return revised
+
+    session = _fresh_session()
+    session.plan = Plan(
+        id="p0",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="define_structure",
+                title="define",
+                status=TaskStatus.RUNNING,
+                assignee_agent_id="planner",
+            ),
+        ],
+        edges=[],
+    )
+    session.goals = [Goal(id="g0", summary="make it")]
+
+    sink = RecordingSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=_StubPlanner())
+
+    drift = DriftEvent(
+        kind=DriftKind.LOOPING_REASONING,
+        severity=DriftSeverity.WARNING,
+        detail="tool-loop detector fired",
+        current_task_id="define_structure",
+    )
+    await steerer._handle_drift(drift, session)
+
+    # Refine applied (plan swapped in).
+    assert session.plan is revised
+    # Nudge queued for consumption by the overlay.
+    assert len(session.pending_nudges) == 1
+    nudge = session.pending_nudges[0]
+    assert "define_structure" in nudge


### PR DESCRIPTION
## Summary

Fixes the architectural gap where plan revisions from autonomous drifts don't actually drive forward progress. Concrete reproducer was a Qwen coordinator on kikuchi stuck retrying `report_task_completed` for a task the planner had already superseded via refine — the run aborted before `define_structure_v2` could execute.

Two structural fixes land together:

- **`fail_fast` respects replacements.** Replaces `_any_failed()` with `_fatally_failed_task_ids()` that excludes FAILED tasks whose refine-spawned successor is live in the current plan revision. Uses structural inference (not a proto `replaces` field) over two id conventions goldfive's refine path produces: shared retry lineage (`retry_<id>`, PENDING/RUNNING only to preserve the lineage-cap semantics) and versioned-successor pattern (`<failed_id>_...` like `define_structure_v2`, any non-failed state). Assignee-scoped when populated.
- **Level 2 nudge wired for coordinator-stuck drift.** `DefaultSteerer` now queues a Level 2 nudge onto `session.pending_nudges` after a successful ABSORB (Level 1 refine) for LOOPING_REASONING / LOOPING_TOOL_CALL / SELF_REPORTED_STUCK — the only way to tell a coordinator still mid-invocation that its plan changed. The overlay's `_run_overlay` consumes the nudge at invocation end and re-invokes the passthrough with a `[GOLDFIVE PLAN REVISION …]` framing header. Replay capped at `_MAX_NUDGE_REPLAYS = 3` and gated on live PENDING/RUNNING work remaining — the #163 amplification guard still holds.
- **`run_aborted_event.reason` names the offending task id(s)** when fail_fast truly fires.

## Design note

Chose structural inference over a proto `replaces` field because the field would cross-cut planner JSON shapes, the refine prompt contract, executor, reporting handlers, and the refine validator. The validator already constrains what shapes the planner emits, and the two conventions above cover both observed outputs. Can be promoted to a proto field later if an LLM planner starts emitting replacements that don't fit either convention.

## Scope

- `goldfive/executors/sequential.py` — helpers `_has_live_replacement`, `_fatally_failed_task_ids`, `_has_live_pending_or_running`; `run()` and `_run_overlay()` call sites updated; `_compose_nudge_replay_message` + replay loop in overlay.
- `goldfive/steerer.py` — `_ABSORB_NUDGE_KINDS` constant; ABSORB branch queues a nudge when applicable.
- `tests/test_overlay_forward_progress.py` — new, 11 tests.

## Test plan

- [x] `pytest tests/` (1016 passed, 46 skipped) with ADK + proto extras
- [x] `ruff check .` — clean
- [x] `ruff format --check` — clean
- [ ] E2E verification on the Qwen/kikuchi stuck-coordinator scenario (per issue: start `make demo` clean, fire orchestrated presentation_agent, expect run-to-completion instead of abort)

Closes #202.