### PR TITLE
fix(adk-wrap, steerer): tighten per-turn judge drain timeout (#271 Gap 3)

### DIFF
--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -531,19 +531,51 @@ class GoldfiveADKAgent(BaseAgent):
         )
         return verdict
 
+    #: Per-turn drain timeout. Bounds how long ``_run_async_impl``'s
+    #: ``finally`` block can block ADK's iterator exit. Phase 2.X
+    #: (goldfive#271 Gap 3): the previous default of 5.0s was inherited
+    #: from :meth:`Steerer.shutdown` and was the root of the residual
+    #: #275-style stale-session race — while the per-turn drain held
+    #: ADK's outer loop for 5s, a concurrent ``/run_sse`` invocation on
+    #: the same outer session could advance the SQLite session's
+    #: ``last_update_time``, leaving the blocked turn's deferred event
+    #: appends behind. 0.5s is plenty for judges that are about to
+    #: complete; stragglers get cancelled and resume drift emit on
+    #: :meth:`Runner.close` (which keeps the longer 5s timeout for
+    #: programmatic teardown).
+    _PER_TURN_DRAIN_TIMEOUT_S: float = 0.5
+
     async def _drain_steerer_background_judges(self) -> None:
         """Call ``steerer.shutdown()`` on the bound runner's steerer, if any.
 
         Duck-typed so custom ``Steerer`` implementations (or stubs used
         in tests) without the method fall through cleanly. Exceptions
         are swallowed: teardown must never mask the run's real outcome.
+
+        Uses a tight :data:`_PER_TURN_DRAIN_TIMEOUT_S` bound so the
+        ``finally`` block doesn't stall ADK's iterator exit when a
+        slow LLM judge is still in flight at run end. The default
+        :meth:`Steerer.shutdown` timeout (5s) survives on
+        :meth:`Runner.close`, where blocking is acceptable.
         """
         steerer = getattr(self._runner, "steerer", None)
         shutdown = getattr(steerer, "shutdown", None)
         if shutdown is None:
             return
         try:
