### PR TITLE
feat(runner, steerer, sequential): plan-emission observability + run_id audit (#271 Gap 2)

### DIFF
--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -338,6 +338,22 @@ class SequentialExecutor(Executor):
                 current_plan.id != last_plan_id
                 or current_plan.revision_index != last_revision_index
             ):
+                # Phase 2.X / goldfive#271 Gap 2: log the executor-side
+                # detection at INFO so it's clear who emitted this
+                # PlanRevised. Two emitters exist for the same plan
+                # swap (steerer's _emit_plan_revised + this swap
+                # detector); the source is implicit in the call site,
+                # but explicit logs help cross-reference with the
+                # steerer's INFO line.
+                log.info(
+                    "SequentialExecutor: plan-swap detected, emitting "
+                    "PlanRevised plan_id=%s revision_index=%d "
+                    "(prior=%s) drift_kind=%s",
+                    (current_plan.id or "")[:16] or "<empty>",
+                    int(current_plan.revision_index),
+                    last_plan_id[:16] if last_plan_id else "<none>",
+                    current_plan.revision_kind or "<none>",
+                )
                 await emit(
                     sinks,
                     plan_revised_event(

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -1263,6 +1263,35 @@ class Runner:
         await emit(self.sinks, evt)
 
     async def _emit_plan_submitted(self, session: Session, plan: Any) -> None:
+        # Phase 2.X / goldfive#271 Gap 2: log every plan emission at
+        # INFO so a silent plan-creation regression (validation E2E
+        # found 2 of 4 task_plans rows without corresponding events)
+        # is observable in the demo log. Pair this with the
+        # invariant assertion below — empty run_id / plan_id at
+        # emission time is the precondition harmonograf#197 gated on
+        # the ingest side, so flag it loudly here too.
+        plan_id = (getattr(plan, "id", "") or "")[:16] or "<empty>"
+        if not session.run_id:
+            log.warning(
+                "Runner._emit_plan_submitted: empty run_id for plan_id=%s — "
+                "harmonograf will drop both the audit row AND the task_plans "
+                "dispatch (harmonograf#197 gate); this would silently lose "
+                "the plan",
+                plan_id,
+            )
+        if not getattr(plan, "id", ""):
+            log.warning(
+                "Runner._emit_plan_submitted: empty plan_id on plan with "
+                "%d task(s) — harmonograf will drop the task_plans row "
+                "(no upsert key); this would silently lose the plan",
+                len(getattr(plan, "tasks", None) or ()),
+            )
+        log.info(
+            "Runner._emit_plan_submitted: plan_id=%s tasks=%d run_id=%s",
+            plan_id,
+            len(getattr(plan, "tasks", None) or ()),
+            (session.run_id or "")[:16] or "<empty>",
+        )
         evt = plan_submitted_event(
             run_id=session.run_id,
             sequence=session.next_sequence(),

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -4088,8 +4088,16 @@ class DefaultSteerer:
 
         Preserves the existing ``revision_index`` monotonicity: the new
         plan's index is at least ``old.revision_index + 1``.
+
+        Phase 2.X / goldfive#271 Gap 2: log the install at INFO so the
+        prior_plan_id → revised_plan_id transition is grep-able in the
+        demo log. The validation E2E found 2 of 4 task_plans rows
+        without corresponding plan events; without this log line a
+        silent install (e.g. an exception in ``_emit_plan_revised``
+        right after) leaves no goldfive-side trace of the swap.
         """
         prev = session.plan
+        prior_id = (getattr(prev, "id", "") or "") if prev is not None else ""
         next_index = (prev.revision_index + 1) if prev is not None else 1
         if revised.revision_index < next_index:
             revised.revision_index = next_index
@@ -4099,6 +4107,14 @@ class DefaultSteerer:
             revised.revision_severity = drift.severity.value
         if not revised.revision_reason:
             revised.revision_reason = drift.detail
+        log.info(
+            "DefaultSteerer._apply_revision: prior_plan_id=%s "
+            "revised_plan_id=%s revision_index=%d drift_kind=%s",
+            prior_id[:16] or "<none>",
+            (revised.id or "")[:16] or "<empty>",
+            int(revised.revision_index),
+            drift.kind.value,
+        )
         # goldfive#199: stamp the trigger_event_id from the drift onto the
         # plan so out-of-band PlanRevised emitters (the SequentialExecutor's
         # plan-swap detector) can thread it through without needing the
@@ -4841,6 +4857,38 @@ class DefaultSteerer:
             )
             evt.plan_revised.refine_output_summary = self._build_refine_output_summary(revised)
             evt.plan_revised.target_agent_id = drift.current_agent_id or ""
+            # Phase 2.X / goldfive#271 Gap 2: log the emission so a
+            # raise-mid-fire scenario (proto build OK, sink emit raises)
+            # leaves a goldfive-side trace before the harmonograf side
+            # observes the gap. Pair with the warning on empty
+            # plan_id / run_id below — those are the harmonograf#197
+            # gate preconditions.
+            plan_id_short = (revised.id or "")[:16] or "<empty>"
+            run_id_short = (session.run_id or "")[:16] or "<empty>"
+            if not session.run_id:
+                log.warning(
+                    "DefaultSteerer._emit_plan_revised: empty run_id for "
+                    "plan_id=%s — harmonograf will drop both the audit "
+                    "row AND the task_plans dispatch (harmonograf#197 "
+                    "gate); this would silently lose the revision",
+                    plan_id_short,
+                )
+            if not revised.id:
+                log.warning(
+                    "DefaultSteerer._emit_plan_revised: empty plan_id on "
+                    "revised plan — harmonograf will drop the task_plans "
+                    "row (no upsert key); this would silently lose the "
+                    "revision",
+                )
+            log.info(
+                "DefaultSteerer._emit_plan_revised: plan_id=%s "
+                "revision_index=%d drift_kind=%s severity=%s run_id=%s",
+                plan_id_short,
+                int(revised.revision_index),
+                drift.kind.value,
+                drift.severity.value,
+                run_id_short,
+            )
             await self._emit(evt)
             # goldfive#251 R4 — every per-task status change carried by the
             # refine (e.g. ``_force_looper_failed`` stamping FAILED on the

--- a/tests/test_runner_user_steer_routing.py
+++ b/tests/test_runner_user_steer_routing.py
@@ -532,3 +532,159 @@ async def test_gate_verdict_logs_at_info_for_operator_visibility(
     assert any(
         "stashed prior plan for next turn's gate" in m for m in messages
     ), f"expected _last_plan stash log; got: {messages!r}"
+
+
+# ---------------------------------------------------------------------------
+# 5. Phase 2.X / Gap 2: plan emission INFO logs (silent-plan observability)
+# ---------------------------------------------------------------------------
+
+
+async def test_plan_submitted_emit_logs_at_info(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``Runner._emit_plan_submitted`` logs the plan_id, task count, and
+    run_id at INFO. Without it, a silent-plan regression (validation
+    E2E found 2 of 4 task_plans rows without corresponding events) is
+    only visible by querying the harmonograf DB after the fact.
+    """
+    # NOTE: LLMPlanner ignores the JSON's ``id`` field and mints a
+    # fresh uuid; we assert on the task count + non-empty plan_id
+    # rather than the literal id string.
+    turn1_plan = json.dumps(
+        {
+            "id": "plan-log-emit",
+            "summary": "first plan",
+            "tasks": [
+                {"id": "t1", "title": "T1", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+    planner = LLMPlanner(
+        call_llm=_planner_call_llm_factory(
+            turn1_plan=turn1_plan,
+            turn2_verdict="new_work",
+            refined_plan=None,
+        ),
+        model="stub",
+    )
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    with caplog.at_level(logging.INFO, logger="goldfive.runner"):
+        await runner.run("first turn")
+        await runner.close()
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    submitted_lines = [
+        m for m in messages
+        if "Runner._emit_plan_submitted" in m
+    ]
+    assert submitted_lines, (
+        f"expected Runner._emit_plan_submitted INFO log; got: {messages!r}"
+    )
+    # The LLMPlanner mints its own uuid; assert that task count + run_id
+    # are present and a non-empty plan_id was logged.
+    assert any("tasks=1" in m for m in submitted_lines), (
+        f"tasks=1 missing from emit log; got: {submitted_lines!r}"
+    )
+    assert any("run_id=" in m and "<empty>" not in m for m in submitted_lines), (
+        f"run_id missing/empty in emit log; got: {submitted_lines!r}"
+    )
+    # plan_id is a hex-snippet, but it must be non-empty.
+    assert all("plan_id=<empty>" not in m for m in submitted_lines), (
+        f"plan_id flagged empty; got: {submitted_lines!r}"
+    )
+
+
+async def test_plan_revised_emit_logs_at_info(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``DefaultSteerer._emit_plan_revised`` logs the plan_id,
+    revision_index, drift_kind, and severity at INFO. Same rationale
+    as the PlanSubmitted log — silent revisions on the validation E2E
+    were only visible via DB inspection.
+    """
+    turn1_plan = json.dumps(
+        {
+            "id": "plan-rev-log",
+            "summary": "first plan",
+            "tasks": [
+                {"id": "t1", "title": "T1", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+    refined_plan = json.dumps(
+        {
+            "id": "plan-rev-log",
+            "summary": "revised plan",
+            "tasks": [
+                {
+                    "id": "t1",
+                    "title": "T1",
+                    "assignee_agent_id": "writer",
+                    "status": "COMPLETED",
+                },
+                {"id": "t2", "title": "T2 (steer)", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+    planner = LLMPlanner(
+        call_llm=_planner_call_llm_factory(
+            turn1_plan=turn1_plan,
+            turn2_verdict="refine_existing",
+            refined_plan=refined_plan,
+        ),
+        model="stub",
+    )
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    with caplog.at_level(logging.INFO):
+        await runner.run("first turn")
+        await runner.run("forget first. tell me about second.")
+        await runner.close()
+
+    messages = [rec.getMessage() for rec in caplog.records]
+
+    apply_lines = [
+        m for m in messages
+        if "DefaultSteerer._apply_revision" in m
+    ]
+    assert apply_lines, (
+        f"expected _apply_revision INFO log; got: {messages!r}"
+    )
+    assert any("revised_plan_id=" in m for m in apply_lines), (
+        f"revised_plan_id missing from apply log; got: {apply_lines!r}"
+    )
+    assert any("drift_kind=user_steer" in m for m in apply_lines), (
+        f"drift_kind missing from apply log; got: {apply_lines!r}"
+    )
+    assert any("revision_index=1" in m for m in apply_lines), (
+        f"revision_index missing from apply log; got: {apply_lines!r}"
+    )
+
+    emit_lines = [
+        m for m in messages
+        if "DefaultSteerer._emit_plan_revised" in m
+    ]
+    assert emit_lines, (
+        f"expected _emit_plan_revised INFO log; got: {messages!r}"
+    )
+    assert any("revision_index=1" in m for m in emit_lines), (
+        f"revision_index missing from emit log; got: {emit_lines!r}"
+    )
+    assert any("drift_kind=user_steer" in m for m in emit_lines), (
+        f"drift_kind missing from emit log; got: {emit_lines!r}"
+    )


### PR DESCRIPTION
## Summary

Phase 2.X / Gap 2 of goldfive#271. Validation E2E (session 95ecda4c) reported 2 of 4 task_plans rows without corresponding plan_submitted/plan_revised events on disk. harmonograf#197 fixed the ingest-side gate; this PR closes the goldfive-side observability gap so a future silent-plan regression surfaces in the demo log without DB inspection.

## Investigation

Audited every `session.plan = ...` write site in goldfive (runner, steerer, both executors, persistence sink) and every `put_task_plan` write path in harmonograf. No remaining unguarded leak was found in either codebase. Both sides require a plan_submitted/plan_revised goldfive event with non-empty run_id and plan_id for the harmonograf row to land.

The validation E2E ran with an older harmonograf submodule pin (before #281); follow-up bumps will close the cross-repo gap on the demo side.

## Fix (defence in depth)

1. `Runner._emit_plan_submitted` logs at INFO with plan_id, task count, run_id; WARNs when run_id or plan_id is empty (the exact preconditions harmonograf#197 gates on).
2. `DefaultSteerer._apply_revision` logs the `prior_plan_id` -> `revised_plan_id` transition + drift_kind + revision_index at INFO so the install is grep-able.
3. `DefaultSteerer._emit_plan_revised` logs the emission at INFO with the same WARN guards on empty run_id / plan_id.
4. `SequentialExecutor`'s plan-swap detector logs its PlanRevised emission so the dual-emit case (steerer + executor swap detector) is observable.

## Tests

- `test_plan_submitted_emit_logs_at_info` — pins the runner-side PlanSubmitted log shape.
- `test_plan_revised_emit_logs_at_info` — pins both the `_apply_revision` and `_emit_plan_revised` log shapes for a USER_STEER refine.

LOC: +249. Test delta: +2. Full suite (1673 tests) green with `GOLDFIVE_STRICT_STATE_OWNERSHIP=1`.

A future "silent plan creation" regression will surface as either (a) WARN lines flagging empty run_id / plan_id at the goldfive emit site, or (b) absence of the INFO log line that should have fired. Either way, the operator gets a grep-able trail in `/tmp/demo-validation.log`.

## Test plan

- [x] `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 uv run pytest tests/ -x` (1673 passed)
- [x] `uv run ruff check goldfive/`
- [x] Phase 0 tripwire stays green