### PR TITLE
fix(runner): route user-steer follow-ups through steerer (regression from #210)

### DIFF
--- a/goldfive/events.py
+++ b/goldfive/events.py
@@ -775,8 +775,22 @@ def task_transitioned_event(
 
     ``source`` vocabulary (see proto comment for the full list):
     ``"llm_report"`` / ``"handler_default"`` / ``"supersedes_reroute"``
-    / ``"plan_revision"`` / ``"cancellation"`` / ``"other"``. Readers
-    MUST tolerate unknown values for forward-compat.
+    / ``"plan_revision"`` / ``"cancellation"`` / ``"executor_dispatch"``
+    / ``"control_rewind"`` / ``"other"``. Readers MUST tolerate unknown
+    values for forward-compat.
+
+    ``"executor_dispatch"`` (F10) — driven by an executor's framework
+    auto-start of a task (the ``ParallelDAGExecutor.run_one`` path
+    that flips ``task.status = RUNNING`` before the adapter invoke);
+    distinguishes a framework-initiated PENDING -> RUNNING from
+    ``"handler_default"`` (LLM ``report_task_*`` with a defaulted pin)
+    and from generic ``"other"``.
+
+    ``"control_rewind"`` (F10) — driven by a ``REWIND_TO`` control
+    message in :mod:`goldfive.executors._control`; the helper marks
+    the target task and every downstream task PENDING so the
+    executor re-walks them. One transition is emitted per affected
+    task.
 
     ``from_status`` / ``to_status`` are the bare lowercase
     :class:`~goldfive.types.TaskStatus` values (``"PENDING"`` /

--- a/goldfive/executors/_control.py
+++ b/goldfive/executors/_control.py
@@ -245,8 +245,8 @@ async def dispatch_control(
                     detail="rewind_to requires payload.task_id",
                 ),
             )
-        ok = _rewind_plan(session, target)
-        if not ok:
+        transitions = _rewind_plan(session, target)
+        if transitions is None:
             return ControlOutcome(
                 ack=_build_ack(
                     msg,
@@ -254,6 +254,32 @@ async def dispatch_control(
                     detail=f"rewind_to: unknown task_id={target!r}",
                 ),
             )
+        # F10 / goldfive#251 R4: emit one ``TaskTransitioned`` with
+        # ``source="control_rewind"`` per affected task so operator
+        # triage can distinguish a control-driven rewind from a
+        # cancellation cascade or a plan_revision flip. The steerer's
+        # _emit_task_transitioned helper is duck-typed on purpose
+        # (custom Steerers may not implement it); failures are
+        # swallowed at debug — observability MUST NOT break the
+        # control path.
+        emit_transition = getattr(steerer, "_emit_task_transitioned", None)
+        if callable(emit_transition):
+            for task, prev_status in transitions:
+                try:
+                    await emit_transition(
+                        session,
+                        task,
+                        from_status=prev_status,
+                        to_status=TaskStatus.PENDING,
+                        source="control_rewind",
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "dispatch_control: TaskTransitioned emit raised for "
+                        "REWIND_TO task=%s: %s",
+                        getattr(task, "id", "?"),
+                        exc,
+                    )
         return ControlOutcome(
             ack=_build_ack(
                 msg,
@@ -421,19 +447,31 @@ async def _resolve_approval(
     return True
 
 
-def _rewind_plan(session: Session, target_task_id: str) -> bool:
+def _rewind_plan(
+    session: Session, target_task_id: str
+) -> list[tuple[Any, TaskStatus]] | None:
     """Reset ``target`` and every downstream task back to ``PENDING``.
 
     Any task transitively reachable from ``target`` via ``plan.edges``
-    is considered downstream. Returns ``True`` if ``target`` exists
-    in the session's plan, else ``False``.
+    is considered downstream. Returns ``None`` if ``target`` does not
+    exist in the session's plan; otherwise returns a list of
+    ``(task, previous_status)`` pairs for every task whose status
+    actually changed (i.e. was non-PENDING before the rewind). The
+    caller uses this list to emit one ``TaskTransitioned`` event per
+    affected task with ``source="control_rewind"``.
+
+    F10 / goldfive#251 R4: emitting from the dispatcher (rather than
+    here) keeps this helper sync + dependency-free, while still giving
+    the typed-observability layer a precise per-task transition row
+    that operators can distinguish from ``cancellation`` cascades and
+    ``plan_revision`` flips.
     """
     plan = session.plan
     if plan is None:
-        return False
+        return None
     tasks_by_id = {t.id: t for t in plan.tasks if t.id}
     if target_task_id not in tasks_by_id:
-        return False
+        return None
 
     children: dict[str, list[str]] = {tid: [] for tid in tasks_by_id}
     for e in plan.edges:
@@ -451,9 +489,13 @@ def _rewind_plan(session: Session, target_task_id: str) -> bool:
             if child not in affected:
                 stack.append(child)
 
+    transitions: list[tuple[Any, TaskStatus]] = []
     for tid in affected:
         task = tasks_by_id[tid]
+        prev = task.status
+        if prev is not TaskStatus.PENDING:
+            transitions.append((task, prev))
         task.status = TaskStatus.PENDING
         session.completed_results.pop(tid, None)
         session.task_progress.pop(tid, None)
-    return True
+    return transitions

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -485,7 +485,34 @@ class ParallelDAGExecutor:
             if sem is not None:
                 await sem.acquire()
             try:
+                # F10 / goldfive#251 R4: framework auto-start of a task
+                # is a real status transition (PENDING -> RUNNING) and
+                # deserves a dedicated source label so operators can
+                # tell it apart from ``handler_default`` (LLM tool call
+                # where ``task_id`` defaulted) and ``other`` (catch-all).
+                # Emit BEFORE the adapter invoke so the transition row
+                # lands in the wire order operators expect (transition
+                # then activity).
+                prev_status = task.status
                 task.status = TaskStatus.RUNNING
+                if prev_status is not TaskStatus.RUNNING:
+                    emit_transition = getattr(steerer, "_emit_task_transitioned", None)
+                    if callable(emit_transition):
+                        try:
+                            await emit_transition(
+                                session,
+                                task,
+                                from_status=prev_status,
+                                to_status=TaskStatus.RUNNING,
+                                source="executor_dispatch",
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            log.debug(
+                                "ParallelDAGExecutor: TaskTransitioned emit raised "
+                                "for task=%s: %s",
+                                task.id,
+                                exc,
+                            )
                 try:
                     inv: InvocationResult | None = await adapter.invoke(task, session)
                 except asyncio.CancelledError:

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -64,7 +64,6 @@ from goldfive.reporting import BUILTIN_REPORTING_TOOLS
 from goldfive.results import ExecutionOutcome
 from goldfive.steerer import DefaultSteerer
 from goldfive.types import (
-    GOAL_SOURCE_USER_STEER,
     DriftEvent,
     DriftKind,
     DriftSeverity,
@@ -391,19 +390,109 @@ class Runner:
         else:
             available_agents = list(self.agent.available_agents)
         plan: Plan | None = None
+        # Set when the refine_existing branch routed through the steerer
+        # and successfully installed a revised plan via _apply_revision.
+        # PlanRevised was already emitted there, so the post-planning
+        # code skips _emit_plan_submitted for this turn.
+        revised_via_steerer = False
         if verdict == "refine_existing" and self._last_plan is not None:
-            # Refine path: treat the new user_input as a steering
-            # directive against the prior plan. Preserves completed
-            # tasks verbatim and asks the planner for a delta of new
-            # PENDING tasks. On any refine failure we fall through to
-            # full generate() below — the safe path is always to ship
-            # a plan.
-            plan = await self._refine_from_user_input(
-                prior_plan=self._last_plan,
-                user_input=user_input if isinstance(user_input, str) else "",
-                goals=list(session.goals),
-                available_agents=available_agents,
-            )
+            # Refine path: route the new user_input through the
+            # steerer's drift-handling pipeline as a synthetic
+            # USER_STEER drift. The steerer's pipeline is the only
+            # site that emits DriftDetected(USER_STEER), preserves
+            # sticky goals via _apply_user_steer_state, drives the
+            # severity ladder, and emits PlanRevised (with the #264
+            # atomicity barrier, RefineAttempted/Failed, the #263
+            # supersedes-coverage validator, and a stable plan_id +
+            # bumped revision_index from _apply_revision). The
+            # pre-#210 fix-bypass path (calling planner.refine
+            # directly + emitting PlanSubmitted on the result) is
+            # gone: it dropped DriftDetected, fresh-minted the
+            # plan_id, reset revision_index, and silently bypassed
+            # every typed observability hook from #258-#267.
+            #
+            # On any refine failure inside the steerer (planner.refine
+            # raised, returned None, or validation rejected the
+            # output), session.plan stays equal to the carried-prior;
+            # we detect that below and fall through to planner.generate.
+            user_text = user_input.strip() if isinstance(user_input, str) else ""
+            if user_text:
+                # Carry the prior plan onto the live session so the
+                # steerer's _apply_revision can compute revision_index
+                # from prev_plan.revision_index + 1 and so a refine
+                # failure leaves the session in a recoverable state.
+                # Mutate run_id so any sink emissions correlate with
+                # this turn (mirrors the conversational path).
+                prior_plan = self._last_plan
+                prior_plan.run_id = session.run_id
+                session.plan = prior_plan
+                _ostate.set_current_plan(session.state, prior_plan)
+                # Bind the steerer early so _handle_drift has sinks +
+                # planner. bind() is idempotent — step 6 below re-binds
+                # with the same args, harmless. bind_adapter() is also
+                # safe to call early; the adapter wiring (step 6b)
+                # re-runs after this. We deliberately do NOT run the
+                # adapter-side bind_steerer here — that hook is also
+                # idempotent at step 6b but we want the steerer-only
+                # plumbing to surface refine emissions, not adapter
+                # plugin callbacks.
+                try:
+                    self.steerer.bind(sinks=list(self.sinks), planner=self.planner)
+                    bind_steerer_adapter = getattr(self.steerer, "bind_adapter", None)
+                    if callable(bind_steerer_adapter):
+                        try:
+                            bind_steerer_adapter(self.agent)
+                        except Exception as exc:  # noqa: BLE001
+                            log.debug(
+                                "steerer.bind_adapter raised on refine_existing path: %s",
+                                exc,
+                            )
+                except Exception as exc:  # noqa: BLE001
+                    # If the bind itself fails, fall through to full
+                    # generate() — the safe path always ships a plan.
+                    log.warning(
+                        "steerer.bind raised on refine_existing path; "
+                        "falling back to generate: %s",
+                        exc,
+                    )
+                else:
+                    # WARNING matches the severity the steerer
+                    # synthesizes for a USER_STEER drift coerced from a
+                    # ControlMessage (see _drift_from_steer_event).
+                    # USER_STEER bypasses the severity gate in
+                    # _should_request_cancel_for_drift anyway — an
+                    # operator directive always honours the cancel +
+                    # refine path.
+                    drift = DriftEvent(
+                        kind=DriftKind.USER_STEER,
+                        severity=DriftSeverity.WARNING,
+                        detail=user_text,
+                    )
+                    try:
+                        await self.steerer._handle_drift(drift, session)
+                    except Exception as exc:  # noqa: BLE001
+                        # Steerer failures must not break the run.
+                        # Reset session.plan so the fall-through to
+                        # generate() below treats this as no-plan.
+                        log.warning(
+                            "steerer._handle_drift raised on refine_existing path; "
+                            "falling back to generate: %s",
+                            exc,
+                        )
+                        session.plan = None
+                    else:
+                        # _apply_revision installs the revised plan
+                        # in-place when refine succeeded — picked up
+                        # via session.plan. If the steerer left
+                        # session.plan unchanged (refine returned
+                        # None / raised / validation rejected the
+                        # revision) it is still the prior plan; reset
+                        # it so the fall-through to generate() runs.
+                        if session.plan is prior_plan:
+                            session.plan = None
+                        else:
+                            plan = session.plan
+                            revised_via_steerer = True
         if plan is None:
             try:
                 plan = await self.planner.generate(
@@ -442,7 +531,13 @@ class Runner:
         # plan id.
         _ostate.set_current_plan(session.state, plan)
 
-        await self._emit_plan_submitted(session, plan)
+        # PlanSubmitted is for fresh plans only. When the
+        # refine_existing branch routed through the steerer and
+        # _apply_revision installed a revised plan, the steerer
+        # already emitted PlanRevised — skip the new-plan event so we
+        # don't double-announce the plan.
+        if not revised_via_steerer:
+            await self._emit_plan_submitted(session, plan)
 
         # 5. Register the seven canonical reporting tools on the adapter.
         try:
@@ -1049,64 +1144,6 @@ class Runner:
             outcome, user_input_summary=_initial_goal_summary(user_input)
         )
         return outcome
-
-    async def _refine_from_user_input(
-        self,
-        *,
-        prior_plan: Plan,
-        user_input: str,
-        goals: list[Goal],
-        available_agents: Any,
-    ) -> Plan | None:
-        """Build a synthetic USER_STEER drift and call ``planner.refine``.
-
-        The new user_input is treated as a steering directive against
-        the prior plan. Returns ``None`` if the planner doesn't
-        support refine or any step raises — the caller then falls
-        through to :meth:`Planner.generate`, which is always safe.
-        """
-        if not user_input.strip():
-            return None
-        refine = getattr(self.planner, "refine", None)
-        if refine is None:
-            return None
-        # Synthesize a steer Goal so the refine prompt can reference it.
-        synth = getattr(self.planner, "synthesize_goal_from_steer", None)
-        steer_goal: Goal | None = None
-        if callable(synth):
-            try:
-                pair = await synth(user_input)
-            except Exception as exc:  # noqa: BLE001
-                log.debug("synthesize_goal_from_steer raised: %s", exc)
-                pair = None
-            if pair is not None:
-                steer_goal, _mode = pair
-        if steer_goal is None:
-            steer_goal = Goal(
-                id="steer",
-                summary=user_input.strip(),
-                source=GOAL_SOURCE_USER_STEER,
-            )
-        else:
-            steer_goal.source = GOAL_SOURCE_USER_STEER
-        refine_goals = list(goals)
-        refine_goals.append(steer_goal)
-        drift = DriftEvent(
-            kind=DriftKind.USER_STEER,
-            severity=DriftSeverity.HIGH,
-            detail=user_input.strip(),
-        )
-        try:
-            return await refine(
-                plan=prior_plan,
-                drift=drift,
-                goals=refine_goals,
-                observed_actions=None,
-                available_agents=available_agents,
-            )
-        except Exception as exc:  # noqa: BLE001
-            log.warning("planner.refine raised from planner_gate path: %s", exc)
-            return None
 
     async def _resolve_goals(
         self,

--- a/proto/goldfive/v1/events.proto
+++ b/proto/goldfive/v1/events.proto
@@ -692,11 +692,26 @@ message InvocationCancelled {
 //                                C) transitioned a running task as a
 //                                consequence (cascade-cancel from a
 //                                CRITICAL drift).
+//   * ``"executor_dispatch"``  — driven by an executor's framework
+//                                auto-start of a task (the
+//                                ``ParallelDAGExecutor.run_one`` path
+//                                that flips ``task.status = RUNNING``
+//                                before the adapter invoke). Distinct
+//                                from ``handler_default`` (LLM tool
+//                                call where ``task_id`` defaulted) and
+//                                from generic ``other``.
+//   * ``"control_rewind"``     — driven by a ``REWIND_TO`` control
+//                                message in
+//                                :mod:`goldfive.executors._control`;
+//                                marks the target task and every
+//                                downstream task PENDING so the
+//                                executor re-walks them. One
+//                                transition is emitted per affected
+//                                task.
 //   * ``"other"``              — any transition that doesn't match a
-//                                more specific source (e.g. framework
-//                                auto-start, control-message rewinds).
-//                                Operators can still surface the row;
-//                                a follow-up may refine the vocabulary.
+//                                more specific source. Operators can
+//                                still surface the row; a follow-up
+//                                may refine the vocabulary.
 message TaskTransitioned {
   // The task that transitioned. After supersedes-reroute this is the
   // SUCCESSOR task id (the one whose status actually changed), not the

--- a/tests/test_runner_user_steer_routing.py
+++ b/tests/test_runner_user_steer_routing.py
@@ -1,0 +1,321 @@
+"""F1 / regression: turn-aware planning gate ``refine_existing`` branch
+must route through the steerer.
+
+PR #210 introduced the planning gate with three verdicts (``new_work``
+/ ``conversational`` / ``refine_existing``). The ``refine_existing``
+branch called ``planner.refine`` directly and treated the output as a
+fresh plan via ``_emit_plan_submitted`` — bypassing every typed
+observability hook from #258-#267 that lives on the steerer's
+drift-handling pipeline.
+
+This test pins the post-fix routing: a ``refine_existing`` verdict
+synthesizes a ``DriftEvent(USER_STEER)`` and hands it to
+``DefaultSteerer._handle_drift``, which:
+
+* emits ``DriftDetected(USER_STEER)`` to sinks,
+* applies user-steer state (sticky goals, processed_steer dedupe),
+* dispatches ``planner.refine`` via the severity ladder,
+* installs the revised plan via ``_apply_revision`` (preserving the
+  prior plan's id and bumping ``revision_index``),
+* emits ``PlanRevised`` (with ``RefineAttempted``/``RefineFailed``
+  from #264, supersedes-coverage validator from #263, atomicity
+  barrier from #264).
+
+Today's E2E (2026-04-24) found this end-to-end: turn-2 steer
+"forget X. tell me about Y." produced a brand-new plan with no
+PlanRevised event, no USER_STEER drift, and silently dropped the
+prior plan's constraints. This test is the unit-level pin for that
+fix.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive import (  # noqa: E402
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    LLMPlanner,
+    PassthroughGoalDeriver,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _kinds(events: list[Any]) -> list[str]:
+    """Capitalize the proto oneof name into a CamelCase event name."""
+    out: list[str] = []
+    for e in events:
+        try:
+            name = e.WhichOneof("payload") or ""
+        except Exception:  # noqa: BLE001
+            name = ""
+        out.append("".join(part.capitalize() for part in name.split("_")) if name else "")
+    return out
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = tools, session
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+def _planner_call_llm_factory(
+    *,
+    turn1_plan: str,
+    turn2_verdict: str,
+    refined_plan: str | None,
+    on_synthesize: str | None = None,
+):
+    """Build an ``async call_llm`` that branches on the system prompt.
+
+    Routes:
+
+    * ``turn-classifier`` system prompt -> turn 2 returns
+      ``turn2_verdict`` (turn 1 returns ``new_work``).
+    * Synthesize-goal system prompt -> ``on_synthesize`` (or a sane
+      default JSON shape).
+    * Refine system prompt -> ``refined_plan``; ``None`` raises.
+    * Anything else -> ``turn1_plan`` (the fresh-plan path).
+    """
+    async def _call_llm(system: str, user: str, model: str) -> str:
+        _ = model
+        # Turn 1 has no prior plan, so the Runner skips the gate
+        # (line ~309 in runner.py: ``if self._last_plan is not None``).
+        # Every "turn-classifier" call therefore corresponds to turn 2+
+        # — return ``turn2_verdict`` deterministically.
+        if "turn-classifier" in system:
+            return json.dumps({"verdict": turn2_verdict, "reason": "follow-up"})
+        # _SYNTHESIZE_GOAL_SYSTEM_PROMPT is invoked from
+        # planner.synthesize_goal_from_steer; the user prompt prefix is
+        # "STEERING DIRECTIVE:" — distinct from the refine_steer
+        # _USER_STEER_SYSTEM_PROMPT which says "STEERING directive"
+        # (lowercase "directive") and "STEERING NOTE" in the body.
+        if "STEERING DIRECTIVE:" in user:
+            return on_synthesize or json.dumps(
+                {"goal": {"id": "g-steer", "summary": "y"}, "mode": "append"}
+            )
+        # USER_STEER refine system prompt uniquely contains
+        # "STEERING directive" (lowercase d) and "in-flight plan".
+        if "STEERING directive" in system or "in-flight plan" in system:
+            if refined_plan is None:
+                raise RuntimeError("refine forced to fail in test")
+            return refined_plan
+        # Generic refine system prompt (non-USER_STEER) contains "drift
+        # event" — kept as a separate branch in case future tests need
+        # it; today our refine_existing test only hits the USER_STEER
+        # path.
+        if "drift event" in system:
+            if refined_plan is None:
+                raise RuntimeError("refine forced to fail in test")
+            return refined_plan
+        # Default: a fresh-plan generate call.
+        return turn1_plan
+
+    return _call_llm
+
+
+# ---------------------------------------------------------------------------
+# 1. refine_existing routes through the steerer + emits DriftDetected
+#    + emits PlanRevised (NOT PlanSubmitted)
+# ---------------------------------------------------------------------------
+
+
+async def test_refine_existing_routes_through_steerer_and_emits_plan_revised() -> None:
+    """The fix: ``refine_existing`` verdict on turn 2 must emit
+    ``DriftDetected(USER_STEER)`` and ``PlanRevised`` (with bumped
+    ``revision_index`` and a stable ``plan_id``), and MUST NOT emit
+    ``PlanSubmitted`` for the revised plan.
+    """
+    turn1_plan = json.dumps(
+        {
+            "id": "plan-original",
+            "summary": "first plan",
+            "tasks": [
+                {"id": "t1", "title": "T1", "assignee_agent_id": "writer"},
+                {"id": "t2", "title": "T2", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+    refined_plan = json.dumps(
+        {
+            "id": "plan-original",  # planner.refine reuses prior plan id
+            "summary": "revised plan",
+            "tasks": [
+                {
+                    "id": "t1",
+                    "title": "T1",
+                    "assignee_agent_id": "writer",
+                    "status": "COMPLETED",
+                },
+                {"id": "t3", "title": "T3 (steer)", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+
+    planner = LLMPlanner(
+        call_llm=_planner_call_llm_factory(
+            turn1_plan=turn1_plan,
+            turn2_verdict="refine_existing",
+            refined_plan=refined_plan,
+        ),
+        model="stub",
+    )
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    out1 = await runner.run("make a 2-slide presentation about solar")
+    assert out1.success
+    turn1_plan_id = out1.session.plan.id
+    turn1_revision_index = out1.session.plan.revision_index
+    turn1_end = len(sink.events)
+
+    out2 = await runner.run("forget solar. tell me about wind power instead.")
+    await runner.close()
+    assert out2.success
+
+    turn2_kinds = _kinds(sink.events[turn1_end:])
+
+    # ------------------------------------------------------------------
+    # F1 root-cause assertions
+    # ------------------------------------------------------------------
+    # The steerer's pipeline emits DriftDetected before refining.
+    assert "DriftDetected" in turn2_kinds, (
+        "USER_STEER drift must appear on the wire — the bug bypassed "
+        "_emit_drift_detected by calling planner.refine directly."
+    )
+    # PlanRevised is the steerer's emit; PlanSubmitted is for fresh plans.
+    assert "PlanRevised" in turn2_kinds, (
+        "refine_existing branch must emit PlanRevised via the steerer; "
+        "the bug emitted PlanSubmitted instead, fresh-minting plan_id."
+    )
+    assert "PlanSubmitted" not in turn2_kinds, (
+        "PlanSubmitted is for fresh plans only — the refined plan is "
+        "announced via PlanRevised, not PlanSubmitted."
+    )
+
+    # The drift detected this turn must be a USER_STEER.
+    drift_kinds_seen: list[int] = []
+    for e in sink.events[turn1_end:]:
+        try:
+            if e.WhichOneof("payload") == "drift_detected":
+                drift_kinds_seen.append(e.drift_detected.kind)
+        except Exception:  # noqa: BLE001
+            continue
+    # DriftKind.USER_STEER's int value — resolved against the proto for stability.
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    assert types_pb2.DRIFT_KIND_USER_STEER in drift_kinds_seen, (
+        "expected USER_STEER among DriftDetected envelopes "
+        f"(saw kinds={drift_kinds_seen!r})"
+    )
+
+    # ------------------------------------------------------------------
+    # plan_id stable + revision_index bumped
+    # ------------------------------------------------------------------
+    assert out2.session.plan is not None
+    assert out2.session.plan.id == turn1_plan_id, (
+        "refine_existing must reuse the prior plan's id "
+        f"(turn1_id={turn1_plan_id!r}, turn2_id={out2.session.plan.id!r}). "
+        "The bug fresh-minted a new plan_id via _emit_plan_submitted."
+    )
+    assert out2.session.plan.revision_index == turn1_revision_index + 1, (
+        "_apply_revision must bump revision_index by 1 — "
+        f"prior={turn1_revision_index}, "
+        f"revised={out2.session.plan.revision_index}. "
+        "The bug returned the planner's freshly-minted plan with "
+        "revision_index=0."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Refine returning None on the steerer path falls back to planner.generate
+# ---------------------------------------------------------------------------
+
+
+async def test_refine_existing_falls_back_to_generate_on_refine_failure() -> None:
+    """When the steerer's refine path fails (planner.refine raises),
+    the runner falls through to ``planner.generate`` and emits
+    ``PlanSubmitted`` for the fresh plan. No ``PlanRevised`` is
+    emitted (the refine never succeeded).
+    """
+    turn1_plan = json.dumps(
+        {
+            "id": "plan-original",
+            "summary": "first plan",
+            "tasks": [
+                {"id": "t1", "title": "T1", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+    fresh_plan_after_refine_fail = turn1_plan  # generate falls through
+
+    planner = LLMPlanner(
+        call_llm=_planner_call_llm_factory(
+            turn1_plan=fresh_plan_after_refine_fail,
+            turn2_verdict="refine_existing",
+            refined_plan=None,  # forces refine to raise
+        ),
+        model="stub",
+    )
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    out1 = await runner.run("turn one")
+    assert out1.success
+    turn1_end = len(sink.events)
+
+    out2 = await runner.run("a steering follow-up")
+    await runner.close()
+    assert out2.success
+
+    turn2_kinds = _kinds(sink.events[turn1_end:])
+
+    # The steerer still got the drift (it ran _handle_drift even on a
+    # refine that raised) — but no revision landed, so no PlanRevised
+    # follow-up.
+    assert "DriftDetected" in turn2_kinds, (
+        "the steerer still emits DriftDetected before attempting refine"
+    )
+    assert "PlanRevised" not in turn2_kinds, (
+        "refine raised — _emit_plan_revised must not fire when no "
+        "revision was applied."
+    )
+    # Fall-through to planner.generate emitted a fresh plan event.
+    assert "PlanSubmitted" in turn2_kinds, (
+        "fall-back path must emit PlanSubmitted for the regenerated "
+        "plan (the safe path always ships a plan)."
+    )

--- a/tests/test_task_transitioned_events.py
+++ b/tests/test_task_transitioned_events.py
@@ -667,3 +667,147 @@ def test_task_transition_refused_factory_defaults() -> None:
     assert p.current_revision == 0
     assert p.agent_name == ""
     assert p.invocation_id == ""
+
+
+# ---------------------------------------------------------------------------
+# 11. F10 / executor_dispatch — ParallelDAGExecutor's framework auto-start
+#     emits TaskTransitioned(source="executor_dispatch") at the
+#     ``task.status = TaskStatus.RUNNING`` mutation point in
+#     :class:`~goldfive.executors.ParallelDAGExecutor`.
+# ---------------------------------------------------------------------------
+
+
+async def test_parallel_executor_dispatch_emits_executor_dispatch_transition() -> None:
+    """When the parallel DAG executor flips a task from PENDING to
+    RUNNING just before invoking the adapter, a TaskTransitioned must
+    land with ``source="executor_dispatch"`` — distinct from
+    ``handler_default`` (LLM tool call where ``task_id`` defaulted)
+    and from generic ``other``.
+    """
+    from goldfive.executors import ParallelDAGExecutor
+    from goldfive.results import InvocationResult
+
+    plan = _plan(
+        Task(id="t1", title="T1", assignee_agent_id="writer"),
+        revision_index=0,
+    )
+    session = _session(plan)
+    session.run_id = "r-pdag"
+    sink = ListSink()
+    steerer = _bound_steerer(sink)
+
+    class _Adapter:
+        async def register_reporting_tools(self, tools: list[Any]) -> None:
+            return None
+
+        @property
+        def available_agents(self) -> list[str]:
+            return ["writer"]
+
+        async def invoke(self, task: Task, session: Session) -> InvocationResult:
+            return InvocationResult(task_id=task.id, text=f"ok {task.id}")
+
+    executor = ParallelDAGExecutor(max_concurrency=0)
+    out = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=_Adapter(),
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+    )
+    assert out.success
+
+    transitions = _transition_events(sink)
+    # The framework auto-start row is the first PENDING -> RUNNING for t1.
+    matching = [
+        e
+        for e in transitions
+        if e.task_transitioned.source == "executor_dispatch"
+        and e.task_transitioned.task_id == "t1"
+        and e.task_transitioned.from_status == TaskStatus.PENDING.value
+        and e.task_transitioned.to_status == TaskStatus.RUNNING.value
+    ]
+    assert len(matching) == 1, (
+        "ParallelDAGExecutor.run_one must emit exactly one "
+        f"TaskTransitioned(source=executor_dispatch) for t1; "
+        f"saw {len(matching)} (all transitions: "
+        f"{[e.task_transitioned.source for e in transitions]!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 12. F10 / control_rewind — REWIND_TO control message emits one
+#     TaskTransitioned per affected task with source="control_rewind".
+# ---------------------------------------------------------------------------
+
+
+async def test_control_rewind_emits_control_rewind_transition() -> None:
+    """A ``REWIND_TO`` control message marks the target task and every
+    downstream task PENDING. F10: each affected task whose status
+    actually changed emits one ``TaskTransitioned`` with
+    ``source="control_rewind"`` so operator triage can distinguish a
+    control-driven rewind from a cancellation cascade or a
+    plan_revision flip.
+    """
+    from goldfive.control import ControlKind, ControlMessage
+    from goldfive.executors._control import dispatch_control
+
+    plan = _plan(
+        Task(
+            id="t0",
+            title="T0",
+            assignee_agent_id="writer",
+            status=TaskStatus.COMPLETED,
+        ),
+        Task(
+            id="t1",
+            title="T1",
+            assignee_agent_id="writer",
+            status=TaskStatus.COMPLETED,
+        ),
+        Task(
+            id="t2",
+            title="T2",
+            assignee_agent_id="writer",
+            status=TaskStatus.COMPLETED,
+        ),
+        edges=[
+            TaskEdge(from_task_id="t0", to_task_id="t1"),
+            TaskEdge(from_task_id="t1", to_task_id="t2"),
+        ],
+        revision_index=0,
+    )
+    session = _session(plan)
+    session.run_id = "r-rewind"
+    session.completed_results = {"t0": "a", "t1": "b", "t2": "c"}
+
+    sink = ListSink()
+    steerer = _bound_steerer(sink)
+
+    msg = ControlMessage(kind=ControlKind.REWIND_TO, payload={"task_id": "t1"})
+    outcome = await dispatch_control(
+        msg, session=session, steerer=steerer, sinks=[sink]
+    )
+
+    # Sanity: rewind succeeded.
+    assert outcome.rewind_task_id == "t1"
+    assert plan.tasks[0].status == TaskStatus.COMPLETED  # t0 unchanged
+    assert plan.tasks[1].status == TaskStatus.PENDING
+    assert plan.tasks[2].status == TaskStatus.PENDING
+
+    transitions = _transition_events(sink)
+    rewind_transitions = [
+        e for e in transitions if e.task_transitioned.source == "control_rewind"
+    ]
+    # Two affected tasks (t1 + t2 — both went COMPLETED -> PENDING).
+    assert len(rewind_transitions) == 2, (
+        f"expected one TaskTransitioned(source=control_rewind) per "
+        f"affected task; saw {len(rewind_transitions)}"
+    )
+    rewind_ids = sorted(e.task_transitioned.task_id for e in rewind_transitions)
+    assert rewind_ids == ["t1", "t2"]
+    for evt in rewind_transitions:
+        payload = evt.task_transitioned
+        assert payload.from_status == TaskStatus.COMPLETED.value
+        assert payload.to_status == TaskStatus.PENDING.value


### PR DESCRIPTION
## Summary

- **F1 root cause (PR #210, c355c58)**: the planning gate's `refine_existing` branch called `planner.refine` directly and emitted `_emit_plan_submitted` on the result, bypassing the steerer's drift-handling pipeline. Effects observed in today's E2E: turn-2 USER_STEER produced a brand-new plan with `revision_index=0` and a fresh plan_id, no `DriftDetected(USER_STEER)` on the wire, no `PlanRevised`, no `RefineAttempted`/`RefineFailed`, and silently dropped prior-plan constraints.
- **Fix**: in `Runner.run`, the `refine_existing` branch now synthesizes a `DriftEvent(kind=USER_STEER, severity=WARNING)` and routes it through `steerer._handle_drift`. That path emits `DriftDetected`, applies user-steer state (sticky goals, processed_steer dedupe), runs the severity ladder, dispatches `planner.refine`, installs the revision via `_apply_revision` (stable plan_id + `revision_index += 1`), and emits `PlanRevised` with the #258-#267 observability stack. On any refine failure (raise / None / validator-rejected), the runner falls through to `planner.generate` for a fresh plan — the safe path always ships a plan. `_refine_from_user_input` was deleted (cleaner inlined). `conversational` and `new_work` branches are unchanged.
- **F10 (bundled, observability-only)**: two new `TaskTransitioned` source labels.
  - `executor_dispatch` — `goldfive/executors/parallel.py` `run_one` framework auto-start of `task.status = RUNNING` (was previously emitted with no source). Distinct from `handler_default` (LLM tool call where task_id defaulted) and `other`.
  - `control_rewind` — `goldfive/executors/_control.py::_rewind_plan` REWIND_TO control message; one transition emitted per affected task (target + every downstream task that was non-PENDING). `_rewind_plan` now returns the affected `(task, prev_status)` list so the dispatcher can plumb the emit (kept sync + dependency-free in the helper itself).
- **Hazard hit**: the brief specified `DriftSeverity.HIGH`, but `goldfive.types.DriftSeverity` only has `INFO/WARNING/CRITICAL`. The pre-fix `_refine_from_user_input` was using `HIGH` too — silent dead-code reference that never actually constructed a drift in production because it raised inside the helper's `try/except`. Used `WARNING` to match `_drift_from_steer_event` (the canonical USER_STEER coercion from a `ControlMessage`). USER_STEER bypasses `_should_request_cancel_for_drift`'s severity gate anyway.

## Test plan
- [x] `uv run pytest tests/` — 1305 passed, 89 skipped.
- [x] `uv run ruff check goldfive/ tests/` — clean.
- [x] F1 unit pin in `tests/test_runner_user_steer_routing.py`:
  - `test_refine_existing_routes_through_steerer_and_emits_plan_revised` — asserts `DriftDetected` and `PlanRevised` land on turn 2, `PlanSubmitted` does NOT, `out2.session.plan.id == turn1_plan_id`, and `revision_index == prior + 1`.
  - `test_refine_existing_falls_back_to_generate_on_refine_failure` — refine raises, `DriftDetected` still emits, no `PlanRevised`, fall-through emits `PlanSubmitted` for the regenerated plan.
- [x] F10 pins in `tests/test_task_transitioned_events.py`:
  - `test_parallel_executor_dispatch_emits_executor_dispatch_transition`.
  - `test_control_rewind_emits_control_rewind_transition` (asserts one transition per affected task with `source="control_rewind"`).