### PR TITLE
fix(adk): scope ADKAdapter cancel-reason / session-id state per goldfive session (#271 follow-up)

### DIFF
--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -1026,7 +1026,24 @@ class ADKAdapter:
         llm_call_timeout_ms: int | None = None,
     ) -> None:
         self._user_id = user_id
-        self._session_id = session_id
+        # Per-(goldfive session.conversation_id) cached ADK session id
+        # for routing under concurrent goldfive sessions on one adapter
+        # (PR #294 audit / goldfive#271 follow-up). The legacy single
+        # ``_session_id`` field stayed shared across every goldfive
+        # session that ever ran on this adapter, so a second concurrent
+        # invocation could pick up the first's cached id and target the
+        # wrong ADK session history. The dict is keyed by
+        # ``Session.conversation_id`` (stable across turns of one
+        # Conversation, unique across concurrent Conversations) so each
+        # logical conversation gets its own ADK session id while
+        # multi-turn continuity within one conversation still works.
+        # The legacy ``_session_id`` attribute survives as a property
+        # backed by ``__legacy_session_id`` so callers that pin a
+        # constructor-supplied id (and the back-compat
+        # ``_pin_outer_session_on_adapter`` write) still observe the
+        # historical single-session shape.
+        self._adk_session_ids_by_conv: dict[str, str] = {}
+        self.__legacy_session_id: str | None = session_id
         self._degraded_prebuilt_runner = False
         # Caller-supplied ADK plugins (e.g. HarmonografTelemetryPlugin).
         # ADK's InMemoryRunner forwards its plugin manager into
@@ -1146,7 +1163,23 @@ class ADKAdapter:
         # so a stale tag can't bleed into the next cancel. See
         # goldfive#139 and
         # :func:`_build_cancelled_response_event` for the content map.
-        self._next_cancel_reason: str = ""
+        #
+        # Per-session keyed dict (PR #294 audit / goldfive#271 follow-up):
+        # the legacy single attribute let session A's USER_STEER tag bleed
+        # into session B's cancel emission when one adapter drove two
+        # concurrent goldfive sessions. Production writers
+        # (:class:`SequentialExecutor`, :class:`ParallelExecutor`,
+        # :class:`DefaultSteerer`) now route through
+        # :meth:`set_next_cancel_reason` which keys by the goldfive
+        # ``Session.id``. The bare ``_next_cancel_reason`` attribute
+        # survives as a property backed by ``__legacy_next_cancel_reason``
+        # for tests and external callers that drive ``invoke`` on a
+        # single session at a time — its read is a fallback consulted
+        # only when the per-session dict has no entry for the current
+        # session id, so cross-session leak through the legacy slot is
+        # impossible in production paths.
+        self._next_cancel_reasons: dict[str, str] = {}
+        self.__legacy_next_cancel_reason: str = ""
         # Handle to the asyncio.Task currently executing
         # :meth:`_invoke_internal` — captured via ``asyncio.current_task()``
         # at entry and cleared in the ``finally`` block. Used by
@@ -1161,7 +1194,17 @@ class ADKAdapter:
         # and test harnesses; the adapter falls back to the lazy-uuid
         # mint in :meth:`_ensure_session`. Live tests in
         # tests/test_live_steering_e2e.py set this explicitly.
-        self._outer_session_id: str | None = None
+        #
+        # PR #294 audit / goldfive#271 follow-up: a single shared field
+        # only carried the FIRST pin's id, hiding subsequent pins from
+        # forensic / log paths when one adapter served multiple outer
+        # adk-web sessions. We keep the legacy ``_outer_session_id``
+        # property for back-compat (tests assert the single-session
+        # shape directly) and additionally maintain
+        # ``_pinned_outer_session_ids`` so structural consumers that
+        # iterate over every pinned outer session see them all.
+        self.__legacy_outer_session_id: str | None = None
+        self._pinned_outer_session_ids: set[str] = set()
 
         # Optional fan-out listeners for raw inner-Runner ADK events.
         # :meth:`Runner.run_streamed` (goldfive: stream-inner-adk-events)
@@ -1189,6 +1232,86 @@ class ADKAdapter:
                     f"state-protocol writes, and drift observation would all "
                     f"be broken"
                 )
