### PR TITLE
fix(planner, steerer): supersedes coverage validator + RefineAttempted/Failed loud at every refine site

### DIFF
--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -336,12 +336,13 @@ class ParallelDAGExecutor:
                         )
                         break
 
-                    refined = await self._refine(
+                    refined, refine_attempt_id = await self._refine(
                         plan=session.plan or plan,
                         drift=drift,
                         planner=planner,
                         session=session,
                         sinks=sinks,
+                        steerer=steerer,
                     )
                     if refined is not None and refined is not (session.plan or plan):
                         refinements_used += 1
@@ -362,6 +363,30 @@ class ParallelDAGExecutor:
                                 session_id=session.id,
                             ),
                         )
+                        # Pair the success with its preceding
+                        # refine_attempted event so dict-event consumers
+                        # can correlate by attempt_id (mirrors the steerer's
+                        # _emit_plan_revised_correlation contract). Skipped
+                        # when the legacy path (no steerer) was taken —
+                        # there's no attempt_id to pair against.
+                        if refine_attempt_id:
+                            emit_corr = getattr(
+                                steerer, "_emit_plan_revised_correlation", None
+                            )
+                            if callable(emit_corr):
+                                try:
+                                    await emit_corr(
+                                        session,
+                                        refined,
+                                        drift,
+                                        attempt_id=refine_attempt_id,
+                                    )
+                                except Exception as exc:  # noqa: BLE001
+                                    log.debug(
+                                        "ParallelDAGExecutor: "
+                                        "steerer._emit_plan_revised_correlation raised: %s",
+                                        exc,
+                                    )
                         # Falls through to loop top: stages recomputed.
                         continue
 
@@ -716,7 +741,8 @@ class ParallelDAGExecutor:
         planner: Planner,
         session: Session,
         sinks: list[EventSink],
-    ) -> Plan | None:
+        steerer: Steerer | None = None,
+    ) -> tuple[Plan | None, str]:
         """Ask ``planner.refine`` for a revision; validate and signal failures.
 
         Unlike the previous quiet-null version, every failure mode
@@ -731,45 +757,143 @@ class ParallelDAGExecutor:
         returned (downstream tasks that depended on a replacement still
         block via ``_pick_next_task`` and the reachability audit).
 
+        ``steerer`` (optional): when bound and the steerer exposes the
+        :meth:`~goldfive.steerer.DefaultSteerer.observe_refine` async
+        context manager, refine attempt is wrapped so every refine
+        produces a paired ``refine_attempted`` + (``refine_failed`` |
+        ``plan_revised``) event regardless of which dispatch path
+        triggered it. This unifies emission across the steerer-driven
+        and executor-driven refine paths — without it, refines via this
+        executor emit no observability and the planner's
+        ``refine_orphaned_tasks`` validator no-ops (it depends on the
+        steerer's span-context provider which is wired through
+        ``_active_session``). See goldfive#263 / #264.
+
+        Returns ``(plan, attempt_id)``. ``plan`` is the validated
+        revised plan or ``None`` on any failure. ``attempt_id`` is the
+        empty string when no steerer was used or no observation was
+        established; otherwise the UUID minted inside ``observe_refine``
+        so callers can stamp it onto the success-path ``plan_revised``
+        correlation event.
+
         See goldfive#134.
         """
