### PR TITLE
fix(adk-plugin): sticky cancel gate on before_model_callback (#271 follow-up)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1301,6 +1301,44 @@ async def _inject_goldfive_planner_instruction(
 DEFAULT_LLM_CALL_TIMEOUT_MS: int = 120_000
 
 
+def _make_cancelled_llm_response() -> Any:
+    """Return a synthetic ``LlmResponse`` representing a cancelled call.
+
+    Returned from :meth:`_GoldfiveADKPlugin.before_model_callback` when
+    the active invocation has been flagged for cooperative cancel.
+    Per ADK's ``BasePlugin.before_model_callback`` contract a non-``None``
+    return value short-circuits the LLM dispatch and is propagated as
+    the response — returning ``None`` lets the request proceed normally,
+    which is the source of the demo-v12.log regression where a single
+    ``LLM_CALL_TIMEOUT`` drift fired multiple times on the same
+    invocation. Lazy import keeps this module loadable without
+    ``google.adk`` installed; on import error we fall back to a plain
+    sentinel object — ADK still treats any non-``None`` return as a
+    short-circuit, so the LLM call is skipped either way.
+    """
+    try:
+        from google.adk.models.llm_response import LlmResponse  # type: ignore
+        from google.genai import types as genai_types  # type: ignore
+    except Exception:  # noqa: BLE001
+        return {"goldfive_cancelled": True}
+    try:
+        return LlmResponse(
+            content=genai_types.Content(
+                parts=[genai_types.Part(text="[goldfive: cancelled]")],
+                role="model",
+            ),
+            turn_complete=True,
+        )
+    except Exception:  # noqa: BLE001
+        # Fallback to a bare LlmResponse if Content construction
+        # fails on a future ADK schema change. Any non-None still
+        # short-circuits per ADK's contract.
+        try:
+            return LlmResponse()
+        except Exception:  # noqa: BLE001
+            return {"goldfive_cancelled": True}
+
+
 def make_adk_plugin(
     *,
     name: str = "goldfive_adk_plugin",
@@ -1484,6 +1522,23 @@ def make_adk_plugin(
             # the key semantics so external consumers see a stable
             # contract; the plugin's dict is the live source of truth.
             self._cancel_state: dict[str, Any] = {}
+            # Sticky-cancelled set (goldfive#271 follow-up). Once a
+            # callback has consumed a ``_cancel_state`` entry for an
+            # invocation, the id is added here and EVERY subsequent
+            # callback for the same invocation short-circuits — even
+            # though ``_cancel_state`` itself was popped (consume-once
+            # semantic) so that the InvocationCancelled sink event
+            # only fires once. Without this, after the first
+            # cancellation, follow-up ``before_model_callback`` /
+            # ``before_tool_callback`` invocations on the SAME
+            # invocation_id would see an empty ``_cancel_state`` and
+            # let the LLM call / tool dispatch proceed — exactly the
+            # bug reproduced in /tmp/demo-v12.log where a single
+            # ``LLM_CALL_TIMEOUT`` drift on ``e-1e9e1f05`` was
+            # followed by 3 more watcher firings on the SAME
+            # invocation. Cleared in :meth:`clear_active_context` and
+            # in :meth:`after_run_callback` for the top-level id.
+            self._cancelled_invocations: set[str] = set()
             # Parent/child invocation map for cancel propagation.
             # ``dict[str, str]`` mapping ``invocation_id ->
             # parent_invocation_id``. Populated on every
@@ -1563,6 +1618,7 @@ def make_adk_plugin(
             # gone, and keeping it would misfire on an unrelated future
             # invocation_id collision.
             self._cancel_state.clear()
+            self._cancelled_invocations.clear()
             self._invocation_parents.clear()
             # goldfive#264 — drop per-invocation pin map.
             self._invocation_pinned_task_id.clear()
@@ -1615,8 +1671,7 @@ def make_adk_plugin(
                     )
                 except Exception as exc:  # noqa: BLE001
                     log.debug(
-                        "_GoldfiveADKPlugin.request_invocation_cancel: "
-                        "descendant walk raised: %s",
+                        "_GoldfiveADKPlugin.request_invocation_cancel: descendant walk raised: %s",
                         exc,
                     )
                     descendants = []
@@ -1661,6 +1716,26 @@ def make_adk_plugin(
             if not invocation_id:
                 return None
             return self._cancel_state.get(str(invocation_id))
+
+        def is_invocation_cancelled(self, invocation_id: str) -> bool:
+            """Return True if ``invocation_id`` is flagged for cancel.
+
+            Sticky: returns True both when an unconsumed
+            :class:`~goldfive.types.CancellationRequest` is pending in
+            ``_cancel_state`` AND when an earlier callback already
+            consumed it (recorded in ``_cancelled_invocations``). The
+            sticky bit is what gives us "every subsequent callback for
+            the same invocation short-circuits", fixing the demo-v12.log
+            regression where the watcher fired multiple times on a
+            single invocation. See class-init comment on
+            ``_cancelled_invocations`` for the full rationale.
+            """
+            if not invocation_id:
+                return False
+            inv_id = str(invocation_id)
+            if inv_id in self._cancelled_invocations:
+                return True
+            return self._cancel_state.get(inv_id) is not None
 
         def set_reconciler(self, reconciler: Any) -> None:
             """Attach a :class:`~goldfive.reconciler.PlanReconciler`.
@@ -1741,13 +1816,16 @@ def make_adk_plugin(
             # cancel in harmonograf. The outer ``ADKAdapter.invoke``
             # loop honours the short-circuit via
             # :meth:`peek_cancel_for_invocation` (below).
-            if inv_id and self._cancel_state.get(inv_id) is not None:
-                request = self.consume_cancel_for_invocation(inv_id)
-                await self._emit_invocation_cancelled(
-                    invocation_id=inv_id,
-                    agent_name="",
-                    request=request,
-                )
+            if inv_id and self.is_invocation_cancelled(inv_id):
+                pending = self._cancel_state.get(inv_id)
+                if pending is not None:
+                    request = self.consume_cancel_for_invocation(inv_id)
+                    self._cancelled_invocations.add(inv_id)
+                    await self._emit_invocation_cancelled(
+                        invocation_id=inv_id,
+                        agent_name="",
+                        request=request,
+                    )
                 return None
 
             # Reset the per-invocation counters so the CONFABULATION_RISK
@@ -1848,13 +1926,16 @@ def make_adk_plugin(
             # turn is skipped entirely. Done BEFORE the pinning /
             # reconciler forward work so a cancelled turn leaves no
             # side-effects on orchestration state.
-            if inv_id and self._cancel_state.get(inv_id) is not None:
-                request = self.consume_cancel_for_invocation(inv_id)
-                await self._emit_invocation_cancelled(
-                    invocation_id=inv_id,
-                    agent_name=agent_name,
-                    request=request,
-                )
+            if inv_id and self.is_invocation_cancelled(inv_id):
+                pending = self._cancel_state.get(inv_id)
+                if pending is not None:
+                    request = self.consume_cancel_for_invocation(inv_id)
+                    self._cancelled_invocations.add(inv_id)
+                    await self._emit_invocation_cancelled(
+                        invocation_id=inv_id,
+                        agent_name=agent_name,
+                        request=request,
+                    )
                 return None
 
             # Layer 1: pin the starting sub-agent's task_id so its
@@ -2007,9 +2088,7 @@ def make_adk_plugin(
                         for task in tasks_list:
                             if str(_safe_attr(task, "id", "") or "") != tid:
                                 continue
-                            assignee = str(
-                                _safe_attr(task, "assignee_agent_id", "") or ""
-                            )
+                            assignee = str(_safe_attr(task, "assignee_agent_id", "") or "")
                             if assignee != agent_name:
                                 continue
                             status = _safe_attr(task, "status", None)
@@ -2036,18 +2115,14 @@ def make_adk_plugin(
             # Build the assignee+status candidate set once; signals 2-4
             # all reuse it. We also keep the parent's tool args (best-
             # effort) so signals 3 / 4 / 8 can score candidates.
-            assignee_candidates = self._candidates_for_agent(
-                tasks_list, agent_name
-            )
+            assignee_candidates = self._candidates_for_agent(tasks_list, agent_name)
             scoring_args = self._scoring_args_for(
                 ctx=ctx,
                 parent_invocation_id=parent_invocation_id,
             )
 
             # ---- Signal 2: DAG-ready exactly-1 -------------------------
-            dag_ready = self._filter_dag_ready(
-                plan, assignee_candidates, task_upstream_ready
-            )
+            dag_ready = self._filter_dag_ready(plan, assignee_candidates, task_upstream_ready)
             if len(dag_ready) == 1:
                 task = dag_ready[0]
                 task_id = str(_safe_attr(task, "id", "") or "")
@@ -2249,13 +2324,9 @@ def make_adk_plugin(
             # ---- Signal 7: assignee bare/compound normalisation -------
             normalised_alt = self._alternate_agent_name_form(agent_name)
             if normalised_alt and normalised_alt != agent_name:
-                alt_assignee = self._candidates_for_agent(
-                    tasks_list, normalised_alt
-                )
+                alt_assignee = self._candidates_for_agent(tasks_list, normalised_alt)
                 if alt_assignee:
-                    alt_dag_ready = self._filter_dag_ready(
-                        plan, alt_assignee, task_upstream_ready
-                    )
+                    alt_dag_ready = self._filter_dag_ready(plan, alt_assignee, task_upstream_ready)
                     chosen = None
                     if len(alt_dag_ready) == 1:
                         chosen = alt_dag_ready[0]
@@ -2269,8 +2340,7 @@ def make_adk_plugin(
                         task_id = str(_safe_attr(chosen, "id", "") or "")
                         if task_id:
                             log.warning(
-                                "pin: assignee normalisation %r->%r "
-                                "found candidate %s",
+                                "pin: assignee normalisation %r->%r found candidate %s",
                                 agent_name,
                                 normalised_alt,
                                 task_id,
@@ -2449,9 +2519,7 @@ def make_adk_plugin(
             # 3) Goals on the session itself.
             goals = _safe_attr(ctx.session, "goals", None) or []
             if goals:
-                summaries = [
-                    str(_safe_attr(g, "summary", "") or "") for g in goals
-                ]
+                summaries = [str(_safe_attr(g, "summary", "") or "") for g in goals]
                 joined = " ".join(s for s in summaries if s).strip()
                 if joined:
                     return joined
@@ -2495,7 +2563,8 @@ def make_adk_plugin(
                 return None
             assignee_candidates = self._candidates_for_agent(tasks, agent_name)
             preferred: list[Any] = [
-                t for t in assignee_candidates
+                t
+                for t in assignee_candidates
                 if str(_safe_attr(t, "id", "") or "") in downstream_ids
             ]
             if not preferred:
@@ -2532,15 +2601,11 @@ def make_adk_plugin(
             """
             from goldfive.types import TaskStatus
 
-            store = OrchestrationStore.for_session(
-                _safe_attr(ctx, "session", None)
-            )
+            store = OrchestrationStore.for_session(_safe_attr(ctx, "session", None))
             binding = store.get_reasoning_extracted_binding(agent_name)
             if binding is None or not binding.task_id:
                 return None
-            tasks_by_id = {
-                str(_safe_attr(t, "id", "") or ""): t for t in tasks
-            }
+            tasks_by_id = {str(_safe_attr(t, "id", "") or ""): t for t in tasks}
             task = tasks_by_id.get(binding.task_id)
             if task is None:
                 return None
@@ -2580,7 +2645,7 @@ def make_adk_plugin(
                     continue
                 if not key.startswith(prefix):
                     continue
-                tid = key[len(prefix):]
+                tid = key[len(prefix) :]
                 if tid:
                     target_task_ids.append(tid)
             if not target_task_ids:
@@ -2589,9 +2654,7 @@ def make_adk_plugin(
             # matching id. We do not require assignee-equality here —
             # the writer keyed on the agent already, and we trust that
             # the correction is for this agent's turn.
-            tasks_by_id = {
-                str(_safe_attr(t, "id", "") or ""): t for t in tasks
-            }
+            tasks_by_id = {str(_safe_attr(t, "id", "") or ""): t for t in tasks}
             for tid in target_task_ids:
                 task = tasks_by_id.get(tid)
                 if task is None:
@@ -2647,9 +2710,7 @@ def make_adk_plugin(
                 # Pin with low confidence.
                 return assignee_candidates[0], 0.4
             if scoring_args is not None:
-                chosen = _score_candidates_by_args(
-                    assignee_candidates, scoring_args
-                )
+                chosen = _score_candidates_by_args(assignee_candidates, scoring_args)
                 if chosen is not None:
                     return chosen, 0.4
             # Tie / no scoring available — pick the first deterministically
@@ -2683,9 +2744,7 @@ def make_adk_plugin(
             if not sinks:
                 return
             kind = (
-                "pin_resolved_low_confidence"
-                if via_signal == "low_confidence"
-                else "pin_resolved"
+                "pin_resolved_low_confidence" if via_signal == "low_confidence" else "pin_resolved"
             )
             session = ctx.session
             run_id = str(_safe_attr(session, "run_id", "") or "")
@@ -2705,14 +2764,10 @@ def make_adk_plugin(
             try:
                 from goldfive.events import emit, make_event  # noqa: PLC0415
 
-                evt = make_event(
-                    run_id, seq, kind, payload, session_id=session_id
-                )
+                evt = make_event(run_id, seq, kind, payload, session_id=session_id)
                 await emit(sinks, evt)
             except Exception as exc:  # noqa: BLE001
-                log.debug(
-                    "_emit_pin_resolved: failed to emit %s: %s", kind, exc
-                )
+                log.debug("_emit_pin_resolved: failed to emit %s: %s", kind, exc)
 
         def _stamp_current_task_id(
             self,
@@ -2764,15 +2819,12 @@ def make_adk_plugin(
                 title = str(_safe_attr(task, "title", "") or "")
             store.set_pin_current_task(
                 task_id,
-                source=_BINDING_SOURCE_BY_LADDER.get(
-                    source, BindingSource.UNKNOWN
-                ),
+                source=_BINDING_SOURCE_BY_LADDER.get(source, BindingSource.UNKNOWN),
                 revision=pin_revision,
                 title=title,
             )
             log.info(
-                "goldfive.pin.set: task_id=%s agent=%s source=%s revision=%d "
-                "invocation_id=%s",
+                "goldfive.pin.set: task_id=%s agent=%s source=%s revision=%d invocation_id=%s",
                 task_id,
                 agent_name,
                 source,
@@ -2881,9 +2933,7 @@ def make_adk_plugin(
             if not task_id:
                 return
             try:
-                pin_revision = int(
-                    _safe_attr(plan, "revision_index", 0) or 0
-                )
+                pin_revision = int(_safe_attr(plan, "revision_index", 0) or 0)
             except (TypeError, ValueError):
                 pin_revision = 0
             store = OrchestrationStore.for_session(ctx.session)
@@ -2994,6 +3044,10 @@ def make_adk_plugin(
             if inv_id:
                 self._invocation_tool_calls.pop(inv_id, None)
                 self._invocation_last_text.pop(inv_id, None)
+                # Drop the sticky-cancelled marker for this invocation
+                # so a future invocation_id collision (e.g. test
+                # harness reuse) doesn't inherit the cancel bit.
+                self._cancelled_invocations.discard(inv_id)
             await self._emit_observability(
                 "agent_invocation_completed",
                 agent_name=agent_name,
@@ -3439,8 +3493,7 @@ def make_adk_plugin(
             steerer = ctx.steerer if ctx is not None else None
             session = ctx.session if ctx is not None else None
             log.warning(
-                "goldfive.llm.timeout invocation_id=%s timeout_s=%.1f "
-                "agent=%s task_id=%s",
+                "goldfive.llm.timeout invocation_id=%s timeout_s=%.1f agent=%s task_id=%s",
                 invocation_id,
                 timeout_s,
                 self._host_agent_name or "?",
@@ -3471,9 +3524,7 @@ def make_adk_plugin(
                             f"({timeout_s:.1f}s) on invocation "
                             f"{invocation_id}"
                         ),
-                        current_task_id=str(
-                            _safe_attr(getattr(ctx, "task", None), "id", "") or ""
-                        ),
+                        current_task_id=str(_safe_attr(getattr(ctx, "task", None), "id", "") or ""),
                         current_agent_id=self._host_agent_name or "",
                     )
                     observation = _as_observation(
@@ -3493,8 +3544,7 @@ def make_adk_plugin(
                             await emit_drift(session, drift)
                         except Exception as exc:  # noqa: BLE001
                             log.debug(
-                                "_run_llm_call_timeout_watcher: "
-                                "_emit_drift_detected raised: %s",
+                                "_run_llm_call_timeout_watcher: _emit_drift_detected raised: %s",
                                 exc,
                             )
                 except Exception as exc:  # noqa: BLE001
@@ -3511,10 +3561,7 @@ def make_adk_plugin(
                     reason="llm_call_timeout",
                     severity=DriftSeverity.CRITICAL,
                     drift_kind=DriftKind.LLM_CALL_TIMEOUT.value,
-                    detail=(
-                        f"LLM call exceeded wall-clock budget "
-                        f"({timeout_s:.1f}s)"
-                    ),
+                    detail=(f"LLM call exceeded wall-clock budget ({timeout_s:.1f}s)"),
                     requested_at_ms=int(time.time() * 1000),
                 )
                 self.request_invocation_cancel(
@@ -3530,7 +3577,7 @@ def make_adk_plugin(
 
         # --- Plan + current-task context -------------------------------
 
-        async def before_model_callback(self, *, callback_context: Any, llm_request: Any) -> None:
+        async def before_model_callback(self, *, callback_context: Any, llm_request: Any) -> Any:
             """GoldfivePlanner request-side instruction injection
             + per-LLM-call instrumentation (goldfive#172).
 
@@ -3564,28 +3611,43 @@ def make_adk_plugin(
             if ctx is None:
                 return None
 
-            # Cooperative-cancellation checkpoint (goldfive#251 Stream C / 7a).
-            # Skip the LLM call when this invocation is flagged for
-            # cancel. This is the checkpoint that matters most in
-            # practice: a mid-flight LLM call is the expensive work
-            # whose output would contaminate the parent transcript.
-            # The ``before_agent_callback`` checkpoint above normally
-            # fires first, but ADK may reach ``before_model_callback``
-            # without ``before_agent_callback`` on some dispatch
-            # shapes (e.g. direct model invocations in tests); this
-            # check is the backstop.
+            # Cooperative-cancellation checkpoint (goldfive#251 Stream C / 7a;
+            # sticky-flag fix from goldfive#271 follow-up). Skip the
+            # LLM call when this invocation is flagged for cancel. This
+            # is the checkpoint that matters most in practice: a
+            # mid-flight LLM call is the expensive work whose output
+            # would contaminate the parent transcript.
+            #
+            # Returns a synthetic ``LlmResponse`` (NOT ``None``) so ADK
+            # actually short-circuits the dispatch — per ADK's
+            # ``BasePlugin.before_model_callback`` contract, returning
+            # ``None`` lets the LLM request proceed normally.
+            #
+            # Uses the sticky :meth:`is_invocation_cancelled` so every
+            # subsequent callback on the same invocation also
+            # short-circuits, even though the cancel-state entry is
+            # popped on first consume (consume-once semantic for the
+            # InvocationCancelled sink event).
             inv_ctx = _safe_attr(callback_context, "_invocation_context", None) or _safe_attr(
                 callback_context, "invocation_context", None
             )
             inv_id_check = str(_safe_attr(inv_ctx, "invocation_id", "") or "")
-            if inv_id_check and self._cancel_state.get(inv_id_check) is not None:
-                request = self.consume_cancel_for_invocation(inv_id_check)
-                await self._emit_invocation_cancelled(
-                    invocation_id=inv_id_check,
-                    agent_name="",
-                    request=request,
-                )
-                return None
+            if inv_id_check and self.is_invocation_cancelled(inv_id_check):
+                pending = self._cancel_state.get(inv_id_check)
+                if pending is not None:
+                    request = self.consume_cancel_for_invocation(inv_id_check)
+                    self._cancelled_invocations.add(inv_id_check)
+                    await self._emit_invocation_cancelled(
+                        invocation_id=inv_id_check,
+                        agent_name="",
+                        request=request,
+                    )
+                else:
+                    log.info(
+                        "goldfive.llm.skip invocation_id=%s reason=cancel-flag-set",
+                        inv_id_check,
+                    )
+                return _make_cancelled_llm_response()
 
             # GoldfivePlanner request-side injection (goldfive#153).
             # Best-effort: never raise from this path; injection failure
@@ -3632,7 +3694,11 @@ def make_adk_plugin(
                     # (operator opted out) or when no SessionContext
                     # is available (the watcher can't emit drifts
                     # without one).
-                    if self._llm_call_timeout_ms > 0 and ctx is not None:
+                    if (
+                        self._llm_call_timeout_ms > 0
+                        and ctx is not None
+                        and not self.is_invocation_cancelled(inv_id)
+                    ):
                         timeout_s = self._llm_call_timeout_ms / 1000.0
                         try:
                             watcher = asyncio.create_task(
@@ -3649,8 +3715,7 @@ def make_adk_plugin(
                             # async callback, but the harness kicks
                             # off with no loop in some unit tests).
                             log.debug(
-                                "before_model_callback: cannot schedule "
-                                "LLM-timeout watcher: %s",
+                                "before_model_callback: cannot schedule LLM-timeout watcher: %s",
                                 exc,
                             )
                     self._invocation_llm_pending[inv_id] = pending
@@ -3703,14 +3768,17 @@ def make_adk_plugin(
                 tool_context, "invocation_context", None
             )
             inv_id_check = str(_safe_attr(inv_ctx, "invocation_id", "") or "")
-            if inv_id_check and self._cancel_state.get(inv_id_check) is not None:
-                request = self.consume_cancel_for_invocation(inv_id_check)
-                await self._emit_invocation_cancelled(
-                    invocation_id=inv_id_check,
-                    agent_name="",
-                    request=request,
-                    tool_name=tool_name,
-                )
+            if inv_id_check and self.is_invocation_cancelled(inv_id_check):
+                pending = self._cancel_state.get(inv_id_check)
+                if pending is not None:
+                    request = self.consume_cancel_for_invocation(inv_id_check)
+                    self._cancelled_invocations.add(inv_id_check)
+                    await self._emit_invocation_cancelled(
+                        invocation_id=inv_id_check,
+                        agent_name="",
+                        request=request,
+                        tool_name=tool_name,
+                    )
                 # MINIMAL LLM-visible response — single-key dict, no
                 # ``reason`` / ``detail`` / ``drift_kind``. The parent
                 # LLM that receives this as an AgentTool response can
@@ -3792,23 +3860,19 @@ def make_adk_plugin(
                 # runs on edge-cases).
                 agent_name = ""
                 try:
-                    inv_ctx = _safe_attr(
-                        tool_context, "_invocation_context", None
-                    ) or _safe_attr(tool_context, "invocation_context", None)
+                    inv_ctx = _safe_attr(tool_context, "_invocation_context", None) or _safe_attr(
+                        tool_context, "invocation_context", None
+                    )
                     running_agent = _safe_attr(inv_ctx, "agent", None)
                     agent_name = str(_safe_attr(running_agent, "name", "") or "")
                     if not agent_name:
-                        agent_name = str(
-                            _safe_attr(ctx, "host_agent_name", "") or ""
-                        )
+                        agent_name = str(_safe_attr(ctx, "host_agent_name", "") or "")
                 except Exception:  # noqa: BLE001
                     agent_name = ""
 
                 has_candidates = False
                 try:
-                    has_candidates = _agent_has_pending_candidates(
-                        ctx, agent_name
-                    )
+                    has_candidates = _agent_has_pending_candidates(ctx, agent_name)
                 except Exception:  # noqa: BLE001 — conservative fall-through
                     has_candidates = False
 
@@ -3823,16 +3887,12 @@ def make_adk_plugin(
                         plan = _safe_attr(ctx.session, "plan", None)
                         tasks = _safe_attr(plan, "tasks", None) or ()
                         for task in tasks:
-                            assignee = str(
-                                _safe_attr(task, "assignee_agent_id", "") or ""
-                            )
+                            assignee = str(_safe_attr(task, "assignee_agent_id", "") or "")
                             if assignee != agent_name:
                                 continue
                             status = _safe_attr(task, "status", None)
                             if status is TaskStatus.PENDING or status is TaskStatus.RUNNING:
-                                candidate_ids.append(
-                                    str(_safe_attr(task, "id", "") or "")
-                                )
+                                candidate_ids.append(str(_safe_attr(task, "id", "") or ""))
                     except Exception:  # noqa: BLE001
                         pass
                     log.warning(
@@ -3859,8 +3919,7 @@ def make_adk_plugin(
                         )
                     except Exception as exc:  # noqa: BLE001
                         log.debug(
-                            "before_tool_callback: pin_unresolved drift emit "
-                            "raised: %s",
+                            "before_tool_callback: pin_unresolved drift emit raised: %s",
                             exc,
                         )
                     return {"acknowledged": True}
@@ -4128,9 +4187,7 @@ def make_adk_plugin(
                     reasoning_agent_name = ""
                     try:
                         running_agent = _safe_attr(inv_ctx, "agent", None)
-                        reasoning_agent_name = str(
-                            _safe_attr(running_agent, "name", "") or ""
-                        )
+                        reasoning_agent_name = str(_safe_attr(running_agent, "name", "") or "")
                     except Exception:  # noqa: BLE001
                         reasoning_agent_name = ""
                     if not reasoning_agent_name:
@@ -4155,8 +4212,7 @@ def make_adk_plugin(
                             )
                         except Exception as exc:  # noqa: BLE001
                             log.debug(
-                                "after_model_callback: observe_reasoning "
-                                "(fallback) raised: %s",
+                                "after_model_callback: observe_reasoning (fallback) raised: %s",
                                 exc,
                             )
                     except Exception as exc:  # noqa: BLE001

--- a/tests/test_cooperative_cancellation.py
+++ b/tests/test_cooperative_cancellation.py
@@ -265,37 +265,56 @@ async def test_before_agent_skips_turn_when_cancelled() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 2. Flag is CONSUMED (read + clear) -- re-entry doesn't re-cancel
+# 2. Flag is CONSUMED (read + clear) -- re-entry doesn't re-emit, but
+#    the cancellation is sticky for the rest of the invocation
+#    (goldfive#271 follow-up; see /tmp/demo-v12.log regression).
 # ---------------------------------------------------------------------------
 
 
 async def test_cancel_flag_consumed_on_first_callback() -> None:
     plugin, sink, _session = _make_plugin()
-    plugin.request_invocation_cancel(
-        invocation_id="inv-1", request=_make_request()
-    )
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request())
 
     inv_ctx = _FakeInvocationContext(
         invocation_id="inv-1",
         session_state={},
     )
-    # First callback consumes the flag.
+
+    # Spy reconciler so we can assert no forward work runs on either
+    # the first or second callback (both must short-circuit).
+    class _Spy:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def on_before_agent(self, **_kwargs: Any) -> None:
+            self.calls += 1
+
+    spy = _Spy()
+    plugin.set_reconciler(spy)
+
+    # First callback consumes the cancel-state entry, emits
+    # InvocationCancelled, marks the invocation sticky-cancelled, and
+    # short-circuits.
     await plugin.before_agent_callback(
         agent=_FakeAgent(name="sub_agent"),
         callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
     )
-    # Flag is gone.
+    # The popped flag is gone from cancel_state...
     assert plugin.peek_cancel_for_invocation("inv-1") is None
-    # A second callback on the same invocation sees no cancel and
-    # proceeds normally (we rely on the reconciler being None so the
-    # path completes without raising).
-    plugin.set_reconciler(None)
+    # ...but the sticky bit is set so subsequent callbacks see the
+    # invocation as still cancelled.
+    assert plugin.is_invocation_cancelled("inv-1") is True
+    # A second callback on the same invocation must ALSO short-circuit
+    # (without re-emitting the sink event). Pre-fix: the reconciler's
+    # ``on_before_agent`` ran and the agent turn proceeded.
     await plugin.before_agent_callback(
         agent=_FakeAgent(name="sub_agent"),
         callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
     )
+    assert spy.calls == 0  # neither callback ran the reconciler
     # Only ONE InvocationCancelled event in total — the second
-    # callback did not re-emit.
+    # callback short-circuited silently (it knows the cancel was
+    # already announced).
     assert len(_cancelled_events(sink)) == 1
 
 
@@ -531,9 +550,7 @@ async def test_no_auto_redispatch_after_cancel() -> None:
     spy = _ReconcilerSpy()
     plugin.set_reconciler(spy)
 
-    plugin.request_invocation_cancel(
-        invocation_id="inv-1", request=_make_request()
-    )
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request())
     inv_ctx = _FakeInvocationContext(
         invocation_id="inv-1",
         session_state={},

--- a/tests/test_llm_call_timeout_watcher_sticky.py
+++ b/tests/test_llm_call_timeout_watcher_sticky.py
@@ -1,0 +1,422 @@
+"""Sticky-cancel gate for the LLM-call timeout watcher (goldfive#271
+follow-up; demo-v12.log regression).
+
+Pre-fix: after the watcher fired CRITICAL on call N of an invocation,
+the cancel marker was POPPED on the next ``before_model_callback``
+(consume-once) and ``before_model_callback`` returned ``None`` —
+which per ADK's contract lets the LLM request proceed. So call N+1
+ran for another full budget, the watcher fired again, and the cycle
+repeated. Demo-v12 showed 4 firings on a single invocation
+``e-1e9e1f05`` and 5 on ``e-f342d38c``.
+
+Post-fix: the plugin tracks a sticky ``_cancelled_invocations`` set;
+every callback consults :meth:`is_invocation_cancelled` which is
+True both when a fresh ``CancellationRequest`` is pending AND when
+an earlier callback already consumed one. ``before_model_callback``
+returns a synthetic ``LlmResponse`` (NOT ``None``) so ADK actually
+short-circuits.
+
+These tests pin the new contract:
+
+* watcher fires once and flags the invocation;
+* the next ``before_model_callback`` sees the sticky flag, returns a
+  non-None response (LLM call skipped), and does NOT schedule a
+  fresh watcher;
+* the next ``before_tool_callback`` returns ``{"status": "cancelled"}``
+  with no second ``InvocationCancelled`` sink emit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+pytest.importorskip("google.adk")
+
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    SessionContext,
+    make_adk_plugin,
+)
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    CancellationRequest,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs (mirrored from test_cooperative_cancellation.py to keep the
+# file self-contained; the plugin only inspects the duck-typed shape)
+# ---------------------------------------------------------------------------
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+def _cancelled_event_count(sink: _ListSink) -> int:
+    out = 0
+    for evt in sink.events:
+        which = getattr(evt, "WhichOneof", None)
+        if which is None:
+            continue
+        try:
+            if which("payload") == "invocation_cancelled":
+                out += 1
+        except Exception:
+            continue
+    return out
+
+
+class _FakeAgent:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+
+
+class _FakeADKSession:
+    def __init__(self) -> None:
+        self.state: dict[str, Any] = {}
+        self.run_id = "run-test"
+        self.id = "session-test"
+
+
+class _FakeInvocationContext:
+    def __init__(self, *, invocation_id: str) -> None:
+        self.invocation_id = invocation_id
+        self.session = _FakeADKSession()
+        self.agent = _FakeAgent(name="coordinator")
+
+
+class _FakeCallbackContext:
+    def __init__(self, *, invocation_context: _FakeInvocationContext) -> None:
+        self._invocation_context = invocation_context
+        self.state = invocation_context.session.state
+
+
+class _FakeToolContext(_FakeCallbackContext):
+    def __init__(self, *, invocation_context: _FakeInvocationContext) -> None:
+        super().__init__(invocation_context=invocation_context)
+        self.function_call_id = "fc-1"
+
+
+class _FakeTool:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+
+
+class _FakeLlmRequest:
+    """Minimal ``llm_request`` stub.
+
+    ``before_model_callback`` reaches into ``contents`` and ``config``
+    via ``_measure_request_chars``; both can be empty / missing without
+    raising.
+    """
+
+    def __init__(self) -> None:
+        self.contents: list[Any] = []
+        self.config = None
+
+
+def _make_plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="run-test",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.RUNNING),
+            Task(id="t2", title="T2", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+
+
+def _make_plugin_with_ctx() -> tuple[Any, _ListSink]:
+    plugin = make_adk_plugin(host_agent_name="coordinator")
+    sink = _ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=None)
+    session = Session(
+        run_id="run-test",
+        goals=[Goal(id="g1", summary="ship")],
+        plan=_make_plan(),
+        current_task_id="t1",
+    )
+    ctx = SessionContext(
+        session=session,
+        steerer=steerer,
+        tools=(),
+        tool_handlers={},
+        host_agent_name="coordinator",
+        task=session.plan.tasks[0],
+    )
+    plugin.set_active_context(ctx)
+    return plugin, sink
+
+
+def _make_request(invocation_id: str) -> CancellationRequest:
+    return CancellationRequest(
+        invocation_id=invocation_id,
+        reason="llm_call_timeout",
+        severity=DriftSeverity.CRITICAL,
+        drift_kind="llm_call_timeout",
+        detail="LLM call exceeded wall-clock budget (120.0s)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_invocation_cancelled — the sticky-aware predicate
+# ---------------------------------------------------------------------------
+
+
+def test_is_invocation_cancelled_false_when_unflagged() -> None:
+    plugin, _ = _make_plugin_with_ctx()
+    assert plugin.is_invocation_cancelled("inv-x") is False
+
+
+def test_is_invocation_cancelled_true_with_pending_request() -> None:
+    plugin, _ = _make_plugin_with_ctx()
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request("inv-1"))
+    assert plugin.is_invocation_cancelled("inv-1") is True
+
+
+def test_is_invocation_cancelled_true_after_consume_via_sticky_set() -> None:
+    """Even after :meth:`consume_cancel_for_invocation` pops the
+    pending request, ``is_invocation_cancelled`` returns True as long
+    as the invocation_id is in the sticky set. This is the bit that
+    fixes /tmp/demo-v12.log."""
+    plugin, _ = _make_plugin_with_ctx()
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request("inv-1"))
+    plugin.consume_cancel_for_invocation("inv-1")
+    plugin._cancelled_invocations.add("inv-1")
+    assert plugin.peek_cancel_for_invocation("inv-1") is None
+    assert plugin.is_invocation_cancelled("inv-1") is True
+
+
+def test_is_invocation_cancelled_empty_id_is_false() -> None:
+    plugin, _ = _make_plugin_with_ctx()
+    assert plugin.is_invocation_cancelled("") is False
+
+
+# ---------------------------------------------------------------------------
+# before_model_callback — short-circuit + sticky bit
+# ---------------------------------------------------------------------------
+
+
+async def test_before_model_short_circuits_when_cancel_pending() -> None:
+    """A fresh cancel marker triggers the InvocationCancelled emit and
+    a non-None LlmResponse return — ADK respects this as a
+    short-circuit per the BasePlugin contract."""
+    plugin, sink = _make_plugin_with_ctx()
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request("inv-1"))
+    inv_ctx = _FakeInvocationContext(invocation_id="inv-1")
+    cb_ctx = _FakeCallbackContext(invocation_context=inv_ctx)
+
+    response = await plugin.before_model_callback(
+        callback_context=cb_ctx, llm_request=_FakeLlmRequest()
+    )
+
+    # Non-None: ADK short-circuits the LLM dispatch.
+    assert response is not None
+    # Sticky bit set so subsequent callbacks also short-circuit.
+    assert plugin.is_invocation_cancelled("inv-1") is True
+    # InvocationCancelled emitted exactly once.
+    assert _cancelled_event_count(sink) == 1
+    # No watcher scheduled — the pending dict has no entry, or the
+    # entry has no live watcher task.
+    pending = plugin._invocation_llm_pending.get("inv-1") or {}
+    watcher = pending.get("watcher") if isinstance(pending, dict) else None
+    assert watcher is None or watcher.done()
+
+
+async def test_before_model_sticky_short_circuit_subsequent_call() -> None:
+    """The fix for /tmp/demo-v12.log: after the watcher fired and the
+    first callback consumed the cancel, the NEXT
+    ``before_model_callback`` on the same invocation must still
+    short-circuit (return non-None) and must NOT schedule another
+    watcher. Pre-fix it returned None and ADK kept dispatching."""
+    plugin, sink = _make_plugin_with_ctx()
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request("inv-1"))
+    inv_ctx = _FakeInvocationContext(invocation_id="inv-1")
+
+    # Call 1 — consumes the marker, emits InvocationCancelled.
+    first = await plugin.before_model_callback(
+        callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
+        llm_request=_FakeLlmRequest(),
+    )
+    assert first is not None
+    assert _cancelled_event_count(sink) == 1
+    assert plugin.peek_cancel_for_invocation("inv-1") is None
+
+    # Call 2 — same invocation_id. Pre-fix: returned None, scheduled
+    # a fresh watcher, the LLM call would proceed and the watcher
+    # would eventually fire AGAIN (the demo-v12 regression).
+    second = await plugin.before_model_callback(
+        callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
+        llm_request=_FakeLlmRequest(),
+    )
+    assert second is not None  # short-circuited again
+    # No new InvocationCancelled emit — only the original.
+    assert _cancelled_event_count(sink) == 1
+    # No watcher scheduled on the second call. ``_invocation_llm_pending``
+    # may have an entry from the first call, but no NEW watcher task.
+    pending = plugin._invocation_llm_pending.get("inv-1") or {}
+    watcher = pending.get("watcher") if isinstance(pending, dict) else None
+    assert watcher is None or watcher.done()
+
+
+async def test_before_model_no_short_circuit_for_unrelated_invocation() -> None:
+    """The sticky bit is per-invocation. Cancelling ``inv-1`` does NOT
+    short-circuit ``inv-2``."""
+    plugin, _sink = _make_plugin_with_ctx()
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request("inv-1"))
+    # Sibling invocation must still proceed.
+    inv2 = _FakeInvocationContext(invocation_id="inv-2")
+    response = await plugin.before_model_callback(
+        callback_context=_FakeCallbackContext(invocation_context=inv2),
+        llm_request=_FakeLlmRequest(),
+    )
+    # Returning ``None`` means "proceed normally". The watcher should
+    # have been scheduled for inv-2.
+    assert response is None
+    pending = plugin._invocation_llm_pending.get("inv-2") or {}
+    watcher = pending.get("watcher") if isinstance(pending, dict) else None
+    if watcher is not None:
+        watcher.cancel()
+
+
+# ---------------------------------------------------------------------------
+# before_tool_callback — short-circuit + sticky bit
+# ---------------------------------------------------------------------------
+
+
+async def test_before_tool_short_circuits_with_cancelled_status() -> None:
+    plugin, sink = _make_plugin_with_ctx()
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request("inv-1"))
+    inv_ctx = _FakeInvocationContext(invocation_id="inv-1")
+    response = await plugin.before_tool_callback(
+        tool=_FakeTool(name="search"),
+        tool_args={"q": "x"},
+        tool_context=_FakeToolContext(invocation_context=inv_ctx),
+    )
+    assert response == {"status": "cancelled"}
+    assert plugin.is_invocation_cancelled("inv-1") is True
+    assert _cancelled_event_count(sink) == 1
+
+
+async def test_before_tool_sticky_short_circuit_no_double_emit() -> None:
+    """Subsequent tool calls on a cancelled invocation also return the
+    cancelled status without re-emitting the sink event."""
+    plugin, sink = _make_plugin_with_ctx()
+    plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request("inv-1"))
+    inv_ctx = _FakeInvocationContext(invocation_id="inv-1")
+    tool_ctx = _FakeToolContext(invocation_context=inv_ctx)
+
+    # First tool call — consumes the marker, emits InvocationCancelled.
+    r1 = await plugin.before_tool_callback(
+        tool=_FakeTool(name="search"),
+        tool_args={},
+        tool_context=tool_ctx,
+    )
+    assert r1 == {"status": "cancelled"}
+    assert _cancelled_event_count(sink) == 1
+    # Second tool call — sticky bit shorts the dispatch silently.
+    r2 = await plugin.before_tool_callback(
+        tool=_FakeTool(name="another_tool"),
+        tool_args={},
+        tool_context=tool_ctx,
+    )
+    assert r2 == {"status": "cancelled"}
+    assert _cancelled_event_count(sink) == 1  # no double-emit
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: after the watcher fires, the next
+# before_model_callback must short-circuit (the demo-v12 regression).
+# ---------------------------------------------------------------------------
+
+
+async def test_watcher_fire_then_next_before_model_short_circuits() -> None:
+    """Drive the watcher to completion, then call
+    ``before_model_callback`` on the same invocation. Pre-fix the
+    second callback returned None and the LLM dispatch proceeded —
+    causing the watcher to fire AGAIN minutes later (demo-v12.log
+    showed 4 firings on a single invocation_id). Post-fix: the second
+    callback short-circuits via the sticky bit."""
+    plugin, sink = _make_plugin_with_ctx()
+    ctx = plugin._active_ctx
+
+    # Drive the watcher with a tiny sleep so it fires synchronously.
+    await plugin._run_llm_call_timeout_watcher(
+        invocation_id="inv-1",
+        timeout_s=0.01,
+        ctx=ctx,
+    )
+    # Watcher set the cancel marker.
+    assert plugin._cancel_state.get("inv-1") is not None
+
+    inv_ctx = _FakeInvocationContext(invocation_id="inv-1")
+
+    # Next before_model_callback — first time we see the marker.
+    r1 = await plugin.before_model_callback(
+        callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
+        llm_request=_FakeLlmRequest(),
+    )
+    assert r1 is not None  # short-circuited
+    assert _cancelled_event_count(sink) == 1
+    # The marker is consumed, but the sticky bit is set.
+    assert plugin.peek_cancel_for_invocation("inv-1") is None
+    assert plugin.is_invocation_cancelled("inv-1") is True
+
+    # Pre-fix bug: this second call returned None and scheduled a
+    # fresh watcher. Post-fix: short-circuits.
+    r2 = await plugin.before_model_callback(
+        callback_context=_FakeCallbackContext(invocation_context=inv_ctx),
+        llm_request=_FakeLlmRequest(),
+    )
+    assert r2 is not None
+    # No new sink emit, no live watcher task.
+    assert _cancelled_event_count(sink) == 1
+    pending = plugin._invocation_llm_pending.get("inv-1") or {}
+    watcher = pending.get("watcher") if isinstance(pending, dict) else None
+    assert watcher is None or watcher.done()
+
+
+# ---------------------------------------------------------------------------
+# Cleanup — the sticky set is released when the invocation ends so a
+# future invocation_id collision doesn't inherit the cancel bit.
+# ---------------------------------------------------------------------------
+
+
+async def test_after_run_clears_sticky_cancelled_for_invocation() -> None:
+    plugin, _sink = _make_plugin_with_ctx()
+    plugin._cancelled_invocations.add("inv-1")
+    inv_ctx = _FakeInvocationContext(invocation_id="inv-1")
+    await plugin.after_run_callback(invocation_context=inv_ctx)
+    assert "inv-1" not in plugin._cancelled_invocations
+
+
+def test_clear_active_context_drops_sticky_set() -> None:
+    plugin, _sink = _make_plugin_with_ctx()
+    plugin._cancelled_invocations.update({"inv-1", "inv-2"})
+    plugin.clear_active_context()
+    assert plugin._cancelled_invocations == set()


### PR DESCRIPTION
## Summary

Pre-fix: after `_run_llm_call_timeout_watcher` fired CRITICAL on call N of an invocation, the cancel marker was popped on the next `before_model_callback` (consume-once) and the callback returned `None` — which per ADK's `BasePlugin.before_model_callback` contract lets the LLM request proceed normally. So call N+1 ran for another full budget, the watcher fired again, and the cycle repeated. `/tmp/demo-v12.log` showed 4 firings on a single invocation `e-1e9e1f05` and 5 more on `e-f342d38c`:

```
16:00:15 WARNING goldfive.llm.timeout invocation_id=e-1e9e1f05 timeout_s=120
16:05:06 WARNING goldfive.llm.timeout invocation_id=e-1e9e1f05 timeout_s=120  <- same invocation
16:09:24 WARNING goldfive.llm.timeout invocation_id=e-1e9e1f05 timeout_s=120
16:12:15 WARNING goldfive.llm.timeout invocation_id=e-1e9e1f05 timeout_s=120
```

## Root cause

`_GoldfiveADKPlugin.consume_cancel_for_invocation` pops the entry from `_cancel_state`. So the chain was: watcher fires -> `_cancel_state[inv_id] = request` -> `before_model_callback` of the NEXT call sees the entry, pops it, emits `InvocationCancelled`, returns `None` -> ADK proceeds with the LLM call -> watcher fires again -> repeat.

Two bugs compounded:
1. `_cancel_state` is consumed-once but `before_model_callback` was the only short-circuit path, so subsequent callbacks for the same invocation saw nothing.
2. Returning `None` from `before_model_callback` does NOT abort the LLM call per ADK's contract — only a non-`None` `LlmResponse` does.

## Fix

- New `_cancelled_invocations: set[str]` field on the plugin — sticky bit, populated on first consume.
- New `is_invocation_cancelled(invocation_id)` predicate — True if either `_cancel_state` has a pending request OR the id is in `_cancelled_invocations`.
- All four cancel checkpoints (`before_run_callback`, `before_agent_callback`, `before_model_callback`, `before_tool_callback`) switched to the sticky predicate. The pending `_cancel_state` consume + `_emit_invocation_cancelled` happen only on the first transition (preserving the consume-once event semantic).
- `before_model_callback` now returns a synthetic `LlmResponse` (via `_make_cancelled_llm_response()`) when cancelled, so ADK actually short-circuits.
- Watcher scheduling is gated on the same predicate as defense-in-depth, so even if a future dispatch shape skips the gate-return path we don't keep firing watchers.
- Sticky bit cleared in `after_run_callback` for the finishing invocation_id and in `clear_active_context` for the whole dispatch — so a future invocation_id reuse doesn't inherit the cancel.

## Test plan

- [x] New `tests/test_llm_call_timeout_watcher_sticky.py` (12 tests). The key regression test `test_watcher_fire_then_next_before_model_short_circuits` drives the watcher to completion then asserts the next `before_model_callback` returns non-None and does NOT schedule a fresh watcher.
- [x] **Empirically verified the regression test FAILS on origin/main** and PASSES on this branch (Phase D self-review):
  ```
  origin/main: assert r1 is not None -> AssertionError: assert None is not None
  this branch: 12 passed
  ```
- [x] Updated `test_cancel_flag_consumed_on_first_callback` in `test_cooperative_cancellation.py` to reflect the new contract — the second callback short-circuits silently, no re-emit.
- [x] Full suite: 1748 passed, 49 skipped (vs 1701 on the parent PR #298)
- [x] `ruff check` + `ruff format --check` clean on touched files

## Self-review

- **Correctness**: regression test fails on `origin/main`, passes on this branch (verified by `git checkout origin/main -- goldfive/adapters/_adk_plugin.py` and re-running the test).
- **Simplicity**: the gate at each callsite is ~5-7 lines (`if cancelled: pop+emit on first; return short-circuit`); the helper for the synthetic `LlmResponse` is the only new module-level surface. No watcher rewrite.
- **Alignment**: matches existing plugin conventions — lazy `google.adk` imports, defensive `try/except Exception` around side-effects, `log.debug`/`log.info` for soft paths, `# noqa: BLE001` on broad excepts. Comment density matches the rest of the file.

## Anything noticed but not fixed

- The `consume_cancel_for_invocation` doctring still says "a re-entry into the same callback (e.g. after the LLM call was already skipped and a follow-up tool call fires) doesn't re-emit the cancelled marker" — accurate post-fix because the sticky bit takes over. Left untouched to keep the diff minimal.
- The existing `_run_llm_call_timeout_watcher` does not terminate the in-flight `generate_content_async` mid-stream (ADK doesn't expose a hook for that). The fix here makes the safety-net design from #298 actually work as advertised, but the in-flight call still runs to completion before the cancel takes effect on the NEXT callback. PR #298's original "Anything noticed but not fixed" note still applies for that aspect.