### PR TITLE
fix(steerer): default plan_revision_cooldown_seconds to 0.0 (disabled)

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -301,7 +301,7 @@ class DefaultSteerer:
         goal_drift_call_llm: ReflectiveCallLLM | None = None,
         goal_drift_model: str = "",
         goal_drift_activity_window: int = 10,
-        plan_revision_cooldown_seconds: float = 30.0,
+        plan_revision_cooldown_seconds: float = 0.0,
     ) -> None:
         """Build a steerer.
 
@@ -349,15 +349,15 @@ class DefaultSteerer:
         plan_revision_cooldown_seconds:
             Minimum interval, in seconds, between two drift-triggered
             plan revisions for the same ``(task_id, drift_kind)`` key.
-            Defaults to ``30.0``. Set to ``0.0`` to disable the cooldown
-            entirely (pre-fix behaviour). Cooldown is scoped per-kind so
-            genuinely different problems (e.g. ``LOOPING_REASONING`` vs
-            ``CONFUSION``) can still replan independently. USER_STEER
-            drifts bypass this gate (user intent is always honoured
-            immediately) and GOAL_DRIFT has its own rate limiting via
-            ``_last_goal_drift_check_ts``, so it also bypasses this
-            gate. See goldfive feedback-loop fix for the observation
-            that prompted this.
+            **Defaults to ``0.0`` — disabled.** Operators who observe
+            replan thrashing from aggressive drift detection can pass a
+            positive value (e.g. ``30.0``) to opt in. Cooldown is scoped
+            per-kind so genuinely different problems (e.g.
+            ``LOOPING_REASONING`` vs ``CONFUSION``) can still replan
+            independently. USER_STEER drifts bypass this gate (user
+            intent is always honoured immediately) and GOAL_DRIFT has
+            its own rate limiting via ``_last_goal_drift_check_ts``, so
+            it also bypasses this gate. See goldfive#227.
 
         See ``docs/design/DRIFT.md`` §"Reflective self-progress check"
         for the full feature-gate semantics. The GOAL_DRIFT check


### PR DESCRIPTION
## Summary

Flips the default of \`plan_revision_cooldown_seconds\` (added in #228) from \`30.0\` to \`0.0\`, making drift-triggered plan-revision cooldown **opt-in**.

## Why

#228's cooldown is a correct remediation for the feedback-loop scenario observed in #227 (aggressive keyword-detector drifts causing replan thrashing). But defaulting it on for every Runner is too aggressive — users running well-tuned drift detectors pay a 30s latency penalty on legitimate drift responses for no benefit.

Now: operators who hit thrashing pass \`DefaultSteerer(plan_revision_cooldown_seconds=30.0)\`. Runners without the thrashing problem get zero-cooldown drift response as before.

## Test plan

- [x] All existing tests in \`tests/test_plan_revision_cooldown.py\` pass (they already pass explicit \`cooldown=\` kwargs).
- [x] Full suite: 1246 passed, 46 skipped.
- [x] \`ruff check\` clean.