### PR TITLE
feat(runner, reporting): make drift self-reporting tools opt-in (#196)

### DIFF
--- a/docs/reference/tool-protocol.md
+++ b/docs/reference/tool-protocol.md
@@ -29,6 +29,35 @@ REPORTING_TOOL_NAMES: tuple[str, ...] = (
 
 Pre-built specs live in `goldfive.reporting.BUILTIN_REPORTING_TOOLS`.
 
+> **Default registration (goldfive#196).** The `Runner` registers only
+> the *lifecycle* subset of these tools by default. The drift-related
+> self-reporting tools — `report_plan_divergence`,
+> `declare_task_skipped`, `declare_task_not_needed` — are **opt-in**
+> via `Runner(drift_self_reporting=...)` (or
+> `goldfive.wrap(drift_self_reporting=...)`):
+>
+> * `False` (default) — register only the lifecycle subset
+>   (`report_task_*`, `report_awaiting_approval`,
+>   `report_new_work_discovered`). Each drift tool's schema costs
+>   ~200-400 prompt tokens AND expands the model's hallucination
+>   surface; the framework's observation paths
+>   (`classify_goal_drift`, `PlanReconciler`, the steerer's refine
+>   machinery) cover the same signal more reliably.
+> * `True` — register the full canonical set (legacy behaviour).
+> * `list[str]` — register the lifecycle subset PLUS the named drift
+>   tools, e.g. `["report_plan_divergence"]` re-enables that one tool
+>   while leaving the declarations off.
+>
+> `report_new_work_discovered` is intentionally NOT in the drift
+> bucket — there is no observation analog for an agent surfacing
+> genuinely new work, so it stays default-on.
+>
+> The lifecycle / drift split is exposed as
+> `goldfive.LIFECYCLE_REPORTING_TOOLS`,
+> `goldfive.DRIFT_SELF_REPORTING_TOOLS`, and
+> `goldfive.DRIFT_SELF_REPORTING_TOOL_NAMES` for adapters /
+> Runner-likes that want to derive the same subset.
+
 Related: [STATE-MACHINE.md](../design/STATE-MACHINE.md),
 [PROTOCOLS.md](../design/PROTOCOLS.md#agentadapter),
 [writing-an-agent-adapter.md](../guides/writing-an-agent-adapter.md),

--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -39,7 +39,13 @@ from goldfive.protocols import (
     Steerer,
 )
 from goldfive.quickstart import quickstart
-from goldfive.reporting import BUILTIN_REPORTING_TOOLS, ReportingToolSpec
+from goldfive.reporting import (
+    BUILTIN_REPORTING_TOOLS,
+    DRIFT_SELF_REPORTING_TOOL_NAMES,
+    DRIFT_SELF_REPORTING_TOOLS,
+    LIFECYCLE_REPORTING_TOOLS,
+    ReportingToolSpec,
+)
 from goldfive.results import ExecutionOutcome, InvocationResult
 from goldfive.runner import Runner
 from goldfive.sinks import (
@@ -70,6 +76,9 @@ __all__ = [
     "AgentAdapter",
     "BUILTIN_REPORTING_TOOLS",
     "CallableAdapter",
+    "DRIFT_SELF_REPORTING_TOOLS",
+    "DRIFT_SELF_REPORTING_TOOL_NAMES",
+    "LIFECYCLE_REPORTING_TOOLS",
     "ControlAck",
     "ControlChannel",
     "ControlKind",

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -161,6 +161,7 @@ def wrap(
     plugins: list[Any] | None = None,
     runtime: RuntimeConfig | None = None,
     dynamic_instruction: bool = True,
+    drift_self_reporting: bool | list[str] = False,
     **legacy_kwargs: Any,
 ) -> Runner:
     """Build a :class:`Runner` that drives ``agent`` with goldfive.
@@ -242,6 +243,20 @@ def wrap(
         :class:`DefaultSteerer` via its config kwargs. An explicit
         ``steerer=`` kwarg wins — the caller keeps full control
         over the steerer they build themselves.
+    drift_self_reporting:
+        Forwarded to :class:`Runner`. Default ``False`` (goldfive#196):
+        only the lifecycle reporting tools (``report_task_started`` /
+        ``_progress`` / ``_completed`` / ``_failed`` / ``_blocked`` /
+        ``_awaiting_approval`` / ``report_new_work_discovered``) are
+        registered on the agent. The drift opinions —
+        ``report_plan_divergence``, ``declare_task_skipped``,
+        ``declare_task_not_needed`` — are NOT registered, so the
+        prompt is smaller and the model can't hallucinate a drift
+        call. The framework's observation paths
+        (``classify_goal_drift``, :class:`PlanReconciler`, the
+        steerer's refine machinery) remain the canonical detectors.
+        Pass ``True`` to restore the full pre-#196 set, or a list of
+        drift tool names to enable a subset.
 
     Returns
     -------
@@ -497,6 +512,7 @@ def wrap(
         sinks=resolved_sinks,
         control=control,
         max_task_invocations=max_task_invocations,
+        drift_self_reporting=drift_self_reporting,
     )
 
     # When the judges were routed through a dedicated JudgeConfig

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -1490,6 +1490,29 @@ _SCHEMA_DECLARE_TASK_NOT_NEEDED = _object_schema(
 # ---------------------------------------------------------------------------
 
 
+# goldfive#196: drift-related self-reporting tools. These overlap with
+# observation-driven detectors (``goldfive.reconciler.PlanReconciler``,
+# the trajectory-level ``classify_goal_drift`` judge, and the steerer's
+# refine machinery), so registering them on every sub-agent is pure
+# downside: they inflate prompt size by ~200-400 tokens each AND expand
+# the agent's hallucination surface (the model can confabulate a drift
+# call when it's confused). The Runner gates them behind an opt-in flag
+# (``Runner(drift_self_reporting=...)``) so the lifecycle subset stays
+# default-on while the drift opinions are off by default. ``True``
+# preserves the legacy behaviour of registering every canonical tool.
+#
+# Note: ``report_new_work_discovered`` is intentionally NOT in this set
+# — there is no observation analog for an agent surfacing genuinely new
+# work, so it stays default-on. See goldfive#196.
+DRIFT_SELF_REPORTING_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "report_plan_divergence",
+        "declare_task_skipped",
+        "declare_task_not_needed",
+    }
+)
+
+
 BUILTIN_REPORTING_TOOLS: list[ReportingToolSpec] = [
     ReportingToolSpec(
         name="report_task_started",
@@ -1616,13 +1639,87 @@ BUILTIN_REPORTING_TOOLS: list[ReportingToolSpec] = [
 ]
 
 
+# goldfive#196: lifecycle / observability subset — every BUILTIN tool
+# whose name is NOT in :data:`DRIFT_SELF_REPORTING_TOOL_NAMES`. This is
+# the default Runner registration set; the drift tools are gated behind
+# ``Runner(drift_self_reporting=...)``. Keep this derived (rather than
+# enumerated by hand) so adding a new lifecycle tool to
+# :data:`BUILTIN_REPORTING_TOOLS` flows through automatically.
+LIFECYCLE_REPORTING_TOOLS: list[ReportingToolSpec] = [
+    spec
+    for spec in BUILTIN_REPORTING_TOOLS
+    if spec.name not in DRIFT_SELF_REPORTING_TOOL_NAMES
+]
+
+
+# goldfive#196: drift-only subset — the BUILTIN tools whose names ARE
+# in :data:`DRIFT_SELF_REPORTING_TOOL_NAMES`. Convenience for callers
+# that want to register the drift tools explicitly via
+# ``Runner(drift_self_reporting=True)`` or
+# ``Runner(drift_self_reporting=[<name>, ...])``.
+DRIFT_SELF_REPORTING_TOOLS: list[ReportingToolSpec] = [
+    spec
+    for spec in BUILTIN_REPORTING_TOOLS
+    if spec.name in DRIFT_SELF_REPORTING_TOOL_NAMES
+]
+
+
+def select_reporting_tools(
+    drift_self_reporting: bool | list[str] | tuple[str, ...] | frozenset[str] | set[str],
+) -> list[ReportingToolSpec]:
+    """Return the reporting tool specs to register based on the opt-in flag.
+
+    ``drift_self_reporting`` semantics (matches ``Runner.__init__``):
+
+    * ``False`` (default for the Runner) — return the lifecycle subset
+      only. Drift tools are NOT registered; the agent cannot
+      self-report ``report_plan_divergence`` /
+      ``declare_task_skipped`` / ``declare_task_not_needed``. The
+      framework's observation paths (``classify_goal_drift``,
+      :class:`~goldfive.reconciler.PlanReconciler`, the steerer's
+      refine machinery) remain the canonical detectors.
+    * ``True`` — return the full ``BUILTIN_REPORTING_TOOLS`` list
+      (legacy behaviour). The agent can self-report every drift kind.
+    * iterable of tool names — return the lifecycle subset PLUS the
+      named drift tools. Names not in
+      :data:`DRIFT_SELF_REPORTING_TOOL_NAMES` are silently ignored
+      (so a typo doesn't accidentally enable a non-drift tool, and
+      there is nothing meaningful to do with a name that isn't a
+      drift tool — lifecycle tools are always on). An empty iterable
+      collapses to the ``False`` case.
+
+    Used by :class:`~goldfive.runner.Runner.run` step 5 to decide
+    which tool specs to hand to ``agent.register_reporting_tools``.
+    Exposed here (rather than as a private helper on Runner) so
+    custom Runner-likes / ad-hoc adapters can derive the same subset
+    from the same flag.
+    """
+    if drift_self_reporting is True:
+        return list(BUILTIN_REPORTING_TOOLS)
+    if drift_self_reporting is False:
+        return list(LIFECYCLE_REPORTING_TOOLS)
+    # Iterable of names — accept list / tuple / set / frozenset.
+    requested = {str(n).strip() for n in drift_self_reporting if str(n).strip()}
+    if not requested:
+        return list(LIFECYCLE_REPORTING_TOOLS)
+    selected: list[ReportingToolSpec] = list(LIFECYCLE_REPORTING_TOOLS)
+    for spec in DRIFT_SELF_REPORTING_TOOLS:
+        if spec.name in requested:
+            selected.append(spec)
+    return selected
+
+
 __all__ = [
     "DECLARATION_KIND_NOT_NEEDED",
     "DECLARATION_KIND_SKIPPED",
     "DECLARATION_KINDS",
     "DECLARATIONS_KEY",
+    "DRIFT_SELF_REPORTING_TOOL_NAMES",
+    "DRIFT_SELF_REPORTING_TOOLS",
+    "LIFECYCLE_REPORTING_TOOLS",
     "ReportingHandler",
     "ReportingToolSpec",
     "REPORTING_TOOL_NAMES",
     "BUILTIN_REPORTING_TOOLS",
+    "select_reporting_tools",
 ]

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -10,10 +10,12 @@ A Runner composes the six pluggable components of a goldfive run:
 * :class:`EventSink` — persists / observes the event stream.
 
 ``Runner.run`` emits a ``RunStarted`` event, derives goals, generates a
-plan, registers the seven canonical reporting tools on the adapter,
-binds the steerer to the sinks+planner, and hands everything to the
-executor. The returned :class:`ExecutionOutcome` carries the final live
-:class:`Session` so callers can inspect completed tasks / artifacts.
+plan, registers the canonical reporting tools on the adapter (the
+lifecycle subset by default, the drift tools opted in via
+``drift_self_reporting=`` — see :class:`Runner`), binds the steerer to
+the sinks+planner, and hands everything to the executor. The returned
+:class:`ExecutionOutcome` carries the final live :class:`Session` so
+callers can inspect completed tasks / artifacts.
 
 Event lifecycle ownership
 -------------------------
@@ -54,7 +56,7 @@ from goldfive.events import (
     run_started_event,
 )
 from goldfive.goal_deriver import PassthroughGoalDeriver
-from goldfive.reporting import BUILTIN_REPORTING_TOOLS
+from goldfive.reporting import select_reporting_tools
 from goldfive.results import ExecutionOutcome
 from goldfive.steerer import DefaultSteerer
 from goldfive.types import (
@@ -143,6 +145,44 @@ class Runner:
 
         Skipped when ``user_input`` is already a ``list[Goal]`` (the
         caller has opted out of natural-language derivation).
+    drift_self_reporting:
+        Opt-in switch for the drift-related self-reporting tools
+        (goldfive#196). These are tools that ask the agent to volunteer
+        a drift opinion the framework can already observe by other
+        means:
+
+        * ``report_plan_divergence`` —
+          :class:`~goldfive.reconciler.PlanReconciler` covers this
+          observationally.
+        * ``declare_task_skipped`` / ``declare_task_not_needed`` —
+          observability-only declarations whose downstream consumer
+          (the next refine) is also fed by the imperative
+          ``report_task_*`` family.
+
+        Each registered tool inflates the sub-agent's prompt by
+        ~200-400 tokens AND expands the model's hallucination surface
+        (a confused agent can confabulate a drift call). Default
+        ``False`` registers ONLY the lifecycle subset
+        (``report_task_started`` / ``_progress`` / ``_completed`` /
+        ``_failed`` / ``_blocked`` / ``_awaiting_approval`` /
+        ``report_new_work_discovered``). The framework's observation
+        paths — ``classify_goal_drift``,
+        :class:`~goldfive.reconciler.PlanReconciler`, the steerer's
+        refine machinery — remain the canonical drift detectors.
+
+        Accepted shapes:
+
+        * ``False`` (default) — lifecycle subset only.
+        * ``True`` — full canonical set (pre-#196 behaviour).
+        * ``list[str]`` — lifecycle subset PLUS the named drift tools
+          (e.g. ``["report_plan_divergence"]`` re-enables that one
+          tool while leaving the declarations off). Names not in
+          :data:`~goldfive.reporting.DRIFT_SELF_REPORTING_TOOL_NAMES`
+          are silently ignored.
+
+        ``report_new_work_discovered`` is intentionally NOT a drift
+        tool — there is no observation analog for an agent surfacing
+        genuinely new work, so it stays default-on.
     """
 
     def __init__(
@@ -159,6 +199,7 @@ class Runner:
         conversation: Conversation | None = None,
         goal_drift_enabled: bool = True,
         planner_gate: Any = "auto",
+        drift_self_reporting: bool | list[str] = False,
         **legacy_kwargs: Any,
     ) -> None:
         if "max_plan_reinvocations" in legacy_kwargs:
@@ -282,6 +323,19 @@ class Runner:
         # via ``Planner.generate`` (pre-#271 behaviour, useful for
         # deterministic replay).
         self._planner_gate: Any = planner_gate
+        # goldfive#196: opt-in switch for the drift-related self-
+        # reporting tools (``report_plan_divergence``,
+        # ``declare_task_skipped``, ``declare_task_not_needed``).
+        # Stored as-is so :meth:`run` step 5 can pass it through to
+        # :func:`goldfive.reporting.select_reporting_tools` on every
+        # turn — supports the ``True`` / ``False`` / ``list[str]``
+        # shapes documented in :class:`Runner`. Materialise lists
+        # eagerly so callers passing a generator / mutable list see
+        # stable behaviour across turns.
+        if isinstance(drift_self_reporting, bool):
+            self.drift_self_reporting: bool | list[str] = drift_self_reporting
+        else:
+            self.drift_self_reporting = [str(n) for n in drift_self_reporting]
         # Cross-turn prior-plan stash lives on :class:`Conversation`
         # (keyed by session id) so a Runner shared across multiple
         # outer ADK sessions does not leak one session's plan into
@@ -650,9 +704,18 @@ class Runner:
                 int(session.plan.revision_index),
             )
 
-        # 5. Register the seven canonical reporting tools on the adapter.
+        # 5. Register the canonical reporting tools on the adapter.
+        # goldfive#196: ``drift_self_reporting`` decides whether the
+        # drift opinions (``report_plan_divergence``,
+        # ``declare_task_skipped``, ``declare_task_not_needed``) ride
+        # along with the lifecycle subset. Default is OFF — the
+        # framework's observation paths (``classify_goal_drift``,
+        # :class:`~goldfive.reconciler.PlanReconciler`, the steerer's
+        # refine machinery) are the canonical detectors.
         try:
-            await self.agent.register_reporting_tools(list(BUILTIN_REPORTING_TOOLS))
+            await self.agent.register_reporting_tools(
+                select_reporting_tools(self.drift_self_reporting)
+            )
         except Exception as exc:  # noqa: BLE001
             reason = f"register_reporting_tools raised: {exc}"
             log.exception("register_reporting_tools raised")

--- a/tests/test_drift_reporting_optin.py
+++ b/tests/test_drift_reporting_optin.py
@@ -1,0 +1,330 @@
+"""Drift self-reporting opt-in (goldfive#196).
+
+The drift-related self-reporting tools (``report_plan_divergence``,
+``declare_task_skipped``, ``declare_task_not_needed``) overlap with the
+framework's observation-driven detectors (``classify_goal_drift``,
+:class:`~goldfive.reconciler.PlanReconciler`, the steerer's refine
+machinery), so registering them on every sub-agent is pure downside:
+each tool's schema inflates the prompt by ~200-400 tokens AND expands
+the model's hallucination surface. Goldfive#196 makes them opt-in via
+``Runner(drift_self_reporting=...)``.
+
+This module pins the contract:
+
+* Default :class:`Runner` registers ONLY the lifecycle subset.
+* ``drift_self_reporting=True`` registers the full canonical set
+  (legacy / pre-#196 behaviour).
+* ``drift_self_reporting=["<name>"]`` registers the lifecycle subset
+  PLUS the named drift tools.
+* ``report_new_work_discovered`` is intentionally NOT a drift tool —
+  there is no observation analog, so it stays default-on.
+* The ``select_reporting_tools`` helper that the Runner uses is
+  exposed at module scope so custom adapters / Runner-likes can derive
+  the same subset from the same flag.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from goldfive import (
+    BUILTIN_REPORTING_TOOLS,
+    DRIFT_SELF_REPORTING_TOOL_NAMES,
+    DRIFT_SELF_REPORTING_TOOLS,
+    LIFECYCLE_REPORTING_TOOLS,
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    LLMPlanner,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+from goldfive.reporting import select_reporting_tools
+
+# ---------------------------------------------------------------------------
+# Constants — pin the documented split
+# ---------------------------------------------------------------------------
+
+
+def test_drift_tool_names_are_the_three_documented() -> None:
+    """The drift-only set is exactly the three tools called out in #196."""
+    assert DRIFT_SELF_REPORTING_TOOL_NAMES == frozenset(
+        {
+            "report_plan_divergence",
+            "declare_task_skipped",
+            "declare_task_not_needed",
+        }
+    )
+
+
+def test_lifecycle_subset_excludes_every_drift_tool() -> None:
+    lifecycle_names = {spec.name for spec in LIFECYCLE_REPORTING_TOOLS}
+    assert lifecycle_names.isdisjoint(DRIFT_SELF_REPORTING_TOOL_NAMES)
+
+
+def test_new_work_discovered_stays_in_lifecycle_subset() -> None:
+    """``report_new_work_discovered`` has no observation analog and stays
+    default-on (per the goldfive#196 spec)."""
+    lifecycle_names = {spec.name for spec in LIFECYCLE_REPORTING_TOOLS}
+    assert "report_new_work_discovered" in lifecycle_names
+
+
+def test_lifecycle_subset_contains_every_status_tool() -> None:
+    """Every ``report_task_*`` lifecycle tool plus ``report_awaiting_approval``
+    is in the default-on subset."""
+    lifecycle_names = {spec.name for spec in LIFECYCLE_REPORTING_TOOLS}
+    expected = {
+        "report_task_started",
+        "report_task_progress",
+        "report_task_completed",
+        "report_task_failed",
+        "report_task_blocked",
+        "report_awaiting_approval",
+        "report_new_work_discovered",
+    }
+    assert expected <= lifecycle_names
+
+
+def test_drift_subset_plus_lifecycle_subset_equals_full_set() -> None:
+    """Partition invariant: every BUILTIN tool is in EXACTLY ONE bucket."""
+    lifecycle_names = {spec.name for spec in LIFECYCLE_REPORTING_TOOLS}
+    drift_names = {spec.name for spec in DRIFT_SELF_REPORTING_TOOLS}
+    builtin_names = {spec.name for spec in BUILTIN_REPORTING_TOOLS}
+    assert lifecycle_names | drift_names == builtin_names
+    assert lifecycle_names & drift_names == set()
+
+
+# ---------------------------------------------------------------------------
+# select_reporting_tools — the helper Runner.run consults
+# ---------------------------------------------------------------------------
+
+
+def _names(specs: list[ReportingToolSpec]) -> set[str]:
+    return {spec.name for spec in specs}
+
+
+def test_select_false_returns_lifecycle_only() -> None:
+    selected = _names(select_reporting_tools(False))
+    assert selected == _names(LIFECYCLE_REPORTING_TOOLS)
+    assert selected.isdisjoint(DRIFT_SELF_REPORTING_TOOL_NAMES)
+
+
+def test_select_true_returns_full_canonical_set() -> None:
+    selected = _names(select_reporting_tools(True))
+    assert selected == _names(BUILTIN_REPORTING_TOOLS)
+
+
+def test_select_list_adds_named_drift_tools_to_lifecycle() -> None:
+    selected = _names(select_reporting_tools(["report_plan_divergence"]))
+    expected = _names(LIFECYCLE_REPORTING_TOOLS) | {"report_plan_divergence"}
+    assert selected == expected
+    # The other drift tools stay off.
+    assert "declare_task_skipped" not in selected
+    assert "declare_task_not_needed" not in selected
+
+
+def test_select_list_with_two_names_enables_both() -> None:
+    selected = _names(
+        select_reporting_tools(["declare_task_skipped", "declare_task_not_needed"])
+    )
+    expected = _names(LIFECYCLE_REPORTING_TOOLS) | {
+        "declare_task_skipped",
+        "declare_task_not_needed",
+    }
+    assert selected == expected
+    assert "report_plan_divergence" not in selected
+
+
+def test_select_empty_list_collapses_to_lifecycle_subset() -> None:
+    """An empty iterable behaves like ``False`` — no drift tools enabled."""
+    selected = _names(select_reporting_tools([]))
+    assert selected == _names(LIFECYCLE_REPORTING_TOOLS)
+
+
+def test_select_silently_ignores_unknown_drift_tool_names() -> None:
+    """Names that aren't in ``DRIFT_SELF_REPORTING_TOOL_NAMES`` are ignored;
+    typos must not silently turn a non-drift tool off."""
+    selected = _names(select_reporting_tools(["report_plan_divergence", "report_typo"]))
+    expected = _names(LIFECYCLE_REPORTING_TOOLS) | {"report_plan_divergence"}
+    assert selected == expected
+
+
+def test_select_accepts_set_and_tuple() -> None:
+    set_selected = _names(select_reporting_tools({"report_plan_divergence"}))
+    tup_selected = _names(select_reporting_tools(("report_plan_divergence",)))
+    expected = _names(LIFECYCLE_REPORTING_TOOLS) | {"report_plan_divergence"}
+    assert set_selected == expected
+    assert tup_selected == expected
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — drift tools land on the adapter only when opted in
+# ---------------------------------------------------------------------------
+
+
+def _linear_plan() -> Plan:
+    return Plan(
+        id="plan",
+        run_id="",
+        goal_ids=["g"],
+        tasks=[Task(id="t1", title="One", assignee_agent_id="writer")],
+        edges=[],
+        summary="one task",
+    )
+
+
+async def _no_op_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = session, tools
+    return InvocationResult(task_id=task.id, text="done")
+
+
+def _build_runner(drift_self_reporting: Any = False) -> tuple[Runner, CallableAdapter]:
+    adapter = CallableAdapter(_no_op_agent, available_agents=["writer"])
+    runner = Runner(
+        agent=adapter,
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[InMemorySink()],
+        drift_self_reporting=drift_self_reporting,
+    )
+    return runner, adapter
+
+
+async def test_runner_default_registers_lifecycle_subset_only() -> None:
+    runner, adapter = _build_runner(drift_self_reporting=False)
+    await runner.run("turn one")
+    await runner.close()
+    registered = {spec.name for spec in adapter._tools}
+    assert registered == _names(LIFECYCLE_REPORTING_TOOLS)
+    assert registered.isdisjoint(DRIFT_SELF_REPORTING_TOOL_NAMES)
+
+
+async def test_runner_drift_true_registers_full_canonical_set() -> None:
+    runner, adapter = _build_runner(drift_self_reporting=True)
+    await runner.run("turn one")
+    await runner.close()
+    registered = {spec.name for spec in adapter._tools}
+    assert registered == _names(BUILTIN_REPORTING_TOOLS)
+
+
+async def test_runner_drift_list_registers_lifecycle_plus_named() -> None:
+    runner, adapter = _build_runner(drift_self_reporting=["report_plan_divergence"])
+    await runner.run("turn one")
+    await runner.close()
+    registered = {spec.name for spec in adapter._tools}
+    expected = _names(LIFECYCLE_REPORTING_TOOLS) | {"report_plan_divergence"}
+    assert registered == expected
+    assert "declare_task_skipped" not in registered
+    assert "declare_task_not_needed" not in registered
+
+
+async def test_runner_drift_list_persists_across_turns() -> None:
+    """The flag is stored on the Runner, so every turn registers the same
+    set. Materialising the list eagerly in __init__ means callers passing
+    a mutable list don't see drift tools changing turn-to-turn."""
+    user_list = ["report_plan_divergence"]
+    runner, adapter = _build_runner(drift_self_reporting=user_list)
+    # Mutate the caller-side list — must not affect Runner behaviour.
+    user_list.append("declare_task_skipped")
+
+    await runner.run("turn one")
+    turn_one = {spec.name for spec in adapter._tools}
+
+    await runner.run("turn two")
+    turn_two = {spec.name for spec in adapter._tools}
+    await runner.close()
+
+    expected = _names(LIFECYCLE_REPORTING_TOOLS) | {"report_plan_divergence"}
+    assert turn_one == expected
+    assert turn_two == expected
+
+
+def test_runner_default_attribute_is_false() -> None:
+    """Constructing without the kwarg should pin the attribute to False —
+    pre-existing call sites get the documented default automatically."""
+    adapter = CallableAdapter(_no_op_agent, available_agents=["writer"])
+    runner = Runner(
+        agent=adapter,
+        planner=StaticPlanner(_linear_plan()),
+        executor=SequentialExecutor(),
+    )
+    assert runner.drift_self_reporting is False
+
+
+# ---------------------------------------------------------------------------
+# convenience.wrap forwards the kwarg
+# ---------------------------------------------------------------------------
+
+
+async def test_wrap_forwards_drift_self_reporting() -> None:
+    """``goldfive.wrap(drift_self_reporting=True)`` propagates to the
+    inner Runner so the prompt-side opt-in works through the high-level
+    API too."""
+    from goldfive import wrap
+
+    plan_json = json.dumps({
+        "summary": "t",
+        "tasks": [{"id": "t1", "title": "T", "assignee_agent_id": "writer"}],
+    })
+
+    async def planner_llm(system: str, user: str, model: str) -> str:
+        _ = system, user, model
+        return plan_json
+
+    runner = wrap(
+        _no_op_agent,
+        planner=LLMPlanner(call_llm=planner_llm, model="stub"),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        executor=SequentialExecutor(),
+        sinks=[InMemorySink()],
+        drift_self_reporting=True,
+    )
+    assert runner.drift_self_reporting is True
+    await runner.close()
+
+
+async def test_wrap_default_is_lifecycle_only() -> None:
+    """Default ``wrap()`` has drift_self_reporting=False on the runner."""
+    from goldfive import wrap
+
+    plan_json = json.dumps({
+        "summary": "t",
+        "tasks": [{"id": "t1", "title": "T", "assignee_agent_id": "writer"}],
+    })
+
+    async def planner_llm(system: str, user: str, model: str) -> str:
+        _ = system, user, model
+        return plan_json
+
+    runner = wrap(
+        _no_op_agent,
+        planner=LLMPlanner(call_llm=planner_llm, model="stub"),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        executor=SequentialExecutor(),
+        sinks=[InMemorySink()],
+    )
+    assert runner.drift_self_reporting is False
+    await runner.close()
+
+
+# ---------------------------------------------------------------------------
+# Edge: TaskEdge unused but imported keeps the test module aligned with
+# the rest of the suite's import style; mark as used so linters stay
+# quiet without a noqa.
+# ---------------------------------------------------------------------------
+
+
+_ = TaskEdge  # noqa: PIE794 — kept for cross-test consistency

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -227,8 +227,17 @@ async def test_runner_aborts_when_planner_returns_none() -> None:
     assert run_kinds == ["RunStarted", "GoalDerived", "RunAborted"]
 
 
-async def test_runner_registers_builtin_reporting_tools() -> None:
-    """The adapter receives the canonical seven reporting tools verbatim."""
+async def test_runner_registers_lifecycle_reporting_tools_by_default() -> None:
+    """Default :class:`Runner` registers the lifecycle subset only.
+
+    goldfive#196 made the drift-related self-reporting tools opt-in,
+    so the default registration contains every BUILTIN tool EXCEPT
+    those in :data:`DRIFT_SELF_REPORTING_TOOL_NAMES`. ``True`` /
+    list-of-names variants are pinned in
+    ``tests/test_drift_reporting_optin.py``.
+    """
+    from goldfive import DRIFT_SELF_REPORTING_TOOL_NAMES, LIFECYCLE_REPORTING_TOOLS
+
     captured: dict[str, Any] = {}
 
     async def agent_fn(
@@ -243,6 +252,35 @@ async def test_runner_registers_builtin_reporting_tools() -> None:
         executor=SequentialExecutor(),
         goal_deriver=PassthroughGoalDeriver("any"),
         sinks=[InMemorySink()],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+    assert outcome.success
+
+    tools = captured["tools"]
+    names = [t.name for t in tools]
+    expected = [t.name for t in LIFECYCLE_REPORTING_TOOLS]
+    assert names == expected
+    assert set(names).isdisjoint(DRIFT_SELF_REPORTING_TOOL_NAMES)
+
+
+async def test_runner_drift_self_reporting_true_registers_full_set() -> None:
+    """``Runner(drift_self_reporting=True)`` restores the pre-#196 set."""
+    captured: dict[str, Any] = {}
+
+    async def agent_fn(
+        task: Task, session: Session, tools: list[ReportingToolSpec]
+    ) -> InvocationResult:
+        captured.setdefault("tools", tools)
+        return InvocationResult(task_id=task.id, text="ok")
+
+    runner = Runner(
+        agent=CallableAdapter(agent_fn, available_agents=["writer"]),
+        planner=StaticPlanner(_hand_built_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("any"),
+        sinks=[InMemorySink()],
+        drift_self_reporting=True,
     )
     outcome = await runner.run("go")
     await runner.close()


### PR DESCRIPTION
## Summary

- Default `Runner` registers only the **lifecycle subset** of reporting tools (`report_task_*`, `report_awaiting_approval`, `report_new_work_discovered`). The drift-related self-reporting tools (`report_plan_divergence`, `declare_task_skipped`, `declare_task_not_needed`) are now opt-in via `Runner(drift_self_reporting=...)`.
- Drops ~600-1200 prompt tokens per sub-agent (each tool schema is 200-400 tokens) and shrinks the model's hallucination surface — a confused agent can't confabulate a drift call when the tool isn't registered.
- Framework's **observation paths remain the canonical detectors**: `classify_goal_drift`, `PlanReconciler`, and the steerer's refine machinery cover the same signal more reliably than the model self-reporting.
- `report_new_work_discovered` intentionally stays default-on — there is no observation analog for an agent surfacing genuinely new work.

## API

```python
Runner(drift_self_reporting=False)            # default: lifecycle only
Runner(drift_self_reporting=True)             # full canonical set (legacy)
Runner(drift_self_reporting=["report_plan_divergence"])  # lifecycle + named
```

Also threaded through `goldfive.wrap(drift_self_reporting=...)`.

New module-level constants:
- `goldfive.LIFECYCLE_REPORTING_TOOLS`
- `goldfive.DRIFT_SELF_REPORTING_TOOLS`
- `goldfive.DRIFT_SELF_REPORTING_TOOL_NAMES`
- `goldfive.reporting.select_reporting_tools(flag)` — the helper Runner.run consults; exposed for adapter authors.

## Test plan

- [x] `tests/test_drift_reporting_optin.py` (19 new tests) — pins partition invariant, the four `select_reporting_tools()` shapes, end-to-end Runner registration through `CallableAdapter._tools`, kwarg persistence across turns, and `wrap()` forwarding.
- [x] `tests/test_runner.py::test_runner_registers_lifecycle_reporting_tools_by_default` updated for new default; `test_runner_drift_self_reporting_true_registers_full_set` added for legacy parity.
- [x] Full suite: 1794 passed, 49 skipped (no regressions).
- [x] `ruff check` clean on touched files.
- [x] Doc update: `docs/reference/tool-protocol.md` documents the split + the trade-off.