### PR TITLE
Turn-aware planning gate: skip re-planning on conversational follow-ups

### DIFF
--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -23,6 +23,11 @@ from goldfive.goal_deriver import (
     PassthroughGoalDeriver,
 )
 from goldfive.planner import LLMPlanner, PassthroughPlanner, StaticPlanner
+from goldfive.planner_gate import (
+    TurnClassification,
+    classify_turn,
+    heuristic_classify_turn,
+)
 from goldfive.protocols import (
     AgentAdapter,
     EventSink,
@@ -102,10 +107,13 @@ __all__ = [
     "Task",
     "TaskEdge",
     "TaskStatus",
+    "TurnClassification",
     "TurnRecord",
     "classify_refusal",
+    "classify_turn",
     "classify_stop_reason",
     "classify_tool_error",
+    "heuristic_classify_turn",
     "quickstart",
     "run",
     "wrap",

--- a/goldfive/planner_gate.py
+++ b/goldfive/planner_gate.py
@@ -1,0 +1,342 @@
+"""Turn-aware planning gate — decide whether to re-plan on a new turn.
+
+Goldfive's :class:`~goldfive.runner.Runner` used to invoke
+:class:`GoalDeriver.derive` + :class:`Planner.generate` on every call
+to :meth:`Runner.run`. Multi-turn conversations where turn N+1 is a
+conversational follow-up ("where is the presentation located?") would
+therefore mint a fresh 6-task workflow plan repeating the whole prior
+run, even though the coordinator LLM itself can answer in one turn
+from conversation history.
+
+This module ships a lightweight classifier that slots in *before*
+``GoalDeriver.derive`` on each turn after the first. Given:
+
+- the prior plan (if any, from ``session.plan``),
+- completed_results (from ``session.completed_results``),
+- the new user_input string,
+- the current conversation_id,
+
+it returns one of three verdicts:
+
+``"new_work"``
+    The user_input introduces genuinely new work that isn't covered
+    by the prior plan. Runner should run full ``GoalDeriver.derive``
+    + ``Planner.generate`` as before.
+
+``"conversational"``
+    The user_input is a follow-up that can be answered from existing
+    context alone. Runner should skip planning entirely — no new
+    GoalDerived or PlanSubmitted for this turn — and let the
+    coordinator answer directly over the existing plan / completed
+    results.
+
+``"refine_existing"``
+    The user_input extends or tweaks the prior plan. Runner should
+    run ``Planner.refine`` against the current plan with the new
+    user_input as a synthesized steer goal, adding delta tasks only
+    rather than re-planning from scratch.
+
+Two classifier modes ship:
+
+* :func:`heuristic_classify_turn` — deterministic rule-based gate.
+  Crude but safe: short follow-ups after a prior plan are assumed
+  conversational; no prior plan forces ``new_work``. Used as the
+  fallback when no ``call_llm`` is available and as the basis for
+  the unit tests.
+
+* :func:`classify_turn` — LLM-backed gate. Takes an async
+  ``call_llm(system, user, model) -> str`` callable and prompts it
+  for a one-word classification. Falls through to
+  :func:`heuristic_classify_turn` on any LLM/parse error so a
+  misbehaving LLM never hangs the Runner.
+
+The Runner is responsible for opt-in wiring (see
+``Runner(planner_gate=...)``): when no gate is supplied the default
+is the LLM-or-heuristic hybrid, and callers can disable by passing
+``planner_gate=None`` for deterministic replay / pure-unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any, Literal
+
+from goldfive.types import Plan
+
+log = logging.getLogger("goldfive.planner_gate")
+
+#: The three classifier verdicts. The Runner's behaviour for each is
+#: documented at module level.
+TurnClassification = Literal["new_work", "conversational", "refine_existing"]
+
+#: Roughly "one sentence of input". Follow-ups under this token budget
+#: that arrive after a prior plan are treated as conversational by the
+#: heuristic fallback. Chosen for safety, not precision — the LLM gate
+#: is the primary classifier when ``call_llm`` is available.
+_HEURISTIC_SHORT_TOKEN_BUDGET: int = 20
+
+#: Canonical verdict set. Lowercased, underscore-joined.
+_ALLOWED: frozenset[str] = frozenset(
+    {"new_work", "conversational", "refine_existing"}
+)
+
+_SYSTEM_PROMPT = """\
+You are a turn-classifier for a multi-agent orchestration system.
+
+The system has already executed a PRIOR PLAN of tasks for the user's
+earlier request(s) in this conversation. Now the user has issued a
+NEW INPUT. Your job is to classify the new input into one of three
+buckets so the orchestrator knows whether to re-plan.
+
+Verdicts:
+
+- "new_work": the new input asks for genuinely new work that is NOT
+  covered by the prior plan's tasks or the completed_results. A
+  wholly new topic, a wholly new artefact, a new outcome the prior
+  plan did not produce.
+
+- "conversational": the new input is a question or clarification
+  about work that has ALREADY been done — e.g. "where did you save
+  the output?", "what was the second slide?", "did you use source
+  X?", "summarise what you did". These can be answered from the
+  existing plan / completed_results / conversation history without
+  running any new tasks.
+
+- "refine_existing": the new input tweaks, extends, or revises the
+  PRIOR PLAN — e.g. "make it funnier", "add a slide about Z",
+  "also translate to Spanish", "change the title". The existing
+  plan's completed tasks should be preserved; a small delta of new
+  tasks is appended.
+
+Guidelines:
+- When in doubt between "conversational" and "refine_existing",
+  prefer "conversational" — the coordinator can always answer and
+  the user can restate if they actually wanted new work.
+- When in doubt between "refine_existing" and "new_work", prefer
+  "refine_existing" — the prior plan's completed tasks give the
+  refined plan a running start.
+
+Reply with a single JSON object and NOTHING ELSE:
+{"verdict": "new_work" | "conversational" | "refine_existing",
+ "reason": "<one-sentence why>"}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _token_count(text: str) -> int:
+    """Cheap whitespace-split token count. Good enough for a budget check."""
+    return len((text or "").split())
+
+
+_FENCE_RE = re.compile(r"^\s*```(?:[a-zA-Z0-9_+-]*)?\s*\n(?P<body>.*?)\n```\s*$", re.DOTALL)
+
+
+def _strip_code_fences(raw: str) -> str:
+    m = _FENCE_RE.match(raw or "")
+    return m.group("body") if m else (raw or "")
+
+
+def _plan_brief(plan: Plan | None) -> str:
+    """Render a compact human-readable summary of the prior plan.
+
+    Used in the LLM prompt. ``None`` collapses to an empty string
+    because a missing prior plan is handled by the caller before we
+    get here (see :func:`classify_turn`).
+    """
+    if plan is None:
+        return ""
+    lines: list[str] = []
+    if plan.summary:
+        lines.append(f"Summary: {plan.summary}")
+    if plan.tasks:
+        lines.append("Tasks:")
+        for t in plan.tasks:
+            tid = t.id or "(no-id)"
+            status = getattr(t.status, "value", str(t.status))
+            title = t.title or t.description or ""
+            lines.append(f"  - [{tid} / {status}] {title}")
+    return "\n".join(lines)
+
+
+def _results_brief(results: Mapping[str, str] | None, *, cap: int = 10) -> str:
+    if not results:
+        return ""
+    entries = list(results.items())[:cap]
+    lines = ["Completed results:"]
+    for tid, summary in entries:
+        snippet = (summary or "").strip().splitlines()
+        one = snippet[0] if snippet else ""
+        if len(one) > 160:
+            one = one[:157] + "..."
+        lines.append(f"  - {tid}: {one}")
+    more = len(results) - len(entries)
+    if more > 0:
+        lines.append(f"  ... and {more} more")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Heuristic fallback
+# ---------------------------------------------------------------------------
+
+
+def heuristic_classify_turn(
+    *,
+    prior_plan: Plan | None,
+    completed_results: Mapping[str, str] | None,
+    user_input: str,
+    conversation_id: str = "",
+) -> TurnClassification:
+    """Deterministic rule-based gate. LLM-free.
+
+    Rules:
+
+    - No prior plan → always ``"new_work"`` (first turn or fresh
+      conversation).
+    - Prior plan exists AND user_input is short (``< 20`` tokens) →
+      ``"conversational"``. Short follow-ups are overwhelmingly
+      questions about prior work, not new workflows.
+    - Otherwise → ``"new_work"``. Conservative default: the heuristic
+      never picks ``"refine_existing"`` on its own because getting the
+      refine path wrong silently mangles the plan, whereas getting
+      ``"new_work"`` wrong just means the user pays for an extra plan
+      that still completes.
+
+    The LLM-backed :func:`classify_turn` is strictly more precise and
+    should be preferred when a ``call_llm`` is available.
+    """
+    _ = conversation_id  # reserved for future heuristics
+    if prior_plan is None or not prior_plan.tasks:
+        return "new_work"
+    if _token_count(user_input) < _HEURISTIC_SHORT_TOKEN_BUDGET:
+        return "conversational"
+    return "new_work"
+
+
+# ---------------------------------------------------------------------------
+# LLM-backed gate
+# ---------------------------------------------------------------------------
+
+
+async def classify_turn(
+    *,
+    call_llm: Callable[[str, str, str], Awaitable[str]] | None,
+    prior_plan: Plan | None,
+    completed_results: Mapping[str, str] | None,
+    user_input: str,
+    conversation_id: str = "",
+    model: str = "",
+) -> TurnClassification:
+    """Classify a turn as new_work / conversational / refine_existing.
+
+    When ``call_llm`` is ``None`` OR ``prior_plan`` is falsy, skips
+    the LLM entirely and delegates to :func:`heuristic_classify_turn`.
+    Keeping the gate off the hot path in both cases is the point of
+    the guard — short-circuiting on missing prior plan avoids an LLM
+    roundtrip on turn 1 of every conversation.
+
+    Any exception raised by ``call_llm`` or any malformed response is
+    logged and collapses to :func:`heuristic_classify_turn`. A
+    misbehaving gate must never hang or mis-route the Runner.
+    """
+    if call_llm is None or prior_plan is None or not prior_plan.tasks:
+        return heuristic_classify_turn(
+            prior_plan=prior_plan,
+            completed_results=completed_results,
+            user_input=user_input,
+            conversation_id=conversation_id,
+        )
+
+    user_prompt = _build_user_prompt(
+        prior_plan=prior_plan,
+        completed_results=completed_results,
+        user_input=user_input,
+        conversation_id=conversation_id,
+    )
+    try:
+        raw = await call_llm(_SYSTEM_PROMPT, user_prompt, model)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("planner_gate.classify_turn: call_llm raised: %s", exc)
+        return heuristic_classify_turn(
+            prior_plan=prior_plan,
+            completed_results=completed_results,
+            user_input=user_input,
+            conversation_id=conversation_id,
+        )
+    verdict = _parse_verdict(raw)
+    if verdict is None:
+        log.warning(
+            "planner_gate.classify_turn: unparseable verdict from LLM; "
+            "falling back to heuristic. raw=%r",
+            raw,
+        )
+        return heuristic_classify_turn(
+            prior_plan=prior_plan,
+            completed_results=completed_results,
+            user_input=user_input,
+            conversation_id=conversation_id,
+        )
+    return verdict
+
+
+def _build_user_prompt(
+    *,
+    prior_plan: Plan | None,
+    completed_results: Mapping[str, str] | None,
+    user_input: str,
+    conversation_id: str,
+) -> str:
+    chunks: list[str] = []
+    if conversation_id:
+        chunks.append(f"Conversation id: {conversation_id}")
+    prior = _plan_brief(prior_plan)
+    if prior:
+        chunks.append("PRIOR PLAN:\n" + prior)
+    results = _results_brief(completed_results)
+    if results:
+        chunks.append(results)
+    chunks.append("NEW USER INPUT:\n" + (user_input or ""))
+    chunks.append(
+        'Classify the new input. Reply JSON only: {"verdict": "...", "reason": "..."}'
+    )
+    return "\n\n".join(chunks)
+
+
+def _parse_verdict(raw: Any) -> TurnClassification | None:
+    """Parse the LLM's response into a canonical verdict, or None on failure."""
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    cleaned = _strip_code_fences(raw).strip()
+    # First try JSON.
+    try:
+        parsed = json.loads(cleaned)
+    except (ValueError, TypeError):
+        parsed = None
+    if isinstance(parsed, dict):
+        verdict = parsed.get("verdict")
+        if isinstance(verdict, str):
+            v = verdict.strip().lower().replace("-", "_").replace(" ", "_")
+            if v in _ALLOWED:
+                return v  # type: ignore[return-value]
+    # Fallback: scan for a bare token. Some models emit just the verdict
+    # string when the prompt is terse enough.
+    lowered = cleaned.lower().replace("-", "_").replace(" ", "_")
+    for candidate in _ALLOWED:
+        # Word-boundary match to avoid "new_workflow" matching "new_work".
+        if re.search(rf"\b{candidate}\b", lowered):
+            return candidate  # type: ignore[return-value]
+    return None
+
+
+__all__ = [
+    "TurnClassification",
+    "classify_turn",
+    "heuristic_classify_turn",
+]

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -54,10 +54,23 @@ from goldfive.events import (
     run_started_event,
 )
 from goldfive.goal_deriver import PassthroughGoalDeriver
+from goldfive.planner_gate import (
+    TurnClassification,
+    classify_turn,
+    heuristic_classify_turn,
+)
 from goldfive.reporting import BUILTIN_REPORTING_TOOLS
 from goldfive.results import ExecutionOutcome
 from goldfive.steerer import DefaultSteerer
-from goldfive.types import Goal, Session
+from goldfive.types import (
+    GOAL_SOURCE_USER_STEER,
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+)
 
 if TYPE_CHECKING:
     from goldfive.control import ControlChannel
@@ -118,6 +131,33 @@ class Runner:
         spurious GOAL_DRIFT firings from the bookkeeping path.
         Has no effect when the steerer was never configured with a
         ``goal_drift_call_llm`` (the feature is already inert).
+    planner_gate:
+        Turn-aware planning gate. On every turn after the first the
+        Runner consults the gate to decide whether to run full
+        ``GoalDeriver.derive`` + ``Planner.generate`` (``"new_work"``),
+        skip planning and let the coordinator answer from context
+        (``"conversational"``), or call ``Planner.refine`` against the
+        prior plan with the new user input as a synthesized steer
+        (``"refine_existing"``). Accepts:
+
+        * A sentinel string ``"auto"`` (default) — use the LLM-backed
+          :func:`goldfive.planner_gate.classify_turn` when a
+          ``call_llm`` is available on the planner, falling through
+          to the deterministic heuristic otherwise. This is the
+          recommended production setting.
+        * ``None`` — disable the gate entirely. Every turn runs full
+          re-planning as in pre-planner-gate behaviour. Useful for
+          deterministic replay and pure-unit tests.
+        * Any async callable with the
+          :func:`~goldfive.planner_gate.classify_turn` signature
+          (``(*, prior_plan, completed_results, user_input,
+          conversation_id) -> str``) — drop-in replacement for the
+          default gate. Must return one of ``"new_work" |
+          "conversational" | "refine_existing"``.
+
+        The gate is always skipped on the first turn of a
+        Conversation (no prior plan to preserve); every first turn
+        runs the full goal-derive + plan-generate path.
     """
 
     def __init__(
@@ -133,6 +173,7 @@ class Runner:
         max_task_invocations: int | None = None,
         conversation: Conversation | None = None,
         goal_drift_enabled: bool = True,
+        planner_gate: Any = "auto",
         **legacy_kwargs: Any,
     ) -> None:
         if "max_plan_reinvocations" in legacy_kwargs:
@@ -178,6 +219,17 @@ class Runner:
         # be monotonic within a run_id, so the terminal marker needs the
         # session that produced the run's other events).
         self._last_session: Session | None = None
+        # Turn-aware planning gate (planner-gate). ``"auto"`` picks the
+        # LLM-backed gate when ``self.planner._call_llm`` exists and
+        # falls back to the pure heuristic otherwise. ``None`` disables
+        # the gate entirely (every turn re-plans). Any other value must
+        # be an async callable implementing the
+        # :func:`goldfive.planner_gate.classify_turn` signature.
+        self._planner_gate: Any = planner_gate
+        # Held across turns so the ``conversational`` path can carry
+        # the prior plan forward onto the freshly minted session
+        # without re-running the planner.
+        self._last_plan: Plan | None = None
 
     # ------------------------------------------------------------------
     # run
@@ -228,6 +280,42 @@ class Runner:
         # 3. Emit RunStarted before anything else for this turn.
         await self._emit_run_started(session, user_input)
 
+        # 3a. Turn-aware planning gate (planner-gate).
+        # Before running goal-derivation + planning for this turn,
+        # ask the classifier whether the new user_input warrants new
+        # work or can be satisfied by the prior plan / conversation
+        # history. First-turn callers (no prior plan) always run full
+        # planning. When ``user_input`` is already a ``list[Goal]``
+        # the caller has opted out of natural-language derivation, so
+        # we also skip the gate.
+        verdict: TurnClassification = "new_work"
+        if self._last_plan is not None and isinstance(user_input, str):
+            try:
+                verdict = await self._classify_turn(
+                    prior_plan=self._last_plan,
+                    completed_results=session.completed_results,
+                    user_input=user_input,
+                )
+            except Exception as exc:  # noqa: BLE001
+                # A misbehaving gate must never hang the Runner; degrade
+                # to full re-planning — the pre-#169 behaviour — so we
+                # always make forward progress.
+                log.warning("planner_gate raised; falling back to new_work: %s", exc)
+                verdict = "new_work"
+
+        # Conversational follow-up: skip goal derivation + planning.
+        # Carry the prior plan forward onto the freshly minted Session
+        # so the executor has something to drive; do not emit
+        # GoalDerived or PlanSubmitted for this turn — the executor
+        # will still close the turn with RunCompleted / RunAborted.
+        if verdict == "conversational":
+            outcome = await self._run_conversational_turn(
+                session=session,
+                user_input=user_input,
+                context=context,
+            )
+            return outcome
+
         # 4. Derive (or accept) goals for this turn. Cross-turn state
         #    lives on ``session.goals`` already (seeded by the
         #    Conversation); we append newly-derived goals that weren't
@@ -272,7 +360,7 @@ class Runner:
             planner_context.update(context)
         planner_context["run_id"] = session.run_id
 
-        # 4. Generate the plan.
+        # 4. Generate (or refine) the plan.
         # Prefer the richer tree shape (goldfive#151) when the adapter
         # exposes it so the planner can constrain assignee_agent_id to
         # real tree names and render the tree in its prompt. Adapters
@@ -284,21 +372,36 @@ class Runner:
             available_agents = list(tree)
         else:
             available_agents = list(self.agent.available_agents)
-        try:
-            plan = await self.planner.generate(
-                goals=session.goals,
+        plan: Plan | None = None
+        if verdict == "refine_existing" and self._last_plan is not None:
+            # Refine path: treat the new user_input as a steering
+            # directive against the prior plan. Preserves completed
+            # tasks verbatim and asks the planner for a delta of new
+            # PENDING tasks. On any refine failure we fall through to
+            # full generate() below — the safe path is always to ship
+            # a plan.
+            plan = await self._refine_from_user_input(
+                prior_plan=self._last_plan,
+                user_input=user_input if isinstance(user_input, str) else "",
+                goals=list(session.goals),
                 available_agents=available_agents,
-                context=planner_context,
             )
-        except Exception as exc:  # noqa: BLE001
-            reason = f"planner.generate raised: {exc}"
-            log.exception("planner.generate raised")
-            await self._emit_run_aborted(session, reason)
-            outcome = ExecutionOutcome(success=False, session=session, reason=reason)
-            self._conversation.absorb_turn(
-                outcome, user_input_summary=_initial_goal_summary(user_input)
-            )
-            return outcome
+        if plan is None:
+            try:
+                plan = await self.planner.generate(
+                    goals=session.goals,
+                    available_agents=available_agents,
+                    context=planner_context,
+                )
+            except Exception as exc:  # noqa: BLE001
+                reason = f"planner.generate raised: {exc}"
+                log.exception("planner.generate raised")
+                await self._emit_run_aborted(session, reason)
+                outcome = ExecutionOutcome(success=False, session=session, reason=reason)
+                self._conversation.absorb_turn(
+                    outcome, user_input_summary=_initial_goal_summary(user_input)
+                )
+                return outcome
 
         if plan is None:
             reason = "no plan generated"
@@ -424,6 +527,13 @@ class Runner:
         _ostate.clear_current_task(session.state)
         _ostate.clear_active_steer(session.state)
 
+        # planner-gate: snapshot the turn's final plan so the next
+        # turn's planner_gate can classify against it. Only stash on
+        # success — an aborted run's plan would poison the next
+        # turn's gate with half-run state.
+        if outcome.success and session.plan is not None:
+            self._last_plan = session.plan
+
         self._conversation.absorb_turn(
             outcome, user_input_summary=_initial_goal_summary(user_input)
         )
@@ -508,6 +618,9 @@ class Runner:
         self._conversation = Conversation.new()
         self._conversation_announced = False
         self._last_session = None
+        # planner-gate: reset turn-aware gate state so the first turn
+        # of the new conversation runs full planning.
+        self._last_plan = None
 
     # ------------------------------------------------------------------
     # close
@@ -607,6 +720,243 @@ class Runner:
     # ------------------------------------------------------------------
     # internals
     # ------------------------------------------------------------------
+
+    async def _classify_turn(
+        self,
+        *,
+        prior_plan: Plan,
+        completed_results: Mapping[str, str],
+        user_input: str,
+    ) -> TurnClassification:
+        """Invoke the planner_gate setting to classify this turn.
+
+        ``planner_gate == None`` short-circuits to ``"new_work"`` so
+        the Runner behaves exactly as before. ``planner_gate ==
+        "auto"`` picks the LLM-backed gate when the planner exposes
+        a ``_call_llm`` and falls through to the heuristic otherwise.
+        Any other value is assumed to be a caller-supplied async
+        callable with the :func:`planner_gate.classify_turn`
+        signature.
+        """
+        gate = self._planner_gate
+        if gate is None:
+            return "new_work"
+        if gate == "auto":
+            call_llm = getattr(self.planner, "_call_llm", None)
+            if call_llm is None:
+                return heuristic_classify_turn(
+                    prior_plan=prior_plan,
+                    completed_results=completed_results,
+                    user_input=user_input,
+                    conversation_id=self._conversation.id,
+                )
+            return await classify_turn(
+                call_llm=call_llm,
+                prior_plan=prior_plan,
+                completed_results=completed_results,
+                user_input=user_input,
+                conversation_id=self._conversation.id,
+                model=getattr(self.planner, "_model", "") or "",
+            )
+        # Caller-supplied async callable.
+        result = await gate(
+            prior_plan=prior_plan,
+            completed_results=completed_results,
+            user_input=user_input,
+            conversation_id=self._conversation.id,
+        )
+        if result not in ("new_work", "conversational", "refine_existing"):
+            log.warning(
+                "planner_gate callable returned non-canonical verdict %r; "
+                "falling back to new_work",
+                result,
+            )
+            return "new_work"
+        return result  # type: ignore[return-value]
+
+    async def _run_conversational_turn(
+        self,
+        *,
+        session: Session,
+        user_input: str | list[Goal],
+        context: Mapping[str, Any] | None,
+    ) -> ExecutionOutcome:
+        """Run a turn classified as ``"conversational"`` by the gate.
+
+        Skips :class:`GoalDeriver.derive`, :meth:`Planner.generate`,
+        and the ``GoalDerived`` / ``PlanSubmitted`` emissions — the
+        prior plan is carried forward onto the freshly minted session
+        and the executor drives the coordinator over existing context.
+        Reporting tools still register and the steerer still binds so
+        the executor's per-task events fire normally; this is the
+        minimum scaffolding the executor needs to turn a single
+        conversational exchange.
+        """
+        _ = context  # currently unused; reserved for future hooks
+        # Carry the prior plan forward. Mutate the prior plan's
+        # run_id to the fresh turn's run_id so sink events correlate
+        # with this turn, but otherwise reuse the same task ids /
+        # statuses so completed tasks stay completed.
+        carried = self._last_plan
+        if carried is None:  # defensive — gate shouldn't have returned
+            return await self._degrade_to_new_work(session, user_input)
+        carried.run_id = session.run_id
+        session.plan = carried
+        _ostate.set_current_plan(session.state, carried)
+        # Do NOT emit GoalDerived / PlanSubmitted — by design, a
+        # conversational turn produces no planning events.
+
+        try:
+            await self.agent.register_reporting_tools(list(BUILTIN_REPORTING_TOOLS))
+        except Exception as exc:  # noqa: BLE001
+            reason = f"register_reporting_tools raised: {exc}"
+            log.exception("register_reporting_tools raised")
+            await self._emit_run_aborted(session, reason)
+            outcome = ExecutionOutcome(success=False, session=session, reason=reason)
+            self._conversation.absorb_turn(
+                outcome, user_input_summary=_initial_goal_summary(user_input)
+            )
+            return outcome
+
+        try:
+            self.steerer.bind(sinks=list(self.sinks), planner=self.planner)
+        except Exception as exc:  # noqa: BLE001
+            reason = f"steerer.bind raised: {exc}"
+            log.exception("steerer.bind raised")
+            await self._emit_run_aborted(session, reason)
+            outcome = ExecutionOutcome(success=False, session=session, reason=reason)
+            self._conversation.absorb_turn(
+                outcome, user_input_summary=_initial_goal_summary(user_input)
+            )
+            return outcome
+
+        bind_adapter_steerer = getattr(self.agent, "bind_steerer", None)
+        if bind_adapter_steerer is not None:
+            try:
+                bind_adapter_steerer(self.steerer)
+            except Exception as exc:  # noqa: BLE001
+                log.debug("adapter.bind_steerer raised on conversational turn: %s", exc)
+        bind_steerer_adapter = getattr(self.steerer, "bind_adapter", None)
+        if callable(bind_steerer_adapter):
+            try:
+                bind_steerer_adapter(self.agent)
+            except Exception as exc:  # noqa: BLE001
+                log.debug("steerer.bind_adapter raised on conversational turn: %s", exc)
+
+        try:
+            executor_kwargs: dict[str, Any] = dict(
+                plan=session.plan,
+                session=session,
+                adapter=self.agent,
+                steerer=self.steerer,
+                planner=self.planner,
+                sinks=list(self.sinks),
+            )
+            if self.control is not None:
+                executor_kwargs["control"] = self.control
+            if isinstance(user_input, str):
+                run_sig = inspect.signature(self.executor.run)
+                if "user_input" in run_sig.parameters:
+                    executor_kwargs["user_input"] = user_input
+            outcome = await self.executor.run(**executor_kwargs)
+        except Exception as exc:  # noqa: BLE001
+            reason = f"executor.run raised (conversational): {exc}"
+            log.exception("executor.run raised (conversational)")
+            await self._emit_run_aborted(session, reason)
+            aborted = ExecutionOutcome(success=False, session=session, reason=reason)
+            self._conversation.absorb_turn(
+                aborted, user_input_summary=_initial_goal_summary(user_input)
+            )
+            return aborted
+
+        _ostate.clear_current_task(session.state)
+        _ostate.clear_active_steer(session.state)
+        # Do NOT overwrite ``self._last_plan`` — the conversational
+        # turn piggy-backed on the prior plan; preserve it verbatim
+        # for the next turn's gate.
+        self._conversation.absorb_turn(
+            outcome, user_input_summary=_initial_goal_summary(user_input)
+        )
+        return outcome
+
+    async def _degrade_to_new_work(
+        self,
+        session: Session,
+        user_input: str | list[Goal],
+    ) -> ExecutionOutcome:
+        """Fallback for a conversational verdict with no prior plan.
+
+        Should never trigger in production — the gate checks for a
+        prior plan before returning ``"conversational"`` — but if it
+        does, we abort cleanly rather than drive the executor over a
+        missing plan.
+        """
+        reason = "planner_gate returned conversational but no prior plan is available"
+        log.warning(reason)
+        await self._emit_run_aborted(session, reason)
+        outcome = ExecutionOutcome(success=False, session=session, reason=reason)
+        self._conversation.absorb_turn(
+            outcome, user_input_summary=_initial_goal_summary(user_input)
+        )
+        return outcome
+
+    async def _refine_from_user_input(
+        self,
+        *,
+        prior_plan: Plan,
+        user_input: str,
+        goals: list[Goal],
+        available_agents: Any,
+    ) -> Plan | None:
+        """Build a synthetic USER_STEER drift and call ``planner.refine``.
+
+        The new user_input is treated as a steering directive against
+        the prior plan. Returns ``None`` if the planner doesn't
+        support refine or any step raises — the caller then falls
+        through to :meth:`Planner.generate`, which is always safe.
+        """
+        if not user_input.strip():
+            return None
+        refine = getattr(self.planner, "refine", None)
+        if refine is None:
+            return None
+        # Synthesize a steer Goal so the refine prompt can reference it.
+        synth = getattr(self.planner, "synthesize_goal_from_steer", None)
+        steer_goal: Goal | None = None
+        if callable(synth):
+            try:
+                pair = await synth(user_input)
+            except Exception as exc:  # noqa: BLE001
+                log.debug("synthesize_goal_from_steer raised: %s", exc)
+                pair = None
+            if pair is not None:
+                steer_goal, _mode = pair
+        if steer_goal is None:
+            steer_goal = Goal(
+                id="steer",
+                summary=user_input.strip(),
+                source=GOAL_SOURCE_USER_STEER,
+            )
+        else:
+            steer_goal.source = GOAL_SOURCE_USER_STEER
+        refine_goals = list(goals)
+        refine_goals.append(steer_goal)
+        drift = DriftEvent(
+            kind=DriftKind.USER_STEER,
+            severity=DriftSeverity.HIGH,
+            detail=user_input.strip(),
+        )
+        try:
+            return await refine(
+                plan=prior_plan,
+                drift=drift,
+                goals=refine_goals,
+                observed_actions=None,
+                available_agents=available_agents,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning("planner.refine raised from planner_gate path: %s", exc)
+            return None
 
     async def _resolve_goals(
         self,

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -311,6 +311,12 @@ async def test_runner_planner_sees_prior_turn_context() -> None:
         executor=SequentialExecutor(),
         goal_deriver=PassthroughGoalDeriver("demo"),
         sinks=[InMemorySink()],
+        # Disable the turn-aware planning gate (planner-gate): this
+        # test exercises the planner-context wiring on turn 2, so we
+        # need Planner.generate to actually run on turn 2 — the gate
+        # would otherwise classify the short "make it funnier" input
+        # as conversational and skip the planner call.
+        planner_gate=None,
     )
     out1 = await runner.run("write a limerick about cats")
     assert out1.success

--- a/tests/test_planner_gate.py
+++ b/tests/test_planner_gate.py
@@ -1,0 +1,234 @@
+"""Unit tests for :mod:`goldfive.planner_gate`.
+
+Covers:
+
+* The deterministic ``heuristic_classify_turn`` fallback: the LLM-free
+  path the Runner uses when ``planner.call_llm`` is missing.
+* The LLM-backed ``classify_turn``: verdict parsing, JSON / bare-token
+  response shapes, fallback to heuristic on parse failure, and the
+  short-circuit when no prior plan is supplied.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from goldfive.planner_gate import (
+    classify_turn,
+    heuristic_classify_turn,
+)
+from goldfive.types import Plan, Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _prior_plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="Gather facts", status=TaskStatus.COMPLETED),
+            Task(id="t2", title="Draft post", status=TaskStatus.COMPLETED),
+            Task(id="t3", title="Review", status=TaskStatus.COMPLETED),
+        ],
+        edges=[],
+        summary="Draft + review a short post.",
+    )
+
+
+def _empty_plan() -> Plan:
+    return Plan(id="empty", run_id="", goal_ids=[], tasks=[], edges=[])
+
+
+def _call_llm_returning(*chunks: str) -> Callable[..., Any]:
+    """Build an async stub that yields canned strings in order."""
+    queue = list(chunks)
+
+    async def _llm(system: str, user: str, model: str) -> str:
+        _ = system, user, model
+        if not queue:
+            raise AssertionError("stub exhausted")
+        return queue.pop(0)
+
+    return _llm
+
+
+# ---------------------------------------------------------------------------
+# Heuristic fallback
+# ---------------------------------------------------------------------------
+
+
+def test_heuristic_no_prior_plan_returns_new_work() -> None:
+    verdict = heuristic_classify_turn(
+        prior_plan=None,
+        completed_results={},
+        user_input="make a 2-slide deck about solar panels",
+        conversation_id="c1",
+    )
+    assert verdict == "new_work"
+
+
+def test_heuristic_empty_prior_plan_returns_new_work() -> None:
+    verdict = heuristic_classify_turn(
+        prior_plan=_empty_plan(),
+        completed_results={},
+        user_input="short follow-up",
+        conversation_id="c1",
+    )
+    assert verdict == "new_work"
+
+
+def test_heuristic_short_follow_up_after_prior_plan_is_conversational() -> None:
+    verdict = heuristic_classify_turn(
+        prior_plan=_prior_plan(),
+        completed_results={"t1": "facts"},
+        user_input="where is the presentation located?",
+        conversation_id="c1",
+    )
+    assert verdict == "conversational"
+
+
+def test_heuristic_long_follow_up_after_prior_plan_is_new_work() -> None:
+    # > 20 tokens — the heuristic's conservative fallback.
+    long_ask = " ".join(["and"] * 25) + " please make a full new workflow"
+    verdict = heuristic_classify_turn(
+        prior_plan=_prior_plan(),
+        completed_results={"t1": "facts"},
+        user_input=long_ask,
+        conversation_id="c1",
+    )
+    assert verdict == "new_work"
+
+
+def test_heuristic_never_returns_refine_existing() -> None:
+    # Heuristic is conservative: never guesses refine; LLM is required
+    # for that verdict.
+    for ui in ["make it funnier", "also add a slide about X", "actually, change the title"]:
+        assert heuristic_classify_turn(
+            prior_plan=_prior_plan(),
+            completed_results={},
+            user_input=ui,
+        ) in ("conversational", "new_work")
+
+
+# ---------------------------------------------------------------------------
+# LLM-backed classifier
+# ---------------------------------------------------------------------------
+
+
+async def test_classify_turn_without_call_llm_delegates_to_heuristic() -> None:
+    verdict = await classify_turn(
+        call_llm=None,
+        prior_plan=_prior_plan(),
+        completed_results={},
+        user_input="where did you save it",
+        conversation_id="c1",
+    )
+    assert verdict == "conversational"
+
+
+async def test_classify_turn_without_prior_plan_skips_llm() -> None:
+    calls: list[tuple[str, str, str]] = []
+
+    async def _llm(system: str, user: str, model: str) -> str:
+        calls.append((system, user, model))
+        return json.dumps({"verdict": "conversational", "reason": "x"})
+
+    verdict = await classify_turn(
+        call_llm=_llm,
+        prior_plan=None,
+        completed_results={},
+        user_input="any",
+        conversation_id="c1",
+    )
+    assert verdict == "new_work"
+    # No LLM call — the gate shortcut fires when there's no prior plan.
+    assert calls == []
+
+
+async def test_classify_turn_parses_json_verdict_conversational() -> None:
+    llm = _call_llm_returning(
+        json.dumps({"verdict": "conversational", "reason": "asking about artefact location"})
+    )
+    verdict = await classify_turn(
+        call_llm=llm,
+        prior_plan=_prior_plan(),
+        completed_results={"t1": "done"},
+        user_input="where is the presentation located?",
+        conversation_id="c1",
+    )
+    assert verdict == "conversational"
+
+
+async def test_classify_turn_parses_json_verdict_refine_existing() -> None:
+    llm = _call_llm_returning(
+        json.dumps({"verdict": "refine_existing", "reason": "extends prior plan"})
+    )
+    verdict = await classify_turn(
+        call_llm=llm,
+        prior_plan=_prior_plan(),
+        completed_results={},
+        user_input="also add a slide about cost of panels",
+        conversation_id="c1",
+    )
+    assert verdict == "refine_existing"
+
+
+async def test_classify_turn_parses_json_verdict_new_work() -> None:
+    llm = _call_llm_returning(
+        json.dumps({"verdict": "new_work", "reason": "wholly new topic"})
+    )
+    verdict = await classify_turn(
+        call_llm=llm,
+        prior_plan=_prior_plan(),
+        completed_results={},
+        user_input="now write me a haiku about birds",
+        conversation_id="c1",
+    )
+    assert verdict == "new_work"
+
+
+async def test_classify_turn_accepts_bare_token_response() -> None:
+    llm = _call_llm_returning("conversational")
+    verdict = await classify_turn(
+        call_llm=llm,
+        prior_plan=_prior_plan(),
+        completed_results={},
+        user_input="where is it?",
+        conversation_id="c1",
+    )
+    assert verdict == "conversational"
+
+
+async def test_classify_turn_malformed_response_falls_back_to_heuristic() -> None:
+    llm = _call_llm_returning("totally not valid json or verdict")
+    # Short input after prior plan → heuristic gives "conversational".
+    verdict = await classify_turn(
+        call_llm=llm,
+        prior_plan=_prior_plan(),
+        completed_results={},
+        user_input="where is it?",
+        conversation_id="c1",
+    )
+    assert verdict == "conversational"
+
+
+async def test_classify_turn_llm_raising_falls_back_to_heuristic() -> None:
+    async def _boom(system: str, user: str, model: str) -> str:
+        raise RuntimeError("provider down")
+
+    # Long input without a prior-plan-aware verdict → heuristic's new_work.
+    long = " ".join(["and"] * 25) + " please do something entirely new"
+    verdict = await classify_turn(
+        call_llm=_boom,
+        prior_plan=_prior_plan(),
+        completed_results={},
+        user_input=long,
+        conversation_id="c1",
+    )
+    assert verdict == "new_work"

