### PR TITLE
fix(planner): cooldown on drift-triggered plan revisions per task+kind

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -301,6 +301,7 @@ class DefaultSteerer:
         goal_drift_call_llm: ReflectiveCallLLM | None = None,
         goal_drift_model: str = "",
         goal_drift_activity_window: int = 10,
+        plan_revision_cooldown_seconds: float = 30.0,
     ) -> None:
         """Build a steerer.
 
@@ -345,6 +346,18 @@ class DefaultSteerer:
             Number of recent-activity entries retained on
             ``session.recent_agent_activity`` and passed to the
             judge. Bounds the prompt size; defaults to ``10``.
+        plan_revision_cooldown_seconds:
+            Minimum interval, in seconds, between two drift-triggered
+            plan revisions for the same ``(task_id, drift_kind)`` key.
+            Defaults to ``30.0``. Set to ``0.0`` to disable the cooldown
+            entirely (pre-fix behaviour). Cooldown is scoped per-kind so
+            genuinely different problems (e.g. ``LOOPING_REASONING`` vs
+            ``CONFUSION``) can still replan independently. USER_STEER
+            drifts bypass this gate (user intent is always honoured
+            immediately) and GOAL_DRIFT has its own rate limiting via
+            ``_last_goal_drift_check_ts``, so it also bypasses this
+            gate. See goldfive feedback-loop fix for the observation
+            that prompted this.
 
         See ``docs/design/DRIFT.md`` §"Reflective self-progress check"
         for the full feature-gate semantics. The GOAL_DRIFT check
@@ -379,6 +392,10 @@ class DefaultSteerer:
         self._goal_drift_check_interval = max(1, int(goal_drift_check_interval))
         self._goal_drift_model = goal_drift_model
         self._goal_drift_activity_window = max(1, int(goal_drift_activity_window))
+        # Drift-triggered plan-revision cooldown (goldfive feedback-loop
+        # fix). Clamped to a non-negative float; ``0.0`` disables the
+        # gate so callers can opt out without subclassing.
+        self._plan_revision_cooldown_seconds = max(0.0, float(plan_revision_cooldown_seconds))
 
     # ------------------------------------------------------------------
     # Protocol-required: wiring
@@ -1625,6 +1642,19 @@ class DefaultSteerer:
             return
         if session.refine_failure_counts.get(counter_key, 0) >= self.REFINE_FAILURE_THRESHOLD:
             return
+        # Plan-revision cooldown (goldfive feedback-loop fix). A cluster
+        # of related drifts (same kind, same task) should not each
+        # trigger a separate ``planner.refine`` -- an observed live run
+        # saw 6 drift events + 4 plan_revised rows in a single short
+        # session, burning LLM budget and thrashing the agent mid-task.
+        # The DriftDetected event already landed on the wire above, so
+        # observability is covered; we just suppress the replan. The
+        # gate is keyed on (task_id, drift_kind) so genuinely different
+        # problems can still replan independently, and USER_STEER /
+        # GOAL_DRIFT bypass it (see the method docstring on
+        # ``_is_plan_revision_cooldown_exempt``).
+        if self._is_plan_revision_gated(drift, session):
+            return
         # Plumb the session into the planner's drift-emitter callback
         # for the duration of this refine call so the planner can emit
         # REFINE_VALIDATION_FAILED drifts through the normal event
@@ -1726,6 +1756,12 @@ class DefaultSteerer:
         prev_plan = session.plan
         self._apply_revision(session, revised, drift)
         await self._emit_plan_revised(session, revised, drift, prev_plan=prev_plan)
+        # Stamp the cooldown table so a follow-up drift of the same
+        # kind+task within ``plan_revision_cooldown_seconds`` is gated.
+        # Only recorded on a revision that *actually landed* (past all
+        # the error / validation short-circuits above) so a failed
+        # refine doesn't wedge the cooldown.
+        self._record_plan_revision(drift, session)
         # Level 3 (CANCEL_REINVOKE) handoff: compose a corrective user
         # message from the drift + refined plan and stash it on the
         # session so the Runner's overlay loop (goldfive#141) can cancel
@@ -2438,6 +2474,82 @@ class DefaultSteerer:
             return ""
         payload = raw.payload if isinstance(raw.payload, dict) else {}
         return str(payload.get("annotation_id", "") or "")
+
+    # ------------------------------------------------------------------
+    # Plan-revision cooldown (drift-triggered replan rate limit)
+    # ------------------------------------------------------------------
+
+    # Drift kinds that always bypass the plan-revision cooldown. USER_STEER
+    # is an explicit user intervention -- user intent is always honoured
+    # immediately, even if a recent autonomous revision on the same task
+    # is still within the window. GOAL_DRIFT is trajectory-level and has
+    # its own rate limiting via ``_last_goal_drift_check_ts`` +
+    # ``_GOAL_DRIFT_TASK_BOUNDARY_MIN_INTERVAL_S`` (goldfive#220).
+    _PLAN_REVISION_COOLDOWN_EXEMPT_KINDS: frozenset[DriftKind] = frozenset(
+        {
+            DriftKind.USER_STEER,
+            DriftKind.USER_CANCEL,
+            DriftKind.GOAL_DRIFT,
+        }
+    )
+
+    def _is_plan_revision_gated(self, drift: DriftEvent, session: Session) -> bool:
+        """Return ``True`` iff a drift-triggered revision should be suppressed.
+
+        Consults ``session._last_plan_revision_at`` keyed on
+        ``(drift.current_task_id, drift.kind.value)``. If the age of
+        the last revision for that key is below
+        ``plan_revision_cooldown_seconds``, logs at DEBUG + INFO and
+        returns ``True``. Otherwise returns ``False``.
+
+        No-op (returns ``False``) when the cooldown is disabled
+        (``plan_revision_cooldown_seconds <= 0``) or the drift kind is
+        in :data:`_PLAN_REVISION_COOLDOWN_EXEMPT_KINDS`.
+        """
+        cooldown = self._plan_revision_cooldown_seconds
+        if cooldown <= 0:
+            return False
+        if drift.kind in self._PLAN_REVISION_COOLDOWN_EXEMPT_KINDS:
+            return False
+        key = (drift.current_task_id, drift.kind.value)
+        last_at = session._last_plan_revision_at.get(key)
+        if last_at is None:
+            return False
+        now = time.monotonic()
+        age = now - last_at
+        if age >= cooldown:
+            return False
+        # Within the cooldown window -- suppress.
+        log.debug(
+            "plan revision suppressed by cooldown (task=%r age=%.1fs cooldown=%.1fs trigger=%r)",
+            drift.current_task_id,
+            age,
+            cooldown,
+            drift.kind.value,
+        )
+        log.info(
+            "goldfive observed a %s drift on task=%r within the plan-revision "
+            "cooldown (%.1fs < %.1fs); skipping replan",
+            drift.kind.value,
+            drift.current_task_id,
+            age,
+            cooldown,
+        )
+        return True
+
+    def _record_plan_revision(self, drift: DriftEvent, session: Session) -> None:
+        """Stamp ``session._last_plan_revision_at`` after a successful revision.
+
+        Called at the very end of the refine path, after the new plan
+        is installed and ``PlanRevised`` has been emitted. Exempt
+        kinds (see :meth:`_is_plan_revision_gated`) are still recorded
+        for completeness -- the gate short-circuits on them
+        independently of whether a stamp exists.
+        """
+        if self._plan_revision_cooldown_seconds <= 0:
+            return
+        key = (drift.current_task_id, drift.kind.value)
+        session._last_plan_revision_at[key] = time.monotonic()
 
     async def _emit_plan_revised(
         self,

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -583,6 +583,18 @@ class Session:
     # and mark the task FAILED after N consecutive failures, preventing
     # the same drift from looping until ``max_task_invocations`` trips.
     refine_failure_counts: dict[tuple[str, str], int] = dataclasses.field(default_factory=dict)
+    # Per-(task_id, drift_kind_value) ``time.monotonic()`` timestamp of the
+    # last plan revision that actually landed (``_emit_plan_revised``).
+    # Consumed by :class:`~goldfive.steerer.DefaultSteerer` to gate
+    # drift-triggered revisions through a short cooldown window so a
+    # cluster of closely-spaced drifts of the same kind on the same task
+    # does not thrash ``planner.refine`` (goldfive feedback-loop fix).
+    # Sentinel task_id ``""`` covers trajectory-wide revisions. Does NOT
+    # apply to USER_STEER (always honoured) or GOAL_DRIFT (has its own
+    # task-boundary rate limit via ``_last_goal_drift_check_ts``).
+    _last_plan_revision_at: dict[tuple[str, str], float] = dataclasses.field(
+        default_factory=dict
+    )
     # Counter of LLM turns observed since the last reflective self-progress
     # check. Incremented by ``DefaultSteerer.note_llm_call`` (which adapters
     # call once per LLM invocation when the opt-in reflective check is

--- a/tests/test_plan_revision_cooldown.py
+++ b/tests/test_plan_revision_cooldown.py
@@ -1,0 +1,328 @@
+"""Unit tests for the drift-triggered plan-revision cooldown.
+
+The cooldown lives in :class:`goldfive.steerer.DefaultSteerer` and
+gates ``planner.refine`` calls on the ``(task_id, drift_kind)`` key.
+These tests drive ``_handle_drift`` directly so each fire is isolated
+from :meth:`DefaultSteerer.observe`'s drift classifier.
+
+See goldfive feedback-loop fix (CRITICAL drift spam producing back-to-
+back ``plan_revised`` rows within seconds).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.control import ControlKind, ControlMessage  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+)
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        return None
+
+
+class StubPlanner:
+    """Planner stub whose ``refine`` returns a fresh plan every call."""
+
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Any | None = None,
+    ) -> Plan | None:
+        return None
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        self.refine_calls.append({"drift": drift})
+        # Return a minimally-valid revised plan. Re-use the incoming
+        # plan's tasks/edges so ``Plan.validate(for_revision=True,
+        # prior=plan)`` passes -- the steerer runs that after refine.
+        revised = Plan(
+            id=plan.id,
+            run_id=plan.run_id,
+            goal_ids=list(plan.goal_ids),
+            tasks=[Task(id=t.id, title=t.title, status=t.status) for t in plan.tasks],
+            edges=[
+                TaskEdge(from_task_id=e.from_task_id, to_task_id=e.to_task_id)
+                for e in plan.edges
+            ],
+            revision_index=plan.revision_index + 1,
+        )
+        return revised
+
+
+def _make_plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="T1"), Task(id="t2", title="T2")],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+
+
+def _make_session() -> Session:
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do the thing")],
+        plan=_make_plan(),
+    )
+
+
+def _drift(
+    kind: DriftKind,
+    *,
+    task_id: str = "t1",
+    severity: DriftSeverity = DriftSeverity.WARNING,
+    detail: str = "drift",
+) -> DriftEvent:
+    return DriftEvent(
+        kind=kind,
+        severity=severity,
+        detail=detail,
+        current_task_id=task_id,
+    )
+
+
+def _plan_revised_count(sink: ListSink) -> int:
+    return sum(1 for e in sink.events if e.WhichOneof("payload") == "plan_revised")
+
+
+def _build(
+    cooldown: float = 30.0,
+) -> tuple[DefaultSteerer, Session, ListSink, StubPlanner]:
+    steerer = DefaultSteerer(plan_revision_cooldown_seconds=cooldown)
+    sink = ListSink()
+    planner = StubPlanner()
+    steerer.bind(sinks=[sink], planner=planner)  # type: ignore[arg-type]
+    session = _make_session()
+    return steerer, session, sink, planner
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_two_off_topic_drifts_within_window_emit_one_plan_revised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two consecutive OFF_TOPIC drifts within 5s -> one plan_revised."""
+    steerer, session, sink, planner = _build(cooldown=30.0)
+
+    clock = [1000.0]
+    monkeypatch.setattr("goldfive.steerer.time.monotonic", lambda: clock[0])
+
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+    clock[0] += 5.0
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+
+    assert _plan_revised_count(sink) == 1
+    assert len(planner.refine_calls) == 1
+
+
+async def test_two_off_topic_drifts_past_cooldown_emit_twice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two OFF_TOPIC drifts 35s apart -> both plan_revised emissions fire."""
+    steerer, session, sink, planner = _build(cooldown=30.0)
+
+    clock = [1000.0]
+    monkeypatch.setattr("goldfive.steerer.time.monotonic", lambda: clock[0])
+
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+    clock[0] += 35.0
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+
+    assert _plan_revised_count(sink) == 2
+    assert len(planner.refine_calls) == 2
+
+
+async def test_different_drift_kinds_do_not_share_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OFF_TOPIC then LOOPING_REASONING within 5s -> both fire.
+
+    The cooldown is scoped per ``(task_id, drift_kind)`` so genuinely
+    different problems replan independently.
+    """
+    steerer, session, sink, planner = _build(cooldown=30.0)
+
+    clock = [1000.0]
+    monkeypatch.setattr("goldfive.steerer.time.monotonic", lambda: clock[0])
+
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+    clock[0] += 5.0
+    await steerer._handle_drift(_drift(DriftKind.LOOPING_REASONING), session)
+
+    assert _plan_revised_count(sink) == 2
+    assert len(planner.refine_calls) == 2
+
+
+async def test_different_task_ids_do_not_share_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drift on task_A then task_B within 5s -> both fire."""
+    steerer, session, sink, planner = _build(cooldown=30.0)
+
+    clock = [1000.0]
+    monkeypatch.setattr("goldfive.steerer.time.monotonic", lambda: clock[0])
+
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
+    clock[0] += 5.0
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t2"), session)
+
+    assert _plan_revised_count(sink) == 2
+    assert len(planner.refine_calls) == 2
+
+
+async def test_user_steer_drift_bypasses_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """USER_STEER drift fires immediately regardless of a recent revision.
+
+    A user steer is an explicit intervention -- we always honour it,
+    even if goldfive just replanned the same task for an autonomous
+    drift.
+    """
+    steerer, session, sink, planner = _build(cooldown=30.0)
+
+    clock = [1000.0]
+    monkeypatch.setattr("goldfive.steerer.time.monotonic", lambda: clock[0])
+
+    # Prime the cooldown with an autonomous drift on t1.
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
+    clock[0] += 2.0
+
+    # Build a USER_STEER drift the way _drift_from_control does: with a
+    # ControlMessage carrying an annotation_id in ``raw``.
+    ctrl = ControlMessage(
+        kind=ControlKind.STEER,
+        payload={"annotation_id": "ann_123", "note": "please pivot to X"},
+    )
+    user_drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="please pivot to X",
+        current_task_id="t1",
+        raw=ctrl,
+    )
+    await steerer._handle_drift(user_drift, session)
+
+    # Two plan_revised rows: one for the autonomous OFF_TOPIC, one for
+    # the user steer that arrived inside the cooldown window.
+    assert _plan_revised_count(sink) == 2
+    # Both refine calls fired (USER_STEER wasn't suppressed).
+    assert len(planner.refine_calls) == 2
+
+
+async def test_goal_drift_does_not_consume_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GOAL_DRIFT path is unaffected by this cooldown (rate-limited elsewhere).
+
+    GOAL_DRIFT maps to PAUSE_ESCALATE in the intervention ladder, so it
+    does NOT hit the refine path and therefore does not stamp the
+    cooldown table. The second OFF_TOPIC drift should see an empty
+    cooldown entry and fire normally.
+    """
+    steerer, session, sink, planner = _build(cooldown=30.0)
+
+    clock = [1000.0]
+    monkeypatch.setattr("goldfive.steerer.time.monotonic", lambda: clock[0])
+
+    # Fire a GOAL_DRIFT first; it routes to PAUSE_ESCALATE and does not
+    # invoke planner.refine.
+    await steerer._handle_drift(
+        _drift(DriftKind.GOAL_DRIFT, task_id="t1", severity=DriftSeverity.CRITICAL),
+        session,
+    )
+    assert len(planner.refine_calls) == 0
+    assert _plan_revised_count(sink) == 0
+
+    # Reset pause flag so the next handle_drift isn't gated by the
+    # pause bookkeeping; the cooldown under test is orthogonal to pause.
+    session.paused_for_human_intervention = False
+
+    clock[0] += 5.0
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
+    assert _plan_revised_count(sink) == 1
+    assert len(planner.refine_calls) == 1
+
+
+async def test_cooldown_zero_disables_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``plan_revision_cooldown_seconds=0.0`` disables the cooldown entirely.
+
+    Two back-to-back identical drifts both replan.
+    """
+    steerer, session, sink, planner = _build(cooldown=0.0)
+
+    clock = [1000.0]
+    monkeypatch.setattr("goldfive.steerer.time.monotonic", lambda: clock[0])
+
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+    # Same tick; with cooldown==0 the gate no-ops.
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+
+    assert _plan_revised_count(sink) == 2
+    assert len(planner.refine_calls) == 2
+
+
+async def test_suppressed_revision_does_not_emit_extra_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A suppressed revision emits DriftDetected but no PlanRevised / refine.
+
+    Operators still see the drift on the wire -- only the replan is
+    throttled.
+    """
+    steerer, session, sink, planner = _build(cooldown=30.0)
+
+    clock = [1000.0]
+    monkeypatch.setattr("goldfive.steerer.time.monotonic", lambda: clock[0])
+
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+    clock[0] += 1.0
+    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    # First handle: drift_detected + plan_revised.
+    # Second handle: drift_detected only (suppressed).
+    assert kinds == ["drift_detected", "plan_revised", "drift_detected"]
+    assert len(planner.refine_calls) == 1

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -300,8 +300,20 @@ async def test_observe_dedupe_does_not_affect_heuristic_drifts() -> None:
     The dedupe set lives only for user-originated STEER annotations;
     content-based classifiers (tool errors, refusals, loops) must
     remain free-running so repeated heuristic signals still escalate.
+
+    This test deliberately fires two identical back-to-back tool-error
+    drifts, which would otherwise be suppressed by the plan-revision
+    cooldown (goldfive feedback-loop fix). The cooldown is an
+    orthogonal rate limit covered by
+    ``tests/test_plan_revision_cooldown.py``; here we disable it so
+    the dedup-set assertion can stand on its own.
     """
     steerer, session, _sink, planner = _bind_fresh()
