### PR TITLE
feat(adapters, reporting): pin versioning — stamp + verify revision at report time

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -381,6 +381,14 @@ def _inject_task_id_from_state(
 # don't race.
 _PENDING_DELEGATIONS_KEY = "goldfive.pending_delegations"
 
+# Mirror of orchestration_state.KEY_CURRENT_TASK_REVISION (goldfive#266).
+# Stable string contract shared between the adapter's ADK side
+# (``_adk_state_protocol``), the goldfive Session.state writers, and the
+# reporting-handler classifier. Re-declared here rather than imported
+# to keep the plugin module ADK-only without pulling
+# orchestration_state into its top-level imports.
+_GF_KEY_CURRENT_TASK_REVISION = "goldfive.current_task_revision"
+
 
 def _resolve_pinned_task_id(*, tool_context: Any) -> str:
     """Return the task_id pinned for this tool invocation, or ``""``.
@@ -405,12 +413,57 @@ def _resolve_pinned_task_id(*, tool_context: Any) -> str:
         pend = state.get(_PENDING_DELEGATIONS_KEY)
         if isinstance(pend, Mapping):
             raw = pend.get(fc_id, "")
-            if isinstance(raw, str) and raw.strip():
-                return raw.strip()
+            # goldfive#266 — entry may be either the legacy ``str``
+            # task_id or the versioned ``{task_id, revision}`` dict.
+            # Tolerate both so custom adapters that pre-date this PR
+            # keep working unchanged.
+            tid = _delegation_pin_task_id(raw)
+            if tid:
+                return tid
     state_tid = state.get(_sp.KEY_CURRENT_TASK_ID, "")
     if isinstance(state_tid, str) and state_tid.strip():
         return state_tid.strip()
     return ""
+
+
+def _delegation_pin_task_id(raw: Any) -> str:
+    """Return the task_id from a pending-delegations entry.
+
+    Tolerates both pre-#266 shapes:
+
+    * ``str`` — legacy direct task_id.
+    * ``Mapping`` with a ``"task_id"`` key — versioned shape that also
+      carries ``"revision"`` for the report-time classifier.
+
+    Returns ``""`` for any malformed / empty input. Strips whitespace
+    so consumers can treat the result as a clean key.
+    """
+    if isinstance(raw, str):
+        return raw.strip()
+    if isinstance(raw, Mapping):
+        tid = raw.get("task_id", "")
+        if isinstance(tid, str):
+            return tid.strip()
+        if tid is not None:
+            return str(tid).strip()
+    return ""
+
+
+def _delegation_pin_revision(raw: Any) -> int:
+    """Return the pin's revision stamp from a pending-delegations entry.
+
+    Pre-#266 (string-shaped) entries return 0 — they predate the
+    revision stamp and the report-time classifier treats 0 as the
+    initial revision (matches the default ``Plan.revision_index=0``,
+    so an unrevised plan looks fresh).
+    """
+    if isinstance(raw, Mapping):
+        rev = raw.get("revision", 0)
+        try:
+            return max(0, int(rev))
+        except (TypeError, ValueError):
+            return 0
+    return 0
 
 
 def _function_call_id_from_tool_context(tool_context: Any) -> str:
@@ -1841,8 +1894,13 @@ def make_adk_plugin(
             if isinstance(gf_state_early, Mapping):
                 pend = gf_state_early.get(_PENDING_DELEGATIONS_KEY)
                 if isinstance(pend, Mapping) and pend:
-                    for tid in pend.values():
-                        if not isinstance(tid, str) or not tid:
+                    for raw_entry in pend.values():
+                        # goldfive#266 — entries may be either the
+                        # legacy bare-string task_id or the new
+                        # ``{task_id, revision}`` dict. Use the
+                        # back-compat extractor.
+                        tid = _delegation_pin_task_id(raw_entry)
+                        if not tid:
                             continue
                         for task in tasks_list:
                             if str(_safe_attr(task, "id", "") or "") != tid:
@@ -2485,10 +2543,25 @@ def make_adk_plugin(
             don't pass the task object keep working — the resolver
             falls back to placeholders.
             """
+            # goldfive#266 — resolve the plan revision in effect at this
+            # write so the report-time classifier in
+            # :mod:`goldfive.reporting` can distinguish a fresh pin from
+            # one set under an older revision. Defensive: missing /
+            # malformed plan reads as 0 so legacy paths keep behaving
+            # like the initial revision.
+            plan_for_rev = _safe_attr(ctx.session, "plan", None)
+            try:
+                pin_revision = int(_safe_attr(plan_for_rev, "revision_index", 0) or 0)
+            except (TypeError, ValueError):
+                pin_revision = 0
             gf_state = _safe_attr(ctx.session, "state", None)
             if isinstance(gf_state, dict):
                 try:
                     gf_state[_sp.KEY_CURRENT_TASK_ID] = task_id
+                    # Stamp revision alongside the id so a later
+                    # report-time read sees the stamp on the same
+                    # session.state surface.
+                    gf_state[_GF_KEY_CURRENT_TASK_REVISION] = pin_revision
                 except Exception as exc:  # noqa: BLE001
                     log.debug(
                         "before_agent_callback: goldfive session.state pin failed: %s",
@@ -2506,6 +2579,12 @@ def make_adk_plugin(
                         _sp.write_current_task(adk_state, task)
                     else:
                         _sp.write_current_task_id(adk_state, task_id)
+                    # Mirror the revision stamp onto ADK session.state
+                    # so reporting handlers reading from the live ADK
+                    # state (custom adapters, sub-Runner contexts) see
+                    # the same value.
+                    if isinstance(adk_state, MutableMapping):
+                        _sp.write_current_task_revision(adk_state, pin_revision)
                 except Exception as exc:  # noqa: BLE001
                     log.debug(
                         "before_agent_callback: ADK session.state pin failed: %s",
@@ -2615,6 +2694,22 @@ def make_adk_plugin(
             task_id = str(_safe_attr(chosen, "id", "") or "")
             if not task_id:
                 return
+            # goldfive#266 — pin entries evolved from
+            # ``{fc_id: task_id_str}`` to
+            # ``{fc_id: {"task_id": str, "revision": int}}`` so the
+            # report-time classifier can tell whether a delegation pin
+            # was set under an older plan revision. Readers
+            # (:func:`_resolve_pinned_task_id`, signal 1 of
+            # :meth:`_pin_current_task_id_for_agent`) tolerate both
+            # shapes for back-compat with custom adapters that pre-date
+            # this PR.
+            try:
+                pin_revision = int(
+                    _safe_attr(plan, "revision_index", 0) or 0
+                )
+            except (TypeError, ValueError):
+                pin_revision = 0
+            entry = {"task_id": task_id, "revision": pin_revision}
             # Stamp the pin onto BOTH the goldfive orchestration
             # session.state (so reporting-tool handlers that read it
             # directly see it) AND the ADK tool_context session.state
@@ -2633,14 +2728,15 @@ def make_adk_plugin(
                 if not isinstance(pend, dict):
                     pend = {}
                     target[_PENDING_DELEGATIONS_KEY] = pend
-                pend[fc_id] = task_id
+                pend[fc_id] = dict(entry)
             log.info(
                 "goldfive: pinned delegation task_id=%s for fc_id=%s "
-                "(sub-agent=%s, %d candidates)",
+                "(sub-agent=%s, %d candidates, revision=%d)",
                 task_id,
                 fc_id,
                 to_agent,
                 len(candidates),
+                pin_revision,
             )
 
         async def after_agent_callback(self, *, agent: Any, callback_context: Any) -> None:

--- a/goldfive/adapters/_adk_state_protocol.py
+++ b/goldfive/adapters/_adk_state_protocol.py
@@ -36,6 +36,14 @@ KEY_CURRENT_TASK_ID = "goldfive.current_task_id"
 KEY_CURRENT_TASK_TITLE = "goldfive.current_task_title"
 KEY_CURRENT_TASK_DESCRIPTION = "goldfive.current_task_description"
 KEY_CURRENT_TASK_ASSIGNEE = "goldfive.current_task_assignee"
+# Plan revision in effect at the moment ``current_task_id`` was
+# stamped (goldfive#266 / pin versioning). Mirrors the orchestration-
+# state key in :mod:`goldfive.orchestration_state` so the value
+# round-trips between goldfive's session.state and ADK's session.state
+# regardless of which surface the reporting handler reads. Missing /
+# malformed entries are read as 0; report-time classifier treats that
+# as "matches initial revision".
+KEY_CURRENT_TASK_REVISION = "goldfive.current_task_revision"
 KEY_PLAN_ID = "goldfive.plan_id"
 KEY_PLAN_SUMMARY = "goldfive.plan_summary"
 KEY_RUN_ID = "goldfive.run_id"
@@ -103,6 +111,7 @@ ALL_KEYS: tuple[str, ...] = (
     KEY_CURRENT_TASK_TITLE,
     KEY_CURRENT_TASK_DESCRIPTION,
     KEY_CURRENT_TASK_ASSIGNEE,
+    KEY_CURRENT_TASK_REVISION,
     KEY_PLAN_ID,
     KEY_PLAN_SUMMARY,
     KEY_RUN_ID,
@@ -283,6 +292,26 @@ def clear_current_task(state: MutableMapping[str, Any]) -> None:
     for key in _CURRENT_TASK_KEYS:
         if key in state:
             state.pop(key, None)
+    state.pop(KEY_CURRENT_TASK_REVISION, None)
+
+
+def write_current_task_revision(
+    state: MutableMapping[str, Any],
+    revision: int,
+) -> None:
+    """Stamp ``goldfive.current_task_revision`` onto ``state``.
+
+    Companion to :func:`write_current_task_id` for goldfive#266 pin
+    versioning. The adapter's pin ladder calls this alongside the
+    id-only write so the report-time classifier in
+    :mod:`goldfive.reporting` can distinguish a fresh pin (matches
+    ``plan.revision_index``) from one set under an older revision.
+    """
+    try:
+        rev = max(0, int(revision))
+    except (TypeError, ValueError):
+        rev = 0
+    _set(state, KEY_CURRENT_TASK_REVISION, rev)
 
 
 def write_plan_context(

--- a/goldfive/orchestration_state.py
+++ b/goldfive/orchestration_state.py
@@ -98,6 +98,19 @@ KEY_CURRENT_PLAN_ID = "goldfive.current_plan_id"
 # Task lifecycle (PlanReconciler)
 KEY_CURRENT_TASK_ID = "goldfive.current_task_id"
 KEY_CURRENT_TASK_TITLE = "goldfive.current_task_title"
+# Revision stamp on the current_task_id pin (goldfive#266 / pin
+# versioning). When the adapter's pin ladder lands a task_id, it also
+# stamps the plan's ``revision_index`` at write time. The reporting
+# handlers consult this stamp at report time to distinguish a "fresh"
+# pin (matches current revision) from a "stale" pin (set under an
+# older revision and the report arrived after a refine landed). Stale
+# pins under a CORRECT-kind supersedes link refuse the transition; the
+# old task's terminal state is historical fact and the correction is a
+# separate work unit. Stale pins under a REPLACE-kind link route to
+# the replacement (existing supersession behaviour). Missing stamp
+# (legacy state, custom adapter that hasn't migrated) reads as 0 so
+# pre-versioning callers preserve their current behaviour.
+KEY_CURRENT_TASK_REVISION = "goldfive.current_task_revision"
 
 # Goals
 KEY_GOALS_SUMMARY = "goldfive.goals_summary"
@@ -129,6 +142,7 @@ ALL_KEYS: tuple[str, ...] = (
     KEY_CURRENT_PLAN_ID,
     KEY_CURRENT_TASK_ID,
     KEY_CURRENT_TASK_TITLE,
+    KEY_CURRENT_TASK_REVISION,
     KEY_GOALS_SUMMARY,
     KEY_ACTIVE_STEER_BODY,
     KEY_ACTIVE_STEER_AT_TURN,
@@ -209,6 +223,43 @@ def clear_current_task(state: MutableMapping[str, Any]) -> None:
     """Remove the current-task keys. Cheap alias used at run end."""
     clear(state, KEY_CURRENT_TASK_ID)
     clear(state, KEY_CURRENT_TASK_TITLE)
+    clear(state, KEY_CURRENT_TASK_REVISION)
+
+
+def stamp_current_task_revision(
+    state: MutableMapping[str, Any],
+    revision: int,
+) -> None:
+    """Stamp ``goldfive.current_task_revision`` alongside the current-task pin.
+
+    Companion writer to :func:`set_current_task` for the goldfive#266
+    pin-versioning path. Callers stamp the plan ``revision_index``
+    in effect at the moment they wrote the pin so report-time handlers
+    can tell a fresh pin from one set under an older plan.
+
+    Negative revisions are clamped to 0; non-int values are coerced
+    via ``int()`` (defensive — readers assume an int-valued field).
+    """
+    try:
+        rev = max(0, int(revision))
+    except (TypeError, ValueError):
+        rev = 0
+    write(state, KEY_CURRENT_TASK_REVISION, rev)
+
+
+def read_current_task_revision(state: Any) -> int:
+    """Return ``goldfive.current_task_revision`` as an int, default 0.
+
+    Tolerant of missing / malformed values (legacy state, custom
+    adapters that pre-date #266) — those read as 0 and the report-time
+    classifier treats them as "match" against the plan's initial
+    ``revision_index=0``.
+    """
+    raw = read(state, KEY_CURRENT_TASK_REVISION, 0)
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 0
 
 
 # ---------------------------------------------------------------------------
@@ -409,6 +460,7 @@ def rotate_current_task_id(
     if plan is None:
         clear(state, KEY_CURRENT_TASK_ID)
         clear(state, KEY_CURRENT_TASK_TITLE)
+        clear(state, KEY_CURRENT_TASK_REVISION)
         return None
 
     candidates: list[Task] = []
@@ -423,12 +475,19 @@ def rotate_current_task_id(
     if len(candidates) == 1:
         next_task = candidates[0]
         set_current_task(state, next_task)
+        # goldfive#266 — stamp the rotation moment's revision so the
+        # next reporting call on this newly-pinned task reads as
+        # "fresh" against the current plan. The adapter's pin ladder
+        # may overwrite this on the next agent invocation; it's fine.
+        rev = int(getattr(plan, "revision_index", 0) or 0)
+        stamp_current_task_revision(state, rev)
         return str(getattr(next_task, "id", "") or "") or None
 
     # Zero or multiple candidates — clear and let the orchestrator
     # re-pin on the next before_agent_callback.
     clear(state, KEY_CURRENT_TASK_ID)
     clear(state, KEY_CURRENT_TASK_TITLE)
+    clear(state, KEY_CURRENT_TASK_REVISION)
     return None
 
 
@@ -474,6 +533,7 @@ __all__ = [
     "KEY_CANCELLED_FUNCTION_CALL_IDS",
     "KEY_CURRENT_PLAN_ID",
     "KEY_CURRENT_TASK_ID",
+    "KEY_CURRENT_TASK_REVISION",
     "KEY_CURRENT_TASK_TITLE",
     "KEY_GOALS_SUMMARY",
     "KEY_PROCESSED_STEER_IDS",
@@ -486,12 +546,14 @@ __all__ = [
     "has_processed_steer_id",
     "read",
     "read_cancelled_function_call_ids",
+    "read_current_task_revision",
     "record_processed_steer_id",
     "refresh_goals_summary",
     "rotate_current_task_id",
     "set_active_steer",
     "set_current_plan",
     "set_current_task",
+    "stamp_current_task_revision",
     "sync_current_task_from_transition",
     "write",
 ]

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -88,6 +88,11 @@ _ACK: dict[str, Any] = {"acknowledged": True}
 # :mod:`._adk_state_protocol`, :mod:`orchestration_state`, and this
 # handler module.
 _STATE_KEY_CURRENT_TASK_ID = "goldfive.current_task_id"
+# Companion key (goldfive#266 / pin versioning) — the plan revision
+# in effect at the moment the adapter wrote the pin. Same back-compat
+# stance: a missing / malformed entry reads as 0, which matches the
+# default ``Plan.revision_index`` so unrevised plans remain "fresh".
+_STATE_KEY_CURRENT_TASK_REVISION = "goldfive.current_task_revision"
 
 
 def _resolve_task_id(args: dict[str, Any], session: Session) -> str:
@@ -293,6 +298,313 @@ def _reroute_if_superseded(session: Session, task_id: str, tool_name: str) -> st
     return resolved
 
 
+# ---------------------------------------------------------------------------
+# Pin freshness classification (goldfive#266 / pin versioning)
+# ---------------------------------------------------------------------------
+
+
+def _read_pin_revision(session: Session) -> int | None:
+    """Return the pin's stamped revision from session state, or ``None``.
+
+    ``None`` indicates "no stamp present" — distinct from a stamp of 0.
+    Custom adapters / legacy sessions / tests that pre-date #266 won't
+    have stamped the key; those callers must keep working unchanged
+    against the legacy ``_reroute_if_superseded`` semantics. Callers
+    that observe ``None`` should treat the pin as fresh (the stamp
+    isn't load-bearing).
+
+    A stamp of ``0`` means "the pin was set under the initial plan
+    revision" and is treated by the classifier as a stale pin against
+    any plan with ``revision_index > 0`` — that's the actual
+    versioning semantics, distinct from "no stamp".
+    """
+    state = getattr(session, "state", None)
+    if not isinstance(state, dict):
+        return None
+    if _STATE_KEY_CURRENT_TASK_REVISION not in state:
+        return None
+    raw = state.get(_STATE_KEY_CURRENT_TASK_REVISION, 0)
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _read_plan_revision(session: Session) -> int:
+    """Return ``session.plan.revision_index`` as an int, default 0.
+
+    Tolerant of missing / mock plans (test stubs, custom executors).
+    """
+    plan = getattr(session, "plan", None)
+    try:
+        return max(0, int(getattr(plan, "revision_index", 0) or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _supersession_successor(
+    session: Session, task_id: str
+) -> tuple[str, SupersessionKind]:
+    """Return ``(successor_task_id, kind)`` for ``task_id``.
+
+    Walks the plan looking for a task whose ``supersedes`` equals
+    ``task_id``. Empty successor + ``UNSPECIFIED`` when no successor
+    exists. Used by the report-time pin classifier — ``REPLACE``
+    successors route, ``CORRECT`` successors refuse, no successor also
+    refuses (ambiguity).
+    """
+    plan = getattr(session, "plan", None)
+    if plan is None or not task_id:
+        return "", SupersessionKind.UNSPECIFIED
+    for t in getattr(plan, "tasks", ()) or ():
+        sup = str(getattr(t, "supersedes", "") or "").strip()
+        if sup != task_id:
+            continue
+        successor_id = str(getattr(t, "id", "") or "").strip()
+        kind = getattr(t, "supersedes_kind", SupersessionKind.UNSPECIFIED)
+        return successor_id, kind
+    return "", SupersessionKind.UNSPECIFIED
+
+
+# Outcomes of :func:`_classify_pin_freshness`:
+#
+# * ``"match"`` — pin revision equals (or exceeds — defensive) current
+#   plan revision. Handler proceeds on the pin's task_id.
+# * ``"stale_replace"`` — pin is older than the current plan revision
+#   and the pin's task has a REPLACE-kind supersedes successor. Handler
+#   routes onto the successor (existing pre-#266 behaviour).
+# * ``"stale_correct"`` — pin is older + the pin's task has a
+#   CORRECT-kind supersedes successor. Handler REFUSES + emits a
+#   ``task_transition_refused`` sink event. The old task's terminal
+#   state is historical fact and the correction is a separate work
+#   unit; transitioning the old task out of terminal would either
+#   destroy fact or shadow the correction.
+# * ``"stale_ambiguous"`` — pin is older + the pin's task has no
+#   supersedes successor. Handler REFUSES; an operator must
+#   disambiguate. Same shape as stale_correct.
+_PinFreshness = str
+
+
+def _classify_pin_freshness(
+    session: Session,
+    task_id: str,
+    *,
+    pin_revision: int,
+    current_revision: int,
+) -> tuple[_PinFreshness, str, SupersessionKind]:
+    """Classify the relationship between a pinned task_id and the live plan.
+
+    Returns ``(freshness, successor_task_id, supersedes_kind)``. The
+    successor is empty for ``"match"`` and ``"stale_ambiguous"``.
+    """
+    if pin_revision >= current_revision:
+        # Future revisions (pin_revision > current_revision) shouldn't
+        # happen under a single executor — the writer reads
+        # plan.revision_index that the report-time reader sees later,
+        # and revisions only ever increment. If it does, treat as a
+        # match (trust the pin) rather than refusing.
+        if pin_revision > current_revision:
+            log.debug(
+                "reporting: pin_revision=%d > current=%d for task_id=%s "
+                "(unexpected; trusting pin)",
+                pin_revision,
+                current_revision,
+                task_id,
+            )
+        return "match", "", SupersessionKind.UNSPECIFIED
+
+    # pin_revision < current_revision — the pin was set under an older
+    # plan. Consult the supersedes graph.
+    successor_id, kind = _supersession_successor(session, task_id)
+    if successor_id and kind is SupersessionKind.REPLACE:
+        return "stale_replace", successor_id, kind
+    if successor_id and kind is SupersessionKind.CORRECT:
+        return "stale_correct", successor_id, kind
+    if successor_id and kind is SupersessionKind.UNSPECIFIED:
+        # Legacy plans pre-#258 didn't carry a supersedes_kind enum.
+        # Preserve the historical "treat unspecified as REPLACE" rerouting
+        # path used by ``_resolve_effective_task_id`` so legacy data
+        # keeps reaching the right handler.
+        return "stale_replace", successor_id, kind
+    return "stale_ambiguous", "", SupersessionKind.UNSPECIFIED
+
+
+def _refused_response() -> dict[str, Any]:
+    """Return the ack-only response for a refused stale-pin transition.
+
+    The LLM still sees ``{"acknowledged": True}`` rather than an error
+    payload — surfacing the refusal as a structured error would create a
+    prompt-injection surface (the LLM might reason against the rejection
+    and bypass the contract). Operators see the refusal via the
+    ``task_transition_refused`` sink event.
+    """
+    return dict(_ACK)
+
+
+async def _classify_and_route_pin(
+    *,
+    session: Session,
+    steerer: Steerer,
+    task_id: str,
+    tool_name: str,
+    attempted_to: TaskStatus,
+) -> tuple[str, dict[str, Any] | None]:
+    """Apply the goldfive#266 pin freshness classifier to ``task_id``.
+
+    Returns ``(effective_task_id, refusal_response_or_None)``:
+
+    * ``("<task_id>", None)`` — proceed; ``effective_task_id`` is
+      either the original task_id (fresh pin) or a routed REPLACE-kind
+      successor (stale-but-recoverable pin).
+    * ``("", {refusal})`` — refuse; the caller returns the refusal
+      response (an ack-only dict) without driving the steerer. A
+      ``task_transition_refused`` sink event has already been emitted.
+
+    Uses the supersedes graph to distinguish a stale REPLACE pin
+    (route) from a stale CORRECT pin (refuse: the old task's terminal
+    state is historical fact, the correction is a separate work unit)
+    and from a stale pin with no successor (refuse: ambiguity —
+    operator must decide).
+
+    Always falls back gracefully on the existing
+    :func:`_reroute_if_superseded` helper when classification yields
+    "match" — preserving the post-#258 behaviour where a fresh pin on a
+    terminal task whose successor is REPLACE-kind still routes (the
+    "agent was retrying its own pin id but the planner already
+    replaced it" path).
+    """
+    pin_rev_opt = _read_pin_revision(session)
+    cur_rev = _read_plan_revision(session)
+    if pin_rev_opt is None:
+        # No stamp present — legacy session, custom adapter, or test
+        # stub that pre-dates #266. Preserve the historical
+        # ``_reroute_if_superseded`` semantics: fresh pin on a
+        # terminal task whose successor is REPLACE-kind routes; no
+        # successor or CORRECT-kind successor falls through to the
+        # handler's existing terminal-state rejection path.
+        return _reroute_if_superseded(session, task_id, tool_name), None
+    pin_rev = pin_rev_opt
+    freshness, successor_id, _kind = _classify_pin_freshness(
+        session,
+        task_id,
+        pin_revision=pin_rev,
+        current_revision=cur_rev,
+    )
+
+    if freshness == "match":
+        # Fresh pin — fall through to the legacy rerouting helper.
+        # This still routes a fresh pin pointing at a terminal task
+        # whose successor is REPLACE-kind (an LLM that retries its
+        # own pin without realising the plan repointed).
+        return _reroute_if_superseded(session, task_id, tool_name), None
+
+    if freshness == "stale_replace":
+        log.info(
+            "reporting: %s called with stale pin task_id=%s "
+            "(pin_rev=%d, current_rev=%d); routing to REPLACE successor=%s",
+            tool_name,
+            task_id,
+            pin_rev,
+            cur_rev,
+            successor_id,
+        )
+        return successor_id or task_id, None
+
+    # stale_correct or stale_ambiguous → refuse.
+    reason = (
+        "stale_pin_correct_supersedes"
+        if freshness == "stale_correct"
+        else "stale_pin_no_supersedes"
+    )
+    log.warning(
+        "reporting: %s REFUSED on stale pin task_id=%s "
+        "(pin_rev=%d, current_rev=%d, reason=%s)",
+        tool_name,
+        task_id,
+        pin_rev,
+        cur_rev,
+        reason,
+    )
+    # Look up the pin's current status in the plan for a faithful
+    # ``attempted_from`` value on the sink event. Falls back to PENDING
+    # if the task isn't in the plan (which would be a separate bug —
+    # the classifier has already consulted the supersedes graph and
+    # found a successor or absence-of-one).
+    pin_task = _find_task_in_session(session, task_id)
+    attempted_from = (
+        pin_task.status if pin_task is not None else TaskStatus.PENDING
+    )
+    await _emit_task_transition_refused(
+        session=session,
+        steerer=steerer,
+        task_id=task_id,
+        attempted_from=attempted_from,
+        attempted_to=attempted_to,
+        reason=reason,
+        pin_revision=pin_rev,
+        current_revision=cur_rev,
+    )
+    return "", _refused_response()
+
+
+async def _emit_task_transition_refused(
+    *,
+    session: Session,
+    steerer: Steerer,
+    task_id: str,
+    attempted_from: TaskStatus,
+    attempted_to: TaskStatus,
+    reason: str,
+    pin_revision: int,
+    current_revision: int,
+    agent_name: str = "",
+    invocation_id: str = "",
+) -> None:
+    """Emit a ``task_transition_refused`` dict envelope onto the sink bus.
+
+    Fired when the report-time pin classifier refuses to drive a stale
+    pin's transition because the old task either has a CORRECT-kind
+    supersedes successor (history vs. correction) or no successor at
+    all (ambiguity — operator must decide). The LLM still sees an
+    ``{"acknowledged": True}`` response so it doesn't reason against
+    the refusal; operators consume this event for the audit trail.
+
+    Dict envelope (not proto) — matches the pattern set by
+    ``refine_attempted`` / ``refine_failed`` (#264) and
+    ``InvocationCancelled`` pre-proto. Promote to proto when the
+    follow-up prioritises it.
+    """
+    sinks = getattr(steerer, "_sinks", None) or []
+    if not sinks:
+        return
+    from goldfive.events import emit, make_event
+
+    payload = {
+        "task_id": task_id,
+        "attempted_from": attempted_from.value,
+        "attempted_to": attempted_to.value,
+        "reason": reason,
+        "pin_revision": int(pin_revision),
+        "current_revision": int(current_revision),
+        "agent_name": agent_name,
+        "invocation_id": invocation_id,
+    }
+    try:
+        evt = make_event(
+            session.run_id,
+            session.next_sequence(),
+            "task_transition_refused",
+            payload,
+            session_id=session.id,
+        )
+        await emit(sinks, evt)
+    except Exception as exc:  # noqa: BLE001 — observability must never break a report
+        log.debug(
+            "reporting._emit_task_transition_refused: failed to emit: %s",
+            exc,
+        )
+
+
 async def _await_plan_stable(session: Session, steerer: Steerer) -> None:
     """Block briefly until the steerer's plan mutation region is idle.
 
@@ -477,7 +789,17 @@ async def _handle_task_started(
     # goldfive a4: barrier against a concurrent fire-and-forget refine
     # mutating the plan mid-read. See ``_await_plan_stable``.
     await _await_plan_stable(session, steerer)
-    task_id = _reroute_if_superseded(session, task_id, "report_task_started")
+    # goldfive#266 — classify pin freshness; refuse stale CORRECT /
+    # ambiguous, route stale REPLACE, fall through on match.
+    task_id, refusal = await _classify_and_route_pin(
+        session=session,
+        steerer=steerer,
+        task_id=task_id,
+        tool_name="report_task_started",
+        attempted_to=TaskStatus.RUNNING,
+    )
+    if refusal is not None:
+        return refusal
     task = _find_task_in_session(session, task_id)
     if task is not None:
         decision = _classify_transition(tool_name="report_task_started", current_status=task.status)
@@ -544,7 +866,15 @@ async def _handle_task_progress(
     if not task_id:
         return _missing_task_id_response("report_task_progress")
     await _await_plan_stable(session, steerer)
-    task_id = _reroute_if_superseded(session, task_id, "report_task_progress")
+    task_id, refusal = await _classify_and_route_pin(
+        session=session,
+        steerer=steerer,
+        task_id=task_id,
+        tool_name="report_task_progress",
+        attempted_to=TaskStatus.RUNNING,
+    )
+    if refusal is not None:
+        return refusal
     task = _find_task_in_session(session, task_id)
     if task is not None:
         # report_task_progress is a liveness tick — only valid on RUNNING.
@@ -581,7 +911,15 @@ async def _handle_task_completed(
     if not task_id:
         return _missing_task_id_response("report_task_completed")
     await _await_plan_stable(session, steerer)
-    task_id = _reroute_if_superseded(session, task_id, "report_task_completed")
+    task_id, refusal = await _classify_and_route_pin(
+        session=session,
+        steerer=steerer,
+        task_id=task_id,
+        tool_name="report_task_completed",
+        attempted_to=TaskStatus.COMPLETED,
+    )
+    if refusal is not None:
+        return refusal
     task = _find_task_in_session(session, task_id)
     if task is not None:
         decision = _classify_transition(
@@ -614,7 +952,15 @@ async def _handle_task_failed(
     if not task_id:
         return _missing_task_id_response("report_task_failed")
     await _await_plan_stable(session, steerer)
-    task_id = _reroute_if_superseded(session, task_id, "report_task_failed")
+    task_id, refusal = await _classify_and_route_pin(
+        session=session,
+        steerer=steerer,
+        task_id=task_id,
+        tool_name="report_task_failed",
+        attempted_to=TaskStatus.FAILED,
+    )
+    if refusal is not None:
+        return refusal
     task = _find_task_in_session(session, task_id)
     if task is not None:
         decision = _classify_transition(tool_name="report_task_failed", current_status=task.status)
@@ -647,7 +993,15 @@ async def _handle_task_blocked(
     if not task_id:
         return _missing_task_id_response("report_task_blocked")
     await _await_plan_stable(session, steerer)
-    task_id = _reroute_if_superseded(session, task_id, "report_task_blocked")
+    task_id, refusal = await _classify_and_route_pin(
+        session=session,
+        steerer=steerer,
+        task_id=task_id,
+        tool_name="report_task_blocked",
+        attempted_to=TaskStatus.BLOCKED,
+    )
+    if refusal is not None:
+        return refusal
     task = _find_task_in_session(session, task_id)
     if task is not None:
         decision = _classify_transition(tool_name="report_task_blocked", current_status=task.status)

--- a/tests/test_hidden_task_id_schema.py
+++ b/tests/test_hidden_task_id_schema.py
@@ -609,8 +609,14 @@ async def test_parallel_agenttool_resolves_by_args() -> None:
     )
 
     pending = session_obj.state.get(_PENDING_DELEGATIONS_KEY) or {}
-    assert pending.get("fc_solar") == "research_solar", pending
-    assert pending.get("fc_wind") == "research_wind", pending
+    # goldfive#266: entries evolved from ``{fc_id: task_id_str}`` to
+    # ``{fc_id: {"task_id": str, "revision": int}}``. Normalise via the
+    # back-compat extractor so the test asserts the contract, not the
+    # storage shape.
+    from goldfive.adapters._adk_plugin import _delegation_pin_task_id
+
+    assert _delegation_pin_task_id(pending.get("fc_solar")) == "research_solar", pending
+    assert _delegation_pin_task_id(pending.get("fc_wind")) == "research_wind", pending
 
 
 async def test_parallel_agenttool_falls_through_on_ambiguous_args() -> None:
@@ -657,7 +663,9 @@ async def test_dag_aware_candidate_filter() -> None:
     )
 
     pending = session_obj.state.get(_PENDING_DELEGATIONS_KEY) or {}
-    pinned = pending.get("fc_gated")
+    from goldfive.adapters._adk_plugin import _delegation_pin_task_id
+
+    pinned = _delegation_pin_task_id(pending.get("fc_gated"))
     # Only "research" is upstream-clear (no predecessors); the
     # "synthesise" task is gated on "research". The pin must be on
     # "research" — NOT on "synthesise" even though its description

--- a/tests/test_pin_versioning.py
+++ b/tests/test_pin_versioning.py
@@ -1,0 +1,622 @@
+"""Tests for goldfive#266 pin versioning.
+
+The brief: every pin write (current_task_id + pending_delegations)
+carries the plan ``revision_index`` in effect at that moment. The
+report-time classifier in :mod:`goldfive.reporting` consults the stamp
+to distinguish:
+
+* **Fresh pin** (pin_revision == current_revision) — proceed normally.
+  A fresh pin pointing at a terminal task whose successor is
+  REPLACE-kind still routes via the existing supersedes helper (LLM
+  retried its own pin and the planner already repointed).
+* **Stale REPLACE pin** (pin_revision < current_revision, successor is
+  REPLACE-kind) — route to the successor (existing behaviour
+  preserved for the most common refine path).
+* **Stale CORRECT pin** (pin_revision < current_revision, successor is
+  CORRECT-kind) — REFUSE. The old task's terminal state is historical
+  fact; the correction is a separate work unit. ``acknowledged: True``
+  is still returned to the LLM (no prompt-injection surface), but a
+  ``task_transition_refused`` sink event flags the refusal for
+  operators.
+* **Stale ambiguous pin** (pin_revision < current_revision, no
+  supersedes successor) — REFUSE. Operator must disambiguate.
+
+Plus:
+
+* Pending-delegations entry shape evolved from ``{fc_id: task_id}``
+  to ``{fc_id: {task_id, revision}}``. Readers tolerate both for
+  back-compat.
+* Stamp is written once at ``_stamp_current_task_id`` so all 8
+  signals of the goldfive#264/#265 pin ladder pick it up uniformly.
+* Concurrent refine: the report handler waits on the steerer's
+  ``_wait_plan_stable`` barrier (#264) before reading
+  ``plan.revision_index``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    SESSION_CONTEXT_STATE_KEY,
+    SessionContext,
+    _delegation_pin_revision,
+    _delegation_pin_task_id,
+    _resolve_pinned_task_id,
+    make_adk_plugin,
+)
+from goldfive.adapters._adk_state_protocol import (  # noqa: E402
+    KEY_CURRENT_TASK_ID,
+    KEY_CURRENT_TASK_REVISION,
+)
+from goldfive.reporting import BUILTIN_REPORTING_TOOLS  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Plan,
+    Session,
+    SupersessionKind,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StateCtx:
+    """Minimal ADK-callback-context stub with a ``session.state`` dict."""
+
+    class _Session:
+        def __init__(self, state: dict) -> None:
+            self.state = state
+
+    class _ToolCtx:
+        def __init__(self, state: dict, fc_id: str) -> None:
+            self._state = state
+            self.function_call_id = fc_id
+
+        @property
+        def session(self) -> Any:
+            return _StateCtx._Session(self._state)
+
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    @property
+    def session(self) -> Any:
+        return _StateCtx._Session(self._state)
+
+
+class _Agent:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _CapturingSink:
+    """Sink stub that captures every emitted event for assertions."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event: Any) -> None:
+        self.events.append(event)
+
+    async def close(self) -> None:
+        pass
+
+
+class _SinkingSteerer:
+    """Steerer stub that exposes ``_sinks`` so the plugin emits events.
+
+    Optional ``wait_plan_stable_delay`` lets a test simulate a refine
+    in flight: the helper sleeps before returning, which is the same
+    semantic as a real DefaultSteerer holding the plan lock.
+    """
+
+    def __init__(
+        self,
+        sinks: list[Any],
+        *,
+        wait_plan_stable_delay: float = 0.0,
+        on_wait: Any = None,
+    ) -> None:
+        self._sinks = list(sinks)
+        self._wait_calls = 0
+        self._wait_delay = wait_plan_stable_delay
+        self._on_wait = on_wait
+
+    async def observe(self, *a: Any, **kw: Any) -> None:  # pragma: no cover
+        pass
+
+    async def _wait_plan_stable(self, session: Any, *, timeout: float = 1.0) -> bool:
+        self._wait_calls += 1
+        if self._on_wait is not None:
+            await self._on_wait(session)
+        if self._wait_delay > 0:
+            await asyncio.sleep(self._wait_delay)
+        return True
+
+    # No-op transitions so the report handlers can drive through.
+    async def mark_task_running(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    async def mark_task_progress(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    async def mark_task_completed(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    async def mark_task_failed(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    async def mark_task_blocked(self, *a: Any, **kw: Any) -> None:
+        pass
+
+
+def _plan_with(
+    *tasks: Task,
+    edges: list[TaskEdge] | None = None,
+    revision_index: int = 0,
+) -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=[],
+        tasks=list(tasks),
+        edges=list(edges or []),
+        summary="",
+        revision_index=revision_index,
+    )
+
+
+def _session_with(plan: Plan | None) -> Session:
+    return Session(run_id="r1", plan=plan)
+
+
+def _ctx_for(
+    session: Session,
+    agent_name: str,
+    *,
+    sinks: list[Any] | None = None,
+) -> tuple[dict, Any]:
+    """Build a ({adk_state}, callback_context) pair for plugin callbacks."""
+    steerer: Any = None
+    if sinks is not None:
+        steerer = _SinkingSteerer(sinks)
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session,
+            steerer=steerer,
+            task=None,
+            tool_handlers={},
+            host_agent_name=agent_name,
+        ),
+    }
+    return state, _StateCtx(state)
+
+
+def _tool(name: str):
+    for t in BUILTIN_REPORTING_TOOLS:
+        if t.name == name:
+            return t
+    raise AssertionError(f"builtin tool {name!r} missing")
+
+
+def _refused_events(events: list[Any]) -> list[dict]:
+    return [
+        e
+        for e in events
+        if isinstance(e, dict) and e.get("kind") == "task_transition_refused"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. Pin stamp revision is written alongside task_id (current_task_id surface).
+# ---------------------------------------------------------------------------
+
+
+async def test_pin_stamp_writes_revision_alongside_task_id() -> None:
+    """The pin ladder stamps ``current_task_revision`` on every signal."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="research", assignee_agent_id="researcher"),
+            revision_index=3,
+        )
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=[_CapturingSink()])
+
+    await plugin.before_agent_callback(
+        agent=_Agent("researcher"),
+        callback_context=ctx,
+    )
+
+    # Pin landed via signal 2 (DAG-ready exactly-1 happy path).
+    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    # And the revision stamp followed it on the same surface.
+    assert state[KEY_CURRENT_TASK_REVISION] == 3
+    # Mirrored on goldfive's session.state too (the shared contract).
+    assert session.state.get("goldfive.current_task_id") == "t1"
+    assert session.state.get("goldfive.current_task_revision") == 3
+
+
+# ---------------------------------------------------------------------------
+# 2. Pending-delegation includes revision in the new dict shape.
+# ---------------------------------------------------------------------------
+
+
+async def test_pending_delegation_carries_revision() -> None:
+    """``_pin_delegation_task_id`` writes the versioned dict shape."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="research solar", assignee_agent_id="researcher"),
+            revision_index=2,
+        )
+    )
+    state, _ = _ctx_for(session, "coord")
+    tool_ctx = _StateCtx._ToolCtx(state, fc_id="fc-42")
+
+    plugin._pin_delegation_task_id(  # type: ignore[attr-defined]
+        ctx=state[SESSION_CONTEXT_STATE_KEY],
+        tool_context=tool_ctx,
+        to_agent="researcher",
+        tool_args={"topic": "research solar"},
+    )
+
+    pend = session.state["goldfive.pending_delegations"]
+    entry = pend["fc-42"]
+    assert isinstance(entry, dict), "delegation entry must be the versioned shape"
+    assert entry["task_id"] == "t1"
+    assert entry["revision"] == 2
+
+    # And the back-compat extractors reproduce the right values.
+    assert _delegation_pin_task_id(entry) == "t1"
+    assert _delegation_pin_revision(entry) == 2
+
+
+# ---------------------------------------------------------------------------
+# 3. Handler: pin_rev == current_rev → normal transition.
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_fresh_pin_proceeds_normally() -> None:
+    plan = _plan_with(
+        Task(id="t1", title="research", assignee_agent_id="researcher"),
+        revision_index=2,
+    )
+    session = _session_with(plan)
+    session.state["goldfive.current_task_id"] = "t1"
+    session.state["goldfive.current_task_revision"] = 2
+
+    sinks = [_CapturingSink()]
+    steerer = _SinkingSteerer(sinks)
+
+    result = await _tool("report_task_started").handler(
+        {"task_id": "t1", "detail": "starting"},
+        session,
+        steerer,
+    )
+
+    assert result == {"acknowledged": True}
+    # No refusal events.
+    assert _refused_events(sinks[0].events) == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Handler: stale pin + REPLACE-supersedes successor → routes to new task.
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_stale_replace_routes_to_successor() -> None:
+    """Pre-#266 behaviour preserved for stale REPLACE-kind chains.
+
+    Refine has replaced ``research_solar`` (now FAILED) with
+    ``research_solar_v2`` (PENDING, supersedes=research_solar,
+    REPLACE-kind). The agent's pin was set under revision 1; the
+    plan is at revision 2 now. Handler should route the call onto
+    ``research_solar_v2`` and proceed.
+    """
+    plan = _plan_with(
+        Task(
+            id="research_solar",
+            title="solar v1",
+            assignee_agent_id="researcher",
+            status=TaskStatus.FAILED,
+        ),
+        Task(
+            id="research_solar_v2",
+            title="solar v2",
+            assignee_agent_id="researcher",
+            status=TaskStatus.PENDING,
+            supersedes="research_solar",
+            supersedes_kind=SupersessionKind.REPLACE,
+        ),
+        revision_index=2,
+    )
+    session = _session_with(plan)
+    session.state["goldfive.current_task_id"] = "research_solar"
+    session.state["goldfive.current_task_revision"] = 1  # stale
+
+    sinks = [_CapturingSink()]
+    steerer = _SinkingSteerer(sinks)
+
+    # Capture the task_id the steerer sees.
+    seen: dict[str, str] = {}
+
+    async def _capture(task_id: str, **kw: Any) -> None:
+        seen["task_id"] = task_id
+
+    steerer.mark_task_running = _capture  # type: ignore[assignment]
+
+    result = await _tool("report_task_started").handler(
+        {"task_id": "research_solar"},
+        session,
+        steerer,
+    )
+
+    assert result == {"acknowledged": True}
+    assert seen["task_id"] == "research_solar_v2", (
+        "stale REPLACE pin should route to the REPLACE-kind successor"
+    )
+    assert _refused_events(sinks[0].events) == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Handler: stale pin + CORRECT-supersedes successor → refuses.
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_stale_correct_refuses_and_emits_event() -> None:
+    """CORRECT-kind successor → refuse + sink event + ack-only response.
+
+    The old task's terminal state is historical fact; the correction is
+    a separate work unit. The LLM still sees ``acknowledged: True`` —
+    surfacing the refusal as an error would create a prompt-injection
+    surface. Operators see the refusal via ``task_transition_refused``.
+    """
+    plan = _plan_with(
+        Task(
+            id="research_solar",
+            title="solar (history)",
+            assignee_agent_id="researcher",
+            status=TaskStatus.COMPLETED,
+        ),
+        Task(
+            id="research_solar_corrected",
+            title="solar with correction",
+            assignee_agent_id="researcher",
+            status=TaskStatus.PENDING,
+            supersedes="research_solar",
+            supersedes_kind=SupersessionKind.CORRECT,
+        ),
+        revision_index=2,
+    )
+    session = _session_with(plan)
+    session.state["goldfive.current_task_id"] = "research_solar"
+    session.state["goldfive.current_task_revision"] = 1  # stale
+
+    sinks = [_CapturingSink()]
+    steerer = _SinkingSteerer(sinks)
+
+    seen_steerer_task_ids: list[str] = []
+
+    async def _capture(task_id: str, **kw: Any) -> None:
+        seen_steerer_task_ids.append(task_id)
+
+    steerer.mark_task_completed = _capture  # type: ignore[assignment]
+
+    result = await _tool("report_task_completed").handler(
+        {"task_id": "research_solar", "summary": "done"},
+        session,
+        steerer,
+    )
+
+    # LLM sees an ack — no prompt-injection surface.
+    assert result == {"acknowledged": True}
+    # Steerer was never driven (the call refused).
+    assert seen_steerer_task_ids == [], (
+        "stale CORRECT pin must not transition the old task; "
+        "its terminal state is historical fact"
+    )
+    # Operator sees the refusal as a sink event.
+    refused = _refused_events(sinks[0].events)
+    assert len(refused) == 1
+    payload = refused[0]["payload"]
+    assert payload["task_id"] == "research_solar"
+    assert payload["reason"] == "stale_pin_correct_supersedes"
+    assert payload["pin_revision"] == 1
+    assert payload["current_revision"] == 2
+    assert payload["attempted_to"] == TaskStatus.COMPLETED.value
+
+
+# ---------------------------------------------------------------------------
+# 6. Handler: stale pin + no supersedes → refuses (ambiguity).
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_stale_no_supersedes_refuses() -> None:
+    plan = _plan_with(
+        Task(
+            id="orphan",
+            title="orphaned by refine",
+            assignee_agent_id="researcher",
+            status=TaskStatus.RUNNING,
+        ),
+        revision_index=3,
+    )
+    session = _session_with(plan)
+    session.state["goldfive.current_task_id"] = "orphan"
+    session.state["goldfive.current_task_revision"] = 1  # stale, no successor
+
+    sinks = [_CapturingSink()]
+    steerer = _SinkingSteerer(sinks)
+
+    seen_steerer_task_ids: list[str] = []
+
+    async def _capture(task_id: str, **kw: Any) -> None:
+        seen_steerer_task_ids.append(task_id)
+
+    steerer.mark_task_progress = _capture  # type: ignore[assignment]
+
+    result = await _tool("report_task_progress").handler(
+        {"task_id": "orphan", "fraction": 0.5},
+        session,
+        steerer,
+    )
+
+    assert result == {"acknowledged": True}
+    assert seen_steerer_task_ids == [], (
+        "stale ambiguous pin must not drive the steerer"
+    )
+    refused = _refused_events(sinks[0].events)
+    assert len(refused) == 1
+    assert refused[0]["payload"]["reason"] == "stale_pin_no_supersedes"
+
+
+# ---------------------------------------------------------------------------
+# 7. Pending-delegation back-compat: legacy string entries read as revision 0.
+# ---------------------------------------------------------------------------
+
+
+def test_pending_delegations_back_compat_string_shape() -> None:
+    """Legacy ``{fc_id: task_id_str}`` entries still read cleanly."""
+    # Bare-string entry — the pre-#266 shape custom adapters may still
+    # write. Both the readers and the back-compat extractors must
+    # accept it without raising.
+    raw_str = "research_solar"
+    assert _delegation_pin_task_id(raw_str) == "research_solar"
+    assert _delegation_pin_revision(raw_str) == 0
+
+    # Dict entry — the new shape.
+    raw_dict = {"task_id": "t2", "revision": 4}
+    assert _delegation_pin_task_id(raw_dict) == "t2"
+    assert _delegation_pin_revision(raw_dict) == 4
+
+    # Malformed values fall through cleanly (don't raise).
+    assert _delegation_pin_task_id(None) == ""
+    assert _delegation_pin_revision({"task_id": "x"}) == 0  # missing rev
+
+    # _resolve_pinned_task_id resolves both shapes.
+    state_legacy: dict[str, Any] = {
+        "goldfive.pending_delegations": {"fc_X": "task_legacy"},
+    }
+    state_new: dict[str, Any] = {
+        "goldfive.pending_delegations": {
+            "fc_X": {"task_id": "task_new", "revision": 7}
+        },
+    }
+    tool_ctx_legacy = _StateCtx._ToolCtx(state_legacy, fc_id="fc_X")
+    tool_ctx_new = _StateCtx._ToolCtx(state_new, fc_id="fc_X")
+    assert _resolve_pinned_task_id(tool_context=tool_ctx_legacy) == "task_legacy"
+    assert _resolve_pinned_task_id(tool_context=tool_ctx_new) == "task_new"
+
+
+# ---------------------------------------------------------------------------
+# 8. _wait_plan_stable: handler waits for concurrent refine to land.
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_waits_for_plan_stable_during_concurrent_refine() -> None:
+    """The handler invokes ``steerer._wait_plan_stable`` before classifying.
+
+    Simulates a refine in flight: the steerer's barrier delays the
+    handler until the refine has bumped ``revision_index``. Without
+    the barrier the handler would read pre-revision state and
+    misclassify a fresh pin as stale (or vice versa).
+    """
+    plan = _plan_with(
+        Task(id="t1", title="task one", assignee_agent_id="researcher"),
+        revision_index=0,
+    )
+    session = _session_with(plan)
+    session.state["goldfive.current_task_id"] = "t1"
+    session.state["goldfive.current_task_revision"] = 0
+
+    sinks = [_CapturingSink()]
+
+    async def _bump_during_wait(_session: Any) -> None:
+        # Simulate the refine landing while the handler is parked at
+        # the barrier — increments revision_index in place.
+        plan.revision_index = 1
+
+    steerer = _SinkingSteerer(sinks, on_wait=_bump_during_wait)
+
+    result = await _tool("report_task_progress").handler(
+        {"task_id": "t1", "fraction": 0.4},
+        session,
+        steerer,
+    )
+
+    assert steerer._wait_calls >= 1, (
+        "handler must consult ``_wait_plan_stable`` before classifying"
+    )
+    # After the simulated refine landed mid-wait, the handler reads
+    # plan.revision_index=1 and pin_revision=0 → stale. The pin task
+    # has no successor → refuse. The LLM still sees ack-only.
+    assert result == {"acknowledged": True}
+    refused = _refused_events(sinks[0].events)
+    assert len(refused) == 1
+    # The refusal observed the post-refine revision.
+    assert refused[0]["payload"]["current_revision"] == 1
+    assert refused[0]["payload"]["pin_revision"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Bonus — fresh pin on a terminal task with REPLACE successor still routes.
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_fresh_pin_routes_through_replace_chain() -> None:
+    """Regression: fresh pin + terminal task + REPLACE successor still routes.
+
+    The classifier returns ``"match"`` and falls through to
+    ``_reroute_if_superseded`` — a fresh stamp must NOT regress the
+    pre-#266 retry-with-replaced-id path.
+    """
+    plan = _plan_with(
+        Task(
+            id="t_old",
+            title="old",
+            assignee_agent_id="researcher",
+            status=TaskStatus.FAILED,
+        ),
+        Task(
+            id="t_new",
+            title="replacement",
+            assignee_agent_id="researcher",
+            status=TaskStatus.PENDING,
+            supersedes="t_old",
+            supersedes_kind=SupersessionKind.REPLACE,
+        ),
+        revision_index=2,
+    )
+    session = _session_with(plan)
+    # Fresh pin (revision matches current).
+    session.state["goldfive.current_task_id"] = "t_old"
+    session.state["goldfive.current_task_revision"] = 2
+
+    sinks = [_CapturingSink()]
+    steerer = _SinkingSteerer(sinks)
+
+    seen: dict[str, str] = {}
+
+    async def _capture(task_id: str, **kw: Any) -> None:
+        seen["task_id"] = task_id
+
+    steerer.mark_task_running = _capture  # type: ignore[assignment]
+
+    result = await _tool("report_task_started").handler(
+        {"task_id": "t_old"},
+        session,
+        steerer,
+    )
+    assert result == {"acknowledged": True}
+    assert seen["task_id"] == "t_new"
+    assert _refused_events(sinks[0].events) == []


### PR DESCRIPTION
## Summary

- Stamps every pin (`current_task_id` + `pending_delegations`) with the `plan.revision_index` in effect at write time.
- Adds a report-time freshness classifier in `goldfive.reporting`: stale `REPLACE`-kind pins route (existing behaviour); stale `CORRECT`-kind pins refuse with a `task_transition_refused` sink event; stale pins with no supersedes successor refuse (ambiguity).
- LLM continues to see `{"acknowledged": True}` on refusal — no prompt-injection surface; operators consume the refusal via the new sink event.

## Why

`_resolve_effective_task_id` previously routed every late report via the `supersedes` chain. After #258 (`SupersessionKind` enum), that's right for `REPLACE` but wrong for `CORRECT` — the old task's terminal state is historical fact, the correction is a separate work unit, and routing the old report onto the correction either destroys fact or shadows the correction. Pin versioning gives handlers the per-call evidence they need to make this decision.

## Implementation notes

- Stamp written exactly once in `_stamp_current_task_id` (the shared helper invoked by all 8 signals of the goldfive#264/#265 pin ladder), so future signals pick it up automatically.
- `pending_delegations` entry shape evolved from `{fc_id: task_id_str}` to `{fc_id: {"task_id": str, "revision": int}}`. Two back-compat extractors (`_delegation_pin_task_id`, `_delegation_pin_revision`) handle the read path; both surfaces tolerate legacy string values.
- Handlers that previously called `_reroute_if_superseded` now call `_classify_and_route_pin`, which delegates to the legacy helper when the pin has no stamp (legacy session / custom adapter / pre-existing test stub) so unaffected callers keep working unchanged.
- Uses #264's `steerer._wait_plan_stable` barrier before reading `plan.revision_index` so concurrent refines don't race the classifier.

## Test plan

- [x] `tests/test_pin_versioning.py` — 9 new tests covering: stamp written, pending-delegation revision dict shape, fresh pin proceeds, stale REPLACE routes, stale CORRECT refuses + emits `task_transition_refused`, stale ambiguous refuses, back-compat string entries read cleanly, `_wait_plan_stable` barrier observed, fresh pin still routes through REPLACE chain.
- [x] Existing tests (1574 pass, 46 skip) — updated `tests/test_hidden_task_id_schema.py` to use the back-compat extractor on `pending_delegations` reads (entries are dicts now).
- [x] `uv run ruff check goldfive/ tests/` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)