### PR TITLE
fix(adk, steerer): prompt-safe pin-fail response + per-agent judge bucket

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -263,9 +263,12 @@ def _agent_has_pending_candidates(ctx: Any, agent_name: str) -> bool:
     * **No candidates** — the agent's work was moved to other agents by
       a plan refine; a silent-ack no-op is correct.
     * **Has candidates** — the pin SHOULD have worked (single match, or
-      delegation-site pin, or fallback). A silent ack would mask a real
-      stall; the caller surfaces ``{"acknowledged": False,
-      "error": "pin_unresolved"}`` instead.
+      delegation-site pin, or fallback). The tool response is still
+      ``{"acknowledged": True}`` so the LLM can't pattern-match on an
+      error shape (observed live: models read ``"error": "pin_unresolved"``
+      as a reasoning cue and bypass the reporting contract). Operator
+      visibility is preserved via a WARNING log + a ``DriftDetected``
+      sink event; see :meth:`_emit_pin_unresolved_drift`.
 
     NOTE: the DAG-readiness gate from
     :meth:`_pin_current_task_id_for_agent` is intentionally NOT applied
@@ -329,14 +332,16 @@ def _inject_task_id_from_state(
     Returns ``True`` when ``tool_args`` now carries a usable ``task_id``
     (either pre-existing non-placeholder, or freshly populated from
     state) and ``False`` when no pin is available — in that case the
-    caller short-circuits with a structured error so the handler never
-    runs on an unpinned call. Pre-#241 the call would have fallen
-    through to the handler's ``missing_task_id`` error, but that path
-    goes back to the LLM via a successful tool response shape and
-    confused the model into retry loops.
+    caller short-circuits with a bare ``{"acknowledged": True}`` and
+    emits operator observability (WARNING log + ``DriftDetected`` sink
+    event) rather than letting the handler run on an unpinned call.
+    Pre-#241 the call would have fallen through to the handler's
+    ``missing_task_id`` error, but that path goes back to the LLM via a
+    successful tool response shape and confused the model into retry
+    loops. Post-#252-followup, even the structured-error shape is gone
+    from the LLM-visible response — see :meth:`_emit_pin_unresolved_drift`.
 
-    NEVER raises — any internal failure degrades to "no pin", letting
-    the caller emit the canonical ``no_task_pinned`` error.
+    NEVER raises — any internal failure degrades to "no pin".
     """
     try:
         if not _is_reporting_tool_name(tool_name):
@@ -384,8 +389,13 @@ def _resolve_pinned_task_id(*, tool_context: Any) -> str:
     keyed by the current invocation's ``function_call_id``), then
     falls back to the agent-turn pin (``goldfive.current_task_id``).
     Returns ``""`` when neither path yields a value — the caller
-    should then fail the call with the ``no_task_pinned`` error
-    rather than invoking the handler on an unpinned arg.
+    should then short-circuit with a bare ``{"acknowledged": True}``
+    (plus a ``DriftDetected`` sink event for operator visibility on
+    the has-candidates branch) rather than invoking the handler on an
+    unpinned arg. Pre-#252-followup the has-candidates branch emitted
+    an ``error: pin_unresolved`` payload, which the LLM read as a
+    reasoning cue and used to bypass the reporting contract — see
+    the pin-leak fix in that PR.
     """
     state = _session_state_from_callback(tool_context)
     if not isinstance(state, Mapping):
@@ -2191,6 +2201,83 @@ def make_adk_plugin(
                     exc,
                 )
 
+        async def _emit_pin_unresolved_drift(
+            self,
+            *,
+            ctx: SessionContext,
+            agent_name: str,
+            tool_name: str,
+            candidate_ids: list[str],
+        ) -> None:
+            """Emit a ``DriftDetected`` for an unresolvable reporting-tool pin.
+
+            Used when ``before_tool_callback`` can't resolve a pin on a
+            reporting tool and the current agent has PENDING / RUNNING
+            candidates in the plan (so the pin SHOULD have worked — not
+            an orchestration-only turn). The tool response to the LLM is
+            a bare ``{"acknowledged": True}``; this drift event is the
+            operator-visible signal that a stall occurred.
+
+            Uses ``DriftKind.OFF_TOPIC`` with a ``reason=pin_unresolved: …``
+            prefix (not a new ``PIN_UNRESOLVED`` proto kind) because the
+            invariant is observer visibility, not wire-level classification.
+            Sink dispatch fails-safe — observability must not block an
+            invocation.
+            """
+            steerer = ctx.steerer
+            if steerer is None:
+                return
+            try:
+                from goldfive.types import (  # noqa: PLC0415 — lazy
+                    DriftEvent,
+                    DriftKind,
+                    DriftSeverity,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_emit_pin_unresolved_drift: cannot import types: %s",
+                    exc,
+                )
+                return
+
+            detail = (
+                f"pin_unresolved: {tool_name} for agent={agent_name or '?'}; "
+                f"candidates=[{', '.join(candidate_ids)}]"
+            )
+            drift = DriftEvent(
+                kind=DriftKind.OFF_TOPIC,
+                severity=DriftSeverity.WARNING,
+                detail=detail,
+                current_task_id=str(_safe_attr(ctx.task, "id", "") or ""),
+                current_agent_id=agent_name or self._host_agent_name,
+            )
+            # Direct sink emission (bypass _handle_drift): this signal is
+            # purely observability — no refine needed. A pin_unresolved
+            # stall gets resolved by the LLM retrying or the orchestrator
+            # intervening, not by a plan revision.
+            sinks = getattr(steerer, "_sinks", None) or []
+            if not sinks:
+                return
+            try:
+                from goldfive.events import (  # noqa: PLC0415 — lazy
+                    drift_detected_event,
+                    emit,
+                )
+
+                run_id = str(_safe_attr(ctx.session, "run_id", "") or "")
+                session_id = str(_safe_attr(ctx.session, "id", "") or "") or run_id
+                try:
+                    seq = ctx.session.next_sequence()
+                except Exception:  # noqa: BLE001
+                    seq = 0
+                evt = drift_detected_event(run_id, seq, drift, session_id=session_id)
+                await emit(sinks, evt)
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_emit_pin_unresolved_drift: direct sink emit failed: %s",
+                    exc,
+                )
+
         async def _emit_observability(self, kind: str, **fields: Any) -> None:
             """Fan out an observability event to the session's sinks.
 
@@ -2402,13 +2489,23 @@ def make_adk_plugin(
             #   here makes the LLM bypass the reporting protocol —
             #   observed live.
             # * **Has candidates** — the pin SHOULD have worked; a
-            #   silent ack would mask a real stall. Return a
-            #   structured ``pin_unresolved`` error so the stall is
-            #   visible.
+            #   silent ack could mask a real stall. To keep the stall
+            #   visible WITHOUT leaking a prompt-injection surface to
+            #   the LLM (observed live: research_agent read an
+            #   ``error: pin_unresolved`` payload and reasoned "This
+            #   might be related to the plan/task system. Let me try
+            #   a different approach — I'll just compile the research
+            #   and create the presentation content directly", bypassing
+            #   the reporting contract), the tool response is the same
+            #   bare ``{"acknowledged": True}``. Operator visibility is
+            #   preserved via a WARNING log AND a ``DriftDetected`` sink
+            #   event (``DriftKind.OFF_TOPIC`` with a ``pin_unresolved:``
+            #   reason prefix). See goldfive#252 follow-up + PR notes.
             #
-            # The silent-ack response carries NO ``detail`` / explanatory
-            # keys — tool responses go back to the LLM verbatim and any
-            # editorialising string is treated as actionable context
+            # The silent-ack response carries NO ``detail`` / ``error`` /
+            # ``no_task_pinned`` / ``pin_unresolved`` keys — tool responses
+            # go back to the LLM verbatim and any editorialising string
+            # (or error-shaped payload) is treated as actionable context
             # (observed live: research_agent paraphrased a detail string
             # into its reasoning and proceeded with stale pre-refine
             # instructions, ignoring the refined scope).
@@ -2447,8 +2544,9 @@ def make_adk_plugin(
                     has_candidates = False
 
                 if has_candidates:
-                    # Gather candidate ids for the diagnostic WARNING
-                    # (nice-to-have; swallow any resolution errors).
+                    # Gather candidate ids for the diagnostic WARNING +
+                    # drift event (nice-to-have; swallow any resolution
+                    # errors).
                     candidate_ids: list[str] = []
                     try:
                         from goldfive.types import TaskStatus
@@ -2470,16 +2568,33 @@ def make_adk_plugin(
                         pass
                     log.warning(
                         "before_tool_callback: pin_unresolved for %s "
-                        "(agent=%s, candidates=[%s]); surfacing structured "
-                        "error rather than silent-ack so the stall is visible",
+                        "(agent=%s, candidates=[%s]); emitting "
+                        "DriftDetected(pin_unresolved) and returning silent "
+                        "ack so the LLM cannot pattern-match on the error",
                         tool_name,
                         agent_name or "?",
                         ", ".join(candidate_ids),
                     )
-                    return {
-                        "acknowledged": False,
-                        "error": "pin_unresolved",
-                    }
+                    # Surface the stall to operators via a sink event so
+                    # it's visible in harmonograf without being visible
+                    # to the LLM. Reuse OFF_TOPIC with a reason prefix
+                    # rather than adding a new proto DriftKind (heavier
+                    # change; the invariant here is operator observability,
+                    # not a new wire-level classification).
+                    try:
+                        await self._emit_pin_unresolved_drift(
+                            ctx=ctx,
+                            agent_name=agent_name,
+                            tool_name=tool_name,
+                            candidate_ids=candidate_ids,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        log.debug(
+                            "before_tool_callback: pin_unresolved drift emit "
+                            "raised: %s",
+                            exc,
+                        )
+                    return {"acknowledged": True}
 
                 log.info(
                     "before_tool_callback: no task pinned for %s; "
@@ -2725,13 +2840,46 @@ def make_adk_plugin(
             if reasoning:
                 observe_reasoning = getattr(ctx.steerer, "observe_reasoning", None)
                 if observe_reasoning is not None:
+                    # Resolve the live agent name so the steerer's
+                    # per-(agent, task) reasoning-judge rate-limit
+                    # bucket isolates agents (goldfive#252 follow-up).
+                    # Prefer the invocation's running agent, fall back
+                    # to the host agent so single-agent runs keep their
+                    # historical bucketing.
+                    reasoning_agent_name = ""
+                    try:
+                        running_agent = _safe_attr(inv_ctx, "agent", None)
+                        reasoning_agent_name = str(
+                            _safe_attr(running_agent, "name", "") or ""
+                        )
+                    except Exception:  # noqa: BLE001
+                        reasoning_agent_name = ""
+                    if not reasoning_agent_name:
+                        reasoning_agent_name = self._host_agent_name or ""
                     try:
                         await observe_reasoning(
                             reasoning,
                             task=ctx.task,
                             session=ctx.session,
                             provider=_infer_provider(llm_response),
+                            agent_name=reasoning_agent_name,
                         )
+                    except TypeError:
+                        # Back-compat: custom steerer without the
+                        # ``agent_name`` kwarg. Fall back silently.
+                        try:
+                            await observe_reasoning(
+                                reasoning,
+                                task=ctx.task,
+                                session=ctx.session,
+                                provider=_infer_provider(llm_response),
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            log.debug(
+                                "after_model_callback: observe_reasoning "
+                                "(fallback) raised: %s",
+                                exc,
+                            )
                     except Exception as exc:  # noqa: BLE001
                         log.debug(
                             "after_model_callback: observe_reasoning raised: %s",

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -1448,6 +1448,7 @@ class ADKAdapter:
         session: Session,
         provider: str = "",
         call_id: str = "",  # noqa: ARG002 -- part of the protocol
+        agent_name: str = "",
     ) -> None:
         """Forward an extracted reasoning block to the bound steerer."""
         steerer = self._steerer
@@ -1456,7 +1457,16 @@ class ADKAdapter:
         observe = getattr(steerer, "observe_reasoning", None)
         if observe is None:
             return
-        await observe(text, task=task, session=session, provider=provider)
+        try:
+            await observe(
+                text,
+                task=task,
+                session=session,
+                provider=provider,
+                agent_name=agent_name,
+            )
+        except TypeError:
+            await observe(text, task=task, session=session, provider=provider)
 
     async def invoke(self, task: Task, session: Session) -> InvocationResult:
         """DEPRECATED — drive one ADK turn for a single ``task``.

