### PR TITLE
fix(steerer): cancel in-flight invocation task on refine (#271 follow-up)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -214,6 +214,36 @@ def _safe_attr(obj: Any, name: str, default: Any = None) -> Any:
     return value if value is not None else default
 
 
+def _safe_task_cancel(task: asyncio.Task[Any], invocation_id: str) -> None:
+    """Cancel ``task`` and log the outcome — used as a deferred
+    ``loop.call_soon`` callback (goldfive#271 follow-up).
+
+    Wrapping the cancel in a free function keeps the
+    ``loop.call_soon(_safe_task_cancel, t, inv_id)`` site reference-
+    free of mutable plugin state — the loop holds only the task and
+    id strings until the cancel fires. Swallows any failure so an
+    already-finished task doesn't surface a spurious traceback to
+    the loop's exception handler.
+    """
+    if task.done():
+        return
+    try:
+        cancelled_now = task.cancel()
+    except Exception as exc:  # noqa: BLE001
+        log.debug(
+            "_safe_task_cancel: task.cancel() for invocation_id=%s raised: %s",
+            invocation_id,
+            exc,
+        )
+        return
+    if cancelled_now:
+        log.info(
+            "goldfive.cancel.task: cancelled in-flight task for "
+            "invocation_id=%s",
+            invocation_id,
+        )
+
+
 def _session_state_from_callback(ctx: Any) -> Any:
     """Return the ADK session.state mutable mapping for a callback ctx.
 
@@ -1560,6 +1590,37 @@ def make_adk_plugin(
             # without racing on the single ``goldfive.current_task_id``
             # slot. Cleared on ``clear_active_context``.
             self._invocation_pinned_task_id: dict[str, str] = {}
+            # Per-invocation asyncio.Task registry (goldfive#271 follow-up
+            # — concurrent-invocation cancel-on-refine bug exposed by v15).
+            # ``dict[str, asyncio.Task]`` mapping ``invocation_id`` to the
+            # asyncio task currently driving that invocation's
+            # ``runner.run_async`` stream. Populated in
+            # :meth:`before_run_callback` (which runs INSIDE the task
+            # ADK is using to drive the invocation, so
+            # ``asyncio.current_task()`` is the right handle). Consumed
+            # by :meth:`request_invocation_cancel` to fire
+            # ``task.cancel()`` on the live invocation when a refine
+            # produced a revised plan that supersedes whatever the
+            # in-flight LLM call is reasoning about.
+            #
+            # Without this, the existing cancel-state flag only
+            # short-circuits the NEXT ``before_model_callback`` /
+            # ``before_tool_callback`` on the same invocation; the
+            # already-running LLM streaming call (which can take
+            # 10+ minutes on a slow model) keeps generating output
+            # that triggers more drift, producing the refine loop
+            # observed in v15presmtx-1. Cancelling the asyncio task
+            # raises ``CancelledError`` inside the
+            # ``runner.run_async`` async-for in
+            # :meth:`ADKAdapter._invoke_internal`; the existing
+            # heal path already emits the synthetic
+            # ``function_response`` so the function_call/_response
+            # invariant is preserved.
+            #
+            # Cleared in :meth:`after_run_callback` (per-invocation
+            # release) and :meth:`clear_active_context` (full reset
+            # at dispatch teardown).
+            self._invocation_tasks: dict[str, asyncio.Task[Any]] = {}
 
         def set_active_context(self, ctx: SessionContext) -> None:
             """Attach the ``SessionContext`` for the running invocation.
@@ -1622,6 +1683,14 @@ def make_adk_plugin(
             self._invocation_parents.clear()
             # goldfive#264 — drop per-invocation pin map.
             self._invocation_pinned_task_id.clear()
+            # goldfive#271 follow-up — drop per-invocation task handles.
+            # We do NOT cancel registered tasks here: this method is
+            # called from ``ADKAdapter.invoke``'s ``finally`` block
+            # AFTER the dispatch has already terminated (normally,
+            # via cancel, or via error). Cancelling here would no-op
+            # because the task is already done; clearing the map
+            # avoids stale handles bleeding into the next dispatch.
+            self._invocation_tasks.clear()
 
         # --- Cooperative cancellation (goldfive#251 Stream C / 7a) -----
 
@@ -1631,6 +1700,7 @@ def make_adk_plugin(
             invocation_id: str,
             request: Any,
             propagate_to_children: bool = True,
+            cancel_inflight_task: bool = False,
         ) -> list[str]:
             """Flag ``invocation_id`` (and optionally its descendants)
             for cooperative cancellation.
@@ -1654,6 +1724,20 @@ def make_adk_plugin(
             Tree-agnostic: the parent/child map is per-invocation, the
             plugin has no notion of "coordinator" vs "sub-agent", and
             every level in the tree is flagged the same way.
+
+            When ``cancel_inflight_task`` is True (goldfive#271 follow-
+            up — v15 concurrent-invocation bug), ALSO fire
+            ``task.cancel()`` on the registered asyncio.Task for each
+            flagged invocation (deferred via
+            :meth:`asyncio.AbstractEventLoop.call_soon` so an inline
+            same-task caller still completes its current emission
+            work before the cancel lands). Default False so the
+            existing pre-refine cancel paths in
+            :meth:`DefaultSteerer._handle_drift` keep their flag-only
+            semantics — the post-refine path
+            :meth:`DefaultSteerer._cancel_inflight_for_revision`
+            opts in explicitly so the cancel only fires AFTER a
+            superseding plan has been installed.
             """
             if not invocation_id:
                 return []
@@ -1686,6 +1770,78 @@ def make_adk_plugin(
                 # overwrite semantics are only for same-id re-writes
                 # from the steerer itself.
                 self._cancel_state.setdefault(flagged_id, request)
+            # Fire ``task.cancel()`` on the registered asyncio.Task for
+            # each flagged invocation when the caller opted in via
+            # ``cancel_inflight_task=True`` (goldfive#271 follow-up —
+            # v15 concurrent-invocation bug). Without this step the
+            # cancel-state flag short-circuits only the NEXT
+            # ``before_model_callback`` / ``before_tool_callback``; the
+            # already-running LLM streaming call (potentially 10+
+            # minutes on a slow model) keeps generating output that
+            # triggers more drift, and the steerer's `refine_steer`
+            # span ends up overlapping the coordinator span by the
+            # full duration of the in-flight LLM call. Cancelling the
+            # task raises ``CancelledError`` inside
+            # ``ADKAdapter._invoke_internal``'s ``async for`` over
+            # ``runner.run_async``; the existing heal path emits the
+            # synthetic ``function_response`` so ADK's
+            # function_call/_response invariant holds.
+            #
+            # IMPORTANT — defer via :meth:`asyncio.AbstractEventLoop.call_soon`:
+            # Drift-detection paths can reach this method synchronously
+            # from inside the same asyncio task that drives the
+            # dispatch (e.g. PlanReconciler emits PLAN_DIVERGENCE from
+            # ``before_agent_callback`` and awaits the steerer's
+            # ``_handle_drift`` inline; the steerer's own
+            # post-refine helper calls us right before
+            # ``_emit_plan_revised``). Calling ``task.cancel()``
+            # directly there would schedule a ``CancelledError`` to
+            # land on the very next ``await`` in the caller's call
+            # chain — including the paired ``_emit_plan_revised``
+            # emit — losing the on-the-wire PlanRevised event.
+            # ``loop.call_soon`` queues the cancel for the NEXT
+            # event-loop turn so the calling
+            # ``_handle_drift`` / ``_promote_drift_to_steer`` /
+            # ``apply_user_steer_with_plan`` finishes its emission
+            # work before the dispatch task observes the cancellation
+            # at its next yield (typically the next iteration of the
+            # ``async for`` in the adapter).
+            #
+            # Best-effort: a missing entry (e.g. the cancel fired
+            # between ``before_run`` registering and the LLM stream
+            # starting) is OK — the cancel-state flag still
+            # short-circuits subsequent callbacks. A done task is also
+            # OK — ``cancel()`` no-ops and we move on. A loop that's
+            # not running falls back to a direct ``cancel()`` so
+            # tests driving the cancel under ``asyncio.run`` still see
+            # it applied.
+            if cancel_inflight_task:
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    loop = None
+                for flagged_id in flagged:
+                    t = self._invocation_tasks.get(flagged_id)
+                    if t is None or t.done():
+                        continue
+                    if loop is not None:
+                        loop.call_soon(_safe_task_cancel, t, flagged_id)
+                    else:
+                        try:
+                            if t.cancel():
+                                log.info(
+                                    "goldfive.cancel.task: cancelled "
+                                    "in-flight task for invocation_id=%s "
+                                    "(no running loop; direct cancel)",
+                                    flagged_id,
+                                )
+                        except Exception as exc:  # noqa: BLE001
+                            log.debug(
+                                "_GoldfiveADKPlugin.request_invocation_cancel: "
+                                "task.cancel() for %s raised: %s",
+                                flagged_id,
+                                exc,
+                            )
             return flagged
 
         def consume_cancel_for_invocation(self, invocation_id: str) -> Any | None:
@@ -1806,6 +1962,21 @@ def make_adk_plugin(
             # steerer having to know the tree shape.
             if inv_id and parent_inv_id:
                 self._invocation_parents[inv_id] = parent_inv_id
+
+            # Register the asyncio.Task currently driving this invocation
+            # (goldfive#271 follow-up — v15 concurrent-invocation bug).
+            # ADK's ``Runner._exec_with_plugin`` runs ``before_run_callback``
+            # in the same task as the dispatch, so
+            # ``asyncio.current_task()`` here IS the task whose
+            # cancellation will raise ``CancelledError`` inside the
+            # adapter's ``async for event in runner.run_async(...)``
+            # loop. :meth:`request_invocation_cancel` consults this map
+            # to fire ``task.cancel()`` when a refine supersedes the
+            # in-flight plan.
+            if inv_id:
+                current = asyncio.current_task()
+                if current is not None:
+                    self._invocation_tasks[inv_id] = current
 
             # Cooperative-cancellation check (goldfive#251 Stream C / 7a).
             # If the adapter / steerer flagged this invocation before
@@ -3048,6 +3219,15 @@ def make_adk_plugin(
                 # so a future invocation_id collision (e.g. test
                 # harness reuse) doesn't inherit the cancel bit.
                 self._cancelled_invocations.discard(inv_id)
+                # Drop the registered task handle (goldfive#271 follow-
+                # up). The invocation has finished — successfully,
+                # cancelled, or errored — and the task will not be
+                # cancellable beyond this point. Leaving the entry in
+                # the map would be harmless but would let an unrelated
+                # late-firing ``request_invocation_cancel`` no-op (the
+                # task is done) AT BEST or, worse, target a future
+                # invocation that happens to reuse the id.
+                self._invocation_tasks.pop(inv_id, None)
             await self._emit_observability(
                 "agent_invocation_completed",
                 agent_name=agent_name,

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -2642,6 +2642,14 @@ class DefaultSteerer:
         # PlanRevisionDiff sidecar (PLAN-LIFECYCLE.md §2, §8 gap #4).
         prev_plan = session.plan
         self._apply_revision(session, revised, drift)
+        # Cancel the in-flight coordinator invocation now that the plan
+        # it was reasoning against has been superseded (goldfive#271
+        # follow-up — v15 concurrent-invocation bug). Order: cancel
+        # BEFORE PlanRevised emit so the synthetic InvocationCancelled
+        # sink event lands adjacent to the revision in the wire log
+        # and operators can correlate the two. Best-effort, never
+        # raises — a no-op cancel still leaves the new plan installed.
+        await self._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
             session, revised, drift, prev_plan=prev_plan, attempt_id=attempt_id
         )
@@ -3111,6 +3119,7 @@ class DefaultSteerer:
         *,
         drift: DriftEvent,
         session: Session,
+        cancel_inflight_task: bool = False,
     ) -> list[str]:
         """Flag the invocation(s) associated with ``drift`` for
         cooperative cancellation (goldfive#251 Stream C / 7a).
@@ -3128,6 +3137,17 @@ class DefaultSteerer:
         the list of flagged invocation ids (including children) for
         observability; callers can log / sink-emit from the list.
 
+        When ``cancel_inflight_task=True`` (goldfive#271 follow-up —
+        v15 concurrent-invocation bug), the plugin ALSO fires
+        ``task.cancel()`` on the registered asyncio.Task driving each
+        flagged invocation, deferred via ``loop.call_soon`` so an
+        inline same-task caller still completes its current emission
+        work before the cancel lands. Default False so the existing
+        pre-refine cancel paths keep their flag-only semantics; the
+        post-refine helper :meth:`_cancel_inflight_for_revision`
+        opts in explicitly so the cancel only fires AFTER a
+        superseding plan has been installed.
+
         Guard rails:
 
         * No-op when no adapter is bound.
@@ -3139,6 +3159,10 @@ class DefaultSteerer:
           falling through silently; the rest of the ladder (refine,
           restart message) still runs and eventually catches up at
           the next task boundary.
+        * Plugins whose ``request_invocation_cancel`` predates
+          ``cancel_inflight_task`` (TypeError on the kwarg) fall back
+          to the kwarg-less call so older third-party plugins don't
+          break — the task-cancel step is silently skipped.
         """
         adapter = self._adapter
         if adapter is None:
@@ -3180,7 +3204,27 @@ class DefaultSteerer:
         flagged: list[str] = []
         for inv_id in invocation_ids:
             try:
-                result = fn(invocation_id=inv_id, request=request)
+                result = fn(
+                    invocation_id=inv_id,
+                    request=request,
+                    cancel_inflight_task=cancel_inflight_task,
+                )
+            except TypeError:
+                # Older plugin without the ``cancel_inflight_task``
+                # kwarg (third-party / pre-#271-follow-up). Fall back
+                # to the legacy signature; the task-cancel step is
+                # silently skipped, but the flag-only contract is
+                # preserved.
+                try:
+                    result = fn(invocation_id=inv_id, request=request)
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "DefaultSteerer.request_invocation_cancel: "
+                        "plugin.request_invocation_cancel(%s) raised: %s",
+                        inv_id,
+                        exc,
+                    )
+                    continue
             except Exception as exc:  # noqa: BLE001
                 log.debug(
                     "DefaultSteerer.request_invocation_cancel: "
@@ -3253,6 +3297,80 @@ class DefaultSteerer:
         if kind is DriftKind.USER_PAUSE:
             return "user_pause"
         return "drift"
+
+    @staticmethod
+    def _is_synthetic_install_user_steer(drift: DriftEvent) -> bool:
+        """Return True for the synthetic USER_STEER drift that
+        :meth:`Runner._install_revision` synthesizes on every turn whose
+        ``handle_turn`` produced a plan.
+
+        That call site stamps a USER_STEER ``DriftEvent`` with
+        ``drift.raw is None`` purely to drive the structural install
+        pipeline through :meth:`apply_user_steer_with_plan`. It is
+        not a refine triggered by a problem with an in-flight
+        invocation, so cancel-on-revision MUST exempt it (cancelling
+        the just-starting coordinator turn against a freshly-installed
+        plan would defeat the whole point of installing it).
+
+        Genuine operator STEERs from a real ControlMessage land here
+        with ``drift.raw`` populated and SHOULD trigger a cancel of
+        the in-flight turn (matching pre-unification USER_STEER cancel
+        semantics). The two callers of
+        :meth:`apply_user_steer_with_plan` are documented in that
+        method's docstring.
+        """
+        return drift.kind is DriftKind.USER_STEER and getattr(drift, "raw", None) is None
+
+    async def _cancel_inflight_for_revision(
+        self, drift: DriftEvent, session: Session
+    ) -> list[str]:
+        """Cancel the in-flight invocation(s) that produced ``drift``.
+
+        Called from every PlanRevised emission path right after the
+        revised plan has been applied to the session and BEFORE the
+        ``PlanRevised`` event is emitted. Closes the gap behind the v15
+        concurrent-invocation bug: a ``refine_steer`` call (10+ minutes
+        on a slow planner) used to overlap the coordinator's invocation
+        for its full duration because the existing cancel-state flag
+        only gates SUBSEQUENT callbacks — the already-running LLM
+        streaming call kept generating output that triggered more
+        drift, looping the refine.
+
+        Skips the synthetic USER_STEER drift
+        :meth:`Runner._install_revision` synthesizes on every turn
+        (see :meth:`_is_synthetic_install_user_steer`). Every other
+        drift kind that produces a successful PlanRevised (refine
+        from drift, refine_steer from goldfive-steer promotion,
+        operator USER_STEER from a real ControlMessage) flows through
+        this method. The plugin's
+        :meth:`request_invocation_cancel` then writes the cancel-state
+        flag (sticky-gate from PR #299) AND fires ``task.cancel()`` on
+        the registered asyncio.Task (goldfive#271 follow-up) so the
+        coordinator's in-flight LLM call observes ``CancelledError``
+        within ~one event-loop tick instead of ~the LLM-call's
+        full duration.
+
+        Best-effort: an unbound adapter, a non-ADK adapter without
+        :meth:`request_invocation_cancel`, or an empty resolved
+        invocation-id list each result in a no-op (the refined plan
+        still lands; the in-flight invocation simply runs to
+        completion under the older, less aggressive contract).
+        """
+        if self._is_synthetic_install_user_steer(drift):
+            return []
+        try:
+            return await self.request_invocation_cancel(
+                drift=drift,
+                session=session,
+                cancel_inflight_task=True,
+            )
+        except Exception as exc:  # noqa: BLE001 — cancel is best-effort
+            log.debug(
+                "DefaultSteerer._cancel_inflight_for_revision: "
+                "request_invocation_cancel raised: %s",
+                exc,
+            )
+            return []
 
     # ------------------------------------------------------------------
     # goldfive-steer-unification: promotion policy + handler
@@ -3544,6 +3662,22 @@ class DefaultSteerer:
         session.refine_failure_counts.pop(counter_key, None)
         prev_plan = session.plan
         self._apply_revision(session, revised, drift)
+        # Cancel the in-flight coordinator invocation now that
+        # ``refine_steer`` produced a superseding plan (goldfive#271
+        # follow-up — v15 concurrent-invocation bug). This is the
+        # path that empirically motivated the fix: a goldfive-steer-
+        # eligible drift (PLAN_DIVERGENCE / OFF_TOPIC / …) at WARNING
+        # severity got refined while the coordinator's LLM call kept
+        # running for the full ``refine_steer`` duration, generating
+        # contaminated output that triggered more drift. Cancelling
+        # here preempts the in-flight LLM call so its remaining
+        # output can't loop the refine.
+        #
+        # Order: cancel BEFORE PlanRevised emit so the synthetic
+        # InvocationCancelled sink event lands adjacent to the
+        # revision and operators can correlate the two on the
+        # gantt timeline.
+        await self._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
             session, revised, drift, prev_plan=prev_plan, attempt_id=attempt_id
         )
@@ -3787,6 +3921,17 @@ class DefaultSteerer:
         attempt_id = self._new_attempt_id()
         await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
         self._apply_revision(session, revised_plan, drift)
+        # Cancel the in-flight invocation when this is a genuine
+        # operator STEER (drift.raw populated) rather than the
+        # synthetic install USER_STEER from
+        # :meth:`Runner._install_revision`. The exemption lives
+        # inside :meth:`_cancel_inflight_for_revision` itself —
+        # see :meth:`_is_synthetic_install_user_steer` for the
+        # rationale (cancelling on every fresh-turn install would
+        # immediately preempt the just-starting coordinator
+        # against the freshly-installed plan, defeating the
+        # whole point of installing it).
+        await self._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
             session,
             revised_plan,

--- a/tests/test_cancel_inflight_on_refine.py
+++ b/tests/test_cancel_inflight_on_refine.py
@@ -1,0 +1,563 @@
+"""Cancel-in-flight-task on refine (goldfive#271 follow-up — v15
+concurrent-invocation bug).
+
+Empirical evidence from ``v15presmtx-1`` (goldfive#271 follow-up
+brief, 2026-04-27): a ``PLAN_DIVERGENCE`` drift kicked off the
+steerer's ``refine_steer`` (a ~10-minute LLM call), but the
+coordinator's in-flight invocation kept making LLM/tool calls against
+the soon-to-be-stale plan. The existing sticky cancel-gate (PR #299)
+short-circuited only the NEXT ``before_model_callback`` /
+``before_tool_callback``; it did NOT cancel the already-running LLM
+streaming call inside that invocation, NOR the asyncio.Task driving
+the dispatch.
+
+This file pins the cancel-on-refine wiring:
+
+1. The plugin registers ``asyncio.current_task()`` keyed by
+   ``invocation_id`` in ``before_run_callback`` so
+   :meth:`request_invocation_cancel` can target the running task.
+2. ``request_invocation_cancel(cancel_inflight_task=True)`` fires
+   ``task.cancel()`` (deferred via ``loop.call_soon``) on the
+   registered task, in addition to writing the cancel-state flag.
+3. ``request_invocation_cancel(cancel_inflight_task=False)`` (the
+   default) leaves the flag-only contract intact — the existing
+   pre-refine CRITICAL cancel path keeps its semantics.
+4. The deferred-cancel path lets the calling coroutine finish its
+   PlanRevised emit before the dispatch task observes the cancel —
+   no lost ``PlanRevised`` event.
+5. The steerer's ``_cancel_inflight_for_revision`` exempts the
+   synthetic install ``USER_STEER`` drift from
+   :meth:`Runner._install_revision` (``drift.raw is None``) so a
+   fresh-turn plan install doesn't immediately preempt the
+   just-starting coordinator.
+6. Successful refine paths
+   (``_handle_drift`` / ``_promote_drift_to_steer`` /
+   ``apply_user_steer_with_plan``) call
+   ``_cancel_inflight_for_revision`` BEFORE
+   ``_emit_plan_revised`` so the cancel and the revision land
+   adjacent to each other on the wire.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+pytest.importorskip("google.adk")
+
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    SessionContext,
+    make_adk_plugin,
+)
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    CancellationRequest,
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgent:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+
+
+class _FakeADKSession:
+    def __init__(self, *, state: dict[str, Any]) -> None:
+        self.state = state
+        self.run_id = "run-test"
+        self.id = "session-test"
+
+
+class _FakeInvocationContext:
+    def __init__(
+        self,
+        *,
+        invocation_id: str,
+        session_state: dict[str, Any],
+        agent_name: str = "coordinator",
+    ) -> None:
+        self.invocation_id = invocation_id
+        self.session = _FakeADKSession(state=session_state)
+        self.agent = _FakeAgent(name=agent_name)
+
+
+def _make_plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="run-test",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.RUNNING),
+            Task(id="t2", title="T2", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+
+
+def _make_session() -> Session:
+    return Session(
+        run_id="run-test",
+        goals=[Goal(id="g1", summary="ship")],
+        plan=_make_plan(),
+        current_task_id="t1",
+    )
+
+
+def _make_request(
+    *,
+    invocation_id: str = "inv-1",
+    severity: DriftSeverity = DriftSeverity.WARNING,
+    reason: str = "drift",
+    drift_kind: str = "plan_divergence",
+) -> CancellationRequest:
+    return CancellationRequest(
+        invocation_id=invocation_id,
+        reason=reason,
+        severity=severity,
+        drift_kind=drift_kind,
+        detail="cancel test",
+    )
+
+
+def _bind_plugin() -> tuple[Any, Session]:
+    plugin = make_adk_plugin(host_agent_name="coordinator")
+    session = _make_session()
+    ctx = SessionContext(
+        session=session,
+        steerer=DefaultSteerer(),
+        tools=(),
+        tool_handlers={},
+        host_agent_name="coordinator",
+        task=session.plan.tasks[0],
+    )
+    plugin.set_active_context(ctx)
+    return plugin, session
+
+
+# ---------------------------------------------------------------------------
+# 1. before_run_callback registers asyncio.current_task() under inv_id
+# ---------------------------------------------------------------------------
+
+
+async def test_before_run_registers_current_task_under_invocation_id() -> None:
+    """The plugin's per-invocation task registry must be populated by
+    ``before_run_callback`` so :meth:`request_invocation_cancel` has a
+    handle to cancel."""
+    plugin, _session = _bind_plugin()
+    inv_ctx = _FakeInvocationContext(
+        invocation_id="inv-A",
+        session_state={},
+        agent_name="coordinator",
+    )
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+    expected = asyncio.current_task()
+    assert plugin._invocation_tasks.get("inv-A") is expected
+
+
+# ---------------------------------------------------------------------------
+# 2. after_run_callback drops the registered task
+# ---------------------------------------------------------------------------
+
+
+async def test_after_run_drops_registered_task() -> None:
+    """``after_run_callback`` releases the per-invocation registry slot
+    so an unrelated late cancel doesn't target a finished invocation."""
+    plugin, _session = _bind_plugin()
+    inv_ctx = _FakeInvocationContext(
+        invocation_id="inv-B",
+        session_state={},
+        agent_name="coordinator",
+    )
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+    assert "inv-B" in plugin._invocation_tasks
+    await plugin.after_run_callback(invocation_context=inv_ctx)
+    assert "inv-B" not in plugin._invocation_tasks
+
+
+# ---------------------------------------------------------------------------
+# 3. request_invocation_cancel(cancel_inflight_task=False) does NOT
+#    fire task.cancel — flag-only legacy contract preserved
+# ---------------------------------------------------------------------------
+
+
+async def test_request_cancel_flag_only_does_not_touch_task() -> None:
+    """Default ``cancel_inflight_task=False`` keeps the pre-#271-follow-
+    up flag-only semantics so the existing CRITICAL pre-refine
+    cancel path doesn't preempt its own refine call."""
+    plugin, _session = _bind_plugin()
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _body() -> None:
+        try:
+            started.set()
+            await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    body_task = asyncio.create_task(_body())
+    await started.wait()
+    plugin._invocation_tasks["inv-1"] = body_task
+
+    plugin.request_invocation_cancel(
+        invocation_id="inv-1",
+        request=_make_request(invocation_id="inv-1"),
+        # cancel_inflight_task defaults to False
+    )
+    # Flag is set -> sticky-cancelled path will engage in callbacks.
+    assert plugin.peek_cancel_for_invocation("inv-1") is not None
+    # Give the loop a tick to drain any (incorrectly) queued callbacks.
+    await asyncio.sleep(0)
+    assert not cancelled.is_set(), (
+        "task.cancel() must NOT fire when cancel_inflight_task is False"
+    )
+
+    body_task.cancel()
+    try:
+        await body_task
+    except asyncio.CancelledError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 4. request_invocation_cancel(cancel_inflight_task=True) DOES fire
+#    task.cancel — deferred via loop.call_soon so the calling
+#    coroutine finishes its current sync work first
+# ---------------------------------------------------------------------------
+
+
+async def test_request_cancel_with_task_flag_cancels_registered_task() -> None:
+    """The new ``cancel_inflight_task=True`` opt-in fires
+    ``task.cancel()`` on the registered task. Cancellation lands within
+    one event-loop tick — well under the 1s budget called out in the
+    brief's regression contract."""
+    plugin, _session = _bind_plugin()
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _body() -> None:
+        try:
+            started.set()
+            await asyncio.sleep(5.0)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    body_task = asyncio.create_task(_body())
+    await started.wait()
+    plugin._invocation_tasks["inv-1"] = body_task
+
+    plugin.request_invocation_cancel(
+        invocation_id="inv-1",
+        request=_make_request(invocation_id="inv-1"),
+        cancel_inflight_task=True,
+    )
+    # Cancel is queued via ``loop.call_soon``; flush the loop until the
+    # body task observes it. Use ``wait_for`` with a generous-but-bounded
+    # budget — the brief's regression contract is "<1s".
+    try:
+        await asyncio.wait_for(body_task, timeout=1.0)
+    except asyncio.CancelledError:
+        pass
+    except TimeoutError:
+        pytest.fail("task.cancel() did not propagate within 1s budget")
+    assert cancelled.is_set()
+
+
+# ---------------------------------------------------------------------------
+# 5. Deferred cancel lets the calling coroutine emit PlanRevised first
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_inflight_task_is_deferred_via_call_soon() -> None:
+    """``loop.call_soon`` deferral is the contract the steerer relies
+    on: the caller (``_handle_drift`` / ``_promote_drift_to_steer``)
+    must finish emitting ``PlanRevised`` BEFORE the cancel lands. We
+    pin the contract by checking that follow-up sync work after the
+    cancel call still runs in the same task on the same yield."""
+    plugin, _session = _bind_plugin()
+
+    body_done = asyncio.Event()
+
+    async def _body() -> None:
+        try:
+            await asyncio.sleep(5.0)
+        except asyncio.CancelledError:
+            body_done.set()
+            raise
+
+    body_task = asyncio.create_task(_body())
+    # Yield once to let _body start running.
+    await asyncio.sleep(0)
+    plugin._invocation_tasks["inv-1"] = body_task
+
+    follow_up_ran = False
+    plugin.request_invocation_cancel(
+        invocation_id="inv-1",
+        request=_make_request(invocation_id="inv-1"),
+        cancel_inflight_task=True,
+    )
+    # Synchronous work after the cancel call runs without seeing
+    # CancelledError — we are NOT the cancelled task, but even if we
+    # were, the deferred cancel wouldn't have fired yet.
+    follow_up_ran = True
+    assert follow_up_ran is True
+    # Now let the loop run the queued cancel callback.
+    try:
+        await asyncio.wait_for(body_task, timeout=1.0)
+    except asyncio.CancelledError:
+        pass
+    except TimeoutError:
+        pytest.fail("queued cancel did not propagate within 1s")
+    assert body_done.is_set()
+
+
+# ---------------------------------------------------------------------------
+# 6. Steerer-level helper: _cancel_inflight_for_revision exempts the
+#    synthetic install USER_STEER drift
+# ---------------------------------------------------------------------------
+
+
+def test_is_synthetic_install_user_steer_classifier() -> None:
+    """The synthetic-install USER_STEER (``drift.raw is None``) is
+    exempt; a real operator USER_STEER (``drift.raw`` populated) is
+    NOT."""
+    synth = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.INFO,
+        detail="install pipeline",
+        # raw=None by default
+    )
+    operator = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.INFO,
+        detail="real steer",
+        raw={"body": "go that way"},
+    )
+    not_user = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="off-plan",
+    )
+    assert DefaultSteerer._is_synthetic_install_user_steer(synth) is True
+    assert DefaultSteerer._is_synthetic_install_user_steer(operator) is False
+    assert DefaultSteerer._is_synthetic_install_user_steer(not_user) is False
+
+
+# ---------------------------------------------------------------------------
+# 7. _cancel_inflight_for_revision no-ops the synthetic install drift
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_inflight_for_revision_skips_synthetic_install() -> None:
+    """A synthetic install USER_STEER (``drift.raw is None``) MUST NOT
+    cancel the in-flight invocation — it's the structural plan-install
+    pipeline, not a corrective steer."""
+
+    class _CountingAdapter:
+        def __init__(self) -> None:
+            self._next_cancel_reason = ""
+            self._plugin = _CountingPlugin()
+
+    class _CountingPlugin:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+            self._top_invocation_id = "inv-X"
+            self._invocation_parents: dict[str, str] = {}
+            self._reconciler = None
+
+        def request_invocation_cancel(self, **kwargs: Any) -> list[str]:
+            self.calls.append(kwargs)
+            return [str(kwargs.get("invocation_id", ""))]
+
+    steerer = DefaultSteerer()
+    adapter = _CountingAdapter()
+    steerer.bind_adapter(adapter)
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.INFO,
+        detail="install pipeline",
+        # raw=None — synthetic
+    )
+    flagged = await steerer._cancel_inflight_for_revision(drift, _make_session())
+    assert flagged == []
+    assert adapter._plugin.calls == []  # plugin must not be touched
+
+
+async def test_cancel_inflight_for_revision_fires_for_real_drift() -> None:
+    """A non-synthetic drift (PLAN_DIVERGENCE, real USER_STEER, OFF_TOPIC,
+    …) MUST forward to the plugin with ``cancel_inflight_task=True``."""
+
+    class _CountingAdapter:
+        def __init__(self) -> None:
+            self._next_cancel_reason = ""
+            self._plugin = _CountingPlugin()
+
+    class _CountingPlugin:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+            self._top_invocation_id = "inv-X"
+            self._invocation_parents: dict[str, str] = {}
+            self._reconciler = None
+
+        def request_invocation_cancel(self, **kwargs: Any) -> list[str]:
+            self.calls.append(kwargs)
+            return [str(kwargs.get("invocation_id", ""))]
+
+    steerer = DefaultSteerer()
+    adapter = _CountingAdapter()
+    steerer.bind_adapter(adapter)
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="off-plan agent",
+        current_task_id="t1",
+        current_agent_id="coordinator",
+    )
+    flagged = await steerer._cancel_inflight_for_revision(drift, _make_session())
+    assert flagged == ["inv-X"]
+    assert len(adapter._plugin.calls) == 1
+    assert adapter._plugin.calls[0]["cancel_inflight_task"] is True
+
+
+# ---------------------------------------------------------------------------
+# 8. End-to-end: PLAN_DIVERGENCE → refine_steer → cancel fires on the
+#    coordinator's task before its long sleep finishes
+# ---------------------------------------------------------------------------
+
+
+async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> None:
+    """Regression test for the v15 bug: a PLAN_DIVERGENCE drift fires
+    refine_steer; the coordinator's in-flight asyncio task is cancelled
+    within the 1s propagation budget instead of running for the full
+    refine duration.
+
+    Simulates the v15 timeline by:
+
+    1. Standing up a steerer bound to a stub planner that pretends to
+       run ``refine_steer`` (returning a revised plan).
+    2. Pinning a long-running coordinator task in the plugin's
+       per-invocation registry.
+    3. Firing a ``PLAN_DIVERGENCE`` (WARNING) drift through
+       ``_handle_drift`` — which routes to ``_promote_drift_to_steer``
+       given the goldfive-steer eligibility set.
+    4. Asserting the coordinator's task observes ``CancelledError``
+       within 1s.
+    """
+
+    revised = Plan(
+        id="p1",
+        run_id="run-test",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.RUNNING),
+            Task(id="t2b", title="Replanned T2"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2b")],
+        revision_kind=DriftKind.PLAN_DIVERGENCE.value,
+        revision_severity=DriftSeverity.WARNING.value,
+        revision_index=1,
+    )
+
+    class _StubPlanner:
+        async def refine_steer(self, **_kwargs: Any) -> Plan:
+            # Realistic ``refine_steer`` is a multi-second LLM call; we
+            # simulate the duration just long enough for the deferred
+            # cancel to land *before* this returns. Were the cancel
+            # not deferred via ``loop.call_soon`` (or worse: not fired
+            # at all) the coordinator's ``await sleep(5.0)`` would run
+            # to completion and the test would time out.
+            return revised
+
+        async def refine(self, **_kwargs: Any) -> Plan:
+            return revised
+
+    plugin = make_adk_plugin(host_agent_name="coordinator")
+    session = _make_session()
+    steerer = DefaultSteerer(
+        goldfive_steer_threshold="warning",
+        goldfive_steer_suppression_window_turns=3,
+    )
+    steerer.bind(sinks=[], planner=_StubPlanner())
+
+    class _Adapter:
+        def __init__(self, plugin: Any) -> None:
+            self._plugin = plugin
+            self._next_cancel_reason = ""
+            self.available_agents = ["coordinator"]
+
+    adapter = _Adapter(plugin)
+    steerer.bind_adapter(adapter)
+
+    ctx = SessionContext(
+        session=session,
+        steerer=steerer,
+        tools=(),
+        tool_handlers={},
+        host_agent_name="coordinator",
+        task=session.plan.tasks[0],
+    )
+    plugin.set_active_context(ctx)
+    plugin._top_invocation_id = "inv-coord-1"
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _coordinator() -> None:
+        try:
+            started.set()
+            await asyncio.sleep(5.0)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    coord_task = asyncio.create_task(_coordinator())
+    await started.wait()
+    plugin._invocation_tasks["inv-coord-1"] = coord_task
+
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.WARNING,
+        detail="coordinator emitted off-plan tool call",
+        current_task_id="t1",
+        current_agent_id="coordinator",
+    )
+    await steerer._handle_drift(drift, session)
+
+    try:
+        await asyncio.wait_for(coord_task, timeout=1.0)
+    except asyncio.CancelledError:
+        pass
+    except TimeoutError:
+        pytest.fail(
+            "coordinator task was not cancelled within 1s of PLAN_DIVERGENCE "
+            "refine — v15 concurrent-invocation bug regressed"
+        )
+    assert cancelled.is_set()
+    # Plan was actually revised — the cancel did not preempt the
+    # PlanRevised emit (the deferral contract is upheld).
+    assert session.plan is revised


