### PR TITLE
fix(runner): scope cross-turn plan stash per session id on Conversation

### DIFF
--- a/goldfive/conversation.py
+++ b/goldfive/conversation.py
@@ -14,7 +14,13 @@ Phase 3 scope (see issue #78):
 
 * ``session.goals`` accumulates across turns (deduplicated by id).
 * ``session.completed_results`` carries over from prior turns.
-* ``session.plan`` resets per turn. Cross-turn plan lineage is v2.
+* ``session.plan`` is seeded each turn from the prior turn's stash
+  (via :meth:`Conversation.prior_plan_for`) so :meth:`Planner.handle_turn`
+  always sees a non-None prior. The carry-forward is gated on
+  ``session_id`` pin state so a Runner shared across multiple outer
+  ADK sessions does not leak one session's plan into another's first
+  turn (goldfive#271 follow-up; pre-fix this lived on
+  ``Runner._last_plan`` and was process-scoped).
 * :class:`TurnRecord` captures a one-sentence summary of each turn so
   the planner can reference them in its prompt.
 
@@ -30,7 +36,7 @@ import time
 import uuid
 from typing import TYPE_CHECKING
 
-from goldfive.types import Goal, Session
+from goldfive.types import Goal, Plan, Session
 
 if TYPE_CHECKING:
     from goldfive.results import ExecutionOutcome
@@ -106,6 +112,31 @@ class Conversation:
     # outer-session pin. Single-turn callers see no change: the cursor
     # starts at 0 on a fresh Conversation.
     _next_sequence: int = 0
+    # Most recently absorbed turn's plan. Used by the Runner to seed
+    # the next turn's ``session.plan`` so :meth:`Planner.handle_turn`
+    # always sees a non-None prior. Pre-fix this lived on
+    # :class:`Runner` as ``_last_plan`` — a process-scoped attribute
+    # that leaked across outer ADK sessions sharing one Runner
+    # (validation v4 Class 1, goldfive#271 follow-up). The seed lookup
+    # (:meth:`prior_plan_for`) gates carry-forward on the session-id
+    # bookkeeping below so an ADK-pinned session boundary defeats the
+    # carry-forward, while a programmatic Runner caller (no pin) still
+    # gets Conversation-level continuity.
+    _last_plan: Plan | None = None
+    # Session id (== ``Session.run_id`` after any
+    # :meth:`Runner.run(session_id=...)` outer-session pin) of the
+    # turn whose plan is held in ``_last_plan``. Default ``""`` means
+    # no plan has been stashed yet — a brand-new Conversation, the
+    # state immediately after :meth:`Runner.new_conversation`.
+    _last_plan_session_id: str = ""
+    # Whether the turn that produced ``_last_plan`` had its session
+    # id explicitly pinned via :meth:`Runner.run(session_id=...)`.
+    # The seed lookup uses this together with the new turn's pin
+    # state to decide whether the session-id check applies:
+    # programmatic (unpinned) callers get unconditional Conversation-
+    # level carry-forward; ADK (pinned) callers must match the prior
+    # turn's pinned id exactly.
+    _last_plan_pinned: bool = False
 
     @classmethod
     def new(cls) -> Conversation:
@@ -139,17 +170,105 @@ class Conversation:
             _next_sequence=self._next_sequence,
         )
 