-        try:
-            refined = await planner.refine(plan=plan, drift=drift, goals=list(session.goals))
-        except Exception as exc:  # noqa: BLE001
-            log.warning("ParallelDAGExecutor: planner.refine raised: %s", exc)
-            await self._emit_refine_failure(
-                session=session,
-                sinks=sinks,
-                source=drift,
-                reason=f"refine raised: {exc}",
-            )
-            return None
-        if refined is None:
-            log.warning(
-                "ParallelDAGExecutor: planner.refine(kind=%s) returned None; plan unchanged",
-                drift.kind.value,
-            )
-            await self._emit_refine_failure(
-                session=session,
-                sinks=sinks,
-                source=drift,
-                reason="planner returned no revised plan",
-            )
-            return None
-        try:
-            refined.validate(for_revision=True, prior=plan)
-        except ValueError as exc:
-            log.warning(
-                "ParallelDAGExecutor: revised plan failed validation (%s); keeping prior plan",
-                exc,
-            )
-            await self._emit_refine_failure(
-                session=session,
-                sinks=sinks,
-                source=drift,
-                reason=f"plan validation failed: {exc}",
-            )
-            return None
+        # If a steerer with observe_refine is bound, route refine
+        # attempt+failure emission through it. Otherwise fall back to
+        # the legacy direct call (test stubs / custom steerers).
+        observe_refine = getattr(steerer, "observe_refine", None) if steerer is not None else None
+        attempt_id: str = ""
+        if observe_refine is not None and callable(observe_refine):
+            cm = observe_refine(session, drift)
+            try:
+                async with cm as ctx_attempt_id:
+                    attempt_id = ctx_attempt_id
+                    refined = await planner.refine(
+                        plan=plan, drift=drift, goals=list(session.goals)
+                    )
+            except Exception as exc:  # noqa: BLE001
+                # observe_refine has already emitted refine_failed; we
+                # ALSO emit the CRITICAL DriftDetected mirror so the
+                # legacy operator-visible signal still lands.
+                log.warning("ParallelDAGExecutor: planner.refine raised: %s", exc)
+                await self._emit_refine_failure(
+                    session=session,
+                    sinks=sinks,
+                    source=drift,
+                    reason=f"refine raised: {exc}",
+                )
+                return None, attempt_id
+            if refined is None:
+                log.warning(
+                    "ParallelDAGExecutor: planner.refine(kind=%s) returned None; plan unchanged",
+                    drift.kind.value,
+                )
+                # Emit refine_failed via the steerer for parity with the
+                # exception path above. observe_refine has already cleared
+                # _active_session by now, so we go through the steerer's
+                # direct emitter.
+                await self._steerer_emit_refine_failed(
+                    steerer=steerer,
+                    session=session,
+                    drift=drift,
+                    attempt_id=attempt_id,
+                    failure_kind="parse_error",
+                    reason="planner returned no revised plan",
+                    detail="",
+                )
+                await self._emit_refine_failure(
+                    session=session,
+                    sinks=sinks,
+                    source=drift,
+                    reason="planner returned no revised plan",
+                )
+                return None, attempt_id
+            try:
+                refined.validate(for_revision=True, prior=plan)
+            except ValueError as exc:
+                log.warning(
+                    "ParallelDAGExecutor: revised plan failed validation (%s); keeping prior plan",
+                    exc,
+                )
+                await self._steerer_emit_refine_failed(
+                    steerer=steerer,
+                    session=session,
+                    drift=drift,
+                    attempt_id=attempt_id,
+                    failure_kind="validator_rejected",
+                    reason=f"plan validation failed: {exc}",
+                    detail=type(exc).__name__,
+                )
+                await self._emit_refine_failure(
+                    session=session,
+                    sinks=sinks,
+                    source=drift,
+                    reason=f"plan validation failed: {exc}",
+                )
+                return None, attempt_id
+        else:
+            # Legacy path — no steerer or no observe_refine. No
+            # refine_attempted/refine_failed emission, but the
+            # CRITICAL DriftDetected mirror is preserved.
+            try:
+                refined = await planner.refine(
+                    plan=plan, drift=drift, goals=list(session.goals)
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.warning("ParallelDAGExecutor: planner.refine raised: %s", exc)
+                await self._emit_refine_failure(
+                    session=session,
+                    sinks=sinks,
+                    source=drift,
+                    reason=f"refine raised: {exc}",
+                )
+                return None, attempt_id
+            if refined is None:
+                log.warning(
+                    "ParallelDAGExecutor: planner.refine(kind=%s) returned None; plan unchanged",
+                    drift.kind.value,
+                )
+                await self._emit_refine_failure(
+                    session=session,
+                    sinks=sinks,
+                    source=drift,
+                    reason="planner returned no revised plan",
+                )
+                return None, attempt_id
+            try:
+                refined.validate(for_revision=True, prior=plan)
+            except ValueError as exc:
+                log.warning(
+                    "ParallelDAGExecutor: revised plan failed validation (%s); keeping prior plan",
+                    exc,
+                )
+                await self._emit_refine_failure(
+                    session=session,
+                    sinks=sinks,
+                    source=drift,
+                    reason=f"plan validation failed: {exc}",
+                )
+                return None, attempt_id
         # goldfive#199: stamp the trigger_event_id on the plan for every
         # refine so harmonograf can strict-id-merge plan-revision rows
         # regardless of whether the executor refined via the steerer or
@@ -782,7 +906,50 @@ class ParallelDAGExecutor:
             trig_id = _trigger_id_from_drift(drift)
             if trig_id:
                 refined.revision_trigger_event_id = trig_id
-        return refined
+        return refined, attempt_id
+
+    @staticmethod
+    async def _steerer_emit_refine_failed(
+        *,
+        steerer: Steerer | None,
+        session: Session,
+        drift: DriftEvent,
+        attempt_id: str,
+        failure_kind: str,
+        reason: str,
+        detail: str,
+    ) -> None:
+        """Best-effort delegate to ``DefaultSteerer._emit_refine_failed``.
+
+        The parallel executor's refine path emits ``refine_failed``
+        events via the bound steerer when one is available so observers
+        can pair attempted/failed/plan-revised by ``attempt_id``. Custom
+        steerers without the ``_emit_refine_failed`` method are tolerated
+        — the call is duck-typed and silently no-ops, which preserves
+        backwards compatibility for tests that pass a stub Steerer.
+
+        Failures inside the steerer's emit are logged and swallowed:
+        observability must never break the run.
+        """
+        if steerer is None:
+            return
+        emit_failed = getattr(steerer, "_emit_refine_failed", None)
+        if not callable(emit_failed):
+            return
+        try:
+            await emit_failed(
+                session,
+                drift,
+                attempt_id=attempt_id,
+                failure_kind=failure_kind,
+                reason=reason,
+                detail=detail,
+            )
+        except Exception as exc:  # noqa: BLE001 — observability must never break the run
+            log.debug(
+                "ParallelDAGExecutor: steerer._emit_refine_failed raised: %s",
+                exc,
+            )
 
     async def _emit_refine_failure(
         self,

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -44,6 +44,7 @@ levels. See goldfive#142 for the full table.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import enum
 import inspect
 import json
@@ -51,7 +52,7 @@ import logging
 import re
 import time
 import uuid
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from goldfive import orchestration_state as _ostate
@@ -3849,6 +3850,76 @@ class DefaultSteerer:
                 "DefaultSteerer._emit_refine_failed: failed to emit: %s",
                 exc,
             )
+
+    @contextlib.asynccontextmanager
+    async def observe_refine(
+        self,
+        session: Session,
+        drift: DriftEvent,
+    ) -> AsyncIterator[str]:
+        """Async context manager that wraps a ``planner.refine`` call with
+        observability emission.
+
+        On enter:
+
+        * Mints a fresh ``attempt_id``.
+        * Stamps ``self._active_session = session`` so the planner's
+          ``_span_ctx_provider`` resolves correctly (this is what powers
+          the planner-side ``refine_orphaned_tasks`` emission and the
+          ``GoldfiveLLMCallStart/End`` spans).
+        * Emits ``refine_attempted`` to the bound sinks.
+
+        On exception:
+
+        * Emits ``refine_failed`` with ``failure_kind="llm_error"``,
+          stamped with the same ``attempt_id``, then re-raises.
+
+        On clean exit (no exception):
+
+        * Clears ``_active_session``.
+        * Caller is responsible for emitting either ``plan_revised``
+          (success) or ``refine_failed`` (returned ``None`` / validator
+          rejected) — the helper has no way to introspect the caller's
+          decision tree from here. Pair with :meth:`_emit_refine_failed`
+          / ``_emit_plan_revised`` using the yielded ``attempt_id``.
+
+        Used by:
+
+        * :meth:`_handle_drift` / :meth:`_promote_drift_to_steer` —
+          the steerer's own refine call sites.
+        * :class:`~goldfive.executors.parallel.ParallelDAGExecutor._refine` —
+          the executor-side refine fallback. Without this helper, the
+          parallel path's refines emit no ``refine_attempted`` /
+          ``refine_failed`` / ``refine_orphaned_tasks`` events, since
+          they bypass the steerer's hand-rolled emission blocks.
+        """
+        attempt_id = self._new_attempt_id()
+        # Setting ``_active_session`` before refine lets the planner's
+        # internal ``_emit_refine_orphaned_tasks`` resolve a sink target
+        # via the bound span-context provider. Without this, the planner's
+        # validator computes orphans, logs the WARNING, but no sink event
+        # lands — exactly the symptom Bug A describes.
+        self._active_session = session
+        try:
+            await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
+            try:
+                yield attempt_id
+            except Exception as exc:  # noqa: BLE001 — refine errors must not break observability
+                # Emit failure event with the same attempt_id so consumers
+                # can pair attempted ↔ failed. We do NOT swallow the
+                # exception — re-raise so the caller's existing error path
+                # (e.g. _emit_refine_failure / fallback plans) runs.
+                await self._emit_refine_failed(
+                    session,
+                    drift,
+                    attempt_id=attempt_id,
+                    failure_kind="llm_error",
+                    reason=str(exc),
+                    detail=type(exc).__name__,
+                )
+                raise
+        finally:
+            self._active_session = None
 
     async def _emit_plan_revised_correlation(
         self,

--- a/tests/test_refine_emit_parity.py
+++ b/tests/test_refine_emit_parity.py
@@ -1,0 +1,714 @@
+"""Parity tests: refine observability events fire from every refine entry point.
+
+Bugs A + B from goldfive G3 (2026-04-24 E2E findings):
+
+* Bug A — :func:`goldfive.planner._check_supersedes_coverage` emits
+  ``refine_orphaned_tasks`` to the wire when refine drops prior tasks
+  without a supersedes link. Today's E2E found 5 dropped tasks but 0
+  events on the sink because the validator's emit hook depends on the
+  steerer's ``_active_session`` plumbing, and the
+  :class:`~goldfive.executors.parallel.ParallelDAGExecutor` refine
+  pathway bypasses the steerer entirely.
+
+* Bug B — ``refine_attempted`` / ``refine_failed`` (PR #264) hook into
+  :class:`~goldfive.steerer.DefaultSteerer._handle_drift` and
+  :meth:`_promote_drift_to_steer`. The parallel executor's direct
+  ``planner.refine`` call site emitted neither.
+
+Both fixes route through a new
+:meth:`~goldfive.steerer.DefaultSteerer.observe_refine` async context
+manager that mints the attempt id, plumbs ``_active_session`` so the
+planner-side orphan emit fires, emits ``refine_attempted`` on enter,
+and ``refine_failed`` on exception. The parallel executor opts in via
+its ``steerer=`` kwarg.
+
+Tests below assert all three events land regardless of which dispatch
+path triggered the refine.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.executors.parallel import ParallelDAGExecutor  # noqa: E402
+from goldfive.planner import LLMPlanner  # noqa: E402
+from goldfive.results import InvocationResult  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    """Sink that records every emitted event (proto + dict)."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+    @property
+    def proto_events(self) -> list[Any]:
+        return [e for e in self.events if hasattr(e, "WhichOneof")]
+
+    @property
+    def dict_events(self) -> list[dict[str, Any]]:
+        return [e for e in self.events if isinstance(e, dict)]
+
+    def by_kind(self, kind: str) -> list[dict[str, Any]]:
+        return [e for e in self.dict_events if e.get("kind") == kind]
+
+
+class _ScriptedLLM:
+    """``call_llm`` stub: returns the next scripted response per call."""
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        self.calls.append((system, user, model))
+        if not self._responses:
+            return ""
+        return self._responses.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# observe_refine — context manager contract
+# ---------------------------------------------------------------------------
+
+
+async def test_observe_refine_emits_attempted_on_enter() -> None:
+    """Entering observe_refine emits exactly one refine_attempted with a
+    fresh attempt_id; ``_active_session`` is plumbed for the duration."""
+    sink = ListSink()
+    steerer = DefaultSteerer()
+
+    class _StubPlanner:
+        async def generate(self, **_: Any) -> Plan | None:
+            return None
+
+        async def refine(self, **_: Any) -> Plan | None:
+            return None
+
+        # ``set_drift_emitter`` / ``set_span_context_provider`` are
+        # required by DefaultSteerer.bind() — duck-typed.
+        def set_drift_emitter(self, emitter: Any) -> None:
+            pass
+
+        def set_span_context_provider(self, provider: Any) -> None:
+            self.provider = provider
+
+    planner = _StubPlanner()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = Session(run_id="r1", goals=[Goal(id="g1", summary="g")])
+    drift = DriftEvent(
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.WARNING,
+        detail="d",
+        current_task_id="t1",
+    )
+
+    async with steerer.observe_refine(session, drift) as attempt_id:
+        # Inside the context the planner's span-ctx provider resolves
+        # to a non-None tuple, so the planner-side _emit_refine_orphaned_tasks
+        # would route to the bound sinks.
+        ctx = planner.provider()
+        assert ctx is not None
+        sinks_arg, run_id, session_id, _task_id, _seq_fn = ctx
+        assert sink in sinks_arg
+        assert run_id == "r1"
+        assert session_id == session.id
+
+    attempted = sink.by_kind("refine_attempted")
+    assert len(attempted) == 1
+    assert attempted[0]["payload"]["attempt_id"] == attempt_id
+    # No failure on clean exit.
+    assert sink.by_kind("refine_failed") == []
+    # _active_session cleared in finally.
+    assert planner.provider() is None
+
+
+async def test_observe_refine_emits_failed_on_exception_and_reraises() -> None:
+    """An exception inside the with-block emits one refine_failed
+    stamped with the same attempt_id, then re-raises so callers' error
+    paths still run."""
+    sink = ListSink()
+    steerer = DefaultSteerer()
+
+    class _StubPlanner:
+        async def generate(self, **_: Any) -> Plan | None:
+            return None
+
+        async def refine(self, **_: Any) -> Plan | None:
+            return None
+
+        def set_drift_emitter(self, emitter: Any) -> None:
+            pass
+
+        def set_span_context_provider(self, provider: Any) -> None:
+            pass
+
+    steerer.bind(sinks=[sink], planner=_StubPlanner())
+    session = Session(run_id="r1", goals=[Goal(id="g1", summary="g")])
+    drift = DriftEvent(
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        severity=DriftSeverity.WARNING,
+        detail="loop",
+        current_task_id="t1",
+    )
+
+    captured_attempt_id: str = ""
+    with pytest.raises(RuntimeError, match="boom"):
+        async with steerer.observe_refine(session, drift) as attempt_id:
+            captured_attempt_id = attempt_id
+            raise RuntimeError("boom")
+
+    attempted = sink.by_kind("refine_attempted")
+    failed = sink.by_kind("refine_failed")
+    assert len(attempted) == 1
+    assert len(failed) == 1
+    assert attempted[0]["payload"]["attempt_id"] == captured_attempt_id
+    assert failed[0]["payload"]["attempt_id"] == captured_attempt_id
+    assert failed[0]["payload"]["failure_kind"] == "llm_error"
+    assert "boom" in failed[0]["payload"]["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Bug A — orphan validator emits via observe_refine span ctx
+# ---------------------------------------------------------------------------
+
+
+async def test_planner_orphan_emit_fires_when_steerer_observes_refine() -> None:
+    """Inside observe_refine, the planner-side _emit_refine_orphaned_tasks
+    resolves a sink target via the steerer's bound span-context provider
+    — so an orphan-producing refine produces the orphan event on the wire.
+
+    Mirrors the live-demo scenario where a PENDING task is silently
+    dropped from the revised plan (no supersedes link, not terminal),
+    today's E2E found 0 events; this asserts the post-fix path emits."""
+    prior = Plan(
+        id="p-prior",
+        run_id="r-orphan",
+        goal_ids=["g1"],
+        summary="prior",
+        tasks=[
+            Task(
+                id="research",
+                title="Research",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="draft_intro",
+                title="Draft intro",
+                assignee_agent_id="writer",
+                status=TaskStatus.PENDING,
+            ),
+            Task(
+                id="draft_body",
+                title="Draft body",
+                assignee_agent_id="writer",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft_intro"),
+            TaskEdge(from_task_id="draft_intro", to_task_id="draft_body"),
+        ],
+        revision_index=0,
+    )
+    # LLM silently drops draft_body — no supersedes, not terminal.
+    refine_response = json.dumps(
+        {
+            "summary": "narrowed",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research",
+                    "assignee_agent_id": "researcher",
+                    "status": "COMPLETED",
+                },
+                {
+                    "id": "draft_intro",
+                    "title": "Draft intro",
+                    "assignee_agent_id": "writer",
+                    "status": "PENDING",
+                },
+            ],
+            "edges": [
+                {"from_task_id": "research", "to_task_id": "draft_intro"},
+            ],
+        }
+    )
+    scripted = _ScriptedLLM([refine_response])
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=1)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = Session(
+        run_id="r-orphan", goals=[Goal(id="g1", summary="g")], plan=prior
+    )
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.WARNING,
+        detail="scope narrowed",
+        current_task_id="draft_body",
+    )
+
+    async with steerer.observe_refine(session, drift) as _attempt_id:
+        revised = await planner.refine(plan=prior, drift=drift, goals=list(session.goals))
+
+    assert revised is not None
+    orphan_events = sink.by_kind("refine_orphaned_tasks")
+    assert len(orphan_events) == 1
+    payload = orphan_events[0]["payload"]
+    assert payload["orphan_count"] == 1
+    assert payload["orphans"][0]["task_id"] == "draft_body"
+
+
+async def test_planner_no_orphan_emit_when_coverage_complete() -> None:
+    """Inverse: a refine with full supersedes coverage emits NO
+    orphan event even though observe_refine plumbed the ctx."""
+    prior = Plan(
+        id="p-clean",
+        run_id="r-clean",
+        goal_ids=["g1"],
+        summary="prior",
+        tasks=[
+            Task(
+                id="research",
+                title="Research",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="draft",
+                title="Draft",
+                assignee_agent_id="writer",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research", to_task_id="draft")],
+        revision_index=0,
+    )
+    refine_response = json.dumps(
+        {
+            "summary": "redirect",
+            "tasks": [
+                {
+                    "id": "research",
+                    "title": "Research",
+                    "assignee_agent_id": "researcher",
+                    "status": "COMPLETED",
+                },
+                {
+                    "id": "draft_v2",
+                    "title": "Draft v2",
+                    "assignee_agent_id": "writer",
+                    "status": "PENDING",
+                    "supersedes": "draft",
+                    "supersedes_kind": "REPLACE",
+                },
+            ],
+            "edges": [{"from_task_id": "research", "to_task_id": "draft_v2"}],
+        }
+    )
+    scripted = _ScriptedLLM([refine_response])
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=1)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = Session(
+        run_id="r-clean", goals=[Goal(id="g1", summary="g")], plan=prior
+    )
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.WARNING,
+        detail="redirect",
+        current_task_id="draft",
+    )
+
+    async with steerer.observe_refine(session, drift) as _attempt_id:
+        revised = await planner.refine(plan=prior, drift=drift, goals=list(session.goals))
+
+    assert revised is not None
+    assert sink.by_kind("refine_orphaned_tasks") == []
+
+
+# ---------------------------------------------------------------------------
+# Bug B — Parallel executor refine path emits attempted/failed
+# ---------------------------------------------------------------------------
+
+
+def _diamond_plan() -> Plan:
+    """A -> {B, C} -> D. Smaller than the canonical 5-task diamond
+    because we don't need wide concurrency for these tests."""
+    return Plan(
+        id="plan-pe",
+        run_id="run-pe",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="A", title="A"),
+            Task(id="B", title="B"),
+            Task(id="C", title="C"),
+            Task(id="D", title="D"),
+        ],
+        edges=[
+            TaskEdge("A", "B"),
+            TaskEdge("A", "C"),
+            TaskEdge("B", "D"),
+            TaskEdge("C", "D"),
+        ],
+    )
+
+
+def _refined_diamond() -> Plan:
+    """Valid refine output for the diamond. revision_index=1 so the
+    structural validator (for_revision=True) accepts the swap."""
+    return Plan(
+        id="plan-pe",
+        run_id="run-pe",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="A", title="A", status=TaskStatus.COMPLETED),
+            Task(id="B", title="B"),
+            Task(id="C", title="C"),
+            Task(id="D", title="D"),
+        ],
+        edges=[
+            TaskEdge("A", "B"),
+            TaskEdge("A", "C"),
+            TaskEdge("B", "D"),
+            TaskEdge("C", "D"),
+        ],
+        revision_index=1,
+    )
+
+
+class _DriftOnceAdapter:
+    """Adapter that surfaces a drift on the first invocation of a
+    designated task, then completes normally on subsequent runs.
+
+    The drift hop is delivered via ``InvocationResult.raw['_drift_to_surface']``
+    — recognised by :class:`_FixedDriftSteerer` below.
+    """
+
+    def __init__(self, *, drift_task: str, drift: DriftEvent) -> None:
+        self._drift_task = drift_task
+        self._drift = drift
+        self._fired = False
+
+    @property
+    def available_agents(self) -> list[str]:
+        return ["default"]
+
+    async def register_reporting_tools(self, tools: list[Any]) -> None:
+        return None
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:
+        drift: DriftEvent | None = None
+        if task.id == self._drift_task and not self._fired:
+            self._fired = True
+            drift = self._drift
+        return InvocationResult(
+            task_id=task.id,
+            text=f"r:{task.id}",
+            raw={"_drift_to_surface": drift},
+        )
+
+
+class _FixedDriftSteerer(DefaultSteerer):
+    """DefaultSteerer subclass that surfaces a drift attached by
+    :class:`_DriftOnceAdapter` to the InvocationResult — so the parallel
+    executor's drift gate fires deterministically without depending on
+    the classifier heuristics. All other behaviour (the
+    :meth:`observe_refine` plumbing under test) is inherited from the
+    real DefaultSteerer.
+    """
+
+    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
+        if isinstance(event, InvocationResult):
+            raw = event.raw or {}
+            if isinstance(raw, dict):
+                drift = raw.get("_drift_to_surface")
+                if isinstance(drift, DriftEvent):
+                    return drift
+        return super().detect_drift(event, session)
+
+
+class _ScriptedRefinePlanner:
+    """Planner that returns a scripted plan (or raises / returns None)
+    when ``refine`` is called. Implements the optional contract surfaces
+    (``set_drift_emitter`` / ``set_span_context_provider``) the steerer
+    duck-types on."""
+
+    def __init__(
+        self,
+        *,
+        revised: Plan | None = None,
+        raise_exc: BaseException | None = None,
+    ) -> None:
+        self._revised = revised
+        self._raise = raise_exc
+        self.refine_calls: list[DriftEvent] = []
+        self.span_ctx_provider: Any | None = None
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: Any,
+        context: Any = None,
+    ) -> Plan | None:
+        return None
+
+    async def refine(self, *, plan: Plan, drift: DriftEvent, goals: list[Goal]) -> Plan | None:
+        self.refine_calls.append(drift)
+        if self._raise is not None:
+            raise self._raise
+        return self._revised
+
+    def set_drift_emitter(self, emitter: Any) -> None:
+        pass
+
+    def set_span_context_provider(self, provider: Any) -> None:
+        self.span_ctx_provider = provider
+
+
+def _drift(*, task_id: str = "B") -> DriftEvent:
+    return DriftEvent(
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.WARNING,
+        detail="boom",
+        current_task_id=task_id,
+    )
+
+
+async def test_parallel_refine_success_emits_attempted_and_correlation() -> None:
+    """End-to-end through ParallelDAGExecutor: a successful refine
+    produces ``refine_attempted`` + correlation ``plan_revised`` dict
+    events with the same attempt_id, AND no ``refine_failed``.
+    """
+    drift = _drift(task_id="B")
+    adapter = _DriftOnceAdapter(drift_task="B", drift=drift)
+    planner = _ScriptedRefinePlanner(revised=_refined_diamond())
+    sink = ListSink()
+    steerer = _FixedDriftSteerer()
+    executor = ParallelDAGExecutor(max_concurrency=0, drift_policy="finish_stage")
+    session = Session(run_id="run-pe", goals=[Goal(id="g1", summary="g")])
+
+    await executor.run(
+        plan=_diamond_plan(),
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    attempted = sink.by_kind("refine_attempted")
+    failed = sink.by_kind("refine_failed")
+    revised_dicts = sink.by_kind("plan_revised")
+    assert len(attempted) >= 1, (
+        "expected at least one refine_attempted event from the parallel executor"
+    )
+    assert len(failed) == 0, "no refine_failed on success"
+    assert len(revised_dicts) >= 1, "expected at least one correlation sidecar"
+    # Pair the first attempted with its correlation by attempt_id.
+    aid_attempted = attempted[0]["payload"]["attempt_id"]
+    matched = [d for d in revised_dicts if d["payload"]["attempt_id"] == aid_attempted]
+    assert matched, "expected correlation event with matching attempt_id"
+
+
+async def test_parallel_refine_raise_emits_attempted_and_failed() -> None:
+    """When ``planner.refine`` raises, the parallel executor emits
+    ``refine_attempted`` + ``refine_failed`` (failure_kind=llm_error)
+    with the same attempt_id, AND no correlation ``plan_revised``."""
+    drift = _drift(task_id="B")
+    adapter = _DriftOnceAdapter(drift_task="B", drift=drift)
+    planner = _ScriptedRefinePlanner(raise_exc=RuntimeError("planner boom"))
+    sink = ListSink()
+    steerer = _FixedDriftSteerer()
+    executor = ParallelDAGExecutor(max_concurrency=0, drift_policy="finish_stage")
+    session = Session(run_id="run-pe", goals=[Goal(id="g1", summary="g")])
+
+    await executor.run(
+        plan=_diamond_plan(),
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    attempted = sink.by_kind("refine_attempted")
+    failed = sink.by_kind("refine_failed")
+    revised_dicts = sink.by_kind("plan_revised")
+    assert len(attempted) >= 1
+    assert len(failed) >= 1
+    assert len(revised_dicts) == 0
+    # Pair attempted/failed by attempt_id.
+    aid_attempted = attempted[0]["payload"]["attempt_id"]
+    matched_failed = [f for f in failed if f["payload"]["attempt_id"] == aid_attempted]
+    assert matched_failed, "expected refine_failed paired with refine_attempted"
+    assert matched_failed[0]["payload"]["failure_kind"] == "llm_error"
+    assert "planner boom" in matched_failed[0]["payload"]["reason"]
+
+
+async def test_parallel_refine_returns_none_emits_failed_with_parse_error() -> None:
+    """``planner.refine`` returning None is treated as ``parse_error``
+    failure_kind via the parallel executor's _refine path."""
+    drift = _drift(task_id="B")
+    adapter = _DriftOnceAdapter(drift_task="B", drift=drift)
+    planner = _ScriptedRefinePlanner(revised=None)
+    sink = ListSink()
+    steerer = _FixedDriftSteerer()
+    executor = ParallelDAGExecutor(max_concurrency=0, drift_policy="finish_stage")
+    session = Session(run_id="run-pe", goals=[Goal(id="g1", summary="g")])
+
+    await executor.run(
+        plan=_diamond_plan(),
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    attempted = sink.by_kind("refine_attempted")
+    failed = sink.by_kind("refine_failed")
+    assert len(attempted) >= 1
+    assert len(failed) >= 1
+    aid_attempted = attempted[0]["payload"]["attempt_id"]
+    matched = [f for f in failed if f["payload"]["attempt_id"] == aid_attempted]
+    assert matched, "expected refine_failed paired with refine_attempted"
+    assert matched[0]["payload"]["failure_kind"] == "parse_error"
+
+
+async def test_parallel_refine_returns_invalid_plan_emits_failed_with_validator_kind() -> None:
+    """Validator rejection produces ``failure_kind=validator_rejected``."""
+    bad_plan = Plan(
+        id="plan-pe",
+        run_id="run-pe",
+        goal_ids=[],
+        tasks=[Task(id="A", title="A", status=TaskStatus.COMPLETED)],
+        # Edge points at an id missing from tasks → validator rejects.
+        edges=[TaskEdge(from_task_id="A", to_task_id="missing")],
+        revision_index=1,
+    )
+    drift = _drift(task_id="B")
+    adapter = _DriftOnceAdapter(drift_task="B", drift=drift)
+    planner = _ScriptedRefinePlanner(revised=bad_plan)
+    sink = ListSink()
+    steerer = _FixedDriftSteerer()
+    executor = ParallelDAGExecutor(max_concurrency=0, drift_policy="finish_stage")
+    session = Session(run_id="run-pe", goals=[Goal(id="g1", summary="g")])
+
+    await executor.run(
+        plan=_diamond_plan(),
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    attempted = sink.by_kind("refine_attempted")
+    failed = sink.by_kind("refine_failed")
+    assert len(attempted) >= 1
+    assert len(failed) >= 1
+    aid = attempted[0]["payload"]["attempt_id"]
+    matched = [f for f in failed if f["payload"]["attempt_id"] == aid]
+    assert matched
+    assert matched[0]["payload"]["failure_kind"] == "validator_rejected"
+
+
+# ---------------------------------------------------------------------------
+# Cross-path: every refine entry point emits the same event family
+# ---------------------------------------------------------------------------
+
+
+async def test_refine_attempted_emitted_from_both_steerer_and_executor_paths() -> None:
+    """End-to-end equivalence: whether the refine fires through
+    :meth:`DefaultSteerer._handle_drift` (steerer-driven) or via
+    :meth:`ParallelDAGExecutor._refine` (executor-driven), a
+    ``refine_attempted`` event lands on the wire.
+
+    Today's E2E found 0 such events from the executor path; this test
+    is the regression guard."""
+    # --- Steerer-driven path -----------------------------------------
+    revised_plan = Plan(
+        id="p-st",
+        run_id="r-st",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="T1"), Task(id="t2", title="T2")],
+        edges=[TaskEdge("t1", "t2")],
+        revision_index=1,
+    )
+    sink_st = ListSink()
+    steerer_st = DefaultSteerer()
+    planner_st = _ScriptedRefinePlanner(revised=revised_plan)
+    steerer_st.bind(sinks=[sink_st], planner=planner_st)
+    session_st = Session(
+        run_id="r-st",
+        goals=[Goal(id="g1", summary="g")],
+        plan=Plan(
+            id="p-st",
+            run_id="r-st",
+            goal_ids=["g1"],
+            tasks=[Task(id="t1", title="T1"), Task(id="t2", title="T2")],
+            edges=[TaskEdge("t1", "t2")],
+        ),
+    )
+    await steerer_st._handle_drift(_drift(task_id="t1"), session_st)
+    assert sink_st.by_kind("refine_attempted"), (
+        "steerer-driven refine emits refine_attempted"
+    )
+
+    # --- Executor-driven path -----------------------------------------
+    drift_ex = _drift(task_id="B")
+    adapter_ex = _DriftOnceAdapter(drift_task="B", drift=drift_ex)
+    planner_ex = _ScriptedRefinePlanner(revised=_refined_diamond())
+    sink_ex = ListSink()
+    steerer_ex = _FixedDriftSteerer()
+    executor = ParallelDAGExecutor(max_concurrency=0, drift_policy="finish_stage")
+    session_ex = Session(run_id="run-pe", goals=[Goal(id="g1", summary="g")])
+
+    await executor.run(
+        plan=_diamond_plan(),
+        session=session_ex,
+        adapter=adapter_ex,
+        steerer=steerer_ex,
+        planner=planner_ex,
+        sinks=[sink_ex],
+    )
+    assert sink_ex.by_kind("refine_attempted"), (
+        "executor-driven refine emits refine_attempted"
+    )


### PR DESCRIPTION
## Summary

Today's E2E found two #258-#267-era observability events emitting at zero rate despite refine firing in the test session:

- `refine_orphaned_tasks` (from #263 supersedes coverage validator)
- `refine_attempted` / `refine_failed` (from #264 atomicity work)

**Root cause for both** (same shape as F1's #270): the emission was hooked into `DefaultSteerer._handle_drift` / `_promote_drift_to_steer`, but the parallel executor's direct `planner.refine` call site (`ParallelDAGExecutor._refine`) bypassed them entirely — and the planner-side `_emit_refine_orphaned_tasks` depends on the steerer's `_active_session` plumbing for span context, which the executor path never set.

**Fix**: introduce a shared async context manager `DefaultSteerer.observe_refine(session, drift)` that mints the attempt_id, stamps `_active_session` for the duration of the refine call, emits `refine_attempted` on enter, and emits `refine_failed` on exception — all with consistent attempt_id correlation. `ParallelDAGExecutor._refine` takes a new optional `steerer=` kwarg (duck-typed) and threads its refine through this helper. The success path also emits a `plan_revised` correlation sidecar stamped with the same `attempt_id` so dict-event consumers can pair attempts with outcomes.

After this fix, every refine attempt — steerer-driven or executor-driven — produces `refine_attempted`, `refine_failed`/`plan_revised` (paired by attempt_id), and (when applicable) `refine_orphaned_tasks` on the wire.

## Test plan

- [x] `uv run pytest tests/test_refine_emit_parity.py` — 9 new parity tests pass
- [x] `uv run pytest tests/test_refine_atomicity_events.py` — 13 existing #264 tests pass
- [x] `uv run pytest tests/test_planner.py` — 64 planner tests pass (covers existing orphan-validator tests)
- [x] `uv run pytest tests/test_parallel_executor.py` — 16 existing tests pass
- [x] `uv run pytest tests/test_steerer.py` — 66 tests pass
- [x] Full suite: 1601 passed (one pre-existing flaky test on HF model load is unrelated)
- [x] `uv run ruff check goldfive/` clean