+    # Hot-patch the cooldown off for this test only. ``_bind_fresh``
+    # builds a default-configured steerer; we need the cooldown window
+    # at 0 so the two identical tool-error observations below both
+    # trigger refine.
+    steerer._plan_revision_cooldown_seconds = 0.0
 
     # A steer populates processed_steer_ids.
     msg = ControlMessage(


### PR DESCRIPTION
Closes #227.

## Summary

- A cluster of related drifts (same kind, same task, fired seconds apart by a jittery detector) previously each spent an LLM call and swapped ``session.plan``. One live ``make demo`` run produced 6 drift events + 4 ``plan_revised`` rows in a short session.
- Gate ``planner.refine`` through a 30s cooldown keyed on ``(task_id, drift_kind)``. ``DriftDetected`` still lands on the wire (observability preserved); only the replan is suppressed, with DEBUG + INFO logs on suppression.
- Bypasses: ``USER_STEER`` / ``USER_CANCEL`` (always honoured); ``GOAL_DRIFT`` (has its own rate limit via ``_last_goal_drift_check_ts`` and maps to ``PAUSE_ESCALATE`` anyway). Per-kind scoping keeps ``LOOPING_REASONING`` and ``OFF_TOPIC`` independent.

## Implementation notes

- New kwarg ``DefaultSteerer(plan_revision_cooldown_seconds=30.0)``. Set to ``0.0`` to disable. No wiring through ``goldfive.wrap`` — the default is fine; the in-flight RuntimeConfig PR can thread it later.
- New ``Session._last_plan_revision_at: dict[(task_id, kind), float]`` stamped on ``time.monotonic()`` after every successful ``_emit_plan_revised``. Only landed revisions stamp, so a failed refine doesn't wedge the cooldown.
- Cooldown check lives in ``_handle_drift`` between the failure-counter short-circuit and the ``planner.refine`` call — this is the one site where drift-triggered revisions actually originate. The executor's out-of-band ``PlanRevised`` emitters (sequential / parallel) only fire *after* ``session.plan`` has already been swapped by the steerer, so they correctly inherit the gate.

## File:line of modification sites

- ``goldfive/steerer.py:311`` — new kwarg in ``DefaultSteerer.__init__``.
- ``goldfive/steerer.py:395-399`` — instance attribute init.
- ``goldfive/steerer.py:1645-1657`` — cooldown gate before ``planner.refine``.
- ``goldfive/steerer.py:1748-1755`` — ``_record_plan_revision`` after ``_emit_plan_revised``.
- ``goldfive/steerer.py:2478-2553`` — ``_is_plan_revision_gated`` + ``_record_plan_revision`` helpers and the ``_PLAN_REVISION_COOLDOWN_EXEMPT_KINDS`` set.
- ``goldfive/types.py:586-597`` — new ``Session._last_plan_revision_at`` dataclass field.

## Test plan

- [x] ``uv run pytest -q`` full suite: **1246 passed, 46 skipped**.
- [x] ``uv run ruff check`` on touched files: clean.
- [x] ``uv run mypy`` on touched source files (``goldfive/steerer.py``, ``goldfive/types.py``, ``tests/test_plan_revision_cooldown.py``): no errors. (``tests/test_steerer_usersteer.py`` retains 1 pre-existing mypy error on the unrelated ``_bind_fresh`` helper.)
- [x] New ``tests/test_plan_revision_cooldown.py`` covers: within-window suppression, past-cooldown fires-again, per-kind isolation, per-task isolation, ``USER_STEER`` bypass, ``GOAL_DRIFT`` does not consume cooldown, ``cooldown=0.0`` disables, and the event-stream shape on suppression.
- [x] ``tests/test_steerer_usersteer.py::test_observe_dedupe_does_not_affect_heuristic_drifts`` updated to hot-patch ``_plan_revision_cooldown_seconds=0.0`` — its intent (dedup set doesn't block heuristic drifts) is orthogonal to this cooldown.

## Coordination

Orthogonal to ``feat/runtime-config`` (typed config will thread the kwarg later) and ``feat/llm-reasoning-drift-judge`` (the rate limit runs downstream of whichever detector fires). No file overlap.