### PR TITLE
fix(adk): report_task_* no-op when no task pinned (prevents LLM protocol bypass after refine)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -2344,9 +2344,19 @@ def make_adk_plugin(
             # goldfive#241 — task_id is hidden from the LLM-facing
             # reporting-tool schema so the model never supplies it.
             # Resolve from state (delegation-site pin first, then the
-            # agent-turn pin). If neither resolves, short-circuit with
-            # a structured ``no_task_pinned`` error — better than
-            # invoking the handler on an unbound reporting call.
+            # agent-turn pin). If neither resolves, return a silent
+            # acknowledgment so the agent's reporting protocol does
+            # NOT crash on plan-revision boundaries that leave the
+            # current agent without a pinned task (e.g. a coordinator
+            # whose own tasks were superseded by refine into tasks
+            # assigned to other agents). A loud error here makes the
+            # LLM bypass the reporting protocol entirely — observed in
+            # live session where the coordinator saw ``no_task_pinned``
+            # post-revision and reasoned "Let me proceed directly with
+            # the research_agent call since the user has already given
+            # me the topic," abandoning the reporting contract.
+            # Observability is preserved via the INFO log below; the
+            # agent sees a no-op success and continues.
             pinned = _inject_task_id_from_state(
                 tool_name=tool_name,
                 tool_args=tool_args,
@@ -2355,13 +2365,16 @@ def make_adk_plugin(
             if _is_reporting_tool_name(tool_name) and not pinned:
                 log.info(
                     "before_tool_callback: no task pinned for %s; "
-                    "short-circuiting with no_task_pinned",
+                    "returning no-op acknowledgment (orchestration-only turn)",
                     tool_name,
                 )
                 return {
-                    "acknowledged": False,
-                    "error": "no_task_pinned",
-                    "detail": "no task bound to this agent invocation",
+                    "acknowledged": True,
+                    "no_task_pinned": True,
+                    "detail": (
+                        "no task currently bound to this agent; "
+                        "report recorded as orchestration-only no-op"
+                    ),
                 }
 
             tool_names_registered = {spec.name for spec in ctx.tools}

--- a/tests/test_hidden_task_id_schema.py
+++ b/tests/test_hidden_task_id_schema.py
@@ -213,15 +213,19 @@ async def test_hidden_task_id_populates_from_state() -> None:
     assert captured == [{"task_id": "t-pinned", "detail": "starting"}]
 
 
-async def test_hidden_task_id_fails_when_state_empty() -> None:
-    """No pin anywhere → the dispatch short-circuits with a
-    structured ``no_task_pinned`` error.
+async def test_hidden_task_id_is_noop_when_state_empty() -> None:
+    """No pin anywhere → the dispatch returns a no-op acknowledgment.
 
-    This is the key contract change from #241 — pre-#241 we'd fall
-    through to the handler's ``missing_task_id`` path, which confused
-    the model and triggered retry loops. Failing fast with a clear
-    error prevents the loop and gives the LLM something actionable
-    to react to.
+    This replaces an earlier "fail with no_task_pinned error" contract.
+    The error variant crashed the LLM's reporting protocol when
+    goldfive's refine moved an agent's assigned work to another agent
+    (e.g. a coordinator whose own tasks were superseded into
+    sub-agent tasks). Observed live: the LLM saw the error and
+    reasoned "task started report didn't work, let me proceed directly
+    with the research_agent call," bypassing the reporting contract
+    entirely. Returning a silent no-op acknowledgment keeps the
+    agent's protocol intact; observability is preserved via an INFO
+    log from the plugin.
     """
     plugin, state, captured, _ = _make_plugin_with_handler("report_task_started")
     # Deliberately not setting KEY_CURRENT_TASK_ID or pending_delegations.
@@ -233,11 +237,14 @@ async def test_hidden_task_id_fails_when_state_empty() -> None:
         tool_context=_Ctx(state),
     )
     assert result == {
-        "acknowledged": False,
-        "error": "no_task_pinned",
-        "detail": "no task bound to this agent invocation",
+        "acknowledged": True,
+        "no_task_pinned": True,
+        "detail": (
+            "no task currently bound to this agent; "
+            "report recorded as orchestration-only no-op"
+        ),
     }
-    # Handler not invoked — captured stays empty.
+    # Handler not invoked — captured stays empty (nothing to report on).
     assert captured == []
 
 


### PR DESCRIPTION
## Summary

Critical regression fix. After goldfive#241/#246 hid \`task_id\` from the LLM-facing reporting-tool schema and started short-circuiting with \`{"error": "no_task_pinned"}\` when no pin resolves, plan revisions that move an agent's work to other agents leave that agent with no pinnable task — and the LLM bypasses the reporting protocol.

Live session evidence (coordinator's reasoning at thought #5):

> "The task started report didn't work because there's no pinned task. Let me proceed directly with the research_agent call since the user has already given me the topic (solar panels). I need to gather comprehensive context and facts about solar panels."

The coordinator then proceeded to feed the raccoon-contaminated research to the web developer.

## Fix

Change the no-pin short-circuit from an error response to a no-op acknowledgment:

\`\`\`json
{"acknowledged": true, "no_task_pinned": true, "detail": "..."}
\`\`\`

The agent's LLM sees a success, the reporting protocol stays intact, and orchestration-only turns (delegation-only, no specific task) behave correctly. Observability preserved via the existing INFO log.

## Test

\`test_hidden_task_id_is_noop_when_state_empty\` (renamed from \`test_hidden_task_id_fails_when_state_empty\`) asserts the new contract. Full suite: 1458 passed, 46 skipped.