+
+    # ------------------------------------------------------------------
+    # Per-session state accessors (PR #294 audit / goldfive#271 follow-up)
+    # ------------------------------------------------------------------
+    #
+    # The ADKAdapter is shared across every goldfive session driven by
+    # one :class:`Runner`. Three pieces of per-invocation state used to
+    # live as bare instance attributes — they leaked across concurrent
+    # sessions because there was no key. The accessors below preserve
+    # the historical single-attribute API (so single-session callers
+    # and tests keep working) while routing production writers through
+    # session-keyed helpers.
+
+    @property
+    def _next_cancel_reason(self) -> str:
+        """Legacy view of the most-recent bare cancel-reason write.
+        See :meth:`set_next_cancel_reason` for the session-aware setter
+        that production code uses.
+        """
+        return self.__legacy_next_cancel_reason
+
+    @_next_cancel_reason.setter
+    def _next_cancel_reason(self, value: str) -> None:
+        self.__legacy_next_cancel_reason = value
+
+    @property
+    def _session_id(self) -> str | None:
+        """Legacy view of the constructor-pinned / outer-pinned ADK session id."""
+        return self.__legacy_session_id
+
+    @_session_id.setter
+    def _session_id(self, value: str | None) -> None:
+        self.__legacy_session_id = value
+
+    @property
+    def _outer_session_id(self) -> str | None:
+        """Legacy view of the most-recent outer adk-web session pin."""
+        return self.__legacy_outer_session_id
+
+    @_outer_session_id.setter
+    def _outer_session_id(self, value: str | None) -> None:
+        self.__legacy_outer_session_id = value
+        if value:
+            self._pinned_outer_session_ids.add(value)
+
+    def set_next_cancel_reason(self, session: Session, reason: str) -> None:
+        """Stamp the next cancel reason for ``session``.
+
+        Replaces the bare ``adapter._next_cancel_reason = X`` write so
+        two concurrent goldfive sessions on one adapter cannot bleed
+        a USER_STEER tag into each other's cancel emission. The reader
+        in :meth:`_invoke_internal` consumes the entry keyed by the
+        active session id; absent that, falls back to the legacy slot
+        so single-session callers (tests, simple scripts) keep their
+        bare-attribute write semantics.
+        """
+        sid = getattr(session, "id", "") or ""
+        if sid:
+            self._next_cancel_reasons[sid] = reason
+        else:
+            self.__legacy_next_cancel_reason = reason
+
+    def _consume_next_cancel_reason(self, session: Session) -> str:
+        """Pop ``session``'s pending cancel reason, falling back to legacy.
+
+        Production writers route through :meth:`set_next_cancel_reason`
+        so the per-session entry wins. Legacy bare-attribute writers
+        (tests, external callers) are still observed via the legacy
+        slot; the legacy slot is only consulted when the per-session
+        dict has no entry for ``session.id`` so cross-session leak
+        through the shared slot is impossible in production paths.
+        """
+        sid = getattr(session, "id", "") or ""
+        if sid and sid in self._next_cancel_reasons:
+            reason = self._next_cancel_reasons.pop(sid)
+            if reason:
+                return reason
+        legacy = self.__legacy_next_cancel_reason
+        self.__legacy_next_cancel_reason = ""
+        return legacy
 
     # ------------------------------------------------------------------
     # Post-construction plugin install
@@ -1596,7 +1719,7 @@ class ADKAdapter:
         """
         task_id = getattr(task, "id", "") if task is not None else ""
 
-        session_id = await self._ensure_session()
+        session_id = await self._ensure_session(session)
         state = await self._get_session_state(session_id)
 
         ctx = SessionContext(
@@ -1713,9 +1836,12 @@ class ADKAdapter:
             # Consume the tag the steerer / executor stashed on us before
             # triggering the cancel (see goldfive#139). An unset tag
             # falls through to the legacy generic reason so existing
-            # heal paths keep the neutral content variant.
-            reason = self._next_cancel_reason or "cancelled_mid_invocation"
-            self._next_cancel_reason = ""
+            # heal paths keep the neutral content variant. Routed
+            # through :meth:`_consume_next_cancel_reason` so the
+            # per-session-keyed entry wins over the legacy shared slot
+            # — eliminates the cross-session leak flagged by PR #294's
+            # audit when one adapter drives multiple goldfive sessions.
+            reason = self._consume_next_cancel_reason(session) or "cancelled_mid_invocation"
             await self._heal_pending_tool_calls(
                 runner=self._runner,
                 session_id=session_id,
@@ -1770,7 +1896,13 @@ class ADKAdapter:
                     )
                 # No cancel fired — drop any stale tag so the NEXT
                 # invoke's cancel (if any) doesn't pick up leftover state.
-                self._next_cancel_reason = ""
+                # Clear BOTH the per-session entry (the production
+                # writers' lane) and the legacy single-slot fallback
+                # so neither path can bleed into the next invocation.
+                sid_for_clear = getattr(session, "id", "") or ""
+                if sid_for_clear:
+                    self._next_cancel_reasons.pop(sid_for_clear, None)
+                self.__legacy_next_cancel_reason = ""
             if self._plugin is not None:
                 # ``clear_active_context`` also clears any attached
                 # reconciler — overlay-mode is strictly per-invocation.
@@ -1796,26 +1928,81 @@ class ADKAdapter:
     # Session plumbing
     # ------------------------------------------------------------------
 
-    async def _ensure_session(self) -> str:
-        """Return the ADK session id for the runner.
+    async def _ensure_session(self, session: Session | None = None) -> str:
+        """Return the ADK session id for ``session``.
 
-        Mints one lazily on first call when the caller didn't pin one
-        via ``session_id=``. Cached on ``self._session_id`` after the
-        first call so every subsequent :meth:`invoke` reuses it — the
-        whole run rolls up under one logical session.
+        Per-conversation cache (PR #294 audit / goldfive#271 follow-up):
+        the ADK session id is keyed by ``session.conversation_id`` so
+        two concurrent goldfive Conversations driven by the same
+        adapter target distinct ADK session histories. Within one
+        Conversation every turn shares the same id — preserving the
+        multi-turn ADK history continuity the legacy single-attribute
+        cache provided.
+
+        Lookup order:
+
+        1. ``self._adk_session_ids_by_conv[conversation_id]`` if
+           cached — reuse so multi-turn callers stay on one ADK
+           session.
+        2. Constructor / outer-pin ``self._session_id`` legacy slot —
+           seeds the cache so legacy single-session callers (no
+           Conversation context, ``Session.conversation_id == ""``)
+           keep working unchanged.
+        3. ``session.id`` (the goldfive ``run_id``, possibly already
+           pinned to the outer adk-web session id by
+           :meth:`Runner.run`) — adopting it here lets the harmonograf
+           plugin co-locate plan + spans on one session id without
+           the older :meth:`_pin_outer_session_on_adapter` shared-slot
+           write.
+        4. Fresh uuid4 mint — programmatic callers with no pin.
         """
