### PR TITLE
Stream inner ADK events through Runner.run_streamed + GoldfiveADKAgent

### DIFF
--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -1072,6 +1072,19 @@ class ADKAdapter:
         # tests/test_live_steering_e2e.py set this explicitly.
         self._outer_session_id: str | None = None
 
+        # Optional fan-out listeners for raw inner-Runner ADK events.
+        # :meth:`Runner.run_streamed` (goldfive: stream-inner-adk-events)
+        # registers a listener here so it can forward every
+        # ``google.adk.events.Event`` out to an outer ADK consumer
+        # (:class:`GoldfiveADKAgent._run_async_impl`) in real time while
+        # the adapter continues its own bookkeeping (pending-tool heal,
+        # reconciler, plugin callbacks). Empty by default — no overhead
+        # for programmatic callers that don't use ``run_streamed``.
+        # Listeners are plain sync callables; they MUST NOT raise and
+        # MUST NOT block on I/O. The adapter swallows listener
+        # exceptions so a faulty subscriber cannot break the real run.
+        self._adk_event_listeners: list[Any] = []
+
         # Wrap-time integrity check: the one runner must carry the
         # goldfive plugin. In degraded mode we skip because the caller
         # may have constructed a runner shape we don't fully control.
@@ -1248,6 +1261,52 @@ class ADKAdapter:
                     f"reporting tools so terminal status can flow back "
                     f"from an AgentTool sub-invocation. See "
                     f"_augment_subtree_with_reporting."
+                )
+
+    # ------------------------------------------------------------------
+    # Inner ADK event fan-out (goldfive: stream-inner-adk-events)
+    # ------------------------------------------------------------------
+
+    def subscribe_adk_events(self, listener: Any) -> None:
+        """Register a sync callable to receive every inner-Runner ADK Event.
+
+        The listener is invoked once per event the adapter consumes from
+        ``runner.run_async(...)``, IN ORDER, BEFORE the adapter's own
+        bookkeeping (pending-tool tracking, final-event detection,
+        runaway-delegation cap) runs. This guarantees the outer
+        consumer sees the exact same event stream ADK delivers, without
+        the adapter filtering or transforming anything.
+
+        Listeners MUST be sync and MUST NOT block on I/O — a
+        ``queue.put_nowait`` or ``list.append`` is the expected shape.
+        Any exception raised by the listener is swallowed with a DEBUG
+        log so a faulty subscriber cannot break the real run.
+        """
+        if listener is None:
+            return
+        if listener in self._adk_event_listeners:
+            return
+        self._adk_event_listeners.append(listener)
+
+    def unsubscribe_adk_events(self, listener: Any) -> None:
+        """Remove a previously-registered ADK Event listener. Idempotent."""
+        try:
+            self._adk_event_listeners.remove(listener)
+        except ValueError:
+            return
+
+    def _dispatch_adk_event(self, event: Any) -> None:
+        """Fan ``event`` out to every registered listener. Swallows raises."""
+        if not self._adk_event_listeners:
+            return
+        for listener in list(self._adk_event_listeners):
+            try:
+                listener(event)
+            except Exception as exc:  # noqa: BLE001 — defensive
+                log.debug(
+                    "ADKAdapter: adk-event listener %r raised (swallowed): %s",
+                    listener,
+                    exc,
                 )
 
     def bind_steerer(self, steerer: Steerer | None) -> None:
@@ -1460,6 +1519,14 @@ class ADKAdapter:
                 session_id=session_id,
                 new_message=new_message,
             ):
+                # Fan the raw event out to any registered listeners
+                # (e.g. :meth:`Runner.run_streamed` forwarding to
+                # :class:`GoldfiveADKAgent._run_async_impl` so adk-web
+                # sees real per-agent activity in its UI) BEFORE we
+                # run any adapter bookkeeping. Dispatch is best-effort
+                # sync and swallows raises — the adapter's own
+                # observation pipeline must not depend on it.
+                self._dispatch_adk_event(event)
                 last_event = event
                 inv_id = getattr(event, "invocation_id", "") or ""
                 if inv_id:

--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -25,10 +25,11 @@ import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from goldfive.results import ExecutionOutcome
+
 if TYPE_CHECKING:
     from goldfive.control import ControlChannel
     from goldfive.protocols import EventSink
-    from goldfive.results import ExecutionOutcome
     from goldfive.runner import Runner
     from goldfive.types import Goal
 
@@ -94,6 +95,11 @@ def _plan_summary_event(outcome: ExecutionOutcome, author: str, invocation_id: s
     """Build the opening Event that summarises the plan we're about to run."""
     session = outcome.session
     plan = getattr(session, "plan", None)
+    return _plan_summary_event_from_plan(plan, author=author, invocation_id=invocation_id)
+
+
+def _plan_summary_event_from_plan(plan: Any, author: str, invocation_id: str) -> Event:
+    """Build a plan-summary Event from a bare :class:`Plan` (may be ``None``)."""
     summary = getattr(plan, "summary", "") or "goldfive plan"
     tasks = list(getattr(plan, "tasks", None) or ())
     lines = [f"**{summary}**"]
@@ -148,13 +154,32 @@ async def _outcome_to_adk_events(
 
     The stream is intentionally minimal: a plan summary up top, one
     Event per completed task, a best-effort line per recorded drift,
-    and a terminal turn-complete Event at the end. This is enough for
-    adk web to render a coherent turn; richer views can subscribe to
-    goldfive's own Event stream via a sink.
+    and a terminal turn-complete Event at the end.
+
+    Retained for back-compat (callers that want to render a full
+    outcome synchronously after the fact). The streaming path
+    (:meth:`GoldfiveADKAgent._run_async_impl`) now uses the finer-
+    grained :func:`_post_run_framing_events` to interleave real
+    inner-Runner events with the goldfive-owned framing.
     """
     invocation_id = str(getattr(ctx, "invocation_id", "") or "")
     yield _plan_summary_event(outcome, author=author, invocation_id=invocation_id)
+    async for event in _post_run_framing_events(outcome, ctx, author=author):
+        yield event
 
+
+async def _post_run_framing_events(
+    outcome: ExecutionOutcome, ctx: InvocationContext, author: str
+) -> AsyncIterator[Event]:
+    """Yield goldfive's own framing events for the end of a streamed run.
+
+    Emits one Event per completed task, one per recorded drift, and the
+    terminal turn-complete Event. These wrap / follow the real inner-
+    Runner events streamed through :meth:`Runner.run_streamed` so
+    adk-web sees goldfive-owned structure around the agent tree's
+    native activity.
+    """
+    invocation_id = str(getattr(ctx, "invocation_id", "") or "")
     session = outcome.session
     completed = getattr(session, "completed_results", None) or {}
     plan = getattr(session, "plan", None)
@@ -297,16 +322,61 @@ class GoldfiveADKAgent(BaseAgent):
         # so a cancelled or early-closed generator leaks open spans. The
         # teardown hook here is the goldfive-side guarantee that orphan
         # INVOCATION spans get flushed regardless of ADK's gap.
+        #
+        # Streaming model (goldfive: stream-inner-adk-events):
+        # :meth:`Runner.run_streamed` yields every raw ADK Event the
+        # inner ``InMemoryRunner`` emits (``transfer_to_agent``,
+        # ``function_call``, ``function_response``, model text parts,
+        # etc.) as they arrive, followed by exactly one trailing
+        # :class:`ExecutionOutcome`. We forward the ADK events through
+        # verbatim so adk-web sees the real agent tree's activity, then
+        # emit goldfive-owned framing (plan summary up front, per-task
+        # result blocks at the end, drift lines, terminal
+        # turn-complete) around them.
+        invocation_id = str(getattr(ctx, "invocation_id", "") or "")
+        plan_summary_yielded = False
         try:
-            outcome = await self._runner.run(
+            outcome: ExecutionOutcome | None = None
+            async for item in self._runner.run_streamed(
                 user_input,
                 context={"adk_ctx": ctx},
                 session_id=outer_sid or None,
-            )
-            async for adk_event in _outcome_to_adk_events(
-                outcome, ctx, author=self.name
             ):
-                yield adk_event
+                if isinstance(item, ExecutionOutcome):
+                    outcome = item
+                    continue
+                # Lazy plan-summary emission: the first real inner-Runner
+                # event reaches us AFTER the Runner has installed a plan
+                # on the session, so we can synthesize the plan summary
+                # with real task titles and yield it BEFORE the first
+                # tree event. On runs that produce zero inner events
+                # (degenerate no-op trees, immediate abort) we still
+                # get to emit it from the outcome branch below.
+                if not plan_summary_yielded and outcome is None:
+                    session = getattr(self._runner, "_last_session", None)
+                    plan = getattr(session, "plan", None) if session is not None else None
+                    if plan is not None:
+                        yield _plan_summary_event_from_plan(
+                            plan,
+                            author=self.name,
+                            invocation_id=invocation_id,
+                        )
+                        plan_summary_yielded = True
+                yield item
+            # Final framing. If we never yielded a plan summary (no
+            # inner events landed before the outcome) fall back to
+            # synthesizing it from the outcome's session so adk-web
+            # still gets a plan header.
+            if outcome is not None:
+                if not plan_summary_yielded:
+                    yield _plan_summary_event(
+                        outcome, author=self.name, invocation_id=invocation_id
+                    )
+                    plan_summary_yielded = True
+                async for adk_event in _post_run_framing_events(
+                    outcome, ctx, author=self.name
+                ):
+                    yield adk_event
         finally:
             self._notify_plugins_on_run_end()
 

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -35,10 +35,11 @@ and are loaded lazily by callers.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import warnings
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from goldfive import orchestration_state as _ostate
@@ -428,6 +429,123 @@ class Runner:
             outcome, user_input_summary=_initial_goal_summary(user_input)
         )
         return outcome
+
+    # ------------------------------------------------------------------
+    # run_streamed — yield inner-adapter framework events in real time
+    # ------------------------------------------------------------------
+
+    async def run_streamed(
+        self,
+        user_input: str | list[Goal],
+        *,
+        context: Mapping[str, Any] | None = None,
+        session_id: str | None = None,
+    ) -> AsyncIterator[Any]:
+        """Execute a run and stream inner-adapter framework events out as they arrive.
+
+        Async generator that yields — in order — every framework-native
+        event the adapter observes mid-invocation (e.g. ADK ``Event``
+        objects: ``transfer_to_agent``, model text parts, function
+        calls, function responses) followed by exactly one trailing
+        :class:`~goldfive.results.ExecutionOutcome` as the final
+        yielded element when the run finishes.
+
+        The trailing ``ExecutionOutcome`` is how callers recover the
+        completed run's success flag, reason, and live
+        :class:`~goldfive.types.Session`. Consumers distinguish the
+        two yielded shapes via ``isinstance(item, ExecutionOutcome)``.
+
+        The equivalent of :meth:`run` — same lifecycle, same sinks, same
+        plugin callbacks, same conversation bookkeeping — is driven in
+        the background. :meth:`run_streamed` does NOT call :meth:`run`
+        recursively; it subscribes to the adapter's event fan-out
+        (:meth:`ADKAdapter.subscribe_adk_events`, when available) and
+        forwards those events through an :class:`asyncio.Queue` so
+        backpressure from the consumer cannot stall the inner Runner.
+
+        Non-ADK adapters (callable, Claude SDK) have no streamable
+        framework events; :meth:`run_streamed` still works for them —
+        it simply yields no mid-run events and produces the outcome at
+        the end, exactly as :meth:`run` would. Callers do not need to
+        switch on adapter type.
+
+        This is the primary path used by
+        :class:`~goldfive.adapters.adk_wrap.GoldfiveADKAgent` so
+        ``adk web`` sees per-agent activity (LLM responses, tool calls,
+        agent transitions) in its UI while the goldfive pipeline runs.
+
+        Parameters mirror :meth:`run` — see that docstring for
+        ``session_id`` semantics.
+        """
+        # Import here so non-ADK consumers don't pay the optional-ADK
+        # import cost when they never call run_streamed.
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+
+        # Subscribe a sync listener to the adapter's raw-event fan-out
+        # when the adapter supports it. The listener enqueues every
+        # event into ``queue`` for us to re-yield. Non-ADK adapters
+        # simply don't expose ``subscribe_adk_events`` — the run still
+        # completes and we yield only the final outcome.
+        subscribe = getattr(self.agent, "subscribe_adk_events", None)
+        unsubscribe = getattr(self.agent, "unsubscribe_adk_events", None)
+
+        def _listener(event: Any) -> None:
+            # ``put_nowait`` is correct here: the queue is unbounded
+            # so it never raises, and we must NOT block the adapter's
+            # event loop on a consumer that's slow to pull.
+            try:
+                queue.put_nowait(event)
+            except Exception:  # noqa: BLE001 — defensive; unbounded queue shouldn't raise
+                log.debug("run_streamed: queue.put_nowait unexpectedly raised")
+
+        if callable(subscribe):
+            subscribe(_listener)
+
+        # Sentinel that tells the consumer loop the run is done and
+        # any remaining events have already been enqueued.
+        _DONE = object()
+
+        async def _drive() -> ExecutionOutcome:
+            try:
+                return await self.run(
+                    user_input,
+                    context=context,
+                    session_id=session_id,
+                )
+            finally:
+                # Signal end-of-stream regardless of success / failure.
+                # The consumer drains any remaining buffered events,
+                # then stops when it sees the sentinel.
+                queue.put_nowait(_DONE)
+
+        run_task: asyncio.Task[ExecutionOutcome] = asyncio.create_task(_drive())
+
+        try:
+            while True:
+                item = await queue.get()
+                if item is _DONE:
+                    break
+                yield item
+            outcome = await run_task
+            yield outcome
+        except (asyncio.CancelledError, GeneratorExit):
+            # Upstream cancelled us (adk-web disconnect) OR the caller
+            # aclose()'d the generator early. Propagate the cancel into
+            # the driver so its ``try/finally`` teardown runs, then
+            # await it to collect the final state — suppressing the
+            # CancelledError so the generator exits cleanly.
+            run_task.cancel()
+            try:
+                await run_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            raise
+        finally:
+            if callable(unsubscribe):
+                try:
+                    unsubscribe(_listener)
+                except Exception as exc:  # noqa: BLE001
+                    log.debug("run_streamed: unsubscribe raised: %s", exc)
 
     # ------------------------------------------------------------------
     # resume — best-effort replay

--- a/tests/test_adk_wrap_passthrough.py
+++ b/tests/test_adk_wrap_passthrough.py
@@ -1,0 +1,223 @@
+"""Tests for :meth:`GoldfiveADKAgent._run_async_impl` streaming behaviour.
+
+Validates that inner-Runner ADK Events are forwarded through to adk-web
+in real time (the "plumb events through" fix), not collapsed into a
+handful of synthetic summary Events emitted only after
+:meth:`Runner.run` returns.
+
+The test drives :meth:`GoldfiveADKAgent._run_async_impl` with a mock
+:class:`InvocationContext`, substitutes a fake adapter ``invoke`` that
+synthesizes inner-Runner Events via the adapter's event fan-out, and
+asserts:
+
+* At least one inner-tree ADK Event reaches adk-web (the real fix).
+* The plan-summary header still fires BEFORE the first inner Event
+  (goldfive-owned framing is preserved).
+* The terminal turn-complete Event still fires last.
+* The last yielded item is a proper ``turn_complete`` Event.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+import goldfive
+from goldfive import InMemorySink, InvocationResult, SequentialExecutor, StaticPlanner
+from goldfive.types import Plan, Task
+
+
+def _one_task_planner() -> StaticPlanner:
+    return StaticPlanner(
+        Plan(
+            id="p1",
+            run_id="",
+            goal_ids=["g1"],
+            tasks=[
+                Task(
+                    id="t1",
+                    title="the task",
+                    description="the task",
+                    assignee_agent_id="inner_agent",
+                )
+            ],
+            edges=[],
+            summary="one task plan",
+        )
+    )
+
+
+def _mk_inner(name: str = "inner_agent") -> Any:
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(
+        name=name,
+        model="fake-model",
+        description="a wrapped agent",
+        instruction="follow instructions",
+    )
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.id = ""
+        self.events: list[Any] = []
+
+
+class _FakeCtx:
+    def __init__(self, text: str) -> None:
+        from google.genai.types import Content, Part  # type: ignore
+
+        self.user_content = Content(role="user", parts=[Part(text=text)])
+        self.session = _FakeSession()
+        self.invocation_id = "invocation-test-passthrough"
+        self.end_invocation = False
+
+
+def _event_text(event: Any) -> str:
+    content = getattr(event, "content", None)
+    parts = getattr(content, "parts", None) or ()
+    return "\n".join(str(getattr(p, "text", "") or "") for p in parts).strip()
+
+
+# ---------------------------------------------------------------------------
+# Inner events plumb through to adk-web
+# ---------------------------------------------------------------------------
+
+
+async def test_run_async_impl_forwards_inner_adk_events(stub_call_llm: Any) -> None:
+    """Inner-Runner events fanned out by the adapter reach the outer Event stream."""
+    from google.adk.events import Event  # type: ignore
+    from google.genai.types import Content, Part  # type: ignore
+
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    adapter = wrapped.runner.agent
+
+    inner_event_1 = Event(
+        invocation_id="inv-1",
+        author=inner.name,
+        content=Content(role="model", parts=[Part(text="inner step 1")]),
+    )
+    inner_event_2 = Event(
+        invocation_id="inv-1",
+        author=inner.name,
+        content=Content(role="model", parts=[Part(text="inner step 2")]),
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        # Simulate the real invoke path fanning ADK events out to
+        # subscribed listeners (that's what the adapter does in its
+        # real ``async for event in self._runner.run_async(...)`` loop).
+        adapter._dispatch_adk_event(inner_event_1)
+        adapter._dispatch_adk_event(inner_event_2)
+        return InvocationResult(task_id=task.id, text="ok: the task")
+
+    adapter.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    ctx = _FakeCtx("make a thing")
+    events = [evt async for evt in wrapped._run_async_impl(ctx)]
+
+    # 1) At least one of the real inner events came through verbatim.
+    forwarded_by_identity = [e for e in events if e is inner_event_1 or e is inner_event_2]
+    assert forwarded_by_identity, (
+        "inner-Runner ADK Events were not forwarded to the outer stream; "
+        "adk-web UI would still be blank"
+    )
+
+    # 2) Plan summary still emitted.
+    plan_summary_events = [
+        e for e in events if _event_text(e).startswith("**one task plan**")
+    ]
+    assert plan_summary_events, "plan-summary framing event missing"
+
+    # 3) Terminal turn_complete event still fires last.
+    assert events[-1].turn_complete is True
+
+
+async def test_run_async_impl_plan_summary_precedes_inner_events(
+    stub_call_llm: Any,
+) -> None:
+    """The goldfive plan summary must land BEFORE any real inner event.
+
+    adk-web renders events in order; the plan summary is the "header"
+    that tells the UI which task block the upcoming tree activity
+    belongs to. If inner events arrive first, the UI shows tree
+    activity with no context.
+    """
+    from google.adk.events import Event  # type: ignore
+    from google.genai.types import Content, Part  # type: ignore
+
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+    adapter = wrapped.runner.agent
+
+    inner_event = Event(
+        invocation_id="inv-1",
+        author=inner.name,
+        content=Content(role="model", parts=[Part(text="inner event")]),
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        adapter._dispatch_adk_event(inner_event)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    ctx = _FakeCtx("go")
+    events = [evt async for evt in wrapped._run_async_impl(ctx)]
+
+    # First plan-summary (by text) must be at a strictly earlier index
+    # than the inner event (by identity).
+    plan_idx = next(
+        (i for i, e in enumerate(events) if _event_text(e).startswith("**one task plan**")),
+        None,
+    )
+    inner_idx = next((i for i, e in enumerate(events) if e is inner_event), None)
+    assert plan_idx is not None, "plan-summary event missing"
+    assert inner_idx is not None, "inner event was not forwarded"
+    assert plan_idx < inner_idx, (
+        f"plan summary landed at index {plan_idx}, after inner event at {inner_idx}; "
+        f"ordering contract broken"
+    )
+
+
+async def test_run_async_impl_still_emits_framing_when_no_inner_events(
+    stub_call_llm: Any,
+) -> None:
+    """Runs with zero inner events must still deliver plan + task + terminal."""
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok: the task")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    ctx = _FakeCtx("go")
+    events = [evt async for evt in wrapped._run_async_impl(ctx)]
+
+    # plan summary + at least one task-result block + terminal.
+    assert len(events) >= 2
+    assert any(_event_text(e).startswith("**one task plan**") for e in events)
+    assert events[-1].turn_complete is True

--- a/tests/test_runner_streamed.py
+++ b/tests/test_runner_streamed.py
@@ -1,0 +1,210 @@
+"""Tests for :meth:`goldfive.Runner.run_streamed`.
+
+Covers the streaming API added to support
+:class:`goldfive.adapters.adk_wrap.GoldfiveADKAgent` forwarding
+inner-Runner ADK events through adk-web in real time.
+
+Two execution paths are verified:
+
+* ADK adapter path — drives a minimal ADK tree through
+  ``Runner.run_streamed`` and asserts at least one ADK
+  ``google.adk.events.Event`` is yielded before the trailing
+  :class:`~goldfive.results.ExecutionOutcome`.
+* Non-ADK (callable) adapter path — the adapter has no framework
+  events; ``run_streamed`` must still yield exactly one item (the
+  outcome) and the run must still succeed.
+
+The existing :meth:`Runner.run` contract is validated indirectly —
+every ``run_streamed`` call ends with the same
+:class:`ExecutionOutcome` that :meth:`run` would have returned.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+import goldfive
+from goldfive import (
+    ExecutionOutcome,
+    InMemorySink,
+    InvocationResult,
+    Runner,
+    SequentialExecutor,
+    StaticPlanner,
+)
+from goldfive.types import Plan, Task
+
+
+def _one_task_planner(task_id: str = "t1", title: str = "the task") -> StaticPlanner:
+    return StaticPlanner(
+        Plan(
+            id="p1",
+            run_id="",
+            goal_ids=["g1"],
+            tasks=[
+                Task(
+                    id=task_id,
+                    title=title,
+                    description=title,
+                    assignee_agent_id="inner_agent",
+                )
+            ],
+            edges=[],
+            summary="one task plan",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# ADK adapter: streaming yields raw inner-Runner Events + outcome
+# ---------------------------------------------------------------------------
+
+
+pytest.importorskip("google.adk")
+
+
+def _mk_inner(name: str = "inner_agent") -> Any:
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(
+        name=name,
+        model="fake-model",
+        description="a wrapped agent",
+        instruction="follow instructions",
+    )
+
+
+async def test_run_streamed_yields_inner_adk_events_then_outcome(
+    stub_call_llm: Any,
+) -> None:
+    """At least one raw ADK Event + a trailing ExecutionOutcome must be yielded."""
+    from google.adk.events import Event  # type: ignore
+
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+    # Substitute a stub for adapter.invoke so we don't drive a real LLM,
+    # BUT still synthesize inner-Runner events via the fan-out so the
+    # streaming path is exercised. We call _dispatch_adk_event directly
+    # from the fake invoke — this is the seam the real invoke path uses
+    # on every event from ``runner.run_async``.
+    adapter = wrapped.runner.agent
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        # Simulate two inner-Runner events during this invoke.
+        from google.genai.types import Content, Part  # type: ignore
+
+        for text in ("step one", "step two"):
+            fake_event = Event(
+                invocation_id="inv-1",
+                author=inner.name,
+                content=Content(role="model", parts=[Part(text=text)]),
+            )
+            adapter._dispatch_adk_event(fake_event)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    adapter.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    items: list[Any] = []
+    async for item in wrapped.runner.run_streamed(
+        [goldfive.Goal(id="g1", summary="go")],
+    ):
+        items.append(item)
+
+    # Last item must be the ExecutionOutcome.
+    assert items, "run_streamed yielded nothing"
+    assert isinstance(items[-1], ExecutionOutcome)
+    assert items[-1].success, items[-1].reason
+
+    # At least one inner-Runner Event must have preceded the outcome.
+    adk_events = [i for i in items[:-1] if isinstance(i, Event)]
+    assert adk_events, "no ADK Events yielded mid-run"
+
+
+async def test_run_streamed_without_inner_events_still_yields_outcome(
+    stub_call_llm: Any,
+) -> None:
+    """If no inner Events fire, run_streamed still produces a single outcome item."""
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    items = [
+        item
+        async for item in wrapped.runner.run_streamed(
+            [goldfive.Goal(id="g1", summary="go")],
+        )
+    ]
+
+    # At minimum: the outcome. Possibly zero pre-outcome items.
+    assert items
+    assert isinstance(items[-1], ExecutionOutcome)
+    assert items[-1].success, items[-1].reason
+
+
+async def test_run_streamed_matches_run_contract() -> None:
+    """``run_streamed``'s final outcome should be shape-equivalent to ``run``."""
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    items = [
+        item
+        async for item in wrapped.runner.run_streamed(
+            [goldfive.Goal(id="g1", summary="go")],
+        )
+    ]
+    outcome = items[-1]
+    assert isinstance(outcome, ExecutionOutcome)
+    # Contract: outcome carries a Session with the run's plan / results.
+    assert outcome.session is not None
+    assert outcome.session.plan is not None
+
+
+# ---------------------------------------------------------------------------
+# Non-ADK adapter (callable): run_streamed degrades gracefully
+# ---------------------------------------------------------------------------
+
+
+async def test_run_streamed_on_callable_adapter_yields_only_outcome() -> None:
+    """Callable adapters have no ADK events; run_streamed must still work."""
+
+    async def _bare_agent(task: Any, session: Any, tools: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    runner: Runner = goldfive.wrap(
+        _bare_agent,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    items = [
+        item async for item in runner.run_streamed([goldfive.Goal(id="g1", summary="go")])
+    ]
+    assert isinstance(items[-1], ExecutionOutcome)
+    assert items[-1].success, items[-1].reason


### PR DESCRIPTION
## Summary

- **adk-web blank UI fix.** `GoldfiveADKAgent._run_async_impl` used to drive the inner `Runner` to completion and only yield four synthetic summary `Event`s (plan, per-task, drift, terminal) to adk-web. All the rich events the inner `InMemoryRunner` emits — `transfer_to_agent`, model text Parts, `function_call` / `function_response` — were consumed by goldfive and never reached the UI. Users felt like they had "stopped talking to their agent tree."
- **New streaming surface.** `Runner.run_streamed(user_input, ...)` is an async generator that yields every inner-adapter framework event in real time, followed by a trailing `ExecutionOutcome`. `ADKAdapter` fans every event from `runner.run_async(...)` out to subscribed listeners via `subscribe_adk_events` / `unsubscribe_adk_events`. `GoldfiveADKAgent._run_async_impl` now forwards those events verbatim to adk-web and interleaves goldfive-owned framing (plan summary, per-task blocks, drift lines, terminal) around them.
- **`Runner.run` contract preserved.** Programmatic callers see no change — same signature, same return type, same sinks, same plugin callbacks, same conversation bookkeeping. Non-ADK adapters (callable, Claude SDK) don't implement `subscribe_adk_events`; `run_streamed` simply yields only the outcome and the run still succeeds.
- **Option 7(c) shared-Runner refactor is explicitly out of scope.** Dual-Runner architecture preserved; `_outcome_to_adk_events` is retained for back-compat.

## Test plan

- [x] `uv run pytest tests/` — 1115 passed, 46 skipped, 0 failed.
- [x] New `tests/test_runner_streamed.py` — ADK tree yields ≥1 `Event` + `ExecutionOutcome`; callable adapter yields only the outcome.
- [x] New `tests/test_adk_wrap_passthrough.py` — `_run_async_impl` forwards real inner events by identity, plan-summary precedes them, terminal event still closes the turn.
- [x] Existing `tests/test_wrap_adk.py` (teardown-hook fan-out, sinks mutation, back-compat) still green.