--- a/goldfive/adapters/callable.py
+++ b/goldfive/adapters/callable.py
@@ -74,6 +74,7 @@ class CallableAdapter:
         session: Session,
         provider: str = "",
         call_id: str = "",  # noqa: ARG002 -- part of the protocol
+        agent_name: str = "",
     ) -> None:
         """Route a reasoning-content block to the bound steerer (if any).
 
@@ -88,7 +89,16 @@ class CallableAdapter:
         observe = getattr(steerer, "observe_reasoning", None)
         if observe is None:
             return
-        await observe(text, task=task, session=session, provider=provider)
+        try:
+            await observe(
+                text,
+                task=task,
+                session=session,
+                provider=provider,
+                agent_name=agent_name,
+            )
+        except TypeError:
+            await observe(text, task=task, session=session, provider=provider)
 
     def bind_steerer(self, steerer: object | None) -> None:
         """Attach the active :class:`~goldfive.protocols.Steerer`.

--- a/goldfive/adapters/claude.py
+++ b/goldfive/adapters/claude.py
@@ -190,6 +190,7 @@ class ClaudeAgentSDKAdapter:
         session: Session,
         provider: str = "anthropic",
         call_id: str = "",  # noqa: ARG002 -- part of the protocol
+        agent_name: str = "",
     ) -> None:
         """Route an Anthropic ``thinking`` block to the bound steerer.
 
@@ -205,7 +206,17 @@ class ClaudeAgentSDKAdapter:
         observe = getattr(steerer, "observe_reasoning", None)
         if observe is None:
             return
-        await observe(text, task=task, session=session, provider=provider)
+        try:
+            await observe(
+                text,
+                task=task,
+                session=session,
+                provider=provider,
+                agent_name=agent_name,
+            )
+        except TypeError:
+            # Back-compat: steerer without the ``agent_name`` kwarg.
+            await observe(text, task=task, session=session, provider=provider)
 
     async def register_reporting_tools(
         self,

--- a/goldfive/protocols.py
+++ b/goldfive/protocols.py
@@ -65,6 +65,7 @@ class Steerer(Protocol):
         task: Task | None = None,
         session: Session,
         provider: str = "",
+        agent_name: str = "",
     ) -> None: ...
 
     async def transition(
@@ -141,6 +142,7 @@ class AgentAdapter(Protocol):
         session: Session,
         provider: str = "",
         call_id: str = "",
+        agent_name: str = "",
     ) -> None: ...
 
     @property

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -1072,6 +1072,7 @@ class DefaultSteerer:
         task: Task | None = None,  # noqa: ARG002 -- reserved for future detectors
         session: Session,
         provider: str = "",  # noqa: ARG002 -- reserved for per-provider dispatch
+        agent_name: str = "",
     ) -> None:
         """Feed a chain-of-thought / reasoning block into the drift pipeline.
 
