### PR TITLE
feat(steerer, planner, adapter): make goldfive steering direct agent behavior

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -259,44 +259,190 @@ def _inject_task_id_from_state(
     tool_name: str,
     tool_args: Any,
     tool_context: Any,
-) -> None:
-    """Best-effort: fill in ``tool_args['task_id']`` from pinned state.
+) -> bool:
+    """Populate ``tool_args['task_id']`` from state for reporting tools.
 
-    This is the goldfive#191 Layer-3 safety net. Mutates ``tool_args`` in
-    place when:
+    goldfive#241 — ``task_id`` is hidden from the LLM-facing reporting-
+    tool schema (see :func:`goldfive.adapters.adk._apply_llm_signature`),
+    so the model cannot supply it. Every reporting-tool call lands here
+    with no ``task_id`` arg; this function is the authoritative
+    resolution layer.
 
-      * ``tool_name`` is a reporting tool (report_task_* or
-        report_awaiting_approval),
-      * ``tool_args`` is a mutable mapping,
-      * the current ``task_id`` arg is missing / blank / a known
-        placeholder,
-      * session.state has a non-empty ``goldfive.current_task_id``.
+    Resolution order, keyed by the invocation's ``function_call_id``:
 
-    NEVER raises — injection is advisory. If anything goes wrong we log
-    at DEBUG and return, letting Layer 2 (handler default-from-state)
-    handle the fallback or surface the error.
+    1. ``goldfive.pending_delegations[<function_call_id>]`` — the
+       delegation-site pin stamped by :meth:`before_tool_callback` for
+       the AgentTool dispatch that spawned the current sub-invocation.
+       This path handles coordinators that fire multiple parallel
+       AgentTool calls to the same sub-agent on the same turn — each
+       parallel dispatch gets its own pin rather than racing on the
+       single ``goldfive.current_task_id`` slot.
+    2. ``session.state[goldfive.current_task_id]`` — the agent-turn
+       pin written by ``before_agent_callback`` at the start of every
+       agent invocation (goldfive#191/#195).
+
+    Returns ``True`` when ``tool_args`` now carries a usable ``task_id``
+    (either pre-existing non-placeholder, or freshly populated from
+    state) and ``False`` when no pin is available — in that case the
+    caller short-circuits with a structured error so the handler never
+    runs on an unpinned call. Pre-#241 the call would have fallen
+    through to the handler's ``missing_task_id`` error, but that path
+    goes back to the LLM via a successful tool response shape and
+    confused the model into retry loops.
+
+    NEVER raises — any internal failure degrades to "no pin", letting
+    the caller emit the canonical ``no_task_pinned`` error.
     """
     try:
         if not _is_reporting_tool_name(tool_name):
-            return
+            return True
         if not isinstance(tool_args, MutableMapping):
-            return
+            return True
         existing = tool_args.get("task_id", "")
         if not _is_placeholder_task_id(existing):
-            return
-        state = _session_state_from_callback(tool_context)
-        if not isinstance(state, Mapping):
-            return
-        state_tid = state.get(_sp.KEY_CURRENT_TASK_ID, "")
-        if not isinstance(state_tid, str) or not state_tid.strip():
-            return
-        tool_args["task_id"] = state_tid
+            # A real-looking id was supplied (e.g. legacy caller,
+            # custom tool that didn't opt into the hidden schema).
+            # Leave it alone so the handler surfaces mismatches as
+            # terminal-task / not-found failures rather than silently
+            # re-targeting the call.
+            return True
+        resolved = _resolve_pinned_task_id(
+            tool_context=tool_context,
+        )
+        if not resolved:
+            return False
+        tool_args["task_id"] = resolved
+        return True
     except Exception:  # noqa: BLE001
         log.debug(
             "before_tool_callback: task_id injection failed for tool=%s",
             tool_name,
             exc_info=True,
         )
+        return False
+
+
+# State-key used to stash per-function_call_id task pins at the
+# delegation site (goldfive#241 Item 3-bis). The plugin's
+# ``before_tool_callback`` writes an entry here when it dispatches an
+# AgentTool call and the reporting-tool callback reads it back when
+# the sub-invocation's tool call arrives. Keyed by the ADK
+# ``function_call_id`` of the AgentTool dispatch so parallel calls
+# don't race.
+_PENDING_DELEGATIONS_KEY = "goldfive.pending_delegations"
+
+
+def _resolve_pinned_task_id(*, tool_context: Any) -> str:
+    """Return the task_id pinned for this tool invocation, or ``""``.
+
+    Consults the delegation-site map first (``pending_delegations``
+    keyed by the current invocation's ``function_call_id``), then
+    falls back to the agent-turn pin (``goldfive.current_task_id``).
+    Returns ``""`` when neither path yields a value — the caller
+    should then fail the call with the ``no_task_pinned`` error
+    rather than invoking the handler on an unpinned arg.
+    """
+    state = _session_state_from_callback(tool_context)
+    if not isinstance(state, Mapping):
+        return ""
+    fc_id = _function_call_id_from_tool_context(tool_context)
+    if fc_id:
+        pend = state.get(_PENDING_DELEGATIONS_KEY)
+        if isinstance(pend, Mapping):
+            raw = pend.get(fc_id, "")
+            if isinstance(raw, str) and raw.strip():
+                return raw.strip()
+    state_tid = state.get(_sp.KEY_CURRENT_TASK_ID, "")
+    if isinstance(state_tid, str) and state_tid.strip():
+        return state_tid.strip()
+    return ""
+
+
+def _function_call_id_from_tool_context(tool_context: Any) -> str:
+    """Best-effort extraction of the current ``function_call_id``.
+
+    ADK's ToolContext carries the active ``function_call_id`` directly;
+    legacy / test stubs may not have the attribute, in which case we
+    degrade to ``""`` (falls back to the agent-turn pin).
+    """
+    fc_id = _safe_attr(tool_context, "function_call_id", "")
+    if isinstance(fc_id, str) and fc_id.strip():
+        return fc_id.strip()
+    return ""
+
+
+def _tokenize_for_matching(text: Any) -> set[str]:
+    """Return the set of lowercase alphanumeric tokens of length ≥4.
+
+    Used by :func:`_score_candidates_by_args` to score candidate tasks
+    against AgentTool args. The ≥4 threshold filters out noisy
+    short-word matches ("in", "of", "the") that would otherwise
+    saturate every candidate's score.
+    """
+    if not isinstance(text, str):
+        text = str(text or "")
+    tokens: set[str] = set()
+    buf: list[str] = []
+    for ch in text.lower():
+        if ch.isalnum():
+            buf.append(ch)
+        else:
+            if buf:
+                tok = "".join(buf)
+                if len(tok) >= 4:
+                    tokens.add(tok)
+                buf.clear()
+    if buf:
+        tok = "".join(buf)
+        if len(tok) >= 4:
+            tokens.add(tok)
+    return tokens
+
+
+def _score_candidates_by_args(candidates: list[Any], tool_args: Any) -> Any:
+    """Return the best-scoring candidate, or ``None`` on tie / zero match.
+
+    Scoring: tokenise ``tool_args`` and each candidate's
+    ``title + description``. Candidate with the highest overlap wins.
+    Ties (two or more candidates with the same top non-zero score)
+    return ``None`` so the caller falls through to the no-pin path;
+    guessing would be worse than letting the sub-agent path handle
+    the ambiguity.
+    """
+    if not candidates:
+        return None
+    # Serialise args into a single token bag. Keys contribute too
+    # (``topic=solar`` contributes "topic" and "solar") because the
+    # key names often hint at which task the call is about.
+    args_text = ""
+    if isinstance(tool_args, Mapping):
+        parts: list[str] = []
+        for k, v in tool_args.items():
+            parts.append(str(k))
+            parts.append(str(v))
+        args_text = " ".join(parts)
+    elif isinstance(tool_args, str):
+        args_text = tool_args
+    arg_tokens = _tokenize_for_matching(args_text)
+    if not arg_tokens:
+        return None
+    best_score = 0
+    best: Any = None
+    tied = False
+    for cand in candidates:
+        title = str(_safe_attr(cand, "title", "") or "")
+        desc = str(_safe_attr(cand, "description", "") or "")
+        cand_tokens = _tokenize_for_matching(f"{title} {desc}")
+        score = len(arg_tokens & cand_tokens)
+        if score > best_score:
+            best_score = score
+            best = cand
+            tied = False
+        elif score == best_score and score > 0:
+            tied = True
+    if best_score == 0 or tied:
+        return None
+    return best
 
 
 def _measure_request_chars(llm_request: Any) -> tuple[int, int]:
@@ -1359,6 +1505,41 @@ def make_adk_plugin(
             # top-level import for a rarely-hot-path enum compare.
             from goldfive.types import TaskStatus, task_upstream_ready
 
+            # goldfive#241 Item 3-bis — delegation-site pin takes
+            # precedence over the agent-turn match. If the parent
+            # coordinator's ``before_tool_callback`` stamped a
+            # task_id for THIS AgentTool dispatch (keyed by
+            # function_call_id), trust that pin and stamp it onto
+            # both state surfaces. Sub-agent ``before_agent_callback``
+            # doesn't carry the function_call_id, but the reporting-
+            # tool path reads ``pending_delegations`` directly anyway;
+            # this branch only matters for the single-match fallback.
+            gf_state_early = _safe_attr(ctx.session, "state", None)
+            if isinstance(gf_state_early, Mapping):
+                pend = gf_state_early.get(_PENDING_DELEGATIONS_KEY)
+                if isinstance(pend, Mapping) and pend:
+                    for tid in pend.values():
+                        if not isinstance(tid, str) or not tid:
+                            continue
+                        for task in tasks:
+                            if str(_safe_attr(task, "id", "") or "") != tid:
+                                continue
+                            assignee = str(
+                                _safe_attr(task, "assignee_agent_id", "") or ""
+                            )
+                            if assignee != agent_name:
+                                continue
+                            status = _safe_attr(task, "status", None)
+                            if status is TaskStatus.PENDING or status is TaskStatus.RUNNING:
+                                self._stamp_current_task_id(
+                                    ctx=ctx,
+                                    callback_context=callback_context,
+                                    task_id=tid,
+                                    agent_name=agent_name,
+                                    source="delegation_pin",
+                                )
+                                return
+
             # Pre-filter: PENDING/RUNNING tasks whose assignee is this
             # agent. This is the pre-#242 candidate set. The DAG-gate
             # below filters it further; we keep the pre-DAG list so we
@@ -1424,10 +1605,31 @@ def make_adk_plugin(
             task_id = str(_safe_attr(task, "id", "") or "")
             if not task_id:
                 return
+            self._stamp_current_task_id(
+                ctx=ctx,
+                callback_context=callback_context,
+                task_id=task_id,
+                agent_name=agent_name,
+                source="single_match",
+            )
 
-            # Stamp the goldfive orchestration-state key first — the
-            # reporting-tool handler fallback in ``invoke_tool`` +
-            # ``reporting.py`` reads from here.
+        def _stamp_current_task_id(
+            self,
+            *,
+            ctx: SessionContext,
+            callback_context: Any,
+            task_id: str,
+            agent_name: str,
+            source: str,
+        ) -> None:
+            """Write ``task_id`` into both state surfaces for the sub-agent.
+
+            Shared by the delegation-site branch and the single-match
+            fallback in :meth:`_pin_current_task_id_for_agent`. The
+            ``source`` label threads into the log line so the operator
+            log shows whether the pin came from the pending-delegations
+            map (goldfive#241) or the legacy assignee-match path.
+            """
             gf_state = _safe_attr(ctx.session, "state", None)
             if isinstance(gf_state, dict):
                 try:
@@ -1437,11 +1639,6 @@ def make_adk_plugin(
                         "before_agent_callback: goldfive session.state pin failed: %s",
                         exc,
                     )
-
-            # Stamp the ADK session.state key — the sibling's Layer 3
-            # (before_tool_callback arg-injection) reads from here and
-            # any agent that inspects ``tool_ctx.state`` directly picks
-            # up the same value.
             adk_state = _session_state_from_callback(callback_context)
             if isinstance(adk_state, Mapping):
                 try:
@@ -1451,11 +1648,132 @@ def make_adk_plugin(
                         "before_agent_callback: ADK session.state pin failed: %s",
                         exc,
                     )
-
             log.info(
-                "goldfive: pinned current_task_id=%s for sub-agent %s",
+                "goldfive: pinned current_task_id=%s for sub-agent %s "
+                "(source=%s)",
                 task_id,
                 agent_name,
+                source,
+            )
+
+        def _pin_delegation_task_id(
+            self,
+            *,
+            ctx: SessionContext,
+            tool_context: Any,
+            to_agent: str,
+            tool_args: Any,
+        ) -> None:
+            """Stamp a per-``function_call_id`` task pin for an AgentTool
+            dispatch so parallel same-agent invocations don't race on the
+            single ``goldfive.current_task_id`` slot.
+
+            goldfive#241 Item 3-bis. Resolution algorithm:
+
+            1. Collect PENDING/RUNNING tasks whose ``assignee_agent_id``
+               matches ``to_agent``.
+            2. Keep only the tasks whose upstream edges all point at
+               COMPLETED predecessors (DAG-aware; a task whose
+               dependency isn't done yet cannot be the target of THIS
+               dispatch).
+            3. If exactly one candidate, that's the pin.
+            4. If multiple candidates, score each against ``tool_args``
+               by keyword overlap with its ``title + description`` and
+               pick the top. Ties or zero-overlap fall through to "no
+               pin" — the sub-agent's ``before_agent_callback`` takes
+               over via the legacy single-match path.
+            5. If zero candidates, no pin.
+
+            Writes to ``ctx.session.state[goldfive.pending_delegations]``
+            (a dict keyed by function_call_id) when a pin resolves.
+            Silent on every failure mode — the worst case is we fall
+            through to the legacy behaviour.
+            """
+            if not to_agent:
+                return
+            fc_id = _function_call_id_from_tool_context(tool_context)
+            if not fc_id:
+                return
+            plan = _safe_attr(ctx.session, "plan", None)
+            if plan is None:
+                return
+            tasks = _safe_attr(plan, "tasks", None) or ()
+            edges = _safe_attr(plan, "edges", None) or ()
+            from goldfive.types import TaskStatus
+
+            completed_ids: set[str] = set()
+            for t in tasks:
+                if _safe_attr(t, "status", None) is TaskStatus.COMPLETED:
+                    tid = str(_safe_attr(t, "id", "") or "")
+                    if tid:
+                        completed_ids.add(tid)
+
+            def _upstream_ok(task_id: str) -> bool:
+                for e in edges:
+                    to_id = str(_safe_attr(e, "to_task_id", "") or "")
+                    if to_id != task_id:
+                        continue
+                    from_id = str(_safe_attr(e, "from_task_id", "") or "")
+                    if from_id and from_id not in completed_ids:
+                        return False
+                return True
+
+            candidates: list[Any] = []
+            for task in tasks:
+                assignee = str(_safe_attr(task, "assignee_agent_id", "") or "")
+                if assignee != to_agent:
+                    continue
+                status = _safe_attr(task, "status", None)
+                if status is not TaskStatus.PENDING and status is not TaskStatus.RUNNING:
+                    continue
+                tid = str(_safe_attr(task, "id", "") or "")
+                if not tid or not _upstream_ok(tid):
+                    continue
+                candidates.append(task)
+
+            if not candidates:
+                return
+            if len(candidates) == 1:
+                chosen = candidates[0]
+            else:
+                chosen = _score_candidates_by_args(candidates, tool_args)
+                if chosen is None:
+                    log.debug(
+                        "before_tool_callback: %d candidates for %s; "
+                        "args did not disambiguate — no pin",
+                        len(candidates),
+                        to_agent,
+                    )
+                    return
+            task_id = str(_safe_attr(chosen, "id", "") or "")
+            if not task_id:
+                return
+            # Stamp the pin onto BOTH the goldfive orchestration
+            # session.state (so reporting-tool handlers that read it
+            # directly see it) AND the ADK tool_context session.state
+            # (so the plugin's before_tool_callback → _resolve_pinned_task_id
+            # sees it on the sub-invocation's ToolContext). The two
+            # dicts are distinct in live ADK — the goldfive Session
+            # is our orchestration state, the ADK session.state is
+            # the live ADK session the Runner drives.
+            for target in (
+                _safe_attr(ctx.session, "state", None),
+                _session_state_from_callback(tool_context),
+            ):
+                if not isinstance(target, dict):
+                    continue
+                pend = target.get(_PENDING_DELEGATIONS_KEY)
+                if not isinstance(pend, dict):
+                    pend = {}
+                    target[_PENDING_DELEGATIONS_KEY] = pend
+                pend[fc_id] = task_id
+            log.info(
+                "goldfive: pinned delegation task_id=%s for fc_id=%s "
+                "(sub-agent=%s, %d candidates)",
+                task_id,
+                fc_id,
+                to_agent,
+                len(candidates),
             )
 
         async def after_agent_callback(self, *, agent: Any, callback_context: Any) -> None:
@@ -2023,21 +2341,28 @@ def make_adk_plugin(
             #
             # See ``docs/design/TASK-LIFECYCLE.md`` §5 for the contract.
             #
-            # goldfive#191 Layer 3 — task_id injection. Before we dispatch
-            # a reporting tool, if the LLM omitted ``task_id`` (or passed
-            # an obvious placeholder like "" / "placeholder" / "unknown"
-            # / "TODO") we fall back to the ``goldfive.current_task_id``
-            # pinned into session.state by ``before_agent_callback`` at
-            # the start of the agent turn. The state write fires first in
-            # ADK's callback order (agent-turn → tool-calls-within-turn)
-            # so by the time we reach here the pin is already visible.
-            # Real-looking task_ids are preserved verbatim — we don't
-            # silently rewrite them even if they look wrong (see #191).
-            _inject_task_id_from_state(
+            # goldfive#241 — task_id is hidden from the LLM-facing
+            # reporting-tool schema so the model never supplies it.
+            # Resolve from state (delegation-site pin first, then the
+            # agent-turn pin). If neither resolves, short-circuit with
+            # a structured ``no_task_pinned`` error — better than
+            # invoking the handler on an unbound reporting call.
+            pinned = _inject_task_id_from_state(
                 tool_name=tool_name,
                 tool_args=tool_args,
                 tool_context=tool_context,
             )
+            if _is_reporting_tool_name(tool_name) and not pinned:
+                log.info(
+                    "before_tool_callback: no task pinned for %s; "
+                    "short-circuiting with no_task_pinned",
+                    tool_name,
+                )
+                return {
+                    "acknowledged": False,
+                    "error": "no_task_pinned",
+                    "detail": "no task bound to this agent invocation",
+                }
 
             tool_names_registered = {spec.name for spec in ctx.tools}
             if tool_name in tool_names_registered:
@@ -2107,6 +2432,30 @@ def make_adk_plugin(
                             "before_tool_callback: reconciler.on_delegation_observed raised: %s",
                             exc,
                         )
+
+                # goldfive#241 Item 3-bis — delegation-site task_id
+                # pinning. When the coordinator fires multiple parallel
+                # AgentTool calls to the same sub-agent in one turn,
+                # each dispatch spawns its own sub-invocation; the
+                # sub-agent's ``before_agent_callback`` cannot
+                # disambiguate because all N parallel calls share the
+                # same (agent_name, session.state) pair. We resolve
+                # the candidate task for THIS AgentTool dispatch and
+                # stash it on ``pending_delegations[<function_call_id>]``
+                # so the reporting-tool callback (which DOES see the
+                # function_call_id) can read the correct pin back.
+                try:
+                    self._pin_delegation_task_id(
+                        ctx=ctx,
+                        tool_context=tool_context,
+                        to_agent=to_agent,
+                        tool_args=tool_args,
+                    )
+                except Exception as exc:  # noqa: BLE001 — best-effort
+                    log.debug(
+                        "before_tool_callback: delegation pin raised: %s",
+                        exc,
+                    )
 
                 # Runaway-delegation cap. Count BEFORE short-circuiting
                 # so the drift fires exactly once at the threshold

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -48,6 +48,7 @@ module is gated so ``import goldfive.adapters.adk`` raises a clear
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import uuid
 from collections.abc import Mapping
@@ -94,6 +95,16 @@ def _build_ack_shim(name: str, description: str):
     with a proper ``__name__`` / docstring for the model to see. The
     real handler routing happens in the plugin's
     ``before_tool_callback`` — this shim is never actually executed.
+
+    The returned function's ``__signature__`` is set explicitly so ADK's
+    :class:`FunctionTool` introspection generates a declaration with
+    only the LLM-author parameters — ``task_id`` is deliberately
+    omitted (goldfive#241). The plugin's ``before_tool_callback`` fills
+    ``task_id`` in from session state before the handler runs; exposing
+    it in the schema led LLMs to either hallucinate bad values or
+    abandon the reporting protocol entirely (live evidence: "the
+    function is still trying to use a task_id parameter even though
+    the schema says it doesn't require any parameters").
     """
 
     def _shim(**kwargs: Any) -> dict[str, Any]:
@@ -105,11 +116,72 @@ def _build_ack_shim(name: str, description: str):
     return _shim
 
 
+# Declared-for-LLM signatures for the built-in reporting tools
+# (goldfive#241 Item 3). Keys are the canonical tool names from
+# :mod:`goldfive.reporting`; values are the list of :class:`inspect.Parameter`
+# entries the ADK FunctionTool will expose to the model. ``task_id`` is
+# deliberately absent from every entry — the plugin's
+# ``before_tool_callback`` resolves it from session state, so the
+# model never sees the field in the tool declaration and cannot
+# abandon the protocol over optional-arg confusion.
+#
+# Callers that register custom reporting tools via
+# :meth:`ADKAdapter.register_reporting_tools` fall back to the legacy
+# ``**kwargs`` signature if their tool name isn't in this map; the
+# injection path in the plugin still hides ``task_id`` from them by
+# stamping it from state before the handler runs.
+def _reporting_tool_signatures() -> dict[str, list[inspect.Parameter]]:
+    P = inspect.Parameter
+    return {
+        "report_task_started": [
+            P("detail", P.KEYWORD_ONLY, default="", annotation=str),
+        ],
+        "report_task_progress": [
+            P("detail", P.KEYWORD_ONLY, default="", annotation=str),
+            P("fraction", P.KEYWORD_ONLY, default=None, annotation=float | None),
+        ],
+        "report_task_completed": [
+            P("summary", P.KEYWORD_ONLY, default="", annotation=str),
+        ],
+        "report_task_failed": [
+            P("reason", P.KEYWORD_ONLY, default="", annotation=str),
+            P("recoverable", P.KEYWORD_ONLY, default=None, annotation=bool | None),
+        ],
+        "report_task_blocked": [
+            P("blocker", P.KEYWORD_ONLY, default="", annotation=str),
+            P("needed", P.KEYWORD_ONLY, default="", annotation=str),
+        ],
+    }
+
+
+def _apply_llm_signature(shim: Any, tool_name: str) -> None:
+    """Attach a restricted ``__signature__`` to ``shim`` so ADK's
+    FunctionTool builds a declaration that hides ``task_id``.
+
+    No-op when ``tool_name`` isn't one of the built-ins — custom
+    reporting tools keep the permissive ``**kwargs`` signature they
+    had pre-#241 (the plugin's task_id injection still runs for them).
+    """
+    params_map = _reporting_tool_signatures()
+    params = params_map.get(tool_name)
+    if params is None:
+        return
+    try:
+        shim.__signature__ = inspect.Signature(parameters=params)
+    except (TypeError, ValueError) as exc:
+        log.debug(
+            "_apply_llm_signature: could not attach signature for %s: %s",
+            tool_name,
+            exc,
+        )
+
+
 def _build_function_tool(spec: ReportingToolSpec) -> Any:
     """Wrap a :class:`ReportingToolSpec` as a ``google.adk.tools.FunctionTool``."""
     from google.adk.tools import FunctionTool  # type: ignore
 
     shim = _build_ack_shim(spec.name, spec.description)
+    _apply_llm_signature(shim, spec.name)
     return FunctionTool(shim)
 
 
@@ -1065,6 +1137,15 @@ class ADKAdapter:
         # goldfive#139 and
         # :func:`_build_cancelled_response_event` for the content map.
         self._next_cancel_reason: str = ""
+        # Handle to the asyncio.Task currently executing
+        # :meth:`_invoke_internal` — captured via ``asyncio.current_task()``
+        # at entry and cleared in the ``finally`` block. Used by
+        # :meth:`request_cancel` (goldfive#241) to fire ``task.cancel()``
+        # on the in-flight invocation from a goldfive-promoted steer so
+        # the contaminated LLM call terminates early instead of running
+        # to completion while the steerer queues a restart for the next
+        # turn. ``None`` when no invocation is in-flight.
+        self._inflight_invoke_task: asyncio.Task[Any] | None = None
         # Outer session id pinned by :class:`GoldfiveADKAgent` when the
         # adapter runs inside adk-web. ``None`` for programmatic callers
         # and test harnesses; the adapter falls back to the lazy-uuid
@@ -1318,6 +1399,47 @@ class ADKAdapter:
         """
         self._steerer = steerer
 
+    async def request_cancel(self, reason: str) -> None:
+        """Cancel the in-flight ADK invocation so a goldfive-promoted
+        steer takes effect immediately rather than on the next turn.
+
+        goldfive#241 — the pre-unification goldfive-steer path (see
+        :meth:`goldfive.steerer.DefaultSteerer._promote_drift_to_steer`)
+        tagged ``_next_cancel_reason`` and queued a restart message but
+        left the in-flight ``runner.run_async`` stream running to
+        completion. Observed consequence: the coordinator kept writing
+        the contaminated reasoning / tool calls into the session for
+        tens of seconds after the drift fired, and the restart landed
+        only on the next turn. This method fires ``task.cancel()`` on
+        the asyncio task currently inside :meth:`_invoke_internal` so
+        the ``generate_content_async`` stream raises ``CancelledError``
+        and the adapter's standard heal path runs with the tag we just
+        stamped on ``_next_cancel_reason``.
+
+        ``reason`` is informational — the ``_next_cancel_reason`` tag
+        is already set by the steerer before this call; we log it here
+        purely for the operator log.
+
+        No-op when no invocation is in-flight (e.g. the drift fires
+        between turns) or when the pinned task is already finished —
+        the steerer's restart message still arrives on the next turn.
+        Never raises: adapters that ignore cancel still get the queued
+        restart via the pre-existing pathway.
+        """
+        task = self._inflight_invoke_task
+        if task is None or task.done():
+            log.debug(
+                "ADKAdapter.request_cancel(reason=%r): no in-flight "
+                "invocation; no-op",
+                reason,
+            )
+            return
+        log.info(
+            "adapter.request_cancel(reason=%r): cancelling in-flight invocation",
+            reason,
+        )
+        task.cancel()
+
     async def emit_reasoning(
         self,
         text: str,
@@ -1513,6 +1635,11 @@ class ADKAdapter:
         self._pending_tool_call_ids.clear()
         self._pending_tool_call_names.clear()
         was_cancelled = False
+        # Pin the task driving this invocation so request_cancel() can
+        # fire ``task.cancel()`` mid-stream (goldfive#241). Cleared in
+        # the ``finally`` block below so a stale handle cannot target
+        # the next invocation.
+        self._inflight_invoke_task = asyncio.current_task()
         try:
             async for event in self._runner.run_async(
                 user_id=self._user_id,
@@ -1633,6 +1760,9 @@ class ADKAdapter:
                     state.pop(SESSION_CONTEXT_STATE_KEY, None)  # type: ignore[attr-defined]
                 except Exception:
                     pass
+            # Release the in-flight task handle so a later
+            # request_cancel() cannot target a completed invocation.
+            self._inflight_invoke_task = None
 
         return InvocationResult(
             task_id=task_id,

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -381,6 +381,50 @@ still as a complete JSON plan, not an empty object).
 
 
 # ---------------------------------------------------------------------------
+# Shared refinement-guidance block (issue #241)
+# ---------------------------------------------------------------------------
+#
+# When a drift triggers refine, the LLM planner's free choice over
+# assignees and DAG shape is the source of two empirically-observed
+# failure modes:
+#
+#   1. Single-agent drift (e.g. research_agent wanders off-topic) gets
+#      "corrected" by reassigning the replacement to a different agent
+#      (e.g. web_developer_agent). The corrective work lands on an
+#      agent that has no relevant context.
+#   2. Multi-stage plans collapse to a single task on refine, because
+#      the LLM treats "refine" as "propose a simpler alternative" when
+#      the actual intent is a minimal correction.
+#
+# The guidance block below steers the planner toward the conservative
+# default (preserve the assignee + DAG shape, emit ``supersedes`` on
+# the replacement) and reserves restructuring for the cases where the
+# drift indicates the agent itself is the problem. Shared across the
+# refine prompt builders so the same contract applies to every refine
+# path that can reshape the plan in response to a drift.
+_REFINEMENT_GUIDANCE_BLOCK = (
+    "REFINEMENT GUIDANCE:\n"
+    "- The drift you're correcting is usually \"small\" — a single "
+    "agent produced off-topic or flawed output on a task it's "
+    "otherwise capable of. Default pattern: replace the drifted task "
+    "with a corrected variant, KEEP THE SAME `assignee_agent_id`, "
+    "and populate `supersedes: <old_task_id>` on the replacement. "
+    "Preserve the surrounding DAG structure (edges, sibling tasks, "
+    "stage count).\n"
+    "- Only reshape the plan (reassign tasks to different agents, "
+    "collapse stages, drop tasks) when the drift indicates the "
+    "agent is systemically incapable — repeated failures on the "
+    "same task, tool errors it can't recover from, refusal-by-the-"
+    "agent, or a pattern the original agent has already failed at.\n"
+    "- Do NOT collapse a multi-stage plan to a single task unless "
+    "the user request genuinely warrants it.\n"
+    "- The `supersedes` field is required on every replacement — "
+    "it's how runtime routing re-pins reports from the old task "
+    "to the new one."
+)
+
+
+# ---------------------------------------------------------------------------
 # JSON parsing helpers (ported from harmonograf_client.planner)
 # ---------------------------------------------------------------------------
 
@@ -1093,6 +1137,7 @@ class LLMPlanner:
             "preserve these verbatim at the start of the returned plan; "
             f"do NOT repeat them in your response):\n{history_json}\n\n"
             f"{directive_header}\n{note}\n\n"
+            f"{_REFINEMENT_GUIDANCE_BLOCK}\n\n"
             f"{invariants}\n\n"
             f"{closing}"
         )
@@ -1624,6 +1669,7 @@ class LLMPlanner:
             f"Current plan:\n{plan_json}\n\n"
             f"Drift event:\n{drift_json}\n\n"
             f"{observed_block}"
+            f"{_REFINEMENT_GUIDANCE_BLOCK}\n\n"
             f"{invariants_block}\n\n"
             "If the plan should change in light of this drift event, respond "
             "with an updated JSON plan using the same schema. If no change "
@@ -1973,6 +2019,7 @@ class LLMPlanner:
             f"Other unfinished tasks (you may keep, drop, or rework):\n"
             f"{json.dumps(others, default=str)}\n\n"
             f"Drift detail:\n{drift.detail}\n\n"
+            f"{_REFINEMENT_GUIDANCE_BLOCK}\n\n"
             f"{invariants_block}\n\n"
             "Generate the updated plan. Respond with JSON only."
         )

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -44,6 +44,7 @@ levels. See goldfive#142 for the full table.
 from __future__ import annotations
 
 import enum
+import inspect
 import json
 import logging
 import re
@@ -2461,6 +2462,45 @@ class DefaultSteerer:
             )
         return reason
 
+    async def _request_adapter_cancel(self, reason: str) -> None:
+        """Invoke the optional ``adapter.request_cancel(reason)`` hook.
+
+        goldfive#241 — a goldfive-promoted steer needs the in-flight
+        LLM call to stop NOW so the contaminated reasoning / tool
+        calls don't keep writing to the session while we queue the
+        restart. The ADK adapter exposes :meth:`ADKAdapter.request_cancel`
+        which fires ``task.cancel()`` on the asyncio task driving
+        ``runner.run_async`` so the stream raises ``CancelledError``
+        and the adapter's standard heal path runs with the already-
+        stamped ``_next_cancel_reason`` tag.
+
+        Optional protocol: adapters that don't implement the method
+        (Claude adapter, callable adapter, test stubs without live
+        invocations) keep the legacy deferred-cancel semantics —
+        ``_next_cancel_reason`` is still tagged, the restart message
+        is still queued, and the next executor checkpoint still
+        terminates the invocation. Tolerates an unbound adapter and
+        swallows every failure so a best-effort cancel cannot break
+        the promotion path.
+        """
+        adapter = self._adapter
+        if adapter is None:
+            return
+        fn = getattr(adapter, "request_cancel", None)
+        if not callable(fn):
+            return
+        try:
+            result = fn(reason)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "DefaultSteerer._request_adapter_cancel(reason=%r): "
+                "adapter raised: %s",
+                reason,
+                exc,
+            )
+
     # ------------------------------------------------------------------
     # goldfive-steer-unification: promotion policy + handler
     # ------------------------------------------------------------------
@@ -2603,6 +2643,15 @@ class DefaultSteerer:
             session._last_cancel_reason_prefix = cancel_reason
         except Exception:  # noqa: BLE001
             pass
+        # 1a. Fire the adapter's request_cancel so the in-flight LLM
+        # call terminates NOW instead of running to completion while
+        # we queue the restart (goldfive#241). Pre-#241 the cancel was
+        # deferred to the next executor checkpoint and the contaminated
+        # invocation finished first — tens of seconds of wasted work
+        # with tainted output landing on the wire. Optional protocol:
+        # adapters that don't implement ``request_cancel`` keep the
+        # legacy deferred-cancel semantics.
+        await self._request_adapter_cancel(cancel_reason)
         # 2. Stamp active-steer state + compose the restart body.
         at_turn = int(getattr(session, "_next_sequence", 0) or 0)
         body = self._compose_goldfive_steer_body(drift)

--- a/tests/test_goldfive_steer_request_cancel.py
+++ b/tests/test_goldfive_steer_request_cancel.py
@@ -1,0 +1,338 @@
+"""Adapter.request_cancel wiring for goldfive-promoted steers (goldfive#241).
+
+Pre-#241 a goldfive-detected drift that cleared the promotion
+threshold queued a restart message via ``pending_corrective_message``
+and tagged ``adapter._next_cancel_reason``, but the in-flight
+``runner.run_async`` stream kept running to completion. Observed
+consequence: the coordinator kept emitting contaminated reasoning /
+tool calls for tens of seconds after the drift fired, and the
+restart only landed on the next executor turn.
+
+#241 wires an optional ``adapter.request_cancel(reason)`` hook
+that the steerer fires on every promoted drift. The ADK adapter
+implements it by calling ``task.cancel()`` on the asyncio task
+inside :meth:`ADKAdapter._invoke_internal` so the LLM stream
+raises ``CancelledError`` and the adapter's standard heal path
+runs with the already-stamped ``_next_cancel_reason`` tag.
+
+This file pins:
+
+* A WARNING OFF_TOPIC drift fires ``adapter.request_cancel(
+  reason="goldfive_off_topic")`` exactly once.
+* The same reason stamped on ``_next_cancel_reason`` and passed to
+  ``request_cancel`` is byte-identical so operator logs line up.
+* An async ``request_cancel`` is awaited (not just scheduled).
+* A sync ``request_cancel`` is also supported (returns non-awaitable).
+* An adapter WITHOUT ``request_cancel`` keeps pre-#241 semantics —
+  the promotion path does not raise.
+* ``ADKAdapter.request_cancel`` is a no-op when no invocation is
+  in-flight (called between turns) and when called with a completed
+  task handle.
+* Calling ``ADKAdapter.request_cancel`` on a pinned in-flight task
+  actually fires ``task.cancel()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubPlanner:
+    """Minimal planner recording refine_steer calls."""
+
+    def __init__(self, revised: Plan | None = None) -> None:
+        self.refine_steer_calls: list[dict[str, Any]] = []
+        self.revised = revised
+
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        return self.revised
+
+    async def refine_steer(self, **kwargs: Any) -> Plan | None:
+        self.refine_steer_calls.append(kwargs)
+        return self.revised
+
+
+class _AsyncCancelAdapter:
+    """Adapter stub exposing an async ``request_cancel``."""
+
+    def __init__(self) -> None:
+        self._next_cancel_reason: str = ""
+        self.request_cancel_calls: list[str] = []
+
+    async def request_cancel(self, reason: str) -> None:
+        self.request_cancel_calls.append(reason)
+
+
+class _SyncCancelAdapter:
+    """Adapter stub whose ``request_cancel`` is synchronous.
+
+    The steerer must still call it successfully — the protocol only
+    requires "callable"; awaitable is optional.
+    """
+
+    def __init__(self) -> None:
+        self._next_cancel_reason: str = ""
+        self.request_cancel_calls: list[str] = []
+
+    def request_cancel(self, reason: str) -> None:
+        self.request_cancel_calls.append(reason)
+
+
+class _NoCancelHookAdapter:
+    """Adapter without ``request_cancel`` — models a non-ADK adapter."""
+
+    def __init__(self) -> None:
+        self._next_cancel_reason: str = ""
+
+
+class _RaisingCancelAdapter:
+    """Adapter whose ``request_cancel`` blows up.
+
+    The steerer must swallow it — a best-effort cancel cannot break
+    the promotion path; the queued restart message still arrives.
+    """
+
+    def __init__(self) -> None:
+        self._next_cancel_reason: str = ""
+        self.request_cancel_calls: list[str] = []
+
+    async def request_cancel(self, reason: str) -> None:
+        self.request_cancel_calls.append(reason)
+        raise RuntimeError("boom")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.COMPLETED),
+            Task(id="t2", title="T2", status=TaskStatus.RUNNING),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+
+
+def _make_session() -> Session:
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="ship it")],
+        plan=_make_plan(),
+        current_task_id="t2",
+    )
+
+
+def _bind(adapter: Any) -> tuple[DefaultSteerer, Session, _StubPlanner]:
+    steerer = DefaultSteerer(
+        goldfive_steer_threshold="warning",
+        goldfive_steer_suppression_window_turns=3,
+    )
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.COMPLETED),
+            Task(id="t2b", title="Replanned T2"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2b")],
+        revision_kind=DriftKind.OFF_TOPIC.value,
+        revision_severity=DriftSeverity.WARNING.value,
+        revision_index=1,
+    )
+    planner = _StubPlanner(revised=revised)
+    session = _make_session()
+    steerer.bind(sinks=[], planner=planner)
+    steerer.bind_adapter(adapter)
+    return steerer, session, planner
+
+
+# ---------------------------------------------------------------------------
+# Steerer -> adapter.request_cancel wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_goldfive_steer_request_cancel_fires() -> None:
+    """A WARNING goldfive-eligible drift fires request_cancel with the
+    goldfive_<kind> reason, exactly once."""
+    adapter = _AsyncCancelAdapter()
+    steerer, session, _ = _bind(adapter)
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="agent wandered",
+        current_task_id="t2",
+    )
+    await steerer._handle_drift(drift, session)
+    assert adapter.request_cancel_calls == ["goldfive_off_topic"]
+    # The same reason is on the cancel-tag so the adapter's healing
+    # path picks it up when CancelledError flows.
+    assert adapter._next_cancel_reason == "goldfive_off_topic"
+
+
+async def test_goldfive_steer_request_cancel_supports_sync_hook() -> None:
+    """A sync ``request_cancel`` callable is also respected."""
+    adapter = _SyncCancelAdapter()
+    steerer, session, _ = _bind(adapter)
+    drift = DriftEvent(
+        kind=DriftKind.INTENT_DIVERGENCE,
+        severity=DriftSeverity.CRITICAL,
+        detail="agent abandoned the goal",
+        current_task_id="t2",
+    )
+    await steerer._handle_drift(drift, session)
+    assert adapter.request_cancel_calls == ["goldfive_intent_divergence"]
+
+
+async def test_goldfive_steer_tolerates_adapter_without_request_cancel() -> None:
+    """An adapter without request_cancel still promotes drift and queues
+    the restart message — no raise, no missed cancel tag."""
+    adapter = _NoCancelHookAdapter()
+    steerer, session, planner = _bind(adapter)
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="minor wander",
+        current_task_id="t2",
+    )
+    await steerer._handle_drift(drift, session)
+    # Cancel-tag still stamped.
+    assert adapter._next_cancel_reason == "goldfive_off_topic"
+    # Refine still ran — the promotion path is intact.
+    assert planner.refine_steer_calls, "refine_steer should have fired"
+
+
+async def test_goldfive_steer_swallows_request_cancel_raise() -> None:
+    """A raising ``request_cancel`` cannot break the promotion path."""
+    adapter = _RaisingCancelAdapter()
+    steerer, session, planner = _bind(adapter)
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="explode",
+        current_task_id="t2",
+    )
+    # Must not raise out.
+    await steerer._handle_drift(drift, session)
+    assert adapter.request_cancel_calls == ["goldfive_off_topic"]
+    assert planner.refine_steer_calls, "refine should still have fired"
+
+
+async def test_user_steer_does_not_call_request_cancel() -> None:
+    """USER_STEER keeps its pre-unification executor-loop cancel path.
+    The promotion-specific ``request_cancel`` hook MUST NOT fire on a
+    USER_STEER drift (the executor owns that cancel; firing here
+    would double-cancel).
+    """
+    adapter = _AsyncCancelAdapter()
+    steerer, session, _ = _bind(adapter)
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.INFO,
+        detail="operator note",
+        current_task_id="t2",
+    )
+    await steerer._handle_drift(drift, session)
+    assert adapter.request_cancel_calls == []
+
+
+# ---------------------------------------------------------------------------
+# ADKAdapter.request_cancel behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_adk_adapter_request_cancel_is_noop_when_no_invocation() -> None:
+    """ADKAdapter.request_cancel with no pinned task is a no-op."""
+    pytest.importorskip("google.adk")
+    from goldfive.adapters.adk import ADKAdapter
+
+    adapter = ADKAdapter.__new__(ADKAdapter)
+    # Minimal attributes the method reads.
+    adapter._inflight_invoke_task = None
+    # Must not raise.
+    await adapter.request_cancel("goldfive_off_topic")
+
+
+async def test_adk_adapter_request_cancel_noop_when_task_done() -> None:
+    """A pinned-but-completed task is also a no-op path."""
+    pytest.importorskip("google.adk")
+    from goldfive.adapters.adk import ADKAdapter
+
+    adapter = ADKAdapter.__new__(ADKAdapter)
+
+    async def _done() -> None:
+        return
+
+    task = asyncio.create_task(_done())
+    await task  # drive it to done
+    adapter._inflight_invoke_task = task
+    await adapter.request_cancel("goldfive_off_topic")
+    # No failure expected; the task is already finished.
+    assert task.done()
+
+
+async def test_adk_adapter_request_cancel_fires_task_cancel() -> None:
+    """When a task IS in-flight, ``request_cancel`` fires ``task.cancel()``
+    and the coroutine observes ``CancelledError``."""
+    pytest.importorskip("google.adk")
+    from goldfive.adapters.adk import ADKAdapter
+
+    adapter = ADKAdapter.__new__(ADKAdapter)
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _body() -> None:
+        started.set()
+        try:
+            await asyncio.sleep(5.0)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = asyncio.create_task(_body())
+    await started.wait()
+    adapter._inflight_invoke_task = task
+    await adapter.request_cancel("goldfive_off_topic")
+    # Give the event loop a chance to propagate the cancel.
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    assert cancelled.is_set()