--- a/tests/test_runner_multi_turn.py
+++ b/tests/test_runner_multi_turn.py
@@ -1,0 +1,224 @@
+"""Runner-level multi-turn gating tests (planner-gate).
+
+Verifies the core promise of the planning gate: a conversational
+follow-up on turn 2 does not re-run goal derivation or planning and
+emits no ``GoalDerived`` / ``PlanSubmitted`` events, but still
+produces a terminal ``RunCompleted``. Turn 1 still runs full planning.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from goldfive import (
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    LLMPlanner,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _linear_plan() -> Plan:
+    return Plan(
+        id="plan-fixture",
+        run_id="",
+        goal_ids=["g"],
+        tasks=[
+            Task(id="research", title="Research", assignee_agent_id="writer"),
+            Task(id="draft", title="Draft", assignee_agent_id="writer"),
+        ],
+        edges=[TaskEdge(from_task_id="research", to_task_id="draft")],
+        summary="Research then draft.",
+    )
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = tools, session
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+def _kinds(events: list[Any]) -> list[str]:
+    out: list[str] = []
+    for e in events:
+        name = e.WhichOneof("payload") or ""
+        out.append("".join(part.capitalize() for part in name.split("_")) if name else "")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_conversational_turn_skips_planning_llm_gate() -> None:
+    """Turn 2 classified as "conversational" must not emit PlanSubmitted."""
+    # An LLM planner whose call_llm returns a full plan on every call —
+    # so we can tell from event counts whether the gate actually
+    # skipped ``generate`` on turn 2. The gate itself also reads the
+    # planner's call_llm; we route gate calls to a separate path by
+    # sniffing the system prompt.
+
+    plan_json = (
+        '{"summary":"t","tasks":[{"id":"t1","title":"T","assignee_agent_id":"writer"}]}'
+    )
+
+    calls: list[tuple[str, str]] = []
+
+    async def planner_llm(system: str, user: str, model: str) -> str:
+        _ = model
+        calls.append((system[:40], user[:40]))
+        # The gate's system prompt starts with the distinctive phrase
+        # "You are a turn-classifier"; route those calls to the
+        # conversational verdict on turn 2 and new_work on turn 1.
+        if "turn-classifier" in system:
+            return '{"verdict": "conversational", "reason": "ask about location"}'
+        # Otherwise it's a plan-generate call.
+        return plan_json
+
+    planner = LLMPlanner(call_llm=planner_llm, model="stub")
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    out1 = await runner.run("make a 2-slide presentation about solar panels")
+    assert out1.success
+    turn1_plan_id = out1.session.plan.id
+    turn1_end_index = len(sink.events)
+
+    out2 = await runner.run("where is the presentation located?")
+    await runner.close()
+
+    turn2_kinds = _kinds(sink.events[turn1_end_index:])
+
+    # Turn 2 emits RunStarted and RunCompleted but NEITHER
+    # GoalDerived nor PlanSubmitted — the gate short-circuited the
+    # planning phase.
+    assert "RunStarted" in turn2_kinds
+    assert "GoalDerived" not in turn2_kinds
+    assert "PlanSubmitted" not in turn2_kinds
+    assert "RunCompleted" in turn2_kinds or "RunAborted" in turn2_kinds
+
+    # Session.plan on turn 2 is the SAME plan id as turn 1 — carried
+    # forward verbatim, not regenerated.
+    assert out2.session.plan is not None
+    assert out2.session.plan.id == turn1_plan_id
+
+
+async def test_first_turn_still_runs_full_planning() -> None:
+    """Turn 1 with no prior plan always runs goal-derive + generate."""
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+    await runner.run("turn one")
+    await runner.close()
+
+    kinds = _kinds(sink.events)
+    assert "RunStarted" in kinds
+    assert "GoalDerived" in kinds
+    assert "PlanSubmitted" in kinds
+
+
+async def test_planner_gate_none_disables_classifier() -> None:
+    """``planner_gate=None`` restores pre-gate behaviour: every turn re-plans."""
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+        planner_gate=None,
+    )
+    await runner.run("turn one")
+    turn1_end = len(sink.events)
+    await runner.run("where is the artefact?")
+    await runner.close()
+
+    turn2 = _kinds(sink.events[turn1_end:])
+    # With the gate disabled, every turn emits GoalDerived +
+    # PlanSubmitted — the pre-gate shape.
+    assert "GoalDerived" in turn2
+    assert "PlanSubmitted" in turn2
+
+
+async def test_caller_supplied_gate_is_invoked() -> None:
+    """Callers can inject a custom classifier callable."""
+    captured: dict[str, Any] = {}
+
+    async def gate(*, prior_plan, completed_results, user_input, conversation_id):
+        captured["user_input"] = user_input
+        captured["conversation_id"] = conversation_id
+        return "conversational"
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+        planner_gate=gate,
+    )
+    await runner.run("turn one")
+    turn1_end = len(sink.events)
+    await runner.run("just a quick question about what you did")
+    await runner.close()
+
+    assert captured["user_input"] == "just a quick question about what you did"
+    assert captured["conversation_id"] == runner.conversation_id
+
+    turn2 = _kinds(sink.events[turn1_end:])
+    # Gate returned "conversational" → no PlanSubmitted on turn 2.
+    assert "PlanSubmitted" not in turn2
+
+
+async def test_conversational_turn_carries_prior_plan_unchanged() -> None:
+    """Turn 2 session.plan identity matches the prior turn's plan id + tasks."""
+
+    async def gate(*, prior_plan, completed_results, user_input, conversation_id):
+        _ = prior_plan, completed_results, user_input, conversation_id
+        return "conversational"
+
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[InMemorySink()],
+        planner_gate=gate,
+    )
+    out1 = await runner.run("turn one")
+    out2 = await runner.run("a follow-up question")
+    await runner.close()
+
+    assert out1.session.plan.id == out2.session.plan.id
+    assert [t.id for t in out1.session.plan.tasks] == [
+        t.id for t in out2.session.plan.tasks
+    ]


