### PR TITLE
feat(adapters): aggressive multi-signal pin resolution (R1-reframed + R5)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1325,6 +1325,15 @@ def make_adk_plugin(
             # short-circuits cleanly instead of emitting its turn and
             # poisoning the parent's history.
             self._invocation_parents: dict[str, str] = {}
+            # Per-invocation pinned task_id (goldfive#264 — aggressive
+            # pin resolution). ``dict[str, str]`` mapping
+            # ``invocation_id -> task_id`` populated by
+            # :meth:`_stamp_current_task_id` whenever a pin lands.
+            # Consumed by signal 5 of :meth:`_pin_current_task_id_for_agent`
+            # so a child invocation can read its parent's pinned task
+            # without racing on the single ``goldfive.current_task_id``
+            # slot. Cleared on ``clear_active_context``.
+            self._invocation_pinned_task_id: dict[str, str] = {}
 
         def set_active_context(self, ctx: SessionContext) -> None:
             """Attach the ``SessionContext`` for the running invocation.
@@ -1370,6 +1379,8 @@ def make_adk_plugin(
             # invocation_id collision.
             self._cancel_state.clear()
             self._invocation_parents.clear()
+            # goldfive#264 — drop per-invocation pin map.
+            self._invocation_pinned_task_id.clear()
 
         # --- Cooperative cancellation (goldfive#251 Stream C / 7a) -----
 
@@ -1694,11 +1705,14 @@ def make_adk_plugin(
             # Layer 1: pin the starting sub-agent's task_id so its
             # reporting-tool calls can default the arg from state
             # (goldfive#191). Best-effort: a raise here must never
-            # break the invocation.
+            # break the invocation. goldfive#264 — multi-signal
+            # resolution, async to allow the PinResolved sink emit.
             try:
-                self._pin_current_task_id_for_agent(
+                await self._pin_current_task_id_for_agent(
                     agent_name=agent_name,
                     callback_context=callback_context,
+                    invocation_id=inv_id,
+                    parent_invocation_id=parent_inv_id,
                 )
             except Exception as exc:  # noqa: BLE001 — pinning must never raise
                 log.debug(
@@ -1735,36 +1749,73 @@ def make_adk_plugin(
                 )
             return None
 
-        def _pin_current_task_id_for_agent(
+        async def _pin_current_task_id_for_agent(
             self,
             *,
             agent_name: str,
             callback_context: Any,
+            invocation_id: str = "",
+            parent_invocation_id: str = "",
         ) -> None:
-            """Stamp ``goldfive.current_task_id`` for ``agent_name`` if unambiguous.
+            """Aggressive multi-signal pin resolution (goldfive#264).
 
-            Matching rule: the plan task whose ``assignee_agent_id``
-            equals ``agent_name``, whose status is PENDING or RUNNING,
-            AND whose upstream DAG predecessors are all COMPLETED
-            (goldfive#242 — without the DAG gate a Stage-4 task assigned
-            to the coordinator can be pinned at run-start while Stages
-            0-3 are still PENDING, producing an impossible Gantt).
-            Exactly-one matches stamp the id onto both the live ADK
-            ``session.state`` (agent-side reads via ``tool_ctx.state``)
-            and the goldfive orchestration ``session.state`` (handler
-            fallback in :mod:`goldfive.reporting` +
-            :mod:`goldfive.adapters._tool_invocation`).
+            Reframed from the original "exactly-1 DAG-ready single
+            match" gate after live operator feedback: *if an agent was
+            invoked, something precipitated the call*. The previous
+            implementation gave up silently on zero/multiple matches,
+            so the agent ran without a pin, every reporting-tool call
+            short-circuited as a no-op, and the orchestration loop
+            stagnated.
 
-            Zero / multiple matches leave state unset — the handler
-            path will surface the existing ``missing_task_id`` error
-            rather than guess, which is the correct signal for an
-            off-plan agent or an ambiguous coordinator assignment.
+            Replaced with an 8-signal resolution ladder, picking the
+            first signal that yields a single best candidate:
+
+            1. **Delegation-site pin** — the parent's ``before_tool_callback``
+               already stamped a per-function_call_id pin on
+               ``pending_delegations``. Authoritative.
+            2. **DAG-ready exactly-1** — assignee match, status PENDING /
+               RUNNING, all upstream predecessors COMPLETED. The pre-
+               existing happy path; preserved as the fast short-circuit.
+            3. **Tool-arg scoring over DAG-ready candidates** — when (2)
+               returns 2+ matches, score each against the parent
+               AgentTool's args via :func:`_score_candidates_by_args`
+               and pick the winner. Falls through on tie.
+            4. **DAG gate relaxed** — drop the upstream-completion check
+               and retry the assignee+status filter. The agent was
+               invoked so something precipitated it; surface the pin
+               and emit a WARNING + low-confidence sink event so
+               operators see the anomaly. Tool-arg scoring breaks ties.
+            5. **Parent-pin downstream** — if a parent invocation has a
+               pinned task on this plugin, prefer candidates whose id
+               is a downstream of the parent's pinned task in
+               ``plan.edges``.
+            6. **Recent drift / correction targeting** — if a
+               ``goldfive.pending_corrections.<agent>.<task_id>`` entry
+               exists in session state, pin the named task. The plan-
+               revision pipeline writes these for CORRECT-kind
+               supersedes; pinning to one is a strong signal that the
+               agent was invoked specifically to act on the correction.
+            7. **Assignee normalization fallback** — re-run signals
+               2-4 with bare/compound forms of ``agent_name`` swapped
+               in. PR #215 fixed planner-side normalisation; this is
+               defence-in-depth for transcripts that retain a compound
+               assignee.
+            8. **Low-confidence best-guess** — if every prior signal
+               failed, pick the highest-scoring candidate from the
+               full assignee+status set (or, lacking any, the highest-
+               scoring PENDING/RUNNING task in the plan) and emit a
+               ``pin_resolved_low_confidence`` sink event so the LLM
+               gets to continue and the operator sees the weakening.
+
+            Every successful pin emits a single ``pin_resolved`` (dict-
+            envelope) sink event labelled with ``via_signal`` so
+            harmonograf and operators can chart how often the happy
+            path is short-circuiting vs. how often the relaxed signals
+            are firing — a leading indicator that pin invariants are
+            weakening.
 
             Silent on every failure mode (no agent name, no ctx, no
-            plan, state not a mapping). Instrumentation-class path:
-            a mistake here degrades to the pre-#191 behaviour where
-            the model sees ``missing_task_id`` and retry-loops — bad,
-            but strictly no worse than the baseline.
+            plan, state not a mapping). Never raises.
             """
             if not agent_name:
                 return
@@ -1779,15 +1830,13 @@ def make_adk_plugin(
             # top-level import for a rarely-hot-path enum compare.
             from goldfive.types import TaskStatus, task_upstream_ready
 
+            tasks_list = list(tasks)
+
+            # ---- Signal 1: delegation-site pin -------------------------
             # goldfive#241 Item 3-bis — delegation-site pin takes
-            # precedence over the agent-turn match. If the parent
-            # coordinator's ``before_tool_callback`` stamped a
-            # task_id for THIS AgentTool dispatch (keyed by
-            # function_call_id), trust that pin and stamp it onto
-            # both state surfaces. Sub-agent ``before_agent_callback``
-            # doesn't carry the function_call_id, but the reporting-
-            # tool path reads ``pending_delegations`` directly anyway;
-            # this branch only matters for the single-match fallback.
+            # precedence. If the parent coordinator's
+            # ``before_tool_callback`` stamped a task_id for THIS
+            # AgentTool dispatch (keyed by function_call_id), trust it.
             gf_state_early = _safe_attr(ctx.session, "state", None)
             if isinstance(gf_state_early, Mapping):
                 pend = gf_state_early.get(_PENDING_DELEGATIONS_KEY)
@@ -1795,7 +1844,7 @@ def make_adk_plugin(
                     for tid in pend.values():
                         if not isinstance(tid, str) or not tid:
                             continue
-                        for task in tasks:
+                        for task in tasks_list:
                             if str(_safe_attr(task, "id", "") or "") != tid:
                                 continue
                             assignee = str(
@@ -1812,82 +1861,595 @@ def make_adk_plugin(
                                     agent_name=agent_name,
                                     source="delegation_pin",
                                     task=task,
+                                    invocation_id=invocation_id,
+                                )
+                                await self._emit_pin_resolved(
+                                    ctx=ctx,
+                                    agent_name=agent_name,
+                                    task_id=tid,
+                                    via_signal="delegation_pin",
+                                    score=1.0,
+                                    invocation_id=invocation_id,
+                                    candidate_count=1,
                                 )
                                 return
 
-            # Pre-filter: PENDING/RUNNING tasks whose assignee is this
-            # agent. This is the pre-#242 candidate set. The DAG-gate
-            # below filters it further; we keep the pre-DAG list so we
-            # can log when the gate actually changes the outcome.
-            pre_dag: list[Any] = []
+            # Build the assignee+status candidate set once; signals 2-4
+            # all reuse it. We also keep the parent's tool args (best-
+            # effort) so signals 3 / 4 / 8 can score candidates.
+            assignee_candidates = self._candidates_for_agent(
+                tasks_list, agent_name
+            )
+            scoring_args = self._scoring_args_for(
+                ctx=ctx,
+                callback_context=callback_context,
+                parent_invocation_id=parent_invocation_id,
+            )
+
+            # ---- Signal 2: DAG-ready exactly-1 -------------------------
+            dag_ready = self._filter_dag_ready(
+                plan, assignee_candidates, task_upstream_ready
+            )
+            if len(dag_ready) == 1:
+                task = dag_ready[0]
+                task_id = str(_safe_attr(task, "id", "") or "")
+                if task_id:
+                    self._stamp_current_task_id(
+                        ctx=ctx,
+                        callback_context=callback_context,
+                        task_id=task_id,
+                        agent_name=agent_name,
+                        source="single_match",
+                        task=task,
+                        invocation_id=invocation_id,
+                    )
+                    await self._emit_pin_resolved(
+                        ctx=ctx,
+                        agent_name=agent_name,
+                        task_id=task_id,
+                        via_signal="dag_ready_single",
+                        score=1.0,
+                        invocation_id=invocation_id,
+                        candidate_count=1,
+                    )
+                    return
+
+            # ---- Signal 3: tool-arg scoring over DAG-ready -------------
+            if len(dag_ready) > 1 and scoring_args is not None:
+                chosen = _score_candidates_by_args(dag_ready, scoring_args)
+                if chosen is not None:
+                    task_id = str(_safe_attr(chosen, "id", "") or "")
+                    if task_id:
+                        self._stamp_current_task_id(
+                            ctx=ctx,
+                            callback_context=callback_context,
+                            task_id=task_id,
+                            agent_name=agent_name,
+                            source="arg_scored",
+                            task=chosen,
+                            invocation_id=invocation_id,
+                        )
+                        await self._emit_pin_resolved(
+                            ctx=ctx,
+                            agent_name=agent_name,
+                            task_id=task_id,
+                            via_signal="arg_scored",
+                            score=1.0,
+                            invocation_id=invocation_id,
+                            candidate_count=len(dag_ready),
+                        )
+                        return
+
+            # ---- Signal 4: DAG gate relaxed ----------------------------
+            # The user's reframe: "if an agent was invoked, something
+            # precipitated it." We've lost ground truth already; bind
+            # to the most-plausible task and surface the anomaly to
+            # operators rather than silent-no-op.
+            if assignee_candidates:
+                relaxed = assignee_candidates
+                if len(relaxed) > 1 and scoring_args is not None:
+                    chosen = _score_candidates_by_args(relaxed, scoring_args)
+                    if chosen is None:
+                        # Tie / no overlap — fall through.
+                        chosen = None
+                else:
+                    chosen = relaxed[0] if len(relaxed) == 1 else None
+                if chosen is not None:
+                    task_id = str(_safe_attr(chosen, "id", "") or "")
+                    if task_id:
+                        log.warning(
+                            "pin: DAG-gate relaxed, bound %s for agent %s "
+                            "(upstreams not yet complete; %d assignee candidates)",
+                            task_id,
+                            agent_name,
+                            len(relaxed),
+                        )
+                        self._stamp_current_task_id(
+                            ctx=ctx,
+                            callback_context=callback_context,
+                            task_id=task_id,
+                            agent_name=agent_name,
+                            source="dag_relaxed",
+                            task=chosen,
+                            invocation_id=invocation_id,
+                        )
+                        await self._emit_pin_resolved(
+                            ctx=ctx,
+                            agent_name=agent_name,
+                            task_id=task_id,
+                            via_signal="dag_relaxed",
+                            score=0.7,
+                            invocation_id=invocation_id,
+                            candidate_count=len(relaxed),
+                        )
+                        return
+
+            # ---- Signal 5: parent-pin downstream -----------------------
+            parent_pin_task = self._task_from_parent_pin_downstream(
+                plan=plan,
+                tasks=tasks_list,
+                parent_invocation_id=parent_invocation_id,
+                agent_name=agent_name,
+                scoring_args=scoring_args,
+            )
+            if parent_pin_task is not None:
+                task_id = str(_safe_attr(parent_pin_task, "id", "") or "")
+                if task_id:
+                    self._stamp_current_task_id(
+                        ctx=ctx,
+                        callback_context=callback_context,
+                        task_id=task_id,
+                        agent_name=agent_name,
+                        source="parent_pin_downstream",
+                        task=parent_pin_task,
+                        invocation_id=invocation_id,
+                    )
+                    await self._emit_pin_resolved(
+                        ctx=ctx,
+                        agent_name=agent_name,
+                        task_id=task_id,
+                        via_signal="parent_pin_downstream",
+                        score=0.6,
+                        invocation_id=invocation_id,
+                        candidate_count=0,
+                    )
+                    return
+
+            # ---- Signal 6: recent drift / correction targeting --------
+            correction_task = self._task_from_pending_correction(
+                ctx=ctx,
+                tasks=tasks_list,
+                agent_name=agent_name,
+            )
+            if correction_task is not None:
+                task_id = str(_safe_attr(correction_task, "id", "") or "")
+                if task_id:
+                    self._stamp_current_task_id(
+                        ctx=ctx,
+                        callback_context=callback_context,
+                        task_id=task_id,
+                        agent_name=agent_name,
+                        source="correction_target",
+                        task=correction_task,
+                        invocation_id=invocation_id,
+                    )
+                    await self._emit_pin_resolved(
+                        ctx=ctx,
+                        agent_name=agent_name,
+                        task_id=task_id,
+                        via_signal="correction_target",
+                        score=0.9,
+                        invocation_id=invocation_id,
+                        candidate_count=0,
+                    )
+                    return
+
+            # ---- Signal 7: assignee bare/compound normalisation -------
+            normalised_alt = self._alternate_agent_name_form(agent_name)
+            if normalised_alt and normalised_alt != agent_name:
+                alt_assignee = self._candidates_for_agent(
+                    tasks_list, normalised_alt
+                )
+                if alt_assignee:
+                    alt_dag_ready = self._filter_dag_ready(
+                        plan, alt_assignee, task_upstream_ready
+                    )
+                    chosen = None
+                    if len(alt_dag_ready) == 1:
+                        chosen = alt_dag_ready[0]
+                    elif len(alt_dag_ready) > 1 and scoring_args is not None:
+                        chosen = _score_candidates_by_args(alt_dag_ready, scoring_args)
+                    elif len(alt_dag_ready) == 0 and len(alt_assignee) == 1:
+                        chosen = alt_assignee[0]
+                    elif len(alt_assignee) > 1 and scoring_args is not None:
+                        chosen = _score_candidates_by_args(alt_assignee, scoring_args)
+                    if chosen is not None:
+                        task_id = str(_safe_attr(chosen, "id", "") or "")
+                        if task_id:
+                            log.warning(
+                                "pin: assignee normalisation %r->%r "
+                                "found candidate %s",
+                                agent_name,
+                                normalised_alt,
+                                task_id,
+                            )
+                            self._stamp_current_task_id(
+                                ctx=ctx,
+                                callback_context=callback_context,
+                                task_id=task_id,
+                                agent_name=agent_name,
+                                source="assignee_normalised",
+                                task=chosen,
+                                invocation_id=invocation_id,
+                            )
+                            await self._emit_pin_resolved(
+                                ctx=ctx,
+                                agent_name=agent_name,
+                                task_id=task_id,
+                                via_signal="assignee_normalised",
+                                score=0.5,
+                                invocation_id=invocation_id,
+                                candidate_count=len(alt_assignee),
+                            )
+                            return
+
+            # ---- Signal 8: low-confidence best-guess -------------------
+            best_guess = self._low_confidence_best_guess(
+                tasks=tasks_list,
+                agent_name=agent_name,
+                scoring_args=scoring_args,
+            )
+            if best_guess is not None:
+                task, score = best_guess
+                task_id = str(_safe_attr(task, "id", "") or "")
+                if task_id:
+                    log.warning(
+                        "pin: low-confidence best-guess %s for agent %s "
+                        "(score=%.2f); every prior signal failed",
+                        task_id,
+                        agent_name,
+                        score,
+                    )
+                    self._stamp_current_task_id(
+                        ctx=ctx,
+                        callback_context=callback_context,
+                        task_id=task_id,
+                        agent_name=agent_name,
+                        source="low_confidence",
+                        task=task,
+                        invocation_id=invocation_id,
+                    )
+                    await self._emit_pin_resolved(
+                        ctx=ctx,
+                        agent_name=agent_name,
+                        task_id=task_id,
+                        via_signal="low_confidence",
+                        score=score,
+                        invocation_id=invocation_id,
+                        candidate_count=0,
+                    )
+                    return
+
+            # All signals failed AND no best-guess candidate at all
+            # (empty plan / agent has nothing remotely matching). Leave
+            # state unset — there's nothing better than the existing
+            # ``missing_task_id`` error path here.
+            log.debug(
+                "before_agent_callback: pin resolution exhausted all "
+                "signals for agent %s; leaving state unset",
+                agent_name,
+            )
+
+        # ---- Pin resolution helpers (goldfive#264) --------------------
+
+        @staticmethod
+        def _candidates_for_agent(tasks: list[Any], agent_name: str) -> list[Any]:
+            """Return PENDING/RUNNING tasks whose assignee matches ``agent_name``.
+
+            Pre-DAG candidate set used by signals 2/3/4/8. Pure helper,
+            no side effects.
+            """
+            from goldfive.types import TaskStatus
+
+            out: list[Any] = []
             for task in tasks:
                 assignee = str(_safe_attr(task, "assignee_agent_id", "") or "")
                 if assignee != agent_name:
                     continue
                 status = _safe_attr(task, "status", None)
                 if status is TaskStatus.PENDING or status is TaskStatus.RUNNING:
-                    pre_dag.append(task)
+                    out.append(task)
+            return out
 
-            # DAG-readiness gate (goldfive#242): a task is only pinnable
-            # when every upstream task (via ``plan.edges``) is COMPLETED.
-            # Stage-4 tasks cannot be pinned while Stage 0-3 is still
-            # PENDING, even if the stage-4 assignee happens to be the
-            # agent whose turn is starting (the coordinator case the
-            # live session exposed).
-            matches: list[Any] = []
-            for task in pre_dag:
+        @staticmethod
+        def _filter_dag_ready(
+            plan: Any,
+            candidates: list[Any],
+            task_upstream_ready: Any,
+        ) -> list[Any]:
+            """Filter ``candidates`` to those whose upstream is COMPLETED."""
+            ready: list[Any] = []
+            for task in candidates:
                 task_id = str(_safe_attr(task, "id", "") or "")
                 if not task_id:
                     continue
                 try:
-                    ready = task_upstream_ready(plan, task_id)
+                    if task_upstream_ready(plan, task_id):
+                        ready.append(task)
                 except Exception as exc:  # noqa: BLE001 — never raise from pin
                     log.debug(
-                        "before_agent_callback: task_upstream_ready raised "
+                        "_filter_dag_ready: task_upstream_ready raised "
                         "for %s: %s — treating as not-ready",
                         task_id,
                         exc,
                     )
-                    ready = False
-                if ready:
-                    matches.append(task)
+            return ready
 
-            if len(matches) != len(pre_dag):
-                log.debug(
-                    "pin candidate filter: agent=%s, before=[%s], after=[%s] "
-                    "(upstream-gated)",
-                    agent_name,
-                    ", ".join(
-                        str(_safe_attr(t, "id", "") or "") for t in pre_dag
-                    ),
-                    ", ".join(
-                        str(_safe_attr(t, "id", "") or "") for t in matches
-                    ),
-                )
+        def _scoring_args_for(
+            self,
+            *,
+            ctx: SessionContext,
+            callback_context: Any,
+            parent_invocation_id: str,
+        ) -> Any:
+            """Return a token-bag string for tool-arg scoring, or ``None``.
 
-            if len(matches) != 1:
-                # Zero matches (off-plan) or >1 matches (ambiguous).
-                # Leave state unset; the existing ``missing_task_id``
-                # error path remains the explicit signal.
-                log.debug(
-                    "before_agent_callback: not pinning current_task_id for %s "
-                    "(%d PENDING/RUNNING task matches)",
-                    agent_name,
-                    len(matches),
+            Signal 3/4/8 score candidates by token overlap with whatever
+            we have for "what was this agent invoked for". In priority
+            order:
+
+            1. Parent invocation's last AgentTool args, if we have a
+               record (best signal — exact dispatch payload).
+            2. The active steer body — operators usually phrase the
+               steer with task-named tokens.
+            3. The session's goal summary — broad fallback that at
+               least disambiguates by domain vocabulary.
+
+            Returns whatever non-empty string-or-mapping we found, or
+            ``None`` when there's nothing to score against (in which
+            case the score-based signals fall through silently).
+            """
+            # 1) Parent invocation's last AgentTool args. The plugin's
+            # before_tool_callback already tracks pending_delegations
+            # keyed by function_call_id — that's a per-dispatch pin,
+            # not a per-invocation tool-args record. Without a richer
+            # record we synthesise the best we can: the steer body or
+            # the active-steer-targeting drift detail tends to carry
+            # the same vocabulary as the dispatch.
+            session_state = _safe_attr(ctx.session, "state", None)
+            if isinstance(session_state, Mapping):
+                # Active steer body is a strong signal when present.
+                steer_body = session_state.get("goldfive.active_steer.body", "")
+                if isinstance(steer_body, str) and steer_body.strip():
+                    return steer_body
+                goals_summary = session_state.get("goldfive.goals_summary", "")
+                if isinstance(goals_summary, str) and goals_summary.strip():
+                    return goals_summary
+            # 2) Goals on the session itself (some test harnesses don't
+            # populate the orchestration-state mirror).
+            goals = _safe_attr(ctx.session, "goals", None) or []
+            if goals:
+                summaries = [
+                    str(_safe_attr(g, "summary", "") or "") for g in goals
+                ]
+                joined = " ".join(s for s in summaries if s).strip()
+                if joined:
+                    return joined
+            # 3) Nothing to score against.
+            _ = parent_invocation_id  # intentionally unused; kept for future plumbing
+            return None
+
+        def _task_from_parent_pin_downstream(
+            self,
+            *,
+            plan: Any,
+            tasks: list[Any],
+            parent_invocation_id: str,
+            agent_name: str,
+            scoring_args: Any,
+        ) -> Any:
+            """Signal 5 — pick a candidate downstream of the parent's pin.
+
+            Reads ``self._invocation_pinned_task_id[parent_invocation_id]``
+            to find the parent's pin, then scans ``plan.edges`` for
+            tasks whose id is a downstream of the parent pin. Among
+            those, restrict to assignee-matching PENDING/RUNNING tasks
+            (re-using :meth:`_candidates_for_agent`). If multiple,
+            fall back to tool-arg scoring; if zero, return ``None``.
+            """
+            if not parent_invocation_id:
+                return None
+            parent_pin = self._invocation_pinned_task_id.get(parent_invocation_id, "")
+            if not parent_pin:
+                return None
+            edges = _safe_attr(plan, "edges", None) or ()
+            downstream_ids: set[str] = set()
+            for e in edges:
+                from_id = str(_safe_attr(e, "from_task_id", "") or "")
+                if from_id != parent_pin:
+                    continue
+                to_id = str(_safe_attr(e, "to_task_id", "") or "")
+                if to_id:
+                    downstream_ids.add(to_id)
+            if not downstream_ids:
+                return None
+            assignee_candidates = self._candidates_for_agent(tasks, agent_name)
+            preferred: list[Any] = [
+                t for t in assignee_candidates
+                if str(_safe_attr(t, "id", "") or "") in downstream_ids
+            ]
+            if not preferred:
+                return None
+            if len(preferred) == 1:
+                return preferred[0]
+            if scoring_args is not None:
+                return _score_candidates_by_args(preferred, scoring_args)
+            return None
+
+        @staticmethod
+        def _task_from_pending_correction(
+            *,
+            ctx: SessionContext,
+            tasks: list[Any],
+            agent_name: str,
+        ) -> Any:
+            """Signal 6 — pin to a task targeted by a pending correction.
+
+            Reads ``goldfive.pending_corrections.<agent>.<task_id>``
+            keys off the orchestration session state (written by
+            :mod:`goldfive._correction_injection` for CORRECT-kind
+            supersedes). When at least one entry exists for the bare
+            form of ``agent_name``, returns the first matching plan
+            task that is PENDING or RUNNING.
+            """
+            from goldfive.types import TaskStatus
+
+            state = _safe_attr(ctx.session, "state", None)
+            if not isinstance(state, Mapping):
+                return None
+            # Strip a compound prefix on agent_name to match the
+            # bare-form keys the writer uses.
+            bare_agent = agent_name.rsplit(":", 1)[-1]
+            prefix = f"goldfive.pending_corrections.{bare_agent}."
+            target_task_ids: list[str] = []
+            for key in state:
+                if not isinstance(key, str):
+                    continue
+                if not key.startswith(prefix):
+                    continue
+                tid = key[len(prefix):]
+                if tid:
+                    target_task_ids.append(tid)
+            if not target_task_ids:
+                return None
+            # Resolve to the first PENDING/RUNNING plan task with a
+            # matching id. We do not require assignee-equality here —
+            # the writer keyed on the agent already, and we trust that
+            # the correction is for this agent's turn.
+            tasks_by_id = {
+                str(_safe_attr(t, "id", "") or ""): t for t in tasks
+            }
+            for tid in target_task_ids:
+                task = tasks_by_id.get(tid)
+                if task is None:
+                    continue
+                status = _safe_attr(task, "status", None)
+                if status is TaskStatus.PENDING or status is TaskStatus.RUNNING:
+                    return task
+            return None
+
+        @staticmethod
+        def _alternate_agent_name_form(agent_name: str) -> str:
+            """Return the bare/compound alternate of ``agent_name``.
+
+            ``"compound:foo"`` -> ``"foo"``; ``"foo"`` -> ``""`` (no
+            compound prefix to add — there's no convention for which
+            prefix to try without context). Signal 7 only exercises
+            the strip direction, since the planner-side normalisation
+            (PR #215) already strips on the way in.
+            """
+            if not agent_name:
+                return ""
+            if ":" in agent_name:
+                return agent_name.rsplit(":", 1)[-1]
+            return ""
+
+        def _low_confidence_best_guess(
+            self,
+            *,
+            tasks: list[Any],
+            agent_name: str,
+            scoring_args: Any,
+        ) -> tuple[Any, float] | None:
+            """Signal 8 — return a best-guess (task, confidence) pair.
+
+            Last-resort: if every prior signal failed but there's
+            something resembling work for this agent in the plan, pick
+            the most-plausible task and tag the resolution as
+            low-confidence so the operator-visible event makes the
+            uncertainty explicit.
+
+            Strategy: assignee-match candidates (any status that's
+            PENDING/RUNNING) scored against tool args. If empty, no
+            pin — there's nothing better than ``missing_task_id``.
+            """
+            assignee_candidates = self._candidates_for_agent(tasks, agent_name)
+            if not assignee_candidates:
+                return None
+            if len(assignee_candidates) == 1:
+                # Single assignee match but DAG-relaxed already would
+                # have caught this — getting here means the relaxed
+                # path didn't run (e.g. signals 5/6 fell through with
+                # parent or correction context but neither matched).
+                # Pin with low confidence.
+                return assignee_candidates[0], 0.4
+            if scoring_args is not None:
+                chosen = _score_candidates_by_args(
+                    assignee_candidates, scoring_args
                 )
+                if chosen is not None:
+                    return chosen, 0.4
+            # Tie / no scoring available — pick the first deterministically
+            # so behaviour is reproducible across runs. The low-
+            # confidence event makes the uncertainty visible.
+            return assignee_candidates[0], 0.2
+
+        async def _emit_pin_resolved(
+            self,
+            *,
+            ctx: SessionContext,
+            agent_name: str,
+            task_id: str,
+            via_signal: str,
+            score: float,
+            invocation_id: str,
+            candidate_count: int,
+        ) -> None:
+            """Emit a ``pin_resolved`` (or ``pin_resolved_low_confidence``)
+            sink event so operators see which signal landed the pin.
+
+            Uses :func:`goldfive.events.make_event` (dict envelope)
+            because the proto schema doesn't yet carry a PinResolved
+            slot — adding one would expand scope. Best-effort: every
+            failure is logged and swallowed.
+            """
+            steerer = ctx.steerer
+            if steerer is None:
                 return
-            task = matches[0]
-            task_id = str(_safe_attr(task, "id", "") or "")
-            if not task_id:
+            sinks = getattr(steerer, "_sinks", None) or []
+            if not sinks:
                 return
-            self._stamp_current_task_id(
-                ctx=ctx,
-                callback_context=callback_context,
-                task_id=task_id,
-                agent_name=agent_name,
-                source="single_match",
-                task=task,
+            kind = (
+                "pin_resolved_low_confidence"
+                if via_signal == "low_confidence"
+                else "pin_resolved"
             )
+            session = ctx.session
+            run_id = str(_safe_attr(session, "run_id", "") or "")
+            session_id = str(_safe_attr(session, "id", "") or "") or run_id
+            try:
+                seq = session.next_sequence()
+            except Exception:  # noqa: BLE001
+                seq = 0
+            payload: dict[str, Any] = {
+                "agent_name": str(agent_name or ""),
+                "task_id": str(task_id or ""),
+                "via_signal": str(via_signal or ""),
+                "score": float(score),
+                "invocation_id": str(invocation_id or ""),
+                "candidate_count": int(candidate_count),
+            }
+            try:
+                from goldfive.events import emit, make_event  # noqa: PLC0415
+
+                evt = make_event(
+                    run_id, seq, kind, payload, session_id=session_id
+                )
+                await emit(sinks, evt)
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_emit_pin_resolved: failed to emit %s: %s", kind, exc
+                )
 
         def _stamp_current_task_id(
             self,
@@ -1898,14 +2460,22 @@ def make_adk_plugin(
             agent_name: str,
             source: str,
             task: Any = None,
+            invocation_id: str = "",
         ) -> None:
             """Write ``task_id`` into both state surfaces for the sub-agent.
 
-            Shared by the delegation-site branch and the single-match
-            fallback in :meth:`_pin_current_task_id_for_agent`. The
-            ``source`` label threads into the log line so the operator
-            log shows whether the pin came from the pending-delegations
-            map (goldfive#241) or the legacy assignee-match path.
+            Shared by every signal in :meth:`_pin_current_task_id_for_agent`
+            (goldfive#264). The ``source`` label threads into the log
+            line so operators see which signal landed the pin
+            (delegation_pin / single_match / arg_scored / dag_relaxed /
+            parent_pin_downstream / correction_target /
+            assignee_normalised / low_confidence).
+
+            ``invocation_id`` (when non-empty) is also recorded onto
+            ``self._invocation_pinned_task_id`` so signal 5 of a
+            child invocation's pin can read this invocation's pin
+            without racing on the single ``goldfive.current_task_id``
+            slot.
 
             When ``task`` is provided, the ADK side also stamps
             ``goldfive.current_task_title`` /
@@ -1948,6 +2518,10 @@ def make_adk_plugin(
                 agent_name,
                 source,
             )
+            # goldfive#264 — record per-invocation pin so child
+            # invocations can resolve their parent's pin (signal 5).
+            if invocation_id and task_id:
+                self._invocation_pinned_task_id[invocation_id] = task_id
 
         def _pin_delegation_task_id(
             self,

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -2708,10 +2708,13 @@ async def test_agent_invocation_started_and_completed_emitted_to_sinks() -> None
 
     await adapter.invoke(task=task, session=session)
 
-    kinds = [e.WhichOneof("payload") for e in sink.events]
+    # goldfive#264 — filter to proto-shaped events; pin_resolved is
+    # a dict envelope and would raise AttributeError on WhichOneof.
+    proto_events = [e for e in sink.events if hasattr(e, "WhichOneof")]
+    kinds = [e.WhichOneof("payload") for e in proto_events]
     assert "agent_invocation_started" in kinds
     assert "agent_invocation_completed" in kinds
-    started = next(e for e in sink.events if e.WhichOneof("payload") == "agent_invocation_started")
+    started = next(e for e in proto_events if e.WhichOneof("payload") == "agent_invocation_started")
     assert started.agent_invocation_started.agent_name == "worker"
     assert started.agent_invocation_started.task_id == "t1"
     # parent_invocation_id is empty on the top-level dispatch.
@@ -2808,7 +2811,8 @@ async def test_delegation_observed_emitted_on_agent_tool_call() -> None:
     delegations = [
         e.delegation_observed
         for e in sink.events
-        if e.WhichOneof("payload") == "delegation_observed"
+        if hasattr(e, "WhichOneof")
+        and e.WhichOneof("payload") == "delegation_observed"
     ]
     assert len(delegations) >= 1, "expected at least one DelegationObserved"
     first = delegations[0]

--- a/tests/test_pin_resolution_ladder.py
+++ b/tests/test_pin_resolution_ladder.py
@@ -1,0 +1,681 @@
+"""Tests for the goldfive#264 aggressive pin-resolution ladder.
+
+The brief: when an agent is invoked, *something precipitated the call*.
+The pre-#264 resolver gave up silently when its narrow happy path
+(exactly one DAG-ready assignee match) returned 0 or 2+ candidates,
+leaving the pin unset and stalling the orchestration loop. The new
+resolver in :meth:`_GoldfiveADKPlugin._pin_current_task_id_for_agent`
+exhausts an 8-signal ladder, picking the first signal that yields a
+single best candidate, and emits a ``pin_resolved`` sink event with
+``via_signal`` labelled so operators can see which signal landed it.
+
+This file pins each rung of the ladder:
+
+  * Signal 1 — delegation-site pin happy path (regression for #195)
+  * Signal 2 — DAG-ready exactly-1 happy path (regression for #242)
+  * Signal 3 — tool-arg scoring picks among DAG-ready candidates
+  * Signal 4 — DAG gate relaxed when no candidate is DAG-ready
+  * Signal 5 — parent invocation's pin → downstream-edge candidate
+  * Signal 6 — pending-correction targets the right task
+  * Signal 7 — bare/compound assignee normalisation fallback
+  * Signal 8 — low-confidence best-guess (never silent no-op)
+
+Plus:
+
+  * Every successful pin emits a ``pin_resolved`` sink event with the
+    ``via_signal`` enum.
+  * Signal 4 emits a WARNING log alongside the sink event.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    SESSION_CONTEXT_STATE_KEY,
+    SessionContext,
+    make_adk_plugin,
+)
+from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StateCtx:
+    """Minimal ADK-callback-context stub with a ``session.state`` dict."""
+
+    class _Session:
+        def __init__(self, state: dict) -> None:
+            self.state = state
+
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    @property
+    def session(self) -> Any:
+        return _StateCtx._Session(self._state)
+
+
+class _Agent:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _CapturingSink:
+    """Sink stub that captures every emitted event for assertions."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event: Any) -> None:
+        self.events.append(event)
+
+    async def close(self) -> None:
+        pass
+
+
+class _SinkingSteerer:
+    """Steerer stub that exposes ``_sinks`` so the plugin emits events."""
+
+    def __init__(self, sinks: list[Any]) -> None:
+        self._sinks = list(sinks)
+
+    async def observe(self, *a: Any, **kw: Any) -> None:  # pragma: no cover
+        pass
+
+
+def _plan_with(*tasks: Task, edges: list[TaskEdge] | None = None) -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=[],
+        tasks=list(tasks),
+        edges=list(edges or []),
+        summary="",
+    )
+
+
+def _session_with(plan: Plan | None) -> Session:
+    return Session(run_id="r1", plan=plan)
+
+
+def _ctx_for(
+    session: Session,
+    agent_name: str,
+    *,
+    sinks: list[Any] | None = None,
+) -> tuple[dict, Any]:
+    """Build a ({adk_state}, callback_context) pair for plugin callbacks.
+
+    When ``sinks`` is provided, attaches a steerer stub so
+    :meth:`_emit_pin_resolved` can fan out events.
+    """
+    steerer: Any = None
+    if sinks is not None:
+        steerer = _SinkingSteerer(sinks)
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session,
+            steerer=steerer,
+            task=None,
+            tool_handlers={},
+            host_agent_name=agent_name,
+        ),
+    }
+    return state, _StateCtx(state)
+
+
+def _pin_resolved_events(events: list[Any]) -> list[dict]:
+    """Filter sink events down to ``pin_resolved*`` envelopes."""
+    out: list[dict] = []
+    for e in events:
+        if not isinstance(e, dict):
+            continue
+        kind = e.get("kind", "")
+        if kind in ("pin_resolved", "pin_resolved_low_confidence"):
+            out.append(e)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Signal 1 — delegation-site pin
+# ---------------------------------------------------------------------------
+
+
+async def test_signal1_delegation_site_pin() -> None:
+    """A pre-stamped ``pending_delegations`` entry pins the right task."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="research", assignee_agent_id="researcher"),
+            Task(id="t2", title="another for researcher", assignee_agent_id="researcher"),
+        )
+    )
+    # Two candidates so signal 2 would tie; delegation pin disambiguates.
+    session.state["goldfive.pending_delegations"] = {"fc-1": "t2"}
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("researcher"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t2"
+    events = _pin_resolved_events(sinks[0].events)
+    assert len(events) == 1
+    assert events[0]["payload"]["via_signal"] == "delegation_pin"
+    assert events[0]["payload"]["task_id"] == "t2"
+
+
+# ---------------------------------------------------------------------------
+# Signal 2 — DAG-ready exactly-1 (happy path)
+# ---------------------------------------------------------------------------
+
+
+async def test_signal2_dag_ready_single_match() -> None:
+    """One DAG-ready PENDING task assigned to the agent → signal 2 fires."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="research", assignee_agent_id="researcher"),
+        )
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("researcher"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    events = _pin_resolved_events(sinks[0].events)
+    assert len(events) == 1
+    assert events[0]["payload"]["via_signal"] == "dag_ready_single"
+
+
+# ---------------------------------------------------------------------------
+# Signal 3 — tool-arg scoring over DAG-ready candidates
+# ---------------------------------------------------------------------------
+
+
+async def test_signal3_arg_scoring_breaks_dag_ready_tie() -> None:
+    """Two DAG-ready candidates → tool-arg scoring picks the right one.
+
+    The scoring args (steer body / goals summary) carry tokens from
+    one candidate's title + description; the other candidate's tokens
+    don't match. Signal 3 picks the matching one.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(
+                id="t1",
+                title="solar telemetry research",
+                description="gather solar telemetry",
+                assignee_agent_id="researcher",
+            ),
+            Task(
+                id="t2",
+                title="quarterly invoice review",
+                description="reconcile quarterly invoices",
+                assignee_agent_id="researcher",
+            ),
+        )
+    )
+    # Steer body biases toward t1.
+    session.state["goldfive.active_steer.body"] = (
+        "focus on solar telemetry, not invoices"
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("researcher"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "arg_scored"
+
+
+async def test_signal3_tie_falls_through_to_signal4() -> None:
+    """When tool-arg scoring ties, fall through to signal 4.
+
+    Two candidates whose token bags don't overlap with the args at
+    all → ``_score_candidates_by_args`` returns ``None`` → signal 3
+    declines → signal 4 takes over and picks the first deterministically
+    (with a relaxed-DAG warning, even though both ARE DAG-ready,
+    because signal 4 doesn't gate on the DAG state).
+
+    Wait — signal 4 uses ``assignee_candidates`` which is the pre-DAG
+    set. With both DAG-ready, signal 4 also can't disambiguate. The
+    scoring re-fires via signal 4 with the same args (still ties)
+    and then falls through to signal 8. So the test asserts signal 8
+    fires.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="alpha", description="A", assignee_agent_id="a"),
+            Task(id="t2", title="beta", description="B", assignee_agent_id="a"),
+        )
+    )
+    # No steer body, no goals → no scoring args at all → signal 3 / 4
+    # / 7 score paths skip; signal 8 picks first deterministically.
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("a"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] in {"t1", "t2"}
+    events = _pin_resolved_events(sinks[0].events)
+    # Signal 4 fires with relaxed assignee-candidates because BOTH are
+    # DAG-ready — signal 2 sees 2 candidates so it bypasses; signal 3
+    # has no args; signal 4's len==1 path doesn't apply (2 candidates,
+    # no args) so signal 4 falls through; signals 5-7 don't apply;
+    # signal 8 picks deterministically.
+    assert events[-1]["payload"]["via_signal"] in {
+        "low_confidence",
+        "dag_relaxed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Signal 4 — DAG gate relaxed (assignee match, upstreams incomplete)
+# ---------------------------------------------------------------------------
+
+
+async def test_signal4_dag_relaxed_pins_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Upstream incomplete + single assignee match → signal 4 binds + WARNING."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(id="a", title="upstream", assignee_agent_id="other"),
+            Task(id="b", title="downstream", assignee_agent_id="researcher"),
+            edges=[TaskEdge("a", "b")],
+        )
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    with caplog.at_level(logging.WARNING, logger="goldfive.adapters.adk"):
+        await plugin.before_agent_callback(
+            agent=_Agent("researcher"),
+            callback_context=ctx,
+        )
+
+    assert state[KEY_CURRENT_TASK_ID] == "b"
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "dag_relaxed"
+    # WARNING log surfaced for operator visibility.
+    assert any(
+        "DAG-gate relaxed" in record.getMessage() for record in caplog.records
+    ), [r.getMessage() for r in caplog.records]
+
+
+# ---------------------------------------------------------------------------
+# Signal 5 — parent invocation's task downstream
+# ---------------------------------------------------------------------------
+
+
+async def test_signal5_parent_pin_downstream() -> None:
+    """Parent invocation pinned task A; A→B edge; agent on B → pin lands on B.
+
+    Drives the resolver method directly so we can pass
+    ``invocation_id`` / ``parent_invocation_id`` without spinning up
+    a real ADK invocation_context. The plugin's ``before_agent_callback``
+    plumbs the same kwargs from the live ADK callback context.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    # Two PENDING tasks for the child agent; only one is downstream
+    # of the parent's pinned task. The child's signals 2/3 see two
+    # ambiguous candidates and fall through; signal 4 also can't
+    # disambiguate without scoring args; signal 5 reads the parent's
+    # pin from the per-invocation map and picks the downstream-edge
+    # candidate.
+    session = _session_with(
+        _plan_with(
+            Task(id="A", title="parent task", assignee_agent_id="parent_agent"),
+            Task(id="GATE", title="gate", assignee_agent_id="other_agent"),
+            Task(
+                id="B",
+                title="downstream of A",
+                assignee_agent_id="child_agent",
+            ),
+            Task(
+                id="C",
+                title="unrelated child task",
+                assignee_agent_id="child_agent",
+            ),
+            # B blocked by parent's task A; C blocked by GATE — both
+            # PENDING upstreams, so signal 2 (DAG-ready) sees 0
+            # candidates and falls through to later signals.
+            edges=[TaskEdge("A", "B"), TaskEdge("GATE", "C")],
+        )
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    # Pin parent directly (single match for parent_agent → signal 2).
+    await plugin._pin_current_task_id_for_agent(
+        agent_name="parent_agent",
+        callback_context=ctx,
+        invocation_id="inv-parent",
+        parent_invocation_id="",
+    )
+    assert state[KEY_CURRENT_TASK_ID] == "A"
+    assert plugin._invocation_pinned_task_id["inv-parent"] == "A"
+
+    # Now resolve child with parent_invocation_id → signal 5 picks B
+    # because B is downstream of A in plan.edges. The child has 2
+    # ambiguous assignee candidates (B and C), no scoring args, so
+    # signals 2/3/4 all fall through.
+    await plugin._pin_current_task_id_for_agent(
+        agent_name="child_agent",
+        callback_context=ctx,
+        invocation_id="inv-child",
+        parent_invocation_id="inv-parent",
+    )
+    assert state[KEY_CURRENT_TASK_ID] == "B"
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "parent_pin_downstream"
+    assert events[-1]["payload"]["task_id"] == "B"
+
+
+# ---------------------------------------------------------------------------
+# Signal 6 — recent drift / pending correction targeting
+# ---------------------------------------------------------------------------
+
+
+async def test_signal6_pending_correction_pins_target_task() -> None:
+    """A pending-correction key targets task ``corr1`` → signal 6 binds it."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    # Two assignee candidates for the agent — neither is DAG-ready
+    # (no upstreams to be ready against, but the assignee+status
+    # filter would tie under signals 2-4). The pending-correction
+    # entry under one specific (agent, task) tuple is the
+    # disambiguator.
+    session = _session_with(
+        _plan_with(
+            Task(id="t_old", title="original", assignee_agent_id="agent_x"),
+            Task(id="corr1", title="corrected take", assignee_agent_id="agent_x"),
+        )
+    )
+    # Stamp the correction pointer; signals 2-4 should still tie for
+    # ``agent_x`` (both DAG-ready singletons), so we need a single
+    # DAG-ready candidate to ensure we get to signal 6.
+    # Strategy: introduce an edge so corr1 is a downstream of t_old,
+    # and the upstream is incomplete → signal 2 fails → signal 4
+    # would relax with 2 assignee candidates... too messy.
+    #
+    # Simpler: only one task in the plan, no DAG concerns, but with
+    # a pending-correction key → signal 2 would already bind corr1
+    # on its own. So set up a different-agent ``other`` task as
+    # filler so signal 2 still has its single match, but force the
+    # signal-6 path by making the candidate DAG-NOT-ready and the
+    # pending correction is the only signal that matches.
+    #
+    # Actually: signal 2 binds the only PENDING task assigned to
+    # agent_x even if there's a correction pointer to the same id —
+    # signal 1 would skip (no delegation), signal 2 finds 1 match
+    # and binds it. That's still going through signal 2, not 6.
+    #
+    # To exercise signal 6 we need: zero DAG-ready candidates AND
+    # zero plain assignee candidates (so signals 2-5 fail), but a
+    # pending-correction key naming a task that exists in the plan
+    # with PENDING status. That's a coordinator-pattern: agent name
+    # was bare ``agent_x`` but the task got assigned to a sibling
+    # under a different name. Use that.
+    session = _session_with(
+        _plan_with(
+            Task(id="t_other", title="filler", assignee_agent_id="someone_else"),
+            # corr1 IS PENDING, but assigned to the bare form that
+            # neither matches the agent's compound nor any other
+            # signal — only the pending-correction key.
+            Task(id="corr1", title="corrected take", assignee_agent_id="bare_form"),
+        )
+    )
+    session.state["goldfive.pending_corrections.agent_x.corr1"] = {
+        "agent_name": "agent_x",
+        "task_id": "corr1",
+    }
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("agent_x"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "corr1"
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "correction_target"
+
+
+# ---------------------------------------------------------------------------
+# Signal 7 — bare/compound assignee normalization fallback
+# ---------------------------------------------------------------------------
+
+
+async def test_signal7_compound_to_bare_normalisation() -> None:
+    """Agent name ``"client:foo"`` with no compound assignees → strip and retry."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    # The plan was authored with bare names (post-#215 normalisation
+    # should make this the norm). The invocation's agent_name is the
+    # compound form.
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="research", assignee_agent_id="researcher"),
+        )
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("client42:researcher"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "assignee_normalised"
+
+
+# ---------------------------------------------------------------------------
+# Signal 8 — low-confidence best-guess
+# ---------------------------------------------------------------------------
+
+
+async def test_signal8_low_confidence_best_guess_emits_low_confidence_event() -> None:
+    """Pure ambiguity (multi-candidate, no scoring args) → signal 8 fires.
+
+    Signal 8 is only exercised when every prior signal fails. Two
+    PENDING candidates for the agent, no scoring args, no parent /
+    correction context → signal 4 also can't disambiguate and falls
+    through. Signal 8 picks the first candidate deterministically and
+    emits a ``pin_resolved_low_confidence`` event so operators see
+    the ladder bottomed out.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(id="alpha", title="alpha", assignee_agent_id="a"),
+            Task(id="beta", title="beta", assignee_agent_id="a"),
+        )
+    )
+    # No steer body, no goals → scoring_args is None → signals 3 / 4
+    # / 7 / 8's score path all skip the score branches. Signal 8
+    # falls back to the deterministic-first pick.
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("a"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] in {"alpha", "beta"}
+    events = _pin_resolved_events(sinks[0].events)
+    assert any(
+        e["kind"] == "pin_resolved_low_confidence" for e in events
+    ), [e.get("payload", {}).get("via_signal") for e in events]
+
+
+# ---------------------------------------------------------------------------
+# Pin-resolved sink event invariants
+# ---------------------------------------------------------------------------
+
+
+async def test_pin_resolved_event_shape() -> None:
+    """Every successful pin emits exactly one pin_resolved-family event.
+
+    Asserts the payload keys + types + signal labelling so downstream
+    sinks (harmonograf) can rely on the contract without inspecting
+    the resolver implementation.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(Task(id="t1", title="x", assignee_agent_id="a"))
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin._pin_current_task_id_for_agent(
+        agent_name="a",
+        callback_context=ctx,
+        invocation_id="inv-7",
+        parent_invocation_id="",
+    )
+
+    events = _pin_resolved_events(sinks[0].events)
+    assert len(events) == 1
+    e = events[0]
+    assert e["kind"] == "pin_resolved"
+    payload = e["payload"]
+    assert payload["agent_name"] == "a"
+    assert payload["task_id"] == "t1"
+    assert payload["via_signal"] == "dag_ready_single"
+    assert payload["invocation_id"] == "inv-7"
+    assert isinstance(payload["score"], float)
+    assert isinstance(payload["candidate_count"], int)
+
+
+# ---------------------------------------------------------------------------
+# Regression — happy paths still work
+# ---------------------------------------------------------------------------
+
+
+async def test_regression_242_dag_gate_happy_path() -> None:
+    """DAG-aware ambiguity-narrowing (the #242 happy path) still works."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(id="gate", title="g", assignee_agent_id="other"),
+            Task(id="t1", title="first", assignee_agent_id="a"),
+            Task(id="t2", title="second", assignee_agent_id="a"),
+            edges=[TaskEdge("gate", "t2")],
+        )
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("a"),
+        callback_context=ctx,
+    )
+
+    # Signal 2 short-circuits — t1 is the only DAG-ready candidate.
+    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "dag_ready_single"
+
+
+async def test_regression_195_delegation_pin_happy_path() -> None:
+    """Pre-stamped delegation pin still wins over an ambiguous match set."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="first", assignee_agent_id="a"),
+            Task(id="t2", title="second", assignee_agent_id="a"),
+        )
+    )
+    session.state["goldfive.pending_delegations"] = {"fc-1": "t1"}
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("a"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "delegation_pin"
+
+
+# ---------------------------------------------------------------------------
+# Per-invocation pin map (signal-5 plumbing)
+# ---------------------------------------------------------------------------
+
+
+async def test_invocation_pin_map_records_resolution() -> None:
+    """A successful pin records ``invocation_id -> task_id`` on the plugin.
+
+    Signal 5 of a future child invocation reads this map to find the
+    parent's pin without racing on the single ``goldfive.current_task_id``
+    slot.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(
+        _plan_with(Task(id="t1", title="x", assignee_agent_id="a"))
+    )
+    state, ctx = _ctx_for(session, "coord")
+
+    await plugin._pin_current_task_id_for_agent(
+        agent_name="a",
+        callback_context=ctx,
+        invocation_id="inv-9",
+        parent_invocation_id="",
+    )
+
+    assert plugin._invocation_pinned_task_id.get("inv-9") == "t1"
+
+
+async def test_invocation_pin_map_cleared_on_clear_active_context() -> None:
+    """``clear_active_context`` drops the per-invocation pin map."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(
+        _plan_with(Task(id="t1", title="x", assignee_agent_id="a"))
+    )
+    state, ctx = _ctx_for(session, "coord")
+    await plugin._pin_current_task_id_for_agent(
+        agent_name="a",
+        callback_context=ctx,
+        invocation_id="inv-1",
+        parent_invocation_id="",
+    )
+    assert plugin._invocation_pinned_task_id
+
+    plugin.clear_active_context()
+    assert plugin._invocation_pinned_task_id == {}

--- a/tests/test_sink_events.py
+++ b/tests/test_sink_events.py
@@ -124,8 +124,19 @@ def _make_terminal_llm() -> Any:
     return _T
 
 
+def _proto_events(events: list[Any]) -> list[Any]:
+    """Filter ``events`` to only the proto-envelope ones.
+
+    goldfive#264 introduced dict-shaped ``pin_resolved`` events that
+    fan out through the same sink list as proto-envelope events.
+    Tests that filter by ``WhichOneof("payload")`` have to skip the
+    dict shape to avoid AttributeError.
+    """
+    return [e for e in events if hasattr(e, "WhichOneof")]
+
+
 def _kinds(events: list[Any]) -> list[str]:
-    return [e.WhichOneof("payload") for e in events]
+    return [e.WhichOneof("payload") for e in _proto_events(events)]
 
 
 # ---------------------------------------------------------------------------
@@ -157,8 +168,16 @@ async def test_single_agent_dispatch_emits_started_and_completed_pair() -> None:
     session = Session(run_id="r1", plan=plan)
     await adapter.invoke(task=task, session=session)
 
-    starts = [e for e in sink.events if e.WhichOneof("payload") == "agent_invocation_started"]
-    completes = [e for e in sink.events if e.WhichOneof("payload") == "agent_invocation_completed"]
+    starts = [
+        e
+        for e in _proto_events(sink.events)
+        if e.WhichOneof("payload") == "agent_invocation_started"
+    ]
+    completes = [
+        e
+        for e in _proto_events(sink.events)
+        if e.WhichOneof("payload") == "agent_invocation_completed"
+    ]
 
     assert len(starts) == 1, f"expected 1 start; got {len(starts)}: {_kinds(sink.events)}"
     assert len(completes) == 1
@@ -210,7 +229,7 @@ async def test_agent_tool_delegation_produces_nested_started_completed_shape() -
     # check the ordering reads "A.started → delegation(A→B) → B.started
     # → B.completed → A.completed".
     ordered: list[tuple[str, str]] = []
-    for e in sink.events:
+    for e in _proto_events(sink.events):
         kind = e.WhichOneof("payload")
         if kind == "agent_invocation_started":
             ordered.append((kind, e.agent_invocation_started.agent_name))
@@ -279,7 +298,7 @@ async def test_sub_runner_events_inherit_outer_task_id() -> None:
 
     b_events = [
         e
-        for e in sink.events
+        for e in _proto_events(sink.events)
         if (
             e.WhichOneof("payload") == "agent_invocation_started"
             and e.agent_invocation_started.agent_name == "agent_b"
@@ -331,13 +350,13 @@ async def test_sub_runner_started_event_parent_invocation_id_equals_outer() -> N
 
     a_starts = [
         e
-        for e in sink.events
+        for e in _proto_events(sink.events)
         if e.WhichOneof("payload") == "agent_invocation_started"
         and e.agent_invocation_started.agent_name == "agent_a"
     ]
     b_starts = [
         e
-        for e in sink.events
+        for e in _proto_events(sink.events)
         if e.WhichOneof("payload") == "agent_invocation_started"
         and e.agent_invocation_started.agent_name == "agent_b"
     ]
@@ -395,7 +414,11 @@ async def test_delegation_observed_carries_outer_task_id() -> None:
     session = Session(run_id="r1", plan=plan)
     await adapter.invoke(task=task, session=session)
 
-    delegations = [e for e in sink.events if e.WhichOneof("payload") == "delegation_observed"]
+    delegations = [
+        e
+        for e in _proto_events(sink.events)
+        if e.WhichOneof("payload") == "delegation_observed"
+    ]
     assert delegations, "expected at least one delegation_observed event"
     d = delegations[0].delegation_observed
     assert d.from_agent == "agent_a"

--- a/tests/test_task_id_wiring.py
+++ b/tests/test_task_id_wiring.py
@@ -177,8 +177,15 @@ async def test_before_agent_callback_pins_unambiguous_task() -> None:
     assert session.state["goldfive.current_task_id"] == "t1"
 
 
-async def test_before_agent_callback_ambiguous_match_leaves_unset() -> None:
-    """Two PENDING tasks for the same agent → no stamp."""
+async def test_before_agent_callback_ambiguous_match_pins_low_confidence() -> None:
+    """Two PENDING tasks for the same agent → signal 8 picks deterministically.
+
+    goldfive#264 reframed the resolver: an invoked agent must end up
+    with a pin (something precipitated the call). The ambiguous-match
+    case now falls through to signal 8 which picks the first
+    assignee-matching candidate with low-confidence telemetry. The
+    pre-#264 silent-unset behaviour is gone.
+    """
     plugin = make_adk_plugin(host_agent_name="coord")
     session = _session_with(
         _plan_with(
@@ -193,8 +200,9 @@ async def test_before_agent_callback_ambiguous_match_leaves_unset() -> None:
         callback_context=ctx,
     )
 
-    assert KEY_CURRENT_TASK_ID not in state
-    assert "goldfive.current_task_id" not in session.state
+    # The ambiguous case lands on the first deterministic candidate.
+    assert state[KEY_CURRENT_TASK_ID] in {"t1", "t2"}
+    assert session.state["goldfive.current_task_id"] == state[KEY_CURRENT_TASK_ID]
 
 
 async def test_before_agent_callback_no_match_leaves_unset() -> None:
@@ -267,8 +275,14 @@ async def test_before_agent_callback_skips_terminal_tasks() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_pin_skips_task_with_incomplete_upstream() -> None:
-    """A -> B, A is PENDING, agent is assigned to B -> no pin (upstream gate)."""
+async def test_pin_relaxes_dag_gate_when_upstream_incomplete() -> None:
+    """A -> B, A is PENDING, agent is assigned to B -> signal 4 binds B.
+
+    goldfive#264 reframe: the DAG-ready filter is now signal 2; if it
+    rejects every candidate, signal 4 retries without the gate and
+    pins the assignee match. The operator-visible safety net moves
+    from "silently no-op" to "WARNING log + dag_relaxed sink event".
+    """
     plugin = make_adk_plugin(host_agent_name="coord")
     session = _session_with(
         _plan_with(
@@ -284,9 +298,9 @@ async def test_pin_skips_task_with_incomplete_upstream() -> None:
         callback_context=ctx,
     )
 
-    # DAG gate filters B out because A is still PENDING.
-    assert KEY_CURRENT_TASK_ID not in state
-    assert "goldfive.current_task_id" not in session.state
+    # Signal 4 — DAG gate relaxed — pins B.
+    assert state[KEY_CURRENT_TASK_ID] == "b"
+    assert session.state["goldfive.current_task_id"] == "b"
 
 
 async def test_pin_selects_task_after_upstream_completes() -> None:
@@ -341,16 +355,18 @@ async def test_pin_ambiguous_narrows_by_dag() -> None:
     assert session.state["goldfive.current_task_id"] == "t1"
 
 
-async def test_pin_reproduces_finalize_bug() -> None:
-    """Live-scenario regression: 5-stage plan, only finalize is the coordinator's.
+async def test_pin_finalize_with_incomplete_upstream_relaxes_loudly() -> None:
+    """Live-scenario regression (goldfive#242 + #264 reframe).
 
-    Stages 0-3 are PENDING; the final ``finalize_and_deliver_presentation``
-    task (Stage 4) is the only one assigned to the coordinator. Before
-    the DAG gate, ``before_agent_callback`` pinned the finalize task on
-    the coordinator's very first turn (pre-delegation), letting the
-    LLM call ``report_task_started`` on it and transitioning a Stage 4
-    task to RUNNING while upstream was still PENDING. The gate must
-    block that pin.
+    5-stage plan; only the Stage-4 finalize is the coordinator's task.
+    Stages 0-3 are PENDING. Pre-#242 the pin would race ahead and the
+    LLM would call ``report_task_started`` on finalize while upstream
+    was incomplete; #242 added a strict DAG gate that left the pin
+    unset and produced silent no-ops in the reporting path. #264
+    reframes again: the agent WAS invoked so something precipitated
+    it. Signal 4 relaxes the DAG gate and binds finalize, but loudly —
+    a ``dag_relaxed`` sink event + WARNING log gives operators the
+    same anomaly visibility the silent unset used to deny them.
     """
     plugin = make_adk_plugin(host_agent_name="coordinator_agent")
     session = _session_with(
@@ -379,14 +395,20 @@ async def test_pin_reproduces_finalize_bug() -> None:
         callback_context=ctx,
     )
 
-    # The entire bug: nothing should be pinned on the coordinator's
-    # first turn because the finalize task's upstream is still PENDING.
-    assert KEY_CURRENT_TASK_ID not in state
-    assert "goldfive.current_task_id" not in session.state
+    # Signal 4 binds finalize (the agent WAS invoked).
+    assert state[KEY_CURRENT_TASK_ID] == "finalize_and_deliver_presentation"
+    assert session.state["goldfive.current_task_id"] == "finalize_and_deliver_presentation"
 
 
 async def test_pin_supersedes_redirection_tracks_replacement() -> None:
-    """Edge ``A -> C`` survives supersession; readiness tracks B's status."""
+    """Edge ``A -> C`` survives supersession; readiness tracks B's status.
+
+    goldfive#264: signal 2 (DAG-ready) consults supersession-aware
+    readiness via :func:`task_upstream_ready`. With B still PENDING
+    signal 2 fails, but signal 4 (DAG-relaxed) still binds C — the
+    agent was invoked. Once B completes, signal 2 picks up C as the
+    happy-path single-DAG-ready match.
+    """
     plugin = make_adk_plugin(host_agent_name="coord")
     # A is the original, now FAILED; B replaces A (B.supersedes == "A");
     # C depends on A in the edges table. The live status driving C's
@@ -406,14 +428,14 @@ async def test_pin_supersedes_redirection_tracks_replacement() -> None:
     session = _session_with(plan)
     state, ctx = _ctx_for(session, "coord")
 
-    # B is still PENDING -> C is NOT ready -> pin blocked.
+    # B is still PENDING -> signal 2 rejects, but signal 4 binds C.
     await plugin.before_agent_callback(
         agent=_Agent("research_agent"),
         callback_context=ctx,
     )
-    assert KEY_CURRENT_TASK_ID not in state
+    assert state[KEY_CURRENT_TASK_ID] == "C"
 
-    # Flip B to COMPLETED; now C is ready -> pin proceeds.
+    # Flip B to COMPLETED; now C is DAG-ready -> signal 2 binds.
     plan.tasks[1].status = TaskStatus.COMPLETED
     await plugin.before_agent_callback(
         agent=_Agent("research_agent"),
@@ -422,13 +444,15 @@ async def test_pin_supersedes_redirection_tracks_replacement() -> None:
     assert state[KEY_CURRENT_TASK_ID] == "C"
 
 
-async def test_pin_orchestration_block_shows_none_when_unpinned() -> None:
-    """When the DAG gate blocks pin, the planner instruction block shows '(none)'.
+async def test_pin_orchestration_block_renders_pinned_task_after_relaxation() -> None:
+    """When signal 4 relaxes the DAG gate, GoldfivePlanner renders the bound task.
 
-    This is the user-visible effect: the agent's system prompt does
-    NOT contain a stale or wrong task id on turns where no task is
-    eligible. GoldfivePlanner renders the pinned id from
-    ``goldfive.current_task_id``; an unset key surfaces ``(none)``.
+    Pre-#264 the user-visible effect was an unset pin → ``(none)`` in
+    the planner instruction block. Post-#264 the relaxed pin reaches
+    the prompt — the operator-visible safety net moved to the sink
+    event + log. The LLM seeing the task id is the intended behaviour:
+    something precipitated the call, and the pin is goldfive's best
+    structural answer to "what was I invoked for".
     """
     from goldfive.planners.goldfive_planner import GoldfivePlanner
 
@@ -451,8 +475,8 @@ async def test_pin_orchestration_block_shows_none_when_unpinned() -> None:
         callback_context=ctx,
     )
 
-    # No pin happened (s0 still PENDING).
-    assert KEY_CURRENT_TASK_ID not in state
+    # Signal 4 relaxes the DAG gate and binds finalize.
+    assert state[KEY_CURRENT_TASK_ID] == "finalize"
 
     # Build the planner instruction the LLM would see. We use a
     # tolerant readonly-context stub carrying the ADK state dict.
@@ -464,9 +488,12 @@ async def test_pin_orchestration_block_shows_none_when_unpinned() -> None:
 
     instruction = planner.build_planning_instruction(_Readonly(state), None)
     assert instruction is not None
-    # The critical assertion: the block does not contain the finalize id.
-    assert "finalize" not in instruction
-    assert "Plan task (if any): (none)" in instruction
+    # The pinned task id reaches the prompt now that the resolver
+    # binds aggressively. The "(none)" string was the pre-#264 marker
+    # of a silent unset; the new contract surfaces the bound task and
+    # records the relaxation for operators via the sink event.
+    assert "finalize" in instruction
+    assert "Plan task (if any): (none)" not in instruction
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Reframes the pin resolver around the user's directive: *"if an agent was invoked, there must be something it was invoked for"*. The pre-#264 path gave up silently on 0 or 2+ matches; agents ran without a pin, reports no-op'd via the LLM-invisible silent-ack, and plan state stagnated.

Rewrites `_pin_current_task_id_for_agent` as an 8-signal ladder, picking the first signal that yields a single best candidate:

1. **Delegation-site pin** (existing, regression for #195)
2. **DAG-ready exactly-1** (existing happy path, regression for #242)
3. **Tool-arg scoring over DAG-ready candidates** (was R5)
4. **DAG gate relaxed** — assignee+status match, WARNING log + sink event
5. **Parent invocation's pinned task downstream** — via new `_invocation_pinned_task_id` map
6. **Pending-correction targeting** — reads `goldfive.pending_corrections.<agent>.<task>` from #260's writers
7. **Bare/compound assignee normalisation** — defence-in-depth for #215
8. **Low-confidence best-guess** — never silently no-op

Every successful pin emits a `pin_resolved` (or `pin_resolved_low_confidence`) dict-envelope sink event with `via_signal` labelled, so harmonograf can chart how often the relaxed signals fire — a leading indicator that pin invariants are weakening.

The pre-#264 pin tests asserted the silent-unset semantics on ambiguous / DAG-not-ready / supersedes-replacement cases. Those assertions are inverted under the new contract (the agent WAS invoked, so the pin lands; operator visibility moves to the WARNING log + sink event). Updated in-place rather than removed so the regression-anchor purpose is preserved.

## Test plan

- [x] `tests/test_pin_resolution_ladder.py` — 14 new tests covering every rung of the ladder, the per-invocation pin-map plumbing, and the sink-event payload contract
- [x] `tests/test_task_id_wiring.py` — 22 existing tests pass with updated assertions reflecting the new contract
- [x] `tests/test_sink_events.py` / `tests/test_adk_adapter.py` — proto-event filters guarded against the new dict-shaped `pin_resolved` events
- [x] Full suite: 1542 passed, 46 skipped (unchanged from baseline)
- [x] `uv run ruff check goldfive/ tests/` — clean