### PR TITLE
Add OpenAI-compatible embedding backend + cosine DEBUG logging

### DIFF
--- a/goldfive/drift/_embed.py
+++ b/goldfive/drift/_embed.py
@@ -1,27 +1,52 @@
 """Optional embedding helpers for reasoning-based drift detection.
 
-The helpers here light up when ``sentence-transformers`` is installed
-(``goldfive[embedding]`` extra). When the dependency is absent every
-function in this module returns ``None`` (or the "no-signal" value)
-silently so the caller can fall through to pattern / hash heuristics.
+Two encoder backends are supported; the right one is chosen lazily the
+first time :func:`_get_model` is called.
+
+1. **OpenAI-compatible HTTP backend** -- selected when the
+   ``GOLDFIVE_EMBEDDING_BASE_URL`` environment variable is set. Posts
+   to ``{BASE_URL}/v1/embeddings`` against any llama.cpp / Ollama /
+   OpenAI-compatible endpoint the caller already has running for
+   inference. Zero extra local install; the user's LLM server is the
+   embedding server. Env vars:
+
+   * ``GOLDFIVE_EMBEDDING_BASE_URL`` -- e.g. ``http://kikuchi.lan:8081``
+     (no trailing slash; ``/v1/embeddings`` is appended).
+   * ``GOLDFIVE_EMBEDDING_MODEL`` -- model name for the request body.
+     Defaults to ``""``; most llama.cpp / Ollama servers accept the
+     empty model (they use the single loaded model).
+   * ``GOLDFIVE_EMBEDDING_API_KEY`` -- optional bearer token.
+   * ``GOLDFIVE_EMBEDDING_TIMEOUT_MS`` -- HTTP timeout, default 10000.
+
+2. **sentence-transformers backend** -- fallback when the env var is
+   unset. Requires the ``goldfive[embedding]`` extra to be installed.
+
+When neither backend is reachable every function in this module
+returns the "no-signal" value (``0.0`` / ``-1.0``) silently so the
+caller can fall through to pattern / hash heuristics.
 
 Design notes
 ------------
-* Import of the heavy ML stack is deferred to first call. Importing
-  :mod:`goldfive.drift._embed` is always safe, even from minimal
-  installs.
-* The model is loaded at most once per process and cached in a module
-  global. It stays loaded for the life of the process -- a 23 MB
-  residue is cheap and avoids the 200 ms warm-up on every reasoning
-  observation.
-* No public API is exposed via :mod:`goldfive.drift.__init__`. These
-  helpers are detector-private; swap the model by replacing the
-  singleton via :func:`set_model` in tests or custom runtimes.
+* Import / network I/O is deferred to first call. Importing this
+  module is always safe, even from minimal installs.
+* The model is loaded at most once per process and cached in a
+  module global.
+* ``set_model()`` is the public escape hatch for tests and custom
+  runtimes. It accepts any object exposing
+  ``encode(list[str]) -> list[vector-like]`` and overrides both the
+  env-driven and the sentence-transformers paths.
+* Per-encode results are additionally memoised in a small LRU
+  (:data:`_CACHE_MAX`) keyed on ``(backend_name, text)`` so that
+  repeated comparisons against history entries do not re-pay the
+  HTTP round-trip. The cache is process-local; drop it by calling
+  :func:`set_model` or :func:`_reset_cache`.
 """
 
 from __future__ import annotations
 
 import logging
+import os
+from collections import OrderedDict
 from typing import Any
 
 log = logging.getLogger("goldfive.drift.reasoning.embed")
@@ -31,23 +56,42 @@ _MODEL: Any | None = None
 _MODEL_UNAVAILABLE: bool = False
 _DEFAULT_MODEL_NAME: str = "all-MiniLM-L6-v2"
 
+# LRU cache for per-text encoded vectors.
+_CACHE_MAX: int = 512
+_CACHE: OrderedDict[tuple[str, str], Any] = OrderedDict()
+
 
 def set_model(model: Any | None) -> None:
     """Install a caller-supplied encoder (tests, custom runtimes).
 
     ``None`` clears the cached model so the next call falls back to
-    lazy loading. Callers that pass a custom encoder should ensure it
-    exposes ``encode(list[str]) -> list[ndarray-like]``.
+    the lazy-load path (env-driven OpenAI backend, else
+    sentence-transformers). Callers that pass a custom encoder should
+    ensure it exposes ``encode(list[str]) -> list[ndarray-like]``.
     """
     global _MODEL, _MODEL_UNAVAILABLE
     _MODEL = model
     _MODEL_UNAVAILABLE = False
+    _reset_cache()
+
+
+def _reset_cache() -> None:
+    """Drop the per-encode LRU cache. Called from :func:`set_model`."""
+    _CACHE.clear()
 
 
 def _get_model() -> Any | None:
-    """Return the lazily-loaded sentence-transformers model, or ``None``.
+    """Return the lazily-loaded encoder, or ``None``.
 