+    def stash_plan(self, session: Session, *, pinned: bool = False) -> None:
+        """Stash ``session.plan`` keyed by ``session.id`` for the next turn.
+
+        ``pinned`` records whether the turn that produced this plan
+        had its session id explicitly pinned via
+        :meth:`Runner.run(session_id=...)`. The next turn's
+        :meth:`prior_plan_for` lookup combines that flag with the
+        next turn's own pin state to decide whether carry-forward
+        applies; see the lookup docstring for the matrix.
+
+        The Runner calls this from its ``finally`` block so the stash
+        runs even on ``BaseException`` (e.g. ``CancelledError`` from
+        ADK closing the runner mid-stream) — the rationale is the
+        same as goldfive#271 Gap 1's original Runner-side stash. The
+        idempotency contract: a subsequent :meth:`absorb_turn` on the
+        same session re-stashes the same (plan, session id, pinned)
+        tuple, so callers that hit both paths produce identical state.
+
+        Skipped (no-op) when ``session.plan`` is ``None`` or empty —
+        an empty plan is not a meaningful prior to carry forward.
+        """
+        if session.plan is not None and session.plan.tasks:
+            self._last_plan = session.plan
+            self._last_plan_session_id = session.id
+            self._last_plan_pinned = pinned
+
+    def prior_plan_for(self, session_id: str, *, pinned: bool = False) -> Plan | None:
+        """Return the stashed prior plan iff carry-forward applies.
+
+        Called by :meth:`Runner.run` to seed ``session.plan`` at the
+        start of a turn AFTER any
+        :meth:`Runner.run(session_id=...)` outer-session pin has
+        finalised the new turn's session id. ``pinned`` records
+        whether the new turn's caller passed an explicit
+        ``session_id`` pin.
+
+        Carry-forward matrix:
+
+        ===========  ===========  =============================
+        prior turn   new turn     carry forward?
+        ===========  ===========  =============================
+        unpinned     unpinned     YES — Conversation-level
+                                  continuity for programmatic
+                                  Runner callers.
+        unpinned     pinned       NO — the pin signals a switch
+                                  to an externally-owned session
+                                  identity; treat as a boundary.
+        pinned       unpinned     NO — symmetric: leaving an
+                                  externally-owned identity is
+                                  also a boundary.
+        pinned       pinned, ids  YES — same outer ADK session
+                       match      across turns; intra-session
+                                  continuity (the pre-fix
+                                  intent of ``_last_plan``).
+        pinned       pinned, ids  NO — the regression case:
+                       differ     two distinct outer ADK
+                                  sessions sharing one Runner,
+                                  validation v4 Class 1.
+        ===========  ===========  =============================
+
+        Returning ``None`` causes the Runner to seed
+        ``session.plan = Plan.empty(...)`` — the correct first-turn
+        behaviour for an outer session that has never been seen
+        before.
+
+        Pre-fix the carry-forward was unconditional: a process-wide
+        ``Runner._last_plan`` field. Validation v4 Class 1 (goldfive#271
+        follow-up) showed that two distinct outer ADK sessions
+        sharing one Runner caused the second session's first turn
+        to inherit the first session's plan, then fail every
+        revision attempt because the leaked plan made no sense for
+        the new request.
+        """
+        if self._last_plan is None:
+            return None
+        # Either side touched the pin → require an exact session-id
+        # match. Both sides unpinned → Conversation-level continuity.
+        if self._last_plan_pinned or pinned:
+            if self._last_plan_session_id != session_id:
+                return None
+        return self._last_plan
+
     def absorb_turn(
         self,
         outcome: ExecutionOutcome,
         *,
         user_input_summary: str = "",
+        pinned: bool = False,
     ) -> TurnRecord:
         """Fold a turn's outcome back into the Conversation.
 
         Called by the Runner after ``executor.run`` returns (successful
         or not — we record the failure so the next turn's planner can
         see it). Returns the newly-appended :class:`TurnRecord`.
+
+        ``pinned`` records whether this turn's caller passed an
+        explicit ``Runner.run(session_id=...)`` outer-session pin so
+        the next turn's :meth:`prior_plan_for` can apply the
+        carry-forward matrix correctly.
         """
         session = outcome.session
         # Merge goals by id so a restated goal doesn't duplicate.
@@ -176,14 +295,20 @@ class Conversation:
         # turn that aborted before any sink emission).
         self._next_sequence = max(self._next_sequence, int(session._next_sequence))
 