@@ -1123,7 +1124,9 @@ class DefaultSteerer:
             # Mode-selected pipeline (judge / embedding / both / off).
             # The judge path is rate-limited per-task; embedding path
             # is synchronous.
-            rl_call_llm = self._maybe_take_reasoning_judge_slot(session)
+            rl_call_llm = self._maybe_take_reasoning_judge_slot(
+                session, agent_name=agent_name
+            )
             # Thread the first bound sink into the judge path so a
             # ``ReasoningJudgeInvoked`` event fires on every judge call,
             # regardless of verdict. ``None`` when no sinks are bound —
@@ -1161,18 +1164,31 @@ class DefaultSteerer:
             return text
         return text[:limit] + " … [truncated]"
 
-    def _maybe_take_reasoning_judge_slot(self, session: Session) -> ReflectiveCallLLM | None:
+    def _maybe_take_reasoning_judge_slot(
+        self,
+        session: Session,
+        *,
+        agent_name: str = "",
+    ) -> ReflectiveCallLLM | None:
         """Return the judge ``call_llm`` when this turn is a judge turn.
 
         Rate-limit policy (goldfive#226):
 
-        * First thinking message of every task always fires.
+        * First thinking message of every (agent, task) bucket always fires.
         * Subsequent messages skip ``(N-1)`` and then fire on the Nth.
-        * Counters are scoped per-task via
+        * Counters are scoped per-(agent, task) via
           ``session._reasoning_judge_counters`` so a task transition
-          resets the window lazily -- the next task id is simply not
-          in the dict yet, so its first message falls into the
-          "count=0" branch.
+          OR an agent switch resets the window lazily -- the next
+          ``(agent, task_id)`` tuple is simply not in the dict yet, so
+          its first message falls into the "count=0" branch.
+
+        Pre-fix the key was a single string keyed on
+        ``current_task_id or ""``. Every unpinned turn from every agent
+        collapsed onto the ``""`` bucket, so agent B's first thinking
+        block could legitimately skip the judge because unrelated
+        agent A's unpinned turn had already incremented the counter.
+        Bucketing by ``(agent_name, task_id)`` isolates each agent's
+        cadence.
 
         Returns ``None`` when the judge is globally disabled (mode
         skips it, or ``reasoning_drift_call_llm`` is unconfigured).
@@ -1183,12 +1199,13 @@ class DefaultSteerer:
         if self._reasoning_drift_mode not in ("judge", "both"):
             return None
         task_id = session.current_task_id or ""
+        key = (agent_name or "", task_id)
         counters = session._reasoning_judge_counters
-        count = counters.get(task_id, 0)
-        # count=0 -> fire (first message on this task), reset to 1.
-        # Otherwise fire when count % rate_limit == 0.
+        count = counters.get(key, 0)
+        # count=0 -> fire (first message on this (agent, task) bucket),
+        # reset to 1. Otherwise fire when count % rate_limit == 0.
         fire = (count % self._reasoning_drift_rate_limit) == 0
-        counters[task_id] = count + 1
+        counters[key] = count + 1
         return self._reasoning_drift_call_llm if fire else None
 
     # ------------------------------------------------------------------

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -725,14 +725,22 @@ class Session:
     # already cost-bounded by the interval; task-boundary scheduling needs
     # its own rate limit. Default 0 (never fired).
     _last_goal_drift_check_ts: float = 0.0
-    # Per-task thinking-message counter for the LLM-as-a-judge reasoning
-    # drift detector (goldfive#226). Task id -> count of ``observe_reasoning``
-    # calls since the last judge firing (or since task transition).
-    # ``DefaultSteerer`` fires the judge on the first message of every task
-    # (count=0) and then every ``reasoning_drift_rate_limit`` messages after
-    # that. Scoped per-task (not per-session) so the first thinking message
-    # on a fresh task always gets a judge call even on rate limits >1.
-    _reasoning_judge_counters: dict[str, int] = dataclasses.field(default_factory=dict)
+    # Per-(agent, task) thinking-message counter for the LLM-as-a-judge
+    # reasoning drift detector (goldfive#226). Keyed by
+    # ``(agent_name, task_id)`` -> count of ``observe_reasoning`` calls
+    # since the last judge firing (or since task/agent transition).
+    # ``DefaultSteerer`` fires the judge on the first message of every
+    # (agent, task) bucket (count=0) and then every
+    # ``reasoning_drift_rate_limit`` messages after that. Scoped
+    # per-(agent, task) — not globally, not per-task — so unrelated
+    # unpinned turns from different agents don't share the empty-task-id
+    # bucket and distort judge cadence. Pre-fix the key was a single
+    # string keyed on ``current_task_id or ""``; every unpinned turn
+    # from every agent collapsed onto the ``""`` bucket and legitimate
+    # first-block judge firings were skipped.
+    _reasoning_judge_counters: dict[tuple[str, str], int] = dataclasses.field(
+        default_factory=dict
+    )
     # Set to ``True`` by :class:`DefaultSteerer` when it escalates a
     # drift to Level 4 of the intervention ladder (goldfive#142).
     # Executors honour this flag the same way they honour a PAUSE

--- a/tests/test_hidden_task_id_schema.py
+++ b/tests/test_hidden_task_id_schema.py
@@ -11,9 +11,14 @@ parameters") and abandoning the reporting protocol entirely.
 either:
 
   * injects it into ``tool_args`` before the handler runs, or
-  * short-circuits the dispatch with a structured ``no_task_pinned``
-    error when neither the delegation-site pin nor the agent-turn
-    pin resolves.
+  * short-circuits the dispatch with a bare ``{"acknowledged": True}``
+    when neither the delegation-site pin nor the agent-turn pin
+    resolves. When the current agent has PENDING/RUNNING candidates
+    in the plan (so the pin SHOULD have worked), a ``DriftDetected``
+    sink event also fires for operator observability — the tool
+    response is still the bare ack so the LLM can't pattern-match
+    on an error payload. See the #252 follow-up for the live
+    prompt-injection evidence that motivated the silent-ack shape.
 
 For coordinators that fire parallel AgentTool calls to the same
 sub-agent on a single turn, the agent-turn pin is not unique
@@ -101,8 +106,47 @@ class _AgentToolStub:
         self.name = tool_name or f"{agent_name}_tool"
 
 
-def _make_plugin_with_handler(tool_name: str, plan: Plan | None = None):
-    """Return (plugin, state_dict, captured) wired for a reporting tool."""
+class _SinkCapture:
+    """Minimal sink stub — collects every event so tests can assert shape.
+
+    ``goldfive.events.emit`` calls ``sink.emit(event_pb)``; the method
+    name matches the ``ListSink`` pattern used elsewhere in the test
+    suite (see ``tests/test_reporting.py``).
+    """
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class _SinkingSteererStub:
+    """Steerer stand-in that exposes ``_sinks`` so the plugin emits drift."""
+
+    def __init__(self, sinks: list[Any]) -> None:
+        self._sinks = list(sinks)
+
+    async def observe(self, *a: Any, **kw: Any) -> None:  # pragma: no cover
+        pass
+
+
+def _make_plugin_with_handler(
+    tool_name: str,
+    plan: Plan | None = None,
+    *,
+    with_sink: bool = False,
+):
+    """Return (plugin, state_dict, captured, session, sink) wired for a reporting tool.
+
+    When ``with_sink=True`` the returned ``SessionContext.steerer`` exposes a
+    ``_sinks`` list so the plugin's ``DriftDetected`` emission path can
+    observe a sink and write to it. Default is ``None`` steerer to keep
+    back-compat with older call sites.
+    """
     captured: list[dict[str, Any]] = []
 
     async def handler(args: Any, session: Any, steerer: Any) -> dict[str, Any]:
@@ -118,17 +162,22 @@ def _make_plugin_with_handler(tool_name: str, plan: Plan | None = None):
     plugin = make_adk_plugin(host_agent_name="coordinator")
     session_obj = Session(run_id="run-1", plan=plan)
     task = Task(id="t-ignored", title="x")
+    sink: _SinkCapture | None = None
+    steerer: Any | None = None
+    if with_sink:
+        sink = _SinkCapture()
+        steerer = _SinkingSteererStub([sink])
     state: dict = {
         SESSION_CONTEXT_STATE_KEY: SessionContext(
             session=session_obj,
-            steerer=None,
+            steerer=steerer,
             task=task,
             tool_handlers={tool_name: handler},
             tools=[spec],
             host_agent_name="coordinator",
         )
     }
-    return plugin, state, captured, session_obj
+    return plugin, state, captured, session_obj, sink
 
 
 # ---------------------------------------------------------------------------
@@ -198,7 +247,7 @@ async def test_hidden_task_id_populates_from_state() -> None:
     """LLM calls ``report_task_started()`` with no task_id arg — the
     callback populates from ``goldfive.current_task_id`` state before
     the handler runs."""
-    plugin, state, captured, _ = _make_plugin_with_handler("report_task_started")
+    plugin, state, captured, _, _ = _make_plugin_with_handler("report_task_started")
     state[KEY_CURRENT_TASK_ID] = "t-pinned"
 
     args: dict[str, Any] = {"detail": "starting"}
@@ -235,7 +284,7 @@ async def test_hidden_task_id_is_noop_when_state_empty() -> None:
     """
     # No plan attached — the agent has zero candidates, the
     # orchestration-only-turn branch applies.
