### PR TITLE
fix(steerer): fire-and-forget reasoning judge so tool dispatch isn't blocked

### DIFF
--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -378,7 +378,35 @@ class GoldfiveADKAgent(BaseAgent):
                 ):
                     yield adk_event
         finally:
+            # Drain any background reasoning-judge tasks the steerer
+            # scheduled during this run (goldfive#251). The judge is
+            # fire-and-forget so ADK tool dispatch isn't blocked behind
+            # a slow LLM; this is the paired run-end drain so judges
+            # don't leak into subsequent runs and so ``CancelledError``
+            # from an adk-web disconnect doesn't orphan the tasks.
+            # Bounded timeout keeps a hung judge from stalling exit.
+            await self._drain_steerer_background_judges()
             self._notify_plugins_on_run_end()
+
+    async def _drain_steerer_background_judges(self) -> None:
+        """Call ``steerer.shutdown()`` on the bound runner's steerer, if any.
+
+        Duck-typed so custom ``Steerer`` implementations (or stubs used
+        in tests) without the method fall through cleanly. Exceptions
+        are swallowed: teardown must never mask the run's real outcome.
+        """
+        steerer = getattr(self._runner, "steerer", None)
+        shutdown = getattr(steerer, "shutdown", None)
+        if shutdown is None:
+            return
+        try:
+            await shutdown()
+        except Exception as exc:  # noqa: BLE001 — defensive
+            log.debug(
+                "GoldfiveADKAgent: steerer.shutdown raised "
+                "(swallowed): %s",
+                exc,
+            )
 
     def _notify_plugins_on_run_end(self) -> None:
         """Fire ``on_run_end()`` on every adapter plugin that defines it.

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -784,6 +784,16 @@ class Runner:
             except Exception as exc:  # noqa: BLE001
                 log.warning("conversation_ended emission raised: %s", exc)
             self._conversation_announced = False
+        # Drain background reasoning-judge tasks the steerer scheduled
+        # via its fire-and-forget judge path (goldfive#251). Bounded
+        # shutdown so a hung LLM judge doesn't stall close. Duck-typed
+        # — custom steerers without ``shutdown`` fall through cleanly.
+        steerer_shutdown = getattr(self.steerer, "shutdown", None)
+        if callable(steerer_shutdown):
+            try:
+                await steerer_shutdown()
+            except Exception as exc:  # noqa: BLE001
+                log.warning("steerer.shutdown() raised: %s", exc)
         for sink in self.sinks:
             try:
                 await sink.close()

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -43,6 +43,7 @@ levels. See goldfive#142 for the full table.
 
 from __future__ import annotations
 
+import asyncio
 import enum
 import inspect
 import json
@@ -543,6 +544,15 @@ class DefaultSteerer:
             _window = 3
         self._goldfive_steer_suppression_window_turns = max(0, _window)
         self._steering_config: SteeringConfig | None = steering_config
+        # Background reasoning-judge tasks (goldfive#251). The LLM-judge
+        # path in :meth:`observe_reasoning` is fire-and-forget so the
+        # adapter's model-response callback can return immediately and
+        # ADK can dispatch tool calls without waiting on a minute-long
+        # local-llama judge round-trip. This set holds the live
+        # ``asyncio.Task`` handles so :meth:`shutdown` can drain them
+        # at run end. Tasks auto-discard themselves via
+        # ``add_done_callback(self._background_judges.discard)``.
+        self._background_judges: set[asyncio.Task[Any]] = set()
 
     # ------------------------------------------------------------------
     # Protocol-required: wiring
@@ -1080,18 +1090,35 @@ class DefaultSteerer:
         ``session.reasoning_history_max``), then runs the reasoning
         detectors. Emits at most one drift per call.
 
-        Pipeline dispatch (goldfive#226):
+        Pipeline dispatch (goldfive#226, refined in #251):
 
         * Always-on detectors — :func:`~goldfive.drift.reasoning.detect_looping_reasoning`
           and :func:`~goldfive.drift.reasoning.detect_confusion` — run
           first on every call. They catch patterns (repetition,
           uncertainty) that the LLM judge does not, and they are cheap.
+          Their drift verdicts are handled SYNCHRONOUSLY: callers
+          awaiting this method see the resulting ``DriftDetected`` sink
+          emission and any refine dispatch before control returns.
         * Mode-selected pipeline — :func:`~goldfive.drift.reasoning.analyze_reasoning`
           runs in the configured ``reasoning_drift_mode``. The LLM judge
           path is rate-limited to at most one call every
           ``reasoning_drift_rate_limit`` thinking messages per task; the
           first thinking message of every task always fires a judge
-          call. Counters reset on task transition.
+          call. Counters reset on task transition. This path is
+          **fire-and-forget**: the judge is scheduled via
+          :func:`asyncio.create_task` and tracked on
+          ``self._background_judges`` so :meth:`shutdown` can drain it
+          at run end. Its drift verdict may therefore arrive AFTER tool
+          calls from the same turn have already dispatched — the refine
+          machinery handles "drift arrives mid-run" via supersedes, so
+          there is no correctness regression; late refines simply apply
+          to a plan state that has already advanced.
+
+        Why the judge path is async: this method is called from the
+        adapter's model-response callback, which is on the critical
+        path for ADK tool dispatch. Awaiting a minute-long local-llama
+        judge round-trip inline serialized every subsequent tool call
+        behind it.
 
         Adapters call this from their model-response callback once they
         have extracted reasoning_content (OpenAI), thinking blocks
@@ -1107,7 +1134,6 @@ class DefaultSteerer:
         if overflow > 0:
             del history[:overflow]
         from goldfive.drift.reasoning import (
-            analyze_reasoning,
             detect_confusion,
             detect_looping_reasoning,
         )
@@ -1116,39 +1142,189 @@ class DefaultSteerer:
         # (LOOPING_REASONING WARNING before CONFUSION INFO) and any
         # fire short-circuits before the mode-selected pipeline so
         # they remain the canonical signal for "repetitive / uncertain"
-        # reasoning regardless of mode.
+        # reasoning regardless of mode. These are cheap and their
+        # verdicts can affect the current turn, so they remain inline.
         drift = detect_looping_reasoning(text, session)
         if drift is None:
             drift = detect_confusion(text, session)
-        if drift is None:
-            # Mode-selected pipeline (judge / embedding / both / off).
-            # The judge path is rate-limited per-task; embedding path
-            # is synchronous.
-            rl_call_llm = self._maybe_take_reasoning_judge_slot(
-                session, agent_name=agent_name
-            )
-            # Thread the first bound sink into the judge path so a
-            # ``ReasoningJudgeInvoked`` event fires on every judge call,
-            # regardless of verdict. ``None`` when no sinks are bound —
-            # the classifier then stays sink-less and behaves as before.
-            judge_sink = self._sinks[0] if self._sinks else None
-            drift = await analyze_reasoning(
-                text,
-                session,
-                mode=self._reasoning_drift_mode,
-                call_llm=rl_call_llm,
-                model=self._reasoning_drift_model,
-                sink=judge_sink,
-            )
-        if drift is None:
+        if drift is not None:
+            # Populate ``trigger_input`` on drifts produced by the
+            # always-on pattern detectors (they do not set it
+            # themselves — they are framework-agnostic).
+            if not drift.trigger_input:
+                drift.trigger_input = self._truncate_trigger_input(text)
+            await self._handle_drift(drift, session)
             return
-        # Populate ``trigger_input`` on drifts produced by the always-on
-        # pattern detectors (they do not set it themselves — they are
-        # framework-agnostic). The judge path already stamps it on
-        # drifts it produces.
-        if not drift.trigger_input:
-            drift.trigger_input = self._truncate_trigger_input(text)
-        await self._handle_drift(drift, session)
+
+        # Mode-selected pipeline (judge / embedding / both / off).
+        # The judge path is rate-limited per-(agent, task) bucket.
+        # Historically this awaited ``analyze_reasoning`` inline; as of
+        # goldfive#251 the judge is fire-and-forget so the
+        # model-response callback can return immediately.
+        rl_call_llm = self._maybe_take_reasoning_judge_slot(
+            session, agent_name=agent_name
+        )
+        # Fast-exit when there's nothing for ``analyze_reasoning`` to
+        # do: ``mode="off"``, or ``mode="judge"`` with no judge slot
+        # (rate-limited or globally disabled). Embedding and "both"
+        # modes always schedule — their embedding pipeline runs even
+        # when the judge slot is empty.
+        if self._reasoning_drift_mode == "off":
+            return
+        if self._reasoning_drift_mode == "judge" and rl_call_llm is None:
+            return
+        # Thread the first bound sink into the judge path so a
+        # ``ReasoningJudgeInvoked`` event fires on every judge call,
+        # regardless of verdict. ``None`` when no sinks are bound —
+        # the classifier then stays sink-less and behaves as before.
+        judge_sink = self._sinks[0] if self._sinks else None
+        # Snapshot the reasoning-history position at schedule time so
+        # the bg pipeline sees the same view the inline pattern
+        # detectors just saw, even if subsequent turns append more
+        # entries before the bg task runs. Without this, a detector
+        # that slices ``history[-N:-1]`` (expecting ``text`` to be the
+        # last entry) would see ``text`` itself in the comparison
+        # window and trivially self-match (goldfive#251 ordering
+        # regression surfaced by the cluster-tightening one-shot
+        # test). ``history_length`` is the length AFTER ``text`` was
+        # appended — the bg path trims ``session.reasoning_history``
+        # to this length for its invocation.
+        history_length = len(session.reasoning_history)
+        bg_task = asyncio.create_task(
+            self._run_judge_background(
+                text=text,
+                session=session,
+                call_llm=rl_call_llm,
+                judge_sink=judge_sink,
+                history_length=history_length,
+            )
+        )
+        self._background_judges.add(bg_task)
+        bg_task.add_done_callback(self._background_judges.discard)
+
+    async def _run_judge_background(
+        self,
+        *,
+        text: str,
+        session: Session,
+        call_llm: ReflectiveCallLLM | None,
+        judge_sink: Any,
+        history_length: int,
+    ) -> None:
+        """Run the mode-selected reasoning drift pipeline off the critical path.
+
+        Scheduled by :meth:`observe_reasoning` as an
+        :func:`asyncio.create_task` so the adapter's model-response
+        callback can return before ADK dispatches the response's tool
+        calls. Awaits :func:`~goldfive.drift.reasoning.analyze_reasoning`
+        and, if it yields a :class:`DriftEvent`, routes it through
+        :meth:`_handle_drift` — same effect as the historical inline
+        path, just resolving later.
+
+        ``history_length`` pins the ``session.reasoning_history`` view
+        the pipeline sees to the same tail index that was in effect
+        when the bg task was scheduled. Later turns that append to
+        the shared history (this same session receiving more
+        reasoning blocks before the bg task runs) would otherwise
+        shift the detectors' "exclude self" slice and generate false
+        self-match LOOPING signals. We temporarily truncate the
+        session view for the duration of this bg invocation and
+        restore it after; concurrent bg tasks serialize on the same
+        session's reasoning_history via the asyncio event loop (no
+        threading) so the save/restore pattern is safe in practice.
+
+        Never raises: any exception (from the judge LLM, the embedding
+        pipeline, or ``_handle_drift``) is logged at ``WARNING`` and
+        swallowed. The background task must not crash the run; the
+        adapter callback that scheduled us has long since returned.
+        """
+        try:
+            from goldfive.drift.reasoning import analyze_reasoning
+
+            # Save the shared live history and swap in a list snapshot
+            # truncated to the length captured at schedule time. Using
+            # list slicing (not mutation) keeps any already-escaped
+            # reference (e.g. a concurrent detector) pointing at the
+            # original list. We restore the live reference in a
+            # ``finally`` so intervening appends are not lost.
+            original_history = session.reasoning_history
+            pinned_history = list(original_history[:history_length])
+            session.reasoning_history = pinned_history
+            try:
+                drift = await analyze_reasoning(
+                    text,
+                    session,
+                    mode=self._reasoning_drift_mode,
+                    call_llm=call_llm,
+                    model=self._reasoning_drift_model,
+                    sink=judge_sink,
+                )
+            finally:
+                # Restore the live history. Any entries appended by
+                # subsequent turns are preserved because we pointed
+                # ``session.reasoning_history`` at a separate list for
+                # our window.
+                session.reasoning_history = original_history
+            if drift is None:
+                return
+            if not drift.trigger_input:
+                drift.trigger_input = self._truncate_trigger_input(text)
+            await self._handle_drift(drift, session)
+        except asyncio.CancelledError:
+            # Propagate cancellation so :meth:`shutdown` / event-loop
+            # teardown can cleanly abort a still-running judge without
+            # the WARNING log below muddying the signal.
+            raise
+        except Exception as exc:  # noqa: BLE001 — background task
+            log.warning(
+                "DefaultSteerer: background reasoning-judge raised "
+                "(swallowed): %s",
+                exc,
+            )
+
+    async def shutdown(self, *, timeout: float = 5.0) -> None:
+        """Drain background reasoning-judge tasks with a bounded wait.
+
+        Called at run / runner teardown so ``asyncio.create_task``
+        handles scheduled by :meth:`observe_reasoning` do not leak
+        beyond the event loop's lifetime. Waits at most ``timeout``
+        seconds (default 5.0) for all tracked judges to finish; any
+        still-running tasks past the timeout are cancelled and awaited
+        briefly so their ``CancelledError`` propagation settles before
+        we return.
+
+        Idempotent: a second call on an empty ``_background_judges``
+        set is a no-op.
+        """
+        if not self._background_judges:
+            return
+        # Snapshot: tasks may be removed from the set by their
+        # done-callbacks while we're iterating.
+        pending = list(self._background_judges)
+        if not pending:
+            return
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True),
+                timeout=max(0.0, float(timeout)),
+            )
+        except TimeoutError:
+            # Cancel the stragglers and give them a beat to unwind so
+            # we don't leave "pending task" warnings on loop close.
+            still_pending = [t for t in pending if not t.done()]
+            for task in still_pending:
+                task.cancel()
+            if still_pending:
+                try:
+                    await asyncio.wait(still_pending, timeout=0.5)
+                except Exception:  # noqa: BLE001 — defensive
+                    pass
+            log.warning(
+                "DefaultSteerer.shutdown: %d background judge task(s) "
+                "exceeded %.2fs timeout; cancelled",
+                len(still_pending),
+                float(timeout),
+            )
 
     @staticmethod
     def _truncate_trigger_input(text: str, limit: int = 2048) -> str:

--- a/tests/test_drift_reasoning.py
+++ b/tests/test_drift_reasoning.py
@@ -12,6 +12,7 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -50,6 +51,19 @@ class ListSink:
 
     async def close(self) -> None:
         pass
+
+
+async def _wait_for_judges(steerer: DefaultSteerer) -> None:
+    """Drain background reasoning-judge tasks scheduled by the steerer.
+
+    Since goldfive#251 :meth:`DefaultSteerer.observe_reasoning` routes
+    the mode-selected pipeline (judge / embedding / both) through
+    ``asyncio.create_task``; tests that assert sink state need to
+    await the pending tasks before inspecting the sink.
+    """
+    pending = list(steerer._background_judges)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
 
 
 class NullPlanner:
@@ -584,6 +598,9 @@ async def test_reasoning_cluster_tightening_is_one_shot_per_task() -> None:
             _pad_tokens("shared", 8) + f" uniqueturn{turn:02d}00 uniqueturn{turn:02d}01"
         )
         await steerer.observe_reasoning(current, session=session)
+    # The embedding pipeline is now fire-and-forget (goldfive#251);
+    # drain before inspecting the sink.
+    await _wait_for_judges(steerer)
 
     drift_events = [
         e for e in sink.events if e.WhichOneof("payload") == "drift_detected"

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -16,6 +16,7 @@ Covers (see goldfive#226):
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -97,6 +98,19 @@ def _task() -> Task:
 
 def _goals() -> list[Goal]:
     return [Goal(id="g1", summary="Publish a memo on solar panels")]
+
+
+async def _wait_for_judges(steerer: DefaultSteerer) -> None:
+    """Drain any background reasoning-judge tasks the steerer scheduled.
+
+    Tests that assert on ``call_llm.calls`` / sink events after
+    :meth:`DefaultSteerer.observe_reasoning` need to wait for the
+    fire-and-forget judge task to finish — the method itself returns
+    before the judge runs (goldfive#251).
+    """
+    pending = list(steerer._background_judges)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
 
 
 def _session_with_task(task_id: str = "t1") -> Session:
@@ -355,20 +369,25 @@ async def test_rate_limit_fires_first_call_then_every_N(
 
     # 1st turn -> judge fires (count=0 starts the task).
     await steerer.observe_reasoning("turn 1", session=session)
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     # 2nd / 3rd turn -> skip (count=1,2).
     await steerer.observe_reasoning("turn 2", session=session)
     await steerer.observe_reasoning("turn 3", session=session)
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     # 4th turn -> fire again (count=3 = 3 % 3 == 0).
     await steerer.observe_reasoning("turn 4", session=session)
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
     # 5th-6th -> skip.
     await steerer.observe_reasoning("turn 5", session=session)
     await steerer.observe_reasoning("turn 6", session=session)
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
     # 7th -> fire.
     await steerer.observe_reasoning("turn 7", session=session)
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 3  # type: ignore[attr-defined]
 
 
@@ -388,6 +407,7 @@ async def test_rate_limit_resets_on_task_transition() -> None:
     # Two thinking messages on t1 -> one judge call (1st fires, 2nd skips).
     await steerer.observe_reasoning("t1 turn 1", session=session)
     await steerer.observe_reasoning("t1 turn 2", session=session)
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
 
     # Task transition: add a fresh task and bind it as current.
@@ -398,6 +418,7 @@ async def test_rate_limit_resets_on_task_transition() -> None:
 
     # First reasoning on t2 -> fresh judge call (the counter for t2 is 0).
     await steerer.observe_reasoning("t2 turn 1", session=session)
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
 
 
@@ -412,6 +433,7 @@ async def test_judge_disabled_when_call_llm_is_none() -> None:
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
     await steerer.observe_reasoning("any thought", session=session)
+    await _wait_for_judges(steerer)
     # Only confusion/looping always-on detectors ran, and neither fires
     # on a single clean-text thinking message with no history.
     assert sink.events == []
@@ -462,8 +484,10 @@ async def test_judge_rate_limit_buckets_per_agent_not_globally() -> None:
 
     # Round 1: both agents fire on their first unpinned block.
     await steerer.observe_reasoning("A turn 1", session=session, agent_name="agent_a")
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     await steerer.observe_reasoning("B turn 1", session=session, agent_name="agent_b")
+    await _wait_for_judges(steerer)
     # The bug reproduces here: pre-fix this would stay at 1 because
     # agent A's turn had already incremented the shared ``""`` bucket.
     assert len(call_llm.calls) == 2, (  # type: ignore[attr-defined]
@@ -475,18 +499,22 @@ async def test_judge_rate_limit_buckets_per_agent_not_globally() -> None:
     # Round 2: both skip (count=1 for each agent's bucket).
     await steerer.observe_reasoning("A turn 2", session=session, agent_name="agent_a")
     await steerer.observe_reasoning("B turn 2", session=session, agent_name="agent_b")
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
 
     # Round 3: both skip again (count=2).
     await steerer.observe_reasoning("A turn 3", session=session, agent_name="agent_a")
     await steerer.observe_reasoning("B turn 3", session=session, agent_name="agent_b")
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
 
     # Round 4: both fire (count=3 % 3 == 0). Confirms the per-agent
     # counters advance independently and are NOT a shared global bucket.
     await steerer.observe_reasoning("A turn 4", session=session, agent_name="agent_a")
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 3  # type: ignore[attr-defined]
     await steerer.observe_reasoning("B turn 4", session=session, agent_name="agent_b")
+    await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 4  # type: ignore[attr-defined]
 
     # Sanity: the counters dict is keyed by (agent_name, task_id) tuples.
@@ -495,3 +523,189 @@ async def test_judge_rate_limit_buckets_per_agent_not_globally() -> None:
     assert ("agent_b", "") in counters
     assert counters[("agent_a", "")] == 4
     assert counters[("agent_b", "")] == 4
+
+
+# ---------------------------------------------------------------------------
+# DefaultSteerer: fire-and-forget judge path (goldfive#251)
+# ---------------------------------------------------------------------------
+
+
+async def test_observe_reasoning_returns_fast_when_judge_is_slow() -> None:
+    """observe_reasoning must not block on the judge LLM.
+
+    The judge's ``call_llm`` sleeps for 60s. ``observe_reasoning``
+    must return within 100 ms because the judge is scheduled as a
+    background task, not awaited inline. This is the correctness
+    target of goldfive#251: the adapter's model-response callback is
+    on the critical path for ADK tool dispatch.
+    """
+
+    async def slow_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        await asyncio.sleep(60)
+        return json.dumps({"on_task": True})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=slow_call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session_with_task()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    loop = asyncio.get_event_loop()
+    t0 = loop.time()
+    await steerer.observe_reasoning("clean on-task reasoning", session=session)
+    elapsed = loop.time() - t0
+    try:
+        assert elapsed < 0.1, (
+            f"observe_reasoning blocked for {elapsed:.3f}s; expected <0.1s "
+            "(fire-and-forget regression)"
+        )
+        # The background task is live and still sleeping.
+        assert len(steerer._background_judges) == 1
+    finally:
+        # Cancel the slow judge so the test doesn't linger.
+        for task in list(steerer._background_judges):
+            task.cancel()
+        await asyncio.gather(
+            *steerer._background_judges, return_exceptions=True
+        )
+
+
+async def test_observe_reasoning_judge_still_fires_in_background() -> None:
+    """The backgrounded judge runs after observe_reasoning returns.
+
+    Schedules a judge that emits an OFF_TOPIC WARNING drift (well
+    below the USER_STEER promotion threshold so the test doesn't
+    tangle with refine-fallback follow-up drifts).
+    :meth:`observe_reasoning` returns immediately; awaiting
+    ``_background_judges`` then completes the judge path and the
+    ``DriftDetected`` sink event materializes on the sink.
+    """
+    call_llm = _stub_call_llm(
+        [{"on_task": False, "severity": "info", "reason": "slightly off"}]
+    )
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session_with_task()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    await steerer.observe_reasoning("raccoons are nocturnal", session=session)
+    # Judge hasn't run yet -> no drift emitted.
+    drift_events_pre = [
+        e for e in sink.events if e.WhichOneof("payload") == "drift_detected"
+    ]
+    assert drift_events_pre == []
+    # Drain the background task.
+    await _wait_for_judges(steerer)
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+    drift_events_post = [
+        e for e in sink.events if e.WhichOneof("payload") == "drift_detected"
+    ]
+    # Exactly one DriftDetected: the INFO OFF_TOPIC from the judge.
+    # (INFO severity stays under the intervention ladder's refine
+    # threshold so no downstream refine-failure drift cascades.)
+    assert len(drift_events_post) == 1
+
+
+async def test_observe_reasoning_judge_exception_does_not_crash(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exception inside the background judge coroutine is swallowed.
+
+    We simulate a failure below the level
+    :func:`classify_reasoning_drift` normally catches by patching
+    :func:`~goldfive.drift.reasoning.analyze_reasoning` to raise
+    directly. The background task's outer try/except must log at
+    WARNING on the steerer logger and keep the set drainable.
+    ``observe_reasoning`` itself must not propagate the failure to
+    the adapter callback that scheduled it.
+    """
+    from goldfive.drift import reasoning as reasoning_mod
+
+    async def _boom(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+        raise RuntimeError("judge exploded")
+
+    monkeypatch.setattr(reasoning_mod, "analyze_reasoning", _boom)
+
+    # Any valid judge wiring -- analyze_reasoning is monkeypatched
+    # before the background task dispatches.
+    call_llm = _stub_call_llm([{"on_task": True}])
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session_with_task()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    with caplog.at_level(logging.WARNING, logger="goldfive.steerer"):
+        await steerer.observe_reasoning("some thought", session=session)
+        await _wait_for_judges(steerer)
+
+    # No drift was emitted (analyze_reasoning never returned a verdict).
+    assert [
+        e for e in sink.events if e.WhichOneof("payload") == "drift_detected"
+    ] == []
+    # The set drains cleanly (the raising task resolved).
+    assert steerer._background_judges == set()
+    # The raise was swallowed and surfaced as a WARNING on the steerer
+    # logger.
+    steerer_warnings = [
+        r for r in caplog.records
+        if r.name == "goldfive.steerer"
+        and r.levelno == logging.WARNING
+        and "background reasoning-judge raised" in r.getMessage()
+    ]
+    assert len(steerer_warnings) == 1
+
+
+async def test_shutdown_bounded_timeout_does_not_wait_for_slow_judge() -> None:
+    """``shutdown(timeout=...)`` returns within the bound even if a judge hangs.
+
+    A hung judge (10s sleep) must not stall runner teardown. The
+    shutdown cancels the stragglers and returns.
+    """
+
+    async def hung_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        await asyncio.sleep(10)
+        return json.dumps({"on_task": True})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=hung_call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session_with_task()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    # Schedule a judge that will be running when shutdown fires.
+    await steerer.observe_reasoning("slow-path thought", session=session)
+    assert len(steerer._background_judges) == 1
+
+    loop = asyncio.get_event_loop()
+    t0 = loop.time()
+    await steerer.shutdown(timeout=0.5)
+    elapsed = loop.time() - t0
+    # 0.5 timeout + 0.5 cancel-drain budget = ~1.0s ceiling; we want
+    # well under the judge's 10s. Allow a little jitter for slow CI.
+    assert elapsed < 2.0, (
+        f"shutdown took {elapsed:.3f}s; expected <2.0s (bounded-timeout regression)"
+    )
+
+
+async def test_shutdown_is_noop_when_no_background_judges() -> None:
+    """Calling ``shutdown`` with nothing in flight is instant and safe."""
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[ListSink()], planner=NullPlanner())
+    # No observe_reasoning call -> empty set.
+    assert steerer._background_judges == set()
+    await steerer.shutdown(timeout=5.0)


### PR DESCRIPTION
## Summary

- `observe_reasoning` previously awaited the LLM-judge path inline in the adapter's model-response callback, which is on the critical path for ADK tool dispatch. A slow local-llama judge serialized every subsequent tool call behind the judge (~minute on live Gantts).
- Always-on pattern detectors (`detect_looping_reasoning`, `detect_confusion`) still run synchronously because they're cheap and must affect the current turn. The mode-selected pipeline (`analyze_reasoning` -> judge / embedding / both) is now scheduled via `asyncio.create_task` and tracked on `DefaultSteerer._background_judges` for bounded shutdown.
- New `DefaultSteerer.shutdown(timeout=5.0)` drains pending background tasks with a hard timeout so hung judges don't stall process exit. Called from the ADK wrap's per-run `finally` (new `_drain_steerer_background_judges`) and from `Runner.close()` for programmatic callers.

## Ordering
Documented in `observe_reasoning`'s docstring: the judge path's drift verdict may arrive after tool calls from the same turn have already dispatched. Refine handles "plan revised mid-run" via supersedes so there's no correctness regression.

One regression caught by the cluster-tightening one-shot test: bg detectors that slice `history[-N:-1]` saw the current text self-match when later turns appended to the shared history before the bg task ran. Fixed by snapshotting `session.reasoning_history` to the length captured at schedule time for the duration of the bg call.

## Test plan
- [x] `uv run pytest tests/ -x` (1465 passed, 46 skipped)
- [x] `uv run ruff check goldfive/ tests/` (clean)
- [x] New tests: fast return under 100 ms when judge sleeps 60 s; judge still fires in background; exceptions in background judge log WARNING and swallow; `shutdown(timeout=0.5)` returns within budget even against a 10 s judge; `shutdown` no-op on empty set.