### PR TITLE
Graduated severity for tool-loop detection: meta vs work, INFO/WARNING/CRITICAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,27 @@ instrumentation — lands alongside.
   (args-quality classification), [#183](https://github.com/pedapudi/goldfive/issues/183)
   (silent tool success / no-progress), [#185](https://github.com/pedapudi/goldfive/issues/185)
   (wrong-tool-for-job).
+- [#204](https://github.com/pedapudi/goldfive/pull/204) **Graduated severity
+  for the tool-loop detector: meta vs work.** The pre-#204 detector fired
+  a flat `WARNING` at 3 exact repeats regardless of tool kind, cascading
+  benign `report_task_completed` retries (meta tools — usually idempotent
+  state-reporting) into plan revisions. Now classified into two categories
+  with their own ladders:
+
+  | Category | Tier INFO | Tier WARNING | Tier CRITICAL |
+  |---|---|---|---|
+  | `meta` (`report_task_*`, `report_awaiting_approval`) | exact=3 | exact=6 | exact=10 |
+  | `work` (every other tool) | exact=3 | exact=3 / name=5 | exact=6 / name=7 |
+
+  The tracker picks the **highest** tier matched in the window and emits
+  one drift (no cascade). Every drift's `raw` dict now carries `category`
+  and `tier` alongside `mode`. The ladder in `DefaultSteerer._LADDER`
+  maps `LOOPING_REASONING` accordingly: INFO → OBSERVE (no plan mutation
+  on benign meta retries), WARNING → ABSORB (refine), CRITICAL first →
+  NUDGE (refine + queue corrective follow-up), CRITICAL repeat →
+  PAUSE_ESCALATE. Default `window` bumped from 7 to 10 so the
+  meta-CRITICAL tier at 10 can actually fire. Env overrides continue to
+  override the work-WARNING tier for backwards compatibility.
 
 ### Earlier
 

--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -132,7 +132,7 @@ parts). See `goldfive/drift/reasoning.py` for the detector pipeline.
 
 | Kind | Trigger | Default severity | Recoverable |
 |---|---|---|---|
-| `LOOPING_REASONING` | Consecutive reasoning blocks share the same SHA-256 prefix (always-on) or cosine-similar above `0.9` (opt-in, `goldfive[embedding]`). Also fired by the tool-call-loop detector in `goldfive.drift.tool_loops` when the ADK plugin's `after_tool_callback` observes repeated `(tool_name, args_hash)` patterns (exact / name / alternating) — see goldfive#181. | `warning` (`info` for the alternating-cycle variant) | yes |
+| `LOOPING_REASONING` | Consecutive reasoning blocks share the same SHA-256 prefix (always-on) or cosine-similar above `0.9` (opt-in, `goldfive[embedding]`). Also fired by the tool-call-loop detector in `goldfive.drift.tool_loops` when the ADK plugin's `after_tool_callback` observes repeated `(tool_name, args_hash)` patterns (exact / name / alternating) — see goldfive#181 and the graduated-severity table in goldfive#204. | `info` · `warning` · `critical` (graduated per tool category + count; `info` for the alternating-cycle variant) | yes |
 | `REASONING_CLUSTER_TIGHTENING` | Max cosine similarity between current reasoning and the last N=5 blocks falls in `[0.75, 0.9)` (opt-in, `goldfive[embedding]`). Graduated early-warning tier below the `LOOPING_REASONING` cliff. One-shot per task. | `info` | yes |
 | `CONFUSION` | Reasoning text has ≥ 3 uncertainty markers ("I'm not sure", "wait", "hmm", …). | `info` | yes |
 | `OFF_TOPIC` | Reasoning cosine-distance from the current task description ≥ `0.7` (requires `goldfive[embedding]`). | `warning` | yes |
@@ -425,31 +425,102 @@ whether to escalate.
 ## Tool-call loop detection (`ToolLoopTracker`)
 
 Per-invocation tool-call loop detector in
-`goldfive/drift/tool_loops.py` (goldfive#181, landed in PR #186). The
-ADK plugin's `after_tool_callback` forwards every tool dispatch —
-reporting tools, AgentTool delegations, MCP tools, custom adapter-
-native tools — into a `ToolLoopTracker` keyed on `(invocation_id,
-agent_name)`. Three patterns fire a `LOOPING_REASONING` drift
-(severity depends on mode):
+`goldfive/drift/tool_loops.py` (goldfive#181, landed in PR #186;
+graduated severity added in goldfive#204). The ADK plugin's
+`after_tool_callback` forwards every tool dispatch — reporting tools,
+AgentTool delegations, MCP tools, custom adapter-native tools — into a
+`ToolLoopTracker` keyed on `(invocation_id, agent_name)`. Matches fire
+a `LOOPING_REASONING` drift; severity depends on mode, count, and
+**tool category**.
 
-| Mode | Trigger | Severity | `raw["mode"]` |
-|---|---|---|---|
-| **Exact loop** | Same `(tool_name, args_hash)` ≥ `exact_threshold=3` times in the last `window=7` calls. | `warning` | `"exact"` |
-| **Name loop** | Same `tool_name` (any args) ≥ `name_threshold=5` times in the window AND no task progress recorded since the window started filling. | `warning` | `"name"` |
-| **Alternating cycle** | A,B,A,B,A pattern over the last `alternating_threshold=5` calls. Suppressed when exact or name mode already fired on the same pair. | `info` | `"alternating"` |
+### Meta-tool vs work-tool classification (goldfive#204)
 
-Thresholds tunable via `GOLDFIVE_TOOL_LOOP_WINDOW` /
-`GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD` /
-`GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD` /
-`GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD` env vars;
-`load_thresholds_from_env()` reads them.
+Not every tool loop is the same. A `report_task_completed × 3` is the
+agent *reporting* state it already reported — usually cheap and
+idempotent on a healthy handler (goldfive#201 made the handlers
+idempotent). A `web_developer_agent × 3` is a *work* loop burning LLM
+tokens.
 
-**Task-progress gate.** Mode 2 requires "no task progress in window";
-`ToolLoopTracker.on_task_progress(invocation_id, agent_name)` clears
-the per-agent buffer whenever a task transitions to a progress state.
-A legitimate repeating tool that *completes* its task (e.g.
-`read_file read_file read_file → report_task_completed`) is not
-flagged because the next observation starts from an empty window.
+The tracker classifies each tool call via `_classify_tool_category`:
+
+- **`meta`** — progress-reporting / metadata tools. Matches `report_task_*`
+  prefixes and `report_awaiting_approval`.
+- **`work`** — every other tool (agent delegations, MCP tools,
+  adapter-native tools, …).
+
+The same loop pattern fires at **different severity** depending on
+category. The tracker walks tiers from highest severity to lowest and
+emits ONE drift at the first matching tier — no cascade of
+`INFO + WARNING + CRITICAL` on the same window.
+
+### Graduated severity table
+
+| Category | Axis | INFO | WARNING | CRITICAL |
+|---|---|---|---|---|
+| `meta`   | exact | 3 | 6 | 10 |
+| `meta`   | name  | —  | — | —  |
+| `work`   | exact | 3 | 3 | 6  |
+| `work`   | name  | — | 5 | 7  |
+
+"exact" counts identical `(tool_name, args_hash)` signatures in the
+window; "name" counts same-`tool_name`-any-args signatures. Category
+is determined per tool — a window containing 3 meta retries **and** 3
+work retries classifies each tool independently and picks the highest
+severity across tools.
+
+An independent **alternating-cycle** mode still fires INFO when the
+last `alternating_threshold=5` calls match an `A,B,A,B,A` pattern
+(suppressed when an exact/name drift already fired on the same
+window).
+
+Every drift's `raw` dict now carries:
+
+- `category` — `"meta"` or `"work"`.
+- `tier` — `"info"` | `"warning"` | `"critical"`.
+- `mode` — `"exact"` | `"name"` | `"alternating"`.
+- `tool_name`, `count`, `window_len`, `invocation_id` (as before).
+
+Thresholds at the **window size** and alternating length are tunable
+via `GOLDFIVE_TOOL_LOOP_WINDOW` / `GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD`.
+The legacy `GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD` /
+`GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD` env vars still work and override
+the **work-category WARNING tier** only (preserving pre-#204
+single-threshold semantics). The graduated CRITICAL tiers and the
+meta-category thresholds are module-level constants (grouped in
+`_META_THRESHOLDS` / `_WORK_THRESHOLDS`) pending a follow-up that
+exposes them via `ServerConfig`.
+
+### Ladder routing for graduated severity
+
+The intervention ladder (below) routes `LOOPING_REASONING` by
+severity:
+
+- **INFO** → Level 0 (`OBSERVE`): record the drift, no plan mutation.
+  This is the benign tier — meta-tool retries at count 3 land here.
+- **WARNING** → Level 1 (`ABSORB`): call `planner.refine`. Unchanged
+  from pre-#204 — work-tool loops at 3+ calls, meta at 6+, work
+  name-axis at 5.
+- **CRITICAL** first → Level 2 (`NUDGE`): refine **and** queue a soft
+  corrective follow-up on `session.pending_nudges` for the overlay
+  loop to pick up. Coordinates with the forward-progress work that
+  wires nudge consumption.
+- **CRITICAL** repeat → Level 4 (`PAUSE_ESCALATE`): if the loop
+  survives the nudge and re-fires CRITICAL after
+  `REFINE_FAILURE_THRESHOLD` occurrences, escalate to a human pause.
+
+### Task-progress gate
+
+**Task-progress gate.** Mode 2 (name axis) requires "no task progress
+in window"; `ToolLoopTracker.on_task_progress(invocation_id,
+agent_name)` clears the per-agent buffer whenever a task transitions
+to a progress state. A legitimate repeating tool that *completes* its
+task (e.g. `read_file read_file read_file → report_task_completed`)
+is not flagged because the next observation starts from an empty
+window. The plugin gates `on_task_progress` on an acknowledged
+success response from the progress-reporting tool (goldfive#192) so
+errored `report_task_*` retries still accumulate.
+
+### Isolation
 
 **Isolation.** Each `(invocation_id, agent_name)` gets its own ring
 buffer, so parallel AgentTool sub-invocations within one outer
@@ -476,8 +547,8 @@ the authoritative table.
 |---|---|---|---|
 | **0** | `OBSERVE` | Emit `DriftDetected`; no further action. | Every `INFO` drift. |
 | **1** | `ABSORB` | Call `planner.refine`; install the revised plan; continue. | `WARNING` drifts with a known kind (`LOOPING_REASONING`, `LOOPING_TOOL_CALL`, `PLAN_DIVERGENCE`, `TOOL_ERROR`, `AGENT_REFUSAL`, `INTENT_DIVERGENCE`, etc.); CRITICAL first-occurrence of most kinds. |
-| **2** | `NUDGE` | Queue a short corrective user message on `session.pending_nudges` for the Runner's overlay loop to pick up at the next invocation boundary. (Not used by default — table entries prefer Level 1 or Level 3. Reserved for future policies.) | Caller overrides. |
-| **3** | `CANCEL_REINVOKE` | Cancel in-flight invocation; refine; compose a corrective user message via `compose_corrective_user_message` for the overlay loop to re-invoke with. | CRITICAL first-occurrence for most refinable kinds (`LOOPING_REASONING`, `PLAN_DIVERGENCE`, `TOOL_ERROR`, `RUNAWAY_DELEGATION`, ...). |
+| **2** | `NUDGE` | Queue a short corrective user message on `session.pending_nudges` for the Runner's overlay loop to pick up at the next invocation boundary. | `LOOPING_REASONING` at CRITICAL (first occurrence) after goldfive#204 — gives the agent a soft corrective prompt before escalating. Also available for caller overrides. |
+| **3** | `CANCEL_REINVOKE` | Cancel in-flight invocation; refine; compose a corrective user message via `compose_corrective_user_message` for the overlay loop to re-invoke with. | CRITICAL first-occurrence for most refinable kinds (`PLAN_DIVERGENCE`, `TOOL_ERROR`, `RUNAWAY_DELEGATION`, ...). (`LOOPING_REASONING` CRITICAL-first now routes to Level 2 via goldfive#204.) |
 | **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; set `session.paused_for_human_intervention = True`; do NOT call `planner.refine`. Runner blocks until a user `RESUME` / `STEER` arrives. | `GOAL_DRIFT` (first & repeat); `REFINE_VALIDATION_FAILED`; `HUMAN_INTERVENTION_REQUIRED`; `INTENT_DIVERGENCE` at CRITICAL; CRITICAL-repeat of almost every kind. |
 | **5** | `TERMINATE` | Run-level abort. Currently only reachable when a Level-4-initiated pause times out and `HUMAN_INTERVENTION_REQUIRED` re-fires as a repeat CRITICAL. | Repeat `HUMAN_INTERVENTION_REQUIRED`. |
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -707,9 +707,9 @@ class ToolLoopTracker:
     def __init__(
         self,
         *,
-        window: int = 7,                   # DEFAULT_WINDOW
-        exact_threshold: int = 3,          # DEFAULT_EXACT_THRESHOLD
-        name_threshold: int = 5,           # DEFAULT_NAME_THRESHOLD
+        window: int = 10,                  # DEFAULT_WINDOW (bumped in #204 to fit meta-CRITICAL@10)
+        exact_threshold: int = 3,          # DEFAULT_EXACT_THRESHOLD (overrides work-WARNING exact)
+        name_threshold: int = 5,           # DEFAULT_NAME_THRESHOLD (overrides work-WARNING name)
         alternating_threshold: int = 5,    # DEFAULT_ALTERNATING_THRESHOLD
     ) -> None: ...
 

--- a/goldfive/drift/tool_loops.py
+++ b/goldfive/drift/tool_loops.py
@@ -1,4 +1,4 @@
-"""Tool-call loop drift detector (goldfive#181).
+"""Tool-call loop drift detector (goldfive#181, #204).
 
 Post-steer replays on weaker models occasionally degenerate into a
 pattern where the coordinator / sub-agent LLM emits the same
@@ -22,24 +22,66 @@ This module is the complementary detector: it observes **every** tool
 call the ADK plugin sees (reporting or otherwise), keyed per
 ``(invocation_id, agent_name)``, and fires a
 ``LOOPING_REASONING``-kind :class:`~goldfive.types.DriftEvent` when
-one of three patterns is detected:
+one of several patterns is detected.
 
-1. **Exact loop** -- same ``(tool_name, args_hash)`` repeats >= the
-   configured ``exact_threshold`` in the last ``window`` calls.
-   WARNING severity.
-2. **Name loop** -- same ``tool_name`` (any args) repeats >= the
-   configured ``name_threshold`` in the last ``window`` calls AND no
-   task-state transition has been recorded in the window. WARNING
-   severity.
-3. **Alternating cycle** -- A,B,A,B,A pattern in the last
-   ``alternating_threshold`` calls. INFO severity.
+Graduated severity (goldfive#204)
+---------------------------------
 
-Mode 2's "no task progress" gate is satisfied by calling
-:meth:`ToolLoopTracker.on_task_progress` whenever a task transitions
-RUNNING -> COMPLETED (or any other meaningful progress signal). That
-clears the per-agent buffer so a legitimate burst of the same tool
-(e.g. a scripted lint + build + test pipeline) is not flagged when
-each call completes its step.
+Not every tool loop is the same. ``report_task_completed`` retrying 3
+times is probably the agent *reporting* state it's already reported
+(cheap, often idempotent on a healthy handler). ``web_developer_agent``
+retrying 3 times is a *work* loop burning LLM tokens.
+
+The tracker now classifies each tool call into one of two categories
+via :func:`_classify_tool_category`:
+
+* **meta** -- progress-reporting / metadata tools (``report_task_*``,
+  ``report_awaiting_approval``). Retries here are usually cheap and
+  benign.
+* **work** -- every other tool. Retries here are expensive.
+
+Each category has its own graduated severity ladder with three tiers.
+At classify time the tracker picks the **highest** tier matched by the
+current window and emits one drift at that severity -- it does NOT
+cascade INFO + WARNING + CRITICAL on the same window:
+
++----------+-------+---------+---------+----------+
+| Category | Tier  | INFO    | WARNING | CRITICAL |
++==========+=======+=========+=========+==========+
+| meta     | exact | 3       | 6       | 10       |
++----------+-------+---------+---------+----------+
+| meta     | name  | (none)  | (none)  | (none)   |
++----------+-------+---------+---------+----------+
+| work     | exact | 3       | 3       | 6        |
++----------+-------+---------+---------+----------+
+| work     | name  | (none)  | 5       | 7        |
++----------+-------+---------+---------+----------+
+
+(The ``exact`` column counts identical ``(name, args_hash)`` signatures
+in the window; the ``name`` column counts same-``name``-any-args
+signatures. Category is determined by the tool being matched, not by
+any other call in the window.)
+
+Work-tier thresholds are chosen to be backwards-compatible with the
+pre-#204 detector: three identical work calls still fire WARNING (what
+the single-threshold detector did), and same-name 5-in-window still
+fires WARNING. CRITICAL is new -- escalates plan revision into cancel-
+reinvoke at higher counts. Meta-tier thresholds push the first WARNING
+out from 3 to 6 so benign ``report_task_*`` retries trigger only an
+INFO drift (OBSERVE -- no plan mutation) until the loop genuinely
+persists.
+
+The alternating-cycle mode (A,B,A,B,A in the tail) remains INFO-only
+and is independent of category -- it's a textural signal that can
+involve either tool kind and the response should be to observe, not
+intervene.
+
+Mode 2's "no task progress" gate (same-name-any-args) is satisfied by
+calling :meth:`ToolLoopTracker.on_task_progress` whenever a task
+transitions RUNNING -> COMPLETED (or any other meaningful progress
+signal). That clears the per-agent buffer so a legitimate burst of the
+same tool (e.g. a scripted lint + build + test pipeline) is not
+flagged when each call completes its step.
 
 .. note::
 
@@ -66,24 +108,19 @@ is intentionally held in a single :class:`ToolLoopTracker` instance
 on the plugin -- we don't need per-session persistence, the whole
 window is ephemeral to one run.
 
-Configuration overrides via environment variables. Defaults chosen
-to balance signal vs noise (see below).
+Configuration
+-------------
 
-* ``GOLDFIVE_TOOL_LOOP_WINDOW`` -- ring-buffer size (default ``7``).
-  Picked so mode 2's 5-in-7 name-repeat check has two "any-other-tool"
-  slots for variance before firing; a stricter ``5`` window made the
-  detector fire on legitimate pipelines in early manual testing.
-* ``GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD`` -- minimum identical
-  signatures to fire mode 1 (default ``3``). Three identical calls in
-  a row is the smallest number that cannot plausibly be a benign
-  retry.
-* ``GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD`` -- minimum same-name calls to
-  fire mode 2 (default ``5``). Five same-name calls in a 7-call window
-  means at most two distinct tools were invoked -- strong signal the
-  agent is stuck grinding on one capability.
-* ``GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD`` -- pattern length for
-  mode 3 (default ``5``). A,B,A,B,A is the smallest alternating pattern
-  that isn't just "ping once, then ping again" noise.
+The window size and the alternating-pattern length remain env-
+overridable (``GOLDFIVE_TOOL_LOOP_WINDOW`` and
+``GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD``). The graduated category
+thresholds are module-level constants (:data:`_META_THRESHOLDS`,
+:data:`_WORK_THRESHOLDS`) grouped so a future PR can surface them via
+``ServerConfig`` / env vars if ops needs to tune. The legacy
+``GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD`` / ``GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD``
+vars are still read by :func:`load_thresholds_from_env` for backwards
+compatibility and override the **work** category's WARNING tier
+(preserving the pre-#204 single-threshold semantics).
 
 The detector is intentionally deterministic (no embeddings, no LLM
 calls). O(1) per tool call modulo the `window` length.
@@ -115,19 +152,110 @@ log = logging.getLogger("goldfive.drift.tool_loops")
 
 
 # ---------------------------------------------------------------------------
-# Tunables
+# Tool-category classifier (goldfive#204)
+# ---------------------------------------------------------------------------
+
+#: Tool-name prefixes that identify "meta" (progress-reporting) tools.
+#: Kept as a tuple so ``str.startswith`` can match any element in one
+#: call. Covers ``report_task_started``, ``_progress``, ``_completed``,
+#: ``_failed``, ``_blocked``.
+_META_TOOL_PREFIXES: tuple[str, ...] = ("report_task_",)
+
+#: Tool-name literals that identify meta tools without a ``report_task_``
+#: prefix. ``report_awaiting_approval`` is metadata for an approval
+#: state transition -- same "not real work" character.
+_META_TOOL_NAMES: frozenset[str] = frozenset({"report_awaiting_approval"})
+
+
+def _classify_tool_category(tool_name: str) -> str:
+    """Return ``"meta"`` for progress-reporting / metadata tools, ``"work"`` otherwise.
+
+    Meta tools don't advance task state; their retries are cheap and
+    often benign (the healthy-path handlers are idempotent -- a repeat
+    ``report_task_completed`` on an already-completed task ACKs without
+    mutating anything). Work tools burn real LLM time / tokens / have
+    side effects, so loops there are expensive and the detector should
+    escalate sooner.
+
+    The classifier is intentionally name-only so it's cheap and
+    deterministic -- no args inspection, no runtime registry lookup.
+    Future meta tools added by adapters should either follow the
+    ``report_task_`` prefix convention or be added to
+    :data:`_META_TOOL_NAMES` explicitly.
+    """
+    if not tool_name:
+        return "work"
+    if tool_name.startswith(_META_TOOL_PREFIXES) or tool_name in _META_TOOL_NAMES:
+        return "meta"
+    return "work"
+
+
+# ---------------------------------------------------------------------------
+# Graduated thresholds per category (goldfive#204)
+# ---------------------------------------------------------------------------
+#
+# Each category exposes three tiers. Each tier has an ``"exact"`` count
+# (minimum identical ``(name, args_hash)`` repeats in the window) and a
+# ``"name"`` count (minimum same-``name``-any-args repeats in the
+# window). ``None`` means that tier/axis does not fire.
+#
+# Reading the table:
+#
+# * At each observation, find the highest tier (CRITICAL > WARNING >
+#   INFO) whose threshold is matched by the window, emit one drift at
+#   that severity, and stop. Do NOT fire all three when thresholds
+#   stack.
+# * "exact" match is checked first; "name" match is checked only if
+#   "exact" did not already classify the tool at the same-or-higher
+#   severity (this preserves the pre-#204 "exact preempts name on the
+#   same tool" suppression rule).
+# * Thresholds chosen so the **work** category's WARNING tier is
+#   backwards-compatible with the pre-#204 single-threshold defaults
+#   (exact=3, name=5). CRITICAL is new at 6/7 respectively. Meta
+#   thresholds push WARNING from 3 to 6 so benign reporting retries
+#   produce only an INFO drift (OBSERVE) until the loop persists.
+
+_META_THRESHOLDS: dict[str, dict[str, int | None]] = {
+    "info": {"exact": 3, "name": None},
+    "warning": {"exact": 6, "name": None},
+    "critical": {"exact": 10, "name": None},
+}
+
+_WORK_THRESHOLDS: dict[str, dict[str, int | None]] = {
+    "info": {"exact": 3, "name": None},
+    "warning": {"exact": 3, "name": 5},
+    "critical": {"exact": 6, "name": 7},
+}
+
+#: Severity tiers in ascending order. Used by :meth:`ToolLoopTracker._classify`
+#: to walk from highest to lowest when picking the single tier to emit.
+_SEVERITY_TIERS: tuple[tuple[str, DriftSeverity], ...] = (
+    ("critical", DriftSeverity.CRITICAL),
+    ("warning", DriftSeverity.WARNING),
+    ("info", DriftSeverity.INFO),
+)
+
+
+# ---------------------------------------------------------------------------
+# Legacy tunables (retained for env-override compatibility + docs)
 # ---------------------------------------------------------------------------
 
 #: Ring-buffer size: how many recent tool calls to retain per
-#: ``(invocation_id, agent_name)`` key. ``7`` is the default so the
-#: 5-in-7 name-repeat check has room for two "other-tool" calls without
-#: firing.
-DEFAULT_WINDOW: int = 7
+#: ``(invocation_id, agent_name)`` key. ``10`` is the default so the
+#: meta-CRITICAL 10-in-window check has room to fire; name-repeat and
+#: alternating checks are unaffected since they only inspect the last
+#: ``name_threshold`` / ``alternating_threshold`` slots.
+DEFAULT_WINDOW: int = 10
 
-#: Mode 1 threshold: exact ``(name, args_hash)`` repeats in the window.
+#: Legacy alias for the work-category WARNING exact threshold. Retained
+#: so callers (and tests) that read the old single-threshold constant
+#: keep working, and so
+#: :envvar:`GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD` still has somewhere to
+#: land.
 DEFAULT_EXACT_THRESHOLD: int = 3
 
-#: Mode 2 threshold: same ``tool_name`` repeats in the window.
+#: Legacy alias for the work-category WARNING name threshold. Same
+#: rationale as above.
 DEFAULT_NAME_THRESHOLD: int = 5
 
 #: Mode 3 threshold: alternating pattern length (A,B,A,B,A == 5).
@@ -166,6 +294,14 @@ def load_thresholds_from_env() -> dict[str, int]:
     Suitable for ``**kwargs``-splatting into :class:`ToolLoopTracker`.
     Missing / malformed vars fall back to the module defaults. Returned
     keys match the tracker's constructor kwargs.
+
+    The ``exact_threshold`` / ``name_threshold`` keys remain in the
+    returned dict for backwards compatibility; under #204 they override
+    the **work** category's WARNING tier only (preserving the pre-#204
+    single-threshold semantics). The graduated CRITICAL tiers and the
+    meta-category thresholds are not env-tunable in this PR -- they
+    live as module constants grouped so a follow-up can make them
+    configurable.
     """
     return {
         "window": _read_int_env("GOLDFIVE_TOOL_LOOP_WINDOW", DEFAULT_WINDOW),
@@ -212,11 +348,26 @@ class ToolLoopTracker:
     task on the same invocation transitions to a progress state so mode
     2's no-progress gate clears.
 
+    Under goldfive#204 the classifier emits **graduated severity**: for
+    a tool matching one of the threshold tiers, the tracker picks the
+    highest tier (CRITICAL > WARNING > INFO) and emits one drift. The
+    alternating-cycle mode (independent, A,B,A,B,A-shaped) still fires
+    INFO only.
+
     The classifier never mutates its buffers after firing -- we do not
     dedupe drifts here. Upstream (the steerer's intervention ladder)
     already dedupes by ``(kind, task_id)`` occurrence count, and a
     repeating loop SHOULD keep emitting so the ladder escalates if the
     agent doesn't recover.
+
+    ``exact_threshold`` / ``name_threshold`` kwargs are retained for
+    backwards compatibility with callers that constructed the tracker
+    with a single-threshold config (tests, env overrides). When
+    provided, they **override the work category's WARNING tier** only;
+    the graduated CRITICAL tiers and the meta category still use the
+    module constants. This preserves the pre-#204 single-threshold
+    semantics for work tools. Tests that exercise CRITICAL should
+    leave these kwargs at their defaults.
     """
 
     def __init__(
@@ -235,33 +386,55 @@ class ToolLoopTracker:
             raise ValueError(f"name_threshold must be positive, got {name_threshold}")
         if alternating_threshold <= 0:
             raise ValueError(f"alternating_threshold must be positive, got {alternating_threshold}")
+
+        self.window = window
+        self.exact_threshold = exact_threshold
+        self.name_threshold = name_threshold
+        self.alternating_threshold = alternating_threshold
+
+        # Build the effective threshold tables. The work-WARNING tier
+        # is overridden by the legacy kwargs so callers supplying the
+        # old single-threshold config get pre-#204 behaviour there.
+        # Meta thresholds and work-CRITICAL/INFO come from the module
+        # constants unchanged.
+        self._meta_thresholds = _META_THRESHOLDS
+        work: dict[str, dict[str, int | None]] = {
+            "info": dict(_WORK_THRESHOLDS["info"]),
+            "warning": {"exact": exact_threshold, "name": name_threshold},
+            "critical": dict(_WORK_THRESHOLDS["critical"]),
+        }
+        # Ensure INFO's exact threshold is never HIGHER than WARNING's
+        # -- otherwise a caller passing exact_threshold=2 would make
+        # INFO unreachable. Clamp defensively.
+        info_exact = work["info"]["exact"]
+        war_exact = work["warning"]["exact"]
+        if info_exact is not None and war_exact is not None and info_exact > war_exact:
+            work["info"]["exact"] = war_exact
+        self._work_thresholds = work
+
         # Sanity: if the window is too small to hold the thresholds,
         # the detector can never fire for that mode. We log a debug
         # warning but still accept the config -- tests pin specific
         # (window, threshold) tuples and we don't want to reject them.
         if window < exact_threshold:
             log.debug(
-                "tool-loop: window=%d < exact_threshold=%d -- mode 1 cannot fire",
+                "tool-loop: window=%d < exact_threshold=%d -- work-WARNING exact cannot fire",
                 window,
                 exact_threshold,
             )
         if window < name_threshold:
             log.debug(
-                "tool-loop: window=%d < name_threshold=%d -- mode 2 cannot fire",
+                "tool-loop: window=%d < name_threshold=%d -- work-WARNING name cannot fire",
                 window,
                 name_threshold,
             )
         if window < alternating_threshold:
             log.debug(
-                "tool-loop: window=%d < alternating_threshold=%d -- mode 3 cannot fire",
+                "tool-loop: window=%d < alternating_threshold=%d -- alternating-cycle cannot fire",
                 window,
                 alternating_threshold,
             )
 
-        self.window = window
-        self.exact_threshold = exact_threshold
-        self.name_threshold = name_threshold
-        self.alternating_threshold = alternating_threshold
         # Keyed by (invocation_id, agent_name). Value: deque of
         # (tool_name, args_hash). Uses ``defaultdict`` with a bound
         # ``maxlen`` so slots auto-size.
@@ -343,85 +516,128 @@ class ToolLoopTracker:
 
     # -- Internal -----------------------------------------------------------
 
+    def _thresholds_for_tool(self, tool_name: str) -> dict[str, dict[str, int | None]]:
+        """Return the per-tier threshold table for ``tool_name``'s category."""
+        if _classify_tool_category(tool_name) == "meta":
+            return self._meta_thresholds
+        return self._work_thresholds
+
     def _classify(
         self,
         key: tuple[str, str],
         *,
         current_task_id: str,
     ) -> list[DriftEvent]:
-        """Return zero or more drift observations for the current window."""
+        """Return zero or more drift observations for the current window.
+
+        Emits **at most one** exact/name-based drift (the highest
+        severity tier matched for the tool that hit threshold) plus,
+        independently, **at most one** alternating-cycle INFO drift.
+        Alternating is suppressed when an exact/name drift already
+        fired -- same rationale as pre-#204 (the weaker signal would
+        be noise on top of the stronger).
+        """
         buf = list(self._buffers[key])
         observations: list[DriftEvent] = []
         invocation_id, agent_name = key
 
-        # --- Mode 1: exact-signature repeat --------------------------------
+        # Pre-compute per-signature and per-name counts in the window.
         exact_counts: dict[tuple[str, str], int] = {}
-        for sig in buf:
-            exact_counts[sig] = exact_counts.get(sig, 0) + 1
-        fired_exact = False
-        for sig, count in exact_counts.items():
-            if count >= self.exact_threshold:
-                tool_name, sig_hash = sig
-                observations.append(
-                    DriftEvent(
-                        kind=DriftKind.LOOPING_REASONING,
-                        severity=DriftSeverity.WARNING,
-                        detail=(f"tool_loop_exact: {tool_name} x {count} in last {len(buf)} calls"),
-                        current_task_id=current_task_id,
-                        current_agent_id=agent_name,
-                        raw={
-                            "mode": "exact",
-                            "tool_name": tool_name,
-                            "args_hash": sig_hash,
-                            "count": count,
-                            "window_len": len(buf),
-                            "invocation_id": invocation_id,
-                        },
-                    )
-                )
-                fired_exact = True
-                break  # at most one exact drift per classify call
-
-        # --- Mode 2: same-name repeat (only if no task progress) -----------
-        # ``on_task_progress`` clears the window, so if we're here with
-        # a full-enough buffer, no progress has been recorded since the
-        # window started filling. No separate token needed.
         name_counts: dict[str, int] = {}
         for sig in buf:
+            exact_counts[sig] = exact_counts.get(sig, 0) + 1
             name_counts[sig[0]] = name_counts.get(sig[0], 0) + 1
-        fired_name = False
-        for name, count in name_counts.items():
-            if count < self.name_threshold:
-                continue
-            # Suppress mode 2 when mode 1 already fired on the same
-            # tool -- it's the same signal, more specific. Mode 2
-            # still fires independently when mode 1 didn't (args
-            # varied across the burst).
-            if fired_exact and any(
-                sig[0] == name and c >= self.exact_threshold for sig, c in exact_counts.items()
-            ):
-                continue
-            observations.append(
-                DriftEvent(
-                    kind=DriftKind.LOOPING_REASONING,
-                    severity=DriftSeverity.WARNING,
-                    detail=(
-                        f"tool_loop_name: {name} x {count} in last "
-                        f"{len(buf)} calls (no task progress)"
-                    ),
-                    current_task_id=current_task_id,
-                    current_agent_id=agent_name,
-                    raw={
-                        "mode": "name",
+
+        # --- Graduated exact/name classification ---------------------------
+        #
+        # For each distinct tool name in the window, find the highest
+        # tier matched (CRITICAL > WARNING > INFO) and emit one drift
+        # at that severity. "exact" axis is checked first; "name" axis
+        # is checked only if "exact" didn't already match the same
+        # tool at the same-or-higher tier (preserves the pre-#204
+        # "exact preempts name on same tool" suppression).
+        #
+        # We iterate over unique tool names (not signatures) so a tool
+        # with varied args contributes to "name" counts even when no
+        # single signature hits the "exact" threshold. We pick the
+        # name with the highest matched tier; if several names match,
+        # we pick the highest severity first (ties broken by
+        # dictionary iteration order, which is stable on CPython).
+        best_drift: DriftEvent | None = None
+        best_tier_index: int | None = None  # 0=critical, 1=warning, 2=info (lower = better)
+
+        for name in name_counts:
+            thresholds = self._thresholds_for_tool(name)
+            name_total = name_counts[name]
+            # Max exact-signature count for this tool in the window.
+            exact_for_name = max(
+                (c for sig, c in exact_counts.items() if sig[0] == name),
+                default=0,
+            )
+            # Walk tiers from highest severity to lowest.
+            for tier_index, (tier_key, severity) in enumerate(_SEVERITY_TIERS):
+                tier = thresholds.get(tier_key) or {}
+                exact_thr = tier.get("exact")
+                name_thr = tier.get("name")
+                hit_exact = exact_thr is not None and exact_for_name >= exact_thr
+                hit_name = name_thr is not None and name_total >= name_thr
+                if not (hit_exact or hit_name):
+                    continue
+
+                # Found the highest tier for this tool. Build a drift.
+                # Prefer the "exact" detail when both axes are
+                # satisfied -- the more specific signal.
+                mode = "exact" if hit_exact else "name"
+                if mode == "exact":
+                    sig = next(
+                        sig
+                        for sig, c in exact_counts.items()
+                        if sig[0] == name and c == exact_for_name
+                    )
+                    detail = f"tool_loop_exact: {name} x {exact_for_name} in last {len(buf)} calls"
+                    raw: dict[str, Any] = {
+                        "mode": "exact",
                         "tool_name": name,
-                        "count": count,
+                        "args_hash": sig[1],
+                        "count": exact_for_name,
                         "window_len": len(buf),
                         "invocation_id": invocation_id,
-                    },
+                        "category": _classify_tool_category(name),
+                        "tier": tier_key,
+                    }
+                else:
+                    detail = (
+                        f"tool_loop_name: {name} x {name_total} in last "
+                        f"{len(buf)} calls (no task progress)"
+                    )
+                    raw = {
+                        "mode": "name",
+                        "tool_name": name,
+                        "count": name_total,
+                        "window_len": len(buf),
+                        "invocation_id": invocation_id,
+                        "category": _classify_tool_category(name),
+                        "tier": tier_key,
+                    }
+
+                candidate = DriftEvent(
+                    kind=DriftKind.LOOPING_REASONING,
+                    severity=severity,
+                    detail=detail,
+                    current_task_id=current_task_id,
+                    current_agent_id=agent_name,
+                    raw=raw,
                 )
-            )
-            fired_name = True
-            break
+                # Keep the highest-severity candidate seen across all
+                # tools. tier_index is 0 for CRITICAL, so "lower is
+                # better" for our "best" accumulator.
+                if best_tier_index is None or tier_index < best_tier_index:
+                    best_drift = candidate
+                    best_tier_index = tier_index
+                break  # stop at the highest tier for this tool
+
+        if best_drift is not None:
+            observations.append(best_drift)
 
         # --- Mode 3: alternating A,B,A,B,A pattern -------------------------
         if len(buf) >= self.alternating_threshold:
@@ -432,10 +648,10 @@ class ToolLoopTracker:
                 and names[0] != names[1]
                 and all(names[i] == names[i % 2] for i in range(len(names)))
             ):
-                # Don't double-fire if mode 1 or 2 already flagged
-                # this same pair -- the alternating signal is weaker
-                # (INFO) and would be noise on top of a WARNING.
-                if not (fired_exact or fired_name):
+                # Don't double-fire if an exact/name drift already
+                # flagged this window -- the alternating signal is
+                # weaker (INFO) and would be noise on top.
+                if best_drift is None:
                     a_name, b_name = names[0], names[1]
                     observations.append(
                         DriftEvent(

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -472,9 +472,7 @@ class DefaultSteerer:
             session.agent_notes[task_id] = detail
         # goldfive#152: stamp current_task_* on the orchestration-state
         # dict so downstream prompt templates / refine paths see it.
-        _ostate.sync_current_task_from_transition(
-            session.state, task, TaskStatus.RUNNING
-        )
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.RUNNING)
         await self._emit_task_started(session, task_id, detail)
 
     async def mark_task_progress(
@@ -521,9 +519,7 @@ class DefaultSteerer:
         if summary:
             session.completed_results[task_id] = summary
         # goldfive#152: clear current_task_* if we were the active task.
-        _ostate.sync_current_task_from_transition(
-            session.state, task, TaskStatus.COMPLETED
-        )
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.COMPLETED)
         await self._emit_task_completed(session, task_id, summary, artifacts or {})
 
     async def mark_task_failed(
@@ -560,9 +556,7 @@ class DefaultSteerer:
         if task.status in _TERMINAL_TASK_STATUSES:
             return
         task.status = TaskStatus.FAILED
-        _ostate.sync_current_task_from_transition(
-            session.state, task, TaskStatus.FAILED
-        )
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.FAILED)
         await self._emit_task_failed(session, task_id, reason, recoverable)
         # Fatal failures cascade downstream via the same primitive used
         # by mark_task_cancelled, so both §6.2 and §6.3 produce the
@@ -642,9 +636,7 @@ class DefaultSteerer:
             # TaskCancelled events for downstream tasks on every call.
             return
         task.status = TaskStatus.CANCELLED
-        _ostate.sync_current_task_from_transition(
-            session.state, task, TaskStatus.CANCELLED
-        )
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.CANCELLED)
         await self._emit_task_cancelled(session, task_id, reason)
         await self.cascade_cancel_downstream(session, task_id)
 
@@ -677,9 +669,7 @@ class DefaultSteerer:
         if task.status in _TERMINAL_TASK_STATUSES:
             return
         task.status = TaskStatus.NOT_NEEDED
-        _ostate.sync_current_task_from_transition(
-            session.state, task, TaskStatus.NOT_NEEDED
-        )
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.NOT_NEEDED)
         # There is no dedicated ``TaskNotNeeded`` proto message;
         # reuse TaskCancelled with the reason prefix so sinks that
         # inspect reason can differentiate if they wish. The live
@@ -794,9 +784,7 @@ class DefaultSteerer:
         """
         if self._is_duplicate_steer(event, session):
             steer_id = self._steer_dedupe_id(event)
-            log.debug(
-                "DefaultSteerer.observe: dropping duplicate STEER id=%s", steer_id
-            )
+            log.debug("DefaultSteerer.observe: dropping duplicate STEER id=%s", steer_id)
             return
         drift = self._drift_from_control(event, session)
         if drift is None:
@@ -1698,10 +1686,23 @@ class DefaultSteerer:
             InterventionLevel.ABSORB,
             (InterventionLevel.CANCEL_REINVOKE, InterventionLevel.PAUSE_ESCALATE),
         ),
+        # LOOPING_REASONING: severity is now graduated (goldfive#204)
+        # -- the tool-loop detector emits INFO / WARNING / CRITICAL
+        # based on count + category (meta vs work). The ladder mirrors
+        # that graduation:
+        #
+        # * INFO  -> OBSERVE (default fallback; benign meta-tool retries
+        #   at the first threshold should not mutate the plan).
+        # * WARNING -> ABSORB (refine plan; unchanged from pre-#204).
+        # * CRITICAL first -> NUDGE (refine AND queue a soft corrective
+        #   follow-up for the overlay loop -- Agent B wires the nudge
+        #   consumption in goldfive#forward-progress).
+        # * CRITICAL repeat -> PAUSE_ESCALATE (escalate to human if the
+        #   loop persists past nudge).
         DriftKind.LOOPING_REASONING: (
             None,
             InterventionLevel.ABSORB,
-            (InterventionLevel.CANCEL_REINVOKE, InterventionLevel.PAUSE_ESCALATE),
+            (InterventionLevel.NUDGE, InterventionLevel.PAUSE_ESCALATE),
         ),
         DriftKind.LOOPING_TOOL_CALL: (
             None,
@@ -1963,9 +1964,7 @@ class DefaultSteerer:
         # event — a cheap, always-available "turn" proxy.
         at_turn = getattr(session, "_next_sequence", 0) or 0
         try:
-            _ostate.set_active_steer(
-                session.state, body=body, at_turn=at_turn, author=author
-            )
+            _ostate.set_active_steer(session.state, body=body, at_turn=at_turn, author=author)
         except Exception as exc:  # noqa: BLE001
             log.debug(
                 "DefaultSteerer._apply_user_steer_state: set_active_steer raised: %s",
@@ -1980,8 +1979,7 @@ class DefaultSteerer:
                 _ostate.record_processed_steer_id(session.state, steer_id)
             except Exception as exc:  # noqa: BLE001
                 log.debug(
-                    "DefaultSteerer._apply_user_steer_state: "
-                    "record_processed_steer_id raised: %s",
+                    "DefaultSteerer._apply_user_steer_state: record_processed_steer_id raised: %s",
                     exc,
                 )
         if not body:

--- a/tests/test_intervention_ladder.py
+++ b/tests/test_intervention_ladder.py
@@ -72,13 +72,18 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         0,
         InterventionLevel.CANCEL_REINVOKE,
     ),
-    # LOOPING_REASONING (no INFO tier in the classifier).
+    # LOOPING_REASONING: graduated severity landed in goldfive#204.
+    # INFO (meta-tool retries at low counts) -> OBSERVE; WARNING ->
+    # ABSORB (unchanged); CRITICAL first -> NUDGE (refine + queue
+    # corrective message for overlay loop); CRITICAL repeat ->
+    # PAUSE_ESCALATE.
+    (DriftKind.LOOPING_REASONING, DriftSeverity.INFO, 0, InterventionLevel.OBSERVE),
     (DriftKind.LOOPING_REASONING, DriftSeverity.WARNING, 0, InterventionLevel.ABSORB),
     (
         DriftKind.LOOPING_REASONING,
         DriftSeverity.CRITICAL,
         0,
-        InterventionLevel.CANCEL_REINVOKE,
+        InterventionLevel.NUDGE,
     ),
     (
         DriftKind.LOOPING_REASONING,

--- a/tests/test_pause_escalate.py
+++ b/tests/test_pause_escalate.py
@@ -343,13 +343,18 @@ async def test_cancel_reinvoke_queues_corrective_message() -> None:
             )
 
     steerer.bind(sinks=[], planner=GoodPlanner())
+    # Use TOOL_ERROR for the Level 3 first-occurrence check:
+    # LOOPING_REASONING's CRITICAL-first tier routes to NUDGE
+    # (Level 2) after goldfive#204, so we pick a drift kind whose
+    # CRITICAL-first tier still routes to CANCEL_REINVOKE AND whose
+    # corrective-template interpolates the current_task_id.
     drift = DriftEvent(
-        kind=DriftKind.LOOPING_REASONING,
+        kind=DriftKind.TOOL_ERROR,
         severity=DriftSeverity.CRITICAL,
-        detail="looped",
+        detail="tool error",
         current_task_id="t1",
     )
     await steerer._handle_drift(drift, session)
     assert session.pending_corrective_message is not None
     assert "t1" in session.pending_corrective_message
-    assert "different approach" in session.pending_corrective_message
+    assert "Try a different approach" in session.pending_corrective_message

--- a/tests/test_tool_loop_exemption_tightening.py
+++ b/tests/test_tool_loop_exemption_tightening.py
@@ -205,6 +205,13 @@ async def test_errored_report_task_started_counts_as_loop() -> None:
     were previously exempt from loop detection. With the tightening,
     the third identical errored retry fires mode 1 at the default
     exact-threshold of 3.
+
+    Under goldfive#204 the severity is now **graduated by category**:
+    ``report_task_*`` is a *meta* tool, so 3 identical retries fire at
+    **INFO** (OBSERVE tier -- no plan mutation), not WARNING. The
+    original #192 invariant that errored retries are NOT exempt from
+    the detector is still enforced -- they produce a drift; the
+    severity just reflects meta-tool character now.
     """
     pytest.importorskip("google.adk")
     steerer = _RecordingToolLoopSteerer()
@@ -222,15 +229,19 @@ async def test_errored_report_task_started_counts_as_loop() -> None:
     await plugin.after_tool_callback(tool=tool, tool_args=args, tool_context=tool_ctx, result=nack)
     assert steerer.drifts == []
 
-    # Call 3: exact-threshold hit -> WARNING drift fires.
+    # Call 3: INFO-tier exact-threshold hit -> INFO drift fires (meta
+    # category; #204). The key invariant from #192 -- errored retries
+    # ARE counted, not exempt -- is still enforced.
     await plugin.after_tool_callback(tool=tool, tool_args=args, tool_context=tool_ctx, result=nack)
     assert len(steerer.drifts) == 1
     drift = steerer.drifts[0]
     assert drift.kind is DriftKind.LOOPING_REASONING
-    assert drift.severity is DriftSeverity.WARNING
+    assert drift.severity is DriftSeverity.INFO
     assert drift.raw is not None
     assert drift.raw.get("mode") == "exact"
     assert drift.raw.get("tool_name") == "report_task_started"
+    assert drift.raw.get("category") == "meta"
+    assert drift.raw.get("tier") == "info"
     assert drift.current_task_id == "t-err"
 
     # The errored call must NOT have reset the window -- subsequent

--- a/tests/test_tool_loops.py
+++ b/tests/test_tool_loops.py
@@ -30,6 +30,7 @@ from goldfive.drift.tool_loops import (
     DEFAULT_NAME_THRESHOLD,
     DEFAULT_WINDOW,
     ToolLoopTracker,
+    _classify_tool_category,
     args_hash,
     load_thresholds_from_env,
 )
@@ -441,3 +442,236 @@ def test_exact_mode_preempts_name_mode_on_same_tool() -> None:
     third = drifts_per_call[2]
     assert len(third) == 1
     assert third[0].raw.get("mode") == "exact"
+
+
+# ---------------------------------------------------------------------------
+# Graduated severity (goldfive#204) -- meta vs work categories
+# ---------------------------------------------------------------------------
+
+
+def test_classify_tool_category_meta_prefixes() -> None:
+    """All ``report_task_*`` names and ``report_awaiting_approval`` are meta."""
+    for name in (
+        "report_task_started",
+        "report_task_progress",
+        "report_task_completed",
+        "report_task_failed",
+        "report_task_blocked",
+        "report_awaiting_approval",
+    ):
+        assert _classify_tool_category(name) == "meta", name
+
+
+def test_classify_tool_category_work_fallback() -> None:
+    """Arbitrary tool names -- including the empty string -- classify as work."""
+    for name in (
+        "web_developer_agent",
+        "research_agent",
+        "patch_file",
+        "read_file",
+        "",
+        "reporter",  # not a ``report_task_`` prefix -- work, not meta
+    ):
+        assert _classify_tool_category(name) == "work", name
+
+
+def test_meta_tool_retries_fire_info_at_3_not_warning() -> None:
+    """Meta tool (``report_task_completed``) x 3 fires INFO, not WARNING.
+
+    Benign meta-tool retries should not mutate the plan -- INFO goes
+    through the ladder at OBSERVE level.
+    """
+    tracker = ToolLoopTracker()
+    drifts_per_call = _seed(
+        tracker,
+        [("report_task_completed", {"task_id": "t1"})] * 3,
+    )
+    # Below threshold on calls 1-2.
+    assert drifts_per_call[0] == []
+    assert drifts_per_call[1] == []
+    # Call 3: INFO fires, not WARNING / CRITICAL.
+    third = drifts_per_call[2]
+    assert len(third) == 1, f"expected single INFO drift, got {third}"
+    drift = third[0]
+    assert drift.kind is DriftKind.LOOPING_REASONING
+    assert drift.severity is DriftSeverity.INFO, (
+        f"meta retry at 3 should be INFO, got {drift.severity}"
+    )
+    assert drift.raw is not None
+    assert drift.raw.get("category") == "meta"
+    assert drift.raw.get("tier") == "info"
+    assert drift.raw.get("mode") == "exact"
+    assert drift.raw.get("count") == 3
+
+
+def test_meta_tool_retries_escalate_to_warning_at_6() -> None:
+    """Meta tool x 6 identical calls escalates to WARNING."""
+    # Default window (10) is large enough to hold 6 identical calls.
+    tracker = ToolLoopTracker()
+    drifts_per_call = _seed(
+        tracker,
+        [("report_task_completed", {"task_id": "t1"})] * 6,
+    )
+    # Calls 3-5 fire INFO (below WARNING threshold of 6).
+    for i in (2, 3, 4):
+        assert drifts_per_call[i], f"expected INFO at call {i + 1}"
+        assert drifts_per_call[i][0].severity is DriftSeverity.INFO
+    # Call 6: WARNING fires.
+    sixth = drifts_per_call[5]
+    assert len(sixth) == 1
+    drift = sixth[0]
+    assert drift.severity is DriftSeverity.WARNING
+    assert drift.raw.get("category") == "meta"
+    assert drift.raw.get("tier") == "warning"
+    assert drift.raw.get("count") == 6
+
+
+def test_work_tool_retries_fire_warning_at_3_as_before() -> None:
+    """Backwards-compat: work tool x 3 exact calls still fires WARNING."""
+    tracker = ToolLoopTracker()
+    drifts_per_call = _seed(
+        tracker,
+        [("web_developer_agent", {"q": "hello"})] * 3,
+    )
+    assert drifts_per_call[0] == drifts_per_call[1] == []
+    third = drifts_per_call[2]
+    assert len(third) == 1
+    drift = third[0]
+    assert drift.kind is DriftKind.LOOPING_REASONING
+    # Pre-#204 behaviour: 3 identical work calls -> WARNING.
+    assert drift.severity is DriftSeverity.WARNING
+    assert drift.raw.get("category") == "work"
+    assert drift.raw.get("tier") == "warning"
+    assert drift.raw.get("mode") == "exact"
+
+
+def test_critical_tool_loops_at_10_meta_or_6_work() -> None:
+    """CRITICAL fires at the right per-category thresholds.
+
+    * Meta exact: 10 identical ``report_task_*`` calls -> CRITICAL.
+    * Work exact: 6 identical work-tool calls -> CRITICAL.
+    """
+    # --- Meta CRITICAL at 10 -------------------------------------------------
+    meta_tracker = ToolLoopTracker()
+    meta_drifts = _seed(
+        meta_tracker,
+        [("report_task_completed", {"task_id": "t1"})] * 10,
+    )
+    tenth = meta_drifts[9]
+    assert len(tenth) == 1
+    assert tenth[0].severity is DriftSeverity.CRITICAL
+    assert tenth[0].raw.get("category") == "meta"
+    assert tenth[0].raw.get("tier") == "critical"
+
+    # --- Work CRITICAL at 6 --------------------------------------------------
+    work_tracker = ToolLoopTracker()
+    work_drifts = _seed(
+        work_tracker,
+        [("web_developer_agent", {"q": "hello"})] * 6,
+    )
+    sixth = work_drifts[5]
+    assert len(sixth) == 1
+    assert sixth[0].severity is DriftSeverity.CRITICAL
+    assert sixth[0].raw.get("category") == "work"
+    assert sixth[0].raw.get("tier") == "critical"
+
+
+def test_work_name_tier_fires_critical_at_7() -> None:
+    """Work tool, args varying, 7 same-name calls -> CRITICAL."""
+    tracker = ToolLoopTracker()
+    # 7 calls to the same work tool with distinct args -- no exact
+    # signature hits, but the name axis trips CRITICAL at 7.
+    drifts = _seed(
+        tracker,
+        [("web_developer_agent", {"q": f"q{i}"}) for i in range(7)],
+    )
+    # Call 5: name count = 5 -> WARNING tier (work name warning=5).
+    assert drifts[4], "expected WARNING at call 5"
+    assert drifts[4][0].severity is DriftSeverity.WARNING
+    # Call 7: name count = 7 -> CRITICAL.
+    seventh = drifts[6]
+    assert len(seventh) == 1
+    drift = seventh[0]
+    assert drift.severity is DriftSeverity.CRITICAL
+    assert drift.raw.get("category") == "work"
+    assert drift.raw.get("tier") == "critical"
+    assert drift.raw.get("mode") == "name"
+
+
+def test_highest_severity_emitted_once() -> None:
+    """At 10 identical meta calls, only CRITICAL fires -- not INFO/WARNING too."""
+    tracker = ToolLoopTracker()
+    drifts = _seed(
+        tracker,
+        [("report_task_completed", {"task_id": "t1"})] * 10,
+    )
+    tenth = drifts[9]
+    # Exactly ONE drift, at CRITICAL -- not a cascade of INFO + WARNING + CRITICAL.
+    assert len(tenth) == 1, f"expected single drift, got {len(tenth)}: {tenth}"
+    assert tenth[0].severity is DriftSeverity.CRITICAL
+
+
+def test_meta_at_3_does_not_fire_warning_or_critical() -> None:
+    """Regression guard: meta x 3 MUST NOT fire WARNING (the original bug)."""
+    tracker = ToolLoopTracker()
+    drifts = _seed(
+        tracker,
+        [("report_task_completed", {"task_id": "t1"})] * 3,
+    )
+    severities = [d.severity for d in drifts[2]]
+    assert DriftSeverity.WARNING not in severities
+    assert DriftSeverity.CRITICAL not in severities
+    assert severities == [DriftSeverity.INFO]
+
+
+def test_mixed_meta_and_work_in_same_window() -> None:
+    """Interleaved meta + work -- each tool classified independently.
+
+    A window holding 3 identical meta calls AND 3 identical work calls
+    should classify the work loop at WARNING (higher severity wins
+    across tools) rather than stopping at the meta INFO.
+    """
+    tracker = ToolLoopTracker()
+    # Interleave so both end up with 3 exact matches in the window.
+    calls = [
+        ("report_task_completed", {"task_id": "t1"}),
+        ("web_developer_agent", {"q": "x"}),
+        ("report_task_completed", {"task_id": "t1"}),
+        ("web_developer_agent", {"q": "x"}),
+        ("report_task_completed", {"task_id": "t1"}),
+        ("web_developer_agent", {"q": "x"}),
+    ]
+    drifts = _seed(tracker, calls)
+    last = drifts[-1]
+    # The work tool matched WARNING (count=3 >= work warning exact=3);
+    # meta only matched INFO (count=3). Highest severity wins -> WARNING.
+    assert len(last) == 1
+    assert last[0].severity is DriftSeverity.WARNING
+    assert last[0].raw.get("category") == "work"
+    assert last[0].raw.get("tool_name") == "web_developer_agent"
+
+
+def test_legacy_exact_threshold_kwarg_overrides_work_warning() -> None:
+    """The ``exact_threshold`` ctor kwarg continues to override work-WARNING.
+
+    Env-override / programmatic callers that passed ``exact_threshold=4``
+    pre-#204 should still see WARNING fire at 4 identical work calls,
+    not 3.
+    """
+    tracker = ToolLoopTracker(exact_threshold=4, name_threshold=10)
+    drifts = _seed(
+        tracker,
+        [("web_developer_agent", {"q": "x"})] * 3,
+    )
+    # At 3 calls: INFO fires (INFO exact=3 module constant, clamped to
+    # the WARNING exact of 4 but not raised above). Since INFO exact=3
+    # and WARNING exact=4, INFO matches but WARNING does not yet.
+    assert drifts[2], "INFO should fire at 3"
+    assert drifts[2][0].severity is DriftSeverity.INFO
+    # At 4 calls: WARNING fires.
+    drifts = _seed(
+        tracker,
+        [("web_developer_agent", {"q": "x"})],
+    )
+    assert drifts[0], "WARNING should fire at 4"
+    assert drifts[0][0].severity is DriftSeverity.WARNING


### PR DESCRIPTION
## Summary

Fixes goldfive#204. The `ToolLoopTracker` (goldfive#181/#186) previously fired a flat `WARNING` at 3 exact repeats for *any* tool. Benign `report_task_completed × 3` retries — which are usually the agent re-reporting already-committed state, idempotent post goldfive#201 — cascaded into plan revisions and in at least one session aborted the run.

This PR classifies each tool call into **`meta`** (`report_task_*`, `report_awaiting_approval`) or **`work`** (everything else) and graduates severity per category. The tracker picks the highest tier matched and emits **one** drift at that severity — no INFO+WARNING+CRITICAL cascade.

### Category / tier matrix

| Category | Tier INFO | Tier WARNING | Tier CRITICAL |
|---|---|---|---|
| `meta` | `exact=3` | `exact=6` | `exact=10` |
| `work` | `exact=3` | `exact=3` / `name=5` | `exact=6` / `name=7` |

`work` WARNING is backwards-compatible with the pre-#204 single-threshold defaults; CRITICAL is new. Default `window` bumped 7 → 10 so the meta-CRITICAL@10 tier can fire. Env overrides (`GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD` / `_NAME_THRESHOLD`) continue to override the work-category WARNING tier only.

### Ladder routing for `LOOPING_REASONING`

In `DefaultSteerer._LADDER`:

- `INFO` → `OBSERVE` (Level 0; no plan mutation — the key fix)
- `WARNING` → `ABSORB` (Level 1; unchanged)
- `CRITICAL` first → `NUDGE` (Level 2; refine + queue corrective follow-up for the forward-progress nudge path to consume)
- `CRITICAL` repeat → `PAUSE_ESCALATE` (Level 4; unchanged)

### Drift `raw` additions

Every drift's `raw` dict now carries `category` (`"meta"`/`"work"`) and `tier` (`"info"`/`"warning"`/`"critical"`) alongside the existing `mode` / `tool_name` / `count` / `window_len` / `invocation_id` keys so sinks can distinguish benign meta retries from real work loops.

### Files

- `goldfive/drift/tool_loops.py` — classifier + graduated thresholds + updated `_classify`.
- `goldfive/steerer.py` — `LOOPING_REASONING` ladder entry: CRITICAL-first now `NUDGE`.
- `tests/test_tool_loops.py` — 10 new cases covering category classification, each severity tier, highest-severity-once, mixed-category windows, legacy-kwarg backwards compat.
- `tests/test_intervention_ladder.py` — pinning test updated for new `LOOPING_REASONING` mapping + new INFO→OBSERVE case.
- `tests/test_pause_escalate.py` — Level 3 corrective-message test switched to `TOOL_ERROR` (which still routes CRITICAL-first → CANCEL_REINVOKE).
- `docs/design/DRIFT.md` — new meta-vs-work subsection with tables; ladder table updated.
- `docs/reference/api.md` — `ToolLoopTracker` signature snippet reflects new default window.
- `CHANGELOG.md` — entry under Unreleased.

### Coordination

- **Agent A (idempotent handlers, #201)** — landed. Makes healthy-path retries return `acknowledged=True` → `on_task_progress` clears the window; this PR's graduated severity provides the right signal when retries still return errored (the genuinely confused case).
- **Agent B (forward-progress / nudge consumption)** — this PR points `LOOPING_REASONING` `CRITICAL`-first at Level 2 (`NUDGE`). Agent B wires the `session.pending_nudges` consumption path.
- **Agent C (cancel reasons)** — orthogonal, no overlap.

## Test plan

- [x] `uv run pytest tests/test_tool_loops.py` — 33 cases (23 existing + 10 new) green
- [x] `uv run pytest tests/test_intervention_ladder.py` — full table including updated `LOOPING_REASONING` rows green
- [x] `uv run pytest tests/test_pause_escalate.py` — Level 3 test rewired to `TOOL_ERROR`, green
- [x] `uv run pytest -q` — 821 passed / 76 skipped
- [x] `uv run ruff check goldfive tests` — clean
- [x] `uv run mypy goldfive/drift/tool_loops.py goldfive/steerer.py` — clean
- [ ] E2E on `presentation_agent` / Qwen — verify SQL:
      `SELECT severity, detail FROM spans WHERE name='goldfive_drift' AND kind_string='LOOPING_REASONING';`
      shows graduated severities (INFO at 3 meta retries, not WARNING).