### PR TITLE
fix(steerer, executors, reporting): C2-C6 cancellation-stash conversions (#271 Phase 3.5)

### DIFF
--- a/docs/design/CANCELLATION-CONTRACT.md
+++ b/docs/design/CANCELLATION-CONTRACT.md
@@ -3,9 +3,10 @@
 **Status.** Phase 3 Addition A of goldfive#271. Sibling to
 [`STATE-OWNERSHIP-CONTRACT.md`](STATE-OWNERSHIP-CONTRACT.md). The
 exception class :class:`goldfive._state_audit.CancellationStashViolation`
-ships in Phase 3; the runtime tripwire mechanism lands with Phase 3.5
-(hard-cancel) when the goldfive task boundary becomes the legitimate
-catch site.
+ships in Phase 3; the C2-C6 audit conversions ship in Phase 3.5
+(this PR). The runtime tripwire mechanism still lands with the
+hard-cancel boundary work, when the goldfive task boundary becomes
+the legitimate catch site.
 
 ## tl;dr
 
@@ -79,11 +80,11 @@ Phase 3 ships an audit pass; Phase 3.5 wires the runtime tripwire.
 | ID | File | Function | Owns | Status | Notes |
 |---|---|---|---|---|---|
 | C1 | `goldfive/runner.py:411` | `_drive_internal` | prior-plan stash | **FIXED** in #287 (`try / finally`) | Validation v2 root-cause |
-| C2 | `goldfive/executors/parallel.py` (multiple) | various | event sequence + sink emit | survey ongoing | Several `try / except Exception` blocks wrap awaits but most stash via `_lock` re-entry — re-audit when boundary lands |
-| C3 | `goldfive/executors/sequential.py` (multiple) | various | event sequence + sink emit | survey ongoing | Same shape as C2 |
-| C4 | `goldfive/steerer.py` (multiple) | refine paths | `_background_judges` set | survey ongoing | Background tasks deliberately swallow on cancel via shutdown drain |
-| C5 | `goldfive/_correction_injection.py` | `clear_correction` | per-task correction body | LOW priority | Best-effort GC; `try / except Exception` swallow is acceptable |
-| C6 | `goldfive/reporting.py` (sink emits) | various | event id stamping | LOW priority | Sink emits are best-effort; broken sink shouldn't break tool calls |
+| C2 | `goldfive/executors/parallel.py` (refine) | `_refine` (steerer-bound + legacy) | CRITICAL drift mirror (`_emit_refine_failure`) | **FIXED** in Phase 3.5 (`except BaseException: emit; raise`) | Both `await planner.refine` call sites; CancelledError now lands the operator-visible "refine cancelled" mirror before propagating |
+| C3 | `goldfive/executors/sequential.py` | refine paths | event sequence + sink emit | **FIXED** transitively via C4 | Sequential refines route through `DefaultSteerer._handle_drift` / `_promote_drift_to_steer`; no direct `await planner.refine` call site here. The mid-stage `await steerer.observe` blocks own no post-await stash (the sequence cursor self-heals on the next emit), so the strict criterion (await + state-stash bypass) does not match any sequential.py site. |
+| C4 | `goldfive/steerer.py` | `_handle_drift`, `_promote_drift_to_steer`, `observe_refine` | paired `refine_failed` (attempt-id correlation) | **FIXED** in Phase 3.5 (`except BaseException: emit; raise`) | All three refine entry points now emit the paired `refine_failed` envelope on `CancelledError` before re-raising, so sinks never see an unmatched `refine_attempted`. The fire-and-forget `_run_judge_background` was already correct (CancelledError handled before `except Exception`; the `_background_judges` set is drained via `shutdown` + `add_done_callback`) |
+| C5 | `goldfive/reporting.py` (`_handle_task_started`) | post-`mark_task_running` correction GC | per-task pending-correction entry | **FIXED** in Phase 3.5 (`try / finally`) | The post-await `_clear_correction_on_started` is now in `finally`, so a `CancelledError` raised inside `await steerer.mark_task_running` no longer leaves a pending correction wedged on session state for an already-acknowledged task. The standalone `clear_correction` helper is sync and was never the bypass site — the bypass was the call-site sequencing in `_handle_task_started` |
+| C6 | `goldfive/reporting.py` (sink emits) | various | event id stamping | **FIXED** by construction | Every reporting sink-emit helper calls `session.next_sequence()` BEFORE the `await emit(...)`, so the cursor is already advanced by the time `CancelledError` lands. The `try / except Exception` around the emit is best-effort observability, not a state-stash. The pinning regression test in `tests/test_cancellation_stash_audit.py::test_c6_sequence_cursor_advances_before_emit_await` makes a future refactor that moves `next_sequence()` after the await regress loudly. |
 
 ### §2.1 Severity classification
 
@@ -104,17 +105,24 @@ Phase 3 ships an audit pass; Phase 3.5 wires the runtime tripwire.
 
 When the goldfive task boundary lands (Phase 3.5):
 
-1. Survey C2-C6 with the full audit pattern; convert HIGH/MEDIUM
-   sites to `try / finally` or `except BaseException: stash; raise`.
+1. **Done.** Survey C2-C6 with the full audit pattern; convert
+   HIGH/MEDIUM sites to `try / finally` or
+   `except BaseException: stash; raise`. Shipped in the
+   Phase 3.5 cancellation-stash PR — see §2 catalog status column.
 2. Wire the runtime tripwire — install
    :class:`CancellationStashViolation` raise machinery (paired with
    the boundary's stack-walk; the boundary becomes the one
    legitimate catch site, and any other site that absorbs
    `CancelledError` without entering its `finally` raises the
    tripwire).
-3. Test surface: `tests/test_cancellation_stash_audit.py` —
-   parametrized over the catalog, fires `CancelledError` at the
-   await, asserts the stash invariant.
+3. **Done.** Test surface:
+   `tests/test_cancellation_stash_audit.py` — fires
+   `CancelledError` at each audited `await`, asserts the stash
+   invariant. Each test fails on `origin/main` (without the
+   conversion) and passes with the fix. C6 is pinned by a
+   complementary regression test that asserts
+   `session.next_sequence()` runs strictly before the sink
+   `await`.
 
 ## §3 Why the boundary is prerequisite
 

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -818,6 +818,26 @@ class ParallelDAGExecutor:
                     reason=f"refine raised: {exc}",
                 )
                 return None, attempt_id