-    plugin, state, captured, _ = _make_plugin_with_handler("report_task_started")
+    plugin, state, captured, _, _ = _make_plugin_with_handler("report_task_started")
     # Deliberately not setting KEY_CURRENT_TASK_ID or pending_delegations.
 
     args: dict[str, Any] = {"detail": "starting"}
@@ -280,12 +329,15 @@ def _ambiguous_plan_for(agent_name: str = "coordinator") -> Plan:
 
 async def test_pin_unresolved_when_agent_has_candidates() -> None:
     """Agent has PENDING candidates but the pin couldn't resolve
-    (ambiguous — >1 match) → surface a structured ``pin_unresolved``
-    error instead of silently ack-ing. A silent ack here would mask
-    a real stall (goldfive#250 follow-up)."""
+    (ambiguous — >1 match) → the LLM-visible response is a bare
+    ``{"acknowledged": True}`` (so the model can't pattern-match on an
+    error payload) AND a ``DriftDetected`` sink event fires for operator
+    observability. Pre-#252-followup the tool response carried an
+    ``error: pin_unresolved`` payload; live research_agent read the
+    payload as a reasoning cue and bypassed the reporting contract."""
     plan = _ambiguous_plan_for("coordinator")
-    plugin, state, captured, _ = _make_plugin_with_handler(
-        "report_task_started", plan=plan
+    plugin, state, captured, _session, sink = _make_plugin_with_handler(
+        "report_task_started", plan=plan, with_sink=True
     )
     # No KEY_CURRENT_TASK_ID / pending_delegations wired — resolution
     # fails despite the agent having candidates.
@@ -296,8 +348,30 @@ async def test_pin_unresolved_when_agent_has_candidates() -> None:
         tool_args=args,
         tool_context=_Ctx(state),
     )
-    assert result == {"acknowledged": False, "error": "pin_unresolved"}
+    # LLM-visible response: bare ack. No error / detail / pin_unresolved
+    # strings that the model could paraphrase into its reasoning.
+    assert result == {"acknowledged": True}
     assert captured == []
+    # Operator-visible response: a DriftDetected event with a
+    # pin_unresolved reason prefix and the candidate task ids in detail.
+    assert sink is not None
+    assert len(sink.events) == 1, (
+        f"expected exactly one sink event, got {len(sink.events)}"
+    )
+    evt = sink.events[0]
+    # Protobuf ``Event`` with a ``drift_detected`` oneof branch.
+    drift = evt.drift_detected
+    assert drift.detail.startswith("pin_unresolved:"), (
+        f"expected pin_unresolved prefix on drift detail, got {drift.detail!r}"
+    )
+    assert "report_task_started" in drift.detail
+    assert "coordinator" in drift.detail
+    # Candidate ids from the ambiguous plan must be present so operators
+    # can see which tasks were eligible.
+    assert "t-alpha" in drift.detail
+    assert "t-beta" in drift.detail
+    # Current-agent attribution for the UI.
+    assert drift.current_agent_id == "coordinator"
 
 
 def _dag_gated_plan_for(agent_name: str = "coordinator") -> Plan:
@@ -334,10 +408,12 @@ async def test_pin_unresolved_when_candidate_is_dag_gated() -> None:
     """Agent has a PENDING candidate but it's upstream-gated. Even
     though the DAG gate would reject it for the pin, the agent still
     has work in the plan, so the pin failure is a stall worth
