### PR TITLE
feat(adapters): pin ladder signal 3 — parent AgentTool args (#265 followup)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -466,6 +466,26 @@ def _delegation_pin_revision(raw: Any) -> int:
     return 0
 
 
+def _delegation_pin_tool_args(raw: Any) -> Mapping[str, Any] | None:
+    """Return the parent AgentTool's tool-call args from an entry, or ``None``.
+
+    Pre-F7 (string-shaped or ``{task_id, revision}``) entries return
+    ``None`` — they predate the tool-args stamp added in #265-followup.
+    Signal 3 of :meth:`_pin_current_task_id_for_agent` consults this
+    to score DAG-ready candidates against the dispatch args (the
+    strongest available signal: the parent literally said "go do
+    *this*"). Falls back to steer body / goals when ``None`` or empty.
+    """
+    if not isinstance(raw, Mapping):
+        return None
+    args = raw.get("tool_args", None)
+    if not isinstance(args, Mapping):
+        return None
+    if not args:
+        return None
+    return args
+
+
 def _function_call_id_from_tool_context(tool_context: Any) -> str:
     """Best-effort extraction of the current ``function_call_id``.
 
@@ -2250,41 +2270,62 @@ def make_adk_plugin(
             callback_context: Any,
             parent_invocation_id: str,
         ) -> Any:
-            """Return a token-bag string for tool-arg scoring, or ``None``.
+            """Return a token-bag string-or-mapping for tool-arg scoring, or ``None``.
 
             Signal 3/4/8 score candidates by token overlap with whatever
             we have for "what was this agent invoked for". In priority
             order:
 
-            1. Parent invocation's last AgentTool args, if we have a
-               record (best signal — exact dispatch payload).
+            1. Parent invocation's AgentTool tool-call args, recorded
+               on ``pending_delegations[<fc_id>].tool_args`` by
+               :meth:`_pin_delegation_task_id` (F7 — #265 followup).
+               This is the strongest signal: the parent literally
+               said "go do *this*". Skipped silently when the entry
+               is pre-F7-shaped (string-only or
+               ``{task_id, revision}`` without ``tool_args``) or when
+               the recorded args produce zero meaningful tokens (e.g.
+               an opaque blob / empty dispatch).
             2. The active steer body — operators usually phrase the
                steer with task-named tokens.
             3. The session's goal summary — broad fallback that at
                least disambiguates by domain vocabulary.
+            4. Goals on the session itself (some test harnesses don't
+               populate the orchestration-state mirror).
 
             Returns whatever non-empty string-or-mapping we found, or
             ``None`` when there's nothing to score against (in which
             case the score-based signals fall through silently).
             """
-            # 1) Parent invocation's last AgentTool args. The plugin's
-            # before_tool_callback already tracks pending_delegations
-            # keyed by function_call_id — that's a per-dispatch pin,
-            # not a per-invocation tool-args record. Without a richer
-            # record we synthesise the best we can: the steer body or
-            # the active-steer-targeting drift detail tends to carry
-            # the same vocabulary as the dispatch.
             session_state = _safe_attr(ctx.session, "state", None)
+            # 1) Parent's AgentTool tool-call args. Iterate
+            # pending_delegations and merge any tool_args payloads we
+            # find — pending entries are usually short-lived (stamped
+            # right before the sub-agent fires, cleared after report)
+            # so the union is a reasonable heuristic when multiple
+            # parallel dispatches landed. Skip when the merged dict
+            # tokenises to nothing.
             if isinstance(session_state, Mapping):
-                # Active steer body is a strong signal when present.
+                pend = session_state.get(_PENDING_DELEGATIONS_KEY)
+                if isinstance(pend, Mapping) and pend:
+                    merged: dict[str, Any] = {}
+                    for raw_entry in pend.values():
+                        ta = _delegation_pin_tool_args(raw_entry)
+                        if ta is None:
+                            continue
+                        merged.update(ta)
+                    if merged and _tokenize_for_matching(
+                        " ".join(f"{k} {v}" for k, v in merged.items())
+                    ):
+                        return merged
+            # 2) Active steer body / goals summary mirrored on session.state.
+            if isinstance(session_state, Mapping):
                 steer_body = session_state.get("goldfive.active_steer.body", "")
                 if isinstance(steer_body, str) and steer_body.strip():
                     return steer_body
                 goals_summary = session_state.get("goldfive.goals_summary", "")
                 if isinstance(goals_summary, str) and goals_summary.strip():
                     return goals_summary
-            # 2) Goals on the session itself (some test harnesses don't
-            # populate the orchestration-state mirror).
+            # 3) Goals on the session itself.
             goals = _safe_attr(ctx.session, "goals", None) or []
             if goals:
                 summaries = [
@@ -2293,7 +2334,7 @@ def make_adk_plugin(
                 joined = " ".join(s for s in summaries if s).strip()
                 if joined:
                     return joined
-            # 3) Nothing to score against.
+            # 4) Nothing to score against.
             _ = parent_invocation_id  # intentionally unused; kept for future plumbing
             return None
 
@@ -2709,7 +2750,19 @@ def make_adk_plugin(
                 )
             except (TypeError, ValueError):
                 pin_revision = 0
-            entry = {"task_id": task_id, "revision": pin_revision}
+            entry: dict[str, Any] = {
+                "task_id": task_id,
+                "revision": pin_revision,
+            }
+            # F7 (#265 followup) — also record the parent's AgentTool
+            # tool-call args. Signal 3 of
+            # :meth:`_pin_current_task_id_for_agent` reads this back as
+            # the highest-priority scoring source (above the active
+            # steer body / goals summary). Only stamp a Mapping; opaque
+            # blobs / non-dict args are treated as "no useful tokens"
+            # and skipped so reads don't have to disambiguate shape.
+            if isinstance(tool_args, Mapping) and tool_args:
+                entry["tool_args"] = dict(tool_args)
             # Stamp the pin onto BOTH the goldfive orchestration
             # session.state (so reporting-tool handlers that read it
             # directly see it) AND the ADK tool_context session.state

--- a/tests/test_pin_resolution_ladder.py
+++ b/tests/test_pin_resolution_ladder.py
@@ -254,6 +254,155 @@ async def test_signal3_arg_scoring_breaks_dag_ready_tie() -> None:
     assert events[-1]["payload"]["via_signal"] == "arg_scored"
 
 
+async def test_signal3_parent_tool_args_outrank_steer_body() -> None:
+    """Parent's stamped AgentTool tool_args is the highest-priority signal 3 source.
+
+    F7 (#265 followup): :meth:`_pin_delegation_task_id` records
+    ``{tool_args: dict}`` on every pending-delegations entry. When
+    signal 1 fails to bind (e.g. signal-1 iterates pend.values()
+    looking for a task-id match but the entry's task is no longer
+    PENDING/RUNNING — or the test stamps an entry whose tid doesn't
+    exist) and signal 2 ties, signal 3's :meth:`_scoring_args_for`
+    consults the recorded parent args BEFORE the steer body / goals
+    summary fallback.
+
+    This test stages a deliberate conflict: the steer body biases
+    toward ``t2`` ("invoices"), but the parent's recorded tool_args
+    bias toward ``t1`` ("solar"). Signal 3 must pick t1, proving
+    parent-args win.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(
+                id="t1",
+                title="solar telemetry research",
+                description="gather solar telemetry",
+                assignee_agent_id="researcher",
+            ),
+            Task(
+                id="t2",
+                title="quarterly invoice review",
+                description="reconcile quarterly invoices",
+                assignee_agent_id="researcher",
+            ),
+        )
+    )
+    # Parent's tool_args bias toward t1 (solar). Use an entry whose
+    # task_id doesn't exist in the plan so signal 1 skips and we drop
+    # into signal 3.
+    session.state["goldfive.pending_delegations"] = {
+        "fc-parent": {
+            "task_id": "missing_id",
+            "revision": 0,
+            "tool_args": {"prompt": "research solar telemetry now"},
+        },
+    }
+    # Steer body biases toward t2 (invoices) — must NOT win.
+    session.state["goldfive.active_steer.body"] = (
+        "look at the quarterly invoices"
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("researcher"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t1", (
+        "parent tool_args (solar) should outrank steer body (invoices)"
+    )
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "arg_scored"
+
+
+async def test_signal3_empty_parent_tool_args_falls_to_steer_body() -> None:
+    """Empty / non-mapping parent tool_args → fall through to steer body.
+
+    F7 hazard: dispatches with no args (or opaque blobs) tokenise to
+    nothing and would otherwise bias signal 3 against the existing
+    steer-body fallback. The signal-3 source priority must skip a
+    parent-args bag that produces zero meaningful tokens.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(
+                id="t1",
+                title="solar telemetry research",
+                description="gather solar telemetry",
+                assignee_agent_id="researcher",
+            ),
+            Task(
+                id="t2",
+                title="quarterly invoice review",
+                description="reconcile quarterly invoices",
+                assignee_agent_id="researcher",
+            ),
+        )
+    )
+    # Parent stamped an entry but with empty / noise-only tool_args.
+    # The token bag should be empty, so signal 3 falls through to the
+    # steer-body branch which biases t2.
+    session.state["goldfive.pending_delegations"] = {
+        "fc-parent": {
+            "task_id": "missing_id",
+            "revision": 0,
+            "tool_args": {},  # empty → skipped
+        },
+    }
+    session.state["goldfive.active_steer.body"] = (
+        "focus on quarterly invoices, not solar"
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("researcher"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t2", (
+        "empty parent tool_args should fall through to steer body"
+    )
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "arg_scored"
+
+
+async def test_signal3_pre_f7_string_pending_delegation_back_compat() -> None:
+    """Pre-F7 (string-only) pending_delegation entries still resolve via signal 1.
+
+    Custom adapters or test fixtures that stamp ``{fc_id: "task_id"}``
+    (the legacy shape, before #266 versioning and before F7 tool_args)
+    must keep working unchanged. This regression pins the back-compat
+    contract: signal 1 reads the bare-string entry, finds the task,
+    and pins it. Signal 3's parent-args branch is silently skipped
+    because :func:`_delegation_pin_tool_args` returns ``None`` for the
+    legacy shape.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(id="t1", title="first", assignee_agent_id="researcher"),
+            Task(id="t2", title="second", assignee_agent_id="researcher"),
+        )
+    )
+    # Legacy shape: bare-string task_id, no revision, no tool_args.
+    session.state["goldfive.pending_delegations"] = {"fc-old": "t2"}
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("researcher"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t2"
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "delegation_pin"
+
+
 async def test_signal3_tie_falls_through_to_signal4() -> None:
     """When tool-arg scoring ties, fall through to signal 4.
 


### PR DESCRIPTION
## Summary

PR #265's brief proposed scoring DAG-ready ambiguous candidates against the parent invocation's AgentTool tool-call args, but the shipping agent deferred that as future-plumbing and used fallback sources (active steer body, goals summary, session goals) instead.

E2E found signal 3+ failing to disambiguate a vanilla "research_agent with multiple candidate tasks" scenario — 6 `pin_unresolved` drifts fired despite goldfive having clear context (the coordinator's AgentTool dispatch had a prompt mentioning the relevant task).

This PR adds the missing source:

- `_pin_delegation_task_id` now records the parent's tool-call args alongside `{task_id, revision}` on each pending_delegations entry.
- `_scoring_args_for` (signal 3 / 4 / 8 source helper) consults parent-args FIRST, falling back to steer body / goals summary / session goals when parent-args tokenise to nothing (empty dispatch / opaque blob).
- Pending-delegations shape evolves: legacy `{fc_id: "task_id_str"}` → `#266` `{fc_id: {task_id, revision}}` → F7 `{fc_id: {task_id, revision, tool_args?}}`. Readers tolerate all three shapes for back-compat with custom adapters and pre-bump fixtures.
- Added `_delegation_pin_tool_args(raw)` extractor (returns `None` for legacy / no-args entries).

## Test plan

- [x] 3 new tests in `tests/test_pin_resolution_ladder.py`:
  - `test_signal3_parent_tool_args_outrank_steer_body` — parent args bias t1, steer body biases t2; pin lands on t1.
  - `test_signal3_empty_parent_tool_args_falls_to_steer_body` — empty args dict skipped, steer body wins.
  - `test_signal3_pre_f7_string_pending_delegation_back_compat` — bare-string entry still resolves via signal 1.
- [x] Full suite: 1587 passed, 46 skipped.
- [x] `ruff check goldfive/` clean.