### PR TITLE
Idempotent reporting handlers + state rotation on terminal transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,26 @@ instrumentation — lands alongside.
   (silent tool success / no-progress), [#185](https://github.com/pedapudi/goldfive/issues/185)
   (wrong-tool-for-job).
 
+### Task-lifecycle
+
+- [#201](https://github.com/pedapudi/goldfive/pull/201) **Idempotent
+  reporting handlers + state rotation on terminal transition.**
+  Reporting-tool retries on a terminal task used to return a single
+  `task_already_terminal` rejection, which conflated benign same-
+  transition retries with real "agent is confused" cross-transitions
+  and tripped the tool-loop detector on both. The handler now owns a
+  per-tool idempotency matrix: same-transition retries (e.g.
+  `report_task_completed` on `COMPLETED`) return
+  `{"acknowledged": True, "idempotent": True, "current_status": ...}`;
+  cross-transitions (e.g. `report_task_started` on `COMPLETED`)
+  return `{"acknowledged": False, "error": "invalid_transition",
+  "current_status": ..., "attempted": ...}`. Terminal transitions
+  additionally rotate `goldfive.current_task_id` via a new
+  `orchestration_state.rotate_current_task_id(state, plan, agent_name)`
+  helper so subsequent tool calls in the same invocation context see
+  a live pointer (stamps the next PENDING/RUNNING task assigned to
+  the same agent when unambiguous; clears otherwise).
+
 ### Earlier
 
 - #163 Overlay executor no longer dispatches soft follow-ups. When

--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -387,28 +387,53 @@ increments — so a malformed-call flood cannot poison session-wide
 state or create a false session drift against the next legitimate
 call.
 
-**Terminal-task rejection.** If the task exists and is already
-terminal (`COMPLETED` / `FAILED` / `CANCELLED`):
+**Terminal-task handling (goldfive#201).** Terminal-task retries are
+owned by the handler, not the dispatcher. The handler's per-tool
+idempotency matrix splits the terminal case two ways:
 
-```python
-{
-    "acknowledged": False,
-    "error": "task_already_terminal",
-    "task_id": "<id>",
-    "current_status": "FAILED",
-    "message": "Task '<id>' is already FAILED. Do not call further "
-               "reporting tools for this task; wait for the "
-               "orchestrator to route you to the next task.",
-}
-```
+* **Same-transition retry** (e.g. `report_task_completed` on a
+  `COMPLETED` task) returns an idempotent ACK. No steerer call, no
+  state mutation, no drift:
 
-**Why a structured error and not a silent ACK.** `{"acknowledged":
-True}` cannot be read by the model as "stop." The structured error
-gives the agent clear, model-readable feedback that loops can
-respect. This is the primary line of defence; §3's quiescence check
-prevents the loop at the invocation level, but this layer is the
-fallback for tools that fire *before* the adapter has observed the
-terminal transition.
+  ```python
+  {
+      "acknowledged": True,
+      "idempotent": True,
+      "current_status": "COMPLETED",
+  }
+  ```
+
+* **Cross-transition** (e.g. `report_task_started` on a `COMPLETED`
+  task, or `report_task_progress` on a `FAILED` task) returns a
+  structured invalid-transition error — a real "agent is confused
+  about state" signal:
+
+  ```python
+  {
+      "acknowledged": False,
+      "error": "invalid_transition",
+      "tool": "<name>",
+      "task_id": "<id>",
+      "current_status": "FAILED",
+      "attempted": "RUNNING",
+      "message": "Cannot 'report_task_started' task '<id>' from FAILED "
+                 "to RUNNING. The task is already in a terminal or "
+                 "otherwise-incompatible state; do not retry.",
+  }
+  ```
+
+Pre-goldfive#201 the dispatcher short-circuited both cases with a
+single `task_already_terminal` error. That shape conflated a
+confused-model retry (benign) with a structural invalid transition
+(a confusion signal) — benign retries tripped the tool-loop detector
+and triggered spurious plan revisions. The matrix separates the two.
+
+**Why a structured error and not a silent ACK on the invalid case.**
+`{"acknowledged": True}` cannot be read by the model as "stop." The
+structured error gives the agent clear, model-readable feedback that
+loops can respect. The idempotent ACK is readable as "already done,
+move on"; the invalid-transition error is readable as "you're
+confused, do not retry this specific transition".
 
 ### 5.2 Layer 2 — idempotency (silent dedup)
 

--- a/goldfive/adapters/_tool_invocation.py
+++ b/goldfive/adapters/_tool_invocation.py
@@ -14,9 +14,17 @@ guard (see :mod:`goldfive.adapters._tool_loop_guard`) so that:
   current plan, is rejected with a structured error **before** any
   other layer runs (so malformed calls can't poison the session
   counter).
-* **Layer 2 — terminal-task rejection.** A call on a task already in
-  ``COMPLETED`` / ``FAILED`` / ``CANCELLED`` is rejected with
-  ``task_already_terminal`` so the agent sees a clear stop signal.
+* **Layer 2 — (handler-owned)**. Terminal-task semantics used to
+  reject here with ``task_already_terminal``. As of goldfive#201 the
+  handler owns that decision with a finer idempotent / invalid-
+  transition split: a retry of the same transition (e.g.
+  ``report_task_completed`` on a COMPLETED task) returns
+  ``{"acknowledged": True, "idempotent": True}``; a
+  cross-transition (e.g. ``report_task_started`` on a COMPLETED
+  task) returns
+  ``{"acknowledged": False, "error": "invalid_transition"}``. Both
+  are still routed through Layer 3 / Layer 4 for loop-detector
+  bookkeeping.
 * **Layer 3 — per-task loop guard.** Duplicate-args calls return a
   cheap ``duplicate`` ACK; a sustained burst (same signature) or
   volume cap (same tool name, varying args) emits a
@@ -46,7 +54,6 @@ from goldfive.adapters._tool_loop_guard import (
     guard_for,
 )
 from goldfive.reporting import ReportingToolSpec
-from goldfive.types import TERMINAL_TASK_STATUSES
 
 if TYPE_CHECKING:  # pragma: no cover - type-only
     from goldfive.protocols import Steerer
@@ -192,29 +199,16 @@ async def invoke_tool(
                     ),
                 }
 
-            # Layer 2 — terminal-task rejection. Models that have
-            # already reported a task as COMPLETED/FAILED/CANCELLED
-            # sometimes keep calling reporting tools for that task —
-            # the first call moved the task to a terminal status (the
-            # Steerer's ``mark_task_*`` guards make subsequent
-            # transitions no-ops), but a bland ``ACK`` back to the
-            # agent doesn't communicate "stop." Without this check, a
-            # model can burn dozens of reporting calls after the task
-            # is already done. Structured error response so the model
-            # has clear, actionable feedback to stop reporting.
-            if task.status in TERMINAL_TASK_STATUSES:
-                return {
-                    "acknowledged": False,
-                    "error": "task_already_terminal",
-                    "task_id": task_id,
-                    "current_status": task.status.value,
-                    "message": (
-                        f"Task {task_id!r} is already {task.status.value}. "
-                        "Do not call further reporting tools for this task; "
-                        "wait for the orchestrator to route you to the next "
-                        "task."
-                    ),
-                }
+            # Layer 2 used to hard-reject terminal-task retries with
+            # ``task_already_terminal``. goldfive#201 moves that
+            # decision into the handler: retries of the same
+            # transition (e.g. ``report_task_completed`` on COMPLETED)
+            # return idempotent=True; cross-transitions (e.g.
+            # ``report_task_started`` on COMPLETED) return
+            # ``invalid_transition``. Both still bookkeep through
+            # Layers 3 + 4 below so a genuine runaway retry still
+            # trips the loop detector, but benign retries no longer
+            # masquerade as confusion signals.
 
     # ------------------------------------------------------------------
     # Layer 3 — per-task loop guard.

--- a/goldfive/orchestration_state.py
+++ b/goldfive/orchestration_state.py
@@ -141,9 +141,7 @@ PROCESSED_STEER_IDS_CAP = 256
 
 def _assert_goldfive_key(key: str) -> None:
     if not key.startswith(GOLDFIVE_PREFIX):
-        raise ValueError(
-            f"goldfive.orchestration_state refuses to write non-goldfive key: {key!r}"
-        )
+        raise ValueError(f"goldfive.orchestration_state refuses to write non-goldfive key: {key!r}")
 
 
 def write(state: MutableMapping[str, Any], key: str, value: Any) -> None:
@@ -357,6 +355,65 @@ def read_cancelled_function_call_ids(state: Any) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+def rotate_current_task_id(
+    state: MutableMapping[str, Any],
+    plan: Plan | None,
+    agent_name: str,
+) -> str | None:
+    """Advance ``goldfive.current_task_id`` after a terminal transition.
+
+    Called from :mod:`goldfive.reporting` when a task transitions to a
+    terminal status (COMPLETED / FAILED / CANCELLED / NOT_NEEDED). The
+    point of this helper is to keep the pin pointed at *work still to
+    do* so subsequent reporting-tool calls in the same invocation
+    context can continue to fall back to the pin instead of failing
+    with ``missing_task_id``.
+
+    Rules:
+
+    * **Rotate** — when exactly one PENDING / RUNNING task remains
+      assigned to ``agent_name`` in ``plan``, stamp its id and return it.
+    * **Clear** — when no PENDING / RUNNING task remains assigned to
+      ``agent_name`` (all done, or none ever assigned), drop the key and
+      return ``None``.
+    * **Clear (ambiguous)** — when multiple PENDING / RUNNING tasks are
+      assigned to ``agent_name`` the helper also clears the key and
+      returns ``None``, deferring to the adapter's
+      ``before_agent_callback`` path to pick the next one when the agent
+      runs again. Stamping an arbitrary pending task here would race
+      with whatever the orchestrator ends up dispatching.
+
+    Tolerant of degenerate input: a ``None`` plan or an empty
+    ``agent_name`` clears the key and returns ``None``. Never raises.
+    """
+    # No plan, no rotation — clear defensively so callers don't keep
+    # driving a stale pointer.
+    if plan is None:
+        clear(state, KEY_CURRENT_TASK_ID)
+        clear(state, KEY_CURRENT_TASK_TITLE)
+        return None
+
+    candidates: list[Task] = []
+    for t in getattr(plan, "tasks", ()) or ():
+        assignee = str(getattr(t, "assignee_agent_id", "") or "")
+        if agent_name and assignee and assignee != agent_name:
+            continue
+        status = getattr(t, "status", None)
+        if status in (TaskStatus.PENDING, TaskStatus.RUNNING):
+            candidates.append(t)
+
+    if len(candidates) == 1:
+        next_task = candidates[0]
+        set_current_task(state, next_task)
+        return str(getattr(next_task, "id", "") or "") or None
+
+    # Zero or multiple candidates — clear and let the orchestrator
+    # re-pin on the next before_agent_callback.
+    clear(state, KEY_CURRENT_TASK_ID)
+    clear(state, KEY_CURRENT_TASK_TITLE)
+    return None
+
+
 def sync_current_task_from_transition(
     state: MutableMapping[str, Any],
     task: Task | None,
@@ -412,6 +469,7 @@ __all__ = [
     "read_cancelled_function_call_ids",
     "record_processed_steer_id",
     "refresh_goals_summary",
+    "rotate_current_task_id",
     "set_active_steer",
     "set_current_plan",
     "set_current_task",

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -24,9 +24,11 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
+from goldfive.types import TaskStatus
+
 if TYPE_CHECKING:
     from goldfive.protocols import Steerer
-    from goldfive.types import Session
+    from goldfive.types import Session, Task
 
 log = logging.getLogger(__name__)
 
@@ -119,6 +121,190 @@ def _resolve_task_id(args: dict[str, Any], session: Session) -> str:
     return ""
 
 
+# ---------------------------------------------------------------------------
+# Idempotency / invalid-transition machinery (goldfive#201)
+# ---------------------------------------------------------------------------
+#
+# Each task-scoped reporting handler consults the task's current status
+# before driving the steerer. Three outcomes:
+#
+# 1. **Real transition** — current status is a legal source for the
+#    tool's target transition; the handler invokes the steerer and
+#    returns ``{"acknowledged": True}``. Terminal transitions also
+#    rotate ``goldfive.current_task_id`` to the next assigned
+#    PENDING/RUNNING task (or clear it).
+# 2. **Idempotent no-op** — current status already matches what the
+#    call would move the task to (e.g. ``report_task_completed`` on a
+#    COMPLETED task). Handler returns
+#    ``{"acknowledged": True, "idempotent": True, "current_status": ...}``
+#    without mutating state. This is the goldfive#201 fix: retries
+#    from a confused model no longer masquerade as tool-loop spam.
+# 3. **Invalid transition** — current status cannot legally transition
+#    under this tool (e.g. ``report_task_started`` on a COMPLETED
+#    task). Handler returns
+#    ``{"acknowledged": False, "error": "invalid_transition",
+#       "current_status": ..., "attempted": ...}``
+#    as a real "agent is confused about state" signal. Loop-detector
+#    owners can surface this directly; it's distinct from a benign
+#    retry.
+#
+# See ``docs/design/TASK-LIFECYCLE.md`` for the status-machine contract.
+
+
+# Tool-name → the status the call would transition the task INTO
+# (i.e. "what does success look like"). Used to detect idempotent
+# retries: when ``current_status`` already equals the target, the call
+# is an ack-only no-op.
+_TOOL_TARGET_STATUS: dict[str, TaskStatus] = {
+    "report_task_started": TaskStatus.RUNNING,
+    "report_task_progress": TaskStatus.RUNNING,  # progress is a liveness tick on a RUNNING task
+    "report_task_completed": TaskStatus.COMPLETED,
+    "report_task_failed": TaskStatus.FAILED,
+    "report_task_blocked": TaskStatus.BLOCKED,
+    "report_awaiting_approval": TaskStatus.BLOCKED,  # mapped onto BLOCKED by the steerer
+}
+
+# Which source statuses are *legal* starting points for each tool.
+# Anything else is either an idempotent no-op (see above) or an
+# ``invalid_transition``. Built from ``docs/design/TASK-LIFECYCLE.md``
+# §"Status transitions". PENDING/RUNNING bookkeeping statuses are the
+# canonical sources; terminal statuses are never a legal source for a
+# different transition.
+_TOOL_VALID_SOURCES: dict[str, frozenset[TaskStatus]] = {
+    "report_task_started": frozenset({TaskStatus.PENDING, TaskStatus.BLOCKED}),
+    "report_task_progress": frozenset({TaskStatus.RUNNING}),
+    "report_task_completed": frozenset(
+        {TaskStatus.PENDING, TaskStatus.RUNNING, TaskStatus.BLOCKED}
+    ),
+    "report_task_failed": frozenset({TaskStatus.PENDING, TaskStatus.RUNNING, TaskStatus.BLOCKED}),
+    "report_task_blocked": frozenset({TaskStatus.PENDING, TaskStatus.RUNNING}),
+    "report_awaiting_approval": frozenset(
+        {TaskStatus.PENDING, TaskStatus.RUNNING, TaskStatus.BLOCKED}
+    ),
+}
+
+# Terminal statuses — duplicated here to avoid a runtime import of
+# ``TERMINAL_TASK_STATUSES`` from ``goldfive.types``; the value set is
+# pinned by ``TaskStatus`` and guarded by a test.
+_TERMINAL_STATUSES: frozenset[TaskStatus] = frozenset(
+    {
+        TaskStatus.COMPLETED,
+        TaskStatus.FAILED,
+        TaskStatus.CANCELLED,
+        TaskStatus.NOT_NEEDED,
+    }
+)
+
+
+def _find_task_in_session(session: Session, task_id: str) -> Task | None:
+    """Return the task in ``session.plan`` with ``task_id``, or ``None``."""
+    plan = getattr(session, "plan", None)
+    if plan is None or not task_id:
+        return None
+    for t in getattr(plan, "tasks", ()) or ():
+        if getattr(t, "id", "") == task_id:
+            return t
+    return None
+
+
+def _idempotent_response(current_status: TaskStatus) -> dict[str, Any]:
+    return {
+        "acknowledged": True,
+        "idempotent": True,
+        "current_status": current_status.value,
+    }
+
+
+def _invalid_transition_response(
+    *,
+    tool_name: str,
+    current_status: TaskStatus,
+    attempted: TaskStatus,
+    task_id: str,
+) -> dict[str, Any]:
+    return {
+        "acknowledged": False,
+        "error": "invalid_transition",
+        "tool": tool_name,
+        "task_id": task_id,
+        "current_status": current_status.value,
+        "attempted": attempted.value,
+        "message": (
+            f"Cannot {tool_name!r} task {task_id!r} from {current_status.value} "
+            f"to {attempted.value}. The task is already in a terminal or "
+            "otherwise-incompatible state; do not retry."
+        ),
+    }
+
+
+def _classify_transition(
+    *,
+    tool_name: str,
+    current_status: TaskStatus,
+) -> str:
+    """Return ``"idempotent"``, ``"invalid"``, or ``"transition"``.
+
+    * ``"idempotent"`` — the call is a no-op because the task is
+      already in the status this tool would move it to (or, for
+      ``report_task_progress``, the task is already RUNNING and a
+      progress tick is always legal there). Handler returns an
+      idempotent ACK without mutating state.
+    * ``"invalid"`` — the call cannot legally transition from
+      ``current_status``. Handler returns an ``invalid_transition``
+      error.
+    * ``"transition"`` — the call is a legitimate transition; the
+      handler drives the steerer normally.
+    """
+    target = _TOOL_TARGET_STATUS.get(tool_name)
+    if target is not None and current_status == target:
+        # Special case: ``report_task_progress`` on a RUNNING task is
+        # always a no-op (a progress tick has no status mutation, but we
+        # treat it as idempotent so the caller sees the same shape).
+        return "idempotent"
+    valid = _TOOL_VALID_SOURCES.get(tool_name)
+    if valid is not None and current_status in valid:
+        return "transition"
+    # Falls through to invalid — covers terminal statuses under every
+    # tool (except when current == target above) and the degenerate
+    # case of ``report_task_progress`` on PENDING etc.
+    return "invalid"
+
+
+def _rotate_after_terminal(
+    session: Session,
+    completed_task: Task,
+) -> None:
+    """Advance ``goldfive.current_task_id`` after a terminal transition.
+
+    Delegates to :func:`goldfive.orchestration_state.rotate_current_task_id`.
+    Imported lazily so this module stays ADK-free and dodges the
+    import-cycle risk between :mod:`goldfive.reporting` and
+    :mod:`goldfive.orchestration_state` (both are imported from
+    :mod:`goldfive.steerer`).
+    """
+    state = getattr(session, "state", None)
+    if not isinstance(state, dict):
+        return
+    plan = getattr(session, "plan", None)
+    agent_name = str(getattr(completed_task, "assignee_agent_id", "") or "")
+
+    # Only rotate if the terminal task was the one we'd been pointing
+    # at — otherwise some other caller owns the pin and we'd clobber
+    # theirs.
+    pinned = state.get(_STATE_KEY_CURRENT_TASK_ID, "")
+    if isinstance(pinned, str):
+        pinned = pinned.strip()
+    else:
+        pinned = str(pinned or "").strip()
+    this_id = str(getattr(completed_task, "id", "") or "")
+    if pinned and pinned != this_id:
+        return
+
+    from goldfive import orchestration_state as _ostate
+
+    _ostate.rotate_current_task_id(state, plan, agent_name)
+
+
 def _missing_task_id_response(tool_name: str) -> dict[str, Any]:
     """Return the canonical ``missing_task_id`` rejection shape.
 
@@ -178,6 +364,18 @@ async def _handle_task_started(
     detail = _str(args, "detail")
     if not task_id:
         return _missing_task_id_response("report_task_started")
+    task = _find_task_in_session(session, task_id)
+    if task is not None:
+        decision = _classify_transition(tool_name="report_task_started", current_status=task.status)
+        if decision == "idempotent":
+            return _idempotent_response(task.status)
+        if decision == "invalid":
+            return _invalid_transition_response(
+                tool_name="report_task_started",
+                current_status=task.status,
+                attempted=TaskStatus.RUNNING,
+                task_id=task_id,
+            )
     await steerer.mark_task_running(task_id, session=session, detail=detail)
     return dict(_ACK)
 
@@ -190,6 +388,24 @@ async def _handle_task_progress(
     detail = _str(args, "detail")
     if not task_id:
         return _missing_task_id_response("report_task_progress")
+    task = _find_task_in_session(session, task_id)
+    if task is not None:
+        # report_task_progress is a liveness tick — only valid on RUNNING.
+        # PENDING / BLOCKED → invalid ("hasn't started or is waiting");
+        # terminal → invalid ("task is done"). RUNNING → always a no-op
+        # style idempotent ACK (the steerer call itself doesn't mutate
+        # status, but we treat it uniformly so the response shape matches
+        # the other handlers).
+        if task.status is TaskStatus.RUNNING:
+            # Legal tick — proceed to steerer (records progress).
+            pass
+        else:
+            return _invalid_transition_response(
+                tool_name="report_task_progress",
+                current_status=task.status,
+                attempted=TaskStatus.RUNNING,
+                task_id=task_id,
+            )
     await steerer.mark_task_progress(task_id, session=session, fraction=fraction, detail=detail)
     return dict(_ACK)
 
@@ -207,9 +423,26 @@ async def _handle_task_completed(
     )
     if not task_id:
         return _missing_task_id_response("report_task_completed")
+    task = _find_task_in_session(session, task_id)
+    if task is not None:
+        decision = _classify_transition(
+            tool_name="report_task_completed", current_status=task.status
+        )
+        if decision == "idempotent":
+            return _idempotent_response(task.status)
+        if decision == "invalid":
+            return _invalid_transition_response(
+                tool_name="report_task_completed",
+                current_status=task.status,
+                attempted=TaskStatus.COMPLETED,
+                task_id=task_id,
+            )
     await steerer.mark_task_completed(
         task_id, session=session, summary=summary, artifacts=artifacts
     )
+    # Rotate the current-task pin now that this one has landed terminal.
+    if task is not None:
+        _rotate_after_terminal(session, task)
     return dict(_ACK)
 
 
@@ -221,12 +454,26 @@ async def _handle_task_failed(
     recoverable = _bool(args, "recoverable", default=True)
     if not task_id:
         return _missing_task_id_response("report_task_failed")
+    task = _find_task_in_session(session, task_id)
+    if task is not None:
+        decision = _classify_transition(tool_name="report_task_failed", current_status=task.status)
+        if decision == "idempotent":
+            return _idempotent_response(task.status)
+        if decision == "invalid":
+            return _invalid_transition_response(
+                tool_name="report_task_failed",
+                current_status=task.status,
+                attempted=TaskStatus.FAILED,
+                task_id=task_id,
+            )
     await steerer.mark_task_failed(
         task_id,
         session=session,
         reason=reason,
         recoverable=recoverable,
     )
+    if task is not None:
+        _rotate_after_terminal(session, task)
     return dict(_ACK)
 
 
@@ -238,6 +485,18 @@ async def _handle_task_blocked(
     needed = _str(args, "needed")
     if not task_id:
         return _missing_task_id_response("report_task_blocked")
+    task = _find_task_in_session(session, task_id)
+    if task is not None:
+        decision = _classify_transition(tool_name="report_task_blocked", current_status=task.status)
+        if decision == "idempotent":
+            return _idempotent_response(task.status)
+        if decision == "invalid":
+            return _invalid_transition_response(
+                tool_name="report_task_blocked",
+                current_status=task.status,
+                attempted=TaskStatus.BLOCKED,
+                task_id=task_id,
+            )
     await steerer.mark_task_blocked(task_id, session=session, blocker=blocker, needed=needed)
     return dict(_ACK)
 
@@ -293,6 +552,19 @@ async def _handle_awaiting_approval(
     timeout_ms = _int(args, "timeout_ms", 0)
     if not task_id:
         return _missing_task_id_response("report_awaiting_approval")
+    # goldfive#201: reject on terminal task up front with the
+    # canonical invalid_transition shape. An already-BLOCKED /
+    # already-RUNNING task falls through to the waiter-reuse path
+    # below (that's the semantic idempotency for approvals — they
+    # block on the existing Event instead of returning a no-op ack).
+    task = _find_task_in_session(session, task_id)
+    if task is not None and task.status in _TERMINAL_STATUSES:
+        return _invalid_transition_response(
+            tool_name="report_awaiting_approval",
+            current_status=task.status,
+            attempted=TaskStatus.BLOCKED,
+            task_id=task_id,
+        )
 
     # Idempotency: reuse an existing waiter if one is already pending.
     waiter = session.pending_approvals.get(task_id)

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -1789,14 +1789,16 @@ async def test_reporting_tool_dispatch_routes_through_invoke_tool(state_ctx_cls)
 async def test_reporting_tool_on_terminal_task_returns_structured_rejection(
     state_ctx_cls,
 ) -> None:
-    """A reporting call on an already-terminal task must get the
-    structured ``task_already_terminal`` error response — NOT a bland
+    """A cross-transition on an already-terminal task (e.g.
+    ``report_task_progress`` on a FAILED task) must return the
+    structured ``invalid_transition`` error — NOT a bland
     ``{"acknowledged": True}``.
 
-    This is the terminal-task rejection layer (layer 1 in
-    ``docs/design/TASK-LIFECYCLE.md`` §5). Fires from inside
-    ``invoke_tool``; this test proves the ADK plugin's dispatch path
-    reaches that layer.
+    goldfive#201 moved this decision out of ``invoke_tool``'s Layer 2
+    and into the handler matrix: same-transition retries become
+    idempotent ACKs, cross-transitions become ``invalid_transition``.
+    This test proves the ADK plugin's dispatch path reaches the
+    handler and the handler surfaces the structured signal.
     """
     from goldfive.adapters._adk_plugin import (
         SESSION_CONTEXT_STATE_KEY,
@@ -1806,25 +1808,9 @@ async def test_reporting_tool_on_terminal_task_returns_structured_rejection(
     from goldfive.reporting import BUILTIN_REPORTING_TOOLS
     from goldfive.types import Plan, TaskStatus
 
-    # The handler must NEVER run when the task is already terminal —
-    # route the call through a spec whose handler raises, to catch a
-    # regression where invoke_tool's short-circuit is skipped.
-    invoked_count = [0]
-
-    async def _boom_handler(args, session, steerer):
-        invoked_count[0] += 1
-        raise AssertionError(
-            "handler must not run on a terminal task; dispatch should "
-            "short-circuit via invoke_tool's terminal rejection"
-        )
-
-    spec_template = next(t for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_progress")
-    spec = ReportingToolSpec(
-        name=spec_template.name,
-        description=spec_template.description,
-        parameters=spec_template.parameters,
-        handler=_boom_handler,
-    )
+    # Use the real built-in spec so the handler's idempotency matrix
+    # runs.
+    spec = next(t for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_progress")
 
     agent = _make_agent()
     adapter = ADKAdapter(agent)
@@ -1862,15 +1848,16 @@ async def test_reporting_tool_on_terminal_task_returns_structured_rejection(
 
     assert isinstance(result, dict)
     assert result.get("acknowledged") is False, (
-        "expected structured rejection; got acknowledged=true. If this "
-        "fails, before_tool_callback is bypassing invoke_tool's "
-        "terminal-task rejection layer."
+        "expected structured invalid_transition rejection; got "
+        "acknowledged=true. If this fails, the handler's matrix is "
+        "being bypassed."
     )
-    assert result.get("error") == "task_already_terminal"
+    assert result.get("error") == "invalid_transition"
     assert result.get("task_id") == "t1"
     assert result.get("current_status") == "FAILED"
-    # Handler must have stayed cold.
-    assert invoked_count[0] == 0
+    assert result.get("attempted") == "RUNNING"
+    # Task status unchanged.
+    assert task.status is TaskStatus.FAILED
 
 
 async def test_reporting_tool_duplicate_returns_duplicate_ack(state_ctx_cls) -> None:

--- a/tests/test_claude_adapter.py
+++ b/tests/test_claude_adapter.py
@@ -370,27 +370,22 @@ def test_pretooluse_hook_passes_through_non_reporting_tools() -> None:
 
 
 def test_pretooluse_hook_on_terminal_task_returns_structured_rejection() -> None:
-    """A reporting call on an already-FAILED task must surface the
-    structured ``task_already_terminal`` error inside the hook's
+    """A cross-transition on an already-FAILED task must surface the
+    structured ``invalid_transition`` error inside the hook's
     ``permissionDecisionReason`` — proof the hook routes through
-    ``invoke_tool``.
+    ``invoke_tool`` into the handler's idempotency matrix
+    (goldfive#201).
     """
     import json as _json
 
+    from goldfive.reporting import BUILTIN_REPORTING_TOOLS
     from goldfive.types import TaskStatus
 
-    async def _boom_handler(args, session, steerer):
-        raise AssertionError(
-            "handler must not run on a terminal task; dispatch should "
-            "short-circuit via invoke_tool's terminal rejection"
-        )
-
-    spec = ReportingToolSpec(
-        name="report_task_progress",
-        description="progress",
-        parameters={"type": "object", "properties": {}},
-        handler=_boom_handler,
-    )
+    # Use the real built-in spec so the handler's idempotency matrix
+    # runs. Pre-goldfive#201 this test used a boom-handler to prove
+    # invoke_tool rejected BEFORE the handler; now the handler itself
+    # owns the decision so we exercise the real one.
+    spec = next(t for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_progress")
 
     adapter = ClaudeAgentSDKAdapter(client_factory=lambda: _StubClient([]))
 
@@ -428,7 +423,7 @@ def test_pretooluse_hook_on_terminal_task_returns_structured_rejection() -> None
         "expected structured rejection; got acknowledged=true. If this "
         "fails, _make_pretooluse_hook is bypassing invoke_tool."
     )
-    assert parsed.get("error") == "task_already_terminal"
+    assert parsed.get("error") == "invalid_transition"
     assert parsed.get("task_id") == "t1"
     assert parsed.get("current_status") == "FAILED"
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -128,6 +128,10 @@ async def test_report_task_started_marks_running() -> None:
 
 async def test_report_task_progress_records_progress() -> None:
     steerer, session, sink, _ = _fresh()
+    # goldfive#201: progress ticks are only valid on RUNNING tasks —
+    # transition t1 first so the handler actually records progress
+    # instead of returning invalid_transition.
+    session.plan.tasks[0].status = TaskStatus.RUNNING
     await _tool("report_task_progress").handler(
         {"task_id": "t1", "fraction": 0.75, "detail": "three of four done"},
         session,
@@ -219,9 +223,7 @@ async def test_report_plan_divergence_fires_refine_and_sets_flag() -> None:
 async def test_handler_tolerates_missing_optional_fields() -> None:
     steerer, session, sink, _ = _fresh()
     # Only required fields — should still transition.
-    await _tool("report_task_started").handler(
-        {"task_id": "t1"}, session, steerer
-    )
+    await _tool("report_task_started").handler({"task_id": "t1"}, session, steerer)
     assert session.plan.tasks[0].status is TaskStatus.RUNNING
     assert sink.events[-1].task_started.detail == ""
 
@@ -230,9 +232,7 @@ async def test_handler_ignores_unknown_task_id_gracefully() -> None:
     steerer, session, sink, _ = _fresh()
     # Unknown task_id — the handler ack's but no event is emitted and
     # no existing task is mutated.
-    out = await _tool("report_task_started").handler(
-        {"task_id": "bogus"}, session, steerer
-    )
+    out = await _tool("report_task_started").handler({"task_id": "bogus"}, session, steerer)
     assert out == {"acknowledged": True}
     assert sink.events == []
     assert all(t.status is TaskStatus.PENDING for t in session.plan.tasks)

--- a/tests/test_reporting_idempotency.py
+++ b/tests/test_reporting_idempotency.py
@@ -1,0 +1,326 @@
+"""Idempotency + invalid-transition tests for reporting handlers.
+
+Covers the Bug A half of goldfive#201 — per-handler idempotency matrix.
+See the module docstring in :mod:`goldfive.reporting` for the table.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.reporting import BUILTIN_REPORTING_TOOLS, ReportingToolSpec  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskStatus,
+)
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class _StubPlanner:
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        return None
+
+
+def _tool(name: str) -> ReportingToolSpec:
+    for t in BUILTIN_REPORTING_TOOLS:
+        if t.name == name:
+            return t
+    raise AssertionError(f"missing builtin tool {name!r}")
+
+
+def _fresh(
+    task_status: TaskStatus = TaskStatus.PENDING,
+) -> tuple[DefaultSteerer, Session, _ListSink]:
+    sink = _ListSink()
+    planner = _StubPlanner()
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do it")],
+        plan=Plan(
+            id="p1",
+            run_id="r1",
+            goal_ids=["g1"],
+            tasks=[
+                Task(
+                    id="t1",
+                    title="A",
+                    assignee_agent_id="worker",
+                    status=task_status,
+                ),
+            ],
+            edges=[],
+        ),
+    )
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    return steerer, session, sink
+
+
+# ---------------------------------------------------------------------------
+# Happy-path regressions (retry on same terminal → idempotent)
+# ---------------------------------------------------------------------------
+
+
+async def test_report_task_completed_on_already_completed_returns_idempotent_ack() -> None:
+    """Calling report_task_completed twice: first transitions, second is
+    idempotent ACK. No second steerer call, no second task_completed
+    event."""
+    steerer, session, sink = _fresh(task_status=TaskStatus.RUNNING)
+
+    first = await _tool("report_task_completed").handler(
+        {"task_id": "t1", "summary": "done"}, session, steerer
+    )
+    assert first == {"acknowledged": True}
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+    completed_events_after_first = sum(
+        1 for e in sink.events if e.WhichOneof("payload") == "task_completed"
+    )
+
+    second = await _tool("report_task_completed").handler(
+        {"task_id": "t1", "summary": "done (again)"}, session, steerer
+    )
+    assert second == {
+        "acknowledged": True,
+        "idempotent": True,
+        "current_status": "COMPLETED",
+    }
+    # No additional task_completed event from the retry.
+    assert (
+        sum(1 for e in sink.events if e.WhichOneof("payload") == "task_completed")
+        == completed_events_after_first
+    )
+    assert session.completed_results["t1"] == "done"  # summary preserved
+
+
+async def test_report_task_completed_on_running_actually_transitions() -> None:
+    """First call (on RUNNING) transitions and returns ``acknowledged=True``
+    without the idempotent flag."""
+    steerer, session, _ = _fresh(task_status=TaskStatus.RUNNING)
+
+    result = await _tool("report_task_completed").handler(
+        {"task_id": "t1", "summary": "all done"}, session, steerer
+    )
+    assert result == {"acknowledged": True}
+    assert "idempotent" not in result
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+
+
+async def test_report_task_completed_on_pending_also_transitions() -> None:
+    """PENDING → COMPLETED is a legal (if unusual) skip-ahead — real
+    transition, not idempotent."""
+    steerer, session, _ = _fresh(task_status=TaskStatus.PENDING)
+
+    result = await _tool("report_task_completed").handler(
+        {"task_id": "t1", "summary": "zero-work complete"}, session, steerer
+    )
+    assert result == {"acknowledged": True}
+    assert "idempotent" not in result
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Invalid-transition shape
+# ---------------------------------------------------------------------------
+
+
+async def test_report_task_started_on_completed_returns_invalid_transition() -> None:
+    steerer, session, _ = _fresh(task_status=TaskStatus.COMPLETED)
+
+    result = await _tool("report_task_started").handler(
+        {"task_id": "t1", "detail": "confused"}, session, steerer
+    )
+
+    assert result["acknowledged"] is False
+    assert result["error"] == "invalid_transition"
+    assert result["tool"] == "report_task_started"
+    assert result["task_id"] == "t1"
+    assert result["current_status"] == "COMPLETED"
+    assert result["attempted"] == "RUNNING"
+    assert "message" in result
+    # Task state unchanged.
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+
+
+async def test_report_task_failed_on_completed_returns_invalid_transition() -> None:
+    steerer, session, _ = _fresh(task_status=TaskStatus.COMPLETED)
+
+    result = await _tool("report_task_failed").handler(
+        {"task_id": "t1", "reason": "late report"}, session, steerer
+    )
+    assert result["acknowledged"] is False
+    assert result["error"] == "invalid_transition"
+    assert result["current_status"] == "COMPLETED"
+    assert result["attempted"] == "FAILED"
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+
+
+async def test_report_task_progress_on_completed_returns_invalid_transition() -> None:
+    steerer, session, _ = _fresh(task_status=TaskStatus.COMPLETED)
+
+    result = await _tool("report_task_progress").handler(
+        {"task_id": "t1", "fraction": 0.5}, session, steerer
+    )
+    assert result["acknowledged"] is False
+    assert result["error"] == "invalid_transition"
+    assert result["current_status"] == "COMPLETED"
+
+
+async def test_report_task_progress_on_pending_returns_invalid_transition() -> None:
+    """Progress ticks are only valid on RUNNING tasks."""
+    steerer, session, _ = _fresh(task_status=TaskStatus.PENDING)
+
+    result = await _tool("report_task_progress").handler(
+        {"task_id": "t1", "fraction": 0.5}, session, steerer
+    )
+    assert result["acknowledged"] is False
+    assert result["error"] == "invalid_transition"
+    assert result["current_status"] == "PENDING"
+
+
+# ---------------------------------------------------------------------------
+# Parameterised idempotency matrix
+# ---------------------------------------------------------------------------
+
+
+# Each row is: (tool_name, extra_args, initial_status, expected_kind,
+# expected_current_status_in_response). ``expected_kind`` is one of
+# ``"idempotent"``, ``"invalid"``, ``"transition"``.
+_MATRIX: list[tuple[str, dict[str, Any], TaskStatus, str, str]] = [
+    # report_task_started: RUNNING → idempotent; terminal → invalid
+    ("report_task_started", {}, TaskStatus.RUNNING, "idempotent", "RUNNING"),
+    ("report_task_started", {}, TaskStatus.COMPLETED, "invalid", "COMPLETED"),
+    ("report_task_started", {}, TaskStatus.FAILED, "invalid", "FAILED"),
+    ("report_task_started", {}, TaskStatus.CANCELLED, "invalid", "CANCELLED"),
+    ("report_task_started", {}, TaskStatus.NOT_NEEDED, "invalid", "NOT_NEEDED"),
+    ("report_task_started", {}, TaskStatus.PENDING, "transition", "PENDING"),
+    # report_task_progress: RUNNING → legal (treated as ok); terminal → invalid
+    ("report_task_progress", {"fraction": 0.5}, TaskStatus.COMPLETED, "invalid", "COMPLETED"),
+    ("report_task_progress", {"fraction": 0.5}, TaskStatus.PENDING, "invalid", "PENDING"),
+    ("report_task_progress", {"fraction": 0.5}, TaskStatus.RUNNING, "transition", "RUNNING"),
+    # report_task_completed: COMPLETED → idempotent; other terminal → invalid
+    ("report_task_completed", {"summary": "x"}, TaskStatus.COMPLETED, "idempotent", "COMPLETED"),
+    ("report_task_completed", {"summary": "x"}, TaskStatus.FAILED, "invalid", "FAILED"),
+    ("report_task_completed", {"summary": "x"}, TaskStatus.CANCELLED, "invalid", "CANCELLED"),
+    ("report_task_completed", {"summary": "x"}, TaskStatus.NOT_NEEDED, "invalid", "NOT_NEEDED"),
+    ("report_task_completed", {"summary": "x"}, TaskStatus.RUNNING, "transition", "RUNNING"),
+    # report_task_failed: FAILED → idempotent; COMPLETED/CANCELLED/NOT_NEEDED → invalid
+    ("report_task_failed", {"reason": "x"}, TaskStatus.FAILED, "idempotent", "FAILED"),
+    ("report_task_failed", {"reason": "x"}, TaskStatus.COMPLETED, "invalid", "COMPLETED"),
+    ("report_task_failed", {"reason": "x"}, TaskStatus.CANCELLED, "invalid", "CANCELLED"),
+    ("report_task_failed", {"reason": "x"}, TaskStatus.NOT_NEEDED, "invalid", "NOT_NEEDED"),
+    ("report_task_failed", {"reason": "x"}, TaskStatus.RUNNING, "transition", "RUNNING"),
+    # report_task_blocked: BLOCKED → idempotent; terminal → invalid
+    ("report_task_blocked", {"blocker": "x"}, TaskStatus.BLOCKED, "idempotent", "BLOCKED"),
+    ("report_task_blocked", {"blocker": "x"}, TaskStatus.COMPLETED, "invalid", "COMPLETED"),
+    ("report_task_blocked", {"blocker": "x"}, TaskStatus.CANCELLED, "invalid", "CANCELLED"),
+    ("report_task_blocked", {"blocker": "x"}, TaskStatus.RUNNING, "transition", "RUNNING"),
+]
+
+
+@pytest.mark.parametrize(
+    "tool_name,extra_args,initial_status,expected_kind,expected_status",
+    _MATRIX,
+)
+async def test_idempotency_matrix(
+    tool_name: str,
+    extra_args: dict[str, Any],
+    initial_status: TaskStatus,
+    expected_kind: str,
+    expected_status: str,
+) -> None:
+    steerer, session, _ = _fresh(task_status=initial_status)
+    args: dict[str, Any] = {"task_id": "t1", **extra_args}
+    result = await _tool(tool_name).handler(args, session, steerer)
+
+    if expected_kind == "idempotent":
+        assert result["acknowledged"] is True, (tool_name, initial_status, result)
+        assert result.get("idempotent") is True, (tool_name, initial_status, result)
+        assert result["current_status"] == expected_status
+        # Status unchanged.
+        assert session.plan.tasks[0].status is initial_status
+    elif expected_kind == "invalid":
+        assert result["acknowledged"] is False, (tool_name, initial_status, result)
+        assert result["error"] == "invalid_transition", (tool_name, initial_status, result)
+        assert result["current_status"] == expected_status
+        assert result["attempted"]  # non-empty
+        assert session.plan.tasks[0].status is initial_status
+    else:  # transition
+        # Handler returns plain ACK when a real transition happens.
+        assert result == {"acknowledged": True}
+
+
+# ---------------------------------------------------------------------------
+# Regression: missing_task_id shape preserved when no resolvable id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name,extra_args",
+    [
+        ("report_task_started", {}),
+        ("report_task_progress", {"fraction": 0.5}),
+        ("report_task_completed", {"summary": "x"}),
+        ("report_task_failed", {"reason": "x"}),
+        ("report_task_blocked", {"blocker": "x"}),
+        ("report_awaiting_approval", {"prompt": "ok?"}),
+    ],
+)
+async def test_missing_task_id_error_shape_preserved(
+    tool_name: str,
+    extra_args: dict[str, Any],
+) -> None:
+    """Regression guard: the canonical ``missing_task_id`` shape still
+    fires for the "no resolvable task_id" path. The new idempotency
+    checks must not mask this error."""
+    steerer, session, _ = _fresh(task_status=TaskStatus.PENDING)
+    # Clear any state fallback.
+    session.state.pop("goldfive.current_task_id", None)
+
+    result = await _tool(tool_name).handler(dict(extra_args), session, steerer)
+
+    assert result["acknowledged"] is False, (tool_name, result)
+    assert result["error"] == "missing_task_id", (tool_name, result)
+    assert result["tool"] == tool_name
+
+
+# ---------------------------------------------------------------------------
+# Unknown task_id stays an ACK (preserves existing handler tolerance)
+# ---------------------------------------------------------------------------
+
+
+async def test_unknown_task_id_still_acks_at_handler_level() -> None:
+    """Existing invariant: when the handler is called directly (i.e., not
+    through ``invoke_tool``'s schema layer) with a bogus task_id, it
+    ACKs without raising. The idempotency check must short-circuit
+    cleanly when ``task`` is None."""
+    steerer, session, _ = _fresh(task_status=TaskStatus.PENDING)
+    result = await _tool("report_task_started").handler(
+        {"task_id": "does-not-exist", "detail": "x"}, session, steerer
+    )
+    assert result == {"acknowledged": True}

--- a/tests/test_state_rotation.py
+++ b/tests/test_state_rotation.py
@@ -1,0 +1,360 @@
+"""Tests for ``goldfive.current_task_id`` rotation on terminal transition.
+
+Covers the Bug B half of goldfive#201:
+
+* When a reporting-tool handler transitions a task to a terminal status
+  (COMPLETED / FAILED / CANCELLED / NOT_NEEDED), the handler rotates
+  ``session.state["goldfive.current_task_id"]`` so subsequent LLM calls
+  in the same invocation context see a live pointer — not a stale one
+  that triggers ``missing_task_id`` rejections.
+
+* The orchestration-state helper
+  :func:`goldfive.orchestration_state.rotate_current_task_id`
+  encapsulates the rotation rules:
+
+  1. Exactly one PENDING / RUNNING task assigned to this agent → pin it.
+  2. Zero PENDING / RUNNING tasks → clear the key.
+  3. Ambiguous (multiple pendings for this agent) → clear the key and
+     let the next ``before_agent_callback`` pick.
+
+* Non-terminal transitions (progress ticks) do NOT rotate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive import orchestration_state as _ostate  # noqa: E402
+from goldfive.reporting import BUILTIN_REPORTING_TOOLS, ReportingToolSpec  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+def _tool(name: str) -> ReportingToolSpec:
+    for t in BUILTIN_REPORTING_TOOLS:
+        if t.name == name:
+            return t
+    raise AssertionError(f"missing builtin tool {name!r}")
+
+
+def _plan(*tasks: Task, edges: list[TaskEdge] | None = None) -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=list(tasks),
+        edges=list(edges) if edges is not None else [],
+    )
+
+
+def _session(plan: Plan) -> Session:
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do it")],
+        plan=plan,
+    )
+
+
+def _bound_steerer() -> DefaultSteerer:
+    sink = _ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=_StubPlanner())
+    return steerer
+
+
+class _StubPlanner:
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# orchestration_state.rotate_current_task_id (pure-helper behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_with_one_pending_pins_the_next_task() -> None:
+    plan = _plan(
+        Task(id="t1", title="A", assignee_agent_id="worker", status=TaskStatus.RUNNING),
+        Task(id="t2", title="B", assignee_agent_id="worker", status=TaskStatus.PENDING),
+    )
+    state: dict[str, Any] = {"goldfive.current_task_id": "t1"}
+
+    # Mark t1 terminal externally (the helper's job is rotation, not
+    # transition).
+    plan.tasks[0].status = TaskStatus.COMPLETED
+
+    out = _ostate.rotate_current_task_id(state, plan, "worker")
+
+    assert out == "t2"
+    assert state["goldfive.current_task_id"] == "t2"
+    assert state["goldfive.current_task_title"] == "B"
+
+
+def test_rotate_with_no_next_clears_the_key() -> None:
+    plan = _plan(
+        Task(
+            id="t1",
+            title="A",
+            assignee_agent_id="worker",
+            status=TaskStatus.COMPLETED,
+        ),
+    )
+    state: dict[str, Any] = {
+        "goldfive.current_task_id": "t1",
+        "goldfive.current_task_title": "A",
+    }
+
+    out = _ostate.rotate_current_task_id(state, plan, "worker")
+
+    assert out is None
+    assert "goldfive.current_task_id" not in state
+    assert "goldfive.current_task_title" not in state
+
+
+def test_rotate_with_ambiguous_next_clears_not_stamps() -> None:
+    """Multiple PENDINGs for the same agent → clear (defer to dispatcher)."""
+    plan = _plan(
+        Task(
+            id="t1",
+            title="A",
+            assignee_agent_id="worker",
+            status=TaskStatus.COMPLETED,
+        ),
+        Task(id="t2", title="B", assignee_agent_id="worker", status=TaskStatus.PENDING),
+        Task(id="t3", title="C", assignee_agent_id="worker", status=TaskStatus.PENDING),
+    )
+    state: dict[str, Any] = {"goldfive.current_task_id": "t1"}
+
+    out = _ostate.rotate_current_task_id(state, plan, "worker")
+
+    assert out is None
+    assert "goldfive.current_task_id" not in state
+
+
+def test_rotate_filters_by_agent_name() -> None:
+    """Tasks assigned to OTHER agents are ignored for the pin."""
+    plan = _plan(
+        Task(
+            id="t1",
+            title="A",
+            assignee_agent_id="worker",
+            status=TaskStatus.COMPLETED,
+        ),
+        # Pending but wrong agent — must be skipped.
+        Task(id="t2", title="B", assignee_agent_id="other", status=TaskStatus.PENDING),
+        # Pending, same agent — the one that wins.
+        Task(id="t3", title="C", assignee_agent_id="worker", status=TaskStatus.PENDING),
+    )
+    state: dict[str, Any] = {"goldfive.current_task_id": "t1"}
+
+    out = _ostate.rotate_current_task_id(state, plan, "worker")
+
+    assert out == "t3"
+    assert state["goldfive.current_task_id"] == "t3"
+
+
+def test_rotate_with_empty_agent_name_considers_all_tasks() -> None:
+    plan = _plan(
+        Task(id="t1", title="A", status=TaskStatus.COMPLETED),
+        Task(id="t2", title="B", status=TaskStatus.PENDING),
+    )
+    state: dict[str, Any] = {"goldfive.current_task_id": "t1"}
+
+    out = _ostate.rotate_current_task_id(state, plan, "")
+
+    assert out == "t2"
+
+
+def test_rotate_with_no_plan_clears_key() -> None:
+    state: dict[str, Any] = {"goldfive.current_task_id": "t1"}
+    out = _ostate.rotate_current_task_id(state, None, "worker")
+    assert out is None
+    assert "goldfive.current_task_id" not in state
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: handler rotates on terminal transition
+# ---------------------------------------------------------------------------
+
+
+async def test_completion_with_one_next_task_rotates() -> None:
+    """Plan A (running, about to complete) + B (pending, same agent) →
+    after A completes, current_task_id becomes B."""
+    steerer = _bound_steerer()
+    plan = _plan(
+        Task(id="t1", title="A", assignee_agent_id="worker", status=TaskStatus.RUNNING),
+        Task(id="t2", title="B", assignee_agent_id="worker", status=TaskStatus.PENDING),
+    )
+    session = _session(plan)
+    session.state["goldfive.current_task_id"] = "t1"
+
+    out = await _tool("report_task_completed").handler(
+        {"task_id": "t1", "summary": "A done"}, session, steerer
+    )
+    assert out == {"acknowledged": True}
+    assert session.state["goldfive.current_task_id"] == "t2"
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+    assert session.plan.tasks[1].status is TaskStatus.PENDING
+
+
+async def test_completion_with_no_next_task_clears() -> None:
+    """Only one task assigned → completion clears the key."""
+    steerer = _bound_steerer()
+    plan = _plan(
+        Task(id="t1", title="A", assignee_agent_id="worker", status=TaskStatus.RUNNING),
+    )
+    session = _session(plan)
+    session.state["goldfive.current_task_id"] = "t1"
+
+    await _tool("report_task_completed").handler(
+        {"task_id": "t1", "summary": "only task done"}, session, steerer
+    )
+    assert "goldfive.current_task_id" not in session.state
+
+
+async def test_completion_with_ambiguous_next_clears_not_rotates() -> None:
+    """Multiple pendings for same agent → cleared, not rotated."""
+    steerer = _bound_steerer()
+    plan = _plan(
+        Task(id="t1", title="A", assignee_agent_id="worker", status=TaskStatus.RUNNING),
+        Task(id="t2", title="B", assignee_agent_id="worker", status=TaskStatus.PENDING),
+        Task(id="t3", title="C", assignee_agent_id="worker", status=TaskStatus.PENDING),
+    )
+    session = _session(plan)
+    session.state["goldfive.current_task_id"] = "t1"
+
+    await _tool("report_task_completed").handler(
+        {"task_id": "t1", "summary": "A done"}, session, steerer
+    )
+    # Ambiguous → cleared, not stamped with t2 or t3.
+    assert "goldfive.current_task_id" not in session.state
+
+
+async def test_rotation_only_on_terminal_transition() -> None:
+    """``report_task_progress`` must NOT rotate."""
+    steerer = _bound_steerer()
+    plan = _plan(
+        Task(id="t1", title="A", assignee_agent_id="worker", status=TaskStatus.RUNNING),
+        Task(id="t2", title="B", assignee_agent_id="worker", status=TaskStatus.PENDING),
+    )
+    session = _session(plan)
+    session.state["goldfive.current_task_id"] = "t1"
+
+    await _tool("report_task_progress").handler(
+        {"task_id": "t1", "fraction": 0.5, "detail": "halfway"}, session, steerer
+    )
+    # Progress is a liveness tick; pin stays on t1.
+    assert session.state["goldfive.current_task_id"] == "t1"
+
+
+async def test_failed_also_rotates_current_task_id() -> None:
+    """Rotation fires on FAILED just like COMPLETED."""
+    steerer = _bound_steerer()
+    plan = _plan(
+        Task(id="t1", title="A", assignee_agent_id="worker", status=TaskStatus.RUNNING),
+        Task(id="t2", title="B", assignee_agent_id="worker", status=TaskStatus.PENDING),
+    )
+    session = _session(plan)
+    session.state["goldfive.current_task_id"] = "t1"
+
+    await _tool("report_task_failed").handler(
+        {"task_id": "t1", "reason": "A blew up", "recoverable": True},
+        session,
+        steerer,
+    )
+    assert session.state["goldfive.current_task_id"] == "t2"
+
+
+async def test_blocked_does_not_rotate() -> None:
+    """BLOCKED is not terminal — pin stays on the blocked task."""
+    steerer = _bound_steerer()
+    plan = _plan(
+        Task(id="t1", title="A", assignee_agent_id="worker", status=TaskStatus.RUNNING),
+        Task(id="t2", title="B", assignee_agent_id="worker", status=TaskStatus.PENDING),
+    )
+    session = _session(plan)
+    session.state["goldfive.current_task_id"] = "t1"
+
+    await _tool("report_task_blocked").handler(
+        {"task_id": "t1", "blocker": "waiting on input", "needed": "CSV"},
+        session,
+        steerer,
+    )
+    # Pin stays on t1 so the caller can re-attempt once unblocked.
+    assert session.state["goldfive.current_task_id"] == "t1"
+
+
+async def test_rotation_respects_existing_pin_to_other_task() -> None:
+    """If another caller owns the pin, a terminal transition on a DIFFERENT
+    task must not steal it away."""
+    steerer = _bound_steerer()
+    plan = _plan(
+        Task(id="t1", title="A", assignee_agent_id="worker", status=TaskStatus.RUNNING),
+        Task(id="t2", title="B", assignee_agent_id="worker", status=TaskStatus.PENDING),
+        Task(id="t3", title="C", assignee_agent_id="worker", status=TaskStatus.RUNNING),
+    )
+    session = _session(plan)
+    # Pin is on t3, not on the task we're about to complete.
+    session.state["goldfive.current_task_id"] = "t3"
+
+    await _tool("report_task_completed").handler(
+        {"task_id": "t1", "summary": "A done"}, session, steerer
+    )
+    # Pin untouched — still pointed at t3.
+    assert session.state["goldfive.current_task_id"] == "t3"
+
+
+async def test_rotation_after_completion_fallback_resolves_next_call() -> None:
+    """After rotation, a subsequent call with an empty task_id resolves
+    via the freshly-rotated pin.
+
+    This is the behavior the live-run failure relied on: after task A
+    completes, the model might issue ``report_task_started`` (or any
+    task-scoped tool) with no task_id arg, expecting the orchestration
+    layer to supply it.
+    """
+    steerer = _bound_steerer()
+    plan = _plan(
+        Task(id="t1", title="A", assignee_agent_id="worker", status=TaskStatus.RUNNING),
+        Task(id="t2", title="B", assignee_agent_id="worker", status=TaskStatus.PENDING),
+    )
+    session = _session(plan)
+    session.state["goldfive.current_task_id"] = "t1"
+
+    await _tool("report_task_completed").handler(
+        {"task_id": "t1", "summary": "A done"}, session, steerer
+    )
+    # Second call: no task_id in args — must resolve t2 from rotated pin.
+    result = await _tool("report_task_started").handler({"detail": "now on B"}, session, steerer)
+    assert result == {"acknowledged": True}
+    assert session.plan.tasks[1].status is TaskStatus.RUNNING

--- a/tests/test_task_id_wiring.py
+++ b/tests/test_task_id_wiring.py
@@ -368,7 +368,22 @@ async def test_all_task_scoped_reporting_tools_default_task_id(
     up), so they follow a different shape — covered separately.
     """
     steerer = _RecordingSteerer()
-    session = _session_with(_plan_with(Task(id="t-1", title="do", assignee_agent_id="a")))
+    # goldfive#201: start the task RUNNING so ``report_task_progress``
+    # is a legal transition under the handler's idempotency matrix
+    # (progress ticks are only valid on RUNNING). Other handlers
+    # (started, completed, failed, blocked) are legal from
+    # RUNNING too, so this starting state works for the whole
+    # parametrisation.
+    session = _session_with(
+        _plan_with(
+            Task(
+                id="t-1",
+                title="do",
+                assignee_agent_id="a",
+                status=TaskStatus.RUNNING,
+            )
+        )
+    )
     session.state["goldfive.current_task_id"] = "t-1"
 
     spec = _get_spec(tool_name)
@@ -380,10 +395,16 @@ async def test_all_task_scoped_reporting_tools_default_task_id(
     assert result.get("error") != "missing_task_id", (
         f"{tool_name} did not default task_id from state: {result!r}"
     )
-    # Handler ran with the resolved id.
-    assert any(t[0] == "t-1" for t in steerer.transitions), (
-        f"{tool_name} did not invoke the handler with t-1: transitions={steerer.transitions!r}"
-    )
+    # Handler ran with the resolved id. (report_task_started is an
+    # idempotent no-op on RUNNING, so it may not register a transition
+    # — accept either a transition or an idempotent ACK for that one.)
+    if tool_name == "report_task_started":
+        assert result.get("acknowledged") is True
+        assert result.get("idempotent") is True
+    else:
+        assert any(t[0] == "t-1" for t in steerer.transitions), (
+            f"{tool_name} did not invoke the handler with t-1: transitions={steerer.transitions!r}"
+        )
 
 
 async def test_report_awaiting_approval_accepts_state_task_id() -> None:

--- a/tests/test_tool_loop_guard.py
+++ b/tests/test_tool_loop_guard.py
@@ -118,12 +118,23 @@ class _RecordingSteerer:
         self.drifts.append(drift)
 
 
-def _session_with_task(task_id: str = "t1") -> Session:
+def _session_with_task(task_id: str = "t1", *, running: bool = False) -> Session:
+    """Build a two-task Session.
+
+    ``running=True`` pre-sets ``t1`` to ``RUNNING`` for tests that
+    exercise handlers which are only legal on a running task (e.g.
+    ``report_task_progress``). See the goldfive#201 handler matrix in
+    :mod:`goldfive.reporting`.
+    """
+    status = TaskStatus.RUNNING if running else TaskStatus.PENDING
     plan = Plan(
         id="p1",
         run_id="r1",
         goal_ids=["g1"],
-        tasks=[Task(id=task_id, title="A"), Task(id="t2", title="B")],
+        tasks=[
+            Task(id=task_id, title="A", status=status),
+            Task(id="t2", title="B"),
+        ],
         edges=[TaskEdge(from_task_id=task_id, to_task_id="t2")],
     )
     return Session(
@@ -169,7 +180,7 @@ async def test_duplicate_call_returns_ack_and_skips_steerer() -> None:
 async def test_progress_with_distinct_args_is_not_duplicate() -> None:
     """Varied progress fractions are real updates, not dupes."""
     steerer = _RecordingSteerer()
-    session = _session_with_task()
+    session = _session_with_task(running=True)
     tools = [_spec("report_task_progress")]
 
     for frac, detail in [(0.2, "early"), (0.5, "midway"), (0.9, "almost")]:
@@ -206,7 +217,7 @@ async def test_eight_identical_calls_fires_drift_exactly_once() -> None:
     further attempt.
     """
     steerer = _RecordingSteerer()
-    session = _session_with_task()
+    session = _session_with_task(running=True)
     tools = [_spec("report_task_progress")]
 
     args = {"task_id": "t1", "fraction": 0.5, "detail": "stuck"}
@@ -236,7 +247,7 @@ async def test_eight_identical_calls_fires_drift_exactly_once() -> None:
 async def test_loop_drift_does_not_re_fire_after_first_emission() -> None:
     """One-shot guard: 16 identical calls still emit only one drift."""
     steerer = _RecordingSteerer()
-    session = _session_with_task()
+    session = _session_with_task(running=True)
     tools = [_spec("report_task_progress")]
 
     args = {"task_id": "t1", "fraction": 0.5, "detail": "stuck"}
@@ -249,7 +260,7 @@ async def test_loop_drift_does_not_re_fire_after_first_emission() -> None:
 async def test_alternating_args_does_not_fire_drift() -> None:
     """Eight calls split between two distinct payloads keep us under threshold."""
     steerer = _RecordingSteerer()
-    session = _session_with_task()
+    session = _session_with_task(running=True)
     tools = [_spec("report_task_progress")]
 
     for i in range(8):
@@ -278,7 +289,7 @@ async def test_volume_cap_fires_on_args_varying_loop() -> None:
     itself hasn't transitioned out of ``RUNNING``.
     """
     steerer = _RecordingSteerer()
-    session = _session_with_task()
+    session = _session_with_task(running=True)
     tools = [_spec("report_task_progress")]
 
     # 14 calls with fresh details should stay below the volume cap.
@@ -310,7 +321,7 @@ async def test_volume_cap_fires_on_args_varying_loop() -> None:
 async def test_volume_cap_is_per_tool_not_cross_tool() -> None:
     """Volume cap counts per tool name; mixing tools stays under the cap."""
     steerer = _RecordingSteerer()
-    session = _session_with_task()
+    session = _session_with_task(running=True)
     tools = [
         _spec("report_task_progress"),
         _spec("report_task_blocked"),
@@ -338,7 +349,7 @@ async def test_volume_cap_is_per_tool_not_cross_tool() -> None:
 async def test_volume_cap_fires_once_per_task() -> None:
     """Once the volume cap fires, further calls do not re-fire drift."""
     steerer = _RecordingSteerer()
-    session = _session_with_task()
+    session = _session_with_task(running=True)
     tools = [_spec("report_task_progress")]
 
     for i in range(30):
@@ -358,12 +369,18 @@ async def test_volume_cap_fires_once_per_task() -> None:
 
 
 async def test_reporting_on_terminal_task_returns_structured_rejection() -> None:
-    """Once a task is terminal, further reporting calls get a clear stop
-    signal — NOT a bland ``acknowledged=true`` that the model would read
-    as "keep going."
+    """Terminal-task retry semantics (goldfive#201).
 
-    The rejection carries the task id and current status so the model can
-    reason about state and route its next turn accordingly.
+    Same-transition retries (e.g. ``report_task_failed`` on an already
+    FAILED task) come back as an idempotent ACK —
+    ``{"acknowledged": True, "idempotent": True}`` — so a confused
+    model's innocent retry no longer masquerades as a tool-loop signal
+    nor triggers a spurious plan revision.
+
+    Cross-transitions on a terminal task (e.g. ``report_task_progress``
+    on a FAILED task) come back as ``invalid_transition`` — a real
+    "agent is confused about state" signal the dispatcher should
+    surface rather than absorb.
     """
     steerer = _RecordingSteerer()
     session = _session_with_task()
@@ -380,7 +397,8 @@ async def test_reporting_on_terminal_task_returns_structured_rejection() -> None
     assert first == {"acknowledged": True}
     assert session.plan.tasks[0].status is TaskStatus.FAILED
 
-    # Second report (on the now-terminal task) must be hard-rejected.
+    # Second report (same transition on the now-terminal task) is an
+    # idempotent no-op ack — handler does NOT re-run the steerer.
     second = await invoke_tool(
         tools,
         "report_task_failed",
@@ -388,13 +406,14 @@ async def test_reporting_on_terminal_task_returns_structured_rejection() -> None
         session,
         steerer,
     )
-    assert second["acknowledged"] is False
-    assert second["error"] == "task_already_terminal"
-    assert second["task_id"] == "t1"
+    assert second["acknowledged"] is True
+    assert second["idempotent"] is True
     assert second["current_status"] == "FAILED"
-    assert "do not" in second["message"].lower()
+    # Only the first call produced a transition; retries did not.
+    assert [t[1] for t in steerer.transitions] == ["FAILED"]
 
-    # A different reporting tool on the same terminal task is also rejected.
+    # A different reporting tool on the same terminal task is a real
+    # invalid-transition signal — not absorbed as idempotent.
     third = await invoke_tool(
         tools,
         "report_task_progress",
@@ -403,40 +422,43 @@ async def test_reporting_on_terminal_task_returns_structured_rejection() -> None
         steerer,
     )
     assert third["acknowledged"] is False
-    assert third["error"] == "task_already_terminal"
+    assert third["error"] == "invalid_transition"
+    assert third["current_status"] == "FAILED"
+    assert third["attempted"] == "RUNNING"
 
 
-async def test_terminal_rejection_does_not_invoke_handler() -> None:
-    """A rejected call does not re-enter the Steerer transition table."""
+async def test_terminal_idempotent_retry_does_not_invoke_handler() -> None:
+    """An idempotent retry does not re-enter the Steerer transition table."""
     steerer = _RecordingSteerer()
     session = _session_with_task()
-    tools = [_spec("report_task_failed")]
+    tools = [_spec("report_task_completed")]
 
     # Pre-mark the task as COMPLETED (e.g., via a prior legitimate call).
     session.plan.tasks[0].status = TaskStatus.COMPLETED
 
     result = await invoke_tool(
         tools,
-        "report_task_failed",
-        {"task_id": "t1", "reason": "late failure report"},
+        "report_task_completed",
+        {"task_id": "t1", "summary": "duplicate report"},
         session,
         steerer,
     )
-    assert result["acknowledged"] is False
-    # Handler was never called → no transitions recorded → task stays COMPLETED.
+    assert result["acknowledged"] is True
+    assert result["idempotent"] is True
+    # Steerer never saw the call.
     assert steerer.transitions == []
     assert session.plan.tasks[0].status is TaskStatus.COMPLETED
 
 
-async def test_terminal_rejection_flood_cannot_burn_llm_budget() -> None:
-    """100 rejected reports cost one lookup each, no handler, no drift.
+async def test_terminal_idempotent_retries_do_not_drive_steerer() -> None:
+    """A modest run of same-transition retries stays cheap.
 
-    This is the scenario we observed in the wild: an agent calls
-    ``report_task_failed`` hundreds of times with fresh ``reason``
-    strings on a task that's already FAILED, burning through ADK's
-    500-LLM-call limit. With the rejection layer, each call bounces
-    cheaply and gives the model a clear ``stop_reporting`` signal — no
-    handler cost, no drift pileup.
+    A confused model that keeps calling ``report_task_failed`` on an
+    already-FAILED task must not (a) drive the steerer repeatedly
+    or (b) emit drift events for the repeat. Each call returns a
+    cheap idempotent ACK. (A runaway flood beyond the per-task
+    volume cap will still trip the loop detector — but that is a
+    separate, legitimate signal handled by the loop guard.)
     """
     steerer = _RecordingSteerer()
     session = _session_with_task()
@@ -445,7 +467,10 @@ async def test_terminal_rejection_flood_cannot_burn_llm_budget() -> None:
     # Mark terminal up front.
     session.plan.tasks[0].status = TaskStatus.FAILED
 
-    for i in range(100):
+    # Stay under the per-task volume cap so the loop detector doesn't
+    # fire — the explicit goal here is that idempotent retries do NOT
+    # themselves trigger loop drift for reasonable repeat counts.
+    for i in range(10):
         result = await invoke_tool(
             tools,
             "report_task_failed",
@@ -453,9 +478,10 @@ async def test_terminal_rejection_flood_cannot_burn_llm_budget() -> None:
             session,
             steerer,
         )
-        assert result["acknowledged"] is False
+        assert result["acknowledged"] is True
+        assert result.get("idempotent") is True
 
-    # No handlers fired, no drift events emitted — rejection is cheap and silent.
+    # No handlers fired, no drift events emitted — retries are cheap.
     assert steerer.transitions == []
     assert steerer.drifts == []
 
@@ -612,7 +638,7 @@ async def test_loop_flagged_short_circuits_subsequent_calls() -> None:
     hard-rejecting until refine resets it.
     """
     steerer = _RecordingSteerer()
-    session = _session_with_task()
+    session = _session_with_task(running=True)
     tools = [_spec("report_task_progress")]
 
     args = {"task_id": "t1", "fraction": 0.5, "detail": "stuck"}
@@ -714,7 +740,9 @@ async def test_session_wide_cap_is_per_tool_not_cross_tool() -> None:
         id="p1",
         run_id="r1",
         goal_ids=["g1"],
-        tasks=[Task(id=f"t{i}", title=f"task-{i}") for i in range(30)],
+        # Start each task RUNNING so ``report_task_progress`` is a
+        # legal transition at the handler layer (goldfive#201).
+        tasks=[Task(id=f"t{i}", title=f"task-{i}", status=TaskStatus.RUNNING) for i in range(30)],
         edges=[],
     )
     session = Session(


### PR DESCRIPTION
## Summary

Fixes two tightly-coupled bugs in reporting + state management (goldfive#201).

**Bug A — idempotency.** Reporting-tool retries on a terminal task used to return a single `task_already_terminal` rejection, conflating benign same-transition retries with real cross-transition confusion signals. Retries tripped the tool-loop detector and triggered spurious plan revisions.

The handler now owns a per-tool idempotency matrix:

| Handler | Current status → behaviour |
|---|---|
| `report_task_started` | RUNNING → idempotent; terminal → invalid_transition |
| `report_task_progress` | RUNNING → legal tick; PENDING / terminal → invalid_transition |
| `report_task_completed` | COMPLETED → idempotent; FAILED/CANCELLED/NOT_NEEDED → invalid_transition; PENDING/RUNNING → real transition |
| `report_task_failed` | FAILED → idempotent; COMPLETED/CANCELLED/NOT_NEEDED → invalid_transition |
| `report_task_blocked` | BLOCKED → idempotent; terminal → invalid_transition |
| `report_awaiting_approval` | BLOCKED → reuse waiter; terminal → invalid_transition |

Layer 2 of `invoke_tool` (the old `task_already_terminal` rejection) is retired — the handler now owns the decision with finer-grain splits.

**Bug B — state rotation.** `goldfive.current_task_id` never rotated on terminal transition, so subsequent tool calls in the same invocation saw a stale pointer and failed with `missing_task_id` when the LLM omitted `task_id`. New helper `orchestration_state.rotate_current_task_id(state, plan, agent_name)` encapsulates the rotation rules:

- Exactly one PENDING/RUNNING task assigned to the agent → stamp its id.
- Zero remaining → clear the key.
- Multiple pending (ambiguous) → clear and defer to the adapter's `before_agent_callback`.

Handlers call it after successful terminal transitions (COMPLETED / FAILED).

## Per-handler summary

| Tool | Target status | Source statuses (legal) | Idempotent at |
|---|---|---|---|
| `report_task_started` | RUNNING | PENDING, BLOCKED | RUNNING |
| `report_task_progress` | (liveness tick) | RUNNING | RUNNING |
| `report_task_completed` | COMPLETED | PENDING, RUNNING, BLOCKED | COMPLETED |
| `report_task_failed` | FAILED | PENDING, RUNNING, BLOCKED | FAILED |
| `report_task_blocked` | BLOCKED | PENDING, RUNNING | BLOCKED |
| `report_awaiting_approval` | BLOCKED | PENDING, RUNNING, BLOCKED | (waiter reuse) |

## Files

- `goldfive/reporting.py` — idempotency matrix + rotation call-sites.
- `goldfive/orchestration_state.py` — new `rotate_current_task_id` helper.
- `goldfive/adapters/_tool_invocation.py` — Layer 2 retired; handler now owns the terminal-task decision.
- `tests/test_reporting_idempotency.py` (new) — 37 cases, full matrix parametrised.
- `tests/test_state_rotation.py` (new) — 14 cases covering helper + end-to-end rotation.
- Existing `test_tool_loop_guard.py` / `test_adk_adapter.py` / `test_claude_adapter.py` / `test_reporting.py` updated to the new shapes.
- `docs/design/TASK-LIFECYCLE.md` + `CHANGELOG.md` updated.

## Test plan

- [x] `uv run pytest -q` — 860 passed, 76 skipped.
- [x] `uv run ruff check .` — clean.
- [ ] End-to-end: `make demo` with orchestrated presentation_agent on Qwen. Verify a retry of `report_task_completed` on a done task surfaces `acknowledged=True, idempotent=True` in the span payload, and that subsequent calls with empty `task_id` resolve via the rotated pin.
- [ ] DB check: no `missing_task_id` errors on well-behaved retries; tool-loop detector does not fire on retry sequences.