-    surfacing — return ``pin_unresolved`` rather than silent-ack."""
+    surfacing via a ``DriftDetected`` sink event — but the tool response
+    must still be a bare ack so the LLM can't read a ``pin_unresolved``
+    error string."""
     plan = _dag_gated_plan_for("coordinator")
-    plugin, state, captured, _ = _make_plugin_with_handler(
-        "report_task_started", plan=plan
+    plugin, state, captured, _session, sink = _make_plugin_with_handler(
+        "report_task_started", plan=plan, with_sink=True
     )
 
     args: dict[str, Any] = {"detail": "starting"}
@@ -346,8 +422,87 @@ async def test_pin_unresolved_when_candidate_is_dag_gated() -> None:
         tool_args=args,
         tool_context=_Ctx(state),
     )
-    assert result == {"acknowledged": False, "error": "pin_unresolved"}
+    assert result == {"acknowledged": True}
     assert captured == []
+    assert sink is not None
+    assert len(sink.events) == 1
+    drift = sink.events[0].drift_detected
+    assert drift.detail.startswith("pin_unresolved:")
+    assert "t-gated" in drift.detail
+
+
+_FORBIDDEN_LLM_KEYS = ("error", "detail", "no_task_pinned", "pin_unresolved")
+
+
+def _assert_prompt_safe(response: Any) -> None:
+    """The LLM-visible response from a pin-fail branch must be a bare
+    ``{"acknowledged": True}`` with no editorialising keys or error-shaped
+    payloads.
+
+    Tool responses go back to the LLM verbatim. Any ``error``, ``detail``,
+    ``no_task_pinned``, or ``pin_unresolved`` string is treated as
+    actionable context (observed live twice: #250's ``detail`` leak and
+    #252's ``error: pin_unresolved`` payload), and the model will bypass
+    the reporting contract rather than retry. The fix is to keep the
+    LLM-facing shape inert — operator visibility goes through the sink
+    event channel instead.
+    """
+    assert isinstance(response, dict), f"expected dict response, got {type(response)}"
+    for key in _FORBIDDEN_LLM_KEYS:
+        assert key not in response, (
+            f"pin-fail response leaked {key!r} to the LLM; this is a "
+            f"prompt-injection surface. Full payload: {response}"
+        )
+    # Bare ack shape — no other keys.
+    assert response == {"acknowledged": True}
+
+
+async def test_pin_fail_responses_never_leak_error_keys_to_llm() -> None:
+    """Invariant: every pin-fail code path in ``before_tool_callback``
+    must return an LLM-visible payload that carries NONE of
+    ``{error, detail, no_task_pinned, pin_unresolved}``.
+
+    This is the single-sentence version of the #250 + #252-followup
+    bug class: any named-problem string in the tool response becomes a
+    prompt-injection surface. Covers both branches:
+
+      * no-candidates (orchestration-only turn),
+      * has-candidates (sink-driven drift emission path).
+    """
+    # Branch 1 — no candidates (no plan).
+    plugin_a, state_a, _cap_a, _s_a, _sink_a = _make_plugin_with_handler(
+        "report_task_started", plan=None, with_sink=True
+    )
+    result_a = await plugin_a.before_tool_callback(
+        tool=_Tool("report_task_started"),
+        tool_args={"detail": "starting"},
+        tool_context=_Ctx(state_a),
+    )
+    _assert_prompt_safe(result_a)
+
+    # Branch 2 — has candidates, ambiguous pin.
+    plan_b = _ambiguous_plan_for("coordinator")
+    plugin_b, state_b, _cap_b, _s_b, _sink_b = _make_plugin_with_handler(
+        "report_task_started", plan=plan_b, with_sink=True
+    )
+    result_b = await plugin_b.before_tool_callback(
+        tool=_Tool("report_task_started"),
+        tool_args={"detail": "starting"},
+        tool_context=_Ctx(state_b),
+    )
+    _assert_prompt_safe(result_b)
+
+    # Branch 3 — has DAG-gated candidate.
+    plan_c = _dag_gated_plan_for("coordinator")
+    plugin_c, state_c, _cap_c, _s_c, _sink_c = _make_plugin_with_handler(
+        "report_task_started", plan=plan_c, with_sink=True
+    )
+    result_c = await plugin_c.before_tool_callback(
+        tool=_Tool("report_task_started"),
+        tool_args={"detail": "starting"},
+        tool_context=_Ctx(state_c),
+    )
+    _assert_prompt_safe(result_c)
 
 
 # ---------------------------------------------------------------------------
