### PR TITLE
fix(runner): stash prior plan across aborts so user-steer routes (#271 Gap 1)

### DIFF
--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -472,11 +472,20 @@ class GoldfiveADKAgent(BaseAgent):
         # Caller has explicitly disabled the gate — don't reintroduce it
         # at the adapter layer.
         if gate is None:
+            log.info(
+                "GoldfiveADKAgent: gate disabled (planner_gate=None); "
+                "Runner.run will treat this turn as new_work"
+            )
             return None
         last_plan = getattr(runner, "_last_plan", None)
         # No prior plan → first turn, gate would always pick new_work.
         # Skip the call to keep the LLM out of the hot path on turn 1.
         if last_plan is None or not getattr(last_plan, "tasks", None):
+            log.info(
+                "GoldfiveADKAgent: gate skipped — no prior plan; "
+                "treating as new_work (user_input_first=%r)",
+                user_input[:80],
+            )
             return None
 
         # Reuse Runner._classify_turn so the planner-gate configuration
@@ -513,6 +522,13 @@ class GoldfiveADKAgent(BaseAgent):
                 verdict,
             )
             return None
+        log.info(
+            "GoldfiveADKAgent: gate verdict=%s prior_plan_id=%s "
+            "user_input_first=%r",
+            verdict,
+            getattr(last_plan, "id", "")[:16] or "<none>",
+            user_input[:80],
+        )
         return verdict
 
     async def _drain_steerer_background_judges(self) -> None:

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -323,9 +323,11 @@ class Runner:
         )
         if pre_verdict in ("new_work", "conversational", "refine_existing"):
             verdict = pre_verdict  # type: ignore[assignment]
-            log.debug(
-                "Runner.run: using adapter-level pre-classified verdict %r",
+            log.info(
+                "Runner.run: gate verdict=%s (source=adapter-prepass) "
+                "prior_plan_id=%s",
                 verdict,
+                (getattr(self._last_plan, "id", "") or "")[:16] or "<none>",
             )
         elif self._last_plan is not None and isinstance(user_input, str):
             try:
@@ -341,6 +343,19 @@ class Runner:
                 # always make forward progress.
                 log.warning("planner_gate raised; falling back to new_work: %s", exc)
                 verdict = "new_work"
+            else:
+                log.info(
+                    "Runner.run: gate verdict=%s (source=runner-inline) "
+                    "prior_plan_id=%s user_input_first=%r",
+                    verdict,
+                    (getattr(self._last_plan, "id", "") or "")[:16] or "<none>",
+                    user_input[:80] if isinstance(user_input, str) else "",
+                )
+        else:
+            log.info(
+                "Runner.run: gate skipped (no prior plan or non-str input); "
+                "treating as new_work"
+            )
 
         # Conversational follow-up: skip goal derivation + planning.
         # Carry the prior plan forward onto the freshly minted Session
@@ -489,6 +504,11 @@ class Runner:
                         kind=DriftKind.USER_STEER,
                         severity=DriftSeverity.WARNING,
                         detail=user_text,
+                    )
+                    log.info(
+                        "Runner.run: routing refine_existing through steerer "
+                        "USER_STEER pipeline (prior_plan_id=%s)",
+                        (prior_plan.id or "")[:16] or "<none>",
                     )
                     try:
                         await self.steerer._handle_drift(drift, session)
@@ -663,11 +683,35 @@ class Runner:
         _ostate.clear_active_steer(session.state)
 
         # planner-gate: snapshot the turn's final plan so the next
