### PR TITLE
feat(steerer, adapters): cooperative cancellation via session-state flag (7a)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1251,6 +1251,37 @@ def make_adk_plugin(
                     "report_awaiting_approval",
                 }
             )
+            # Cooperative cancellation state (goldfive#251 Stream C / 7a).
+            # Authoritative source for the cancel-requested flag:
+            # ``dict[str, CancellationRequest]`` keyed by ``invocation_id``.
+            # The steerer writes entries here via
+            # :meth:`request_invocation_cancel` on the adapter; every
+            # adapter callback checks the dict at the top of its body
+            # and, when an entry matches the current invocation_id,
+            # consumes it (read + clear — same-invocation re-entry won't
+            # re-cancel) and short-circuits the dispatch.
+            #
+            # Stored on the plugin instance rather than ADK session.state
+            # because ``InMemorySessionService`` shallow-copies state on
+            # every ``get_session`` (see the same rationale that drove
+            # goldfive#170 for the _active_ctx field), which would make
+            # cross-callback reads unreliable. The state-protocol module
+            # (:data:`_adk_state_protocol.KEY_CANCEL_REQUESTED`) documents
+            # the key semantics so external consumers see a stable
+            # contract; the plugin's dict is the live source of truth.
+            self._cancel_state: dict[str, Any] = {}
+            # Parent/child invocation map for cancel propagation.
+            # ``dict[str, str]`` mapping ``invocation_id ->
+            # parent_invocation_id``. Populated on every
+            # ``before_run_callback`` that observes a fresh invocation_id
+            # with a known parent (the top-level invocation_id pinned on
+            # the first ``before_run``). Consumed by
+            # :meth:`request_invocation_cancel` so that cancelling a
+            # parent also flags its spawned sub-invocations — this is
+            # how a cancelled coordinator's mid-flight AgentTool child
+            # short-circuits cleanly instead of emitting its turn and
+            # poisoning the parent's history.
+            self._invocation_parents: dict[str, str] = {}
 
         def set_active_context(self, ctx: SessionContext) -> None:
             """Attach the ``SessionContext`` for the running invocation.
@@ -1288,6 +1319,109 @@ def make_adk_plugin(
             # state from the just-finished dispatch doesn't leak into
             # the next one on the same plugin instance (goldfive#181).
             self._tool_loop_tracker.clear()
+            # Drop any lingering cancellation state / parent map so the
+            # next dispatch starts clean (goldfive#251). A request that
+            # was never consumed means the callback path never ran —
+            # still safe to drop because the invocation it targeted is
+            # gone, and keeping it would misfire on an unrelated future
+            # invocation_id collision.
+            self._cancel_state.clear()
+            self._invocation_parents.clear()
+
+        # --- Cooperative cancellation (goldfive#251 Stream C / 7a) -----
+
+        def request_invocation_cancel(
+            self,
+            *,
+            invocation_id: str,
+            request: Any,
+            propagate_to_children: bool = True,
+        ) -> list[str]:
+            """Flag ``invocation_id`` (and optionally its descendants)
+            for cooperative cancellation.
+
+            Called by :class:`~goldfive.steerer.DefaultSteerer` when a
+            drift at CRITICAL severity (or a user-initiated cancel)
+            warrants aborting an in-flight adapter dispatch. Writes an
+            entry to the plugin's ``_cancel_state`` dict keyed by the
+            invocation id; every adapter callback consults the dict at
+            the top of its body and short-circuits when its own id
+            matches.
+
+            When ``propagate_to_children`` is True (the default), the
+            recorded parent/child map is walked breadth-first and an
+            entry is added for every transitive descendant of
+            ``invocation_id`` so an in-flight AgentTool sub-invocation
+            is also flagged. The returned list contains every id that
+            was flagged — the target itself plus any descendants — so
+            callers can sink-report the full set if they want.
+
+            Tree-agnostic: the parent/child map is per-invocation, the
+            plugin has no notion of "coordinator" vs "sub-agent", and
+            every level in the tree is flagged the same way.
+            """
+            if not invocation_id:
+                return []
+            flagged: list[str] = [str(invocation_id)]
+            # Walk the parent/child map when propagation is enabled.
+            # Order is unspecified; deduplication happens inside
+            # ``descendants_of_invocation`` via a seen-set.
+            if propagate_to_children:
+                try:
+                    from goldfive.adapters import _adk_state_protocol as _sp_local
+
+                    descendants = _sp_local.descendants_of_invocation(
+                        {_sp_local.KEY_INVOCATION_PARENTS: self._invocation_parents},
+                        invocation_id,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "_GoldfiveADKPlugin.request_invocation_cancel: "
+                        "descendant walk raised: %s",
+                        exc,
+                    )
+                    descendants = []
+                flagged.extend(descendants)
+            for flagged_id in flagged:
+                # Preserve the first-writer's request for each id so a
+                # parent cancel with reason="user_steer" doesn't get
+                # silently overwritten by a descendant-propagation pass
+                # reusing the parent's request object. When a descendant
+                # already has a distinct request pending (uncommon but
+                # possible), keep the earlier one — the more-recent
+                # overwrite semantics are only for same-id re-writes
+                # from the steerer itself.
+                self._cancel_state.setdefault(flagged_id, request)
+            return flagged
+
+        def consume_cancel_for_invocation(self, invocation_id: str) -> Any | None:
+            """Read the pending cancel for ``invocation_id`` and clear it.
+
+            Callback-facing helper. Returns the
+            :class:`~goldfive.types.CancellationRequest` when one was
+            pending, or ``None`` otherwise. Clearing before returning
+            gives the "cancel fires once" semantic: a re-entry into the
+            same callback (e.g. after the LLM call was already skipped
+            and a follow-up tool call fires) doesn't re-emit the
+            cancelled marker.
+            """
+            if not invocation_id:
+                return None
+            return self._cancel_state.pop(str(invocation_id), None)
+
+        def peek_cancel_for_invocation(self, invocation_id: str) -> Any | None:
+            """Return the pending cancel for ``invocation_id`` without
+            clearing it.
+
+            Diagnostic / test helper. Production callback paths use
+            :meth:`consume_cancel_for_invocation`; this method exists so
+            the adapter's ``invoke`` loop can check whether a cancel was
+            flagged on the current dispatch without side-effecting the
+            consume-once semantic.
+            """
+            if not invocation_id:
+                return None
+            return self._cancel_state.get(str(invocation_id))
 
         def set_reconciler(self, reconciler: Any) -> None:
             """Attach a :class:`~goldfive.reconciler.PlanReconciler`.