--- a/tests/test_hidden_task_id_schema.py
+++ b/tests/test_hidden_task_id_schema.py
@@ -1,0 +1,473 @@
+"""Hidden-from-LLM ``task_id`` schema + delegation-site pinning (goldfive#241).
+
+Pre-#241 the ``report_task_*`` tool schemas exposed ``task_id`` as
+an optional parameter. Live evidence showed LLMs confused by the
+optional-ness ("the function is still trying to use a task_id
+parameter even though the schema says it doesn't require any
+parameters") and abandoning the reporting protocol entirely.
+
+#241 drops ``task_id`` from the LLM-visible schema. The plugin's
+``before_tool_callback`` resolves the pin from session state and
+either:
+
+  * injects it into ``tool_args`` before the handler runs, or
+  * short-circuits the dispatch with a structured ``no_task_pinned``
+    error when neither the delegation-site pin nor the agent-turn
+    pin resolves.
+
+For coordinators that fire parallel AgentTool calls to the same
+sub-agent on a single turn, the agent-turn pin is not unique
+enough (all N parallel dispatches share the same agent_name). The
+plugin now stamps per-``function_call_id`` pins at the delegation
+site (``goldfive.pending_delegations``), resolved against
+``tool_args`` keyword overlap when there are multiple candidates.
+
+Skipped entirely when ``google.adk`` is not installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    _PENDING_DELEGATIONS_KEY,
+    SESSION_CONTEXT_STATE_KEY,
+    SessionContext,
+    _score_candidates_by_args,
+    _tokenize_for_matching,
+    make_adk_plugin,
+)
+from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID  # noqa: E402
+from goldfive.adapters.adk import (  # noqa: E402
+    _apply_llm_signature,
+    _build_ack_shim,
+    _build_function_tool,
+    _reporting_tool_signatures,
+)
+from goldfive.reporting import ReportingToolSpec  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers reused across tests
+# ---------------------------------------------------------------------------
+
+
+class _Ctx:
+    """Minimal ADK-callback-context stub with a mutable state dict.
+
+    Mirrors the fixture in tests/test_before_tool_task_id_injection.py
+    so the plugin's ``_resolve_ctx`` → ``_session_state_from_callback``
+    paths see the state we wire.
+    """
+
+    class _Session:
+        def __init__(self, state: dict) -> None:
+            self.state = state
+
+    def __init__(self, state: dict, function_call_id: str = "") -> None:
+        self._state = state
+        self.function_call_id = function_call_id
+
+    @property
+    def session(self) -> Any:
+        return _Ctx._Session(self._state)
+
+
+class _Tool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _AgentToolStub:
+    """Stubbed AgentTool — duck-types as ``(agent=..., name=...)``."""
+
+    def __init__(self, agent_name: str, tool_name: str = "") -> None:
+        class _Agent:
+            pass
+
+        a = _Agent()
+        a.name = agent_name
+        self.agent = a
+        self.name = tool_name or f"{agent_name}_tool"
+
+
+def _make_plugin_with_handler(tool_name: str, plan: Plan | None = None):
+    """Return (plugin, state_dict, captured) wired for a reporting tool."""
+    captured: list[dict[str, Any]] = []
+
+    async def handler(args: Any, session: Any, steerer: Any) -> dict[str, Any]:
+        captured.append(dict(args))
+        return {"acknowledged": True, "echo": dict(args)}
+
+    spec = ReportingToolSpec(
+        name=tool_name,
+        description="",
+        parameters={"type": "object", "properties": {}},
+        handler=handler,
+    )
+    plugin = make_adk_plugin(host_agent_name="coordinator")
+    session_obj = Session(run_id="run-1", plan=plan)
+    task = Task(id="t-ignored", title="x")
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session_obj,
+            steerer=None,
+            task=task,
+            tool_handlers={tool_name: handler},
+            tools=[spec],
+            host_agent_name="coordinator",
+        )
+    }
+    return plugin, state, captured, session_obj
+
+
+# ---------------------------------------------------------------------------
+# Schema visibility (task_id is NOT in the LLM-facing declaration)
+# ---------------------------------------------------------------------------
+
+
+def test_reporting_tool_signatures_omit_task_id() -> None:
+    """Every built-in reporting tool's declared signature must not
+    mention ``task_id`` — the LLM must never see it."""
+    sigs = _reporting_tool_signatures()
+    for tool_name, params in sigs.items():
+        names = [p.name for p in params]
+        assert "task_id" not in names, (
+            f"task_id leaked into LLM-facing schema for {tool_name}: {names}"
+        )
+
+
+def test_function_tool_declaration_excludes_task_id() -> None:
+    """Round-trip through ADK's FunctionTool — the declared parameters
+    the LLM sees must not include ``task_id``."""
+    for tool_name in (
+        "report_task_started",
+        "report_task_progress",
+        "report_task_completed",
+        "report_task_failed",
+        "report_task_blocked",
+    ):
+        spec = ReportingToolSpec(
+            name=tool_name,
+            description="doc",
+            parameters={"type": "object", "properties": {}},
+            handler=lambda *a, **k: {"acknowledged": True},
+        )
+        ft = _build_function_tool(spec)
+        decl = ft._get_declaration()
+        # FunctionDeclaration may have None parameters (no args at all)
+        # or a Schema with a properties map.
+        params = getattr(decl, "parameters", None)
+        if params is None:
+            continue
+        props = getattr(params, "properties", None) or {}
+        assert "task_id" not in props, (
+            f"task_id leaked into the FunctionDeclaration for {tool_name}: "
+            f"{list(props.keys())}"
+        )
+
+
+def test_apply_llm_signature_noop_for_unknown_tool() -> None:
+    """Custom tool names fall through to the legacy permissive
+    signature — the injection path still covers them."""
+    shim = _build_ack_shim("custom_tool", "doc")
+    _apply_llm_signature(shim, "custom_tool")
+    # No __signature__ attached when the name isn't one of the
+    # built-ins.
+    assert not hasattr(shim, "__signature__") or shim.__signature__ is None or (
+        "task_id" not in [p.name for p in shim.__signature__.parameters.values()]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Injection + short-circuit behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_hidden_task_id_populates_from_state() -> None:
+    """LLM calls ``report_task_started()`` with no task_id arg — the
+    callback populates from ``goldfive.current_task_id`` state before
+    the handler runs."""
+    plugin, state, captured, _ = _make_plugin_with_handler("report_task_started")
+    state[KEY_CURRENT_TASK_ID] = "t-pinned"
+
+    args: dict[str, Any] = {"detail": "starting"}
+    result = await plugin.before_tool_callback(
+        tool=_Tool("report_task_started"),
+        tool_args=args,
+        tool_context=_Ctx(state),
+    )
+    # Tool dispatch reached the handler — the args map was mutated
+    # to carry the pinned id.
+    assert result == {"acknowledged": True, "echo": {"task_id": "t-pinned", "detail": "starting"}}
+    assert captured == [{"task_id": "t-pinned", "detail": "starting"}]
+
+
+async def test_hidden_task_id_fails_when_state_empty() -> None:
+    """No pin anywhere → the dispatch short-circuits with a
+    structured ``no_task_pinned`` error.
+
+    This is the key contract change from #241 — pre-#241 we'd fall
+    through to the handler's ``missing_task_id`` path, which confused
+    the model and triggered retry loops. Failing fast with a clear
+    error prevents the loop and gives the LLM something actionable
+    to react to.
+    """
+    plugin, state, captured, _ = _make_plugin_with_handler("report_task_started")
+    # Deliberately not setting KEY_CURRENT_TASK_ID or pending_delegations.
+
+    args: dict[str, Any] = {"detail": "starting"}
+    result = await plugin.before_tool_callback(
+        tool=_Tool("report_task_started"),
+        tool_args=args,
+        tool_context=_Ctx(state),
+    )
+    assert result == {
+        "acknowledged": False,
+        "error": "no_task_pinned",
+        "detail": "no task bound to this agent invocation",
+    }
+    # Handler not invoked — captured stays empty.
+    assert captured == []
+
+
+# ---------------------------------------------------------------------------
+# Delegation-site pinning (Item 3-bis)
+# ---------------------------------------------------------------------------
+
+
+def _parallel_plan() -> Plan:
+    """Plan with two PENDING tasks both assigned to ``research_agent``.
+
+    The coordinator fires two parallel AgentTool calls with different
+    args (``topic=solar`` vs ``topic=wind``). Each call must resolve
+    to the correctly-matching task at the delegation site.
+    """
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar",
+                description="Gather facts on solar power",
+                assignee_agent_id="research_agent",
+                status=TaskStatus.PENDING,
+            ),
+            Task(
+                id="research_wind",
+                title="Research wind",
+                description="Gather facts on wind power",
+                assignee_agent_id="research_agent",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[],
+        summary="Parallel research",
+    )
+
+
+def _gated_plan() -> Plan:
+    """Plan where a PENDING task has an INCOMPLETE upstream predecessor.
+
+    The DAG-aware candidate filter must exclude tasks whose dependency
+    isn't COMPLETED yet — grafting onto them would be wrong even if
+    the args match.
+    """
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research",
+                title="Research raw",
+                description="Gather facts on solar power",
+                assignee_agent_id="research_agent",
+                status=TaskStatus.PENDING,  # upstream NOT COMPLETED
+            ),
+            Task(
+                id="synthesise",
+                title="Synthesise brief on solar",
+                description="Compile solar briefing after research",
+                assignee_agent_id="research_agent",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research", to_task_id="synthesise")],
+        summary="Gated",
+    )
+
+
+async def test_parallel_agenttool_resolves_by_args() -> None:
+    """Two parallel AgentTool calls with distinguishing args each
+    resolve to the matching plan task at the delegation site.
+
+    Post-conditions:
+      * ``goldfive.pending_delegations[fc_A]`` == ``research_solar``,
+      * ``goldfive.pending_delegations[fc_B]`` == ``research_wind``.
+
+    A subsequent ``report_task_completed()`` call inside the solar
+    sub-invocation (fc_A) reads the solar pin and attributes the
+    report correctly.
+    """
+    plan = _parallel_plan()
+    plugin, state, _captured, session_obj = _make_plugin_with_handler(
+        "report_task_completed", plan=plan
+    )
+
+    # Dispatch two parallel AgentTool calls with different args.
+    tool_solar = _AgentToolStub("research_agent", tool_name="research_agent_tool")
+    tool_wind = _AgentToolStub("research_agent", tool_name="research_agent_tool")
+
+    ctx_solar = _Ctx(state, function_call_id="fc_solar")
+    ctx_wind = _Ctx(state, function_call_id="fc_wind")
+    await plugin.before_tool_callback(
+        tool=tool_solar,
+        tool_args={"topic": "solar power basics"},
+        tool_context=ctx_solar,
+    )
+    await plugin.before_tool_callback(
+        tool=tool_wind,
+        tool_args={"topic": "wind turbines overview"},
+        tool_context=ctx_wind,
+    )
+
+    pending = session_obj.state.get(_PENDING_DELEGATIONS_KEY) or {}
+    assert pending.get("fc_solar") == "research_solar", pending
+    assert pending.get("fc_wind") == "research_wind", pending
+
+
+async def test_parallel_agenttool_falls_through_on_ambiguous_args() -> None:
+    """Parallel dispatches whose args don't distinguish candidates
+    produce no delegation pin; sub-invocations fall back to the
+    agent-turn pin path (which, for an ambiguous coordinator, ALSO
+    leaves state unset — no guess)."""
+    plan = _parallel_plan()
+    plugin, state, _captured, session_obj = _make_plugin_with_handler(
+        "report_task_completed", plan=plan
+    )
+
+    tool = _AgentToolStub("research_agent", tool_name="research_agent_tool")
+    ctx = _Ctx(state, function_call_id="fc_ambig")
+    # Args don't carry distinguishing keywords.
+    await plugin.before_tool_callback(
+        tool=tool,
+        tool_args={"misc": "please proceed"},
+        tool_context=ctx,
+    )
+
+    pending = session_obj.state.get(_PENDING_DELEGATIONS_KEY) or {}
+    assert pending.get("fc_ambig") is None, (
+        "Ambiguous args must NOT produce a delegation pin; fall "
+        "through to the legacy path."
+    )
+
+
+async def test_dag_aware_candidate_filter() -> None:
+    """A PENDING task whose upstream is not COMPLETED is NOT eligible
+    to be the target of a delegation."""
+    plan = _gated_plan()
+    plugin, state, _captured, session_obj = _make_plugin_with_handler(
+        "report_task_completed", plan=plan
+    )
+
+    tool = _AgentToolStub("research_agent", tool_name="research_agent_tool")
+    ctx = _Ctx(state, function_call_id="fc_gated")
+    # Args that would match BOTH tasks' descriptions ("solar").
+    await plugin.before_tool_callback(
+        tool=tool,
+        tool_args={"topic": "solar briefing"},
+        tool_context=ctx,
+    )
+
+    pending = session_obj.state.get(_PENDING_DELEGATIONS_KEY) or {}
+    pinned = pending.get("fc_gated")
+    # Only "research" is upstream-clear (no predecessors); the
+    # "synthesise" task is gated on "research". The pin must be on
+    # "research" — NOT on "synthesise" even though its description
+    # also matches "solar".
+    assert pinned == "research", (
+        f"DAG-aware filter should have excluded the gated 'synthesise' task; "
+        f"got {pinned!r}"
+    )
+
+
+async def test_delegation_pin_beats_agent_turn_pin() -> None:
+    """When both a delegation-site pin (via ``pending_delegations``)
+    AND an agent-turn pin (``goldfive.current_task_id``) are
+    available, the delegation pin wins — it's the more specific
+    resolution."""
+    plan = _parallel_plan()
+    plugin, state, captured, session_obj = _make_plugin_with_handler(
+        "report_task_completed", plan=plan
+    )
+
+    # Simulate: coordinator already stamped delegation pin for fc_A
+    # on the ADK tool_context state (this is what the reporting-tool
+    # callback reads from).
+    state[_PENDING_DELEGATIONS_KEY] = {"fc_A": "research_solar"}
+    # Agent-turn pin sits on a different task (stale from an earlier turn).
+    state[KEY_CURRENT_TASK_ID] = "research_wind"
+
+    args: dict[str, Any] = {"summary": "done"}
+    await plugin.before_tool_callback(
+        tool=_Tool("report_task_completed"),
+        tool_args=args,
+        tool_context=_Ctx(state, function_call_id="fc_A"),
+    )
+
+    # The delegation-site pin wins — handler sees research_solar.
+    assert captured == [{"task_id": "research_solar", "summary": "done"}]
+
+
+# ---------------------------------------------------------------------------
+# Scoring / tokenisation unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_tokenize_for_matching_filters_short_tokens() -> None:
+    """Tokens must be lowercase, alphanumeric, length ≥4."""
+    toks = _tokenize_for_matching("Research Solar Power (2026 edition)")
+    assert "research" in toks
+    assert "solar" in toks
+    assert "power" in toks
+    # Short / noise tokens filtered.
+    assert "in" not in toks
+    # Year (4 digits) included — still ≥4.
+    assert "2026" in toks
+
+
+def test_score_candidates_by_args_picks_best_match() -> None:
+    """Highest-overlap candidate wins; ties return None."""
+
+    class _T:
+        def __init__(self, title: str, description: str = "") -> None:
+            self.title = title
+            self.description = description
+
+    solar = _T("Research solar power", "")
+    wind = _T("Research wind turbines", "")
+    choice = _score_candidates_by_args(
+        [solar, wind],
+        {"topic": "solar basics for beginners"},
+    )
+    assert choice is solar
+
+    # Tie → None (args match neither uniquely).
+    choice = _score_candidates_by_args(
+        [solar, wind],
+        {"note": "please proceed"},  # no matching tokens
+    )
+    assert choice is None

--- a/tests/test_planner_refine_guidance.py
+++ b/tests/test_planner_refine_guidance.py
@@ -1,0 +1,246 @@
+"""Refinement-guidance block tests (goldfive#241 Item 1).
+
+When the planner's refine-prompt builders render their user prompt,
+they must include a REFINEMENT GUIDANCE block that steers the
+planner-LLM toward the conservative correction pattern (preserve the
+drifted task's assignee, preserve the DAG shape, emit ``supersedes``
+on replacements) rather than reshaping the plan on every small drift.
+
+The live evidence behind this block: a research_agent drift on a
+multi-stage plan caused the LLM to collapse 5 stages to 1 task and
+reassign it to web_developer_agent. The correction never ran on
+research_agent and the replacement landed on an agent with no
+relevant context. See goldfive#241 for the full trace.
+
+These tests are pure prompt-text assertions — the goal is to pin
+that every refine path that can reshape the plan on a drift carries
+the guidance block. No LLM is invoked.
+"""
+
+from __future__ import annotations
+
+import json
+
+from goldfive.planner import (
+    _REFINEMENT_GUIDANCE_BLOCK,
+    LLMPlanner,
+)
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _base_goals() -> list[Goal]:
+    return [Goal(id="g1", summary="Ship the thing.")]
+
+
+def _plan_with_running_task() -> Plan:
+    return Plan(
+        id="plan-1",
+        run_id="run-1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research",
+                title="Research goldfish facts",
+                description="Gather facts.",
+                assignee_agent_id="research_agent",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="draft",
+                title="Draft the post",
+                description="Write a 500-word draft.",
+                assignee_agent_id="writer",
+                status=TaskStatus.RUNNING,
+            ),
+            Task(
+                id="review",
+                title="Review the draft",
+                description="Editorial pass.",
+                assignee_agent_id="editor",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft"),
+            TaskEdge(from_task_id="draft", to_task_id="review"),
+        ],
+        summary="Blog post pipeline.",
+        revision_index=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt-text assertions
+# ---------------------------------------------------------------------------
+
+
+def test_guidance_block_constant_contains_key_instructions() -> None:
+    """Sanity-pin the constant's wording so accidental edits that
+    dilute the guidance fail loudly. The three load-bearing phrases
+    are the preserve-assignee rule, the supersedes requirement, and
+    the don't-collapse-stages clause."""
+    text = _REFINEMENT_GUIDANCE_BLOCK
+    assert "REFINEMENT GUIDANCE" in text
+    assert "KEEP THE SAME `assignee_agent_id`" in text
+    assert "supersedes" in text
+    assert "systemically incapable" in text
+    assert "Do NOT collapse a multi-stage plan to a single task" in text
+
+
+def test_guidance_appears_in_steer_prompt_user_source() -> None:
+    """``_build_steer_prompt(source='user')`` is the user-steer path;
+    must carry the guidance."""
+    planner = LLMPlanner(call_llm=_StubLLM(response=""))
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="focus on X instead",
+        current_task_id="draft",
+    )
+    prompt = planner._build_steer_prompt(
+        completed=[_plan_with_running_task().tasks[0]],
+        drift=drift,
+        goals=_base_goals(),
+        source="user",
+    )
+    assert "REFINEMENT GUIDANCE" in prompt
+    assert "KEEP THE SAME `assignee_agent_id`" in prompt
+
+
+def test_guidance_appears_in_steer_prompt_goldfive_source() -> None:
+    """``_build_steer_prompt(source='goldfive')`` is the promoted
+    goldfive-detected-drift path (post-#240 steer unification); must
+    carry the guidance."""
+    planner = LLMPlanner(call_llm=_StubLLM(response=""))
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="research_agent wandered into raccoons",
+        current_task_id="research",
+    )
+    prompt = planner._build_steer_prompt(
+        completed=[],
+        drift=drift,
+        goals=_base_goals(),
+        source="goldfive",
+    )
+    assert "REFINEMENT GUIDANCE" in prompt
+    assert "supersedes" in prompt
+
+
+def test_guidance_appears_in_generic_refine_prompt() -> None:
+    """``_build_refine_prompt`` is the generic refine entry — used by
+    TOOL_ERROR, AGENT_REFUSAL, NEW_WORK_DISCOVERED, etc."""
+    planner = LLMPlanner(call_llm=_StubLLM(response=""))
+    drift = DriftEvent(
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.WARNING,
+        detail="tool foo returned 500",
+        current_task_id="draft",
+    )
+    prompt = planner._build_refine_prompt(
+        plan=_plan_with_running_task(),
+        drift=drift,
+        goals=_base_goals(),
+    )
+    assert "REFINEMENT GUIDANCE" in prompt
+    assert "Do NOT collapse a multi-stage plan" in prompt
+
+
+def test_guidance_appears_in_looping_tool_call_prompt() -> None:
+    """``_build_looping_tool_call_prompt`` is the fail-and-regenerate
+    path; must carry the guidance too — the "route around a loop"
+    repair is structurally the same kind of reshape decision."""
+    planner = LLMPlanner(call_llm=_StubLLM(response=""))
+    plan = _plan_with_running_task()
+    looping = plan.tasks[1]  # draft
+    drift = DriftEvent(
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        severity=DriftSeverity.WARNING,
+        detail="writer stuck in a search loop",
+        current_task_id="draft",
+    )
+    prompt = planner._build_looping_tool_call_prompt(
+        plan=plan,
+        drift=drift,
+        goals=_base_goals(),
+        looping_task=looping,
+    )
+    assert "REFINEMENT GUIDANCE" in prompt
+    assert "assignee_agent_id" in prompt
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: refine() threads the guidance through to the LLM call
+# ---------------------------------------------------------------------------
+
+
+async def test_refine_guidance_reaches_llm_via_plan_divergence() -> None:
+    """Send a PLAN_DIVERGENCE drift (no observed_actions) through the
+    generic refine path and assert the captured LLM user prompt
+    carries the guidance block. This is the outermost assertion:
+    short-circuiting the prompt builder without updating refine()
+    would still pass the direct-builder tests above."""
+    # Echo plan — valid revision returning the plan unchanged.
+    plan = _plan_with_running_task()
+    echo = json.dumps(
+        {
+            "summary": plan.summary,
+            "tasks": [
+                {
+                    "id": t.id,
+                    "title": t.title,
+                    "description": t.description,
+                    "assignee_agent_id": t.assignee_agent_id,
+                    "status": str(t.status),
+                }
+                for t in plan.tasks
+            ],
+            "edges": [
+                {"from_task_id": e.from_task_id, "to_task_id": e.to_task_id}
+                for e in plan.edges
+            ],
+        }
+    )
+    stub = _StubLLM(response=echo)
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="observed agent activity diverges",
+        current_task_id="draft",
+    )
+    await planner.refine(plan=plan, drift=drift, goals=_base_goals())
+    assert stub.calls, "LLM was not invoked"
+    _system, user_prompt, _model = stub.calls[0]
+    assert "REFINEMENT GUIDANCE" in user_prompt
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubLLM:
+    """Minimal call_llm stub that captures prompts."""
+
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        self.calls.append((system, user, model))
+        return self.response


