### PR TITLE
fix(planner): preserve supersedes through fallback clones; pin proto string round-trip

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -860,6 +860,12 @@ class StaticPlanner:
                     predicted_start_ms=t.predicted_start_ms,
                     predicted_duration_ms=t.predicted_duration_ms,
                     bound_span_id=t.bound_span_id,
+                    # goldfive#251: preserve supersession metadata when
+                    # cloning the StaticPlanner template so callers that
+                    # bake supersedes into a hard-coded plan (tests,
+                    # CLIs) see it survive the per-call clone.
+                    supersedes=t.supersedes,
+                    supersedes_kind=t.supersedes_kind,
                 )
                 for t in self._template.tasks
             ],
@@ -2552,6 +2558,16 @@ class LLMPlanner:
                         description=looping_task.description,
                         assignee_agent_id=looping_task.assignee_agent_id,
                         status=TaskStatus.FAILED,
+                        # goldfive#251: preserve the supersession provenance
+                        # when re-inserting the looping task into the
+                        # revised plan. Dropping these fields here turned a
+                        # CORRECT-kind chain into an orphan, which the
+                        # downstream supersedes-coverage validator would
+                        # then flag as a regression (or, worse, the steerer
+                        # would re-pin to the wrong successor). See the
+                        # paired regression in test_planner.py.
+                        supersedes=looping_task.supersedes,
+                        supersedes_kind=looping_task.supersedes_kind,
                     ),
                 )
             return revised
@@ -2611,6 +2627,13 @@ class LLMPlanner:
                         predicted_start_ms=t.predicted_start_ms,
                         predicted_duration_ms=t.predicted_duration_ms,
                         bound_span_id=t.bound_span_id,
+                        # goldfive#251: preserve supersession provenance
+                        # through the deterministic-fallback path. Without
+                        # this, a CORRECT-kind chain that hits the fallback
+                        # would erase the link to the prior task and the
+                        # supersedes-coverage validator would orphan it.
+                        supersedes=t.supersedes,
+                        supersedes_kind=t.supersedes_kind,
                     )
                 )
                 found = True
@@ -2625,6 +2648,8 @@ class LLMPlanner:
                         predicted_start_ms=t.predicted_start_ms,
                         predicted_duration_ms=t.predicted_duration_ms,
                         bound_span_id=t.bound_span_id,
+                        supersedes=t.supersedes,
+                        supersedes_kind=t.supersedes_kind,
                     )
                 )
         if not found and looping_task is not None and loop_id:
@@ -2635,6 +2660,8 @@ class LLMPlanner:
                     description=looping_task.description,
                     assignee_agent_id=looping_task.assignee_agent_id,
                     status=TaskStatus.FAILED,
+                    supersedes=looping_task.supersedes,
+                    supersedes_kind=looping_task.supersedes_kind,
                 )
             )
         return Plan(

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -18,6 +18,7 @@ from goldfive.types import (
     DriftSeverity,
     Goal,
     Plan,
+    SupersessionKind,
     Task,
     TaskEdge,
     TaskStatus,
@@ -71,6 +72,77 @@ def test_task_round_trip() -> None:
 def test_task_default_status_round_trip() -> None:
     t = Task(id="t1", title="A")
     assert from_pb_task(to_pb_task(t)) == t
+
+
+def test_task_supersedes_string_round_trip_no_char_split() -> None:
+    """``Task.supersedes`` survives proto round-trip as a single string.
+
+    Regression guard for the char-split hypothesis from the goldfive#251
+    audit. The proto field is a singular ``string supersedes = 9``; if a
+    producer-side bug ever wired a list-iterable into it (e.g. via
+    ``list.extend(str)`` instead of ``list.append(str)``), the round-trip
+    would either raise on serialise or silently truncate. Pin both
+    invariants:
+
+    * ``round_trip(t).supersedes`` is the SAME str instance value, NOT a
+      list of characters and NOT the empty string.
+    * The pb-side field's Python type is ``str`` after parse.
+    """
+    t = Task(
+        id="research_solar_flares_v2",
+        title="Research solar flares (v2)",
+        supersedes="research_solar_flares",
+        supersedes_kind=SupersessionKind.CORRECT,
+    )
+    pb = to_pb_task(t)
+    # Pb singular-string fields surface as Python str, not list[str] /
+    # list[int] — verify we did not accidentally encode the field via a
+    # repeated-string path that would char-iterate the value.
+    assert isinstance(pb.supersedes, str)
+    assert pb.supersedes == "research_solar_flares"
+    recovered = from_pb_task(pb)
+    assert isinstance(recovered.supersedes, str)
+    assert recovered.supersedes == "research_solar_flares"
+    # And: the dataclass round-trip preserves equality on the field
+    # AND on supersedes_kind.
+    assert recovered == t
+
+
+def test_plan_supersedes_round_trip_via_plan_revised_event() -> None:
+    """``Task.supersedes`` survives the full PlanRevised envelope path.
+
+    Goes one level above ``test_task_supersedes_string_round_trip``: pins
+    the field through the same pipeline a real refine takes — the steerer
+    builds ``PlanRevised(plan=...)`` via ``to_pb_plan(plan)`` and emits
+    it, sinks parse the bytes back. This is the path the goldfive#251
+    correction-injection write-side relies on; if the round-trip char-
+    splits, every dynainst correction-block render would render the
+    superseded id as ``r, e, s, e, ...`` instead of the ``research_...``
+    string the LLM should see.
+    """
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research_solar_flares", title="research", status=TaskStatus.COMPLETED),
+            Task(
+                id="correct_research_solar_flares",
+                title="research (corrected)",
+                supersedes="research_solar_flares",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+        ],
+        edges=[],
+    )
+    recovered = from_pb_plan(to_pb_plan(plan))
+    assert recovered == plan
+    # Spot-check the specific field: it must be a single string, never
+    # a list of chars.
+    target = next(t for t in recovered.tasks if t.id == "correct_research_solar_flares")
+    assert isinstance(target.supersedes, str)
+    assert target.supersedes == "research_solar_flares"
+    assert target.supersedes_kind is SupersessionKind.CORRECT
 
 
 def test_task_edge_round_trip() -> None:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2079,3 +2079,170 @@ async def test_refine_emits_no_orphan_event_when_coverage_complete() -> None:
         if isinstance(e, dict) and e.get("kind") == "refine_orphaned_tasks"
     ]
     assert orphan_events == []