-        # turn's planner_gate can classify against it. Only stash on
-        # success — an aborted run's plan would poison the next
-        # turn's gate with half-run state.
-        if outcome.success and session.plan is not None:
+        # turn's planner_gate can classify against it.
+        #
+        # Rationale (Phase 2.X / goldfive#271 Gap 1): the previous
+        # ``outcome.success and ...`` guard discarded the prior plan on
+        # ANY abort — including goldfive-driven CRITICAL drift cancels.
+        # That left ``_last_plan = None`` for the next turn even when
+        # the turn produced a real plan and partially executed it.
+        # The ADK-web user-steer flow hit this on the validation E2E:
+        # turn 1 was cancelled by a CRITICAL goal-drift, turn 2's user
+        # steer arrived next, and the gate found ``_last_plan = None``
+        # so it short-circuited to ``new_work`` — silently skipping the
+        # steerer's USER_STEER pipeline (no DriftDetected(USER_STEER),
+        # no PlanRevised, no sticky-goal preservation).
+        #
+        # Stash any non-None ``session.plan`` (whether the turn
+        # succeeded, was cancelled, or aborted on a planner-bind error)
+        # so the next turn's gate can refine against it. The plan id
+        # remains a stable refine target; the steerer's
+        # ``_apply_revision`` resolves the new revision off
+        # ``prev_plan.revision_index + 1`` and the planner's refine
+        # call carries the prior plan's tasks forward verbatim.
+        if session.plan is not None:
             self._last_plan = session.plan
+            log.info(
+                "Runner.run: stashed prior plan for next turn's gate "
+                "(plan_id=%s success=%s)",
+                (session.plan.id or "")[:16] or "<none>",
+                outcome.success,
+            )
 
         self._conversation.absorb_turn(
             outcome, user_input_summary=_initial_goal_summary(user_input)

--- a/tests/test_adk_adapter_gate.py
+++ b/tests/test_adk_adapter_gate.py
@@ -689,3 +689,102 @@ async def test_adapter_gate_heuristic_catches_steer_language() -> None:
         "USER_STEER; the regression goldfive#270 documented is back"
     )
     assert plan_revised, "no PlanRevised on the wire after USER_STEER"
