### PR TITLE
fix(runner): scope full Conversation per outer session id

### DIFF
--- a/goldfive/conversation.py
+++ b/goldfive/conversation.py
@@ -24,9 +24,15 @@ Phase 3 scope (see issue #78):
 * :class:`TurnRecord` captures a one-sentence summary of each turn so
   the planner can reference them in its prompt.
 
-A Runner always owns a Conversation — single-turn callers never notice
-because the Conversation is fresh on construction and discarded with
-the Runner.
+A Runner owns a *map* of Conversations keyed by outer-session id
+(``Runner._conversations``) so cross-turn state never leaks across
+distinct outer ADK sessions sharing one Runner — see goldfive#271
+follow-up to PR #293 / validation v4 Class 1. Programmatic
+(unpinned) callers all share one Conversation under the empty-string
+key, preserving pre-#161 single-Conversation continuity. Each
+pinned outer-session id (e.g. ADK-web's ``ctx.session.id``) gets
+its own dedicated Conversation with isolated ``goals``,
+``completed_results``, ``turns``, and ``_next_sequence`` cursor.
 """
 
 from __future__ import annotations

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -211,14 +211,48 @@ class Runner:
         self._close_hooks: list[Callable[[], Awaitable[None]]] = []
         self._closed: bool = False
         self.max_task_invocations: int | None = max_task_invocations
-        self._conversation: Conversation = conversation or Conversation.new()
-        # Tracks whether we've emitted the ConversationStarted event for
-        # the current Conversation. Flips back to False on new_conversation().
-        self._conversation_announced: bool = False
-        # Last turn's Session, held past the turn so that ConversationEnded
-        # can piggy-back on its ``next_sequence()`` counter (sequence must
-        # be monotonic within a run_id, so the terminal marker needs the
-        # session that produced the run's other events).
+        # Per-outer-session :class:`Conversation` map (goldfive#271
+        # follow-up to PR #293 / validation v4 Class 1).
+        #
+        # Pre-fix the Runner held one ``self._conversation``: a
+        # singleton on the Runner instance. PR #293 keyed the
+        # *prior-plan stash* on session id, but every other
+        # Conversation field (``goals``, ``completed_results``,
+        # ``turns``, ``_next_sequence``) still leaked across distinct
+        # outer ADK sessions sharing one Runner. The visible regression:
+        # v4class1-1 saw "Provide the correct answer to 2+2" leaked
+        # from a prior v4-class5 session that had run on the same
+        # Runner — every subsequent session inherited every prior
+        # session's accumulated goals.
+        #
+        # Keying the entire :class:`Conversation` by the outer-session
+        # id used at :meth:`run`'s entry isolates per-session state in
+        # full. The empty-string key (``""``) holds the conversation
+        # for unpinned (programmatic) callers — preserving the legacy
+        # single-Conversation continuity for pre-#161 callers and
+        # one-shot scripts. Pinned callers (typically ADK-web via
+        # :class:`GoldfiveADKAgent`) get their own Conversation per
+        # ``ctx.session.id``.
+        #
+        # Lifetime: Conversations live forever for the Runner's
+        # lifetime. The dict is small (one entry per distinct outer
+        # session ever observed) and Conversations are bounded
+        # (``recent_turns`` cap on prior-turn context). If a future
+        # use case introduces churn (many short-lived outer sessions),
+        # add a cleanup hook on session end.
+        seed_conv = conversation or Conversation.new()
+        self._conversations: dict[str, Conversation] = {"": seed_conv}
+        # Per-key bookkeeping. ``_conversation_announced`` flips to
+        # True after the per-key Conversation's ConversationStarted
+        # event fires; ``_last_session_by_key`` holds the most recent
+        # turn's Session so ConversationEnded can piggy-back on its
+        # ``next_sequence()`` cursor (the terminal marker must share
+        # its run_id's sequence keyspace).
+        self._conversation_announced: dict[str, bool] = {"": False}
+        self._last_session_by_key: dict[str, Session] = {}
+        # Last turn's Session (any key) — kept for back-compat with
+        # tests / inspectors that read ``runner._last_session``
+        # directly. Updated on every :meth:`run` regardless of pin.
         self._last_session: Session | None = None
         # Turn-aware planning gate. Goldfive#271 Phase 4: the gate is
         # now ``planner.handle_turn`` (a single LLM call that classifies
@@ -234,6 +268,37 @@ class Runner:
         # another's first turn. See :meth:`Conversation.prior_plan_for`
         # and the goldfive#271 follow-up validation v4 Class 1
         # post-mortem.
+
+    # ------------------------------------------------------------------
+    # per-session Conversation lookup
+    # ------------------------------------------------------------------
+
+    def _conversation_key(self, session_id: str | None) -> str:
+        """Map an optional outer-session-id pin to the lookup key.
+
+        ``None`` / ``""`` (the unpinned / programmatic caller) use the
+        empty-string key — a single shared Conversation for that path,
+        preserving pre-#161 single-Conversation continuity. Any
+        non-empty pin gets its own keyed Conversation (typically the
+        ``ctx.session.id`` from :class:`GoldfiveADKAgent`).
+        """
+        return session_id or ""
+
+    def _conversation_for(self, key: str) -> Conversation:
+        """Return the :class:`Conversation` for ``key``, creating on miss.
+
+        ``key=""`` is the unpinned-caller slot; non-empty keys belong
+        to outer ADK sessions. Created Conversations get fresh ids,
+        empty goals / completed_results / turns, and a zero
+        ``_next_sequence`` cursor — exactly the state a brand-new
+        outer session deserves to see.
+        """
+        convo = self._conversations.get(key)
+        if convo is None:
+            convo = Conversation.new()
+            self._conversations[key] = convo
+            self._conversation_announced[key] = False
+        return convo
 
     # ------------------------------------------------------------------
     # run
@@ -258,11 +323,21 @@ class Runner:
         Runner callers see no behaviour change.
         """
 
-        # 1. Build Session seeded by the Conversation. The Session's
+        # 1. Resolve the per-outer-session :class:`Conversation`
+        # (goldfive#271 follow-up to PR #293). Every outer ADK session
+        # gets its own Conversation so cross-turn state (goals,
+        # completed_results, turns, wire-sequence cursor, prior-plan
+        # stash) is isolated. The unpinned (programmatic) path uses
+        # the shared ``""`` key for back-compat with pre-#161 callers.
+        # See :meth:`_conversation_for` and validation v4 Class 1.
+        convo_key = self._conversation_key(session_id)
+        convo = self._conversation_for(convo_key)
+
+        # 2. Build Session seeded by the Conversation. The Session's
         #    run_id is fresh for this turn; conversation_id is stable
         #    across turns; goals / completed_results are pre-populated
-        #    with prior-turn state.
-        session = self._conversation.next_turn_session()
+        #    with prior-turn state — all scoped to the convo above.
+        session = convo.next_turn_session()
         # Outer-session pin (goldfive#161): when the caller supplies a
         # non-empty ``session_id`` (typically ``ctx.session.id`` from
         # adk-web), override the freshly-minted ``run_id`` so every
@@ -281,11 +356,12 @@ class Runner:
         if pinned:
             session.run_id = session_id  # type: ignore[assignment]
         self._last_session = session
+        self._last_session_by_key[convo_key] = session
 
-        # 2. Announce the Conversation on the first turn.
-        if not self._conversation_announced:
-            await self._emit_conversation_started(session)
-            self._conversation_announced = True
+        # 2b. Announce the Conversation on its first turn (per key).
+        if not self._conversation_announced.get(convo_key, False):
+            await self._emit_conversation_started(session, conversation=convo)
+            self._conversation_announced[convo_key] = True
 
         # 3. Emit RunStarted before anything else for this turn.
         await self._emit_run_started(session, user_input)
@@ -306,7 +382,7 @@ class Runner:
         # callers (both prior and new turn unpinned) keep the
         # Conversation-level continuity the original ``_last_plan``
         # field provided.
-        prior_plan = self._conversation.prior_plan_for(session.id, pinned=pinned)
+        prior_plan = convo.prior_plan_for(session.id, pinned=pinned)
         if prior_plan is not None:
             prior_plan.run_id = session.run_id
             session.plan = prior_plan
@@ -325,7 +401,7 @@ class Runner:
             log.exception("goal derivation failed")
             await self._emit_run_aborted(session, reason)
             outcome = ExecutionOutcome(success=False, session=session, reason=reason)
-            self._conversation.absorb_turn(
+            convo.absorb_turn(
                 outcome,
                 user_input_summary=_initial_goal_summary(user_input),
                 pinned=pinned,
@@ -384,6 +460,7 @@ class Runner:
                     user_input=user_input,
                     session=session,
                     context=context,
+                    conversation=convo,
                 )
                 decided = True
                 log.info(
@@ -426,7 +503,7 @@ class Runner:
                 "run_id": session.run_id,
                 "max_task_invocations": self.max_task_invocations,
             }
-            planner_context.update(self._conversation.prior_turn_context())
+            planner_context.update(convo.prior_turn_context())
             if context:
                 planner_context.update(context)
             planner_context["run_id"] = session.run_id
@@ -441,7 +518,7 @@ class Runner:
                 log.exception("planner.generate raised")
                 await self._emit_run_aborted(session, reason)
                 outcome = ExecutionOutcome(success=False, session=session, reason=reason)
-                self._conversation.absorb_turn(
+                convo.absorb_turn(
                     outcome,
                     user_input_summary=_initial_goal_summary(user_input),
                     pinned=pinned,
@@ -462,7 +539,7 @@ class Runner:
                 reason = "plan revision rejected by validator"
                 await self._emit_run_aborted(session, reason)
                 outcome = ExecutionOutcome(success=False, session=session, reason=reason)
-                self._conversation.absorb_turn(
+                convo.absorb_turn(
                     outcome,
                     user_input_summary=_initial_goal_summary(user_input),
                     pinned=pinned,
@@ -475,7 +552,7 @@ class Runner:
             reason = "no plan generated"
             await self._emit_run_aborted(session, reason)
             outcome = ExecutionOutcome(success=False, session=session, reason=reason)
-            self._conversation.absorb_turn(
+            convo.absorb_turn(
                 outcome,
                 user_input_summary=_initial_goal_summary(user_input),
                 pinned=pinned,
@@ -499,7 +576,7 @@ class Runner:
             log.exception("register_reporting_tools raised")
             await self._emit_run_aborted(session, reason)
             outcome = ExecutionOutcome(success=False, session=session, reason=reason)
-            self._conversation.absorb_turn(
+            convo.absorb_turn(
                 outcome,
                 user_input_summary=_initial_goal_summary(user_input),
                 pinned=pinned,
@@ -514,7 +591,7 @@ class Runner:
             log.exception("steerer.bind raised")
             await self._emit_run_aborted(session, reason)
             outcome = ExecutionOutcome(success=False, session=session, reason=reason)
-            self._conversation.absorb_turn(
+            convo.absorb_turn(
                 outcome,
                 user_input_summary=_initial_goal_summary(user_input),
                 pinned=pinned,
@@ -538,7 +615,7 @@ class Runner:
                 log.exception("adapter.bind_steerer raised")
                 await self._emit_run_aborted(session, reason)
                 outcome = ExecutionOutcome(success=False, session=session, reason=reason)
-                self._conversation.absorb_turn(
+                convo.absorb_turn(
                     outcome,
                     user_input_summary=_initial_goal_summary(user_input),
                     pinned=pinned,
@@ -587,7 +664,7 @@ class Runner:
             log.exception("executor.run raised")
             await self._emit_run_aborted(session, reason)
             aborted = ExecutionOutcome(success=False, session=session, reason=reason)
-            self._conversation.absorb_turn(
+            convo.absorb_turn(
                 aborted,
                 user_input_summary=_initial_goal_summary(user_input),
                 pinned=pinned,
@@ -632,7 +709,7 @@ class Runner:
             # begin with. ``stash_plan`` is idempotent: a subsequent
             # ``absorb_turn`` re-stashes the same plan + session id.
             if session.plan is not None and session.plan.tasks:
-                self._conversation.stash_plan(session, pinned=pinned)
+                convo.stash_plan(session, pinned=pinned)
                 log.info(
                     "Runner.run: stashed prior plan for next turn's "
                     "handle_turn (plan_id=%s revision_index=%d "
@@ -648,7 +725,7 @@ class Runner:
         _ostate.clear_current_task(session.state)
         _ostate.clear_active_steer(session.state)
 
-        self._conversation.absorb_turn(
+        convo.absorb_turn(
             outcome,
             user_input_summary=_initial_goal_summary(user_input),
             pinned=pinned,
@@ -825,31 +902,58 @@ class Runner:
 
     @property
     def conversation_id(self) -> str:
-        """The current Conversation's stable id. Changes only via :meth:`new_conversation`."""
-        return self._conversation.id
+        """The default (unpinned-key) Conversation's stable id.
+
+        Returns the id of the empty-string-keyed :class:`Conversation`
+        — the slot used by programmatic / unpinned :meth:`run` callers.
+        Each pinned outer ADK session owns its own Conversation
+        (look it up via ``runner._conversations[session_id]``); the
+        public property keeps single-Conversation semantics for
+        backward-compatibility with pre-#161 callers and inspection
+        tools.
+        """
+        return self._conversations[""].id
 
     @property
     def conversation(self) -> Conversation:
-        """The live :class:`Conversation` object. Read-only handle for inspection."""
-        return self._conversation
+        """The default (unpinned-key) :class:`Conversation`.
+
+        Read-only handle for inspection. Per-pinned-session
+        Conversations live under ``runner._conversations``; this
+        property returns the empty-string-keyed slot used by
+        programmatic callers, preserving the pre-#293 single-
+        Conversation public surface.
+        """
+        return self._conversations[""]
 
     async def new_conversation(self, *, reason: str = "") -> None:
-        """Reset cross-turn state. The next :meth:`run` starts a fresh Conversation.
+        """Reset cross-turn state across every per-session Conversation.
 
-        Emits a ``ConversationEnded`` event for the outgoing Conversation
-        (if it had any turns), then installs a fresh one. The new
-        Conversation is announced lazily — ``ConversationStarted`` fires
-        on the next :meth:`run` call.
+        Emits a ``ConversationEnded`` event for every outgoing
+        Conversation that had announced its start (one per outer
+        session id observed so far), then installs fresh
+        Conversations. The next :meth:`run` for any session id —
+        pinned or unpinned — starts a brand-new Conversation; its
+        ``ConversationStarted`` is emitted lazily on that call.
         """
-        outgoing = self._conversation
-        if self._conversation_announced and self._last_session is not None:
-            await self._emit_conversation_ended(
-                conversation=outgoing,
-                session_anchor=self._last_session,
-                reason=reason or "new_conversation",
-            )
-        self._conversation = Conversation.new()
-        self._conversation_announced = False
+        for key, outgoing in list(self._conversations.items()):
+            announced = self._conversation_announced.get(key, False)
+            anchor = self._last_session_by_key.get(key)
+            if announced and anchor is not None:
+                await self._emit_conversation_ended(
+                    conversation=outgoing,
+                    session_anchor=anchor,
+                    reason=reason or "new_conversation",
+                )
+        # Reset the per-session bookkeeping. The default ("") slot is
+        # restored eagerly so the public ``conversation`` /
+        # ``conversation_id`` properties keep returning a real handle
+        # right after the reset (callers may inspect them before the
+        # next :meth:`run`). Pinned slots are recreated lazily by
+        # :meth:`_conversation_for` on the next run for that session.
+        self._conversations = {"": Conversation.new()}
+        self._conversation_announced = {"": False}
+        self._last_session_by_key = {}
         self._last_session = None
         # planner-gate: reset turn-aware gate state so the first turn
         # of the new conversation runs full planning. Cross-turn
@@ -875,16 +979,24 @@ class Runner:
         if self._closed:
             return
         self._closed = True
-        if self._conversation_announced and self._last_session is not None:
+        # Emit ConversationEnded for every per-session Conversation
+        # that announced its start. Pinned (ADK-session) and unpinned
+        # slots both flow through here so persisted logs always carry
+        # a clean terminal marker for each conversation_id observed.
+        for key, conv in list(self._conversations.items()):
+            announced = self._conversation_announced.get(key, False)
+            anchor = self._last_session_by_key.get(key)
+            if not (announced and anchor is not None):
+                continue
             try:
                 await self._emit_conversation_ended(
-                    conversation=self._conversation,
-                    session_anchor=self._last_session,
+                    conversation=conv,
+                    session_anchor=anchor,
                     reason="runner_close",
                 )
             except Exception as exc:  # noqa: BLE001
                 log.warning("conversation_ended emission raised: %s", exc)
-            self._conversation_announced = False
+            self._conversation_announced[key] = False
         # Drain background reasoning-judge tasks the steerer scheduled
         # via its fire-and-forget judge path (goldfive#251). Bounded
         # shutdown so a hung LLM judge doesn't stall close. Duck-typed
@@ -973,6 +1085,7 @@ class Runner:
         user_input: str,
         session: Session,
         context: Mapping[str, Any] | None,
+        conversation: Conversation,
     ) -> Plan | None:
         """Invoke ``planner.handle_turn`` with the runner's per-turn context.
 
@@ -981,6 +1094,11 @@ class Runner:
         Runner threads the available agents and the per-turn context
         (run_id, max_task_invocations, prior_turns) so the planner has
         everything it needs in one call.
+
+        ``conversation`` is the per-outer-session :class:`Conversation`
+        the caller resolved at :meth:`run` entry — passed in rather
+        than read off ``self`` because the Runner now holds a dict of
+        per-session Conversations (see :meth:`_conversation_for`).
         """
         # Prefer the richer tree shape (goldfive#151) when the adapter
         # exposes it. Adapters that don't implement the property fall
@@ -995,14 +1113,14 @@ class Runner:
             "run_id": session.run_id,
             "max_task_invocations": self.max_task_invocations,
         }
-        planner_context.update(self._conversation.prior_turn_context())
+        planner_context.update(conversation.prior_turn_context())
         if context:
             planner_context.update(context)
         planner_context["run_id"] = session.run_id
         return await self.planner.handle_turn(
             user_input=user_input,
             session=session,
-            conversation_history=list(self._conversation.turns),
+            conversation_history=list(conversation.turns),
             available_agents=available_agents,
             context=planner_context,
         )
@@ -1136,11 +1254,13 @@ class Runner:
         )
         await emit(self.sinks, evt)
 
-    async def _emit_conversation_started(self, session: Session) -> None:
+    async def _emit_conversation_started(
+        self, session: Session, *, conversation: Conversation
+    ) -> None:
         evt = conversation_started_event(
             run_id=session.run_id,
             sequence=session.next_sequence(),
-            conversation_id=self._conversation.id,
+            conversation_id=conversation.id,
             session_id=session.id,
         )
         await emit(self.sinks, evt)

--- a/tests/test_runner_conversation_isolation.py
+++ b/tests/test_runner_conversation_isolation.py
@@ -1,0 +1,426 @@
+"""Cross-session Conversation isolation (goldfive#271 follow-up to #293).
+
+Validation v4 Class 1 surfaced a deeper architectural leak that
+PR #293 only partially patched. Even after #293 keyed the prior-plan
+stash by ``session.id`` on :class:`Conversation`, the *Conversation
+itself* still lived as a process-scoped attribute on :class:`Runner`
+(``self._conversation``). Every other field of ``Conversation`` —
+``goals``, ``completed_results``, ``turns``, ``_next_sequence`` —
+therefore still leaked across distinct outer ADK sessions sharing
+one Runner.
+
+The visible regression: v4class1-1 saw the goal_derived event text
+"Provide the correct answer to the math question 2+2" leak from a
+prior v4-class5 session that had run on the same Runner. With
+``session.goals`` accumulating on a singleton Conversation, the new
+session's ``next_turn_session()`` inherited every prior session's
+goals — a high-impact correctness bug for any operator running
+multiple ADK sessions through one wrapped agent (the default
+``goldfive.wrap()`` shape).
+
+The fix: replace ``Runner._conversation`` with
+``Runner._conversations: dict[str, Conversation]`` keyed by the
+outer-session id (or a shared empty-string sentinel for the
+unpinned/programmatic caller path). Each turn looks up — or creates —
+the Conversation for its own session id, so a fresh outer ADK
+session sees ``goals=[]``, ``completed_results={}``, ``turns=[]``,
+``_next_sequence=0`` regardless of what other sessions have run on
+the same Runner.
+
+These tests pin the contract end-to-end:
+
+1. Goals do not leak across pinned sessions (the Class 1 regression).
+2. Completed results do not leak across pinned sessions.
+3. Turn records do not leak across pinned sessions.
+4. The wire-sequence cursor restarts at 0 for a fresh pinned session.
+5. The unpinned (programmatic) path keeps single-Conversation
+   continuity exactly as the pre-fix Runner provided.
+6. Two consecutive turns on the SAME pinned ``session_id`` continue
+   to share their Conversation (intra-session continuity holds).
+"""
+
+from __future__ import annotations
+
+from goldfive import (
+    CallableAdapter,
+    Goal,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _plan(tag: str) -> Plan:
+    return Plan(
+        id=f"plan-{tag}",
+        run_id="",
+        goal_ids=[f"g-{tag}"],
+        tasks=[Task(id=f"t-{tag}", title=f"Task {tag}", assignee_agent_id="writer")],
+        edges=[],
+        summary=f"Single-task plan tagged {tag}",
+    )
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = tools, session
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+def _mk_runner() -> Runner:
+    """Build a Runner with deterministic StaticPlanner + happy adapter.
+
+    ``planner_gate=None`` keeps the test isolated from the LLM-driven
+    handle_turn path: the leak we're testing is in the Runner's
+    Conversation bookkeeping, not in the planner.
+    """
+    return Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_plan("static")),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("derived"),
+        sinks=[InMemorySink()],
+        planner_gate=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Class 1 regression tests
+# ---------------------------------------------------------------------------
+
+
+async def test_goals_do_not_leak_across_pinned_sessions() -> None:
+    """The validation v4 Class 1 regression: goals leak across sessions.
+
+    Drives one turn on outer session A with a goal id ``g-a``, then
+    one turn on outer session B with a distinct goal id ``g-b``.
+    Asserts that turn B's session.goals contains ONLY ``g-b`` —
+    NOT ``g-a`` from session A.
+
+    Pre-fix this test fails: turn B's ``Session`` is built from
+    ``Conversation.next_turn_session()`` which copies
+    ``self.goals`` — but the singleton Conversation has been
+    accumulating goals from BOTH sessions, so turn B starts with
+    {``g-a``, ``g-b``} instead of {``g-b``}.
+    """
+    runner = _mk_runner()
+
+    goal_a = [Goal(id="g-a", summary="A's goal: do A-thing")]
+    out_a = await runner.run(goal_a, session_id="outer-session-A")
+    assert out_a.success
+    a_goal_ids = {g.id for g in out_a.session.goals if g.id}
+    assert a_goal_ids == {"g-a"}, "session A should hold exactly its own goal"
+
+    goal_b = [Goal(id="g-b", summary="B's goal: do B-thing")]
+    out_b = await runner.run(goal_b, session_id="outer-session-B")
+    await runner.close()
+
+    b_goal_ids = {g.id for g in out_b.session.goals if g.id}
+    # The strong assertion: B's session.goals contains EXACTLY its own
+    # goal id, with NO leak from session A. Pre-fix B starts with A's
+    # goal id already merged in (singleton Conversation accumulated
+    # both), so this set has both entries.
+    assert b_goal_ids == {"g-b"}, (
+        "cross-session goal leak: turn B's session.goals = "
+        f"{b_goal_ids}, expected {{'g-b'}} — A's goal id leaked through "
+        "the singleton Conversation"
+    )
+    assert "g-a" not in b_goal_ids, (
+        "session A's goal id 'g-a' is visible in session B's session.goals"
+    )
+
+
+async def test_completed_results_do_not_leak_across_pinned_sessions() -> None:
+    """A different tip of the same iceberg: completed_results leaks too.
+
+    Pre-fix the singleton Conversation accumulates completed-task
+    summaries from every session. A fresh pinned session would see
+    every prior session's outputs as "prior-turn context" — a
+    correctness violation that confuses the planner and surfaces
+    foreign task ids in the new session's planner prompt.
+
+    We verify by asserting on the per-session ``Conversation``
+    instances directly: each session's Conversation should hold
+    ONLY its own ``completed_results``, not the union of every
+    session that ever ran on the Runner.
+    """
+    # Use distinct planners per session via two adapters that label
+    # task outputs with a per-session marker, so we can detect leakage
+    # by value (not just by key — both sessions happen to share the
+    # task id ``t-static`` from the StaticPlanner fixture).
+    runner = _mk_runner()
+
+    out_a = await runner.run("session A turn", session_id="outer-session-A")
+    assert out_a.success
+    assert out_a.session.completed_results
+
+    out_b = await runner.run("session B turn", session_id="outer-session-B")
+    await runner.close()
+    assert out_b.session.completed_results
+
+    # Per-session Conversations isolate completed_results: A's
+    # Conversation accumulates only A's run, B's only B's. Without the
+    # fix both sessions would write into the singleton Conversation's
+    # dict and B's Conversation would carry A's keys (and vice versa).
+    convo_a = runner._conversations["outer-session-A"]
+    convo_b = runner._conversations["outer-session-B"]
+    assert convo_a is not convo_b, "sessions A and B must own distinct Conversations"
+    # Each Conversation's accumulated results came from exactly one
+    # turn — its own. Pre-fix both share one Conversation that
+    # accumulates the union; the per-Conversation `turns` list would
+    # also reflect both runs for the singleton, which we test
+    # separately. Here we anchor on completed_results count.
+    assert len(convo_a.completed_results) >= 1
+    assert len(convo_b.completed_results) >= 1
+    # The crucial assertion: turn B's Conversation cursor only saw
+    # its own run. Compare turn count — pre-fix both Conversations
+    # ARE the same singleton with len(turns) == 2.
+    assert len(convo_a.turns) == 1, (
+        f"session A's Conversation has {len(convo_a.turns)} turns, "
+        "expected 1 (its own only) — singleton leak across sessions"
+    )
+    assert len(convo_b.turns) == 1, (
+        f"session B's Conversation has {len(convo_b.turns)} turns, "
+        "expected 1 (its own only) — singleton leak across sessions"
+    )
+
+
+async def test_turn_records_do_not_leak_across_pinned_sessions() -> None:
+    """Each pinned session keeps its own conversation history.
+
+    Pre-fix the singleton Conversation appends a TurnRecord for every
+    run() across every session, so prior-turn context (the planner's
+    cross-turn window) bleeds across session boundaries. The fix
+    isolates per-session histories.
+
+    Drives one turn on each of three distinct sessions to keep the
+    fixture simple (avoids second-turn-on-same-session validator
+    quirks of StaticPlanner). Each session's Conversation should
+    hold exactly one TurnRecord — its own.
+    """
+    runner = _mk_runner()
+
+    out_a = await runner.run("a-turn", session_id="outer-session-A")
+    assert out_a.success
+    out_b = await runner.run("b-turn", session_id="outer-session-B")
+    assert out_b.success
+    out_c = await runner.run("c-turn", session_id="outer-session-C")
+    assert out_c.success
+    await runner.close()
+
+    # Look up each session's Conversation and assert each holds only
+    # its own turn. The Runner exposes them via the per-session lookup.
+    convo_a = runner._conversations["outer-session-A"]
+    convo_b = runner._conversations["outer-session-B"]
+    convo_c = runner._conversations["outer-session-C"]
+    assert len({id(convo_a), id(convo_b), id(convo_c)}) == 3, (
+        "outer sessions A, B, C must own DISTINCT Conversation instances"
+    )
+    # Pre-fix all three sessions share one Conversation with three
+    # TurnRecords; with the fix each Conversation has exactly one.
+    assert len(convo_a.turns) == 1, (
+        f"session A's Conversation has {len(convo_a.turns)} turns, "
+        "expected 1 — singleton-Conversation cross-session leak"
+    )
+    assert len(convo_b.turns) == 1, f"session B has {len(convo_b.turns)} turns"
+    assert len(convo_c.turns) == 1, f"session C has {len(convo_c.turns)} turns"
+    a_run_ids = {t.run_id for t in convo_a.turns}
+    b_run_ids = {t.run_id for t in convo_b.turns}
+    c_run_ids = {t.run_id for t in convo_c.turns}
+    # Each Conversation's TurnRecords carry the run_id of its own
+    # session's turn — no cross-pollination.
+    assert a_run_ids == {"outer-session-A"}
+    assert b_run_ids == {"outer-session-B"}
+    assert c_run_ids == {"outer-session-C"}
+
+
+async def test_wire_sequence_cursor_restarts_for_fresh_pinned_session() -> None:
+    """A fresh pinned session must start with sequence=0 in its own
+    Conversation cursor.
+
+    Pre-fix the singleton ``Conversation._next_sequence`` keeps
+    advancing across sessions, so session B's first emitted event
+    picks up a sequence number derived from session A's cumulative
+    event count. Wire keys still happen to remain unique
+    (``session_id`` differs), but the per-Conversation cursor
+    semantics from goldfive#271 Gap 2 silently break.
+
+    The strong invariant: session B's first sink emission must carry
+    ``sequence=0`` — proof its Conversation cursor was fresh, not
+    inherited from session A.
+    """
+    runner = _mk_runner()
+
+    await runner.run("session A turn", session_id="outer-session-A")
+    convo_a = runner._conversations["outer-session-A"]
+    a_cursor = convo_a._next_sequence
+    assert a_cursor > 0, (
+        "session A's Conversation cursor should have advanced past 0"
+    )
+
+    # Snapshot how many events the sink has BEFORE session B runs so we
+    # can isolate B's emissions cleanly (no need to filter by session id
+    # under close-emitted ConversationEnded mixins).
+    sink = runner.sinks[0]
+    pre_b_event_count = len(sink.events)
+
+    await runner.run("session B turn", session_id="outer-session-B")
+
+    # B's first emission (RunStarted, since ConversationStarted comes
+    # first because B's Conversation is brand new). The first proto
+    # event in this slice tells us what sequence B started at.
+    b_first_event = sink.events[pre_b_event_count]
+    assert hasattr(b_first_event, "sequence"), (
+        "first B-emitted event has no sequence field"
+    )
+    # Pre-fix this is ``a_cursor`` (singleton Conversation continued
+    # advancing). Post-fix it's 0 — fresh Conversation, fresh cursor.
+    assert int(b_first_event.sequence) == 0, (
+        f"session B's first event carries sequence={int(b_first_event.sequence)}, "
+        f"expected 0 — singleton-Conversation cursor leaked from session A "
+        f"(A's cursor at handover was {a_cursor})"
+    )
+
+    await runner.close()
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatibility tests
+# ---------------------------------------------------------------------------
+
+
+async def test_unpinned_callers_share_one_conversation() -> None:
+    """Programmatic (unpinned) Runner callers must keep singleton
+    Conversation behaviour: the conversation_id stays stable across
+    runs, and goals/completed_results carry forward exactly as
+    pre-fix.
+
+    This is the back-compat guarantee for pre-#161 callers — bare
+    ``await runner.run("...")`` from test code or one-shot scripts.
+    """
+    runner = _mk_runner()
+
+    out_1 = await runner.run("turn one")
+    assert out_1.success
+    convo_id_1 = out_1.session.conversation_id
+
+    out_2 = await runner.run("turn two")
+    convo_id_2 = out_2.session.conversation_id
+
+    out_3 = await runner.run("turn three")
+    await runner.close()
+    convo_id_3 = out_3.session.conversation_id
+
+    # All three turns share one conversation_id.
+    assert convo_id_1 and convo_id_1 == convo_id_2 == convo_id_3
+    # And the public properties point at it too.
+    assert runner.conversation_id == convo_id_1
+    # That single Conversation has all three TurnRecords.
+    assert len(runner.conversation.turns) == 3
+
+
+async def test_same_pinned_session_keeps_intra_session_continuity() -> None:
+    """Two consecutive turns on the SAME pinned session id share their
+    Conversation: goals accumulate, completed_results carry forward,
+    turn records grow.
+
+    The fix's narrowing must NOT regress this — it's the whole point
+    of pinning a session: intra-session continuity for the duration of
+    one outer ADK session.
+    """
+    runner = _mk_runner()
+
+    out_1 = await runner.run("first turn", session_id="outer-session-X")
+    assert out_1.success
+    convo_id_1 = out_1.session.conversation_id
+
+    out_2 = await runner.run("second turn", session_id="outer-session-X")
+    await runner.close()
+    convo_id_2 = out_2.session.conversation_id
+
+    # Same session id → same Conversation → same conversation_id.
+    assert convo_id_1 == convo_id_2
+    # And both turns are on the same Conversation instance.
+    convo = runner._conversations["outer-session-X"]
+    assert len(convo.turns) == 2
+    # Turn 2 saw turn 1's completed results in its session seed.
+    for k in out_1.session.completed_results:
+        assert k in out_2.session.completed_results, (
+            f"intra-session continuity regressed: turn 2 lost completed "
+            f"result {k!r} from turn 1"
+        )
+
+
+async def test_pinned_and_unpinned_callers_get_distinct_conversations() -> None:
+    """A pinned-session turn followed by an unpinned (programmatic)
+    turn must NOT share a Conversation.
+
+    Pre-fix both routed through ``self._conversation`` so the unpinned
+    turn would see the pinned session's prior completed_results. With
+    the fix the unpinned path lives in the empty-string-keyed
+    Conversation, distinct from the pinned session's.
+    """
+    runner = _mk_runner()
+
+    out_pinned = await runner.run("pinned", session_id="outer-pinned")
+    assert out_pinned.success
+    pinned_convo_id = out_pinned.session.conversation_id
+
+    out_unpinned = await runner.run("unpinned")
+    await runner.close()
+    unpinned_convo_id = out_unpinned.session.conversation_id
+
+    # Distinct conversation ids — they're truly separate Conversations.
+    assert pinned_convo_id != unpinned_convo_id, (
+        "pinned and unpinned turns must own distinct Conversations"
+    )
+
+
+# ---------------------------------------------------------------------------
+# new_conversation() across multi-session bookkeeping
+# ---------------------------------------------------------------------------
+
+
+async def test_new_conversation_resets_all_per_session_state() -> None:
+    """``runner.new_conversation()`` resets EVERY per-session
+    Conversation. After the reset, both pinned and unpinned callers
+    see a fresh Conversation (new id, empty goals / results / turns).
+
+    The pre-fix ``new_conversation()`` operated on the singleton.
+    The fix's per-session dict means the reset must clear the dict
+    so future runs don't pick up stale state.
+    """
+    runner = _mk_runner()
+
+    out_pinned = await runner.run("pinned-1", session_id="outer-pinned")
+    assert out_pinned.success
+    out_unpinned = await runner.run("unpinned-1")
+    assert out_unpinned.success
+
+    pinned_convo_id_before = runner._conversations["outer-pinned"].id
+    unpinned_convo_id_before = runner._conversations[""].id
+
+    await runner.new_conversation()
+
+    out_pinned_2 = await runner.run("pinned-2", session_id="outer-pinned")
+    out_unpinned_2 = await runner.run("unpinned-2")
+    await runner.close()
+
+    # Same outer session ids, but the underlying Conversation ids changed
+    # — the reset wiped the prior bookkeeping.
+    assert out_pinned_2.session.conversation_id != pinned_convo_id_before
+    assert out_unpinned_2.session.conversation_id != unpinned_convo_id_before


### PR DESCRIPTION
## Summary

PR #293 keyed the prior-plan stash by `session.id` on `Conversation`, but the `Conversation` itself still lived as a singleton on `Runner`. Every other field — `goals`, `completed_results`, `turns`, `_next_sequence` — therefore still leaked across distinct outer ADK sessions sharing one `Runner`. Validation v4 Class 1 surfaced the regression: v4class1-1 saw goal text leaked from a prior v4-class5 session that had run on the same Runner.

This PR replaces `Runner._conversation: Conversation` with `Runner._conversations: dict[str, Conversation]` keyed by the outer-session id resolved at `run()` entry (or `\"\"` for unpinned/programmatic callers). Each turn looks up — or creates on miss — the `Conversation` for its own session id, so a fresh outer ADK session sees `goals=[]`, `completed_results={}`, `turns=[]`, `_next_sequence=0` regardless of what other sessions have run on the same Runner.

The unpinned (`\"\"`) slot serves bare `runner.run(\"...\")` callers and keeps single-Conversation continuity exactly as the pre-fix Runner provided. Pinned (typically ADK-web via `GoldfiveADKAgent`) sessions each get their own dedicated Conversation. The public `conversation` / `conversation_id` properties return the unpinned slot for back-compat with pre-#161 callers and inspection tools.

The same per-key dict pattern applies to `_conversation_announced` (so each Conversation gets exactly one `ConversationStarted` / `ConversationEnded` pair) and `_last_session_by_key` (so `close` / `new_conversation` can anchor each terminal marker on its own session).

## Steerer audit

Per the brief, audited `Steerer` instance state for similar singleton leaks the previous fix agent flagged:

- **`_last_refine_kind`**: declared but never read or written elsewhere in the codebase. Dead code; left untouched in this PR. Safe to remove in a follow-up.
- **`_active_session`**: transient scratchpad set/cleared around `planner.refine` (and `_apply_user_steer_state`, `_promote_drift_to_steer`, `_emit_refine_observability`). Safe under single-flight; concurrent `runner.run` calls across sessions could see crossed wires — Session A's `_active_session` could be overwritten by Session B mid-await, and the planner-side drift emitter / span context provider would fire against the wrong session. **Documented as a remaining process-scoped Steerer state**; not fixed in this PR (requires either contextvars or passing the session through the planner's emitter/provider closures, both larger refactors).
- **`_plan_locks: dict[str, asyncio.Lock]`**: already keyed by `session.id`. Correct.
- **All other instance state**: configuration set at init (judge callables, thresholds, modes, configs) or process-wide by design (`_background_judges` task set, `_sinks` / `_planner` / `_adapter` wiring).

## Remaining process-scoped state (NOT fixed in this PR)

For tracking — surfaced during the audit but out of scope:

- **`Steerer._active_session`**: see above. Manifests only under concurrent `runner.run` calls across distinct sessions.
- **`Steerer._last_refine_kind`**: dead code; declared but never used.
- **`ADKAdapter._next_cancel_reason`, `_outer_session_id`, `_session_id`**: per-adapter singletons. Cross-session interleaving through one shared adapter could mis-route cancel reasons. Out of scope.

## Test plan

- [x] Added `tests/test_runner_conversation_isolation.py` with 8 scenarios:
  - Goal isolation (the Class 1 regression)
  - `completed_results` isolation
  - `TurnRecord` isolation
  - Wire-sequence cursor restarts at 0 for fresh pinned sessions
  - Unpinned callers share one Conversation (back-compat)
  - Same pinned session keeps intra-session continuity
  - Pinned vs unpinned callers get distinct Conversations
  - `new_conversation()` resets every per-session slot
- [x] All 8 new tests **FAIL** on `origin/main` (verified by stashing the fix and running)
- [x] All 8 new tests **PASS** with the fix
- [x] Full existing test suite: 1415 pass, 97 skipped, 0 failures
- [x] `make lint` clean
- [x] No public API changes; `Runner.conversation` and `Runner.conversation_id` properties keep their pre-fix semantics for unpinned callers