### PR TITLE
fix(conversation): cross-turn wire sequence cursor (#271 Gap 2)

### DIFF
--- a/goldfive/conversation.py
+++ b/goldfive/conversation.py
@@ -90,6 +90,22 @@ class Conversation:
     goals: list[Goal] = dataclasses.field(default_factory=list)
     completed_results: dict[str, str] = dataclasses.field(default_factory=dict)
     turns: list[TurnRecord] = dataclasses.field(default_factory=list)
+    # Conversation-level wire sequence cursor (goldfive#271 Gap 2).
+    # Each turn's :class:`Session` seeds its private ``_next_sequence``
+    # from this value, then on :meth:`absorb_turn` writes the post-turn
+    # high-water mark back. Reason: when goldfive#161's outer-session
+    # pin causes ``Session.run_id`` to repeat across turns,
+    # harmonograf's ``goldfive_events`` PK ``(session_id, run_id,
+    # sequence)`` collides on the second turn's early events (sequence
+    # 0, 1, 2, ...) which match turn 1's already-persisted rows. The
+    # storage layer's ``INSERT OR IGNORE`` then silently drops the
+    # second turn's plan_submitted, agent_invocation_started, etc.
+    # Carrying a Conversation-level cursor across turns makes
+    # ``sequence`` unique per (conversation, run_id-or-session_id) so
+    # the persisted-event keyspace stays collision-free even under the
+    # outer-session pin. Single-turn callers see no change: the cursor
+    # starts at 0 on a fresh Conversation.
+    _next_sequence: int = 0
 
     @classmethod
     def new(cls) -> Conversation:
@@ -108,6 +124,11 @@ class Conversation:
         (not aliases) the accumulated ``goals`` and ``completed_results``
         so the executor's in-turn mutations do not retroactively
         rewrite the Conversation's record.
+
+        The Session's wire-sequence counter (``Session._next_sequence``)
+        is seeded from the Conversation's running cursor so per-turn
+        events are globally unique within the conversation; see the
+        ``_next_sequence`` docstring on :class:`Conversation`.
         """
         return Session(
             run_id=uuid.uuid4().hex,
@@ -115,6 +136,7 @@ class Conversation:
             started_at_ms=_now_ms(),
             goals=list(self.goals),
             completed_results=dict(self.completed_results),
+            _next_sequence=self._next_sequence,
         )
 
     def absorb_turn(
@@ -143,6 +165,16 @@ class Conversation:
         # that a revised result on a follow-up turn is visible to the
         # turn after it.
         self.completed_results.update(session.completed_results)
+
+        # goldfive#271 Gap 2: lift the turn's high-water sequence back to
+        # the Conversation cursor so the next ``next_turn_session()``
+        # picks up where this turn left off. This keeps wire sequences
+        # globally unique within the Conversation, which matters when
+        # goldfive#161's outer-session pin makes ``Session.run_id``
+        # constant across turns. Use ``max`` to be defensive against an
+        # outcome whose Session never advanced past the seed (e.g. a
+        # turn that aborted before any sink emission).
+        self._next_sequence = max(self._next_sequence, int(session._next_sequence))
 
         plan_summary = ""
         completed_ids: list[str] = []

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -903,7 +903,13 @@ class Session:
     # call ids so prompt templates / refine paths / downstream planners
     # can read a single, framework-agnostic source of truth.
     state: dict[str, Any] = dataclasses.field(default_factory=dict)
-    # monotonic event sequence counter for sinks
+    # Monotonic event sequence counter for sinks. When this Session was
+    # built by :meth:`Conversation.next_turn_session`, the seed value is
+    # the Conversation's running cursor (lifted from the previous turn's
+    # high-water mark on :meth:`Conversation.absorb_turn`) — see
+    # goldfive#271 Gap 2. Bare ``Session(run_id=...)`` constructions
+    # remain at 0 so single-Session callers (tests, programmatic use)
+    # see no behaviour change.
     _next_sequence: int = 0
 
     def next_sequence(self) -> int:

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -166,6 +166,116 @@ def test_conversation_prior_turn_context_caps_window() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Wire-sequence cursor across turns (goldfive#271 Gap 2)
+# ---------------------------------------------------------------------------
+#
+# Validation v2 of issue #271 surfaced that ``Session._next_sequence``
+# resets to 0 on every ``next_turn_session()`` call, which collides
+# with harmonograf's persisted-event PK ``(session_id, run_id,
+# sequence)`` whenever goldfive#161's outer-session pin makes
+# ``Session.run_id`` repeat across turns. The Conversation-level cursor
+# guarantees that wire sequences are globally unique within the
+# conversation so persisted events never silently drop on a multi-turn
+# session.
+
+
+def test_conversation_seeds_session_sequence_from_running_cursor() -> None:
+    conv = Conversation.new()
+
+    s1 = conv.next_turn_session()
+    assert s1.next_sequence() == 0
+    assert s1.next_sequence() == 1
+    # Manually advance to mimic a turn that emitted three events.
+    assert s1.next_sequence() == 2
+
+    # absorb_turn lifts the high-water mark back to the Conversation.
+    from goldfive.results import ExecutionOutcome
+
+    conv.absorb_turn(ExecutionOutcome(success=True, session=s1))
+    assert conv._next_sequence == 3
+
+    # Turn 2 picks up where turn 1 left off — no collision with turn 1's
+    # already-emitted (session_id, run_id, 0/1/2) wire keys.
+    s2 = conv.next_turn_session()
+    assert s2.next_sequence() == 3
+    assert s2.next_sequence() == 4
+
+    conv.absorb_turn(ExecutionOutcome(success=True, session=s2))
+    assert conv._next_sequence == 5
+
+
+def test_conversation_sequence_unique_under_outer_session_pin() -> None:
+    """Reproduces goldfive#271 Gap 2: with the outer-session pin
+    forcing both turns to share ``run_id`` (and therefore ``session_id``,
+    since ``Session.id`` aliases ``run_id``), every emitted ``(run_id,
+    sequence)`` pair must remain globally unique across the whole
+    conversation. Otherwise harmonograf's INSERT OR IGNORE silently
+    drops the second turn's plan_submitted, agent_invocation_started,
+    and similar early-turn events.
+    """
+    from goldfive.results import ExecutionOutcome
+
+    conv = Conversation.new()
+    pinned_run_id = "outer-adk-session-abc123"
+
+    # Turn 1 — pinned to the outer session id, emits five events.
+    s1 = conv.next_turn_session()
+    s1.run_id = pinned_run_id
+    turn1_keys = {(s1.run_id, s1.next_sequence()) for _ in range(5)}
+    conv.absorb_turn(ExecutionOutcome(success=True, session=s1))
+
+    # Turn 2 — same pin, emits five more events.
+    s2 = conv.next_turn_session()
+    s2.run_id = pinned_run_id
+    turn2_keys = {(s2.run_id, s2.next_sequence()) for _ in range(5)}
+    conv.absorb_turn(ExecutionOutcome(success=True, session=s2))
+
+    # The collision regression: every (run_id, sequence) pair in turn 2
+    # would equal one in turn 1 prior to the fix, and harmonograf's
+    # storage layer would silently drop turn 2's events.
+    assert turn1_keys.isdisjoint(turn2_keys), (
+        "wire-key collision across turns under outer-session pin: "
+        f"turn1={sorted(turn1_keys)} turn2={sorted(turn2_keys)}"
+    )
+    assert len(turn1_keys) == 5 and len(turn2_keys) == 5
+
+
+def test_conversation_sequence_reset_on_new_conversation() -> None:
+    """new_conversation() restarts the cursor at 0 — fresh
+    Conversations carry a fresh wire-sequence keyspace."""
+    from goldfive.results import ExecutionOutcome
+
+    conv = Conversation.new()
+    s1 = conv.next_turn_session()
+    for _ in range(7):
+        s1.next_sequence()
+    conv.absorb_turn(ExecutionOutcome(success=True, session=s1))
+    assert conv._next_sequence == 7
+
+    fresh = Conversation.new()
+    assert fresh._next_sequence == 0
+    s_fresh = fresh.next_turn_session()
+    assert s_fresh.next_sequence() == 0
+
+
+def test_conversation_absorb_turn_is_robust_to_unstamped_session() -> None:
+    """absorb_turn uses ``max(...)`` so an outcome whose Session never
+    emitted (e.g. an early-abort path) doesn't accidentally roll the
+    cursor backwards."""
+    from goldfive.results import ExecutionOutcome
+
+    conv = Conversation.new()
+    # Pretend a prior turn already consumed sequences 0-9.
+    conv._next_sequence = 10
+
+    s = conv.next_turn_session()
+    assert s._next_sequence == 10
+    # An aborted turn never advances its own counter.
+    conv.absorb_turn(ExecutionOutcome(success=False, session=s, reason="abort"))
+    assert conv._next_sequence == 10  # Did not roll backwards.
+
+
+# ---------------------------------------------------------------------------
 # Runner integration
 # ---------------------------------------------------------------------------
 
@@ -216,6 +326,46 @@ async def test_runner_second_turn_session_sees_prior_completed_results() -> None
     for k, v in turn1_results.items():
         assert k in out2.session.completed_results
         assert out2.session.completed_results[k] == v
+
+
+async def test_runner_wire_sequences_unique_under_outer_session_pin() -> None:
+    """End-to-end reproduction of goldfive#271 Gap 2.
+
+    Drives two ``runner.run(...)`` calls with the same ``session_id``
+    pin (mimicking goldfive#161's outer-session pin from
+    :class:`GoldfiveADKAgent`). Asserts every emitted event has a
+    globally-unique ``(session_id, run_id, sequence)`` triple — the
+    exact tuple harmonograf's storage layer uses as its
+    ``goldfive_events`` PK. Prior to the fix turn 2's early events
+    (sequence 0, 1, 2, ...) collided with turn 1 and silently dropped
+    on INSERT OR IGNORE.
+    """
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+    pinned = "outer-adk-session-deadbeef"
+
+    await runner.run("turn one", session_id=pinned)
+    await runner.run("turn two", session_id=pinned)
+    await runner.close()
+
+    keys = [
+        (evt.session_id, evt.run_id, int(evt.sequence)) for evt in sink.events
+    ]
+    # Every event must have a unique (session_id, run_id, sequence) so
+    # harmonograf's PK never collides.
+    assert len(keys) == len(set(keys)), (
+        f"wire-key collision in sink stream: "
+        f"duplicates={[k for k in keys if keys.count(k) > 1]}"
+    )
+    # And the pin actually held — both turns share the same session_id /
+    # run_id, which is the precondition that creates the collision risk.
+    assert {evt.run_id for evt in sink.events} == {pinned}
 
 
 async def test_runner_session_carries_conversation_id() -> None:


### PR DESCRIPTION
## Summary

- Validation v2 of #271 found that turns 2+ of a multi-turn session silently lose `plan_submitted`, `agent_invocation_started`, etc. when goldfive#161's outer-session pin collapses `Session.run_id` across every turn.
- Root cause: `Session._next_sequence` resets to 0 per turn, so `(session_id, run_id, sequence)` keys repeat across turns and harmonograf's `INSERT OR IGNORE` on the `goldfive_events` PK silently drops them.
- Fix: `Conversation` now carries a `_next_sequence` cursor. `next_turn_session` seeds the new `Session._next_sequence` from it; `absorb_turn` lifts the post-turn high-water mark back to the Conversation (max-guarded against aborted turns).

## Why this option vs the alternatives

Three options surfaced from validation v2:

| Option | Trade-off |
|---|---|
| **(a) Conversation-level cursor** *(this PR)* | Addresses the semantic invariant directly. Zero schema changes. Preserves first-write-wins idempotency that other sinks/replay paths depend on. |
| (b) harmonograf storage PK strengthened | Heavy SQLite migration. Papers over the source of the collision. |
| (c) `INSERT OR REPLACE` on a synthetic id | Changes idempotency to last-write-wins, breaking the existing `_handle_span_start` contract. |

Option (a) wins because the broken invariant ("wire sequences are unique within `(session_id, run_id)`") lives in goldfive — fix it at the source.

## Empirical evidence

`/tmp/demo-validation-v2.log` shows 4 plans emitted across one session via `runner._emit_plan_submitted`, all with the same `run_id` (`f73ba4d5...`). Querying the demo DB shows only 1 `plan_submitted` row persisted under that session — the other 3 collided on `(session_id, run_id, sequence)` and were silently dropped by `INSERT OR IGNORE`.

The new `test_runner_wire_sequences_unique_under_outer_session_pin` test reproduces this exactly: it drives two `runner.run(...)` calls with the same `session_id` pin and asserts every emitted event has a unique `(session_id, run_id, sequence)` triple. Test fails on `main` with the literal collision (`('outer-adk-session-deadbeef', 'outer-adk-session-deadbeef', 0/1/2)` appearing twice) and passes with the fix.

## Test plan

- [x] Reproduce the bug in a unit test that fails without the fix
- [x] Confirm the fix makes that test pass (`test_runner_wire_sequences_unique_under_outer_session_pin`)
- [x] 4 additional regressions covering: cursor seeding, outer-pin collision avoidance, `new_conversation()` cursor reset, and `absorb_turn` robustness against aborted turns
- [x] Full `pytest tests/` suite: 1697 passed, 46 skipped (no regressions)
- [x] Self-review: no debug prints, no dead code, no premature abstractions; matches existing dataclass + `next_sequence()` style on `Session`
- [ ] Bump harmonograf submodule once merged (separate PR)

Closes #271 Gap 2.