-    The first failed import flips ``_MODEL_UNAVAILABLE`` so subsequent
+    Preference order (first match wins):
+
+    1. A test- or caller-installed model via :func:`set_model`.
+    2. An OpenAI-compatible HTTP backend when
+       ``GOLDFIVE_EMBEDDING_BASE_URL`` is set in the environment.
+    3. A ``sentence-transformers`` model loaded from the
+       ``goldfive[embedding]`` extra.
+
+    The first failed path flips ``_MODEL_UNAVAILABLE`` so subsequent
     calls skip the import cost. Callers must check for ``None``.
     """
     global _MODEL, _MODEL_UNAVAILABLE
@@ -55,13 +99,28 @@ def _get_model() -> Any | None:
         return _MODEL
     if _MODEL_UNAVAILABLE:
         return None
+
+    base_url = os.environ.get("GOLDFIVE_EMBEDDING_BASE_URL", "").strip()
+    if base_url:
+        backend = _try_load_openai_backend(base_url)
+        if backend is not None:
+            _MODEL = backend
+            return _MODEL
+        # Env var set but backend failed to build: do NOT silently fall
+        # through to sentence-transformers -- the user configured an
+        # HTTP endpoint; honour that by flipping to unavailable so they
+        # see "no-signal" instead of surprise-local-encoding.
+        _MODEL_UNAVAILABLE = True
+        return None
+
     try:
         from sentence_transformers import SentenceTransformer
     except Exception as exc:  # noqa: BLE001 -- any import issue disables
         log.debug(
             "sentence-transformers not available (%s); install the "
-            "`goldfive[embedding]` extra to enable semantic reasoning "
-            "drift detection",
+            "`goldfive[embedding]` extra or set "
+            "GOLDFIVE_EMBEDDING_BASE_URL to use an OpenAI-compatible "
+            "remote embedding endpoint",
             exc,
         )
         _MODEL_UNAVAILABLE = True
@@ -77,6 +136,191 @@ def _get_model() -> Any | None:
         _MODEL_UNAVAILABLE = True
         return None
     return _MODEL
+
+
+def _try_load_openai_backend(base_url: str) -> Any | None:
+    """Construct an :class:`_OpenAIEmbeddingBackend`, or return ``None``.
+
+    Splitting this out lets tests assert backend construction without
+    going through the full ``_get_model`` state machine.
+    """
+    model_name = os.environ.get("GOLDFIVE_EMBEDDING_MODEL", "")
+    api_key = os.environ.get("GOLDFIVE_EMBEDDING_API_KEY") or None
+    try:
+        timeout_ms = int(os.environ.get("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "10000"))
+    except ValueError:
+        timeout_ms = 10000
+    try:
+        return _OpenAIEmbeddingBackend(
+            base_url=base_url,
+            model=model_name,
+            api_key=api_key,
+            timeout_ms=timeout_ms,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.debug(
+            "failed to build OpenAI-compatible embedding backend "
+            "(base_url=%r): %s",
+            base_url,
+            exc,
+        )
+        return None
+
+
+class _OpenAIEmbeddingBackend:
+    """Encoder backed by an OpenAI-compatible ``/v1/embeddings`` endpoint.
+
+    Exposes the same ``encode(list[str]) -> list[list[float]]`` surface
+    as the sentence-transformers adapter, so drop-in usage works.
+
+    Uses the ``openai`` SDK when importable (for auth / retry
+    consistency with the rest of the harmonograf client stack); falls
+    back to raw ``httpx`` when it is not.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str = "",
+        api_key: str | None = None,
+        timeout_ms: int = 10000,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        self._api_key = api_key
+        self._timeout_s = max(0.1, timeout_ms / 1000.0)
+        self._openai_client: Any | None = None
+        self._httpx_client: Any | None = None
+        self._prefer_sdk = self._try_build_openai_client()
+
+    def _try_build_openai_client(self) -> bool:
+        try:
+            from openai import OpenAI  # type: ignore[import-not-found]
+        except Exception:  # noqa: BLE001
+            return False
+        try:
+            # The OpenAI SDK requires ``api_key`` to be a non-empty
+            # string; llama.cpp servers don't check it, so pass a
+            # placeholder when the user hasn't configured one.
+            self._openai_client = OpenAI(
+                base_url=f"{self._base_url}/v1",
+                api_key=self._api_key or "not-needed",
+                timeout=self._timeout_s,
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001
+            log.debug("openai SDK client construction failed: %s", exc)
+            self._openai_client = None
+            return False
+
+    def _get_httpx_client(self) -> Any | None:
+        if self._httpx_client is not None:
+            return self._httpx_client
+        try:
+            import httpx
+        except Exception as exc:  # noqa: BLE001
+            log.debug("httpx not importable for embedding backend: %s", exc)
+            return None
+        self._httpx_client = httpx.Client(timeout=self._timeout_s)
+        return self._httpx_client
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        """Return one vector per input text.
+
+        Network / parse errors yield an empty list; callers upstream
+        treat that as "no signal" and fall through to the 0.0 / -1.0
+        defaults.
+        """
+        if not texts:
+            return []
+        if self._prefer_sdk and self._openai_client is not None:
+            vectors = self._encode_via_sdk(texts)
+            if vectors is not None:
+                return vectors
+            # SDK path failed -- fall through to raw httpx before giving up.
+        return self._encode_via_httpx(texts) or []
+
+    def _encode_via_sdk(self, texts: list[str]) -> list[list[float]] | None:
+        assert self._openai_client is not None
+        try:
+            resp = self._openai_client.embeddings.create(
+                model=self._model or "",
+                input=texts,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.debug("openai SDK embeddings.create failed: %s", exc)
+            return None
+        return _parse_openai_response(resp)
+
+    def _encode_via_httpx(self, texts: list[str]) -> list[list[float]] | None:
+        client = self._get_httpx_client()
+        if client is None:
+            return None
+        url = f"{self._base_url}/v1/embeddings"
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        payload: dict[str, Any] = {"input": texts}
+        if self._model:
+            payload["model"] = self._model
+        else:
+            # llama.cpp / Ollama tolerate ``model=""`` or a missing
+            # field; always send an explicit key so servers that
+            # *require* the field (strict OpenAI) complain loudly
+            # rather than embedding silence.
+            payload["model"] = ""
+        try:
+            r = client.post(url, json=payload, headers=headers)
+            r.raise_for_status()
+            body = r.json()
+        except Exception as exc:  # noqa: BLE001
+            log.debug("httpx embedding POST to %s failed: %s", url, exc)
+            return None
+        return _parse_openai_response(body)
+
+
+def _parse_openai_response(resp: Any) -> list[list[float]] | None:
+    """Extract vectors from an OpenAI ``/v1/embeddings`` response shape.
+
+    Accepts either a dict (raw JSON from ``httpx``) or an SDK
+    ``CreateEmbeddingResponse``-like object. Returns ``None`` if the
+    response doesn't match the expected shape -- callers treat that as
+    "no signal".
+
+    Defensive against three real-world footguns:
+
+    * ``data`` missing entirely (error responses: ``{"error": ...}``).
+    * ``data[i].embedding`` being a nested list (some llama.cpp builds
+      wrap it one level deep for pooled vs per-token embeddings).
+    * ``embedding`` items being non-numeric (strings, ``None``).
+    """
+    try:
+        data = resp["data"] if isinstance(resp, dict) else resp.data  # noqa: B009
+    except Exception:  # noqa: BLE001
+        log.debug("embedding response missing 'data' field: %r", resp)
+        return None
+    if not isinstance(data, list) or not data:
+        log.debug("embedding response 'data' is empty or not a list")
+        return None
+    out: list[list[float]] = []
+    for item in data:
+        try:
+            emb = item["embedding"] if isinstance(item, dict) else item.embedding
+        except Exception:  # noqa: BLE001
+            log.debug("embedding item missing 'embedding' field: %r", item)
+            return None
+        # Unwrap one level of nesting for servers that return
+        # ``[[...]]`` instead of ``[...]``.
+        if isinstance(emb, list) and emb and isinstance(emb[0], list):
+            emb = emb[0]
+        try:
+            vec = [float(x) for x in emb]
+        except Exception:  # noqa: BLE001
+            log.debug("embedding item has non-numeric values: %r", emb)
+            return None
+        out.append(vec)
+    return out
 
 
 def available() -> bool:
@@ -112,6 +356,17 @@ def _cosine(a: Any, b: Any) -> float:
     return dot / (na * nb)
 
 
+def _backend_name(model: Any) -> str:
+    """Return a stable identifier used as the first half of the cache key.
+
+    A different encoder identity => a different cache bucket, so that
+    swapping the model via :func:`set_model` in tests cannot return
+    stale vectors from an earlier run.
+    """
+    cls = type(model).__name__
+    return f"{cls}:{id(model)}"
+
+
 def _encode(model: Any, text: str) -> Any | None:
     if not text:
         return None
@@ -124,6 +379,31 @@ def _encode(model: Any, text: str) -> Any | None:
         return vecs[0]
     except Exception:  # noqa: BLE001
         return None
+
+
+def _cached_encode(model: Any, text: str) -> Any | None:
+    """LRU-cached wrapper around :func:`_encode`.
+
+    The sentence-transformers path is cheap, but the OpenAI HTTP path
+    pays a round-trip per call and :func:`max_similarity` re-encodes
+    each history entry on every new observation. The cache holds at
+    most :data:`_CACHE_MAX` entries and evicts oldest-first.
+    """
+    if not text:
+        return None
+    key = (_backend_name(model), text)
+    hit = _CACHE.get(key)
+    if hit is not None:
+        _CACHE.move_to_end(key)
+        return hit
+    vec = _encode(model, text)
+    if vec is None:
+        return None
+    _CACHE[key] = vec
+    _CACHE.move_to_end(key)
+    while len(_CACHE) > _CACHE_MAX:
+        _CACHE.popitem(last=False)
+    return vec
 
 
 def max_similarity(current: str, history: list[str]) -> float:
@@ -139,12 +419,12 @@ def max_similarity(current: str, history: list[str]) -> float:
     model = _get_model()
     if model is None:
         return 0.0
-    cur = _encode(model, current)
+    cur = _cached_encode(model, current)
     if cur is None:
         return 0.0
     best = 0.0
     for past in history:
-        past_vec = _encode(model, past)
+        past_vec = _cached_encode(model, past)
         if past_vec is None:
             continue
         sim = _cosine(cur, past_vec)
@@ -165,8 +445,8 @@ def distance_to_topic(text: str, topic: str) -> float:
     model = _get_model()
     if model is None:
         return -1.0
-    tv = _encode(model, text)
-    topic_v = _encode(model, topic)
+    tv = _cached_encode(model, text)
+    topic_v = _cached_encode(model, topic)
     if tv is None or topic_v is None:
         return -1.0
     return 1.0 - _cosine(tv, topic_v)

--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -37,6 +37,7 @@ severity differentiates.
 from __future__ import annotations
 
 import hashlib
+import logging
 import re
 from typing import TYPE_CHECKING
 
@@ -45,6 +46,9 @@ from goldfive.types import DriftEvent, DriftKind, DriftSeverity
 
 if TYPE_CHECKING:
     from goldfive.types import Session, Task
+
+
+log = logging.getLogger(__name__)
 
 
 __all__ = [
@@ -235,6 +239,16 @@ def detect_intent_divergence(
     # encoder is loadable; otherwise fall through to the pattern path.
     if _embed.available():
         sim = _embed.max_similarity(text, [reference])
+        log.debug(
+            "intent_divergence: cosine=%.3f "
+            "(thresholds healthy=%.2f minor=%.2f warning=%.2f); "
+            "text_head=%r",
+            sim,
+            INTENT_DIVERGENCE_HEALTHY_SIMILARITY,
+            INTENT_DIVERGENCE_MINOR_SIMILARITY,
+            INTENT_DIVERGENCE_WARNING_SIMILARITY,
+            text[:80],
+        )
         severity = _severity_from_similarity(sim)
         if severity is None:
             return None
@@ -387,6 +401,12 @@ def detect_looping_reasoning(
                 raw=text,
             )
     sim = _embed.max_similarity(text, history)
+    log.debug(
+        "looping_reasoning: cosine=%.3f over %d prior turns (threshold=%.2f)",
+        sim,
+        len(history),
+        LOOPING_REASONING_SIMILARITY_THRESHOLD,
+    )
     if sim >= LOOPING_REASONING_SIMILARITY_THRESHOLD:
         return DriftEvent(
             kind=DriftKind.LOOPING_REASONING,
@@ -437,6 +457,14 @@ def detect_reasoning_cluster_tightening(
     if not history:
         return None
     sim = _embed.max_similarity(text, history)
+    log.debug(
+        "reasoning_cluster_tightening: cosine=%.3f over %d prior turns "
+        "(band=[%.2f, %.2f))",
+        sim,
+        len(history),
+        REASONING_CLUSTER_SIMILARITY_THRESHOLD,
+        LOOPING_REASONING_SIMILARITY_THRESHOLD,
+    )
     # max_similarity returns 0.0 both when the model is unavailable and
     # when the genuine cosine is zero; either way the early-warning tier
     # stays silent. This matches ``detect_off_topic``'s graceful-degrade
@@ -474,6 +502,12 @@ def detect_off_topic(text: str, session: Session) -> DriftEvent | None:
     if not topic:
         return None
     dist = _embed.distance_to_topic(text, topic)
+    log.debug(
+        "off_topic: distance=%.3f (threshold=%.2f); task=%r",
+        dist,
+        OFF_TOPIC_DISTANCE_THRESHOLD,
+        topic[:60],
+    )
     if dist < 0:
         return None
     if dist < OFF_TOPIC_DISTANCE_THRESHOLD:

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -1,0 +1,322 @@
+"""Tests for the OpenAI-compatible embedding backend in
+:mod:`goldfive.drift._embed`.
+
+Covers:
+
+* Env-driven backend selection via ``GOLDFIVE_EMBEDDING_BASE_URL``.
+* Response parsing (happy path, malformed, network error).
+* LRU cache hits and eviction.
+* ``set_model`` overriding env-driven config.
+
+All tests mock out the HTTP layer -- we never hit a real endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from goldfive.drift import _embed
+
+
+@pytest.fixture(autouse=True)
+def _reset_embed_state(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Ensure each test starts from a clean slate.
+
+    ``set_model(None)`` both clears any installed encoder and resets
+    ``_MODEL_UNAVAILABLE`` so the lazy-load path can run again. We
+    also scrub the env vars so one test leaking a ``setenv`` can't
+    influence another.
+    """
+    _embed.set_model(None)
+    monkeypatch.delenv("GOLDFIVE_EMBEDDING_BASE_URL", raising=False)
+    monkeypatch.delenv("GOLDFIVE_EMBEDDING_MODEL", raising=False)
+    monkeypatch.delenv("GOLDFIVE_EMBEDDING_API_KEY", raising=False)
+    monkeypatch.delenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", raising=False)
+    yield
+    _embed.set_model(None)
+
+
+def _canonical_response(vectors: list[list[float]]) -> dict[str, Any]:
+    """Build a canonical OpenAI ``/v1/embeddings`` response envelope."""
+    return {
+        "object": "list",
+        "data": [
+            {"object": "embedding", "index": i, "embedding": v}
+            for i, v in enumerate(vectors)
+        ],
+        "model": "test-model",
+        "usage": {"prompt_tokens": 0, "total_tokens": 0},
+    }
+
+
+class _FakeBackend:
+    """Test double with the same .encode shape as the real backend."""
+
+    def __init__(self, vectors_by_text: dict[str, list[float]]) -> None:
+        self._by_text = vectors_by_text
+        self.calls: list[list[str]] = []
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        return [self._by_text[t] for t in texts]
+
+
+# ---------------------------------------------------------------------------
+# Env-driven backend selection
+# ---------------------------------------------------------------------------
+
+
+def test_openai_backend_env_driven(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Setting the env var lights up the HTTP backend, and the encode
+    path returns a cosine in ``[-1, 1]``."""
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://fake:9999")
+
+    def fake_build(base_url: str) -> Any:
+        assert base_url == "http://fake:9999"
+        return _FakeBackend(
+            {
+                "foo": [1.0, 0.0, 0.0],
+                "bar": [0.0, 1.0, 0.0],
+            }
+        )
+
+    monkeypatch.setattr(_embed, "_try_load_openai_backend", fake_build)
+
+    assert _embed.available() is True
+    sim = _embed.max_similarity("foo", ["bar"])
+    assert -1.0 <= sim <= 1.0
+    # Orthogonal unit vectors -> cosine == 0.
+    assert abs(sim) < 1e-6
+
+
+def test_openai_backend_response_parsing() -> None:
+    """Feed the canonical OpenAI envelope and assert vectors come out."""
+    resp = _canonical_response([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+    vectors = _embed._parse_openai_response(resp)
+    assert vectors == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+
+def test_openai_backend_sdk_object_response_parsing() -> None:
+    """Parse an object-shaped SDK response (attrs, not dict keys)."""
+
+    class _Item:
+        def __init__(self, embedding: list[float]) -> None:
+            self.embedding = embedding
+
+    class _Resp:
+        def __init__(self, items: list[_Item]) -> None:
+            self.data = items
+
+    resp = _Resp([_Item([1.0, 2.0]), _Item([3.0, 4.0])])
+    vectors = _embed._parse_openai_response(resp)
+    assert vectors == [[1.0, 2.0], [3.0, 4.0]]
+
+
+def test_openai_backend_nested_embedding_unwrapped() -> None:
+    """Some llama.cpp builds wrap embeddings as ``[[...]]``; unwrap it."""
+    resp = {
+        "data": [
+            {"embedding": [[0.5, 0.5]]},
+        ]
+    }
+    vectors = _embed._parse_openai_response(resp)
+    assert vectors == [[0.5, 0.5]]
+
+
+def test_openai_backend_malformed_response() -> None:
+    """Missing ``data`` / non-numeric values -> ``None`` from parser,
+    ``0.0`` from ``max_similarity``."""
+    # No ``data`` field (error response shape).
+    assert _embed._parse_openai_response({"error": "no embeddings mode"}) is None
+    # ``data`` not a list.
+    assert _embed._parse_openai_response({"data": "oops"}) is None
+    # Non-numeric embedding entries.
+    assert (
+        _embed._parse_openai_response({"data": [{"embedding": ["not", "a", "number"]}]})
+        is None
+    )
+    # Bare garbage (not a dict, no ``.data`` attr).
+    assert _embed._parse_openai_response(42) is None
+
+
+def test_openai_backend_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the backend's ``encode`` blows up, ``max_similarity`` /
+    ``distance_to_topic`` return ``0.0`` / ``-1.0`` rather than
+    propagating the exception."""
+
+    class _ExplodingBackend:
+        def encode(self, texts: list[str]) -> list[list[float]]:
+            raise RuntimeError("connection refused")
+
+    _embed.set_model(_ExplodingBackend())
+    assert _embed.max_similarity("a", ["b"]) == 0.0
+    assert _embed.distance_to_topic("a", "b") == -1.0
+
+
+def test_cached_encode_hits_on_repeat() -> None:
+    """Calling the same text twice hits the cache the second time."""
+    backend = _FakeBackend({"hello": [1.0, 0.0]})
+    _embed.set_model(backend)
+
+    first = _embed._cached_encode(backend, "hello")
+    second = _embed._cached_encode(backend, "hello")
+    assert first == [1.0, 0.0]
+    assert second == [1.0, 0.0]
+    # Underlying encode was called exactly once despite two reads.
+    assert len(backend.calls) == 1
+
+
+def test_cached_encode_lru_eviction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fill the cache past its cap; oldest entry drops first."""
+    # Shrink the cap for the test so we don't need 513 encodes.
+    monkeypatch.setattr(_embed, "_CACHE_MAX", 3)
+    _embed._reset_cache()
+
+    vectors = {
+        "a": [1.0, 0.0],
+        "b": [0.0, 1.0],
+        "c": [1.0, 1.0],
+        "d": [2.0, 0.0],
+    }
+    backend = _FakeBackend(vectors)
+    _embed.set_model(backend)
+
+    # Fill the cache.
+    for t in ("a", "b", "c"):
+        _embed._cached_encode(backend, t)
+    assert len(backend.calls) == 3
+    # Adding a fourth entry evicts "a" (oldest).
+    _embed._cached_encode(backend, "d")
+    assert len(backend.calls) == 4
+    # Re-reading "a" re-encodes (cache miss).
+    _embed._cached_encode(backend, "a")
+    assert len(backend.calls) == 5
+    # Re-reading "d" (still warm) does not.
+    _embed._cached_encode(backend, "d")
+    assert len(backend.calls) == 5
+
+
+def test_set_model_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``set_model(fake)`` wins over ``GOLDFIVE_EMBEDDING_BASE_URL``."""
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://should-not-be-used")
+    # If ``_get_model`` ever reaches this, it would hit the real loader
+    # and raise; we never want to see it happen when set_model is in
+    # effect, so the mock is punitive.
+    monkeypatch.setattr(
+        _embed,
+        "_try_load_openai_backend",
+        lambda url: (_ for _ in ()).throw(AssertionError("env path used")),
+    )
+
+    fake = _FakeBackend({"foo": [1.0, 0.0], "bar": [0.0, 1.0]})
+    _embed.set_model(fake)
+
+    sim = _embed.max_similarity("foo", ["bar"])
+    assert abs(sim) < 1e-6
+    # Each text encoded exactly once (once the cache warmed up).
+    assert fake.calls, "fake.encode must have been called"
+
+
+def test_openai_backend_env_failure_does_not_fall_back_to_st(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the user configured an HTTP endpoint but the backend cannot
+    build, we prefer "no signal" over silently loading a local
+    sentence-transformers model the user did not ask for."""
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://fake:9999")
+    monkeypatch.setattr(_embed, "_try_load_openai_backend", lambda _url: None)
+
+    assert _embed.available() is False
+
+
+def test_openai_backend_builder_honours_model_and_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_try_load_openai_backend`` reads every optional env var."""
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_MODEL", "qwen3-embed")
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_API_KEY", "secret")
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "2500")
+
+    captured: dict[str, Any] = {}
+
+    class _Spy:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(_embed, "_OpenAIEmbeddingBackend", _Spy)
+
+    backend = _embed._try_load_openai_backend("http://host:8081/")
+    assert backend is not None
+    assert captured["base_url"] == "http://host:8081/"
+    assert captured["model"] == "qwen3-embed"
+    assert captured["api_key"] == "secret"
+    assert captured["timeout_ms"] == 2500
+
+
+def test_openai_backend_httpx_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the ``openai`` SDK is not available, the backend falls
+    through to ``httpx`` and parses the same response shape."""
+    # Force the SDK path off.
+    monkeypatch.setattr(
+        _embed._OpenAIEmbeddingBackend,
+        "_try_build_openai_client",
+        lambda self: False,
+    )
+
+    captured_request: dict[str, Any] = {}
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict[str, Any]:
+            return _canonical_response([[1.0, 0.0], [0.0, 1.0]])
+
+    class _FakeHttpxClient:
+        def post(
+            self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+        ) -> _FakeResponse:
+            captured_request["url"] = url
+            captured_request["json"] = json
+            captured_request["headers"] = headers
+            return _FakeResponse()
+
+    backend = _embed._OpenAIEmbeddingBackend(
+        base_url="http://srv:8081",
+        model="qwen",
+        api_key="k",
+        timeout_ms=1000,
+    )
+    # Short-circuit lazy httpx client construction.
+    backend._httpx_client = _FakeHttpxClient()
+
+    out = backend.encode(["hello", "world"])
+    assert out == [[1.0, 0.0], [0.0, 1.0]]
+    assert captured_request["url"] == "http://srv:8081/v1/embeddings"
+    assert captured_request["json"]["model"] == "qwen"
+    assert captured_request["json"]["input"] == ["hello", "world"]
+    assert captured_request["headers"]["Authorization"] == "Bearer k"
+
+
+def test_openai_backend_httpx_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An HTTP error on the httpx path returns ``None`` (no signal)
+    instead of propagating."""
+
+    class _Raising:
+        def post(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("boom")
+
+    backend = _embed._OpenAIEmbeddingBackend(
+        base_url="http://srv:8081",
+        model="",
+        api_key=None,
+        timeout_ms=1000,
+    )
+    # Force SDK path off and inject the raising httpx client.
+    backend._prefer_sdk = False
+    backend._openai_client = None
+    backend._httpx_client = _Raising()
+
+    assert backend.encode(["foo"]) == []

--- a/tests/test_reasoning_logging.py
+++ b/tests/test_reasoning_logging.py
@@ -1,0 +1,225 @@
+"""DEBUG-log assertions for the four embedding-driven drift detectors.
+
+Operators reading the log should be able to distinguish "detector
+didn't fire because the similarity was high" from "detector didn't
+fire because the embedding model is unavailable." Each detector in
+:mod:`goldfive.drift.reasoning` emits a single DEBUG line with the
+cosine value and its threshold context whenever the embedding model
+is consulted.
+
+We install a fixed-similarity encoder so the cosine is deterministic
+and can appear verbatim in the log assertion.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.drift import reasoning as dreason  # noqa: E402
+from goldfive.drift._embed import set_model  # noqa: E402
+from goldfive.types import Goal, Plan, Session, Task  # noqa: E402
+
+
+class _FixedSimilarityEncoder:
+    """2-D unit-circle encoder: cosine between two registered texts
+    equals ``cos(theta_a - theta_b)``."""
+
+    def __init__(self) -> None:
+        self._by_text: dict[str, tuple[float, float]] = {}
+
+    def set(self, text: str, angle_rad: float) -> None:
+        self._by_text[text] = (math.cos(angle_rad), math.sin(angle_rad))
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        return [list(self._by_text.get(t, (1.0, 0.0))) for t in texts]
+
+
+def _session_basic(
+    *,
+    goals_summary: str = "produce a report on solar panels",
+    title: str = "solar power panels",
+    description: str = "write comparison of solar panels",
+) -> Session:
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title=title, description=description)],
+        edges=[],
+    )
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary=goals_summary)],
+        plan=plan,
+        current_task_id="t1",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_embed() -> Any:
+    from goldfive.drift import _embed as embed_mod
+
+    set_model(None)
+    embed_mod._MODEL_UNAVAILABLE = True
+    yield
+    set_model(None)
+    embed_mod._MODEL_UNAVAILABLE = True
+
+
+# ---------------------------------------------------------------------------
+# intent_divergence
+# ---------------------------------------------------------------------------
+
+
+def test_intent_divergence_logs_cosine(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    reasoning_text = "alpha bravo charlie"
+    goals_summary = "alpha bravo charlie delta"
+    task_title = "echo foxtrot"
+    task_description = "golf hotel india juliet"
+    reference = f"{goals_summary} {task_title} {task_description}"
+
+    encoder = _FixedSimilarityEncoder()
+    encoder.set(reference, 0.0)
+    # Use cos(theta)=0.8 -> healthy, no drift, but the DEBUG line still fires.
+    encoder.set(reasoning_text, math.acos(0.8))
+    set_model(encoder)
+
+    session = _session_basic(
+        goals_summary=goals_summary,
+        title=task_title,
+        description=task_description,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning"):
+        dreason.detect_intent_divergence(reasoning_text, session)
+
+    matching = [
+        r
+        for r in caplog.records
+        if r.name == "goldfive.drift.reasoning"
+        and "intent_divergence:" in r.getMessage()
+    ]
+    assert len(matching) == 1, [r.getMessage() for r in caplog.records]
+    msg = matching[0].getMessage()
+    assert "cosine=0.800" in msg
+    assert "healthy=" in msg
+    assert "text_head=" in msg
+
+
+# ---------------------------------------------------------------------------
+# off_topic
+# ---------------------------------------------------------------------------
+
+
+def test_off_topic_logs_distance(caplog: pytest.LogCaptureFixture) -> None:
+    reasoning_text = "off topic reasoning"
+    task_title = "solar power panels"
+    task_description = "write comparison of solar panels"
+    topic = f"{task_title} {task_description}"
+
+    encoder = _FixedSimilarityEncoder()
+    encoder.set(topic, 0.0)
+    # distance = 0.2, below the 0.7 threshold: detector doesn't fire
+    # but the DEBUG line must still land so operators can see why.
+    encoder.set(reasoning_text, math.acos(0.8))
+    set_model(encoder)
+
+    session = _session_basic(title=task_title, description=task_description)
+
+    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning"):
+        dreason.detect_off_topic(reasoning_text, session)
+
+    matching = [
+        r
+        for r in caplog.records
+        if r.name == "goldfive.drift.reasoning"
+        and "off_topic:" in r.getMessage()
+    ]
+    assert len(matching) == 1, [r.getMessage() for r in caplog.records]
+    msg = matching[0].getMessage()
+    assert "distance=0.200" in msg
+    assert "threshold=0.70" in msg
+    assert "task=" in msg
+
+
+# ---------------------------------------------------------------------------
+# looping_reasoning (embedding tier)
+# ---------------------------------------------------------------------------
+
+
+def test_looping_reasoning_logs_cosine(caplog: pytest.LogCaptureFixture) -> None:
+    current = "current reasoning text"
+    past = "past reasoning text"
+
+    encoder = _FixedSimilarityEncoder()
+    encoder.set(current, 0.0)
+    encoder.set(past, math.acos(0.5))  # cos = 0.5, below the 0.9 cliff.
+    set_model(encoder)
+
+    session = _session_basic()
+    # Steerer contract: current lives at -1, priors before it.
+    session.reasoning_history = [past, current]
+
+    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning"):
+        dreason.detect_looping_reasoning(current, session)
+
+    matching = [
+        r
+        for r in caplog.records
+        if r.name == "goldfive.drift.reasoning"
+        and "looping_reasoning:" in r.getMessage()
+    ]
+    assert len(matching) == 1, [r.getMessage() for r in caplog.records]
+    msg = matching[0].getMessage()
+    assert "cosine=0.500" in msg
+    assert "prior turns" in msg
+    assert "threshold=0.90" in msg
+
+
+# ---------------------------------------------------------------------------
+# reasoning_cluster_tightening
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_tightening_logs_cosine(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    current = "current reasoning text"
+    past = "past reasoning text"
+
+    encoder = _FixedSimilarityEncoder()
+    encoder.set(current, 0.0)
+    # cos = 0.4 -- below the 0.75 cluster floor, so the detector
+    # doesn't fire; the DEBUG line still logs.
+    encoder.set(past, math.acos(0.4))
+    set_model(encoder)
+
+    session = _session_basic()
+    session.reasoning_history = [past, current]
+
+    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning"):
+        dreason.detect_reasoning_cluster_tightening(current, session)
+
+    matching = [
+        r
+        for r in caplog.records
+        if r.name == "goldfive.drift.reasoning"
+        and "reasoning_cluster_tightening:" in r.getMessage()
+    ]
+    assert len(matching) == 1, [r.getMessage() for r in caplog.records]
+    msg = matching[0].getMessage()
+    assert "cosine=0.400" in msg
+    assert "band=" in msg


### PR DESCRIPTION
Closes #222.

## Summary

Two foundational, model-agnostic improvements to the reasoning-drift
pipeline in `goldfive.drift`.

### 1. OpenAI-compatible HTTP embedding backend (`goldfive/drift/_embed.py`)

Lets operators point goldfive's embedding calls at any OpenAI-compatible
`/v1/embeddings` endpoint they already run for inference (llama.cpp,
Ollama, real OpenAI, etc.) instead of pulling in the heavy local
`sentence-transformers` stack. Zero extra install; the LLM server is
the embedding server.

Env vars:
- `GOLDFIVE_EMBEDDING_BASE_URL` — e.g. `http://kikuchi.lan:8081`. Presence
  of this var selects the HTTP backend. Absence falls back to
  sentence-transformers (unchanged).
- `GOLDFIVE_EMBEDDING_MODEL` — optional model name for the request body.
- `GOLDFIVE_EMBEDDING_API_KEY` — optional bearer token.
- `GOLDFIVE_EMBEDDING_TIMEOUT_MS` — HTTP timeout, default 10000.

Implementation notes:
- `openai` SDK preferred for auth/retry parity with the rest of the
  client stack; `httpx` fallback when the SDK is not importable.
- Shared response parser tolerates dict and object envelopes, nested
  `[[...]]` pooled embeddings, and hard error bodies (returns `None`;
  upstream treats as "no signal").
- Per-text LRU cache (`_cached_encode`) keyed on backend identity so
  `max_similarity` does not re-post every history entry on each call.
- Env-var failure does NOT silently fall back to
  sentence-transformers — operator intent is respected.
- `set_model()` remains the test/custom-runtime escape hatch and wins
  over env-driven config.

### 2. Cosine DEBUG logging across all four embedding-driven detectors

`intent_divergence`, `looping_reasoning`, `reasoning_cluster_tightening`,
and `off_topic` each emit one DEBUG line per call with the observed
cosine / distance plus the active threshold. Operators can now tell
"detector didn't fire because the similarity was high" apart from
"detector didn't fire because the model was unavailable" just by
reading the log.

### Threshold values

No threshold changes ship in this PR. Initial scope included threshold
nudges (`OFF_TOPIC_DISTANCE_THRESHOLD` 0.7→0.35 and
`INTENT_DIVERGENCE_HEALTHY_SIMILARITY` 0.6→0.7). Empirical calibration
against Qwen3-Embedding-0.6B-Q4_K_M at `kikuchi.lan:8081` showed this
model has a compressed similarity distribution where a reasoning block
containing "Slide 2: Raccoons" alongside solar-panel content scores
cosine 0.909 vs the task topic — statistically indistinguishable from
on-topic reasoning at 0.911. Whole-block threshold tuning cannot
separate these cases on this model. A follow-up PR will address this
at the granularity layer (sentence-level embedding or promoting
`_has_unreferenced_keyword` to a standalone detector).

## Test plan

- [x] `tests/test_embedding_backend.py` — env-driven selection,
      response parsing (happy / malformed / nested / SDK object shape),
      LRU hit + eviction, httpx fallback, `set_model` override, SDK
      failure → "no signal".
- [x] `tests/test_reasoning_logging.py` — each detector emits its
      DEBUG line with deterministic cosine / distance values via a
      unit-circle stub encoder.
- [x] Full suite: 1208 passed, 46 skipped.
- [x] `uv run ruff check goldfive/drift/ tests/` clean.
- [x] `uv run mypy goldfive/drift/_embed.py goldfive/drift/reasoning.py` clean.
