### PR TITLE
LLM-as-a-judge reasoning-drift detector + unwire noisy keyword heuristic

### DIFF
--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -240,12 +240,18 @@ def wrap(
     if steerer is not None:
         resolved_steerer = steerer
     elif resolved_call_llm is not None:
+        # Same call_llm wires into both the trajectory-level goal-drift
+        # judge (goldfive#218) and the per-thinking-message reasoning
+        # judge (goldfive#226). Default ``reasoning_drift_mode`` on the
+        # steerer is ``"judge"`` -- see :class:`DefaultSteerer`.
         resolved_steerer = DefaultSteerer(
             goal_drift_call_llm=resolved_call_llm,
             goal_drift_model=resolved_model,
             goal_drift_config=resolved_runtime.goal_drift,
             tool_loop_config=resolved_runtime.tool_loops,
             reasoning_drift_config=resolved_runtime.reasoning_drift,
+            reasoning_drift_call_llm=resolved_call_llm,
+            reasoning_drift_model=resolved_model,
         )
     else:
         resolved_steerer = DefaultSteerer(

--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -39,9 +39,15 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from goldfive.drift import _embed
+from goldfive.drift.reasoning_judge import (
+    CallLLM as JudgeCallLLM,
+)
+from goldfive.drift.reasoning_judge import (
+    classify_reasoning_drift,
+)
 from goldfive.types import DriftEvent, DriftKind, DriftSeverity
 
 if TYPE_CHECKING:
@@ -52,9 +58,26 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+# Pipeline-selection mode. See :func:`analyze_reasoning` for semantics.
+#
+# * ``"judge"``    — LLM-as-a-judge only (plus the always-on loop /
+#                    confusion detectors which live upstream in
+#                    :meth:`DefaultSteerer.observe_reasoning`).
+# * ``"embedding"`` — the legacy embedding-based pipeline.
+# * ``"both"``     — run both; the higher-severity drift wins. Ties
+#                    are broken by the embedding path (runs first,
+#                    synchronous).
+# * ``"off"``      — no off-topic / intent / keyword checks. The
+#                    always-on loop + confusion detectors continue to
+#                    run upstream.
+ReasoningDriftMode = Literal["judge", "embedding", "both", "off"]
+DEFAULT_REASONING_DRIFT_MODE: ReasoningDriftMode = "judge"
+
+
 __all__ = [
     "CONFUSION_MARKERS",
     "CONFUSION_MIN_HITS",
+    "DEFAULT_REASONING_DRIFT_MODE",
     "INTENT_DIVERGENCE_HEALTHY_SIMILARITY",
     "INTENT_DIVERGENCE_MINOR_SIMILARITY",
     "INTENT_DIVERGENCE_WARNING_SIMILARITY",
@@ -62,6 +85,7 @@ __all__ = [
     "LOOPING_REASONING_SIMILARITY_THRESHOLD",
     "OFF_TOPIC_DISTANCE_THRESHOLD",
     "REASONING_CLUSTER_SIMILARITY_THRESHOLD",
+    "ReasoningDriftMode",
     "SENTENCE_LEVEL_MIN_BLOCK_LENGTH",
     "SENTENCE_LEVEL_MAX_SENTENCES",
     "analyze_reasoning",
@@ -329,16 +353,19 @@ def detect_intent_divergence(
     an explicit "my goal is / let's focus on" phrase whose proposal
     tokens do not overlap with any goal summary fires at WARNING.
 
-    Either path may be bumped one step (INFO -> WARNING -> CRITICAL)
-    when the reasoning text mentions a significant noun / keyword that
-    does not appear in ``session.goals`` OR in the current task's
-    title / description -- a cheap "talking about something unrelated"
-    signal that catches soft divergence the cosine score alone may
-    smooth over.
-
     The kind is stable. Severity differentiates -- callers that filter
     by kind see one signal, callers that care about urgency read the
     ``severity`` field.
+
+    .. note::
+
+       The historical ``_has_unreferenced_keyword`` severity-bump that
+       promoted one tier on any 5+ char token absent from goals + task
+       was removed. The lexical heuristic fired on generic English
+       vocabulary not present in the task description, contaminating
+       the embedding signal with noise. The helper is preserved for
+       backward compatibility (external callers may still import it)
+       but has no in-tree consumer.
     """
     if not text:
         return None
@@ -368,8 +395,12 @@ def detect_intent_divergence(
         severity = _severity_from_similarity(sim)
         if severity is None:
             return None
-        if _has_unreferenced_keyword(text, goals_text, task_topic):
-            severity = _bump_severity(severity)
+        # NOTE: the historical ``_has_unreferenced_keyword`` severity-bump
+        # was removed. The lexical heuristic fired on generic English
+        # vocabulary ("wants", "asking", "interactive", "slideshow") that
+        # isn't in the task description, which bumped real embedding
+        # triggers to spurious CRITICAL severities. The cosine band alone
+        # now determines severity. See PR description rationale.
         detail = (
             f"reasoning diverged from goals (cosine={sim:.2f}): "
             f"reference={reference[:80]!r}"
@@ -390,14 +421,21 @@ def _pattern_intent_divergence(
     text: str,
     session: Session,
     goals_text: str,
-    task_topic: str,
+    task_topic: str,  # noqa: ARG001 -- kept for signature stability
 ) -> DriftEvent | None:
     """Return an INTENT_DIVERGENCE drift from regex-only signals.
 
-    Fires at WARNING by default when an off-goal "focus on X" phrase
-    sits next to tokens that do not appear in the goal summary. An
-    unreferenced-keyword mismatch elsewhere in the text bumps severity
-    to CRITICAL.
+    Fires at WARNING when an off-goal "focus on X" phrase sits next to
+    tokens that do not appear in the goal summary.
+
+    .. note::
+
+       The historical ``_has_unreferenced_keyword`` bump that pushed
+       severity to CRITICAL was removed. The lexical heuristic fired on
+       generic English vocabulary and degraded the reliability of the
+       real pattern trigger. Pattern-path severity is flat WARNING now.
+       ``task_topic`` is retained in the signature for backward
+       compatibility with callers that pass it positionally.
     """
     match = _INTENT_DIVERGENCE_MARKERS.search(text)
     if match is None:
@@ -421,8 +459,6 @@ def _pattern_intent_divergence(
     if any(tok in goals_lower for tok in tokens):
         return None
     severity = DriftSeverity.WARNING
-    if _has_unreferenced_keyword(text, goals_text, task_topic):
-        severity = _bump_severity(severity)
     snippet = (text[max(0, match.start() - 40) : match.end() + 80]).strip()
     return DriftEvent(
         kind=DriftKind.INTENT_DIVERGENCE,
@@ -471,8 +507,19 @@ def _has_unreferenced_keyword(
 
     We require a 5-char minimum to avoid matching on generic English
     (``with``, ``from``); stopwords strip the common connectives that
-    slip past the length gate. The check is deliberately conservative
-    -- one odd token can bump severity by one step, never more.
+    slip past the length gate.
+
+    .. deprecated:: goldfive#226
+
+       This helper has **no in-tree consumer** after the keyword
+       severity-bump was removed from :func:`detect_intent_divergence`
+       and :func:`_pattern_intent_divergence`. The 5-char stopword
+       rule still fired on generic English vocabulary absent from
+       task descriptions, so a noisy heuristic was bumping real
+       embedding signals to spurious CRITICAL severities. Kept as a
+       module-private helper for symmetry with
+       :func:`detect_unreferenced_keyword` (which is itself retained
+       for backward compatibility with external imports).
     """
     if not text:
         return False
@@ -761,9 +808,7 @@ def detect_unreferenced_keyword(
     ========================  ==========
 
     A "keyword" is any 5+ char alpha token from ``text`` that is not a
-    stopword — same rule as :func:`_has_unreferenced_keyword`, so the
-    standalone detector and the severity-bump path in
-    :func:`detect_intent_divergence` stay behaviourally consistent.
+    stopword — same rule as :func:`_has_unreferenced_keyword`.
 
     One-shot per task: the detector fires at most once per
     ``session.current_task_id`` via ``session.unreferenced_keyword_flagged``.
@@ -774,11 +819,17 @@ def detect_unreferenced_keyword(
     Returns ``None`` when there is no reference text (no goals and no
     bound task), matching :func:`detect_off_topic`'s precondition.
 
-    Rationale: whole-block cosine is empirically a weak separator on
-    real embedding models (see #223), so the lexical signal is often
-    the only one that fires on genuine drift. The severity-bump path
-    in :func:`detect_intent_divergence` is left intact — it still adds
-    signal when both paths agree.
+    .. deprecated:: goldfive#226
+
+       This detector is **no longer wired into** :func:`analyze_reasoning`
+       in any mode. The lexical heuristic fired on generic English
+       vocabulary not present in the task description (``wants``,
+       ``asking``, ``interactive``, ``slideshow``), producing noisy
+       CRITICAL drifts on routine reasoning. The function is retained
+       as an exported helper for external callers that imported it
+       directly, but there is no in-tree consumer. Prefer the LLM-judge
+       mode (:func:`goldfive.drift.reasoning_judge.classify_reasoning_drift`)
+       or the embedding pipeline for genuine off-topic detection.
     """
     if not text:
         return None
@@ -852,39 +903,33 @@ def detect_confusion(text: str, session: Session) -> DriftEvent | None:
 # ---------------------------------------------------------------------------
 
 
-def analyze_reasoning(text: str, session: Session) -> DriftEvent | None:
-    """Run the reasoning-drift pipeline against ``text``.
+_SEVERITY_ORDER: dict[DriftSeverity, int] = {
+    DriftSeverity.INFO: 0,
+    DriftSeverity.WARNING: 1,
+    DriftSeverity.CRITICAL: 2,
+}
 
-    Emits at most one drift per call. Detectors are tried in the order
-    that preserves the worst-signal-wins invariant:
-    INTENT_DIVERGENCE (graduated INFO/WARNING/CRITICAL) ->
-    LOOPING_REASONING (WARNING) -> OFF_TOPIC (WARNING, whole-text +
-    sentence-level) -> UNREFERENCED_KEYWORD (OFF_TOPIC kind, graduated
-    by count) -> REASONING_CLUSTER_TIGHTENING (INFO) -> CONFUSION (INFO).
 
-    INTENT_DIVERGENCE runs first even at INFO severity so its kind is
-    stable; callers that only care about warning-and-up simply filter
-    by ``severity``.
+def _embedding_pipeline(text: str, session: Session) -> DriftEvent | None:
+    """Run the embedding-based pipeline (``mode="embedding"``).
 
-    LOOPING_REASONING (cosine >= 0.9) must run before
-    REASONING_CLUSTER_TIGHTENING (0.75 <= cosine < 0.9) so that a
-    tight-loop observation emits the cliff drift and never the INFO
-    tier — the two are mutually exclusive by construction, and running
-    LOOPING_REASONING first keeps the "no double-fire" invariant
-    cheap to reason about.
+    Detectors run in worst-signal-wins order:
+    INTENT_DIVERGENCE -> LOOPING_REASONING -> OFF_TOPIC (with the
+    sentence-level min-cosine path from #224) ->
+    REASONING_CLUSTER_TIGHTENING -> CONFUSION. Ordering rationale
+    lives in :func:`analyze_reasoning`.
 
-    ``detect_unreferenced_keyword`` runs AFTER ``detect_off_topic``
-    (both the whole-text and sentence-level paths) and BEFORE
-    ``detect_reasoning_cluster_tightening``. Rationale:
-    ``detect_off_topic`` and the intent-divergence embedding path own
-    the "pure semantic drift" signal; ``detect_unreferenced_keyword``
-    owns the lexical signal. Both may be right; we prefer the
-    embedding-based drift when it fires, and fall back to lexical when
-    the whole-block cosine fails to separate drift from on-topic (the
-    scenario documented in #223).
+    .. note::
+
+       :func:`detect_unreferenced_keyword` is intentionally NOT called
+       here. The lexical keyword heuristic fired on generic English
+       vocabulary not present in the task description (``wants``,
+       ``asking``, ``interactive``, ``slideshow``), producing noisy
+       CRITICAL drifts on routine reasoning. The function is retained
+       as an exported helper for backward compatibility with external
+       callers, but it no longer contributes to the pipeline's output
+       post goldfive#226.
     """
-    if not text:
-        return None
     drift = detect_intent_divergence(text, session)
     if drift is not None:
         return drift
@@ -894,9 +939,6 @@ def analyze_reasoning(text: str, session: Session) -> DriftEvent | None:
     drift = detect_off_topic(text, session)
     if drift is not None:
         return drift
-    drift = detect_unreferenced_keyword(text, session)
-    if drift is not None:
-        return drift
     drift = detect_reasoning_cluster_tightening(text, session)
     if drift is not None:
         return drift
@@ -904,6 +946,112 @@ def analyze_reasoning(text: str, session: Session) -> DriftEvent | None:
     if drift is not None:
         return drift
     return None
+
+
+async def _run_judge(
+    text: str,
+    session: Session,
+    *,
+    call_llm: JudgeCallLLM,
+    model: str,
+) -> DriftEvent | None:
+    """Dispatch ``classify_reasoning_drift`` against the current task."""
+    task = _current_task(session)
+    return await classify_reasoning_drift(
+        reasoning=text,
+        task=task,
+        goals=list(session.goals),
+        model=model,
+        call_llm=call_llm,
+        current_task_id=session.current_task_id,
+    )
+
+
+async def analyze_reasoning(
+    text: str,
+    session: Session,
+    *,
+    mode: ReasoningDriftMode = "embedding",
+    call_llm: JudgeCallLLM | None = None,
+    model: str = "",
+) -> DriftEvent | None:
+    """Run the reasoning-drift pipeline against ``text``.
+
+    Emits at most one drift per call. The behaviour is selected by
+    ``mode``:
+
+    * ``"embedding"`` — embedding-based pipeline. Detectors are tried
+      in worst-signal-wins order: INTENT_DIVERGENCE ->
+      LOOPING_REASONING -> OFF_TOPIC (whole-text + sentence-level
+      min-cosine from #224) -> REASONING_CLUSTER_TIGHTENING ->
+      CONFUSION. INTENT_DIVERGENCE runs first even at INFO severity so
+      its kind is stable; callers that only care about warning-and-up
+      simply filter by ``severity``. LOOPING_REASONING (cosine >= 0.9)
+      runs before REASONING_CLUSTER_TIGHTENING (0.75 <= cosine < 0.9)
+      so tight-loop observations emit the cliff drift and never the
+      INFO tier.
+
+    * ``"judge"`` — LLM-as-a-judge (goldfive#226). Dispatches to
+      :func:`classify_reasoning_drift` with ``call_llm`` / ``model``.
+      When ``call_llm`` is ``None`` the judge path silently no-ops so
+      tests without a live LLM do not crash. The cheap orthogonal
+      always-on detectors (LOOPING_REASONING, CONFUSION) run upstream
+      in :meth:`DefaultSteerer.observe_reasoning` in every mode.
+
+    * ``"both"`` — run the embedding pipeline and the judge; the
+      higher-severity drift wins. Tie-breaker is embedding (runs first,
+      synchronously). When ``call_llm`` is ``None`` this degrades to
+      ``"embedding"``.
+
+    * ``"off"`` — skip the mode-selected pipeline entirely. The
+      always-on loop + confusion detectors continue to run upstream in
+      :meth:`DefaultSteerer.observe_reasoning`.
+
+    .. note::
+
+       The keyword heuristic (:func:`detect_unreferenced_keyword`) is
+       no longer part of the active pipeline in any mode. It fired on
+       generic English vocabulary that isn't in the task description
+       (real examples: ``wants``, ``asking``, ``interactive``,
+       ``slideshow``), producing noisy CRITICAL drifts on routine
+       reasoning. The function is retained as an exported helper for
+       backward compatibility with external callers.
+    """
+    if not text:
+        return None
+    if mode == "off":
+        return None
+    if mode == "embedding":
+        return _embedding_pipeline(text, session)
+    if mode == "judge":
+        if call_llm is None:
+            return None
+        return await _run_judge(text, session, call_llm=call_llm, model=model)
+    if mode == "both":
+        embedding_drift = _embedding_pipeline(text, session)
+        judge_drift: DriftEvent | None = None
+        if call_llm is not None:
+            judge_drift = await _run_judge(
+                text, session, call_llm=call_llm, model=model
+            )
+        if embedding_drift is None:
+            return judge_drift
+        if judge_drift is None:
+            return embedding_drift
+        # Both fired — worst-severity wins. Embedding wins ties
+        # (deterministic, synchronous path).
+        if _SEVERITY_ORDER[judge_drift.severity] > _SEVERITY_ORDER[
+            embedding_drift.severity
+        ]:
+            return judge_drift
+        return embedding_drift
+    # Unknown mode -- log and fall back to the legacy pipeline so the
+    # run is never broken by a typo'd config value.
+    log.warning(
+        "analyze_reasoning: unknown mode=%r; falling back to 'embedding'",
+        mode,
+    )
+    return _embedding_pipeline(text, session)
 
 
 # Small stopword set used by the intent-divergence token-overlap check.

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -1,0 +1,310 @@
+"""Per-thinking-message LLM-as-a-judge reasoning-drift classifier.
+
+Sibling to :mod:`goldfive.drift.goals`: the goal-drift judge asks
+"is the whole trajectory progressing?" once every N agent invocations,
+while :func:`classify_reasoning_drift` asks "is *this* reasoning block
+on task?" at (rate-limited) per-thinking-message cadence.
+
+Design goals (see goldfive#226):
+
+* **Cost-bounded.** At most one LLM call per invocation of this
+  function. The caller (the steerer) owns the rate-limit policy
+  (see ``DefaultSteerer.reasoning_drift_rate_limit``) so flaky judges
+  cannot spam the run.
+* **No false positives on plumbing failures.** The LLM raising,
+  returning malformed JSON, or returning a dict missing the
+  ``on_task`` key all yield ``None``. Only an explicit
+  ``{"on_task": false, ...}`` response produces a ``DriftEvent``.
+* **Framework-neutral.** Like :func:`classify_goal_drift`, this
+  classifier does not import from :mod:`goldfive.steerer` or any
+  adapter -- it takes the data it needs via keyword arguments and
+  returns a :class:`DriftEvent` or ``None``.
+
+The prompt is pinned via module-level constants
+(:data:`REASONING_DRIFT_SYSTEM_PROMPT` /
+:data:`REASONING_DRIFT_USER_PROMPT_TEMPLATE`) so operators can override
+wording without re-implementing the parse logic. Rationale for the
+empirical failure of the pre-existing embedding-based pipeline lives in
+goldfive#223 / #224 / #226.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable, Iterable, Sequence
+from typing import Any
+
+from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Goal, Task
+
+log = logging.getLogger(__name__)
+
+
+__all__ = [
+    "CallLLM",
+    "REASONING_DRIFT_MAX_REASONING_CHARS",
+    "REASONING_DRIFT_SYSTEM_PROMPT",
+    "REASONING_DRIFT_USER_PROMPT_TEMPLATE",
+    "classify_reasoning_drift",
+]
+
+
+# Shape matches :mod:`goldfive.drift.goals` / ``LLMPlanner`` so operators
+# can reuse the same callable across judges.
+CallLLM = Callable[[str, str, str], Awaitable[str]]
+
+
+# Reasoning blocks on real chain-of-thought models routinely hit several
+# KB. We truncate before prompting so one long block cannot blow the
+# judge's context budget. 1500 chars keeps ~300-400 tokens of reasoning
+# -- enough context for an on-task/off-task call on every corpus we have
+# calibrated against (goldfive#223).
+REASONING_DRIFT_MAX_REASONING_CHARS: int = 1500
+
+
+# Prompt templates. Module-level so tests (and subclasses of the
+# steerer) can override the wording without re-implementing the parse
+# logic.
+REASONING_DRIFT_SYSTEM_PROMPT: str = (
+    "You are assessing whether an autonomous agent's chain-of-thought "
+    "is staying focused on its explicit task and goals. Reply with a "
+    "single JSON object and nothing else."
+)
+
+REASONING_DRIFT_USER_PROMPT_TEMPLATE: str = (
+    "You are assessing whether an autonomous agent's chain-of-thought "
+    "is on task.\n\n"
+    "GOALS:\n{goals_block}\n\n"
+    "CURRENT TASK:\n{task_block}\n\n"
+    "REASONING (the agent's most recent chain-of-thought block):\n"
+    "{reasoning_block}\n\n"
+    "Decide: does the reasoning stay focused on the explicit task and "
+    "goals above? Answer STRICTLY in one of these two JSON shapes:\n"
+    '{{"on_task": true}}\n'
+    "OR\n"
+    '{{"on_task": false, "severity": "info"|"warning"|"critical", '
+    '"reason": "one-sentence explanation"}}\n\n'
+    "on_task=true = reasoning is working toward the task / goals "
+    "(clarifying sub-steps, exploring tradeoffs, working through a "
+    "calculation all count as on_task).\n"
+    "on_task=false = reasoning has drifted to an unrelated topic, is "
+    "proposing to abandon the task, or is otherwise off-course.\n"
+    "Severity guidance when on_task=false:\n"
+    "- info = mild tangent that may self-correct next turn.\n"
+    "- warning = clear off-topic content that deserves a nudge.\n"
+    "- critical = proposing to abandon or replace the task/goal."
+)
+
+
+# Liberal JSON extractor. Real LLMs emit markdown code fences and prose
+# even with strong "reply JSON only" instructions. Mirrors the extractor
+# in :mod:`goldfive.drift.goals`.
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _parse_response(raw: Any) -> dict[str, Any] | None:
+    """Extract the first JSON object from ``raw`` or return ``None``."""
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    stripped = raw.strip()
+    try:
+        decoded = json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        match = _JSON_OBJECT_RE.search(stripped)
+        if match is None:
+            return None
+        try:
+            decoded = json.loads(match.group(0))
+        except (json.JSONDecodeError, ValueError):
+            return None
+    if not isinstance(decoded, dict):
+        return None
+    return decoded
+
+
+def _format_goals(goals: Sequence[Goal] | Iterable[Any] | None) -> str:
+    if not goals:
+        return "(no goals recorded)"
+    lines: list[str] = []
+    for i, g in enumerate(goals, start=1):
+        gid = str(getattr(g, "id", "") or "")
+        summary = str(getattr(g, "summary", "") or "")
+        if not summary and isinstance(g, str):
+            summary = g
+        prefix = f"{i}."
+        if gid:
+            lines.append(f"{prefix} [{gid}] {summary}")
+        else:
+            lines.append(f"{prefix} {summary}")
+    return "\n".join(lines) if lines else "(no goals recorded)"
+
+
+def _format_task(task: Task | Any | None) -> str:
+    if task is None:
+        return "(no task bound)"
+    tid = str(getattr(task, "id", "") or "")
+    title = str(getattr(task, "title", "") or "")
+    description = str(getattr(task, "description", "") or "")
+    lines: list[str] = []
+    if tid:
+        lines.append(f"id: {tid}")
+    if title:
+        lines.append(f"title: {title}")
+    if description:
+        lines.append(f"description: {description}")
+    return "\n".join(lines) if lines else "(no task bound)"
+
+
+def _format_reasoning(reasoning: str) -> str:
+    if not reasoning:
+        return "(empty reasoning)"
+    if len(reasoning) <= REASONING_DRIFT_MAX_REASONING_CHARS:
+        return reasoning
+    return reasoning[:REASONING_DRIFT_MAX_REASONING_CHARS] + " ... [truncated]"
+
+
+# Map the judge's ``severity`` string to a :class:`DriftSeverity`. Missing
+# or unknown values fall through to WARNING so a drift verdict is never
+# silently swallowed by a bad severity string.
+_SEVERITY_MAP: dict[str, DriftSeverity] = {
+    "info": DriftSeverity.INFO,
+    "warning": DriftSeverity.WARNING,
+    "critical": DriftSeverity.CRITICAL,
+}
+
+
+def _severity_from_verdict(raw: Any) -> DriftSeverity:
+    if not isinstance(raw, str):
+        return DriftSeverity.WARNING
+    return _SEVERITY_MAP.get(raw.strip().lower(), DriftSeverity.WARNING)
+
+
+async def classify_reasoning_drift(
+    *,
+    reasoning: str,
+    task: Task | None,
+    goals: Sequence[Goal] | Iterable[Any] | None,
+    model: str,
+    call_llm: CallLLM,
+    current_task_id: str = "",
+    current_agent_id: str = "",
+    system_prompt: str | None = None,
+    user_prompt_template: str | None = None,
+) -> DriftEvent | None:
+    """Ask an LLM-judge whether ``reasoning`` is on-task.
+
+    Returns a :class:`DriftEvent` of kind
+    :data:`~goldfive.types.DriftKind.OFF_TOPIC` when the judge returns
+    ``{"on_task": false, ...}``. Severity comes from the judge's
+    ``severity`` field (``info`` / ``warning`` / ``critical``);
+    missing / unknown values default to
+    :data:`~goldfive.types.DriftSeverity.WARNING`.
+
+    Returns ``None`` in every other case:
+
+    * judge returns ``{"on_task": true}`` (the on-track signal),
+    * judge returns malformed / non-JSON text,
+    * judge returns a dict missing / with a non-boolean ``on_task``,
+    * ``call_llm`` raises.
+
+    The "quiet on failure" contract matches :func:`classify_goal_drift`
+    (goldfive#143). A flaky judge must not spam operator UIs with
+    false-positive OFF_TOPIC alarms.
+
+    Parameters
+    ----------
+    reasoning:
+        The reasoning / chain-of-thought block to classify. Truncated
+        to :data:`REASONING_DRIFT_MAX_REASONING_CHARS` before prompting
+        so pathologically long blocks cannot blow the context budget.
+        Empty or whitespace-only ``reasoning`` is treated as nothing to
+        classify -- returns ``None`` without calling the LLM.
+    task:
+        The currently-bound :class:`Task` (typically from
+        ``session.current_task_id``). May be ``None`` when no task is
+        active; the judge then has only ``goals`` to compare against.
+    goals:
+        The session's goals. Each entry should have ``id`` / ``summary``
+        attributes or be a plain str. May be ``None`` / empty.
+    model:
+        Model name forwarded verbatim to ``call_llm``. Empty string is
+        permitted; model-bound callables can substitute their own
+        default.
+    call_llm:
+        Async ``(system, user, model) -> str`` callable. Awaited at
+        most once per invocation.
+    current_task_id / current_agent_id:
+        Stamped onto the returned ``DriftEvent`` for sink correlation.
+        Optional -- empty strings are fine when no task is active.
+    system_prompt / user_prompt_template:
+        Override the default prompts. Operators wanting a different
+        judge style can pass their own; the defaults match the shape
+        pinned in :data:`REASONING_DRIFT_USER_PROMPT_TEMPLATE`.
+    """
+    if not reasoning or not reasoning.strip():
+        return None
+    system = system_prompt or REASONING_DRIFT_SYSTEM_PROMPT
+    template = user_prompt_template or REASONING_DRIFT_USER_PROMPT_TEMPLATE
+    user = template.format(
+        goals_block=_format_goals(goals),
+        task_block=_format_task(task),
+        reasoning_block=_format_reasoning(reasoning),
+    )
+    try:
+        raw = await call_llm(system, user, model)
+    except Exception as exc:  # noqa: BLE001 - never break the run
+        log.warning(
+            "classify_reasoning_drift: call_llm raised %s; no drift emitted",
+            exc,
+        )
+        return None
+    raw_str = raw if isinstance(raw, str) else ""
+    log.debug(
+        "classify_reasoning_drift: raw response (%d chars): %s",
+        len(raw_str),
+        raw_str[:500],
+    )
+    parsed = _parse_response(raw)
+    if parsed is None:
+        log.debug(
+            "classify_reasoning_drift: response was not JSON (raw=%r); "
+            "no drift emitted",
+            raw_str[:200],
+        )
+        return None
+    on_task = parsed.get("on_task")
+    if not isinstance(on_task, bool):
+        log.debug(
+            "classify_reasoning_drift: parsed=%r lacks boolean 'on_task' "
+            "key; no drift emitted",
+            parsed,
+        )
+        return None
+    if on_task:
+        log.debug(
+            "classify_reasoning_drift: judge says on-track (reason=%r)",
+            parsed.get("reason", ""),
+        )
+        return None
+    severity = _severity_from_verdict(parsed.get("severity"))
+    reason = str(parsed.get("reason", "") or "").strip()
+    log.info(
+        "classify_reasoning_drift: drift detected (severity=%s, reason=%r); "
+        "emitting OFF_TOPIC event",
+        severity.value,
+        reason,
+    )
+    detail = (
+        f"reasoning drift: {reason}"
+        if reason
+        else "reasoning drift detected (judge returned no reason)"
+    )
+    return DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=severity,
+        detail=detail,
+        current_task_id=current_task_id,
+        current_agent_id=current_agent_id,
+        raw=reasoning,
+    )

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -57,6 +57,10 @@ from goldfive.drift import (
     classify_stop_reason,
     classify_tool_error,
 )
+from goldfive.drift.reasoning import (
+    DEFAULT_REASONING_DRIFT_MODE,
+    ReasoningDriftMode,
+)
 from goldfive.types import (
     TERMINAL_TASK_STATUSES,
     DriftEvent,
@@ -309,6 +313,10 @@ class DefaultSteerer:
         goal_drift_config: GoalDriftConfig | None = None,
         tool_loop_config: ToolLoopConfig | None = None,
         reasoning_drift_config: ReasoningDriftConfig | None = None,
+        reasoning_drift_mode: ReasoningDriftMode = DEFAULT_REASONING_DRIFT_MODE,
+        reasoning_drift_call_llm: ReflectiveCallLLM | None = None,
+        reasoning_drift_model: str = "",
+        reasoning_drift_rate_limit: int = 3,
         plan_revision_cooldown_seconds: float = 0.0,
     ) -> None:
         """Build a steerer.
@@ -386,6 +394,28 @@ class DefaultSteerer:
             detector thresholds pick it up. Process-wide (see the
             module docstring on :mod:`goldfive.drift.reasoning` for
             the multi-Runner caveat). Added in #225.
+        reasoning_drift_mode:
+            Pipeline selection for :meth:`observe_reasoning`.
+            ``"judge"`` (default) runs the LLM judge (goldfive#226);
+            ``"embedding"`` runs the legacy embedding pipeline;
+            ``"both"`` runs both with higher-severity-wins reconciliation;
+            ``"off"`` disables off-topic detection (the always-on loop
+            and confusion detectors continue to run).
+        reasoning_drift_call_llm:
+            Optional async ``(system_prompt, user_prompt, model) -> str``
+            callable used by the LLM-as-a-judge reasoning-drift detector.
+            Required for ``reasoning_drift_mode`` in ``"judge"`` / ``"both"``
+            to fire; silently no-ops when ``None`` so tests without a
+            live LLM do not crash. Shape matches ``goal_drift_call_llm``
+            so the same callable can be reused.
+        reasoning_drift_model:
+            Model name forwarded to ``reasoning_drift_call_llm``.
+        reasoning_drift_rate_limit:
+            Run the judge once every N thinking messages per task.
+            ``N=1`` fires on every thinking message; ``N=3`` (the
+            default) fires on the 1st, 4th, 7th ... per task. The
+            first thinking message of every task always gets a judge
+            call; counters reset on task transition.
         plan_revision_cooldown_seconds:
             Minimum interval, in seconds, between two drift-triggered
             plan revisions for the same ``(task_id, drift_kind)`` key.
@@ -467,6 +497,17 @@ class DefaultSteerer:
             from goldfive.drift import reasoning as _reasoning
 
             _reasoning.configure(reasoning_drift_config)
+        # Per-thinking-message reasoning-drift judge wiring (goldfive#226).
+        # Mode selects which detectors run in :meth:`observe_reasoning`;
+        # the judge callable / model are forwarded to the LLM-as-a-judge
+        # path. ``None`` callable silently no-ops the judge (tests without
+        # a live LLM stay green).
+        self._reasoning_drift_mode: ReasoningDriftMode = reasoning_drift_mode
+        self._reasoning_drift_call_llm: ReflectiveCallLLM | None = (
+            reasoning_drift_call_llm
+        )
+        self._reasoning_drift_model = reasoning_drift_model
+        self._reasoning_drift_rate_limit = max(1, int(reasoning_drift_rate_limit))
         # Drift-triggered plan-revision cooldown (goldfive#227).
         # Clamped to a non-negative float; ``0.0`` disables the gate
         # so callers can opt out without subclassing.
@@ -975,6 +1016,19 @@ class DefaultSteerer:
         ``session.reasoning_history_max``), then runs the reasoning
         detectors. Emits at most one drift per call.
 
+        Pipeline dispatch (goldfive#226):
+
+        * Always-on detectors — :func:`~goldfive.drift.reasoning.detect_looping_reasoning`
+          and :func:`~goldfive.drift.reasoning.detect_confusion` — run
+          first on every call. They catch patterns (repetition,
+          uncertainty) that the LLM judge does not, and they are cheap.
+        * Mode-selected pipeline — :func:`~goldfive.drift.reasoning.analyze_reasoning`
+          runs in the configured ``reasoning_drift_mode``. The LLM judge
+          path is rate-limited to at most one call every
+          ``reasoning_drift_rate_limit`` thinking messages per task; the
+          first thinking message of every task always fires a judge
+          call. Counters reset on task transition.
+
         Adapters call this from their model-response callback once they
         have extracted reasoning_content (OpenAI), thinking blocks
         (Anthropic), or thought parts (Google). Safe to call with empty
@@ -988,12 +1042,67 @@ class DefaultSteerer:
         overflow = len(history) - cap
         if overflow > 0:
             del history[:overflow]
-        from goldfive.drift.reasoning import analyze_reasoning
+        from goldfive.drift.reasoning import (
+            analyze_reasoning,
+            detect_confusion,
+            detect_looping_reasoning,
+        )
 
-        drift = analyze_reasoning(text, session)
+        # Always-on pattern detectors. They emit in severity order
+        # (LOOPING_REASONING WARNING before CONFUSION INFO) and any
+        # fire short-circuits before the mode-selected pipeline so
+        # they remain the canonical signal for "repetitive / uncertain"
+        # reasoning regardless of mode.
+        drift = detect_looping_reasoning(text, session)
+        if drift is None:
+            drift = detect_confusion(text, session)
+        if drift is None:
+            # Mode-selected pipeline (judge / embedding / both / off).
+            # The judge path is rate-limited per-task; embedding path
+            # is synchronous.
+            rl_call_llm = self._maybe_take_reasoning_judge_slot(session)
+            drift = await analyze_reasoning(
+                text,
+                session,
+                mode=self._reasoning_drift_mode,
+                call_llm=rl_call_llm,
+                model=self._reasoning_drift_model,
+            )
         if drift is None:
             return
         await self._handle_drift(drift, session)
+
+    def _maybe_take_reasoning_judge_slot(
+        self, session: Session
+    ) -> ReflectiveCallLLM | None:
+        """Return the judge ``call_llm`` when this turn is a judge turn.
+
+        Rate-limit policy (goldfive#226):
+
+        * First thinking message of every task always fires.
+        * Subsequent messages skip ``(N-1)`` and then fire on the Nth.
+        * Counters are scoped per-task via
+          ``session._reasoning_judge_counters`` so a task transition
+          resets the window lazily -- the next task id is simply not
+          in the dict yet, so its first message falls into the
+          "count=0" branch.
+
+        Returns ``None`` when the judge is globally disabled (mode
+        skips it, or ``reasoning_drift_call_llm`` is unconfigured).
+        Also ``None`` on skip turns even when armed.
+        """
+        if self._reasoning_drift_call_llm is None:
+            return None
+        if self._reasoning_drift_mode not in ("judge", "both"):
+            return None
+        task_id = session.current_task_id or ""
+        counters = session._reasoning_judge_counters
+        count = counters.get(task_id, 0)
+        # count=0 -> fire (first message on this task), reset to 1.
+        # Otherwise fire when count % rate_limit == 0.
+        fire = (count % self._reasoning_drift_rate_limit) == 0
+        counters[task_id] = count + 1
+        return self._reasoning_drift_call_llm if fire else None
 
     # ------------------------------------------------------------------
     # Reflective self-progress check (opt-in)

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -631,6 +631,14 @@ class Session:
     # already cost-bounded by the interval; task-boundary scheduling needs
     # its own rate limit. Default 0 (never fired).
     _last_goal_drift_check_ts: float = 0.0
+    # Per-task thinking-message counter for the LLM-as-a-judge reasoning
+    # drift detector (goldfive#226). Task id -> count of ``observe_reasoning``
+    # calls since the last judge firing (or since task transition).
+    # ``DefaultSteerer`` fires the judge on the first message of every task
+    # (count=0) and then every ``reasoning_drift_rate_limit`` messages after
+    # that. Scoped per-task (not per-session) so the first thinking message
+    # on a fresh task always gets a judge call even on rate limits >1.
+    _reasoning_judge_counters: dict[str, int] = dataclasses.field(default_factory=dict)
     # Set to ``True`` by :class:`DefaultSteerer` when it escalates a
     # drift to Level 4 of the intervention ladder (goldfive#142).
     # Executors honour this flag the same way they honour a PAUSE

--- a/tests/test_drift_reasoning.py
+++ b/tests/test_drift_reasoning.py
@@ -154,11 +154,10 @@ def test_confusion_suppressed_below_threshold() -> None:
 
 
 def test_intent_divergence_pattern_path_fires_when_goal_proposes_unrelated_focus() -> None:
-    # No embedding model -> pattern-based fallback. Default severity is
-    # WARNING; a keyword mismatch elsewhere in the text bumps it to
-    # CRITICAL (covered in the dedicated test below). The "cryptocurrency
-    # trading dashboard" text here has several 5+ char tokens absent
-    # from the goal summary, so severity bumps to CRITICAL.
+    # No embedding model -> pattern-based fallback. Severity is flat
+    # WARNING post goldfive#226 -- the historical keyword-mismatch bump
+    # to CRITICAL was removed because the lexical heuristic fired on
+    # generic English vocabulary absent from task descriptions.
     session = _session_with_task(
         goals=[Goal(id="g1", summary="write a slide review report")]
     )
@@ -169,19 +168,15 @@ def test_intent_divergence_pattern_path_fires_when_goal_proposes_unrelated_focus
     drift = dreason.detect_intent_divergence(text, session)
     assert drift is not None
     assert drift.kind is DriftKind.INTENT_DIVERGENCE
-    # Proposal tokens disjoint AND unrelated keywords present -> bumped
-    # from WARNING up to CRITICAL.
-    assert drift.severity is DriftSeverity.CRITICAL
+    assert drift.severity is DriftSeverity.WARNING
 
 
-def test_intent_divergence_pattern_path_warning_without_keyword_mismatch() -> None:
-    # The unreferenced-keyword bump only fires on 5+ char non-stopword
-    # tokens that appear in the reasoning but not in goals+task. Here
-    # every 5+ char token in the reasoning also shows up in the task
-    # description, so the bump is suppressed and severity stays at
-    # WARNING. Meanwhile the proposal tokens ("tactics", "champion",
-    # "shortly") are disjoint from the goal summary, so the pattern
-    # detector still fires.
+def test_intent_divergence_pattern_path_stays_warning() -> None:
+    # Pattern-path severity is flat WARNING in all cases post-#226.
+    # This test pins the invariant explicitly: even when every 5+ char
+    # token in the reasoning also appears in the task description
+    # (i.e. the pre-#226 keyword-mismatch bump would have been
+    # suppressed), the pattern path still emits WARNING.
     session = _session_with_task(
         title="pivot actually focus report",
         description="pivot actually focus report tactics champion shortly goal",
@@ -460,14 +455,15 @@ def test_intent_divergence_critical_below_0_2() -> None:
     assert drift.severity is DriftSeverity.CRITICAL
 
 
-def test_intent_divergence_keyword_mismatch_upgrades_severity() -> None:
+def test_intent_divergence_keyword_mismatch_does_not_bump_severity() -> None:
     import math
 
-    # Cosine sits in the INFO band (0.5). The reasoning text mentions
-    # "blockchain" -- a 5+ char non-stopword absent from both the goal
-    # summary and the task topic -> severity bumps INFO -> WARNING.
-    # All other 5+ char reasoning tokens DO appear in the reference, so
-    # only the off-topic keyword drives the bump.
+    # Post goldfive#226 the historical keyword-mismatch severity bump
+    # was removed -- it fired on generic English vocabulary absent from
+    # task descriptions and noisily promoted real embedding triggers to
+    # spurious CRITICAL severities. Cosine bands alone determine
+    # severity. Here cosine is 0.5 (INFO band), and the stray 5+ char
+    # off-reference token "blockchain" must NOT bump the verdict.
     reasoning_text = "alpha bravo blockchain charlie"
     session = _intent_session(
         reasoning_text=reasoning_text,
@@ -476,8 +472,8 @@ def test_intent_divergence_keyword_mismatch_upgrades_severity() -> None:
     drift = dreason.detect_intent_divergence(reasoning_text, session)
     assert drift is not None
     assert drift.kind is DriftKind.INTENT_DIVERGENCE
-    # INFO (cosine band) + unreferenced keyword "blockchain" -> WARNING.
-    assert drift.severity is DriftSeverity.WARNING
+    # Severity stays at INFO (cosine band only, no keyword bump).
+    assert drift.severity is DriftSeverity.INFO
 
 
 # ---------------------------------------------------------------------------
@@ -559,7 +555,10 @@ def test_reasoning_cluster_tightening_does_not_fire_below_0_75() -> None:
 
 async def test_reasoning_cluster_tightening_is_one_shot_per_task() -> None:
     set_model(_StubEncoder())
-    steerer = DefaultSteerer()
+    # Cluster-tightening is an embedding-pipeline signal; engage it
+    # explicitly. The default ``mode="judge"`` with no ``call_llm`` would
+    # silently skip the embedding path.
+    steerer = DefaultSteerer(reasoning_drift_mode="embedding")
     session = _cluster_session()
     sink = ListSink()
     planner = NullPlanner()
@@ -608,7 +607,7 @@ async def test_reasoning_cluster_tightening_is_one_shot_per_task() -> None:
     assert looping == []
 
 
-def test_reasoning_high_similarity_skips_tightening_fires_loop() -> None:
+async def test_reasoning_high_similarity_skips_tightening_fires_loop() -> None:
     set_model(_StubEncoder())
     session = _cluster_session()
     current = _pad_tokens("shared", 10)
@@ -621,7 +620,7 @@ def test_reasoning_high_similarity_skips_tightening_fires_loop() -> None:
         _pad_tokens("shared", 10) + f" filler{block:02d}" for block in range(3)
     ]
     session.reasoning_history = [*priors, current]
-    drift = dreason.analyze_reasoning(current, session)
+    drift = await dreason.analyze_reasoning(current, session, mode="embedding")
     assert drift is not None
     # Cliff owns the signal; tightening must not steal it.
     assert drift.kind is DriftKind.LOOPING_REASONING
@@ -659,7 +658,7 @@ def test_reasoning_cluster_skipped_when_embeddings_unavailable(
 # ---------------------------------------------------------------------------
 
 
-def test_analyze_reasoning_prefers_intent_divergence_over_confusion() -> None:
+async def test_analyze_reasoning_prefers_intent_divergence_over_confusion() -> None:
     session = _session_with_task(
         goals=[Goal(id="g1", summary="write tax report")]
     )
@@ -669,12 +668,12 @@ def test_analyze_reasoning_prefers_intent_divergence_over_confusion() -> None:
         "Hmm, I'm not sure. Wait, let me change goals -- actually, let's "
         "focus on building a video game instead. I don't know about taxes."
     )
-    drift = dreason.analyze_reasoning(text, session)
+    drift = await dreason.analyze_reasoning(text, session, mode="embedding")
     assert drift is not None
     assert drift.kind is DriftKind.INTENT_DIVERGENCE
 
 
-def test_analyze_reasoning_returns_none_on_clean_text() -> None:
+async def test_analyze_reasoning_returns_none_on_clean_text() -> None:
     # Every 5+ char non-stopword token in the reasoning also appears in
     # the default goals+task reference ("produce a slide review report"
     # + "Review the slides" + "Read every slide and list any typos
@@ -682,7 +681,7 @@ def test_analyze_reasoning_returns_none_on_clean_text() -> None:
     # silent alongside the intent-divergence / off-topic paths.
     session = _session_with_task()
     text = "slide review: read each slide, list the typos found."
-    assert dreason.analyze_reasoning(text, session) is None
+    assert await dreason.analyze_reasoning(text, session, mode="embedding") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -1,0 +1,417 @@
+"""Unit tests for :mod:`goldfive.drift.reasoning_judge` and the
+per-task rate limit on :meth:`DefaultSteerer.observe_reasoning`.
+
+Covers (see goldfive#226):
+
+* Happy-path JSON responses (on_task=true / on_task=false with each
+  severity).
+* Malformed JSON / missing keys / LLM raises -> quiet (``None``).
+* Log lines: DEBUG for parse paths, INFO on drift emission, WARNING
+  when ``call_llm`` raises. Mirrors the logging pattern from
+  :mod:`goldfive.drift.goals`.
+* Rate limit: first thinking message on every task always fires; then
+  every ``reasoning_drift_rate_limit`` messages after. Counters reset
+  on task transition.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.drift import reasoning_judge as rjudge  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class NullPlanner:
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        return None
+
+
+def _stub_call_llm(responses: list[Any]):
+    """Async ``CallLLM``-shaped stub popping responses in order."""
+    queue = list(responses)
+    calls: list[tuple[str, str, str]] = []
+
+    async def _call_llm(system: str, user: str, model: str) -> str:
+        calls.append((system, user, model))
+        if not queue:
+            raise AssertionError("stub call_llm exhausted")
+        resp = queue.pop(0)
+        if isinstance(resp, (dict, list)):
+            return json.dumps(resp)
+        if isinstance(resp, Exception):
+            raise resp
+        return str(resp)
+
+    _call_llm.calls = calls  # type: ignore[attr-defined]
+    return _call_llm
+
+
+def _raising_call_llm(exc: Exception):
+    async def _call_llm(system: str, user: str, model: str) -> str:
+        raise exc
+
+    return _call_llm
+
+
+def _task() -> Task:
+    return Task(id="t1", title="Research solar panels", description="Find specs")
+
+
+def _goals() -> list[Goal]:
+    return [Goal(id="g1", summary="Publish a memo on solar panels")]
+
+
+def _session_with_task(task_id: str = "t1") -> Session:
+    task = Task(id=task_id, title="Research solar panels", description="Find specs")
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[task],
+        edges=[],
+    )
+    return Session(
+        run_id="r1",
+        goals=_goals(),
+        plan=plan,
+        current_task_id=task_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# classify_reasoning_drift: happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_on_task_true_returns_none() -> None:
+    call_llm = _stub_call_llm([{"on_task": True}])
+    drift = await rjudge.classify_reasoning_drift(
+        reasoning="I should look up the solar panel efficiency ratings.",
+        task=_task(),
+        goals=_goals(),
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert drift is None
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    "severity_str, expected_severity",
+    [
+        ("info", DriftSeverity.INFO),
+        ("warning", DriftSeverity.WARNING),
+        ("critical", DriftSeverity.CRITICAL),
+    ],
+)
+async def test_on_task_false_maps_severity(
+    severity_str: str, expected_severity: DriftSeverity
+) -> None:
+    call_llm = _stub_call_llm(
+        [{"on_task": False, "severity": severity_str, "reason": "drifted to raccoons"}]
+    )
+    drift = await rjudge.classify_reasoning_drift(
+        reasoning="Raccoons have masks but this is about solar panels.",
+        task=_task(),
+        goals=_goals(),
+        model="fake",
+        call_llm=call_llm,
+        current_task_id="t1",
+        current_agent_id="a1",
+    )
+    assert drift is not None
+    assert drift.kind is DriftKind.OFF_TOPIC
+    assert drift.severity is expected_severity
+    assert "raccoons" in drift.detail
+    assert drift.current_task_id == "t1"
+    assert drift.current_agent_id == "a1"
+
+
+async def test_missing_severity_defaults_to_warning() -> None:
+    call_llm = _stub_call_llm([{"on_task": False, "reason": "drifted"}])
+    drift = await rjudge.classify_reasoning_drift(
+        reasoning="off-topic thought",
+        task=_task(),
+        goals=_goals(),
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert drift is not None
+    assert drift.severity is DriftSeverity.WARNING
+
+
+async def test_unknown_severity_defaults_to_warning() -> None:
+    call_llm = _stub_call_llm([{"on_task": False, "severity": "CATASTROPHIC"}])
+    drift = await rjudge.classify_reasoning_drift(
+        reasoning="off-topic thought",
+        task=_task(),
+        goals=_goals(),
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert drift is not None
+    assert drift.severity is DriftSeverity.WARNING
+
+
+async def test_tolerates_markdown_fenced_json() -> None:
+    raw = '```json\n{"on_task": false, "severity": "warning", "reason": "off"}\n```'
+    call_llm = _stub_call_llm([raw])
+    drift = await rjudge.classify_reasoning_drift(
+        reasoning="thought",
+        task=_task(),
+        goals=_goals(),
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert drift is not None
+    assert drift.severity is DriftSeverity.WARNING
+
+
+# ---------------------------------------------------------------------------
+# classify_reasoning_drift: quiet-on-failure
+# ---------------------------------------------------------------------------
+
+
+async def test_malformed_json_returns_none_with_debug_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    call_llm = _stub_call_llm(["not json at all"])
+    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning_judge"):
+        drift = await rjudge.classify_reasoning_drift(
+            reasoning="thought",
+            task=_task(),
+            goals=_goals(),
+            model="fake",
+            call_llm=call_llm,
+        )
+    assert drift is None
+    assert any(
+        "response was not JSON" in r.getMessage()
+        and r.name == "goldfive.drift.reasoning_judge"
+        for r in caplog.records
+    ), [r.getMessage() for r in caplog.records]
+
+
+async def test_missing_on_task_key_returns_none_with_debug_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    call_llm = _stub_call_llm([{"verdict": "drift"}])
+    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning_judge"):
+        drift = await rjudge.classify_reasoning_drift(
+            reasoning="thought",
+            task=_task(),
+            goals=_goals(),
+            model="fake",
+            call_llm=call_llm,
+        )
+    assert drift is None
+    assert any(
+        "lacks boolean 'on_task'" in r.getMessage()
+        and r.name == "goldfive.drift.reasoning_judge"
+        for r in caplog.records
+    )
+
+
+async def test_non_boolean_on_task_returns_none() -> None:
+    call_llm = _stub_call_llm([{"on_task": "yes"}])
+    drift = await rjudge.classify_reasoning_drift(
+        reasoning="thought",
+        task=_task(),
+        goals=_goals(),
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert drift is None
+
+
+async def test_call_llm_raises_returns_none_with_warning_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    call_llm = _raising_call_llm(RuntimeError("boom"))
+    with caplog.at_level(logging.WARNING, logger="goldfive.drift.reasoning_judge"):
+        drift = await rjudge.classify_reasoning_drift(
+            reasoning="thought",
+            task=_task(),
+            goals=_goals(),
+            model="fake",
+            call_llm=call_llm,
+        )
+    assert drift is None
+    matching = [
+        r for r in caplog.records
+        if r.name == "goldfive.drift.reasoning_judge"
+        and "call_llm raised" in r.getMessage()
+    ]
+    assert len(matching) == 1
+    assert matching[0].levelno == logging.WARNING
+
+
+async def test_drift_emission_logs_info(caplog: pytest.LogCaptureFixture) -> None:
+    call_llm = _stub_call_llm(
+        [{"on_task": False, "severity": "critical", "reason": "off"}]
+    )
+    with caplog.at_level(logging.INFO, logger="goldfive.drift.reasoning_judge"):
+        drift = await rjudge.classify_reasoning_drift(
+            reasoning="thought",
+            task=_task(),
+            goals=_goals(),
+            model="fake",
+            call_llm=call_llm,
+        )
+    assert drift is not None
+    assert any(
+        "drift detected" in r.getMessage() and r.levelno == logging.INFO
+        for r in caplog.records
+    )
+
+
+async def test_empty_reasoning_does_not_call_llm() -> None:
+    call_llm = _stub_call_llm([{"on_task": True}])
+    drift = await rjudge.classify_reasoning_drift(
+        reasoning="   ",
+        task=_task(),
+        goals=_goals(),
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert drift is None
+    # LLM untouched — rate-limiting / short-circuit semantics.
+    assert call_llm.calls == []  # type: ignore[attr-defined]
+
+
+async def test_truncates_long_reasoning_in_prompt() -> None:
+    call_llm = _stub_call_llm([{"on_task": True}])
+    big = "x " * (rjudge.REASONING_DRIFT_MAX_REASONING_CHARS + 500)
+    await rjudge.classify_reasoning_drift(
+        reasoning=big,
+        task=_task(),
+        goals=_goals(),
+        model="fake",
+        call_llm=call_llm,
+    )
+    # The user prompt carries the truncation marker, not the full text.
+    _system, user, _model = call_llm.calls[0]  # type: ignore[attr-defined]
+    assert "[truncated]" in user
+    assert len(user) < len(big) + 2000  # prompt framing but not full 3500 chars
+
+
+# ---------------------------------------------------------------------------
+# DefaultSteerer: per-task rate limit
+# ---------------------------------------------------------------------------
+
+
+async def test_rate_limit_fires_first_call_then_every_N(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Rate limit 3: judge fires on messages 1, 4, 7, ... per task."""
+    call_llm = _stub_call_llm([{"on_task": True}] * 10)
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_rate_limit=3,
+        reasoning_drift_mode="judge",
+    )
+    session = _session_with_task()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    # 1st turn -> judge fires (count=0 starts the task).
+    await steerer.observe_reasoning("turn 1", session=session)
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+    # 2nd / 3rd turn -> skip (count=1,2).
+    await steerer.observe_reasoning("turn 2", session=session)
+    await steerer.observe_reasoning("turn 3", session=session)
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+    # 4th turn -> fire again (count=3 = 3 % 3 == 0).
+    await steerer.observe_reasoning("turn 4", session=session)
+    assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
+    # 5th-6th -> skip.
+    await steerer.observe_reasoning("turn 5", session=session)
+    await steerer.observe_reasoning("turn 6", session=session)
+    assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
+    # 7th -> fire.
+    await steerer.observe_reasoning("turn 7", session=session)
+    assert len(call_llm.calls) == 3  # type: ignore[attr-defined]
+
+
+async def test_rate_limit_resets_on_task_transition() -> None:
+    """The first reasoning message on a fresh task always fires a judge call."""
+    call_llm = _stub_call_llm([{"on_task": True}] * 10)
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_rate_limit=3,
+        reasoning_drift_mode="judge",
+    )
+    session = _session_with_task("t1")
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    # Two thinking messages on t1 -> one judge call (1st fires, 2nd skips).
+    await steerer.observe_reasoning("t1 turn 1", session=session)
+    await steerer.observe_reasoning("t1 turn 2", session=session)
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+
+    # Task transition: add a fresh task and bind it as current.
+    new_task = Task(id="t2", title="Different task", description="...")
+    assert session.plan is not None
+    session.plan.tasks.append(new_task)
+    session.current_task_id = "t2"
+
+    # First reasoning on t2 -> fresh judge call (the counter for t2 is 0).
+    await steerer.observe_reasoning("t2 turn 1", session=session)
+    assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
+
+
+async def test_judge_disabled_when_call_llm_is_none() -> None:
+    """Default-mode judge with no call_llm silently no-ops."""
+    steerer = DefaultSteerer(
+        reasoning_drift_mode="judge",
+        reasoning_drift_call_llm=None,
+    )
+    session = _session_with_task()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    await steerer.observe_reasoning("any thought", session=session)
+    # Only confusion/looping always-on detectors ran, and neither fires
+    # on a single clean-text thinking message with no history.
+    assert sink.events == []

--- a/tests/test_reasoning_keyword_detector.py
+++ b/tests/test_reasoning_keyword_detector.py
@@ -165,19 +165,25 @@ def test_detail_caps_preview_at_three_keywords() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Pipeline integration
+# Pipeline integration: detector is UNWIRED from ``analyze_reasoning``.
+#
+# Post goldfive#226 the keyword detector is retained as a standalone
+# exported function (tests above) but no longer contributes to the
+# synchronous pipeline in any mode. Rationale: the lexical heuristic
+# fired on generic English vocabulary absent from task descriptions
+# ("wants", "asking", "interactive", "slideshow"), producing noisy
+# CRITICAL drifts on routine reasoning. The two regression tests below
+# pin that the pipeline stays quiet on the same raccoon stimulus the
+# pre-226 code relied on.
 # ---------------------------------------------------------------------------
 
 
-def test_pipeline_fires_unreferenced_keyword_when_off_topic_silent(
+async def test_pipeline_does_not_fire_keyword_drift_in_embedding_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When the embedding model is unavailable (so ``detect_off_topic``
-    and ``detect_intent_divergence``'s embedding path stay quiet), the
-    lexical keyword detector still fires via ``analyze_reasoning``.
-
-    This is the #223 raccoon regression: whole-block cosine missed the
-    drift on real models; the keyword path owns the signal.
+    """With embeddings unavailable and the keyword detector unwired,
+    ``analyze_reasoning`` in ``"embedding"`` mode stays quiet on the
+    raccoon stimulus the pre-226 code relied on.
     """
     from goldfive.drift import _embed as _embed_mod
     from goldfive.drift._embed import set_model
@@ -190,21 +196,18 @@ def test_pipeline_fires_unreferenced_keyword_when_off_topic_silent(
         "Slide 1: Solar Panels. Slide 2: Raccoons (habitat, diet, "
         "behaviour). Let me compile comprehensive info."
     )
-    drift = dreason.analyze_reasoning(text, session)
-    assert drift is not None
-    assert drift.kind is DriftKind.OFF_TOPIC
-    # At least raccoons, habitat, behaviour are surplus -> WARNING or
-    # CRITICAL depending on whether "diet" (4 chars, skipped) and
-    # "compile" / "comprehensive" / "presentation" land in the
-    # reference. We only assert severity is at least WARNING.
-    assert drift.severity in (DriftSeverity.WARNING, DriftSeverity.CRITICAL)
+    drift = await dreason.analyze_reasoning(text, session, mode="embedding")
+    # Pattern-path intent-divergence does not match this text, embedding
+    # backends are silent without a model, and the keyword detector is
+    # unwired. The pipeline returns None.
+    assert drift is None
 
 
-def test_pipeline_runs_unreferenced_keyword_after_off_topic() -> None:
-    """``detect_unreferenced_keyword`` runs AFTER ``detect_off_topic``
-    and BEFORE ``detect_reasoning_cluster_tightening``. Verify by
-    isolating the detector call against a session where whole-text
-    embedding is unavailable — keyword-only signal must still fire.
+async def test_pipeline_off_mode_is_silent() -> None:
+    """``mode="off"`` skips every mode-selected detector. The always-on
+    loop + confusion detectors live in the steerer (see
+    ``test_drift_reasoning.py::test_observe_reasoning_*``) and are not
+    consulted by :func:`analyze_reasoning` itself.
     """
     from goldfive.drift import _embed as _embed_mod
     from goldfive.drift._embed import set_model
@@ -216,11 +219,7 @@ def test_pipeline_runs_unreferenced_keyword_after_off_topic() -> None:
         "Slide 1: solar panels. Slide 2: raccoons habitat species "
         "behaviour zoology climate."
     )
-    drift = dreason.analyze_reasoning(text, session)
-    assert drift is not None
-    assert drift.kind is DriftKind.OFF_TOPIC
-    # Keyword detector's diagnostic contains "off-task keywords:".
-    assert "off-task keywords" in drift.detail
+    assert await dreason.analyze_reasoning(text, session, mode="off") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reasoning_mode_dispatch.py
+++ b/tests/test_reasoning_mode_dispatch.py
@@ -1,0 +1,359 @@
+"""Mode-dispatch tests for :func:`goldfive.drift.reasoning.analyze_reasoning`.
+
+For each of the four modes (``"judge"`` / ``"embedding"`` / ``"both"`` /
+``"off"``) verify which detectors run, and that the
+worst-severity-wins reconciliation in ``"both"`` is deterministic.
+
+We monkeypatch the embedding helpers and stub ``call_llm`` so both
+pipelines produce deterministic drifts; the ``both`` tests then flex
+the severity ladder (INFO < WARNING < CRITICAL) to prove embedding
+wins ties and judge wins strict higher severity.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.drift import reasoning as dreason  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+)
+
+
+def _session() -> Session:
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="Research solar panels", description="Find specs")],
+        edges=[],
+    )
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="Publish a memo on solar panels")],
+        plan=plan,
+        current_task_id="t1",
+    )
+
+
+def _stub_judge_call_llm(responses: list[Any]):
+    queue = list(responses)
+    calls: list[tuple[str, str, str]] = []
+
+    async def _call_llm(system: str, user: str, model: str) -> str:
+        calls.append((system, user, model))
+        if not queue:
+            raise AssertionError("stub call_llm exhausted")
+        resp = queue.pop(0)
+        return json.dumps(resp) if isinstance(resp, (dict, list)) else str(resp)
+
+    _call_llm.calls = calls  # type: ignore[attr-defined]
+    return _call_llm
+
+
+# ---------------------------------------------------------------------------
+# mode="off"
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_off_returns_none_regardless_of_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No embedding detector runs and no judge fires in off-mode."""
+    calls: list[str] = []
+
+    def _track(name):
+        def _f(text, session):
+            calls.append(name)
+            return None
+        return _f
+
+    for fn in (
+        "detect_intent_divergence",
+        "detect_looping_reasoning",
+        "detect_off_topic",
+        "detect_reasoning_cluster_tightening",
+        "detect_confusion",
+    ):
+        monkeypatch.setattr(dreason, fn, _track(fn))
+
+    judge_calls: list[str] = []
+
+    async def _judge(**kwargs):
+        judge_calls.append("judge")
+        return None
+
+    monkeypatch.setattr(dreason, "classify_reasoning_drift", _judge)
+
+    drift = await dreason.analyze_reasoning(
+        "arbitrary reasoning", _session(), mode="off", call_llm=_stub_judge_call_llm([])
+    )
+    assert drift is None
+    assert calls == []
+    assert judge_calls == []
+
+
+# ---------------------------------------------------------------------------
+# mode="embedding"
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_embedding_runs_embedding_detectors_and_skips_judge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def _track(name, returns=None):
+        def _f(text, session):
+            calls.append(name)
+            return returns
+        return _f
+
+    for fn in (
+        "detect_intent_divergence",
+        "detect_looping_reasoning",
+        "detect_off_topic",
+        "detect_reasoning_cluster_tightening",
+        "detect_confusion",
+    ):
+        monkeypatch.setattr(dreason, fn, _track(fn))
+
+    judge_calls: list[str] = []
+
+    async def _judge(**kwargs):
+        judge_calls.append("judge")
+        return None
+
+    monkeypatch.setattr(dreason, "classify_reasoning_drift", _judge)
+
+    drift = await dreason.analyze_reasoning(
+        "text", _session(), mode="embedding",
+        call_llm=_stub_judge_call_llm([{"on_task": False}]),
+    )
+    assert drift is None
+    # Every embedding detector got a chance (they all returned None).
+    # ``detect_unreferenced_keyword`` is intentionally unwired post #226.
+    assert calls == [
+        "detect_intent_divergence",
+        "detect_looping_reasoning",
+        "detect_off_topic",
+        "detect_reasoning_cluster_tightening",
+        "detect_confusion",
+    ]
+    assert judge_calls == []
+
+
+# ---------------------------------------------------------------------------
+# mode="judge"
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_judge_skips_embedding_and_runs_judge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    embedding_calls: list[str] = []
+    for fn in (
+        "detect_intent_divergence",
+        "detect_looping_reasoning",
+        "detect_off_topic",
+        "detect_unreferenced_keyword",
+        "detect_reasoning_cluster_tightening",
+        "detect_confusion",
+    ):
+        def _maker(name):
+            def _f(text, session):
+                embedding_calls.append(name)
+                return None
+            return _f
+
+        monkeypatch.setattr(dreason, fn, _maker(fn))
+
+    call_llm = _stub_judge_call_llm([{"on_task": True}])
+    drift = await dreason.analyze_reasoning(
+        "text", _session(), mode="judge", call_llm=call_llm, model="fake",
+    )
+    assert drift is None
+    assert embedding_calls == []
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+
+
+async def test_mode_judge_with_no_call_llm_silently_no_ops() -> None:
+    drift = await dreason.analyze_reasoning(
+        "text", _session(), mode="judge", call_llm=None,
+    )
+    assert drift is None
+
+
+# ---------------------------------------------------------------------------
+# mode="both"
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_both_embedding_wins_tie_on_equal_severity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both paths fire with the SAME severity, embedding wins
+    (deterministic, synchronous path).
+    """
+    embedding_drift = DriftEvent(
+        kind=DriftKind.INTENT_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="embedding path fired",
+        current_task_id="t1",
+    )
+    monkeypatch.setattr(
+        dreason,
+        "_embedding_pipeline",
+        lambda text, session: embedding_drift,
+    )
+    call_llm = _stub_judge_call_llm(
+        [{"on_task": False, "severity": "warning", "reason": "judge path fired"}]
+    )
+
+    drift = await dreason.analyze_reasoning(
+        "text", _session(), mode="both", call_llm=call_llm, model="fake",
+    )
+    assert drift is embedding_drift
+
+
+async def test_mode_both_judge_wins_higher_severity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Judge drift at CRITICAL wins over embedding drift at WARNING."""
+    embedding_drift = DriftEvent(
+        kind=DriftKind.INTENT_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="embedding",
+        current_task_id="t1",
+    )
+    monkeypatch.setattr(
+        dreason,
+        "_embedding_pipeline",
+        lambda text, session: embedding_drift,
+    )
+    call_llm = _stub_judge_call_llm(
+        [{"on_task": False, "severity": "critical", "reason": "severe drift"}]
+    )
+
+    drift = await dreason.analyze_reasoning(
+        "text", _session(), mode="both", call_llm=call_llm, model="fake",
+    )
+    assert drift is not None
+    assert drift.severity is DriftSeverity.CRITICAL
+    assert "severe drift" in drift.detail  # came from judge
+
+
+async def test_mode_both_embedding_wins_higher_severity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    embedding_drift = DriftEvent(
+        kind=DriftKind.INTENT_DIVERGENCE,
+        severity=DriftSeverity.CRITICAL,
+        detail="embedding",
+        current_task_id="t1",
+    )
+    monkeypatch.setattr(
+        dreason,
+        "_embedding_pipeline",
+        lambda text, session: embedding_drift,
+    )
+    call_llm = _stub_judge_call_llm(
+        [{"on_task": False, "severity": "info", "reason": "mild"}]
+    )
+
+    drift = await dreason.analyze_reasoning(
+        "text", _session(), mode="both", call_llm=call_llm, model="fake",
+    )
+    assert drift is embedding_drift
+
+
+async def test_mode_both_judge_alone_when_embedding_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dreason, "_embedding_pipeline", lambda text, session: None)
+    call_llm = _stub_judge_call_llm(
+        [{"on_task": False, "severity": "warning", "reason": "off"}]
+    )
+    drift = await dreason.analyze_reasoning(
+        "text", _session(), mode="both", call_llm=call_llm, model="fake",
+    )
+    assert drift is not None
+    assert drift.severity is DriftSeverity.WARNING
+
+
+async def test_mode_both_embedding_alone_when_judge_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    embedding_drift = DriftEvent(
+        kind=DriftKind.INTENT_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="embedding",
+        current_task_id="t1",
+    )
+    monkeypatch.setattr(
+        dreason,
+        "_embedding_pipeline",
+        lambda text, session: embedding_drift,
+    )
+    call_llm = _stub_judge_call_llm([{"on_task": True}])
+    drift = await dreason.analyze_reasoning(
+        "text", _session(), mode="both", call_llm=call_llm, model="fake",
+    )
+    assert drift is embedding_drift
+
+
+async def test_mode_both_without_call_llm_degrades_to_embedding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    embedding_drift = DriftEvent(
+        kind=DriftKind.INTENT_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="embedding",
+        current_task_id="t1",
+    )
+    monkeypatch.setattr(
+        dreason,
+        "_embedding_pipeline",
+        lambda text, session: embedding_drift,
+    )
+    drift = await dreason.analyze_reasoning(
+        "text", _session(), mode="both", call_llm=None,
+    )
+    assert drift is embedding_drift
+
+
+# ---------------------------------------------------------------------------
+# unknown modes fall back to embedding
+# ---------------------------------------------------------------------------
+
+
+async def test_unknown_mode_falls_back_to_embedding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fired: list[str] = []
+    monkeypatch.setattr(
+        dreason,
+        "_embedding_pipeline",
+        lambda text, session: fired.append("embedding") or None,  # type: ignore[func-returns-value]
+    )
+    drift = await dreason.analyze_reasoning(
+        "text", _session(), mode="bogus",  # type: ignore[arg-type]
+    )
+    assert drift is None
+    assert fired == ["embedding"]

--- a/tests/test_reasoning_sentence_level.py
+++ b/tests/test_reasoning_sentence_level.py
@@ -317,7 +317,7 @@ def test_sentence_level_silent_without_model() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_calibration_pipeline_fires_via_sentence_level() -> None:
+async def test_calibration_pipeline_fires_via_sentence_level() -> None:
     """Replicate the #223 calibration cosines in a stub encoder and
     verify ``analyze_reasoning`` emits OFF_TOPIC.
 
@@ -354,7 +354,7 @@ def test_calibration_pipeline_fires_via_sentence_level() -> None:
     encoder.set_cosine(text, 0.90)  # whole-block stays high per #223
     set_model(encoder)
 
-    drift = dreason.analyze_reasoning(text, session)
+    drift = await dreason.analyze_reasoning(text, session, mode="embedding")
     assert drift is not None
     assert drift.kind is DriftKind.OFF_TOPIC
     # Sentence-level path owns the signal -- detail calls out the

--- a/tests/test_wrap_goal_drift_wiring.py
+++ b/tests/test_wrap_goal_drift_wiring.py
@@ -125,6 +125,43 @@ def test_wrap_wires_call_llm_into_default_steerer() -> None:
     assert steerer._goal_drift_model == "fake-model"
 
 
+def test_wrap_wires_call_llm_into_reasoning_drift_judge() -> None:
+    """goldfive.wrap threads ``call_llm`` into the reasoning-drift judge too.
+
+    Regression guard on goldfive#226: ``wrap()`` must wire
+    ``reasoning_drift_call_llm`` / ``reasoning_drift_model`` on the
+    default steerer, otherwise the default mode (``"judge"``) would
+    silently no-op despite the user passing a callable.
+    """
+    call_llm = _stub_call_llm([])
+    runner = goldfive.wrap(
+        _noop_agent,
+        call_llm=call_llm,
+        model="fake-model",
+        sinks=[],
+    )
+    steerer = runner.steerer
+    assert isinstance(steerer, DefaultSteerer)
+    assert steerer._reasoning_drift_call_llm is call_llm
+    assert steerer._reasoning_drift_model == "fake-model"
+    # Default mode stays ``"judge"`` -- same callable wires both judges.
+    assert steerer._reasoning_drift_mode == "judge"
+
+
+def test_wrap_does_not_arm_reasoning_judge_when_steerer_explicit() -> None:
+    """An explicit ``steerer=`` wins: wrap() does not patch kwargs in."""
+    call_llm = _stub_call_llm([])
+    explicit = DefaultSteerer(reasoning_drift_call_llm=None)
+    runner = goldfive.wrap(
+        _noop_agent,
+        call_llm=call_llm,
+        steerer=explicit,
+        sinks=[],
+    )
+    assert runner.steerer is explicit
+    assert runner.steerer._reasoning_drift_call_llm is None
+
+
 def test_wrap_preserves_explicit_steerer() -> None:
     """wrap(steerer=...) never overrides the caller's steerer."""
     call_llm = _stub_call_llm([{"progressing": True}])


### PR DESCRIPTION
## Summary

Adds a per-thinking-message LLM-as-a-judge reasoning-drift detector (`goldfive.drift.reasoning_judge.classify_reasoning_drift`) with mode selection (`judge` / `embedding` / `both` / `off`) on `analyze_reasoning`, and unwires the noisy keyword-mismatch path from the pipeline.

- **New LLM judge.** Sibling to the trajectory-level goal-drift judge (#143/#218): asks "is this reasoning on-task?" given the current task + goals + a truncated reasoning block, returns `{"on_task": false, "severity": ..., "reason": ...}`. Emits a graded OFF_TOPIC drift; returns `None` quietly on plumbing failures so a flaky judge cannot spam the event stream.

- **Mode selection.** `ReasoningDriftMode = Literal["judge", "embedding", "both", "off"]` on `analyze_reasoning`. Default is `"judge"`. `"both"` runs the embedding pipeline and the judge; higher-severity wins, embedding wins ties. `"off"` skips the mode-selected pipeline entirely — only the always-on cheap detectors run.

- **Always-on loop + confusion.** `detect_looping_reasoning` and `detect_confusion` run on every `observe_reasoning` call in **all modes** (including `judge` and `off`). They are cheap, orthogonal, and catch failure shapes the embedding pipeline and the judge both miss.

- **Rate-limited per-task.** The judge fires on the first thinking message of every task and then every N (default `3`) thereafter, scoped per-task via `session._reasoning_judge_counters`. Task transitions lazy-reset the window.

- **`wrap()` wiring.** `goldfive.wrap(call_llm=...)` threads the same callable into both the goal-drift judge (#218) and the reasoning-drift judge so the default mode actually fires without extra plumbing.

## Amendment: keyword detector unwired

Live operation showed `detect_unreferenced_keyword` firing on generic English vocabulary that isn't in the task description — `wants`, `asking`, `interactive`, `slideshow` — producing a session with **6 CRITICAL drifts** on meta-cognitive English vocabulary from routine reasoning. The lexical 5+ char / stopword heuristic is too noisy to live in the active pipeline.

- `detect_unreferenced_keyword` is **no longer called from `analyze_reasoning`** in any mode. The function is retained as an exported module symbol (backward compatibility for external importers); it has no in-tree consumer.
- The `_has_unreferenced_keyword` severity-bump is **removed from `detect_intent_divergence`** (both the embedding and pattern paths). Bumping a real embedding trigger with a noisy signal degrades the embedding path's reliability. The helper remains defined; no consumer in-tree.

Net result: the embedding-mode pipeline is now `detect_intent_divergence` (no bump) -> `detect_looping_reasoning` -> `detect_off_topic` (with the #224 sentence-level min-cosine path intact — that's the good signal we're keeping) -> `detect_reasoning_cluster_tightening` -> `detect_confusion`.

## Test plan

- [x] Full suite passes: `uv run pytest -q` -> **1065 passed, 78 skipped** (all skips pre-existing, mostly no-embedding-extra gates).
- [x] Ruff clean on touched files.
- [x] mypy clean on touched files.
- [x] Standalone `detect_unreferenced_keyword` tests still pass (function remains importable & callable).
- [x] Pipeline-integration tests inverted: `analyze_reasoning` in `"embedding"` mode stays silent on the raccoon stimulus the pre-226 code relied on for keyword firing.
- [x] `detect_intent_divergence` severity-bump tests assert the un-bumped severity.
- [x] New test coverage: `tests/test_reasoning_judge.py` (judge classifier), `tests/test_reasoning_mode_dispatch.py` (mode dispatch contract — confirms `detect_unreferenced_keyword` is NOT in the embedding sequence), `tests/test_wrap_goal_drift_wiring.py` (`wrap()` wires the judge).