### PR TITLE
feat(config): introduce RuntimeConfig dataclasses; thread through wrap()

### DIFF
--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 __version__ = "0.1.0"
 
 from goldfive.adapters.callable import CallableAdapter
+from goldfive.config import (
+    EmbeddingConfig,
+    GoalDriftConfig,
+    ReasoningDriftConfig,
+    RuntimeConfig,
+    ToolLoopConfig,
+)
 from goldfive.control import (
     AckResult,
     ControlAck,
@@ -77,6 +84,7 @@ __all__ = [
     "DriftEvent",
     "DriftKind",
     "DriftSeverity",
+    "EmbeddingConfig",
     "EventSink",
     "ExecutionOutcome",
     "Executor",
@@ -84,6 +92,7 @@ __all__ = [
     "GRPCSink",
     "Goal",
     "GoalDeriver",
+    "GoalDriftConfig",
     "InMemorySink",
     "InvocationResult",
     "JSONLPersistenceSink",
@@ -97,8 +106,10 @@ __all__ = [
     "PassthroughPlanner",
     "Plan",
     "Planner",
+    "ReasoningDriftConfig",
     "ReportingToolSpec",
     "Runner",
+    "RuntimeConfig",
     "SQLitePersistenceSink",
     "SequentialExecutor",
     "Session",
@@ -107,6 +118,7 @@ __all__ = [
     "Task",
     "TaskEdge",
     "TaskStatus",
+    "ToolLoopConfig",
     "TurnClassification",
     "TurnRecord",
     "classify_refusal",

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1018,16 +1018,19 @@ def make_adk_plugin(
             # tool call the plugin sees in ``after_tool_callback`` and
             # fires a ``LOOPING_REASONING`` drift when any of the
             # three configured patterns (exact / name / alternating)
-            # trips. Thresholds read from ``GOLDFIVE_TOOL_LOOP_*`` env
-            # vars, falling back to the defaults documented in
-            # :mod:`goldfive.drift.tool_loops`. Lazy import so the
-            # plugin module stays importable without the drift helpers
-            # materialised — matches the pattern used for the
-            # confabulation classifier.
+            # trips. Thresholds are sourced from
+            # :func:`~goldfive.drift.tool_loops.resolve_thresholds`,
+            # which prefers an installed
+            # :class:`~goldfive.config.ToolLoopConfig` (goldfive#225,
+            # wired by :func:`goldfive.wrap`) and falls back to
+            # ``GOLDFIVE_TOOL_LOOP_*`` env vars and then the module
+            # defaults. Lazy import so the plugin module stays
+            # importable without the drift helpers materialised —
+            # matches the pattern used for the confabulation classifier.
             from goldfive.drift import tool_loops as _tool_loops
 
             self._tool_loop_tracker = _tool_loops.ToolLoopTracker(
-                **_tool_loops.load_thresholds_from_env()
+                **_tool_loops.resolve_thresholds()
             )
             # Reporting-tool names that indicate forward task progress
             # and therefore can clear the tool-loop tracker's window

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -1,0 +1,372 @@
+"""Typed, per-Runner configuration for goldfive (goldfive#225).
+
+goldfive has accumulated ad-hoc configuration knobs across four
+subsystems, each with a different mechanism:
+
+1. **Embedding backend** (#221). ``GOLDFIVE_EMBEDDING_BASE_URL`` /
+   ``_MODEL`` / ``_API_KEY`` / ``_TIMEOUT_MS`` read at first call in
+   :mod:`goldfive.drift._embed`.
+2. **Tool-loop detector**. ``GOLDFIVE_TOOL_LOOP_WINDOW`` /
+   ``_EXACT_THRESHOLD`` / ``_NAME_THRESHOLD`` / ``_ALTERNATING_THRESHOLD``
+   read in :mod:`goldfive.drift.tool_loops`.
+3. **Reasoning-drift thresholds**. Module-level constants in
+   :mod:`goldfive.drift.reasoning` with no env wiring at all.
+4. **Goal-drift scheduling**. Kwargs on
+   :class:`~goldfive.steerer.DefaultSteerer` that ``goldfive.wrap()``
+   does not thread through.
+
+This module introduces a typed :class:`RuntimeConfig` dataclass with
+four sub-configs that collapses those four surfaces into a single
+object operators can pass to :func:`goldfive.wrap`. The ``from_env()``
+classmethods preserve the existing env-var surface (names unchanged
+where they already exist; new ``GOLDFIVE_DRIFT_*`` / ``GOLDFIVE_GOAL_DRIFT_*``
+names for the knobs that did not previously have env wiring) so
+``goldfive.wrap(tree)`` with no ``runtime=`` kwarg remains byte-
+identical to pre-#225 behaviour.
+
+Dataclasses are deliberately **mutable** (``frozen=False``). Operators
+commonly tweak a field after constructing from env (e.g. load
+defaults then bump ``goal_drift.check_interval`` for a debugging run).
+Callers who want a snapshot can :func:`dataclasses.replace` to build a
+variant without mutating the source.
+
+See :func:`goldfive.wrap` for the installation path and
+``docs/design/DRIFT.md`` §"Per-Runner runtime config" for the design
+note.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+
+__all__ = [
+    "EmbeddingConfig",
+    "GoalDriftConfig",
+    "ReasoningDriftConfig",
+    "RuntimeConfig",
+    "ToolLoopConfig",
+]
+
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Env helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_int_env(name: str, default: int) -> int:
+    """Best-effort positive-integer env override; returns default on any failure.
+
+    Matches the semantics of
+    :func:`goldfive.drift.tool_loops._read_int_env` (and, indirectly,
+    :func:`goldfive.drift._embed._try_load_openai_backend`'s timeout
+    read). Non-integer / non-positive / missing values silently fall
+    back to the default.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        log.debug(
+            "runtime-config: ignoring non-integer %s=%r (using default %d)",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if val <= 0:
+        log.debug(
+            "runtime-config: ignoring non-positive %s=%d (using default %d)",
+            name,
+            val,
+            default,
+        )
+        return default
+    return val
+
+
+def _read_float_env(name: str, default: float) -> float:
+    """Best-effort float env override; returns default on any failure.
+
+    Unlike :func:`_read_int_env` we do **not** require the value to be
+    positive — a reasoning-drift threshold of ``0.0`` is a valid (if
+    degenerate) configuration. Parse failures fall back to the default
+    with a debug log.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        log.debug(
+            "runtime-config: ignoring non-float %s=%r (using default %s)",
+            name,
+            raw,
+            default,
+        )
+        return default
+
+
+def _read_str_env(name: str, default: str) -> str:
+    """Return ``os.environ[name]`` or ``default`` when missing.
+
+    The empty string is a legitimate value for model names (llama.cpp
+    tolerates ``model=""``), so we do NOT treat empty as "missing" here
+    — the caller may explicitly want to clear a default.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw
+
+
+def _read_optional_str_env(name: str, default: str | None) -> str | None:
+    """Return ``os.environ[name]`` or ``default``. Empty string -> ``None``.
+
+    Used for fields whose Python type is ``str | None`` (e.g.
+    ``api_key``, ``base_url``) where the semantic "unset" value is
+    ``None``, not the empty string.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    return stripped
+
+
+# ---------------------------------------------------------------------------
+# Sub-configs
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class EmbeddingConfig:
+    """Configuration for the embedding backend used by reasoning-drift detectors.
+
+    When ``base_url`` is ``None`` the OpenAI-compatible HTTP backend is
+    skipped and the lazy-load path in :mod:`goldfive.drift._embed`
+    falls through to sentence-transformers (if the ``goldfive[embedding]``
+    extra is installed). When ``base_url`` is set, the HTTP backend is
+    used exclusively — no silent fall-through to sentence-transformers
+    on HTTP failure (matches the pre-#225 env-driven contract).
+    """
+
+    base_url: str | None = None
+    model: str = ""
+    api_key: str | None = None
+    timeout_ms: int = 10_000
+
+    @classmethod
+    def from_env(cls) -> EmbeddingConfig:
+        """Read ``GOLDFIVE_EMBEDDING_*`` env vars into an instance.
+
+        Missing vars fall back to the field defaults. Preserves the
+        exact env-var surface documented in
+        :mod:`goldfive.drift._embed`.
+        """
+        defaults = cls()
+        return cls(
+            base_url=_read_optional_str_env(
+                "GOLDFIVE_EMBEDDING_BASE_URL", defaults.base_url
+            ),
+            model=_read_str_env("GOLDFIVE_EMBEDDING_MODEL", defaults.model),
+            api_key=_read_optional_str_env(
+                "GOLDFIVE_EMBEDDING_API_KEY", defaults.api_key
+            ),
+            timeout_ms=_read_int_env(
+                "GOLDFIVE_EMBEDDING_TIMEOUT_MS", defaults.timeout_ms
+            ),
+        )
+
+
+@dataclasses.dataclass
+class ToolLoopConfig:
+    """Configuration for :class:`~goldfive.drift.tool_loops.ToolLoopTracker`.
+
+    ``exact_threshold`` / ``name_threshold`` override the **work**
+    category's WARNING tier only; the graduated CRITICAL tiers and
+    the meta-category thresholds remain module constants. This
+    preserves the pre-#204 single-threshold semantics for work tools.
+    See :mod:`goldfive.drift.tool_loops` §"Graduated thresholds per
+    category" for the full table.
+    """
+
+    window: int = 10
+    exact_threshold: int = 3
+    name_threshold: int = 5
+    alternating_threshold: int = 5
+
+    @classmethod
+    def from_env(cls) -> ToolLoopConfig:
+        """Read ``GOLDFIVE_TOOL_LOOP_*`` env vars into an instance.
+
+        Names preserved from :func:`goldfive.drift.tool_loops.load_thresholds_from_env`.
+        """
+        defaults = cls()
+        return cls(
+            window=_read_int_env("GOLDFIVE_TOOL_LOOP_WINDOW", defaults.window),
+            exact_threshold=_read_int_env(
+                "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD", defaults.exact_threshold
+            ),
+            name_threshold=_read_int_env(
+                "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD", defaults.name_threshold
+            ),
+            alternating_threshold=_read_int_env(
+                "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD",
+                defaults.alternating_threshold,
+            ),
+        )
+
+
+@dataclasses.dataclass
+class ReasoningDriftConfig:
+    """Thresholds for the reasoning-drift detectors.
+
+    Field defaults match the module-level constants in
+    :mod:`goldfive.drift.reasoning` one-for-one. Operators who want to
+    tune these previously had to fork the module; now they can either
+    set the corresponding env var (``GOLDFIVE_DRIFT_*``) or pass a
+    :class:`RuntimeConfig` explicitly.
+
+    Installation is process-wide via
+    :func:`goldfive.drift.reasoning.configure` — "last Runner wins"
+    for processes that host multiple Runners concurrently. The
+    tradeoff is documented at the install site. If two-Runners-in-
+    one-process with different drift thresholds becomes a real use
+    case, #225's follow-up plan is to move the config onto
+    :class:`~goldfive.types.Session` and read it per-session in each
+    detector.
+    """
+
+    off_topic_distance_threshold: float = 0.7
+    intent_divergence_healthy_similarity: float = 0.6
+    intent_divergence_minor_similarity: float = 0.4
+    intent_divergence_warning_similarity: float = 0.2
+    looping_reasoning_similarity_threshold: float = 0.9
+    reasoning_cluster_similarity_threshold: float = 0.75
+    looping_reasoning_hash_window: int = 5
+    confusion_min_hits: int = 3
+
+    @classmethod
+    def from_env(cls) -> ReasoningDriftConfig:
+        """Read ``GOLDFIVE_DRIFT_*`` env vars into an instance.
+
+        New env surface introduced by #225 — the reasoning-drift
+        thresholds had no env wiring before. Names are chosen to be
+        self-descriptive and lowercased versions match the dataclass
+        fields verbatim.
+        """
+        defaults = cls()
+        return cls(
+            off_topic_distance_threshold=_read_float_env(
+                "GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE",
+                defaults.off_topic_distance_threshold,
+            ),
+            intent_divergence_healthy_similarity=_read_float_env(
+                "GOLDFIVE_DRIFT_INTENT_HEALTHY_SIMILARITY",
+                defaults.intent_divergence_healthy_similarity,
+            ),
+            intent_divergence_minor_similarity=_read_float_env(
+                "GOLDFIVE_DRIFT_INTENT_MINOR_SIMILARITY",
+                defaults.intent_divergence_minor_similarity,
+            ),
+            intent_divergence_warning_similarity=_read_float_env(
+                "GOLDFIVE_DRIFT_INTENT_WARNING_SIMILARITY",
+                defaults.intent_divergence_warning_similarity,
+            ),
+            looping_reasoning_similarity_threshold=_read_float_env(
+                "GOLDFIVE_DRIFT_LOOPING_SIMILARITY",
+                defaults.looping_reasoning_similarity_threshold,
+            ),
+            reasoning_cluster_similarity_threshold=_read_float_env(
+                "GOLDFIVE_DRIFT_CLUSTER_SIMILARITY",
+                defaults.reasoning_cluster_similarity_threshold,
+            ),
+            looping_reasoning_hash_window=_read_int_env(
+                "GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW",
+                defaults.looping_reasoning_hash_window,
+            ),
+            confusion_min_hits=_read_int_env(
+                "GOLDFIVE_DRIFT_CONFUSION_MIN_HITS",
+                defaults.confusion_min_hits,
+            ),
+        )
+
+
+@dataclasses.dataclass
+class GoalDriftConfig:
+    """Scheduling for the trajectory-level GOAL_DRIFT judge (#143).
+
+    ``check_interval`` is the number of agent-invocation turns between
+    judge calls; ``activity_window`` bounds
+    ``session.recent_agent_activity`` and hence the prompt size. Both
+    were previously ``DefaultSteerer`` kwargs with no env or
+    ``wrap()``-level override; this config surfaces them.
+    """
+
+    check_interval: int = 5
+    activity_window: int = 10
+
+    @classmethod
+    def from_env(cls) -> GoalDriftConfig:
+        """Read ``GOLDFIVE_GOAL_DRIFT_*`` env vars into an instance."""
+        defaults = cls()
+        return cls(
+            check_interval=_read_int_env(
+                "GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL",
+                defaults.check_interval,
+            ),
+            activity_window=_read_int_env(
+                "GOLDFIVE_GOAL_DRIFT_ACTIVITY_WINDOW",
+                defaults.activity_window,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Aggregate
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class RuntimeConfig:
+    """Per-Runner typed configuration aggregate.
+
+    Pass to :func:`goldfive.wrap` via the ``runtime=`` kwarg to install
+    all four sub-configs at once. When the kwarg is omitted, ``wrap()``
+    builds an instance from the environment via :meth:`from_env` —
+    byte-identical to pre-#225 behaviour for callers that relied on
+    env vars or accepted the built-in defaults.
+    """
+
+    embedding: EmbeddingConfig = dataclasses.field(default_factory=EmbeddingConfig)
+    tool_loops: ToolLoopConfig = dataclasses.field(default_factory=ToolLoopConfig)
+    reasoning_drift: ReasoningDriftConfig = dataclasses.field(
+        default_factory=ReasoningDriftConfig
+    )
+    goal_drift: GoalDriftConfig = dataclasses.field(default_factory=GoalDriftConfig)
+
+    @classmethod
+    def from_env(cls) -> RuntimeConfig:
+        """Build a :class:`RuntimeConfig` by reading every supported env var.
+
+        Aggregates the four sub-``from_env`` calls. Each sub-config is
+        independent: a missing env var in one subsystem does not affect
+        the others. The result is a fresh instance; callers may mutate
+        it in place or :func:`dataclasses.replace` to derive a variant.
+        """
+        return cls(
+            embedding=EmbeddingConfig.from_env(),
+            tool_loops=ToolLoopConfig.from_env(),
+            reasoning_drift=ReasoningDriftConfig.from_env(),
+            goal_drift=GoalDriftConfig.from_env(),
+        )

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 from goldfive._llm_detect import CallLLM, detect_llm
 from goldfive.adapters.auto import auto_adapter, is_adk_agent
+from goldfive.config import RuntimeConfig
 from goldfive.executors.sequential import SequentialExecutor
 from goldfive.goal_deriver import LiteralGoalDeriver, LLMGoalDeriver
 from goldfive.planner import LLMPlanner, PassthroughPlanner
@@ -63,6 +64,7 @@ def wrap(
     model: str | None = None,
     max_task_invocations: int | None = None,
     plugins: list[Any] | None = None,
+    runtime: RuntimeConfig | None = None,
     **legacy_kwargs: Any,
 ) -> Runner:
     """Build a :class:`Runner` that drives ``agent`` with goldfive.
@@ -116,6 +118,19 @@ def wrap(
         same plugins as the coordinator — not just the
         ``App(plugins=[...])``-level root runner. Ignored for
         non-ADK agents. See goldfive#121.
+    runtime:
+        Optional :class:`~goldfive.config.RuntimeConfig` (goldfive#225)
+        bundling the four typed-config surfaces: embedding backend,
+        tool-loop detector thresholds, reasoning-drift thresholds, and
+        goal-drift scheduling. When ``None`` (the default) ``wrap()``
+        builds an instance from the environment via
+        :meth:`RuntimeConfig.from_env` so pre-#225 callers get
+        byte-identical behaviour. When provided, the config is
+        installed into the per-process embedding backend and
+        reasoning-drift module, and threaded into the default
+        :class:`DefaultSteerer` via its config kwargs. An explicit
+        ``steerer=`` kwarg wins — the caller keeps full control
+        over the steerer they build themselves.
 
     Returns
     -------
@@ -133,6 +148,25 @@ def wrap(
         ``cast(GoldfiveADKAgent, goldfive.wrap(...))`` themselves.
     """
     adapter = auto_adapter(agent, plugins=plugins)
+
+    # Resolve the runtime config (goldfive#225). When ``runtime`` is
+    # not supplied we build one from the environment so pre-#225
+    # callers — and the env-var tests they already ship — keep working
+    # without modification. The resolved config is then installed
+    # eagerly into the embedding backend's module-level state; the
+    # reasoning-drift module is installed later inside ``DefaultSteerer``
+    # when the steerer-default branch runs (so callers who pass their
+    # own ``steerer=`` can make their own installation decisions).
+    resolved_runtime: RuntimeConfig = (
+        runtime if runtime is not None else RuntimeConfig.from_env()
+    )
+    from goldfive.drift import _embed as _embed_module
+    from goldfive.drift import reasoning as _reasoning_module
+    from goldfive.drift import tool_loops as _tool_loops_module
+
+    _embed_module.configure(resolved_runtime.embedding)
+    _reasoning_module.configure(resolved_runtime.reasoning_drift)
+    _tool_loops_module.configure(resolved_runtime.tool_loops)
 
     resolved_call_llm: CallLLM | None = call_llm
     resolved_model: str = model or ""
@@ -209,9 +243,16 @@ def wrap(
         resolved_steerer = DefaultSteerer(
             goal_drift_call_llm=resolved_call_llm,
             goal_drift_model=resolved_model,
+            goal_drift_config=resolved_runtime.goal_drift,
+            tool_loop_config=resolved_runtime.tool_loops,
+            reasoning_drift_config=resolved_runtime.reasoning_drift,
         )
     else:
-        resolved_steerer = DefaultSteerer()
+        resolved_steerer = DefaultSteerer(
+            goal_drift_config=resolved_runtime.goal_drift,
+            tool_loop_config=resolved_runtime.tool_loops,
+            reasoning_drift_config=resolved_runtime.reasoning_drift,
+        )
     resolved_sinks: list[EventSink] = list(sinks) if sinks is not None else [LoggingSink()]
 
     runner = Runner(

--- a/goldfive/drift/_embed.py
+++ b/goldfive/drift/_embed.py
@@ -47,7 +47,10 @@ from __future__ import annotations
 import logging
 import os
 from collections import OrderedDict
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from goldfive.config import EmbeddingConfig
 
 log = logging.getLogger("goldfive.drift.reasoning.embed")
 
@@ -55,6 +58,12 @@ log = logging.getLogger("goldfive.drift.reasoning.embed")
 _MODEL: Any | None = None
 _MODEL_UNAVAILABLE: bool = False
 _DEFAULT_MODEL_NAME: str = "all-MiniLM-L6-v2"
+
+# Installed per-Runner embedding config (goldfive#225). When non-None,
+# the :func:`_get_model` lazy-load path reads backend parameters from
+# this object instead of environment variables. ``None`` preserves the
+# pre-#225 env-driven behaviour exactly.
+_CONFIG: EmbeddingConfig | None = None
 
 # LRU cache for per-text encoded vectors.
 _CACHE_MAX: int = 512
@@ -71,6 +80,33 @@ def set_model(model: Any | None) -> None:
     """
     global _MODEL, _MODEL_UNAVAILABLE
     _MODEL = model
+    _MODEL_UNAVAILABLE = False
+    _reset_cache()
+
+
+def configure(config: EmbeddingConfig | None) -> None:
+    """Install a :class:`~goldfive.config.EmbeddingConfig` for this process.
+
+    Called by :func:`goldfive.wrap` with the ``runtime.embedding``
+    dataclass. Once installed the env-based auto-config path in
+    :func:`_get_model` is skipped — the config wins over env vars.
+    Passing ``None`` reverts to env-driven behaviour.
+
+    This also drops any cached encoder so the next :func:`_get_model`
+    call re-enters the lazy-load path with the new configuration.
+    :func:`set_model` (the test escape hatch) is NOT cleared — callers
+    who want to replace a test-installed encoder with a config-driven
+    one should call ``set_model(None)`` first.
+    """
+    global _CONFIG, _MODEL, _MODEL_UNAVAILABLE
+    _CONFIG = config
+    # Only flush the cached backend when the caller did not previously
+    # install their own via ``set_model``. Tests that set a fake
+    # encoder + also install a config expect the fake to keep winning.
+    if _MODEL is None or not isinstance(_MODEL, _OpenAIEmbeddingBackend):
+        pass  # keep a test-installed model alive
+    else:
+        _MODEL = None
     _MODEL_UNAVAILABLE = False
     _reset_cache()
 
@@ -100,16 +136,25 @@ def _get_model() -> Any | None:
     if _MODEL_UNAVAILABLE:
         return None
 
-    base_url = os.environ.get("GOLDFIVE_EMBEDDING_BASE_URL", "").strip()
+    # Prefer an installed RuntimeConfig over env vars (goldfive#225).
+    # When ``configure()`` has been called with a non-None base_url,
+    # its values win; otherwise we fall back to env lookup to preserve
+    # the pre-#225 contract for callers that never touched the new API.
+    base_url = ""
+    if _CONFIG is not None and _CONFIG.base_url:
+        base_url = _CONFIG.base_url.strip()
+    else:
+        base_url = os.environ.get("GOLDFIVE_EMBEDDING_BASE_URL", "").strip()
     if base_url:
         backend = _try_load_openai_backend(base_url)
         if backend is not None:
             _MODEL = backend
             return _MODEL
-        # Env var set but backend failed to build: do NOT silently fall
-        # through to sentence-transformers -- the user configured an
-        # HTTP endpoint; honour that by flipping to unavailable so they
-        # see "no-signal" instead of surprise-local-encoding.
+        # Base URL configured but backend failed to build: do NOT
+        # silently fall through to sentence-transformers -- the user
+        # configured an HTTP endpoint; honour that by flipping to
+        # unavailable so they see "no-signal" instead of surprise-
+        # local-encoding.
         _MODEL_UNAVAILABLE = True
         return None
 
@@ -143,13 +188,23 @@ def _try_load_openai_backend(base_url: str) -> Any | None:
 
     Splitting this out lets tests assert backend construction without
     going through the full ``_get_model`` state machine.
+
+    Under goldfive#225, parameters are pulled from the installed
+    :class:`~goldfive.config.EmbeddingConfig` when one is set; missing
+    fields fall back to env vars, then to the built-in defaults — the
+    same precedence as :func:`_get_model` uses for ``base_url``.
     """
-    model_name = os.environ.get("GOLDFIVE_EMBEDDING_MODEL", "")
-    api_key = os.environ.get("GOLDFIVE_EMBEDDING_API_KEY") or None
-    try:
-        timeout_ms = int(os.environ.get("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "10000"))
-    except ValueError:
-        timeout_ms = 10000
+    if _CONFIG is not None:
+        model_name = _CONFIG.model
+        api_key = _CONFIG.api_key
+        timeout_ms = _CONFIG.timeout_ms
+    else:
+        model_name = os.environ.get("GOLDFIVE_EMBEDDING_MODEL", "")
+        api_key = os.environ.get("GOLDFIVE_EMBEDDING_API_KEY") or None
+        try:
+            timeout_ms = int(os.environ.get("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "10000"))
+        except ValueError:
+            timeout_ms = 10000
     try:
         return _OpenAIEmbeddingBackend(
             base_url=base_url,

--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -45,6 +45,7 @@ from goldfive.drift import _embed
 from goldfive.types import DriftEvent, DriftKind, DriftSeverity
 
 if TYPE_CHECKING:
+    from goldfive.config import ReasoningDriftConfig
     from goldfive.types import Session, Task
 
 
@@ -171,6 +172,98 @@ INTENT_DIVERGENCE_WARNING_SIMILARITY: float = 0.2
 
 
 # ---------------------------------------------------------------------------
+# Runtime-config installation (goldfive#225)
+# ---------------------------------------------------------------------------
+#
+# Module-level ``_CONFIG`` + :func:`configure` form the per-Runner
+# threshold override channel. When ``_CONFIG`` is ``None`` (default)
+# the detectors read the module-level constants above — byte-identical
+# to pre-#225 behaviour. When a :class:`~goldfive.config.ReasoningDriftConfig`
+# is installed, the detectors read from it instead.
+#
+# Installation is **process-wide**: two Runners in one process share
+# the last-installed config. :class:`~goldfive.steerer.DefaultSteerer.observe_reasoning`
+# is the sole entry point to the pipeline, and the observed race
+# (Runner A installs config, Runner B installs config, Runner A's
+# observe_reasoning fires against Runner B's thresholds) is minor in
+# practice — the thresholds are for heuristic drift detection, not
+# correctness-critical limits.
+#
+# Alternative: attach the config to :class:`~goldfive.types.Session`
+# and thread it through every free-function detector. ~5x LOC and
+# requires touching every detector signature. Revisit if two-Runners-
+# in-one-process with differing thresholds becomes a real use case.
+
+_CONFIG: ReasoningDriftConfig | None = None
+
+
+def configure(config: ReasoningDriftConfig | None) -> None:
+    """Install a :class:`~goldfive.config.ReasoningDriftConfig` for this process.
+
+    Called by :func:`goldfive.wrap` with ``runtime.reasoning_drift``.
+    Passing ``None`` clears the override so detectors fall back to the
+    module-level constants — used in test teardown to avoid cross-test
+    leakage.
+    """
+    global _CONFIG
+    _CONFIG = config
+
+
+def _looping_hash_window() -> int:
+    """Return the active LOOPING_REASONING hash-window size.
+
+    Either the installed config's field or the module-level constant.
+    Wrapping the lookup in a helper keeps the detector call sites
+    terse and makes the config/no-config branch obvious in tests.
+    """
+    if _CONFIG is not None:
+        return _CONFIG.looping_reasoning_hash_window
+    return LOOPING_REASONING_HASH_WINDOW
+
+
+def _looping_similarity_threshold() -> float:
+    if _CONFIG is not None:
+        return _CONFIG.looping_reasoning_similarity_threshold
+    return LOOPING_REASONING_SIMILARITY_THRESHOLD
+
+
+def _cluster_similarity_threshold() -> float:
+    if _CONFIG is not None:
+        return _CONFIG.reasoning_cluster_similarity_threshold
+    return REASONING_CLUSTER_SIMILARITY_THRESHOLD
+
+
+def _off_topic_distance_threshold() -> float:
+    if _CONFIG is not None:
+        return _CONFIG.off_topic_distance_threshold
+    return OFF_TOPIC_DISTANCE_THRESHOLD
+
+
+def _intent_healthy_similarity() -> float:
+    if _CONFIG is not None:
+        return _CONFIG.intent_divergence_healthy_similarity
+    return INTENT_DIVERGENCE_HEALTHY_SIMILARITY
+
+
+def _intent_minor_similarity() -> float:
+    if _CONFIG is not None:
+        return _CONFIG.intent_divergence_minor_similarity
+    return INTENT_DIVERGENCE_MINOR_SIMILARITY
+
+
+def _intent_warning_similarity() -> float:
+    if _CONFIG is not None:
+        return _CONFIG.intent_divergence_warning_similarity
+    return INTENT_DIVERGENCE_WARNING_SIMILARITY
+
+
+def _confusion_min_hits() -> int:
+    if _CONFIG is not None:
+        return _CONFIG.confusion_min_hits
+    return CONFUSION_MIN_HITS
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -267,9 +360,9 @@ def detect_intent_divergence(
             "(thresholds healthy=%.2f minor=%.2f warning=%.2f); "
             "text_head=%r",
             sim,
-            INTENT_DIVERGENCE_HEALTHY_SIMILARITY,
-            INTENT_DIVERGENCE_MINOR_SIMILARITY,
-            INTENT_DIVERGENCE_WARNING_SIMILARITY,
+            _intent_healthy_similarity(),
+            _intent_minor_similarity(),
+            _intent_warning_similarity(),
             text[:80],
         )
         severity = _severity_from_similarity(sim)
@@ -344,13 +437,15 @@ def _severity_from_similarity(sim: float) -> DriftSeverity | None:
     """Map a cosine-similarity score to an INTENT_DIVERGENCE severity.
 
     Returns ``None`` for "healthy" scores (>= ``HEALTHY``) so the
-    caller can suppress the drift entirely.
+    caller can suppress the drift entirely. Thresholds are read from
+    the installed :class:`~goldfive.config.ReasoningDriftConfig` when
+    one is set (goldfive#225), else from the module-level constants.
     """
-    if sim >= INTENT_DIVERGENCE_HEALTHY_SIMILARITY:
+    if sim >= _intent_healthy_similarity():
         return None
-    if sim >= INTENT_DIVERGENCE_MINOR_SIMILARITY:
+    if sim >= _intent_minor_similarity():
         return DriftSeverity.INFO
-    if sim >= INTENT_DIVERGENCE_WARNING_SIMILARITY:
+    if sim >= _intent_warning_similarity():
         return DriftSeverity.WARNING
     return DriftSeverity.CRITICAL
 
@@ -404,8 +499,9 @@ def detect_looping_reasoning(
     is inspected but not mutated here -- the steerer appends the new
     reasoning block before running the pipeline.
     """
+    hash_window = _looping_hash_window()
     history = [
-        h for h in session.reasoning_history[-LOOPING_REASONING_HASH_WINDOW - 1 : -1]
+        h for h in session.reasoning_history[-hash_window - 1 : -1]
         if h
     ]
     if not history or not text:
@@ -424,13 +520,14 @@ def detect_looping_reasoning(
                 raw=text,
             )
     sim = _embed.max_similarity(text, history)
+    loop_threshold = _looping_similarity_threshold()
     log.debug(
         "looping_reasoning: cosine=%.3f over %d prior turns (threshold=%.2f)",
         sim,
         len(history),
-        LOOPING_REASONING_SIMILARITY_THRESHOLD,
+        loop_threshold,
     )
-    if sim >= LOOPING_REASONING_SIMILARITY_THRESHOLD:
+    if sim >= loop_threshold:
         return DriftEvent(
             kind=DriftKind.LOOPING_REASONING,
             severity=DriftSeverity.WARNING,
@@ -473,28 +570,31 @@ def detect_reasoning_cluster_tightening(
     task_id = session.current_task_id or ""
     if task_id and task_id in session.reasoning_cluster_flagged:
         return None
+    hash_window = _looping_hash_window()
     history = [
-        h for h in session.reasoning_history[-LOOPING_REASONING_HASH_WINDOW - 1 : -1]
+        h for h in session.reasoning_history[-hash_window - 1 : -1]
         if h
     ]
     if not history:
         return None
     sim = _embed.max_similarity(text, history)
+    cluster_threshold = _cluster_similarity_threshold()
+    loop_threshold = _looping_similarity_threshold()
     log.debug(
         "reasoning_cluster_tightening: cosine=%.3f over %d prior turns "
         "(band=[%.2f, %.2f))",
         sim,
         len(history),
-        REASONING_CLUSTER_SIMILARITY_THRESHOLD,
-        LOOPING_REASONING_SIMILARITY_THRESHOLD,
+        cluster_threshold,
+        loop_threshold,
     )
     # max_similarity returns 0.0 both when the model is unavailable and
     # when the genuine cosine is zero; either way the early-warning tier
     # stays silent. This matches ``detect_off_topic``'s graceful-degrade
     # contract.
-    if sim < REASONING_CLUSTER_SIMILARITY_THRESHOLD:
+    if sim < cluster_threshold:
         return None
-    if sim >= LOOPING_REASONING_SIMILARITY_THRESHOLD:
+    if sim >= loop_threshold:
         # Cliff tier owns this regime -- do not double-fire.
         return None
     if task_id:
@@ -544,19 +644,20 @@ def detect_off_topic(text: str, session: Session) -> DriftEvent | None:
     if not topic:
         return None
     dist = _embed.distance_to_topic(text, topic)
+    off_topic_threshold = _off_topic_distance_threshold()
     log.debug(
         "off_topic: distance=%.3f (threshold=%.2f); task=%r",
         dist,
-        OFF_TOPIC_DISTANCE_THRESHOLD,
+        off_topic_threshold,
         topic[:60],
     )
-    if dist >= 0 and dist >= OFF_TOPIC_DISTANCE_THRESHOLD:
+    if dist >= 0 and dist >= off_topic_threshold:
         return DriftEvent(
             kind=DriftKind.OFF_TOPIC,
             severity=DriftSeverity.WARNING,
             detail=(
                 f"reasoning far from task (distance={dist:.2f} >= "
-                f"{OFF_TOPIC_DISTANCE_THRESHOLD:.2f}): task={topic[:60]!r}"
+                f"{off_topic_threshold:.2f}): task={topic[:60]!r}"
             ),
             current_task_id=session.current_task_id,
             raw=text,
@@ -586,10 +687,10 @@ def detect_off_topic(text: str, session: Session) -> DriftEvent | None:
     log.debug(
         "off_topic: sentence-level scan (%d sentences, threshold=%.2f): %s",
         len(per_sentence),
-        OFF_TOPIC_DISTANCE_THRESHOLD,
+        off_topic_threshold,
         [(round(d, 3), s[:40]) for d, s in per_sentence],
     )
-    if worst is None or worst[0] < OFF_TOPIC_DISTANCE_THRESHOLD:
+    if worst is None or worst[0] < off_topic_threshold:
         return None
     worst_dist, worst_sentence = worst
     return DriftEvent(
@@ -597,7 +698,7 @@ def detect_off_topic(text: str, session: Session) -> DriftEvent | None:
         severity=DriftSeverity.WARNING,
         detail=(
             f"reasoning has off-topic sentence (distance={worst_dist:.2f} "
-            f">= {OFF_TOPIC_DISTANCE_THRESHOLD:.2f}): {worst_sentence[:80]!r}"
+            f">= {off_topic_threshold:.2f}): {worst_sentence[:80]!r}"
         ),
         current_task_id=session.current_task_id,
         raw=text,
@@ -727,11 +828,15 @@ def detect_unreferenced_keyword(
 def detect_confusion(text: str, session: Session) -> DriftEvent | None:
     """Return :data:`DriftKind.CONFUSION` when the reasoning text has
     at least :data:`CONFUSION_MIN_HITS` uncertainty markers.
+
+    The threshold is read from the installed
+    :class:`~goldfive.config.ReasoningDriftConfig` when one is set
+    (goldfive#225), else from :data:`CONFUSION_MIN_HITS`.
     """
     if not text:
         return None
     hits = CONFUSION_MARKERS.findall(text)
-    if len(hits) < CONFUSION_MIN_HITS:
+    if len(hits) < _confusion_min_hits():
         return None
     return DriftEvent(
         kind=DriftKind.CONFUSION,

--- a/goldfive/drift/tool_loops.py
+++ b/goldfive/drift/tool_loops.py
@@ -135,9 +135,12 @@ import json
 import logging
 import os
 from collections import defaultdict, deque
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+
+if TYPE_CHECKING:
+    from goldfive.config import ToolLoopConfig
 
 __all__ = [
     "DEFAULT_WINDOW",
@@ -147,10 +150,47 @@ __all__ = [
     "ToolLoopTracker",
     "args_hash",
     "load_thresholds_from_env",
+    "thresholds_from_config",
 ]
 
 
 log = logging.getLogger("goldfive.drift.tool_loops")
+
+
+# Installed per-process tool-loop config (goldfive#225). When non-None,
+# :func:`resolve_thresholds` returns the config's fields; otherwise it
+# falls back to :func:`load_thresholds_from_env`. Process-wide for the
+# same reason :mod:`goldfive.drift.reasoning` is: the ADK plugin builds
+# its tracker at plugin-init time before any Runner context is bound,
+# and we want ``goldfive.wrap(runtime=...)`` to influence the tracker
+# the plugin builds for that Runner. Operators who need per-Runner
+# isolation in a multi-Runner process can call :func:`configure` just
+# before ``wrap()`` for each Runner.
+_CONFIG: ToolLoopConfig | None = None
+
+
+def configure(config: ToolLoopConfig | None) -> None:
+    """Install a :class:`~goldfive.config.ToolLoopConfig` for this process.
+
+    Called by :func:`goldfive.wrap` with ``runtime.tool_loops``.
+    Passing ``None`` reverts to env-driven / default behaviour.
+    """
+    global _CONFIG
+    _CONFIG = config
+
+
+def resolve_thresholds() -> dict[str, int]:
+    """Return tracker-constructor kwargs sourced from the active config.
+
+    Precedence: the installed :class:`~goldfive.config.ToolLoopConfig`
+    (via :func:`configure`) wins over :func:`load_thresholds_from_env`
+    which in turn wins over the module-level defaults. This is the
+    helper plugins should splat into :class:`ToolLoopTracker` under
+    goldfive#225.
+    """
+    if _CONFIG is not None:
+        return thresholds_from_config(_CONFIG)
+    return load_thresholds_from_env()
 
 
 # ---------------------------------------------------------------------------
@@ -316,6 +356,22 @@ def load_thresholds_from_env() -> dict[str, int]:
         "alternating_threshold": _read_int_env(
             "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD", DEFAULT_ALTERNATING_THRESHOLD
         ),
+    }
+
+
+def thresholds_from_config(config: ToolLoopConfig) -> dict[str, int]:
+    """Adapt a :class:`~goldfive.config.ToolLoopConfig` to tracker kwargs.
+
+    Mirrors :func:`load_thresholds_from_env` so callers can splat the
+    result into :class:`ToolLoopTracker` without worrying about which
+    source they read from. Added under goldfive#225 alongside the
+    typed-config refactor.
+    """
+    return {
+        "window": config.window,
+        "exact_threshold": config.exact_threshold,
+        "name_threshold": config.name_threshold,
+        "alternating_threshold": config.alternating_threshold,
     }
 
 

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -70,6 +70,11 @@ from goldfive.types import (
 )
 
 if TYPE_CHECKING:
+    from goldfive.config import (
+        GoalDriftConfig,
+        ReasoningDriftConfig,
+        ToolLoopConfig,
+    )
     from goldfive.protocols import EventSink, Planner
 
 # Shape of the opt-in reflective LLM callable. Matches the signature of
@@ -297,10 +302,13 @@ class DefaultSteerer:
         reflective_check_interval: int = 15,
         reflective_call_llm: ReflectiveCallLLM | None = None,
         reflective_model: str = "",
-        goal_drift_check_interval: int = 5,
+        goal_drift_check_interval: int | None = None,
         goal_drift_call_llm: ReflectiveCallLLM | None = None,
         goal_drift_model: str = "",
-        goal_drift_activity_window: int = 10,
+        goal_drift_activity_window: int | None = None,
+        goal_drift_config: GoalDriftConfig | None = None,
+        tool_loop_config: ToolLoopConfig | None = None,
+        reasoning_drift_config: ReasoningDriftConfig | None = None,
         plan_revision_cooldown_seconds: float = 0.0,
     ) -> None:
         """Build a steerer.
@@ -328,7 +336,8 @@ class DefaultSteerer:
         goal_drift_check_interval:
             Number of agent-invocation turns (as reported via
             :meth:`note_agent_turn`) between trajectory-level
-            GOAL_DRIFT checks. Defaults to ``5``. Ignored when
+            GOAL_DRIFT checks. Defaults to ``5`` when
+            ``goal_drift_config`` is also ``None``. Ignored when
             ``goal_drift_call_llm`` is ``None``.
         goal_drift_call_llm:
             Optional async callable ``(system_prompt, user_prompt,
@@ -345,7 +354,38 @@ class DefaultSteerer:
         goal_drift_activity_window:
             Number of recent-activity entries retained on
             ``session.recent_agent_activity`` and passed to the
-            judge. Bounds the prompt size; defaults to ``10``.
+            judge. Bounds the prompt size; defaults to ``10`` when
+            ``goal_drift_config`` is also ``None``.
+        goal_drift_config:
+            Optional :class:`~goldfive.config.GoalDriftConfig` (see
+            goldfive#225). When provided, its fields supply fallback
+            defaults for ``goal_drift_check_interval`` and
+            ``goal_drift_activity_window``. **Precedence**: an
+            explicit individual kwarg (``goal_drift_check_interval=``
+            or ``goal_drift_activity_window=``) wins over the config
+            dataclass; the config wins over the module-level
+            built-in. This matches :func:`goldfive.wrap`'s contract
+            where operators can pass a fully-typed ``RuntimeConfig``
+            at the top level and still selectively override a single
+            knob on a per-steerer basis.
+        tool_loop_config:
+            Optional :class:`~goldfive.config.ToolLoopConfig`. Stored
+            on the steerer so callers (the ADK plugin, custom
+            adapters) can pull thresholds via
+            :meth:`get_tool_loop_config` instead of re-reading env
+            vars. The steerer itself does NOT instantiate a
+            :class:`~goldfive.drift.tool_loops.ToolLoopTracker` — the
+            plugin still owns that — but exposing the config here
+            keeps the four typed knobs co-located on a single
+            component. Precedence: the config field is advisory; the
+            plugin is free to honour or ignore it. Added in #225.
+        reasoning_drift_config:
+            Optional :class:`~goldfive.config.ReasoningDriftConfig`.
+            When provided, :meth:`observe_reasoning` installs it via
+            :func:`goldfive.drift.reasoning.configure` so the
+            detector thresholds pick it up. Process-wide (see the
+            module docstring on :mod:`goldfive.drift.reasoning` for
+            the multi-Runner caveat). Added in #225.
         plan_revision_cooldown_seconds:
             Minimum interval, in seconds, between two drift-triggered
             plan revisions for the same ``(task_id, drift_kind)`` key.
@@ -388,14 +428,51 @@ class DefaultSteerer:
         self._reflective_model = reflective_model
         # GOAL_DRIFT (goldfive#143) wiring. Same opt-in contract as the
         # reflective check: feature is inert unless a callable is passed.
+        #
+        # Precedence resolution (goldfive#225): an explicit individual
+        # kwarg wins over the config dataclass which wins over the
+        # module-level default. ``None`` on the individual kwarg means
+        # "not explicitly set", which is the trigger to fall through to
+        # the config / default.
         self._goal_drift_call_llm: ReflectiveCallLLM | None = goal_drift_call_llm
-        self._goal_drift_check_interval = max(1, int(goal_drift_check_interval))
+        if goal_drift_check_interval is not None:
+            _check_interval = goal_drift_check_interval
+        elif goal_drift_config is not None:
+            _check_interval = goal_drift_config.check_interval
+        else:
+            _check_interval = 5
+        self._goal_drift_check_interval = max(1, int(_check_interval))
         self._goal_drift_model = goal_drift_model
-        self._goal_drift_activity_window = max(1, int(goal_drift_activity_window))
-        # Drift-triggered plan-revision cooldown (goldfive feedback-loop
-        # fix). Clamped to a non-negative float; ``0.0`` disables the
-        # gate so callers can opt out without subclassing.
-        self._plan_revision_cooldown_seconds = max(0.0, float(plan_revision_cooldown_seconds))
+        if goal_drift_activity_window is not None:
+            _activity_window = goal_drift_activity_window
+        elif goal_drift_config is not None:
+            _activity_window = goal_drift_config.activity_window
+        else:
+            _activity_window = 10
+        self._goal_drift_activity_window = max(1, int(_activity_window))
+        # Typed-config stash (goldfive#225). Retained as-is so
+        # downstream consumers (plugins, tests) can introspect the
+        # effective configuration without reconstructing it from the
+        # scalar fields above.
+        self._goal_drift_config: GoalDriftConfig | None = goal_drift_config
+        self._tool_loop_config: ToolLoopConfig | None = tool_loop_config
+        self._reasoning_drift_config: ReasoningDriftConfig | None = (
+            reasoning_drift_config
+        )
+        # Install the reasoning-drift thresholds eagerly so any
+        # ``observe_reasoning`` call on any session sees the
+        # Runner-scoped config. Process-wide — see the installation-
+        # site docstring on :mod:`goldfive.drift.reasoning`.
+        if reasoning_drift_config is not None:
+            from goldfive.drift import reasoning as _reasoning
+
+            _reasoning.configure(reasoning_drift_config)
+        # Drift-triggered plan-revision cooldown (goldfive#227).
+        # Clamped to a non-negative float; ``0.0`` disables the gate
+        # so callers can opt out without subclassing.
+        self._plan_revision_cooldown_seconds = max(
+            0.0, float(plan_revision_cooldown_seconds)
+        )
 
     # ------------------------------------------------------------------
     # Protocol-required: wiring
@@ -427,6 +504,19 @@ class DefaultSteerer:
         variant.
         """
         self._adapter = adapter
+
+    def get_tool_loop_config(self) -> ToolLoopConfig | None:
+        """Return the :class:`~goldfive.config.ToolLoopConfig` stashed at init, if any.
+
+        Plugins (the ADK plugin) call this when constructing a
+        :class:`~goldfive.drift.tool_loops.ToolLoopTracker` so the
+        tracker's thresholds come from the :class:`RuntimeConfig`
+        threaded through :func:`goldfive.wrap` instead of from env
+        vars. Returns ``None`` when the steerer was built without a
+        config, in which case callers should fall back to
+        :func:`~goldfive.drift.tool_loops.load_thresholds_from_env`.
+        """
+        return self._tool_loop_config
 
     async def _emit_planner_refine_validation_failed(self, drift: DriftEvent) -> None:
         """Emit a planner-side drift through the DriftDetected pipeline.

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -27,15 +27,21 @@ def _reset_embed_state(monkeypatch: pytest.MonkeyPatch) -> Any:
     ``set_model(None)`` both clears any installed encoder and resets
     ``_MODEL_UNAVAILABLE`` so the lazy-load path can run again. We
     also scrub the env vars so one test leaking a ``setenv`` can't
-    influence another.
+    influence another. Under goldfive#225 ``configure(None)`` also
+    clears any :class:`~goldfive.config.EmbeddingConfig` a prior
+    ``goldfive.wrap()`` call may have installed; without this, the
+    env-var behaviour these tests exercise would be short-circuited
+    by a leaked config from another test module.
     """
     _embed.set_model(None)
+    _embed.configure(None)
     monkeypatch.delenv("GOLDFIVE_EMBEDDING_BASE_URL", raising=False)
     monkeypatch.delenv("GOLDFIVE_EMBEDDING_MODEL", raising=False)
     monkeypatch.delenv("GOLDFIVE_EMBEDDING_API_KEY", raising=False)
     monkeypatch.delenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", raising=False)
     yield
     _embed.set_model(None)
+    _embed.configure(None)
 
 
 def _canonical_response(vectors: list[list[float]]) -> dict[str, Any]:

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -1,0 +1,301 @@
+"""Tests for the typed :class:`~goldfive.config.RuntimeConfig` dataclasses.
+
+Regression suite for goldfive#225. Covers:
+
+* Each sub-config's ``from_env`` classmethod reads every supported env
+  var, and subsets fall back cleanly to field defaults.
+* ``RuntimeConfig.from_env`` aggregates the four sub-``from_env``
+  calls.
+* The dataclasses are mutable (``frozen=False``) so operators can
+  tweak a field after constructing from env -- this is an intentional
+  design choice called out in the module docstring.
+* Equality is value-based (default dataclass behaviour) so tests can
+  assert ``config == expected`` cleanly.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from goldfive.config import (
+    EmbeddingConfig,
+    GoalDriftConfig,
+    ReasoningDriftConfig,
+    RuntimeConfig,
+    ToolLoopConfig,
+)
+
+# ---------------------------------------------------------------------------
+# EmbeddingConfig
+# ---------------------------------------------------------------------------
+
+
+def test_embedding_config_defaults() -> None:
+    """Field defaults match the pre-#225 fall-through behaviour."""
+    cfg = EmbeddingConfig()
+    assert cfg.base_url is None
+    assert cfg.model == ""
+    assert cfg.api_key is None
+    assert cfg.timeout_ms == 10_000
+
+
+def test_embedding_config_from_env_all_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All four env vars map to the matching fields."""
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://llm.local:8080")
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_MODEL", "qwen3-embed")
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_API_KEY", "secret-token")
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "2500")
+    cfg = EmbeddingConfig.from_env()
+    assert cfg.base_url == "http://llm.local:8080"
+    assert cfg.model == "qwen3-embed"
+    assert cfg.api_key == "secret-token"
+    assert cfg.timeout_ms == 2500
+
+
+def test_embedding_config_from_env_subset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A partial env landscape fills in remaining fields with defaults."""
+    for name in (
+        "GOLDFIVE_EMBEDDING_BASE_URL",
+        "GOLDFIVE_EMBEDDING_MODEL",
+        "GOLDFIVE_EMBEDDING_API_KEY",
+        "GOLDFIVE_EMBEDDING_TIMEOUT_MS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://partial:1234")
+    cfg = EmbeddingConfig.from_env()
+    assert cfg.base_url == "http://partial:1234"
+    # Remaining fields keep the built-in defaults.
+    assert cfg.model == ""
+    assert cfg.api_key is None
+    assert cfg.timeout_ms == 10_000
+
+
+def test_embedding_config_empty_base_url_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit empty string is treated as "not set" (maps to ``None``)."""
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "   ")
+    cfg = EmbeddingConfig.from_env()
+    assert cfg.base_url is None
+
+
+def test_embedding_config_invalid_timeout_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-integer / non-positive timeouts fall back to the default."""
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "abc")
+    assert EmbeddingConfig.from_env().timeout_ms == 10_000
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "0")
+    assert EmbeddingConfig.from_env().timeout_ms == 10_000
+
+
+# ---------------------------------------------------------------------------
+# ToolLoopConfig
+# ---------------------------------------------------------------------------
+
+
+def test_tool_loop_config_defaults() -> None:
+    """Defaults track :mod:`goldfive.drift.tool_loops` module constants."""
+    cfg = ToolLoopConfig()
+    assert cfg.window == 10
+    assert cfg.exact_threshold == 3
+    assert cfg.name_threshold == 5
+    assert cfg.alternating_threshold == 5
+
+
+def test_tool_loop_config_from_env_all_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All four env vars map to the matching fields."""
+    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_WINDOW", "12")
+    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD", "4")
+    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD", "7")
+    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD", "6")
+    cfg = ToolLoopConfig.from_env()
+    assert cfg.window == 12
+    assert cfg.exact_threshold == 4
+    assert cfg.name_threshold == 7
+    assert cfg.alternating_threshold == 6
+
+
+def test_tool_loop_config_from_env_subset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing vars fall back to the built-in defaults."""
+    for name in (
+        "GOLDFIVE_TOOL_LOOP_WINDOW",
+        "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD",
+        "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD",
+        "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_WINDOW", "15")
+    cfg = ToolLoopConfig.from_env()
+    assert cfg.window == 15
+    assert cfg.exact_threshold == 3
+    assert cfg.name_threshold == 5
+    assert cfg.alternating_threshold == 5
+
+
+# ---------------------------------------------------------------------------
+# ReasoningDriftConfig
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_drift_config_defaults() -> None:
+    """Defaults mirror the module-level constants in
+    :mod:`goldfive.drift.reasoning`.
+    """
+    cfg = ReasoningDriftConfig()
+    assert cfg.off_topic_distance_threshold == 0.7
+    assert cfg.intent_divergence_healthy_similarity == 0.6
+    assert cfg.intent_divergence_minor_similarity == 0.4
+    assert cfg.intent_divergence_warning_similarity == 0.2
+    assert cfg.looping_reasoning_similarity_threshold == 0.9
+    assert cfg.reasoning_cluster_similarity_threshold == 0.75
+    assert cfg.looping_reasoning_hash_window == 5
+    assert cfg.confusion_min_hits == 3
+
+
+def test_reasoning_drift_config_from_env_all_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The new ``GOLDFIVE_DRIFT_*`` env vars map to the matching fields."""
+    monkeypatch.setenv("GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE", "0.55")
+    monkeypatch.setenv("GOLDFIVE_DRIFT_INTENT_HEALTHY_SIMILARITY", "0.7")
+    monkeypatch.setenv("GOLDFIVE_DRIFT_INTENT_MINOR_SIMILARITY", "0.5")
+    monkeypatch.setenv("GOLDFIVE_DRIFT_INTENT_WARNING_SIMILARITY", "0.3")
+    monkeypatch.setenv("GOLDFIVE_DRIFT_LOOPING_SIMILARITY", "0.85")
+    monkeypatch.setenv("GOLDFIVE_DRIFT_CLUSTER_SIMILARITY", "0.7")
+    monkeypatch.setenv("GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW", "8")
+    monkeypatch.setenv("GOLDFIVE_DRIFT_CONFUSION_MIN_HITS", "5")
+    cfg = ReasoningDriftConfig.from_env()
+    assert cfg.off_topic_distance_threshold == 0.55
+    assert cfg.intent_divergence_healthy_similarity == 0.7
+    assert cfg.intent_divergence_minor_similarity == 0.5
+    assert cfg.intent_divergence_warning_similarity == 0.3
+    assert cfg.looping_reasoning_similarity_threshold == 0.85
+    assert cfg.reasoning_cluster_similarity_threshold == 0.7
+    assert cfg.looping_reasoning_hash_window == 8
+    assert cfg.confusion_min_hits == 5
+
+
+def test_reasoning_drift_config_from_env_missing_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing env vars revert to defaults."""
+    for name in (
+        "GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE",
+        "GOLDFIVE_DRIFT_INTENT_HEALTHY_SIMILARITY",
+        "GOLDFIVE_DRIFT_INTENT_MINOR_SIMILARITY",
+        "GOLDFIVE_DRIFT_INTENT_WARNING_SIMILARITY",
+        "GOLDFIVE_DRIFT_LOOPING_SIMILARITY",
+        "GOLDFIVE_DRIFT_CLUSTER_SIMILARITY",
+        "GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW",
+        "GOLDFIVE_DRIFT_CONFUSION_MIN_HITS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    cfg = ReasoningDriftConfig.from_env()
+    assert cfg == ReasoningDriftConfig()
+
+
+def test_reasoning_drift_config_from_env_bad_float_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-float env var falls back to the default, not a crash."""
+    monkeypatch.setenv("GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE", "not-a-float")
+    cfg = ReasoningDriftConfig.from_env()
+    assert cfg.off_topic_distance_threshold == 0.7
+
+
+# ---------------------------------------------------------------------------
+# GoalDriftConfig
+# ---------------------------------------------------------------------------
+
+
+def test_goal_drift_config_defaults() -> None:
+    cfg = GoalDriftConfig()
+    assert cfg.check_interval == 5
+    assert cfg.activity_window == 10
+
+
+def test_goal_drift_config_from_env_all_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL", "8")
+    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_ACTIVITY_WINDOW", "25")
+    cfg = GoalDriftConfig.from_env()
+    assert cfg.check_interval == 8
+    assert cfg.activity_window == 25
+
+
+def test_goal_drift_config_from_env_subset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL", raising=False)
+    monkeypatch.delenv("GOLDFIVE_GOAL_DRIFT_ACTIVITY_WINDOW", raising=False)
+    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL", "3")
+    cfg = GoalDriftConfig.from_env()
+    assert cfg.check_interval == 3
+    assert cfg.activity_window == 10
+
+
+# ---------------------------------------------------------------------------
+# RuntimeConfig
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_config_defaults() -> None:
+    """Default aggregate composes defaults of each sub-config."""
+    cfg = RuntimeConfig()
+    assert cfg.embedding == EmbeddingConfig()
+    assert cfg.tool_loops == ToolLoopConfig()
+    assert cfg.reasoning_drift == ReasoningDriftConfig()
+    assert cfg.goal_drift == GoalDriftConfig()
+
+
+def test_runtime_config_from_env_aggregates_all_four(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each sub-``from_env`` is called and the results are aggregated."""
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://agg:7000")
+    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_WINDOW", "14")
+    monkeypatch.setenv("GOLDFIVE_DRIFT_CONFUSION_MIN_HITS", "6")
+    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL", "7")
+    cfg = RuntimeConfig.from_env()
+    assert cfg.embedding.base_url == "http://agg:7000"
+    assert cfg.tool_loops.window == 14
+    assert cfg.reasoning_drift.confusion_min_hits == 6
+    assert cfg.goal_drift.check_interval == 7
+
+
+def test_runtime_config_equality_and_mutable_semantics() -> None:
+    """Instances are value-equal and fields are mutable (``frozen=False``).
+
+    The dataclasses are deliberately **not** frozen so operators can
+    patch a single field after constructing from env (e.g. bumping
+    ``goal_drift.check_interval`` for a debugging run). Callers who
+    want an immutable snapshot should use :func:`dataclasses.replace`
+    to derive a variant.
+    """
+    a = RuntimeConfig()
+    b = RuntimeConfig()
+    assert a == b
+
+    # Mutation is allowed.
+    a.goal_drift.check_interval = 99
+    assert a != b
+
+    # ``dataclasses.replace`` builds a divergent instance without
+    # mutating the source.
+    derived = dataclasses.replace(
+        b, goal_drift=dataclasses.replace(b.goal_drift, check_interval=42)
+    )
+    assert derived.goal_drift.check_interval == 42
+    assert b.goal_drift.check_interval == 5  # untouched

--- a/tests/test_wrap_runtime_config.py
+++ b/tests/test_wrap_runtime_config.py
@@ -1,0 +1,230 @@
+"""Tests that :func:`goldfive.wrap` threads a ``RuntimeConfig`` through
+into the embedding backend, reasoning-drift module, tool-loops module,
+and the default steerer.
+
+Regression suite for goldfive#225. Key invariants:
+
+* Passing ``runtime=cfg`` installs every sub-config.
+* Omitting ``runtime=`` builds one from the environment so the
+  pre-#225 contract is preserved (byte-identical behaviour to what
+  ``wrap()`` did before).
+* An explicit ``steerer=`` kwarg wins over the runtime-derived steerer
+  — the caller keeps full control.
+* The precedence rule on ``DefaultSteerer.__init__`` is: explicit
+  individual kwarg > config dataclass > module default.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+import goldfive  # noqa: E402
+from goldfive.config import (  # noqa: E402
+    EmbeddingConfig,
+    GoalDriftConfig,
+    ReasoningDriftConfig,
+    RuntimeConfig,
+    ToolLoopConfig,
+)
+from goldfive.drift import _embed  # noqa: E402
+from goldfive.drift import reasoning as _reasoning  # noqa: E402
+from goldfive.drift import tool_loops as _tool_loops  # noqa: E402
+from goldfive.results import InvocationResult  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _scrub_module_state(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Clear every module-level config slot and env var before each test.
+
+    Tests that install a config via ``wrap()`` must leave the process
+    in a clean state for downstream tests — otherwise the reasoning-
+    drift detectors run against last-test thresholds.
+    """
+    _embed.set_model(None)
+    _embed.configure(None)
+    _reasoning.configure(None)
+    _tool_loops.configure(None)
+    for name in (
+        "GOLDFIVE_EMBEDDING_BASE_URL",
+        "GOLDFIVE_EMBEDDING_MODEL",
+        "GOLDFIVE_EMBEDDING_API_KEY",
+        "GOLDFIVE_EMBEDDING_TIMEOUT_MS",
+        "GOLDFIVE_TOOL_LOOP_WINDOW",
+        "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD",
+        "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD",
+        "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD",
+        "GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE",
+        "GOLDFIVE_DRIFT_CONFUSION_MIN_HITS",
+        "GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL",
+        "GOLDFIVE_GOAL_DRIFT_ACTIVITY_WINDOW",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    _embed.set_model(None)
+    _embed.configure(None)
+    _reasoning.configure(None)
+    _tool_loops.configure(None)
+
+
+async def _noop_agent(task: Any, session: Any, tools: Any) -> InvocationResult:
+    return InvocationResult(task_id=getattr(task, "id", ""), text="ok")
+
+
+# ---------------------------------------------------------------------------
+# Runtime config threads through wrap()
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_threads_runtime_config() -> None:
+    """A non-default ``RuntimeConfig`` propagates into every subsystem."""
+    cfg = RuntimeConfig(
+        embedding=EmbeddingConfig(
+            base_url="http://runtime:9000",
+            model="custom-embed",
+            timeout_ms=7500,
+        ),
+        tool_loops=ToolLoopConfig(
+            window=15, exact_threshold=4, name_threshold=6, alternating_threshold=6
+        ),
+        reasoning_drift=ReasoningDriftConfig(
+            off_topic_distance_threshold=0.55,
+            confusion_min_hits=6,
+        ),
+        goal_drift=GoalDriftConfig(check_interval=8, activity_window=25),
+    )
+    runner = goldfive.wrap(_noop_agent, runtime=cfg, sinks=[])
+
+    # _embed module sees the embedding sub-config.
+    assert _embed._CONFIG is cfg.embedding
+
+    # Reasoning-drift module sees its sub-config.
+    assert _reasoning._CONFIG is cfg.reasoning_drift
+    # The helper accessors honour the installed config.
+    assert _reasoning._off_topic_distance_threshold() == 0.55
+    assert _reasoning._confusion_min_hits() == 6
+
+    # Tool-loops module sees its sub-config.
+    assert _tool_loops._CONFIG is cfg.tool_loops
+    assert _tool_loops.resolve_thresholds() == {
+        "window": 15,
+        "exact_threshold": 4,
+        "name_threshold": 6,
+        "alternating_threshold": 6,
+    }
+
+    # Steerer picks up goal-drift + tool-loop + reasoning-drift configs.
+    steerer = runner.steerer
+    assert isinstance(steerer, DefaultSteerer)
+    assert steerer._goal_drift_check_interval == 8
+    assert steerer._goal_drift_activity_window == 25
+    assert steerer._tool_loop_config is cfg.tool_loops
+    assert steerer._reasoning_drift_config is cfg.reasoning_drift
+    assert steerer._goal_drift_config is cfg.goal_drift
+
+
+def test_wrap_falls_back_to_from_env_when_runtime_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With ``runtime=None`` (the default) env vars drive the effective config."""
+    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL", "11")
+    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_ACTIVITY_WINDOW", "30")
+    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_WINDOW", "13")
+    monkeypatch.setenv("GOLDFIVE_DRIFT_CONFUSION_MIN_HITS", "7")
+    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://envfall:1234")
+
+    runner = goldfive.wrap(_noop_agent, sinks=[])
+
+    steerer = runner.steerer
+    assert isinstance(steerer, DefaultSteerer)
+    assert steerer._goal_drift_check_interval == 11
+    assert steerer._goal_drift_activity_window == 30
+
+    assert _tool_loops.resolve_thresholds()["window"] == 13
+    assert _reasoning._confusion_min_hits() == 7
+    assert _embed._CONFIG is not None
+    assert _embed._CONFIG.base_url == "http://envfall:1234"
+
+
+def test_wrap_runtime_none_uses_defaults_when_env_empty() -> None:
+    """With no runtime and no env, defaults match pre-#225 behaviour."""
+    runner = goldfive.wrap(_noop_agent, sinks=[])
+    steerer = runner.steerer
+    assert isinstance(steerer, DefaultSteerer)
+    # Pre-#225 defaults: check_interval=5, activity_window=10.
+    assert steerer._goal_drift_check_interval == 5
+    assert steerer._goal_drift_activity_window == 10
+
+
+def test_wrap_explicit_steerer_wins_over_runtime() -> None:
+    """``steerer=`` bypasses the runtime-derived steerer configuration."""
+    cfg = RuntimeConfig(goal_drift=GoalDriftConfig(check_interval=99))
+    explicit = DefaultSteerer(goal_drift_check_interval=3)
+    runner = goldfive.wrap(_noop_agent, runtime=cfg, steerer=explicit, sinks=[])
+    assert runner.steerer is explicit
+    assert runner.steerer._goal_drift_check_interval == 3
+    # The embedding / reasoning / tool-loop modules are still configured
+    # by wrap() itself — those channels are independent of the steerer.
+    assert _embed._CONFIG is cfg.embedding
+
+
+# ---------------------------------------------------------------------------
+# DefaultSteerer precedence
+# ---------------------------------------------------------------------------
+
+
+def test_default_steerer_explicit_kwarg_wins_over_config() -> None:
+    """explicit kwarg > config dataclass > module default."""
+    cfg = GoalDriftConfig(check_interval=42, activity_window=99)
+    # Explicit kwarg wins.
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=7,
+        goal_drift_config=cfg,
+    )
+    assert steerer._goal_drift_check_interval == 7
+    # The non-overridden field still comes from the config.
+    assert steerer._goal_drift_activity_window == 99
+
+
+def test_default_steerer_config_wins_over_default() -> None:
+    """When no explicit kwarg is passed, config values take effect."""
+    cfg = GoalDriftConfig(check_interval=12, activity_window=20)
+    steerer = DefaultSteerer(goal_drift_config=cfg)
+    assert steerer._goal_drift_check_interval == 12
+    assert steerer._goal_drift_activity_window == 20
+
+
+def test_default_steerer_no_config_no_kwarg_uses_module_default() -> None:
+    """Back-compat: bare ``DefaultSteerer()`` still yields the pre-#225 defaults."""
+    steerer = DefaultSteerer()
+    assert steerer._goal_drift_check_interval == 5
+    assert steerer._goal_drift_activity_window == 10
+    assert steerer._goal_drift_config is None
+    assert steerer._tool_loop_config is None
+    assert steerer._reasoning_drift_config is None
+
+
+def test_default_steerer_installs_reasoning_config_on_init() -> None:
+    """Passing ``reasoning_drift_config=`` installs it into the module."""
+    cfg = ReasoningDriftConfig(off_topic_distance_threshold=0.42)
+    DefaultSteerer(reasoning_drift_config=cfg)
+    assert _reasoning._CONFIG is cfg
+    assert _reasoning._off_topic_distance_threshold() == 0.42
+
+
+def test_default_steerer_get_tool_loop_config_returns_stashed() -> None:
+    """The steerer exposes the stashed config for plugins to consult."""
+    cfg = ToolLoopConfig(window=15)
+    steerer = DefaultSteerer(tool_loop_config=cfg)
+    assert steerer.get_tool_loop_config() is cfg
+    bare = DefaultSteerer()
+    assert bare.get_tool_loop_config() is None


### PR DESCRIPTION
Closes #225.

## Summary

Introduces a typed `RuntimeConfig` dataclass that collapses goldfive's
ad-hoc per-Runner configuration surface into one object operators pass
to `goldfive.wrap(runtime=...)`:

- `EmbeddingConfig` — pre-existing `GOLDFIVE_EMBEDDING_*` env surface
- `ToolLoopConfig` — pre-existing `GOLDFIVE_TOOL_LOOP_*` env surface
- `ReasoningDriftConfig` — **new** `GOLDFIVE_DRIFT_*` env surface for
  thresholds that previously lived only as module constants in
  `goldfive/drift/reasoning.py`
- `GoalDriftConfig` — **new** `GOLDFIVE_GOAL_DRIFT_*` env surface for
  scheduling knobs that `DefaultSteerer` accepted as kwargs but that
  `goldfive.wrap()` did not thread through

Each sub-config has a `from_env()` classmethod. `RuntimeConfig.from_env()`
aggregates the four. `goldfive.wrap()` without a `runtime=` kwarg builds
an instance from the environment, so the existing 1265-test suite passes
with zero modifications to pre-#225 callers.

Every env var that worked before continues to work. Module-level
constants (`OFF_TOPIC_DISTANCE_THRESHOLD` etc.) stay importable and
unchanged in value — they remain the fallback when no `RuntimeConfig`
is installed.

## Before / after

Before — operators forked to tune reasoning-drift thresholds, set env
vars for tool-loop / embedding config, and built their own steerer to
change goal-drift scheduling:

```python
os.environ["GOLDFIVE_TOOL_LOOP_WINDOW"] = "15"
os.environ["GOLDFIVE_EMBEDDING_BASE_URL"] = "http://my-llm:8081"
# reasoning-drift thresholds -- no knob exists, operator forks
runner = goldfive.wrap(
    tree,
    steerer=DefaultSteerer(
        goal_drift_check_interval=8,
        goal_drift_call_llm=my_llm,
    ),
)
```

After — a single typed object:

```python
from goldfive import (
    EmbeddingConfig, GoalDriftConfig, ReasoningDriftConfig,
    RuntimeConfig, ToolLoopConfig,
)

cfg = RuntimeConfig(
    embedding=EmbeddingConfig(base_url="http://my-llm:8081"),
    tool_loops=ToolLoopConfig(window=15),
    reasoning_drift=ReasoningDriftConfig(off_topic_distance_threshold=0.55),
    goal_drift=GoalDriftConfig(check_interval=8),
)
runner = goldfive.wrap(tree, runtime=cfg)
```

Or the env-equivalent for the three newly-configurable knobs:

```bash
GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE=0.55 \
GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL=8 \
python -m my_app
```

## Design choices

- **Process-wide `configure()` for reasoning-drift and tool-loops**
  instead of session-attached config. ~30 LOC vs ~150 LOC. The
  multi-Runner-in-one-process race is minor in practice — documented in
  both module docstrings. Revisitable later if the use case lights up.
- **Dataclasses are `frozen=False`** so operators can tweak a field
  after constructing from env (e.g. bump `goal_drift.check_interval`
  for a debug run). Callers who want an immutable snapshot can
  `dataclasses.replace` to derive a variant.
- **Precedence on `DefaultSteerer.__init__`**: explicit individual
  kwarg > config dataclass > module default. Preserves backward
  compatibility with every existing `DefaultSteerer(goal_drift_call_llm=...)`
  call pattern.

## Test plan

- [x] 27 new tests across `tests/test_runtime_config.py` and
      `tests/test_wrap_runtime_config.py` cover sub-config `from_env`,
      aggregation, `wrap()` threading, explicit-steerer override, and
      precedence semantics.
- [x] Full suite: 1265 passed, 46 skipped (pre-existing skips).
- [x] `uv run ruff check goldfive/ tests/test_runtime_config.py
      tests/test_wrap_runtime_config.py tests/test_embedding_backend.py`
      clean.
- [x] `uv run mypy goldfive/config.py goldfive/convenience.py
      goldfive/steerer.py goldfive/drift/_embed.py
      goldfive/drift/tool_loops.py goldfive/drift/reasoning.py` — no
      new errors (one pre-existing error on `convenience.py:273` about
      `GoldfiveADKAgent` vs `Runner` return is unrelated).