### PR TITLE
fix(adk): adapter-level planner-gate + steer-language heuristic

### DIFF
--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -240,6 +240,13 @@ class GoldfiveADKAgent(BaseAgent):
 
     _inner: Any = PrivateAttr(default=None)
     _runner: Runner = PrivateAttr(default=None)  # type: ignore[assignment]
+    # Adapter-level planner-gate dedup. Holds the (invocation_id,
+    # user_input) tuple of the most recent message we already classified
+    # for this wrapper, so a redrive of the same invocation does not
+    # double-classify and double-route through the steerer. See
+    # :meth:`_run_async_impl`'s adapter-level gate path. ``None`` means
+    # no message has been classified yet.
+    _last_classified: Any = PrivateAttr(default=None)
 
     def __init__(self, *, inner: Any, runner: Runner) -> None:
         super().__init__(
@@ -249,6 +256,7 @@ class GoldfiveADKAgent(BaseAgent):
         )
         self._inner = inner
         self._runner = runner
+        self._last_classified = None
 
     # ------------------------------------------------------------------
     # BaseAgent extension point
@@ -309,6 +317,49 @@ class GoldfiveADKAgent(BaseAgent):
             )
             return
 
+        # Adapter-level planner-gate (goldfive#270 follow-up). Classify
+        # the freshly-arrived user message HERE — at the goldfive code
+        # closest to ADK's user-message arrival point — so the verdict
+        # is computed before the inner :meth:`Runner.run` rebuilds the
+        # session. The verdict rides through ``context`` into Runner.run
+        # which honours it via ``_RUN_CONTEXT_PRECLASSIFIED_VERDICT_KEY``
+        # and skips its own :meth:`_classify_turn` call.
+        #
+        # Why both layers? :meth:`Runner.run` retains its own gate for
+        # non-ADK callers (programmatic, Claude SDK, callable) that
+        # bypass the wrapper entirely. The adapter-level pre-pass
+        # documents intent: "the gate IS evaluated for ADK-web turns,
+        # at the adapter boundary, before the inner pipeline starts."
+        #
+        # Dedup: a redrive of the same invocation_id with the same
+        # user_input must not double-classify (and double-route through
+        # the steerer's USER_STEER pipeline). The
+        # :attr:`_last_classified` cache keys on
+        # ``(invocation_id, user_input)`` and short-circuits on hit.
+        invocation_id_for_gate = str(getattr(ctx, "invocation_id", "") or "")
+        gate_cache_key = (invocation_id_for_gate, user_input)
+        pre_verdict: Any = None
+        if self._last_classified == gate_cache_key:
+            log.debug(
+                "GoldfiveADKAgent: gate dedup — same (invocation_id, "
+                "user_input) already classified; reusing prior verdict"
+            )
+            pre_verdict = getattr(self, "_last_classified_verdict", None)
+        else:
+            try:
+                pre_verdict = await self._classify_user_message_for_adk(user_input)
+            except Exception as exc:  # noqa: BLE001
+                # Adapter-side gate must never break a run; fall back to
+                # letting Runner.run classify itself.
+                log.warning(
+                    "GoldfiveADKAgent: adapter-level gate raised; "
+                    "falling back to runner-side gate: %s",
+                    exc,
+                )
+                pre_verdict = None
+            self._last_classified = gate_cache_key
+            self._last_classified_verdict = pre_verdict
+
         # try/finally wraps the entire run so ``_notify_plugins_on_run_end``
         # fires on ALL exit paths — normal completion, adapter raise,
         # upstream ``CancelledError`` (adk-web disconnect mid-stream), or
@@ -337,9 +388,16 @@ class GoldfiveADKAgent(BaseAgent):
         plan_summary_yielded = False
         try:
             outcome: ExecutionOutcome | None = None
+            run_context: dict[str, Any] = {"adk_ctx": ctx}
+            if pre_verdict is not None:
+                # Threaded into Runner.run via context — Runner.run reads
+                # this key, skips its own _classify_turn, and uses the
+                # adapter-side verdict directly. See
+                # :data:`goldfive.runner._RUN_CONTEXT_PRECLASSIFIED_VERDICT_KEY`.
+                run_context["_adk_pre_classified_verdict"] = pre_verdict
             async for item in self._runner.run_streamed(
                 user_input,
-                context={"adk_ctx": ctx},
+                context=run_context,
                 session_id=outer_sid or None,
             ):
                 if isinstance(item, ExecutionOutcome):
@@ -387,6 +445,76 @@ class GoldfiveADKAgent(BaseAgent):
             # Bounded timeout keeps a hung judge from stalling exit.
             await self._drain_steerer_background_judges()
             self._notify_plugins_on_run_end()
