### PR TITLE
fix(config): thread reasoning-drift mode through RuntimeConfig + env

### DIFF
--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -41,6 +41,11 @@ import dataclasses
 import logging
 import os
 
+from goldfive.drift.reasoning import (
+    DEFAULT_REASONING_DRIFT_MODE,
+    ReasoningDriftMode,
+)
+
 __all__ = [
     "EmbeddingConfig",
     "GoalDriftConfig",
@@ -112,6 +117,38 @@ def _read_float_env(name: str, default: float) -> float:
             default,
         )
         return default
+
+
+_VALID_REASONING_DRIFT_MODES: frozenset[str] = frozenset(
+    {"judge", "embedding", "both", "off"}
+)
+
+
+def _read_reasoning_drift_mode_env(
+    name: str, default: ReasoningDriftMode
+) -> ReasoningDriftMode:
+    """Return ``os.environ[name]`` as a ``ReasoningDriftMode``, or ``default``.
+
+    Accepts exactly the four literal values of
+    :data:`~goldfive.drift.reasoning.ReasoningDriftMode`
+    (``"judge"`` / ``"embedding"`` / ``"both"`` / ``"off"``).
+    Anything else logs a WARNING and falls back to ``default`` so a
+    typo in the env never silently disables drift detection.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if value in _VALID_REASONING_DRIFT_MODES:
+        return value  # type: ignore[return-value]
+    log.warning(
+        "ignoring unknown %s=%r (expected one of %s); using default %r",
+        name,
+        raw,
+        sorted(_VALID_REASONING_DRIFT_MODES),
+        default,
+    )
+    return default
 
 
 def _read_str_env(name: str, default: str) -> str:
@@ -247,6 +284,7 @@ class ReasoningDriftConfig:
     detector.
     """
 
+    mode: ReasoningDriftMode = DEFAULT_REASONING_DRIFT_MODE
     off_topic_distance_threshold: float = 0.7
     intent_divergence_healthy_similarity: float = 0.6
     intent_divergence_minor_similarity: float = 0.4
@@ -267,6 +305,9 @@ class ReasoningDriftConfig:
         """
         defaults = cls()
         return cls(
+            mode=_read_reasoning_drift_mode_env(
+                "GOLDFIVE_DRIFT_REASONING_MODE", defaults.mode
+            ),
             off_topic_distance_threshold=_read_float_env(
                 "GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE",
                 defaults.off_topic_distance_threshold,

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -250,6 +250,7 @@ def wrap(
             goal_drift_config=resolved_runtime.goal_drift,
             tool_loop_config=resolved_runtime.tool_loops,
             reasoning_drift_config=resolved_runtime.reasoning_drift,
+            reasoning_drift_mode=resolved_runtime.reasoning_drift.mode,
             reasoning_drift_call_llm=resolved_call_llm,
             reasoning_drift_model=resolved_model,
         )
@@ -258,6 +259,7 @@ def wrap(
             goal_drift_config=resolved_runtime.goal_drift,
             tool_loop_config=resolved_runtime.tool_loops,
             reasoning_drift_config=resolved_runtime.reasoning_drift,
+            reasoning_drift_mode=resolved_runtime.reasoning_drift.mode,
         )
     resolved_sinks: list[EventSink] = list(sinks) if sinks is not None else [LoggingSink()]
 

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -153,6 +153,7 @@ def test_reasoning_drift_config_defaults() -> None:
     :mod:`goldfive.drift.reasoning`.
     """
     cfg = ReasoningDriftConfig()
+    assert cfg.mode == "judge"
     assert cfg.off_topic_distance_threshold == 0.7
     assert cfg.intent_divergence_healthy_similarity == 0.6
     assert cfg.intent_divergence_minor_similarity == 0.4
@@ -161,6 +162,40 @@ def test_reasoning_drift_config_defaults() -> None:
     assert cfg.reasoning_cluster_similarity_threshold == 0.75
     assert cfg.looping_reasoning_hash_window == 5
     assert cfg.confusion_min_hits == 3
