### PR TITLE
Add Task.cancel_reason field so storage-backed sinks have a schema slot

### DIFF
--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -170,6 +170,18 @@ class Task:
     predicted_start_ms: int = 0
     predicted_duration_ms: int = 0
     bound_span_id: str = ""
+    #: goldfive#205 — structured reason for the most recent CANCELLED /
+    #: FAILED transition. Colon-prefixed tag + provenance id:
+    #: ``upstream_failed:<id>``, ``run_aborted:<reason>``,
+    #: ``user_cancel:<annotation_id>``, ``user_steer:<annotation_id>``,
+    #: ``superseded_by_revision:<replacement_id>``. Empty for PENDING /
+    #: RUNNING / COMPLETED / BLOCKED tasks. Populated by downstream
+    #: sinks (harmonograf's ingest pipeline, persistence sink) from the
+    #: ``TaskCancelled.reason`` / ``TaskFailed.reason`` envelope fields;
+    #: goldfive's own in-memory planner / steerer does not mutate this
+    #: field — it exists so storage-backed consumers have a stable
+    #: schema slot threaded through the Task dataclass they re-export.
+    cancel_reason: str = ""
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Summary

Follow-up to #204 (goldfive#205). The Task dataclass re-exported by harmonograf needed a stable field for the structured cancel reason — without it, downstream storage has to carry a parallel dict or subclass Task locally.

One-line additive change: `cancel_reason: str = \"\"` with default empty. Goldfive's own planner / steerer does not mutate this field; it exists purely so storage-backed consumers (harmonograf's sqlite storage, the persistence sink) have a first-class place to thread the value from `TaskCancelled.reason` / `TaskFailed.reason` event envelopes.

## Test plan

- [x] Full goldfive test suite: 1044 passed, 46 skipped, 0 failures.
- [x] Ruff clean.