### PR TITLE
fix(adapters, reporting): migrate V3 + V4 off ADK session.state (Phase 2.1)

### DIFF
--- a/docs/design/STATE-OWNERSHIP-CONTRACT.md
+++ b/docs/design/STATE-OWNERSHIP-CONTRACT.md
@@ -66,7 +66,8 @@ The two dicts are easy to confuse at the call site because both end in `.state`.
 | 0 | This document, audit catalog (§5), runtime tripwire (`goldfive/_state_audit.py`) | **Done (#278)** |
 | 1 | Introduce `OrchestrationStore` — single typed handle that owns goldfive's orchestration state. Extract reasoning / pin / cancel state off `Session.state` onto the store. No ADK-side change yet. | **Done (#279)** |
 | 2.0 | Eliminate the bridge (V2) and the now-unused initial seeds (V1, V5). The dynamic-instruction resolver and `GoldfivePlanner` read goldfive `Session.state` directly via the `SessionContext` stash + `OrchestrationStore`. Closes goldfive#275. | **Done (Phase 2.0)** |
-| 2.x | Migrate the remaining catalog entries (V3 — per-agent pin write, V4 — delegation pin write, V7 / V8 — `SessionContext` stash). | Planned |
+| 2.1 | Migrate the per-agent pin (V3) and the delegation-site pin (V4). Both move to goldfive `Session.state` exclusively via `OrchestrationStore`; readers consult goldfive Session via the plugin reference. After this phase, no callback-time write to ADK `session.state` from inside the wrap remains. | **Done (Phase 2.1)** |
+| 2.x | Clean up V7 / V8 — the `SessionContext` stash is dead in production paths but legacy tests still drive through it. | Planned |
 | 3 | Tripwire flips on by default in production. Catalog is empty. | Planned |
 
 A future contributor can verify a Phase-2 PR by:
@@ -97,21 +98,15 @@ Every place goldfive writes to ADK `session.state` (or a structure ADK considers
 - **Status.** Eliminated by Phase 2.0 of goldfive#271. The literal site of goldfive#275. The bridge function `_bridge_orchestration_state` and its inline subroutine `_bridge_pending_corrections` are deleted; the resolver / planner read goldfive `Session.state` directly via `OrchestrationStore`.
 - **Original target.** `goldfive/adapters/_adk_plugin.py:1679` called `_bridge_orchestration_state` to mirror `goldfive.active_steer.body`, `goldfive.active_steer.at_turn`, `goldfive.goals_summary`, `goldfive.cancelled_function_call_ids`, and every `goldfive.pending_corrections.<agent>.<task>` key onto ADK `session.state`.
 
-#### V3 — `_stamp_current_task_id` (called from `before_agent_callback`)
+#### V3 — `_stamp_current_task_id` (called from `before_agent_callback`) — **MIGRATED (Phase 2.1)**
 
-- **File:line.** `goldfive/adapters/_adk_plugin.py:2620-2628`
-- **State written.** `goldfive.current_task_id`, `goldfive.current_task_title`, `goldfive.current_task_description`, `goldfive.current_task_assignee`, `goldfive.current_task_revision`.
-- **Why.** Pins the active task per-agent invocation (#191/#195/#266) so the dynamic-instruction resolver renders the right title/description block and `report_task_*` tools can resolve their target without an LLM-supplied id.
-- **Severity.** **blocker.** Fires once per `before_agent_callback`, every agent turn, every sub-invocation. The same write also stamps `goldfive.Session.state` (line 2601-2605) — the dual-write is the structural shape Phase 1's `OrchestrationStore` collapses.
-- **Migration target.** Phase 2. The pin is structural goldfive state; the orchestration store will be the only writer, the ADK side will be a derived view via `append_event`.
+- **Status.** Eliminated by Phase 2.1 of goldfive#271. The per-agent pin lands on goldfive `Session.state` exclusively via `OrchestrationStore.set_pin_current_task`. Readers (the dynamic-instruction resolver, the reporting handlers, `_resolve_pinned_task_id`) consult goldfive Session via the plugin reference (`session_context_from_invocation`) — no callback-time write to ADK `session.state` remains.
+- **Original target.** `goldfive/adapters/_adk_plugin.py:2620-2628` wrote `goldfive.current_task_id`, `goldfive.current_task_title`, `goldfive.current_task_description`, `goldfive.current_task_assignee`, `goldfive.current_task_revision` onto both surfaces. The protocol-module writers (`_sp.write_current_task` / `_sp.write_current_task_id` / `_sp.write_current_task_revision` / `_sp.clear_current_task`) are deleted; only the read-side key constants remain.
 
-#### V4 — `_pin_delegation_task_id` (called from `before_tool_callback`)
+#### V4 — `_pin_delegation_task_id` (called from `before_tool_callback`) — **MIGRATED (Phase 2.1)**
 
-- **File:line.** `goldfive/adapters/_adk_plugin.py:2778-2783`
-- **State written.** `goldfive.pending_delegations` (a dict keyed by `function_call_id`).
-- **Why.** Per-`function_call_id` pin (#241 Item 3-bis) so parallel AgentTool dispatches to the same sub-agent on the same turn don't race on the single `goldfive.current_task_id` slot. Stamped on **both** `ctx.session.state` (orchestration) and the ADK `tool_context` session.state.
-- **Severity.** **blocker.** Same pattern as V3 — dual-write inside a tool callback is exactly the path #275 traces. Fires multiple times per turn for fan-out coordinators.
-- **Migration target.** Phase 2. The orchestration-side write stays; the ADK-side write becomes `append_event` or, better, the resolver reads the orchestration store directly (Phase 3).
+- **Status.** Eliminated by Phase 2.1 of goldfive#271. The per-`function_call_id` pin lands on goldfive `Session.state` exclusively via `OrchestrationStore.set_pending_delegation`. The reporting-tool callback's `_resolve_pinned_task_id` reads the same store via the plugin reference.
+- **Original target.** `goldfive/adapters/_adk_plugin.py:2778-2783` wrote `goldfive.pending_delegations` (a dict keyed by `function_call_id`) onto both `ctx.session.state` (orchestration) AND the ADK `tool_context` session.state.
 
 #### V5 — `before_model_callback`: defensive duplicate seed — **MIGRATED (Phase 2.0)**
 

--- a/goldfive/_state_audit.py
+++ b/goldfive/_state_audit.py
@@ -267,14 +267,15 @@ _KNOWN_CALLERS: frozenset[tuple[str, str]] = frozenset(
         # bridge, and the before_model_callback duplicate seed all
         # deleted. The dynamic-instruction resolver and GoldfivePlanner
         # read goldfive Session directly via the SessionContext stash.
-        # V3 — _stamp_current_task_id (called from before_agent_callback)
-        # writes the per-agent pin onto both surfaces.
-        ("goldfive/adapters/_adk_plugin.py", "_stamp_current_task_id"),
-        ("goldfive/adapters/_adk_plugin.py", "before_agent_callback"),
-        # V4 — _pin_delegation_task_id (called from before_tool_callback)
-        # writes per-function_call_id pins.
-        ("goldfive/adapters/_adk_plugin.py", "_pin_delegation_task_id"),
-        ("goldfive/adapters/_adk_plugin.py", "before_tool_callback"),
+        # V3 / V4 — MIGRATED in Phase 2.1 (goldfive#271). The per-agent
+        # pin (``_stamp_current_task_id``) and the delegation-site pin
+        # (``_pin_delegation_task_id``) now write only to goldfive
+        # ``Session.state`` via :class:`OrchestrationStore`. The
+        # readers (the dynamic-instruction resolver, reporting handlers,
+        # ``_resolve_pinned_task_id``) consult goldfive Session via the
+        # plugin reference (``session_context_from_invocation``) — no
+        # callback-time write to ADK ``session.state`` from inside the
+        # wrap remains.
         # V7 / V8 — ADKAdapter.invoke stashes / clears
         # SESSION_CONTEXT_STATE_KEY before / after run_async. Outside
         # any callback frame — listed here for completeness; the
@@ -288,10 +289,6 @@ _KNOWN_CALLERS: frozenset[tuple[str, str]] = frozenset(
         # mutation, so we catalog it too — otherwise the stack walk
         # might stop at _set instead of reaching the real caller.
         ("goldfive/adapters/_adk_state_protocol.py", "_set"),
-        ("goldfive/adapters/_adk_state_protocol.py", "write_current_task"),
-        ("goldfive/adapters/_adk_state_protocol.py", "write_current_task_id"),
-        ("goldfive/adapters/_adk_state_protocol.py", "write_current_task_revision"),
-        ("goldfive/adapters/_adk_state_protocol.py", "clear_current_task"),
         ("goldfive/adapters/_adk_state_protocol.py", "write_cancel_request"),
         ("goldfive/adapters/_adk_state_protocol.py", "register_invocation_parent"),
         ("goldfive/adapters/_adk_state_protocol.py", "consume_cancel_request"),

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -41,8 +41,12 @@ import time
 from collections.abc import Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any
 
-from goldfive.adapters import _adk_state_protocol as _sp
 from goldfive.adapters._tool_invocation import invoke_tool
+from goldfive.orchestration_store import (
+    PENDING_DELEGATIONS_KEY,
+    BindingSource,
+    OrchestrationStore,
+)
 
 if TYPE_CHECKING:
     from goldfive.protocols import Steerer
@@ -419,30 +423,38 @@ def _inject_task_id_from_state(
         return False
 
 
-# State-key used to stash per-function_call_id task pins at the
-# delegation site (goldfive#241 Item 3-bis). The plugin's
-# ``before_tool_callback`` writes an entry here when it dispatches an
-# AgentTool call and the reporting-tool callback reads it back when
-# the sub-invocation's tool call arrives. Keyed by the ADK
-# ``function_call_id`` of the AgentTool dispatch so parallel calls
-# don't race.
-_PENDING_DELEGATIONS_KEY = "goldfive.pending_delegations"
+# Re-export under the legacy module-private name so downstream tests
+# and custom adapters that import :data:`_PENDING_DELEGATIONS_KEY` keep
+# working unchanged. Phase 2.1 (goldfive#271) moved the canonical
+# definition into :mod:`goldfive.orchestration_store`; the value is
+# unchanged.
+_PENDING_DELEGATIONS_KEY = PENDING_DELEGATIONS_KEY
 
-# Mirror of orchestration_state.KEY_CURRENT_TASK_REVISION (goldfive#266).
-# Stable string contract shared between the adapter's ADK side
-# (``_adk_state_protocol``), the goldfive Session.state writers, and the
-# reporting-handler classifier. Re-declared here rather than imported
-# to keep the plugin module ADK-only without pulling
-# orchestration_state into its top-level imports.
-_GF_KEY_CURRENT_TASK_REVISION = "goldfive.current_task_revision"
+# Map the pin-ladder ``source`` strings used in :meth:`_stamp_current_task_id`'s
+# log line onto :class:`BindingSource` enum values so the orchestration
+# store records typed attribution alongside the pin write. Phase 2.1 of
+# goldfive#271 — the source label is now a structural part of the pin,
+# not just a free-form log token.
+_BINDING_SOURCE_BY_LADDER: dict[str, BindingSource] = {
+    "delegation_pin": BindingSource.DELEGATION_PIN,
+    "single_match": BindingSource.AGENT_CALLBACK,
+    "arg_scored": BindingSource.AGENT_CALLBACK,
+    "dag_relaxed": BindingSource.AGENT_CALLBACK,
+    "parent_pin_downstream": BindingSource.AGENT_CALLBACK,
+    "reasoning_binding": BindingSource.REASONING,
+    "correction_target": BindingSource.CORRECTION_TARGET,
+    "assignee_normalised": BindingSource.AGENT_CALLBACK,
+    "low_confidence": BindingSource.LOW_CONFIDENCE,
+}
 
 
 def _resolve_pinned_task_id(*, tool_context: Any) -> str:
     """Return the task_id pinned for this tool invocation, or ``""``.
 
-    Consults the delegation-site map first (``pending_delegations``
-    keyed by the current invocation's ``function_call_id``), then
-    falls back to the agent-turn pin (``goldfive.current_task_id``).
+    Consults the delegation-site map first
+    (:meth:`OrchestrationStore.get_pending_delegation` keyed by the
+    current invocation's ``function_call_id``), then falls back to
+    the agent-turn pin (:meth:`OrchestrationStore.pin_current_task`).
     Returns ``""`` when neither path yields a value — the caller
     should then short-circuit with a bare ``{"acknowledged": True}``
     (plus a ``DriftDetected`` sink event for operator visibility on
@@ -451,26 +463,69 @@ def _resolve_pinned_task_id(*, tool_context: Any) -> str:
     an ``error: pin_unresolved`` payload, which the LLM read as a
     reasoning cue and used to bypass the reporting contract — see
     the pin-leak fix in that PR.
+
+    Phase 2.1 of goldfive#271 — V4 reader. The store walks goldfive
+    ``Session.state`` reached either via the live plugin reference
+    (production path) or the legacy V7 SessionContext stash on ADK
+    state (unit-test path). No callback-time read of ADK state for
+    pin keys remains.
     """
-    state = _session_state_from_callback(tool_context)
-    if not isinstance(state, Mapping):
-        return ""
+    session = _goldfive_session_from_tool_context(tool_context)
+    store = OrchestrationStore.for_session(session) if session is not None else None
     fc_id = _function_call_id_from_tool_context(tool_context)
-    if fc_id:
-        pend = state.get(_PENDING_DELEGATIONS_KEY)
-        if isinstance(pend, Mapping):
-            raw = pend.get(fc_id, "")
-            # goldfive#266 — entry may be either the legacy ``str``
-            # task_id or the versioned ``{task_id, revision}`` dict.
-            # Tolerate both so custom adapters that pre-date this PR
-            # keep working unchanged.
-            tid = _delegation_pin_task_id(raw)
-            if tid:
-                return tid
-    state_tid = state.get(_sp.KEY_CURRENT_TASK_ID, "")
-    if isinstance(state_tid, str) and state_tid.strip():
-        return state_tid.strip()
+    via = ""
+    pinned = ""
+    if store is not None and fc_id:
+        delegation = store.get_pending_delegation(fc_id)
+        if delegation is not None and delegation.is_set():
+            pinned = delegation.task_id
+            via = "delegation_pin"
+    if not pinned and store is not None:
+        agent_pin = store.pin_current_task()
+        if agent_pin:
+            pinned = agent_pin
+            via = "agent_pin"
+    if pinned:
+        log.debug(
+            "goldfive.pin.read: task_id=%s via=%s fc_id=%s",
+            pinned,
+            via,
+            fc_id or "-",
+        )
+        return pinned
     return ""
+
+
+def _goldfive_session_from_tool_context(tool_context: Any) -> Any:
+    """Return the goldfive ``Session`` reachable from a ``tool_context``.
+
+    Phase 2.1 of goldfive#271. Resolution order matches the
+    dynamic-instruction resolver's :func:`_goldfive_session_from_readonly_context`:
+
+    1. Walk the invocation's ``plugin_manager.plugins`` for the
+       goldfive plugin and read its ``_active_ctx.session``. Live-run
+       path — set by :meth:`set_active_context`.
+    2. Legacy V7 ``SESSION_CONTEXT_STATE_KEY`` stash on the callback's
+       ``session.state``. Used by unit tests that drive the plugin
+       with a hand-built state dict without going through the
+       plugin's lifecycle.
+
+    Returns ``None`` when neither resolves so the caller can degrade
+    cleanly.
+    """
+    inv_ctx = _safe_attr(tool_context, "_invocation_context", None) or _safe_attr(
+        tool_context, "invocation_context", None
+    )
+    if inv_ctx is not None:
+        ctx = session_context_from_invocation(inv_ctx)
+        if ctx is not None:
+            session = getattr(ctx, "session", None)
+            if session is not None:
+                return session
+    legacy_ctx = _session_context_from_callback(tool_context)
+    if legacy_ctx is not None:
+        return getattr(legacy_ctx, "session", None)
+    return None
 
 
 def _delegation_pin_task_id(raw: Any) -> str:
@@ -1923,7 +1978,6 @@ def make_adk_plugin(
                             if status is TaskStatus.PENDING or status is TaskStatus.RUNNING:
                                 self._stamp_current_task_id(
                                     ctx=ctx,
-                                    callback_context=callback_context,
                                     task_id=tid,
                                     agent_name=agent_name,
                                     source="delegation_pin",
@@ -1949,7 +2003,6 @@ def make_adk_plugin(
             )
             scoring_args = self._scoring_args_for(
                 ctx=ctx,
-                callback_context=callback_context,
                 parent_invocation_id=parent_invocation_id,
             )
 
@@ -1963,7 +2016,6 @@ def make_adk_plugin(
                 if task_id:
                     self._stamp_current_task_id(
                         ctx=ctx,
-                        callback_context=callback_context,
                         task_id=task_id,
                         agent_name=agent_name,
                         source="single_match",
@@ -1989,7 +2041,6 @@ def make_adk_plugin(
                     if task_id:
                         self._stamp_current_task_id(
                             ctx=ctx,
-                            callback_context=callback_context,
                             task_id=task_id,
                             agent_name=agent_name,
                             source="arg_scored",
@@ -2033,7 +2084,6 @@ def make_adk_plugin(
                         )
                         self._stamp_current_task_id(
                             ctx=ctx,
-                            callback_context=callback_context,
                             task_id=task_id,
                             agent_name=agent_name,
                             source="dag_relaxed",
@@ -2064,7 +2114,6 @@ def make_adk_plugin(
                 if task_id:
                     self._stamp_current_task_id(
                         ctx=ctx,
-                        callback_context=callback_context,
                         task_id=task_id,
                         agent_name=agent_name,
                         source="parent_pin_downstream",
@@ -2115,7 +2164,6 @@ def make_adk_plugin(
                 if task_id:
                     self._stamp_current_task_id(
                         ctx=ctx,
-                        callback_context=callback_context,
                         task_id=task_id,
                         agent_name=agent_name,
                         source="reasoning_binding",
@@ -2143,7 +2191,6 @@ def make_adk_plugin(
                 if task_id:
                     self._stamp_current_task_id(
                         ctx=ctx,
-                        callback_context=callback_context,
                         task_id=task_id,
                         agent_name=agent_name,
                         source="correction_target",
@@ -2192,7 +2239,6 @@ def make_adk_plugin(
                             )
                             self._stamp_current_task_id(
                                 ctx=ctx,
-                                callback_context=callback_context,
                                 task_id=task_id,
                                 agent_name=agent_name,
                                 source="assignee_normalised",
@@ -2229,7 +2275,6 @@ def make_adk_plugin(
                     )
                     self._stamp_current_task_id(
                         ctx=ctx,
-                        callback_context=callback_context,
                         task_id=task_id,
                         agent_name=agent_name,
                         source="low_confidence",
@@ -2306,7 +2351,6 @@ def make_adk_plugin(
             self,
             *,
             ctx: SessionContext,
-            callback_context: Any,
             parent_invocation_id: str,
         ) -> Any:
             """Return a token-bag string-or-mapping for tool-arg scoring, or ``None``.
@@ -2448,7 +2492,6 @@ def make_adk_plugin(
             against ``"agent_x"`` and a sub-runner pinning under
             ``"client42:agent_x"`` both find the same binding.
             """
-            from goldfive.orchestration_store import OrchestrationStore
             from goldfive.types import TaskStatus
 
             store = OrchestrationStore.for_session(
@@ -2637,14 +2680,13 @@ def make_adk_plugin(
             self,
             *,
             ctx: SessionContext,
-            callback_context: Any,
             task_id: str,
             agent_name: str,
             source: str,
             task: Any = None,
             invocation_id: str = "",
         ) -> None:
-            """Write ``task_id`` into both state surfaces for the sub-agent.
+            """Write ``task_id`` onto goldfive ``Session.state`` for the sub-agent.
 
             Shared by every signal in :meth:`_pin_current_task_id_for_agent`
             (goldfive#264). The ``source`` label threads into the log
@@ -2659,13 +2701,13 @@ def make_adk_plugin(
             without racing on the single ``goldfive.current_task_id``
             slot.
 
-            When ``task`` is provided, the ADK side also stamps
-            ``goldfive.current_task_title`` /
-            ``goldfive.current_task_description`` so the dynamic
-            instruction resolver (goldfive#251) can render plan-causal
-            prompts without re-walking the plan. Legacy callers that
-            don't pass the task object keep working — the resolver
-            falls back to placeholders.
+            Phase 2.1 of goldfive#271 — V3 of the audit catalog. The
+            pin lands on goldfive's own ``Session.state`` exclusively,
+            via :class:`~goldfive.orchestration_store.OrchestrationStore`.
+            The dynamic-instruction resolver and reporting handlers
+            both read goldfive Session via the plugin reference
+            (:func:`session_context_from_invocation`) — no callback-time
+            mutation of ADK ``session.state`` happens here anymore.
             """
             # goldfive#266 — resolve the plan revision in effect at this
             # write so the report-time classifier in
@@ -2678,48 +2720,26 @@ def make_adk_plugin(
                 pin_revision = int(_safe_attr(plan_for_rev, "revision_index", 0) or 0)
             except (TypeError, ValueError):
                 pin_revision = 0
-            gf_state = _safe_attr(ctx.session, "state", None)
-            if isinstance(gf_state, dict):
-                try:
-                    gf_state[_sp.KEY_CURRENT_TASK_ID] = task_id
-                    # Stamp revision alongside the id so a later
-                    # report-time read sees the stamp on the same
-                    # session.state surface.
-                    gf_state[_GF_KEY_CURRENT_TASK_REVISION] = pin_revision
-                except Exception as exc:  # noqa: BLE001
-                    log.debug(
-                        "before_agent_callback: goldfive session.state pin failed: %s",
-                        exc,
-                    )
-            adk_state = _session_state_from_callback(callback_context)
-            if isinstance(adk_state, Mapping):
-                try:
-                    if task is not None:
-                        # write_current_task stamps all four fields
-                        # (id / title / description / assignee) from the
-                        # Task. Prefer this over the narrow id-only write
-                        # so the dynamic-instruction resolver (#251)
-                        # sees the title + description it needs.
-                        _sp.write_current_task(adk_state, task)
-                    else:
-                        _sp.write_current_task_id(adk_state, task_id)
-                    # Mirror the revision stamp onto ADK session.state
-                    # so reporting handlers reading from the live ADK
-                    # state (custom adapters, sub-Runner contexts) see
-                    # the same value.
-                    if isinstance(adk_state, MutableMapping):
-                        _sp.write_current_task_revision(adk_state, pin_revision)
-                except Exception as exc:  # noqa: BLE001
-                    log.debug(
-                        "before_agent_callback: ADK session.state pin failed: %s",
-                        exc,
-                    )
+            store = OrchestrationStore.for_session(ctx.session)
+            title = ""
+            if task is not None:
+                title = str(_safe_attr(task, "title", "") or "")
+            store.set_pin_current_task(
+                task_id,
+                source=_BINDING_SOURCE_BY_LADDER.get(
+                    source, BindingSource.UNKNOWN
+                ),
+                revision=pin_revision,
+                title=title,
+            )
             log.info(
-                "goldfive: pinned current_task_id=%s for sub-agent %s "
-                "(source=%s)",
+                "goldfive.pin.set: task_id=%s agent=%s source=%s revision=%d "
+                "invocation_id=%s",
                 task_id,
                 agent_name,
                 source,
+                pin_revision,
+                invocation_id or "-",
             )
             # goldfive#264 — record per-invocation pin so child
             # invocations can resolve their parent's pin (signal 5).
@@ -2754,10 +2774,14 @@ def make_adk_plugin(
                over via the legacy single-match path.
             5. If zero candidates, no pin.
 
-            Writes to ``ctx.session.state[goldfive.pending_delegations]``
-            (a dict keyed by function_call_id) when a pin resolves.
-            Silent on every failure mode — the worst case is we fall
-            through to the legacy behaviour.
+            Phase 2.1 of goldfive#271 — V4 of the audit catalog. The
+            pin lands on goldfive's ``Session.state`` exclusively,
+            via :meth:`OrchestrationStore.set_pending_delegation`. The
+            sub-invocation's ``before_tool_callback`` reads it back via
+            :func:`_resolve_pinned_task_id` (which now consults goldfive
+            Session via the plugin reference). Silent on every failure
+            mode — the worst case is we fall through to the legacy
+            behaviour.
             """
             if not to_agent:
                 return
@@ -2818,56 +2842,22 @@ def make_adk_plugin(
             task_id = str(_safe_attr(chosen, "id", "") or "")
             if not task_id:
                 return
-            # goldfive#266 — pin entries evolved from
-            # ``{fc_id: task_id_str}`` to
-            # ``{fc_id: {"task_id": str, "revision": int}}`` so the
-            # report-time classifier can tell whether a delegation pin
-            # was set under an older plan revision. Readers
-            # (:func:`_resolve_pinned_task_id`, signal 1 of
-            # :meth:`_pin_current_task_id_for_agent`) tolerate both
-            # shapes for back-compat with custom adapters that pre-date
-            # this PR.
             try:
                 pin_revision = int(
                     _safe_attr(plan, "revision_index", 0) or 0
                 )
             except (TypeError, ValueError):
                 pin_revision = 0
-            entry: dict[str, Any] = {
-                "task_id": task_id,
-                "revision": pin_revision,
-            }
-            # F7 (#265 followup) — also record the parent's AgentTool
-            # tool-call args. Signal 3 of
-            # :meth:`_pin_current_task_id_for_agent` reads this back as
-            # the highest-priority scoring source (above the active
-            # steer body / goals summary). Only stamp a Mapping; opaque
-            # blobs / non-dict args are treated as "no useful tokens"
-            # and skipped so reads don't have to disambiguate shape.
-            if isinstance(tool_args, Mapping) and tool_args:
-                entry["tool_args"] = dict(tool_args)
-            # Stamp the pin onto BOTH the goldfive orchestration
-            # session.state (so reporting-tool handlers that read it
-            # directly see it) AND the ADK tool_context session.state
-            # (so the plugin's before_tool_callback → _resolve_pinned_task_id
-            # sees it on the sub-invocation's ToolContext). The two
-            # dicts are distinct in live ADK — the goldfive Session
-            # is our orchestration state, the ADK session.state is
-            # the live ADK session the Runner drives.
-            for target in (
-                _safe_attr(ctx.session, "state", None),
-                _session_state_from_callback(tool_context),
-            ):
-                if not isinstance(target, dict):
-                    continue
-                pend = target.get(_PENDING_DELEGATIONS_KEY)
-                if not isinstance(pend, dict):
-                    pend = {}
-                    target[_PENDING_DELEGATIONS_KEY] = pend
-                pend[fc_id] = dict(entry)
+            store = OrchestrationStore.for_session(ctx.session)
+            store.set_pending_delegation(
+                fc_id,
+                task_id=task_id,
+                revision=pin_revision,
+                tool_args=tool_args if isinstance(tool_args, Mapping) else None,
+            )
             log.info(
-                "goldfive: pinned delegation task_id=%s for fc_id=%s "
-                "(sub-agent=%s, %d candidates, revision=%d)",
+                "goldfive.delegation_pin.set: task_id=%s fc_id=%s "
+                "sub_agent=%s candidates=%d revision=%d",
                 task_id,
                 fc_id,
                 to_agent,

--- a/goldfive/adapters/_adk_state_protocol.py
+++ b/goldfive/adapters/_adk_state_protocol.py
@@ -99,13 +99,6 @@ KEY_CANCEL_REQUESTED = "goldfive.cancel_requested"
 # way.
 KEY_INVOCATION_PARENTS = "goldfive.invocation_parents"
 
-_CURRENT_TASK_KEYS: tuple[str, ...] = (
-    KEY_CURRENT_TASK_ID,
-    KEY_CURRENT_TASK_TITLE,
-    KEY_CURRENT_TASK_DESCRIPTION,
-    KEY_CURRENT_TASK_ASSIGNEE,
-)
-
 ALL_KEYS: tuple[str, ...] = (
     KEY_CURRENT_TASK_ID,
     KEY_CURRENT_TASK_TITLE,
@@ -242,76 +235,14 @@ def read_divergence_flag(state: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def write_current_task_id(state: MutableMapping[str, Any], task_id: str) -> None:
-    """Stamp just ``goldfive.current_task_id`` onto ``state``.
-
-    Narrower than :func:`write_current_task` which rewrites all four
-    ``current_task_*`` keys from a :class:`Task`. Used by the adapter's
-    ``before_agent_callback`` pin path (goldfive#191 Layer 1) where the
-    plugin only knows the id at delegation time and doesn't want to
-    overwrite the title/description/assignee written earlier by the
-    reconciler.
-
-    Empty / None ``task_id`` is a no-op — callers that want to clear
-    the key should use :func:`clear_current_task`.
-    """
-    if not task_id:
-        return
-    _set(state, KEY_CURRENT_TASK_ID, _safe_str(task_id))
-
-
-def write_current_task(state: MutableMapping[str, Any], task: Any) -> None:
-    """Mutate state with current_task_* fields from a :class:`goldfive.types.Task`.
-
-    Accepts anything that duck-types to goldfive's ``Task`` (``.id``,
-    ``.title``, ``.description``, ``.assignee_agent_id``) or a mapping
-    with equivalent keys. ``None`` clears the current task.
-    """
-    if task is None:
-        clear_current_task(state)
-        return
-
-    if isinstance(task, Mapping):
-        tid = task.get("id", "")
-        title = task.get("title", "")
-        description = task.get("description", "")
-        assignee = task.get("assignee") or task.get("assignee_agent_id", "")
-    else:
-        tid = getattr(task, "id", "")
-        title = getattr(task, "title", "")
-        description = getattr(task, "description", "")
-        assignee = getattr(task, "assignee_agent_id", "") or getattr(task, "assignee", "")
-
-    _set(state, KEY_CURRENT_TASK_ID, _safe_str(tid))
-    _set(state, KEY_CURRENT_TASK_TITLE, _safe_str(title))
-    _set(state, KEY_CURRENT_TASK_DESCRIPTION, _safe_str(description))
-    _set(state, KEY_CURRENT_TASK_ASSIGNEE, _safe_str(assignee))
-
-
-def clear_current_task(state: MutableMapping[str, Any]) -> None:
-    for key in _CURRENT_TASK_KEYS:
-        if key in state:
-            state.pop(key, None)
-    state.pop(KEY_CURRENT_TASK_REVISION, None)
-
-
-def write_current_task_revision(
-    state: MutableMapping[str, Any],
-    revision: int,
-) -> None:
-    """Stamp ``goldfive.current_task_revision`` onto ``state``.
-
-    Companion to :func:`write_current_task_id` for goldfive#266 pin
-    versioning. The adapter's pin ladder calls this alongside the
-    id-only write so the report-time classifier in
-    :mod:`goldfive.reporting` can distinguish a fresh pin (matches
-    ``plan.revision_index``) from one set under an older revision.
-    """
-    try:
-        rev = max(0, int(revision))
-    except (TypeError, ValueError):
-        rev = 0
-    _set(state, KEY_CURRENT_TASK_REVISION, rev)
+# Note: the adapter-side ``write_current_task`` / ``write_current_task_id``
+# / ``write_current_task_revision`` / ``clear_current_task`` writers were
+# removed in Phase 2.1 of goldfive#271. The pin lives on goldfive
+# ``Session.state`` exclusively now (see
+# :mod:`goldfive.orchestration_store`); no callback-time write to ADK
+# ``session.state`` for the pin keys remains. The key constants stay
+# (read-side contract for custom adapters that consult the live ADK
+# session) but the writers are gone.
 
 
 # ---------------------------------------------------------------------------

--- a/goldfive/orchestration_store.py
+++ b/goldfive/orchestration_store.py
@@ -107,6 +107,7 @@ __all__ = [
     "BindingSource",
     "DelegationPin",
     "OrchestrationStore",
+    "PENDING_DELEGATIONS_KEY",
     "REASONING_BINDINGS_KEY",
     "ReasoningBinding",
 ]
@@ -117,6 +118,16 @@ __all__ = [
 # accepts it. Value shape: ``dict[agent_name, ReasoningBinding-as-dict]``
 # for cheap JSON serialisation by sinks that round-trip the state dict.
 REASONING_BINDINGS_KEY = "goldfive.reasoning_extracted_bindings"
+
+# State key for the per-``function_call_id`` delegation-pin map
+# (goldfive#241 Item 3-bis, V4 in the Phase 0 audit catalog). Phase 2.1
+# of goldfive#271 — consolidated here so writers and readers agree on
+# one source of truth on goldfive's own ``Session.state``.
+#
+# Value shape: ``dict[function_call_id, {task_id, revision, tool_args?}]``.
+# Legacy entries stamped by pre-#266 adapters were bare strings; the
+# :class:`DelegationPin` accessor normalises both shapes.
+PENDING_DELEGATIONS_KEY = "goldfive.pending_delegations"
 
 
 # ---------------------------------------------------------------------------
@@ -489,7 +500,7 @@ class OrchestrationStore:
         """
         if not fc_id:
             return None
-        pend = self._get("goldfive.pending_delegations", None)
+        pend = self._get(PENDING_DELEGATIONS_KEY, None)
         if not isinstance(pend, Mapping):
             return None
         raw = pend.get(fc_id)
@@ -513,6 +524,67 @@ class OrchestrationStore:
                 args = None
             return DelegationPin(task_id=tid, revision=rev, tool_args=args)
         return None
+
+    def iter_pending_delegations(self) -> Mapping[str, Any]:
+        """Return the raw ``pending_delegations`` map (or empty mapping).
+
+        The plugin's pin-resolution ladder needs to walk every entry
+        (signal 1 iterates to find a task-id match across all parallel
+        dispatches; signal 3 merges every entry's ``tool_args`` into a
+        single token bag for scoring). Returns the live dict so callers
+        can iterate with ``.values()`` / ``.items()`` without a copy.
+        """
+        pend = self._get(PENDING_DELEGATIONS_KEY, None)
+        if isinstance(pend, Mapping):
+            return pend
+        return {}
+
+    # -- Write: pending delegations -------------------------------------
+
+    def set_pending_delegation(
+        self,
+        fc_id: str,
+        *,
+        task_id: str,
+        revision: int = 0,
+        tool_args: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Stamp a per-``function_call_id`` delegation pin.
+
+        V4 of the Phase 0 audit (goldfive#271) — every delegation-site
+        write now lands here on goldfive ``Session.state`` rather than
+        on ADK ``session.state``. The pin-resolution ladder + reporting
+        handlers consult this same store, so a single write is enough.
+
+        ``tool_args`` (when provided as a non-empty Mapping) is stamped
+        alongside the pin so signal 3 of the ladder can score
+        candidates against the parent's literal dispatch args (F7 /
+        #265 followup). Empty / non-mapping args are dropped — the
+        scorer treats those as zero-token signals.
+
+        No-op when ``fc_id`` or ``task_id`` is empty, or when the
+        backing state is not a mutable dict (defensive — production
+        state is always a dict; tests sometimes pass MappingProxyType
+        snapshots).
+        """
+        if not fc_id or not task_id:
+            return
+        if not isinstance(self._state, dict):
+            return
+        existing = self._state.get(PENDING_DELEGATIONS_KEY)
+        bucket: dict[str, Any]
+        if isinstance(existing, dict):
+            bucket = existing
+        else:
+            bucket = {}
+        entry: dict[str, Any] = {
+            "task_id": str(task_id),
+            "revision": int(revision),
+        }
+        if isinstance(tool_args, Mapping) and tool_args:
+            entry["tool_args"] = dict(tool_args)
+        bucket[str(fc_id)] = entry
+        _ostate.write(self._state, PENDING_DELEGATIONS_KEY, bucket)
 
     # -- Read: reasoning-extracted bindings (NEW Phase 1) ---------------
 

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -80,20 +80,6 @@ REPORTING_TOOL_NAMES: tuple[str, ...] = (
 
 _ACK: dict[str, Any] = {"acknowledged": True}
 
-# Orchestration-state key the adapter stamps at delegation time
-# (goldfive#191). Handlers fall back to this value when the model's
-# tool call omits ``task_id``. Re-declared here rather than imported
-# from :mod:`goldfive.orchestration_state` to avoid a circular import
-# — the string is a stable contract shared between the adapter's
-# :mod:`._adk_state_protocol`, :mod:`orchestration_state`, and this
-# handler module.
-_STATE_KEY_CURRENT_TASK_ID = "goldfive.current_task_id"
-# Companion key (goldfive#266 / pin versioning) — the plan revision
-# in effect at the moment the adapter wrote the pin. Same back-compat
-# stance: a missing / malformed entry reads as 0, which matches the
-# default ``Plan.revision_index`` so unrevised plans remain "fresh".
-_STATE_KEY_CURRENT_TASK_REVISION = "goldfive.current_task_revision"
-
 
 def _resolve_task_id(args: dict[str, Any], session: Session) -> str:
     """Return the task_id to act on, falling back to session state.
@@ -101,7 +87,7 @@ def _resolve_task_id(args: dict[str, Any], session: Session) -> str:
     Order of precedence (goldfive#191):
 
     1. ``args["task_id"]`` — explicit model-provided id always wins.
-    2. ``session.state["goldfive.current_task_id"]`` — the id pinned
+    2. ``OrchestrationStore.pin_current_task()`` — the id pinned
        by the adapter's ``before_agent_callback`` when the current
        sub-agent has exactly one PENDING/RUNNING task assigned to
        it. Closes the loop where the LLM's tool call omits the
@@ -125,7 +111,8 @@ def _resolve_task_id_with_source(
       ``task_id`` arg.
     * ``"handler_default"`` — the arg was absent / empty / None and the
       handler defaulted to the adapter-stamped pin
-      (``goldfive.current_task_id``). This is the goldfive#191 path.
+      (:meth:`OrchestrationStore.pin_current_task`). This is the
+      goldfive#191 path.
     * ``""`` — neither source resolved a value (caller short-circuits
       with the canonical ``missing_task_id`` rejection).
 
@@ -133,23 +120,27 @@ def _resolve_task_id_with_source(
     distinguish a direct LLM-driven transition from one that piggy-
     backed on the adapter pin. The tuple-returning variant is
     additive; existing callers stay on :func:`_resolve_task_id`.
+
+    Phase 2.1 of goldfive#271 — the read funnels through
+    :class:`~goldfive.orchestration_store.OrchestrationStore` so the
+    handler is decoupled from goldfive ``Session.state``'s on-disk
+    key strings.
     """
     raw = args.get("task_id")
     if raw is not None:
         task_id = str(raw).strip()
         if task_id:
             return task_id, "llm_report"
-    state = getattr(session, "state", None)
-    if isinstance(state, dict):
-        fallback = state.get(_STATE_KEY_CURRENT_TASK_ID, "")
-        if isinstance(fallback, str):
-            value = fallback.strip()
-        elif fallback is not None:
-            value = str(fallback).strip()
-        else:
-            value = ""
-        if value:
-            return value, "handler_default"
+    from goldfive.orchestration_store import OrchestrationStore
+
+    store = OrchestrationStore.for_session(session)
+    fallback = store.pin_current_task().strip()
+    if fallback:
+        log.debug(
+            "reporting: defaulted task_id=%s from OrchestrationStore",
+            fallback,
+        )
+        return fallback, "handler_default"
     return "", ""
 
 
@@ -345,16 +336,14 @@ def _read_pin_revision(session: Session) -> int | None:
     any plan with ``revision_index > 0`` — that's the actual
     versioning semantics, distinct from "no stamp".
     """
+    from goldfive import orchestration_state as _ostate
+
     state = getattr(session, "state", None)
     if not isinstance(state, dict):
         return None
-    if _STATE_KEY_CURRENT_TASK_REVISION not in state:
+    if _ostate.KEY_CURRENT_TASK_REVISION not in state:
         return None
-    raw = state.get(_STATE_KEY_CURRENT_TASK_REVISION, 0)
-    try:
-        return max(0, int(raw))
-    except (TypeError, ValueError):
-        return 0
+    return _ostate.read_current_task_revision(state)
 
 
 def _read_plan_revision(session: Session) -> int:
@@ -725,7 +714,7 @@ def _rotate_after_terminal(
     session: Session,
     completed_task: Task,
 ) -> None:
-    """Advance ``goldfive.current_task_id`` after a terminal transition.
+    """Advance the current-task pin after a terminal transition.
 
     Delegates to :func:`goldfive.orchestration_state.rotate_current_task_id`.
     Imported lazily so this module stays ADK-free and dodges the
@@ -733,6 +722,9 @@ def _rotate_after_terminal(
     :mod:`goldfive.orchestration_state` (both are imported from
     :mod:`goldfive.steerer`).
     """
+    from goldfive import orchestration_state as _ostate
+    from goldfive.orchestration_store import OrchestrationStore
+
     state = getattr(session, "state", None)
     if not isinstance(state, dict):
         return
@@ -742,16 +734,10 @@ def _rotate_after_terminal(
     # Only rotate if the terminal task was the one we'd been pointing
     # at — otherwise some other caller owns the pin and we'd clobber
     # theirs.
-    pinned = state.get(_STATE_KEY_CURRENT_TASK_ID, "")
-    if isinstance(pinned, str):
-        pinned = pinned.strip()
-    else:
-        pinned = str(pinned or "").strip()
+    pinned = OrchestrationStore.for_session(session).pin_current_task().strip()
     this_id = str(getattr(completed_task, "id", "") or "")
     if pinned and pinned != this_id:
         return
-
-    from goldfive import orchestration_state as _ostate
 
     _ostate.rotate_current_task_id(state, plan, agent_name)
 

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -2443,16 +2443,18 @@ async def test_invoke_always_drives_the_one_runner() -> None:
 
 async def test_state_protocol_writes_propagate_through_agent_tool_subtree() -> None:
     """RELIABILITY CONTRACT: task T dispatched to agent A with
-    ``AgentTool(B)`` must let B's ``before_model_callback`` see
-    ``state[goldfive.current_task_id] == T.id``.
+    ``AgentTool(B)`` must let B's ``before_model_callback`` reach
+    the goldfive ``Session.state`` via the plugin reference and find
+    ``goldfive.current_task_id == T.id``.
 
-    Previously these state writes were done against a shallow copy of
-    the session returned by ``InMemorySessionService.get_session`` and
-    were flagged "best-effort". They now happen inside the plugin's
-    ``before_run_callback`` against the LIVE invocation session, so
-    they propagate through AgentTool sub-Runners automatically (each
-    sub-Runner inherits the plugin and fires its own
-    ``before_run_callback`` that seeds the sub-session's live state).
+    Phase 2.1 of goldfive#271 — the pin no longer lands on ADK
+    ``session.state``; readers reach the goldfive Session through the
+    plugin's ``_active_ctx`` (set by ``set_active_context`` before
+    ``runner.run_async``). This test verifies the live-run path keeps
+    working across an AgentTool sub-Runner: the plugin instance is
+    shared with the sub-Runner so ``session_context_from_invocation``
+    finds the goldfive Session no matter which invocation fires the
+    callback.
     """
     from google.adk.agents import Agent
     from google.adk.models.base_llm import BaseLlm
@@ -2460,8 +2462,9 @@ async def test_state_protocol_writes_propagate_through_agent_tool_subtree() -> N
     from google.adk.tools.agent_tool import AgentTool
     from google.genai import types as genai_types
 
-    from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
+    from goldfive.adapters._adk_plugin import session_context_from_invocation
     from goldfive.adapters.adk import ADKAdapter
+    from goldfive.orchestration_store import OrchestrationStore
 
     observed_task_ids_in_B: list[str] = []
 
@@ -2527,21 +2530,18 @@ async def test_state_protocol_writes_propagate_through_agent_tool_subtree() -> N
                     turn_complete=True,
                 )
 
-    # Agent B — registers a pre-model callback that records the
-    # goldfive.current_task_id on the sub-session's live state.
+    # Agent B — registers a pre-model callback that resolves the
+    # goldfive Session via the plugin reference and reads the pin
+    # via the OrchestrationStore. Phase 2.1 of goldfive#271 — the pin
+    # lives on goldfive ``Session.state`` exclusively.
     def _b_before_model(callback_context: Any, llm_request: Any) -> None:  # noqa: ARG001
-        state = getattr(getattr(callback_context, "_invocation_context", None), "session", None)
-        if state is not None:
-            state = getattr(state, "state", None)
-        if state is None:
-            state = getattr(getattr(callback_context, "session", None), "state", None)
-        tid = None
-        if state is not None:
-            try:
-                tid = state.get(KEY_CURRENT_TASK_ID)
-            except Exception:
-                tid = None
-        observed_task_ids_in_B.append(str(tid or ""))
+        inv_ctx = getattr(callback_context, "_invocation_context", None) or getattr(
+            callback_context, "invocation_context", None
+        )
+        ctx = session_context_from_invocation(inv_ctx)
+        session = getattr(ctx, "session", None) if ctx is not None else None
+        store = OrchestrationStore.for_session(session)
+        observed_task_ids_in_B.append(store.pin_current_task())
 
     agent_b = Agent(
         name="agent_b",

--- a/tests/test_before_tool_task_id_injection.py
+++ b/tests/test_before_tool_task_id_injection.py
@@ -60,13 +60,18 @@ class _Tool:
 
 
 def _make_plugin_with_reporting_spec(tool_name: str):
-    """Return (plugin, state_dict) wired for a single reporting tool.
+    """Return (plugin, state_dict, captured, session) wired for a single reporting tool.
 
     The plugin is built via :func:`make_adk_plugin` (the public factory)
     and wired to a :class:`SessionContext` so the reporting-tool match in
     ``before_tool_callback`` fires. The handler is a no-op that echoes
     the args the plugin dispatched with — callers inspect that echo to
     verify injection.
+
+    Phase 2.1 of goldfive#271 — the pin keys live on goldfive
+    ``Session.state``, not on the ADK state dict. Tests set the pin via
+    ``session.state[...] = ...``; the plugin reads it back through the
+    ``SessionContext`` stash.
     """
     from goldfive.adapters._adk_plugin import (
         SESSION_CONTEXT_STATE_KEY,
@@ -100,7 +105,7 @@ def _make_plugin_with_reporting_spec(tool_name: str):
             host_agent_name="test_agent",
         )
     }
-    return plugin, state, captured
+    return plugin, state, captured, session_obj
 
 
 # ---------------------------------------------------------------------------
@@ -112,8 +117,10 @@ async def test_empty_arg_replaced_from_state() -> None:
     """An empty task_id on a report_task_* call is filled from pinned state."""
     from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
 
-    plugin, state, captured = _make_plugin_with_reporting_spec("report_task_completed")
-    state[KEY_CURRENT_TASK_ID] = "t-1"
+    plugin, state, captured, session = _make_plugin_with_reporting_spec(
+        "report_task_completed"
+    )
+    session.state[KEY_CURRENT_TASK_ID] = "t-1"
 
     args: dict[str, Any] = {"task_id": "", "summary": "done"}
     await plugin.before_tool_callback(
@@ -124,7 +131,7 @@ async def test_empty_arg_replaced_from_state() -> None:
 
     assert args["task_id"] == "t-1", (
         "Layer 3 must overwrite an empty task_id with the pinned "
-        "goldfive.current_task_id from state."
+        "goldfive.current_task_id from session.state."
     )
     # And the handler must have seen the corrected arg.
     assert captured == [{"task_id": "t-1", "summary": "done"}]
@@ -135,10 +142,10 @@ async def test_placeholder_arg_replaced() -> None:
     from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
 
     for placeholder in ("placeholder", "unknown", "TODO", "  ", "none", "N/A"):
-        plugin, state, captured = _make_plugin_with_reporting_spec(
+        plugin, state, captured, session = _make_plugin_with_reporting_spec(
             "report_task_progress"
         )
-        state[KEY_CURRENT_TASK_ID] = "t-1"
+        session.state[KEY_CURRENT_TASK_ID] = "t-1"
 
         args: dict[str, Any] = {"task_id": placeholder, "detail": "x"}
         await plugin.before_tool_callback(
@@ -149,7 +156,7 @@ async def test_placeholder_arg_replaced() -> None:
 
         assert args["task_id"] == "t-1", (
             f"placeholder {placeholder!r} must be replaced with the pinned "
-            "task_id from state."
+            "task_id from session.state."
         )
 
 
@@ -163,8 +170,8 @@ async def test_real_looking_arg_preserved() -> None:
     """
     from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
 
-    plugin, state, _ = _make_plugin_with_reporting_spec("report_task_failed")
-    state[KEY_CURRENT_TASK_ID] = "t-1"
+    plugin, state, _, session = _make_plugin_with_reporting_spec("report_task_failed")
+    session.state[KEY_CURRENT_TASK_ID] = "t-1"
 
     args: dict[str, Any] = {"task_id": "t-42", "error": "boom"}
     await plugin.before_tool_callback(
@@ -183,8 +190,10 @@ async def test_awaiting_approval_also_injected() -> None:
     """report_awaiting_approval is part of the reporting-tool family."""
     from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
 
-    plugin, state, _ = _make_plugin_with_reporting_spec("report_awaiting_approval")
-    state[KEY_CURRENT_TASK_ID] = "t-1"
+    plugin, state, _, session = _make_plugin_with_reporting_spec(
+        "report_awaiting_approval"
+    )
+    session.state[KEY_CURRENT_TASK_ID] = "t-1"
 
     args: dict[str, Any] = {"task_id": ""}
     await plugin.before_tool_callback(
@@ -240,7 +249,9 @@ async def test_non_report_tool_untouched() -> None:
 
 async def test_missing_state_leaves_args_unchanged() -> None:
     """No pinned task_id in state → args untouched; Layer 2 will handle it."""
-    plugin, state, _ = _make_plugin_with_reporting_spec("report_task_started")
+    plugin, state, _, _session = _make_plugin_with_reporting_spec(
+        "report_task_started"
+    )
     # Note: NOT setting KEY_CURRENT_TASK_ID.
 
     args: dict[str, Any] = {"task_id": ""}
@@ -309,17 +320,20 @@ async def test_injection_sees_layer1_state_stamp() -> None:
     """Sanity: a state write done BEFORE the tool callback is visible to it.
 
     This is the ordering contract Layer 3 depends on — Layer 1's
-    ``before_agent_callback`` writes to session.state at agent-turn start,
-    and every ``before_tool_callback`` within that turn sees the write.
-    We simulate that by writing the state key, then dispatching, then
-    asserting the injection happened.
+    ``before_agent_callback`` writes to goldfive ``session.state`` at
+    agent-turn start, and every ``before_tool_callback`` within that
+    turn sees the write through the SessionContext stash. We simulate
+    that by writing the state key on goldfive ``session.state``, then
+    dispatching, then asserting the injection happened.
     """
     from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
 
-    plugin, state, _ = _make_plugin_with_reporting_spec("report_task_blocked")
+    plugin, state, _, session = _make_plugin_with_reporting_spec(
+        "report_task_blocked"
+    )
 
     # Layer-1-style write (simulating what before_agent_callback does).
-    state[KEY_CURRENT_TASK_ID] = "t-layer1"
+    session.state[KEY_CURRENT_TASK_ID] = "t-layer1"
 
     # Layer-3 tool-call entry.
     args: dict[str, Any] = {"task_id": "", "blocked_on": "dep-x"}

--- a/tests/test_hidden_task_id_schema.py
+++ b/tests/test_hidden_task_id_schema.py
@@ -245,10 +245,12 @@ def test_apply_llm_signature_noop_for_unknown_tool() -> None:
 
 async def test_hidden_task_id_populates_from_state() -> None:
     """LLM calls ``report_task_started()`` with no task_id arg — the
-    callback populates from ``goldfive.current_task_id`` state before
-    the handler runs."""
-    plugin, state, captured, _, _ = _make_plugin_with_handler("report_task_started")
-    state[KEY_CURRENT_TASK_ID] = "t-pinned"
+    callback populates from ``goldfive.current_task_id`` on goldfive
+    ``Session.state`` before the handler runs."""
+    plugin, state, captured, session_obj, _ = _make_plugin_with_handler(
+        "report_task_started"
+    )
+    session_obj.state[KEY_CURRENT_TASK_ID] = "t-pinned"
 
     args: dict[str, Any] = {"detail": "starting"}
     result = await plugin.before_tool_callback(
@@ -686,12 +688,12 @@ async def test_delegation_pin_beats_agent_turn_pin() -> None:
         "report_task_completed", plan=plan
     )
 
-    # Simulate: coordinator already stamped delegation pin for fc_A
-    # on the ADK tool_context state (this is what the reporting-tool
-    # callback reads from).
-    state[_PENDING_DELEGATIONS_KEY] = {"fc_A": "research_solar"}
+    # Simulate: coordinator already stamped delegation pin for fc_A on
+    # goldfive Session.state. Phase 2.1 (goldfive#271) — V4 readers
+    # consult goldfive Session via the SessionContext stash.
+    session_obj.state[_PENDING_DELEGATIONS_KEY] = {"fc_A": "research_solar"}
     # Agent-turn pin sits on a different task (stale from an earlier turn).
-    state[KEY_CURRENT_TASK_ID] = "research_wind"
+    session_obj.state[KEY_CURRENT_TASK_ID] = "research_wind"
 
     args: dict[str, Any] = {"summary": "done"}
     await plugin.before_tool_callback(

--- a/tests/test_pin_resolution_ladder.py
+++ b/tests/test_pin_resolution_ladder.py
@@ -174,7 +174,7 @@ async def test_signal1_delegation_site_pin() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t2"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t2"
     events = _pin_resolved_events(sinks[0].events)
     assert len(events) == 1
     assert events[0]["payload"]["via_signal"] == "delegation_pin"
@@ -202,7 +202,7 @@ async def test_signal2_dag_ready_single_match() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t1"
     events = _pin_resolved_events(sinks[0].events)
     assert len(events) == 1
     assert events[0]["payload"]["via_signal"] == "dag_ready_single"
@@ -249,7 +249,7 @@ async def test_signal3_arg_scoring_breaks_dag_ready_tie() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t1"
     events = _pin_resolved_events(sinks[0].events)
     assert events[-1]["payload"]["via_signal"] == "arg_scored"
 
@@ -310,7 +310,7 @@ async def test_signal3_parent_tool_args_outrank_steer_body() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t1", (
+    assert session.state[KEY_CURRENT_TASK_ID] == "t1", (
         "parent tool_args (solar) should outrank steer body (invoices)"
     )
     events = _pin_resolved_events(sinks[0].events)
@@ -363,7 +363,7 @@ async def test_signal3_empty_parent_tool_args_falls_to_steer_body() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t2", (
+    assert session.state[KEY_CURRENT_TASK_ID] == "t2", (
         "empty parent tool_args should fall through to steer body"
     )
     events = _pin_resolved_events(sinks[0].events)
@@ -398,7 +398,7 @@ async def test_signal3_pre_f7_string_pending_delegation_back_compat() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t2"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t2"
     events = _pin_resolved_events(sinks[0].events)
     assert events[-1]["payload"]["via_signal"] == "delegation_pin"
 
@@ -435,7 +435,7 @@ async def test_signal3_tie_falls_through_to_signal4() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] in {"t1", "t2"}
+    assert session.state[KEY_CURRENT_TASK_ID] in {"t1", "t2"}
     events = _pin_resolved_events(sinks[0].events)
     # Signal 4 fires with relaxed assignee-candidates because BOTH are
     # DAG-ready — signal 2 sees 2 candidates so it bypasses; signal 3
@@ -474,7 +474,7 @@ async def test_signal4_dag_relaxed_pins_with_warning(
             callback_context=ctx,
         )
 
-    assert state[KEY_CURRENT_TASK_ID] == "b"
+    assert session.state[KEY_CURRENT_TASK_ID] == "b"
     events = _pin_resolved_events(sinks[0].events)
     assert events[-1]["payload"]["via_signal"] == "dag_relaxed"
     # WARNING log surfaced for operator visibility.
@@ -533,7 +533,7 @@ async def test_signal5_parent_pin_downstream() -> None:
         invocation_id="inv-parent",
         parent_invocation_id="",
     )
-    assert state[KEY_CURRENT_TASK_ID] == "A"
+    assert session.state[KEY_CURRENT_TASK_ID] == "A"
     assert plugin._invocation_pinned_task_id["inv-parent"] == "A"
 
     # Now resolve child with parent_invocation_id → signal 5 picks B
@@ -546,7 +546,7 @@ async def test_signal5_parent_pin_downstream() -> None:
         invocation_id="inv-child",
         parent_invocation_id="inv-parent",
     )
-    assert state[KEY_CURRENT_TASK_ID] == "B"
+    assert session.state[KEY_CURRENT_TASK_ID] == "B"
     events = _pin_resolved_events(sinks[0].events)
     assert events[-1]["payload"]["via_signal"] == "parent_pin_downstream"
     assert events[-1]["payload"]["task_id"] == "B"
@@ -598,7 +598,7 @@ async def test_signal6_reasoning_binding_pins_target_task() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t_beta"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t_beta"
     events = _pin_resolved_events(sinks[0].events)
     assert events[-1]["payload"]["via_signal"] == "reasoning_binding"
 
@@ -635,7 +635,7 @@ async def test_signal6_reasoning_binding_falls_through_when_task_terminal() -> N
 
     # Binding rejected (target terminal) → signal 2 binds the only
     # remaining DAG-ready PENDING candidate.
-    assert state[KEY_CURRENT_TASK_ID] == "t_beta"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t_beta"
     events = _pin_resolved_events(sinks[0].events)
     assert events[-1]["payload"]["via_signal"] != "reasoning_binding"
 
@@ -700,7 +700,7 @@ async def test_signal6_pending_correction_pins_target_task() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "corr1"
+    assert session.state[KEY_CURRENT_TASK_ID] == "corr1"
     events = _pin_resolved_events(sinks[0].events)
     assert events[-1]["payload"]["via_signal"] == "correction_target"
 
@@ -729,7 +729,7 @@ async def test_signal7_compound_to_bare_normalisation() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t1"
     events = _pin_resolved_events(sinks[0].events)
     assert events[-1]["payload"]["via_signal"] == "assignee_normalised"
 
@@ -767,7 +767,7 @@ async def test_signal8_low_confidence_best_guess_emits_low_confidence_event() ->
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] in {"alpha", "beta"}
+    assert session.state[KEY_CURRENT_TASK_ID] in {"alpha", "beta"}
     events = _pin_resolved_events(sinks[0].events)
     assert any(
         e["kind"] == "pin_resolved_low_confidence" for e in events
@@ -838,7 +838,7 @@ async def test_regression_242_dag_gate_happy_path() -> None:
     )
 
     # Signal 2 short-circuits — t1 is the only DAG-ready candidate.
-    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t1"
     events = _pin_resolved_events(sinks[0].events)
     assert events[-1]["payload"]["via_signal"] == "dag_ready_single"
 
@@ -861,7 +861,7 @@ async def test_regression_195_delegation_pin_happy_path() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t1"
     events = _pin_resolved_events(sinks[0].events)
     assert events[-1]["payload"]["via_signal"] == "delegation_pin"
 

--- a/tests/test_pin_versioning.py
+++ b/tests/test_pin_versioning.py
@@ -251,12 +251,13 @@ async def test_pin_stamp_writes_revision_alongside_task_id() -> None:
     )
 
     # Pin landed via signal 2 (DAG-ready exactly-1 happy path).
-    assert state[KEY_CURRENT_TASK_ID] == "t1"
-    # And the revision stamp followed it on the same surface.
-    assert state[KEY_CURRENT_TASK_REVISION] == 3
-    # Mirrored on goldfive's session.state too (the shared contract).
+    # Phase 2.1 of goldfive#271 — the pin lives on goldfive Session.state
+    # exclusively; ADK state is no longer mutated by the pin ladder.
     assert session.state.get("goldfive.current_task_id") == "t1"
     assert session.state.get("goldfive.current_task_revision") == 3
+    # And nothing leaked onto the ADK-side state dict.
+    assert KEY_CURRENT_TASK_ID not in state
+    assert KEY_CURRENT_TASK_REVISION not in state
 
 
 # ---------------------------------------------------------------------------
@@ -516,14 +517,32 @@ def test_pending_delegations_back_compat_string_shape() -> None:
     assert _delegation_pin_task_id(None) == ""
     assert _delegation_pin_revision({"task_id": "x"}) == 0  # missing rev
 
-    # _resolve_pinned_task_id resolves both shapes.
+    # _resolve_pinned_task_id resolves both shapes via the SessionContext
+    # stash that points at goldfive Session.state. Phase 2.1 of
+    # goldfive#271 — readers consult the goldfive Session, not ADK state.
+    session_legacy = Session(run_id="r1")
+    session_legacy.state["goldfive.pending_delegations"] = {"fc_X": "task_legacy"}
     state_legacy: dict[str, Any] = {
-        "goldfive.pending_delegations": {"fc_X": "task_legacy"},
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session_legacy,
+            steerer=None,
+            task=None,
+            tool_handlers={},
+            host_agent_name="coord",
+        ),
+    }
+    session_new = Session(run_id="r1")
+    session_new.state["goldfive.pending_delegations"] = {
+        "fc_X": {"task_id": "task_new", "revision": 7}
     }
     state_new: dict[str, Any] = {
-        "goldfive.pending_delegations": {
-            "fc_X": {"task_id": "task_new", "revision": 7}
-        },
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session_new,
+            steerer=None,
+            task=None,
+            tool_handlers={},
+            host_agent_name="coord",
+        ),
     }
     tool_ctx_legacy = _StateCtx._ToolCtx(state_legacy, fc_id="fc_X")
     tool_ctx_new = _StateCtx._ToolCtx(state_new, fc_id="fc_X")

--- a/tests/test_state_audit.py
+++ b/tests/test_state_audit.py
@@ -154,19 +154,19 @@ def test_no_callback_frame_allows_any_write() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_catalogued_violation_v3_passes_when_driven_through_plugin() -> None:
-    """Drive V3 (``before_agent_callback`` pin write) and assert no raise.
+def test_catalogued_callback_path_allows_writer() -> None:
+    """A catalogued callback (e.g. ``write_cancel_request``) lands cleanly.
 
-    This is the integration test the brief asks for. With the
-    tripwire enabled and a goldfive callback frame active, a
-    catalogued write (V3 — the per-agent pin at
-    ``_stamp_current_task_id`` / ``before_agent_callback``) must
-    pass without raising — the catalog entry covers it.
+    With the tripwire enabled and a goldfive callback frame active, a
+    write through one of the still-catalogued protocol writers (here
+    :func:`write_cancel_request` for cooperative cancellation) passes
+    the audit because ``write_cancel_request`` itself appears in
+    ``_KNOWN_CALLERS``.
 
-    Implementation: drive ``write_current_task_id`` directly. The
-    test runs from a ``tests/`` file so the broad ``tests/`` allow
-    in the catalog is what suppresses the audit; the production V3
-    path's own catalog entry covers the real plugin call.
+    Phase 2.1 of goldfive#271 — V3 / V4's own catalog entries are
+    gone (the plugin no longer writes ADK state for the pin), but
+    the cooperative-cancellation writers stay catalogued because
+    they're still load-bearing for cancel propagation.
     """
     pytest.importorskip("google.adk")
     from goldfive.adapters import _adk_state_protocol as sp
@@ -176,14 +176,7 @@ def test_catalogued_violation_v3_passes_when_driven_through_plugin() -> None:
 
     class _FakePlugin:
         async def before_agent_callback(self) -> None:
-            # Catalog entry: ("goldfive/adapters/_adk_plugin.py",
-            # "before_agent_callback"). The stack walk matches by
-            # filename-suffix on the calling module — but our test
-            # file is ``test_state_audit.py``, so we must rely on
-            # the broad ``tests/`` allow rather than the V3 entry.
-            # That broad allow IS in the catalog (so this is exactly
-            # the smoke test "catalogued site -> no raise").
-            sp.write_current_task_id(state, "task-42")
+            sp.write_cancel_request(state, invocation_id="inv-1", request="cancel")
 
     import asyncio
 
@@ -192,7 +185,7 @@ def test_catalogued_violation_v3_passes_when_driven_through_plugin() -> None:
         asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
             plugin.before_agent_callback()
         )
-    assert state["goldfive.current_task_id"] == "task-42"
+    assert state["goldfive.cancel_requested"] == {"inv-1": "cancel"}
 
 
 def test_real_plugin_callbacks_are_wrapped() -> None:
@@ -214,35 +207,29 @@ def test_real_plugin_callbacks_are_wrapped() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_catalog_includes_callback_methods_that_still_write() -> None:
-    """The catalog enumerates every plugin callback method that still
-    writes to ADK ``session.state``.
+def test_catalog_excludes_callbacks_with_no_remaining_writes() -> None:
+    """No plugin callback that's been migrated should appear in the catalog.
 
-    A new callback method added to the plugin must be added to the
-    catalog (or, better, structured so the tripwire's contextvar set
-    by :func:`wrap_plugin_callbacks` is the only thing recording it).
-
-    Phase 2.0 of goldfive#271 — V1 / V2 / V5 are migrated, so
-    ``before_run_callback`` and ``before_model_callback`` no longer
-    write ADK state and have been removed from the catalog. The
-    remaining callback writers are V3 (``before_agent_callback``) and
-    V4 (``before_tool_callback``).
+    Phase 2.0 of goldfive#271 migrated V1 / V2 / V5
+    (``before_run_callback`` / ``before_model_callback`` writers).
+    Phase 2.1 (this PR) migrated V3 / V4 (``before_agent_callback`` /
+    ``before_tool_callback`` writers — the per-agent pin and the
+    delegation-site pin both moved to goldfive ``Session.state``).
+    None of those callback names should remain in the catalog — a
+    regression that re-introduces an ADK-state write from any of them
+    must fail the audit loudly.
     """
     catalogued_qualnames = {q for (_, q) in _state_audit._KNOWN_CALLERS}
-    for method_name in (
+    for migrated in (
+        "before_run_callback",
+        "before_model_callback",
         "before_agent_callback",
         "before_tool_callback",
+        "_stamp_current_task_id",
+        "_pin_delegation_task_id",
     ):
-        assert method_name in catalogued_qualnames, (
-            f"plugin callback {method_name!r} missing from _KNOWN_CALLERS"
-        )
-    # V1 / V5 callbacks: migrated. They MUST NOT carry catalog
-    # entries — a regression that re-introduces an ADK-state write
-    # from before_run_callback / before_model_callback should fail
-    # the audit loudly.
-    for migrated in ("before_run_callback", "before_model_callback"):
         assert migrated not in catalogued_qualnames, (
-            f"{migrated!r} still in catalog after Phase 2.0 migration"
+            f"{migrated!r} still in catalog after migration"
         )
 
 
@@ -250,20 +237,19 @@ def test_known_callers_count_after_phase_2_migration() -> None:
     """Catalog shrinks monotonically as Phase 2 migrations land.
 
     Phase 0 (#278) shipped the catalog with the full set of pre-
-    existing violations. Phase 2.0 (this PR) migrated V1, V2, V5 +
-    the bridge writers, so the count must be strictly smaller than
-    Phase 0's baseline. Phase 2.x will continue to drop the count
-    as V3 / V4 / V7 / V8 migrate.
+    existing violations. Phase 2.0 migrated V1, V2, V5 + the bridge
+    writers. Phase 2.1 (this PR) migrated V3 + V4 — both pin write
+    paths now land on goldfive ``Session.state`` exclusively, so
+    their catalog entries are gone. The count must be strictly
+    smaller than the Phase 2.0 baseline (which had 18 entries).
     """
     expected = _state_audit.known_callers_count()
-    # Phase 0 baseline was 25; after Phase 2.0 we expect strictly
-    # fewer. The lower bound is loose — the test is asserting the
-    # direction (down) and that we didn't accidentally collapse to
-    # zero before V3 / V4 migrate.
-    assert 5 <= expected < 25, (
-        f"catalog count={expected} unexpected; Phase 0 baseline was 25 "
-        "and Phase 2.0 should have shrunk it without zeroing out the "
-        "still-present V3 / V4 / V7-V8 entries."
+    # Phase 2.0 baseline was 18; after Phase 2.1 we expect strictly
+    # fewer (V3 + V4 entries removed). Lower bound stays loose so
+    # the test is asserting direction (down), not an exact count.
+    assert 5 <= expected < 18, (
+        f"catalog count={expected} unexpected; Phase 2.0 baseline was 18 "
+        "and Phase 2.1 should have shrunk it (V3 / V4 entries removed)."
     )
 
 
@@ -289,22 +275,27 @@ def test_state_audit_is_off_in_production_default() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Real-violation reproducer: drive an ACTUAL catalogued write
-# (V3 — _stamp_current_task_id) and assert the audit allows it; then
-# strip its catalog entry and assert the audit raises. This is the
-# strongest demonstration that the tripwire would catch a regression
-# at this exact violation site.
+# Phase 2.1 — V3 / V4 migrated. The plugin's ``_stamp_current_task_id``
+# (V3) and ``_pin_delegation_task_id`` (V4) no longer write ADK
+# session.state. Reproducer tests that previously drove those code
+# paths through the tripwire are gone with the migration.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_v3_stamp_current_task_id_is_catalogued() -> None:
-    """V3 catalog entry covers ``_stamp_current_task_id`` writes.
+async def test_v3_v4_pin_writes_no_longer_touch_adk_state() -> None:
+    """The pin no longer mutates ADK ``session.state`` from a callback.
 
-    Drives the real plugin's `_stamp_current_task_id` and asserts no
-    raise. Then strips the V3 catalog entry and asserts the audit
-    fires — pinning that the catalog entry is what's keeping the
-    existing call site green.
+    Drives the real plugin's ``_stamp_current_task_id`` (V3 site) and
+    ``_pin_delegation_task_id`` (V4 site) inside a goldfive callback
+    frame and asserts:
+
+    * the goldfive ``Session.state`` carries the pin keys, and
+    * the ADK-side state dict is untouched (no leakage).
+
+    This is the structural assertion behind Phase 2.1's catalog
+    removal: with no callback-time write to ADK state, the audit
+    has nothing to flag at these sites.
     """
     pytest.importorskip("google.adk")
     from goldfive.adapters._adk_plugin import (
@@ -312,6 +303,7 @@ async def test_v3_stamp_current_task_id_is_catalogued() -> None:
         SessionContext,
         make_adk_plugin,
     )
+    from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
     from goldfive.types import Plan, Session, Task, TaskStatus
 
     plugin = make_adk_plugin(name="audit-test", host_agent_name="root")
@@ -340,75 +332,26 @@ async def test_v3_stamp_current_task_id_is_catalogued() -> None:
         host_agent_name="root",
     )
 
-    # Build a fake callback_context whose ``state`` is a real dict
-    # — the stamp helper reads this via _session_state_from_callback.
     class _FakeCtx:
         def __init__(self) -> None:
             self.state: dict[str, object] = {SESSION_CONTEXT_STATE_KEY: ctx}
 
     fake_cb_ctx = _FakeCtx()
 
-    # The stamp helper is a method on the plugin instance. Call it
-    # inside a goldfive callback frame so the tripwire's active-frame
-    # ContextVar is set — mirroring how real callbacks invoke it.
     _force_on_state()
+    # V3 — the pin landing path. After Phase 2.1 it lands only on
+    # goldfive Session.state.
     with _state_audit.goldfive_callback("before_agent_callback"):
         plugin._stamp_current_task_id(  # type: ignore[attr-defined]
             ctx=ctx,
-            callback_context=fake_cb_ctx,
             task_id="t1",
             agent_name="root",
-            source="test",
+            source="single_match",
             task=task,
             invocation_id="inv-1",
         )
 
-    # The catalogued V3 site should have stamped both surfaces.
-    from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
-
-    assert fake_cb_ctx.state[KEY_CURRENT_TASK_ID] == "t1"
     assert gf_session.state[KEY_CURRENT_TASK_ID] == "t1"
-
-    # Now strip every catalog entry that could short-circuit the
-    # stack walk on this particular violation — V3 itself
-    # (``_stamp_current_task_id`` / ``before_agent_callback``), the
-    # protocol-module helpers it funnels through, and the broad
-    # ``tests/`` allow. This simulates "what would happen if a
-    # future PR removed the opt-out without first migrating the
-    # call site" — i.e. the exact regression the tripwire is
-    # supposed to catch.
-    original = _state_audit._KNOWN_CALLERS
-    pruned = frozenset(
-        {
-            (f, q)
-            for (f, q) in original
-            if "_stamp_current_task_id" not in q
-            and "before_agent_callback" not in q
-            and "write_current_task" not in q
-            and "_set" not in q
-            and not f.startswith("tests/")
-        }
+    assert KEY_CURRENT_TASK_ID not in fake_cb_ctx.state, (
+        "V3 must not write ADK state after Phase 2.1"
     )
-    _state_audit._KNOWN_CALLERS = pruned  # type: ignore[misc]
-    try:
-        # Reset the state dict so the second invocation has a clean slate.
-        fake_cb_ctx.state = {SESSION_CONTEXT_STATE_KEY: ctx}
-        with _state_audit.goldfive_callback("before_agent_callback"):
-            with pytest.raises(StateOwnershipViolation) as excinfo:
-                plugin._stamp_current_task_id(  # type: ignore[attr-defined]
-                    ctx=ctx,
-                    callback_context=fake_cb_ctx,
-                    task_id="t1",
-                    agent_name="root",
-                    source="test",
-                    task=task,
-                    invocation_id="inv-1",
-                )
-    finally:
-        _state_audit._KNOWN_CALLERS = original  # type: ignore[misc]
-
-    # The error message should call out the offending key + the
-    # callback name + the migration target.
-    msg = str(excinfo.value)
-    assert "before_agent_callback" in msg
-    assert "goldfive." in msg  # one of the goldfive.* keys

--- a/tests/test_state_protocol_propagation.py
+++ b/tests/test_state_protocol_propagation.py
@@ -106,53 +106,28 @@ class _StubSteerer:
         pass
 
 
-def _read_state_via_before_model(observed: dict[str, Any]):
-    """Return a ``before_model_callback`` that snapshots every
-    ``goldfive.*`` state key into ``observed`` on entry.
+def _read_pin_via_before_model(observed: dict[str, Any]):
+    """Return a ``before_model_callback`` that snapshots the pin into ``observed``.
 
-    ADK invokes this as a sync function receiving ``callback_context``
-    and ``llm_request``. Navigates the several shapes callback_context
-    may expose (``_invocation_context.session.state`` / ``session.state``)
-    so the snapshot works across ADK versions.
+    Phase 2.1 of goldfive#271 — readers consult goldfive
+    ``Session.state`` via the plugin reference, not ADK
+    ``session.state``. Walks ``invocation_context.plugin_manager`` for
+    the goldfive plugin and reads its ``_active_ctx.session`` — same
+    shape as :func:`session_context_from_invocation`.
     """
-    from goldfive.adapters._adk_state_protocol import (
-        KEY_CURRENT_TASK_ASSIGNEE,
-        KEY_CURRENT_TASK_ID,
-        KEY_CURRENT_TASK_TITLE,
-        KEY_PLAN_ID,
-        KEY_PLAN_SUMMARY,
-        KEY_RUN_ID,
-        KEY_TOOLS_AVAILABLE,
-    )
+    from goldfive.adapters._adk_plugin import session_context_from_invocation
+    from goldfive.orchestration_store import OrchestrationStore
 
     def _before_model(callback_context: Any, llm_request: Any) -> None:  # noqa: ARG001
-        inv_ctx = getattr(callback_context, "_invocation_context", None)
-        state = None
-        if inv_ctx is not None:
-            sess = getattr(inv_ctx, "session", None)
-            state = getattr(sess, "state", None)
-        if state is None:
-            sess = getattr(callback_context, "session", None)
-            state = getattr(sess, "state", None)
-        if state is None:
-            return None
-        # Snapshot only the first time — some B callbacks may fire more
-        # than once if the scripted LLM hands more turns to B.
+        inv_ctx = getattr(callback_context, "_invocation_context", None) or getattr(
+            callback_context, "invocation_context", None
+        )
+        ctx = session_context_from_invocation(inv_ctx)
+        session = getattr(ctx, "session", None) if ctx is not None else None
         if observed:
             return None
-        for key in (
-            KEY_RUN_ID,
-            KEY_PLAN_ID,
-            KEY_PLAN_SUMMARY,
-            KEY_CURRENT_TASK_ID,
-            KEY_CURRENT_TASK_TITLE,
-            KEY_CURRENT_TASK_ASSIGNEE,
-            KEY_TOOLS_AVAILABLE,
-        ):
-            try:
-                observed[key] = state.get(key)
-            except Exception:
-                observed[key] = None
+        store = OrchestrationStore.for_session(session)
+        observed["pin_current_task"] = store.pin_current_task()
         return None
 
     return _before_model
@@ -164,14 +139,19 @@ def _read_state_via_before_model(observed: dict[str, Any]):
 
 
 async def test_state_protocol_current_task_id_visible_in_sub_runner() -> None:
-    """B's ``before_model_callback`` sees ``goldfive.current_task_id`` on
-    the sub-Runner's live session — the authoritative state-protocol
-    write must cross the AgentTool boundary.
+    """B's ``before_model_callback`` resolves the pin via the plugin
+    reference and sees ``my-task-id`` on the goldfive Session — the
+    pin must be reachable across an AgentTool boundary.
+
+    Phase 2.1 of goldfive#271 — the pin no longer lives on ADK
+    ``session.state``. The plugin instance is shared with the
+    sub-Runner so :func:`session_context_from_invocation` resolves
+    the same goldfive Session no matter which invocation fires the
+    callback.
     """
     from google.adk.agents import Agent
     from google.adk.tools.agent_tool import AgentTool
 
-    from goldfive.adapters._adk_state_protocol import KEY_CURRENT_TASK_ID
     from goldfive.adapters.adk import ADKAdapter
 
     observed: dict[str, Any] = {}
@@ -179,7 +159,7 @@ async def test_state_protocol_current_task_id_visible_in_sub_runner() -> None:
         name="agent_b",
         model=_make_agent_b_llm()(),
         instruction="",
-        before_model_callback=_read_state_via_before_model(observed),
+        before_model_callback=_read_pin_via_before_model(observed),
     )
     agent_a = Agent(
         name="agent_a",
@@ -197,10 +177,10 @@ async def test_state_protocol_current_task_id_visible_in_sub_runner() -> None:
     await adapter.invoke(task=task, session=session)
 
     assert observed, "B's before_model_callback never ran — AgentTool dispatch broke"
-    assert observed.get(KEY_CURRENT_TASK_ID) == "my-task-id", (
-        f"B's sub-Runner saw current_task_id={observed.get(KEY_CURRENT_TASK_ID)!r}; "
-        "expected 'my-task-id'. The authoritative state write in "
-        "plugin.before_run_callback did not propagate through AgentTool."
+    assert observed.get("pin_current_task") == "my-task-id", (
+        f"B's sub-Runner saw pin={observed.get('pin_current_task')!r}; "
+        "expected 'my-task-id'. The pin write in _stamp_current_task_id "
+        "did not propagate through AgentTool."
     )
 
 

--- a/tests/test_task_id_wiring.py
+++ b/tests/test_task_id_wiring.py
@@ -193,7 +193,7 @@ async def test_before_agent_callback_pins_unambiguous_task() -> None:
     )
 
     # ADK session.state side (sub-agent-visible).
-    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t1"
     # Goldfive orchestration-state side (handler fallback).
     assert session.state["goldfive.current_task_id"] == "t1"
 
@@ -222,8 +222,9 @@ async def test_before_agent_callback_ambiguous_match_pins_low_confidence() -> No
     )
 
     # The ambiguous case lands on the first deterministic candidate.
-    assert state[KEY_CURRENT_TASK_ID] in {"t1", "t2"}
-    assert session.state["goldfive.current_task_id"] == state[KEY_CURRENT_TASK_ID]
+    # Phase 2.1 — pin lives on goldfive Session.state exclusively.
+    assert session.state[KEY_CURRENT_TASK_ID] in {"t1", "t2"}
+    assert KEY_CURRENT_TASK_ID not in state
 
 
 async def test_before_agent_callback_no_match_leaves_unset() -> None:
@@ -263,7 +264,7 @@ async def test_before_agent_callback_includes_running_tasks() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t1"
     assert session.state["goldfive.current_task_id"] == "t1"
 
 
@@ -320,7 +321,7 @@ async def test_pin_relaxes_dag_gate_when_upstream_incomplete() -> None:
     )
 
     # Signal 4 — DAG gate relaxed — pins B.
-    assert state[KEY_CURRENT_TASK_ID] == "b"
+    assert session.state[KEY_CURRENT_TASK_ID] == "b"
     assert session.state["goldfive.current_task_id"] == "b"
 
 
@@ -346,7 +347,7 @@ async def test_pin_selects_task_after_upstream_completes() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "b"
+    assert session.state[KEY_CURRENT_TASK_ID] == "b"
     assert session.state["goldfive.current_task_id"] == "b"
 
 
@@ -372,7 +373,7 @@ async def test_pin_ambiguous_narrows_by_dag() -> None:
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t1"
     assert session.state["goldfive.current_task_id"] == "t1"
 
 
@@ -417,7 +418,7 @@ async def test_pin_finalize_with_incomplete_upstream_relaxes_loudly() -> None:
     )
 
     # Signal 4 binds finalize (the agent WAS invoked).
-    assert state[KEY_CURRENT_TASK_ID] == "finalize_and_deliver_presentation"
+    assert session.state[KEY_CURRENT_TASK_ID] == "finalize_and_deliver_presentation"
     assert session.state["goldfive.current_task_id"] == "finalize_and_deliver_presentation"
 
 
@@ -454,7 +455,7 @@ async def test_pin_supersedes_redirection_tracks_replacement() -> None:
         agent=_Agent("research_agent"),
         callback_context=ctx,
     )
-    assert state[KEY_CURRENT_TASK_ID] == "C"
+    assert session.state[KEY_CURRENT_TASK_ID] == "C"
 
     # Flip B to COMPLETED; now C is DAG-ready -> signal 2 binds.
     plan.tasks[1].status = TaskStatus.COMPLETED
@@ -462,7 +463,7 @@ async def test_pin_supersedes_redirection_tracks_replacement() -> None:
         agent=_Agent("research_agent"),
         callback_context=ctx,
     )
-    assert state[KEY_CURRENT_TASK_ID] == "C"
+    assert session.state[KEY_CURRENT_TASK_ID] == "C"
 
 
 async def test_pin_orchestration_block_renders_pinned_task_after_relaxation() -> None:
@@ -497,7 +498,7 @@ async def test_pin_orchestration_block_renders_pinned_task_after_relaxation() ->
     )
 
     # Signal 4 relaxes the DAG gate and binds finalize.
-    assert state[KEY_CURRENT_TASK_ID] == "finalize"
+    assert session.state[KEY_CURRENT_TASK_ID] == "finalize"
 
     # Build the planner instruction the LLM would see. We use a
     # tolerant readonly-context stub carrying the ADK state dict.
@@ -770,5 +771,5 @@ async def test_before_agent_callback_pins_when_plan_came_from_compound_json() ->
         callback_context=ctx,
     )
 
-    assert state[KEY_CURRENT_TASK_ID] == "t1"
+    assert session.state[KEY_CURRENT_TASK_ID] == "t1"
     assert session.state["goldfive.current_task_id"] == "t1"


### PR DESCRIPTION
## Summary

After Phase 2.0 (#280) eliminated V1/V2/V5, V3 (per-agent pin in `_stamp_current_task_id`) and V4 (delegation-site pin in `_pin_delegation_task_id`) remained as the last callback-time mutations of ADK `session.state` from inside goldfive's wrap. Both fire on every dispatch in production-shaped flows.

This PR migrates both. After this PR, every callback-time write to ADK `session.state` from inside the wrap is eliminated. The remaining audit entries (V6 / V7 / V8 / V9) are non-callback contexts — Phase 0's documented "mitigated" class.

- **V3** — `_stamp_current_task_id` writes go through `OrchestrationStore.set_pin_current_task` only. The dynamic-instruction resolver and reporting handlers read goldfive `Session.state` via the plugin reference (`session_context_from_invocation` — Phase 2.0's pattern).
- **V4** — `_pin_delegation_task_id` writes go through new typed accessor `OrchestrationStore.set_pending_delegation`. `_resolve_pinned_task_id` reads via the same store, walking goldfive `Session.state` reached through the plugin's `_active_ctx`.
- Reporting handlers' state reads now funnel through `OrchestrationStore` — decoupling the handler from on-disk key strings.
- `_KNOWN_CALLERS` in `goldfive/_state_audit.py` loses V3 + V4 entries (catalog count: 18 → 7).
- The unused adapter-side writers (`_sp.write_current_task` / `_sp.write_current_task_id` / `_sp.write_current_task_revision` / `_sp.clear_current_task`) are deleted — only the read-side key constants remain.

Includes structured runtime logging for pin set/read + delegation pin stamp/consume events to help debug production-shaped ADK-web flows.

Closes Phase 2 of #271.

## Test plan

- [x] `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 uv run pytest tests/ -x` — 1664 passed, 46 skipped
- [x] `uv run ruff check goldfive/` — clean
- [x] V3 / V4 explicitly removed from `_KNOWN_CALLERS` (verified at goldfive/_state_audit.py:263-300)
- [x] Net diff: -70 LOC across goldfive/ and tests/