-        if self._session_id:
-            # Ensure the session exists on the runner's service. Safe to
-            # call repeatedly; create_session is typically idempotent
-            # for a given (app_name, user_id, session_id) triple and we
-            # swallow any conflict so tests that pre-create the session
-            # keep working.
-            await self._touch_session(self._session_id)
-            return self._session_id
+        conv_key = ""
+        if session is not None:
+            conv_key = getattr(session, "conversation_id", "") or ""
 
-        self._session_id = str(uuid.uuid4())
-        await self._touch_session(self._session_id)
-        return self._session_id
+        # 1. Per-conversation cache hit — multi-turn callers reuse the
+        #    same ADK session id within one logical Conversation.
+        cached = self._adk_session_ids_by_conv.get(conv_key)
+        if cached:
+            await self._touch_session(cached)
+            return cached
+
+        # 2. Legacy single-attribute pin (constructor ``session_id=``
+        #    or :meth:`_pin_outer_session_on_adapter` write). Applies
+        #    ONLY to the empty-conv-id legacy bucket so concurrent
+        #    goldfive Conversations cannot collide on the shared slot.
+        if conv_key == "" and self.__legacy_session_id:
+            sid = self.__legacy_session_id
+            self._adk_session_ids_by_conv[""] = sid
+            await self._touch_session(sid)
+            return sid
+
+        # 3. Inherit ``session.id`` when present — typically the outer
+        #    adk-web session id pinned by :meth:`Runner.run(session_id=)`.
+        #    Adopting it here lets the harmonograf plugin co-locate plan
+        #    + spans on one session id without the older shared-slot
+        #    pin-on-adapter dance.
+        if session is not None:
+            sid_from_session = getattr(session, "id", "") or ""
+            if sid_from_session:
+                self._adk_session_ids_by_conv[conv_key] = sid_from_session
+                # Mirror to the legacy slot ONLY when the slot is the
+                # legacy empty-conv-id bucket and currently empty.
+                # Mirroring per-conversation derivations would
+                # reintroduce the cross-session leak we just fixed.
+                if conv_key == "" and not self.__legacy_session_id:
+                    self.__legacy_session_id = sid_from_session
+                await self._touch_session(sid_from_session)
+                return sid_from_session
+
+        # 4. Lazy uuid4 mint — programmatic callers with no pin and no
+        #    Runner-overridden session.run_id.
+        minted = str(uuid.uuid4())
+        self._adk_session_ids_by_conv[conv_key] = minted
+        if conv_key == "" and not self.__legacy_session_id:
+            self.__legacy_session_id = minted
+        await self._touch_session(minted)
+        return minted
 
     async def _touch_session(self, session_id: str) -> None:
         """Best-effort ``create_session`` on the runner's session service.

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -86,16 +86,31 @@ _StageResult = tuple[Task, InvocationResult | None, DriftEvent | None, BaseExcep
 _CANCEL_REASON_USER_STEER: str = "user_steer"
 
 
-def _tag_adapter_cancel_user_steer(adapter: Any) -> None:
-    """Tag ``adapter._next_cancel_reason`` with the USER_STEER symbolic reason.
+def _tag_adapter_cancel_user_steer(adapter: Any, session: Any = None) -> None:
+    """Tag the adapter's next mid-invocation cancel with the USER_STEER reason.
 
     Called just before the executor triggers ``task.cancel()`` on any
     in-flight stage invoke task so the adapter's mid-invocation cancel
     handler picks up the tag and appends an LLM-actionable synthetic
-    ``function_response`` (instead of the legacy generic jargon).
-    Adapters that don't expose ``_next_cancel_reason`` are tolerated
-    via a duck-typed write. See goldfive#139.
+    ``function_response`` (instead of the legacy generic jargon). See
+    goldfive#139.
+
+    Routes through :meth:`ADKAdapter.set_next_cancel_reason` when the
+    adapter exposes it (PR #294 audit / goldfive#271 follow-up) so
+    the tag is keyed by ``session.id`` and cannot bleed across
+    concurrent goldfive sessions sharing one adapter. Falls back to
+    the bare attribute write for adapters / stubs that predate the
+    helper.
     """