+        # Stash the turn's final plan keyed by the session id (and
+        # pin state) that produced it so the next turn's
+        # :meth:`prior_plan_for` lookup applies the documented
+        # carry-forward matrix. Empty plans are skipped (no-op); see
+        # :meth:`stash_plan` for the idempotency contract this shares
+        # with the Runner's ``finally``-block invocation.
+        self.stash_plan(session, pinned=pinned)
+
         plan_summary = ""
         completed_ids: list[str] = []
         if session.plan is not None:
             plan_summary = session.plan.summary or ""
             completed_ids = [
-                t.id
-                for t in session.plan.tasks
-                if t.status.value == "COMPLETED" and t.id
+                t.id for t in session.plan.tasks if t.status.value == "COMPLETED" and t.id
             ]
 
         record = TurnRecord(

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -228,10 +228,12 @@ class Runner:
         # via ``Planner.generate`` (pre-#271 behaviour, useful for
         # deterministic replay).
         self._planner_gate: Any = planner_gate
-        # Held across turns so the ``conversational`` path can carry
-        # the prior plan forward onto the freshly minted session
-        # without re-running the planner.
-        self._last_plan: Plan | None = None
+        # Cross-turn prior-plan stash lives on :class:`Conversation`
+        # (keyed by session id) so a Runner shared across multiple
+        # outer ADK sessions does not leak one session's plan into
+        # another's first turn. See :meth:`Conversation.prior_plan_for`
+        # and the goldfive#271 follow-up validation v4 Class 1
+        # post-mortem.
 
     # ------------------------------------------------------------------
     # run
@@ -270,8 +272,14 @@ class Runner:
         # harmonograf spans already target — resolving the
         # "plan view has empty Gantt" regression from the overlay
         # architecture.
-        if session_id:
-            session.run_id = session_id
+        # Track whether the caller explicitly pinned the session id so
+        # the Conversation's prior-plan carry-forward (and the
+        # symmetric stash on absorb_turn) can apply the documented
+        # carry-forward matrix — see :meth:`Conversation.prior_plan_for`
+        # and goldfive#271 follow-up validation v4 Class 1.
+        pinned = bool(session_id)
+        if pinned:
+            session.run_id = session_id  # type: ignore[assignment]
         self._last_session = session
 
         # 2. Announce the Conversation on the first turn.
@@ -287,9 +295,21 @@ class Runner:
         # sees a non-None ``session.plan``. The Runner has a single
         # install path post-Phase-4: every plan landed by the planner
         # becomes the next revision of this seed (revision_index += 1).
-        if self._last_plan is not None:
-            self._last_plan.run_id = session.run_id
-            session.plan = self._last_plan
+        #
+        # The prior-plan lookup combines ``session.id`` (== ``run_id``
+        # after any outer-session pin above) with the caller's pin
+        # state. A turn on a different outer ADK session sharing this
+        # Runner (pinned-vs-pinned with mismatched ids, or a
+        # pinned-prior followed by an unpinned new turn) sees
+        # ``Plan.empty()`` rather than the stash from another session
+        # (validation v4 Class 1 / goldfive#271 follow-up). Programmatic
+        # callers (both prior and new turn unpinned) keep the
+        # Conversation-level continuity the original ``_last_plan``
+        # field provided.
+        prior_plan = self._conversation.prior_plan_for(session.id, pinned=pinned)
+        if prior_plan is not None:
+            prior_plan.run_id = session.run_id
+            session.plan = prior_plan
         else:
             session.plan = Plan.empty(run_id=session.run_id)
         _ostate.set_current_plan(session.state, session.plan)
@@ -306,7 +326,9 @@ class Runner:
             await self._emit_run_aborted(session, reason)
             outcome = ExecutionOutcome(success=False, session=session, reason=reason)
             self._conversation.absorb_turn(
-                outcome, user_input_summary=_initial_goal_summary(user_input)
+                outcome,
+                user_input_summary=_initial_goal_summary(user_input),
+                pinned=pinned,
             )
             return outcome
 
@@ -376,8 +398,7 @@ class Runner:
                 # A misbehaving handle_turn must never break the run;
                 # fall through to generate (legacy first-turn path).
                 log.warning(
-                    "planner.handle_turn raised; falling through to "
-                    "generate: %s",
+                    "planner.handle_turn raised; falling through to generate: %s",
                     exc,
                 )
                 decided = False
@@ -421,7 +442,9 @@ class Runner:
                 await self._emit_run_aborted(session, reason)
                 outcome = ExecutionOutcome(success=False, session=session, reason=reason)
                 self._conversation.absorb_turn(
-                    outcome, user_input_summary=_initial_goal_summary(user_input)
+                    outcome,
+                    user_input_summary=_initial_goal_summary(user_input),
+                    pinned=pinned,
                 )
                 return outcome
 
@@ -440,7 +463,9 @@ class Runner:
                 await self._emit_run_aborted(session, reason)
                 outcome = ExecutionOutcome(success=False, session=session, reason=reason)
                 self._conversation.absorb_turn(
-                    outcome, user_input_summary=_initial_goal_summary(user_input)
+                    outcome,
+                    user_input_summary=_initial_goal_summary(user_input),
+                    pinned=pinned,
                 )
                 return outcome
         elif not session.plan.tasks:
@@ -451,7 +476,9 @@ class Runner:
             await self._emit_run_aborted(session, reason)
             outcome = ExecutionOutcome(success=False, session=session, reason=reason)
             self._conversation.absorb_turn(
-                outcome, user_input_summary=_initial_goal_summary(user_input)
+                outcome,
+                user_input_summary=_initial_goal_summary(user_input),
+                pinned=pinned,
             )
             return outcome
         else:
@@ -459,8 +486,7 @@ class Runner:
             # session.plan unchanged. No PlanRevised — the prior
             # revision is still the right one for this turn.
             log.info(
-                "Runner.run: conversational turn — reusing prior "
-                "plan_id=%s revision_index=%d",
+                "Runner.run: conversational turn — reusing prior plan_id=%s revision_index=%d",
                 (session.plan.id or "")[:16] or "<none>",
                 int(session.plan.revision_index),
             )
@@ -474,7 +500,9 @@ class Runner:
             await self._emit_run_aborted(session, reason)
             outcome = ExecutionOutcome(success=False, session=session, reason=reason)
             self._conversation.absorb_turn(
-                outcome, user_input_summary=_initial_goal_summary(user_input)
+                outcome,
+                user_input_summary=_initial_goal_summary(user_input),
+                pinned=pinned,
             )
             return outcome
 
@@ -487,7 +515,9 @@ class Runner:
             await self._emit_run_aborted(session, reason)
             outcome = ExecutionOutcome(success=False, session=session, reason=reason)
             self._conversation.absorb_turn(
-                outcome, user_input_summary=_initial_goal_summary(user_input)
+                outcome,
+                user_input_summary=_initial_goal_summary(user_input),
+                pinned=pinned,
             )
             return outcome
 
@@ -509,7 +539,9 @@ class Runner:
                 await self._emit_run_aborted(session, reason)
                 outcome = ExecutionOutcome(success=False, session=session, reason=reason)
                 self._conversation.absorb_turn(
-                    outcome, user_input_summary=_initial_goal_summary(user_input)
+                    outcome,
+                    user_input_summary=_initial_goal_summary(user_input),
+                    pinned=pinned,
                 )
                 return outcome
 
@@ -556,7 +588,9 @@ class Runner:
             await self._emit_run_aborted(session, reason)
             aborted = ExecutionOutcome(success=False, session=session, reason=reason)
             self._conversation.absorb_turn(
-                aborted, user_input_summary=_initial_goal_summary(user_input)
+                aborted,
+                user_input_summary=_initial_goal_summary(user_input),
+                pinned=pinned,
             )
             return aborted
         finally:
@@ -571,11 +605,10 @@ class Runner:
             # ``CancelledError`` is a ``BaseException`` (not an
             # ``Exception``) the ``except Exception`` handler above did
             # NOT catch it. Control flowed out of ``run`` entirely and
-            # the stash was skipped, leaving ``_last_plan = None`` for
+            # the stash was skipped, leaving the prior plan empty for
             # the next turn even though the turn produced a real plan.
             # The ADK-web user-steer flow hit this on validation v2:
-            # zero "stashed prior plan" log lines across 4 turns and
-            # "GoldfiveADKAgent: gate skipped — no prior plan" 4 times.
+            # zero stash log lines across 4 turns.
             #
             # Putting the stash in ``finally`` runs it regardless of how
             # the executor exited — normal success, ``Exception`` (e.g.
@@ -583,13 +616,30 @@ class Runner:
             # ``CancelledError`` from ADK closing the runner mid-stream).
             # The exception still propagates after the stash; this block
             # does not swallow it.
+            #
+            # The stash itself lives on :class:`Conversation`
+            # (validation v4 Class 1 / goldfive#271 follow-up): scoping
+            # by session id means a turn on a fresh outer ADK session
+            # sharing this Runner does not inherit a prior plan from
+            # another session. :meth:`Conversation.absorb_turn` (called
+            # on every normal-completion / handled-exception return
+            # path below) folds the stash in alongside the goals /
+            # completed_results merge. The explicit ``stash_plan`` call
+            # here covers the ``BaseException`` (e.g. ``CancelledError``
+            # from ADK closing the runner mid-stream) path that bypasses
+            # ``absorb_turn`` entirely — the same rationale as the
+            # original Gap 1 fix that put the stash in ``finally`` to
+            # begin with. ``stash_plan`` is idempotent: a subsequent
+            # ``absorb_turn`` re-stashes the same plan + session id.
             if session.plan is not None and session.plan.tasks:
-                self._last_plan = session.plan
+                self._conversation.stash_plan(session, pinned=pinned)
                 log.info(
                     "Runner.run: stashed prior plan for next turn's "
-                    "handle_turn (plan_id=%s revision_index=%d)",
+                    "handle_turn (plan_id=%s revision_index=%d "
+                    "session_id=%s)",
                     (session.plan.id or "")[:16] or "<none>",
                     int(session.plan.revision_index),
+                    (session.id or "")[:16] or "<none>",
                 )
 
         # goldfive#152: clear the current_task_* stamp at run end.
@@ -599,7 +649,9 @@ class Runner:
         _ostate.clear_active_steer(session.state)
 
         self._conversation.absorb_turn(
-            outcome, user_input_summary=_initial_goal_summary(user_input)
+            outcome,
+            user_input_summary=_initial_goal_summary(user_input),
+            pinned=pinned,
         )
         return outcome
 
@@ -800,8 +852,11 @@ class Runner:
         self._conversation_announced = False
         self._last_session = None
         # planner-gate: reset turn-aware gate state so the first turn
-        # of the new conversation runs full planning.
-        self._last_plan = None
+        # of the new conversation runs full planning. Cross-turn
+        # plan stash now lives on :class:`Conversation` (keyed by
+        # session id; see goldfive#271 follow-up); the fresh
+        # ``Conversation.new()`` above already starts with
+        # ``_last_plan = None``, so no Runner-side reset is needed.
 
     # ------------------------------------------------------------------
     # close
@@ -989,9 +1044,7 @@ class Runner:
             if callable(bind_steerer_adapter):
                 bind_steerer_adapter(self.agent)
         except Exception as exc:  # noqa: BLE001
-            log.warning(
-                "Runner._install_revision: steerer/adapter bind raised: %s", exc
-            )
+            log.warning("Runner._install_revision: steerer/adapter bind raised: %s", exc)
             return False
         # Stamp run_id on the revised plan so sink emissions correlate
         # with this turn.
@@ -1002,9 +1055,7 @@ class Runner:
         # steerer's apply_user_steer_with_plan does the bookkeeping +
         # validation + revision install + PlanRevised emit.
         user_text = (
-            user_input.strip()
-            if isinstance(user_input, str)
-            else _initial_goal_summary(user_input)
+            user_input.strip() if isinstance(user_input, str) else _initial_goal_summary(user_input)
         )
         drift = DriftEvent(
             kind=DriftKind.USER_STEER,
@@ -1019,8 +1070,7 @@ class Runner:
             )
         except Exception as exc:  # noqa: BLE001
             log.warning(
-                "Runner._install_revision: apply_user_steer_with_plan "
-                "raised: %s",
+                "Runner._install_revision: apply_user_steer_with_plan raised: %s",
                 exc,
             )
             return False

--- a/tests/test_runner_cross_session_isolation.py
+++ b/tests/test_runner_cross_session_isolation.py
@@ -1,0 +1,332 @@
+"""Cross-session prior-plan isolation (goldfive#271 follow-up).
+
+Validation v4 Class 1 surfaced a process-scoped leak:
+:class:`Runner` stashed the prior turn's plan on
+``self._last_plan``, a Runner attribute. When a single Runner served
+two distinct outer ADK sessions (different ``ctx.session.id``), the
+second session's first turn picked up the FIRST session's stashed
+plan as its prior plan, then asked ``planner.handle_turn`` to revise
+it for an unrelated user_input — every revision attempt failed
+validation because the original plan's tasks made no sense for the
+new request.
+
+The fix moves the stash onto :class:`Conversation` and keys it by the
+session id observed at stash time. A subsequent turn's prior-plan
+seed is restored only when the new turn's session id matches; a turn
+on a *different* session.id (a fresh outer ADK session sharing the
+Runner) sees ``Plan.empty()`` exactly as if the Runner had just been
+constructed.
+
+These tests pin the contract:
+
+1. Two consecutive turns on different ``session_id`` values must NOT
+   share the prior-plan stash (the regression case).
+2. Two consecutive turns on the SAME ``session_id`` must continue to
+   propagate the prior plan (the existing intra-session continuity
+   guarantee, validated so the fix doesn't regress it).
+3. A turn on one ``session_id`` followed by a turn with no
+   ``session_id`` pin (programmatic Runner caller) likewise must not
+   leak the pinned session's plan into the unpinned turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from goldfive import (
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _plan(tag: str) -> Plan:
+    """A trivial one-task plan whose id encodes ``tag`` so we can assert
+    which plan a session ended up with."""
+    return Plan(
+        id=f"plan-{tag}",
+        run_id="",
+        goal_ids=[f"g-{tag}"],
+        tasks=[
+            Task(id=f"t-{tag}", title=f"Task {tag}", assignee_agent_id="writer"),
+        ],
+        edges=[],
+        summary=f"Single-task plan tagged {tag}",
+    )
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = tools, session
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+def _mk_runner(planner_plan: Plan) -> Runner:
+    """Build a Runner with a deterministic StaticPlanner and a happy
+    callable adapter. ``planner_gate=None`` keeps the test isolated
+    from the LLM-driven handle_turn path: the leak we're testing is
+    in the Runner's seed/stash bookkeeping, not in the planner.
+    """
+    return Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(planner_plan),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[InMemorySink()],
+        planner_gate=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_two_runs_different_session_ids_do_not_share_prior_plan() -> None:
+    """The regression: turn on session A then turn on session B.
+
+    With the leak in place, turn 2's seed restores the plan stashed
+    by turn 1 (because it's a process-wide Runner attribute) — so
+    turn 2's session.plan id starts as turn 1's plan id BEFORE the
+    planner replaces it. With the fix, turn 2 sees ``Plan.empty()``
+    seeded — the prior plan is keyed by session.id and turn 2's
+    session.id doesn't match.
+
+    We assert directly on the seed observed at the start of turn B's
+    planner call — the leak's downstream symptom (validator rejecting
+    every revision because the leaked tasks don't match the new user
+    intent) is what produced ``outcome.success = False`` in
+    validation v4 Class 1, but the root-cause assertion is on the
+    seed itself.
+    """
+    runner = _mk_runner(_plan("static"))
+
+    # The Runner installs the prior plan onto ``session.plan`` BEFORE
+    # invoking the planner, so we can read what the planner saw by
+    # inspecting the Session passed by reference. ``StaticPlanner.generate``
+    # doesn't take ``session`` directly, so grab the live session off
+    # the runner's last-session pointer at the moment generate runs.
+    seeded_plan_at_turn_2: list[Plan | None] = []
+    real_generate = runner.planner.generate
+
+    async def _capturing_generate(*args: Any, **kwargs: Any) -> Plan:
+        seeded_plan_at_turn_2.append(
+            runner._last_session.plan if runner._last_session is not None else None
+        )
+        return await real_generate(*args, **kwargs)
+
+    # Patch generate to record the seed. ``handle_turn`` isn't on
+    # StaticPlanner so the Runner falls through to generate every
+    # turn (``planner_gate=None`` reinforces this).
+    runner.planner.generate = _capturing_generate  # type: ignore[method-assign]
+
+    out_a = await runner.run("turn on session A", session_id="outer-session-A")
+    assert out_a.success
+    assert out_a.session.id == "outer-session-A"
+    # Turn A produced a real plan with at least one task — that's the
+    # precondition the stash sees as "worth carrying forward".
+    assert out_a.session.plan is not None and out_a.session.plan.tasks
+
+    # Reset the capture so we only record what turn B's planner sees.
+    seeded_plan_at_turn_2.clear()
+
+    await runner.run("turn on session B", session_id="outer-session-B")
+    await runner.close()
+
+    # The seed observed at the start of turn B's planner call must be
+    # an empty seed (no tasks) — NOT the prior plan from session A.
+    # Even if the run aborted downstream (it does today, on the leak,
+    # because the validator rejects every revision attempt against the
+    # foreign plan), the seed is the root-cause assertion.
+    assert seeded_plan_at_turn_2, "planner.generate was not invoked on turn B"
+    seeded = seeded_plan_at_turn_2[0]
+    assert seeded is not None
+    assert not seeded.tasks, (
+        f"cross-session leak: turn B's seed carries {len(seeded.tasks)} "
+        f"task(s) from turn A's plan id={seeded.id!r}"
+    )
+
+
+async def test_two_runs_same_session_id_propagate_prior_plan() -> None:
+    """Within a single outer session, the prior-plan stash MUST carry
+    forward — that's the intra-session continuity the original
+    ``_last_plan`` field was designed to provide.
+
+    The fix narrows the carry-forward to same-session only, so this
+    behaviour must not regress.
+    """
+    runner = _mk_runner(_plan("static"))
+
+    seeded_plan_at_turn_2: list[Plan | None] = []
+    real_generate = runner.planner.generate
+
+    async def _capturing_generate(*args: Any, **kwargs: Any) -> Plan:
+        seeded_plan_at_turn_2.append(
+            runner._last_session.plan if runner._last_session is not None else None
+        )
+        return await real_generate(*args, **kwargs)
+
+    runner.planner.generate = _capturing_generate  # type: ignore[method-assign]
+
+    out_1 = await runner.run("first turn", session_id="outer-session-X")
+    assert out_1.success
+    expected_plan_id = out_1.session.plan.id
+    seeded_plan_at_turn_2.clear()
+
+    # Turn 2 may abort downstream because StaticPlanner's revision-of-
+    # the-same-plan attempt is rejected by the validator (no actual
+    # change). That's fine — this test asserts on the SEED at the
+    # planner-call boundary, which is the contract under test.
+    await runner.run("second turn", session_id="outer-session-X")
+    await runner.close()
+
+    assert seeded_plan_at_turn_2, "planner.generate was not invoked on turn 2"
+    seeded = seeded_plan_at_turn_2[0]
+    assert seeded is not None
+    # Same outer session id — turn 2's seed should carry turn 1's tasks.
+    assert seeded.tasks, (
+        "intra-session continuity regressed: turn 2's seed has no "
+        "tasks despite sharing session.id with turn 1"
+    )
+    # And it should carry the SAME plan id — Phase 4 promise: plan_id
+    # is the conversation's identity within a single session.
+    assert seeded.id == expected_plan_id
+
+
+async def test_pinned_session_does_not_leak_into_unpinned_turn() -> None:
+    """A pinned-session turn followed by an unpinned (programmatic)
+    turn must not leak the pinned session's plan.
+
+    Mirrors a real pattern: an ADK-driven turn (session pinned to
+    ``ctx.session.id``) followed by a bare ``runner.run("...")``
+    call from test code or a different consumer.
+    """
+    runner = _mk_runner(_plan("static"))
+
+    seeded_plan_observations: list[Plan | None] = []
+    real_generate = runner.planner.generate
+
+    async def _capturing_generate(*args: Any, **kwargs: Any) -> Plan:
+        seeded_plan_observations.append(
+            runner._last_session.plan if runner._last_session is not None else None
+        )
+        return await real_generate(*args, **kwargs)
+
+    runner.planner.generate = _capturing_generate  # type: ignore[method-assign]
+
+    # Turn 1: pinned to a specific outer session id.
+    out_pinned = await runner.run("pinned turn", session_id="outer-pinned")
+    assert out_pinned.success
+    seeded_plan_observations.clear()
+
+    # Turn 2: no session_id — Conversation mints a fresh uuid4 run_id.
+    out_unpinned = await runner.run("unpinned turn")
+    await runner.close()
+    # The unpinned turn's session id must differ from the pinned one.
+    assert out_unpinned.session.id != "outer-pinned"
+
+    assert seeded_plan_observations, "planner.generate was not invoked on turn 2"
+    seeded = seeded_plan_observations[0]
+    assert seeded is not None
+    assert not seeded.tasks, (
+        "cross-session leak into unpinned turn: seed carries "
+        f"{len(seeded.tasks)} task(s) from the pinned session's plan"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit-level coverage of :meth:`Conversation.prior_plan_for`
+#
+# The Runner-level tests above exercise the public-API contract; these
+# pin the carry-forward matrix directly on the Conversation primitive
+# so a future refactor that touches the matrix without touching the
+# Runner still trips the regression net.
+# ---------------------------------------------------------------------------
+
+
+def test_conversation_prior_plan_unpinned_to_unpinned_carries_forward() -> None:
+    from goldfive.conversation import Conversation
+
+    convo = Conversation.new()
+    sess = Session(run_id="programmatic-A", conversation_id=convo.id)
+    sess.plan = _plan("first")
+    convo.stash_plan(sess, pinned=False)
+
+    # New turn, unpinned (different uuid4 run_id, as
+    # next_turn_session() would mint).
+    out = convo.prior_plan_for("programmatic-B", pinned=False)
+    assert out is not None
+    assert out.id == "plan-first"
+
+
+def test_conversation_prior_plan_pinned_same_id_carries_forward() -> None:
+    from goldfive.conversation import Conversation
+
+    convo = Conversation.new()
+    sess = Session(run_id="outer-X", conversation_id=convo.id)
+    sess.plan = _plan("first")
+    convo.stash_plan(sess, pinned=True)
+
+    out = convo.prior_plan_for("outer-X", pinned=True)
+    assert out is not None
+    assert out.id == "plan-first"
+
+
+def test_conversation_prior_plan_pinned_different_id_does_not_carry() -> None:
+    from goldfive.conversation import Conversation
+
+    convo = Conversation.new()
+    sess = Session(run_id="outer-X", conversation_id=convo.id)
+    sess.plan = _plan("first")
+    convo.stash_plan(sess, pinned=True)
+
+    assert convo.prior_plan_for("outer-Y", pinned=True) is None
+
+
+def test_conversation_prior_plan_pin_state_mismatch_does_not_carry() -> None:
+    from goldfive.conversation import Conversation
+
+    convo = Conversation.new()
+    sess = Session(run_id="outer-X", conversation_id=convo.id)
+    sess.plan = _plan("first")
+    convo.stash_plan(sess, pinned=True)
+
+    # New turn unpinned: even though no session-id check would apply
+    # for unpinned-vs-unpinned, a pinned prior crosses an externally-
+    # owned boundary that must not leak.
+    assert convo.prior_plan_for("any-id", pinned=False) is None
+
+    # Symmetric: unpinned prior, then a new pinned turn establishes
+    # an external owner; don't carry the bare prior into it.
+    convo2 = Conversation.new()
+    sess2 = Session(run_id="programmatic", conversation_id=convo2.id)
+    sess2.plan = _plan("first")
+    convo2.stash_plan(sess2, pinned=False)
+    assert convo2.prior_plan_for("outer-Z", pinned=True) is None
+
+
+def test_conversation_stash_plan_skips_empty_plan() -> None:
+    from goldfive.conversation import Conversation
+
+    convo = Conversation.new()
+    sess = Session(run_id="programmatic-A", conversation_id=convo.id)
+    sess.plan = Plan.empty(run_id=sess.run_id)  # no tasks
+    convo.stash_plan(sess, pinned=False)
+
+    # Empty seed never becomes a "prior" — same-shape lookup returns None.
+    assert convo.prior_plan_for("programmatic-B", pinned=False) is None


### PR DESCRIPTION
## Summary

- Fixes a process-scoped plan-leak surfaced by validation v4 Class 1: `Runner._last_plan` lived on the Runner singleton, so a Runner shared across two distinct outer ADK sessions seeded the second session's first turn with the first session's stashed plan. `handle_turn` then asked the planner to revise a foreign plan against an unrelated `user_input` — every revision attempt failed validation and the run aborted.
- Moves the stash onto `Conversation` as `_last_plan` + `_last_plan_session_id` + `_last_plan_pinned`, exposed via `stash_plan()` and `prior_plan_for()`. Carry-forward applies a documented matrix: both turns unpinned → Conversation-level continuity (programmatic Runner callers); either turn pinned → require an exact session-id match.
- ADK callers (always pinned via `session_id=ctx.session.id`) get session-scoped isolation; bare Runner callers (always unpinned) keep the intra-conversation continuity `Runner._last_plan` provided.

## Carry-forward matrix

| prior turn | new turn | carry forward? |
| --- | --- | --- |
| unpinned | unpinned | YES — Conversation-level continuity (programmatic) |
| unpinned | pinned | NO — boundary into externally-owned identity |
| pinned | unpinned | NO — boundary out of externally-owned identity |
| pinned | pinned, ids match | YES — same outer ADK session continuity |
| pinned | pinned, ids differ | NO — the regression case (validation v4 Class 1) |

## Test plan

- [x] New `tests/test_runner_cross_session_isolation.py` (8 tests) covers all 5 matrix entries plus 3 Runner-level scenarios. Verified the 3 Runner-level tests fail on origin/main and pass with the fix.
- [x] Full test suite: `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 uv run pytest -x` → **1696 passed, 46 skipped** (was 1691 passed before; +5 net new tests).
- [x] `ruff check` + `ruff format` clean on all touched files.