### PR TITLE
feat: correction injection for CORRECT-kind supersedes (Stream D)

### DIFF
--- a/goldfive/_correction_injection.py
+++ b/goldfive/_correction_injection.py
@@ -1,0 +1,451 @@
+"""Correction-injection write-side for CORRECT-kind supersedes (goldfive#251 Stream D).
+
+Goldfive#251 threads plan-causal context into wrapped-agent prompts
+through three streams:
+
+* Stream A (:mod:`goldfive.types`) — :class:`SupersessionKind` enum +
+  the refiner-side topology for CORRECT-kind supersedes (old task stays
+  COMPLETED; new task attached as a correction child in the DAG).
+* Stream B (:mod:`goldfive.adapters._adk_dynainst`) — dynamic instruction
+  resolver that appends a ``(agent_name, task_id)``-keyed pending
+  correction onto the agent's system prompt every turn.
+* Stream C (:mod:`goldfive.adapters._adk_plugin` +
+  :mod:`goldfive.adapters._adk_state_protocol`) — cooperative cancel of
+  the offending in-flight invocation when the drift is CRITICAL.
+
+This module owns the **write-side** of Stream B's read contract. When
+the refine in
+:meth:`goldfive.steerer.DefaultSteerer._emit_plan_revised` installs a
+new task carrying ``supersedes_kind == SupersessionKind.CORRECT``, the
+helper :func:`queue_corrections_for_revision` here composes one
+structured correction dict per CORRECT-kind new task and stamps it
+under :data:`goldfive.adapters._adk_state_protocol.KEY_PENDING_CORRECTIONS`
+on the goldfive orchestration :class:`~goldfive.types.Session.state`.
+
+Data flow
+---------
+
+1. Refine lands a CORRECT-kind supersedes link on a new task.
+2. :func:`queue_corrections_for_revision` writes the correction dict
+   into goldfive orchestration state, keyed
+   ``goldfive.pending_corrections.<agent_name>.<task_id>``.
+3. On the next root invocation, the adapter's ``before_run_callback``
+   bridges every ``goldfive.pending_corrections.*`` key from the
+   goldfive session state onto the ADK live session.state (goldfive#170
+   state bridge, extended for this key family in
+   :meth:`goldfive.adapters._adk_plugin._bridge_orchestration_state`).
+4. The dynamic instruction resolver (Stream B) reads its
+   ``(agent_name, current_task_id)``-keyed entry and — for dict values
+   — formats it via :func:`format_correction_block` before appending
+   to the composed system prompt.
+5. Agent sees the correction block on its next turn and proceeds on
+   the corrected task. Once the agent calls ``report_task_started``
+   on the correction task id, :func:`clear_correction` GC's the entry
+   (agent has acknowledged the new context).
+
+Correction-text design
+----------------------
+
+The correction body is **directive, not diagnostic**. We tell the LLM
+what to do on the new task — not what went wrong with the old task —
+to avoid the pattern-matching failure modes documented on goldfive#250
+/ #252 / #253 / #259: when the LLM sees problem-naming language
+("failed", "broken", "incorrect") it often invents workarounds (meta-
+commentary about the failure, retries of the wrong thing, apologies)
+instead of proceeding with the corrected work.
+
+The diagnostic data (drift kind, drift detail, superseded task title
++ id, revision number, issued_at_ms) is still present in the
+correction dict for programmatic consumers (sinks, observability) —
+it's just not rendered into the prompt text.
+
+Agent-agnostic
+--------------
+
+Every wrapped LlmAgent is a potential correction recipient. The
+``agent_name`` baked into each correction key is whatever assignee
+the refine named on the new task — there is no assumption that the
+tree has a "coordinator" agent, explicit or implicit. Correction
+routing follows the plan's own assignment, nothing more.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+
+from goldfive.adapters import _adk_state_protocol as _sp
+from goldfive.types import (
+    DriftEvent,
+    Plan,
+    SupersessionKind,
+    Task,
+)
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Key helpers
+# ---------------------------------------------------------------------------
+
+
+def pending_correction_key(agent_name: str, task_id: str) -> str:
+    """Return the full state key a correction is stamped under.
+
+    Same formula as
+    :func:`goldfive.adapters._adk_dynainst.pending_correction_key` —
+    re-exported here so the write-side doesn't pull in the ADK adapter
+    module (which has its own dependencies). The string contract is
+    shared; either spelling produces the same key.
+    """
+    return f"{_sp.KEY_PENDING_CORRECTIONS}.{agent_name}.{task_id}"
+
+
+def is_pending_correction_key(key: str) -> bool:
+    """Return True when ``key`` belongs to the pending-corrections family."""
+    prefix = _sp.KEY_PENDING_CORRECTIONS + "."
+    return isinstance(key, str) and key.startswith(prefix)
+
+
+# ---------------------------------------------------------------------------
+# Write-side
+# ---------------------------------------------------------------------------
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _bare_agent_name(value: Any) -> str:
+    """Normalise a raw agent id to its bare form.
+
+    Accepts strings like ``"agent.sub"`` or namespaced variants and
+    returns the last dotted segment. Tolerates anything mapping-shaped
+    or with a ``.name`` attribute so the caller doesn't have to
+    pre-strip. Empty / malformed input yields ``""``.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        s = value.strip()
+    else:
+        s = str(getattr(value, "name", value) or "").strip()
+    if not s:
+        return ""
+    # Many call sites already pass a bare name; this is defensive for
+    # call sites that may pass a fully-qualified id.
+    if "." in s:
+        return s.rsplit(".", 1)[-1]
+    return s
+
+
+def build_correction_payload(
+    *,
+    new_task: Task,
+    old_task: Task,
+    drift: DriftEvent,
+    revision_number: int,
+    issued_at_ms: int | None = None,
+) -> dict[str, Any]:
+    """Compose one correction dict for a CORRECT-kind supersedes link.
+
+    Does NOT write to state; pure value constructor so tests can pin
+    the shape without reaching into a Session.
+
+    Fields match the read-side contract consumed by
+    :func:`format_correction_block` — changing the shape requires a
+    paired change there.
+    """
+    drift_kind_value = ""
+    drift_kind = getattr(drift, "kind", None)
+    if drift_kind is not None:
+        # DriftKind is a StrEnum; ``.name`` gives the python-identifier
+        # spelling (e.g. ``OFF_TOPIC``) and ``.value`` the wire string
+        # (``"off_topic"``). We emit the lower-case wire form so sinks
+        # and prompt templates see a consistent spelling.
+        drift_kind_value = str(getattr(drift_kind, "value", drift_kind) or "").lower()
+
+    drift_reason = str(getattr(drift, "detail", "") or "")
+
+    ts = issued_at_ms if issued_at_ms is not None else _now_ms()
+
+    return {
+        "agent_name": _bare_agent_name(getattr(new_task, "assignee_agent_id", "")),
+        "task_id": str(getattr(new_task, "id", "") or ""),
+        "superseded_task_id": str(getattr(new_task, "supersedes", "") or ""),
+        "superseded_task_title": str(getattr(old_task, "title", "") or ""),
+        "drift_kind": drift_kind_value,
+        "drift_reason": drift_reason,
+        "revision_number": int(revision_number),
+        "issued_at_ms": int(ts),
+    }
+
+
+def _session_state(session: Any) -> MutableMapping[str, Any] | None:
+    """Return the goldfive orchestration state dict, or None if absent."""
+    state = getattr(session, "state", None)
+    if isinstance(state, MutableMapping):
+        return state
+    return None
+
+
+def write_correction(
+    session: Any,
+    correction: Mapping[str, Any],
+) -> str | None:
+    """Stamp a correction dict on the orchestration session state.
+
+    Returns the state key used, or ``None`` when the correction was
+    rejected (missing agent_name / task_id / session state dict).
+    """
+    state = _session_state(session)
+    if state is None:
+        return None
+    agent_name = str(correction.get("agent_name", "") or "")
+    task_id = str(correction.get("task_id", "") or "")
+    if not agent_name or not task_id:
+        return None
+    key = pending_correction_key(agent_name, task_id)
+    # Store a plain dict so downstream serialisers (sinks, persistence)
+    # can round-trip the value without needing to know about this
+    # module's dataclass / helper contract. ``dict(correction)`` copies
+    # defensively so later mutation of the source mapping doesn't
+    # silently leak into state.
+    state[key] = dict(correction)
+    return key
+
+
+def queue_corrections_for_revision(
+    *,
+    session: Any,
+    revised: Plan,
+    prev_plan: Plan | None,
+    drift: DriftEvent,
+) -> list[str]:
+    """Scan ``revised`` for CORRECT-kind supersedes and stamp corrections.
+
+    Called from
+    :meth:`goldfive.steerer.DefaultSteerer._emit_plan_revised` right
+    after :meth:`_integrate_correction_supersedes` has rewired the DAG.
+
+    For every new task carrying ``supersedes_kind == CORRECT`` we:
+
+    * Look up the superseded task on the revised plan (it stays in the
+      plan as a historical COMPLETED node — the CORRECT topology is
+      exactly that, old kept, new inserted as a child). Fall back to
+      ``prev_plan`` when the revised plan doesn't expose it (defensive;
+      in practice the CORRECT path keeps the old task).
+    * Build a correction dict (title of old, drift kind + reason from
+      the triggering drift, revision number).
+    * Write it under ``goldfive.pending_corrections.<agent>.<task_id>``.
+
+    Returns the list of state keys written so callers (tests, sinks)
+    can assert on multi-correction revisions.
+
+    No-op when ``revised`` has no CORRECT-kind supersedes links, when
+    the session has no state dict, or when the triggering drift is
+    None (defensive — the steerer always provides one in practice).
+    """
+    if revised is None or drift is None:
+        return []
+    state = _session_state(session)
+    if state is None:
+        return []
+
+    revised_tasks: list[Task] = list(getattr(revised, "tasks", None) or [])
+    if not revised_tasks:
+        return []
+
+    revised_by_id: dict[str, Task] = {str(t.id): t for t in revised_tasks if t.id}
+    prev_by_id: dict[str, Task] = {}
+    if prev_plan is not None:
+        for t in getattr(prev_plan, "tasks", None) or ():
+            if getattr(t, "id", ""):
+                prev_by_id[str(t.id)] = t
+
+    written_keys: list[str] = []
+    revision_number = int(getattr(revised, "revision_index", 0) or 0)
+    now_ms = _now_ms()
+
+    for new_task in revised_tasks:
+        if getattr(new_task, "supersedes_kind", None) is not SupersessionKind.CORRECT:
+            continue
+        old_id = str(getattr(new_task, "supersedes", "") or "").strip()
+        new_id = str(getattr(new_task, "id", "") or "").strip()
+        if not old_id or not new_id:
+            continue
+        assignee = _bare_agent_name(getattr(new_task, "assignee_agent_id", ""))
+        if not assignee:
+            # Without an assignee we have no (agent, task) key to write.
+            # Log and skip; the plan is still structurally valid (the
+            # correction just never materialises into a prompt).
+            log.debug(
+                "queue_corrections_for_revision: CORRECT-kind task %r has no assignee; "
+                "skipping correction write",
+                new_id,
+            )
+            continue
+        old_task = revised_by_id.get(old_id) or prev_by_id.get(old_id)
+        if old_task is None:
+            # Structural validator would have rejected a CORRECT-kind
+            # link pointing at an unknown id, so in practice this is
+            # unreachable. Defensive skip rather than raise.
+            log.debug(
+                "queue_corrections_for_revision: superseded id %r not found "
+                "in revised or prev plan; skipping correction for task %r",
+                old_id,
+                new_id,
+            )
+            continue
+        payload = build_correction_payload(
+            new_task=new_task,
+            old_task=old_task,
+            drift=drift,
+            revision_number=revision_number,
+            issued_at_ms=now_ms,
+        )
+        key = write_correction(session, payload)
+        if key is not None:
+            written_keys.append(key)
+            log.info(
+                "correction queued for agent=%r task=%r (superseded=%r, drift=%s, rev=%d)",
+                payload["agent_name"],
+                payload["task_id"],
+                payload["superseded_task_id"],
+                payload["drift_kind"] or "(none)",
+                revision_number,
+            )
+    return written_keys
+
+
+# ---------------------------------------------------------------------------
+# Garbage-collection (clears)
+# ---------------------------------------------------------------------------
+
+
+def clear_correction(
+    session: Any,
+    *,
+    agent_name: str,
+    task_id: str,
+) -> bool:
+    """Remove the pending correction for ``(agent_name, task_id)``.
+
+    Returns True when a correction was cleared, False when no entry
+    existed (or the session has no state dict).
+
+    Called from :mod:`goldfive.reporting` on
+    :func:`report_task_started` for the correction task — the agent
+    acknowledging the new task is our cue to stop re-injecting the
+    correction block on subsequent turns.
+    """
+    if not agent_name or not task_id:
+        return False
+    state = _session_state(session)
+    if state is None:
+        return False
+    key = pending_correction_key(agent_name, task_id)
+    if key in state:
+        state.pop(key, None)
+        log.info(
+            "cleared pending correction for agent=%r task=%r",
+            agent_name,
+            task_id,
+        )
+        return True
+    return False
+
+
+def clear_corrections_for_task(
+    session: Any,
+    task_id: str,
+) -> list[str]:
+    """Remove every pending correction targeted at ``task_id``.
+
+    Used by the plan-revision GC path in
+    :meth:`goldfive.steerer.DefaultSteerer._emit_plan_revised`: when a
+    new revision supersedes a correction task, every correction keyed
+    on that task id becomes obsolete (the agent is no longer on that
+    task and the follow-up revision speaks for the current context).
+
+    Matches across all agents — a correction is ``(agent, task)``-keyed
+    but a plan-revision supersession names a task, not an agent, so
+    the sweep is task-scoped. Returns the list of cleared state keys.
+    """
+    if not task_id:
+        return []
+    state = _session_state(session)
+    if state is None:
+        return []
+    suffix = f".{task_id}"
+    prefix = _sp.KEY_PENDING_CORRECTIONS + "."
+    cleared: list[str] = []
+    # Snapshot keys before mutating — we pop while iterating otherwise.
+    for key in list(state.keys()):
+        if not isinstance(key, str):
+            continue
+        if not key.startswith(prefix):
+            continue
+        if not key.endswith(suffix):
+            continue
+        state.pop(key, None)
+        cleared.append(key)
+    if cleared:
+        log.info(
+            "cleared %d pending correction(s) scoped to task=%r (task was superseded by revision)",
+            len(cleared),
+            task_id,
+        )
+    return cleared
+
+
+def clear_obsolete_corrections_on_revision(
+    session: Any,
+    revised: Plan,
+) -> list[str]:
+    """Sweep corrections whose target task was superseded in ``revised``.
+
+    Walks the revised plan for any task whose own ``supersedes`` points
+    at an earlier task id, and drops every correction keyed on that
+    earlier id. Idempotent — a second call on the same revised plan
+    finds nothing to clear.
+
+    Paired with :func:`queue_corrections_for_revision` so one refine
+    can simultaneously:
+
+    * Queue new corrections for fresh CORRECT-kind supersedes, AND
+    * Evict corrections for tasks the new revision itself supersedes
+      (CORRECT or REPLACE — both make the prior pending correction
+      obsolete, because the agent is moving onto the replacement /
+      correction-of-the-correction).
+
+    Returns the list of cleared state keys.
+    """
+    if revised is None:
+        return []
+    superseded_ids: set[str] = set()
+    for task in getattr(revised, "tasks", None) or ():
+        sup = str(getattr(task, "supersedes", "") or "").strip()
+        if sup:
+            superseded_ids.add(sup)
+    if not superseded_ids:
+        return []
+    cleared: list[str] = []
+    for old_id in superseded_ids:
+        cleared.extend(clear_corrections_for_task(session, old_id))
+    return cleared
+
+
+__all__ = [
+    "build_correction_payload",
+    "clear_correction",
+    "clear_corrections_for_task",
+    "clear_obsolete_corrections_on_revision",
+    "is_pending_correction_key",
+    "pending_correction_key",
+    "queue_corrections_for_revision",
+    "write_correction",
+]

