### PR TITLE
feat(reporting, audit): declarations + cancellation contract (#271 Phase 3)

### DIFF
--- a/docs/design/CANCELLATION-CONTRACT.md
+++ b/docs/design/CANCELLATION-CONTRACT.md
@@ -1,0 +1,143 @@
+# Cancellation propagation contract
+
+**Status.** Phase 3 Addition A of goldfive#271. Sibling to
+[`STATE-OWNERSHIP-CONTRACT.md`](STATE-OWNERSHIP-CONTRACT.md). The
+exception class :class:`goldfive._state_audit.CancellationStashViolation`
+ships in Phase 3; the runtime tripwire mechanism lands with Phase 3.5
+(hard-cancel) when the goldfive task boundary becomes the legitimate
+catch site.
+
+## tl;dr
+
+`asyncio.CancelledError` has been a `BaseException` subclass since
+Python 3.8. `except Exception:` does NOT catch it. Code that wraps
+an `await` in `try / except Exception:` and owns state-stash duties
+(plan snapshot, event flush, drift-detector teardown) silently
+**bypasses** the housekeeping when `CancelledError` propagates —
+because the broad catch fires only on `Exception` subclasses, and
+`CancelledError` skates past straight through whatever cleanup the
+broader `try` block would have performed before the catch.
+
+The validation-v2 audit found this happening at
+`goldfive/runner.py:411` (the executor's `try / except Exception`
+that wraps the per-task drive). When ADK closed the runner
+mid-stream, the executor's `except Exception` block skipped every
+post-execution housekeeping step. The fix shipped as the
+**`runner.py:411` `try / finally`** in PR #287 (goldfive#271 Gap 1
+v2): the prior plan snapshot now lives in `finally`, not in the
+`except Exception` body, so it runs regardless of whether the await
+returned normally, raised an `Exception`, or raised
+`CancelledError`.
+
+## §1 Compliant patterns
+
+### §1.1 Preferred — `try / finally`
+
+```python
+try:
+    result = await some_call()
+    self._handle_result(result)
+except Exception as exc:
+    self._handle_failure(exc)
+finally:
+    # ALWAYS runs, including when CancelledError propagates.
+    self._stash_prior_state()
+    self._flush_events()
+```
+
+This is the form Gap 1 v2 (PR #287) used to fix the runner.py bug.
+
+### §1.2 Acceptable — `except Exception ... except BaseException: stash; raise`
+
+When the `Exception` branch needs specific recovery behaviour that
+doesn't fit the bare-`finally` shape:
+
+```python
+try:
+    result = await some_call()
+except Exception as exc:
+    self._record_recoverable_failure(exc)
+    return None
+except BaseException:
+    # CancelledError (or KeyboardInterrupt) — preserve the stash AND re-raise.
+    self._stash_prior_state()
+    raise
+```
+
+The `except BaseException: stash; raise` MUST `raise` — swallowing
+`CancelledError` would defeat asyncio's cancellation contract. This
+form is reserved for the cases where the `Exception` block does
+something the `finally` shape can't (e.g. computing a recoverable
+default before swallowing the exception entirely).
+
+## §2 Catalog of audited sites
+
+This section mirrors the §5 audit catalog of
+[`STATE-OWNERSHIP-CONTRACT.md`](STATE-OWNERSHIP-CONTRACT.md).
+Phase 3 ships an audit pass; Phase 3.5 wires the runtime tripwire.
+
+| ID | File | Function | Owns | Status | Notes |
+|---|---|---|---|---|---|
+| C1 | `goldfive/runner.py:411` | `_drive_internal` | prior-plan stash | **FIXED** in #287 (`try / finally`) | Validation v2 root-cause |
+| C2 | `goldfive/executors/parallel.py` (multiple) | various | event sequence + sink emit | survey ongoing | Several `try / except Exception` blocks wrap awaits but most stash via `_lock` re-entry — re-audit when boundary lands |
+| C3 | `goldfive/executors/sequential.py` (multiple) | various | event sequence + sink emit | survey ongoing | Same shape as C2 |
+| C4 | `goldfive/steerer.py` (multiple) | refine paths | `_background_judges` set | survey ongoing | Background tasks deliberately swallow on cancel via shutdown drain |
+| C5 | `goldfive/_correction_injection.py` | `clear_correction` | per-task correction body | LOW priority | Best-effort GC; `try / except Exception` swallow is acceptable |
+| C6 | `goldfive/reporting.py` (sink emits) | various | event id stamping | LOW priority | Sink emits are best-effort; broken sink shouldn't break tool calls |
+
+### §2.1 Severity classification
+
+* **HIGH** — stash carries cross-await state that downstream state
+  machines depend on. C1 (the runner.py:411 bypass) was HIGH; the
+  prior plan snapshot is consumed by user-steer routing, so
+  losing it means the next user steer is mis-routed. **Status:
+  fixed**.
+* **MEDIUM** — stash owns observability state (event sequence
+  cursors, sink dispatch). Loss is observable in the timeline gap
+  but doesn't break state machines downstream. C2 / C3 are
+  MEDIUM; the sequence cursor self-heals on the next emit, but
+  the gap is operator-visible.
+* **LOW** — stash is best-effort GC of transient state. C5 / C6
+  are LOW; the GC will run on the next applicable event.
+
+### §2.2 Phase 3.5 plan
+
+When the goldfive task boundary lands (Phase 3.5):
+
+1. Survey C2-C6 with the full audit pattern; convert HIGH/MEDIUM
+   sites to `try / finally` or `except BaseException: stash; raise`.
+2. Wire the runtime tripwire — install
+   :class:`CancellationStashViolation` raise machinery (paired with
+   the boundary's stack-walk; the boundary becomes the one
+   legitimate catch site, and any other site that absorbs
+   `CancelledError` without entering its `finally` raises the
+   tripwire).
+3. Test surface: `tests/test_cancellation_stash_audit.py` —
+   parametrized over the catalog, fires `CancelledError` at the
+   await, asserts the stash invariant.
+
+## §3 Why the boundary is prerequisite
+
+The goldfive task boundary (Phase 3.5) is the ONE place we expect
+`CancelledError` to be caught — the boundary converts it into a
+structured marker (`InvocationBoundaryExited(reason="cancelled")`)
+and emits an `InvocationCancelled` sink event before letting ADK
+see a normal return. Without that boundary, every `try / finally`
+conversion in the audit catalog would bubble `CancelledError` all
+the way to ADK's runner, which has its own ideas about what
+cancellation means and may surface it as a tool failure or a model
+exception.
+
+The audit-pass + class-only ship in Phase 3 lets us land the
+boundary in 3.5 without simultaneously fighting a regression
+cascade across every catalogued site. The ordering is deliberate:
+
+1. **Phase 3 (this PR).** Audit catalog. Class definition. Doc.
+2. **Phase 3 follow-up.** Convert HIGH-severity sites to
+   `try / finally`. Most are already done (C1 in #287; the
+   sequential executor's cooperative-cancel paths are
+   self-cleaning by design).
+3. **Phase 3.5.** Goldfive task boundary becomes the catch site.
+   Runtime tripwire installs. Remaining audit sites convert in
+   the same PR.
+4. **Phase 4+.** Hard cancel wires `task.cancel()` from the steerer.

