### PR TITLE
feat(orchestration-store, drift): typed Session.state handle + reasoning extraction (Phase 1, #271)

### DIFF
--- a/goldfive/adapters/_adk_dynainst.py
+++ b/goldfive/adapters/_adk_dynainst.py
@@ -107,6 +107,51 @@ def format_correction_block(correction: Mapping[str, Any]) -> str:
     )
 
 
+def _read_pending_correction(
+    *,
+    state: Mapping[str, Any],
+    agent_name: str,
+    current_task_id: str,
+) -> str:
+    """Resolve the pending-correction block for ``(agent, task)``.
+
+    Phase 1 of goldfive#271 — read-of-record migration. Tries the
+    goldfive :class:`~goldfive.orchestration_store.OrchestrationStore`
+    first when the resolver can reach the goldfive Session via the
+    SessionContext stash on ADK state; falls back to reading the
+    bridged ADK state value when the goldfive Session isn't reachable
+    (legacy tests, pre-#152 adapters).
+
+    Always returns a string (empty when no correction exists / the
+    payload is malformed). Caller appends the result to the
+    instruction block when non-empty.
+    """
+    # Goldfive-side read (Phase 1 target).
+    session = _goldfive_session_from_state(state)
+    if session is not None:
+        try:
+            from goldfive.orchestration_store import OrchestrationStore
+
+            store = OrchestrationStore.for_session(session)
+            value = store.get_correction(agent_name, current_task_id)
+            if value is not None:
+                return _resolve_pending_correction(value)
+        except Exception as exc:  # noqa: BLE001 — defensive
+            log.debug(
+                "_read_pending_correction: store lookup raised for "
+                "agent=%r task=%r: %s — falling back to ADK state",
+                agent_name,
+                current_task_id,
+                exc,
+            )
+    # ADK-side fallback. Reads the bridged copy V2 maintains so
+    # legacy unit tests / custom adapters that don't stash a
+    # SessionContext keep working.
+    return _resolve_pending_correction(
+        state.get(pending_correction_key(agent_name, current_task_id))
+    )
+
+
 def _resolve_pending_correction(raw: Any) -> str:
     """Normalise a pending-correction state value to the final prompt string.
 
@@ -186,6 +231,27 @@ def _compose_instruction(
     return block
 
 
+def _goldfive_session_from_state(state: Mapping[str, Any]) -> Any:
+    """Return the goldfive ``Session`` reachable from ADK ``state``, or ``None``.
+
+    The ADK adapter stashes a
+    :class:`~goldfive.adapters._adk_plugin.SessionContext` onto ADK
+    ``session.state`` under ``"goldfive._session_context"`` (V7 in the
+    Phase 0 audit). When present, the ``.session`` attribute is the
+    goldfive :class:`~goldfive.types.Session` whose
+    :attr:`~goldfive.types.Session.state` dict is the goldfive-owned
+    orchestration store. Returns ``None`` when the key is missing
+    (pre-#152 path, or a custom adapter that doesn't stash) so the
+    resolver can fall back to reading from ADK state directly.
+    """
+    if not isinstance(state, Mapping):
+        return None
+    ctx = state.get("goldfive._session_context")
+    if ctx is None:
+        return None
+    return getattr(ctx, "session", None)
+
+
 def make_dynamic_instruction(
     original_instruction: str,
     agent_name: str,
@@ -203,6 +269,17 @@ def make_dynamic_instruction(
 
     The resolver is pure: given the same state it returns the same
     string. No side effects, no persistence.
+
+    Phase 1 of goldfive#271 — when the resolver can reach the goldfive
+    :class:`~goldfive.types.Session` via the
+    :data:`SESSION_CONTEXT_STATE_KEY` stash, the pending-correction
+    lookup goes through
+    :class:`~goldfive.orchestration_store.OrchestrationStore` so the
+    typed accessor is the read of record. When the goldfive Session
+    isn't reachable (legacy unit tests that drive the resolver against
+    a plain ADK state dict, or pre-#152 adapters), the resolver falls
+    back to reading the bridged ADK state directly — same behaviour
+    as before Phase 1.
     """
 
     def resolver(readonly_ctx: Any) -> str:
@@ -223,10 +300,10 @@ def make_dynamic_instruction(
                 state.get(_sp.KEY_CURRENT_TASK_DESCRIPTION, "") or ""
             )
 
-            pending_correction = _resolve_pending_correction(
-                state.get(
-                    pending_correction_key(agent_name, current_task_id),
-                )
+            pending_correction = _read_pending_correction(
+                state=state,
+                agent_name=agent_name,
+                current_task_id=current_task_id,
             )
 
             return _compose_instruction(

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -2093,7 +2093,57 @@ def make_adk_plugin(
                     )
                     return
 
-            # ---- Signal 6: recent drift / correction targeting --------
+            # ---- Signal 6: recent drift / correction / reasoning ------
+            #
+            # Phase 1 of goldfive#271 — Signal 6 has two sub-signals,
+            # consulted in confidence order:
+            #
+            #   6a. Reasoning-extracted binding. The LLM judge in
+            #       :mod:`goldfive.drift.reasoning_judge` returns a
+            #       ``focused_task_id`` + ``focus_confidence`` per
+            #       chain-of-thought block. When the steerer recorded
+            #       a binding for this agent and confidence is at the
+            #       configured threshold, the ladder consumes it as
+            #       a real signal — the agent's *stated intent* names
+            #       which plan task it's working on, which is a
+            #       stronger signal than guessing from token overlap.
+            #
+            #   6b. Pending-correction targeting (the pre-existing
+            #       Signal 6). When a CORRECT-kind supersedes wrote a
+            #       ``goldfive.pending_corrections.<agent>.<task>``
+            #       key, the ladder pins to the correction target.
+            #
+            # When 6a doesn't fire (no binding, low-confidence binding,
+            # binding's task is no longer PENDING/RUNNING) the ladder
+            # falls through to 6b unchanged.
+            reasoning_task = self._task_from_reasoning_binding(
+                ctx=ctx,
+                tasks=tasks_list,
+                agent_name=agent_name,
+            )
+            if reasoning_task is not None:
+                task_id = str(_safe_attr(reasoning_task, "id", "") or "")
+                if task_id:
+                    self._stamp_current_task_id(
+                        ctx=ctx,
+                        callback_context=callback_context,
+                        task_id=task_id,
+                        agent_name=agent_name,
+                        source="reasoning_binding",
+                        task=reasoning_task,
+                        invocation_id=invocation_id,
+                    )
+                    await self._emit_pin_resolved(
+                        ctx=ctx,
+                        agent_name=agent_name,
+                        task_id=task_id,
+                        via_signal="reasoning_binding",
+                        score=0.85,
+                        invocation_id=invocation_id,
+                        candidate_count=0,
+                    )
+                    return
+
             correction_task = self._task_from_pending_correction(
                 ctx=ctx,
                 tasks=tasks_list,
@@ -2383,6 +2433,50 @@ def make_adk_plugin(
                 return preferred[0]
             if scoring_args is not None:
                 return _score_candidates_by_args(preferred, scoring_args)
+            return None
+
+        @staticmethod
+        def _task_from_reasoning_binding(
+            *,
+            ctx: SessionContext,
+            tasks: list[Any],
+            agent_name: str,
+        ) -> Any:
+            """Signal 6a — pin to the task named by a reasoning-extracted binding.
+
+            Phase 1 of goldfive#271. Consults
+            :class:`~goldfive.orchestration_store.OrchestrationStore`
+            for a binding stamped by the steerer's reasoning-judge
+            background path; the binding's
+            ``focused_task_id`` is matched against the plan and the
+            matching PENDING/RUNNING task is returned (or ``None`` if
+            the binding doesn't exist, was below the steerer's
+            configured confidence threshold and was thus never recorded,
+            or names a task that's no longer in the active set).
+
+            The store handles agent-name normalisation (compound /
+            bare-form fallback) so a coordinator that fires the judge
+            against ``"agent_x"`` and a sub-runner pinning under
+            ``"client42:agent_x"`` both find the same binding.
+            """
+            from goldfive.orchestration_store import OrchestrationStore
+            from goldfive.types import TaskStatus
+
+            store = OrchestrationStore.for_session(
+                _safe_attr(ctx, "session", None)
+            )
+            binding = store.get_reasoning_extracted_binding(agent_name)
+            if binding is None or not binding.task_id:
+                return None
+            tasks_by_id = {
+                str(_safe_attr(t, "id", "") or ""): t for t in tasks
+            }
+            task = tasks_by_id.get(binding.task_id)
+            if task is None:
+                return None
+            status = _safe_attr(task, "status", None)
+            if status is TaskStatus.PENDING or status is TaskStatus.RUNNING:
+                return task
             return None
 
         @staticmethod

--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -46,7 +46,9 @@ from goldfive.drift.reasoning_judge import (
     CallLLM as JudgeCallLLM,
 )
 from goldfive.drift.reasoning_judge import (
-    classify_reasoning_drift,
+    ReasoningJudgeVerdict,
+    classify_reasoning_drift,  # noqa: F401 — re-export consumed by tests
+    classify_reasoning_drift_with_focus,
 )
 from goldfive.types import DriftEvent, DriftKind, DriftSeverity
 
@@ -89,6 +91,7 @@ __all__ = [
     "SENTENCE_LEVEL_MIN_BLOCK_LENGTH",
     "SENTENCE_LEVEL_MAX_SENTENCES",
     "analyze_reasoning",
+    "analyze_reasoning_with_focus",
     "detect_confusion",
     "detect_intent_divergence",
     "detect_looping_reasoning",
@@ -956,7 +959,11 @@ async def _run_judge(
     model: str,
     sink: Any = None,
 ) -> DriftEvent | None:
-    """Dispatch ``classify_reasoning_drift`` against the current task.
+    """Dispatch :func:`classify_reasoning_drift` against the current task.
+
+    Returns just the drift component of the extended verdict. Steerer
+    callers that need the attribution fields call
+    :func:`_run_judge_with_focus` directly.
 
     When ``sink`` is provided it is forwarded into the classifier so a
     ``ReasoningJudgeInvoked`` event is emitted on every invocation
@@ -964,11 +971,37 @@ async def _run_judge(
     sequence are stamped from the session so downstream consumers can
     correlate the observability event with the session's other events.
     """
+    verdict = await _run_judge_with_focus(
+        text, session, call_llm=call_llm, model=model, sink=sink
+    )
+    return verdict.drift
+
+
+async def _run_judge_with_focus(
+    text: str,
+    session: Session,
+    *,
+    call_llm: JudgeCallLLM,
+    model: str,
+    sink: Any = None,
+) -> ReasoningJudgeVerdict:
+    """Dispatch :func:`classify_reasoning_drift_with_focus` against the current task.
+
+    Phase 1 of goldfive#271 — returns the full verdict (drift +
+    attribution fields) so the steerer can record a reasoning-extracted
+    binding onto :class:`~goldfive.orchestration_store.OrchestrationStore`
+    when ``focus_confidence`` clears the configured threshold.
+
+    Same shape as :func:`_run_judge` for the LLM call itself; the only
+    delta is the return type. Stamps ``plan`` so the prompt's
+    plan-tasks-attribution section is populated.
+    """
     task = _current_task(session)
-    return await classify_reasoning_drift(
+    return await classify_reasoning_drift_with_focus(
         reasoning=text,
         task=task,
         goals=list(session.goals),
+        plan=getattr(session, "plan", None),
         model=model,
         call_llm=call_llm,
         current_task_id=session.current_task_id,
@@ -977,6 +1010,91 @@ async def _run_judge(
         session_id=session.id,
         sequence_fn=session.next_sequence,
     )
+
+
+async def analyze_reasoning_with_focus(
+    text: str,
+    session: Session,
+    *,
+    mode: ReasoningDriftMode = "embedding",
+    call_llm: JudgeCallLLM | None = None,
+    model: str = "",
+    sink: Any = None,
+) -> ReasoningJudgeVerdict:
+    """Phase-1 sibling of :func:`analyze_reasoning` returning a focused verdict.
+
+    Same selection logic as :func:`analyze_reasoning`; the only
+    difference is the return type. When the judge path runs, callers
+    get the full
+    :class:`~goldfive.drift.reasoning_judge.ReasoningJudgeVerdict` —
+    drift + ``focused_task_id`` + ``focus_confidence`` +
+    ``stated_intent``. The legacy embedding pipeline, which has no
+    judge, returns a verdict with the embedding-derived drift and
+    empty attribution fields (the embedding pipeline can't attribute
+    against the plan-tasks list).
+
+    Modes:
+
+    * ``"judge"`` — runs only the judge; verdict carries judge fields.
+    * ``"embedding"`` — runs the embedding pipeline; verdict has
+      ``drift`` set when off-topic and empty attribution fields.
+    * ``"both"`` — both pipelines fire; the worst-severity drift
+      wins (same tie-break as :func:`analyze_reasoning`); attribution
+      fields come from the judge regardless of which drift won.
+    * ``"off"`` — empty verdict.
+
+    The legacy :func:`analyze_reasoning` is unchanged — it now
+    delegates to this function and returns ``verdict.drift`` for
+    back-compat with every existing caller.
+    """
+    if not text or mode == "off":
+        return ReasoningJudgeVerdict(drift=None)
+    if mode == "embedding":
+        return ReasoningJudgeVerdict(drift=_embedding_pipeline(text, session))
+    if mode == "judge":
+        if call_llm is None:
+            return ReasoningJudgeVerdict(drift=None)
+        return await _run_judge_with_focus(
+            text, session, call_llm=call_llm, model=model, sink=sink
+        )
+    if mode == "both":
+        embedding_drift = _embedding_pipeline(text, session)
+        judge_verdict: ReasoningJudgeVerdict | None = None
+        if call_llm is not None:
+            judge_verdict = await _run_judge_with_focus(
+                text, session, call_llm=call_llm, model=model, sink=sink
+            )
+        if judge_verdict is None:
+            return ReasoningJudgeVerdict(drift=embedding_drift)
+        if embedding_drift is None:
+            return judge_verdict
+        # Both fired — worst-severity wins. Embedding wins ties
+        # (deterministic, synchronous path). Either way, the
+        # attribution fields come from the judge — the embedding
+        # pipeline doesn't produce them.
+        if judge_verdict.drift is None:
+            return ReasoningJudgeVerdict(
+                drift=embedding_drift,
+                focused_task_id=judge_verdict.focused_task_id,
+                focus_confidence=judge_verdict.focus_confidence,
+                stated_intent=judge_verdict.stated_intent,
+            )
+        if _SEVERITY_ORDER[judge_verdict.drift.severity] > _SEVERITY_ORDER[
+            embedding_drift.severity
+        ]:
+            return judge_verdict
+        return ReasoningJudgeVerdict(
+            drift=embedding_drift,
+            focused_task_id=judge_verdict.focused_task_id,
+            focus_confidence=judge_verdict.focus_confidence,
+            stated_intent=judge_verdict.stated_intent,
+        )
+    log.warning(
+        "analyze_reasoning_with_focus: unknown mode=%r; falling back "
+        "to 'embedding'",
+        mode,
+    )
+    return ReasoningJudgeVerdict(drift=_embedding_pipeline(text, session))
 
 
 async def analyze_reasoning(

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -26,10 +26,21 @@ The prompt is pinned via module-level constants
 wording without re-implementing the parse logic. Rationale for the
 empirical failure of the pre-existing embedding-based pipeline lives in
 goldfive#223 / #224 / #226.
+
+Phase 1 of goldfive#271 adds an *attribution* signal alongside the
+on-task verdict: :func:`classify_reasoning_drift_with_focus` returns
+``focused_task_id`` + ``focus_confidence`` extracted from the same
+LLM call. Same prompt, same cost; the prompt is extended to ask the
+judge to name the plan task the reasoning is actually working on. The
+caller (typically :class:`~goldfive.steerer.DefaultSteerer`) writes
+the binding onto :class:`~goldfive.orchestration_store.OrchestrationStore`
+when confidence is above a threshold; the pin-resolution ladder reads
+it back as a real signal.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 import re
@@ -37,19 +48,23 @@ import time
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from typing import Any
 
-from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Goal, Task
+from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Goal, Plan, Task
 
 log = logging.getLogger(__name__)
 
 
 __all__ = [
     "CallLLM",
+    "PLAN_TASKS_SUMMARY_MAX_CHARS",
     "REASONING_JUDGE_MAX_REASONING_INPUT_CHARS",
     "REASONING_JUDGE_MAX_RAW_RESPONSE_CHARS",
     "REASONING_DRIFT_MAX_REASONING_CHARS",
     "REASONING_DRIFT_SYSTEM_PROMPT",
     "REASONING_DRIFT_USER_PROMPT_TEMPLATE",
+    "ReasoningJudgeVerdict",
     "classify_reasoning_drift",
+    "classify_reasoning_drift_with_focus",
+    "format_plan_tasks_summary",
     "truncate_for_observability",
 ]
 
@@ -107,25 +122,43 @@ REASONING_DRIFT_SYSTEM_PROMPT: str = (
 REASONING_DRIFT_USER_PROMPT_TEMPLATE: str = (
     "You are assessing whether an autonomous agent's chain-of-thought "
     "is on task.\n\n"
+    "PLAN TASKS (id -> title):\n{plan_tasks_summary}\n\n"
+    "CURRENTLY BOUND TASK:\n{task_block}\n\n"
     "GOALS:\n{goals_block}\n\n"
-    "CURRENT TASK:\n{task_block}\n\n"
     "REASONING (the agent's most recent chain-of-thought block):\n"
     "{reasoning_block}\n\n"
-    "Decide: does the reasoning stay focused on the explicit task and "
-    "goals above? Answer STRICTLY in one of these two JSON shapes:\n"
-    '{{"on_task": true}}\n'
-    "OR\n"
-    '{{"on_task": false, "severity": "info"|"warning"|"critical", '
-    '"reason": "one-sentence explanation"}}\n\n'
-    "on_task=true = reasoning is working toward the task / goals "
+    "Decide TWO things:\n"
+    "1. Does the reasoning stay focused on the explicit task and "
+    "goals above? (the on-task verdict)\n"
+    "2. Which task in the PLAN TASKS list above is the reasoning "
+    "actually working on right now? (the attribution verdict — answer "
+    "with a task id from the list, or '' when the reasoning is not "
+    "working on any plan task / is off-plan)\n\n"
+    "Reply with a single JSON object and nothing else, in this shape:\n"
+    "{{\n"
+    '  "on_task": true|false,\n'
+    '  "severity": "info"|"warning"|"critical",\n'
+    '  "reason": "one-sentence explanation",\n'
+    '  "focused_task_id": "<id from PLAN TASKS, or \'\' if off-plan>",\n'
+    '  "focus_confidence": 0.0-1.0,\n'
+    '  "stated_intent": "one-sentence summary of what the agent says it '
+    'is doing"\n'
+    "}}\n\n"
+    "on_task=true = reasoning is working toward the bound task / goals "
     "(clarifying sub-steps, exploring tradeoffs, working through a "
-    "calculation all count as on_task).\n"
+    "calculation all count as on_task). When on_task=true, severity / "
+    "reason may be omitted or empty.\n"
     "on_task=false = reasoning has drifted to an unrelated topic, is "
     "proposing to abandon the task, or is otherwise off-course.\n"
     "Severity guidance when on_task=false:\n"
     "- info = mild tangent that may self-correct next turn.\n"
     "- warning = clear off-topic content that deserves a nudge.\n"
-    "- critical = proposing to abandon or replace the task/goal."
+    "- critical = proposing to abandon or replace the task/goal.\n\n"
+    "focused_task_id MUST be the literal id of one of the listed plan "
+    "tasks, or an empty string when the reasoning is not working on "
+    "any plan task. focus_confidence is your subjective certainty in "
+    "the attribution: 1.0 when the reasoning explicitly names the "
+    "task, 0.0 when you are guessing."
 )
 
 
@@ -196,6 +229,94 @@ def _format_reasoning(reasoning: str) -> str:
     return reasoning[:REASONING_DRIFT_MAX_REASONING_CHARS] + " ... [truncated]"
 
 
+# Hard cap on the plan-tasks-summary section of the prompt. Phase-1
+# brief calls for truncation when the plan grows large enough that the
+# rendered list would dominate the judge's context budget. 2000 chars
+# is the agreed cap (~500 tokens) — comfortably below the prompt's
+# overall budget while leaving room for ~50 tasks at typical title
+# length.
+PLAN_TASKS_SUMMARY_MAX_CHARS: int = 2000
+
+
+def format_plan_tasks_summary(
+    plan: Plan | None,
+    *,
+    max_chars: int = PLAN_TASKS_SUMMARY_MAX_CHARS,
+) -> str:
+    """Render ``plan.tasks`` as a one-per-line ``id -> title`` summary.
+
+    Empty / None plan renders as ``"(no plan tasks)"`` so the prompt
+    template renders cleanly when the plan hasn't been built yet.
+
+    Truncation: when the rendered text exceeds ``max_chars`` we drop
+    suffix lines and append a ``"... [N more tasks]"`` marker so the
+    judge knows the list is incomplete. Truncation prefers to keep the
+    head of the list (most recently planned tasks tend to be most
+    relevant for a "what is the agent working on right now?" judgement
+    — they are at the front of typical refines).
+    """
+    if plan is None or not getattr(plan, "tasks", None):
+        return "(no plan tasks)"
+    lines: list[str] = []
+    rendered_chars = 0
+    truncated = 0
+    tasks = list(plan.tasks)
+    for i, task in enumerate(tasks):
+        tid = str(getattr(task, "id", "") or "")
+        title = str(getattr(task, "title", "") or "(untitled)")
+        line = f"- {tid} -> {title}" if tid else f"- (no id) -> {title}"
+        if rendered_chars + len(line) + 1 > max_chars and lines:
+            truncated = len(tasks) - i
+            break
+        lines.append(line)
+        rendered_chars += len(line) + 1
+    if truncated > 0:
+        lines.append(f"... [{truncated} more task(s) elided]")
+    if not lines:
+        return "(no plan tasks)"
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Extended verdict (Phase 1 of goldfive#271)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ReasoningJudgeVerdict:
+    """Extended verdict returned by :func:`classify_reasoning_drift_with_focus`.
+
+    Carries both the existing on-task ``DriftEvent`` (or ``None`` when
+    the judge was on-task / failed quietly) and the new attribution
+    fields the Phase-1 prompt extension extracts.
+
+    ``drift`` is the same value the legacy
+    :func:`classify_reasoning_drift` returns, so callers that only
+    care about the drift signal can do
+    ``verdict.drift if verdict else None``.
+
+    ``focused_task_id`` is the plan-task id the judge identified as
+    "what the agent is actually working on right now". Empty string
+    when the judge declined to attribute (off-plan reasoning, or
+    response missing the field). The pin-resolution ladder consumes
+    this; the ``focus_confidence`` lets the consumer gate
+    low-certainty bindings.
+
+    ``focus_confidence`` is the judge's subjective certainty. Clamped
+    to ``[0.0, 1.0]``. Defaults to ``0.0`` when the field is missing
+    or malformed — the caller's threshold then naturally rejects it.
+
+    ``stated_intent`` is the judge's one-sentence summary of what the
+    agent claims to be doing. Optional — surfaced for sinks /
+    observability; not consumed by any current pin-resolution logic.
+    """
+
+    drift: DriftEvent | None
+    focused_task_id: str = ""
+    focus_confidence: float = 0.0
+    stated_intent: str = ""
+
+
 # Map the judge's ``severity`` string to a :class:`DriftSeverity`. Missing
 # or unknown values fall through to WARNING so a drift verdict is never
 # silently swallowed by a bad severity string.
@@ -227,26 +348,89 @@ async def classify_reasoning_drift(
     run_id: str = "",
     session_id: str = "",
     sequence_fn: Callable[[], int] | None = None,
+    plan: Plan | None = None,
 ) -> DriftEvent | None:
     """Ask an LLM-judge whether ``reasoning`` is on-task.
 
-    Returns a :class:`DriftEvent` of kind
-    :data:`~goldfive.types.DriftKind.OFF_TOPIC` when the judge returns
-    ``{"on_task": false, ...}``. Severity comes from the judge's
-    ``severity`` field (``info`` / ``warning`` / ``critical``);
-    missing / unknown values default to
-    :data:`~goldfive.types.DriftSeverity.WARNING`.
+    Back-compat wrapper around
+    :func:`classify_reasoning_drift_with_focus`: returns just the
+    drift component of the extended verdict so existing callers
+    (test suite, third-party importers) keep their ``DriftEvent | None``
+    return shape.
 
-    Returns ``None`` in every other case:
+    See :func:`classify_reasoning_drift_with_focus` for the full
+    parameter docs and the new attribution fields. Phase 1 of
+    goldfive#271 added an optional ``plan`` keyword that the extended
+    function uses to render the plan-tasks attribution prompt; legacy
+    callers can omit it and the prompt renders ``"(no plan tasks)"``
+    for that section.
+    """
+    verdict = await classify_reasoning_drift_with_focus(
+        reasoning=reasoning,
+        task=task,
+        goals=goals,
+        model=model,
+        call_llm=call_llm,
+        current_task_id=current_task_id,
+        current_agent_id=current_agent_id,
+        system_prompt=system_prompt,
+        user_prompt_template=user_prompt_template,
+        sink=sink,
+        run_id=run_id,
+        session_id=session_id,
+        sequence_fn=sequence_fn,
+        plan=plan,
+    )
+    return verdict.drift
 
-    * judge returns ``{"on_task": true}`` (the on-track signal),
-    * judge returns malformed / non-JSON text,
-    * judge returns a dict missing / with a non-boolean ``on_task``,
-    * ``call_llm`` raises.
+
+async def classify_reasoning_drift_with_focus(
+    *,
+    reasoning: str,
+    task: Task | None,
+    goals: Sequence[Goal] | Iterable[Any] | None,
+    model: str,
+    call_llm: CallLLM,
+    current_task_id: str = "",
+    current_agent_id: str = "",
+    system_prompt: str | None = None,
+    user_prompt_template: str | None = None,
+    sink: Any = None,
+    run_id: str = "",
+    session_id: str = "",
+    sequence_fn: Callable[[], int] | None = None,
+    plan: Plan | None = None,
+) -> ReasoningJudgeVerdict:
+    """Ask an LLM-judge whether ``reasoning`` is on-task AND which task it works on.
+
+    Phase 1 of goldfive#271 — the extended judge call. Same LLM
+    request, same cost as the legacy
+    :func:`classify_reasoning_drift`; the prompt template is extended
+    to ask the judge to attribute the reasoning to a specific plan
+    task, returning ``focused_task_id`` + ``focus_confidence``
+    alongside the existing ``on_task`` / ``severity`` / ``reason``
+    fields.
+
+    Returns a :class:`ReasoningJudgeVerdict`:
+
+    * ``verdict.drift`` — same as the legacy function. A
+      :class:`DriftEvent` of kind
+      :data:`~goldfive.types.DriftKind.OFF_TOPIC` when the judge
+      returns ``{"on_task": false, ...}``; ``None`` for on-task
+      verdicts and every quiet-failure path (malformed JSON, missing
+      ``on_task``, ``call_llm`` raised, empty reasoning).
+    * ``verdict.focused_task_id`` — the judge's plan-task attribution.
+      Empty string when the judge declined to attribute, when the
+      response was malformed, or when the call failed.
+    * ``verdict.focus_confidence`` — the judge's subjective certainty,
+      clamped to ``[0.0, 1.0]``. ``0.0`` for every quiet-failure path.
+    * ``verdict.stated_intent`` — optional one-sentence summary the
+      judge produced. Empty when missing or after a failure.
 
     The "quiet on failure" contract matches :func:`classify_goal_drift`
     (goldfive#143). A flaky judge must not spam operator UIs with
-    false-positive OFF_TOPIC alarms.
+    false-positive OFF_TOPIC alarms — the extended fields default to
+    "no signal" rather than raising.
 
     Parameters
     ----------
@@ -255,14 +439,21 @@ async def classify_reasoning_drift(
         to :data:`REASONING_DRIFT_MAX_REASONING_CHARS` before prompting
         so pathologically long blocks cannot blow the context budget.
         Empty or whitespace-only ``reasoning`` is treated as nothing to
-        classify -- returns ``None`` without calling the LLM.
+        classify -- returns an empty verdict without calling the LLM.
     task:
         The currently-bound :class:`Task` (typically from
         ``session.current_task_id``). May be ``None`` when no task is
-        active; the judge then has only ``goals`` to compare against.
+        active; the judge then has only ``goals`` and ``plan`` to
+        compare against.
     goals:
         The session's goals. Each entry should have ``id`` / ``summary``
         attributes or be a plain str. May be ``None`` / empty.
+    plan:
+        The session's plan. The judge needs the list of plan tasks to
+        attribute the reasoning ("which task is the agent actually
+        working on?") — when ``None``, the prompt renders an empty
+        plan-tasks block and the judge will return an empty
+        ``focused_task_id``.
     model:
         Model name forwarded verbatim to ``call_llm``. Empty string is
         permitted; model-bound callables can substitute their own
@@ -295,10 +486,11 @@ async def classify_reasoning_drift(
         should pass the session's ``next_sequence``).
     """
     if not reasoning or not reasoning.strip():
-        return None
+        return ReasoningJudgeVerdict(drift=None)
     system = system_prompt or REASONING_DRIFT_SYSTEM_PROMPT
     template = user_prompt_template or REASONING_DRIFT_USER_PROMPT_TEMPLATE
     user = template.format(
+        plan_tasks_summary=format_plan_tasks_summary(plan),
         goals_block=_format_goals(goals),
         task_block=_format_task(task),
         reasoning_block=_format_reasoning(reasoning),
@@ -326,6 +518,13 @@ async def classify_reasoning_drift(
     reason = ""
     drift: DriftEvent | None = None
     parsed: dict[str, Any] | None = None
+    # Phase 1 — extended attribution fields. Default to "no signal" so
+    # every quiet-failure path (call raises, malformed JSON, missing
+    # field, malformed numeric confidence) yields an empty verdict the
+    # caller's threshold naturally rejects.
+    focused_task_id_parsed: str = ""
+    focus_confidence_parsed: float = 0.0
+    stated_intent_parsed: str = ""
     try:
         async with goldfive_llm_span(
             sinks=span_sinks,
@@ -356,6 +555,28 @@ async def classify_reasoning_drift(
                         severity_str = _severity_from_verdict(
                             parsed.get("severity")
                         ).value.lower()
+                # Extended attribution fields — extracted regardless of
+                # the on_task verdict. The judge can name a focused
+                # task whether or not it considers the reasoning on the
+                # currently-bound one (off-task reasoning still has a
+                # focus — that's how the steerer learns the agent has
+                # silently switched to a different plan task).
+                focused_raw = parsed.get("focused_task_id", "")
+                if isinstance(focused_raw, str):
+                    focused_task_id_parsed = focused_raw.strip()
+                conf_raw = parsed.get("focus_confidence", 0.0)
+                try:
+                    focus_confidence_parsed = float(conf_raw)
+                except (TypeError, ValueError):
+                    focus_confidence_parsed = 0.0
+                # Clamp to [0.0, 1.0]; the prompt asks for 0.0-1.0 but
+                # we don't trust the LLM not to drift outside.
+                focus_confidence_parsed = max(
+                    0.0, min(1.0, focus_confidence_parsed)
+                )
+                intent_raw = parsed.get("stated_intent", "")
+                if isinstance(intent_raw, str):
+                    stated_intent_parsed = intent_raw.strip()
             # Build the span's output / decision strings from the parsed
             # verdict so harmonograf can render "judged agent/task:
             # on-task" inline.
@@ -466,7 +687,12 @@ async def classify_reasoning_drift(
             severity=severity_str,
             reason=reason,
         )
-    return drift
+    return ReasoningJudgeVerdict(
+        drift=drift,
+        focused_task_id=focused_task_id_parsed,
+        focus_confidence=focus_confidence_parsed,
+        stated_intent=stated_intent_parsed,
+    )
 
 
 async def _emit_judge_invoked(

--- a/goldfive/orchestration_store.py
+++ b/goldfive/orchestration_store.py
@@ -1,0 +1,605 @@
+"""Typed accessor over goldfive ``Session.state`` for orchestration data.
+
+Phase 1 of goldfive#271 — see ``docs/design/STATE-OWNERSHIP-CONTRACT.md``
+for the contract this layer enforces, and Phase 0's audit catalog
+(``§5`` of that doc) for the full set of writers/readers Phase 2 will
+collapse onto this surface.
+
+What this module is
+-------------------
+
+A thin, typed handle wrapping goldfive's own
+:class:`~goldfive.types.Session.state` dict. Replaces ad-hoc
+``session.state.get('goldfive.foo')`` reads and ``session.state[...] = v``
+writes scattered across the codebase with named methods + small typed
+result objects (``ActiveSteer``, ``DelegationPin``, ``ReasoningBinding``).
+
+What this module is NOT
+-----------------------
+
+* **NOT a wrapper over ADK's ``session.state``.** That dict is owned by
+  ADK; goldfive callbacks must not mutate it (Phase 0 contract §3.3).
+  The ADK-side reads in
+  :mod:`~goldfive.adapters._adk_dynainst` and
+  :mod:`~goldfive.planners.goldfive_planner` consult ADK's state
+  copy that the bridge (Phase 2 migration target V2) maintains; this
+  store is the goldfive-internal source of truth that bridge reads
+  *from*.
+* **NOT a replacement for** :mod:`goldfive.orchestration_state`'s
+  primitive read/write helpers. Those keep their existing call sites
+  untouched in Phase 1 — this module is a read-side veneer that
+  supersedes the *ad-hoc* ``state.get(...)`` callers cataloged in the
+  Phase 0 audit. Phase 2 collapses the writers; Phase 3 collapses the
+  bridge.
+* **NOT exhaustive.** Phase 1's surface covers only the recurring
+  operations Phase 1's brief calls out plus the new reasoning-extracted
+  binding. Subsequent phases extend the surface as they migrate
+  additional sites.
+
+Initial surface (Phase 1)
+-------------------------
+
+Reads (replacing ad-hoc ``state.get('goldfive.xxx')`` callers):
+
+* :meth:`OrchestrationStore.pin_current_task` — current task pin id
+* :meth:`OrchestrationStore.pin_current_task_revision` — pin revision
+* :meth:`OrchestrationStore.get_active_steer` — active steer, typed
+* :meth:`OrchestrationStore.get_correction` — pending-correction body
+* :meth:`OrchestrationStore.get_pending_delegation` — per-fc_id pin
+
+Writes:
+
+* :meth:`OrchestrationStore.set_pin_current_task` — write the pin
+  (with a documented :class:`BindingSource`)
+* :meth:`OrchestrationStore.record_reasoning_extracted_binding` —
+  the **only NEW write site** introduced by Phase 1. Records the LLM
+  judge's stated-intent binding so the pin-resolution ladder's signal
+  6 can consume it as a real signal.
+* :meth:`OrchestrationStore.clear_reasoning_extracted_binding` —
+  companion clear (called on task transition).
+
+Reasoning-extracted bindings
+----------------------------
+
+A new orchestration-state slot,
+``goldfive.reasoning_extracted_bindings`` (a dict keyed by agent name),
+records the LLM judge's stated-intent attribution from
+:func:`~goldfive.drift.reasoning_judge.classify_reasoning_drift`. When
+the judge returns ``focused_task_id`` + ``focus_confidence`` and the
+confidence is above a configured threshold, the steerer records a
+binding here; the pin-resolution ladder's signal 6 consults it.
+
+Threshold semantics:
+
+* The threshold is a steerer-level config knob (default ``0.7``); the
+  store stamps whatever confidence it's given and lets the consumer
+  decide.
+* The recorded binding includes the originating ``run_id`` /
+  ``session_id`` / ``agent_name`` / ``task_id`` / ``confidence``
+  plus a ``recorded_at_turn`` so consumers can dismiss stale bindings.
+
+Surface evolution
+-----------------
+
+Each Phase-2 migration of a writer adds a corresponding ``set_*`` /
+``clear_*`` method here. As the bridge collapses (Phase 3) the read
+side migrates to take a ``ReadonlyContext`` adapter; until then the
+reads return cached views of goldfive ``Session.state`` and the bridge
+copies them onto ADK's state.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from goldfive import orchestration_state as _ostate
+from goldfive.adapters import _adk_dynainst as _dynainst
+
+if TYPE_CHECKING:  # pragma: no cover — type-check only
+    from goldfive.types import Session
+
+
+__all__ = [
+    "ActiveSteer",
+    "BindingSource",
+    "DelegationPin",
+    "OrchestrationStore",
+    "REASONING_BINDINGS_KEY",
+    "ReasoningBinding",
+]
+
+
+# State key for the new reasoning-extracted bindings slot. Lives under
+# the goldfive prefix so :func:`goldfive.orchestration_state.write`
+# accepts it. Value shape: ``dict[agent_name, ReasoningBinding-as-dict]``
+# for cheap JSON serialisation by sinks that round-trip the state dict.
+REASONING_BINDINGS_KEY = "goldfive.reasoning_extracted_bindings"
+
+
+# ---------------------------------------------------------------------------
+# Typed result objects
+# ---------------------------------------------------------------------------
+
+
+class BindingSource(StrEnum):
+    """Origin of a current-task pin write.
+
+    Stamped onto the pin so the pin-resolution ladder's events can
+    distinguish a pin set by an agent-turn callback from one set by
+    a delegation site, a steerer rotation, or a reasoning-extracted
+    binding.
+
+    Phase 1 only consumes the value for observability + the new
+    reasoning-extracted-binding signal in the pin ladder; Phase 2's
+    full migration will use it to attribute every catalogued writer.
+    """
+
+    DELEGATION_PIN = "delegation_pin"
+    AGENT_CALLBACK = "agent_callback"
+    REASONING = "reasoning"
+    CORRECTION_TARGET = "correction_target"
+    STEERER_ROTATION = "steerer_rotation"
+    LOW_CONFIDENCE = "low_confidence"
+    UNKNOWN = "unknown"
+
+
+@dataclasses.dataclass(frozen=True)
+class ActiveSteer:
+    """Typed view of the active steer slots on goldfive ``Session.state``.
+
+    Wraps the four
+    :data:`~goldfive.orchestration_state.KEY_ACTIVE_STEER_BODY` /
+    ``_AT_TURN`` / ``_AUTHOR`` / ``_SOURCE`` keys so callers don't
+    string-fish through the state dict.
+    """
+
+    body: str
+    at_turn: int
+    author: str
+    source: str  # "user" | "goldfive" | ""
+
+    def is_active(self) -> bool:
+        """True when a steer is currently set (non-empty body)."""
+        return bool(self.body)
+
+
+@dataclasses.dataclass(frozen=True)
+class DelegationPin:
+    """Typed view of a single ``goldfive.pending_delegations`` entry.
+
+    The on-disk shape supports both legacy bare-string and the
+    versioned ``{task_id, revision, tool_args}`` dict (goldfive#266 /
+    F7). This dataclass normalises both shapes for callers.
+    """
+
+    task_id: str
+    revision: int = 0
+    tool_args: Mapping[str, Any] | None = None
+
+    def is_set(self) -> bool:
+        return bool(self.task_id)
+
+
+@dataclasses.dataclass(frozen=True)
+class ReasoningBinding:
+    """Typed view of a reasoning-extracted binding.
+
+    Persisted as a plain dict under
+    :data:`REASONING_BINDINGS_KEY[agent_name]` so sinks can round-trip
+    the state dict; this dataclass is the in-process view.
+
+    ``recorded_at_turn`` is the session sequence value at the moment
+    the binding was recorded; consumers can compare it against the
+    current sequence to dismiss bindings older than N turns. ``0``
+    means "no sequence recorded" (e.g. test fixture without a session
+    sequence counter).
+    """
+
+    agent_name: str
+    task_id: str
+    confidence: float
+    recorded_at_turn: int = 0
+    run_id: str = ""
+    session_id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent_name": self.agent_name,
+            "task_id": self.task_id,
+            "confidence": float(self.confidence),
+            "recorded_at_turn": int(self.recorded_at_turn),
+            "run_id": self.run_id,
+            "session_id": self.session_id,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> ReasoningBinding | None:
+        """Construct from a state-dict value, or ``None`` on garbage.
+
+        Tolerant of partial dicts (sink-shaped, persistence-restored)
+        so a missing ``run_id`` / ``session_id`` doesn't drop a
+        legitimate binding.
+        """
+        if not isinstance(raw, Mapping):
+            return None
+        try:
+            task_id = str(raw.get("task_id", "") or "")
+            confidence = float(raw.get("confidence", 0.0) or 0.0)
+            agent_name = str(raw.get("agent_name", "") or "")
+        except (TypeError, ValueError):
+            return None
+        if not task_id:
+            return None
+        try:
+            recorded_at_turn = int(raw.get("recorded_at_turn", 0) or 0)
+        except (TypeError, ValueError):
+            recorded_at_turn = 0
+        return cls(
+            agent_name=agent_name,
+            task_id=task_id,
+            confidence=confidence,
+            recorded_at_turn=recorded_at_turn,
+            run_id=str(raw.get("run_id", "") or ""),
+            session_id=str(raw.get("session_id", "") or ""),
+        )
+
+
+# ---------------------------------------------------------------------------
+# OrchestrationStore — typed handle
+# ---------------------------------------------------------------------------
+
+
+class OrchestrationStore:
+    """Typed handle over goldfive ``Session.state``.
+
+    Construct with :meth:`for_session` (when you have a goldfive
+    :class:`~goldfive.types.Session`) or :meth:`for_state` (when you
+    only have the state dict, e.g. in test scaffolding or in callbacks
+    that reach the goldfive Session via
+    :data:`~goldfive.adapters._adk_plugin.SESSION_CONTEXT_STATE_KEY`).
+
+    All accessors are forgiving: missing / malformed entries return
+    typed defaults rather than raising. The store is a *view* — it
+    does not own the underlying dict and concurrent writers can mutate
+    it between calls. Callers who need a snapshot should call once and
+    cache.
+    """
+
+    __slots__ = ("_state",)
+
+    def __init__(self, state: Any) -> None:
+        # We accept any mapping-shaped object — goldfive's Session.state
+        # is a plain dict; tests sometimes pass a ``MappingProxyType``
+        # over the same dict. Read paths tolerate both; write paths
+        # require :class:`MutableMapping` (raised lazily by the helper).
+        self._state = state if isinstance(state, Mapping) else {}
+
+    # -- Constructors ----------------------------------------------------
+
+    @classmethod
+    def for_session(cls, session: Session | None) -> OrchestrationStore:
+        """Build a store backed by ``session.state``.
+
+        ``None`` yields an empty-state store (writes are silently
+        dropped) so callers who can't guarantee a session — e.g.
+        defensive paths inside ADK callbacks — never raise.
+        """
+        if session is None:
+            return cls({})
+        return cls(getattr(session, "state", {}))
+
+    @classmethod
+    def for_state(cls, state: Any) -> OrchestrationStore:
+        """Build a store backed by an arbitrary state dict."""
+        return cls(state)
+
+    # -- Internal helpers -----------------------------------------------
+
+    def _get(self, key: str, default: Any = None) -> Any:
+        return _ostate.read(self._state, key, default)
+
+    # -- Read: pin -------------------------------------------------------
+
+    def pin_current_task(self) -> str:
+        """Return ``goldfive.current_task_id``, or ``""`` when unset.
+
+        Replaces ``state.get('goldfive.current_task_id', '')`` with
+        a typed accessor. Phase 1's primary read-migration target on
+        the goldfive side.
+        """
+        value = self._get(_ostate.KEY_CURRENT_TASK_ID, "")
+        if isinstance(value, str):
+            return value
+        return ""
+
+    def pin_current_task_title(self) -> str:
+        """Return ``goldfive.current_task_title``, or ``""``."""
+        value = self._get(_ostate.KEY_CURRENT_TASK_TITLE, "")
+        if isinstance(value, str):
+            return value
+        return ""
+
+    def pin_current_task_revision(self) -> int:
+        """Return the revision stamp on the current pin (0 when unset)."""
+        return _ostate.read_current_task_revision(self._state)
+
+    # -- Write: pin ------------------------------------------------------
+
+    def set_pin_current_task(
+        self,
+        task_id: str,
+        *,
+        source: BindingSource = BindingSource.UNKNOWN,
+        revision: int | None = None,
+        title: str = "",
+    ) -> None:
+        """Stamp the current-task pin.
+
+        ``source`` is the :class:`BindingSource` documenting which
+        ladder-rung / callback wrote the pin. Phase 1 uses it for
+        observability only — Phase 2 wires it through every catalogued
+        writer for full attribution. Passing ``BindingSource.UNKNOWN``
+        is fine for code paths whose attribution hasn't been migrated
+        yet.
+
+        ``revision`` (when provided) stamps
+        ``goldfive.current_task_revision`` alongside the id.
+        ``None`` leaves the existing revision untouched.
+
+        No-op when ``task_id`` is empty — callers should use
+        :meth:`clear_pin_current_task` to clear.
+        """
+        if not task_id:
+            return
+        if not isinstance(self._state, dict):
+            # Read-only state (e.g. a MappingProxyType view); silently
+            # drop the write so the caller's defensive path remains
+            # safe. Production state is always a mutable dict.
+            return
+        # Reuse the orchestration_state primitives so the
+        # ``goldfive.*``-prefix assertion still fires; this keeps the
+        # store's writes funneled through the same place the catalog
+        # is verified against.
+        _ostate.write(self._state, _ostate.KEY_CURRENT_TASK_ID, str(task_id))
+        if title:
+            _ostate.write(self._state, _ostate.KEY_CURRENT_TASK_TITLE, str(title))
+        if revision is not None:
+            _ostate.stamp_current_task_revision(self._state, int(revision))
+        # ``source`` is recorded as part of the binding registry below
+        # rather than on the pin slot itself; the pin slot pre-dates
+        # the source vocabulary and Phase 2 will collapse the two.
+        _ = source  # documented for migration; not stored on the pin slot
+
+    def clear_pin_current_task(self) -> None:
+        """Clear the current-task pin slots. Idempotent."""
+        if not isinstance(self._state, dict):
+            return
+        _ostate.clear_current_task(self._state)
+
+    # -- Read: active steer ---------------------------------------------
+
+    def get_active_steer(self) -> ActiveSteer | None:
+        """Return the active steer, or ``None`` when no steer is set.
+
+        Replaces the four-key dance
+        ``state.get(KEY_ACTIVE_STEER_BODY, '')`` etc. with one typed
+        read. ``None`` is returned when the body is empty (the canonical
+        "no steer" signal) so callers can ``if store.get_active_steer():``
+        without re-checking ``.body``.
+        """
+        body = self._get(_ostate.KEY_ACTIVE_STEER_BODY, "")
+        if not isinstance(body, str) or not body:
+            return None
+        try:
+            at_turn = int(self._get(_ostate.KEY_ACTIVE_STEER_AT_TURN, 0) or 0)
+        except (TypeError, ValueError):
+            at_turn = 0
+        author_raw = self._get(_ostate.KEY_ACTIVE_STEER_AUTHOR, "")
+        source_raw = self._get(_ostate.KEY_ACTIVE_STEER_SOURCE, "")
+        return ActiveSteer(
+            body=body,
+            at_turn=at_turn,
+            author=str(author_raw or ""),
+            source=str(source_raw or ""),
+        )
+
+    # -- Read: correction ------------------------------------------------
+
+    def get_correction(self, agent_name: str, task_id: str) -> Any:
+        """Return the pending-correction value for an ``(agent, task)``.
+
+        The shape is whatever
+        :mod:`goldfive._correction_injection` writes — typically a
+        :class:`Mapping` with ``superseded_task_id`` /
+        ``revision_number`` / etc. (rendered via
+        :func:`goldfive.adapters._adk_dynainst.format_correction_block`)
+        but tests / external callers may have written a pre-rendered
+        string. ``None`` means no pending correction.
+        """
+        if not agent_name or not task_id:
+            return None
+        key = _dynainst.pending_correction_key(agent_name, task_id)
+        return self._get(key, None)
+
+    def has_correction(self, agent_name: str, task_id: str) -> bool:
+        """True when a pending correction exists for ``(agent, task)``."""
+        return self.get_correction(agent_name, task_id) is not None
+
+    def iter_corrections_for_agent(self, agent_name: str) -> list[str]:
+        """Return every task_id with a pending correction for ``agent_name``.
+
+        Used by pin-ladder signal 6 to enumerate correction targets
+        without rebuilding the prefix-matching loop at every call site.
+        """
+        if not agent_name or not isinstance(self._state, Mapping):
+            return []
+        # Strip a compound prefix so callers passing the bare or the
+        # compound form both find the writer's bare-form keys. Mirrors
+        # the matching the existing ``_task_from_pending_correction``
+        # helper does inline today.
+        bare = agent_name.rsplit(":", 1)[-1]
+        prefix = f"goldfive.pending_corrections.{bare}."
+        out: list[str] = []
+        for key in self._state:
+            if not isinstance(key, str):
+                continue
+            if not key.startswith(prefix):
+                continue
+            tid = key[len(prefix):]
+            if tid:
+                out.append(tid)
+        return out
+
+    # -- Read: pending delegations --------------------------------------
+
+    def get_pending_delegation(self, fc_id: str) -> DelegationPin | None:
+        """Return the per-``function_call_id`` delegation pin, or ``None``.
+
+        Tolerant of both legacy bare-string entries and the versioned
+        ``{task_id, revision, tool_args}`` dict shape (goldfive#266 +
+        F7). Callers used to inline the shape-test; this normalises.
+        """
+        if not fc_id:
+            return None
+        pend = self._get("goldfive.pending_delegations", None)
+        if not isinstance(pend, Mapping):
+            return None
+        raw = pend.get(fc_id)
+        if raw is None:
+            return None
+        if isinstance(raw, str):
+            tid = raw.strip()
+            if not tid:
+                return None
+            return DelegationPin(task_id=tid)
+        if isinstance(raw, Mapping):
+            tid = str(raw.get("task_id", "") or "").strip()
+            if not tid:
+                return None
+            try:
+                rev = int(raw.get("revision", 0) or 0)
+            except (TypeError, ValueError):
+                rev = 0
+            args = raw.get("tool_args")
+            if not isinstance(args, Mapping):
+                args = None
+            return DelegationPin(task_id=tid, revision=rev, tool_args=args)
+        return None
+
+    # -- Read: reasoning-extracted bindings (NEW Phase 1) ---------------
+
+    def get_reasoning_extracted_binding(
+        self,
+        agent_name: str,
+    ) -> ReasoningBinding | None:
+        """Return the most recent reasoning-extracted binding for ``agent_name``.
+
+        Phase 1's NEW read path — consumed by the pin-resolution
+        ladder's signal 6 (and by future correction / drift logic that
+        wants to consult the LLM judge's stated-intent attribution).
+
+        Returns ``None`` when no binding exists for the agent (or when
+        the recorded entry is malformed). Callers gate on confidence
+        themselves; the store stamps whatever the writer recorded.
+
+        The lookup strips compound-form prefixes the same way
+        :meth:`iter_corrections_for_agent` does, so a compound
+        ``"client42:agent_x"`` finds the bare ``agent_x`` binding the
+        judge recorded.
+        """
+        if not agent_name:
+            return None
+        registry = self._get(REASONING_BINDINGS_KEY, None)
+        if not isinstance(registry, Mapping):
+            return None
+        # Try the exact form, then the bare-form fallback so
+        # compound-named callers (``"client:foo"``) still match a bare
+        # binding the judge recorded for ``foo``.
+        raw = registry.get(agent_name)
+        if raw is None:
+            bare = agent_name.rsplit(":", 1)[-1]
+            if bare and bare != agent_name:
+                raw = registry.get(bare)
+        if raw is None:
+            return None
+        return ReasoningBinding.from_dict(raw)
+
+    # -- Write: reasoning-extracted bindings (NEW Phase 1) --------------
+
+    def record_reasoning_extracted_binding(
+        self,
+        *,
+        agent_name: str,
+        task_id: str,
+        confidence: float,
+        recorded_at_turn: int = 0,
+        run_id: str = "",
+        session_id: str = "",
+    ) -> ReasoningBinding | None:
+        """Stamp a reasoning-extracted binding for ``agent_name``.
+
+        Phase 1's only NEW write site. Called by the steerer's reasoning
+        observation path when
+        :func:`~goldfive.drift.reasoning_judge.classify_reasoning_drift`
+        returns a ``focused_task_id`` with confidence above the
+        configured threshold.
+
+        Returns the recorded :class:`ReasoningBinding` (for caller
+        observability) or ``None`` when the inputs were rejected
+        (empty ``agent_name`` / ``task_id``, or read-only state).
+        Confidence is clamped to ``[0.0, 1.0]``.
+        """
+        if not agent_name or not task_id:
+            return None
+        if not isinstance(self._state, dict):
+            return None
+        try:
+            conf = float(confidence)
+        except (TypeError, ValueError):
+            conf = 0.0
+        conf = max(0.0, min(1.0, conf))
+        binding = ReasoningBinding(
+            agent_name=str(agent_name),
+            task_id=str(task_id),
+            confidence=conf,
+            recorded_at_turn=int(recorded_at_turn),
+            run_id=str(run_id or ""),
+            session_id=str(session_id or ""),
+        )
+        # Read-modify-write the registry so unrelated agents' bindings
+        # are preserved. Tolerate a non-dict existing value (legacy
+        # state shape) by replacing it with a fresh registry rather
+        # than appending to a malformed structure.
+        registry = self._state.get(REASONING_BINDINGS_KEY)
+        if not isinstance(registry, dict):
+            registry = {}
+        # Stamp under the bare form so :meth:`get_reasoning_extracted_binding`
+        # finds it for both compound and bare lookups. The judge owns
+        # the agent-name normalisation policy; the store records the
+        # form the caller supplied (callers normalise before calling).
+        registry[binding.agent_name] = binding.to_dict()
+        _ostate.write(self._state, REASONING_BINDINGS_KEY, registry)
+        return binding
+
+    def clear_reasoning_extracted_binding(self, agent_name: str) -> None:
+        """Drop the binding for ``agent_name`` (idempotent).
+
+        Called on task transition for the agent so a binding that
+        targeted the now-completed task doesn't leak forward and
+        mis-pin the next invocation.
+        """
+        if not agent_name or not isinstance(self._state, dict):
+            return
+        registry = self._state.get(REASONING_BINDINGS_KEY)
+        if not isinstance(registry, dict):
+            return
+        registry.pop(agent_name, None)
+        # Also try the bare form in case the writer used compound but
+        # the caller is clearing with the bare form (or vice-versa).
+        bare = agent_name.rsplit(":", 1)[-1]
+        if bare and bare != agent_name:
+            registry.pop(bare, None)
+        _ostate.write(self._state, REASONING_BINDINGS_KEY, registry)

--- a/goldfive/planners/goldfive_planner.py
+++ b/goldfive/planners/goldfive_planner.py
@@ -153,6 +153,26 @@ def _state_get(state: Any, key: str, default: str = "") -> str:
     return str(value)
 
 
+def _goldfive_session_from_state(state: Any) -> Any:
+    """Return the goldfive ``Session`` reachable via ADK state, or ``None``.
+
+    Mirrors :func:`goldfive.adapters._adk_dynainst._goldfive_session_from_state`.
+    The ADK adapter stashes a
+    :class:`~goldfive.adapters._adk_plugin.SessionContext` onto ADK
+    ``session.state`` under ``"goldfive._session_context"``; when
+    present, the ``.session`` attribute is the goldfive
+    :class:`~goldfive.types.Session` whose state dict is goldfive's
+    own orchestration store. Returns ``None`` when the key is missing
+    so the planner can fall back to reading ADK state directly.
+    """
+    if not isinstance(state, Mapping):
+        return None
+    ctx = state.get("goldfive._session_context")
+    if ctx is None:
+        return None
+    return getattr(ctx, "session", None)
+
+
 def _state_list(state: Any, key: str) -> list[str]:
     """Tolerant list-of-strings read for ``state``."""
     if not isinstance(state, Mapping):
@@ -290,21 +310,75 @@ class GoldfivePlanner(BasePlanner):
         is called first and **prepended** so the user planner's framing
         lands above goldfive's per-turn state block.
 
+        Phase 1 of goldfive#271 — when the planner can reach the
+        goldfive :class:`~goldfive.types.Session` via the
+        ``goldfive._session_context`` stash on ADK state, the
+        active-steer / pin reads go through
+        :class:`~goldfive.orchestration_store.OrchestrationStore` so
+        the typed accessor is the read of record. Falls back to
+        reading ADK state directly when the goldfive Session isn't
+        reachable (custom adapters that don't stash a SessionContext,
+        legacy unit tests).
+
         Returns ``None`` only when an internal error prevents building
         any instruction — never returns an empty string (empty would
         cause ADK to skip the append, hiding the bug).
         """
         state = _extract_state(readonly_context)
 
-        # Collect the placeholders off state. All keys default to the
+        # Collect the placeholders. Phase 1 of goldfive#271 — prefer
+        # the goldfive OrchestrationStore when reachable AND when its
+        # Session.state has populated values. ADK state remains the
+        # fallback so the existing bridge path (V1/V5/V2 writes to ADK
+        # state by ``before_model_callback`` / ``before_run_callback``)
+        # keeps working unchanged. All keys default to the
         # ``(none)`` marker so the block still renders when state is
         # sparse — e.g. before #152 populates the new keys — making
         # this module a soft dependency.
-        task_id = _state_get(state, KEY_CURRENT_TASK_ID) or _NONE_MARKER
-        task_title = _state_get(state, KEY_CURRENT_TASK_TITLE) or _NONE_MARKER
+        adk_task_id = _state_get(state, KEY_CURRENT_TASK_ID)
+        adk_task_title = _state_get(state, KEY_CURRENT_TASK_TITLE)
+        adk_steer_body = _state_get(state, KEY_ACTIVE_STEER_BODY)
+        adk_steer_source = _state_get(state, KEY_ACTIVE_STEER_SOURCE).strip().lower()
+
+        gf_session = _goldfive_session_from_state(state)
+        gf_task_id = ""
+        gf_task_title = ""
+        gf_steer_body = ""
+        gf_steer_source = ""
+        if gf_session is not None:
+            try:
+                from goldfive.orchestration_store import OrchestrationStore
+
+                store = OrchestrationStore.for_session(gf_session)
+                gf_task_id = store.pin_current_task()
+                gf_task_title = store.pin_current_task_title()
+                active = store.get_active_steer()
+                if active is not None:
+                    gf_steer_body = active.body
+                    gf_steer_source = active.source.strip().lower()
+            except Exception as exc:  # noqa: BLE001 — defensive
+                log.debug(
+                    "GoldfivePlanner: OrchestrationStore read raised: %s "
+                    "— falling back to ADK state",
+                    exc,
+                )
+
+        # Prefer goldfive store value when it's populated; ADK state
+        # is the fallback. This preserves the V1/V5 bridge write path
+        # (test scaffolding writes to ADK state via the plugin and
+        # expects the planner to render those values) while making
+        # the OrchestrationStore the read of record once Phase 2's
+        # writers migrate to write goldfive-side first.
+        task_id = gf_task_id or adk_task_id or _NONE_MARKER
+        task_title = gf_task_title or adk_task_title or _NONE_MARKER
+        steer_body_raw = gf_steer_body or adk_steer_body
+        steer_source_raw = gf_steer_source or adk_steer_source
+        # Goals-summary stays read from ADK state — it is bridged from
+        # goldfive Session.state so the value is identical, and the
+        # planner only needs the formatted string. Keeping a single
+        # access pattern here avoids a cross-module dependency on the
+        # goldfive Goals helper for the formatting-only read.
         goals_summary = _state_get(state, KEY_GOALS_SUMMARY) or _NONE_MARKER
-        steer_body_raw = _state_get(state, KEY_ACTIVE_STEER_BODY)
-        steer_source_raw = _state_get(state, KEY_ACTIVE_STEER_SOURCE).strip().lower()
 
         # goldfive-steer-unification: source-aware attribution line so
         # the LLM sees whether the active steer is an operator

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -325,6 +325,7 @@ class DefaultSteerer:
         reasoning_drift_call_llm: ReflectiveCallLLM | None = None,
         reasoning_drift_model: str = "",
         reasoning_drift_rate_limit: int = 3,
+        reasoning_binding_confidence_threshold: float = 0.7,
         plan_revision_cooldown_seconds: float = 0.0,
         steering_config: SteeringConfig | None = None,
         goldfive_steer_threshold: str | None = None,
@@ -515,6 +516,21 @@ class DefaultSteerer:
         self._reasoning_drift_call_llm: ReflectiveCallLLM | None = reasoning_drift_call_llm
         self._reasoning_drift_model = reasoning_drift_model
         self._reasoning_drift_rate_limit = max(1, int(reasoning_drift_rate_limit))
+        # Phase 1 of goldfive#271 — confidence threshold for recording a
+        # reasoning-extracted binding onto OrchestrationStore. The
+        # judge returns a focus_confidence in [0.0, 1.0]; bindings with
+        # confidence >= this threshold are stamped, lower-confidence
+        # ones are discarded so the pin-resolution ladder doesn't
+        # consume noisy attributions. Clamped to [0.0, 1.0]. Defaults
+        # to 0.7 — empirically the band where the judge's
+        # plan-task attribution stops being a guess.
+        try:
+            _conf_threshold = float(reasoning_binding_confidence_threshold)
+        except (TypeError, ValueError):
+            _conf_threshold = 0.7
+        self._reasoning_binding_confidence_threshold: float = max(
+            0.0, min(1.0, _conf_threshold)
+        )
         # Drift-triggered plan-revision cooldown (goldfive#227).
         # Clamped to a non-negative float; ``0.0`` disables the gate
         # so callers can opt out without subclassing.
@@ -1294,6 +1310,7 @@ class DefaultSteerer:
                 call_llm=rl_call_llm,
                 judge_sink=judge_sink,
                 history_length=history_length,
+                agent_name=agent_name,
             )
         )
         self._background_judges.add(bg_task)
@@ -1307,6 +1324,7 @@ class DefaultSteerer:
         call_llm: ReflectiveCallLLM | None,
         judge_sink: Any,
         history_length: int,
+        agent_name: str = "",
     ) -> None:
         """Run the mode-selected reasoning drift pipeline off the critical path.
 
@@ -1336,7 +1354,7 @@ class DefaultSteerer:
         adapter callback that scheduled us has long since returned.
         """
         try:
-            from goldfive.drift.reasoning import analyze_reasoning
+            from goldfive.drift.reasoning import analyze_reasoning_with_focus
 
             # Save the shared live history and swap in a list snapshot
             # truncated to the length captured at schedule time. Using
@@ -1348,7 +1366,14 @@ class DefaultSteerer:
             pinned_history = list(original_history[:history_length])
             session.reasoning_history = pinned_history
             try:
-                drift = await analyze_reasoning(
+                # Phase 1 of goldfive#271 — call the focused-verdict
+                # path so we get the judge's plan-task attribution
+                # alongside the drift signal. ``analyze_reasoning_with_focus``
+                # is a sibling of ``analyze_reasoning`` that threads a
+                # :class:`ReasoningJudgeVerdict` instead of just the
+                # drift; legacy callers of ``analyze_reasoning`` keep
+                # their existing return shape.
+                verdict = await analyze_reasoning_with_focus(
                     text,
                     session,
                     mode=self._reasoning_drift_mode,
@@ -1362,6 +1387,19 @@ class DefaultSteerer:
                 # ``session.reasoning_history`` at a separate list for
                 # our window.
                 session.reasoning_history = original_history
+
+            # Record the reasoning-extracted binding onto the
+            # orchestration store regardless of the drift verdict —
+            # an on-task verdict that names a different plan task is
+            # itself a useful pin-resolution signal (the agent has
+            # silently moved to a different task without reporting).
+            self._maybe_record_reasoning_binding(
+                session=session,
+                verdict=verdict,
+                agent_name=agent_name,
+            )
+
+            drift = verdict.drift
             if drift is None:
                 return
             if not drift.trigger_input:
@@ -1375,6 +1413,72 @@ class DefaultSteerer:
         except Exception as exc:  # noqa: BLE001 — background task
             log.warning(
                 "DefaultSteerer: background reasoning-judge raised "
+                "(swallowed): %s",
+                exc,
+            )
+
+    def _maybe_record_reasoning_binding(
+        self,
+        *,
+        session: Session,
+        verdict: Any,
+        agent_name: str,
+    ) -> None:
+        """Stamp a reasoning-extracted binding onto the OrchestrationStore.
+
+        Phase 1 of goldfive#271. Called from
+        :meth:`_run_judge_background` after the LLM judge returns its
+        :class:`~goldfive.drift.reasoning_judge.ReasoningJudgeVerdict`.
+        Records a binding when:
+
+        * the verdict carries a non-empty ``focused_task_id``,
+        * the agent name is non-empty (we key bindings by agent),
+        * ``focus_confidence`` is at least the configured threshold.
+
+        Lower-confidence verdicts are silently dropped so the pin
+        ladder doesn't consume noisy bindings. Failures inside the
+        store helper degrade silently — the judge's primary job is
+        the drift signal, not the binding.
+        """
+        if not agent_name:
+            return
+        focused = getattr(verdict, "focused_task_id", "")
+        if not focused:
+            return
+        confidence = float(getattr(verdict, "focus_confidence", 0.0) or 0.0)
+        if confidence < self._reasoning_binding_confidence_threshold:
+            log.debug(
+                "DefaultSteerer: reasoning binding for agent=%r "
+                "task=%r dropped (confidence=%.2f < threshold=%.2f)",
+                agent_name,
+                focused,
+                confidence,
+                self._reasoning_binding_confidence_threshold,
+            )
+            return
+        try:
+            from goldfive.orchestration_store import OrchestrationStore
+
+            store = OrchestrationStore.for_session(session)
+            recorded = store.record_reasoning_extracted_binding(
+                agent_name=agent_name,
+                task_id=focused,
+                confidence=confidence,
+                recorded_at_turn=session.next_sequence(),
+                run_id=session.run_id,
+                session_id=session.id,
+            )
+            if recorded is not None:
+                log.info(
+                    "DefaultSteerer: recorded reasoning-extracted binding "
+                    "agent=%r task=%r confidence=%.2f",
+                    agent_name,
+                    focused,
+                    confidence,
+                )
+        except Exception as exc:  # noqa: BLE001 — never break the run
+            log.warning(
+                "DefaultSteerer: record_reasoning_extracted_binding raised "
                 "(swallowed): %s",
                 exc,
             )
@@ -3158,29 +3262,24 @@ class DefaultSteerer:
         if not self._severity_meets_promotion_threshold(drift.severity):
             return False
         # Consult the active user steer freshness window.
+        # Phase 1 of goldfive#271 — read through OrchestrationStore so
+        # the active-steer slot reads from a single named accessor; the
+        # underlying ``_ostate.read`` calls still funnel through the
+        # goldfive Session.state dict, just behind a typed surface.
         window = self._goldfive_steer_suppression_window_turns
         if window > 0:
-            active_source = _ostate.read(
-                session.state, _ostate.KEY_ACTIVE_STEER_SOURCE, ""
-            )
-            active_at_turn = _ostate.read(
-                session.state, _ostate.KEY_ACTIVE_STEER_AT_TURN, None
-            )
-            if str(active_source or "").lower() == "user" and isinstance(
-                active_at_turn, int
-            ):
+            from goldfive.orchestration_store import OrchestrationStore
+
+            active = OrchestrationStore.for_session(session).get_active_steer()
+            if active is not None and active.source.lower() == "user":
                 current_turn = int(getattr(session, "_next_sequence", 0) or 0)
-                age = current_turn - int(active_at_turn)
+                age = current_turn - active.at_turn
                 if 0 <= age < window:
-                    active_body = str(
-                        _ostate.read(session.state, _ostate.KEY_ACTIVE_STEER_BODY, "")
-                        or ""
-                    )
                     drift.suppressed_by_user_steer = True
                     log.info(
                         "goldfive steer suppressed: user steer %r is active "
                         "(age=%d turns, window=%d)",
-                        active_body,
+                        active.body,
                         age,
                         window,
                     )
@@ -4584,13 +4683,15 @@ class DefaultSteerer:
         # 2. goldfive orchestration session.state pin (the reporting-
         # tool fallback's source of truth). Use the canonical state key
         # so tests that inspect the state dict directly see the update.
+        # Phase 1 of goldfive#271 — read through OrchestrationStore;
+        # the write stays at this call site (Phase 2 migration target
+        # per the catalog).
         state = getattr(session, "state", None)
         if isinstance(state, dict):
-            state_pinned = state.get(_ostate.KEY_CURRENT_TASK_ID, "")
-            if isinstance(state_pinned, str):
-                state_pinned_s = state_pinned.strip()
-            else:
-                state_pinned_s = str(state_pinned or "").strip()
+            from goldfive.orchestration_store import OrchestrationStore
+
+            store = OrchestrationStore.for_state(state)
+            state_pinned_s = store.pin_current_task().strip()
             if state_pinned_s and state_pinned_s in supersession:
                 resolved = _resolve_chain(state_pinned_s)
                 if resolved != state_pinned_s:

--- a/tests/test_orchestration_store.py
+++ b/tests/test_orchestration_store.py
@@ -1,0 +1,475 @@
+"""Tests for the Phase-1 :class:`OrchestrationStore` typed handle.
+
+goldfive#271 Phase 1. Pins:
+
+* Each accessor's read/write contract — pin / active steer / correction
+  / pending-delegation / reasoning-extracted binding.
+* Reasoning extraction binding workflow: judge returns
+  ``focused_task_id``; store records; pin resolution sees the new
+  binding (covered in :mod:`tests.test_pin_resolution_ladder`).
+* The store doesn't leak to ADK ``session.state`` — Phase 0's
+  tripwire stays green throughout (autouse fixture in conftest.py
+  already sets ``GOLDFIVE_STRICT_STATE_OWNERSHIP=1``; any unintended
+  ADK-state mutation would raise here).
+* Read fallback: store-first; legacy state slot as backup for compat.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive import orchestration_state as _ostate  # noqa: E402
+from goldfive.orchestration_store import (  # noqa: E402
+    REASONING_BINDINGS_KEY,
+    ActiveSteer,
+    BindingSource,
+    DelegationPin,
+    OrchestrationStore,
+    ReasoningBinding,
+)
+from goldfive.types import Plan, Session, Task  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_for_session_uses_session_state_dict() -> None:
+    """``for_session`` returns a store backed by ``session.state``."""
+    session = Session(run_id="r1")
+    store = OrchestrationStore.for_session(session)
+    # Empty initially.
+    assert store.pin_current_task() == ""
+    # Mutating through the store reflects on ``session.state``.
+    store.set_pin_current_task("t1", source=BindingSource.AGENT_CALLBACK)
+    assert session.state[_ostate.KEY_CURRENT_TASK_ID] == "t1"
+
+
+def test_for_session_none_yields_empty_view() -> None:
+    """``for_session(None)`` is safe — reads default; writes drop silently."""
+    store = OrchestrationStore.for_session(None)
+    assert store.pin_current_task() == ""
+    # Write should silently drop — no exception, no side effect.
+    store.set_pin_current_task("t1")
+
+
+def test_for_state_uses_arbitrary_dict() -> None:
+    """``for_state`` accepts a plain dict (test scaffolding)."""
+    state: dict = {}
+    store = OrchestrationStore.for_state(state)
+    store.set_pin_current_task("tA", source=BindingSource.AGENT_CALLBACK)
+    assert state[_ostate.KEY_CURRENT_TASK_ID] == "tA"
+
+
+def test_construction_tolerates_non_mapping() -> None:
+    """A non-mapping ``state`` argument degrades to an empty store."""
+    store = OrchestrationStore(state=object())
+    assert store.pin_current_task() == ""
+    # And writes are no-ops, since the underlying dict isn't present.
+    store.set_pin_current_task("xx")
+
+
+# ---------------------------------------------------------------------------
+# Pin
+# ---------------------------------------------------------------------------
+
+
+def test_pin_round_trip() -> None:
+    """``set_pin_current_task`` writes; ``pin_current_task`` reads back."""
+    session = Session(run_id="r1")
+    store = OrchestrationStore.for_session(session)
+    store.set_pin_current_task(
+        "task-42",
+        source=BindingSource.AGENT_CALLBACK,
+        title="Drive forward",
+        revision=3,
+    )
+    assert store.pin_current_task() == "task-42"
+    assert store.pin_current_task_title() == "Drive forward"
+    assert store.pin_current_task_revision() == 3
+
+
+def test_pin_empty_id_is_noop() -> None:
+    """An empty task_id does not clobber the existing pin."""
+    session = Session(run_id="r1")
+    session.state[_ostate.KEY_CURRENT_TASK_ID] = "existing"
+    OrchestrationStore.for_session(session).set_pin_current_task("")
+    assert session.state[_ostate.KEY_CURRENT_TASK_ID] == "existing"
+
+
+def test_pin_clear() -> None:
+    """``clear_pin_current_task`` removes id, title, revision."""
+    session = Session(run_id="r1")
+    store = OrchestrationStore.for_session(session)
+    store.set_pin_current_task("t", title="x", revision=1)
+    store.clear_pin_current_task()
+    assert _ostate.KEY_CURRENT_TASK_ID not in session.state
+    assert _ostate.KEY_CURRENT_TASK_TITLE not in session.state
+
+
+def test_pin_revision_default_zero_when_unset() -> None:
+    """Reading the revision before any write returns ``0``."""
+    store = OrchestrationStore.for_session(Session(run_id="r1"))
+    assert store.pin_current_task_revision() == 0
+
+
+# ---------------------------------------------------------------------------
+# Active steer
+# ---------------------------------------------------------------------------
+
+
+def test_get_active_steer_returns_none_when_unset() -> None:
+    """No body recorded → ``get_active_steer()`` returns ``None``."""
+    store = OrchestrationStore.for_session(Session(run_id="r1"))
+    assert store.get_active_steer() is None
+
+
+def test_get_active_steer_round_trip() -> None:
+    """A stamped active steer reads back as a typed view."""
+    session = Session(run_id="r1")
+    _ostate.set_active_steer(
+        session.state,
+        body="focus on X",
+        at_turn=12,
+        author="op@example",
+        source="user",
+    )
+    active = OrchestrationStore.for_session(session).get_active_steer()
+    assert isinstance(active, ActiveSteer)
+    assert active.body == "focus on X"
+    assert active.at_turn == 12
+    assert active.author == "op@example"
+    assert active.source == "user"
+    assert active.is_active()
+
+
+def test_active_steer_empty_body_returns_none() -> None:
+    """Explicitly-empty body still reads as 'no steer' (None)."""
+    session = Session(run_id="r1")
+    session.state[_ostate.KEY_ACTIVE_STEER_BODY] = ""
+    session.state[_ostate.KEY_ACTIVE_STEER_AT_TURN] = 5
+    assert OrchestrationStore.for_session(session).get_active_steer() is None
+
+
+# ---------------------------------------------------------------------------
+# Pending corrections
+# ---------------------------------------------------------------------------
+
+
+def test_get_correction_returns_none_when_unset() -> None:
+    store = OrchestrationStore.for_session(Session(run_id="r1"))
+    assert store.get_correction("agent_x", "task_y") is None
+    assert not store.has_correction("agent_x", "task_y")
+
+
+def test_get_correction_round_trip_dict_payload() -> None:
+    """A dict correction payload reads back unchanged."""
+    session = Session(run_id="r1")
+    payload = {
+        "agent_name": "agent_x",
+        "task_id": "task_y",
+        "superseded_task_id": "task_old",
+        "revision_number": 2,
+    }
+    session.state["goldfive.pending_corrections.agent_x.task_y"] = payload
+    store = OrchestrationStore.for_session(session)
+    assert store.has_correction("agent_x", "task_y")
+    assert store.get_correction("agent_x", "task_y") == payload
+
+
+def test_iter_corrections_for_agent() -> None:
+    session = Session(run_id="r1")
+    session.state["goldfive.pending_corrections.agent_x.task_a"] = {"a": 1}
+    session.state["goldfive.pending_corrections.agent_x.task_b"] = {"b": 1}
+    session.state["goldfive.pending_corrections.other.task_c"] = {"c": 1}
+    found = sorted(
+        OrchestrationStore.for_session(session).iter_corrections_for_agent(
+            "agent_x"
+        )
+    )
+    assert found == ["task_a", "task_b"]
+
+
+def test_iter_corrections_strips_compound_agent_form() -> None:
+    """Compound ``client42:agent_x`` finds bare ``agent_x`` writes."""
+    session = Session(run_id="r1")
+    session.state["goldfive.pending_corrections.agent_x.task_a"] = {"a": 1}
+    found = OrchestrationStore.for_session(session).iter_corrections_for_agent(
+        "client42:agent_x"
+    )
+    assert found == ["task_a"]
+
+
+# ---------------------------------------------------------------------------
+# Pending delegations
+# ---------------------------------------------------------------------------
+
+
+def test_get_pending_delegation_versioned_dict() -> None:
+    """The new ``{task_id, revision, tool_args}`` shape resolves cleanly."""
+    session = Session(run_id="r1")
+    session.state["goldfive.pending_delegations"] = {
+        "fc-1": {
+            "task_id": "tA",
+            "revision": 7,
+            "tool_args": {"q": "solar"},
+        },
+    }
+    pin = OrchestrationStore.for_session(session).get_pending_delegation("fc-1")
+    assert isinstance(pin, DelegationPin)
+    assert pin.task_id == "tA"
+    assert pin.revision == 7
+    assert pin.tool_args == {"q": "solar"}
+    assert pin.is_set()
+
+
+def test_get_pending_delegation_legacy_string_shape() -> None:
+    """The pre-#266 bare-string entry shape still resolves."""
+    session = Session(run_id="r1")
+    session.state["goldfive.pending_delegations"] = {"fc-1": "tLegacy"}
+    pin = OrchestrationStore.for_session(session).get_pending_delegation("fc-1")
+    assert pin is not None
+    assert pin.task_id == "tLegacy"
+    assert pin.revision == 0
+
+
+def test_get_pending_delegation_missing_returns_none() -> None:
+    store = OrchestrationStore.for_session(Session(run_id="r1"))
+    assert store.get_pending_delegation("fc-zzz") is None
+    assert store.get_pending_delegation("") is None
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-extracted bindings (NEW Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def test_record_reasoning_binding_round_trip() -> None:
+    """A recorded binding reads back via ``get_reasoning_extracted_binding``."""
+    session = Session(run_id="run-1")
+    store = OrchestrationStore.for_session(session)
+    rec = store.record_reasoning_extracted_binding(
+        agent_name="agent_x",
+        task_id="t1",
+        confidence=0.85,
+        recorded_at_turn=4,
+        run_id="run-1",
+        session_id="run-1",
+    )
+    assert rec is not None
+    assert rec.confidence == pytest.approx(0.85)
+    fetched = store.get_reasoning_extracted_binding("agent_x")
+    assert fetched is not None
+    assert fetched.task_id == "t1"
+    assert fetched.confidence == pytest.approx(0.85)
+    assert fetched.recorded_at_turn == 4
+
+
+def test_record_reasoning_binding_clamps_confidence() -> None:
+    """Confidence outside ``[0, 1]`` is clamped at write time."""
+    session = Session(run_id="r1")
+    store = OrchestrationStore.for_session(session)
+    rec = store.record_reasoning_extracted_binding(
+        agent_name="a", task_id="t", confidence=1.5
+    )
+    assert rec is not None
+    assert rec.confidence == 1.0
+    rec2 = store.record_reasoning_extracted_binding(
+        agent_name="b", task_id="t", confidence=-0.4
+    )
+    assert rec2 is not None
+    assert rec2.confidence == 0.0
+
+
+def test_record_reasoning_binding_rejects_empty_inputs() -> None:
+    """Empty agent / task name skips the write."""
+    session = Session(run_id="r1")
+    store = OrchestrationStore.for_session(session)
+    assert store.record_reasoning_extracted_binding(
+        agent_name="", task_id="t", confidence=0.9
+    ) is None
+    assert store.record_reasoning_extracted_binding(
+        agent_name="a", task_id="", confidence=0.9
+    ) is None
+    assert REASONING_BINDINGS_KEY not in session.state
+
+
+def test_get_reasoning_binding_compound_falls_back_to_bare() -> None:
+    """A compound ``client42:agent_x`` lookup finds the bare-form binding."""
+    session = Session(run_id="r1")
+    OrchestrationStore.for_session(session).record_reasoning_extracted_binding(
+        agent_name="agent_x", task_id="t1", confidence=0.9
+    )
+    fetched = OrchestrationStore.for_session(session).get_reasoning_extracted_binding(
+        "client42:agent_x"
+    )
+    assert fetched is not None
+    assert fetched.task_id == "t1"
+
+
+def test_clear_reasoning_binding_drops_entry() -> None:
+    session = Session(run_id="r1")
+    store = OrchestrationStore.for_session(session)
+    store.record_reasoning_extracted_binding(
+        agent_name="agent_x", task_id="t1", confidence=0.9
+    )
+    store.clear_reasoning_extracted_binding("agent_x")
+    assert store.get_reasoning_extracted_binding("agent_x") is None
+
+
+def test_record_preserves_unrelated_bindings() -> None:
+    """Recording for one agent doesn't clobber another agent's binding."""
+    session = Session(run_id="r1")
+    store = OrchestrationStore.for_session(session)
+    store.record_reasoning_extracted_binding(
+        agent_name="alpha", task_id="t_alpha", confidence=0.8
+    )
+    store.record_reasoning_extracted_binding(
+        agent_name="beta", task_id="t_beta", confidence=0.9
+    )
+    assert store.get_reasoning_extracted_binding("alpha").task_id == "t_alpha"
+    assert store.get_reasoning_extracted_binding("beta").task_id == "t_beta"
+
+
+def test_record_overwrites_same_agent_binding() -> None:
+    """A second record for the same agent supersedes the first."""
+    session = Session(run_id="r1")
+    store = OrchestrationStore.for_session(session)
+    store.record_reasoning_extracted_binding(
+        agent_name="a", task_id="t1", confidence=0.5
+    )
+    store.record_reasoning_extracted_binding(
+        agent_name="a", task_id="t2", confidence=0.95
+    )
+    fetched = store.get_reasoning_extracted_binding("a")
+    assert fetched.task_id == "t2"
+    assert fetched.confidence == pytest.approx(0.95)
+
+
+def test_reasoning_binding_dict_round_trip() -> None:
+    """``ReasoningBinding.from_dict`` reverses ``to_dict`` faithfully."""
+    b = ReasoningBinding(
+        agent_name="a",
+        task_id="t",
+        confidence=0.7,
+        recorded_at_turn=4,
+        run_id="r",
+        session_id="s",
+    )
+    rebuilt = ReasoningBinding.from_dict(b.to_dict())
+    assert rebuilt == b
+
+
+def test_reasoning_binding_from_dict_rejects_garbage() -> None:
+    assert ReasoningBinding.from_dict(None) is None
+    assert ReasoningBinding.from_dict("not a dict") is None
+    assert ReasoningBinding.from_dict({}) is None  # missing task_id
+    assert ReasoningBinding.from_dict({"task_id": ""}) is None
+
+
+# ---------------------------------------------------------------------------
+# Read fallback / no-leak invariants
+# ---------------------------------------------------------------------------
+
+
+def test_store_does_not_write_to_adk_state() -> None:
+    """The store wraps goldfive ``Session.state``, never ADK's session.state.
+
+    The autouse ``_state_audit_enabled`` fixture in conftest.py sets
+    ``GOLDFIVE_STRICT_STATE_OWNERSHIP=1`` for every test. If the store
+    leaked a write to ADK's session.state from a callback frame, the
+    tripwire would raise. Exercising every write path here provides
+    structural coverage that the store doesn't introduce a new
+    Phase-0 violation.
+    """
+    session = Session(run_id="r1")
+    store = OrchestrationStore.for_session(session)
+    store.set_pin_current_task("t1", source=BindingSource.AGENT_CALLBACK, revision=2)
+    store.record_reasoning_extracted_binding(
+        agent_name="a", task_id="t1", confidence=0.9
+    )
+    store.clear_reasoning_extracted_binding("a")
+    store.clear_pin_current_task()
+    # If the audit had fired, we'd never have reached the assertions.
+    assert _ostate.KEY_CURRENT_TASK_ID not in session.state
+
+
+def test_store_reads_match_legacy_state_layout() -> None:
+    """A pre-existing legacy state dict is readable through the store.
+
+    Drives the back-compat path: code that wrote keys directly under
+    the goldfive prefix (orchestration_state primitives) is read by
+    the new typed accessors without re-stamping. Phase 1's read
+    migration relies on this — existing writers stay where they are
+    (Phase 2's job to migrate them) while readers move to the typed
+    accessors.
+    """
+    session = Session(run_id="r1")
+    # Legacy direct-state writes (the writers Phase 2 will migrate).
+    session.state[_ostate.KEY_CURRENT_TASK_ID] = "legacy-task"
+    session.state[_ostate.KEY_CURRENT_TASK_TITLE] = "Legacy Title"
+    session.state[_ostate.KEY_CURRENT_TASK_REVISION] = 5
+    _ostate.set_active_steer(
+        session.state,
+        body="legacy",
+        at_turn=2,
+        author="op",
+        source="user",
+    )
+    session.state["goldfive.pending_corrections.agent_x.legacy-task"] = {
+        "agent_name": "agent_x",
+        "task_id": "legacy-task",
+    }
+    session.state["goldfive.pending_delegations"] = {"fc-1": "legacy-task"}
+
+    store = OrchestrationStore.for_session(session)
+    assert store.pin_current_task() == "legacy-task"
+    assert store.pin_current_task_title() == "Legacy Title"
+    assert store.pin_current_task_revision() == 5
+    active = store.get_active_steer()
+    assert active is not None and active.body == "legacy"
+    assert store.has_correction("agent_x", "legacy-task")
+    pin = store.get_pending_delegation("fc-1")
+    assert pin is not None and pin.task_id == "legacy-task"
+
+
+def test_binding_workflow_with_plan_pin_resolution_signal() -> None:
+    """End-to-end: store records → pin ladder helper finds matching task.
+
+    This is the integration shape the steerer's reasoning-judge
+    background path depends on. Validated end-to-end in
+    ``test_pin_resolution_ladder`` against the live plugin
+    callback; this test pins the orchestration_store contract that
+    the binding's ``task_id`` matches a plan task by id.
+    """
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="t_alpha", title="Alpha", assignee_agent_id="agent_x"),
+            Task(id="t_beta", title="Beta", assignee_agent_id="agent_x"),
+        ],
+        edges=[],
+        summary="",
+    )
+    session = Session(run_id="r1", plan=plan)
+    store = OrchestrationStore.for_session(session)
+    store.record_reasoning_extracted_binding(
+        agent_name="agent_x",
+        task_id="t_beta",
+        confidence=0.92,
+    )
+    binding = store.get_reasoning_extracted_binding("agent_x")
+    assert binding is not None and binding.task_id == "t_beta"
+    # The matching plan task is locatable by id.
+    matching = next((t for t in plan.tasks if t.id == binding.task_id), None)
+    assert matching is not None
+    assert matching.title == "Beta"

--- a/tests/test_pin_resolution_ladder.py
+++ b/tests/test_pin_resolution_ladder.py
@@ -557,6 +557,89 @@ async def test_signal5_parent_pin_downstream() -> None:
 # ---------------------------------------------------------------------------
 
 
+async def test_signal6_reasoning_binding_pins_target_task() -> None:
+    """A reasoning-extracted binding routes the agent to the named task.
+
+    Phase 1 of goldfive#271: when the steerer's reasoning judge has
+    recorded a binding (via OrchestrationStore) and confidence is at
+    the threshold, the pin ladder's signal 6 fires before the
+    correction-targeting sub-signal.
+
+    Setup forces every prior signal to fail:
+
+      * No delegation pin (signal 1).
+      * Two PENDING tasks for the agent so signal 2 ties.
+      * No DAG edges and no scoring args, so signals 3 / 4 / 5 also
+        skip / tie.
+      * No pending corrections, so signal 6's correction sub-signal
+        also skips.
+
+    The reasoning binding is the only signal that can disambiguate.
+    """
+    from goldfive.orchestration_store import OrchestrationStore
+
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    session = _session_with(
+        _plan_with(
+            Task(id="t_alpha", title="Alpha", assignee_agent_id="agent_x"),
+            Task(id="t_beta", title="Beta", assignee_agent_id="agent_x"),
+        )
+    )
+    OrchestrationStore.for_session(session).record_reasoning_extracted_binding(
+        agent_name="agent_x",
+        task_id="t_beta",
+        confidence=0.9,
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("agent_x"),
+        callback_context=ctx,
+    )
+
+    assert state[KEY_CURRENT_TASK_ID] == "t_beta"
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] == "reasoning_binding"
+
+
+async def test_signal6_reasoning_binding_falls_through_when_task_terminal() -> None:
+    """A binding pointing at a COMPLETED task falls through to other signals."""
+    from goldfive.orchestration_store import OrchestrationStore
+    from goldfive.types import TaskStatus
+
+    plugin = make_adk_plugin(host_agent_name="coord")
+    sinks = [_CapturingSink()]
+    plan = _plan_with(
+        Task(
+            id="t_alpha",
+            title="Alpha",
+            assignee_agent_id="agent_x",
+            status=TaskStatus.COMPLETED,
+        ),
+        Task(id="t_beta", title="Beta", assignee_agent_id="agent_x"),
+    )
+    session = _session_with(plan)
+    # Binding still names the completed task.
+    OrchestrationStore.for_session(session).record_reasoning_extracted_binding(
+        agent_name="agent_x",
+        task_id="t_alpha",
+        confidence=0.95,
+    )
+    state, ctx = _ctx_for(session, "coord", sinks=sinks)
+
+    await plugin.before_agent_callback(
+        agent=_Agent("agent_x"),
+        callback_context=ctx,
+    )
+
+    # Binding rejected (target terminal) → signal 2 binds the only
+    # remaining DAG-ready PENDING candidate.
+    assert state[KEY_CURRENT_TASK_ID] == "t_beta"
+    events = _pin_resolved_events(sinks[0].events)
+    assert events[-1]["payload"]["via_signal"] != "reasoning_binding"
+
+
 async def test_signal6_pending_correction_pins_target_task() -> None:
     """A pending-correction key targets task ``corr1`` → signal 6 binds it."""
     plugin = make_adk_plugin(host_agent_name="coord")

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -33,6 +33,7 @@ pytestmark = pytest.mark.skipif(
 from goldfive.drift import reasoning_judge as rjudge  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
+    DriftEvent,
     DriftKind,
     DriftSeverity,
     Goal,
@@ -632,7 +633,12 @@ async def test_observe_reasoning_judge_exception_does_not_crash(
     async def _boom(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
         raise RuntimeError("judge exploded")
 
+    # The steerer's background judge uses ``analyze_reasoning_with_focus``
+    # since Phase 1 of goldfive#271 (extended verdict path). Patch both
+    # entry points so the test stays robust whichever one the steerer
+    # ends up calling.
     monkeypatch.setattr(reasoning_mod, "analyze_reasoning", _boom)
+    monkeypatch.setattr(reasoning_mod, "analyze_reasoning_with_focus", _boom)
 
     # Any valid judge wiring -- analyze_reasoning is monkeypatched
     # before the background task dispatches.
@@ -709,3 +715,263 @@ async def test_shutdown_is_noop_when_no_background_judges() -> None:
     # No observe_reasoning call -> empty set.
     assert steerer._background_judges == set()
     await steerer.shutdown(timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 of goldfive#271 — extended verdict (focused_task_id)
+# ---------------------------------------------------------------------------
+
+
+async def test_classify_with_focus_returns_verdict_with_attribution() -> None:
+    """The judge's focused_task_id + confidence surface on the verdict."""
+    call_llm = _stub_call_llm(
+        [
+            {
+                "on_task": True,
+                "focused_task_id": "t1",
+                "focus_confidence": 0.9,
+                "stated_intent": "researching solar panels",
+            }
+        ]
+    )
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="Research solar panels")],
+        edges=[],
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="I'll start by reviewing the solar-panel datasheets.",
+        task=_task(),
+        goals=_goals(),
+        plan=plan,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is None  # on-task
+    assert verdict.focused_task_id == "t1"
+    assert verdict.focus_confidence == 0.9
+    assert verdict.stated_intent == "researching solar panels"
+
+
+async def test_classify_with_focus_off_task_carries_drift_and_attribution() -> None:
+    """An off-task verdict still records the focus the agent has switched to."""
+    call_llm = _stub_call_llm(
+        [
+            {
+                "on_task": False,
+                "severity": "warning",
+                "reason": "switched to write_report",
+                "focused_task_id": "t2",
+                "focus_confidence": 0.95,
+                "stated_intent": "writing the final report",
+            }
+        ]
+    )
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="Research"),
+            Task(id="t2", title="Write report"),
+        ],
+        edges=[],
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="Let me just start drafting the report instead.",
+        task=Task(id="t1", title="Research"),
+        goals=[],
+        plan=plan,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.kind == DriftKind.OFF_TOPIC
+    assert verdict.drift.severity == DriftSeverity.WARNING
+    # Off-task reasoning still reveals attribution: t2.
+    assert verdict.focused_task_id == "t2"
+    assert verdict.focus_confidence == 0.95
+
+
+async def test_classify_with_focus_clamps_confidence_to_unit_interval() -> None:
+    """Confidence outside [0, 1] is clamped at parse time."""
+    call_llm = _stub_call_llm(
+        [{"on_task": True, "focused_task_id": "t1", "focus_confidence": 5.0}]
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thinking",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.focus_confidence == 1.0
+
+
+async def test_classify_with_focus_off_plan_yields_empty_focus() -> None:
+    """A judge that returns no attribution gives focused_task_id=''."""
+    call_llm = _stub_call_llm(
+        [
+            {
+                "on_task": False,
+                "severity": "info",
+                "focused_task_id": "",
+                "focus_confidence": 0.0,
+            }
+        ]
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="random tangent",
+        task=_task(),
+        goals=[],
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.focused_task_id == ""
+    assert verdict.focus_confidence == 0.0
+
+
+async def test_classify_with_focus_malformed_response_returns_empty_verdict() -> None:
+    """A non-JSON response yields a verdict with everything empty."""
+    call_llm = _stub_call_llm(["this is not JSON at all"])
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thinking",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is None
+    assert verdict.focused_task_id == ""
+    assert verdict.focus_confidence == 0.0
+
+
+async def test_classify_with_focus_call_llm_raises_returns_empty_verdict() -> None:
+    """An LLM exception leaves attribution fields at default ('no signal')."""
+    call_llm = _raising_call_llm(RuntimeError("503"))
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thinking",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is None
+    assert verdict.focused_task_id == ""
+    assert verdict.focus_confidence == 0.0
+
+
+async def test_classify_with_focus_empty_reasoning_skips_llm_call() -> None:
+    """An empty reasoning block returns an empty verdict without calling the LLM."""
+    call_llm = _stub_call_llm([])  # would fail if called
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is None
+    assert verdict.focused_task_id == ""
+
+
+async def test_legacy_classify_reasoning_drift_returns_drift_only() -> None:
+    """The back-compat wrapper returns just the drift component.
+
+    Existing call sites depend on ``DriftEvent | None`` — the
+    extended fields live on
+    :func:`classify_reasoning_drift_with_focus`. This test pins the
+    delegating wrapper.
+    """
+    call_llm = _stub_call_llm(
+        [
+            {
+                "on_task": False,
+                "severity": "critical",
+                "focused_task_id": "t1",
+                "focus_confidence": 0.9,
+            }
+        ]
+    )
+    drift = await rjudge.classify_reasoning_drift(
+        reasoning="abandon ship",
+        task=_task(),
+        goals=_goals(),
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert isinstance(drift, DriftEvent)
+    assert drift.severity == DriftSeverity.CRITICAL
+
+
+# ---------------------------------------------------------------------------
+# Plan-tasks summary truncation
+# ---------------------------------------------------------------------------
+
+
+def test_format_plan_tasks_summary_renders_id_arrow_title() -> None:
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="t1", title="Alpha"),
+            Task(id="t2", title="Beta"),
+        ],
+        edges=[],
+    )
+    rendered = rjudge.format_plan_tasks_summary(plan)
+    assert "- t1 -> Alpha" in rendered
+    assert "- t2 -> Beta" in rendered
+
+
+def test_format_plan_tasks_summary_truncates_when_over_budget() -> None:
+    """A pathologically long task list is truncated with a marker."""
+    tasks = [
+        Task(id=f"t{i}", title="x" * 80)
+        for i in range(100)
+    ]
+    plan = Plan(id="p1", run_id="r1", goal_ids=[], tasks=tasks, edges=[])
+    rendered = rjudge.format_plan_tasks_summary(plan, max_chars=200)
+    # Truncation marker is present.
+    assert "more task" in rendered
+    # The rendered text obeys the cap (modulo the truncation line).
+    body_lines = [
+        line for line in rendered.splitlines()
+        if not line.startswith("...")
+    ]
+    assert sum(len(line) for line in body_lines) <= 220  # cap + small slack
+
+
+def test_format_plan_tasks_summary_empty_plan_renders_placeholder() -> None:
+    assert rjudge.format_plan_tasks_summary(None) == "(no plan tasks)"
+    empty_plan = Plan(id="p1", run_id="r1", goal_ids=[], tasks=[], edges=[])
+    assert rjudge.format_plan_tasks_summary(empty_plan) == "(no plan tasks)"
+
+
+def test_classify_with_focus_renders_plan_tasks_into_prompt() -> None:
+    """The judge's user prompt includes the plan-tasks summary section."""
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[Task(id="t1", title="Alpha"), Task(id="t2", title="Beta")],
+        edges=[],
+    )
+    rendered = rjudge.REASONING_DRIFT_USER_PROMPT_TEMPLATE.format(
+        plan_tasks_summary=rjudge.format_plan_tasks_summary(plan),
+        goals_block="(no goals)",
+        task_block="(no task bound)",
+        reasoning_block="thinking",
+    )
+    assert "PLAN TASKS" in rendered
+    assert "t1 -> Alpha" in rendered
+    assert "focused_task_id" in rendered
+    assert "focus_confidence" in rendered


### PR DESCRIPTION
## Summary

- New `goldfive/orchestration_store.py`: typed `OrchestrationStore` over goldfive's own `Session.state` (the dict Phase 0's audit already classifies as compliant). Initial surface covers pin / active steer / corrections / pending delegations + a new reasoning-extracted-binding registry.
- `classify_reasoning_drift_with_focus` (Phase 1's only new write source): the existing reasoning judge now returns `focused_task_id` + `focus_confidence` + `stated_intent` alongside the legacy `on_task` verdict. Same LLM call, zero incremental cost. Legacy `classify_reasoning_drift` stays as a back-compat wrapper.
- Read migration: `DefaultSteerer`'s active-steer + pin reads, the dynamic-instruction resolver's pending-correction lookup, and `GoldfivePlanner.build_planning_instruction` consult the store first; legacy ADK state remains as the documented fallback so existing bridge writes keep working.
- Pin-resolution ladder signal 6 grows a sub-signal `reasoning_binding` that fires before the existing `correction_target` when a binding above the configured confidence threshold (default 0.7, knob on `DefaultSteerer`) names a PENDING/RUNNING plan task.

Phase 0's runtime tripwire (`GOLDFIVE_STRICT_STATE_OWNERSHIP=1`) stays green. No new ADK session.state writes; the catalog is unchanged.

## Phase fit

This is Phase 1 of #271. Phase 0 (#278) installed the contract + tripwire. Phase 2 will migrate the catalogued ADK-side writers onto `append_event(state_delta=...)` — the OrchestrationStore introduced here gives those writers a single typed read-of-record to point at.

## Test plan

- [x] `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 uv run pytest tests/` — 1673 passed, 46 skipped
- [x] `uv run ruff check goldfive/` — clean
- [x] Phase 0 tripwire green: `tests/test_state_audit.py` (11 tests, all pass; `known_callers_count` unchanged at 25)
- [x] New tests: `tests/test_orchestration_store.py` (30) + extended `tests/test_reasoning_judge.py` (11 new) + extended `tests/test_pin_resolution_ladder.py` (2 new for signal 6)