--- a/goldfive/adapters/_adk_dynainst.py
+++ b/goldfive/adapters/_adk_dynainst.py
@@ -49,6 +49,88 @@ def pending_correction_key(agent_name: str, task_id: str) -> str:
     return f"{_sp.KEY_PENDING_CORRECTIONS}.{agent_name}.{task_id}"
 
 
+def format_correction_block(correction: Mapping[str, Any]) -> str:
+    """Render a pending-correction dict into the prompt block a resolver appends.
+
+    Stream D (goldfive#251 :mod:`goldfive._correction_injection`) writes a
+    structured dict describing the correction; this helper is the Stream
+    B (resolver) side of that contract and owns the exact language the
+    LLM sees.
+
+    Design principle: **directive, not diagnostic.** We tell the LLM
+    what to do on the corrected task ("focus only on", "do not
+    propagate"), NOT what went wrong with the prior task ("was broken",
+    "failed"). Problem-naming language is an attractor for LLM pattern-
+    matching failure modes — meta-commentary, apologies, retries of the
+    wrong thing (see goldfive#250 / #252 / #253 / #259's lessons on
+    response-shape minimality). The diagnostic data (drift kind, drift
+    reason, revision number) is still present in the dict for sinks /
+    observability but is deliberately NOT interpolated into the LLM-
+    visible block.
+
+    The rendered block is designed to slot after the ``Current
+    assigned task`` section via :func:`_compose_instruction`:
+
+        ---
+        Plan was revised (REV {n}). Your prior output for
+        task "{superseded_task_title}" (id {superseded_task_id}) was
+        superseded.
+
+        Focus only on the revised scope as described above in
+        "Current assigned task." Do not propagate the superseded
+        content into downstream dispatches.
+        ---
+
+    Missing fields degrade to sensible placeholders so a partial dict
+    (sink-shaped, persistence-restored) still renders cleanly.
+    """
+    if not isinstance(correction, Mapping):
+        return ""
+    rev = correction.get("revision_number", 0)
+    try:
+        rev_num = int(rev) if rev is not None else 0
+    except (TypeError, ValueError):
+        rev_num = 0
+    superseded_title = str(correction.get("superseded_task_title", "") or "(prior task)")
+    superseded_id = str(correction.get("superseded_task_id", "") or "")
+    id_fragment = f" (id {superseded_id})" if superseded_id else ""
+
+    return (
+        "---\n"
+        f"Plan was revised (REV {rev_num}). Your prior output for "
+        f"task \"{superseded_title}\"{id_fragment} was superseded.\n"
+        "\n"
+        "Focus only on the revised scope as described above in "
+        "\"Current assigned task.\" Do not propagate the superseded "
+        "content into downstream dispatches.\n"
+        "---"
+    )
+
+
+def _resolve_pending_correction(raw: Any) -> str:
+    """Normalise a pending-correction state value to the final prompt string.
+
+    Accepts three shapes so the resolver stays forgiving as Stream D's
+    write contract evolves:
+
+    * Mapping — the structured dict Stream D writes; rendered via
+      :func:`format_correction_block`.
+    * Non-empty string — treated as a pre-rendered block (back-compat
+      path for tests and operators who stamped a literal string into
+      state before Stream D existed, or who want to override the
+      template for a one-off).
+    * Anything else (None, empty string, bool, int) — degrades to an
+      empty string, which :func:`_compose_instruction` then skips.
+    """
+    if raw is None:
+        return ""
+    if isinstance(raw, Mapping):
+        return format_correction_block(raw)
+    if isinstance(raw, str):
+        return raw
+    return ""
+
+
 def _state_from_readonly_context(readonly_ctx: Any) -> Mapping[str, Any]:
     """Pull ``session.state`` off a ``ReadonlyContext`` defensively.
 
@@ -141,12 +223,10 @@ def make_dynamic_instruction(
                 state.get(_sp.KEY_CURRENT_TASK_DESCRIPTION, "") or ""
             )
 
-            pending_correction = str(
+            pending_correction = _resolve_pending_correction(
                 state.get(
                     pending_correction_key(agent_name, current_task_id),
-                    "",
                 )
-                or ""
             )
 
             return _compose_instruction(
@@ -320,6 +400,7 @@ def log_dynamic_instruction_opt_out(root_agent: Any) -> None:
 
 
 __all__ = [
+    "format_correction_block",
     "install_dynamic_instructions",
     "is_dynamic_instruction",
     "log_dynamic_instruction_opt_out",

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1113,6 +1113,49 @@ async def _inject_goldfive_planner_instruction(
         )
 
 
+def _bridge_pending_corrections(gf_state: Any, adk_state: Any) -> None:
+    """Mirror every ``goldfive.pending_corrections.*`` key from ``gf_state`` onto ``adk_state``.
+
+    goldfive#251 Stream D. Structural (prefix-scoped) bridge rather than
+    a per-key copy because the correction family is ``(agent,
+    task)``-expanded — goldfive doesn't know the set of keys at
+    plugin-init time. Idempotent: re-running on the same pair of states
+    restores whatever ``gf_state`` has NOW and evicts ADK entries
+    ``gf_state`` no longer carries. That eviction is the mechanism by
+    which a :func:`goldfive._correction_injection.clear_correction`
+    call on the orchestration state reaches the dynamic instruction
+    resolver on the ADK side.
+
+    Called from :meth:`make_adk_plugin`'s inner
+    ``_bridge_orchestration_state`` once per ``before_run_callback``;
+    also directly unit-testable as a module-level helper with any pair
+    of dicts.
+
+    Silent on non-mapping inputs so one malformed state never blocks
+    the rest of the bridge.
+    """
+    if not isinstance(adk_state, MutableMapping):
+        return
+    prefix = _sp.KEY_PENDING_CORRECTIONS + "."
+    # Snapshot the gf-side keys first so mutation during the loop is
+    # impossible.
+    gf_keys: dict[str, Any] = {}
+    if isinstance(gf_state, Mapping):
+        for k, v in gf_state.items():
+            if isinstance(k, str) and k.startswith(prefix):
+                gf_keys[k] = v
+    # Evict any ADK-side correction key that no longer exists on the
+    # goldfive side. This is the mechanism by which a clear on
+    # gf_state reaches the resolver (the resolver reads the ADK copy
+    # via ``readonly_context.state``).
+    for k in list(adk_state.keys()):
+        if isinstance(k, str) and k.startswith(prefix) and k not in gf_keys:
+            adk_state.pop(k, None)
+    # Copy fresh values through.
+    for k, v in gf_keys.items():
+        adk_state[k] = v
+
+
 def make_adk_plugin(
     *,
     name: str = "goldfive_adk_plugin",
@@ -2229,6 +2272,21 @@ def make_adk_plugin(
             except Exception as exc:  # noqa: BLE001
                 log.debug(
                     "_bridge_orchestration_state: cancelled_ids bridge failed: %s",
+                    exc,
+                )
+            # goldfive#251 Stream D: pending-corrections bridge. Keys
+            # under ``goldfive.pending_corrections.<agent>.<task>`` are
+            # written by :mod:`goldfive._correction_injection` on refine
+            # landing. They're prefix-scoped and per-(agent, task), so
+            # the bridge is structural — copy anything present under
+            # the family prefix, evict anything the orchestration side
+            # has cleared. The dynamic instruction resolver reads the
+            # ADK-side copy per turn.
+            try:
+                _bridge_pending_corrections(gf_state, adk_state)
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_bridge_orchestration_state: pending_corrections bridge failed: %s",
                     exc,
                 )
 

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -464,7 +464,48 @@ async def _handle_task_started(
                 task_id=task_id,
             )
     await steerer.mark_task_running(task_id, session=session, detail=detail)
+    # goldfive#251 Stream D: the agent has acknowledged the (possibly
+    # corrected) task; clear any queued correction scoped to this
+    # ``(agent, task_id)`` pair. The correction block only needs to be
+    # injected until the agent is on-task — further turns should see
+    # the unadorned instruction. ``report_task_failed`` does NOT clear
+    # (failure is not acknowledgment, and a re-invocation still needs
+    # the correction).
+    _clear_correction_on_started(session, task)
     return dict(_ACK)
+
+
+def _clear_correction_on_started(session: Session, task: Task | None) -> None:
+    """Best-effort GC of the pending correction for this task's assignee.
+
+    The correction is keyed by ``(agent_name, task_id)``; we recover
+    ``agent_name`` from ``task.assignee_agent_id`` on the plan. When
+    the task is unknown (shouldn't happen by the time we reach this
+    handler — ``_handle_task_started`` has already looked it up — but
+    defensive for edge cases) the clear is silently skipped.
+
+    Isolated so the call site in ``_handle_task_started`` stays terse
+    and so the import of the correction-injection module is paid only
+    in handler paths that actually need it.
+    """
+    if task is None:
+        return
+    from goldfive._correction_injection import clear_correction
+
+    assignee = str(getattr(task, "assignee_agent_id", "") or "").strip()
+    task_id = str(getattr(task, "id", "") or "").strip()
+    if not assignee or not task_id:
+        return
+    # Normalise the same way the write-side does so keys round-trip.
+    if "." in assignee:
+        assignee = assignee.rsplit(".", 1)[-1]
+    try:
+        clear_correction(session, agent_name=assignee, task_id=task_id)
+    except Exception as exc:  # noqa: BLE001
+        log.debug(
+            "reporting: clear_correction on report_task_started raised: %s",
+            exc,
+        )
 
 
 async def _handle_task_progress(

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -4017,6 +4017,10 @@ class DefaultSteerer:
         *,
         prev_plan: Plan | None = None,
     ) -> None:
+        from goldfive._correction_injection import (
+            clear_obsolete_corrections_on_revision,
+            queue_corrections_for_revision,
+        )
         from goldfive.conv import to_pb_plan
         from goldfive.events import build_plan_revision_diff
 
@@ -4028,6 +4032,29 @@ class DefaultSteerer:
         # correction. No-op for REPLACE-kind (existing behaviour is
         # preserved) and for plans without supersedes.
         self._integrate_correction_supersedes(revised)
+
+        # goldfive#251 Stream D: GC corrections for tasks superseded by
+        # this revision BEFORE queuing new ones. A task whose correction
+        # is about to be obsoleted (because the new revision supersedes
+        # the correction task itself) must have its stale correction
+        # dropped. Runs first so a same-revision CORRECT->CORRECT chain
+        # (T -> T' -> T'') doesn't race: the T correction is cleared
+        # here, then T''s correction is written below.
+        clear_obsolete_corrections_on_revision(session, revised)
+
+        # goldfive#251 Stream D: for every NEW task with supersedes_kind
+        # == CORRECT, stamp a structured correction dict on the
+        # orchestration session state under
+        # ``goldfive.pending_corrections.<agent_name>.<task_id>``. The
+        # dynamic instruction resolver (Stream B) reads this on the next
+        # turn and appends a directive-style correction block to the
+        # agent's system prompt. No-op on refines with no CORRECT links.
+        queue_corrections_for_revision(
+            session=session,
+            revised=revised,
+            prev_plan=prev_plan,
+            drift=drift,
+        )
 
         # goldfive#237: re-pin ``current_task_id`` onto any replacement
         # task the revision introduces. Without this, agents keep

--- a/tests/test_correction_injection.py
+++ b/tests/test_correction_injection.py
@@ -1,0 +1,808 @@
+"""Tests for correction injection (goldfive#251 Stream D).
+
+Covers the write-side machinery in :mod:`goldfive._correction_injection`
+and its integration with:
+
+* :mod:`goldfive.steerer` — ``_emit_plan_revised`` queues corrections
+  for every CORRECT-kind supersedes and GC's corrections for tasks
+  superseded by the revision.
+* :mod:`goldfive.reporting` — ``_handle_task_started`` clears the
+  correction once the agent acknowledges the new task.
+* :mod:`goldfive.adapters._adk_dynainst` —
+  :func:`format_correction_block` renders the dict into directive,
+  NOT diagnostic, prompt text; the dynamic resolver picks the rendered
+  block up via the ``(agent_name, task_id)``-keyed state entry.
+* :mod:`goldfive.adapters._adk_plugin` — the bridge propagates every
+  ``goldfive.pending_corrections.*`` key from orchestration state onto
+  ADK session.state every invocation.
+* :mod:`goldfive.adapters._adk_state_protocol` — cancellation does
+  NOT perturb queued corrections (Streams C + D are orthogonal by
+  design).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive._correction_injection import (  # noqa: E402
+    build_correction_payload,
+    clear_correction,
+    clear_corrections_for_task,
+    clear_obsolete_corrections_on_revision,
+    is_pending_correction_key,
+    pending_correction_key,
+    queue_corrections_for_revision,
+    write_correction,
+)
+from goldfive.adapters import _adk_state_protocol as _sp  # noqa: E402
+from goldfive.reporting import BUILTIN_REPORTING_TOOLS  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    CancellationRequest,
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    SupersessionKind,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        return None
+
+
+class _StubPlanner:
+    def __init__(self, revised: Plan | None = None) -> None:
+        self.revised = revised
+
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        return self.revised
+
+
+def _tool(name: str):
+    for t in BUILTIN_REPORTING_TOOLS:
+        if t.name == name:
+            return t
+    raise AssertionError(f"builtin tool {name!r} missing")
+
+
+def _session(plan: Plan) -> Session:
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="drive solar research to a report")],
+        plan=plan,
+    )
+
+
+def _drift(kind: DriftKind = DriftKind.OFF_TOPIC, detail: str = "drifted off topic") -> DriftEvent:
+    return DriftEvent(
+        kind=kind,
+        severity=DriftSeverity.WARNING,
+        detail=detail,
+        current_task_id="research_solar",
+    )
+
+
+def _base_plan() -> Plan:
+    """Seed plan with one COMPLETED research task that will be CORRECTED."""
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar options",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="research_agent",
+            ),
+            Task(
+                id="write_report",
+                title="Write final report",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="writer_agent",
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research_solar", to_task_id="write_report")],
+        revision_index=0,
+    )
+
+
+def _revised_with_one_correct() -> Plan:
+    """Refine output: research_solar COMPLETED; corrected task is a CORRECT child."""
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar options",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="research_agent",
+            ),
+            Task(
+                id="research_solar_corrected",
+                title="Research solar options (corrected scope)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="research_agent",
+                supersedes="research_solar",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+            Task(
+                id="write_report",
+                title="Write final report",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="writer_agent",
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research_solar", to_task_id="write_report")],
+        revision_index=1,
+    )
+
+
+async def _emit(
+    steerer: DefaultSteerer, session: Session, revised: Plan, drift: DriftEvent
+) -> None:
+    prev = session.plan
+    steerer._apply_revision(session, revised, drift)
+    await steerer._emit_plan_revised(session, revised, drift, prev_plan=prev)
+
+
+# ---------------------------------------------------------------------------
+# 1. CORRECT-kind refine writes a correction to state.
+# ---------------------------------------------------------------------------
+
+
+async def test_correct_kind_supersedes_writes_correction_to_state() -> None:
+    session = _session(_base_plan())
+    revised = _revised_with_one_correct()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
+
+    drift = _drift(kind=DriftKind.OFF_TOPIC, detail="veered to batteries")
+    await _emit(steerer, session, revised, drift)
+
+    key = pending_correction_key("research_agent", "research_solar_corrected")
+    assert key in session.state
+    payload = session.state[key]
+    assert isinstance(payload, dict)
+    assert payload["agent_name"] == "research_agent"
+    assert payload["task_id"] == "research_solar_corrected"
+    assert payload["superseded_task_id"] == "research_solar"
+    assert payload["superseded_task_title"] == "Research solar options"
+    assert payload["drift_kind"] == "off_topic"
+    assert payload["drift_reason"] == "veered to batteries"
+    assert payload["revision_number"] >= 1
+    assert isinstance(payload["issued_at_ms"], int)
+    assert payload["issued_at_ms"] > 0
+
+
+# ---------------------------------------------------------------------------
+# 2. REPLACE-kind refine does NOT write a correction.
+# ---------------------------------------------------------------------------
+
+
+async def test_replace_kind_supersedes_does_not_write_correction() -> None:
+    # Seed plan: research_solar is PENDING (not COMPLETED) — the usual
+    # REPLACE scenario.
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar options",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="research_agent",
+            ),
+        ],
+        edges=[],
+        revision_index=0,
+    )
+    session = _session(plan)
+
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar_v2",
+                title="Research solar options (rescoped)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="research_agent",
+                supersedes="research_solar",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+        ],
+        edges=[],
+        revision_index=1,
+    )
+
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
+    await _emit(steerer, session, revised, _drift())
+
+    # No pending_corrections.* keys should exist.
+    correction_keys = [k for k in session.state if is_pending_correction_key(k)]
+    assert correction_keys == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Multiple CORRECT supersedes in one refine -> multiple corrections.
+# ---------------------------------------------------------------------------
+
+
+async def test_multiple_correct_supersedes_write_multiple_corrections() -> None:
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="research_agent",
+            ),
+            Task(
+                id="analyze_solar",
+                title="Analyze solar findings",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="analysis_agent",
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research_solar", to_task_id="analyze_solar")],
+        revision_index=0,
+    )
+    session = _session(plan)
+
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="research_agent",
+            ),
+            Task(
+                id="research_solar_corrected",
+                title="Research solar (corrected)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="research_agent",
+                supersedes="research_solar",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+            Task(
+                id="analyze_solar",
+                title="Analyze solar findings",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="analysis_agent",
+            ),
+            Task(
+                id="analyze_solar_corrected",
+                title="Analyze solar findings (corrected)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="analysis_agent",
+                supersedes="analyze_solar",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research_solar", to_task_id="analyze_solar")],
+        revision_index=1,
+    )
+
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
+    await _emit(steerer, session, revised, _drift())
+
+    k1 = pending_correction_key("research_agent", "research_solar_corrected")
+    k2 = pending_correction_key("analysis_agent", "analyze_solar_corrected")
+    assert k1 in session.state
+    assert k2 in session.state
+    assert session.state[k1]["superseded_task_id"] == "research_solar"
+    assert session.state[k2]["superseded_task_id"] == "analyze_solar"
+
+
+# ---------------------------------------------------------------------------
+# 4. Correction cleared on report_task_started.
+# ---------------------------------------------------------------------------
+
+
+async def test_correction_cleared_on_report_task_started() -> None:
+    plan = _revised_with_one_correct()
+    session = _session(plan)
+    # Pre-seed a correction as Stream D would have written it.
+    key = pending_correction_key("research_agent", "research_solar_corrected")
+    session.state[key] = {
+        "agent_name": "research_agent",
+        "task_id": "research_solar_corrected",
+        "superseded_task_id": "research_solar",
+        "superseded_task_title": "Research solar options",
+        "drift_kind": "off_topic",
+        "drift_reason": "veered",
+        "revision_number": 1,
+        "issued_at_ms": 123456789,
+    }
+    assert key in session.state
+
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
+
+    await _tool("report_task_started").handler(
+        {"task_id": "research_solar_corrected", "detail": "starting"},
+        session,
+        steerer,
+    )
+    assert key not in session.state
+
+
+# ---------------------------------------------------------------------------
+# 5. Correction NOT cleared on report_task_failed.
+# ---------------------------------------------------------------------------
+
+
+async def test_correction_not_cleared_on_report_task_failed() -> None:
+    plan = _revised_with_one_correct()
+    # Mark the correction task RUNNING so failed is a legal transition.
+    for t in plan.tasks:
+        if t.id == "research_solar_corrected":
+            t.status = TaskStatus.RUNNING
+    session = _session(plan)
+    key = pending_correction_key("research_agent", "research_solar_corrected")
+    session.state[key] = {
+        "agent_name": "research_agent",
+        "task_id": "research_solar_corrected",
+        "superseded_task_id": "research_solar",
+        "superseded_task_title": "Research solar options",
+        "drift_kind": "off_topic",
+        "drift_reason": "veered",
+        "revision_number": 1,
+        "issued_at_ms": 123456789,
+    }
+
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
+
+    await _tool("report_task_failed").handler(
+        {"task_id": "research_solar_corrected", "reason": "dead end"},
+        session,
+        steerer,
+    )
+    assert key in session.state, "failure is not acknowledgment — correction must persist"
+
+
+# ---------------------------------------------------------------------------
+# 6. Correction cleared when the correction task itself is superseded.
+# ---------------------------------------------------------------------------
+
+
+async def test_correction_cleared_when_correction_task_itself_superseded() -> None:
+    # Seed a plan where research_solar_corrected already exists with a
+    # queued correction; then a second revision supersedes _corrected
+    # with _corrected_v2.
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="research_agent",
+            ),
+            Task(
+                id="research_solar_corrected",
+                title="Research solar (corrected)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="research_agent",
+                supersedes="research_solar",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research_solar", to_task_id="research_solar_corrected")],
+        revision_index=1,
+    )
+    session = _session(plan)
+    stale_key = pending_correction_key("research_agent", "research_solar_corrected")
+    session.state[stale_key] = {
+        "agent_name": "research_agent",
+        "task_id": "research_solar_corrected",
+        "superseded_task_id": "research_solar",
+        "superseded_task_title": "Research solar",
+        "drift_kind": "off_topic",
+        "drift_reason": "veered",
+        "revision_number": 1,
+        "issued_at_ms": 100,
+    }
+
+    # Revision 2: correction task itself is REPLACEd.
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="research_agent",
+            ),
+            Task(
+                id="research_solar_corrected_v2",
+                title="Research solar (corrected v2)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="research_agent",
+                supersedes="research_solar_corrected",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research_solar", to_task_id="research_solar_corrected_v2")
+        ],
+        revision_index=2,
+    )
+
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
+    await _emit(steerer, session, revised, _drift())
+
+    assert stale_key not in session.state, (
+        "correction for the task that was just superseded should be GC'd"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Correction survives a Stream C cancellation.
+# ---------------------------------------------------------------------------
+
+
+def test_correction_survives_stream_c_cancellation() -> None:
+    """Cancellation of the in-flight invocation does not evict a queued correction."""
+    plan = _revised_with_one_correct()
+    session = _session(plan)
+
+    corr_key = pending_correction_key("research_agent", "research_solar_corrected")
+    session.state[corr_key] = {
+        "agent_name": "research_agent",
+        "task_id": "research_solar_corrected",
+        "superseded_task_id": "research_solar",
+        "superseded_task_title": "Research solar options",
+        "drift_kind": "off_topic",
+        "drift_reason": "veered",
+        "revision_number": 1,
+        "issued_at_ms": 100,
+    }
+
+    # Simulate Stream C cancel writing + consuming a request.
+    _sp.write_cancel_request(
+        session.state,
+        invocation_id="inv-1",
+        request=CancellationRequest(
+            invocation_id="inv-1",
+            reason="drift",
+            severity=DriftSeverity.CRITICAL,
+            drift_id="did-1",
+            drift_kind=DriftKind.OFF_TOPIC.value,
+            detail="CRITICAL off-topic",
+        ),
+    )
+    consumed = _sp.consume_cancel_request(session.state, "inv-1")
+    assert consumed is not None
+
+    # Correction must still be present — cancellation and correction
+    # are orthogonal per-axis concerns.
+    assert corr_key in session.state
+
+
+# ---------------------------------------------------------------------------
+# 8. Format helper language is directive, not diagnostic.
+# ---------------------------------------------------------------------------
+
+
+def test_format_correction_block_is_directive_not_diagnostic() -> None:
+    from goldfive.adapters._adk_dynainst import format_correction_block
+
+    block = format_correction_block(
+        {
+            "agent_name": "research_agent",
+            "task_id": "T_corrected",
+            "superseded_task_id": "T_old",
+            "superseded_task_title": "Research solar options",
+            "drift_kind": "off_topic",
+            "drift_reason": "the agent veered into batteries",
+            "revision_number": 3,
+            "issued_at_ms": 123,
+        }
+    )
+    # Directive language: present.
+    assert "Focus only on" in block
+    assert "Do not propagate" in block
+
+    # Diagnostic / problem-naming language: MUST be absent so the LLM
+    # doesn't pattern-match on failure-shape prompts (#250/#252/#253/#259).
+    forbidden = [
+        "was broken",
+        "broke",
+        "failed",
+        "error",
+        "mistake",
+        "incorrect",
+        "wrong",
+    ]
+    low = block.lower()
+    for word in forbidden:
+        assert word not in low, f"format_correction_block leaked diagnostic word {word!r}"
+
+    # Structural expectations on the rendered block.
+    assert "REV 3" in block
+    assert "Research solar options" in block  # superseded task title is referenced
+    # The triggering drift detail is NOT interpolated into the LLM-facing block
+    # (it is retained in the dict for sinks / observability).
+    assert "veered into batteries" not in block
+    assert "off_topic" not in block
+
+
+# ---------------------------------------------------------------------------
+# 9. Integration with dynamic resolver.
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_resolver_picks_up_correction_dict() -> None:
+    pytest.importorskip("google.adk")
+    from goldfive.adapters._adk_dynainst import make_dynamic_instruction
+
+    resolver = make_dynamic_instruction(
+        original_instruction="you are the researcher",
+        agent_name="research_agent",
+    )
+
+    class _Ctx:
+        def __init__(self, state: dict[str, Any]) -> None:
+            self.state = state
+
+    state: dict[str, Any] = {
+        _sp.KEY_CURRENT_TASK_ID: "research_solar_corrected",
+        _sp.KEY_CURRENT_TASK_TITLE: "Research solar options (corrected)",
+        _sp.KEY_CURRENT_TASK_DESCRIPTION: "narrowed scope",
+        pending_correction_key("research_agent", "research_solar_corrected"): {
+            "agent_name": "research_agent",
+            "task_id": "research_solar_corrected",
+            "superseded_task_id": "research_solar",
+            "superseded_task_title": "Research solar options",
+            "drift_kind": "off_topic",
+            "drift_reason": "veered",
+            "revision_number": 2,
+            "issued_at_ms": 123,
+        },
+    }
+    out = resolver(_Ctx(state))
+    assert "you are the researcher" in out
+    assert "Current assigned task:" in out
+    # Directive correction block:
+    assert "Focus only on" in out
+    assert "REV 2" in out
+
+
+# ---------------------------------------------------------------------------
+# 10. State bridge propagation gf -> adk.
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_propagates_pending_corrections_gf_to_adk() -> None:
+    """Module-level ``_bridge_pending_corrections`` copies goldfive.pending_corrections.* keys.
+
+    Exercises the prefix-scoped bridge directly with a pair of dicts:
+    writes on goldfive orchestration state land on ADK state, and
+    subsequent clears on goldfive state evict the ADK-side copies so
+    the dynamic instruction resolver stops rendering a dead correction.
+    """
+    from goldfive.adapters._adk_plugin import _bridge_pending_corrections
+
+    gf_state: dict[str, Any] = {}
+    adk_state: dict[str, Any] = {}
+
+    # Write two corrections gf-side.
+    corr_a = pending_correction_key("agent_a", "task_1")
+    corr_b = pending_correction_key("agent_b", "task_2")
+    gf_state[corr_a] = {"agent_name": "agent_a", "task_id": "task_1", "revision_number": 1}
+    gf_state[corr_b] = {"agent_name": "agent_b", "task_id": "task_2", "revision_number": 1}
+    # Non-correction goldfive keys must NOT bleed through this bridge.
+    gf_state["goldfive.current_task_id"] = "unrelated"
+
+    _bridge_pending_corrections(gf_state, adk_state)
+
+    assert corr_a in adk_state
+    assert corr_b in adk_state
+    assert adk_state[corr_a] == gf_state[corr_a]
+    # The non-correction key must not be copied by this particular bridge.
+    assert "goldfive.current_task_id" not in adk_state
+
+    # Now clear one gf-side and re-bridge: ADK-side eviction must follow.
+    del gf_state[corr_a]
+    _bridge_pending_corrections(gf_state, adk_state)
+    assert corr_a not in adk_state
+    assert corr_b in adk_state
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the pure helpers.
+# ---------------------------------------------------------------------------
+
+
+def test_build_correction_payload_shapes_fields() -> None:
+    old = Task(id="T_old", title="Old work")
+    new = Task(
+        id="T_new",
+        title="New work (corrected)",
+        assignee_agent_id="agent_x",
+        supersedes="T_old",
+        supersedes_kind=SupersessionKind.CORRECT,
+    )
+    d = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="veered",
+    )
+    payload = build_correction_payload(
+        new_task=new, old_task=old, drift=d, revision_number=5, issued_at_ms=42
+    )
+    assert payload == {
+        "agent_name": "agent_x",
+        "task_id": "T_new",
+        "superseded_task_id": "T_old",
+        "superseded_task_title": "Old work",
+        "drift_kind": "off_topic",
+        "drift_reason": "veered",
+        "revision_number": 5,
+        "issued_at_ms": 42,
+    }
+
+
+def test_write_correction_round_trips() -> None:
+    session = _session(_base_plan())
+    key = write_correction(
+        session,
+        {
+            "agent_name": "a1",
+            "task_id": "t1",
+            "superseded_task_id": "t0",
+            "superseded_task_title": "old",
+            "drift_kind": "off_topic",
+            "drift_reason": "veered",
+            "revision_number": 1,
+            "issued_at_ms": 7,
+        },
+    )
+    assert key == pending_correction_key("a1", "t1")
+    assert session.state[key]["task_id"] == "t1"
+
+
+def test_write_correction_rejects_when_agent_or_task_missing() -> None:
+    session = _session(_base_plan())
+    assert write_correction(session, {"agent_name": "a1", "task_id": ""}) is None
+    assert write_correction(session, {"agent_name": "", "task_id": "t1"}) is None
+    assert not any(is_pending_correction_key(k) for k in session.state)
+
+
+def test_clear_correction_removes_entry() -> None:
+    session = _session(_base_plan())
+    key = pending_correction_key("a1", "t1")
+    session.state[key] = {"agent_name": "a1", "task_id": "t1"}
+    assert clear_correction(session, agent_name="a1", task_id="t1") is True
+    assert key not in session.state
+    # Second call — idempotent no-op.
+    assert clear_correction(session, agent_name="a1", task_id="t1") is False
+
+
+def test_clear_corrections_for_task_sweeps_all_agents() -> None:
+    session = _session(_base_plan())
+    session.state[pending_correction_key("a1", "t1")] = {"agent_name": "a1", "task_id": "t1"}
+    session.state[pending_correction_key("a2", "t1")] = {"agent_name": "a2", "task_id": "t1"}
+    session.state[pending_correction_key("a1", "t2")] = {"agent_name": "a1", "task_id": "t2"}
+    cleared = clear_corrections_for_task(session, "t1")
+    assert sorted(cleared) == sorted(
+        [
+            pending_correction_key("a1", "t1"),
+            pending_correction_key("a2", "t1"),
+        ]
+    )
+    assert pending_correction_key("a1", "t2") in session.state
+
+
+def test_clear_obsolete_on_revision_drops_superseded_task_corrections() -> None:
+    session = _session(_base_plan())
+    session.state[pending_correction_key("agent_a", "t_old")] = {
+        "agent_name": "agent_a",
+        "task_id": "t_old",
+    }
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t_old", title="old", assignee_agent_id="agent_a"),
+            Task(
+                id="t_new",
+                title="new",
+                assignee_agent_id="agent_a",
+                supersedes="t_old",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+        ],
+        edges=[],
+        revision_index=2,
+    )
+    cleared = clear_obsolete_corrections_on_revision(session, revised)
+    assert cleared == [pending_correction_key("agent_a", "t_old")]
+
+
+def test_queue_corrections_skips_task_without_assignee() -> None:
+    """No assignee -> correction is silently skipped (no key can be formed)."""
+    session = _session(_base_plan())
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t_old", title="old", status=TaskStatus.COMPLETED),
+            Task(
+                id="t_new",
+                title="new",
+                # No assignee_agent_id
+                supersedes="t_old",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+        ],
+        edges=[],
+        revision_index=1,
+    )
+    keys = queue_corrections_for_revision(
+        session=session,
+        revised=revised,
+        prev_plan=None,
+        drift=_drift(),
+    )
+    assert keys == []
+    assert not any(is_pending_correction_key(k) for k in session.state)
+
+
+def test_pending_correction_key_prefix_is_stable() -> None:
+    """The key prefix is part of the state-bridge contract."""
+    assert pending_correction_key("a", "t") == "goldfive.pending_corrections.a.t"
+    assert is_pending_correction_key("goldfive.pending_corrections.a.t")
+    assert not is_pending_correction_key("goldfive.current_task_id")