@@ -1351,6 +1485,31 @@ def make_adk_plugin(
                 # First before_run for this dispatch — pin it so nested
                 # AgentTool sub-Runners can attribute themselves below.
                 self._top_invocation_id = inv_id
+
+            # Register the parent/child relationship for cooperative
+            # cancellation propagation (goldfive#251). A cancel targeting
+            # the parent id can then flag this child id without the
+            # steerer having to know the tree shape.
+            if inv_id and parent_inv_id:
+                self._invocation_parents[inv_id] = parent_inv_id
+
+            # Cooperative-cancellation check (goldfive#251 Stream C / 7a).
+            # If the adapter / steerer flagged this invocation before
+            # ``run_async`` actually yielded to ADK, short-circuit the
+            # whole dispatch: skip the state-protocol write, skip the
+            # AgentInvocationStarted emit, and emit an
+            # InvocationCancelled sink event so operators see the
+            # cancel in harmonograf. The outer ``ADKAdapter.invoke``
+            # loop honours the short-circuit via
+            # :meth:`peek_cancel_for_invocation` (below).
+            if inv_id and self._cancel_state.get(inv_id) is not None:
+                request = self.consume_cancel_for_invocation(inv_id)
+                await self._emit_invocation_cancelled(
+                    invocation_id=inv_id,
+                    agent_name="",
+                    request=request,
+                )
+                return None
 
             # Reset the per-invocation counters so the CONFABULATION_RISK
             # check in ``after_run_callback`` sees only the tool calls
@@ -1471,6 +1630,23 @@ def make_adk_plugin(
             parent_inv_id = ""
             if inv_id and self._top_invocation_id and inv_id != self._top_invocation_id:
                 parent_inv_id = self._top_invocation_id
+
+            # Cooperative-cancellation checkpoint (goldfive#251 Stream C / 7a).
+            # When a cancel was flagged for this invocation_id (by the
+            # steerer's CRITICAL-severity ladder path, or by a programmatic
+            # caller), consume the request, emit an InvocationCancelled
+            # sink event, and short-circuit the callback — the agent's
+            # turn is skipped entirely. Done BEFORE the pinning /
+            # reconciler forward work so a cancelled turn leaves no
+            # side-effects on orchestration state.
+            if inv_id and self._cancel_state.get(inv_id) is not None:
+                request = self.consume_cancel_for_invocation(inv_id)
+                await self._emit_invocation_cancelled(
+                    invocation_id=inv_id,
+                    agent_name=agent_name,
+                    request=request,
+                )
+                return None
 
             # Layer 1: pin the starting sub-agent's task_id so its
             # reporting-tool calls can default the arg from state
@@ -2325,6 +2501,95 @@ def make_adk_plugin(
             except Exception as exc:  # noqa: BLE001
                 log.debug("_emit_observability: failed to emit %s: %s", kind, exc)
 
+        async def _emit_invocation_cancelled(
+            self,
+            *,
+            invocation_id: str,
+            agent_name: str = "",
+            request: Any = None,
+            tool_name: str = "",
+        ) -> None:
+            """Emit an ``InvocationCancelled`` sink event (goldfive#251).
+
+            Operator-visible only — does NOT propagate to the LLM
+            (that's what the minimal ``{"status": "cancelled"}`` tool
+            response is for). Rich context: the invocation id, agent
+            name, triggering reason / drift kind / severity / drift
+            id, and an optional tool name when the cancel fired at a
+            tool-dispatch checkpoint.
+
+            Uses :func:`goldfive.events.make_event` (dict envelope)
+            rather than a proto envelope because the proto schema
+            doesn't yet carry an ``InvocationCancelled`` message —
+            adding a new proto + regen would expand the scope of this
+            change beyond Stream C. Dict events round-trip through the
+            same sink fan-out (``goldfive.events.emit``) as proto
+            events, so harmonograf's ingest path can handle both. A
+            follow-up proto slot can be minted if / when sink-side
+            strict typing is needed.
+
+            Best-effort: every failure is logged and swallowed —
+            observability must never block a callback.
+            """
+            ctx = self._active_ctx
+            if ctx is None:
+                return
+            steerer = ctx.steerer
+            if steerer is None:
+                return
+            sinks = getattr(steerer, "_sinks", None) or []
+            if not sinks:
+                return
+            session = ctx.session
+            run_id = str(_safe_attr(session, "run_id", "") or "")
+            session_id = str(_safe_attr(session, "id", "") or "") or run_id
+            try:
+                seq = session.next_sequence()
+            except Exception:  # noqa: BLE001
+                seq = 0
+            # Extract fields from the CancellationRequest dataclass if
+            # provided. Duck-typed so a plain dict or an unfamiliar
+            # shape still rounds-trips without raising.
+            reason = ""
+            severity = ""
+            drift_id = ""
+            drift_kind = ""
+            detail = ""
+            if request is not None:
+                reason = str(_safe_attr(request, "reason", "") or "")
+                sev_val = _safe_attr(request, "severity", None)
+                severity = str(getattr(sev_val, "value", sev_val) or "")
+                drift_id = str(_safe_attr(request, "drift_id", "") or "")
+                drift_kind = str(_safe_attr(request, "drift_kind", "") or "")
+                detail = str(_safe_attr(request, "detail", "") or "")
+            payload: dict[str, Any] = {
+                "invocation_id": str(invocation_id or ""),
+                "agent_name": str(agent_name or ""),
+                "reason": reason,
+                "severity": severity,
+                "drift_id": drift_id,
+                "drift_kind": drift_kind,
+                "detail": detail,
+            }
+            if tool_name:
+                payload["tool_name"] = str(tool_name)
+            try:
+                from goldfive.events import emit, make_event  # noqa: PLC0415 — lazy
+
+                evt = make_event(
+                    run_id,
+                    seq,
+                    "invocation_cancelled",
+                    payload,
+                    session_id=session_id,
+                )
+                await emit(sinks, evt)
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_emit_invocation_cancelled: failed to emit: %s",
+                    exc,
+                )
+
         # --- Plan + current-task context -------------------------------
 
         async def before_model_callback(self, *, callback_context: Any, llm_request: Any) -> None:
@@ -2362,6 +2627,30 @@ def make_adk_plugin(
             ctx = self._resolve_ctx(callback_context)
             if ctx is None:
                 return None
+
+            # Cooperative-cancellation checkpoint (goldfive#251 Stream C / 7a).
+            # Skip the LLM call when this invocation is flagged for
+            # cancel. This is the checkpoint that matters most in
+            # practice: a mid-flight LLM call is the expensive work
+            # whose output would contaminate the parent transcript.
+            # The ``before_agent_callback`` checkpoint above normally
+            # fires first, but ADK may reach ``before_model_callback``
+            # without ``before_agent_callback`` on some dispatch
+            # shapes (e.g. direct model invocations in tests); this
+            # check is the backstop.
+            inv_ctx = _safe_attr(callback_context, "_invocation_context", None) or _safe_attr(
+                callback_context, "invocation_context", None
+            )
+            inv_id_check = str(_safe_attr(inv_ctx, "invocation_id", "") or "")
+            if inv_id_check and self._cancel_state.get(inv_id_check) is not None:
+                request = self.consume_cancel_for_invocation(inv_id_check)
+                await self._emit_invocation_cancelled(
+                    invocation_id=inv_id_check,
+                    agent_name="",
+                    request=request,
+                )
+                return None
+
             state = _session_state_from_callback(callback_context)
             if not isinstance(state, dict):
                 try:
@@ -2449,6 +2738,38 @@ def make_adk_plugin(
             if not tool_name:
                 func = _safe_attr(tool, "func", None)
                 tool_name = str(_safe_attr(func, "__name__", "") or "")
+
+            # Cooperative-cancellation checkpoint (goldfive#251 Stream C / 7a).
+            # When this invocation was flagged for cancel (either the
+            # steerer at CRITICAL severity or a user-initiated cancel),
+            # skip tool dispatch and return a MINIMAL LLM-visible tool
+            # response: ``{"status": "cancelled"}``. The minimal shape
+            # is deliberate — richer shapes (``reason``, ``detail``,
+            # ``drift_kind``) become prompt-injection vectors (see
+            # lessons from goldfive#250 / #252 / #253 where LLMs
+            # pattern-matched on error strings and invented workarounds).
+            # Rich context for operators lives on the
+            # InvocationCancelled sink event emitted by
+            # :meth:`_emit_invocation_cancelled`.
+            inv_ctx = _safe_attr(tool_context, "_invocation_context", None) or _safe_attr(
+                tool_context, "invocation_context", None
+            )
+            inv_id_check = str(_safe_attr(inv_ctx, "invocation_id", "") or "")
+            if inv_id_check and self._cancel_state.get(inv_id_check) is not None:
+                request = self.consume_cancel_for_invocation(inv_id_check)
+                await self._emit_invocation_cancelled(
+                    invocation_id=inv_id_check,
+                    agent_name="",
+                    request=request,
+                    tool_name=tool_name,
+                )
+                # MINIMAL LLM-visible response — single-key dict, no
+                # ``reason`` / ``detail`` / ``drift_kind``. The parent
+                # LLM that receives this as an AgentTool response can
+                # pattern-match only on the word "cancelled" and
+                # should defer to the plan-revised context it sees on
+                # its next turn to decide whether to re-dispatch.
+                return {"status": "cancelled"}
 
             # Reporting-tool short-circuit takes precedence: a tool named
             # e.g. report_task_started should never also be gated by

--- a/goldfive/adapters/_adk_state_protocol.py
+++ b/goldfive/adapters/_adk_state_protocol.py
@@ -63,6 +63,25 @@ KEY_ACTIVE_STEER_AT_TURN = "goldfive.active_steer.at_turn"
 KEY_GOALS_SUMMARY = "goldfive.goals_summary"
 KEY_CANCELLED_FUNCTION_CALL_IDS = "goldfive.cancelled_function_call_ids"
 
+# Cooperative cancellation (goldfive#251 Stream C / 7a). Value is a
+# ``dict[str, CancellationRequest]`` keyed by ``invocation_id``. Every
+# adapter callback that can short-circuit a dispatch checks for an
+# entry under the current invocation_id at the top of the callback
+# and, when present, consumes it (reads + clears) and short-circuits
+# the dispatch. See
+# :mod:`goldfive.adapters._cancel_state` for the helper API and
+# :class:`goldfive.types.CancellationRequest` for the payload shape.
+KEY_CANCEL_REQUESTED = "goldfive.cancel_requested"
+# Parent -> invocation_id bookkeeping for cancellation propagation.
+# ``dict[str, str]`` mapping ``invocation_id -> parent_invocation_id``.
+# Written by the plugin's ``before_run_callback`` whenever a fresh
+# invocation_id is observed; consumed by the cancel-propagation helper
+# so cancelling an invocation also flags its spawned children.
+# Tree-agnostic — the map is per-invocation and carries no notion of
+# "coordinator" or "root"; every agent's children are handled the same
+# way.
+KEY_INVOCATION_PARENTS = "goldfive.invocation_parents"
+
 _CURRENT_TASK_KEYS: tuple[str, ...] = (
     KEY_CURRENT_TASK_ID,
     KEY_CURRENT_TASK_TITLE,
@@ -89,6 +108,8 @@ ALL_KEYS: tuple[str, ...] = (
     KEY_ACTIVE_STEER_AT_TURN,
     KEY_GOALS_SUMMARY,
     KEY_CANCELLED_FUNCTION_CALL_IDS,
+    KEY_CANCEL_REQUESTED,
+    KEY_INVOCATION_PARENTS,
 )
 
 
@@ -400,6 +421,171 @@ def set_cancelled_function_call_ids_on_adk_state(
         state.pop(KEY_CANCELLED_FUNCTION_CALL_IDS, None)
         return
     _set(state, KEY_CANCELLED_FUNCTION_CALL_IDS, cleaned)
+
+
+# ---------------------------------------------------------------------------
+# Cooperative cancellation (goldfive#251 Stream C / 7a)
+#
+# The helpers below manage two state keys used by cooperative
+# cancellation:
+#
+# * :data:`KEY_CANCEL_REQUESTED` — ``dict[str, CancellationRequest]``
+#   keyed by ``invocation_id``; every adapter callback that can
+#   short-circuit a dispatch reads (and consumes) the entry for its
+#   own invocation_id at the top of the callback.
+# * :data:`KEY_INVOCATION_PARENTS` — ``dict[str, str]`` mapping
+#   ``invocation_id -> parent_invocation_id`` so cancel propagation
+#   can flag children when a parent is cancelled, without requiring
+#   the plugin to walk ADK's own context graph.
+#
+# ``CancellationRequest`` is imported lazily to avoid a module-level
+# circular dependency (``goldfive.types`` imports are cheap but we
+# keep this file import-lean so it can load in tests that don't have
+# the ADK optional-dependency group).
+# ---------------------------------------------------------------------------
+
+
+def write_cancel_request(
+    state: MutableMapping[str, Any],
+    *,
+    invocation_id: str,
+    request: Any,
+) -> None:
+    """Stamp a :class:`~goldfive.types.CancellationRequest` on ``state``.
+
+    No-op when ``invocation_id`` is empty. ``request`` is stored
+    verbatim so consumers get the original dataclass (not a copy) —
+    this is the cheapest handoff between the steerer (producer) and
+    the adapter callbacks (consumers) on a per-invocation basis.
+
+    Multiple requests for different invocation_ids coexist in the
+    same dict; a second write for the same id overwrites the prior
+    request (the more-recent cancel wins, same as the steerer's
+    Level-3 corrective-message slot).
+    """
+    if not invocation_id:
+        return
+    bucket = state.get(KEY_CANCEL_REQUESTED)
+    if not isinstance(bucket, dict):
+        bucket = {}
+    bucket[str(invocation_id)] = request
+    _set(state, KEY_CANCEL_REQUESTED, bucket)
+
+
+def read_cancel_request(state: Any, invocation_id: str) -> Any | None:
+    """Return the :class:`~goldfive.types.CancellationRequest` for
+    ``invocation_id``, or ``None`` when no cancel is pending.
+
+    Read-only — callers that want "cancel fires once" semantics must
+    use :func:`consume_cancel_request` instead, which clears the
+    entry after reading so re-entry into the same callback doesn't
+    re-cancel.
+    """
+    if not invocation_id:
+        return None
+    bucket = _safe_get(state, KEY_CANCEL_REQUESTED, None)
+    if not isinstance(bucket, Mapping):
+        return None
+    return bucket.get(str(invocation_id))
+
+
+def consume_cancel_request(
+    state: MutableMapping[str, Any],
+    invocation_id: str,
+) -> Any | None:
+    """Read the cancel request for ``invocation_id`` and clear it.
+
+    Returns the :class:`~goldfive.types.CancellationRequest` dataclass
+    (not a copy) when one was pending, or ``None`` otherwise. The
+    flag is removed from ``state`` BEFORE returning so a re-entry
+    into the same callback (e.g. a retry after the LLM call was
+    already cancelled and a new before_tool fires for a lingering
+    tool call) does not re-emit the cancelled response.
+    """
+    if not invocation_id:
+        return None
+    bucket = state.get(KEY_CANCEL_REQUESTED) if isinstance(state, MutableMapping) else None
+    if not isinstance(bucket, dict):
+        return None
+    request = bucket.pop(str(invocation_id), None)
+    # Cleanup: if the bucket is now empty, remove the key entirely so
+    # downstream readers distinguish "no cancels ever" from "a cancel
+    # was processed and cleared".
+    if not bucket:
+        state.pop(KEY_CANCEL_REQUESTED, None)
+    else:
+        _set(state, KEY_CANCEL_REQUESTED, bucket)
+    return request
+
+
+def register_invocation_parent(
+    state: MutableMapping[str, Any],
+    *,
+    invocation_id: str,
+    parent_invocation_id: str,
+) -> None:
+    """Record that ``invocation_id`` was spawned by
+    ``parent_invocation_id``.
+
+    Called from the plugin's ``before_run_callback`` (or equivalent)
+    once per invocation so cancel propagation can walk the chain
+    without needing to know the ADK context graph. No-op when either
+    id is empty.
+    """
+    if not invocation_id or not parent_invocation_id:
+        return
+    parents = state.get(KEY_INVOCATION_PARENTS)
+    if not isinstance(parents, dict):
+        parents = {}
+    parents[str(invocation_id)] = str(parent_invocation_id)
+    _set(state, KEY_INVOCATION_PARENTS, parents)
+
+
+def children_of_invocation(state: Any, invocation_id: str) -> list[str]:
+    """Return the immediate children of ``invocation_id``.
+
+    Reads the ``KEY_INVOCATION_PARENTS`` map and returns the list of
+    invocation_ids whose parent is ``invocation_id``. Empty list when
+    the invocation has no children or the map hasn't been populated.
+    """
+    if not invocation_id:
+        return []
+    parents = _safe_get(state, KEY_INVOCATION_PARENTS, None)
+    if not isinstance(parents, Mapping):
+        return []
+    target = str(invocation_id)
+    return [str(child) for child, parent in parents.items() if parent == target]
+
+
+def descendants_of_invocation(state: Any, invocation_id: str) -> list[str]:
+    """Return every transitive descendant of ``invocation_id``.
+
+    Walks the parent map breadth-first so cancel propagation can flag
+    the entire sub-tree in one pass. The order is unspecified but the
+    ``invocation_id`` itself is NOT included in the result — callers
+    that want the full cancelled set should prepend it themselves.
+    """
+    if not invocation_id:
+        return []
+    parents = _safe_get(state, KEY_INVOCATION_PARENTS, None)
+    if not isinstance(parents, Mapping):
+        return []
+    # Build reverse index: parent -> [children]
+    reverse: dict[str, list[str]] = {}
+    for child, parent in parents.items():
+        reverse.setdefault(str(parent), []).append(str(child))
+    out: list[str] = []
+    frontier = [str(invocation_id)]
+    seen: set[str] = {str(invocation_id)}
+    while frontier:
+        node = frontier.pop(0)
+        for child in reverse.get(node, ()):
+            if child in seen:
+                continue
+            seen.add(child)
+            out.append(child)
+            frontier.append(child)
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -50,7 +50,7 @@ import json
 import logging
 import re
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from goldfive import orchestration_state as _ostate
@@ -65,6 +65,7 @@ from goldfive.drift.reasoning import (
 )
 from goldfive.types import (
     TERMINAL_TASK_STATUSES,
+    CancellationRequest,
     DriftEvent,
     DriftKind,
     DriftSeverity,
@@ -2170,6 +2171,31 @@ class DefaultSteerer:
             # happened, and running another refine for this signal
             # would race against it.
             return
+        # Cooperative cancellation (goldfive#251 Stream C / 7a). Severity
+        # ladder decision: CRITICAL drifts (and ONLY critical drifts)
+        # flag the currently-active invocation(s) for cooperative
+        # cancel before the refine / promote path runs. INFO + WARNING
+        # severities do NOT cancel — they flow through the usual
+        # observe / absorb / nudge channels. User-authored drifts
+        # (USER_STEER / USER_CANCEL / USER_PAUSE) additionally bypass
+        # the severity gate because an operator directive must be
+        # honoured even when emitted at a lower severity tier.
+        #
+        # The actual short-circuit happens in the ADK plugin's next
+        # ``before_agent_callback`` / ``before_model_callback`` /
+        # ``before_tool_callback``; this call just writes the flag.
+        # Whether to re-dispatch after the cancel is the parent
+        # agent's decision, informed by plan-causal prompting from
+        # Stream B — the framework itself does NOT auto-reinvoke.
+        if self._should_request_cancel_for_drift(drift):
+            try:
+                await self.request_invocation_cancel(drift=drift, session=session)
+            except Exception as exc:  # noqa: BLE001 — cancel is best-effort
+                log.debug(
+                    "DefaultSteerer._handle_drift: "
+                    "request_invocation_cancel raised: %s",
+                    exc,
+                )
         if promote_to_steer:
             await self._promote_drift_to_steer(drift, session)
             return
@@ -2731,6 +2757,213 @@ class DefaultSteerer:
                 reason,
                 exc,
             )
+
+    # ------------------------------------------------------------------
+    # Cooperative cancellation (goldfive#251 Stream C / 7a)
+    # ------------------------------------------------------------------
+
+    def _resolve_active_invocation_ids(
+        self, drift: DriftEvent, session: Session
+    ) -> list[str]:
+        """Resolve which invocation_id(s) a cancel should target.
+
+        Returns an ordered list of invocation ids that are "active"
+        with respect to the triggering drift. The primary source is
+        the reconciler's invocation bookkeeping (goldfive#151
+        introduced the ``_invocation_agent`` / ``_invocation_parent``
+        maps). When the reconciler is unavailable or empty, falls
+        back to the drift's ``current_agent_id``-keyed invocation
+        (best effort via the adapter's active-context invocation id)
+        and finally returns an empty list.
+
+        Tree-agnostic: the method does NOT special-case "the
+        coordinator" or "the root agent" — it targets whichever
+        invocation matches the drift's context and lets the plugin's
+        child-propagation logic flag the rest of the sub-tree.
+        """
+        candidates: list[str] = []
+        reconciler = getattr(session, "_reconciler", None)
+        if reconciler is None:
+            # The steerer doesn't hold a direct reference to the
+            # reconciler; the adapter's plugin does. Walk it via the
+            # adapter when the plugin exposes the attribute.
+            adapter = self._adapter
+            plugin = getattr(adapter, "_plugin", None) if adapter is not None else None
+            reconciler = getattr(plugin, "_reconciler", None) if plugin is not None else None
+        if reconciler is not None:
+            try:
+                inv_agent = getattr(reconciler, "_invocation_agent", None)
+                if isinstance(inv_agent, Mapping) and drift.current_agent_id:
+                    # Match by agent name — most drifts carry
+                    # ``current_agent_id`` set to the running agent's name.
+                    for inv_id, agent_name in inv_agent.items():
+                        if agent_name == drift.current_agent_id and inv_id:
+                            candidates.append(str(inv_id))
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "DefaultSteerer._resolve_active_invocation_ids: "
+                    "reconciler lookup raised: %s",
+                    exc,
+                )
+        # Fallback: the adapter's plugin pins a top-level invocation_id
+        # for the currently-driving dispatch. When the reconciler lookup
+        # produced nothing, the top-level id is the best we can do —
+        # cancel propagation from there will flag any sub-invocations.
+        if not candidates:
+            adapter = self._adapter
+            plugin = getattr(adapter, "_plugin", None) if adapter is not None else None
+            top = str(getattr(plugin, "_top_invocation_id", "") or "")
+            if top:
+                candidates.append(top)
+        return candidates
+
+    async def request_invocation_cancel(
+        self,
+        *,
+        drift: DriftEvent,
+        session: Session,
+    ) -> list[str]:
+        """Flag the invocation(s) associated with ``drift`` for
+        cooperative cancellation (goldfive#251 Stream C / 7a).
+
+        Called from :meth:`_handle_drift` and
+        :meth:`_promote_drift_to_steer` when the drift's severity is
+        CRITICAL — the only tier on the ladder that reaches the hard
+        cancel per the severity decision. INFO / WARNING drifts flow
+        through their usual nudge / absorb paths without touching
+        this method.
+
+        Writes a :class:`~goldfive.types.CancellationRequest` onto the
+        adapter's plugin state for every resolved active invocation
+        id. The plugin propagates to children automatically. Returns
+        the list of flagged invocation ids (including children) for
+        observability; callers can log / sink-emit from the list.
+
+        Guard rails:
+
+        * No-op when no adapter is bound.
+        * No-op when no active invocation can be resolved (e.g. the
+          drift was synthesized before any agent turn started) — this
+          is the "empty invocation-id guard" called out in the brief.
+        * Tolerates missing plugin methods (third-party adapters that
+          don't implement :meth:`request_invocation_cancel`) by
+          falling through silently; the rest of the ladder (refine,
+          restart message) still runs and eventually catches up at
+          the next task boundary.
+        """
+        adapter = self._adapter
+        if adapter is None:
+            return []
+        plugin = getattr(adapter, "_plugin", None)
+        if plugin is None:
+            return []
+        fn = getattr(plugin, "request_invocation_cancel", None)
+        if not callable(fn):
+            return []
+        invocation_ids = self._resolve_active_invocation_ids(drift, session)
+        if not invocation_ids:
+            # Empty invocation-id guard — drift has no identifiable
+            # in-flight invocation. Don't fabricate one; the cancel
+            # would misfire on whatever invocation happens to share a
+            # blank id. The drift still observed, refine still runs;
+            # cancel is a best-effort add-on.
+            log.debug(
+                "DefaultSteerer.request_invocation_cancel: no active invocation "
+                "for drift kind=%s agent=%s task=%s — skipping cancel",
+                drift.kind.value,
+                drift.current_agent_id or "-",
+                drift.current_task_id or "-",
+            )
+            return []
+        # Build the request once and reuse for every targeted id so
+        # sink events from propagation share a common fingerprint.
+        import time as _time_mod
+
+        request = CancellationRequest(
+            invocation_id=invocation_ids[0],
+            reason=self._cancel_reason_for_drift(drift),
+            severity=drift.severity,
+            drift_id=str(getattr(drift, "id", "") or ""),
+            drift_kind=drift.kind.value,
+            requested_at_ms=int(_time_mod.time() * 1000),
+            detail=(drift.detail or "")[:200],
+        )
+        flagged: list[str] = []
+        for inv_id in invocation_ids:
+            try:
+                result = fn(invocation_id=inv_id, request=request)
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "DefaultSteerer.request_invocation_cancel: "
+                    "plugin.request_invocation_cancel(%s) raised: %s",
+                    inv_id,
+                    exc,
+                )
+                continue
+            if isinstance(result, list):
+                flagged.extend(str(x) for x in result)
+            else:
+                flagged.append(inv_id)
+        if flagged:
+            log.info(
+                "DefaultSteerer.request_invocation_cancel: flagged "
+                "invocations=%s for drift kind=%s severity=%s",
+                flagged,
+                drift.kind.value,
+                drift.severity.value,
+            )
+        return flagged
+
+    @staticmethod
+    def _should_request_cancel_for_drift(drift: DriftEvent) -> bool:
+        """Decide whether a drift warrants a cooperative cancel.
+
+        Severity ladder (goldfive#251 design decision):
+
+        * ``DriftSeverity.INFO`` — never cancels. Info drifts are
+          either periodic-check signals or soft one-shots; cancel
+          would be disproportionate.
+        * ``DriftSeverity.WARNING`` — never cancels. Warning drifts
+          route to the existing ABSORB / NUDGE ladder paths; the
+          refined plan lands on the next task boundary without
+          preempting the in-flight turn.
+        * ``DriftSeverity.CRITICAL`` — cancels. The in-flight turn's
+          output is likely to contaminate its parent's transcript
+          (stale prompt, wrong scope, broken tool); short-circuit
+          cleanly and let the parent see ``{"status": "cancelled"}``.
+
+        User-authored drifts (``USER_STEER`` / ``USER_CANCEL`` /
+        ``USER_PAUSE``) bypass the severity gate — an operator
+        directive must be honoured even when the ControlMessage-to-
+        DriftEvent coercion landed on a lower severity tier.
+        """
+        if drift.kind in (
+            DriftKind.USER_STEER,
+            DriftKind.USER_CANCEL,
+            DriftKind.USER_PAUSE,
+        ):
+            return True
+        return drift.severity is DriftSeverity.CRITICAL
+
+    @staticmethod
+    def _cancel_reason_for_drift(drift: DriftEvent) -> str:
+        """Map a drift into a short symbolic reason for the
+        :class:`~goldfive.types.CancellationRequest`.
+
+        USER_STEER / USER_CANCEL / USER_PAUSE get the matching
+        ``"user_*"`` shorthand; everything else uses ``"drift"`` as
+        the generic tag. The reason is OPERATOR-visible only (lives
+        on the InvocationCancelled sink event), so this string is
+        free to be descriptive without prompt-injection concerns.
+        """
+        kind = drift.kind
+        if kind is DriftKind.USER_STEER:
+            return "user_steer"
+        if kind is DriftKind.USER_CANCEL:
+            return "user_cancel"
+        if kind is DriftKind.USER_PAUSE:
+            return "user_pause"
+        return "drift"
 
     # ------------------------------------------------------------------
     # goldfive-steer-unification: promotion policy + handler

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -161,6 +161,85 @@ def severity_rank(sev: DriftSeverity | str) -> int:
 
 
 @dataclasses.dataclass
+class CancellationRequest:
+    """Cooperative-cancellation directive for one in-flight invocation (goldfive#251).
+
+    Written by :class:`~goldfive.steerer.DefaultSteerer` into the ADK
+    ``session.state`` under
+    :data:`goldfive.adapters._adk_state_protocol.KEY_CANCEL_REQUESTED`
+    (a ``dict[str, CancellationRequest]`` keyed by ``invocation_id``)
+    when a drift at CRITICAL severity warrants aborting the in-flight
+    adapter dispatch without tearing down the whole run.
+
+    Every adapter callback that can short-circuit a dispatch
+    (``before_agent_callback``, ``before_model_callback``,
+    ``before_tool_callback``) checks the flag keyed by the current
+    ``invocation_id`` at the top of the callback. When set, the
+    callback consumes the request (read-then-clear), emits an
+    ``InvocationCancelled`` sink event carrying the rich context, and
+    short-circuits the dispatch:
+
+    * ``before_agent_callback`` — returns without invoking the agent.
+    * ``before_tool_callback`` — returns ``{"status": "cancelled"}`` as
+      the tool response so the parent LLM sees a minimal, prompt-safe
+      marker (rich context stays in the sink event, NOT in the
+      LLM-visible response — see goldfive#250 / #252 / #253 lessons).
+    * ``before_model_callback`` — skips the LLM call.
+
+    The rich ``CancellationRequest`` is deliberately NOT the object
+    surfaced to the LLM. It exists for PROGRAMMATIC consumers
+    (harmonograf observability, future Stream D correction-injection
+    logic). The LLM-visible surface is the flat ``{"status":
+    "cancelled"}`` dict above.
+
+    Fields
+    ------
+    invocation_id:
+        ADK ``invocation_id`` of the dispatch this request targets.
+        Cancellation is agent-AGNOSTIC — a parent-child chain of
+        invocations is handled by propagating a separate request per
+        invocation_id, not by naming an agent role.
+    reason:
+        Short symbolic reason (``"drift"``, ``"user_steer"``,
+        ``"plan_revised"``, …). Free-form string; consumers pattern-
+        match prefixes when useful, but the wire contract is just "a
+        string for the sink event".
+    severity:
+        Severity of the triggering drift. Only CRITICAL reaches cancel
+        per the severity ladder (goldfive#142); recorded here so sink
+        consumers can differentiate a user-requested cancel (always
+        honoured regardless of severity) from a graduated-drift cancel.
+    drift_id:
+        Cross-reference to the triggering ``DriftEvent.id`` when this
+        request was minted from a drift. Empty string for user-control
+        cancels or programmatic calls with no drift origin.
+    requested_at_ms:
+        Wall-clock milliseconds at request time. Defaults to 0 so
+        the structure is a cheap ``dataclass()`` literal in tests; the
+        steerer's cancel-request path stamps it on mint.
+    """
+
+    invocation_id: str
+    reason: str = "drift"
+    severity: DriftSeverity = DriftSeverity.CRITICAL
+    drift_id: str = ""
+    requested_at_ms: int = 0
+    # Free-form human-readable detail for operator-visible sink events.
+    # NOT exposed to the LLM (the LLM-visible response is
+    # ``{"status": "cancelled"}`` with no reason/detail/drift_kind — see
+    # lessons from goldfive#250 / #252 / #253). Populated by the steerer
+    # with a short one-line description of why cancel fired so
+    # harmonograf's intervention aggregator has something to render.
+    detail: str = ""
+    # Drift kind that triggered the cancel, if any. Sink-event only;
+    # never reaches the LLM. Stored as the string value of
+    # :class:`DriftKind` rather than the enum itself to keep the
+    # dataclass serialisable by plain ``dataclasses.asdict`` without
+    # importing the enum registry.
+    drift_kind: str = ""
+
+
+@dataclasses.dataclass
 class Task:
     id: str
     title: str

--- a/tests/test_cooperative_cancellation.py
+++ b/tests/test_cooperative_cancellation.py
@@ -1,0 +1,602 @@
+"""Cooperative-cancellation tests (goldfive#251 Stream C / 7a).
+
+Ships the adapter callback + steerer wiring for cancellable
+in-flight invocations. Each test pins one invariant from the
+design brief:
+
+1. Cancel flag set -> ``before_agent_callback`` skips turn.
+2. Flag is CONSUMED (read + clear) — re-entry doesn't re-cancel.
+3. ``before_tool_callback`` returns ``{"status": "cancelled"}`` for
+   a cancelled invocation.
+4. Cancellation emits an ``InvocationCancelled`` sink event with the
+   rich context (operator-visible; not LLM-visible).
+5. Parent-child propagation: cancelling an invocation also flags its
+   spawned sub-invocations.
+6. Severity ladder — INFO drift does NOT cancel.
+7. Severity ladder — CRITICAL drift DOES cancel the active
+   invocation.
+8. Empty invocation-id guard — a drift with no resolvable active
+   invocation doesn't crash and doesn't fabricate a target.
+9. LLM-visible response is MINIMAL — no ``reason`` / ``detail`` /
+   ``drift_kind`` leaks. Invariant.
+10. No auto re-dispatch — after cancel fires, the framework does NOT
+    re-call the agent. The parent's next turn handles the cancelled
+    marker itself.
+
+The ADK plugin tests use a minimal stub that mimics the attribute
+shape of the live ADK ``callback_context`` / ``tool_context`` /
+``invocation_context`` types without pulling in ADK as a test
+dependency — keeps the file usable in environments that don't have
+the ``adk`` extra installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+pytest.importorskip("google.adk")
+
+from goldfive.adapters import _adk_state_protocol as _sp  # noqa: E402
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    SessionContext,
+    make_adk_plugin,
+)
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    CancellationRequest,
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+def _cancelled_events(sink: ListSink) -> list[Any]:
+    """Filter dict-envelope events by ``kind == "invocation_cancelled"``."""
+    out: list[Any] = []
+    for evt in sink.events:
+        getter = getattr(evt, "get", None)
+        if getter is None:
+            continue
+        if getter("kind") == "invocation_cancelled":
+            out.append(evt)
+    return out
+
+
+class _FakeInvocationContext:
+    """Mimics ADK ``InvocationContext`` enough for the plugin's
+    callback paths: exposes ``invocation_id``, ``session`` (with
+    ``state`` + ``run_id`` + ``id``), and ``agent`` (with ``name``).
+    """
+
+    def __init__(
+        self,
+        *,
+        invocation_id: str,
+        session_state: dict[str, Any],
+        agent_name: str = "sub_agent",
+    ) -> None:
+        self.invocation_id = invocation_id
+        self.session = _FakeADKSession(state=session_state)
+        self.agent = _FakeAgent(name=agent_name)
+
+
+class _FakeADKSession:
+    def __init__(self, *, state: dict[str, Any]) -> None:
+        self.state = state
+        self.run_id = "run-test"
+        self.id = "session-test"
+
+
+class _FakeAgent:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+
+
+class _FakeCallbackContext:
+    """Mimics ADK ``CallbackContext`` — holds ``_invocation_context``."""
+
+    def __init__(self, *, invocation_context: _FakeInvocationContext) -> None:
+        self._invocation_context = invocation_context
+        # A minimal ``state`` attribute that points at the same mapping
+        # ADK state-protocol callbacks read. The real ADK wrapper is
+        # richer (``state.to_dict()`` / ``state.delta``), but the plugin
+        # code paths we exercise only dereference a Mapping.
+        self.state = invocation_context.session.state
+
+
+class _FakeToolContext(_FakeCallbackContext):
+    """``ToolContext`` extends ``CallbackContext`` with a function_call_id."""
+
+    def __init__(
+        self,
+        *,
+        invocation_context: _FakeInvocationContext,
+        function_call_id: str = "fc-1",
+    ) -> None:
+        super().__init__(invocation_context=invocation_context)
+        self.function_call_id = function_call_id
+
+
+class _FakeTool:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+
+
+class _StubAdapter:
+    """Adapter stub exposing just the plugin slot the steerer needs."""
+
+    def __init__(self, plugin: Any) -> None:
+        self._plugin = plugin
+        self._next_cancel_reason: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_plugin(*, with_sinks: bool = True) -> tuple[Any, ListSink, Session]:
+    """Build a fresh plugin instance + an attached SessionContext so
+    the plugin's ``_emit_invocation_cancelled`` path can fan out."""
+    plugin = make_adk_plugin(host_agent_name="coordinator")
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    if with_sinks:
+        steerer.bind(sinks=[sink], planner=None)
+    session = Session(
+        run_id="run-test",
+        goals=[Goal(id="g1", summary="ship")],
+        plan=_make_plan(),
+        current_task_id="t1",
+    )
+    ctx = SessionContext(
+        session=session,
+        steerer=steerer,
+        tools=(),
+        tool_handlers={},
+        host_agent_name="coordinator",
+        task=session.plan.tasks[0],
+    )
+    plugin.set_active_context(ctx)
+    return plugin, sink, session
+
+
+def _make_plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="run-test",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.RUNNING),
+            Task(id="t2", title="T2", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+
+
+def _make_request(
+    *,
+    invocation_id: str = "inv-1",
+    severity: DriftSeverity = DriftSeverity.CRITICAL,
+    reason: str = "drift",
+    drift_kind: str = "off_topic",
+) -> CancellationRequest:
+    return CancellationRequest(
+        invocation_id=invocation_id,
+        reason=reason,
+        severity=severity,
+        drift_kind=drift_kind,
+        detail="cancel test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Flag set -> before_agent_callback skips turn
+# ---------------------------------------------------------------------------
+
+
+async def test_before_agent_skips_turn_when_cancelled() -> None:
+    plugin, sink, _session = _make_plugin()
+    request = _make_request(invocation_id="inv-1")
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=request)
+    assert plugin.peek_cancel_for_invocation("inv-1") is request
+
+    # Attach a reconciler spy so we can prove the pinning / reconciler
+    # forward work did NOT run — the callback short-circuited.
+    class _Spy:
+        def __init__(self) -> None:
+            self.before_agent_calls = 0
+
+        async def on_before_agent(self, **_kwargs: Any) -> None:
+            self.before_agent_calls += 1
+
+    spy = _Spy()
+    plugin.set_reconciler(spy)
+
+    inv_ctx = _FakeInvocationContext(
+        invocation_id="inv-1",
+        session_state={},
+        agent_name="sub_agent",
+    )
+    await plugin.before_agent_callback(
+        agent=_FakeAgent(name="sub_agent"),
+        callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
+    )
+
+    # Reconciler forward did NOT fire — agent turn was skipped.
+    assert spy.before_agent_calls == 0
+    # Sink received an InvocationCancelled event.
+    assert len(_cancelled_events(sink)) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Flag is CONSUMED (read + clear) -- re-entry doesn't re-cancel
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_flag_consumed_on_first_callback() -> None:
+    plugin, sink, _session = _make_plugin()
+    plugin.request_invocation_cancel(
+        invocation_id="inv-1", request=_make_request()
+    )
+
+    inv_ctx = _FakeInvocationContext(
+        invocation_id="inv-1",
+        session_state={},
+    )
+    # First callback consumes the flag.
+    await plugin.before_agent_callback(
+        agent=_FakeAgent(name="sub_agent"),
+        callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
+    )
+    # Flag is gone.
+    assert plugin.peek_cancel_for_invocation("inv-1") is None
+    # A second callback on the same invocation sees no cancel and
+    # proceeds normally (we rely on the reconciler being None so the
+    # path completes without raising).
+    plugin.set_reconciler(None)
+    await plugin.before_agent_callback(
+        agent=_FakeAgent(name="sub_agent"),
+        callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
+    )
+    # Only ONE InvocationCancelled event in total — the second
+    # callback did not re-emit.
+    assert len(_cancelled_events(sink)) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. before_tool_callback returns {"status": "cancelled"} when cancelled
+# ---------------------------------------------------------------------------
+
+
+async def test_before_tool_returns_cancelled_status() -> None:
+    plugin, _sink, _session = _make_plugin()
+    plugin.request_invocation_cancel(
+        invocation_id="inv-1",
+        request=_make_request(drift_kind="off_topic", reason="drift"),
+    )
+
+    inv_ctx = _FakeInvocationContext(
+        invocation_id="inv-1",
+        session_state={},
+    )
+    tool_ctx = _FakeToolContext(invocation_context=inv_ctx)
+    response = await plugin.before_tool_callback(
+        tool=_FakeTool(name="search"),
+        tool_args={"query": "test"},
+        tool_context=tool_ctx,
+    )
+    assert response == {"status": "cancelled"}
+
+
+# ---------------------------------------------------------------------------
+# 4. InvocationCancelled sink event carries rich context
+# ---------------------------------------------------------------------------
+
+
+async def test_invocation_cancelled_sink_event_rich_fields() -> None:
+    plugin, sink, _session = _make_plugin()
+    request = _make_request(
+        invocation_id="inv-1",
+        reason="user_steer",
+        severity=DriftSeverity.CRITICAL,
+        drift_kind="off_topic",
+    )
+    request.drift_id = "drift-abc"
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=request)
+    inv_ctx = _FakeInvocationContext(
+        invocation_id="inv-1",
+        session_state={},
+        agent_name="planner_agent",
+    )
+    await plugin.before_agent_callback(
+        agent=_FakeAgent(name="planner_agent"),
+        callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
+    )
+    cancelled = _cancelled_events(sink)
+    assert len(cancelled) == 1
+    payload = cancelled[0]["payload"]
+    assert payload["invocation_id"] == "inv-1"
+    assert payload["agent_name"] == "planner_agent"
+    assert payload["reason"] == "user_steer"
+    assert payload["severity"] == "critical"
+    assert payload["drift_id"] == "drift-abc"
+    assert payload["drift_kind"] == "off_topic"
+
+
+# ---------------------------------------------------------------------------
+# 5. Parent-child propagation
+# ---------------------------------------------------------------------------
+
+
+def test_parent_cancel_propagates_to_children() -> None:
+    plugin, _sink, _session = _make_plugin()
+    # Record a small tree: A -> B, B -> C
+    plugin._invocation_parents["inv-B"] = "inv-A"
+    plugin._invocation_parents["inv-C"] = "inv-B"
+    # Independent sibling that must NOT be flagged.
+    plugin._invocation_parents["inv-D"] = "inv-X"
+
+    flagged = plugin.request_invocation_cancel(
+        invocation_id="inv-A",
+        request=_make_request(invocation_id="inv-A"),
+    )
+    assert set(flagged) == {"inv-A", "inv-B", "inv-C"}
+    # The state dict really carries entries for every flagged id.
+    assert plugin.peek_cancel_for_invocation("inv-A") is not None
+    assert plugin.peek_cancel_for_invocation("inv-B") is not None
+    assert plugin.peek_cancel_for_invocation("inv-C") is not None
+    # Unrelated sibling is clear.
+    assert plugin.peek_cancel_for_invocation("inv-D") is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Severity ladder -- INFO drift does NOT cancel
+# ---------------------------------------------------------------------------
+
+
+async def test_info_drift_does_not_request_cancel() -> None:
+    plugin, _sink, session = _make_plugin()
+    adapter = _StubAdapter(plugin)
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[], planner=None)
+    steerer.bind_adapter(adapter)
+    # Tell the plugin what the top-level invocation_id is so
+    # ``_resolve_active_invocation_ids`` has something to target
+    # (without this the empty-invocation-id guard would short-circuit
+    # cancel independently and we couldn't distinguish the severity
+    # gate from the empty-guard).
+    plugin._top_invocation_id = "inv-A"
+
+    drift = DriftEvent(
+        kind=DriftKind.CONFUSION,
+        severity=DriftSeverity.INFO,
+        current_task_id="t1",
+        current_agent_id="sub_agent",
+    )
+    await steerer._handle_drift(drift, session)
+    # No cancel was flagged for any invocation.
+    assert plugin.peek_cancel_for_invocation("inv-A") is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Severity ladder -- CRITICAL drift DOES cancel
+# ---------------------------------------------------------------------------
+
+
+async def test_critical_drift_requests_cancel() -> None:
+    plugin, _sink, session = _make_plugin()
+    adapter = _StubAdapter(plugin)
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[], planner=None)
+    steerer.bind_adapter(adapter)
+    plugin._top_invocation_id = "inv-A"
+
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.CRITICAL,
+        current_task_id="t1",
+        current_agent_id="sub_agent",
+    )
+    await steerer._handle_drift(drift, session)
+    # Cancel was flagged for the resolved invocation id.
+    req = plugin.peek_cancel_for_invocation("inv-A")
+    assert req is not None
+    assert req.severity is DriftSeverity.CRITICAL
+    assert req.drift_kind == DriftKind.OFF_TOPIC.value
+
+
+# ---------------------------------------------------------------------------
+# 8. Empty invocation-id guard
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_noop_when_no_active_invocation() -> None:
+    plugin, _sink, session = _make_plugin()
+    adapter = _StubAdapter(plugin)
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[], planner=None)
+    steerer.bind_adapter(adapter)
+    # DELIBERATELY do NOT pin a top invocation id.
+    plugin._top_invocation_id = ""
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.CRITICAL,
+        # No current_agent_id / current_task_id either.
+    )
+    # Does not raise.
+    flagged = await steerer.request_invocation_cancel(drift=drift, session=session)
+    assert flagged == []
+
+
+# ---------------------------------------------------------------------------
+# 9. LLM-visible response is MINIMAL -- invariant
+# ---------------------------------------------------------------------------
+
+
+async def test_llm_visible_cancelled_response_is_minimal() -> None:
+    """The tool response returned to the LLM must be ``{"status":
+    "cancelled"}`` — bare shape. No ``reason`` / ``detail`` /
+    ``drift_kind`` leak that the parent LLM could pattern-match on
+    and invent workarounds (lesson from goldfive#250 / #252 / #253).
+    """
+    plugin, _sink, _session = _make_plugin()
+    request = _make_request(
+        reason="user_steer",
+        drift_kind="off_topic",
+    )
+    request.detail = "the agent wandered into raccoons"
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=request)
+
+    inv_ctx = _FakeInvocationContext(
+        invocation_id="inv-1",
+        session_state={},
+    )
+    response = await plugin.before_tool_callback(
+        tool=_FakeTool(name="search"),
+        tool_args={},
+        tool_context=_FakeToolContext(invocation_context=inv_ctx),
+    )
+    # Bare shape. No reason, no detail, no drift_kind — the LLM can
+    # only pattern-match on the single word "cancelled".
+    assert response == {"status": "cancelled"}
+    assert set(response.keys()) == {"status"}
+    # Specifically forbidden keys (prompt-injection risk):
+    for forbidden in ("reason", "detail", "drift_kind", "severity", "drift_id"):
+        assert forbidden not in response
+
+
+# ---------------------------------------------------------------------------
+# 10. No auto re-dispatch -- cancel stops the invocation; parent decides next
+# ---------------------------------------------------------------------------
+
+
+async def test_no_auto_redispatch_after_cancel() -> None:
+    """After a cancel fires, the framework does NOT re-call the
+    agent. The plugin's job is to skip the in-flight invocation
+    cleanly; re-dispatch (if any) is the parent's decision, driven
+    by its own next-turn prompt (Stream B plan-causal prompting).
+    """
+    plugin, sink, _session = _make_plugin()
+
+    class _ReconcilerSpy:
+        def __init__(self) -> None:
+            self.before_agent_calls = 0
+            self.delegation_calls = 0
+
+        async def on_before_agent(self, **_kwargs: Any) -> None:
+            self.before_agent_calls += 1
+
+        async def on_delegation_observed(self, **_kwargs: Any) -> None:
+            self.delegation_calls += 1
+
+        async def on_after_agent(self, **_kwargs: Any) -> None:
+            pass
+
+    spy = _ReconcilerSpy()
+    plugin.set_reconciler(spy)
+
+    plugin.request_invocation_cancel(
+        invocation_id="inv-1", request=_make_request()
+    )
+    inv_ctx = _FakeInvocationContext(
+        invocation_id="inv-1",
+        session_state={},
+    )
+    # One "attempt" at before_agent — gets cancelled.
+    await plugin.before_agent_callback(
+        agent=_FakeAgent(name="sub_agent"),
+        callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
+    )
+    # The framework did NOT make a second call on our behalf.
+    # (If it had, ``before_agent_calls`` would be > 0 because the
+    # second call would have found the flag consumed and proceeded
+    # through the reconciler path.)
+    assert spy.before_agent_calls == 0
+    # A single cancelled event landed; no follow-up
+    # "re-dispatched" marker of any kind.
+    assert len(_cancelled_events(sink)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Extra: user-initiated cancel bypasses the severity gate
+# ---------------------------------------------------------------------------
+
+
+async def test_user_steer_drift_bypasses_severity_gate() -> None:
+    plugin, _sink, session = _make_plugin()
+    adapter = _StubAdapter(plugin)
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[], planner=None)
+    steerer.bind_adapter(adapter)
+    plugin._top_invocation_id = "inv-A"
+
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,  # below CRITICAL
+        detail="please pivot",
+    )
+    # The user-authored drift goes through _handle_drift's promotion
+    # path before cancel is considered; ensure the directly-reachable
+    # cancel API honours the bypass.
+    flagged = await steerer.request_invocation_cancel(drift=drift, session=session)
+    assert "inv-A" in flagged
+
+
+# ---------------------------------------------------------------------------
+# Extra: state-protocol helpers round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_state_protocol_cancel_helpers_roundtrip() -> None:
+    state: dict[str, Any] = {}
+    req = _make_request(invocation_id="inv-1")
+    _sp.write_cancel_request(state, invocation_id="inv-1", request=req)
+    assert _sp.read_cancel_request(state, "inv-1") is req
+    # Consume clears the entry.
+    assert _sp.consume_cancel_request(state, "inv-1") is req
+    assert _sp.read_cancel_request(state, "inv-1") is None
+    assert _sp.KEY_CANCEL_REQUESTED not in state
+
+
+def test_state_protocol_descendants_walk() -> None:
+    state: dict[str, Any] = {}
+    _sp.register_invocation_parent(state, invocation_id="B", parent_invocation_id="A")
+    _sp.register_invocation_parent(state, invocation_id="C", parent_invocation_id="B")
+    _sp.register_invocation_parent(state, invocation_id="D", parent_invocation_id="A")
+    _sp.register_invocation_parent(state, invocation_id="X", parent_invocation_id="Y")
+    descendants = _sp.descendants_of_invocation(state, "A")
+    assert set(descendants) == {"B", "C", "D"}
+    # Unrelated chain not touched.
+    assert "X" not in descendants
+    assert "Y" not in descendants


