### PR TITLE
fix(steerer): revert #246's real-cancel path (causes run_abort)

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -2643,15 +2643,21 @@ class DefaultSteerer:
             session._last_cancel_reason_prefix = cancel_reason
         except Exception:  # noqa: BLE001
             pass
-        # 1a. Fire the adapter's request_cancel so the in-flight LLM
-        # call terminates NOW instead of running to completion while
-        # we queue the restart (goldfive#241). Pre-#241 the cancel was
-        # deferred to the next executor checkpoint and the contaminated
-        # invocation finished first — tens of seconds of wasted work
-        # with tainted output landing on the wire. Optional protocol:
-        # adapters that don't implement ``request_cancel`` keep the
-        # legacy deferred-cancel semantics.
-        await self._request_adapter_cancel(cancel_reason)
+        # 1a. NOTE (#241 emergency revert): previously we fired
+        # ``adapter.request_cancel(reason)`` here to terminate the
+        # in-flight LLM call immediately. In practice that
+        # ``task.cancel()`` propagated a ``CancelledError`` past the
+        # executor's invocation-scope catch and killed the entire run
+        # — observed as ``run_aborted`` immediately after a
+        # goldfive-detected drift. Reverted to the pre-#241 deferred-
+        # cancel semantics: we stamp ``_next_cancel_reason`` (above)
+        # and queue a restart message; the executor loop sees the
+        # queue at the next invocation boundary and resumes with the
+        # refined plan. The taint of letting the in-flight call run
+        # to completion is a lesser evil than aborting the run.
+        # Proper fix (future): scope the cancel to the LLM stream
+        # only, or catch ``CancelledError`` at the goldfive-steer
+        # boundary and continue.
         # 2. Stamp active-steer state + compose the restart body.
         at_turn = int(getattr(session, "_next_sequence", 0) or 0)
         body = self._compose_goldfive_steer_body(drift)

--- a/tests/test_goldfive_steer_request_cancel.py
+++ b/tests/test_goldfive_steer_request_cancel.py
@@ -200,7 +200,7 @@ async def test_goldfive_steer_request_cancel_fires() -> None:
         current_task_id="t2",
     )
     await steerer._handle_drift(drift, session)
-    assert adapter.request_cancel_calls == ["goldfive_off_topic"]
+    assert adapter.request_cancel_calls == []  # reverted: deferred-cancel only
     # The same reason is on the cancel-tag so the adapter's healing
     # path picks it up when CancelledError flows.
     assert adapter._next_cancel_reason == "goldfive_off_topic"
@@ -217,7 +217,7 @@ async def test_goldfive_steer_request_cancel_supports_sync_hook() -> None:
         current_task_id="t2",
     )
     await steerer._handle_drift(drift, session)
-    assert adapter.request_cancel_calls == ["goldfive_intent_divergence"]
+    assert adapter.request_cancel_calls == []  # reverted: deferred-cancel only
 
 
 async def test_goldfive_steer_tolerates_adapter_without_request_cancel() -> None:
@@ -250,7 +250,7 @@ async def test_goldfive_steer_swallows_request_cancel_raise() -> None:
     )
     # Must not raise out.
     await steerer._handle_drift(drift, session)
-    assert adapter.request_cancel_calls == ["goldfive_off_topic"]
+    assert adapter.request_cancel_calls == []  # reverted: deferred-cancel only
     assert planner.refine_steer_calls, "refine should still have fired"
 
 


### PR DESCRIPTION
## Emergency revert

#246's \`adapter.request_cancel(reason)\` call in \`_promote_drift_to_steer\` causes the **entire run to abort** on any WARNING+ goldfive-detected drift. Live session evidence:

\`\`\`
INFO reasoning_judge.py: classify_reasoning_drift: drift detected (severity=warning,
     reason='The agent hallucinates an unrelated research topic (raccoons)...');
     emitting OFF_TOPIC event
INFO adk.py: adapter.request_cancel(reason='goldfive_off_topic'): cancelling in-flight invocation
→ run_aborted
\`\`\`

No refine, no restart. The whole session dies on first drift.

## Root cause

\`ADKAdapter.request_cancel()\` calls \`task.cancel()\` on the pinned in-flight invocation task. The \`CancelledError\` propagates up past the executor's invocation-scope catch and terminates the whole run coroutine — not just the LLM stream we wanted to interrupt.

## Revert scope

Drops the \`_request_adapter_cancel(cancel_reason)\` call from \`_promote_drift_to_steer\`. The rest of the path is preserved:
- \`_tag_adapter_cancel_reason_for_promotion\` still stamps \`_next_cancel_reason\`.
- Session-visible cancel prefix still set.
- The queued restart message still composed.
- Plan refine still fires.
- Executor sees the queue at the next invocation checkpoint and resumes with the refined plan.

This is the pre-#246 deferred-cancel semantics. At worst the contaminated in-flight invocation runs to completion before the refine takes effect — a lesser evil than aborting the run.

The \`ADKAdapter.request_cancel\` method stays defined so a proper fix can re-land later without re-adding the adapter hook.

## Tests

\`tests/test_goldfive_steer_request_cancel.py\` updated to assert the reverted semantics:
- \`adapter.request_cancel_calls == []\` (cancel NOT fired).
- \`adapter._next_cancel_reason == "goldfive_off_topic"\` (still stamped).
- \`planner.refine_steer_calls\` truthy (refine still fires).

Full suite: 1439 passed, 46 skipped.

## Proper fix (separate PR, later)

Scope the cancel to just the LLM response stream, or catch \`CancelledError\` at the goldfive-steer boundary in the executor and continue into the refine path. Design discussion needed.