### PR TITLE
fix(planner, steerer): preserve goal qualifications across user steers (#271 Gap 5)

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -2937,6 +2937,16 @@ class LLMPlanner:
     #: classify whether the steer is additive (APPEND) or a
     #: scrap-and-pivot (REPLACE). Keep the shape tight so a minimal
     #: response is enough.
+    #:
+    #: Phase 2.X (goldfive#271 Gap 5): when prior goals are supplied
+    #: in the user prompt, the LLM is instructed to MERGE persistent
+    #: qualifications (numeric caps, format requirements, output
+    #: structure) into the new goal so a topic pivot doesn't drop
+    #: sticky context. The validation E2E observed "Create a
+    #: presentation about solar panels with no more than 2 slides."
+    #: → after steer → "Provide informative content about solar
+    #: flares." (both the "presentation" frame AND the "2 slides"
+    #: cap dropped). This guidance closes that gap.
     _SYNTHESIZE_GOAL_SYSTEM_PROMPT: str = (
         "You are a goal extractor for a multi-agent orchestration system. "
         "A human operator has just issued a STEERING directive mid-run. "
@@ -2954,14 +2964,41 @@ class LLMPlanner:
         "- Use 'append' when the steer adds a new concern alongside "
         "existing goals (e.g. 'also include X', 'while you're at it, Y').\n"
         "- The id should be short (<=16 chars) and unique-looking; "
-        "'steer' is an acceptable default when no better label fits."
+        "'steer' is an acceptable default when no better label fits.\n"
+        "- When PRIOR GOALS are listed in the user prompt, MERGE their "
+        "persistent qualifications into the new goal summary unless the "
+        "steer explicitly removes them. Persistent qualifications are: "
+        "numeric caps ('no more than 2 slides', 'at most 500 words', "
+        "'under 5 minutes'), format requirements ('in markdown', 'as "
+        "bullet points', 'as a 2-slide presentation'), output type "
+        "('a presentation', 'a report', 'a summary'), and scope "
+        "qualifiers ('for a non-technical audience', 'only public "
+        "data'). The topic / subject changes; the structural frame "
+        "carries forward. Example: prior goal 'Create a presentation "
+        "about solar panels with no more than 2 slides.' + steer "
+        "'forget solar panels — tell me about wind power instead' → "
+        "new goal 'Create a presentation about wind power with no "
+        "more than 2 slides.' (NOT 'Provide content about wind "
+        "power.').\n"
+        "- Drop a qualification only when the steer explicitly removes "
+        "it (e.g. 'forget the slide-count cap', 'no longer needs to be "
+        "a presentation')."
     )
 
     async def synthesize_goal_from_steer(
         self,
         steer_body: str,
+        prior_goals: list[Goal] | None = None,
     ) -> tuple[Goal, str] | None:
         """Synthesize a ``Goal`` from a USER_STEER body via one LLM call.
+
+        ``prior_goals`` (Phase 2.X / goldfive#271 Gap 5) is the live
+        ``session.goals`` list. When non-empty, the LLM is instructed
+        to merge persistent qualifications (numeric caps, format
+        requirements, output type, scope qualifiers) into the new
+        goal summary so a topic pivot preserves sticky context. The
+        steerer's ``_apply_user_steer_state`` passes the pre-steer
+        goals here.
 
         Returns ``(goal, mode)`` where ``mode`` is ``"append"`` or
         ``"replace"``. Returns ``None`` on LLM error / parse failure so
@@ -2978,7 +3015,22 @@ class LLMPlanner:
         body = (steer_body or "").strip()
         if not body:
             return None
+        prior_block = ""
+        if prior_goals:
+            prior_summaries = [
+                g.summary.strip() for g in prior_goals
+                if g.summary and g.summary.strip()
+            ]
+            if prior_summaries:
+                prior_block = (
+                    "PRIOR GOALS (preserve their persistent "
+                    "qualifications unless the steer explicitly removes "
+                    "them):\n"
+                    + "\n".join(f"- {s}" for s in prior_summaries)
+                    + "\n\n"
+                )
         user_prompt = (
+            f"{prior_block}"
             f"STEERING DIRECTIVE:\n{body}\n\n"
             "Extract the durable Goal and classify the mode. Reply JSON only."
         )

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -105,6 +105,233 @@ __all__ = [
 ]
 
 
+# Phase 2.X / goldfive#271 Gap 5 — persistent qualification patterns.
+#
+# When a USER_STEER pivots the topic, the LLM's synthesised goal often
+# drops sticky qualifications from the prior goal (numeric caps, format
+# requirements, output type). The validation E2E observed:
+#
+#   prior:  "Create a presentation about solar panels with no more
+#            than 2 slides."
+#   after:  "Provide informative content about solar flares."  (BAD)
+#   wanted: "Create a presentation about solar flares with no more
+#            than 2 slides."
+#
+# These regexes pick out canonical qualifications from the prior goal's
+# summary so :func:`_merge_prior_qualifications_into_goal` can append
+# them to a synth goal that didn't already include them.
+_NUMERIC_CAP_RE = re.compile(
+    r"\b("
+    r"(?:no\s+more\s+than|at\s+most|up\s+to|under|fewer\s+than|less\s+than|"
+    r"exactly|only|just)\s+\d+\s+\w+"
+    r"|\d+\s+(?:or\s+fewer|or\s+less)"
+    r")\b",
+    re.IGNORECASE,
+)
+_FORMAT_HINT_RE = re.compile(
+    r"\b("
+    r"in\s+(?:markdown|html|json|yaml|plain\s+text|bullet\s+points|prose)"
+    r"|as\s+(?:bullet\s+points|a\s+(?:list|table|presentation|report|"
+    r"summary|essay|outline))"
+    r")\b",
+    re.IGNORECASE,
+)
+_OUTPUT_TYPE_RE = re.compile(
+    r"\b(?:create|build|make|write|generate|draft|prepare|provide)\s+"
+    r"(?:a|an|the)\s+(presentation|report|summary|outline|essay|"
+    r"deck|slide(?:show)?|slides|demo|website|webpage|article|guide|"
+    r"plan)\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_qualifications(text: str) -> list[str]:
+    """Return the canonical qualification phrases present in ``text``.
+
+    Heuristic — looks for the patterns most often dropped on a topic
+    pivot (numeric caps, format hints, output-type framings). Used by
+    :func:`_merge_prior_qualifications_into_goal` to detect what was
+    in the prior goal and is missing from the synthesised one.
+    """
+    if not text:
+        return []
+    out: list[str] = []
+    for m in _NUMERIC_CAP_RE.finditer(text):
+        out.append(m.group(1))
+    for m in _FORMAT_HINT_RE.finditer(text):
+        out.append(m.group(1))
+    return out
+
+
+def _extract_output_type(text: str) -> str:
+    """Return the canonical output type phrase from ``text`` if any.
+
+    e.g. "Create a presentation about solar panels..." → "presentation".
+    Returns the matched output-type noun (lowercased) or ``""`` when no
+    output-type framing is present.
+    """
+    if not text:
+        return ""
+    m = _OUTPUT_TYPE_RE.search(text)
+    return m.group(1).lower() if m else ""
+
+
+def _looks_like_explicit_removal(steer_body: str, qualification: str) -> bool:
+    """Return True when ``steer_body`` explicitly removes ``qualification``.
+
+    Pattern: the steer says "no longer", "drop", "remove", "forget the",
+    or "without" near the qualification's keywords. Conservative —
+    a false negative just preserves a qualification the user wanted
+    dropped (the user can restate); a false positive (preserving when
+    they wanted dropped) is the actual regression we're guarding against.
+    """
+    if not steer_body or not qualification:
+        return False
+    body_lower = steer_body.lower()
+    qual_lower = qualification.lower()
+    # Pull out a "core" keyword from the qualification — first noun-ish
+    # word (skip the cap leader like "no more than"). For "no more than
+    # 2 slides" the core is "slides"; for "in markdown" it's "markdown".
+    parts = qual_lower.split()
+    core = parts[-1] if parts else qual_lower
+    # Look for explicit removal verbs near the core keyword.
+    removal_re = re.compile(
+        r"\b(?:no\s+longer|drop|remove|forget|without|skip)\b[^.]*\b"
+        + re.escape(core)
+        + r"\b",
+        re.IGNORECASE,
+    )
+    return bool(removal_re.search(body_lower))
+
+
+def _merge_prior_qualifications_into_goal(
+    synth_goal: Goal,
+    prior_goals: list[Goal],
+    *,
+    steer_body: str = "",
+) -> Goal:
+    """Augment ``synth_goal`` with prior-goal qualifications it dropped.
+
+    Phase 2.X / goldfive#271 Gap 5 safety net. The LLM synthesizer is
+    instructed to merge qualifications via the system prompt, but
+    will sometimes drop them anyway. This deterministic post-process
+    re-attaches:
+
+    * **Numeric caps** ("no more than 2 slides", "at most 500 words",
+      "under 5 minutes").
+    * **Format hints** ("in markdown", "as bullet points", "as a
+      report").
+    * **Output type** ("a presentation", "a report") — preserved by
+      rewriting the verb-phrase prefix when the synth goal opens with
+      a generic "provide content" / "give information" framing.
+
+    A qualification is dropped from the merge when the steer body
+    explicitly removes it (see :func:`_looks_like_explicit_removal`).
+    Otherwise it's appended to the synth goal's summary if missing.
+
+    Returns a NEW :class:`Goal` (mutating the input would surprise
+    callers that hold the synth result for logging).
+    """
+    if not prior_goals or synth_goal is None:
+        return synth_goal
+    summary = synth_goal.summary or ""
+    summary_lower = summary.lower()
+    # Collect qualifications across all prior goals, dedup by lowercased
+    # text (preserving first-encountered casing).
+    seen: set[str] = set()
+    new_qualifications: list[str] = []
+    new_output_type = ""
+    for g in prior_goals:
+        if not g.summary:
+            continue
+        for q in _extract_qualifications(g.summary):
+            q_lower = q.lower()
+            if q_lower in seen:
+                continue
+            if q_lower in summary_lower:
+                seen.add(q_lower)
+                continue
+            if _looks_like_explicit_removal(steer_body, q):
+                seen.add(q_lower)
+                continue
+            seen.add(q_lower)
+            new_qualifications.append(q)
+        # Output-type framing — only adopt the FIRST prior goal's type
+        # (multiple priors with different types would rather wait for
+        # the user to restate; this is a conservative default).
+        if not new_output_type:
+            ot = _extract_output_type(g.summary)
+            if (
+                ot
+                and ot not in summary_lower
+                and not _looks_like_explicit_removal(steer_body, ot)
+            ):
+                new_output_type = ot
+    if not new_qualifications and not new_output_type:
+        return synth_goal
+    # Build the merged summary. The output-type rewrite tries to keep
+    # the steer's topic intact while restoring the prior framing —
+    # "Provide content about solar flares" → "Create a presentation
+    # about solar flares". Heuristic: replace a leading generic verb
+    # phrase ("provide", "give", "tell me about", "share") with
+    # "Create a/an <output_type> about" when the synth's summary
+    # opens that way.
+    merged_summary = summary
+    if new_output_type:
+        merged_summary = _rewrite_output_type_prefix(merged_summary, new_output_type)
+    if new_qualifications:
+        # Strip any trailing punctuation, append the qualifications
+        # joined with " ", and reapply a terminal period.
+        trimmed = merged_summary.rstrip(" .!?")
+        joined = " ".join(new_qualifications)
+        # Use "with" as the connective; matches the prior goal's phrasing
+        # in the canonical example. If "with" already appears in the
+        # synth, fall back to ", ".
+        connective = ", " if " with " in trimmed.lower() else " with "
+        merged_summary = f"{trimmed}{connective}{joined}."
+    log.info(
+        "DefaultSteerer: merged %d qualification(s) and output_type=%r "
+        "from prior goals into synth goal (was=%r, now=%r)",
+        len(new_qualifications),
+        new_output_type,
+        summary,
+        merged_summary,
+    )
+    return Goal(id=synth_goal.id, summary=merged_summary)
+
+
+_GENERIC_VERB_PREFIX_RE = re.compile(
+    r"^\s*(?P<verb>provide|give|share|tell\s+me|tell\s+us|describe|"
+    r"summarise|summarize|explain|present)\s+(?:me\s+|us\s+)?"
+    r"(?P<filler>(?:with\s+|the\s+)?(?:informative\s+|relevant\s+|some\s+|"
+    r"useful\s+|detailed\s+)?content\s+|some\s+information\s+|"
+    r"information\s+|details\s+|an?\s+overview\s+|details\s+)?"
+    r"(?:about\s+|on\s+|of\s+|regarding\s+)?",
+    re.IGNORECASE,
+)
+
+
+def _rewrite_output_type_prefix(summary: str, output_type: str) -> str:
+    """Rewrite a generic "provide content" prefix to "Create a <output_type> about".
+
+    Phase 2.X / goldfive#271 Gap 5 helper. Used by
+    :func:`_merge_prior_qualifications_into_goal` to preserve the
+    prior goal's output-type framing when the synth goal dropped it.
+    Returns the original summary unchanged when no generic prefix is
+    detected — the prior framing only re-applies when the synth used
+    one of the dropping forms.
+    """
+    if not summary or not output_type:
+        return summary
+    article = "an" if output_type[:1] in "aeiouAEIOU" else "a"
+    new_prefix = f"Create {article} {output_type} about "
+    m = _GENERIC_VERB_PREFIX_RE.match(summary)
+    if not m:
+        return summary
+    rest = summary[m.end():]
+    return new_prefix + rest
+
+
 class InterventionLevel(enum.IntEnum):
     """The graduated intervention ladder (goldfive#142).
 
@@ -3643,9 +3870,22 @@ class DefaultSteerer:
             # active_steer.* keys still landed (readers may want to know
             # "a steer was fired even if empty"). Keep goals as-is.
             return
-        synth_goal, mode = await self._synthesize_goal_from_steer(body)
+        # Phase 2.X / goldfive#271 Gap 5: snapshot the prior goals so
+        # the synthesizer can merge persistent qualifications into the
+        # new goal. Done BEFORE we mutate session.goals below.
+        prior_goals_snapshot = list(session.goals)
+        synth_goal, mode = await self._synthesize_goal_from_steer(
+            body, prior_goals=prior_goals_snapshot
+        )
         if synth_goal is None:
             return
+        # Heuristic safety net: if the LLM didn't preserve the prior
+        # goals' persistent qualifications, merge them in by pattern
+        # match. Cheap insurance against an LLM that ignored the
+        # MERGE-qualifications guideline in the prompt.
+        synth_goal = _merge_prior_qualifications_into_goal(
+            synth_goal, prior_goals_snapshot, steer_body=body
+        )
         mode_norm = (mode or "append").strip().lower()
         if mode_norm == "replace":
             session.goals.clear()
@@ -3677,8 +3917,15 @@ class DefaultSteerer:
     async def _synthesize_goal_from_steer(
         self,
         steer_body: str,
+        prior_goals: list[Goal] | None = None,
     ) -> tuple[Goal | None, str]:
         """Call ``planner.synthesize_goal_from_steer`` if available.
+
+        ``prior_goals`` (Phase 2.X / goldfive#271 Gap 5) is forwarded
+        to the planner so it can merge persistent qualifications
+        (numeric caps, format requirements) into the synthesised goal.
+        Older planners that don't accept the parameter fall through
+        via a TypeError catch.
 
         Returns ``(goal, mode)`` where ``mode`` is ``"append"`` or
         ``"replace"``. Falls back to a passthrough goal (APPEND) when
@@ -3692,7 +3939,21 @@ class DefaultSteerer:
         if not callable(synth):
             return Goal(id="steer", summary=steer_body), "append"
         try:
-            result = await synth(steer_body)
+            result = await synth(steer_body, prior_goals=prior_goals)
+        except TypeError:
+            # Older planners that don't accept ``prior_goals`` — fall
+            # through to the legacy single-arg call. The heuristic
+            # qualification-merge in ``_apply_user_steer_state`` is the
+            # safety net for those callers.
+            try:
+                result = await synth(steer_body)
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "DefaultSteerer: planner.synthesize_goal_from_steer raised "
+                    "%s; falling back to passthrough append",
+                    exc,
+                )
+                return Goal(id="steer", summary=steer_body), "append"
         except Exception as exc:  # noqa: BLE001
             log.warning(
                 "DefaultSteerer: planner.synthesize_goal_from_steer raised "

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1543,6 +1543,84 @@ async def test_synthesize_goal_from_steer_defaults_mode_when_invalid() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Phase 2.X / goldfive#271 Gap 5: prior_goals threaded into the prompt
+# ---------------------------------------------------------------------------
+
+
+async def test_synthesize_goal_from_steer_includes_prior_goals_in_prompt() -> None:
+    """Phase 2.X: when ``prior_goals`` is non-empty, the user prompt
+    includes a ``PRIOR GOALS`` block listing each prior summary so the
+    LLM can merge persistent qualifications into the synthesised goal.
+
+    The validation E2E observed prior goal "Create a presentation
+    about solar panels with no more than 2 slides." → after a topic
+    pivot, the synthesised goal lost both the "presentation" frame
+    and the "2 slides" cap.
+    """
+    from goldfive.types import Goal
+
+    scripted = _SynthLLM(
+        json.dumps(
+            {
+                "goal": {
+                    "id": "steer1",
+                    "summary": (
+                        "Create a presentation about wind power with no "
+                        "more than 2 slides."
+                    ),
+                },
+                "mode": "replace",
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    prior = [
+        Goal(
+            id="g1",
+            summary=(
+                "Create a presentation about solar panels with no more "
+                "than 2 slides."
+            ),
+        )
+    ]
+    result = await planner.synthesize_goal_from_steer(
+        "forget solar panels — tell me about wind power instead",
+        prior_goals=prior,
+    )
+    assert result is not None
+
+    _sys, user_prompt, _model = scripted.calls[0]
+    assert "PRIOR GOALS" in user_prompt, (
+        f"PRIOR GOALS block missing from user prompt; got: {user_prompt!r}"
+    )
+    assert "no more than 2 slides" in user_prompt, (
+        f"prior qualification missing; got: {user_prompt!r}"
+    )
+
+
+async def test_synthesize_goal_from_steer_no_prior_goals_block_when_empty() -> None:
+    """Empty / None ``prior_goals`` keeps the original prompt shape —
+    no PRIOR GOALS block. Back-compat for callers that don't pass it.
+    """
+    scripted = _SynthLLM(
+        json.dumps(
+            {
+                "goal": {"id": "steer1", "summary": "x"},
+                "mode": "append",
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    await planner.synthesize_goal_from_steer("a steer", prior_goals=None)
+    _sys, user_prompt, _model = scripted.calls[0]
+    assert "PRIOR GOALS" not in user_prompt
+    # And the system prompt's qualification-merge guideline is always
+    # present (it's the LLM's instruction, regardless of whether the
+    # user prompt has prior goals to merge from).
+    assert "MERGE their persistent qualifications" in _sys
+
+
+# ---------------------------------------------------------------------------
 # Compound assignee normalization (goldfive#214)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -968,3 +968,242 @@ async def test_autonomous_refine_stamps_drift_id_on_plan_revised(
             evt.plan_revised.plan.revision_trigger_event_id
             == evt.plan_revised.trigger_event_id
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2.X / goldfive#271 Gap 5: prior-goal qualifications preserved
+# ---------------------------------------------------------------------------
+
+
+from goldfive.steerer import (  # noqa: E402
+    _extract_output_type,
+    _extract_qualifications,
+    _looks_like_explicit_removal,
+    _merge_prior_qualifications_into_goal,
+)
+
+
+def test_extract_qualifications_finds_numeric_caps() -> None:
+    """Numeric caps ("no more than N", "at most N", "under N") are
+    detected. These are the canonical "sticky" qualifications the
+    validation E2E saw dropped on a topic pivot.
+    """
+    quals = _extract_qualifications(
+        "Create a presentation about solar panels with no more than 2 slides."
+    )
+    assert any("no more than 2 slides" in q.lower() for q in quals)
+
+
+def test_extract_qualifications_finds_format_hints() -> None:
+    """Format hints ("in markdown", "as bullet points") are detected."""
+    quals = _extract_qualifications("Summarise the report in markdown.")
+    assert any("in markdown" in q.lower() for q in quals)
+    quals = _extract_qualifications("Output as bullet points")
+    assert any("bullet points" in q.lower() for q in quals)
+
+
+def test_extract_output_type_finds_canonical_types() -> None:
+    """Output-type framing ("Create a presentation", "Build a report")
+    is detected.
+    """
+    assert _extract_output_type(
+        "Create a presentation about solar panels"
+    ) == "presentation"
+    assert _extract_output_type("Build a report on Q3 sales") == "report"
+    assert _extract_output_type("Provide content about X") == ""
+
+
+def test_looks_like_explicit_removal_matches_drop_directives() -> None:
+    """Steers that explicitly remove a qualification ("forget the slide
+    cap", "no longer needs to be a presentation") are detected.
+    """
+    assert _looks_like_explicit_removal(
+        "forget the slides cap and just write me a long doc",
+        "no more than 2 slides",
+    )
+    assert _looks_like_explicit_removal(
+        "no longer needs to be in markdown — just plain text",
+        "in markdown",
+    )
+
+
+def test_looks_like_explicit_removal_does_not_overfire_on_topic_pivot() -> None:
+    """Pure topic pivots ("forget X. tell me about Y instead") don't
+    match — the cap is preserved.
+    """
+    # The steer body says "forget solar panels" — that's a topic pivot,
+    # not a removal of "no more than 2 slides". The keyword "slides"
+    # is not near the "forget" verb.
+    assert not _looks_like_explicit_removal(
+        "forget solar panels. tell me about wind power instead.",
+        "no more than 2 slides",
+    )
+
+
+def test_merge_appends_missing_numeric_cap() -> None:
+    """The validation regression: prior goal had "no more than 2 slides";
+    LLM-synthesised goal dropped it. The post-process re-attaches.
+    """
+    prior = [
+        Goal(
+            id="g1",
+            summary=(
+                "Create a presentation about solar panels with no more "
+                "than 2 slides."
+            ),
+        )
+    ]
+    synth = Goal(
+        id="steer1",
+        summary="Provide informative content about solar flares.",
+    )
+    merged = _merge_prior_qualifications_into_goal(
+        synth, prior, steer_body="forget solar panels — solar flares"
+    )
+    assert "no more than 2 slides" in merged.summary.lower(), (
+        f"merge dropped the prior cap; got summary={merged.summary!r}"
+    )
+
+
+def test_merge_rewrites_output_type_prefix() -> None:
+    """The synth goal opens with "Provide content about ..." — the
+    prior goal said "Create a presentation about ...". The merge
+    rewrites the prefix so the output type is preserved.
+    """
+    prior = [
+        Goal(
+            id="g1",
+            summary="Create a presentation about solar panels.",
+        )
+    ]
+    synth = Goal(
+        id="steer1",
+        summary="Provide informative content about solar flares.",
+    )
+    merged = _merge_prior_qualifications_into_goal(
+        synth, prior, steer_body="forget solar panels — solar flares"
+    )
+    assert merged.summary.lower().startswith("create a presentation about"), (
+        f"output type rewrite failed; got {merged.summary!r}"
+    )
+
+
+def test_merge_keeps_existing_summary_when_no_qualifications_to_add() -> None:
+    """No prior qualifications + no output-type rewrite → return synth
+    unchanged. This is the no-op path for steers that don't trigger a
+    merge.
+    """
+    prior = [Goal(id="g1", summary="Tell me about cats.")]
+    synth = Goal(id="steer1", summary="Tell me about dogs.")
+    merged = _merge_prior_qualifications_into_goal(
+        synth, prior, steer_body="actually, dogs instead"
+    )
+    assert merged.summary == "Tell me about dogs."
+
+
+def test_merge_drops_qualification_on_explicit_removal() -> None:
+    """When the steer explicitly removes a qualification, the merge
+    does NOT preserve it. False positives on preservation are the
+    actual regression we're guarding against.
+    """
+    prior = [
+        Goal(
+            id="g1",
+            summary=(
+                "Create a presentation about solar panels with no more "
+                "than 2 slides."
+            ),
+        )
+    ]
+    synth = Goal(
+        id="steer1",
+        summary="Provide informative content about wind power.",
+    )
+    # The removal phrase must mention the qualification's core keyword
+    # ("slides" — the noun in "no more than 2 slides") near a removal
+    # verb ("drop", "no longer", "forget", "without", "skip").
+    merged = _merge_prior_qualifications_into_goal(
+        synth,
+        prior,
+        steer_body=(
+            "drop the cap on slides — give me a long doc about wind power"
+        ),
+    )
+    assert "no more than 2 slides" not in merged.summary.lower(), (
+        f"merge preserved qualification despite explicit removal; "
+        f"got {merged.summary!r}"
+    )
+
+
+def test_merge_skips_when_synth_already_contains_qualification() -> None:
+    """If the LLM's synth already has the qualification (because it
+    followed the prompt's MERGE guideline), the heuristic doesn't
+    duplicate it.
+    """
+    prior = [
+        Goal(id="g1", summary="Create a presentation with no more than 2 slides."),
+    ]
+    synth = Goal(
+        id="steer1",
+        summary="Create a presentation about wind power with no more than 2 slides.",
+    )
+    merged = _merge_prior_qualifications_into_goal(
+        synth, prior, steer_body="forget solar — wind power"
+    )
+    # Count occurrences — must be exactly one.
+    count = merged.summary.lower().count("no more than 2 slides")
+    assert count == 1, (
+        f"qualification duplicated in summary; got {merged.summary!r}"
+    )
+
+
+async def test_apply_user_steer_state_preserves_2_slide_cap_e2e() -> None:
+    """End-to-end: ``_apply_user_steer_state`` runs against a session
+    with a prior 2-slide-cap goal; the steer body is a topic pivot;
+    the post-state ``session.goals`` must include the cap.
+    """
+    steerer, session, _sink, _planner = _bind_fresh()
+
+    # Replace the bare goal with the validation E2E's prior shape.
+    session.goals = [
+        Goal(
+            id="g1",
+            summary=(
+                "Create a presentation about solar panels with no more "
+                "than 2 slides."
+            ),
+        )
+    ]
+
+    # Plug a planner that synthesises the dropping form (mirroring the
+    # validation E2E) so the heuristic post-process is what's tested.
+    async def _drop_synth(steer_body: str, prior_goals=None):
+        return Goal(
+            id="steer1",
+            summary="Provide informative content about solar flares.",
+        ), "replace"
+
+    steerer._planner.synthesize_goal_from_steer = _drop_synth  # type: ignore[attr-defined]
+
+    msg = ControlMessage(
+        kind=ControlKind.STEER,
+        payload={"note": "forget solar panels. tell me about solar flares."},
+    )
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="forget solar panels. tell me about solar flares.",
+        raw=msg,
+    )
+
+    await steerer._apply_user_steer_state(drift, session)
+
+    # The post-merge goal must carry the 2-slide cap forward.
+    new_summaries = " ".join(g.summary for g in session.goals if g.summary)
+    assert "no more than 2 slides" in new_summaries.lower(), (
+        f"2-slide cap was dropped during steer; goals={session.goals!r}"
+    )
+    # The output-type framing ("a presentation") must also survive.
+    assert "presentation" in new_summaries.lower(), (
+        f"output type was dropped during steer; goals={session.goals!r}"
+    )


### PR DESCRIPTION
## Summary

Phase 2.X / Gap 5 of goldfive#271. Validation E2E (session 95ecda4c) saw the prior goal "Create a presentation about solar panels with no more than 2 slides." reduced to "Provide informative content about solar flares." after the topic pivot — both the "presentation" framing AND the "no more than 2 slides" cap dropped at the formal goal-store level.

## Root cause

`LLMPlanner.synthesize_goal_from_steer` constructed the new Goal from the steer body alone (no prior-goal context). The system prompt asked for a fresh "summary"; the LLM produced one without the prior framing. The steerer's `_apply_user_steer_state` then replaced `session.goals` with the bare new goal.

## Fix (two-layer)

1. **LLM-side merge**: `synthesize_goal_from_steer` now accepts an optional `prior_goals` parameter. When supplied, the user prompt includes a `PRIOR GOALS` block, and the system prompt instructs the LLM to MERGE persistent qualifications (numeric caps, format hints, output type, scope qualifiers) unless the steer explicitly removes them. The validation scenario is the prompt's worked example.
2. **Heuristic post-process**: `_merge_prior_qualifications_into_goal` runs after the LLM call as insurance against an LLM that ignored the merge guideline. Pattern-matches:
   - Numeric caps: "no more than N", "at most N", "under N"
   - Format hints: "in markdown", "as bullet points"
   - Output-type framing: rewrites "Provide content about X" → "Create a presentation about X" when the prior goal had a presentation frame
   - `_looks_like_explicit_removal` skips a qualification the steer explicitly removed

The steerer threads `prior_goals=session.goals` (snapshotted before the post-steer mutations) through `_apply_user_steer_state` to the planner. Back-compat for older planners without the kwarg via a `TypeError` catch.

## Tests

- `test_synthesize_goal_from_steer_includes_prior_goals_in_prompt` — new prompt shape.
- `test_extract_qualifications_*`, `test_extract_output_type_*`, `test_looks_like_explicit_removal_*` — heuristic building blocks.
- `test_merge_appends_missing_numeric_cap` — validation regression replay.
- `test_merge_rewrites_output_type_prefix` — "Provide content about X" → "Create a presentation about X".
- `test_merge_drops_qualification_on_explicit_removal` / `test_merge_skips_when_synth_already_contains_qualification` / `test_merge_keeps_existing_summary_when_no_qualifications_to_add` — negative paths.
- `test_apply_user_steer_state_preserves_2_slide_cap_e2e` — end-to-end pin.

LOC: +633 / -3. Test delta: +13. Full suite (1692 tests) green with `GOLDFIVE_STRICT_STATE_OWNERSHIP=1`.

## Test plan

- [x] `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 uv run pytest tests/ -x` (1692 passed)
- [x] `uv run ruff check goldfive/`
- [x] Phase 0 tripwire stays green