+
+
+# ---------------------------------------------------------------------------
+# 8. Phase 2.X / Gap 1: adapter gate logs verdict at INFO for visibility
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_gate_logs_verdict_at_info(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The adapter-level gate emits an INFO log line capturing the
+    verdict, prior_plan_id, and user_input prefix on each turn after
+    the first. This is the operator-visible signal that the gate fired
+    and what it decided — without it (the demo log on the validation
+    E2E was silent on the gate), debugging gate misclassifications
+    requires re-running with DEBUG enabled.
+    """
+    import logging as _logging
+
+    sink = InMemorySink()
+    wrapped = _build_wrapped(planner_gate="auto", sinks=[sink])
+    _seed_prior_plan(wrapped)
+
+    async def _force_refine(*, prior_plan, completed_results, user_input, session):
+        return "refine_existing"
+
+    wrapped.runner._classify_turn = _force_refine
+
+    revised = Plan(
+        id="prior-1",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Gather facts",
+                description="x",
+                assignee_agent_id="inner_agent",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="t2-new",
+                title="Pivot",
+                description="y",
+                assignee_agent_id="inner_agent",
+            ),
+        ],
+        edges=[],
+        summary="Pivoted plan",
+    )
+
+    async def _fake_refine(*, plan, drift, goals, **kwargs):
+        return revised
+
+    wrapped.runner.planner.refine = _fake_refine  # type: ignore[method-assign]
+
+    ctx = _FakeCtx("forget panels. flares instead.")
+    with caplog.at_level(_logging.INFO, logger="goldfive.adapters.adk_wrap"):
+        [e async for e in wrapped._run_async_impl(ctx)]
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    verdict_lines = [m for m in messages if "gate verdict=" in m]
+    assert verdict_lines, (
+        f"adapter gate did not emit an INFO verdict log; got: {messages!r}"
+    )
+    assert any("verdict=refine_existing" in m for m in verdict_lines), (
+        f"adapter gate verdict missed; got: {verdict_lines!r}"
+    )
+    # The log carries the user_input prefix so an operator can correlate
+    # the verdict with the actual message.
+    assert any("forget panels" in m for m in verdict_lines), (
+        f"verdict log missing user_input snippet; got: {verdict_lines!r}"
+    )
+
+
+async def test_adapter_gate_logs_skip_reason_when_no_prior_plan(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When no prior plan exists the adapter gate skips classification
+    and logs the reason at INFO. This makes the "gate didn't fire"
+    case observable in the demo log.
+    """
+    import logging as _logging
+
+    wrapped = _build_wrapped(planner_gate="auto")
+    # No _last_plan stamped — first turn.
+
+    ctx = _FakeCtx("first message of the conversation")
+    with caplog.at_level(_logging.INFO, logger="goldfive.adapters.adk_wrap"):
+        [e async for e in wrapped._run_async_impl(ctx)]
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    skip_lines = [m for m in messages if "gate skipped" in m]
+    assert skip_lines, (
+        f"expected gate-skipped INFO log when no prior plan; got: {messages!r}"
+    )
+    assert any("no prior plan" in m for m in skip_lines), (
+        f"skip log should mention 'no prior plan'; got: {skip_lines!r}"
+    )

--- a/tests/test_runner_user_steer_routing.py
+++ b/tests/test_runner_user_steer_routing.py
@@ -1,6 +1,12 @@
 """F1 / regression: turn-aware planning gate ``refine_existing`` branch
 must route through the steerer.
 
+Phase 2.X (goldfive#271 Gap 1):
+``_last_plan`` is now stashed for the next turn even when the prior
+turn aborted, and the gate's verdict is logged at INFO so operators
+can grep ``/tmp/demo-validation.log`` for the actual classification.
+
+
 PR #210 introduced the planning gate with three verdicts (``new_work``
 / ``conversational`` / ``refine_existing``). The ``refine_existing``
 branch called ``planner.refine`` directly and treated the output as a
@@ -31,6 +37,7 @@ fix.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 import pytest
@@ -319,3 +326,209 @@ async def test_refine_existing_falls_back_to_generate_on_refine_failure() -> Non
         "fall-back path must emit PlanSubmitted for the regenerated "
         "plan (the safe path always ships a plan)."
     )
+
+
+# ---------------------------------------------------------------------------
+# 3. Phase 2.X / Gap 1: prior plan stashed across an aborted turn so the
+#    next turn's planner-gate can route through USER_STEER.
+# ---------------------------------------------------------------------------
+
+
+async def test_prior_plan_stashed_when_turn_aborts_so_next_steer_routes() -> None:
+    """Regression for goldfive#271 Gap 1.
+
+    Scenario from the validation E2E:
+
+    1. Turn 1 builds a plan and starts executing it.
+    2. Turn 1 aborts mid-flight (in this test: a task fails so the
+       executor returns ``ExecutionOutcome(success=False)``).
+    3. Turn 2 is a user steer ("forget X. tell me about Y.").
+
+    Pre-Phase-2.X the runner only stashed ``_last_plan`` on
+    ``outcome.success=True``, so the gate on turn 2 found
+    ``_last_plan = None`` and short-circuited to ``new_work`` —
+    silently dropping the steerer's USER_STEER pipeline. The fix
+    stashes the plan whenever ``session.plan`` is non-None so the
+    gate can refine against it on the next turn even if the prior
+    turn was cancelled or failed.
+    """
+    turn1_plan = json.dumps(
+        {
+            "id": "plan-aborted",
+            "summary": "first plan that aborts",
+            "tasks": [
+                {"id": "t1", "title": "T1", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+    refined_plan = json.dumps(
+        {
+            "id": "plan-aborted",
+            "summary": "revised after steer",
+            "tasks": [
+                {
+                    "id": "t1",
+                    "title": "T1",
+                    "assignee_agent_id": "writer",
+                    "status": "FAILED",
+                },
+                {"id": "t2", "title": "T2 (steer)", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+
+    planner = LLMPlanner(
+        call_llm=_planner_call_llm_factory(
+            turn1_plan=turn1_plan,
+            turn2_verdict="refine_existing",
+            refined_plan=refined_plan,
+        ),
+        model="stub",
+    )
+
+    async def _failing_agent(
+        task: Task,
+        session: Session,
+        tools: list[ReportingToolSpec],
+    ) -> InvocationResult:
+        _ = tools, session
+        return InvocationResult(task_id=task.id, text="boom", success=False)
+
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_failing_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    out1 = await runner.run("make a 2-slide presentation about solar")
+    # Turn 1 aborts (the agent returns success=False) — but a plan IS
+    # installed on the session before the executor runs.
+    assert not out1.success
+    assert out1.session.plan is not None
+    turn1_plan_id = out1.session.plan.id
+    turn1_revision_index = out1.session.plan.revision_index
+    turn1_end = len(sink.events)
+
+    # The fix: ``_last_plan`` is stashed despite the abort.
+    assert runner._last_plan is not None, (
+        "Gap 1 regression: the runner must stash session.plan for the "
+        "next turn's gate even when the turn aborted; otherwise the "
+        "next user steer skips the USER_STEER pipeline."
+    )
+    assert runner._last_plan.id == turn1_plan_id
+
+    # Turn 2: user steer should classify as refine_existing and route
+    # through the steerer's USER_STEER pipeline.
+    out2 = await runner.run("forget solar. tell me about wind power instead.")
+    await runner.close()
+
+    turn2_kinds = _kinds(sink.events[turn1_end:])
+    assert "DriftDetected" in turn2_kinds, (
+        "USER_STEER drift must appear on the wire even when the prior "
+        "turn aborted — the prior plan is enough context for the gate."
+    )
+    assert "PlanRevised" in turn2_kinds, (
+        "refine_existing routes through the steerer's USER_STEER "
+        "pipeline; PlanRevised must fire with bumped revision_index."
+    )
+
+    # plan_id stable + revision_index bumped (same invariants as the
+    # success-path test but exercised through the abort recovery).
+    assert out2.session.plan is not None
+    assert out2.session.plan.id == turn1_plan_id
+    assert out2.session.plan.revision_index == turn1_revision_index + 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Phase 2.X / Gap 1: gate verdict + USER_STEER routing log lines
+# ---------------------------------------------------------------------------
+
+
+async def test_gate_verdict_logs_at_info_for_operator_visibility(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The runner's planner-gate emits one INFO-level log line per turn
+    capturing the verdict. A future operator debugging an E2E should
+    be able to grep for ``Runner.run: gate verdict=`` and reconstruct
+    the classification path that drove the turn.
+    """
+    turn1_plan = json.dumps(
+        {
+            "id": "plan-log",
+            "summary": "first plan",
+            "tasks": [
+                {"id": "t1", "title": "T1", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+    refined_plan = json.dumps(
+        {
+            "id": "plan-log",
+            "summary": "revised plan",
+            "tasks": [
+                {
+                    "id": "t1",
+                    "title": "T1",
+                    "assignee_agent_id": "writer",
+                    "status": "COMPLETED",
+                },
+                {"id": "t2", "title": "T2 (steer)", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+    planner = LLMPlanner(
+        call_llm=_planner_call_llm_factory(
+            turn1_plan=turn1_plan,
+            turn2_verdict="refine_existing",
+            refined_plan=refined_plan,
+        ),
+        model="stub",
+    )
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    with caplog.at_level(logging.INFO, logger="goldfive.runner"):
+        await runner.run("first turn")
+        await runner.run("forget first. tell me about second instead.")
+        await runner.close()
+
+    messages = [rec.getMessage() for rec in caplog.records]
+
+    # First turn: no prior plan → gate skipped log.
+    assert any(
+        "gate skipped (no prior plan or non-str input)" in m for m in messages
+    ), f"expected gate-skipped log on first turn; got: {messages!r}"
+
+    # Second turn: gate verdict logged with verdict + prior_plan_id +
+    # user_input snippet.
+    verdict_lines = [m for m in messages if "gate verdict=" in m]
+    assert verdict_lines, (
+        f"expected at least one gate verdict log; got: {messages!r}"
+    )
+    assert any("verdict=refine_existing" in m for m in verdict_lines), (
+        f"expected refine_existing verdict in logs; got: {verdict_lines!r}"
+    )
+
+    # USER_STEER routing log fires when refine_existing routes through
+    # the steerer.
+    assert any(
+        "routing refine_existing through steerer USER_STEER pipeline" in m
+        for m in messages
+    ), (
+        "expected USER_STEER routing log; got: "
+        f"{[m for m in messages if 'USER_STEER' in m]!r}"
+    )
+
+    # _last_plan stash log on a successful turn.
+    assert any(
+        "stashed prior plan for next turn's gate" in m for m in messages
+    ), f"expected _last_plan stash log; got: {messages!r}"


### PR DESCRIPTION
## Summary

Phase 2.X / Gap 1 of goldfive#271. Validation session 95ecda4c-16de-41f6-bbd7-cce16106bf73 recorded 0 of 8 drifts as `DRIFT_KIND_USER_STEER` even though the user issued two explicit steers. This PR fixes the root cause and adds operator-visible logging at the gate sites.

## Root cause

The runner only stashed `_last_plan` when `outcome.success=True`. When goldfive cancels turn 1 mid-flight (CRITICAL goldfive-detected drift, executor abort, etc.) and a user steer arrives next, the gate finds `_last_plan = None`, short-circuits to `new_work`, and silently skips the steerer's USER_STEER pipeline. Result: no `DriftDetected(USER_STEER)`, no `PlanRevised`, no sticky-goal preservation via `_apply_user_steer_state`.

Validation evidence:
- 14:20:57 — goldfive cancels turn 1 (GOAL_DRIFT critical)
- ~14:20:57 — user types "forget solar panels. tell me about solar flares." → turn 2 starts
- 14:21:46 — turn 1 closes with `success=False`; `_last_plan` not stashed
- 14:24:43 — turn 2 delegation pin for `research_solar_flares` with NO prior `plan_revised` event

## Fix

1. Drop the `outcome.success` guard on the `_last_plan` stash. Any non-None `session.plan` is enough context for the next turn's gate; `_apply_revision` resolves the new revision off `prev_plan.revision_index + 1` regardless of how the prior turn ended.
2. INFO-level structured logging at every gate decision site so future E2E debugging can grep `/tmp/demo-validation.log`:
   - `Runner.run: gate verdict=...` (source=adapter-prepass / runner-inline)
   - `Runner.run: gate skipped (no prior plan or non-str input)`
   - `Runner.run: routing refine_existing through steerer USER_STEER pipeline`
   - `Runner.run: stashed prior plan for next turn's gate`
   - `GoldfiveADKAgent: gate verdict=... prior_plan_id=... user_input_first=...`
   - `GoldfiveADKAgent: gate skipped — no prior plan`

## Tests

- `test_prior_plan_stashed_when_turn_aborts_so_next_steer_routes` — turn 1 aborts with a plan installed → turn 2's steer routes through USER_STEER.
- `test_gate_verdict_logs_at_info_for_operator_visibility` — pins runner-side log lines.
- `test_adapter_gate_logs_verdict_at_info` and `test_adapter_gate_logs_skip_reason_when_no_prior_plan` — pin adapter-side log lines.

LOC: +378 / -6. Test delta: +4. Full suite (1668 tests) green with `GOLDFIVE_STRICT_STATE_OWNERSHIP=1`.

## Test plan

- [x] `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 uv run pytest tests/ -x` (1668 passed)
- [x] `uv run ruff check goldfive/`
- [x] Phase 0 tripwire stays green