+    setter = getattr(adapter, "set_next_cancel_reason", None)
+    if callable(setter) and session is not None:
+        try:
+            setter(session, _CANCEL_REASON_USER_STEER)
+            return
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "ParallelDAGExecutor: set_next_cancel_reason raised: %s", exc
+            )
     try:
         adapter._next_cancel_reason = _CANCEL_REASON_USER_STEER
     except Exception as exc:  # noqa: BLE001
@@ -671,7 +686,7 @@ class ParallelDAGExecutor:
                             # content instead of the legacy generic
                             # jargon. See goldfive#139.
                             if outcome.steer_message is not None:
-                                _tag_adapter_cancel_user_steer(adapter)
+                                _tag_adapter_cancel_user_steer(adapter, session=session)
                             await _cancel_stage_tasks()
                             break
                         # Non-interrupting control (PAUSE/RESUME/

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -89,16 +89,31 @@ def _steer_cancel_reason_prefix(steer_msg: Any) -> str:
     return "user_steer:steer"
 
 
-def _tag_adapter_cancel_user_steer(adapter: Any) -> None:
-    """Tag ``adapter._next_cancel_reason`` with the USER_STEER symbolic reason.
+def _tag_adapter_cancel_user_steer(adapter: Any, session: Any = None) -> None:
+    """Tag the adapter's next mid-invocation cancel with the USER_STEER reason.
 
     Called just before the executor triggers ``task.cancel()`` on the
     in-flight invoke task so the adapter's mid-invocation cancel
     handler picks up the tag and appends an LLM-actionable synthetic
