### PR TITLE
feat(planner): validate supersedes coverage on refine output

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -641,6 +641,80 @@ def _normalize_supersession_kinds(revised: Plan, *, prior: Plan | None) -> None:
             task.supersedes_kind = expected
 
 
+#: Old-task statuses that don't require a supersedes link when dropped.
+#: A FAILED or CANCELLED task in the prior plan represents work that was
+#: already conclusively closed — the refine output may legitimately drop
+#: it without naming a successor (the run will end up with the failure /
+#: cancel still on the books from the prior plan even if the rebuilt
+#: revision doesn't carry the slot forward). COMPLETED is intentionally
+#: excluded: a dropped COMPLETED task IS an accountability gap because
+#: its result is durable provenance for the run.
+_ABSORBING_TERMINAL_STATUSES: frozenset[TaskStatus] = frozenset(
+    {TaskStatus.FAILED, TaskStatus.CANCELLED}
+)
+
+
+def _check_supersedes_coverage(
+    revised: Plan,
+    *,
+    prior: Plan | None,
+) -> list[Task]:
+    """Return the list of prior tasks dropped without a supersedes link.
+
+    A "dropped" task is one whose id appears in ``prior.tasks`` but not
+    in ``revised.tasks``. Coverage is satisfied when:
+
+    * Some new task in ``revised`` has ``supersedes`` pointing at the
+      dropped id (REPLACE or CORRECT — both count; the kind is the
+      semantic flavour of the link, not its existence). OR
+    * The dropped task's status in ``prior`` is in
+      :data:`_ABSORBING_TERMINAL_STATUSES` (FAILED / CANCELLED): the
+      old work is conclusively closed and doesn't need a successor.
+
+    Tasks that fail both predicates are **orphans**: dropped from the
+    plan with no provenance trail. Returns the orphan ``Task`` objects
+    (from ``prior``) so callers can include id + title in operator-
+    visible telemetry. Order matches ``prior.tasks`` for deterministic
+    log output.
+
+    The CORRECT-kind supersedes case (test 5) doesn't appear here at
+    all: in a CORRECT chain the old task is COMPLETED and is preserved
+    verbatim in ``revised`` (Option B contract), so it's never in the
+    ``dropped`` set in the first place. We don't need to special-case
+    CORRECT vs REPLACE — both kinds satisfy "some task supersedes me"
+    identically.
+
+    .. note::
+
+       Future work: when an orphan has a same-assignee, semantically-
+       similar-title new task in ``revised`` (e.g. via embedding-based
+       title similarity), auto-assign ``supersedes`` instead of just
+       reporting. Out of scope for this observability-first validator
+       — rejection / auto-heal is deferred until orphans become a
+       systemic problem rather than a legitimate scope-narrowing
+       outcome (e.g. user steer "ignore pianos" genuinely orphaning
+       the piano-presentation task).
+    """
+    if prior is None:
+        return []
+    new_ids = {t.id for t in revised.tasks if t.id}
+    supersedes_targets = {
+        (t.supersedes or "").strip()
+        for t in revised.tasks
+        if (t.supersedes or "").strip()
+    }
+    orphans: list[Task] = []
+    for old in prior.tasks:
+        if not old.id or old.id in new_ids:
+            continue
+        if old.id in supersedes_targets:
+            continue  # covered by a new task's supersedes link
+        if old.status in _ABSORBING_TERMINAL_STATUSES:
+            continue  # FAILED/CANCELLED don't need a successor
+        orphans.append(old)
+    return orphans
+
+
 def _plan_from_json(
     obj: Any,
     *,
@@ -1647,6 +1721,91 @@ class LLMPlanner:
                 exc,
             )
 
