### PR TITLE
fix(adapter): DAG-aware candidate filter in _pin_current_task_id_for_agent

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1324,12 +1324,16 @@ def make_adk_plugin(
             """Stamp ``goldfive.current_task_id`` for ``agent_name`` if unambiguous.
 
             Matching rule: the plan task whose ``assignee_agent_id``
-            equals ``agent_name`` and whose status is PENDING or
-            RUNNING. Exactly-one matches stamp the id onto both the
-            live ADK ``session.state`` (agent-side reads via
-            ``tool_ctx.state``) and the goldfive orchestration
-            ``session.state`` (handler fallback in
-            :mod:`goldfive.reporting` + :mod:`goldfive.adapters._tool_invocation`).
+            equals ``agent_name``, whose status is PENDING or RUNNING,
+            AND whose upstream DAG predecessors are all COMPLETED
+            (goldfive#242 — without the DAG gate a Stage-4 task assigned
+            to the coordinator can be pinned at run-start while Stages
+            0-3 are still PENDING, producing an impossible Gantt).
+            Exactly-one matches stamp the id onto both the live ADK
+            ``session.state`` (agent-side reads via ``tool_ctx.state``)
+            and the goldfive orchestration ``session.state`` (handler
+            fallback in :mod:`goldfive.reporting` +
+            :mod:`goldfive.adapters._tool_invocation`).
 
             Zero / multiple matches leave state unset — the handler
             path will surface the existing ``missing_task_id`` error
@@ -1353,18 +1357,57 @@ def make_adk_plugin(
             tasks = _safe_attr(plan, "tasks", None) or ()
             # Import here so the type is available without forcing a
             # top-level import for a rarely-hot-path enum compare.
-            from goldfive.types import TaskStatus
+            from goldfive.types import TaskStatus, task_upstream_ready
 
-            matches: list[Any] = []
+            # Pre-filter: PENDING/RUNNING tasks whose assignee is this
+            # agent. This is the pre-#242 candidate set. The DAG-gate
+            # below filters it further; we keep the pre-DAG list so we
+            # can log when the gate actually changes the outcome.
+            pre_dag: list[Any] = []
             for task in tasks:
                 assignee = str(_safe_attr(task, "assignee_agent_id", "") or "")
                 if assignee != agent_name:
                     continue
                 status = _safe_attr(task, "status", None)
                 if status is TaskStatus.PENDING or status is TaskStatus.RUNNING:
+                    pre_dag.append(task)
+
+            # DAG-readiness gate (goldfive#242): a task is only pinnable
+            # when every upstream task (via ``plan.edges``) is COMPLETED.
+            # Stage-4 tasks cannot be pinned while Stage 0-3 is still
+            # PENDING, even if the stage-4 assignee happens to be the
+            # agent whose turn is starting (the coordinator case the
+            # live session exposed).
+            matches: list[Any] = []
+            for task in pre_dag:
+                task_id = str(_safe_attr(task, "id", "") or "")
+                if not task_id:
+                    continue
+                try:
+                    ready = task_upstream_ready(plan, task_id)
+                except Exception as exc:  # noqa: BLE001 — never raise from pin
+                    log.debug(
+                        "before_agent_callback: task_upstream_ready raised "
+                        "for %s: %s — treating as not-ready",
+                        task_id,
+                        exc,
+                    )
+                    ready = False
+                if ready:
                     matches.append(task)
-                    if len(matches) > 1:
-                        break  # ambiguous — no need to count further
+
+            if len(matches) != len(pre_dag):
+                log.debug(
+                    "pin candidate filter: agent=%s, before=[%s], after=[%s] "
+                    "(upstream-gated)",
+                    agent_name,
+                    ", ".join(
+                        str(_safe_attr(t, "id", "") or "") for t in pre_dag
+                    ),
+                    ", ".join(
+                        str(_safe_attr(t, "id", "") or "") for t in matches
+                    ),
+                )
 
             if len(matches) != 1:
                 # Zero matches (off-plan) or >1 matches (ambiguous).

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -445,6 +445,62 @@ class Plan:
         return stages
 
 
+def task_upstream_ready(plan: Plan, task_id: str) -> bool:
+    """Return ``True`` if every upstream task of ``task_id`` is COMPLETED.
+
+    Walks ``plan.edges`` to find all edges with ``to_task_id == task_id``
+    and checks that each ``from_task_id``'s status is
+    :attr:`TaskStatus.COMPLETED`. Tasks with no upstream edges are
+    trivially ready.
+
+    Supersession-aware: when an upstream predecessor ``A`` has been
+    superseded by a replacement ``B`` (``B.supersedes == A.id``) and
+    the edges table still references the original ``A``, the helper
+    resolves to ``B``'s status instead. This fallback is vestigial
+    when the refiner copies edges to point at the replacement id
+    directly -- but some refine paths leave the edges pointing at the
+    pre-supersession id, so we redirect here to keep the readiness
+    evaluation anchored to the live task.
+
+    Missing-endpoint edges (unknown ``from_task_id``) are treated as
+    *not ready* -- callers should validate the plan upstream, but a
+    dangling edge here conservatively blocks pinning rather than
+    silently allowing an underspecified downstream to run.
+
+    This helper is the DAG-readiness primitive the ADK adapter uses
+    to gate ``goldfive.current_task_id`` pinning so a downstream task
+    cannot be stamped onto an agent while its predecessors are still
+    in flight (goldfive#242).
+    """
+    if not task_id:
+        return True
+
+    tasks_by_id: dict[str, Task] = {t.id: t for t in plan.tasks if t.id}
+    # Supersession map: old_id -> replacement Task. The replacement's
+    # status is what we want to evaluate when the edges table still
+    # references the old (likely terminal) id.
+    replacement_of: dict[str, Task] = {}
+    for t in plan.tasks:
+        if t.supersedes and t.supersedes in tasks_by_id:
+            replacement_of[t.supersedes] = t
+
+    for e in plan.edges:
+        if e.to_task_id != task_id:
+            continue
+        upstream = tasks_by_id.get(e.from_task_id)
+        if upstream is None:
+            # Dangling edge — conservatively not ready.
+            return False
+        # Redirect through supersession when the edge still names the
+        # superseded task. The replacement's status is the live signal.
+        replacement = replacement_of.get(upstream.id)
+        if replacement is not None:
+            upstream = replacement
+        if upstream.status is not TaskStatus.COMPLETED:
+            return False
+    return True
+
+
 #: Conventional value for :attr:`Goal.source` indicating a goal was added
 #: by a ``USER_STEER`` directive (goldfive#152 / #154). Goals carrying
 #: this source are treated as "sticky": ``LLMPlanner.refine`` will

--- a/tests/test_task_id_wiring.py
+++ b/tests/test_task_id_wiring.py
@@ -263,6 +263,213 @@ async def test_before_agent_callback_skips_terminal_tasks() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Layer 1 (goldfive#242) — DAG-aware candidate filter
+# ---------------------------------------------------------------------------
+
+
+async def test_pin_skips_task_with_incomplete_upstream() -> None:
+    """A -> B, A is PENDING, agent is assigned to B -> no pin (upstream gate)."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(
+        _plan_with(
+            Task(id="a", title="A", assignee_agent_id="other"),
+            Task(id="b", title="B", assignee_agent_id="research_agent"),
+            edges=[TaskEdge("a", "b")],
+        )
+    )
+    state, ctx = _ctx_for(session, "coord")
+
+    await plugin.before_agent_callback(
+        agent=_Agent("research_agent"),
+        callback_context=ctx,
+    )
+
+    # DAG gate filters B out because A is still PENDING.
+    assert KEY_CURRENT_TASK_ID not in state
+    assert "goldfive.current_task_id" not in session.state
+
+
+async def test_pin_selects_task_after_upstream_completes() -> None:
+    """A COMPLETED, B PENDING, agent assigned to B -> B is pinned."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(
+        _plan_with(
+            Task(
+                id="a",
+                title="A",
+                assignee_agent_id="other",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(id="b", title="B", assignee_agent_id="research_agent"),
+            edges=[TaskEdge("a", "b")],
+        )
+    )
+    state, ctx = _ctx_for(session, "coord")
+
+    await plugin.before_agent_callback(
+        agent=_Agent("research_agent"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "b"
+    assert session.state["goldfive.current_task_id"] == "b"
+
+
+async def test_pin_ambiguous_narrows_by_dag() -> None:
+    """Two agent-matches, one has incomplete upstream -> singleton remains, pins."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    # ``t1`` is free of upstream deps; ``t2`` depends on ``gate`` which
+    # is still PENDING. Without the DAG gate both would be candidates
+    # and pin would bail on ambiguity; with the gate, only ``t1``
+    # remains.
+    session = _session_with(
+        _plan_with(
+            Task(id="gate", title="gate", assignee_agent_id="other"),
+            Task(id="t1", title="first", assignee_agent_id="research_agent"),
+            Task(id="t2", title="second", assignee_agent_id="research_agent"),
+            edges=[TaskEdge("gate", "t2")],
+        )
+    )
+    state, ctx = _ctx_for(session, "coord")
+
+    await plugin.before_agent_callback(
+        agent=_Agent("research_agent"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state["goldfive.current_task_id"] == "t1"
+
+
+async def test_pin_reproduces_finalize_bug() -> None:
+    """Live-scenario regression: 5-stage plan, only finalize is the coordinator's.
+
+    Stages 0-3 are PENDING; the final ``finalize_and_deliver_presentation``
+    task (Stage 4) is the only one assigned to the coordinator. Before
+    the DAG gate, ``before_agent_callback`` pinned the finalize task on
+    the coordinator's very first turn (pre-delegation), letting the
+    LLM call ``report_task_started`` on it and transitioning a Stage 4
+    task to RUNNING while upstream was still PENDING. The gate must
+    block that pin.
+    """
+    plugin = make_adk_plugin(host_agent_name="coordinator_agent")
+    session = _session_with(
+        _plan_with(
+            Task(id="s0", title="Gather", assignee_agent_id="researcher"),
+            Task(id="s1", title="Outline", assignee_agent_id="outliner"),
+            Task(id="s2", title="Draft", assignee_agent_id="writer"),
+            Task(id="s3", title="Review", assignee_agent_id="reviewer"),
+            Task(
+                id="finalize_and_deliver_presentation",
+                title="Finalize",
+                assignee_agent_id="coordinator_agent",
+            ),
+            edges=[
+                TaskEdge("s0", "s1"),
+                TaskEdge("s1", "s2"),
+                TaskEdge("s2", "s3"),
+                TaskEdge("s3", "finalize_and_deliver_presentation"),
+            ],
+        )
+    )
+    state, ctx = _ctx_for(session, "coordinator_agent")
+
+    await plugin.before_agent_callback(
+        agent=_Agent("coordinator_agent"),
+        callback_context=ctx,
+    )
+
+    # The entire bug: nothing should be pinned on the coordinator's
+    # first turn because the finalize task's upstream is still PENDING.
+    assert KEY_CURRENT_TASK_ID not in state
+    assert "goldfive.current_task_id" not in session.state
+
+
+async def test_pin_supersedes_redirection_tracks_replacement() -> None:
+    """Edge ``A -> C`` survives supersession; readiness tracks B's status."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    # A is the original, now FAILED; B replaces A (B.supersedes == "A");
+    # C depends on A in the edges table. The live status driving C's
+    # readiness must be B's (PENDING), not A's (FAILED).
+    plan = _plan_with(
+        Task(id="A", title="A", status=TaskStatus.FAILED, assignee_agent_id="other"),
+        Task(
+            id="B",
+            title="B",
+            status=TaskStatus.PENDING,
+            assignee_agent_id="other",
+            supersedes="A",
+        ),
+        Task(id="C", title="C", assignee_agent_id="research_agent"),
+        edges=[TaskEdge("A", "C")],
+    )
+    session = _session_with(plan)
+    state, ctx = _ctx_for(session, "coord")
+
+    # B is still PENDING -> C is NOT ready -> pin blocked.
+    await plugin.before_agent_callback(
+        agent=_Agent("research_agent"),
+        callback_context=ctx,
+    )
+    assert KEY_CURRENT_TASK_ID not in state
+
+    # Flip B to COMPLETED; now C is ready -> pin proceeds.
+    plan.tasks[1].status = TaskStatus.COMPLETED
+    await plugin.before_agent_callback(
+        agent=_Agent("research_agent"),
+        callback_context=ctx,
+    )
+    assert state[KEY_CURRENT_TASK_ID] == "C"
+
+
+async def test_pin_orchestration_block_shows_none_when_unpinned() -> None:
+    """When the DAG gate blocks pin, the planner instruction block shows '(none)'.
+
+    This is the user-visible effect: the agent's system prompt does
+    NOT contain a stale or wrong task id on turns where no task is
+    eligible. GoldfivePlanner renders the pinned id from
+    ``goldfive.current_task_id``; an unset key surfaces ``(none)``.
+    """
+    from goldfive.planners.goldfive_planner import GoldfivePlanner
+
+    plugin = make_adk_plugin(host_agent_name="coordinator_agent")
+    session = _session_with(
+        _plan_with(
+            Task(id="s0", title="Gather", assignee_agent_id="researcher"),
+            Task(
+                id="finalize",
+                title="Finalize",
+                assignee_agent_id="coordinator_agent",
+            ),
+            edges=[TaskEdge("s0", "finalize")],
+        )
+    )
+    state, ctx = _ctx_for(session, "coordinator_agent")
+
+    await plugin.before_agent_callback(
+        agent=_Agent("coordinator_agent"),
+        callback_context=ctx,
+    )
+
+    # No pin happened (s0 still PENDING).
+    assert KEY_CURRENT_TASK_ID not in state
+
+    # Build the planner instruction the LLM would see. We use a
+    # tolerant readonly-context stub carrying the ADK state dict.
+    planner = GoldfivePlanner(session=session)
+
+    class _Readonly:
+        def __init__(self, s: dict) -> None:
+            self.state = s
+
+    instruction = planner.build_planning_instruction(_Readonly(state), None)
+    assert instruction is not None
+    # The critical assertion: the block does not contain the finalize id.
+    assert "finalize" not in instruction
+    assert "Plan task (if any): (none)" in instruction
+
+
+# ---------------------------------------------------------------------------
 # Layer 2 — reporting-tool handlers default task_id from state
 # ---------------------------------------------------------------------------
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -14,6 +14,7 @@ from goldfive.types import (
     Task,
     TaskEdge,
     TaskStatus,
+    task_upstream_ready,
 )
 
 # ---------------------------------------------------------------------------
@@ -663,3 +664,149 @@ class TestPlanValidate:
         )
         revision.validate(for_revision=True)
         revision.validate(for_revision=False)
+
+
+# ---------------------------------------------------------------------------
+# DAG readiness helper (goldfive#242)
+# ---------------------------------------------------------------------------
+
+
+def _mk_plan_tasks(tasks: list[Task], edges: list[TaskEdge] | None = None) -> Plan:
+    return Plan(
+        id="p",
+        run_id="r",
+        goal_ids=[],
+        tasks=list(tasks),
+        edges=list(edges or []),
+    )
+
+
+class TestTaskUpstreamReady:
+    def test_zero_upstream_edges_is_ready(self) -> None:
+        plan = _mk_plan_tasks(
+            [Task(id="a", title="A"), Task(id="b", title="B")],
+            edges=[],
+        )
+        assert task_upstream_ready(plan, "a") is True
+        assert task_upstream_ready(plan, "b") is True
+
+    def test_single_upstream_completed_is_ready(self) -> None:
+        plan = _mk_plan_tasks(
+            [
+                Task(id="a", title="A", status=TaskStatus.COMPLETED),
+                Task(id="b", title="B", status=TaskStatus.PENDING),
+            ],
+            edges=[TaskEdge("a", "b")],
+        )
+        assert task_upstream_ready(plan, "b") is True
+
+    def test_single_upstream_pending_is_not_ready(self) -> None:
+        plan = _mk_plan_tasks(
+            [
+                Task(id="a", title="A", status=TaskStatus.PENDING),
+                Task(id="b", title="B", status=TaskStatus.PENDING),
+            ],
+            edges=[TaskEdge("a", "b")],
+        )
+        assert task_upstream_ready(plan, "b") is False
+
+    def test_upstream_running_is_not_ready(self) -> None:
+        plan = _mk_plan_tasks(
+            [
+                Task(id="a", title="A", status=TaskStatus.RUNNING),
+                Task(id="b", title="B", status=TaskStatus.PENDING),
+            ],
+            edges=[TaskEdge("a", "b")],
+        )
+        assert task_upstream_ready(plan, "b") is False
+
+    def test_upstream_failed_is_not_ready(self) -> None:
+        # FAILED is not COMPLETED — downstream cannot be pinned.
+        plan = _mk_plan_tasks(
+            [
+                Task(id="a", title="A", status=TaskStatus.FAILED),
+                Task(id="b", title="B", status=TaskStatus.PENDING),
+            ],
+            edges=[TaskEdge("a", "b")],
+        )
+        assert task_upstream_ready(plan, "b") is False
+
+    def test_mixed_upstream_one_pending_blocks(self) -> None:
+        # Two upstreams; one COMPLETED, one PENDING -> not ready.
+        plan = _mk_plan_tasks(
+            [
+                Task(id="a", title="A", status=TaskStatus.COMPLETED),
+                Task(id="b", title="B", status=TaskStatus.PENDING),
+                Task(id="c", title="C", status=TaskStatus.PENDING),
+            ],
+            edges=[TaskEdge("a", "c"), TaskEdge("b", "c")],
+        )
+        assert task_upstream_ready(plan, "c") is False
+
+    def test_mixed_upstream_all_completed_is_ready(self) -> None:
+        plan = _mk_plan_tasks(
+            [
+                Task(id="a", title="A", status=TaskStatus.COMPLETED),
+                Task(id="b", title="B", status=TaskStatus.COMPLETED),
+                Task(id="c", title="C", status=TaskStatus.PENDING),
+            ],
+            edges=[TaskEdge("a", "c"), TaskEdge("b", "c")],
+        )
+        assert task_upstream_ready(plan, "c") is True
+
+    def test_irrelevant_edges_are_ignored(self) -> None:
+        # Edges that do not terminate at ``task_id`` are ignored.
+        plan = _mk_plan_tasks(
+            [
+                Task(id="a", title="A", status=TaskStatus.PENDING),
+                Task(id="b", title="B", status=TaskStatus.PENDING),
+                Task(id="c", title="C", status=TaskStatus.PENDING),
+            ],
+            edges=[TaskEdge("a", "b")],
+        )
+        # c has no incoming edges at all.
+        assert task_upstream_ready(plan, "c") is True
+
+    def test_empty_task_id_trivially_ready(self) -> None:
+        # Edge case — caller has no task id to evaluate, treat as ready
+        # (the adapter's pin logic checks the return of ``task.id`` too
+        # and skips empty-id tasks upstream of this call).
+        plan = _mk_plan_tasks([])
+        assert task_upstream_ready(plan, "") is True
+
+    def test_dangling_edge_blocks(self) -> None:
+        # Edge references an unknown from-task -> conservative False.
+        plan = _mk_plan_tasks(
+            [Task(id="b", title="B", status=TaskStatus.PENDING)],
+            edges=[TaskEdge("ghost", "b")],
+        )
+        assert task_upstream_ready(plan, "b") is False
+
+    def test_supersedes_redirects_upstream_status(self) -> None:
+        # The live scenario: edge ``A -> C`` exists in the plan. ``A``
+        # failed; the refiner added ``B`` with ``supersedes="A"`` and
+        # marked ``A`` FAILED. The edge is still ``A -> C`` — the
+        # readiness of C must now track ``B``'s status (the live
+        # replacement), not ``A``'s FAILED status.
+        plan = _mk_plan_tasks(
+            [
+                Task(id="A", title="A", status=TaskStatus.FAILED),
+                Task(
+                    id="B",
+                    title="B (replacement)",
+                    status=TaskStatus.PENDING,
+                    supersedes="A",
+                ),
+                Task(id="C", title="C", status=TaskStatus.PENDING),
+            ],
+            edges=[TaskEdge("A", "C")],
+        )
+        # B is PENDING, so C is NOT ready yet. Critically: we should
+        # NOT have short-circuited on A's FAILED status and blocked C
+        # forever (nor should we have ignored the edge and reported C
+        # as ready).
+        assert task_upstream_ready(plan, "C") is False
+
+        # Flip B to COMPLETED — C becomes ready.
+        plan.tasks[1].status = TaskStatus.COMPLETED
+        assert task_upstream_ready(plan, "C") is True


### PR DESCRIPTION
Closes #241.

## The bug

`_GoldfiveADKPlugin._pin_current_task_id_for_agent` (in `goldfive/adapters/_adk_plugin.py`) selected the pin candidate using only `(assignee_agent_id, status in {PENDING, RUNNING})` and ignored the plan's DAG edges. A task whose upstream predecessors were still in-flight could be stamped onto an agent at the moment that agent's turn started, letting the LLM call `report_task_started` on a future-stage task while upstream stages were still PENDING.

Live scenario that surfaced it: a 5-stage presentation plan where `finalize_and_deliver_presentation` (Stage 4) was the only task assigned to `coordinator_agent`. On the coordinator's first turn the pin logic selected finalize as its unique match, the `[GOLDFIVE ORCHESTRATION CONTEXT]` block told the LLM `Plan task: finalize...`, and the coordinator called `report_task_started` on finalize — transitioning a Stage-4 task to RUNNING while Stages 0-3 were still PENDING.

## The fix

One-line candidate-filter change, backed by a new helper.

### `task_upstream_ready(plan, task_id)` (new, in `goldfive/types.py`)

Walks `plan.edges` for `to_task_id == task_id` and returns True only when every `from_task_id`'s status is COMPLETED. Tasks with no upstream edges are trivially ready. Supersession-aware: when upstream `A` is replaced by `B` (`B.supersedes == A.id`), readiness is evaluated against `B`'s live status, not `A`'s — important because some refine paths leave edges pointing at the pre-supersession id.

### `_pin_current_task_id_for_agent` (updated)

Before:
```python
matches = [t for t in tasks
           if t.assignee_agent_id == agent_name
           and t.status in (PENDING, RUNNING)]
```

After:
```python
pre_dag = [... same as before ...]
matches = [t for t in pre_dag if task_upstream_ready(plan, t.id)]
```

The rest of the logic (singleton → pin, zero/ambiguous → bail) is unchanged. Debug-logs when the DAG gate actually changes the outcome so the pin trajectory is diagnosable.

## What this is NOT

**Role-agnostic** — no `is_root`, `parent_agent`, "suppress-pin-on-coordinator", or "skip-first-turn" heuristics. Every agent gets the same filter. This respects the `feedback_no_prompt_contract.md` memory: we don't assume user coordinator prompts have a specific shape, and we don't encode "coordinator is orchestrator" anywhere.

## Composition with parallel work

- `feat/refine-cancel-and-hidden-task-id` also touches `_adk_plugin.py` for the delegation-site pin. That branch will adopt `task_upstream_ready` at rebase time (or inline a simple version that we later extract).
- `feat/goldfive-internal-llm-spans` is orthogonal.

## Tests

- `tests/test_types.py::TestTaskUpstreamReady` — 11 unit tests on the helper (zero/one/mixed upstream, failed/running upstream, irrelevant edges, dangling edges, supersession redirection).
- `tests/test_task_id_wiring.py` — 7 new tests on `_pin_current_task_id_for_agent` covering:
  - `test_pin_skips_task_with_incomplete_upstream`
  - `test_pin_selects_task_after_upstream_completes`
  - `test_pin_ambiguous_narrows_by_dag` (DAG gate converts ambiguous → singleton)
  - `test_pin_reproduces_finalize_bug` (exact live-scenario reproduction)
  - `test_pin_supersedes_redirection_tracks_replacement`
  - `test_pin_orchestration_block_shows_none_when_unpinned` (confirms `Plan task (if any): (none)` appears when no task is pinned — the user-visible contract)

## Notes on deliverables

- **Supersedes fallback was used** — the helper actively redirects through `supersedes` when the edges table references the superseded id. Whether this is strictly necessary in practice depends on refine-path edge-rewriting which isn't uniform across all paths; keeping the redirect makes the helper correct independent of refine behaviour.
- **Full-suite pass count:** 1403 passed, 46 skipped, 1 pre-existing flake (`test_reasoning_judge.py::test_rate_limit_resets_on_task_transition`, reproduces on untouched `origin/main`).
- **Ruff + mypy:** clean on touched lines (pre-existing mypy errors on `_adk_plugin.py` are unchanged).

## Test plan

- [x] `task_upstream_ready` unit tests (11)
- [x] `_pin_current_task_id_for_agent` behaviour tests (7)
- [x] Live-scenario regression (`test_pin_reproduces_finalize_bug`)
- [x] Supersession edge-redirection covered
- [x] Orchestration-context block integration (`Plan task (if any): (none)` when no pin)
- [x] `uv run pytest -q` full suite (1 pre-existing flake, unrelated)
- [x] `uv run ruff check` clean on touched files
- [x] `uv run mypy` no new errors on touched files