### PR TITLE
feat(steerer): fire goal-drift judge on task boundaries + log judge response

### DIFF
--- a/goldfive/drift/goals.py
+++ b/goldfive/drift/goals.py
@@ -273,19 +273,41 @@ async def classify_goal_drift(
     except Exception as exc:  # noqa: BLE001 - never break the run
         log.warning("classify_goal_drift: call_llm raised %s; no drift emitted", exc)
         return None
+    # Debug-log the raw judge response so operators can distinguish
+    # "judge said progressing=true" from "judge returned garbage" without
+    # bisecting (goldfive#219). Truncated to 500 chars to bound log size.
+    raw_str = raw if isinstance(raw, str) else ""
+    log.debug(
+        "classify_goal_drift: raw response (%d chars): %s",
+        len(raw_str),
+        raw_str[:500],
+    )
     parsed = _parse_response(raw)
     if parsed is None:
-        log.debug("classify_goal_drift: response was not JSON; no drift emitted")
+        log.debug(
+            "classify_goal_drift: response was not JSON (raw=%r); no drift emitted",
+            raw_str[:200],
+        )
         return None
     progressing = parsed.get("progressing")
     if not isinstance(progressing, bool):
         log.debug(
-            "classify_goal_drift: response missing boolean 'progressing' key; no drift emitted"
+            "classify_goal_drift: parsed=%r lacks boolean 'progressing' key; "
+            "no drift emitted",
+            parsed,
         )
         return None
     if progressing:
+        log.debug(
+            "classify_goal_drift: judge says on-track (reason=%r)",
+            parsed.get("reason", ""),
+        )
         return None
     reason = str(parsed.get("reason", "") or "").strip()
+    log.info(
+        "classify_goal_drift: drift detected (reason=%r); emitting GOAL_DRIFT event",
+        reason,
+    )
     detail = (
         f"goal drift detected: {reason}"
         if reason

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -47,6 +47,7 @@ import enum
 import json
 import logging
 import re
+import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -564,6 +565,8 @@ class DefaultSteerer:
         # goldfive#152: clear current_task_* if we were the active task.
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.COMPLETED)
         await self._emit_task_completed(session, task_id, summary, artifacts or {})
+        # goldfive#219: task boundary is a natural goal-drift checkpoint.
+        await self._maybe_run_goal_drift_on_task_boundary(session)
 
     async def mark_task_failed(
         self,
@@ -601,6 +604,8 @@ class DefaultSteerer:
         task.status = TaskStatus.FAILED
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.FAILED)
         await self._emit_task_failed(session, task_id, reason, recoverable)
+        # goldfive#219: task boundary is a natural goal-drift checkpoint.
+        await self._maybe_run_goal_drift_on_task_boundary(session)
         # Fatal failures cascade downstream via the same primitive used
         # by mark_task_cancelled, so both §6.2 and §6.3 produce the
         # same TaskCancelled event stream and share rejection guards.
@@ -681,6 +686,12 @@ class DefaultSteerer:
         task.status = TaskStatus.CANCELLED
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.CANCELLED)
         await self._emit_task_cancelled(session, task_id, reason)
