### PR TITLE
feat(convenience, adapters): dynamic instruction resolver (Stream B of #251)

### DIFF
--- a/goldfive/adapters/_adk_dynainst.py
+++ b/goldfive/adapters/_adk_dynainst.py
@@ -1,0 +1,328 @@
+"""Dynamic instruction resolver for goldfive-wrapped ADK ``LlmAgent``\\s.
+
+Goldfive#251 — plan-causal prompting.
+
+Each wrapped ``LlmAgent``'s ``instruction`` field is bound at
+``LlmAgent(...)`` construction time. When goldfive's plan changes
+mid-run (refine landing, task supersedes, correction injection), the
+plan updates in ``session.state`` but the agent's baked-in prompt does
+not — so the LLM keeps executing its original instruction and only
+"observes" the plan shift through unrelated channels.
+
+This module fixes that by replacing each wrapped ``LlmAgent``'s static
+``instruction`` string with a callable ``(ReadonlyContext) -> str`` that
+resolves the agent's current task from ``session.state`` at every turn.
+ADK's ``canonical_instruction`` invokes the callable per turn and
+returns ``bypass_state_injection=True`` for the result, so refine
+landing in state is picked up on the NEXT turn with no transcript
+rewrite.
+
+The resolver is **agent-agnostic**: works for any wrapped ``LlmAgent``
+(coordinator, sub-agent, root-with-tools, leaf). The current-task
+resolution is driven entirely by whatever is pinned in state for this
+specific agent invocation via
+:data:`goldfive.adapters._adk_state_protocol.KEY_CURRENT_TASK_ID`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from goldfive.adapters import _adk_state_protocol as _sp
+
+log = logging.getLogger("goldfive.adapters._adk_dynainst")
+
+
+_MISSING_TITLE_PLACEHOLDER = "(title unset)"
+_MISSING_DESCRIPTION_PLACEHOLDER = "(description unset)"
+
+
+def pending_correction_key(agent_name: str, task_id: str) -> str:
+    """Return the full state key for a pending correction.
+
+    Keyed by ``(agent_name, task_id)`` so a correction targeted at one
+    agent/task pair does not leak into another agent's prompt. Stream D
+    (correction injection) owns the writer; this module owns the reader.
+    """
+    return f"{_sp.KEY_PENDING_CORRECTIONS}.{agent_name}.{task_id}"
+
+
+def _state_from_readonly_context(readonly_ctx: Any) -> Mapping[str, Any]:
+    """Pull ``session.state`` off a ``ReadonlyContext`` defensively.
+
+    ADK exposes ``readonly_context.state`` as a ``MappingProxyType`` over
+    the live session.state dict. We accept anything mapping-shaped and
+    degrade to an empty dict on exotic / stub contexts so the resolver
+    never raises from inside ADK's instruction pipeline.
+    """
+    state = getattr(readonly_ctx, "state", None)
+    if isinstance(state, Mapping):
+        return state
+    return {}
+
+
+def _compose_instruction(
+    *,
+    original: str,
+    task_id: str,
+    task_title: str,
+    task_description: str,
+    pending_correction: str,
+) -> str:
+    """Assemble the final prompt string the LLM sees this turn.
+
+    Shape:
+
+        {original}
+
+        ---
+
+        Current assigned task:
+          id: {task_id}
+          title: {task_title}
+          description: {task_description}
+
+        {pending_correction}  # appended only when non-empty
+    """
+    title = task_title or _MISSING_TITLE_PLACEHOLDER
+    description = task_description or _MISSING_DESCRIPTION_PLACEHOLDER
+
+    block = (
+        f"{original}\n"
+        "\n"
+        "---\n"
+        "\n"
+        "Current assigned task:\n"
+        f"  id: {task_id}\n"
+        f"  title: {title}\n"
+        f"  description: {description}\n"
+    )
+    if pending_correction:
+        block = f"{block}\n{pending_correction}\n"
+    return block
+
+
+def make_dynamic_instruction(
+    original_instruction: str,
+    agent_name: str,
+) -> Callable[[Any], str]:
+    """Return a resolver matching ADK's ``InstructionProvider`` signature.
+
+    The returned callable:
+
+    * Reads ``session.state`` off the ``ReadonlyContext``.
+    * If no current-task id is pinned for this agent, returns the
+      ``original_instruction`` verbatim (pre-plan turns stay unchanged).
+    * Otherwise composes the original + a current-task block.
+    * If a pending correction exists for ``(agent_name, current_task_id)``
+      the block is appended (Stream D will write; we just read).
+
+    The resolver is pure: given the same state it returns the same
+    string. No side effects, no persistence.
+    """
+
+    def resolver(readonly_ctx: Any) -> str:
+        try:
+            state = _state_from_readonly_context(readonly_ctx)
+
+            current_task_id = str(state.get(_sp.KEY_CURRENT_TASK_ID, "") or "")
+            if not current_task_id:
+                # No pin — pre-plan turn, or an agent that doesn't need
+                # plan-causal augmentation this turn. Return the caller's
+                # instruction verbatim.
+                return original_instruction
+
+            current_task_title = str(
+                state.get(_sp.KEY_CURRENT_TASK_TITLE, "") or ""
+            )
+            current_task_description = str(
+                state.get(_sp.KEY_CURRENT_TASK_DESCRIPTION, "") or ""
+            )
+
+            pending_correction = str(
+                state.get(
+                    pending_correction_key(agent_name, current_task_id),
+                    "",
+                )
+                or ""
+            )
+
+            return _compose_instruction(
+                original=original_instruction,
+                task_id=current_task_id,
+                task_title=current_task_title,
+                task_description=current_task_description,
+                pending_correction=pending_correction,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Instrumentation path — any failure here degrades to the
+            # original instruction so the agent still runs. ADK's own
+            # pipeline would otherwise surface this as an InternalError
+            # mid-turn, which is the worst possible failure mode.
+            log.debug(
+                "dynamic_instruction resolver raised for agent=%r: %s "
+                "(falling back to original instruction)",
+                agent_name,
+                exc,
+            )
+            return original_instruction
+
+    # Stamp provenance on the closure so test code and tree-walk
+    # idempotency checks can recognise it without relying on repr.
+    resolver._goldfive_dynamic_instruction = True  # type: ignore[attr-defined]
+    resolver._goldfive_agent_name = agent_name  # type: ignore[attr-defined]
+    resolver._goldfive_original_instruction = original_instruction  # type: ignore[attr-defined]
+    return resolver
+
+
+def is_dynamic_instruction(value: Any) -> bool:
+    """Return True when ``value`` is a resolver produced by this module."""
+    return bool(getattr(value, "_goldfive_dynamic_instruction", False))
+
+
+def _looks_like_llm_agent(node: Any) -> bool:
+    """Duck-type check for an ADK ``LlmAgent`` without importing ADK.
+
+    ``LlmAgent`` carries an ``instruction`` pydantic field (``Union[str,
+    InstructionProvider]``). ``SequentialAgent`` / ``ParallelAgent`` /
+    custom ``BaseAgent`` subclasses do not. Presence of ``instruction``
+    is a stable discriminator and avoids forcing an ADK import at
+    wrap-time.
+    """
+    return node is not None and hasattr(node, "instruction")
+
+
+def install_dynamic_instructions(root_agent: Any) -> int:
+    """Replace every reachable ``LlmAgent``'s ``instruction`` with a resolver.
+
+    Traverses the same three edges the rest of the adapter uses
+    (``sub_agents`` / ``inner_agent`` / ``AgentTool.agent``) so any
+    wrapped-tree shape is covered: coordinator+AgentTool, native
+    ``sub_agents``, nested tool trees, etc.
+
+    For every ``LlmAgent`` encountered:
+
+    * If the existing ``instruction`` is already a dynamic resolver (re-
+      wrap on the same tree): skip. Idempotent.
+    * If it is a callable (user-supplied ``InstructionProvider``): leave
+      it alone — the caller is already managing their own dynamic
+      resolution, and we must not double-wrap them.
+    * If it is a string (the common case): capture the string as the
+      closure's ``original``, capture ``agent.name`` for correction
+      lookup, install the resolver.
+
+    Non-``LlmAgent`` nodes are walked through but not modified.
+
+    Returns the number of agents that had their instruction replaced.
+    Silent on assignment failures (frozen pydantic models): one bad
+    agent must not block the rest of the tree.
+    """
+    if root_agent is None:
+        return 0
+
+    touched = 0
+    seen: set[int] = set()
+    stack: list[Any] = [root_agent]
+    while stack:
+        cur = stack.pop()
+        if cur is None or id(cur) in seen:
+            continue
+        seen.add(id(cur))
+
+        # Walk edges BEFORE the LlmAgent check so non-LlmAgent containers
+        # (SequentialAgent, ParallelAgent) still propagate to their
+        # children. Same pattern as _attach_goldfive_planner_to_tree.
+        for sub in getattr(cur, "sub_agents", None) or ():
+            stack.append(sub)
+        inner = getattr(cur, "inner_agent", None)
+        if inner is not None:
+            stack.append(inner)
+        for tool in getattr(cur, "tools", None) or ():
+            nested = getattr(tool, "agent", None)
+            if nested is not None:
+                stack.append(nested)
+
+        if not _looks_like_llm_agent(cur):
+            continue
+
+        existing = getattr(cur, "instruction", "")
+        if is_dynamic_instruction(existing):
+            log.debug(
+                "dynamic instruction already installed for %r — skipping",
+                getattr(cur, "name", "<unnamed>"),
+            )
+            continue
+        if callable(existing):
+            log.debug(
+                "agent %r has a user-supplied InstructionProvider "
+                "(callable) — leaving it alone",
+                getattr(cur, "name", "<unnamed>"),
+            )
+            continue
+        original = existing if isinstance(existing, str) else ""
+
+        agent_name = str(getattr(cur, "name", "") or "")
+        resolver = make_dynamic_instruction(
+            original_instruction=original,
+            agent_name=agent_name,
+        )
+        try:
+            cur.instruction = resolver
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "could not install dynamic instruction for agent %r: %s",
+                agent_name,
+                exc,
+            )
+            continue
+        log.debug("dynamic instruction installed for %r", agent_name)
+        touched += 1
+
+    return touched
+
+
+def log_dynamic_instruction_opt_out(root_agent: Any) -> None:
+    """Emit one INFO log per reachable ``LlmAgent`` when the caller opted out.
+
+    Walks the same edges as :func:`install_dynamic_instructions` but
+    does not mutate anything. Exists so the operator log shows which
+    agents in the tree are running with static instructions — useful
+    for debugging "why isn't refine landing in this agent's prompt?"
+    after the fact.
+    """
+    if root_agent is None:
+        return
+    seen: set[int] = set()
+    stack: list[Any] = [root_agent]
+    while stack:
+        cur = stack.pop()
+        if cur is None or id(cur) in seen:
+            continue
+        seen.add(id(cur))
+
+        for sub in getattr(cur, "sub_agents", None) or ():
+            stack.append(sub)
+        inner = getattr(cur, "inner_agent", None)
+        if inner is not None:
+            stack.append(inner)
+        for tool in getattr(cur, "tools", None) or ():
+            nested = getattr(tool, "agent", None)
+            if nested is not None:
+                stack.append(nested)
+
+        if _looks_like_llm_agent(cur):
+            log.info(
+                "goldfive.wrap: dynamic_instruction OPT-OUT for %r",
+                getattr(cur, "name", "<unnamed>"),
+            )
+
+
+__all__ = [
+    "install_dynamic_instructions",
+    "is_dynamic_instruction",
+    "log_dynamic_instruction_opt_out",
+    "make_dynamic_instruction",
+    "pending_correction_key",
+]

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1592,6 +1592,7 @@ def make_adk_plugin(
                                     task_id=tid,
                                     agent_name=agent_name,
                                     source="delegation_pin",
+                                    task=task,
                                 )
                                 return
 
@@ -1666,6 +1667,7 @@ def make_adk_plugin(
                 task_id=task_id,
                 agent_name=agent_name,
                 source="single_match",
+                task=task,
             )
 
         def _stamp_current_task_id(
@@ -1676,6 +1678,7 @@ def make_adk_plugin(
             task_id: str,
             agent_name: str,
             source: str,
+            task: Any = None,
         ) -> None:
             """Write ``task_id`` into both state surfaces for the sub-agent.
 
@@ -1684,6 +1687,14 @@ def make_adk_plugin(
             ``source`` label threads into the log line so the operator
             log shows whether the pin came from the pending-delegations
             map (goldfive#241) or the legacy assignee-match path.
+
+            When ``task`` is provided, the ADK side also stamps
+            ``goldfive.current_task_title`` /
+            ``goldfive.current_task_description`` so the dynamic
+            instruction resolver (goldfive#251) can render plan-causal
+            prompts without re-walking the plan. Legacy callers that
+            don't pass the task object keep working — the resolver
+            falls back to placeholders.
             """
             gf_state = _safe_attr(ctx.session, "state", None)
             if isinstance(gf_state, dict):
@@ -1697,7 +1708,15 @@ def make_adk_plugin(
             adk_state = _session_state_from_callback(callback_context)
             if isinstance(adk_state, Mapping):
                 try:
-                    _sp.write_current_task_id(adk_state, task_id)
+                    if task is not None:
+                        # write_current_task stamps all four fields
+                        # (id / title / description / assignee) from the
+                        # Task. Prefer this over the narrow id-only write
+                        # so the dynamic-instruction resolver (#251)
+                        # sees the title + description it needs.
+                        _sp.write_current_task(adk_state, task)
+                    else:
+                        _sp.write_current_task_id(adk_state, task_id)
                 except Exception as exc:  # noqa: BLE001
                     log.debug(
                         "before_agent_callback: ADK session.state pin failed: %s",

--- a/goldfive/adapters/_adk_state_protocol.py
+++ b/goldfive/adapters/_adk_state_protocol.py
@@ -49,6 +49,15 @@ KEY_TASK_OUTCOME = "goldfive.task_outcome"
 KEY_AGENT_NOTE = "goldfive.agent_note"
 KEY_DIVERGENCE_FLAG = "goldfive.divergence_flag"
 
+# Dynamic instruction (goldfive#251). Prefix key for correction-injection
+# bodies written by Stream D's correction-injection path and read by the
+# dynamic instruction resolver in :mod:`goldfive.adapters._adk_dynainst`.
+# The full key is ``{prefix}.{agent_name}.{task_id}`` so a correction is
+# scoped to the exact agent+task pair it was authored for and does not
+# leak into sibling agents or later tasks. Reader-only in this module;
+# Stream D owns the writer.
+KEY_PENDING_CORRECTIONS = "goldfive.pending_corrections"
+
 # Orchestration -> Agents (goldfive#170 — bridged from
 # ``goldfive.Session.state`` into the live ADK session.state so
 # :class:`~goldfive.planners.goldfive_planner.GoldfivePlanner` sees them

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -152,6 +152,7 @@ def wrap(
     max_task_invocations: int | None = None,
     plugins: list[Any] | None = None,
     runtime: RuntimeConfig | None = None,
+    dynamic_instruction: bool = True,
     **legacy_kwargs: Any,
 ) -> Runner:
     """Build a :class:`Runner` that drives ``agent`` with goldfive.
@@ -205,6 +206,18 @@ def wrap(
         same plugins as the coordinator — not just the
         ``App(plugins=[...])``-level root runner. Ignored for
         non-ADK agents. See goldfive#121.
+    dynamic_instruction:
+        Default-on (goldfive#251). When ``True`` (the default) every
+        reachable ``LlmAgent`` in an ADK wrap target has its static
+        ``instruction`` string replaced with a callable resolver that
+        re-reads the agent's current-task context from ``session.state``
+        at every turn. The effect is plan-causal prompting: when refine
+        lands a revised description mid-run, the NEXT turn of the
+        affected agent automatically sees the new task without
+        transcript rewrite. Pass ``dynamic_instruction=False`` to keep
+        the original static strings (e.g. for deterministic prompts
+        under test, or when the caller is already managing their own
+        dynamic resolution). Ignored for non-ADK agents.
     runtime:
         Optional :class:`~goldfive.config.RuntimeConfig` (goldfive#225)
         bundling the typed-config surfaces: embedding backend,
@@ -237,6 +250,28 @@ def wrap(
         ``BaseAgent`` side can annotate
         ``cast(GoldfiveADKAgent, goldfive.wrap(...))`` themselves.
     """
+    # Dynamic instruction resolver (goldfive#251). Default-on per user
+    # review decision. Mutates each reachable LlmAgent's ``instruction``
+    # field in-place so the LLM sees a plan-causal prompt every turn,
+    # not just the baked-in string from construction time. Only
+    # meaningful for ADK agents (LlmAgent has the ``instruction``
+    # field); the installer is a no-op on other tree shapes.
+    if is_adk_agent(agent):
+        from goldfive.adapters._adk_dynainst import (
+            install_dynamic_instructions,
+            log_dynamic_instruction_opt_out,
+        )
+
+        if dynamic_instruction:
+            touched = install_dynamic_instructions(agent)
+            if touched:
+                log.debug(
+                    "goldfive.wrap: dynamic_instruction installed on %d agent(s)",
+                    touched,
+                )
+        else:
+            log_dynamic_instruction_opt_out(agent)
+
     adapter = auto_adapter(agent, plugins=plugins)
 
     # Resolve the runtime config (goldfive#225). When ``runtime`` is

--- a/tests/test_dynamic_instruction.py
+++ b/tests/test_dynamic_instruction.py
@@ -1,0 +1,364 @@
+"""Tests for the dynamic instruction resolver (goldfive#251 Stream B).
+
+Covers:
+
+* Resolver semantics — no pin, pinned, correction placeholder, legacy-
+  state fallback, per-turn re-evaluation.
+* ``goldfive.wrap()`` integration — default-on, opt-out via
+  ``dynamic_instruction=False``, LlmAgent-only tree walk, per-agent
+  independent resolution.
+
+Gated on the ``adk`` extra; ADK is where this code is load-bearing.
+The non-ADK shapes (Claude SDK, CallableAdapter) don't have an
+``instruction`` surface to swap, so the installer is a silent no-op
+for them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+import goldfive
+from goldfive import InMemorySink, StaticPlanner
+from goldfive.adapters import _adk_state_protocol as _sp
+from goldfive.adapters._adk_dynainst import (
+    install_dynamic_instructions,
+    is_dynamic_instruction,
+    make_dynamic_instruction,
+    pending_correction_key,
+)
+from goldfive.types import Plan, Task
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _one_task_planner() -> StaticPlanner:
+    return StaticPlanner(
+        Plan(
+            id="p1",
+            run_id="",
+            goal_ids=["g1"],
+            tasks=[
+                Task(
+                    id="t1",
+                    title="the task",
+                    description="do the thing",
+                    assignee_agent_id="inner_agent",
+                )
+            ],
+            edges=[],
+            summary="one task plan",
+        )
+    )
+
+
+def _mk_llm_agent(
+    name: str = "inner_agent",
+    instruction: str = "follow instructions",
+) -> Any:
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(
+        name=name,
+        model="fake-model",
+        description="a wrapped agent",
+        instruction=instruction,
+    )
+
+
+class _ReadonlyCtxStub:
+    """Minimal ``ReadonlyContext`` stand-in for resolver unit tests.
+
+    Exposes only ``state`` since that is all the resolver reads. Using a
+    stub avoids constructing a full ADK ``InvocationContext`` which
+    requires a session service and other machinery we don't need here.
+    """
+
+    def __init__(self, state: dict[str, Any]) -> None:
+        self.state = state
+
+
+# ---------------------------------------------------------------------------
+# Resolver semantics
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_returns_original_when_no_pin() -> None:
+    """No ``goldfive.current_task_id`` in state -> original string verbatim."""
+    resolver = make_dynamic_instruction(
+        original_instruction="you are a helper",
+        agent_name="inner_agent",
+    )
+    ctx = _ReadonlyCtxStub(state={})
+    assert resolver(ctx) == "you are a helper"
+
+    # Explicit empty string also counts as "no pin" -- the plugin clears
+    # the pin that way when no unambiguous match exists.
+    ctx2 = _ReadonlyCtxStub(state={_sp.KEY_CURRENT_TASK_ID: ""})
+    assert resolver(ctx2) == "you are a helper"
+
+
+def test_resolver_composes_when_pinned() -> None:
+    """Pin + title + description -> composed instruction."""
+    resolver = make_dynamic_instruction(
+        original_instruction="you are a helper",
+        agent_name="inner_agent",
+    )
+    ctx = _ReadonlyCtxStub(
+        state={
+            _sp.KEY_CURRENT_TASK_ID: "t1",
+            _sp.KEY_CURRENT_TASK_TITLE: "the task",
+            _sp.KEY_CURRENT_TASK_DESCRIPTION: "do the thing",
+        }
+    )
+    out = resolver(ctx)
+    assert out.startswith("you are a helper")
+    assert "Current assigned task:" in out
+    assert "id: t1" in out
+    assert "title: the task" in out
+    assert "description: do the thing" in out
+
+
+def test_resolver_uses_placeholders_for_legacy_state() -> None:
+    """Task id pinned but no title/description -> placeholder strings (not crash)."""
+    resolver = make_dynamic_instruction(
+        original_instruction="you are a helper",
+        agent_name="inner_agent",
+    )
+    ctx = _ReadonlyCtxStub(state={_sp.KEY_CURRENT_TASK_ID: "t1"})
+    out = resolver(ctx)
+    assert "id: t1" in out
+    assert "(title unset)" in out
+    assert "(description unset)" in out
+
+
+def test_resolver_appends_correction_when_present() -> None:
+    """Pending correction for (agent, task) -> correction block appended."""
+    resolver = make_dynamic_instruction(
+        original_instruction="you are a helper",
+        agent_name="inner_agent",
+    )
+    key = pending_correction_key("inner_agent", "t1")
+    ctx = _ReadonlyCtxStub(
+        state={
+            _sp.KEY_CURRENT_TASK_ID: "t1",
+            _sp.KEY_CURRENT_TASK_TITLE: "the task",
+            _sp.KEY_CURRENT_TASK_DESCRIPTION: "do the thing",
+            key: "CORRECTION: you missed the acceptance criterion on output format",
+        }
+    )
+    out = resolver(ctx)
+    assert "CORRECTION:" in out
+    assert "acceptance criterion" in out
+
+
+def test_resolver_no_correction_when_keyed_to_other_agent() -> None:
+    """Corrections are scoped by (agent, task); another agent's correction is ignored."""
+    resolver = make_dynamic_instruction(
+        original_instruction="you are a helper",
+        agent_name="inner_agent",
+    )
+    ctx = _ReadonlyCtxStub(
+        state={
+            _sp.KEY_CURRENT_TASK_ID: "t1",
+            _sp.KEY_CURRENT_TASK_TITLE: "the task",
+            _sp.KEY_CURRENT_TASK_DESCRIPTION: "do the thing",
+            pending_correction_key("other_agent", "t1"): "not for you",
+            pending_correction_key("inner_agent", "t_other"): "not this task",
+        }
+    )
+    out = resolver(ctx)
+    assert "not for you" not in out
+    assert "not this task" not in out
+
+
+def test_resolver_re_evaluates_per_turn() -> None:
+    """Changing state between calls produces a different composed string."""
+    resolver = make_dynamic_instruction(
+        original_instruction="you are a helper",
+        agent_name="inner_agent",
+    )
+    state: dict[str, Any] = {
+        _sp.KEY_CURRENT_TASK_ID: "t1",
+        _sp.KEY_CURRENT_TASK_TITLE: "first",
+        _sp.KEY_CURRENT_TASK_DESCRIPTION: "first description",
+    }
+    ctx = _ReadonlyCtxStub(state=state)
+    first = resolver(ctx)
+    assert "title: first" in first
+
+    # Simulate refine landing a revised description.
+    state[_sp.KEY_CURRENT_TASK_DESCRIPTION] = "refined description"
+    second = resolver(ctx)
+    assert "refined description" in second
+    assert first != second
+
+
+def test_resolver_tolerates_exotic_readonly_context() -> None:
+    """Resolver degrades to the original instruction on a context without ``state``."""
+    resolver = make_dynamic_instruction(
+        original_instruction="you are a helper",
+        agent_name="inner_agent",
+    )
+
+    class _NoState:
+        pass
+
+    assert resolver(_NoState()) == "you are a helper"
+
+
+# ---------------------------------------------------------------------------
+# goldfive.wrap() integration
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_installs_resolver_by_default() -> None:
+    """Default-on: wrapping an ADK agent replaces ``instruction`` with a callable."""
+    inner = _mk_llm_agent()
+    assert isinstance(inner.instruction, str)
+
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+    _ = wrapped  # keep the Runner alive; inner is mutated in-place
+
+    assert callable(inner.instruction)
+    assert is_dynamic_instruction(inner.instruction)
+
+
+def test_wrap_opt_out_keeps_static_instruction() -> None:
+    """``dynamic_instruction=False`` leaves the original string in place."""
+    inner = _mk_llm_agent(instruction="static prompt text")
+
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+        dynamic_instruction=False,
+    )
+    _ = wrapped
+
+    assert inner.instruction == "static prompt text"
+    assert not callable(inner.instruction)
+
+
+def test_install_only_touches_llm_agents_in_tree() -> None:
+    """A tree mixing LlmAgent + a container agent has only the LlmAgents swapped."""
+    from google.adk.agents.sequential_agent import SequentialAgent  # type: ignore
+
+    leaf_a = _mk_llm_agent(name="leaf_a", instruction="prompt A")
+    leaf_b = _mk_llm_agent(name="leaf_b", instruction="prompt B")
+    container = SequentialAgent(
+        name="container",
+        sub_agents=[leaf_a, leaf_b],
+    )
+
+    touched = install_dynamic_instructions(container)
+    assert touched == 2
+    assert is_dynamic_instruction(leaf_a.instruction)
+    assert is_dynamic_instruction(leaf_b.instruction)
+    # SequentialAgent has no ``instruction`` field — the walk skips it.
+    assert not hasattr(container, "instruction") or not is_dynamic_instruction(
+        getattr(container, "instruction", None)
+    )
+
+
+def test_install_is_idempotent() -> None:
+    """Re-running the installer on an already-wrapped tree is a no-op."""
+    leaf = _mk_llm_agent()
+    touched_1 = install_dynamic_instructions(leaf)
+    resolver_after_1 = leaf.instruction
+    touched_2 = install_dynamic_instructions(leaf)
+    resolver_after_2 = leaf.instruction
+
+    assert touched_1 == 1
+    assert touched_2 == 0
+    # Same resolver object — not double-wrapped.
+    assert resolver_after_1 is resolver_after_2
+
+
+def test_install_leaves_user_supplied_callable_alone() -> None:
+    """A user already using an ``InstructionProvider`` callable is not double-wrapped."""
+
+    def user_provider(ctx: Any) -> str:
+        return "user-dynamic prompt"
+
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    agent = LlmAgent(
+        name="user_dyn",
+        model="fake-model",
+        description="user-managed dynamic",
+        instruction=user_provider,  # type: ignore[arg-type]
+    )
+
+    touched = install_dynamic_instructions(agent)
+    assert touched == 0
+    assert agent.instruction is user_provider
+    assert not is_dynamic_instruction(agent.instruction)
+
+
+def test_multiple_agents_resolve_independently() -> None:
+    """Two LlmAgents in a tree each get their own resolver keyed on their name."""
+    from google.adk.agents.sequential_agent import SequentialAgent  # type: ignore
+
+    leaf_a = _mk_llm_agent(name="leaf_a", instruction="prompt for A")
+    leaf_b = _mk_llm_agent(name="leaf_b", instruction="prompt for B")
+    container = SequentialAgent(
+        name="container",
+        sub_agents=[leaf_a, leaf_b],
+    )
+
+    install_dynamic_instructions(container)
+
+    state = {
+        _sp.KEY_CURRENT_TASK_ID: "tA",
+        _sp.KEY_CURRENT_TASK_TITLE: "title for A",
+        _sp.KEY_CURRENT_TASK_DESCRIPTION: "description for A",
+        pending_correction_key("leaf_a", "tA"): "CORRECTION for A",
+    }
+    ctx = _ReadonlyCtxStub(state=state)
+
+    out_a = leaf_a.instruction(ctx)  # type: ignore[operator]
+    out_b = leaf_b.instruction(ctx)  # type: ignore[operator]
+
+    assert out_a.startswith("prompt for A")
+    assert out_b.startswith("prompt for B")
+    assert "CORRECTION for A" in out_a
+    # leaf_b sees the same task pin but no correction targeted at it.
+    assert "CORRECTION for A" not in out_b
+
+
+def test_resolver_survives_canonical_instruction_contract() -> None:
+    """The installed callable returns a str and is picked up by ADK's
+    ``LlmAgent.canonical_instruction`` (i.e. matches the ``InstructionProvider``
+    type alias). Smoke test against ADK's actual consumer."""
+    import asyncio
+
+    leaf = _mk_llm_agent(instruction="static")
+    install_dynamic_instructions(leaf)
+
+    state = {
+        _sp.KEY_CURRENT_TASK_ID: "t1",
+        _sp.KEY_CURRENT_TASK_TITLE: "title",
+        _sp.KEY_CURRENT_TASK_DESCRIPTION: "desc",
+    }
+    ctx = _ReadonlyCtxStub(state=state)
+
+    # Drive LlmAgent.canonical_instruction directly: it accepts anything
+    # duck-typed as a ReadonlyContext (it only passes it to the provider
+    # callable; doesn't inspect its attrs itself).
+    instruction, bypass_state_injection = asyncio.run(leaf.canonical_instruction(ctx))
+    assert isinstance(instruction, str)
+    assert "id: t1" in instruction
+    # When the resolved instruction is from a provider, ADK returns True
+    # so state-template ``{placeholder}`` substitution is skipped.
+    assert bypass_state_injection is True


### PR DESCRIPTION
## Summary
- Replaces each wrapped `LlmAgent`'s static `instruction` string with a callable `(ReadonlyContext) -> str` that resolves the current task from `session.state` at every turn. Plan-causal prompting: when refine lands a revised description mid-run, the NEXT turn of the affected agent sees the new description automatically -- no transcript rewrite, no event-stream injection.
- **Agent-agnostic.** Works for any `LlmAgent` in the wrapped tree (coordinator, sub-agent, root-with-tools, leaf). Pin is keyed on `goldfive.current_task_id`; the resolver never special-cases "the coordinator."
- **Default-on.** `goldfive.wrap()` installs the resolver automatically for ADK targets. Opt-out via `dynamic_instruction=False`.
- Adds `KEY_PENDING_CORRECTIONS` prefix and `pending_correction_key(agent, task)`; resolver reads it. Stream D (correction injection) will populate.

## Implementation notes
- New module `goldfive/adapters/_adk_dynainst.py`: `make_dynamic_instruction(...)`, `install_dynamic_instructions(root)`, `is_dynamic_instruction(...)`. Tree walk mirrors `_attach_goldfive_planner_to_tree` (sub_agents / inner_agent / tools[*].agent). Idempotent (re-wrap is a no-op); leaves user-supplied `InstructionProvider` callables alone.
- `_stamp_current_task_id` in `_adk_plugin.py` now accepts the Task object and switches to `write_current_task` so `title` + `description` land alongside the id on the ADK session.state. Both existing call sites already had the task in scope, so zero extra threading.
- Resolver is pure + defensive: any exception inside it falls back to the original instruction (any crash in an instruction-callable would otherwise abort the turn).

## Test plan
- [x] `tests/test_dynamic_instruction.py` added (+14 tests): no-pin passthrough, pinned composition, legacy-state placeholders, correction injection, correction scoping, per-turn re-evaluation, exotic-ctx tolerance, `wrap()` default-on, `dynamic_instruction=False` opt-out, idempotent install, user-callable preserved, multi-agent independent resolution, `LlmAgent.canonical_instruction` contract smoke test.
- [x] Full suite: 1481 passed, 46 skipped, 0 failures.
- [x] `ruff check goldfive/` clean.