### PR DESCRIPTION
Closes #245.

## Summary

Three coordinated changes so goldfive's steering actually directs agent behavior instead of merely documenting interventions. The three are thematically unified and ship together.

### 1. Refine prompt preserves assignee + DAG shape

Add a shared REFINEMENT GUIDANCE block to the three refine-prompt builders (`_build_steer_prompt`, `_build_refine_prompt`, `_build_looping_tool_call_prompt`). The block steers the planner-LLM toward the conservative default (replace the drifted task with a corrected variant, keep the same `assignee_agent_id`, emit `supersedes: <old_id>` on the replacement, preserve the surrounding DAG) and reserves reshaping for cases where the agent itself is the problem. Explicitly discourages collapsing a multi-stage plan to a single task.

**Live evidence**: research_agent drift refined into a single web_developer_agent task — original agent never saw the correction, replacement had no relevant context.

### 2. Real cancel for goldfive-promoted steers

Pre-#240 the goldfive-steer path tagged `_next_cancel_reason` and queued a restart message via `pending_corrective_message`, but the in-flight LLM call ran to completion. Observed: 37s of contaminated output after the drift fired.

Add an optional `adapter.request_cancel(reason)` protocol hook:

- **ADKAdapter** pins the asyncio task driving `_invoke_internal` (captured via `asyncio.current_task()` at entry, cleared in the finally block) and fires `task.cancel()` on it so the `runner.run_async` stream raises `CancelledError` and the adapter's standard heal path runs with the already-stamped `_next_cancel_reason` tag.
- **DefaultSteerer._promote_drift_to_steer** calls the hook right after stamping the cancel reason.
- Adapters without the hook (Claude, callable, test stubs) keep the pre-#241 deferred-cancel semantics — the queued restart still arrives on the next executor turn.