+            except BaseException as exc:  # noqa: BLE001
+                # Phase 3.5 (CANCELLATION-CONTRACT.md §C2): ``CancelledError``
+                # bypasses ``except Exception`` (since Py 3.8 it is a
+                # ``BaseException``). The CRITICAL drift mirror is the
+                # operator-visible "refine failed" signal; without this
+                # branch a refine cancelled mid-flight would leave
+                # sinks observing only the original drift, with no
+                # follow-up explaining why the plan didn't change.
+                # Re-raise so cancellation continues to propagate.
+                log.warning(
+                    "ParallelDAGExecutor: planner.refine cancelled: %s",
+                    type(exc).__name__,
+                )
+                await self._emit_refine_failure(
+                    session=session,
+                    sinks=sinks,
+                    source=drift,
+                    reason=f"refine cancelled: {type(exc).__name__}",
+                )
+                raise
             if refined is None:
                 log.warning(
                     "ParallelDAGExecutor: planner.refine(kind=%s) returned None; plan unchanged",
@@ -883,6 +903,23 @@ class ParallelDAGExecutor:
                     reason=f"refine raised: {exc}",
                 )
                 return None, attempt_id
+            except BaseException as exc:  # noqa: BLE001
+                # Phase 3.5 (CANCELLATION-CONTRACT.md §C2): ``CancelledError``
+                # bypasses ``except Exception``; emit the CRITICAL drift
+                # mirror so the operator-visible "refine cancelled" signal
+                # still lands, then re-raise to preserve cancellation
+                # propagation per the asyncio contract.
+                log.warning(
+                    "ParallelDAGExecutor: planner.refine cancelled (legacy path): %s",
+                    type(exc).__name__,
+                )
+                await self._emit_refine_failure(
+                    session=session,
+                    sinks=sinks,
+                    source=drift,
+                    reason=f"refine cancelled: {type(exc).__name__}",
+                )
+                raise
             if refined is None:
                 log.warning(
                     "ParallelDAGExecutor: planner.refine(kind=%s) returned None; plan unchanged",

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -849,7 +849,14 @@ async def _handle_task_started(
                 attempted=TaskStatus.RUNNING,
                 task_id=task_id,
             )
-    await steerer.mark_task_running(task_id, session=session, detail=detail, source=source)
+    # Phase 3.5 (CANCELLATION-CONTRACT.md §C5): wrap the
+    # ``mark_task_running`` await in ``try/finally`` so the correction
+    # GC fires even when ``CancelledError`` (a ``BaseException`` since
+    # Py 3.8) propagates out mid-await. Without the ``finally`` a
+    # cancelled report-task-started leaves the pending correction
+    # entry on session state, and the next turn re-injects the
+    # correction block on a task the agent has already acknowledged.
+    #
     # goldfive#251 Stream D: the agent has acknowledged the (possibly
     # corrected) task; clear any queued correction scoped to this
     # ``(agent, task_id)`` pair. The correction block only needs to be
@@ -857,7 +864,12 @@ async def _handle_task_started(
     # the unadorned instruction. ``report_task_failed`` does NOT clear
     # (failure is not acknowledgment, and a re-invocation still needs
     # the correction).
-    _clear_correction_on_started(session, task)
+    try:
+        await steerer.mark_task_running(
+            task_id, session=session, detail=detail, source=source
+        )
+    finally:
+        _clear_correction_on_started(session, task)
     return dict(_ACK)
 
 

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -2582,6 +2582,25 @@ class DefaultSteerer:
                 await self._emit_refine_failure(session, drift, reason=str(exc))
                 await self._register_refine_failure(session, drift, counter_key)
                 return
+            except BaseException as exc:  # noqa: BLE001
+                # Phase 3.5 (CANCELLATION-CONTRACT.md §C4): ``CancelledError``
+                # bypasses the ``except Exception`` branch (it is a
+                # ``BaseException`` since Py 3.8). Emit the paired
+                # ``refine_failed`` observability event so a refine cancelled
+                # mid-flight does not leave sinks with an unmatched
+                # ``refine_attempted``. The ``finally`` below still resets
+                # ``_active_session_var``; we only own the paired-event
+                # stash here. Re-raise so cancellation continues to
+                # propagate per the asyncio contract.
+                await self._emit_refine_failed(
+                    session,
+                    drift,
+                    attempt_id=attempt_id,
+                    failure_kind="cancelled",
+                    reason=f"refine cancelled: {type(exc).__name__}",
+                    detail=type(exc).__name__,
+                )
+                raise
         finally:
             self._active_session_var.reset(_active_session_token)
         if revised is None:
@@ -3643,6 +3662,21 @@ class DefaultSteerer:
             await self._emit_refine_failure(session, drift, reason=str(exc))
             await self._register_refine_failure(session, drift, counter_key)
             return
+        except BaseException as exc:  # noqa: BLE001
+            # Phase 3.5 (CANCELLATION-CONTRACT.md §C4): ``CancelledError``
+            # bypasses the ``except Exception`` branch above. Emit the
+            # paired ``refine_failed`` so cancelled goldfive-steer refines
+            # do not leave sinks with an unmatched ``refine_attempted``.
+            # Re-raise to preserve asyncio cancellation propagation.
+            await self._emit_refine_failed(
+                session,
+                drift,
+                attempt_id=attempt_id,
+                failure_kind="cancelled",
+                reason=f"refine cancelled: {type(exc).__name__}",
+                detail=type(exc).__name__,
+            )
+            raise
         finally:
             self._active_session_var.reset(_active_session_token)
         if revised is None:
@@ -4310,6 +4344,25 @@ class DefaultSteerer:
                     attempt_id=attempt_id,
                     failure_kind="llm_error",
                     reason=str(exc),
+                    detail=type(exc).__name__,
+                )
+                raise
+            except BaseException as exc:  # noqa: BLE001
+                # Phase 3.5 (CANCELLATION-CONTRACT.md §C4): ``CancelledError``
+                # is a ``BaseException`` (not ``Exception``) since Py 3.8, so
+                # the ``except Exception`` branch above does NOT catch it. If
+                # a refine is cancelled mid-flight (e.g. ADK closes the
+                # runner, harness interrupts the loop) the paired
+                # ``refine_failed`` observability event would be skipped,
+                # leaving sinks with an unmatched ``refine_attempted``.
+                # Emit the pair-completing failure event AND re-raise so
+                # cancellation still propagates per the asyncio contract.
+                await self._emit_refine_failed(
+                    session,
+                    drift,
+                    attempt_id=attempt_id,
+                    failure_kind="cancelled",
+                    reason=f"refine cancelled: {type(exc).__name__}",
                     detail=type(exc).__name__,
                 )
                 raise

--- a/tests/test_cancellation_stash_audit.py
+++ b/tests/test_cancellation_stash_audit.py
@@ -50,7 +50,6 @@ from goldfive._correction_injection import (  # noqa: E402
     pending_correction_key,
     write_correction,
 )
-from goldfive.adapters import _adk_state_protocol as _sp  # noqa: E402
 from goldfive.executors.parallel import ParallelDAGExecutor  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
@@ -63,7 +62,6 @@ from goldfive.types import (  # noqa: E402
     Task,
     TaskStatus,
 )
-
 
 # ---------------------------------------------------------------------------
 # Test doubles

--- a/tests/test_cancellation_stash_audit.py
+++ b/tests/test_cancellation_stash_audit.py
@@ -1,0 +1,499 @@
+"""Phase 3.5 regression tests: CancelledError must not bypass state-stash duties.
+
+goldfive#271 Phase 3 (PR #290) catalogued five sites
+(:doc:`docs/design/CANCELLATION-CONTRACT.md` §C2-C6) where an
+``except Exception:`` block wrapped an ``await`` and owned a state-stash
+duty. Because :class:`asyncio.CancelledError` has been a
+:class:`BaseException` subclass since Py 3.8, those broad catches did
+NOT fire on cancellation — control flowed past the stash entirely,
+leaving sinks with unmatched ``refine_attempted`` events, the executor
+without a CRITICAL drift mirror to explain why the plan didn't change,
+and (in the reporting tool path) pending corrections wedged on session
+state for a task the agent had already acknowledged.
+
+C1 (the runner.py:411 case) shipped its ``try/finally`` in PR #287.
+Phase 3.5 closes the remaining C2-C6 sites:
+
+* C2 — :class:`ParallelDAGExecutor._refine` (steerer-bound + legacy).
+* C3 — :class:`SequentialExecutor` refines route through the steerer
+  and inherit the C4 fix.
+* C4 — :class:`DefaultSteerer._handle_drift`,
+  :meth:`DefaultSteerer._promote_drift_to_steer`, and
+  :meth:`DefaultSteerer.observe_refine`.
+* C5 — :func:`goldfive.reporting._handle_task_started`'s
+  ``mark_task_running`` await (correction GC must run on cancel).
+* C6 — sink emits stamp the sequence cursor BEFORE the await, so the
+  cursor is already advanced by the time ``CancelledError`` lands.
+  (No conversion required — covered for completeness.)
+
+Each test fires a real :class:`asyncio.CancelledError` at the audited
+``await`` and asserts the stash invariant holds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive import reporting as _reporting  # noqa: E402
+from goldfive._correction_injection import (  # noqa: E402
+    pending_correction_key,
+    write_correction,
+)
+from goldfive.adapters import _adk_state_protocol as _sp  # noqa: E402
+from goldfive.executors.parallel import ParallelDAGExecutor  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    """Sink that records every emitted event (proto + dict)."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+    @property
+    def proto_events(self) -> list[Any]:
+        return [e for e in self.events if hasattr(e, "WhichOneof")]
+
+    @property
+    def dict_events(self) -> list[dict[str, Any]]:
+        return [e for e in self.events if isinstance(e, dict)]
+
+    def by_kind(self, kind: str) -> list[dict[str, Any]]:
+        return [e for e in self.dict_events if e.get("kind") == kind]
+
+    def by_proto_oneof(self, name: str) -> list[Any]:
+        return [e for e in self.proto_events if e.WhichOneof("payload") == name]
+
+
+class _StubPlanner:
+    """Minimal Planner duck-type satisfying ``DefaultSteerer.bind``."""
+
+    def __init__(self, *, refine_impl: Any = None) -> None:
+        self._refine_impl = refine_impl
+
+    async def generate(self, **_: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        if self._refine_impl is None:
+            return None
+        return await self._refine_impl(**kwargs)
+
+    def set_drift_emitter(self, emitter: Any) -> None:  # pragma: no cover
+        pass
+
+    def set_span_context_provider(self, provider: Any) -> None:
+        self.provider = provider
+
+
+def _drift() -> DriftEvent:
+    return DriftEvent(
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.WARNING,
+        detail="audit-fixture",
+        current_task_id="t1",
+    )
+
+
+def _session() -> Session:
+    return Session(run_id="r1", goals=[Goal(id="g1", summary="g")])
+
+
+# ---------------------------------------------------------------------------
+# C4 — DefaultSteerer.observe_refine: CancelledError must still emit
+# the paired ``refine_failed`` so sinks see the attempted/failed pair.
+# ---------------------------------------------------------------------------
+
+
+async def test_c4_observe_refine_emits_refine_failed_on_cancellederror_and_reraises() -> None:
+    """Phase 3.5 §C4: ``CancelledError`` (BaseException, not Exception)
+    raised inside the ``observe_refine`` cm body MUST still emit a paired
+    ``refine_failed`` envelope before propagating. Without the
+    ``except BaseException`` branch on this cm the sink saw an unmatched
+    ``refine_attempted``.
+    """
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=_StubPlanner())
+    session = _session()
+    drift = _drift()
+
+    captured_attempt_id: str = ""
+    with pytest.raises(asyncio.CancelledError):
+        async with steerer.observe_refine(session, drift) as attempt_id:
+            captured_attempt_id = attempt_id
+            raise asyncio.CancelledError()
+
+    attempted = sink.by_kind("refine_attempted")
+    failed = sink.by_kind("refine_failed")
+    assert len(attempted) == 1, "attempted must land before the cancel"
+    assert len(failed) == 1, (
+        "Phase 3.5 §C4: refine_failed MUST be emitted even when the "
+        "refine body raises CancelledError. Pre-fix the except Exception "
+        "branch did NOT catch CancelledError, so the paired event was "
+        "skipped and sinks saw an unmatched refine_attempted."
+    )
+    assert failed[0]["payload"]["attempt_id"] == captured_attempt_id
+    assert failed[0]["payload"]["failure_kind"] == "cancelled"
+
+
+async def test_c4_observe_refine_aclose_mid_refine_emits_failed() -> None:
+    """Same invariant as above but exercised via the ``aclose()`` path
+    on the inner generator: simulate ADK closing the runner mid-refine
+    by cancelling the awaiting task.
+    """
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=_StubPlanner())
+    session = _session()
+    drift = _drift()
+
+    started = asyncio.Event()
+    captured: dict[str, str] = {}
+
+    async def _refine_user() -> None:
+        async with steerer.observe_refine(session, drift) as attempt_id:
+            captured["id"] = attempt_id
+            started.set()
+            # Simulate a long-running refine the canceller will interrupt.
+            await asyncio.sleep(60)
+
+    task = asyncio.create_task(_refine_user())
+    await started.wait()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    attempted = sink.by_kind("refine_attempted")
+    failed = sink.by_kind("refine_failed")
+    assert len(attempted) == 1
+    assert len(failed) == 1
+    assert failed[0]["payload"]["attempt_id"] == captured["id"]
+    assert failed[0]["payload"]["failure_kind"] == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# C4 — DefaultSteerer._handle_drift: planner.refine cancelled mid-flight
+# emits the paired ``refine_failed`` AND lets CancelledError propagate.
+# ---------------------------------------------------------------------------
+
+
+async def test_c4_handle_drift_emits_refine_failed_when_refine_cancelled() -> None:
+    """``_handle_drift`` wraps ``await planner.refine`` in
+    ``try / except Exception``. ``CancelledError`` bypassed it; Phase
+    3.5 adds the ``except BaseException`` branch that emits the paired
+    ``refine_failed`` before re-raising."""
+    sink = ListSink()
+    steerer = DefaultSteerer()
+
+    async def _cancelling_refine(**_: Any) -> Plan | None:
+        raise asyncio.CancelledError()
+
+    planner = _StubPlanner(refine_impl=_cancelling_refine)
+    steerer.bind(sinks=[sink], planner=planner)
+
+    session = _session()
+    session.plan = Plan(
+        id="p1",
+        run_id=session.run_id,
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", assignee_agent_id="agent_a", status=TaskStatus.PENDING)
+        ],
+        edges=[],
+    )
+    drift = _drift()
+
+    with pytest.raises(asyncio.CancelledError):
+        await steerer._handle_drift(drift, session)
+
+    failed = sink.by_kind("refine_failed")
+    assert len(failed) >= 1, (
+        "Phase 3.5 §C4: refine_failed MUST be emitted even when "
+        "planner.refine raises CancelledError. Pre-fix the except "
+        "Exception branch did NOT catch it, so the paired observability "
+        "event was skipped."
+    )
+    assert any(f["payload"]["failure_kind"] == "cancelled" for f in failed)
+
+
+# ---------------------------------------------------------------------------
+# C2 — ParallelDAGExecutor._refine: CancelledError must still emit the
+# CRITICAL DriftDetected mirror so operators see "refine cancelled".
+# ---------------------------------------------------------------------------
+
+
+async def test_c2_parallel_refine_cancelled_emits_critical_mirror_steerer_path() -> None:
+    """Steerer-bound parallel-executor refine path: CancelledError
+    bypassed the ``except Exception`` block so the CRITICAL drift
+    mirror was skipped. Phase 3.5 adds the BaseException branch."""
+    sink = ListSink()
+    steerer = DefaultSteerer()
+
+    async def _cancelling_refine(**_: Any) -> Plan | None:
+        raise asyncio.CancelledError()
+
+    planner = _StubPlanner(refine_impl=_cancelling_refine)
+    steerer.bind(sinks=[sink], planner=planner)
+    executor = ParallelDAGExecutor()
+
+    session = _session()
+    session.plan = Plan(
+        id="p1",
+        run_id=session.run_id,
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", assignee_agent_id="agent_a", status=TaskStatus.PENDING)
+        ],
+        edges=[],
+    )
+    drift = _drift()
+
+    with pytest.raises(asyncio.CancelledError):
+        await executor._refine(
+            plan=session.plan,
+            drift=drift,
+            planner=planner,
+            session=session,
+            sinks=[sink],
+            steerer=steerer,
+        )
+
+    # CRITICAL mirror is emitted as a DriftDetected proto event with
+    # severity=CRITICAL, NOT a dict. The legacy sink-visible signal.
+    drift_protos = sink.by_proto_oneof("drift_detected")
+    critical = [e for e in drift_protos if "cancelled" in e.drift_detected.detail.lower()]
+    assert critical, (
+        "Phase 3.5 §C2: the CRITICAL refine-cancelled mirror MUST land "
+        "even when planner.refine raises CancelledError. Pre-fix the "
+        "except Exception branch was bypassed and operators saw the "
+        "original drift but no follow-up explaining why the plan didn't "
+        "change."
+    )
+
+
+async def test_c2_parallel_refine_cancelled_emits_critical_mirror_legacy_path() -> None:
+    """Legacy (no steerer) parallel-executor refine path: same invariant.
+    The legacy fallback runs without ``observe_refine`` and owns its
+    own CRITICAL mirror; this branch must also fire on cancel."""
+    sink = ListSink()
+    executor = ParallelDAGExecutor()
+
+    async def _cancelling_refine(**_: Any) -> Plan | None:
+        raise asyncio.CancelledError()
+
+    planner = _StubPlanner(refine_impl=_cancelling_refine)
+
+    session = _session()
+    session.plan = Plan(
+        id="p1",
+        run_id=session.run_id,
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", assignee_agent_id="agent_a", status=TaskStatus.PENDING)
+        ],
+        edges=[],
+    )
+    drift = _drift()
+
+    with pytest.raises(asyncio.CancelledError):
+        # No ``steerer=`` kwarg → legacy refine path.
+        await executor._refine(
+            plan=session.plan,
+            drift=drift,
+            planner=planner,
+            session=session,
+            sinks=[sink],
+        )
+
+    drift_protos = sink.by_proto_oneof("drift_detected")
+    critical = [e for e in drift_protos if "cancelled" in e.drift_detected.detail.lower()]
+    assert critical, (
+        "Phase 3.5 §C2 (legacy path): the CRITICAL refine-cancelled "
+        "mirror must also fire on the no-steerer path; otherwise legacy "
+        "executors silently swallow cancellation observability."
+    )
+
+
+# ---------------------------------------------------------------------------
+# C3 — SequentialExecutor refine routes through the steerer; the C4
+# fix above covers it. This guard keeps that contract honest by
+# pinning that the steerer's refine entry points (which sequential.py
+# delegates to) emit refine_failed on CancelledError. Already covered
+# by ``test_c4_handle_drift_emits_refine_failed_when_refine_cancelled``.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# C5 — _handle_task_started: correction GC must run even if
+# ``await steerer.mark_task_running`` is cancelled mid-flight.
+# ---------------------------------------------------------------------------
+
+
+class _CancellingSteererForTaskStarted:
+    """Steerer stub whose ``mark_task_running`` raises CancelledError."""
+
+    def __init__(self) -> None:
+        self._sinks: list[Any] = []
+        self.calls: list[str] = []
+
+    async def mark_task_running(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        detail: str = "",
+        source: str = "",
+    ) -> None:
+        self.calls.append(task_id)
+        raise asyncio.CancelledError()
+
+    # Optional protocol surface used by the reporting handler:
+    async def transition(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+        pass
+
+    async def _wait_plan_stable(self, _session: Session) -> None:
+        return None
+
+
+async def test_c5_clear_correction_runs_when_mark_running_cancelled() -> None:
+    """Phase 3.5 §C5: ``_handle_task_started`` calls
+    ``await steerer.mark_task_running`` and then synchronously
+    ``_clear_correction_on_started``. Pre-fix the post-await clear was
+    skipped on CancelledError, leaving the pending correction wedged
+    on session state for a task the agent had just acknowledged.
+    The fix wraps the await in ``try/finally`` so the GC runs on
+    every exit including BaseException.
+    """
+    session = _session()
+    session.plan = Plan(
+        id="p1",
+        run_id=session.run_id,
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t-correction",
+                title="corrected task",
+                assignee_agent_id="writer",
+                status=TaskStatus.PENDING,
+            )
+        ],
+        edges=[],
+    )
+
+    # Seed a pending correction the GC should clear.
+    correction_key = pending_correction_key("writer", "t-correction")
+    write_correction(
+        session,
+        {
+            "agent_name": "writer",
+            "task_id": "t-correction",
+            "drift_kind": "off_topic",
+            "drift_reason": "fixture",
+            "revision_number": 1,
+            "issued_at_ms": 0,
+        },
+    )
+    assert correction_key in session.state, "fixture sanity"
+
+    steerer = _CancellingSteererForTaskStarted()
+
+    with pytest.raises(asyncio.CancelledError):
+        await _reporting._handle_task_started(
+            {"task_id": "t-correction"},
+            session,
+            steerer,  # type: ignore[arg-type]
+        )
+
+    assert steerer.calls == ["t-correction"], "the await must have been entered"
+    assert correction_key not in session.state, (
+        "Phase 3.5 §C5: the pending correction MUST be cleared even "
+        "when mark_task_running raises CancelledError. Pre-fix the "
+        "post-await ``_clear_correction_on_started`` call was skipped "
+        "and the next turn re-injected an already-acknowledged correction."
+    )
+
+
+# ---------------------------------------------------------------------------
+# C6 — sink emits stamp the sequence cursor BEFORE the await; the
+# cursor advance is therefore not bypassed by CancelledError. We keep
+# a small assertion here to pin that contract so a future refactor
+# that moves ``next_sequence()`` after the ``await`` regresses loudly.
+# ---------------------------------------------------------------------------
+
+
+async def test_c6_sequence_cursor_advances_before_emit_await() -> None:
+    """Phase 3.5 §C6: ``session.next_sequence()`` is called BEFORE the
+    ``await emit(...)`` in every reporting helper that fires a sink
+    event. Pinning this here means a future refactor that moves the
+    cursor advance after the await would be caught by this test —
+    that re-ordering would be a state-stash bypass.
+    """
+    session = _session()
+    seq_before = session._next_sequence
+
+    class _CancellingSink:
+        async def emit(self, _event: Any) -> None:
+            raise asyncio.CancelledError()
+
+        async def close(self) -> None:  # pragma: no cover
+            pass
+
+    class _StubSteerer:
+        def __init__(self, sinks: list[Any]) -> None:
+            self._sinks = sinks
+
+    sink = _CancellingSink()
+    steerer = _StubSteerer([sink])
+
+    with pytest.raises(asyncio.CancelledError):
+        await _reporting._emit_task_transition_refused(
+            session=session,
+            steerer=steerer,  # type: ignore[arg-type]
+            task_id="t1",
+            attempted_from=TaskStatus.PENDING,
+            attempted_to=TaskStatus.RUNNING,
+            reason="cancelled-fixture",
+            pin_revision=0,
+            current_revision=0,
+        )
+
+    assert session._next_sequence > seq_before, (
+        "Phase 3.5 §C6: next_sequence() must advance before the await, "
+        "so a CancelledError mid-emit cannot leave the cursor in a "
+        "rewound state. If this assertion regresses, a refactor moved "
+        "the cursor advance after the sink await — which would be a "
+        "real state-stash bypass."
+    )