+
+
+@pytest.mark.parametrize("mode", ["judge", "embedding", "both", "off"])
+def test_reasoning_drift_config_from_env_mode(
+    monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """`GOLDFIVE_DRIFT_REASONING_MODE` selects the pipeline mode."""
+    monkeypatch.setenv("GOLDFIVE_DRIFT_REASONING_MODE", mode)
+    cfg = ReasoningDriftConfig.from_env()
+    assert cfg.mode == mode
+
+
+def test_reasoning_drift_config_from_env_mode_is_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mode parsing tolerates case variations + surrounding whitespace."""
+    monkeypatch.setenv("GOLDFIVE_DRIFT_REASONING_MODE", "  Embedding  ")
+    cfg = ReasoningDriftConfig.from_env()
+    assert cfg.mode == "embedding"
+
+
+def test_reasoning_drift_config_from_env_mode_invalid_warns_and_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown mode logs a WARNING and falls back to the default."""
+    monkeypatch.setenv("GOLDFIVE_DRIFT_REASONING_MODE", "bogus")
+    with caplog.at_level("WARNING", logger="goldfive.config"):
+        cfg = ReasoningDriftConfig.from_env()
+    assert cfg.mode == "judge"
+    warnings = [
+        r for r in caplog.records if "GOLDFIVE_DRIFT_REASONING_MODE" in r.getMessage()
+    ]
+    assert len(warnings) == 1
 
 
 def test_reasoning_drift_config_from_env_all_vars(

--- a/tests/test_wrap_runtime_config.py
+++ b/tests/test_wrap_runtime_config.py
@@ -130,6 +130,30 @@ def test_wrap_threads_runtime_config() -> None:
     assert steerer._tool_loop_config is cfg.tool_loops
     assert steerer._reasoning_drift_config is cfg.reasoning_drift
     assert steerer._goal_drift_config is cfg.goal_drift
+    # Mode flows from the config into the steerer.
+    assert steerer._reasoning_drift_mode == "judge"
+
+
+def test_wrap_threads_reasoning_drift_mode_from_config() -> None:
+    """A non-default ``reasoning_drift.mode`` propagates into the steerer."""
+    cfg = RuntimeConfig(
+        reasoning_drift=ReasoningDriftConfig(mode="embedding"),
+    )
+    runner = goldfive.wrap(_noop_agent, runtime=cfg, sinks=[])
+    steerer = runner.steerer
+    assert isinstance(steerer, DefaultSteerer)
+    assert steerer._reasoning_drift_mode == "embedding"
+
+
+def test_wrap_threads_reasoning_drift_mode_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`GOLDFIVE_DRIFT_REASONING_MODE=both make demo` end-to-end."""
+    monkeypatch.setenv("GOLDFIVE_DRIFT_REASONING_MODE", "both")
+    runner = goldfive.wrap(_noop_agent, sinks=[])
+    steerer = runner.steerer
+    assert isinstance(steerer, DefaultSteerer)
+    assert steerer._reasoning_drift_mode == "both"
 
 
 def test_wrap_falls_back_to_from_env_when_runtime_none(


### PR DESCRIPTION
## Summary

Closes a coordination gap between goldfive#229 (RuntimeConfig dataclasses) and goldfive#230 (LLM judge + mode selection). The \`mode\` field landed on \`DefaultSteerer\` but not on \`ReasoningDriftConfig\`, so operators calling \`goldfive.wrap()\` or \`make demo\` had no env-driven way to switch between \`"judge"\` (default) / \`"embedding"\` / \`"both"\` / \`"off"\`.

## Changes

- \`goldfive/config.py\`: \`ReasoningDriftConfig.mode: ReasoningDriftMode = "judge"\` field. \`from_env()\` reads \`GOLDFIVE_DRIFT_REASONING_MODE\` via a new helper that validates against the four literal values (case-insensitive, whitespace-tolerant; unknown values log a WARNING and fall back to default).
- \`goldfive/convenience.py\`: \`goldfive.wrap()\` now passes \`reasoning_drift_mode=resolved_runtime.reasoning_drift.mode\` to \`DefaultSteerer\` on both construction paths (with and without resolved \`call_llm\`).

## Usage

After this lands:

\`\`\`bash
GOLDFIVE_DRIFT_REASONING_MODE=embedding make demo   # legacy pipeline
GOLDFIVE_DRIFT_REASONING_MODE=both make demo        # both, higher-severity wins
GOLDFIVE_DRIFT_REASONING_MODE=off make demo         # loop + confusion only
\`\`\`

Programmatic:

\`\`\`python
goldfive.wrap(tree, runtime=RuntimeConfig(
    reasoning_drift=ReasoningDriftConfig(mode="both")))
\`\`\`

Explicit \`DefaultSteerer(reasoning_drift_mode=...)\` still wins over the config per the existing precedence rule.

## Tests

- \`tests/test_runtime_config.py\`: \`mode\` default, env-driven parametrized test for all four modes, case-insensitive parsing, unknown-value → WARNING + default fallback.
- \`tests/test_wrap_runtime_config.py\`: \`wrap()\` threads \`mode\` into \`DefaultSteerer._reasoning_drift_mode\` both via explicit \`RuntimeConfig\` and via env.
- Full suite: 1311 passed, 46 skipped (was 1303 at \`1ab10e1\`, +8 new).
- \`ruff check\` clean. \`mypy\` shows the same pre-existing error as main; no new errors.