### PR DESCRIPTION
## Summary

Closes part of goldfive#251 (Stream C / 7a). Adds cooperative cancellation so a refine firing mid-run can abort the in-flight adapter invocation cleanly — bounded blast radius, no whole-run teardown (the failure mode that forced the goldfive#247 revert of goldfive#246).

### User review decisions baked in

- **Ship 7a only.** Adapter callbacks check a per-invocation flag and short-circuit cleanly. LLM-call-level cancellation (7b — `asyncio.shield`) documented as goldfive#256 for future work.
- **Minimal LLM-visible response** — `{\"status\": \"cancelled\"}`, single key. No `reason` / `detail` / `drift_kind` leak the parent LLM could pattern-match on and invent workarounds (same lesson as goldfive#250 / #252 / #253). Rich context lives on an `InvocationCancelled` sink event for operator observability only.
- **Severity ladder governs cancel.** CRITICAL drifts cancel; INFO / WARNING don't. User-authored drifts (`USER_STEER` / `USER_CANCEL` / `USER_PAUSE`) bypass the severity gate so an operator directive is always honoured.
- **No auto re-dispatch.** Framework stops the in-flight invocation; the parent agent decides whether to re-invoke via plan-causal prompting (Stream B). Not every drift warrants redoing the work.
- **Agent-agnostic.** Cancel targets `invocation_id`, never an agent role. No assumption of a coordinator or root agent anywhere in the code paths.
- **Parent-child propagation.** Cancelling an invocation flags its spawned sub-invocations via a per-invocation parent map populated by `before_run_callback`.

### Implementation

- `types.py` — new `CancellationRequest` dataclass.
- `adapters/_adk_state_protocol.py` — new `KEY_CANCEL_REQUESTED` / `KEY_INVOCATION_PARENTS` keys and `write_cancel_request` / `consume_cancel_request` / `descendants_of_invocation` helpers.
- `adapters/_adk_plugin.py` — plugin owns the authoritative cancel dict + parent/child map (ADK `InMemorySessionService` shallow-copies state per `get_session`, same rationale that drove goldfive#170 for `_active_ctx`). New `request_invocation_cancel` / `consume_cancel_for_invocation` / `peek_cancel_for_invocation` public methods. Cancel checkpoints added to `before_run_callback`, `before_agent_callback`, `before_model_callback`, and `before_tool_callback`. `_emit_invocation_cancelled` fans a dict envelope (via `events.make_event`) to the steerer's sinks — no proto schema change required this round; a typed slot can be minted later if sink strict typing is needed.
- `steerer.py` — `request_invocation_cancel()` wired into `_handle_drift` ahead of the promote / ladder paths. `_should_request_cancel_for_drift` encodes the severity gate. `_resolve_active_invocation_ids` walks the reconciler + plugin bookkeeping to target active invocations without assuming any agent role.

## Test plan

- [x] `uv run pytest tests/test_cooperative_cancellation.py` — 13 new tests, all green.
- [x] `uv run pytest tests/` — 1480 existing + 13 new = 1493 passed, 46 skipped.
- [x] `uv run ruff check goldfive/` — clean.

New tests pin every invariant from the brief: callback checkpoint short-circuits, consume-once semantics, parent-child propagation, severity ladder (INFO blocked / CRITICAL cancels / user-authored bypass), LLM-visible minimality (invariant test forbidding `reason` / `detail` / `drift_kind`), empty-invocation-id guard, no auto re-dispatch, state-protocol helper round-trip.