### PR DESCRIPTION
## Bug reproduction

> `Runner.run(user_input)` unconditionally invokes `GoalDeriver.derive` + `Planner.generate` on every turn of a multi-turn Conversation. Reproduced: user asks "make a 2-slide presentation about solar panels" → full 6-task plan runs, all tasks complete, coordinator reports. User then asks follow-up "where is the presentation located?" — `GoalDeriver` mints a new goal, `LLMPlanner.generate` synthesizes a new 6-task plan that repeats the whole workflow ("locate files", "research content", "design slides", "create presentation", "validate", "report"). The coordinator LLM itself correctly answers in a single turn because it sees conversation history, but the *plan* is absurd.
>
> Screenshot-confirmed: `2 plans · 12 tasks` in the orchestration timeline for a session where the second turn was purely conversational.

## Fix

New `goldfive.planner_gate` module ships a classifier slotting in before `GoalDeriver.derive` on every turn after the first. Three verdicts:

| Verdict | Runner behaviour |
| --- | --- |
| `new_work` | Run full `GoalDeriver.derive` + `Planner.generate` (current behaviour). Emits `GoalDerived` + `PlanSubmitted`. |
| `conversational` | Skip planning entirely. Prior plan carried forward onto the fresh Session. Emits `RunStarted` → executor answers → `RunCompleted`. No `GoalDerived` / `PlanSubmitted` for the turn. |
| `refine_existing` | Call `Planner.refine` against the prior plan with the new user_input synthesized into a `USER_STEER` drift. Completed tasks preserved; a delta of new PENDING tasks is appended. |