-            await shutdown()
+            await shutdown(timeout=self._PER_TURN_DRAIN_TIMEOUT_S)
+        except TypeError:
+            # Custom Steerers without the timeout kwarg get the legacy
+            # default. Best-effort fallthrough so we don't break third-
+            # party steerers that haven't been updated.
+            try:
+                await shutdown()
+            except Exception as exc:  # noqa: BLE001 — defensive
+                log.debug(
+                    "GoldfiveADKAgent: steerer.shutdown raised "
+                    "(swallowed): %s",
+                    exc,
+                )
         except Exception as exc:  # noqa: BLE001 — defensive
             log.debug(
                 "GoldfiveADKAgent: steerer.shutdown raised "

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -1520,12 +1520,29 @@ class DefaultSteerer:
                     await asyncio.wait(still_pending, timeout=0.5)
                 except Exception:  # noqa: BLE001 — defensive
                     pass
-            log.warning(
-                "DefaultSteerer.shutdown: %d background judge task(s) "
-                "exceeded %.2fs timeout; cancelled",
-                len(still_pending),
-                float(timeout),
-            )
+            # Phase 2.X (goldfive#271 Gap 3): only WARN when stragglers
+            # were actually cancelled. The TimeoutError can fire even
+            # when every task completed in the same instant the timeout
+            # expired (gather scheduling vs. wait_for race) — those
+            # cases logged ``cancelled 0 tasks`` which was both
+            # confusing and noisy in the demo log. The DEBUG line
+            # preserves visibility for diagnostics while keeping INFO
+            # / WARNING reserved for the real "we cancelled work"
+            # signal.
+            if still_pending:
+                log.warning(
+                    "DefaultSteerer.shutdown: %d background judge task(s) "
+                    "exceeded %.2fs timeout; cancelled",
+                    len(still_pending),
+                    float(timeout),
+                )
+            else:
+                log.debug(
+                    "DefaultSteerer.shutdown: %.2fs timeout expired but "
+                    "all judges completed in the same instant; nothing "
+                    "to cancel",
+                    float(timeout),
+                )
 
     @staticmethod
     def _truncate_trigger_input(text: str, limit: int = 2048) -> str:

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -717,6 +717,55 @@ async def test_shutdown_is_noop_when_no_background_judges() -> None:
     await steerer.shutdown(timeout=5.0)
 
 
+async def test_shutdown_quiet_when_zero_tasks_actually_cancelled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Phase 2.X (goldfive#271 Gap 3): the ``shutdown`` WARNING fires
+    only when there were actually stragglers to cancel.
+
+    A judge that completes in the same instant the timeout fires can
+    leave ``still_pending`` empty even though ``wait_for`` raised
+    ``TimeoutError``. The previous unconditional WARNING logged
+    ``cancelled 0 tasks`` which was both confusing and noisy in the
+    demo log. The DEBUG line preserves diagnostic visibility.
+    """
+
+    async def fast_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        # Returns immediately so the judge completes before / during
+        # the shutdown's wait_for. With timeout=0.0 we deterministically
+        # hit the "TimeoutError but 0 still pending" branch.
+        return json.dumps({"on_task": True})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=fast_call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session_with_task()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    await steerer.observe_reasoning("a thought", session=session)
+
+    with caplog.at_level(logging.WARNING, logger="goldfive.steerer"):
+        # timeout=0.0 → wait_for raises TimeoutError immediately even
+        # if the gather wins the race in the same instant.
+        await steerer.shutdown(timeout=0.0)
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "exceeded" in r.getMessage()
+    ]
+    if warnings:
+        # If a WARNING fired, it must NOT be the misleading "0 tasks"
+        # variant — that's the regression we're guarding against.
+        for rec in warnings:
+            assert "0 background judge task(s)" not in rec.getMessage(), (
+                "shutdown WARNING regressed to 'cancelled 0 tasks' shape; "
+                f"got {rec.getMessage()!r}"
+            )
+
+
 # ---------------------------------------------------------------------------
 # Phase 1 of goldfive#271 — extended verdict (focused_task_id)
 # ---------------------------------------------------------------------------

--- a/tests/test_wrap_adk.py
+++ b/tests/test_wrap_adk.py
@@ -419,6 +419,116 @@ async def test_run_async_impl_without_on_run_end_plugins_still_works(
 
 
 # ---------------------------------------------------------------------------
+# Phase 2.X / goldfive#271 Gap 3: per-turn judge drain is bounded tightly
+# ---------------------------------------------------------------------------
+
+
+async def test_per_turn_drain_uses_short_timeout_not_runner_close_default(
+    stub_call_llm: Any,
+) -> None:
+    """``_drain_steerer_background_judges`` passes the
+    :data:`GoldfiveADKAgent._PER_TURN_DRAIN_TIMEOUT_S` to
+    ``Steerer.shutdown`` so a slow judge can't stall ADK's iterator
+    exit for the full :meth:`Steerer.shutdown` default (5s).
+
+    Validation E2E (session 95ecda4c) saw the residual #275-style
+    stale-session race after the per-turn drain held ADK's outer
+    loop for 5s while a concurrent ``/run_sse`` invocation advanced
+    the SQLite session. Tightening the per-turn timeout to 0.5s
+    bounds the race window.
+    """
+    from unittest.mock import AsyncMock
+
+    from goldfive import InvocationResult, SequentialExecutor
+
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    # Spy the steerer's shutdown to capture the timeout argument.
+    captured_timeouts: list[float | None] = []
+
+    async def _spy_shutdown(*args: Any, **kwargs: Any) -> None:
+        captured_timeouts.append(kwargs.get("timeout"))
+
+    wrapped.runner.steerer.shutdown = _spy_shutdown  # type: ignore[method-assign]
+
+    ctx = _FakeCtx("do a thing")
+    [evt async for evt in wrapped._run_async_impl(ctx)]
+
+    assert captured_timeouts, (
+        "_drain_steerer_background_judges did not call steerer.shutdown"
+    )
+    timeout = captured_timeouts[0]
+    assert timeout is not None, (
+        "per-turn drain must pass an explicit timeout (got None)"
+    )
+    # Tight enough that a 5s shutdown can't blow it open. We assert
+    # well under 1s as the regression bound.
+    assert timeout <= 1.0, (
+        f"per-turn drain timeout regressed to {timeout!r}; expected <= 1s"
+    )
+
+
+async def test_per_turn_drain_falls_back_when_steerer_shutdown_lacks_timeout(
+    stub_call_llm: Any,
+) -> None:
+    """Custom Steerers without the ``timeout=`` kwarg fall through to
+    the legacy default-call shape. This is the back-compat path for
+    third-party Steerers that haven't been updated for the per-turn
+    timeout knob.
+    """
+    from unittest.mock import AsyncMock
+
+    from goldfive import InvocationResult, SequentialExecutor
+
+    inner = _mk_inner()
+    wrapped = goldfive.wrap(
+        inner,
+        planner=_one_task_planner(),
+        sinks=[InMemorySink()],
+    )
+
+    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text="ok")
+
+    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
+    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
+
+    # Old-shape shutdown: no timeout kwarg, raises TypeError when one
+    # is passed. The drain helper must catch the TypeError and retry
+    # with no kwargs.
+    call_log: list[str] = []
+
+    async def _legacy_shutdown() -> None:
+        call_log.append("no-kwargs")
+
+    async def _entry_shutdown(*args: Any, **kwargs: Any) -> None:
+        if kwargs:
+            raise TypeError("legacy shutdown takes no kwargs")
+        call_log.append("entry")
+        await _legacy_shutdown()
+
+    wrapped.runner.steerer.shutdown = _entry_shutdown  # type: ignore[method-assign]
+
+    ctx = _FakeCtx("do a thing")
+    [evt async for evt in wrapped._run_async_impl(ctx)]
+
+    # The fallthrough call shape (no kwargs) was reached after the
+    # initial timeout-kwarg call raised TypeError.
+    assert "entry" in call_log
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Phase 2.X / Gap 3 of goldfive#271. Closes the residual #275-style stale-session race observed at 14:33:03 in the validation E2E (session 95ecda4c-16de-41f6-bbd7-cce16106bf73). Phase 2.0 (#280) fixed the bridge-write path; this PR fixes the long per-turn drain that interacts badly with ADK's optimistic-concurrency session locking.

## Root cause

`_drain_steerer_background_judges` called `Steerer.shutdown()` with the default 5s timeout. ADK's `_exec_with_plugin` blocks on `__anext__` while the generator's `finally` block runs, so the per-turn drain held ADK's outer iterator for up to 5s. ADK does NOT serialize concurrent `/run_sse` requests on the same session; a turn arriving during the drain can advance the SQLite session's `update_time`, leaving the blocked turn's deferred event appends behind. The race is wider than necessary because the per-turn drain is observability cleanup — it doesn't need 5s.

Investigation note: the brief hypothesised the steerer's shutdown was flushing events to ADK. It does not; neither does the background judge. The actual goldfive contribution was the 5s blocking window. Tightening the per-turn timeout closes that window.

## Fix

1. Tighten the per-turn drain to 0.5s via `GoldfiveADKAgent._PER_TURN_DRAIN_TIMEOUT_S`. Surviving judges complete on `Runner.close()` (keeps the 5s default for programmatic teardown).
2. Tolerate older `Steerer.shutdown` shapes without the `timeout=` kwarg via a `TypeError` fallback.
3. `Steerer.shutdown` only WARNs when stragglers were ACTUALLY cancelled — the previous unconditional WARN inside the `TimeoutError` branch logged `cancelled 0 tasks` whenever the gather won the race in the same instant the timeout fired. DEBUG line preserves diagnostic visibility.

## Tests

- `test_per_turn_drain_uses_short_timeout_not_runner_close_default` — pins the timeout argument passed to `Steerer.shutdown` from the per-turn drain.
- `test_per_turn_drain_falls_back_when_steerer_shutdown_lacks_timeout` — back-compat path for third-party Steerers.
- `test_shutdown_quiet_when_zero_tasks_actually_cancelled` — pins the steerer-side log noise fix.

LOC: +215 / -7. Test delta: +3. Full suite (1671 tests) green with `GOLDFIVE_STRICT_STATE_OWNERSHIP=1`.

## Test plan

- [x] `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 uv run pytest tests/ -x` (1671 passed)
- [x] `uv run ruff check goldfive/`
- [x] Phase 0 tripwire stays green