### PR DESCRIPTION
## Summary

Fixes the v15 concurrent-invocation bug exposed by `v15presmtx-1`: when goldfive fires a `PLAN_DIVERGENCE` drift and the steerer fires `refine_steer` (~10-minute LLM call), the coordinator's in-flight invocation kept making LLM/tool calls against the soon-to-be-stale plan, looping the refine via contaminated output. The existing sticky cancel-gate (PR #299) only short-circuits the **next** `before_model_callback` / `before_tool_callback`; it does NOT cancel the already-running LLM streaming call nor the `asyncio.Task` driving the dispatch.

- Plugin gains `_invocation_tasks: dict[str, asyncio.Task]`, populated in `before_run_callback` (where `asyncio.current_task()` is the dispatch task per ADK's `_exec_with_plugin`) and cleared in `after_run_callback` / `clear_active_context`.
- `request_invocation_cancel` grows a `cancel_inflight_task` kwarg (default `False`, preserving the flag-only contract for the existing pre-refine CRITICAL cancel path). When `True`, fires `task.cancel()` deferred via `loop.call_soon` so an inline same-task caller finishes its `PlanRevised` emit before the cancel lands.
- Steerer's new `_cancel_inflight_for_revision` exempts the synthetic install `USER_STEER` (`Runner._install_revision`, `drift.raw is None`) and is called from all three `PlanRevised` emission sites: `_handle_drift` refine, `_promote_drift_to_steer` refine_steer, and `apply_user_steer_with_plan`.

## Test plan

- [x] `tests/test_cancel_inflight_on_refine.py` — 9 new tests pin the per-invocation registry, deferral contract, synthetic-install exemption, and end-to-end PLAN_DIVERGENCE → cancel propagation within 1s while preserving the PlanRevised emit.
- [x] `tests/test_cooperative_cancellation.py` — 13 existing tests continue to pass (`cancel_inflight_task` defaults to `False`).
- [x] `tests/test_goldfive_steer_request_cancel.py` — 8 tests pass; the deferred-cancel contract via `loop.call_soon` doesn't conflict with the legacy `adapter.request_cancel` path.
- [x] Full suite: 1760 passed, 49 skipped (was 1751 / 49 pre-fix; +9 new tests).
- [x] `ruff check` clean.