### PR DESCRIPTION
## Summary

Closes part of goldfive#251 -- Stream D, the final composition of Streams A (SupersessionKind), B (dynamic instruction resolver), and C (cooperative cancel).

When a refine produces a CORRECT-kind supersedes (new task is a correction child of a drift-contaminated COMPLETED old task), this stream writes a structured correction dict onto session.state keyed by `(agent_name, task_id)`. The dynamic instruction resolver (Stream B) already reads from that key; now it has data. The agent's next turn sees an appended system-prompt block that directs it to focus on the revised scope and not propagate superseded content.

## Design

- **Directive, not diagnostic.** Correction language is "Focus only on" / "Do not propagate", NOT "was broken" / "failed". Avoids LLM pattern-matching on error shapes (same lesson from #250 / #252 / #253 / #259). Diagnostic data (drift kind, reason, revision) stays in the dict for sinks but is not interpolated into the prompt.
- **Per-task scope.** One correction per `(agent, task)`. Multiple CORRECT supersedes in one refine write independent entries.
- **Agent-agnostic.** Works for any wrapped LlmAgent assigned a correction task. No assumption of a coordinator or root agent.
- **GC on `report_task_started`:** agent has acknowledged the new context; correction is cleared.
- **GC on correction-task-itself being superseded:** correction is obsolete (the same-revision chain edge case).
- **Survives cancellation (Stream C):** a cancelled invocation producing no output still has a queued correction for its next invocation on the same task.
- User-role-injection alternative is documented as goldfive#255; this PR ships system-append only per the user's review decision.

## Files

- `goldfive/_correction_injection.py` (new) -- write-side + GC helpers.
- `goldfive/steerer.py` -- `_emit_plan_revised` queues corrections after integrating the CORRECT DAG topology; GC of obsolete corrections runs first.
- `goldfive/reporting.py` -- `_handle_task_started` clears the correction for `(assignee, task_id)` on acknowledgment.
- `goldfive/adapters/_adk_dynainst.py` -- `format_correction_block` renders the dict; resolver accepts dict (formatted) or string (back-compat).
- `goldfive/adapters/_adk_plugin.py` -- `_bridge_pending_corrections` prefix-copies `goldfive.pending_corrections.*` gf->adk, including evictions.

## Test plan

- [x] `uv run pytest tests/` -- 1523 passed, 46 skipped (+18 new)
- [x] `uv run ruff check goldfive/ tests/` -- all checks passed
- [x] New `tests/test_correction_injection.py` covers:
  - CORRECT writes correction; REPLACE does not; multiple CORRECTs write independent entries
  - GC on `report_task_started`; NO GC on `report_task_failed`
  - GC on correction task itself being superseded by a later revision
  - Correction survives a Stream C cancellation
  - Format language is directive (not diagnostic); assert absence of "failed"/"broken"/"wrong"/etc.
  - Dynamic resolver picks up the dict via the shared key and renders the block
  - Bridge propagates `pending_corrections.*` gf->adk and evicts on clear
  - Payload builder shape; write rejection on missing agent_name / task_id; clear/sweep helpers