+
+    async def _classify_user_message_for_adk(
+        self, user_input: str
+    ) -> Any:
+        """Classify the freshly-arrived ADK user message via the planner-gate.
+
+        Mirrors :meth:`Runner._classify_turn` but reads the planner-gate
+        configuration off the wrapped Runner so settings and overrides
+        already in place (``planner_gate=None``, custom callable, ``"auto"``
+        with the planner's ``_call_llm``) are honoured identically.
+
+        Returns one of:
+
+        * ``"new_work"``, ``"conversational"``, ``"refine_existing"`` —
+          the normal three-verdict set; passed through ``context`` into
+          :meth:`Runner.run` which uses it instead of running its own
+          gate.
+        * ``None`` — gate disabled (planner_gate=None on the Runner) OR
+          first turn (no prior plan to refine against). The Runner-side
+          gate's existing logic handles the no-prior-plan case identically
+          (returns ``"new_work"``); returning ``None`` from this method
+          keeps the contract explicit.
+        """
+        runner = self._runner
+        gate = getattr(runner, "_planner_gate", "auto")
+        # Caller has explicitly disabled the gate — don't reintroduce it
+        # at the adapter layer.
+        if gate is None:
+            return None
+        last_plan = getattr(runner, "_last_plan", None)
+        # No prior plan → first turn, gate would always pick new_work.
+        # Skip the call to keep the LLM out of the hot path on turn 1.
+        if last_plan is None or not getattr(last_plan, "tasks", None):
+            return None
+
+        # Reuse Runner._classify_turn so the planner-gate configuration
+        # (callable / "auto" / heuristic) is honoured exactly once.
+        #
+        # ``session=None`` is intentional — the wrapper does not yet
+        # have a goldfive Session for THIS turn (Runner.run mints it
+        # inside). The classify_turn span will simply omit session_id /
+        # run_id; harmonograf still gets the planner-gate decision span,
+        # just unattached to the turn's run_id. The verdict carried
+        # forward via context ties back to the run when Runner.run uses
+        # it.
+        try:
+            verdict = await runner._classify_turn(
+                prior_plan=last_plan,
+                completed_results={},
+                user_input=user_input,
+                session=None,
+            )
+        except Exception as exc:  # noqa: BLE001 — never break the run on gate
+            log.warning(
+                "GoldfiveADKAgent._classify_user_message_for_adk: gate raised; "
+                "falling back to runner-side gate: %s",
+                exc,
+            )
+            return None
+        # Defensive: surface any non-canonical verdict as None so Runner.run
+        # falls through to its own classification (which has identical
+        # safety nets).
+        if verdict not in ("new_work", "conversational", "refine_existing"):
+            log.warning(
+                "GoldfiveADKAgent._classify_user_message_for_adk: gate returned "
+                "non-canonical %r; ignoring",
+                verdict,
+            )
+            return None
+        return verdict
 
     async def _drain_steerer_background_judges(self) -> None:
         """Call ``steerer.shutdown()`` on the bound runner's steerer, if any.

--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -322,8 +322,8 @@ class GoldfiveADKAgent(BaseAgent):
         # closest to ADK's user-message arrival point — so the verdict
         # is computed before the inner :meth:`Runner.run` rebuilds the
         # session. The verdict rides through ``context`` into Runner.run
-        # which honours it via ``_RUN_CONTEXT_PRECLASSIFIED_VERDICT_KEY``
-        # and skips its own :meth:`_classify_turn` call.
+        # under the ``_adk_pre_classified_verdict`` key; Runner.run
+        # honours it and skips its own :meth:`_classify_turn` call.
         #
         # Why both layers? :meth:`Runner.run` retains its own gate for
         # non-ADK callers (programmatic, Claude SDK, callable) that
@@ -392,8 +392,7 @@ class GoldfiveADKAgent(BaseAgent):
             if pre_verdict is not None:
                 # Threaded into Runner.run via context — Runner.run reads
                 # this key, skips its own _classify_turn, and uses the
-                # adapter-side verdict directly. See
-                # :data:`goldfive.runner._RUN_CONTEXT_PRECLASSIFIED_VERDICT_KEY`.
+                # adapter-side verdict directly.
                 run_context["_adk_pre_classified_verdict"] = pre_verdict
             async for item in self._runner.run_streamed(
                 user_input,

--- a/goldfive/planner_gate.py
+++ b/goldfive/planner_gate.py
@@ -83,6 +83,50 @@ _ALLOWED: frozenset[str] = frozenset(
     {"new_work", "conversational", "refine_existing"}
 )
 
+#: Steer-language regex. A non-empty match in the user's input forces the
+#: heuristic to return ``"refine_existing"`` regardless of token count —
+#: catches the "forget X, do Y instead" / "no, don't X, do Y" pivot pattern
+#: that previously fell through to ``"conversational"`` (token < 20) or
+#: ``"new_work"`` (token >= 20). Both fall-through verdicts dropped the
+#: prior plan's constraints and bypassed the steerer's pipeline (no
+#: PlanRevised, no DriftDetected(USER_STEER), no sticky-goal preservation),
+#: which is what the goldfive#270 E2E hit.
+#:
+#: Anchored to start-of-string OR a sentence break so "I'd like to forget
+#: about ..." doesn't false-positive — only leading directives match.
+_STEER_PATTERN_RE = re.compile(
+    r"(?:^|[.?!]\s+)(?:"
+    r"forget|"
+    r"never mind|"
+    r"nevermind|"
+    r"scratch that|"
+    r"strike that|"
+    r"actually,?\s+|"
+    r"wait,?\s+|"
+    r"no,?\s+(?:wait|don't|do not|not)|"
+    r"stop\b|"
+    r"instead\b|"
+    r"change(?:\s+(?:that|the\s+plan|topic|to))|"
+    r"switch\s+to|"
+    r"do not\b|"
+    r"don't\b|"
+    r"no longer\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_steer(text: str) -> bool:
+    """Return True if ``text`` opens with a directive that revises prior work.
+
+    See :data:`_STEER_PATTERN_RE`. Used by :func:`heuristic_classify_turn`
+    to escape the token-count-only branch and route steer-shaped messages
+    through ``refine_existing`` so the runner's USER_STEER pipeline fires.
+    """
+    if not text:
+        return False
+    return bool(_STEER_PATTERN_RE.search(text))
+
 _SYSTEM_PROMPT = """\
 You are a turn-classifier for a multi-agent orchestration system.
 
@@ -111,13 +155,30 @@ Verdicts:
   plan's completed tasks should be preserved; a small delta of new
   tasks is appended.
 
+  This bucket also covers PIVOT directives that revise the topic
+  while keeping the same artefact / output format — e.g. "forget
+  X, tell me about Y instead", "no, don't do X, do Y", "switch the
+  topic to Z", "instead of X let's do Y", "scratch that — Y", "I
+  changed my mind — Y". These are NOT new_work: they keep the prior
+  plan's structural constraints (slide count, output type, audience)
+  and only swap the subject. Routing them to refine_existing
+  preserves those constraints; routing them to new_work silently
+  drops them.
+
 Guidelines:
 - When in doubt between "conversational" and "refine_existing",
   prefer "conversational" — the coordinator can always answer and
   the user can restate if they actually wanted new work.
 - When in doubt between "refine_existing" and "new_work", prefer
   "refine_existing" — the prior plan's completed tasks give the