+
+
+# ---------------------------------------------------------------------------
+# Fallback / deterministic-revision preservation of supersedes (#251 hardening)
+#
+# The looping-tool-call refine path has two non-LLM clones that historically
+# rebuilt ``Task`` records without ``supersedes`` / ``supersedes_kind``:
+#
+#   * ``_fallback_fail_loop_plan`` — deterministic LLM-can't-help branch.
+#   * ``_force_looper_failed`` post-parse hook (inside ``_refine_looping_tool_call``).
+#   * ``StaticPlanner.generate`` template clone.
+#
+# Dropping those fields silently breaks goldfive#251 supersedes coverage:
+# a CORRECT-kind chain that hits any of these clones loses its provenance
+# link, the supersedes-coverage validator orphans the prior task, and the
+# steerer's ``_repin_current_task_on_supersedes`` can't follow the chain.
+# Pin the invariant for each clone path. Strings are compared verbatim so
+# any future regression that char-splits the field (e.g. via
+# ``list.extend(str)``) would also fail loudly here.
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_fail_loop_plan_preserves_supersedes_on_existing_task() -> None:
+    """``_fallback_fail_loop_plan`` does NOT erase a CORRECT-kind link.
+
+    The looping task in ``plan`` carries ``supersedes='research_solar'`` /
+    ``supersedes_kind=CORRECT``. The fallback marks it FAILED — and must
+    keep both fields intact on the rebuilt Task.
+    """
+    looping_task = Task(
+        id="correct_research_solar",
+        title="Research solar (corrected)",
+        assignee_agent_id="researcher",
+        status=TaskStatus.RUNNING,
+        supersedes="research_solar",
+        supersedes_kind=SupersessionKind.CORRECT,
+    )
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            looping_task,
+        ],
+        edges=[],
+    )
+    drift = DriftEvent(
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        severity=DriftSeverity.WARNING,
+        detail="loop",
+        current_task_id="correct_research_solar",
+    )
+    fallback = LLMPlanner._fallback_fail_loop_plan(plan, drift, looping_task)
+    looper = next(t for t in fallback.tasks if t.id == "correct_research_solar")
+    assert looper.status is TaskStatus.FAILED
+    # The string MUST round-trip verbatim — never a list of chars, never empty.
+    assert isinstance(looper.supersedes, str)
+    assert looper.supersedes == "research_solar"
+    assert looper.supersedes_kind is SupersessionKind.CORRECT
+    # And the prior COMPLETED task's empty supersedes also round-trips.
+    research = next(t for t in fallback.tasks if t.id == "research_solar")
+    assert isinstance(research.supersedes, str)
+    assert research.supersedes == ""
+    assert research.supersedes_kind is SupersessionKind.UNSPECIFIED
+
+
+def test_fallback_fail_loop_plan_preserves_supersedes_on_inserted_task() -> None:
+    """When the loop task is missing from ``plan``, the fallback re-inserts it.
+
+    The re-insertion path was the original ``supersedes``-stripping site:
+    the synthesised Task carried only the title / assignee / FAILED status.
+    Pin that the supersession metadata is kept in the synthetic insertion
+    too, so a CORRECT chain survives even when the LLM dropped the looper
+    from its proposed revision.
+    """
+    looping_task = Task(
+        id="correct_research_solar",
+        title="Research solar (corrected)",
+        assignee_agent_id="researcher",
+        status=TaskStatus.RUNNING,
+        supersedes="research_solar",
+        supersedes_kind=SupersessionKind.CORRECT,
+    )
+    # Plan does NOT contain the looping task — exercises the synthetic
+    # insertion branch.
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+        ],
+        edges=[],
+    )
+    drift = DriftEvent(
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        severity=DriftSeverity.WARNING,
+        detail="loop",
+        current_task_id="correct_research_solar",
+    )
+    fallback = LLMPlanner._fallback_fail_loop_plan(plan, drift, looping_task)
+    looper = next(
+        (t for t in fallback.tasks if t.id == "correct_research_solar"), None
+    )
+    assert looper is not None
+    assert looper.status is TaskStatus.FAILED
+    assert isinstance(looper.supersedes, str)
+    assert looper.supersedes == "research_solar"
+    assert looper.supersedes_kind is SupersessionKind.CORRECT
+
+
+def test_static_planner_template_clone_preserves_supersedes() -> None:
+    """``StaticPlanner.generate`` clones the template per-call.
+
+    Verify the clone preserves ``supersedes`` / ``supersedes_kind`` on
+    every task, including correction successors. Without preservation a
+    test or CLI that bakes a CORRECT-chain into the template would lose
+    the provenance on the first call, then never recover.
+    """
+    from goldfive.planner import StaticPlanner
+
+    template = Plan(
+        id="static-plan",
+        run_id="static-run",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="correct_research_solar",
+                title="Research solar (corrected)",
+                supersedes="research_solar",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+        ],
+        edges=[],
+    )
+    sp = StaticPlanner(template)
+
+    import asyncio
+
+    cloned = asyncio.run(
+        sp.generate(
+            goals=[Goal(id="g1", summary="ship it")],
+            available_agents=None,
+            context={"run_id": "fresh-run"},
+        )
+    )
+    assert cloned is not None
+    correction = next(t for t in cloned.tasks if t.id == "correct_research_solar")
+    assert isinstance(correction.supersedes, str)
+    assert correction.supersedes == "research_solar"
+    assert correction.supersedes_kind is SupersessionKind.CORRECT