@@ -432,7 +587,7 @@ async def test_parallel_agenttool_resolves_by_args() -> None:
     report correctly.
     """
     plan = _parallel_plan()
-    plugin, state, _captured, session_obj = _make_plugin_with_handler(
+    plugin, state, _captured, session_obj, _sink = _make_plugin_with_handler(
         "report_task_completed", plan=plan
     )
 
@@ -464,7 +619,7 @@ async def test_parallel_agenttool_falls_through_on_ambiguous_args() -> None:
     agent-turn pin path (which, for an ambiguous coordinator, ALSO
     leaves state unset — no guess)."""
     plan = _parallel_plan()
-    plugin, state, _captured, session_obj = _make_plugin_with_handler(
+    plugin, state, _captured, session_obj, _sink = _make_plugin_with_handler(
         "report_task_completed", plan=plan
     )
 
@@ -488,7 +643,7 @@ async def test_dag_aware_candidate_filter() -> None:
     """A PENDING task whose upstream is not COMPLETED is NOT eligible
     to be the target of a delegation."""
     plan = _gated_plan()
-    plugin, state, _captured, session_obj = _make_plugin_with_handler(
+    plugin, state, _captured, session_obj, _sink = _make_plugin_with_handler(
         "report_task_completed", plan=plan
     )
 
@@ -519,7 +674,7 @@ async def test_delegation_pin_beats_agent_turn_pin() -> None:
     available, the delegation pin wins — it's the more specific
     resolution."""
     plan = _parallel_plan()
-    plugin, state, captured, session_obj = _make_plugin_with_handler(
+    plugin, state, captured, session_obj, _sink = _make_plugin_with_handler(
         "report_task_completed", plan=plan
     )
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -69,6 +69,7 @@ class _SteererStub:
         task: Any = None,
         session: Any,
         provider: str = "",
+        agent_name: str = "",
     ) -> None:
         return None
 

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -415,3 +415,83 @@ async def test_judge_disabled_when_call_llm_is_none() -> None:
     # Only confusion/looping always-on detectors ran, and neither fires
     # on a single clean-text thinking message with no history.
     assert sink.events == []
+
+
+async def test_judge_rate_limit_buckets_per_agent_not_globally() -> None:
+    """Two agents firing unpinned thinking blocks don't share a counter bucket.
+
+    Pre-fix the rate-limit counter keyed on ``current_task_id or ""``,
+    so every unpinned turn from every agent collapsed onto the ``""``
+    bucket. Agent B's legitimate first thinking block on an unpinned
+    turn could legitimately fail to fire the judge because unrelated
+    agent A's unpinned turn had already incremented the ``""`` counter.
+
+    Post-fix the key is ``(agent_name, task_id)``. Each agent gets
+    its own counter, so agent A's first unpinned block fires, and
+    agent B's first unpinned block ALSO fires independently.
+
+    Test matrix (rate_limit=3, task_id=""):
+
+        agent A turn 1 -> FIRE (count=0)    expected calls=1
+        agent B turn 1 -> FIRE (count=0)    expected calls=2
+        agent A turn 2 -> skip (count=1)    expected calls=2
+        agent B turn 2 -> skip (count=1)    expected calls=2
+        agent A turn 3 -> skip (count=2)    expected calls=2
+        agent B turn 3 -> skip (count=2)    expected calls=2
+
+    With the old global-""-bucket code calls would have been 1 after
+    agent B's first turn (skipped because agent A already consumed
+    the ``count=0`` firing slot).
+    """
+    call_llm = _stub_call_llm([{"on_task": True}] * 10)
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_rate_limit=3,
+        reasoning_drift_mode="judge",
+    )
+    # Session with no current_task_id — both agents' turns are unpinned.
+    session = Session(
+        run_id="r1",
+        goals=_goals(),
+        plan=Plan(id="p1", run_id="r1", goal_ids=["g1"], tasks=[], edges=[]),
+        current_task_id="",
+    )
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    # Round 1: both agents fire on their first unpinned block.
+    await steerer.observe_reasoning("A turn 1", session=session, agent_name="agent_a")
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+    await steerer.observe_reasoning("B turn 1", session=session, agent_name="agent_b")
+    # The bug reproduces here: pre-fix this would stay at 1 because
+    # agent A's turn had already incremented the shared ``""`` bucket.
+    assert len(call_llm.calls) == 2, (  # type: ignore[attr-defined]
+        f"agent_b's first unpinned block must fire the judge independently "
+        f"of agent_a's. Got {len(call_llm.calls)} calls; expected 2. "  # type: ignore[attr-defined]
+        f"Pre-fix both agents shared the ``(\"\", \"\")`` bucket."
+    )
+
+    # Round 2: both skip (count=1 for each agent's bucket).
+    await steerer.observe_reasoning("A turn 2", session=session, agent_name="agent_a")
+    await steerer.observe_reasoning("B turn 2", session=session, agent_name="agent_b")
+    assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
+
+    # Round 3: both skip again (count=2).
+    await steerer.observe_reasoning("A turn 3", session=session, agent_name="agent_a")
+    await steerer.observe_reasoning("B turn 3", session=session, agent_name="agent_b")
+    assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
+
+    # Round 4: both fire (count=3 % 3 == 0). Confirms the per-agent
+    # counters advance independently and are NOT a shared global bucket.
+    await steerer.observe_reasoning("A turn 4", session=session, agent_name="agent_a")
+    assert len(call_llm.calls) == 3  # type: ignore[attr-defined]
+    await steerer.observe_reasoning("B turn 4", session=session, agent_name="agent_b")
+    assert len(call_llm.calls) == 4  # type: ignore[attr-defined]
+
+    # Sanity: the counters dict is keyed by (agent_name, task_id) tuples.
+    counters = session._reasoning_judge_counters
+    assert ("agent_a", "") in counters
+    assert ("agent_b", "") in counters
+    assert counters[("agent_a", "")] == 4
+    assert counters[("agent_b", "")] == 4


### PR DESCRIPTION
## Summary

Two surgical fixes following the #252 post-mortem + a separately-identified
rate-limiter bug.

### 1. Pin-unresolved leak to the LLM (#252 follow-up)

#252 shipped `{\"acknowledged\": False, \"error\": \"pin_unresolved\"}` on
pin-fail-with-candidates, intending operator visibility. Live evidence shows
the LLM read the payload as a reasoning cue:

> *\"I'm getting an error about 'pin_unresolved'. This might be related to
> the plan/task system. Let me try a different approach - I'll just compile
> the research and create the presentation content directly.\"*

and bypassed the reporting contract. Same category of prompt-injection as
#250's `detail` string — tool responses go back to the LLM verbatim and any
editorialising / problem-naming string is treated as actionable context.

**Fix:** drop the error payload. `before_tool_callback` now returns a bare
`{\"acknowledged\": True}` on pin-fail regardless of whether the agent has
candidates. Operator visibility is preserved via:

- A `WARNING` log with `agent_name` + candidate task ids, and
- A new `DriftDetected` sink event (`DriftKind.OFF_TOPIC` + a
  `\"pin_unresolved: ...\"` reason prefix). Reused `OFF_TOPIC` rather than
  adding a new proto `DriftKind` — the invariant is observer visibility,
  not a new wire-level classification, and new proto kinds are heavier.

### 2. Judge rate-limit bucket key (per-agent isolation)

`DefaultSteerer._maybe_take_reasoning_judge_slot` keyed the per-task counter
on `task_id or \"\"`. Every unpinned turn from every agent collapsed onto the
shared `\"\"` bucket, so agent B's legitimate first thinking block on a fresh
unpinned turn could skip the judge because unrelated agent A had already
incremented the counter. Judge cadence distorted; drift detection hole.

**Fix:** bucket by `(agent_name, task_id)` tuple. Session type annotation
updated to `dict[tuple[str, str], int]`. Plumbed `agent_name` through
`observe_reasoning` / `emit_reasoning` as an optional kwarg on the
Protocol; adapters forward the live-invocation agent name resolved from
`_invocation_context.agent.name`. Back-compat handled via `TypeError`
fallback for custom steerers without the new kwarg.

### Invariant test

New `test_pin_fail_responses_never_leak_error_keys_to_llm` asserts that
the LLM-visible response from **every** pin-fail branch (no candidates,
ambiguous candidates, DAG-gated candidates) carries NONE of
`{error, detail, no_task_pinned, pin_unresolved}`. This is the
single-sentence codification of the #250 + #252-followup bug class.

## Test plan

- [x] `uv run pytest tests/test_hidden_task_id_schema.py` (14/14 passing)
- [x] `uv run pytest tests/test_reasoning_judge.py` (16/17 — 1 pre-existing
      failure on `test_rate_limit_resets_on_task_transition`, unrelated to
      these changes; reproduces on `origin/main`)
- [x] `uv run pytest tests/` — 1461 passed, 1 pre-existing failure
- [x] `uv run ruff check goldfive/` clean
- [x] +2 new tests: per-agent judge bucketing + the pin-leak invariant