### PR TITLE
Do not emit drift_detected for read-only status_query controls

### DIFF
--- a/docs/design/VOCABULARY.md
+++ b/docs/design/VOCABULARY.md
@@ -410,7 +410,7 @@ session-state mutation, not drift synthesis.
 
 | `DriftKind` | Value | Default severity | Trigger |
 |---|---|---|---|
-| `CUSTOM` | `"custom"` | caller's choice | Caller-supplied drift kind. Used by `emit_status_report` for `STATUS_QUERY` audit events (severity `INFO`). Prefer a named kind when one fits. |
+| `CUSTOM` | `"custom"` | caller's choice | Caller-supplied drift kind. Prefer a named kind when one fits. |
 
 ### Count check
 
@@ -445,7 +445,7 @@ and who emits each. Factories for every kind live in `goldfive/events.py`.
 | `task_failed` | `task_failed_event` | **Steerer** | `mark_task_failed` — `RUNNING → FAILED`. |
 | `task_blocked` | `task_blocked_event` | **Steerer** | `mark_task_blocked` — `RUNNING → BLOCKED`. |
 | `task_cancelled` | `task_cancelled_event` | **Steerer** | `mark_task_cancelled` — `* → CANCELLED`. |
-| `drift_detected` | `drift_detected_event` | **Steerer** | Every successful `_handle_drift` call. Also used by `control_received_event` and `emit_status_report`. |
+| `drift_detected` | `drift_detected_event` | **Steerer** | Every successful `_handle_drift` call. Also used by `control_received_event`. (`STATUS_QUERY` is read-only — it does NOT emit drift events; the snapshot is returned via the control-channel ack's `detail` field.) |
 | `run_completed` | `run_completed_event` | **Executor** | Terminal success — all tasks reached a terminal state with the plan fully realized. |
 | `run_aborted` | `run_aborted_event` | **Runner** *or* **Executor** | Runner emits on setup failure (pre-executor). Executor emits on reinvocation cap, cancel, or unrecoverable drift. |
 

--- a/goldfive/executors/_control.py
+++ b/goldfive/executors/_control.py
@@ -29,9 +29,10 @@ members and their raw string equivalents — ``ControlKind`` is a
   can produce a fresh plan on the ``USER_STEER`` drift.
 * ``REWIND_TO`` — mark a task and every downstream task ``PENDING``
   so the executor re-walks them.
-* ``STATUS_QUERY`` — synthesize a status-snapshot event on the sinks
-  (forward-compat; not in the Phase-1 ``ControlKind`` enum, but
-  recognized if an external caller sends the string).
+* ``STATUS_QUERY`` — read-only probe. Returns a compact status
+  snapshot string via the ack's ``detail`` field. Does NOT emit any
+  sink events: status polling must not register as drift or pollute
+  observer streams.
 * ``INTERCEPT_TRANSFER`` — toggle ``session._intercept_transfer`` so
   adapters that honour the flag refuse transfers.
 * ``APPROVE`` / ``REJECT`` — resolve a pending human-in-the-loop
@@ -60,9 +61,9 @@ log = logging.getLogger(__name__)
 __all__ = [
     "ControlOutcome",
     "_ControlCancelled",
+    "build_status_snapshot",
     "dispatch_control",
     "drain_controls",
-    "emit_status_report",
 ]
 
 
@@ -136,24 +137,21 @@ def _kind_value(msg: ControlMessage) -> str:
     return str(getattr(raw, "value", raw)).upper()
 
 
-async def emit_status_report(
-    *,
-    session: Session,
-    sinks: list[EventSink],
-    control_id: str,
-) -> None:
-    """Emit a synthetic status report as a ``DriftDetected`` event.
+def build_status_snapshot(*, session: Session, control_id: str) -> str:
+    """Build a compact status-snapshot string for a STATUS_QUERY ack.
 
     STATUS_QUERY messages ask the runner "what are you working on right
-    now?" Reuses the existing ``DriftDetected`` payload (no proto regen
-    for Phase 1 — see issue #71) with kind ``CUSTOM`` and a detail
-    string that encodes a compact status snapshot. External observers
-    pick the message up off the sink stream and surface it to the UI.
-    """
-    from goldfive.events import drift_detected_event
-    from goldfive.events import emit as emit_event
-    from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+    now?" This is a read-only probe — it MUST NOT emit any drift events
+    or pollute the sink stream. The snapshot string is returned via the
+    control-channel ack's ``detail`` field so the frontend can poll
+    cheaply without generating observer-visible drift markers.
 
+    Previous versions (pre goldfive#XXX) synthesised a ``DriftDetected``
+    event here, which meant every status poll produced 2 drift rows in
+    the sink chain. A 5-minute e2e run saw 33,666 bogus
+    ``drift_detected`` events with ``kind=0`` (UNSPECIFIED) — this
+    helper is the fix.
+    """
     plan = session.plan
     total = len(plan.tasks) if plan is not None else 0
     completed_ids: list[str] = []
@@ -169,31 +167,11 @@ async def emit_status_report(
                 TaskStatus.BLOCKED,
             ):
                 pending_ids.append(t.id)
-    detail = (
+    return (
         f"status_query control_id={control_id} current_task={current} "
         f"completed={len(completed_ids)}/{total} "
         f"pending={','.join(pending_ids) or '-'}"
     )
-    drift = DriftEvent(
-        kind=DriftKind.CUSTOM,
-        severity=DriftSeverity.INFO,
-        detail=detail,
-        current_task_id=current,
-    )
-    try:
-        evt = drift_detected_event(
-            run_id=session.run_id,
-            sequence=session.next_sequence(),
-            drift=drift,
-            session_id=session.id,
-        )
-    except Exception as exc:  # noqa: BLE001 — proto stubs may be missing
-        log.debug("emit_status_report: proto event build failed: %s", exc)
-        return
-    try:
-        await emit_event(sinks, evt)
-    except Exception as exc:  # noqa: BLE001
-        log.debug("emit_status_report: sink emit raised: %s", exc)
 
 
 async def dispatch_control(
@@ -286,9 +264,15 @@ async def dispatch_control(
         )
 
     if kind == "STATUS_QUERY":
-        await emit_status_report(session=session, sinks=sinks, control_id=msg.id)
+        # Read-only probe: return the status snapshot via the ack's
+        # `detail` field. Do NOT emit a drift event — status polls must
+        # not pollute the sink stream or register as drift markers in
+        # the frontend. See the module docstring for the background
+        # (goldfive#XXX: 33k bogus drift_detected events from
+        # status_query polling in a single 5-min e2e run).
+        snapshot = build_status_snapshot(session=session, control_id=msg.id)
         return ControlOutcome(
-            ack=_build_ack(msg, result=AckResult.SUCCESS, detail="status emitted"),
+            ack=_build_ack(msg, result=AckResult.SUCCESS, detail=snapshot),
         )
 
     if kind == "INTERCEPT_TRANSFER":

--- a/tests/test_executor_control.py
+++ b/tests/test_executor_control.py
@@ -519,11 +519,20 @@ async def test_rewind_helper_resets_target_and_downstream_only() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Sequential executor: STATUS_QUERY emits a synthetic event
+# Sequential executor: STATUS_QUERY is a read-only probe — no drift events
 # ---------------------------------------------------------------------------
 
 
-async def test_sequential_status_query_emits_event_and_acks_success() -> None:
+async def test_sequential_status_query_emits_no_drift_and_returns_snapshot_in_ack() -> None:
+    """STATUS_QUERY must NOT emit any drift_detected (or other) sink
+    events — it is a read-only probe. The status snapshot is returned
+    via the ack's ``detail`` field so the frontend can poll cheaply
+    without polluting the sink stream.
+
+    Regression test for the "33k bogus drift_detected events per 5-min
+    run" bug: each status_query poll previously fired a
+    ``DriftDetected`` with ``kind=0`` (UNSPECIFIED) on every sink.
+    """
     plan = _linear_plan(["t0", "t1"])
     session = _fresh_session()
     steerer = StubSteerer()
@@ -535,15 +544,13 @@ async def test_sequential_status_query_emits_event_and_acks_success() -> None:
 
     async def _handler(task: Task, session: Session) -> InvocationResult:
         if task.id == "t0":
-            # Send a STATUS_QUERY while t0 is running. Using a raw
-            # string kind is the forward-compat path; ControlMessage's
-            # kind field is not runtime-enforced.
-            await channel.send(
-                ControlMessage(kind="STATUS_QUERY", payload={})  # type: ignore[arg-type]
-            )
+            # Fire several STATUS_QUERY probes to mirror a polling
+            # frontend; none should produce drift events.
+            for _ in range(5):
+                await channel.send(
+                    ControlMessage(kind="STATUS_QUERY", payload={})  # type: ignore[arg-type]
+                )
             status_sent.set()
-            # Brief sleep so the executor has time to pick up the
-            # control message before the adapter returns.
             await asyncio.sleep(0.1)
         for t in session.plan.tasks:
             if t.id == task.id:
@@ -568,12 +575,20 @@ async def test_sequential_status_query_emits_event_and_acks_success() -> None:
 
     assert outcome.success is True
     assert status_sent.is_set()
-    # A DriftDetected event was emitted for the status report.
+    # ZERO drift events from status_query polling. Any drift detail
+    # matching "status_query" is a regression.
     drifts = sink.drift_events()
-    assert any("status_query" in (getattr(d, "detail", "")) for d in drifts)
-    # Ack was SUCCESS.
-    acks = await _drain_acks(channel, count=1, timeout=1.0)
-    assert len(acks) == 1 and acks[0].result == AckResult.SUCCESS
+    offending = [d for d in drifts if "status_query" in getattr(d, "detail", "")]
+    assert offending == [], (
+        f"STATUS_QUERY must not emit drift_detected events; got {offending!r}"
+    )
+    # All 5 polls get SUCCESS acks whose detail carries the snapshot.
+    acks = await _drain_acks(channel, count=5, timeout=1.0)
+    assert len(acks) == 5
+    assert all(a.result == AckResult.SUCCESS for a in acks)
+    assert all("status_query" in a.detail for a in acks), (
+        f"expected snapshot in ack.detail; got {[a.detail for a in acks]!r}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_live_steering_e2e.py
+++ b/tests/test_live_steering_e2e.py
@@ -17,8 +17,9 @@ Scenarios covered:
 * PAUSE between tasks blocks the executor until RESUME arrives.
 * REWIND_TO resets a target task plus every downstream task back to
   ``PENDING`` so the executor re-walks them.
-* STATUS_QUERY emits a synthetic :class:`DriftDetected` report on the
-  sinks and acks ``SUCCESS``.
+* STATUS_QUERY is a read-only probe — it does NOT emit any sink
+  events; the status snapshot is returned via the ack's ``detail``
+  field.
 
 Module-level tests in ``tests/test_executor_control.py`` already cover
 executor-level semantics with a stub steerer; the tests here verify the
@@ -437,8 +438,15 @@ async def test_rewind_resets_target_and_downstream_tasks() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_status_query_emits_synthetic_report() -> None:
-    """STATUS_QUERY emits a synthetic ``DriftDetected`` status event."""
+async def test_status_query_is_readonly_no_drift_snapshot_in_ack() -> None:
+    """STATUS_QUERY is a read-only probe: NO sink events, snapshot in ack.
+
+    Regression guard for the "33k bogus drift_detected events per
+    5-minute e2e run" bug: every status_query poll used to produce a
+    synthetic ``DriftDetected`` event with ``kind=0`` (UNSPECIFIED),
+    crushing harmonograf's DB and frontend rendering. Status snapshots
+    now flow back via the ack's ``detail`` field only.
+    """
 
     sink = InMemorySink()
     channel = ControlChannel()
@@ -478,10 +486,16 @@ async def test_status_query_emits_synthetic_report() -> None:
     assert outcome.success is True
     assert status_sent.is_set()
 
+    # NO drift events should mention status_query. Any drift row tagged
+    # with status_query is a regression of the 33k-drift bug.
     details = _drift_details(sink.events)
-    assert any("status_query" in d for d in details), (
-        f"expected a status_query drift emission; got drift details={details}"
+    offending = [d for d in details if "status_query" in d]
+    assert offending == [], (
+        f"STATUS_QUERY must not emit drift_detected events; got {offending!r}"
     )
 
     acks = await _drain_acks(channel, count=1, timeout=1.0)
-    assert len(acks) == 1 and acks[0].result == AckResult.SUCCESS
+    assert len(acks) == 1
+    assert acks[0].result == AckResult.SUCCESS
+    # Snapshot is returned via the ack's detail field.
+    assert "status_query" in acks[0].detail


### PR DESCRIPTION
## Bug (DB-verified)

In a single ~5-minute e2e run (harmonograf session `0f4959c9-798e-44b8-8cc2-ab049d0bb415`), goldfive emitted **33,666 `drift_detected` events**, all with `kind=0` (DRIFT_KIND_UNSPECIFIED) and `detail` strings like `status_query control_id=ctl_492f4889e1ab4eee current_task=create_slide1 complete`. Each `status_query` poll produced 2 drift events on the sink chain, which:

- pollutes harmonograf's DB,
- crushes frontend rendering, and
- produces bogus "drift storm" markers meaningless to operators.

`STATUS_QUERY` is a read-only control command — the frontend polls it to ask "what is the current state". It is not a drift observation and should not emit drift events.

## Root cause

`goldfive/executors/_control.py::emit_status_report` synthesised a `DriftDetected` event on every STATUS_QUERY dispatch (the `Phase 1 — no proto regen` shortcut from issue #71). The proto int enum fell through to `0` (UNSPECIFIED) on the wire despite the helper writing `DriftKind.CUSTOM`, so the DB rows were doubly useless — noisy *and* untyped.

## Fix

STATUS_QUERY now returns the status snapshot via the control-channel ack's `detail` field — the same mechanism every other control kind already uses to report results. Zero sink events are produced by a status poll.

All other control kinds (STEER, CANCEL, PAUSE, RESUME, REWIND_TO, INTERCEPT_TRANSFER, APPROVE/REJECT) are unchanged — their drift emissions are the intended intervention surface.

The helper is renamed from `emit_status_report` to `build_status_snapshot` to reflect the new signature (returns `str`; no I/O, no sinks).

## Tests

- `tests/test_executor_control.py`: fires 5 STATUS_QUERY probes on one run and asserts **zero** `drift_detected` events reach the sinks, and that all 5 acks carry the snapshot in `detail`.
- `tests/test_live_steering_e2e.py`: updated the e2e STATUS_QUERY test to the same contract.
- All existing STEER/CANCEL/PAUSE/RESUME/REWIND tests continue to pass.

## Test plan

- [x] `uv run pytest tests/` — **1112 passed, 46 skipped** locally
- [x] Targeted control-path tests pass (`test_executor_control.py`, `test_live_steering_e2e.py`, `test_control_primitive.py`, `test_control_proto.py`)
- [x] Manual review: no other callers of `emit_status_report` in code (two doc-only references in `VOCABULARY.md` updated)
- [ ] Post-merge: run the same e2e harmonograf session and verify `drift_detected` event count drops to the handful that correspond to actual interventions