-    ``function_response`` (instead of the legacy generic jargon). Adapters
-    that don't expose ``_next_cancel_reason`` are tolerated via a
-    duck-typed write. See goldfive#139.
+    ``function_response`` (instead of the legacy generic jargon). See
+    goldfive#139.
+
+    Routes through :meth:`ADKAdapter.set_next_cancel_reason` when the
+    adapter exposes it (PR #294 audit / goldfive#271 follow-up) so the
+    tag is keyed by ``session.id`` and cannot bleed across concurrent
+    goldfive sessions sharing one adapter. Falls back to the bare
+    ``_next_cancel_reason`` attribute for adapters / stubs that
+    predate the helper.
     """
+    setter = getattr(adapter, "set_next_cancel_reason", None)
+    if callable(setter) and session is not None:
+        try:
+            setter(session, _CANCEL_REASON_USER_STEER)
+            return
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "SequentialExecutor: set_next_cancel_reason raised: %s", exc
+            )
     try:
         adapter._next_cancel_reason = _CANCEL_REASON_USER_STEER
     except Exception as exc:  # noqa: BLE001
@@ -1306,7 +1321,7 @@ class SequentialExecutor(Executor):
                 # handler (and the synthetic function_response it
                 # appends) carries LLM-actionable content instead of
                 # the legacy generic jargon. See goldfive#139.
-                _tag_adapter_cancel_user_steer(adapter)
+                _tag_adapter_cancel_user_steer(adapter, session=session)
                 await self._cancel_invoke_task(invoke_task)
                 return ("steer", outcome.steer_message)
 

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -2356,7 +2356,7 @@ class DefaultSteerer:
         # attribute (duck-typed) or no adapter is bound. See
         # goldfive#139 and
         # :func:`goldfive.adapters.adk._build_cancelled_response_event`.
-        self._tag_adapter_cancel_reason(drift)
+        self._tag_adapter_cancel_reason(drift, session=session)
         # goldfive#152: USER_STEER-specific side effects -- write the
         # active-steer bookkeeping onto the orchestration-state dict
         # and synthesize a durable Goal from the steer body so
@@ -2932,14 +2932,24 @@ class DefaultSteerer:
     # :data:`goldfive.adapters.adk.SYMBOLIC_REASON_USER_STEER` etc.
     _ADAPTER_CANCEL_REASON_USER_STEER: str = "user_steer"
 
-    def _tag_adapter_cancel_reason(self, drift: DriftEvent) -> None:
-        """Set ``adapter._next_cancel_reason`` based on ``drift.kind``.
+    def _tag_adapter_cancel_reason(
+        self, drift: DriftEvent, *, session: Session | None = None
+    ) -> None:
+        """Set the next adapter cancel reason based on ``drift.kind``.
 
         USER_STEER drift -> ``"user_steer"``. Other kinds currently leave
         the tag unset so the adapter falls through to the generic
         content variant. Tolerates adapters that don't carry the
         attribute (no-op) and an unbound adapter (no-op). See
         goldfive#139.
+
+        Routes the write through
+        :meth:`ADKAdapter.set_next_cancel_reason` when the adapter
+        exposes that helper (PR #294 audit / goldfive#271 follow-up)
+        so the tag is keyed by ``session.id`` and cannot bleed across
+        concurrent goldfive sessions sharing one adapter. Falls back
+        to the bare attribute write for adapters / stubs that predate
+        the helper.
 
         The goldfive-steer-unification promotion path uses a separate
         helper (:meth:`_tag_adapter_cancel_reason_for_promotion`) to
@@ -2955,36 +2965,51 @@ class DefaultSteerer:
             reason = self._ADAPTER_CANCEL_REASON_USER_STEER
         else:
             return
-        try:
-            adapter._next_cancel_reason = reason
-        except Exception as exc:  # noqa: BLE001
-            # Adapter doesn't expose the attribute — tolerated.
-            log.debug(
-                "DefaultSteerer: could not tag adapter cancel reason: %s",
-                exc,
-            )
+        self._write_adapter_cancel_reason(adapter, reason, session)
 
-    def _tag_adapter_cancel_reason_for_promotion(self, drift: DriftEvent) -> str:
+    def _tag_adapter_cancel_reason_for_promotion(
+        self, drift: DriftEvent, *, session: Session | None = None
+    ) -> str:
         """Stamp a goldfive-specific cancel reason on the bound adapter.
 
         Returns the reason string stamped (or synthesised) so callers
         can record it on the session for downstream observability.
         Mirrors :meth:`_tag_adapter_cancel_reason` semantics: adapters
-        without ``_next_cancel_reason`` are tolerated.
+        without the per-session helper are tolerated.
         """
         reason = f"goldfive_{drift.kind.name.lower()}"
         adapter = self._adapter
         if adapter is None:
             return reason
+        self._write_adapter_cancel_reason(adapter, reason, session)
+        return reason
+
+    @staticmethod
+    def _write_adapter_cancel_reason(
+        adapter: Any, reason: str, session: Session | None
+    ) -> None:
+        """Route the cancel-reason tag through the session-aware helper.
+
+        Falls back to the legacy bare-attribute write for adapters /
+        stubs that don't expose :meth:`set_next_cancel_reason`. See
+        :meth:`ADKAdapter.set_next_cancel_reason` for the rationale.
+        """
+        setter = getattr(adapter, "set_next_cancel_reason", None)
+        if callable(setter) and session is not None:
+            try:
+                setter(session, reason)
+                return
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "DefaultSteerer: set_next_cancel_reason raised: %s", exc
+                )
         try:
             adapter._next_cancel_reason = reason
         except Exception as exc:  # noqa: BLE001
             log.debug(
-                "DefaultSteerer: could not tag adapter cancel reason for "
-                "goldfive promotion: %s",
+                "DefaultSteerer: could not tag adapter cancel reason: %s",
                 exc,
             )
-        return reason
 
     async def _request_adapter_cancel(self, reason: str) -> None:
         """Invoke the optional ``adapter.request_cancel(reason)`` hook.
@@ -3361,7 +3386,9 @@ class DefaultSteerer:
         semantics identical to USER_STEER.
         """
         # 1. Tag adapter cancel reason.
-        cancel_reason = self._tag_adapter_cancel_reason_for_promotion(drift)
+        cancel_reason = self._tag_adapter_cancel_reason_for_promotion(
+            drift, session=session
+        )
         # Session-visible cancel prefix so ``_mark_cancelled_if_live``
         # stamps it on any TaskCancelled the executor emits for the
         # in-flight task as part of the promotion.

--- a/tests/test_adk_adapter_concurrent_sessions.py
+++ b/tests/test_adk_adapter_concurrent_sessions.py
@@ -1,0 +1,403 @@
+"""Regression tests for per-(adapter, session) state isolation.
+
+PR #294's audit flagged three :class:`ADKAdapter` instance attributes
+as concurrent-runs hazards because one adapter is shared across every
+goldfive session driven by a :class:`Runner`:
+
+* ``_next_cancel_reason`` — the symbolic tag the steerer / executor
+  stamps before triggering a mid-invocation cancel so the synthetic
+  ``function_response`` carries LLM-actionable content. Cross-session
+  leak: a USER_STEER tag stamped for session A's invocation could be
+  consumed by session B's cancel emission, mislabelling B's cancel.
+* ``_session_id`` — the cached ADK session id chosen by
+  :meth:`ADKAdapter._ensure_session`. Cross-session leak: the first
+  invocation's mint sticks across every concurrent invocation, so two
+  goldfive Conversations target the same ADK session history (history
+  bleed; corrupts tool-id pairing).
+* ``_outer_session_id`` — the outer adk-web session pinned by
+  :meth:`GoldfiveADKAgent._pin_outer_session_on_adapter`. Forensic
+  field, but the single-attribute store hid every pin after the first.
+
+These tests exercise the per-session helpers
+(:meth:`ADKAdapter.set_next_cancel_reason`,
+:meth:`ADKAdapter._consume_next_cancel_reason`,
+:meth:`ADKAdapter._ensure_session`, and the
+``_pinned_outer_session_ids`` set) plus an end-to-end mid-invocation
+cancel path. They fail on origin/main and pass with the per-session
+dict refactor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from goldfive.types import Session, Task
+
+
+# ---------------------------------------------------------------------------
+# Minimal ADK fakes (mirrors helpers in tests/test_adk_adapter.py).
+# ---------------------------------------------------------------------------
+
+
+def _make_agent() -> Any:
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(
+        name="concurrent_agent",
+        model="fake-model",
+        description="Test agent",
+        instruction="Test.",
+    )
+
+
+class _FakeADKSession:
+    def __init__(self, sid: str = "") -> None:
+        self.id = sid
+        self.events: list = []
+        self.state: dict = {}
+
+
+class _FakeSessionService:
+    """Tracks append_event calls per ADK session id.
+
+    ``create_session`` is keyed by ``session_id`` so two distinct
+    goldfive Conversations get distinct ADK sessions, making
+    cross-session leak observable.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, _FakeADKSession] = {}
+        self.appended_by_sid: dict[str, list] = {}
+
+    async def create_session(
+        self, *, app_name: str, user_id: str, session_id: str
+    ) -> _FakeADKSession:
+        sess = self._sessions.get(session_id)
+        if sess is None:
+            sess = _FakeADKSession(sid=session_id)
+            self._sessions[session_id] = sess
+            self.appended_by_sid.setdefault(session_id, [])
+        return sess
+
+    async def get_session(
+        self, *, app_name: str, user_id: str, session_id: str
+    ) -> _FakeADKSession:
+        return self._sessions.setdefault(
+            session_id, _FakeADKSession(sid=session_id)
+        )
+
+    async def append_event(self, *, session, event):
+        self.appended_by_sid.setdefault(session.id, []).append(event)
+        session.events.append(event)
+        return event
+
+
+class _FakeRunner:
+    """Runner stub whose ``run_async`` consults a per-session script."""
+
+    def __init__(self, agent) -> None:
+        self.agent = agent
+        self.app_name = "concurrent-app"
+        self.session_service = _FakeSessionService()
+        self.plugin_manager = None
+        self.plugins: list = []
+        self._scripts: dict[str, Any] = {}
+
+    def script_for(self, session_id: str, factory) -> None:
+        self._scripts[session_id] = factory
+
+    async def run_async(self, *, user_id: str, session_id: str, new_message=None):
+        factory = self._scripts.get(session_id)
+        if factory is None:
+
+            async def _empty():
+                if False:
+                    yield None
+
+            factory = _empty
+        async for event in factory():
+            yield event
+
+
+def _mk_function_call_event(
+    *, call_id: str, name: str, invocation_id: str = "inv-c"
+):
+    from google.adk.events.event import Event  # type: ignore
+    from google.genai import types  # type: ignore
+
+    part = types.Part(function_call=types.FunctionCall(id=call_id, name=name))
+    return Event(
+        invocation_id=invocation_id,
+        author="concurrent_agent",
+        content=types.Content(role="model", parts=[part]),
+    )
+
+
+def _make_session(*, conversation_id: str, run_id: str) -> Session:
+    """Build a goldfive Session with explicit conversation + run ids.
+
+    Mirrors what :meth:`Runner._run_locked` produces for outer-pinned
+    invocations: ``conversation_id`` from a Conversation lookup keyed
+    on the outer adk-web session id, ``run_id`` overridden to that
+    same outer id (so :attr:`Session.id` returns the outer id).
+    """
+    return Session(run_id=run_id, conversation_id=conversation_id)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests — per-session state isolation
+# ---------------------------------------------------------------------------
+
+
+def test_set_next_cancel_reason_does_not_leak_across_sessions() -> None:
+    """A reason set for session A is invisible to session B's consumer.
+
+    Direct unit-level check on
+    :meth:`ADKAdapter.set_next_cancel_reason` /
+    :meth:`ADKAdapter._consume_next_cancel_reason`. On origin/main both
+    sessions read / write the same ``_next_cancel_reason`` string
+    attribute, so session B's consume returns ``"user_steer"`` even
+    though no tag was ever set for B.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    agent = _make_agent()
+    runner = _FakeRunner(agent)
+    adapter = ADKAdapter(runner)
+
+    session_a = _make_session(conversation_id="conv-A", run_id="adk-outer-A")
+    session_b = _make_session(conversation_id="conv-B", run_id="adk-outer-B")
+
+    adapter.set_next_cancel_reason(session_a, "user_steer")
+
+    # Session B's consume must NOT pick up A's tag.
+    b_reason = adapter._consume_next_cancel_reason(session_b)
+    assert b_reason == "", (
+        "session B leaked session A's user_steer tag through the "
+        f"shared cancel-reason slot; got {b_reason!r}"
+    )
+
+    # Session A's consume DOES return its tag, then clears it.
+    a_reason = adapter._consume_next_cancel_reason(session_a)
+    assert a_reason == "user_steer"
+    a_reason_again = adapter._consume_next_cancel_reason(session_a)
+    assert a_reason_again == ""
+
+
+def test_legacy_bare_attribute_write_falls_through_to_consume() -> None:
+    """Single-session callers / tests using ``adapter._next_cancel_reason = X``
+    still see the tag consumed on the next cancel.
+
+    Back-compat: legacy bare writes go into a fallback slot the
+    consumer reads only when the per-session entry for the active
+    session id is empty. Without this, every test in the codebase
+    that drives ``adapter._next_cancel_reason = ...`` directly would
+    break.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    agent = _make_agent()
+    runner = _FakeRunner(agent)
+    adapter = ADKAdapter(runner)
+
+    # Single-session legacy use: bare-attribute write, then consume.
+    session = _make_session(conversation_id="conv-solo", run_id="adk-outer-solo")
+    adapter._next_cancel_reason = "user_steer"
+    assert adapter._consume_next_cancel_reason(session) == "user_steer"
+    # Cleared after consume.
+    assert adapter._next_cancel_reason == ""
+
+
+async def test_ensure_session_caches_per_conversation() -> None:
+    """Two concurrent goldfive Conversations get distinct ADK session ids.
+
+    On origin/main ``_ensure_session`` mints once and caches on the
+    shared ``_session_id`` attribute, so the second concurrent
+    Conversation's invocation observes the FIRST Conversation's id and
+    targets the wrong ADK session history. With the per-conversation
+    cache, each Conversation gets its own id keyed by
+    ``Session.conversation_id``.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    agent = _make_agent()
+    runner = _FakeRunner(agent)
+    adapter = ADKAdapter(runner)
+
+    session_a = _make_session(conversation_id="conv-A", run_id="adk-outer-A")
+    session_b = _make_session(conversation_id="conv-B", run_id="adk-outer-B")
+
+    sid_a = await adapter._ensure_session(session_a)
+    sid_b = await adapter._ensure_session(session_b)
+
+    assert sid_a != sid_b, (
+        "concurrent goldfive Conversations must resolve to distinct "
+        f"ADK session ids; got {sid_a!r} == {sid_b!r}"
+    )
+    # The chosen ids inherit ``session.id`` (Runner.run(session_id=)
+    # outer pin) for adk-web flows, giving harmonograf one id across
+    # plan + spans without the older shared-slot pin-on-adapter dance.
+    assert sid_a == "adk-outer-A"
+    assert sid_b == "adk-outer-B"
+
+    # Re-resolution within the same Conversation reuses the cached id
+    # (multi-turn ADK history continuity is preserved).
+    sid_a_again = await adapter._ensure_session(session_a)
+    sid_b_again = await adapter._ensure_session(session_b)
+    assert sid_a_again == sid_a
+    assert sid_b_again == sid_b
+
+
+async def test_ensure_session_legacy_pin_only_applies_to_empty_conv_bucket() -> None:
+    """A constructor / outer-pin ``_session_id`` never leaks into other Conversations.
+
+    Tests like ``tests/test_adk_adapter_overlay.py`` set
+    ``adapter._session_id = "stub-session"`` for single-session use.
+    The legacy pin must only seed the empty-conversation-id bucket so
+    a subsequent concurrent Conversation does not adopt the pinned id
+    by accident.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    agent = _make_agent()
+    runner = _FakeRunner(agent)
+    adapter = ADKAdapter(runner)
+    adapter._session_id = "stub-session"
+
+    # Empty conversation_id (legacy single-session caller) → adopts the pin.
+    legacy_session = Session(run_id="r1")
+    sid_legacy = await adapter._ensure_session(legacy_session)
+    assert sid_legacy == "stub-session"
+
+    # Non-empty conversation_id (concurrent Conversation) → ignores
+    # the legacy pin, derives from session.id.
+    other_session = _make_session(
+        conversation_id="conv-other", run_id="adk-outer-other"
+    )
+    sid_other = await adapter._ensure_session(other_session)
+    assert sid_other == "adk-outer-other", (
+        "legacy ``_session_id`` pin leaked into a concurrent "
+        f"Conversation; got {sid_other!r}"
+    )
+
+
+def test_outer_session_id_pin_records_every_outer_session() -> None:
+    """Pinning the same adapter from two outer sessions retains both ids.
+
+    On origin/main ``_outer_session_id`` is a single string, so the
+    second pin overwrites (or, with the existing
+    ``not adapter._outer_session_id`` guard in
+    :meth:`GoldfiveADKAgent._pin_outer_session_on_adapter`, silently
+    drops) the second outer session id — forensic logging sees only
+    the first pinned outer id forever after.
+
+    With the fix, every distinct pinned outer sid is recorded on
+    ``_pinned_outer_session_ids`` (a set), so log / forensic
+    consumers can see the full set of outer adk-web sessions the
+    adapter has served.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    agent = _make_agent()
+    runner = _FakeRunner(agent)
+    adapter = ADKAdapter(runner)
+
+    adapter._outer_session_id = "adk-outer-A"
+    adapter._outer_session_id = "adk-outer-B"
+
+    pinned = adapter._pinned_outer_session_ids
+    assert "adk-outer-A" in pinned
+    assert "adk-outer-B" in pinned
+
+
+async def test_invoke_cancel_uses_session_keyed_reason_not_legacy_slot() -> None:
+    """End-to-end check: an in-flight invoke's cancel consumes the
+    session-keyed reason, ignoring a stale value left in the legacy
+    slot from a different session's flow.
+
+    Scenario:
+
+    1. Session B sets a USER_STEER reason via the bare-attribute
+       legacy path (simulating a stale tag left behind by a
+       pre-#294 caller or a test that doesn't use the helper).
+    2. Session A starts an invoke, then we set A's reason via the
+       per-session helper.
+    3. A's task is cancelled.
+
+    With the fix, A's cancel reads its session-keyed entry first
+    and the synthetic function_response carries the user_steer
+    variant — the stale legacy slot is NOT consulted. On origin/main
+    both writes targeted the same shared attribute so whichever
+    write landed last won, hiding the cross-session hazard behind a
+    last-writer-wins flake.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    agent = _make_agent()
+    runner = _FakeRunner(agent)
+    adapter = ADKAdapter(runner)
+
+    session_a = _make_session(conversation_id="conv-A", run_id="adk-outer-A")
+    session_b = _make_session(conversation_id="conv-B", run_id="adk-outer-B")
+
+    a_started = asyncio.Event()
+    a_block = asyncio.Event()
+
+    async def _script_a():
+        yield _mk_function_call_event(call_id="call-a", name="search")
+        a_started.set()
+        await a_block.wait()
+        yield None  # pragma: no cover
+
+    runner.script_for("adk-outer-A", _script_a)
+
+    # Stash a value via the legacy bare-attribute path "for session B".
+    # In the per-session-keyed design this lands in the shared fallback
+    # slot only — it never gets routed to session A's heal path.
+    adapter._next_cancel_reason = "stale_from_session_b"
+
+    invoke_a = asyncio.create_task(
+        adapter.invoke(Task(id="ta", title="A"), session_a),
+        name="invoke-A",
+    )
+    await asyncio.wait_for(a_started.wait(), timeout=2.0)
+
+    # Now set the proper per-session reason for A via the helper.
+    adapter.set_next_cancel_reason(session_a, "user_steer")
+
+    invoke_a.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await invoke_a
+
+    appended_a = runner.session_service.appended_by_sid.get("adk-outer-A", [])
+    assert appended_a, "session A must have a healed function_response"
+    statuses: list[str] = []
+    for ev in appended_a:
+        for fr in ev.get_function_responses():
+            payload = fr.response or {}
+            if "status" in payload:
+                statuses.append(str(payload.get("status", "")))
+    assert "cancelled_by_user_steering" in statuses, (
+        "session A's per-session cancel reason did NOT win over the "
+        f"legacy slot; got statuses={statuses!r}"
+    )
+
+    # Session B never invoked, so it has no healed events. The legacy
+    # slot's stale ``stale_from_session_b`` value did not bleed into
+    # any session-keyed lookup.
+    assert "adk-outer-B" not in runner.session_service.appended_by_sid
+    # Direct per-session consume from B confirms isolation.
+    b_reason = adapter._consume_next_cancel_reason(session_b)
+    # On origin/main this would be the user_steer tag set for A
+    # (single shared attribute, last write wins). With the fix it's
+    # only the legacy fallback that survived (cleared after A's
+    # invocation consumed it).
+    assert b_reason != "user_steer", (
+        "session B leaked session A's user_steer tag: "
+        f"got {b_reason!r}"
+    )

--- a/tests/test_adk_adapter_concurrent_sessions.py
+++ b/tests/test_adk_adapter_concurrent_sessions.py
@@ -35,9 +35,7 @@ from typing import Any
 import pytest
 
 pytest.importorskip("google.adk")
-
 from goldfive.types import Session, Task
-
 
 # ---------------------------------------------------------------------------
 # Minimal ADK fakes (mirrors helpers in tests/test_adk_adapter.py).


### PR DESCRIPTION
## Summary

PR #294's audit flagged three `ADKAdapter` instance attributes as concurrent-runs hazards because one adapter is shared across every goldfive session driven by a `Runner`:

- `_next_cancel_reason` — single-string slot let session A's USER_STEER tag bleed into session B's cancel emission
- `_session_id` — single cache stuck the first invocation's ADK session id across every concurrent invocation
- `_outer_session_id` — single field hid every outer adk-web pin after the first

Fix: replace each bare attribute with a per-session dict keyed by the appropriate goldfive identifier, mirroring the `Runner._conversations` / `_plan_locks` per-key pattern. Production writers (`SequentialExecutor`, `ParallelExecutor`, `DefaultSteerer`) route through a new `set_next_cancel_reason(session, reason)` helper; the bare attributes survive as properties for back-compat with single-session tests.

- `_next_cancel_reasons: dict[str, str]` keyed by `Session.id`
- `_adk_session_ids_by_conv: dict[str, str]` keyed by `Session.conversation_id`
- `_pinned_outer_session_ids: set[str]` — forensic set of every outer adk-web pin

## Test plan

- [x] New `tests/test_adk_adapter_concurrent_sessions.py` (6 tests):
  - Cross-session cancel-reason leak
  - Legacy bare-attribute fallback
  - Per-conversation `_ensure_session` cache isolation
  - Legacy pin scoped to empty-conv-id bucket only
  - Outer-session pin set retains every id
  - End-to-end mid-invocation cancel uses session-keyed reason
- [x] Verified all 6 fail on `origin/main` and pass with this change
- [x] Full suite green (`GOLDFIVE_STRICT_STATE_OWNERSHIP=1 uv run pytest`): 1741 passed, 1 pre-existing flaky failure unrelated to this change (`test_reasoning_judge.py::test_rate_limit_resets_on_task_transition`, fails identically on origin/main)
- [x] Existing single-session tests (`test_adk_adapter.py`, `test_steer_unification.py`, `test_goldfive_session_pin_outer.py`, `test_cancel_propagation.py`, `test_adk_adapter_overlay.py`, `test_cooperative_cancellation.py`, `test_goldfive_steer_request_cancel.py`) all green via the legacy property fallback