### PR TITLE
fix(planner-gate): factual-question heuristic + LLM short-circuit (#271 Gap 4)

### DIFF
--- a/goldfive/planner_gate.py
+++ b/goldfive/planner_gate.py
@@ -127,6 +127,59 @@ def _looks_like_steer(text: str) -> bool:
         return False
     return bool(_STEER_PATTERN_RE.search(text))
 
+
+#: Factual-question regex (Phase 2.X / goldfive#271 Gap 4). Matches the
+#: open-ended interrogative shape of "where/when/how/what/why/which/who"
+#: + "is/will/did/does/are/was/were/have/can" when the question is about
+#: the existing work. Stronger than the bare token-count heuristic — a
+#: 6-token question like "where will the slides be saved?" was being
+#: mis-routed to ``refine_existing`` by the LLM gate. The heuristic
+#: returns ``"conversational"`` for these unconditionally.
+#:
+#: Anchored to start-of-string OR a sentence break so "Tell me more
+#: about where the data is" doesn't false-positive.
+_FACTUAL_QUESTION_RE = re.compile(
+    r"(?:^|[.?!]\s+)(?:"
+    r"where(?:\s+(?:is|are|was|were|will|did|does|do|can|could|should|would|the|am)\b)|"
+    r"when(?:\s+(?:is|are|was|were|will|did|does|do|can|could|should|would|the|am)\b)|"
+    r"how(?:\s+(?:is|are|was|were|will|did|does|do|can|could|should|would|much|many|long|the)\b)|"
+    r"what(?:'s|\s+(?:is|are|was|were|will|did|does|do|can|could|should|would|happened|the))|"
+    r"why(?:\s+(?:is|are|was|were|did|does|do|can|could|should|would|the))|"
+    r"which(?:\s+(?:is|are|was|were|did|does|do|the|one|of))|"
+    r"who(?:'s|\s+(?:is|are|was|were|did|does|do|the))|"
+    r"can\s+you\s+(?:tell|show|explain|describe|list)|"
+    r"could\s+you\s+(?:tell|show|explain|describe|list)|"
+    r"did\s+you|"
+    r"is\s+(?:the|it|that|there)|"
+    r"are\s+(?:the|those|there)"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_factual_question(text: str) -> bool:
+    """Return True if ``text`` opens with a factual interrogative.
+
+    Phase 2.X / goldfive#271 Gap 4: the LLM gate misclassified
+    "where will the slides be saved?" as ``refine_existing`` despite
+    the prompt's explicit example of "where did you save the output?"
+    as conversational. The future-tense / "will be" framing tripped
+    the LLM. This heuristic catches the canonical factual-question
+    openers (where/when/how/what/why/which/who + auxiliary verb) and
+    routes them through ``conversational`` deterministically before
+    the LLM gate runs.
+
+    Note: false positives are cheap (a steer phrased as a question
+    just gets answered conversationally — the user can restate),
+    while false negatives (mis-routing a factual question to
+    refine_existing) trigger an unwanted re-plan with sticky-goal
+    side effects. The asymmetry justifies a slightly aggressive
+    pattern.
+    """
+    if not text:
+        return False
+    return bool(_FACTUAL_QUESTION_RE.search(text))
+
 _SYSTEM_PROMPT = """\
 You are a turn-classifier for a multi-agent orchestration system.
 
@@ -143,11 +196,30 @@ Verdicts:
   plan did not produce.
 
 - "conversational": the new input is a question or clarification
-  about work that has ALREADY been done — e.g. "where did you save
-  the output?", "what was the second slide?", "did you use source
-  X?", "summarise what you did". These can be answered from the
+  about work that has ALREADY been done OR a question about the
+  artefact's properties (where it lives, how it works, what it
+  looks like, who made which part). These can be answered from the
   existing plan / completed_results / conversation history without
   running any new tasks.
+
+  Examples (ALL conversational):
+  * "where did you save the output?"
+  * "where will the slides be saved?" (future-tense factual question)
+  * "where is the file located?"
+  * "what was the second slide?" / "what was the title?"
+  * "what is this about?" / "what does it do?"
+  * "did you use source X?" / "did you include Y?"
+  * "is the presentation done?" / "is it ready?"
+  * "how does the slideshow work?" / "how do I open it?"
+  * "summarise what you did"
+  * "tell me more about X" (X already covered by the plan)
+  * "can you explain how Y works"
+
+  Future tense ("will be"), present continuous, AND past tense are
+  all conversational when the question targets the prior plan or
+  its outputs. The grammatical tense does NOT change the bucket —
+  what matters is whether the question can be ANSWERED without
+  running new tasks.
 
 - "refine_existing": the new input tweaks, extends, or revises the
   PRIOR PLAN — e.g. "make it funnier", "add a slide about Z",
@@ -166,6 +238,13 @@ Verdicts:
   drops them.
 
 Guidelines:
+- Factual interrogatives that open with where/when/how/what/why/
+  which/who + a state verb (is/are/will/did/does/was/were/can/could)
+  are conversational by default — they ask about prior state, not
+  request new work. Only classify them as refine_existing when the
+  question contains an EXPLICIT directive ("can you ALSO add a
+  slide about X?", "what if we changed the title?") — a bare
+  question is just a question.
 - When in doubt between "conversational" and "refine_existing",
   prefer "conversational" — the coordinator can always answer and
   the user can restate if they actually wanted new work.
@@ -273,6 +352,14 @@ def heuristic_classify_turn(
       ``"conversational"`` (short input) or ``"new_work"`` (long
       input), both of which silently lost the constraints — see
       goldfive#270 E2E.
+    - Prior plan exists AND :func:`_looks_like_factual_question`
+      matches → ``"conversational"``. Factual interrogatives ("where
+      will", "how does", "did you", "what is") are nearly always
+      asking about prior work. Phase 2.X (goldfive#271 Gap 4)
+      regression: "where will the slides be saved?" was mis-routed
+      to ``refine_existing`` by the LLM gate despite the prompt's
+      explicit example. Catching it heuristically routes around the
+      LLM uncertainty.
     - Prior plan exists AND user_input is short (``< 20`` tokens) →
       ``"conversational"``. Short follow-ups that AREN'T steer-shaped
       are overwhelmingly questions about prior work.
@@ -287,6 +374,8 @@ def heuristic_classify_turn(
         return "new_work"
     if _looks_like_steer(user_input):
         return "refine_existing"
+    if _looks_like_factual_question(user_input):
+        return "conversational"
     if _token_count(user_input) < _HEURISTIC_SHORT_TOKEN_BUDGET:
         return "conversational"
     return "new_work"
@@ -329,6 +418,31 @@ async def classify_turn(
             user_input=user_input,
             conversation_id=conversation_id,
         )
+
+    # Phase 2.X / goldfive#271 Gap 4: heuristic short-circuit for the
+    # two patterns where the LLM has historically misclassified —
+    # explicit steer language and explicit factual interrogatives.
+    # Both patterns are unambiguous; running the LLM for them just
+    # adds latency and risks a wrong answer ("where will the slides
+    # be saved?" got refine_existing in the validation E2E).
+    #
+    # Falls through to the LLM only when the heuristic returns
+    # ``"new_work"`` — that's the broad "no signal" bucket where the
+    # LLM's nuance pays off.
+    if _looks_like_steer(user_input):
+        log.info(
+            "planner_gate.classify_turn: heuristic short-circuit "
+            "(steer pattern) -> refine_existing; user_input_first=%r",
+            user_input[:80],
+        )
+        return "refine_existing"
+    if _looks_like_factual_question(user_input):
+        log.info(
+            "planner_gate.classify_turn: heuristic short-circuit "
+            "(factual question) -> conversational; user_input_first=%r",
+            user_input[:80],
+        )
+        return "conversational"
 
     user_prompt = _build_user_prompt(
         prior_plan=prior_plan,

--- a/tests/test_planner_gate.py
+++ b/tests/test_planner_gate.py
@@ -292,3 +292,166 @@ async def test_classify_turn_llm_raising_falls_back_to_heuristic() -> None:
         conversation_id="c1",
     )
     assert verdict == "new_work"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2.X / goldfive#271 Gap 4: factual-question short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_heuristic_factual_question_routes_conversational() -> None:
+    """Phase 2.X (goldfive#271 Gap 4): factual interrogatives that
+    open with where/when/how/what/why/which/who + auxiliary verb route
+    through ``conversational`` deterministically, not via the
+    token-count fallback alone.
+
+    The validation E2E saw "where will the slides be saved?" mis-routed
+    to ``refine_existing`` by the LLM gate. The heuristic catches it
+    before the LLM runs.
+    """
+    factual_questions = [
+        "where will the slides be saved?",  # the validation regression
+        "where is the file located?",
+        "where are the outputs?",
+        "when did you finish the deck?",
+        "when will it be done?",
+        "how does the slideshow work?",
+        "how do I open the file?",
+        "how many slides does it have?",
+        "what is the title of the deck?",
+        "what's the second slide about?",
+        "what was the source you used?",
+        "why did you pick that title?",
+        "which template did you use?",
+        "who wrote the second slide?",
+        "did you include the cost slide?",
+        "is the presentation done?",
+        "are the slides ready?",
+        "can you tell me where it lives?",
+        "could you explain the structure?",
+    ]
+    for ui in factual_questions:
+        verdict = heuristic_classify_turn(
+            prior_plan=_prior_plan(),
+            completed_results={},
+            user_input=ui,
+        )
+        assert verdict == "conversational", (
+            f"factual question {ui!r} should route conversational; "
+            f"got {verdict!r}"
+        )
+
+
+def test_heuristic_factual_question_does_not_match_steer_phrasing() -> None:
+    """Phrases with ``where``/``when``/``how`` that ARE steers must NOT
+    match the factual-question heuristic — the steer regex runs first
+    and wins.
+    """
+    # "switch to" is a steer pattern; "where would..." is conditional.
+    # The first sentence is a steer; the heuristic returns refine_existing.
+    verdict = heuristic_classify_turn(
+        prior_plan=_prior_plan(),
+        completed_results={},
+        user_input="switch to a different topic. where do we start?",
+    )
+    assert verdict == "refine_existing", (
+        f"steer-then-question should still route refine_existing; got {verdict!r}"
+    )
+
+
+def test_heuristic_factual_question_requires_prior_plan() -> None:
+    """First turn (no prior plan) still returns ``new_work`` even on a
+    factual-question opener — there's nothing to ask about yet.
+    """
+    verdict = heuristic_classify_turn(
+        prior_plan=None,
+        completed_results={},
+        user_input="where is it?",
+    )
+    assert verdict == "new_work"
+
+
+async def test_classify_turn_factual_question_short_circuits_llm() -> None:
+    """The LLM gate is bypassed when the user message matches the
+    factual-question heuristic. Pre-Phase-2.X the LLM was always
+    consulted; the validation E2E showed it returning ``refine_existing``
+    for "where will the slides be saved?". Short-circuiting the LLM
+    eliminates the regression path.
+    """
+    llm_calls: list[tuple[str, str, str]] = []
+
+    async def _llm(system: str, user: str, model: str) -> str:
+        llm_calls.append((system, user, model))
+        # If the LLM IS called, it would return refine_existing — the
+        # validation regression. The heuristic must intercept BEFORE
+        # the LLM gets the chance.
+        return json.dumps({"verdict": "refine_existing", "reason": "wrong"})
+
+    verdict = await classify_turn(
+        call_llm=_llm,
+        prior_plan=_prior_plan(),
+        completed_results={"t1": "facts"},
+        user_input="where will the slides be saved?",
+        conversation_id="c1",
+    )
+    assert verdict == "conversational", (
+        f"factual question should route conversational without LLM; "
+        f"got {verdict!r}"
+    )
+    assert llm_calls == [], (
+        "LLM was called despite factual-question heuristic short-circuit; "
+        "the regression path is open"
+    )
+
+
+async def test_classify_turn_steer_language_short_circuits_llm() -> None:
+    """The LLM gate is also bypassed for steer-language openers — same
+    rationale as the factual-question short-circuit. The LLM was prone
+    to misclassifying topic pivots as ``new_work`` (silently dropping
+    sticky constraints), so explicit steer language routes to
+    ``refine_existing`` deterministically.
+    """
+    llm_calls: list[tuple[str, str, str]] = []
+
+    async def _llm(system: str, user: str, model: str) -> str:
+        llm_calls.append((system, user, model))
+        return json.dumps({"verdict": "new_work", "reason": "wrong"})
+
+    verdict = await classify_turn(
+        call_llm=_llm,
+        prior_plan=_prior_plan(),
+        completed_results={},
+        user_input="forget solar panels. tell me about wind power instead.",
+        conversation_id="c1",
+    )
+    assert verdict == "refine_existing"
+    assert llm_calls == []
+
+
+async def test_classify_turn_falls_through_to_llm_for_ambiguous_input() -> None:
+    """Inputs that match neither the steer nor factual-question
+    heuristic still consult the LLM. This is the "no signal" bucket
+    where the LLM's nuance pays off — refining a request, asking for
+    extension, or making genuinely new work.
+    """
+    llm_calls: list[tuple[str, str, str]] = []
+
+    async def _llm(system: str, user: str, model: str) -> str:
+        llm_calls.append((system, user, model))
+        return json.dumps({"verdict": "refine_existing", "reason": "extends prior"})
+
+    ambiguous = (
+        "please make the deck more colourful and add an extra section "
+        "about cost benefits over a five year horizon"
+    )
+    verdict = await classify_turn(
+        call_llm=_llm,
+        prior_plan=_prior_plan(),
+        completed_results={},
+        user_input=ambiguous,
+        conversation_id="c1",
+    )
+    assert verdict == "refine_existing"
+    assert len(llm_calls) == 1, (
+        f"expected exactly one LLM call for ambiguous input; got {len(llm_calls)}"
+    )


### PR DESCRIPTION
## Summary

Phase 2.X / Gap 4 of goldfive#271. Validation E2E (session 95ecda4c) saw "where will the slides be saved?" misclassified as `refine_existing`, triggering plan #3 with 6 new tasks. The brief explicitly forbade conversational follow-ups producing full re-plans.

## Root cause

The heuristic returned `conversational` (short input, not steer-shaped), but the LLM gate ran on top and overrode with `refine_existing`. The future-tense phrasing ("will be saved") confused the LLM despite the prompt's example of "where did you save the output?". The verdict reached `Runner.run`, which routed through the steerer's USER_STEER pipeline and minted plan #3.

## Fix

1. New `_FACTUAL_QUESTION_RE` matching where/when/how/what/why/which/who + auxiliary verb, plus `can/could you tell|show|explain|describe|list`, `did you`, and `is/are` + locator. Heuristic returns `conversational` for these unconditionally.
2. `classify_turn` short-circuits the LLM when the steer pattern OR factual-question pattern matches. The LLM is consulted only for the broad "no signal" bucket where its nuance pays off. Both regression patterns (steer → `new_work` mis-route, factual question → `refine_existing` mis-route) are now off-LLM-path.
3. LLM prompt strengthened with explicit factual-question examples spanning future tense, present continuous, past tense, and `can you tell me` framing, plus a guideline that grammatical tense does not change the bucket.

## Tests

- `test_heuristic_factual_question_routes_conversational` — 19 distinct factual-question shapes.
- `test_heuristic_factual_question_does_not_match_steer_phrasing` — "steer wins over question" precedence.
- `test_heuristic_factual_question_requires_prior_plan` — first-turn invariant.
- `test_classify_turn_factual_question_short_circuits_llm` / `test_classify_turn_steer_language_short_circuits_llm` — LLM-bypass paths.
- `test_classify_turn_falls_through_to_llm_for_ambiguous_input` — no-signal LLM consult.

LOC: +280 / -3. Test delta: +6. Full suite (1679 tests) green with `GOLDFIVE_STRICT_STATE_OWNERSHIP=1`.

## Test plan

- [x] `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 uv run pytest tests/ -x` (1679 passed)
- [x] `uv run ruff check goldfive/`
- [x] Phase 0 tripwire stays green