USER_STEER keeps its executor-loop cancel path unchanged; the new hook fires only on goldfive-promoted drifts so the two don't double-cancel.

### 3. Hidden `task_id` schema + delegation-site pinning

Drop `task_id` from the LLM-visible `report_task_*` tool declarations. Attach explicit `inspect.Signature` to the built-in shims so ADK's `FunctionTool` builds a declaration without `task_id`.

**Live reasoning from the model that motivated this**: "the function is still trying to use a task_id parameter even though the schema says it doesn't require any parameters".

`_inject_task_id_from_state` now returns a bool; the callback short-circuits with `{"error": "no_task_pinned", "detail": "no task bound to this agent invocation"}` when neither pin resolves — better than invoking the handler on an unpinned call.

For parallel same-agent AgentTool dispatches, the agent-turn pin isn't unique (all N parallel calls share the same `(agent_name, session.state)` pair). Add a delegation-site pin keyed by `function_call_id` (`goldfive.pending_delegations`): when the `before_tool_callback` sees an AgentTool dispatch, resolve PENDING/RUNNING tasks assigned to the sub-agent, filter by DAG-ready upstream, and score against `tool_args` keyword overlap with `title + description` when there are multiple candidates. The reporting-tool callback inside the sub-invocation reads back via `function_call_id`, beating the stale agent-turn pin.

## Test plan

- [x] `uv run pytest -q` — 1412 passed, 46 skipped (previously 1387, +25 new tests)
- [x] `uv run ruff check` — clean on all touched files
- [x] `uv run mypy` — no new errors on touched files (11 pre-existing errors unchanged)
- [x] Prompt-text assertions in `test_planner_refine_guidance.py` (6 tests) pin the guidance block through every refine path.
- [x] `test_goldfive_steer_request_cancel.py` (8 tests) covers async / sync / missing / raising `request_cancel`, the USER_STEER no-call guarantee, and ADKAdapter-level no-op / task-done / real-cancel semantics.
- [x] `test_hidden_task_id_schema.py` (11 tests) covers schema hiding (FunctionDeclaration round-trip), state-pin short-circuit, parallel-dispatch args-matching, DAG-aware filter, delegation-pin-beats-agent-turn-pin, plus tokenisation / scoring helpers.
- [ ] Live harmonograf session to confirm the three load-bearing behaviors (operator to follow up): refine preserves assignee, mid-invocation drift actually kills the LLM call, reporting calls succeed on the first try.