-  refined plan a running start.
+  refined plan a running start, and the prior plan's structural
+  constraints survive the pivot.
+- Steer-language openers ("forget", "instead", "no, don't ...",
+  "scratch that", "actually", "wait, ...", "stop", "change the
+  topic", "switch to") are strong refine_existing signals — only
+  classify them as new_work when the user explicitly says they want
+  to abandon the artefact entirely (e.g. "forget the slides, just
+  give me the bullet points").
 
 Reply with a single JSON object and NOTHING ELSE:
 {"verdict": "new_work" | "conversational" | "refine_existing",
@@ -196,25 +257,36 @@ def heuristic_classify_turn(
 ) -> TurnClassification:
     """Deterministic rule-based gate. LLM-free.
 
-    Rules:
+    Rules (in order):
 
     - No prior plan → always ``"new_work"`` (first turn or fresh
       conversation).
+    - Prior plan exists AND :func:`_looks_like_steer` matches →
+      ``"refine_existing"``. Steer-language openers ("forget X",
+      "instead", "no, don't ..., do ...") overwhelmingly indicate the
+      user is pivoting prior work, not asking a clarifying question
+      and not requesting a wholly new workflow. Routing these through
+      the refine pipeline preserves the prior plan's sticky context
+      (slide count, output format) while letting the steerer emit
+      ``DriftDetected(USER_STEER)`` and ``PlanRevised``. Without this
+      branch the heuristic dropped steer messages into
+      ``"conversational"`` (short input) or ``"new_work"`` (long
+      input), both of which silently lost the constraints — see
+      goldfive#270 E2E.
     - Prior plan exists AND user_input is short (``< 20`` tokens) →
-      ``"conversational"``. Short follow-ups are overwhelmingly
-      questions about prior work, not new workflows.
-    - Otherwise → ``"new_work"``. Conservative default: the heuristic
-      never picks ``"refine_existing"`` on its own because getting the
-      refine path wrong silently mangles the plan, whereas getting
-      ``"new_work"`` wrong just means the user pays for an extra plan
-      that still completes.
+      ``"conversational"``. Short follow-ups that AREN'T steer-shaped
+      are overwhelmingly questions about prior work.
+    - Otherwise → ``"new_work"``.
 
     The LLM-backed :func:`classify_turn` is strictly more precise and
-    should be preferred when a ``call_llm`` is available.
+    should be preferred when a ``call_llm`` is available; this gate is
+    a deterministic fallback for offline / mock-mode runs.
     """
     _ = conversation_id  # reserved for future heuristics
     if prior_plan is None or not prior_plan.tasks:
         return "new_work"
+    if _looks_like_steer(user_input):
+        return "refine_existing"
     if _token_count(user_input) < _HEURISTIC_SHORT_TOKEN_BUDGET:
         return "conversational"
     return "new_work"

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -304,8 +304,30 @@ class Runner:
         # planning. When ``user_input`` is already a ``list[Goal]``
         # the caller has opted out of natural-language derivation, so
         # we also skip the gate.
+        #
+        # Pre-classified verdict short-circuit (goldfive#270 follow-up):
+        # :class:`~goldfive.adapters.adk_wrap.GoldfiveADKAgent` runs the
+        # gate at the adapter boundary (the goldfive code closest to
+        # ADK-web's user-message arrival point) and threads its verdict
+        # into ``context["_adk_pre_classified_verdict"]``. When that key
+        # is present we honour it directly, skipping
+        # :meth:`_classify_turn` entirely so the LLM gate fires once
+        # per turn at most. Non-ADK callers (programmatic, callable
+        # adapter, Claude SDK) supply no such key and run the gate
+        # in-line as before.
         verdict: TurnClassification = "new_work"
-        if self._last_plan is not None and isinstance(user_input, str):
+        pre_verdict = (
+            (context or {}).get("_adk_pre_classified_verdict")
+            if isinstance(context, Mapping)
+            else None
+        )
+        if pre_verdict in ("new_work", "conversational", "refine_existing"):
+            verdict = pre_verdict  # type: ignore[assignment]
+            log.debug(
+                "Runner.run: using adapter-level pre-classified verdict %r",
+                verdict,
+            )
+        elif self._last_plan is not None and isinstance(user_input, str):
             try:
                 verdict = await self._classify_turn(
                     prior_plan=self._last_plan,

--- a/tests/test_adk_adapter_gate.py
+++ b/tests/test_adk_adapter_gate.py
@@ -1,0 +1,691 @@
+"""Tests for the adapter-level planner-gate (goldfive#270 follow-up).
+
+The runner-side gate (:meth:`goldfive.runner.Runner._classify_turn`)
+ships the same three-verdict classifier on every call to
+:meth:`Runner.run`. For ADK-web turns the classifier ALSO runs at the
+adapter boundary — :meth:`GoldfiveADKAgent._run_async_impl` calls
+:meth:`GoldfiveADKAgent._classify_user_message_for_adk` BEFORE handing
+control to :meth:`Runner.run_streamed`, threads the verdict through
+``context["_adk_pre_classified_verdict"]``, and Runner.run honours it
+instead of running the gate twice.
+
+Coverage:
+
+1. ``refine_existing`` verdict at the adapter boundary makes Runner.run
+   route through the steerer's USER_STEER pipeline (PlanRevised emitted,
+   revision_index bumped, no fresh PlanSubmitted).
+2. ``conversational`` verdict skips planning AND skips the steerer
+   entirely.
+3. ``new_work`` verdict triggers the normal generate / dispatch path
+   exactly as it would have without the adapter pre-pass.
+4. First turn (no prior plan) — adapter classifier returns ``None``,
+   Runner.run runs its own gate (which itself returns ``new_work``).
+5. Replay dedup — re-driving the same (invocation_id, user_input)
+   does NOT classify a second time.
+6. Suppression interaction — once a USER_STEER fired this turn, a
+   later goldfive-detected drift gets ``suppressed_by_user_steer=True``
+   on the wire (the runner's existing _should_promote_to_steer
+   machinery already handles this; the test verifies it still works
+   when the steer was routed via the adapter pre-classification).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+import goldfive
+from goldfive import InMemorySink, InvocationResult, SequentialExecutor, StaticPlanner
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Plan,
+    Task,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Event-shape helpers
+#
+# Goldfive sinks observe a mix of proto-shaped events (set via the typed
+# `make_event_*` factories in goldfive.events) and dict-shaped events
+# (set via `make_event` for callers that don't need protos). The helpers
+# below normalise both shapes so a single test asserts against either —
+# the test layer doesn't care which envelope a given emission picked.
+# ---------------------------------------------------------------------------
+
+
+def _is_proto(evt: Any) -> bool:
+    return hasattr(evt, "HasField")
+
+
+def _proto_drift_detected(evt: Any) -> Any | None:
+    """Return the drift_detected sub-message if this is a proto event with that field set."""
+    if not _is_proto(evt):
+        return None
+    try:
+        if evt.HasField("drift_detected"):
+            return evt.drift_detected
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _drift_user_steer_events(events: list[Any]) -> list[Any]:
+    """Filter for DriftDetected(USER_STEER) on either envelope shape.
+
+    Proto kind is an enum int — resolve via the proto pb2 enum module
+    so we don't hard-code the underlying integer value (it's stable but
+    enum-managed elsewhere).
+    """
+    # Lazy import to keep this module light when proto isn't installed.
+    from goldfive.pb.goldfive.v1 import types_pb2  # type: ignore
+
+    user_steer_value = types_pb2.DriftKind.Value("DRIFT_KIND_USER_STEER")
+    out: list[Any] = []
+    for e in events:
+        dd = _proto_drift_detected(e)
+        if dd is not None and int(dd.kind) == user_steer_value:
+            out.append(e)
+            continue
+        # Dict shape (not currently used by USER_STEER emit, but
+        # defensive): kind == "drift_detected", payload includes
+        # drift_kind == "user_steer".
+        if isinstance(e, dict) and e.get("kind") == "drift_detected":
+            payload = e.get("payload") or {}
+            if str(payload.get("drift_kind", "")).lower().endswith("user_steer"):
+                out.append(e)
+    return out
+
+
+def _all_drift_events(events: list[Any]) -> list[Any]:
+    """All DriftDetected events on either envelope shape (any kind)."""
+    out: list[Any] = []
+    for e in events:
+        if _proto_drift_detected(e) is not None:
+            out.append(e)
+            continue
+        if isinstance(e, dict) and e.get("kind") == "drift_detected":
+            out.append(e)
+    return out
+
+
+def _drift_suppressed_by_user_steer(evt: Any) -> bool:
+    dd = _proto_drift_detected(evt)
+    if dd is not None:
+        return bool(getattr(dd, "suppressed_by_user_steer", False))
+    if isinstance(evt, dict):
+        payload = evt.get("payload") or {}
+        return bool(payload.get("suppressed_by_user_steer", False))
+    return False
+
+
+def _plan_submitted_events(events: list[Any]) -> list[Any]:
+    out: list[Any] = []
+    for e in events:
+        if _is_proto(e):
+            try:
+                if e.HasField("plan_submitted"):
+                    out.append(e)
+            except Exception:  # noqa: BLE001
+                pass
+            continue
+        if isinstance(e, dict) and e.get("kind") == "plan_submitted":
+            out.append(e)
+    return out
+
+
+def _plan_revised_events(events: list[Any]) -> list[Any]:
+    out: list[Any] = []
+    for e in events:
+        if _is_proto(e):
+            try:
+                if e.HasField("plan_revised"):
+                    out.append(e)
+            except Exception:  # noqa: BLE001
+                pass
+            continue
+        if isinstance(e, dict) and e.get("kind") == "plan_revised":
+            out.append(e)
+    return out
+
+
+def _plan_revised_revision_index(evt: Any) -> int | None:
+    if _is_proto(evt):
+        try:
+            if evt.HasField("plan_revised"):
+                return int(evt.plan_revised.revision_index)
+        except Exception:  # noqa: BLE001
+            return None
+    if isinstance(evt, dict) and evt.get("kind") == "plan_revised":
+        payload = evt.get("payload") or {}
+        ri = payload.get("revision_index")
+        if isinstance(ri, int):
+            return ri
+        try:
+            return int(ri) if ri is not None else None
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _completed_plan() -> Plan:
+    return Plan(
+        id="prior-1",
+        run_id="r-prior",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Gather facts",
+                description="x",
+                assignee_agent_id="inner_agent",
+                status=TaskStatus.COMPLETED,
+            ),
+        ],
+        edges=[],
+        summary="Prior plan completed",
+    )
+
+
+def _two_task_planner() -> StaticPlanner:
+    return StaticPlanner(
+        Plan(
+            id="p1",
+            run_id="",
+            goal_ids=["g1"],
+            tasks=[
+                Task(
+                    id="t1",
+                    title="Task one",
+                    description="x",
+                    assignee_agent_id="inner_agent",
+                ),
+                Task(
+                    id="t2",
+                    title="Task two",
+                    description="y",
+                    assignee_agent_id="inner_agent",
+                ),
+            ],
+            edges=[],
+            summary="two task plan",
+        )
+    )
+
+
+def _mk_inner(name: str = "inner_agent") -> Any:
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(
+        name=name,
+        model="fake-model",
+        description="a wrapped agent",
+        instruction="follow instructions",
+    )
+
+
+class _FakeSession:
+    def __init__(self, sid: str = "outer-sess") -> None:
+        self.id = sid
+        self.events: list[Any] = []
+
+
+class _FakeCtx:
+    def __init__(self, text: str, *, invocation_id: str = "inv-1") -> None:
+        from google.genai.types import Content, Part  # type: ignore
+
+        self.user_content = Content(role="user", parts=[Part(text=text)])
+        self.session = _FakeSession()
+        self.invocation_id = invocation_id
+        self.end_invocation = False
+
+
+def _build_wrapped(
+    *,
+    planner: Any | None = None,
+    planner_gate: Any = "auto",
+    sinks: list[Any] | None = None,
+) -> Any:
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=planner or _two_task_planner(),
+        sinks=sinks if sinks is not None else [InMemorySink()],
+    )
+    wrapped.runner._planner_gate = planner_gate
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=4)
+    adapter = wrapped.runner.agent
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text=f"ok: {task.id}")
+
+    adapter.invoke = AsyncMock(side_effect=_fake_invoke)
+    return wrapped
+
+
+def _seed_prior_plan(wrapped: Any) -> None:
+    """Stamp a completed plan onto the runner so turn-2 has prior context."""
+    wrapped.runner._last_plan = _completed_plan()
+
+
+# ---------------------------------------------------------------------------
+# 1. refine_existing → USER_STEER pipeline fires from the adapter pre-pass
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_gate_refine_existing_routes_through_steerer() -> None:
+    """``refine_existing`` from the adapter pre-pass drives the steerer's
+    USER_STEER pipeline: PlanRevised emits with bumped revision_index,
+    no fresh PlanSubmitted is observed.
+    """
+    sink = InMemorySink()
+    wrapped = _build_wrapped(planner_gate="auto", sinks=[sink])
+
+    # Seed a prior plan so the adapter-level gate runs (no-prior-plan
+    # short-circuits to None and lets Runner.run handle).
+    _seed_prior_plan(wrapped)
+
+    # Force the gate to refine_existing by replacing _classify_turn on
+    # the runner. The adapter helper delegates to this method.
+    classify_calls: list[Any] = []
+
+    async def _force_refine(*, prior_plan, completed_results, user_input, session):
+        classify_calls.append(user_input)
+        return "refine_existing"
+
+    wrapped.runner._classify_turn = _force_refine
+
+    # Stub the planner.refine to return a clean revised plan so the
+    # steerer's _apply_revision installs it cleanly.
+    revised = Plan(
+        id="prior-1",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Gather facts",
+                description="x",
+                assignee_agent_id="inner_agent",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="t2-new",
+                title="Pivot to flares",
+                description="z",
+                assignee_agent_id="inner_agent",
+            ),
+        ],
+        edges=[],
+        summary="Pivoted plan",
+        revision_index=0,  # _apply_revision bumps from prior+1
+    )
+
+    async def _fake_refine(*, plan, drift, goals, **kwargs):
+        return revised
+
+    wrapped.runner.planner.refine = _fake_refine  # type: ignore[method-assign]
+
+    ctx = _FakeCtx("forget solar panels. tell me about solar flares instead.")
+    events_yielded = [e async for e in wrapped._run_async_impl(ctx)]
+    assert events_yielded  # smoke
+
+    # The classifier was consulted exactly once via the adapter pre-pass.
+    # Runner.run's own _classify_turn would also call it, but the pre-
+    # classified verdict short-circuits it — so we expect exactly one.
+    assert len(classify_calls) == 1, (
+        f"expected one classifier call from adapter pre-pass; got "
+        f"{len(classify_calls)}: {classify_calls}"
+    )
+
+    # Wire-level checks: a DriftDetected(USER_STEER) and a PlanRevised
+    # event landed on the sink.
+    sink_events = list(sink.events)
+    drift_events = _drift_user_steer_events(sink_events)
+    plan_revised = _plan_revised_events(sink_events)
+    assert drift_events, (
+        "no DriftDetected(USER_STEER) on the wire; the adapter-level "
+        "refine_existing path didn't reach steerer._handle_drift"
+    )
+    assert plan_revised, (
+        "no PlanRevised on the wire; the steerer's _apply_revision did "
+        "not install the revised plan"
+    )
+    # revision_index must increment from the prior's 0 → 1.
+    ri = _plan_revised_revision_index(plan_revised[-1])
+    assert ri == 1, f"expected revision_index=1; got {ri!r}"
+
+
+# ---------------------------------------------------------------------------
+# 2. conversational → no steerer, no planner.refine
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_gate_conversational_skips_steerer() -> None:
+    """``conversational`` verdict from the adapter pre-pass leaves the
+    steerer's pipeline entirely alone — no DriftDetected, no PlanRevised.
+    """
+    sink = InMemorySink()
+    wrapped = _build_wrapped(planner_gate="auto", sinks=[sink])
+    _seed_prior_plan(wrapped)
+
+    async def _force_conv(*, prior_plan, completed_results, user_input, session):
+        return "conversational"
+
+    wrapped.runner._classify_turn = _force_conv
+
+    refine_calls: list[Any] = []
+
+    async def _trip_refine(**kwargs):
+        refine_calls.append(kwargs)
+        return None
+
+    wrapped.runner.planner.refine = _trip_refine  # type: ignore[method-assign]
+
+    ctx = _FakeCtx("where are the slides saved?")
+    [e async for e in wrapped._run_async_impl(ctx)]
+
+    sink_events = list(sink.events)
+    assert not _drift_user_steer_events(sink_events), (
+        "USER_STEER fired on a conversational turn"
+    )
+    assert not _plan_revised_events(sink_events), (
+        "PlanRevised fired on a conversational turn"
+    )
+    assert not refine_calls, "planner.refine called on a conversational turn"
+
+
+# ---------------------------------------------------------------------------
+# 3. new_work → normal generate + plan submitted
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_gate_new_work_runs_normal_planner_path() -> None:
+    """``new_work`` verdict produces a fresh PlanSubmitted (full
+    re-planning). The adapter pre-pass should not interfere.
+    """
+    sink = InMemorySink()
+    wrapped = _build_wrapped(planner_gate="auto", sinks=[sink])
+    _seed_prior_plan(wrapped)
+
+    async def _force_new(*, prior_plan, completed_results, user_input, session):
+        return "new_work"
+
+    wrapped.runner._classify_turn = _force_new
+
+    ctx = _FakeCtx("a wholly new and unrelated workflow about pasta")
+    [e async for e in wrapped._run_async_impl(ctx)]
+
+    sink_events = list(sink.events)
+    plan_submitted = _plan_submitted_events(sink_events)
+    plan_revised = _plan_revised_events(sink_events)
+    assert plan_submitted, "expected PlanSubmitted on a new_work turn"
+    assert not plan_revised, "PlanRevised should not fire on a new_work turn"
+
+
+# ---------------------------------------------------------------------------
+# 4. First turn — gate returns None, Runner.run handles
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_gate_first_turn_short_circuits_to_none() -> None:
+    """No prior plan ⇒ adapter classifier returns None ⇒ Runner.run runs
+    its own gate (which also returns new_work for first-turn callers)
+    and the run proceeds normally.
+    """
+    wrapped = _build_wrapped(planner_gate="auto")
+    # No prior plan stamped — first turn.
+    classify_calls: list[Any] = []
+
+    async def _spy(*, prior_plan, completed_results, user_input, session):
+        classify_calls.append(user_input)
+        return "new_work"
+
+    wrapped.runner._classify_turn = _spy
+
+    ctx = _FakeCtx("make a thing")
+    events = [e async for e in wrapped._run_async_impl(ctx)]
+    assert events  # smoke — the run executed
+
+    # The adapter pre-pass short-circuits on no-prior-plan and never
+    # calls _classify_turn. Runner.run also short-circuits because
+    # _last_plan is None on the first turn (per its own gate guard).
+    # Net: zero classifier calls.
+    assert classify_calls == [], (
+        f"expected no classifier calls on first turn (no prior plan); "
+        f"got {classify_calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Replay dedup — same invocation_id + user_input is not classified twice
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_gate_replay_does_not_double_classify() -> None:
+    """Re-driving the same invocation_id with identical user_input must
+    only classify once: the adapter caches (invocation_id, user_input)
+    on the wrapper.
+    """
+    wrapped = _build_wrapped(planner_gate="auto")
+    _seed_prior_plan(wrapped)
+
+    classify_calls: list[Any] = []
+
+    async def _spy(*, prior_plan, completed_results, user_input, session):
+        classify_calls.append(user_input)
+        return "new_work"
+
+    wrapped.runner._classify_turn = _spy
+
+    ctx_a = _FakeCtx("update the slides please", invocation_id="inv-replay")
+    [e async for e in wrapped._run_async_impl(ctx_a)]
+    first_calls = list(classify_calls)
+    assert len(first_calls) == 1, "expected 1 call on the first drive"
+
+    # Replay the same invocation_id + user_input.
+    ctx_b = _FakeCtx("update the slides please", invocation_id="inv-replay")
+    [e async for e in wrapped._run_async_impl(ctx_b)]
+
+    assert classify_calls == first_calls, (
+        f"replay double-classified: {classify_calls!r}"
+    )
+
+
+async def test_adapter_gate_distinct_invocation_id_classifies_again() -> None:
+    """The dedup key includes invocation_id, so a fresh invocation with
+    the same text DOES re-classify (a real turn, not a replay).
+    """
+    wrapped = _build_wrapped(planner_gate="auto")
+    _seed_prior_plan(wrapped)
+
+    classify_calls: list[Any] = []
+
+    async def _spy(*, prior_plan, completed_results, user_input, session):
+        classify_calls.append(user_input)
+        return "new_work"
+
+    wrapped.runner._classify_turn = _spy
+
+    ctx_a = _FakeCtx("ok then continue", invocation_id="inv-A")
+    [e async for e in wrapped._run_async_impl(ctx_a)]
+    ctx_b = _FakeCtx("ok then continue", invocation_id="inv-B")
+    [e async for e in wrapped._run_async_impl(ctx_b)]
+
+    assert len(classify_calls) == 2, (
+        f"distinct invocation_ids should classify twice; got "
+        f"{classify_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Suppression — goldfive drift after a fresh USER_STEER carries the flag
+# ---------------------------------------------------------------------------
+
+
+async def test_user_steer_suppresses_subsequent_goldfive_drift() -> None:
+    """Within a USER_STEER's freshness window the steerer's
+    :meth:`_should_promote_to_steer` stamps ``suppressed_by_user_steer``
+    on a subsequent goldfive-authored drift.
+
+    This test pins the contract that the adapter-routed USER_STEER path
+    leaves the same orchestration state behind that the historical
+    direct-steerer path did, so the existing suppression machinery
+    keeps working without modification.
+
+    The run-end ``clear_active_steer`` call in Runner.run wipes the
+    state when the run completes, so this test re-enacts the
+    in-window state explicitly before firing the goldfive drift —
+    that's what the steerer would see during a still-running turn
+    in production (drift detected mid-run, after the USER_STEER lands
+    but before the run completes).
+    """
+    sink = InMemorySink()
+    wrapped = _build_wrapped(planner_gate="auto", sinks=[sink])
+    _seed_prior_plan(wrapped)
+
+    async def _force_refine(*, prior_plan, completed_results, user_input, session):
+        return "refine_existing"
+
+    wrapped.runner._classify_turn = _force_refine
+
+    revised = Plan(
+        id="prior-1",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Gather facts",
+                description="x",
+                assignee_agent_id="inner_agent",
+                status=TaskStatus.COMPLETED,
+            ),
+        ],
+        edges=[],
+        summary="No-op revision",
+    )
+
+    async def _fake_refine(*, plan, drift, goals, **kwargs):
+        return revised
+
+    wrapped.runner.planner.refine = _fake_refine  # type: ignore[method-assign]
+
+    # Drive the run end-to-end so the USER_STEER lands.
+    ctx = _FakeCtx("forget panels. flares instead.")
+    events_yielded = [e async for e in wrapped._run_async_impl(ctx)]
+    assert events_yielded  # smoke
+
+    # Re-stamp active_steer state to simulate an in-window mid-run
+    # observation (the run-end clear_active_steer would otherwise have
+    # wiped it). This is the state the suppression check actually sees
+    # in production when a goldfive drift fires mid-turn.
+    steerer = wrapped.runner.steerer
+    session = wrapped.runner._last_session
+    assert session is not None
+    from goldfive.orchestration_state import set_active_steer
+
+    set_active_steer(
+        session.state,
+        body="forget panels. flares instead.",
+        at_turn=int(getattr(session, "_next_sequence", 0) or 0),
+        author="user",
+        source="user",
+    )
+
+    later_drift = DriftEvent(
+        kind=DriftKind.LOOPING_REASONING,
+        severity=DriftSeverity.WARNING,
+        detail="goldfive observation",
+        authored_by="goldfive",
+    )
+    await steerer._handle_drift(later_drift, session)
+
+    # Find the LAST DriftDetected on the wire — the goldfive one we
+    # just fired — and assert the suppression flag is set.
+    sink_events = list(sink.events)
+    drift_events = _all_drift_events(sink_events)
+    assert len(drift_events) >= 2, (
+        "expected USER_STEER + goldfive drift on the wire; got "
+        f"{len(drift_events)} drift event(s)"
+    )
+    last_suppressed = _drift_suppressed_by_user_steer(drift_events[-1])
+    assert last_suppressed is True, (
+        "goldfive drift after a fresh USER_STEER did not carry "
+        "suppressed_by_user_steer=True; suppression machinery missed "
+        "the adapter-routed steer"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Heuristic-mode integration — the heuristic now catches steer language
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_gate_heuristic_catches_steer_language() -> None:
+    """End-to-end with the heuristic gate (no LLM): a steer-shaped
+    user message produces refine_existing → USER_STEER → PlanRevised.
+
+    Previously the heuristic returned ``conversational`` (short input)
+    or ``new_work`` (long input), both of which silently dropped the
+    prior plan's structural constraints. This test pins the fixed
+    behaviour.
+    """
+    sink = InMemorySink()
+    wrapped = _build_wrapped(planner_gate="auto", sinks=[sink])
+    # No call_llm → "auto" falls through to heuristic_classify_turn.
+    wrapped.runner.planner._call_llm = None  # type: ignore[attr-defined]
+    _seed_prior_plan(wrapped)
+
+    revised = Plan(
+        id="prior-1",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Gather facts",
+                description="x",
+                assignee_agent_id="inner_agent",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="t2-new",
+                title="Pivot",
+                description="z",
+                assignee_agent_id="inner_agent",
+            ),
+        ],
+        edges=[],
+        summary="Heuristic-routed pivot",
+    )
+
+    async def _fake_refine(*, plan, drift, goals, **kwargs):
+        return revised
+
+    wrapped.runner.planner.refine = _fake_refine  # type: ignore[method-assign]
+
+    # Steer-shaped opener — the heuristic now matches and routes to
+    # refine_existing.
+    ctx = _FakeCtx("forget solar panels. tell me about solar flares instead.")
+    [e async for e in wrapped._run_async_impl(ctx)]
+
+    sink_events = list(sink.events)
+    user_steers = _drift_user_steer_events(sink_events)
+    plan_revised = _plan_revised_events(sink_events)
+    assert user_steers, (
+        "heuristic gate did not route a steer-shaped message through "
+        "USER_STEER; the regression goldfive#270 documented is back"
+    )
+    assert plan_revised, "no PlanRevised on the wire after USER_STEER"

--- a/tests/test_planner_gate.py
+++ b/tests/test_planner_gate.py
@@ -105,15 +105,75 @@ def test_heuristic_long_follow_up_after_prior_plan_is_new_work() -> None:
     assert verdict == "new_work"
 
 
-def test_heuristic_never_returns_refine_existing() -> None:
-    # Heuristic is conservative: never guesses refine; LLM is required
-    # for that verdict.
-    for ui in ["make it funnier", "also add a slide about X", "actually, change the title"]:
+def test_heuristic_non_steer_inputs_avoid_refine_existing() -> None:
+    # Non-steer inputs (asks that don't open with a steer-pattern
+    # directive) still resolve to conversational / new_work — the
+    # heuristic only escalates to refine_existing when it sees a
+    # steer-language opener (see test_heuristic_steer_language_*).
+    for ui in [
+        "make it funnier",
+        "also add a slide about X",
+        "what was the title again",
+    ]:
         assert heuristic_classify_turn(
             prior_plan=_prior_plan(),
             completed_results={},
             user_input=ui,
         ) in ("conversational", "new_work")
+
+
+def test_heuristic_steer_language_returns_refine_existing() -> None:
+    # goldfive#270 follow-up: messages that open with steer-language
+    # ("forget X", "instead", "no, don't ..., do ...", "switch to",
+    # "scratch that", "actually, ...") route through refine_existing
+    # so the runner emits PlanRevised + DriftDetected(USER_STEER) and
+    # preserves the prior plan's structural constraints. Pre-fix the
+    # heuristic returned "conversational" (short input) or "new_work"
+    # (long input), both of which silently dropped sticky context.
+    steer_messages = [
+        "forget solar panels. tell me about solar flares instead.",
+        "no, don't do solar panels — switch to solar flares.",
+        "actually, change the topic to solar flares.",
+        "scratch that. solar flares please.",
+        "instead, do a presentation about solar flares.",
+        "wait, change the plan — solar flares.",
+        "stop. solar flares only.",
+    ]
+    for ui in steer_messages:
+        verdict = heuristic_classify_turn(
+            prior_plan=_prior_plan(),
+            completed_results={},
+            user_input=ui,
+        )
+        assert verdict == "refine_existing", (
+            f"steer-language opener {ui!r} should route refine_existing, "
+            f"got {verdict!r}"
+        )
+
+
+def test_heuristic_steer_language_requires_prior_plan() -> None:
+    # First turn (no prior plan) still returns new_work even on a
+    # steer-shaped opener — there's nothing to refine yet.
+    verdict = heuristic_classify_turn(
+        prior_plan=None,
+        completed_results={},
+        user_input="forget that. tell me about solar flares.",
+    )
+    assert verdict == "new_work"
+
+
+def test_heuristic_inline_steer_word_does_not_match() -> None:
+    # The steer regex is anchored to the start of the message OR a
+    # sentence break, so "forget" appearing mid-clause as part of a
+    # question doesn't mis-route. "I'll never forget the time you ..."
+    # is a conversational reminisce, not a steer.
+    verdict = heuristic_classify_turn(
+        prior_plan=_prior_plan(),
+        completed_results={},
+        user_input="I'll never forget the time you nailed it",
+    )
+    # Short input → conversational (NOT refine_existing).
+    assert verdict == "conversational"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR #270 (F1) wired the conversational/refine_existing gate into `Runner.run`. The G1 brief asserted ADK-web bypasses `Runner.run` and asked for the gate at the ADK adapter level. An empirical check showed `Runner.run` IS called via `run_streamed` for ADK-web turns — so the gate was firing — but classifying steer-shaped messages (`"forget X. tell me about Y."`) as `"conversational"` (heuristic < 20 tokens) or `"new_work"` (LLM gate misclassifying a topic pivot as new work). Both fall-through verdicts dropped the prior plan's sticky constraints (slide count, output format) and silently skipped the steerer's USER_STEER pipeline — which is what the goldfive#270 E2E hit.

This PR:

1. **Adapter-level gate.** `GoldfiveADKAgent._run_async_impl` now classifies the freshly-arrived user message via `_classify_user_message_for_adk` BEFORE handing control to `run_streamed`. The verdict rides through `context["_adk_pre_classified_verdict"]` into `Runner.run`, which honours it instead of running its own `_classify_turn` so the LLM gate fires once per turn at most. Runner-side gate retained for non-ADK callers (programmatic / callable / Claude SDK).
2. **Dedup.** Replays of the same `(invocation_id, user_input)` reuse the prior verdict from a wrapper-local cache so a redrive does not double-route through the steerer.
3. **Heuristic fix (the actual E2E regression).** The heuristic now recognises steer-language openers (`forget`, `instead`, `no, don't ...`, `scratch that`, `actually,`, `switch to`, `stop`, `change the topic`) and routes them to `refine_existing`. Pre-fix the heuristic only ever returned `conversational` (short input) or `new_work` (long input); `refine_existing` was unreachable without the LLM gate. The `_STEER_PATTERN_RE` is anchored to start-of-string OR a sentence break so mid-clause `"I'll never forget ..."` doesn't false-positive.
4. **LLM-gate prompt sharpening.** Adds explicit guidance for the pivot-without-artefact-change pattern: openers like `"forget X, do Y"` keep the prior plan's structural constraints (slide count, output type) and should route `refine_existing`, not `new_work` — only an explicit artefact abandonment (`"forget the slides, just give me bullets"`) is `new_work`.

## Investigation note (the brief's premise)

The brief asserted ADK-web routes around `goldfive.Runner` and claimed F1 wired the gate into dead code. I instrumented `Runner._classify_turn` and drove a multi-turn wrap end-to-end via `_run_async_impl` (the same path ADK-web takes when `goldfive.wrap(tree)` is the `App.root_agent`). Result: the gate IS consulted on turn 2. `_run_async_impl` calls `self._runner.run_streamed(...)` which calls `self.run(...)` → the runner-side gate runs.

What was actually broken: the heuristic returned `"conversational"` for a 16-token steer like `"forget solar panels. tell me about solar flares instead. ..."` because it only checked token count. The LLM-backed gate (when wired) was also at risk of classifying topic pivots as `new_work`.

I shipped the adapter-level gate per the brief's intent anyway — same classifier, same routing, just consulted at the adapter boundary AND threaded into Runner.run via context. Observability of the gate decision now lives at the goldfive code closest to where ADK-web's user message arrives, which matches the brief's stated goal even though the underlying premise (Runner.run bypass) didn't reproduce.

## ADK callback hook

Hook used: `goldfive/adapters/adk_wrap.py::GoldfiveADKAgent._run_async_impl` (line 308 onward in the new file). This is the goldfive code closest to ADK's user-message arrival point — `BaseAgent.run_async` is `@final` and dispatches to this protected hook with `ctx.user_content` already populated. The plugin-level callbacks (`before_run_callback`, etc.) in `_adk_plugin.py` were also considered but rejected: at that layer the plugin's `_active_ctx` is None on the OUTER invocation (set only when ADKAdapter.invoke fires for a sub-agent), so we'd have no Runner reference. `_run_async_impl` has direct access to `self._runner` and is the documented BaseAgent extension seam.

## Fresh-message detection

`_FakeCtx.user_content` (real ADK shape: `google.genai.types.Content`) carries the latest user turn — already extracted by the existing `_extract_user_input(ctx)` helper at the top of `_run_async_impl`. The dedup key is `(invocation_id, user_input)` cached on the wrapper as a `PrivateAttr`; same invocation_id + same text = no re-classification. A fresh invocation_id with the same text DOES re-classify (real new turn, not a replay) — covered by `test_adapter_gate_distinct_invocation_id_classifies_again`.

## Test plan

- [x] `tests/test_adk_adapter_gate.py` — 8 new tests (6 from brief + 2 dedup variants):
  - `refine_existing` routes through steerer pipeline (DriftDetected(USER_STEER), PlanRevised, revision_index bumped)
  - `conversational` skips steerer entirely (no DriftDetected, no PlanRevised, no planner.refine call)
  - `new_work` runs normal generate path (PlanSubmitted, no PlanRevised)
  - First turn (no prior plan) — adapter classifier returns None, Runner.run handles
  - Replay dedup — same `(invocation_id, user_input)` does not double-classify
  - Distinct invocation_id with same text DOES re-classify
  - Suppression — goldfive drift after a fresh USER_STEER carries `suppressed_by_user_steer=True`
  - Heuristic-mode integration — steer-shaped messages route refine_existing end-to-end
- [x] `tests/test_planner_gate.py` — 4 new heuristic tests covering steer-language matching, prior-plan requirement, and inline-word non-matching; existing `test_heuristic_never_returns_refine_existing` reframed to `test_heuristic_non_steer_inputs_avoid_refine_existing` (contract change).
- [x] Full suite: `1604 passed, 46 skipped` (no regressions).
- [x] `uv run ruff check goldfive/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)