### PR TITLE
fix(planner): normalize compound assignee_agent_id to bare form

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -85,6 +85,8 @@ Requirements for the plan:
    the provided available_agents list. If multiple agents could do a
    task, pick the most specialised one. If no agent fits, assign it
    to the coordinator/root agent rather than inventing an id.
+   `assignee_agent_id` must be the bare agent name as listed above —
+   do NOT add a namespace, client prefix, or `<something>:` qualifier.
 
 5. STABILITY. Task ids must be short, unique, and stable strings
    (e.g. "research", "draft_intro", "review_final"). Descriptions
@@ -396,6 +398,18 @@ def _strip_code_fences(raw: str) -> str:
     return raw
 
 
+def _normalize_assignee(raw: str) -> str:
+    if ":" not in raw:
+        return raw
+    bare = raw.rsplit(":", 1)[-1]
+    log.warning(
+        "planner emitted compound assignee_agent_id=%r; normalized to %r",
+        raw,
+        bare,
+    )
+    return bare
+
+
 def _coerce_status(raw: Any) -> TaskStatus:
     text = str(raw or "PENDING").upper()
     if text not in _VALID_TASK_STATUSES:
@@ -436,7 +450,9 @@ def _plan_from_json(
                 id=tid,
                 title=title,
                 description=str(t.get("description") or ""),
-                assignee_agent_id=str(t.get("assignee_agent_id") or ""),
+                assignee_agent_id=_normalize_assignee(
+                    str(t.get("assignee_agent_id") or "")
+                ),
                 status=_coerce_status(t.get("status")),
                 predicted_start_ms=int(t.get("predicted_start_ms") or 0),
                 predicted_duration_ms=int(t.get("predicted_duration_ms") or 0),

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -10,9 +10,13 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from goldfive.planner import (
+    _DEFAULT_SYSTEM_PROMPT,
     LLMPlanner,
     PassthroughPlanner,
+    _normalize_assignee,
     _plan_from_json,
     _strip_code_fences,
 )
@@ -1534,3 +1538,110 @@ async def test_synthesize_goal_from_steer_defaults_mode_when_invalid() -> None:
     assert result is not None
     _goal, mode = result
     assert mode == "append"
+
+
+# ---------------------------------------------------------------------------
+# Compound assignee normalization (goldfive#214)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_assignee_strips_compound_form() -> None:
+    assert (
+        _normalize_assignee("presentation-orchestrated-9b2b3a9c7289:research_agent")
+        == "research_agent"
+    )
+
+
+def test_normalize_assignee_passes_bare_form_through() -> None:
+    assert _normalize_assignee("research_agent") == "research_agent"
+    assert _normalize_assignee("") == ""
+
+
+def test_normalize_assignee_uses_last_colon() -> None:
+    # Defensive: multi-segment prefixes still yield the trailing bare name.
+    assert _normalize_assignee("a:b:c:research_agent") == "research_agent"
+
+
+def test_plan_from_json_normalizes_compound_assignees(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = {
+        "summary": "s",
+        "tasks": [
+            {
+                "id": "t1",
+                "title": "research",
+                "assignee_agent_id": "client-xyz:research_agent",
+            },
+            {
+                "id": "t2",
+                "title": "draft",
+                "assignee_agent_id": "client-xyz:writer",
+            },
+        ],
+    }
+    with caplog.at_level("WARNING", logger="goldfive.planner"):
+        plan = _plan_from_json(payload, run_id="r", goal_ids=[])
+    assert plan is not None
+    assert [t.assignee_agent_id for t in plan.tasks] == ["research_agent", "writer"]
+    compound_warnings = [
+        r for r in caplog.records if "compound assignee_agent_id" in r.getMessage()
+    ]
+    assert len(compound_warnings) == 2
+
+
+def test_plan_from_json_leaves_bare_assignees_unchanged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = {
+        "summary": "s",
+        "tasks": [
+            {"id": "t1", "title": "research", "assignee_agent_id": "research_agent"},
+            {"id": "t2", "title": "draft", "assignee_agent_id": "writer"},
+        ],
+    }
+    with caplog.at_level("WARNING", logger="goldfive.planner"):
+        plan = _plan_from_json(payload, run_id="r", goal_ids=[])
+    assert plan is not None
+    assert [t.assignee_agent_id for t in plan.tasks] == ["research_agent", "writer"]
+    compound_warnings = [
+        r for r in caplog.records if "compound assignee_agent_id" in r.getMessage()
+    ]
+    assert compound_warnings == []
+
+
+def test_plan_from_json_normalizes_mixed_assignees(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = {
+        "summary": "s",
+        "tasks": [
+            {"id": "t1", "title": "research", "assignee_agent_id": "research_agent"},
+            {
+                "id": "t2",
+                "title": "draft",
+                "assignee_agent_id": "client-xyz:writer",
+            },
+            {"id": "t3", "title": "review", "assignee_agent_id": "reviewer"},
+        ],
+    }
+    with caplog.at_level("WARNING", logger="goldfive.planner"):
+        plan = _plan_from_json(payload, run_id="r", goal_ids=[])
+    assert plan is not None
+    assert [t.assignee_agent_id for t in plan.tasks] == [
+        "research_agent",
+        "writer",
+        "reviewer",
+    ]
+    compound_warnings = [
+        r for r in caplog.records if "compound assignee_agent_id" in r.getMessage()
+    ]
+    assert len(compound_warnings) == 1
+    assert "'client-xyz:writer'" in compound_warnings[0].getMessage()
+    assert "'writer'" in compound_warnings[0].getMessage()
+
+
+def test_default_system_prompt_forbids_compound_assignee() -> None:
+    # Regression guard against the planner prompt drifting away from the
+    # explicit "bare name only" directive added alongside #214.
+    assert "do NOT add a namespace" in _DEFAULT_SYSTEM_PROMPT

--- a/tests/test_task_id_wiring.py
+++ b/tests/test_task_id_wiring.py
@@ -446,3 +446,53 @@ async def test_missing_task_id_still_rejects_when_state_empty() -> None:
         assert result["error"] == "missing_task_id", bad_args
     # No handler runs → no transitions.
     assert steerer.transitions == []
+
+
+# ---------------------------------------------------------------------------
+# Compound-assignee end-to-end (goldfive#214)
+# ---------------------------------------------------------------------------
+
+
+async def test_before_agent_callback_pins_when_plan_came_from_compound_json() -> None:
+    """Plans built from compound-form planner JSON still pin the right task.
+
+    Regression guard for #214: the planner's JSON→TaskPlan path normalizes
+    ``"<client>:<agent>"`` to the bare ADK name, so the reconciler /
+    plugin match (`assignee == agent_name`) finds exactly one candidate.
+    """
+    from goldfive.planner import _plan_from_json
+
+    payload = {
+        "summary": "s",
+        "tasks": [
+            {
+                "id": "t1",
+                "title": "research",
+                "assignee_agent_id": "presentation-orchestrated-9b2b3a9c7289:research_agent",
+            },
+            {
+                "id": "t2",
+                "title": "code",
+                "assignee_agent_id": "presentation-orchestrated-9b2b3a9c7289:web_developer",
+            },
+        ],
+    }
+    plan = _plan_from_json(payload, run_id="r1", goal_ids=[])
+    assert plan is not None
+    # Sanity: normalization happened at parse time.
+    assert [t.assignee_agent_id for t in plan.tasks] == [
+        "research_agent",
+        "web_developer",
+    ]
+
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(plan)
+    state, ctx = _ctx_for(session, "coord")
+
+    await plugin.before_agent_callback(
+        agent=_Agent("research_agent"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state["goldfive.current_task_id"] == "t1"


### PR DESCRIPTION
## Summary

Closes #214. The planner LLM sometimes emits `task.assignee_agent_id` in the compound `"<client_id>:<agent_name>"` form instead of the bare ADK agent name. Every downstream matcher (reconciler.py:478, _adk_plugin.py:1358 `_pin_current_task_id_for_agent`) compares with plain `==`, so matching silently fails: `current_task_id` never gets pinned, #193's arg injection has no id to inject, and the sub-agent's LLM thrashes guessing `task_id` from the plan JSON — observable as long tool-prelude latency and apparent "no forward progress."

## Fix

Two-line behavioural change, all inside `goldfive/planner.py`:

1. New `_normalize_assignee(raw: str) -> str` helper. If the value contains `":"`, strip everything up to and including the last `":"`, and log a WARNING `"planner emitted compound assignee_agent_id=%r; normalized to %r"`.
2. Call it from `_plan_from_json` — the single JSON→TaskPlan chokepoint for every planner path (`generate`, `refine`, `_refine_looping_tool_call`, `_refine_user_steer`).
3. One-sentence addition to `_DEFAULT_SYSTEM_PROMPT`'s ASSIGNMENTS block: *"`assignee_agent_id` must be the bare agent name as listed above — do NOT add a namespace, client prefix, or `<something>:` qualifier."*

No changes to `harmonograf_client` — that sink's pass-through of colon-strings is downstream of this fix and no longer sees compound values.

## Tests

Added in `tests/test_planner.py`:

- `_normalize_assignee` unit tests (compound, bare, multi-colon)
- `_plan_from_json` normalizes all-compound / leaves all-bare unchanged / normalizes mixed (with caplog assertions that the WARNING fires exactly once per compound task)
- Prompt regression guard: `"do NOT add a namespace" in _DEFAULT_SYSTEM_PROMPT`

Added in `tests/test_task_id_wiring.py`:

- End-to-end: a plan built from compound-form planner JSON routes through `_pin_current_task_id_for_agent` and correctly binds bare `"research_agent"` → `"t1"` on both the ADK-side and goldfive-side session.state.

## Test results

- `uv run pytest tests/test_planner.py tests/test_task_id_wiring.py -q` — 73 passed, 0 failed
- `uv run pytest -q` (full suite) — 998 passed, 46 skipped, 0 failed
- `uv run ruff check goldfive/planner.py tests/test_planner.py tests/test_task_id_wiring.py` — clean
- `uv run mypy goldfive/planner.py` — same 6 pre-existing errors as `main`, zero new ones

## Test plan

- [x] Unit: `_normalize_assignee` on compound / bare / multi-colon inputs
- [x] Unit: `_plan_from_json` on compound / bare / mixed JSON payloads
- [x] Log assertion: WARNING fires exactly once per compound task
- [x] Prompt regression guard on the added directive
- [x] Integration: compound-JSON plan → `_pin_current_task_id_for_agent` pins the right task
- [x] Full `pytest -q`, `ruff`, `mypy` clean on touched files