+        # goldfive#219: task boundary is a natural goal-drift checkpoint.
+        # Fire before cascade so the judge sees the initiator's transition;
+        # cascade-cancel downstream tasks share the same rate-limit bucket
+        # and will no-op as subsequent boundary fires fall within the
+        # 10s guard.
+        await self._maybe_run_goal_drift_on_task_boundary(session)
         await self.cascade_cancel_downstream(session, task_id)
 
     async def mark_task_not_needed(
@@ -720,6 +731,8 @@ class DefaultSteerer:
         await self._emit_task_cancelled(
             session, task_id, f"not_needed: {reason}" if reason else "not_needed"
         )
+        # goldfive#219: task boundary is a natural goal-drift checkpoint.
+        await self._maybe_run_goal_drift_on_task_boundary(session)
 
     async def cascade_cancel_downstream(
         self,
@@ -1109,6 +1122,51 @@ class DefaultSteerer:
             return
         # Reset before running so a check that itself triggers further
         # invocations in the agent loop doesn't double-fire.
+        session._agent_turns_since_goal_check = 0
+        await self.maybe_run_goal_drift_check(session)
+
+    # Minimum spacing between two task-boundary-triggered GOAL_DRIFT
+    # judge calls, in seconds (goldfive#219). Task transitions can
+    # arrive back-to-back (e.g. a cascade-cancel fan-out or a fast
+    # research→write→review pipeline), and we don't want to pay for
+    # N LLM calls per burst; one is enough to catch drift. Turn-based
+    # scheduling has its own interval (``goal_drift_check_interval``)
+    # and is not affected by this guard.
+    _GOAL_DRIFT_TASK_BOUNDARY_MIN_INTERVAL_S: float = 10.0
+
+    async def _maybe_run_goal_drift_on_task_boundary(self, session: Session) -> None:
+        """Fire :meth:`maybe_run_goal_drift_check` on a task transition.
+
+        Task completions / failures / cancellations are natural
+        "am I still on plan?" checkpoints, so we fire the judge here
+        in addition to the turn-counter-driven path (goldfive#219).
+        Short pipelines that finish before ``goal_drift_check_interval``
+        turns would otherwise never trigger the judge.
+
+        Rate-limited: if two task transitions happen within
+        :data:`_GOAL_DRIFT_TASK_BOUNDARY_MIN_INTERVAL_S` seconds of
+        each other, only the first fires a judge call. Callers pass
+        a fresh ``time.time()`` implicitly via the session-stored
+        ``_last_goal_drift_check_ts``.
+
+        Also resets ``session._agent_turns_since_goal_check`` so a
+        task boundary that lands on exactly the interval boundary
+        does not pay for two back-to-back judge calls.
+
+        No-ops when ``goal_drift_call_llm`` is unconfigured — that
+        gate is enforced inside :meth:`maybe_run_goal_drift_check`;
+        we short-circuit here only to avoid bumping the timestamp
+        when no judge will run.
+        """
+        if self._goal_drift_call_llm is None:
+            return
+        now = time.time()
+        last = getattr(session, "_last_goal_drift_check_ts", 0.0)
+        if now - last < self._GOAL_DRIFT_TASK_BOUNDARY_MIN_INTERVAL_S:
+            return
+        session._last_goal_drift_check_ts = now
+        # Reset the turn counter so the next turn-interval check starts
+        # fresh rather than firing one more judge call on the next turn.
         session._agent_turns_since_goal_check = 0
         await self.maybe_run_goal_drift_check(session)
 

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -602,6 +602,14 @@ class Session:
     # ``task_id``, ``detail``) rather than a full event proto to keep
     # this framework-neutral.
     recent_agent_activity: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+    # Monotonic-ish timestamp (``time.time()``, seconds since epoch) of the
+    # last GOAL_DRIFT judge call fired via the task-boundary trigger
+    # (goldfive#219). Prevents two task transitions <10s apart from paying
+    # for back-to-back judge calls. Distinct from
+    # ``_agent_turns_since_goal_check`` because turn-based scheduling is
+    # already cost-bounded by the interval; task-boundary scheduling needs
+    # its own rate limit. Default 0 (never fired).
+    _last_goal_drift_check_ts: float = 0.0
     # Set to ``True`` by :class:`DefaultSteerer` when it escalates a
     # drift to Level 4 of the intervention ladder (goldfive#142).
     # Executors honour this flag the same way they honour a PAUSE

--- a/tests/test_goal_drift_classifier.py
+++ b/tests/test_goal_drift_classifier.py
@@ -498,3 +498,185 @@ async def test_runner_goal_drift_enabled_true_is_default_and_preserves_wiring() 
     )
     assert runner.goal_drift_enabled is True
     assert steerer._goal_drift_call_llm is call_llm
+
+
+# ---------------------------------------------------------------------------
+# Task-boundary trigger (goldfive#219)
+# ---------------------------------------------------------------------------
+
+
+async def test_task_boundary_fires_goal_drift_check_on_mark_task_completed() -> None:
+    """mark_task_completed fires the judge exactly once after emit.
+
+    Regression on goldfive#219: short pipelines (e.g. coordinator →
+    research → web_dev → reviewer) complete before the turn counter
+    reaches the configured interval, so the turn-based judge never
+    fires. Task transitions are the natural fallback.
+    """
+    call_llm = _stub_call_llm([{"progressing": True}])
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=100,  # Way above any turn count.
+        goal_drift_call_llm=call_llm,
+    )
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+    session = _make_session()
+
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+    # Turn counter is reset on task-boundary fire so we don't double-pay.
+    assert session._agent_turns_since_goal_check == 0
+
+
+async def test_task_boundary_fires_on_mark_task_failed_and_cancelled() -> None:
+    """Both FAILED and CANCELLED transitions trigger the judge."""
+    # Provide four responses: one per transition we'll drive below. The
+    # 10s rate limit is enforced via _last_goal_drift_check_ts; we reset
+    # it between calls to simulate "enough real time has passed".
+    call_llm = _stub_call_llm(
+        [{"progressing": True}, {"progressing": True}, {"progressing": True}]
+    )
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=100,
+        goal_drift_call_llm=call_llm,
+    )
+    steerer.bind(sinks=[ListSink()], planner=StubPlanner())
+    session = _make_session()
+
+    await steerer.mark_task_failed("t1", session=session, reason="boom")
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+
+    # Rewind the rate-limit clock so the next boundary fires.
+    session._last_goal_drift_check_ts = 0.0
+    await steerer.mark_task_cancelled("t2", session=session, reason="no longer needed")
+    assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
+
+
+async def test_task_boundary_fires_independent_of_turn_counter() -> None:
+    """Turn counter at 0 (never incremented) → task boundary still fires."""
+    call_llm = _stub_call_llm([{"progressing": True}])
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=5,
+        goal_drift_call_llm=call_llm,
+    )
+    steerer.bind(sinks=[ListSink()], planner=StubPlanner())
+    session = _make_session()
+    assert session._agent_turns_since_goal_check == 0
+
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+
+
+async def test_task_boundary_rate_limited_within_ten_seconds() -> None:
+    """Two task transitions 1s apart → judge only fires once."""
+    call_llm = _stub_call_llm([{"progressing": True}, {"progressing": True}])
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=100,
+        goal_drift_call_llm=call_llm,
+    )
+    steerer.bind(sinks=[ListSink()], planner=StubPlanner())
+    session = _make_session()
+
+    # First transition primes the timestamp.
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+    first_ts = session._last_goal_drift_check_ts
+    assert first_ts > 0.0
+
+    # Second transition <1s later: should be suppressed by the 10s guard.
+    await steerer.mark_task_completed("t2", session=session, summary="done")
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+    # Timestamp must NOT advance on a suppressed call.
+    assert session._last_goal_drift_check_ts == first_ts
+
+
+async def test_task_boundary_noop_when_goal_drift_not_wired() -> None:
+    """Without a ``goal_drift_call_llm`` the boundary trigger is silent.
+
+    Also asserts ``_last_goal_drift_check_ts`` stays at its default so
+    the timestamp is only advanced when a real judge call is made.
+    """
+    steerer = DefaultSteerer(goal_drift_call_llm=None)
+    steerer.bind(sinks=[ListSink()], planner=StubPlanner())
+    session = _make_session()
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+    assert session._last_goal_drift_check_ts == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Judge-response logging (goldfive#219)
+# ---------------------------------------------------------------------------
+
+
+async def test_classifier_logs_on_track_at_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """progressing=true → DEBUG log with 'on-track' so operators can diagnose."""
+    call_llm = _stub_call_llm([{"progressing": True, "reason": "writing in progress"}])
+    with caplog.at_level("DEBUG", logger="goldfive.drift.goals"):
+        drift = await classify_goal_drift(
+            goals=[Goal(id="g1", summary="ship memo")],
+            plan=None,
+            observed_actions=[],
+            model="m",
+            call_llm=call_llm,
+        )
+    assert drift is None
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("on-track" in m for m in messages), messages
+    # Raw response is also logged at DEBUG for every call.
+    assert any("raw response" in m for m in messages), messages
+
+
+async def test_classifier_logs_drift_detected_at_info(caplog: pytest.LogCaptureFixture) -> None:
+    """progressing=false → INFO log with 'drift detected' so operators see it
+    without having to crank logging to DEBUG."""
+    reason = "researching raccoons instead of solar panels"
+    call_llm = _stub_call_llm([{"progressing": False, "reason": reason}])
+    with caplog.at_level("INFO", logger="goldfive.drift.goals"):
+        drift = await classify_goal_drift(
+            goals=[Goal(id="g1", summary="ship memo")],
+            plan=None,
+            observed_actions=[],
+            model="m",
+            call_llm=call_llm,
+        )
+    assert drift is not None
+    info_msgs = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+    assert any("drift detected" in m and "raccoons" in m for m in info_msgs), info_msgs
+
+
+async def test_classifier_logs_malformed_json_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Malformed response → DEBUG log including the raw text snippet."""
+    call_llm = _stub_call_llm(["this is not JSON at all -- raccoons everywhere"])
+    with caplog.at_level("DEBUG", logger="goldfive.drift.goals"):
+        drift = await classify_goal_drift(
+            goals=[Goal(id="g1", summary="ship memo")],
+            plan=None,
+            observed_actions=[],
+            model="m",
+            call_llm=call_llm,
+        )
+    assert drift is None
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "not JSON" in m and "raccoons" in m for m in messages
+    ), messages
+
+
+async def test_classifier_logs_missing_progressing_key_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dict without 'progressing' key → DEBUG log with 'lacks boolean'."""
+    call_llm = _stub_call_llm([{"reason": "no key"}])
+    with caplog.at_level("DEBUG", logger="goldfive.drift.goals"):
+        drift = await classify_goal_drift(
+            goals=[Goal(id="g1", summary="ship memo")],
+            plan=None,
+            observed_actions=[],
+            model="m",
+            call_llm=call_llm,
+        )
+    assert drift is None
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("lacks boolean" in m for m in messages), messages


### PR DESCRIPTION
Closes #219

## Summary

- Adds a task-boundary trigger for the trajectory-level GOAL_DRIFT judge so short pipelines (e.g. the presentation demo) no longer silently skip the check. Fires in ``mark_task_completed`` / ``mark_task_failed`` / ``mark_task_cancelled`` / ``mark_task_not_needed`` *after* the ``_emit_task_*`` call, rate-limited to once per 10 seconds via new ``session._last_goal_drift_check_ts``.
- Existing turn-counter scheduling is unchanged; the two triggers compose. Task-boundary fires reset ``_agent_turns_since_goal_check`` so coincident turn+boundary events don't pay twice.
- ``classify_goal_drift`` now logs its verdict: DEBUG for raw response / malformed-JSON / missing-key / on-track, INFO for drift-detected. Distinguishes "judge said progressing=true" from "judge returned garbage" without DEBUG-trawling the filesystem.

## Where the hook lives

``goldfive/steerer.py::DefaultSteerer._maybe_run_goal_drift_on_task_boundary`` is called from each ``mark_task_*`` family method immediately after the corresponding ``_emit_task_*`` invocation. This is the same layer that emits the ``TaskCompleted`` / ``TaskFailed`` / ``TaskCancelled`` proto events; the reconciler and reporting-tool handlers both route through these ``mark_task_*`` methods, so the trigger catches both reporting-tool-driven transitions and reconciler-driven ones without extra wiring.

## Test plan

- [x] New unit tests on the task-boundary trigger (completed/failed/cancelled, turn-counter-independent, rate-limit, no-op when unwired).
- [x] New ``caplog`` tests on the four new log paths (on-track DEBUG, drift-detected INFO, malformed-JSON DEBUG, missing-key DEBUG).
- [x] ``uv run pytest tests/test_steerer.py tests/test_goal_drift_classifier.py tests/test_wrap_goal_drift_wiring.py tests/test_plan_reconciler.py -q`` → 121 passed.
- [x] ``uv run pytest -q`` → **1191 passed, 46 skipped**.
- [x] ``uv run ruff check`` on touched files → clean.
- [x] ``uv run mypy`` on touched files → clean.