## Modes

- **LLM-backed** (`classify_turn`): invoked when the planner exposes a `_call_llm`. Asks the LLM to return `{"verdict": ..., "reason": ...}`. Malformed or raising responses fall through to the heuristic.
- **Deterministic heuristic** (`heuristic_classify_turn`): no prior plan → `new_work`; short follow-up (< 20 tokens) after a prior plan → `conversational`; otherwise `new_work`. Conservative by design — the heuristic never guesses `refine_existing`.

## Runner API

`Runner(..., planner_gate=...)` accepts:

- `"auto"` (default) — LLM-or-heuristic hybrid.
- `None` — disable gating entirely (pre-gate behaviour; useful for deterministic replay and unit tests).
- Any async callable with the `classify_turn` signature — drop-in replacement.

First turn always runs full planning (no prior plan to classify against). `new_conversation()` resets the stashed prior plan.

## Test plan

- [x] `tests/test_planner_gate.py` — 13 unit tests covering the heuristic fallback and LLM-backed classifier (JSON / bare-token / malformed / exception / empty-prior-plan paths).
- [x] `tests/test_runner_multi_turn.py` — 5 integration tests: turn 1 still plans, turn 2 conversational skips `PlanSubmitted`, `planner_gate=None` disables the gate, caller-supplied async gate is invoked, prior plan id + tasks carry forward unchanged.
- [x] `tests/test_conversation.py::test_runner_planner_sees_prior_turn_context` now passes `planner_gate=None` so it keeps exercising the planner-context wiring on turn 2.
- [x] Full suite: 930 passed, 76 skipped.

## Scope

Does not touch the Executor, Steerer, reconciler, `LLMPlanner` prompts, or `GoalDeriver`.