### PR TITLE
fix(adk): drop detail leak + surface pin-unresolved when agent has work

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -254,6 +254,51 @@ def _is_reporting_tool_name(tool_name: str) -> bool:
     return tool_name.startswith("report_task_") or tool_name == _REPORT_AWAITING_APPROVAL
 
 
+def _agent_has_pending_candidates(ctx: Any, agent_name: str) -> bool:
+    """Return True if the plan has any PENDING/RUNNING task for ``agent_name``.
+
+    Used to distinguish the two failure modes when the reporting-tool
+    ``task_id`` pin cannot be resolved (goldfive#250 follow-up):
+
+    * **No candidates** — the agent's work was moved to other agents by
+      a plan refine; a silent-ack no-op is correct.
+    * **Has candidates** — the pin SHOULD have worked (single match, or
+      delegation-site pin, or fallback). A silent ack would mask a real
+      stall; the caller surfaces ``{"acknowledged": False,
+      "error": "pin_unresolved"}`` instead.
+
+    NOTE: the DAG-readiness gate from
+    :meth:`_pin_current_task_id_for_agent` is intentionally NOT applied
+    here. Even a DAG-gated candidate means the agent's turn shouldn't
+    be happening yet, which is also a stall worth surfacing rather than
+    silencing.
+
+    Silent on every failure (missing ctx / plan / non-iterable tasks);
+    the caller falls back to the conservative silent-ack path when this
+    returns ``False``.
+    """
+    if not agent_name:
+        return False
+    try:
+        plan = _safe_attr(ctx, "session", None)
+        plan = _safe_attr(plan, "plan", None) if plan is not None else None
+        if plan is None:
+            return False
+        tasks = _safe_attr(plan, "tasks", None) or ()
+        from goldfive.types import TaskStatus
+
+        for task in tasks:
+            assignee = str(_safe_attr(task, "assignee_agent_id", "") or "")
+            if assignee != agent_name:
+                continue
+            status = _safe_attr(task, "status", None)
+            if status is TaskStatus.PENDING or status is TaskStatus.RUNNING:
+                return True
+    except Exception:  # noqa: BLE001 — diagnostic-only
+        return False
+    return False
+
+
 def _inject_task_id_from_state(
     *,
     tool_name: str,
@@ -2344,38 +2389,104 @@ def make_adk_plugin(
             # goldfive#241 — task_id is hidden from the LLM-facing
             # reporting-tool schema so the model never supplies it.
             # Resolve from state (delegation-site pin first, then the
-            # agent-turn pin). If neither resolves, return a silent
-            # acknowledgment so the agent's reporting protocol does
-            # NOT crash on plan-revision boundaries that leave the
-            # current agent without a pinned task (e.g. a coordinator
-            # whose own tasks were superseded by refine into tasks
-            # assigned to other agents). A loud error here makes the
-            # LLM bypass the reporting protocol entirely — observed in
-            # live session where the coordinator saw ``no_task_pinned``
-            # post-revision and reasoned "Let me proceed directly with
-            # the research_agent call since the user has already given
-            # me the topic," abandoning the reporting contract.
-            # Observability is preserved via the INFO log below; the
-            # agent sees a no-op success and continues.
+            # agent-turn pin). If neither resolves, the response branch
+            # depends on whether the current agent actually has work in
+            # the plan (goldfive#250 follow-up):
+            #
+            # * **No PENDING/RUNNING candidates for this agent** — a
+            #   legit orchestration-only turn (e.g. coordinator whose
+            #   tasks were superseded by a plan refine into tasks
+            #   assigned to other agents). Return a bare silent
+            #   acknowledgment so the agent's reporting protocol does
+            #   NOT crash on plan-revision boundaries. A loud error
+            #   here makes the LLM bypass the reporting protocol —
+            #   observed live.
+            # * **Has candidates** — the pin SHOULD have worked; a
+            #   silent ack would mask a real stall. Return a
+            #   structured ``pin_unresolved`` error so the stall is
+            #   visible.
+            #
+            # The silent-ack response carries NO ``detail`` / explanatory
+            # keys — tool responses go back to the LLM verbatim and any
+            # editorialising string is treated as actionable context
+            # (observed live: research_agent paraphrased a detail string
+            # into its reasoning and proceeded with stale pre-refine
+            # instructions, ignoring the refined scope).
             pinned = _inject_task_id_from_state(
                 tool_name=tool_name,
                 tool_args=tool_args,
                 tool_context=tool_context,
             )
             if _is_reporting_tool_name(tool_name) and not pinned:
+                # Resolve the current agent name — prefer the live
+                # invocation's agent (tool_context._invocation_context.
+                # agent.name), fall back to the host agent from
+                # SessionContext. Any resolution failure degrades to
+                # the silent-ack path (conservative — avoid breaking
+                # runs on edge-cases).
+                agent_name = ""
+                try:
+                    inv_ctx = _safe_attr(
+                        tool_context, "_invocation_context", None
+                    ) or _safe_attr(tool_context, "invocation_context", None)
+                    running_agent = _safe_attr(inv_ctx, "agent", None)
+                    agent_name = str(_safe_attr(running_agent, "name", "") or "")
+                    if not agent_name:
+                        agent_name = str(
+                            _safe_attr(ctx, "host_agent_name", "") or ""
+                        )
+                except Exception:  # noqa: BLE001
+                    agent_name = ""
+
+                has_candidates = False
+                try:
+                    has_candidates = _agent_has_pending_candidates(
+                        ctx, agent_name
+                    )
+                except Exception:  # noqa: BLE001 — conservative fall-through
+                    has_candidates = False
+
+                if has_candidates:
+                    # Gather candidate ids for the diagnostic WARNING
+                    # (nice-to-have; swallow any resolution errors).
+                    candidate_ids: list[str] = []
+                    try:
+                        from goldfive.types import TaskStatus
+
+                        plan = _safe_attr(ctx.session, "plan", None)
+                        tasks = _safe_attr(plan, "tasks", None) or ()
+                        for task in tasks:
+                            assignee = str(
+                                _safe_attr(task, "assignee_agent_id", "") or ""
+                            )
+                            if assignee != agent_name:
+                                continue
+                            status = _safe_attr(task, "status", None)
+                            if status is TaskStatus.PENDING or status is TaskStatus.RUNNING:
+                                candidate_ids.append(
+                                    str(_safe_attr(task, "id", "") or "")
+                                )
+                    except Exception:  # noqa: BLE001
+                        pass
+                    log.warning(
+                        "before_tool_callback: pin_unresolved for %s "
+                        "(agent=%s, candidates=[%s]); surfacing structured "
+                        "error rather than silent-ack so the stall is visible",
+                        tool_name,
+                        agent_name or "?",
+                        ", ".join(candidate_ids),
+                    )
+                    return {
+                        "acknowledged": False,
+                        "error": "pin_unresolved",
+                    }
+
                 log.info(
                     "before_tool_callback: no task pinned for %s; "
                     "returning no-op acknowledgment (orchestration-only turn)",
                     tool_name,
                 )
-                return {
-                    "acknowledged": True,
-                    "no_task_pinned": True,
-                    "detail": (
-                        "no task currently bound to this agent; "
-                        "report recorded as orchestration-only no-op"
-                    ),
-                }
+                return {"acknowledged": True}
 
             tool_names_registered = {spec.name for spec in ctx.tools}
             if tool_name in tool_names_registered:

--- a/tests/test_hidden_task_id_schema.py
+++ b/tests/test_hidden_task_id_schema.py
@@ -214,19 +214,27 @@ async def test_hidden_task_id_populates_from_state() -> None:
 
 
 async def test_hidden_task_id_is_noop_when_state_empty() -> None:
-    """No pin anywhere → the dispatch returns a no-op acknowledgment.
+    """No pin anywhere + no candidates in plan → bare silent ack.
 
-    This replaces an earlier "fail with no_task_pinned error" contract.
-    The error variant crashed the LLM's reporting protocol when
-    goldfive's refine moved an agent's assigned work to another agent
-    (e.g. a coordinator whose own tasks were superseded into
-    sub-agent tasks). Observed live: the LLM saw the error and
+    This replaces an earlier "fail with no_task_pinned error" contract
+    (goldfive#250). The error variant crashed the LLM's reporting
+    protocol when goldfive's refine moved an agent's assigned work to
+    another agent (e.g. a coordinator whose own tasks were superseded
+    into sub-agent tasks). Observed live: the LLM saw the error and
     reasoned "task started report didn't work, let me proceed directly
     with the research_agent call," bypassing the reporting contract
-    entirely. Returning a silent no-op acknowledgment keeps the
-    agent's protocol intact; observability is preserved via an INFO
+    entirely.
+
+    The response must be EXACTLY ``{"acknowledged": True}`` — no
+    ``detail`` / ``no_task_pinned`` keys (goldfive#250 follow-up). Tool
+    responses go back to the LLM verbatim and any editorialising string
+    is treated as actionable context: live research_agent paraphrased
+    a ``detail`` string into its reasoning and proceeded with stale
+    pre-refine instructions. Observability is preserved via an INFO
     log from the plugin.
     """
+    # No plan attached — the agent has zero candidates, the
+    # orchestration-only-turn branch applies.
     plugin, state, captured, _ = _make_plugin_with_handler("report_task_started")
     # Deliberately not setting KEY_CURRENT_TASK_ID or pending_delegations.
 
@@ -236,15 +244,109 @@ async def test_hidden_task_id_is_noop_when_state_empty() -> None:
         tool_args=args,
         tool_context=_Ctx(state),
     )
-    assert result == {
-        "acknowledged": True,
-        "no_task_pinned": True,
-        "detail": (
-            "no task currently bound to this agent; "
-            "report recorded as orchestration-only no-op"
-        ),
-    }
+    assert result == {"acknowledged": True}
     # Handler not invoked — captured stays empty (nothing to report on).
+    assert captured == []
+
+
+def _ambiguous_plan_for(agent_name: str = "coordinator") -> Plan:
+    """Two PENDING tasks both assigned to ``agent_name`` → pin is
+    ambiguous (>1 single-match candidates), but the agent DOES have
+    work in the plan."""
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t-alpha",
+                title="Alpha",
+                description="First task",
+                assignee_agent_id=agent_name,
+                status=TaskStatus.PENDING,
+            ),
+            Task(
+                id="t-beta",
+                title="Beta",
+                description="Second task",
+                assignee_agent_id=agent_name,
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[],
+        summary="Ambiguous",
+    )
+
+
+async def test_pin_unresolved_when_agent_has_candidates() -> None:
+    """Agent has PENDING candidates but the pin couldn't resolve
+    (ambiguous — >1 match) → surface a structured ``pin_unresolved``
+    error instead of silently ack-ing. A silent ack here would mask
+    a real stall (goldfive#250 follow-up)."""
+    plan = _ambiguous_plan_for("coordinator")
+    plugin, state, captured, _ = _make_plugin_with_handler(
+        "report_task_started", plan=plan
+    )
+    # No KEY_CURRENT_TASK_ID / pending_delegations wired — resolution
+    # fails despite the agent having candidates.
+
+    args: dict[str, Any] = {"detail": "starting"}
+    result = await plugin.before_tool_callback(
+        tool=_Tool("report_task_started"),
+        tool_args=args,
+        tool_context=_Ctx(state),
+    )
+    assert result == {"acknowledged": False, "error": "pin_unresolved"}
+    assert captured == []
+
+
+def _dag_gated_plan_for(agent_name: str = "coordinator") -> Plan:
+    """PENDING task assigned to ``agent_name`` but upstream is NOT
+    COMPLETED. The agent has a candidate, but it's DAG-gated — the
+    agent's turn shouldn't be happening yet, which is ALSO a stall
+    worth surfacing rather than silencing (goldfive#250 follow-up)."""
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t-upstream",
+                title="Upstream",
+                description="Precursor work",
+                assignee_agent_id="other_agent",
+                status=TaskStatus.PENDING,  # NOT COMPLETED
+            ),
+            Task(
+                id="t-gated",
+                title="Gated",
+                description="Downstream work",
+                assignee_agent_id=agent_name,
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="t-upstream", to_task_id="t-gated")],
+        summary="DAG-gated",
+    )
+
+
+async def test_pin_unresolved_when_candidate_is_dag_gated() -> None:
+    """Agent has a PENDING candidate but it's upstream-gated. Even
+    though the DAG gate would reject it for the pin, the agent still
+    has work in the plan, so the pin failure is a stall worth
+    surfacing — return ``pin_unresolved`` rather than silent-ack."""
+    plan = _dag_gated_plan_for("coordinator")
+    plugin, state, captured, _ = _make_plugin_with_handler(
+        "report_task_started", plan=plan
+    )
+
+    args: dict[str, Any] = {"detail": "starting"}
+    result = await plugin.before_tool_callback(
+        tool=_Tool("report_task_started"),
+        tool_args=args,
+        tool_context=_Ctx(state),
+    )
+    assert result == {"acknowledged": False, "error": "pin_unresolved"}
     assert captured == []
 
 


### PR DESCRIPTION
## Summary

Two coordinated fixes to #250's no-op acknowledgment path for `report_task_*` tools when the `task_id` pin can't be resolved:

1. **Drop the `detail` leak.** #250 shipped a `detail` string ("no task currently bound to this agent; report recorded as orchestration-only no-op") that went back to the LLM verbatim. Observed live: research_agent post-refine paraphrased this into its own reasoning and proceeded with its **stale pre-refine instructions** because the detail string read as license to proceed without a task binding. Tool responses must not editorialize. The no-op now returns exactly `{"acknowledged": True}`.

2. **Gate the silent-ack on "agent has no candidates."** #250 couldn't distinguish two failure modes:
   - *Legit orchestration-only turn* (the scenario it was designed for): the agent's work was moved to other agents by a plan refine; zero PENDING/RUNNING candidates for this agent.
   - *Pin failed despite candidates existing*: a real stall that should surface, not be silently ack'd.

   Now: if the plan has any PENDING/RUNNING task assigned to the agent, return `{"acknowledged": False, "error": "pin_unresolved"}` (with a WARNING log carrying agent name + candidate ids). If zero candidates, keep the bare silent-ack.

New helper `_agent_has_pending_candidates(ctx, agent_name) -> bool` extracts the shared filter; the DAG-readiness gate is intentionally NOT applied (even a DAG-gated candidate means the agent's turn shouldn't be happening, which is also a stall worth surfacing).

## Test plan

- [x] Updated `test_hidden_task_id_is_noop_when_state_empty`: asserts response is EXACTLY `{"acknowledged": True}` (no `detail`, no `no_task_pinned`).
- [x] New `test_pin_unresolved_when_agent_has_candidates`: ambiguous plan (>1 PENDING candidates for the agent) + no pin -> `{"acknowledged": False, "error": "pin_unresolved"}`.
- [x] New `test_pin_unresolved_when_candidate_is_dag_gated`: agent has a PENDING candidate blocked by an incomplete upstream -> still returns `pin_unresolved` (DAG-gate NOT applied to the candidate check).
- [x] `uv run pytest tests/test_hidden_task_id_schema.py -v` -> 13/13 pass (10 pre-existing + 3 new).
- [x] `uv run pytest tests/` -> 1459 pass, 46 skipped. One unrelated pre-existing failure on `main` (`test_reasoning_judge.py::test_rate_limit_resets_on_task_transition`).
- [x] `uv run ruff check goldfive/adapters/_adk_plugin.py` -> clean.