### PR TITLE
fix(wrap): named-model WARNING shows agent.name, not class name

### DIFF
--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -323,13 +323,19 @@ def wrap(
     # ``call_llm=`` or an explicit ``JudgeConfig`` suppresses the
     # warning (the operator has already made a deliberate choice).
     if _call_llm_from_detect and not judge_from_config:
+        # Prefer the agent's own ``.name`` ("coordinator_agent", "research_agent",
+        # ...) over the Python class name ("LlmAgent", "BaseAgent", ...) — the
+        # latter is nearly useless for identifying *which* agent in a tree the
+        # LLM was detected from. Fall through to the class name only when the
+        # object has no usable ``.name`` attribute (non-ADK shapes).
+        _agent_label = getattr(agent, "name", "") or type(agent).__name__
         log.warning(
             "goldfive.wrap: judge LLM not explicitly configured; inheriting "
             "%r from agent %r (detected via ADK model attribute). Set "
             "GOLDFIVE_JUDGE_BASE_URL / GOLDFIVE_JUDGE_MODEL to route "
             "goldfive's judges to a dedicated endpoint.",
             _detected_model_name,
-            type(agent).__name__,
+            _agent_label,
         )
 
     resolved_planner: Planner

--- a/tests/test_wrap_goal_drift_wiring.py
+++ b/tests/test_wrap_goal_drift_wiring.py
@@ -315,11 +315,24 @@ def _patch_detect_llm(monkeypatch: pytest.MonkeyPatch, model_name: str) -> Any:
 class _MyAgent:
     """Async-callable agent shape accepted by ``auto_adapter``.
 
-    We deliberately use an instance-level callable so
-    ``type(agent).__name__`` in :func:`goldfive.wrap` resolves to
-    ``_MyAgent`` (the class name) — that's what the named-model
-    WARNING prints, and the test asserts on it.
+    No ``.name`` attribute — the named-model WARNING falls through to
+    ``type(agent).__name__`` (``_MyAgent``) and the assertion below
+    exercises that fallback.
     """
+
+    async def __call__(self, task: Any, session: Any, tools: Any) -> InvocationResult:
+        return InvocationResult(task_id=getattr(task, "id", ""), text="ok")
+
+
+class _NamedAgent:
+    """Async-callable agent shape with an ADK-style ``.name`` attribute.
+
+    Exercises the preferred branch of the named-model WARNING: prefer
+    the agent's own ``.name`` (``coordinator_agent`` in the real ADK
+    demo) over the Python class name (``LlmAgent`` / ``_NamedAgent``).
+    """
+
+    name = "coordinator_agent"
 
     async def __call__(self, task: Any, session: Any, tools: Any) -> InvocationResult:
         return InvocationResult(task_id=getattr(task, "id", ""), text="ok")
@@ -349,6 +362,35 @@ def test_wrap_warns_named_model_on_detection(
     assert "gpt-4o-mini" in msg
     assert "_MyAgent" in msg
     assert "GOLDFIVE_JUDGE_BASE_URL" in msg
+
+
+def test_wrap_warns_named_model_prefers_agent_name_over_class_name(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When the agent has a ``.name`` attribute the WARNING uses that.
+
+    Regression guard: the first version of this WARNING printed
+    ``type(agent).__name__`` unconditionally, so live demo logs
+    showed "agent 'LlmAgent'" — the ADK base class name — instead
+    of "agent 'coordinator_agent'", which is what operators actually
+    care about.
+    """
+    _patch_detect_llm(monkeypatch, "gpt-4o-mini")
+
+    with caplog.at_level(logging.WARNING, logger="goldfive.wrap"):
+        goldfive.wrap(_NamedAgent(), sinks=[])
+
+    matching = [
+        r
+        for r in caplog.records
+        if r.name == "goldfive.wrap"
+        and "judge LLM not explicitly configured" in r.getMessage()
+    ]
+    assert len(matching) == 1
+    msg = matching[0].getMessage()
+    assert "coordinator_agent" in msg
+    assert "_NamedAgent" not in msg  # class name should NOT appear
 
 
 def test_wrap_suppresses_named_model_warning_when_call_llm_explicit(


### PR DESCRIPTION
## Summary

The named-model WARNING introduced in #235 logged the Python class name (\`LlmAgent\`, \`BaseAgent\`) instead of the agent's \`.name\` attribute (\`coordinator_agent\`, \`research_agent\`). Live demo output from harmonograf session:

\`\`\`
2026-04-23 17:39:35,752 - WARNING - convenience.py:326 - goldfive.wrap:
judge LLM not explicitly configured; inheriting 'openai/qwen3.5:122b'
from agent 'LlmAgent' (detected via ADK model attribute). ...
\`\`\`

The operator's takeaway is meaningless — "LlmAgent" identifies nothing in a tree that has five LLM agents.

## Fix

One-line change: \`_agent_label = getattr(agent, "name", "") or type(agent).__name__\`. Prefer the agent's own \`.name\` (the ADK-assigned identifier); fall through to the class name only when the agent has no \`.name\`.

## Test

Added \`test_wrap_warns_named_model_prefers_agent_name_over_class_name\` with a \`_NamedAgent\` shape that has \`name = "coordinator_agent"\`. Asserts the WARNING contains \`"coordinator_agent"\` and does NOT contain the class name. Existing \`_MyAgent\` test still covers the class-name fallback path.