### PR TITLE
fix(runner): stash prior plan in finally so CancelledError doesn't skip (#271 Gap 1 v2)

### DIFF
--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -675,43 +675,43 @@ class Runner:
                 aborted, user_input_summary=_initial_goal_summary(user_input)
             )
             return aborted
+        finally:
+            # planner-gate: snapshot the turn's final plan so the next
+            # turn's planner_gate can classify against it.
+            #
+            # Rationale (Phase 2.X v2 / goldfive#271 Gap 1): the prior
+            # post-success-path stash (PR #282) was bypassed when ADK
+            # closed the runner mid-flight — the executor coroutine was
+            # cancelled, ``CancelledError`` propagated out of
+            # ``await self.executor.run(...)``, and since Py 3.8
+            # ``CancelledError`` is a ``BaseException`` (not an
+            # ``Exception``) the ``except Exception`` handler above did
+            # NOT catch it. Control flowed out of ``run`` entirely and
+            # the stash was skipped, leaving ``_last_plan = None`` for
+            # the next turn even though the turn produced a real plan.
+            # The ADK-web user-steer flow hit this on validation v2:
+            # zero "stashed prior plan" log lines across 4 turns and
+            # "GoldfiveADKAgent: gate skipped — no prior plan" 4 times.
+            #
+            # Putting the stash in ``finally`` runs it regardless of how
+            # the executor exited — normal success, ``Exception`` (e.g.
+            # planner bind error), or ``BaseException`` (e.g.
+            # ``CancelledError`` from ADK closing the runner mid-stream).
+            # The exception still propagates after the stash; this block
+            # does not swallow it.
+            if session.plan is not None:
+                self._last_plan = session.plan
+                log.info(
+                    "Runner.run: stashed prior plan for next turn's gate "
+                    "(plan_id=%s)",
+                    (session.plan.id or "")[:16] or "<none>",
+                )
 
         # goldfive#152: clear the current_task_* stamp at run end.
         # The plan id + goals summary stay (they remain meaningful
         # cross-turn on the owning Conversation).
         _ostate.clear_current_task(session.state)
         _ostate.clear_active_steer(session.state)