+    async def _emit_refine_orphaned_tasks(
+        self,
+        prior_plan: Plan,
+        revised: Plan,
+        orphans: list[Task],
+    ) -> None:
+        """Emit a ``refine_orphaned_tasks`` sink event for operator visibility.
+
+        Fires when :func:`_check_supersedes_coverage` finds prior tasks
+        that were dropped by the refine output without a supersedes
+        link or an absorbing-terminal status. This is **telemetry only**
+        — the refine still applies. Some orphans are legitimate (a
+        scope-narrowing user steer can validly remove a task with no
+        replacement concept), so blocking would be too strict; surfacing
+        gives operators the visibility to spot careless drops.
+
+        Routes through the planner's span-context provider (the same
+        snapshot used by ``goldfive_llm_span``) so the event lands on
+        every bound sink with the correct ``run_id`` / ``session_id`` /
+        sequence. A no-op when the planner is used standalone (no
+        provider, e.g. unit tests not exercising sinks).
+        """
+        if not orphans:
+            return
+        if self._span_ctx_provider is None:
+            return
+        try:
+            ctx = self._span_ctx_provider()
+        except Exception:  # noqa: BLE001 -- observability must never break refine
+            return
+        if ctx is None:
+            return
+        sinks, run_id, session_id, _task_id, seq_fn = ctx
+        if not sinks or seq_fn is None:
+            return
+        try:
+            from goldfive.events import emit, make_event  # noqa: PLC0415 — lazy
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "LLMPlanner: events module unavailable; dropping "
+                "refine_orphaned_tasks signal (%s)",
+                exc,
+            )
+            return
+        payload: dict[str, Any] = {
+            "prior_plan_id": prior_plan.id,
+            "prior_revision_index": prior_plan.revision_index,
+            "revised_plan_id": revised.id,
+            "revised_revision_index": revised.revision_index,
+            "orphan_count": len(orphans),
+            "orphans": [
+                {
+                    "task_id": t.id,
+                    "title": t.title,
+                    "status": t.status.value,
+                    "assignee_agent_id": t.assignee_agent_id,
+                }
+                for t in orphans
+            ],
+        }
+        try:
+            seq = seq_fn()
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "LLMPlanner: sequence_fn raised; dropping "
+                "refine_orphaned_tasks signal (%s)",
+                exc,
+            )
+            return
+        try:
+            evt = make_event(
+                run_id or "",
+                seq,
+                "refine_orphaned_tasks",
+                payload,
+                session_id=session_id or "",
+            )
+            await emit(list(sinks), evt)
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "LLMPlanner: failed to emit refine_orphaned_tasks event "
+                "(%s); dropping signal",
+                exc,
+            )
+
     async def _call_and_validate_refine(
         self,
         *,
@@ -1862,6 +2021,23 @@ class LLMPlanner:
                 if attempt < attempts:
                     user_prompt = self._build_correction_prompt(base_user_prompt, last_error)
                 continue
+            # Supersedes coverage (observability only — never rejects).
+            # For every prior task absent from the revision, check that
+            # some new task supersedes it OR that the prior status is
+            # absorbing-terminal (FAILED/CANCELLED). Surviving orphans
+            # are surfaced as a WARNING + ``refine_orphaned_tasks`` sink
+            # event so operators can spot careless drops without
+            # blocking legitimate scope-narrowing refines.
+            orphans = _check_supersedes_coverage(revised, prior=prior_plan)
+            if orphans:
+                log.warning(
+                    "%s: refine output dropped %d prior task(s) without a "
+                    "supersedes link or terminal status: %s",
+                    log_prefix,
+                    len(orphans),
+                    ", ".join(f"{t.id!r} ({t.title!r})" for t in orphans),
+                )
+                await self._emit_refine_orphaned_tasks(prior_plan, revised, orphans)
             return revised, "", False
         return None, last_error, False
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -16,6 +16,7 @@ from goldfive.planner import (
     _DEFAULT_SYSTEM_PROMPT,
     LLMPlanner,
     PassthroughPlanner,
+    _check_supersedes_coverage,
     _normalize_assignee,
     _plan_from_json,
     _strip_code_fences,
@@ -26,6 +27,7 @@ from goldfive.types import (
     DriftSeverity,
     Goal,
     Plan,
+    SupersessionKind,
     Task,
     TaskEdge,
     TaskStatus,
@@ -1645,3 +1647,435 @@ def test_default_system_prompt_forbids_compound_assignee() -> None:
     # Regression guard against the planner prompt drifting away from the
     # explicit "bare name only" directive added alongside #214.
     assert "do NOT add a namespace" in _DEFAULT_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Supersedes coverage validator (observability — never rejects)
+# ---------------------------------------------------------------------------
+
+
+def _coverage_prior_plan(*, statuses: dict[str, TaskStatus] | None = None) -> Plan:
+    """A 3-task prior plan whose statuses can be tweaked per test.
+
+    ``a`` / ``b`` / ``c`` default to PENDING / RUNNING / PENDING. Tests
+    that need terminal-status priors override via ``statuses``.
+    """
+    statuses = statuses or {}
+    return Plan(
+        id="p-prior",
+        run_id="r-cov",
+        goal_ids=["g1"],
+        summary="prior",
+        tasks=[
+            Task(
+                id="a",
+                title="alpha",
+                assignee_agent_id="agent_x",
+                status=statuses.get("a", TaskStatus.PENDING),
+            ),
+            Task(
+                id="b",
+                title="bravo",
+                assignee_agent_id="agent_y",
+                status=statuses.get("b", TaskStatus.RUNNING),
+            ),
+            Task(
+                id="c",
+                title="charlie",
+                assignee_agent_id="agent_z",
+                status=statuses.get("c", TaskStatus.PENDING),
+            ),
+        ],
+        edges=[],
+        revision_index=0,
+    )
+
+
+def test_supersedes_coverage_no_orphans_when_every_drop_is_superseded() -> None:
+    """Test 1 — full coverage. All dropped tasks have a supersedes link
+    from some new task in the revised plan. Validator returns no
+    orphans."""
+    prior = _coverage_prior_plan()
+    revised = Plan(
+        id="p-revised",
+        run_id="r-cov",
+        goal_ids=["g1"],
+        summary="revised",
+        tasks=[
+            Task(
+                id="a2",
+                title="alpha v2",
+                assignee_agent_id="agent_x",
+                status=TaskStatus.PENDING,
+                supersedes="a",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+            Task(
+                id="b2",
+                title="bravo v2",
+                assignee_agent_id="agent_y",
+                status=TaskStatus.PENDING,
+                supersedes="b",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+            Task(
+                id="c2",
+                title="charlie v2",
+                assignee_agent_id="agent_z",
+                status=TaskStatus.PENDING,
+                supersedes="c",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+        ],
+        edges=[],
+        revision_index=1,
+    )
+    orphans = _check_supersedes_coverage(revised, prior=prior)
+    assert orphans == []
+
+
+def test_supersedes_coverage_terminal_drops_are_covered_by_default() -> None:
+    """Test 2 — all dropped priors are FAILED / CANCELLED. Absorbing-
+    terminal old tasks don't need a supersedes link."""
+    prior = _coverage_prior_plan(
+        statuses={
+            "a": TaskStatus.FAILED,
+            "b": TaskStatus.CANCELLED,
+            "c": TaskStatus.FAILED,
+        }
+    )
+    revised = Plan(
+        id="p-revised",
+        run_id="r-cov",
+        goal_ids=["g1"],
+        summary="revised — all priors absorbed by terminal status",
+        tasks=[
+            Task(
+                id="brand_new",
+                title="fresh work, not a replacement",
+                assignee_agent_id="agent_x",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[],
+        revision_index=1,
+    )
+    orphans = _check_supersedes_coverage(revised, prior=prior)
+    assert orphans == []
+
+
+def test_supersedes_coverage_pending_drop_with_no_link_is_orphan() -> None:
+    """Test 3 — legitimate orphan: a PENDING prior task is dropped with
+    no supersedes from any new task. Validator surfaces it."""
+    prior = _coverage_prior_plan()
+    # Drop ``b`` entirely (no successor, not terminal). ``a`` and ``c``
+    # are kept verbatim so they do not contribute to the dropped set.
+    revised = Plan(
+        id="p-revised",
+        run_id="r-cov",
+        goal_ids=["g1"],
+        summary="revised",
+        tasks=[
+            prior.tasks[0],  # a — preserved
+            prior.tasks[2],  # c — preserved
+        ],
+        edges=[],
+        revision_index=1,
+    )
+    orphans = _check_supersedes_coverage(revised, prior=prior)
+    assert [t.id for t in orphans] == ["b"]
+    assert orphans[0].title == "bravo"
+
+
+def test_supersedes_coverage_mixed_only_orphan_uncovered() -> None:
+    """Test 4 — mixed: one drop is superseded, one is FAILED-terminal,
+    one is a legitimate orphan. Only the orphan is reported."""
+    prior = _coverage_prior_plan(
+        statuses={
+            "a": TaskStatus.PENDING,
+            "b": TaskStatus.FAILED,  # terminal — absorbed
+            "c": TaskStatus.PENDING,  # orphan
+        }
+    )
+    revised = Plan(
+        id="p-revised",
+        run_id="r-cov",
+        goal_ids=["g1"],
+        summary="revised",
+        tasks=[
+            Task(
+                id="a2",
+                title="alpha v2",
+                assignee_agent_id="agent_x",
+                status=TaskStatus.PENDING,
+                supersedes="a",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+            # ``b`` is dropped but FAILED in prior — covered by status.
+            # ``c`` is dropped with no supersedes → orphan.
+        ],
+        edges=[],
+        revision_index=1,
+    )
+    orphans = _check_supersedes_coverage(revised, prior=prior)
+    assert [t.id for t in orphans] == ["c"]
+
+
+def test_supersedes_coverage_correct_kind_chain_is_not_a_drop() -> None:
+    """Test 5 — CORRECT-kind supersession: the prior COMPLETED task is
+    preserved verbatim in the revision (Option B contract — terminal
+    tasks are immutable across refines), and a new task supersedes it
+    with kind=CORRECT. The COMPLETED task is therefore NOT in the
+    dropped set, and there are no orphans."""
+    prior = Plan(
+        id="p-prior",
+        run_id="r-cov",
+        goal_ids=["g1"],
+        summary="prior",
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar options",
+                assignee_agent_id="research_agent",
+                status=TaskStatus.COMPLETED,
+            ),
+        ],
+        edges=[],
+        revision_index=0,
+    )
+    revised = Plan(
+        id="p-revised",
+        run_id="r-cov",
+        goal_ids=["g1"],
+        summary="revised — correction supersedes",
+        tasks=[
+            # Prior COMPLETED task preserved verbatim.
+            prior.tasks[0],
+            # New task corrects it.
+            Task(
+                id="research_solar_corrected",
+                title="Research solar options (corrected facts)",
+                assignee_agent_id="research_agent",
+                status=TaskStatus.PENDING,
+                supersedes="research_solar",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+        ],
+        edges=[],
+        revision_index=1,
+    )
+    orphans = _check_supersedes_coverage(revised, prior=prior)
+    # Even if the COMPLETED task were somehow dropped, CORRECT-kind
+    # links count toward "covered" identically to REPLACE — the
+    # validator only cares whether *some* new task names the old id.
+    assert orphans == []
+    # And confirm the dropped set is genuinely empty: no prior id is
+    # missing from revised.
+    new_ids = {t.id for t in revised.tasks}
+    dropped = {t.id for t in prior.tasks} - new_ids
+    assert dropped == set()
+
+
+async def test_refine_emits_orphan_event_on_legitimate_drop(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """End-to-end: a refine response that drops a PENDING prior task
+    without a supersedes link triggers a WARNING log + a
+    ``refine_orphaned_tasks`` sink event. The refine still applies."""
+    from goldfive.sinks.memory import InMemorySink
+
+    # Prior plan: one COMPLETED task (preserved) + two PENDING tasks
+    # (one of which the LLM will silently drop).
+    prior = Plan(
+        id="p-prior",
+        run_id="r-orphan",
+        goal_ids=["g1"],
+        summary="prior",
+        tasks=[
+            Task(
+                id="research",
+                title="Research goldfish",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="draft_intro",
+                title="Draft intro",
+                assignee_agent_id="writer",
+                status=TaskStatus.PENDING,
+            ),
+            Task(
+                id="draft_body",
+                title="Draft body",
+                assignee_agent_id="writer",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft_intro"),
+            TaskEdge(from_task_id="draft_intro", to_task_id="draft_body"),
+        ],
+        revision_index=0,
+    )
+    # LLM drops ``draft_body`` entirely — no supersedes, not terminal.
+    refine_response = json.dumps(
+        {
+            "summary": "narrowed scope",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research goldfish",
+                    "assignee_agent_id": "researcher",
+                    "status": "COMPLETED",
+                },
+                {
+                    "id": "draft_intro",
+                    "title": "Draft intro",
+                    "assignee_agent_id": "writer",
+                    "status": "PENDING",
+                },
+            ],
+            "edges": [
+                {"from_task_id": "research", "to_task_id": "draft_intro"},
+            ],
+        }
+    )
+    scripted = _ScriptedLLM([refine_response])
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=1)
+
+    # Wire a span context provider so the planner knows which sinks to
+    # emit on. (Mirrors ``DefaultSteerer.bind`` minus the steerer.)
+    sink = InMemorySink()
+    seq = iter(range(1000))
+
+    def provider() -> object:
+        return ([sink], "r-orphan", "s-orphan", "draft_body", lambda: next(seq))
+
+    planner.set_span_context_provider(provider)
+
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.WARNING,
+        detail="scope narrowed",
+        current_task_id="draft_body",
+    )
+
+    with caplog.at_level("WARNING", logger="goldfive.planner"):
+        revised = await planner.refine(plan=prior, drift=drift, goals=_goals())
+
+    # Refine applied (validator does not reject — observability only).
+    assert revised is not None
+    assert {t.id for t in revised.tasks} == {"research", "draft_intro"}
+    # WARNING log surfaced the orphan.
+    orphan_warnings = [
+        r
+        for r in caplog.records
+        if "supersedes link or terminal status" in r.getMessage()
+    ]
+    assert len(orphan_warnings) == 1
+    assert "'draft_body'" in orphan_warnings[0].getMessage()
+    # Sink event emitted with kind=refine_orphaned_tasks and orphan
+    # detail in the payload.
+    orphan_events = [
+        e
+        for e in sink.events
+        if isinstance(e, dict) and e.get("kind") == "refine_orphaned_tasks"
+    ]
+    assert len(orphan_events) == 1
+    payload = orphan_events[0]["payload"]
+    assert payload["orphan_count"] == 1
+    assert payload["prior_plan_id"] == "p-prior"
+    assert payload["prior_revision_index"] == 0
+    # ``revision_index`` on the freshly-parsed revised plan reflects the
+    # LLM JSON (default 0); the caller bumps it AFTER
+    # ``_call_and_validate_refine`` returns, which is downstream of this
+    # validator. Asserting on the at-validation-time value documents
+    # that contract.
+    assert payload["revised_revision_index"] == 0
+    assert len(payload["orphans"]) == 1
+    orphan = payload["orphans"][0]
+    assert orphan["task_id"] == "draft_body"
+    assert orphan["title"] == "Draft body"
+    assert orphan["status"] == TaskStatus.PENDING.value
+    assert orphan["assignee_agent_id"] == "writer"
+
+
+async def test_refine_emits_no_orphan_event_when_coverage_complete() -> None:
+    """Inverse of the orphan integration test: a refine response with
+    full supersedes coverage emits NO ``refine_orphaned_tasks`` event."""
+    from goldfive.sinks.memory import InMemorySink
+
+    prior = Plan(
+        id="p-prior",
+        run_id="r-clean",
+        goal_ids=["g1"],
+        summary="prior",
+        tasks=[
+            Task(
+                id="research",
+                title="Research goldfish",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="draft",
+                title="Draft post",
+                assignee_agent_id="writer",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft"),
+        ],
+        revision_index=0,
+    )
+    # LLM replaces ``draft`` with ``draft_v2`` carrying a supersedes link.
+    refine_response = json.dumps(
+        {
+            "summary": "redirected draft",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research goldfish",
+                    "assignee_agent_id": "researcher",
+                    "status": "COMPLETED",
+                },
+                {
+                    "id": "draft_v2",
+                    "title": "Draft post (new angle)",
+                    "assignee_agent_id": "writer",
+                    "status": "PENDING",
+                    "supersedes": "draft",
+                    "supersedes_kind": "REPLACE",
+                },
+            ],
+            "edges": [
+                {"from_task_id": "research", "to_task_id": "draft_v2"},
+            ],
+        }
+    )
+    scripted = _ScriptedLLM([refine_response])
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=1)
+    sink = InMemorySink()
+    seq = iter(range(1000))
+
+    def provider() -> object:
+        return ([sink], "r-clean", "s-clean", "draft", lambda: next(seq))
+
+    planner.set_span_context_provider(provider)
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.WARNING,
+        detail="redirect",
+        current_task_id="draft",
+    )
+
+    revised = await planner.refine(plan=prior, drift=drift, goals=_goals())
+
+    assert revised is not None
+    orphan_events = [
+        e
+        for e in sink.events
+        if isinstance(e, dict) and e.get("kind") == "refine_orphaned_tasks"
+    ]
+    assert orphan_events == []


### PR DESCRIPTION
## Summary

- Adds a post-parse validator on the refine output retry loop that flags prior tasks dropped without a supersedes link or absorbing-terminal status (FAILED/CANCELLED)
- Surfaces orphans as a WARNING log plus a new `refine_orphaned_tasks` sink event carrying orphan id/title/status/assignee — does NOT reject the refine, since legitimate scope-narrowing refines (e.g. user steer "ignore pianos") may validly orphan tasks
- COMPLETED prior tasks are NOT in the absorbing-terminal set: a dropped COMPLETED task is real provenance loss

## Hook site

`LLMPlanner._call_and_validate_refine` — after `validate(for_revision=True)`, the goal-preservation check, and the assignee-registry check all succeed, before returning `(revised, "", False)`. Coexists with the `_normalize_supersession_kinds` Option B coercer that runs earlier in the same loop.

## Sink event

New kind: `refine_orphaned_tasks` (string-keyed dict event via `goldfive.events.make_event`). Routed through the planner's existing `_span_ctx_provider` so it lands on the same sinks/run/session as `goldfive_llm_call_*` spans, with no additional steerer wiring.

## CORRECT-kind judgment call

A CORRECT-kind chain doesn't reach the validator as an orphan candidate at all: the prior COMPLETED task is preserved verbatim in the revision (Option B contract — terminal tasks are immutable), so it's never in the dropped set. The validator therefore doesn't need to special-case CORRECT vs REPLACE — both kinds satisfy "some new task names this old id" identically. Test 5 documents this directly.

## Future work (docstring only)

Heuristic auto-assignment of `supersedes` for orphans with same-assignee, semantically-similar-title successors. Out of scope for observability-first.

## Test plan

- [x] `_check_supersedes_coverage` direct: full coverage, all-terminal, legitimate orphan, mixed, CORRECT-chain
- [x] End-to-end refine integration: WARNING log + `refine_orphaned_tasks` sink event payload assertions
- [x] End-to-end refine integration (negative): full coverage emits no event
- [x] `uv run pytest tests/` — 1275 passed, 87 skipped
- [x] `uv run ruff check goldfive/` — clean