### PR DESCRIPTION
## Summary

Phase 3 (PR #290) catalogued five sites where `except Exception:` blocks wrap `await` and own state-stash duties. Because `asyncio.CancelledError` is a `BaseException` (not `Exception`) since Py 3.8, those broad catches did NOT fire on cancellation — control flowed past the stash entirely. C1 (runner.py:411) shipped its `try/finally` in PR #287; this PR closes C2-C6.

- **C2** — `ParallelDAGExecutor._refine` (steerer-bound + legacy). Both `await planner.refine` call sites gain `except BaseException: emit; raise` so the CRITICAL `DriftDetected` mirror still lands when refine is cancelled mid-flight.
- **C3** — Sequential refines route through `DefaultSteerer`; FIXED transitively via C4 (no direct `await planner.refine` site in sequential.py).
- **C4** — `DefaultSteerer._handle_drift`, `DefaultSteerer._promote_drift_to_steer`, and `DefaultSteerer.observe_refine`. All three refine entry points emit the paired `refine_failed` envelope on `CancelledError` before re-raising, so sinks never see an unmatched `refine_attempted`.
- **C5** — `reporting._handle_task_started` wraps `await steerer.mark_task_running` in `try/finally` so `_clear_correction_on_started` runs even on cancellation.
- **C6** — Sink-emit helpers stamp `session.next_sequence()` BEFORE the `await emit(...)`; FIXED by construction, pinned by a regression test guarding against a future refactor that moves the cursor advance after the await.

All conversions follow the C1 pattern from PR #287 (`try/finally` preferred; `except BaseException: stash; raise` when the Exception path has different cleanup).

## Test plan

- [x] New: `tests/test_cancellation_stash_audit.py` — 7 tests, one per audited site (C6 is FIXED-by-construction so its test pins existing-correct behaviour).
- [x] Verified each conversion: 6 tests fail on `origin/main` (without the conversion) and all 7 pass with the fix.
- [x] Full suite: `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 pytest tests/` → 1451 passed / 106 skipped (baseline 1444, +7 new tests).
- [x] Catalog rows in `docs/design/CANCELLATION-CONTRACT.md` updated to FIXED with rationale per row.