-
-        # planner-gate: snapshot the turn's final plan so the next
-        # turn's planner_gate can classify against it.
-        #
-        # Rationale (Phase 2.X / goldfive#271 Gap 1): the previous
-        # ``outcome.success and ...`` guard discarded the prior plan on
-        # ANY abort — including goldfive-driven CRITICAL drift cancels.
-        # That left ``_last_plan = None`` for the next turn even when
-        # the turn produced a real plan and partially executed it.
-        # The ADK-web user-steer flow hit this on the validation E2E:
-        # turn 1 was cancelled by a CRITICAL goal-drift, turn 2's user
-        # steer arrived next, and the gate found ``_last_plan = None``
-        # so it short-circuited to ``new_work`` — silently skipping the
-        # steerer's USER_STEER pipeline (no DriftDetected(USER_STEER),
-        # no PlanRevised, no sticky-goal preservation).
-        #
-        # Stash any non-None ``session.plan`` (whether the turn
-        # succeeded, was cancelled, or aborted on a planner-bind error)
-        # so the next turn's gate can refine against it. The plan id
-        # remains a stable refine target; the steerer's
-        # ``_apply_revision`` resolves the new revision off
-        # ``prev_plan.revision_index + 1`` and the planner's refine
-        # call carries the prior plan's tasks forward verbatim.
-        if session.plan is not None:
-            self._last_plan = session.plan
-            log.info(
-                "Runner.run: stashed prior plan for next turn's gate "
-                "(plan_id=%s success=%s)",
-                (session.plan.id or "")[:16] or "<none>",
-                outcome.success,
-            )
 
         self._conversation.absorb_turn(
             outcome, user_input_summary=_initial_goal_summary(user_input)

--- a/tests/test_runner_user_steer_routing.py
+++ b/tests/test_runner_user_steer_routing.py
@@ -36,6 +36,7 @@ fix.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -687,4 +688,166 @@ async def test_plan_revised_emit_logs_at_info(
     )
     assert any("drift_kind=user_steer" in m for m in emit_lines), (
         f"drift_kind missing from emit log; got: {emit_lines!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Phase 2.X v2 / Gap 1: stash runs in ``finally`` so CancelledError
+#    (BaseException, not Exception) does not bypass it.
+# ---------------------------------------------------------------------------
+
+
+class _CancellingExecutor:
+    """Test executor: sleeps briefly then raises ``asyncio.CancelledError``.
+
+    Models ADK closing the runner mid-flight — the executor coroutine is
+    cancelled and ``CancelledError`` (a ``BaseException`` since Py 3.8,
+    NOT an ``Exception``) propagates out of ``await self.executor.run(...)``.
+    Pre-fix the ``except Exception`` handler in ``Runner.run`` did NOT catch
+    it and the ``_last_plan`` stash in the post-success path was skipped.
+    """
+
+    async def run(self, **kwargs: Any) -> Any:
+        # Brief sleep so the cancel happens after the runner installed
+        # ``session.plan`` (which is true here because the stamp lives
+        # in ``Runner.run`` itself before the executor handoff — see
+        # ``session.plan = plan`` ~line 568).
+        await asyncio.sleep(0)
+        raise asyncio.CancelledError("simulated ADK closing the runner")
+
+
+class _RaisingExecutor:
+    """Test executor: raises ``ValueError`` immediately.
+
+    Pre-fix this case was already handled by the existing
+    ``except Exception`` block — the stash was nonetheless skipped because
+    that block ``return``-ed before reaching the post-success-path stash.
+    Post-fix the stash lives in ``finally`` and runs in both cases.
+    """
+
+    async def run(self, **kwargs: Any) -> Any:
+        raise ValueError("simulated executor failure")
+
+
+async def test_stash_runs_when_executor_raises_cancellederror() -> None:
+    """Regression for goldfive#271 Gap 1 v2.
+
+    When ADK closes the runner mid-flight the executor coroutine is
+    cancelled and ``CancelledError`` (``BaseException``, not
+    ``Exception``) propagates. The stash MUST run in ``finally`` so the
+    next turn's planner-gate sees the prior plan.
+
+    Validation v2 evidence: zero ``stashed prior plan`` log lines across
+    4 turns; ``GoldfiveADKAgent: gate skipped — no prior plan`` 4 times.
+    """
+    turn1_plan = json.dumps(
+        {
+            "id": "plan-cancel",
+            "summary": "plan that gets cancelled mid-flight",
+            "tasks": [
+                {"id": "t1", "title": "T1", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+    planner = LLMPlanner(
+        call_llm=_planner_call_llm_factory(
+            turn1_plan=turn1_plan,
+            turn2_verdict="new_work",
+            refined_plan=None,
+        ),
+        model="stub",
+    )
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=_CancellingExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[InMemorySink()],
+    )
+
+    cancelled_propagated = False
+    try:
+        await runner.run("first turn")
+    except BaseException:  # noqa: BLE001 — verifying CancelledError (BaseException) propagates
+        cancelled_propagated = True
+    finally:
+        # close() must run before assertions so the planner's call_llm
+        # and sinks are cleaned up regardless of the propagated error.
+        await runner.close()
+
+    assert cancelled_propagated, (
+        "CancelledError must propagate out of runner.run — the finally "
+        "block stashes the plan but does NOT swallow the exception."
+    )
+
+    # The fix: the plan is stashed via the finally block even though
+    # CancelledError bypassed the ``except Exception`` handler.
+    assert runner._last_plan is not None, (
+        "Gap 1 v2: the runner MUST stash session.plan in finally so "
+        "CancelledError (BaseException) does not skip the stash. Pre-fix "
+        "_last_plan was None here because control flowed out of run() "
+        "via CancelledError without reaching the post-success-path stash."
+    )
+    # Plan id is stable; the LLMPlanner mints its own uuid so we just
+    # assert it is non-empty.
+    assert runner._last_plan.id, (
+        "stashed plan must carry a non-empty id"
+    )
+
+
+async def test_stash_runs_when_executor_raises_exception() -> None:
+    """Companion regression for the existing ``Exception`` path.
+
+    Pre-fix the ``except Exception`` block ``return``-ed before reaching
+    the post-success-path stash, so ``_last_plan`` was also None after
+    a planner-bind error or any executor-raised ``Exception``. Post-fix
+    the stash in ``finally`` runs in both the ``Exception`` and
+    ``BaseException`` paths.
+    """
+    turn1_plan = json.dumps(
+        {
+            "id": "plan-raise",
+            "summary": "plan that raises during execution",
+            "tasks": [
+                {"id": "t1", "title": "T1", "assignee_agent_id": "writer"},
+            ],
+        }
+    )
+    planner = LLMPlanner(
+        call_llm=_planner_call_llm_factory(
+            turn1_plan=turn1_plan,
+            turn2_verdict="new_work",
+            refined_plan=None,
+        ),
+        model="stub",
+    )
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=_RaisingExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[InMemorySink()],
+    )
+
+    # The ``except Exception`` handler catches ValueError and returns an
+    # aborted ExecutionOutcome — so this does NOT raise.
+    outcome = await runner.run("first turn")
+    await runner.close()
+
+    assert not outcome.success
+    assert "executor.run raised" in outcome.reason
+    assert "simulated executor failure" in outcome.reason
+
+    # The fix: the plan is stashed via the finally block on the
+    # Exception path too. Pre-fix the ``except Exception`` block
+    # ``return``-ed before the post-success-path stash, so _last_plan
+    # was None even on this path.
+    assert runner._last_plan is not None, (
+        "Gap 1 v2: the runner MUST stash session.plan in finally on the "
+        "Exception path too. The original ``except Exception`` block "
+        "``return``-ed before reaching the post-success-path stash, so "
+        "the prior plan was lost on every executor failure."
+    )
+    assert runner._last_plan.id, (
+        "stashed plan must carry a non-empty id"
     )


### PR DESCRIPTION
## Summary

Phase 2.X v2 / Gap 1 of goldfive#271 — proper root-cause fix on top of #282.

PR #282 dropped the `outcome.success` guard on the `_last_plan` stash, but left the stash in the post-success path AFTER the `except Exception` handler. Validation v2 (4-turn ADK-web session) found the stash STILL never fires:

- 0 `Runner.run: stashed prior plan for next turn's gate` log lines across 4 turns
- 4 `GoldfiveADKAgent: gate skipped — no prior plan` log lines
- USER_STEER drift never fires; the planner-gate short-circuits to `new_work` on every turn

## Empirical root cause (validation v2)

When ADK closes the runner mid-flight (validation v2 log: `Closing runner... Runner closed.`), the executor coroutine is cancelled and `asyncio.CancelledError` propagates out of `await self.executor.run(...)`.

Since Py 3.8 `CancelledError` is a `BaseException`, NOT an `Exception` — so the `except Exception` block (`runner.py:669`, `noqa: BLE001`) does NOT catch it. Control flows out of `run` entirely without ever reaching the post-success-path stash at the old line ~707.

## Fix

Move the stash into a `try / except Exception / finally` block on the executor handoff. The finally runs regardless of:

- Normal success (outcome returned)
- `Exception` (e.g., executor raises a planner bind error — `except` branch returns aborted, but `finally` still runs first)
- `BaseException` (e.g., `CancelledError` from ADK closing the runner — `except Exception` is bypassed; `finally` runs; `CancelledError` continues to propagate)

The finally block does NOT swallow exceptions — verified by the regression test below.

## Diff scope

- `goldfive/runner.py`: stash moved into a `finally` block; duplicate post-success stash removed; `success=%s` dropped from log format (the `outcome` variable may be unset on the `BaseException` path; the format is now invariant of how the executor exited).
- `tests/test_runner_user_steer_routing.py`: 2 new regression tests + 1 import line.

## Tests

- `test_stash_runs_when_executor_raises_cancellederror` — fake executor raises `CancelledError`; assert (a) `CancelledError` propagates out of `runner.run` (does NOT swallow signal) AND (b) `runner._last_plan` is stashed.
- `test_stash_runs_when_executor_raises_exception` — fake executor raises `ValueError`; assert `runner._last_plan` is stashed via the `finally` even though the `except Exception` block returns early.

Both new tests were verified to FAIL without the runner.py fix and PASS with it.

Full suite: **1395 passed / 98 skipped** with `GOLDFIVE_STRICT_STATE_OWNERSHIP=1`. No new failures, no test count regression vs main.

## Self-review (Phase Z)

1. **Correctness**: Python guarantees `finally` runs before `return` from the `except` branch and before any propagating `BaseException`. Tests assert the post-runner.run state for both. The `outcome` variable is only read in the post-finally code path, where the success path is the only way to reach it — no NameError risk.
2. **Simplicity**: stash code lives in exactly one place now (was: one location in the success path; now: one location in the finally). Removed the success= field from the log format because it cannot be reliably evaluated on the BaseException path. No defensive try/except in the finally block.
3. **Alignment with existing design**: log format `"Runner.run: <action> (key=%s)"` matches the surrounding gate-verdict and gate-skipped logs. `noqa: BLE001` placement matches existing convention.
4. **One more diff read**: no debug prints, no commented-out code, no TODOs.

## Test plan

- [x] `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 uv run pytest -x` (1395 passed)
- [x] `uv run ruff check goldfive/runner.py tests/test_runner_user_steer_routing.py` (clean)
- [x] New tests verified to fail on origin/main and pass with the fix