### PR TITLE
conv: drop pb parameter from enum helpers (fail loud on missing names)

### DIFF
--- a/goldfive/conv.py
+++ b/goldfive/conv.py
@@ -47,6 +47,26 @@ def _pb_module() -> Any:
 # ---------------------------------------------------------------------------
 
 
+def _strict_enum_value(pb: Any, name: str) -> int:
+    """Resolve ``name`` to its proto enum int on ``pb`` or raise.
+
+    The historical helpers used ``getattr(pb, name, 0)`` which silently
+    returned the UNSPECIFIED sentinel when callers passed the wrong proto
+    module (see goldfive#211 — the status_query dispatch path accidentally
+    passed ``events_pb2`` and downgraded 50k+ drift events to ``kind=0``).
+
+    Callers must not pass the wrong module; this helper refuses to paper
+    over missing names so that kind of mistake fails loud in tests instead
+    of silently corrupting the wire. The ``_pb_module()`` /
+    ``_events_pb_module()`` / ``_control_pb_module()`` accessors are the
+    only legitimate sources.
+    """
+    try:
+        return getattr(pb, name)
+    except AttributeError as exc:
+        raise ValueError(f"unknown proto enum value: {name}") from exc
+
+
 _TASK_STATUS_TO_PB: dict[TaskStatus, str] = {
     TaskStatus.PENDING: "TASK_STATUS_PENDING",
     TaskStatus.RUNNING: "TASK_STATUS_RUNNING",
@@ -62,14 +82,16 @@ _TASK_STATUS_TO_PB: dict[TaskStatus, str] = {
 _PB_TO_TASK_STATUS: dict[str, TaskStatus] = {v: k for k, v in _TASK_STATUS_TO_PB.items()}
 
 
-def _task_status_to_pb(status: TaskStatus, pb: Any) -> int:
+def _task_status_to_pb(status: TaskStatus) -> int:
+    pb = _pb_module()
     name = _TASK_STATUS_TO_PB[status]
-    return getattr(pb, name, 0)
+    return _strict_enum_value(pb, name)
 
 
-def _task_status_from_pb(value: int, pb: Any) -> TaskStatus:
+def _task_status_from_pb(value: int) -> TaskStatus:
     # Resolve enum name from value and map back; unknown / unspecified falls
     # back to PENDING so callers never crash on forward-compatible inputs.
+    pb = _pb_module()
     try:
         name = pb.TaskStatus.Name(value)
     except (ValueError, AttributeError):
@@ -85,12 +107,14 @@ _DRIFT_SEVERITY_TO_PB: dict[DriftSeverity, str] = {
 _PB_TO_DRIFT_SEVERITY: dict[str, DriftSeverity] = {v: k for k, v in _DRIFT_SEVERITY_TO_PB.items()}
 
 
-def _drift_severity_to_pb(severity: DriftSeverity, pb: Any) -> int:
+def _drift_severity_to_pb(severity: DriftSeverity) -> int:
+    pb = _pb_module()
     name = _DRIFT_SEVERITY_TO_PB[severity]
-    return getattr(pb, name, 0)
+    return _strict_enum_value(pb, name)
 
 
-def _drift_severity_from_pb(value: int, pb: Any) -> DriftSeverity:
+def _drift_severity_from_pb(value: int) -> DriftSeverity:
+    pb = _pb_module()
     try:
         name = pb.DriftSeverity.Name(value)
     except (ValueError, AttributeError):
@@ -98,14 +122,22 @@ def _drift_severity_from_pb(value: int, pb: Any) -> DriftSeverity:
     return _PB_TO_DRIFT_SEVERITY.get(name, DriftSeverity.INFO)
 
 
-def _drift_kind_to_pb(kind: DriftKind, pb: Any) -> int:
+def _drift_kind_to_pb(kind: DriftKind) -> int:
     # Proto convention: DRIFT_KIND_<UPPER_SNAKE> values mirror the enum
-    # member name (not the wire value). Fall back to CUSTOM when absent.
+    # member name (not the wire value). Python-side ``DriftKind`` has a
+    # few members (e.g. ``USER_PAUSE``) that intentionally aren't on the
+    # wire; those legitimately degrade to ``DRIFT_KIND_CUSTOM`` rather
+    # than raising. Any other unknown name is a bug and raises via
+    # :func:`_strict_enum_value`.
+    pb = _pb_module()
     name = f"DRIFT_KIND_{kind.name}"
-    return getattr(pb, name, getattr(pb, "DRIFT_KIND_CUSTOM", 0))
+    if hasattr(pb, name):
+        return _strict_enum_value(pb, name)
+    return _strict_enum_value(pb, "DRIFT_KIND_CUSTOM")
 
 
-def _drift_kind_from_pb(value: int, pb: Any) -> DriftKind:
+def _drift_kind_from_pb(value: int) -> DriftKind:
+    pb = _pb_module()
     try:
         name = pb.DriftKind.Name(value)
     except (ValueError, AttributeError):
@@ -132,7 +164,7 @@ def to_pb_task(task: Task) -> Any:
         title=task.title,
         description=task.description,
         assignee_agent_id=task.assignee_agent_id,
-        status=_task_status_to_pb(task.status, pb),
+        status=_task_status_to_pb(task.status),
         predicted_start_ms=task.predicted_start_ms,
         predicted_duration_ms=task.predicted_duration_ms,
         bound_span_id=task.bound_span_id,
@@ -141,13 +173,12 @@ def to_pb_task(task: Task) -> Any:
 
 
 def from_pb_task(msg: Any) -> Task:
-    pb = _pb_module()
     return Task(
         id=msg.id,
         title=msg.title,
         description=msg.description,
         assignee_agent_id=msg.assignee_agent_id,
-        status=_task_status_from_pb(msg.status, pb),
+        status=_task_status_from_pb(msg.status),
         predicted_start_ms=msg.predicted_start_ms,
         predicted_duration_ms=msg.predicted_duration_ms,
         bound_span_id=msg.bound_span_id,
@@ -173,48 +204,52 @@ def from_pb_task_edge(msg: Any) -> TaskEdge:
 # ---------------------------------------------------------------------------
 
 
-def _plan_revision_kind_to_pb(value: str, pb: Any) -> int:
+def _plan_revision_kind_to_pb(value: str) -> int:
     """Convert a dataclass ``Plan.revision_kind`` (a ``DriftKind`` string
     value or ``""``) into the matching proto enum int. Empty string →
     ``DRIFT_KIND_UNSPECIFIED``; unknown value → ``DRIFT_KIND_CUSTOM``.
     """
+    pb = _pb_module()
     if not value:
-        return getattr(pb, "DRIFT_KIND_UNSPECIFIED", 0)
+        return _strict_enum_value(pb, "DRIFT_KIND_UNSPECIFIED")
     try:
         kind = DriftKind(value)
     except ValueError:
-        return getattr(pb, "DRIFT_KIND_CUSTOM", 0)
-    return _drift_kind_to_pb(kind, pb)
+        return _strict_enum_value(pb, "DRIFT_KIND_CUSTOM")
+    return _drift_kind_to_pb(kind)
 
 
-def _plan_revision_severity_to_pb(value: str, pb: Any) -> int:
+def _plan_revision_severity_to_pb(value: str) -> int:
+    pb = _pb_module()
     if not value:
-        return getattr(pb, "DRIFT_SEVERITY_UNSPECIFIED", 0)
+        return _strict_enum_value(pb, "DRIFT_SEVERITY_UNSPECIFIED")
     try:
         severity = DriftSeverity(value)
     except ValueError:
-        return getattr(pb, "DRIFT_SEVERITY_UNSPECIFIED", 0)
-    return _drift_severity_to_pb(severity, pb)
+        return _strict_enum_value(pb, "DRIFT_SEVERITY_UNSPECIFIED")
+    return _drift_severity_to_pb(severity)
 
 
-def _plan_revision_kind_from_pb(value: int, pb: Any) -> str:
+def _plan_revision_kind_from_pb(value: int) -> str:
+    pb = _pb_module()
     try:
         name = pb.DriftKind.Name(value)
     except (ValueError, AttributeError):
         return ""
     if name == "DRIFT_KIND_UNSPECIFIED":
         return ""
-    return _drift_kind_from_pb(value, pb).value
+    return _drift_kind_from_pb(value).value
 
 
-def _plan_revision_severity_from_pb(value: int, pb: Any) -> str:
+def _plan_revision_severity_from_pb(value: int) -> str:
+    pb = _pb_module()
     try:
         name = pb.DriftSeverity.Name(value)
     except (ValueError, AttributeError):
         return ""
     if name == "DRIFT_SEVERITY_UNSPECIFIED":
         return ""
-    return _drift_severity_from_pb(value, pb).value
+    return _drift_severity_from_pb(value).value
 
 
 def to_pb_plan(plan: Plan) -> Any:
@@ -224,8 +259,8 @@ def to_pb_plan(plan: Plan) -> Any:
         run_id=plan.run_id,
         summary=plan.summary,
         revision_reason=plan.revision_reason,
-        revision_kind=_plan_revision_kind_to_pb(plan.revision_kind, pb),
-        revision_severity=_plan_revision_severity_to_pb(plan.revision_severity, pb),
+        revision_kind=_plan_revision_kind_to_pb(plan.revision_kind),
+        revision_severity=_plan_revision_severity_to_pb(plan.revision_severity),
         revision_index=plan.revision_index,
         # goldfive#199: carry the trigger_event_id on the Plan so
         # out-of-band PlanRevised emitters can thread it through without
@@ -242,7 +277,6 @@ def to_pb_plan(plan: Plan) -> Any:
 
 
 def from_pb_plan(msg: Any) -> Plan:
-    pb = _pb_module()
     return Plan(
         id=msg.id,
         run_id=msg.run_id,
@@ -251,8 +285,8 @@ def from_pb_plan(msg: Any) -> Plan:
         edges=[from_pb_task_edge(e) for e in msg.edges],
         summary=msg.summary,
         revision_reason=msg.revision_reason,
-        revision_kind=_plan_revision_kind_from_pb(msg.revision_kind, pb),
-        revision_severity=_plan_revision_severity_from_pb(msg.revision_severity, pb),
+        revision_kind=_plan_revision_kind_from_pb(msg.revision_kind),
+        revision_severity=_plan_revision_severity_from_pb(msg.revision_severity),
         revision_index=msg.revision_index,
         # goldfive#199: round-trip the trigger_event_id so persistence
         # sinks that re-emit stored plans don't lose the dedup key.
@@ -310,11 +344,10 @@ def _events_pb_module() -> Any:
 
 def to_pb_drift_event(evt: DriftEvent) -> Any:
     """Convert a :class:`DriftEvent` to the wire ``DriftDetected`` proto."""
-    types_pb = _pb_module()
     events_pb = _events_pb_module()
     return events_pb.DriftDetected(
-        kind=_drift_kind_to_pb(evt.kind, types_pb),
-        severity=_drift_severity_to_pb(evt.severity, types_pb),
+        kind=_drift_kind_to_pb(evt.kind),
+        severity=_drift_severity_to_pb(evt.severity),
         detail=evt.detail,
         current_task_id=evt.current_task_id,
         current_agent_id=evt.current_agent_id,
@@ -322,10 +355,9 @@ def to_pb_drift_event(evt: DriftEvent) -> Any:
 
 
 def from_pb_drift_event(msg: Any) -> DriftEvent:
-    pb = _pb_module()
     return DriftEvent(
-        kind=_drift_kind_from_pb(msg.kind, pb),
-        severity=_drift_severity_from_pb(msg.severity, pb),
+        kind=_drift_kind_from_pb(msg.kind),
+        severity=_drift_severity_from_pb(msg.severity),
         detail=msg.detail,
         current_task_id=msg.current_task_id,
         current_agent_id=msg.current_agent_id,
@@ -371,12 +403,14 @@ _CONTROL_KIND_TO_PB: dict[ControlKind, str] = {
 _PB_TO_CONTROL_KIND: dict[str, ControlKind] = {v: k for k, v in _CONTROL_KIND_TO_PB.items()}
 
 
-def _control_kind_to_pb(kind: ControlKind, pb: Any) -> int:
+def _control_kind_to_pb(kind: ControlKind) -> int:
+    pb = _control_pb_module()
     name = _CONTROL_KIND_TO_PB[kind]
-    return getattr(pb, name, 0)
+    return _strict_enum_value(pb, name)
 
 
-def _control_kind_from_pb(value: int, pb: Any) -> ControlKind:
+def _control_kind_from_pb(value: int) -> ControlKind:
+    pb = _control_pb_module()
     try:
         name = pb.ControlKind.Name(value)
     except (ValueError, AttributeError):
@@ -397,12 +431,14 @@ _ACK_RESULT_TO_PB: dict[AckResult, str] = {
 _PB_TO_ACK_RESULT: dict[str, AckResult] = {v: k for k, v in _ACK_RESULT_TO_PB.items()}
 
 
-def _ack_result_to_pb(result: AckResult, pb: Any) -> int:
+def _ack_result_to_pb(result: AckResult) -> int:
+    pb = _control_pb_module()
     name = _ACK_RESULT_TO_PB[result]
-    return getattr(pb, name, 0)
+    return _strict_enum_value(pb, name)
 
 
-def _ack_result_from_pb(value: int, pb: Any) -> AckResult:
+def _ack_result_from_pb(value: int) -> AckResult:
+    pb = _control_pb_module()
     try:
         name = pb.ControlAckResult.Name(value)
     except (ValueError, AttributeError):
@@ -469,7 +505,7 @@ def to_pb_control_event(msg: ControlMessage) -> Any:
     pb = _control_pb_module()
     kwargs: dict[str, Any] = {
         "id": msg.id,
-        "kind": _control_kind_to_pb(msg.kind, pb),
+        "kind": _control_kind_to_pb(msg.kind),
     }
     builder = _PAYLOAD_BUILDERS.get(msg.kind)
     if builder is not None:
@@ -483,8 +519,7 @@ def to_pb_control_event(msg: ControlMessage) -> Any:
 
 def from_pb_control_event(pb_msg: Any) -> ControlMessage:
     """Convert a ``ControlEvent`` proto back to a :class:`ControlMessage`."""
-    pb = _control_pb_module()
-    kind = _control_kind_from_pb(pb_msg.kind, pb)
+    kind = _control_kind_from_pb(pb_msg.kind)
     payload: dict[str, Any] = {}
     which = pb_msg.WhichOneof("payload")
     if which == "steer":
@@ -530,7 +565,7 @@ def to_pb_control_ack(ack: ControlAck) -> Any:
     result = AckResult(ack.result)
     pb_ack = pb.ControlAck(
         control_id=ack.control_id,
-        result=_ack_result_to_pb(result, pb),
+        result=_ack_result_to_pb(result),
         detail=ack.detail,
     )
     if ack.acked_at_ms:
@@ -540,13 +575,12 @@ def to_pb_control_ack(ack: ControlAck) -> Any:
 
 def from_pb_control_ack(pb_msg: Any) -> ControlAck:
     """Convert a ``ControlAck`` proto back to a :class:`ControlAck`."""
-    pb = _control_pb_module()
     acked_at_ms = 0
     if pb_msg.HasField("acked_at"):
         acked_at_ms = pb_msg.acked_at.ToMilliseconds()
     return ControlAck(
         control_id=pb_msg.control_id,
-        result=_ack_result_from_pb(pb_msg.result, pb),
+        result=_ack_result_from_pb(pb_msg.result),
         detail=pb_msg.detail,
         acked_at_ms=acked_at_ms,
     )

--- a/tests/test_conv_strict.py
+++ b/tests/test_conv_strict.py
@@ -1,0 +1,166 @@
+"""Strict-enum tests for goldfive.conv (issue #211 regression guard).
+
+Before this refactor the private ``_*_to_pb`` helpers took a ``pb``
+argument and used ``getattr(pb, NAME, 0)`` to look up enum ints. That
+silent fallback meant a caller passing the wrong proto module (``events_pb2``
+instead of ``types_pb2``) got ``UNSPECIFIED`` (= 0) on the wire, with no
+indication of the mistake. The status_query dispatch path hit this bug
+in goldfive#211 and downgraded 50,212 drift events to ``kind=0``.
+
+The fix: the helpers take no ``pb`` argument — they resolve the module
+internally — and missing names raise ``ValueError`` instead of returning
+0. These tests pin the new contract and the expected wire values.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from goldfive.types import DriftKind, DriftSeverity, TaskStatus
+
+
+def _pb_available() -> bool:
+    try:
+        return importlib.util.find_spec("goldfive.pb.goldfive.v1.types_pb2") is not None
+    except (ModuleNotFoundError, ImportError):
+        return False
+
+
+_PB_AVAILABLE = _pb_available()
+
+pytestmark = pytest.mark.skipif(
+    not _PB_AVAILABLE,
+    reason="goldfive protobuf stubs not generated yet (depends on issue #3)",
+)
+
+
+# ---------------------------------------------------------------------------
+# DriftKind: verify explicit wire values for the key motivating cases.
+#
+# These are the values called out in the goldfive#211 writeup. If the
+# proto source of truth ever renumbers, this test fails loud — which is
+# exactly what we want; wire-value changes need a migration, not a
+# silent downgrade.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind,expected_wire_value",
+    [
+        (DriftKind.CUSTOM, 25),
+        (DriftKind.PLAN_DIVERGENCE, 4),
+        (DriftKind.LOOPING_REASONING, 27),
+        (DriftKind.USER_STEER, 5),
+        (DriftKind.TASK_FAILED_FATAL, 8),
+    ],
+)
+def test_drift_kind_to_pb_pins_expected_wire_values(kind, expected_wire_value) -> None:
+    from goldfive.conv import _drift_kind_to_pb
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    wire = _drift_kind_to_pb(kind)
+    assert wire == expected_wire_value
+    # Double-check: the wire int really does resolve to the expected name
+    # on the types_pb2 module (not events_pb2).
+    assert types_pb2.DriftKind.Name(wire) == f"DRIFT_KIND_{kind.name}"
+
+
+def test_drift_kind_to_pb_takes_no_pb_argument() -> None:
+    """Regression guard for goldfive#211. The helper used to take a ``pb``
+    argument and silently returned 0 when the wrong module was passed.
+    The new signature takes no module — a caller *cannot* pass the wrong
+    thing even if they try.
+    """
+    from goldfive.conv import _drift_kind_to_pb
+    from goldfive.pb.goldfive.v1 import events_pb2
+
+    # Positional-only TypeError path: passing events_pb2 is now a runtime
+    # TypeError rather than a silent 0.
+    with pytest.raises(TypeError):
+        _drift_kind_to_pb(DriftKind.CUSTOM, events_pb2)  # type: ignore[call-arg]
+
+    # Without the stray argument, CUSTOM resolves to its real wire value.
+    assert _drift_kind_to_pb(DriftKind.CUSTOM) == 25
+
+
+def test_drift_kind_user_pause_degrades_to_custom() -> None:
+    """``DriftKind.USER_PAUSE`` exists on the Python side but intentionally
+    is not on the wire (see proto/goldfive/v1/types.proto). It legitimately
+    degrades to DRIFT_KIND_CUSTOM rather than raising.
+    """
+    from goldfive.conv import _drift_kind_to_pb
+
+    assert _drift_kind_to_pb(DriftKind.USER_PAUSE) == 25  # DRIFT_KIND_CUSTOM
+
+
+# ---------------------------------------------------------------------------
+# TaskStatus round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", list(TaskStatus))
+def test_task_status_round_trip(status) -> None:
+    from goldfive.conv import _task_status_from_pb, _task_status_to_pb
+
+    wire = _task_status_to_pb(status)
+    assert wire != 0, f"{status} serialized to UNSPECIFIED"
+    assert _task_status_from_pb(wire) == status
+
+
+# ---------------------------------------------------------------------------
+# DriftSeverity round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("severity", list(DriftSeverity))
+def test_drift_severity_round_trip(severity) -> None:
+    from goldfive.conv import _drift_severity_from_pb, _drift_severity_to_pb
+
+    wire = _drift_severity_to_pb(severity)
+    assert wire != 0, f"{severity} serialized to UNSPECIFIED"
+    assert _drift_severity_from_pb(wire) == severity
+
+
+# ---------------------------------------------------------------------------
+# DriftKind round-trip (every wire-defined member should round-trip
+# without loss; USER_PAUSE is excluded per the comment above).
+# ---------------------------------------------------------------------------
+
+
+_DRIFT_KINDS_ON_WIRE = [k for k in DriftKind if k is not DriftKind.USER_PAUSE]
+
+
+@pytest.mark.parametrize("kind", _DRIFT_KINDS_ON_WIRE)
+def test_drift_kind_round_trip(kind) -> None:
+    from goldfive.conv import _drift_kind_from_pb, _drift_kind_to_pb
+
+    wire = _drift_kind_to_pb(kind)
+    assert wire != 0, f"{kind} serialized to UNSPECIFIED"
+    assert _drift_kind_from_pb(wire) == kind
+
+
+# ---------------------------------------------------------------------------
+# Strict lookup fails loud on unknown names.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_enum_value_raises_on_missing_name() -> None:
+    """The new ``_strict_enum_value`` helper is what replaced the silent
+    ``getattr(pb, name, 0)`` pattern. Missing names must raise so that a
+    future proto regeneration that drops a kind surfaces in tests instead
+    of silently downgrading the wire.
+    """
+    from goldfive.conv import _strict_enum_value
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    with pytest.raises(ValueError, match="unknown proto enum value"):
+        _strict_enum_value(types_pb2, "DRIFT_KIND_THIS_NAME_DOES_NOT_EXIST")
+
+    # And passing the wrong module (events_pb2) for a types-enum name also
+    # fails loud. This is the concrete goldfive#211 regression path.
+    from goldfive.pb.goldfive.v1 import events_pb2
+
+    with pytest.raises(ValueError, match="unknown proto enum value"):
+        _strict_enum_value(events_pb2, "DRIFT_KIND_CUSTOM")


### PR DESCRIPTION
## Summary

- The private enum-to-proto helpers in `goldfive/conv.py` took a `pb` module argument and used `getattr(pb, NAME, 0)` to look up enum ints. If a caller passed the wrong proto module (enum value constants like `DRIFT_KIND_CUSTOM` live on `types_pb2`, not `events_pb2`), the silent `0` default downgraded the wire to `UNSPECIFIED` with no indication of the mistake. The status_query dispatch path hit this in goldfive#211 and downgraded 50,212 drift events in a single session to `kind=0`.
- This PR drops the `pb` argument from every enum-to-proto helper — each helper resolves its module internally via `_pb_module()` / `_events_pb_module()` / `_control_pb_module()` so callers *cannot* pass the wrong module. The silent `getattr(pb, name, 0)` pattern is replaced by a `_strict_enum_value` helper that raises `ValueError` on missing names so future proto regressions fail loud in tests.
- `_*_from_pb` duals keep their forward-compat fallbacks (unknown wire value → `CUSTOM` / `PENDING` / `INFO`) — the legitimate use of a silent default. `DriftKind.USER_PAUSE` still legitimately degrades to `DRIFT_KIND_CUSTOM` (not on the wire).
- No public entry point (`to_pb_drift_event`, `to_pb_task`, `to_pb_plan`, `to_pb_control_event`, `to_pb_control_ack`, and their duals) changes signature. Wire format unchanged.

Context: goldfive#211.

## Test plan

- [x] `uv run pytest tests/` — 966 passed, 78 skipped (no new failures)
- [x] `uv run ruff check goldfive/conv.py tests/test_conv_strict.py` — clean
- [x] New `tests/test_conv_strict.py`:
  - Pins expected wire values for the motivating DriftKind members (`CUSTOM=25`, `PLAN_DIVERGENCE=4`, `LOOPING_REASONING=27`, `USER_STEER=5`, `TASK_FAILED_FATAL=8`) — fails loud on renumbering.
  - Full round-trip for every `TaskStatus` / `DriftSeverity` / wire-defined `DriftKind` member.
  - Regression guard proves `_drift_kind_to_pb(DriftKind.CUSTOM)` returns 25 and there is no way to pass the wrong module; `_strict_enum_value(events_pb2, "DRIFT_KIND_CUSTOM")` raises `ValueError` (the concrete goldfive#211 path).