### PR DESCRIPTION
## Summary

Two-part audit from the goldfive#251 supersedes pipeline in E2E session `de7320e7-ee45-421b-9cec-36a07a6497eb` (3 `task_plans` rows but only 2 plan envelopes in `goldfive_events`).

### Bug A — Task.supersedes char-split (NOT a goldfive bug)

Hypothesis: producer-side `list.extend(str)` was iterating supersedes character-by-character.

**Empirical finding: not confirmed.** Decoding the actual `plan_revised` event for this session shows `Task.supersedes='research_solar_flares'` as a single string — the proto field is `string supersedes = 9` (singular), and goldfive's emit / convert paths handle it correctly. No char-split exists today.

Defensive guardrail shipped: `tests/test_conv.py` regression tests pin that `Task.supersedes` round-trips as `str` (never `list[str]` / `list[int]`) through both `to_pb_task` / `from_pb_task` AND the full `PlanRevised` envelope path. Any future `extend(str)`-shaped regression fails loudly at the proto seam.

### Bug B — silent plan-creation paths (real, root cause is harmonograf-side)

Leak confirmed: 3 `task_plans` rows for the session, but only 2 corresponding plan envelopes in `goldfive_events`. The mystery plans entered storage via `_on_plan_submitted` / `_on_plan_revised` dispatch but the event itself was NOT persisted to `goldfive_events`.

**Root cause is on the harmonograf side, not goldfive.** The ingest gate at `server/harmonograf_server/ingest.py:840` (added in harmonograf#113) conditions persistence on `kind is not None and run_id`, but the dispatch chain that follows runs unconditionally. So a plan event with empty `envelope.run_id` writes a `task_plans` row without a `goldfive_events` row.

**Recommendation**: open harmonograf follow-up to either (a) always persist known-kind events even when `run_id` is empty, or (b) refuse to dispatch when `run_id` is empty so the two tables stay consistent. Goldfive should also defensively assert `session.run_id` non-empty at every plan-emit site, but that is preventive — the actual leak surface is the harmonograf gate.

### What this PR ships on the goldfive side

Three latent supersedes-stripping clones in `planner.py` that drop supersession provenance through deterministic fallback paths:

- `_refine_looping_tool_call`'s `_force_looper_failed` post-parse hook re-inserts the looping task without `supersedes` / `supersedes_kind`.
- `_fallback_fail_loop_plan` rebuilds every Task in the plan AND the optional re-insertion without those fields.
- `StaticPlanner.generate`'s per-call template clone drops them.

A CORRECT-kind chain that hits any of these clones loses its link to the prior task; the supersedes-coverage validator (#251) then orphans the prior task and the steerer's `_repin_current_task_on_supersedes` can't follow the chain. Tests pin the invariant on each clone path.

## Test plan

- [x] `uv run pytest tests/` — 1312 passed, 89 skipped
- [x] `uv run ruff check goldfive/ tests/` — all checks passed
- [x] New regression tests:
  - `tests/test_conv.py::test_task_supersedes_string_round_trip_no_char_split`
  - `tests/test_conv.py::test_plan_supersedes_round_trip_via_plan_revised_event`
  - `tests/test_planner.py::test_fallback_fail_loop_plan_preserves_supersedes_on_existing_task`
  - `tests/test_planner.py::test_fallback_fail_loop_plan_preserves_supersedes_on_inserted_task`
  - `tests/test_planner.py::test_static_planner_template_clone_preserves_supersedes`