--- a/goldfive/_state_audit.py
+++ b/goldfive/_state_audit.py
@@ -103,6 +103,34 @@ class StateOwnershipViolation(BaseException):
     """
 
 
+class CancellationStashViolation(BaseException):
+    """Raised when ``CancelledError`` propagates through a stash-owning await
+    without entering a ``finally`` block.
+
+    goldfive#271 Phase 3 Addition A. Validation v2 found that
+    ``runner.py:411``'s ``try / except Exception`` block silently
+    bypassed all post-execution housekeeping when ADK closed the
+    runner mid-stream — the executor's broad ``except Exception``
+    let ``CancelledError`` skate past every state-stash, every event
+    flush, every drift-detector teardown, because ``CancelledError``
+    has been a ``BaseException`` subclass since Python 3.8 and is NOT
+    caught by ``except Exception``.
+
+    **Inherits from :class:`BaseException`** for the same reason as
+    :class:`StateOwnershipViolation`: the defensive ``try / except
+    Exception`` blocks the audit catalogues would otherwise swallow
+    the violation marker.
+
+    Phase 3 ships only the EXCEPTION CLASS + the audit document under
+    ``docs/design/CANCELLATION-CONTRACT.md`` (sibling to
+    ``STATE-OWNERSHIP-CONTRACT.md``). The runtime tripwire mechanism
+    (paired with the goldfive task boundary that is the one place
+    we'll catch ``CancelledError``) lands with Phase 3.5's hard-cancel
+    work — there's no point installing the runtime check before the
+    boundary exists to be the legitimate catch site.
+    """
+
+
 @dataclass(frozen=True)
 class _CallbackFrame:
     """Bookkeeping for an active goldfive callback.

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -58,9 +58,15 @@ class ReportingToolSpec:
     handler: ReportingHandler
 
 
-# The eight canonical reporting tool names. These are a stable contract: the
+# The ten canonical reporting tool names. These are a stable contract: the
 # adapter must surface tools with exactly these names so that the Steerer can
 # interpret them uniformly across frameworks. Do not rename.
+#
+# goldfive#271 Phase 3: ``declare_task_skipped`` and ``declare_task_not_needed``
+# are observability-only (no plan mutation, no steerer drive); they emit a
+# ``TaskDeclarationReceived`` event so the operator can see "agent
+# volunteered skip" before the imperative ``report_task_*`` surface
+# either confirms or contradicts it.
 REPORTING_TOOL_NAMES: tuple[str, ...] = (
     "report_task_started",
     "report_task_progress",
@@ -70,6 +76,28 @@ REPORTING_TOOL_NAMES: tuple[str, ...] = (
     "report_new_work_discovered",
     "report_plan_divergence",
     "report_awaiting_approval",
+    "declare_task_skipped",
+    "declare_task_not_needed",
+)
+
+
+# State key for the per-Session declarations log. Lives under the
+# ``goldfive.*`` namespace so :func:`goldfive.orchestration_state.write`
+# accepts it. Value shape: ``dict[(kind, task_id), {kind, task_id,
+# reason, recorded_at_seq}]`` keyed by ``(declaration_kind, task_id)``
+# so the second declaration of the same kind on the same task is a
+# no-op.
+DECLARATIONS_KEY = "goldfive.task_declarations"
+
+
+# Vocabulary of declaration kinds. Mirrors the proto envelope's `kind`
+# field once it gets promoted (Phase 3.5/4 cleanup); for now lives as
+# a string vocabulary on the dict envelope.
+DECLARATION_KIND_SKIPPED: str = "skipped"
+DECLARATION_KIND_NOT_NEEDED: str = "not_needed"
+DECLARATION_KINDS: tuple[str, ...] = (
+    DECLARATION_KIND_SKIPPED,
+    DECLARATION_KIND_NOT_NEEDED,
 )
 
 
@@ -100,9 +128,7 @@ def _resolve_task_id(args: dict[str, Any], session: Session) -> str:
     return _resolve_task_id_with_source(args, session)[0]
 
 
-def _resolve_task_id_with_source(
-    args: dict[str, Any], session: Session
-) -> tuple[str, str]:
+def _resolve_task_id_with_source(args: dict[str, Any], session: Session) -> tuple[str, str]:
     """Resolve ``task_id`` and report whether it came from args or state.
 
     Returns ``(task_id, source)`` where ``source`` is one of:
@@ -358,9 +384,7 @@ def _read_plan_revision(session: Session) -> int:
         return 0
 
 
-def _supersession_successor(
-    session: Session, task_id: str
-) -> tuple[str, SupersessionKind]:
+def _supersession_successor(session: Session, task_id: str) -> tuple[str, SupersessionKind]:
     """Return ``(successor_task_id, kind)`` for ``task_id``.
 
     Walks the plan looking for a task whose ``supersedes`` equals
@@ -421,8 +445,7 @@ def _classify_pin_freshness(
         # match (trust the pin) rather than refusing.
         if pin_revision > current_revision:
             log.debug(
-                "reporting: pin_revision=%d > current=%d for task_id=%s "
-                "(unexpected; trusting pin)",
+                "reporting: pin_revision=%d > current=%d for task_id=%s (unexpected; trusting pin)",
                 pin_revision,
                 current_revision,
                 task_id,
@@ -539,8 +562,7 @@ async def _classify_and_route_pin(
         else "stale_pin_no_supersedes"
     )
     log.warning(
-        "reporting: %s REFUSED on stale pin task_id=%s "
-        "(pin_rev=%d, current_rev=%d, reason=%s)",
+        "reporting: %s REFUSED on stale pin task_id=%s (pin_rev=%d, current_rev=%d, reason=%s)",
         tool_name,
         task_id,
         pin_rev,
@@ -553,9 +575,7 @@ async def _classify_and_route_pin(
     # the classifier has already consulted the supersedes graph and
     # found a successor or absence-of-one).
     pin_task = _find_task_in_session(session, task_id)
-    attempted_from = (
-        pin_task.status if pin_task is not None else TaskStatus.PENDING
-    )
+    attempted_from = pin_task.status if pin_task is not None else TaskStatus.PENDING
     await _emit_task_transition_refused(
         session=session,
         steerer=steerer,
@@ -1074,6 +1094,159 @@ async def _handle_plan_divergence(
     return dict(_ACK)
 
 
+async def _emit_task_declaration_received(
+    *,
+    session: Session,
+    steerer: Steerer,
+    kind: str,
+    task_id: str,
+    reason: str,
+) -> None:
+    """Emit a ``TaskDeclarationReceived`` dict envelope onto the sink bus.
+
+    goldfive#271 Phase 3: structural declarations from the agent
+    (``declare_task_skipped``, ``declare_task_not_needed``) are
+    observability-only — they do NOT mutate plan state. Operators see
+    the declaration on the sink so they can compare it against the
+    imperative ``report_task_*`` surface that follows. The dict
+    envelope is the same low-cost path used for ``RefineAttempted``
+    / ``RefineFailed`` (PR #264) before those are promoted to typed
+    proto. A future cleanup may promote ``TaskDeclarationReceived``
+    to a proper proto message; until then the dict shape with a
+    well-known ``kind`` field is the contract.
+
+    ``source_signal`` is fixed to ``"DECLARATION"`` so downstream
+    consumers can distinguish a self-volunteered declaration from a
+    framework-driven inference (steerer rotation, reconciler
+    NOT_NEEDED stamp).
+    """
+    sinks = getattr(steerer, "_sinks", None) or []
+    if not sinks:
+        return
+    from goldfive.events import emit, make_event
+
+    payload = {
+        "kind": str(kind),
+        "task_id": str(task_id),
+        "reason": str(reason),
+        "source_signal": "DECLARATION",
+    }
+    try:
+        evt = make_event(
+            session.run_id,
+            session.next_sequence(),
+            "task_declaration_received",
+            payload,
+            session_id=session.id,
+        )
+        await emit(sinks, evt)
+    except Exception as exc:  # noqa: BLE001 — observability must never break a tool call
+        log.debug(
+            "reporting._emit_task_declaration_received: failed to emit: %s",
+            exc,
+        )
+
+
+def _record_declaration(session: Session, kind: str, task_id: str, reason: str) -> bool:
+    """Record a declaration on session.state; return True if newly recorded.
+
+    Idempotent: a second declaration of the same ``(kind, task_id)``
+    pair is a no-op (returns False, no event re-emitted). The recorded
+    body intentionally keeps the FIRST reason — late declarations don't
+    rewrite history.
+    """
+    state = getattr(session, "state", None)
+    if not isinstance(state, dict):
+        # Defensive: callers without a real Session.state still drive
+        # the emit path (no-op idempotency).
+        return True
+    declarations = state.get(DECLARATIONS_KEY)
+    if not isinstance(declarations, dict):
+        declarations = {}
+        state[DECLARATIONS_KEY] = declarations
+    key = f"{kind}:{task_id}"
+    if key in declarations:
+        return False
+    declarations[key] = {
+        "kind": kind,
+        "task_id": task_id,
+        "reason": reason,
+        # Best-effort sequence stamp for ordering when read back later.
+        "recorded_at_seq": int(getattr(session, "_next_sequence", 0)),
+    }
+    return True
+
+
+async def _handle_declaration(
+    args: dict[str, Any],
+    session: Session,
+    steerer: Steerer,
+    *,
+    kind: str,
+    tool_name: str,
+) -> dict[str, Any]:
+    """Shared body for ``declare_task_skipped`` / ``declare_task_not_needed``.
+
+    Both handlers are observability-only:
+
+    * Resolve ``task_id`` (explicit > pin default — same precedence as
+      the ``report_task_*`` family).
+    * Idempotency: skip the emit when the declaration is a duplicate
+      of the same ``(kind, task_id)`` pair.
+    * Emit ``TaskDeclarationReceived`` on the sink bus.
+    * Return ``{"acknowledged": True}`` — never fail the agent's tool
+      call on a declaration.
+
+    DOES NOT mutate plan state. The steerer's ``_apply_revision``
+    machinery remains the only path that can transition a task; this
+    declaration just queues an advisory signal that the next refine
+    consumes (Phase 4 work).
+    """
+    task_id, _source = _resolve_task_id_with_source(args, session)
+    reason = _str(args, "reason")
+    if not task_id:
+        return _missing_task_id_response(tool_name)
+    is_new = _record_declaration(session, kind, task_id, reason)
+    if is_new:
+        await _emit_task_declaration_received(
+            session=session,
+            steerer=steerer,
+            kind=kind,
+            task_id=task_id,
+            reason=reason,
+        )
+    # Return shape mirrors the ``report_task_*`` family: ``acknowledged``
+    # tells the LLM "we got it", and ``idempotent`` flags the duplicate
+    # case so observability can distinguish first-time vs. repeat.
+    if is_new:
+        return dict(_ACK)
+    return {"acknowledged": True, "idempotent": True}
+
+
+async def _handle_declare_task_skipped(
+    args: dict[str, Any], session: Session, steerer: Steerer
+) -> dict[str, Any]:
+    return await _handle_declaration(
+        args,
+        session,
+        steerer,
+        kind=DECLARATION_KIND_SKIPPED,
+        tool_name="declare_task_skipped",
+    )
+
+
+async def _handle_declare_task_not_needed(
+    args: dict[str, Any], session: Session, steerer: Steerer
+) -> dict[str, Any]:
+    return await _handle_declaration(
+        args,
+        session,
+        steerer,
+        kind=DECLARATION_KIND_NOT_NEEDED,
+        tool_name="declare_task_not_needed",
+    )
+
+
 async def _handle_awaiting_approval(
     args: dict[str, Any], session: Session, steerer: Steerer
 ) -> dict[str, Any]:
@@ -1294,6 +1467,24 @@ _SCHEMA_AWAITING_APPROVAL = _object_schema(
 )
 
 
+_SCHEMA_DECLARE_TASK_SKIPPED = _object_schema(
+    required=["reason"],
+    properties={
+        "task_id": {"type": "string"},
+        "reason": {"type": "string"},
+    },
+)
+
+
+_SCHEMA_DECLARE_TASK_NOT_NEEDED = _object_schema(
+    required=["reason"],
+    properties={
+        "task_id": {"type": "string"},
+        "reason": {"type": "string"},
+    },
+)
+
+
 # ---------------------------------------------------------------------------
 # Built-in tool specs
 # ---------------------------------------------------------------------------
@@ -1385,10 +1576,51 @@ BUILTIN_REPORTING_TOOLS: list[ReportingToolSpec] = [
         parameters=_SCHEMA_AWAITING_APPROVAL,
         handler=_handle_awaiting_approval,
     ),
+    # goldfive#271 Phase 3: structural declarations. Observability-only
+    # — they emit a TaskDeclarationReceived sink event so operators can
+    # see the agent's stated intent without the framework auto-mutating
+    # the plan in response. The imperative report_task_* surface
+    # remains the only path to actually transition a task; declarations
+    # are advisory signals the next refine consumes.
+    ReportingToolSpec(
+        name="declare_task_skipped",
+        description=(
+            "Declare that you are intentionally skipping a task — you read "
+            "the plan, you saw the task, and you decided not to do it (e.g. "
+            "duplicate work already done by another agent, or work the "
+            "user clarified is no longer needed). 'reason' is a one-line "
+            "explanation. This is an OBSERVABILITY signal — the framework "
+            "records it but does NOT remove the task from the plan. If you "
+            "want to actually fail or cancel the task, use report_task_failed. "
+            "Idempotent: a second declaration of the same kind on the same "
+            "task is a no-op."
+        ),
+        parameters=_SCHEMA_DECLARE_TASK_SKIPPED,
+        handler=_handle_declare_task_skipped,
+    ),
+    ReportingToolSpec(
+        name="declare_task_not_needed",
+        description=(
+            "Declare that a planned task is no longer needed — your work "
+            "made the task redundant (e.g. an upstream change satisfies it, "
+            "or the goal evolved past it). 'reason' is a one-line "
+            "explanation. This is an OBSERVABILITY signal — the framework "
+            "records it but does NOT remove the task from the plan. The "
+            "next refine considers your declaration when deciding whether "
+            "to mark the task NOT_NEEDED. Idempotent: a second declaration "
+            "of the same kind on the same task is a no-op."
+        ),
+        parameters=_SCHEMA_DECLARE_TASK_NOT_NEEDED,
+        handler=_handle_declare_task_not_needed,
+    ),
 ]
 
 
 __all__ = [
+    "DECLARATION_KIND_NOT_NEEDED",
+    "DECLARATION_KIND_SKIPPED",
+    "DECLARATION_KINDS",
+    "DECLARATIONS_KEY",
     "ReportingHandler",
     "ReportingToolSpec",
     "REPORTING_TOOL_NAMES",

--- a/tests/test_approval_flow.py
+++ b/tests/test_approval_flow.py
@@ -69,9 +69,7 @@ class ListSink:
         pass
 
     def payload_kinds(self) -> list[str]:
-        return [
-            e.WhichOneof("payload") for e in self.events if hasattr(e, "WhichOneof")
-        ]
+        return [e.WhichOneof("payload") for e in self.events if hasattr(e, "WhichOneof")]
 
 
 class _StubSteerer:
@@ -121,8 +119,13 @@ def _find_handler(name: str) -> Any:
 
 
 def test_eighth_reporting_tool_is_report_awaiting_approval() -> None:
-    assert REPORTING_TOOL_NAMES[-1] == "report_awaiting_approval"
-    assert len(REPORTING_TOOL_NAMES) == 8
+    # report_awaiting_approval is the 8th canonical reporting tool. The
+    # ninth and tenth are ``declare_task_skipped`` and
+    # ``declare_task_not_needed`` (goldfive#271 Phase 3 — observability-
+    # only structural declarations) — the awaiting_approval position
+    # in the tuple is preserved.
+    assert REPORTING_TOOL_NAMES[7] == "report_awaiting_approval"
+    assert len(REPORTING_TOOL_NAMES) == 10
     names = {spec.name for spec in BUILTIN_REPORTING_TOOLS}
     assert "report_awaiting_approval" in names
 
@@ -173,9 +176,7 @@ async def test_task_level_approve_resumes_handler() -> None:
         kind=ControlKind.APPROVE,
         payload={"target_id": "t1", "detail": "looks fine"},
     )
-    outcome = await dispatch_control(
-        msg, session=session, steerer=steerer, sinks=[sink]
-    )
+    outcome = await dispatch_control(msg, session=session, steerer=steerer, sinks=[sink])
     assert outcome.ack.result.value == "SUCCESS"
 
     result = await asyncio.wait_for(task, timeout=1.0)
@@ -215,9 +216,7 @@ async def test_task_level_reject_resumes_handler() -> None:
         kind=ControlKind.REJECT,
         payload={"target_id": "t1", "detail": "absolutely not"},
     )
-    outcome = await dispatch_control(
-        msg, session=session, steerer=steerer, sinks=[sink]
-    )
+    outcome = await dispatch_control(msg, session=session, steerer=steerer, sinks=[sink])
     assert outcome.ack.result.value == "SUCCESS"
 
     result = await asyncio.wait_for(task, timeout=1.0)
@@ -255,9 +254,7 @@ async def test_dispatch_approve_unknown_target_fails_ack() -> None:
         kind=ControlKind.APPROVE,
         payload={"target_id": "nope", "detail": ""},
     )
-    outcome = await dispatch_control(
-        msg, session=session, steerer=steerer, sinks=[sink]
-    )
+    outcome = await dispatch_control(msg, session=session, steerer=steerer, sinks=[sink])
     assert outcome.ack.result.value == "FAILURE"
     assert "no pending approval" in outcome.ack.detail
 
@@ -269,9 +266,7 @@ async def test_dispatch_approve_missing_target_fails_ack() -> None:
     steerer.bind(sinks=[sink], planner=None)
 
     msg = ControlMessage(kind=ControlKind.APPROVE, payload={})
-    outcome = await dispatch_control(
-        msg, session=session, steerer=steerer, sinks=[sink]
-    )
+    outcome = await dispatch_control(msg, session=session, steerer=steerer, sinks=[sink])
     assert outcome.ack.result.value == "FAILURE"
     assert "requires payload.target_id" in outcome.ack.detail
 
@@ -318,9 +313,7 @@ class _FakeToolContext:
 
 def test_tool_requires_confirmation_bool() -> None:
     assert _tool_requires_confirmation(_FakeTool(require_confirmation=True), {})
-    assert not _tool_requires_confirmation(
-        _FakeTool(require_confirmation=False), {}
-    )
+    assert not _tool_requires_confirmation(_FakeTool(require_confirmation=False), {})
 
 
 def test_tool_requires_confirmation_callable() -> None:
@@ -364,9 +357,7 @@ async def test_tool_level_approve_falls_through() -> None:
         kind=ControlKind.APPROVE,
         payload={"target_id": "adk-abc123", "detail": "proceed"},
     )
-    outcome = await dispatch_control(
-        msg, session=session, steerer=steerer, sinks=[sink]
-    )
+    outcome = await dispatch_control(msg, session=session, steerer=steerer, sinks=[sink])
     assert outcome.ack.result.value == "SUCCESS"
 
     result = await asyncio.wait_for(task, timeout=1.0)
@@ -481,9 +472,7 @@ async def test_task_and_tool_waiters_resolve_independently() -> None:
     # Register a task-level waiter via the reporting handler.
     task_handler = _find_handler("report_awaiting_approval")
     task_fut = asyncio.create_task(
-        task_handler(
-            {"task_id": "t1", "prompt": "task-level?"}, session, steerer
-        )
+        task_handler({"task_id": "t1", "prompt": "task-level?"}, session, steerer)
     )
     for _ in range(20):
         if "t1" in session.pending_approvals:
@@ -514,17 +503,13 @@ async def test_task_and_tool_waiters_resolve_independently() -> None:
 
     # Reject the tool, approve the task.
     await dispatch_control(
-        ControlMessage(
-            kind=ControlKind.REJECT, payload={"target_id": "adk-tool"}
-        ),
+        ControlMessage(kind=ControlKind.REJECT, payload={"target_id": "adk-tool"}),
         session=session,
         steerer=steerer,
         sinks=[sink],
     )
     await dispatch_control(
-        ControlMessage(
-            kind=ControlKind.APPROVE, payload={"target_id": "t1"}
-        ),
+        ControlMessage(kind=ControlKind.APPROVE, payload={"target_id": "t1"}),
         session=session,
         steerer=steerer,
         sinks=[sink],

--- a/tests/test_reporting_declarations.py
+++ b/tests/test_reporting_declarations.py
@@ -1,0 +1,327 @@
+"""Tests for ``declare_task_skipped`` / ``declare_task_not_needed``.
+
+goldfive#271 Phase 3 — structural declaration tools. Observability-only:
+the handlers emit a ``TaskDeclarationReceived`` event and NEVER mutate
+plan state. The imperative ``report_task_*`` surface remains the only
+path that drives the steerer; declarations are advisory signals queued
+for the next refine to consume.
+
+These tests pin:
+
+1. Both handlers emit a ``task_declaration_received`` envelope with the
+   right ``kind``, ``task_id``, ``reason``, and ``source_signal``.
+2. Handlers NEVER mutate plan state (status, edges, tasks).
+3. Idempotent on duplicate declarations of the same ``(kind, task_id)``
+   pair — the second call is a no-op (no second event emitted, no
+   recorded body rewritten).
+4. The two tools are wired into ``BUILTIN_REPORTING_TOOLS`` and
+   ``REPORTING_TOOL_NAMES``.
+5. Distinct kinds on the same task each emit independently.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.reporting import (  # noqa: E402
+    BUILTIN_REPORTING_TOOLS,
+    DECLARATION_KIND_NOT_NEEDED,
+    DECLARATION_KIND_SKIPPED,
+    DECLARATION_KINDS,
+    DECLARATIONS_KEY,
+    REPORTING_TOOL_NAMES,
+    ReportingToolSpec,
+)
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+def _plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="A"), Task(id="t2", title="B")],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+
+
+def _fresh() -> tuple[DefaultSteerer, Session, ListSink]:
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do it")],
+        plan=_plan(),
+    )
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=None)
+    return steerer, session, sink
+
+
+def _tool(name: str) -> ReportingToolSpec:
+    for t in BUILTIN_REPORTING_TOOLS:
+        if t.name == name:
+            return t
+    raise AssertionError(f"builtin tool {name!r} missing")
+
+
+def _declarations(events: list[Any]) -> list[Any]:
+    """Return only the ``task_declaration_received`` dict envelopes."""
+    return [
+        e for e in events if isinstance(e, dict) and e.get("kind") == "task_declaration_received"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_declarations_in_canonical_names() -> None:
+    """Both declaration tools appear in ``REPORTING_TOOL_NAMES``."""
+    assert "declare_task_skipped" in REPORTING_TOOL_NAMES
+    assert "declare_task_not_needed" in REPORTING_TOOL_NAMES
+
+
+def test_declaration_kinds_vocabulary() -> None:
+    """The ``DECLARATION_KINDS`` tuple holds the two known kinds."""
+    assert DECLARATION_KINDS == (DECLARATION_KIND_SKIPPED, DECLARATION_KIND_NOT_NEEDED)
+    assert DECLARATION_KIND_SKIPPED == "skipped"
+    assert DECLARATION_KIND_NOT_NEEDED == "not_needed"
+
+
+def test_declarations_in_builtin_tools() -> None:
+    """Both declaration tool specs are wired into ``BUILTIN_REPORTING_TOOLS``."""
+    skipped = _tool("declare_task_skipped")
+    not_needed = _tool("declare_task_not_needed")
+    assert callable(skipped.handler)
+    assert callable(not_needed.handler)
+    assert skipped.parameters.get("type") == "object"
+    assert not_needed.parameters.get("type") == "object"
+    # Both schemas require ``reason``.
+    assert skipped.parameters.get("required") == ["reason"]
+    assert not_needed.parameters.get("required") == ["reason"]
+    # Neither requires ``task_id`` (defaulting from session pin is the
+    # contract — same as report_task_*).
+    assert "task_id" not in skipped.parameters.get("required", [])
+    assert "task_id" not in not_needed.parameters.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# declare_task_skipped
+# ---------------------------------------------------------------------------
+
+
+async def test_declare_task_skipped_emits_event() -> None:
+    """Handler emits a single ``task_declaration_received`` envelope."""
+    steerer, session, sink = _fresh()
+    out = await _tool("declare_task_skipped").handler(
+        {"task_id": "t1", "reason": "duplicate of upstream work"}, session, steerer
+    )
+    assert out == {"acknowledged": True}
+    decls = _declarations(sink.events)
+    assert len(decls) == 1
+    payload = decls[0]["payload"]
+    assert payload["kind"] == "skipped"
+    assert payload["task_id"] == "t1"
+    assert payload["reason"] == "duplicate of upstream work"
+    assert payload["source_signal"] == "DECLARATION"
+
+
+async def test_declare_task_skipped_does_not_mutate_plan() -> None:
+    """Plan state is NEVER touched by the declaration handler."""
+    steerer, session, sink = _fresh()
+    plan_before = session.plan
+    statuses_before = [t.status for t in session.plan.tasks]
+    edges_before = list(session.plan.edges)
+    await _tool("declare_task_skipped").handler(
+        {"task_id": "t1", "reason": "skip me"}, session, steerer
+    )
+    # Plan identity unchanged.
+    assert session.plan is plan_before
+    # Task statuses unchanged.
+    assert [t.status for t in session.plan.tasks] == statuses_before
+    # Edges unchanged.
+    assert session.plan.edges == edges_before
+    # No task transitioned.
+    assert session.plan.tasks[0].status is TaskStatus.PENDING
+
+
+async def test_declare_task_skipped_idempotent_on_duplicate() -> None:
+    """Second declaration of the same kind+task is a no-op."""
+    steerer, session, sink = _fresh()
+    await _tool("declare_task_skipped").handler(
+        {"task_id": "t1", "reason": "first"}, session, steerer
+    )
+    out = await _tool("declare_task_skipped").handler(
+        {"task_id": "t1", "reason": "second"}, session, steerer
+    )
+    assert out == {"acknowledged": True, "idempotent": True}
+    # Only ONE event emitted.
+    decls = _declarations(sink.events)
+    assert len(decls) == 1
+    # The recorded body keeps the FIRST reason.
+    assert decls[0]["payload"]["reason"] == "first"
+
+
+async def test_declare_task_skipped_records_to_session_state() -> None:
+    """Declaration is recorded on session.state under DECLARATIONS_KEY."""
+    steerer, session, sink = _fresh()
+    await _tool("declare_task_skipped").handler(
+        {"task_id": "t1", "reason": "noop"}, session, steerer
+    )
+    decls = session.state.get(DECLARATIONS_KEY)
+    assert isinstance(decls, dict)
+    body = decls.get("skipped:t1")
+    assert body is not None
+    assert body["kind"] == "skipped"
+    assert body["task_id"] == "t1"
+    assert body["reason"] == "noop"
+
+
+async def test_declare_task_skipped_missing_task_id() -> None:
+    """Missing task_id returns the canonical missing_task_id rejection."""
+    steerer, session, sink = _fresh()
+    out = await _tool("declare_task_skipped").handler({"reason": "no id"}, session, steerer)
+    assert out["acknowledged"] is False
+    assert out["error"] == "missing_task_id"
+    assert out["tool"] == "declare_task_skipped"
+    # No event emitted.
+    assert _declarations(sink.events) == []
+
+
+# ---------------------------------------------------------------------------
+# declare_task_not_needed
+# ---------------------------------------------------------------------------
+
+
+async def test_declare_task_not_needed_emits_event() -> None:
+    steerer, session, sink = _fresh()
+    out = await _tool("declare_task_not_needed").handler(
+        {"task_id": "t2", "reason": "satisfied by upstream"}, session, steerer
+    )
+    assert out == {"acknowledged": True}
+    decls = _declarations(sink.events)
+    assert len(decls) == 1
+    payload = decls[0]["payload"]
+    assert payload["kind"] == "not_needed"
+    assert payload["task_id"] == "t2"
+    assert payload["reason"] == "satisfied by upstream"
+    assert payload["source_signal"] == "DECLARATION"
+
+
+async def test_declare_task_not_needed_does_not_mutate_plan() -> None:
+    """``declare_task_not_needed`` does NOT stamp NOT_NEEDED on the task.
+
+    The reconciler / next refine consumes the declaration as a signal;
+    the handler itself remains observability-only. Pin this contract
+    so a future "let's just stamp it" refactor doesn't accidentally
+    bypass the structural-steering machinery.
+    """
+    steerer, session, sink = _fresh()
+    plan_before = session.plan
+    await _tool("declare_task_not_needed").handler(
+        {"task_id": "t2", "reason": "noop"}, session, steerer
+    )
+    assert session.plan is plan_before
+    # Task t2 stayed PENDING — handler did NOT mark it NOT_NEEDED.
+    t2 = next(t for t in session.plan.tasks if t.id == "t2")
+    assert t2.status is TaskStatus.PENDING
+
+
+async def test_declare_task_not_needed_idempotent() -> None:
+    steerer, session, sink = _fresh()
+    await _tool("declare_task_not_needed").handler(
+        {"task_id": "t2", "reason": "first"}, session, steerer
+    )
+    out = await _tool("declare_task_not_needed").handler(
+        {"task_id": "t2", "reason": "second"}, session, steerer
+    )
+    assert out == {"acknowledged": True, "idempotent": True}
+    decls = _declarations(sink.events)
+    assert len(decls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-kind
+# ---------------------------------------------------------------------------
+
+
+async def test_distinct_kinds_on_same_task_each_emit() -> None:
+    """``skipped`` + ``not_needed`` on the same task are tracked separately."""
+    steerer, session, sink = _fresh()
+    await _tool("declare_task_skipped").handler(
+        {"task_id": "t1", "reason": "skip"}, session, steerer
+    )
+    await _tool("declare_task_not_needed").handler(
+        {"task_id": "t1", "reason": "don't need"}, session, steerer
+    )
+    decls = _declarations(sink.events)
+    assert len(decls) == 2
+    kinds = {d["payload"]["kind"] for d in decls}
+    assert kinds == {"skipped", "not_needed"}
+
+
+async def test_distinct_tasks_each_emit_independently() -> None:
+    """Same kind on two different task ids emits twice."""
+    steerer, session, sink = _fresh()
+    await _tool("declare_task_skipped").handler(
+        {"task_id": "t1", "reason": "first task"}, session, steerer
+    )
+    await _tool("declare_task_skipped").handler(
+        {"task_id": "t2", "reason": "second task"}, session, steerer
+    )
+    decls = _declarations(sink.events)
+    assert len(decls) == 2
+    task_ids = {d["payload"]["task_id"] for d in decls}
+    assert task_ids == {"t1", "t2"}
+
+
+# ---------------------------------------------------------------------------
+# Defaulting from session.state pin
+# ---------------------------------------------------------------------------
+
+
+async def test_declare_task_skipped_defaults_from_pin() -> None:
+    """Omitted task_id resolves from the goldfive.current_task_id pin.
+
+    Mirrors the report_task_* defaulting contract (goldfive#191) — the
+    declaration tools use the same precedence so an agent that drops
+    the explicit arg still gets routed correctly.
+    """
+    from goldfive import orchestration_state as _ostate
+
+    steerer, session, sink = _fresh()
+    _ostate.write(session.state, _ostate.KEY_CURRENT_TASK_ID, "t1")
+    out = await _tool("declare_task_skipped").handler({"reason": "implicit task"}, session, steerer)
+    assert out == {"acknowledged": True}
+    decls = _declarations(sink.events)
+    assert len(decls) == 1
+    assert decls[0]["payload"]["task_id"] == "t1"


### PR DESCRIPTION
## Summary

Phase 3 main work for goldfive#271 — ships the structural declaration
tools and the cancellation-contract scaffolding. Defers the goldfive-
owned task boundary to Phase 3.5 because the existing ADK plugin
already has cooperative-cancellation infrastructure (#251 Stream C);
wedging a second boundary in alongside it without coordination would
be a regression risk (see PR description below).

## What lands

### Structural declarations (observability-only)

Two new reporting tools, NEVER mutate plan state:

* ``declare_task_skipped(task_id, reason)`` — agent volunteered "I'm
  skipping this task".
* ``declare_task_not_needed(task_id, reason)`` — agent volunteered
  "this task is no longer needed".

Both emit a ``task_declaration_received`` dict envelope onto the sink
bus and record the declaration on ``session.state[DECLARATIONS_KEY]``
for next-refine consumption (Phase 4 work). Idempotent on duplicate
``(kind, task_id)`` pairs.

Wired into ``BUILTIN_REPORTING_TOOLS`` as the 9th and 10th canonical
tools. ``REPORTING_TOOL_NAMES`` grows from 8 to 10.

### Cancellation contract scaffolding (Addition A)

* ``goldfive._state_audit.CancellationStashViolation`` — new
  ``BaseException`` subclass, paired with a comprehensive
  ``docs/design/CANCELLATION-CONTRACT.md`` audit doc.
* The runner.py:411 bypass that validation v2 surfaced is already
  fixed (PR #287). The contract doc catalogs C1 (FIXED) and the
  remaining MEDIUM/LOW sites (C2-C6) for the Phase 3.5 sweep.

The runtime tripwire mechanism is intentionally NOT installed in this
PR — it requires the goldfive task boundary to be the legitimate
catch site, and the boundary lands in Phase 3.5.

## Deviations from the plan

The plan specified three pieces (boundary, declarations, cancellation
audit). This PR ships **declarations + audit doc + exception class
only**, deferring the boundary. Reasoning:

* The plan assumes goldfive currently has no asyncio-task scope
  tracking around invocations.
* In practice, the ADK adapter has a sophisticated cooperative-
  cancellation mechanism already (#251 Stream C).
* Wedging a second goldfive-owned ``asyncio.Task`` perimeter around
  the existing machinery without coordination would either duplicate
  the cancellation surface or race it.
* The right move is to design the boundary in coordination with
  Stream C in Phase 3.5; declarations + the audit infrastructure are
  shippable independently and unblock Phase 4.

The plan's ``OrchestrationStore.active_invocations`` slot is
intentionally NOT added — it lands when the boundary it tracks does.

## Test plan

- [x] ``tests/test_reporting_declarations.py`` — 14 tests covering
  tool wiring, emit shape, plan-mutation forbidden, idempotency,
  defaulting from session pin, distinct-kinds-on-same-task, and
  missing_task_id rejection.
- [x] ``test_approval_flow.py::test_eighth_reporting_tool_is_report_awaiting_approval``
  updated to assert position 7 + count 10.
- [x] All 1730 existing tests pass with
  ``GOLDFIVE_STRICT_STATE_OWNERSHIP=1`` (up from 1716 baseline).
- [x] ``ruff check`` clean on touched files.

## LOC counts

* Code: +302 LOC across ``goldfive/reporting.py`` +
  ``goldfive/_state_audit.py``.
* Tests: +312 LOC.
* Docs: +175 LOC (cancellation contract).

## Phase 3.5 follow-ups

1. Goldfive task boundary in coordination with Stream C.
2. ``OrchestrationStore.active_invocations`` slot.
3. Convert HIGH/MEDIUM audit sites (C2-C6) to ``try / finally``.
4. Install the ``CancellationStashViolation`` runtime tripwire.
5. Promote ``task_declaration_received`` from dict envelope to typed
   proto.

Refs goldfive#271 Phase 3.