### PR TITLE
feat(audit): wire CancellationStashViolation tripwire (#271 Phase 3.5 component 2)

### DIFF
--- a/docs/design/CANCELLATION-CONTRACT.md
+++ b/docs/design/CANCELLATION-CONTRACT.md
@@ -1,12 +1,26 @@
 # Cancellation propagation contract
 
 **Status.** Phase 3 Addition A of goldfive#271. Sibling to
-[`STATE-OWNERSHIP-CONTRACT.md`](STATE-OWNERSHIP-CONTRACT.md). The
-exception class :class:`goldfive._state_audit.CancellationStashViolation`
-ships in Phase 3; the C2-C6 audit conversions ship in Phase 3.5
-(this PR). The runtime tripwire mechanism still lands with the
-hard-cancel boundary work, when the goldfive task boundary becomes
-the legitimate catch site.
+[`STATE-OWNERSHIP-CONTRACT.md`](STATE-OWNERSHIP-CONTRACT.md).
+
+* :class:`goldfive._state_audit.CancellationStashViolation` shipped
+  in Phase 3 (PR #290).
+* The C2-C6 audit conversions shipped in Phase 3.5 component 1
+  (PRs #306, #307 + the boundary catch site at
+  :meth:`ADKAdapter._invoke_internal`).
+* The runtime tripwire — every audited site wrapped in
+  :func:`goldfive._state_audit.cancellation_stash_audited` and the
+  boundary catch site invoking
+  :func:`goldfive._state_audit.assert_stash_invariant` — shipped
+  in Phase 3.5 component 2 (this PR). **The tripwire is now active.**
+
+**Default-off.** The tripwire is gated on
+``GOLDFIVE_STRICT_STATE_OWNERSHIP`` (the same env switch as
+:class:`StateOwnershipViolation`). Production deploys with the
+variable unset never raise from the boundary check; the audited
+sites pay one ContextVar push/pop per enter/exit and nothing more.
+Tests run with strict mode on by default via the auto-applied
+``_state_audit_enabled`` fixture in ``tests/conftest.py``.
 
 ## tl;dr
 
@@ -101,28 +115,36 @@ Phase 3 ships an audit pass; Phase 3.5 wires the runtime tripwire.
 * **LOW** — stash is best-effort GC of transient state. C5 / C6
   are LOW; the GC will run on the next applicable event.
 
-### §2.2 Phase 3.5 plan
-
-When the goldfive task boundary lands (Phase 3.5):
+### §2.2 Phase 3.5 plan — completed
 
 1. **Done.** Survey C2-C6 with the full audit pattern; convert
    HIGH/MEDIUM sites to `try / finally` or
    `except BaseException: stash; raise`. Shipped in the
    Phase 3.5 cancellation-stash PR — see §2 catalog status column.
-2. Wire the runtime tripwire — install
-   :class:`CancellationStashViolation` raise machinery (paired with
-   the boundary's stack-walk; the boundary becomes the one
-   legitimate catch site, and any other site that absorbs
-   `CancelledError` without entering its `finally` raises the
-   tripwire).
+2. **Done.** Wire the runtime tripwire. Every audited site
+   (C1-C5) is wrapped in
+   `goldfive._state_audit.cancellation_stash_audited(name)`; the
+   compliance branch (`finally:` or `except BaseException:`) calls
+   `goldfive._state_audit.mark_stash_completed()` before re-raising;
+   the boundary at `ADKAdapter._invoke_internal`'s
+   `except asyncio.CancelledError:` arm calls
+   `goldfive._state_audit.assert_stash_invariant(cause=...)` which
+   walks the open-marker stack and raises
+   `CancellationStashViolation` (a `BaseException` so
+   `except Exception` cannot swallow it) for any retained marker
+   whose compliance flag is False. C6 needs no instrumentation
+   because the sequence cursor advances before the `await` by
+   construction.
 3. **Done.** Test surface:
-   `tests/test_cancellation_stash_audit.py` — fires
-   `CancelledError` at each audited `await`, asserts the stash
-   invariant. Each test fails on `origin/main` (without the
-   conversion) and passes with the fix. C6 is pinned by a
-   complementary regression test that asserts
-   `session.next_sequence()` runs strictly before the sink
-   `await`.
+   * `tests/test_cancellation_stash_audit.py` — fires
+     `CancelledError` at each audited `await`, asserts the stash
+     invariant. Each test fails on `origin/main` (without the
+     conversion) and passes with the fix.
+   * `tests/test_cancellation_stash_tripwire.py` — synthetic
+     audited sites that verify the tripwire raises
+     `CancellationStashViolation` for a bypass site under strict
+     mode, never raises for a compliant site, and never raises
+     under strict-mode-off regardless of compliance.
 
 ## §3 Why the boundary is prerequisite
 
@@ -138,14 +160,18 @@ exception.
 
 The audit-pass + class-only ship in Phase 3 lets us land the
 boundary in 3.5 without simultaneously fighting a regression
-cascade across every catalogued site. The ordering is deliberate:
+cascade across every catalogued site. The ordering was:
 
-1. **Phase 3 (this PR).** Audit catalog. Class definition. Doc.
+1. **Phase 3.** Audit catalog. Class definition. Doc.
 2. **Phase 3 follow-up.** Convert HIGH-severity sites to
-   `try / finally`. Most are already done (C1 in #287; the
+   `try / finally`. Most were already done (C1 in #287; the
    sequential executor's cooperative-cancel paths are
    self-cleaning by design).
-3. **Phase 3.5.** Goldfive task boundary becomes the catch site.
-   Runtime tripwire installs. Remaining audit sites convert in
-   the same PR.
-4. **Phase 4+.** Hard cancel wires `task.cancel()` from the steerer.
+3. **Phase 3.5 component 1.** Goldfive task boundary becomes the
+   catch site. C2-C5 audit conversions to
+   `except BaseException: stash; raise` or `try / finally` shipped.
+4. **Phase 3.5 component 2 (this PR).** Runtime tripwire wired:
+   audited sites instrumented via
+   `cancellation_stash_audited` + `mark_stash_completed`; boundary
+   catch site invokes `assert_stash_invariant`.
+5. **Phase 4+.** Hard cancel wires `task.cancel()` from the steerer.

--- a/goldfive/_state_audit.py
+++ b/goldfive/_state_audit.py
@@ -121,13 +121,25 @@ class CancellationStashViolation(BaseException):
     Exception`` blocks the audit catalogues would otherwise swallow
     the violation marker.
 
-    Phase 3 ships only the EXCEPTION CLASS + the audit document under
+    Phase 3 shipped only the EXCEPTION CLASS + the audit document under
     ``docs/design/CANCELLATION-CONTRACT.md`` (sibling to
-    ``STATE-OWNERSHIP-CONTRACT.md``). The runtime tripwire mechanism
-    (paired with the goldfive task boundary that is the one place
-    we'll catch ``CancelledError``) lands with Phase 3.5's hard-cancel
-    work — there's no point installing the runtime check before the
-    boundary exists to be the legitimate catch site.
+    ``STATE-OWNERSHIP-CONTRACT.md``). Phase 3.5 (this module) wires the
+    runtime tripwire: the goldfive boundary at
+    :meth:`ADKAdapter._invoke_internal` is the canonical
+    ``CancelledError`` catch site, and every audited stash-owning site
+    (§C1-C6) is wrapped in :func:`cancellation_stash_audited` so the
+    catch site can verify the stash invariant fired before the cancel
+    propagated up. A site that started but never ran its compliance
+    branch (neither the ``finally`` block nor the
+    ``except BaseException: stash; raise`` arm) raises this class,
+    chained onto the original ``CancelledError`` as ``__cause__``.
+
+    **Default-off contract.** The tripwire is opt-in via
+    ``GOLDFIVE_STRICT_STATE_OWNERSHIP`` (the same env gate as
+    :class:`StateOwnershipViolation`). Production deploys with the
+    variable unset never pay more than a per-site contextvar
+    push/pop; the boundary check itself short-circuits on
+    :func:`is_enabled` returning False before walking any state.
     """
 
 
@@ -539,3 +551,275 @@ def wrap_plugin_callbacks(plugin: Any) -> Any:
 # always safe — production deploys with the env var unset never pay
 # more than one ContextVar read per protocol write.
 _install_protocol_patch()
+
+
+# ---------------------------------------------------------------------------
+# Cancellation-stash tripwire (Phase 3.5)
+# ---------------------------------------------------------------------------
+#
+# The mechanism: every audited site (C1-C6 in
+# ``docs/design/CANCELLATION-CONTRACT.md``) wraps its stash-owning
+# block in :func:`cancellation_stash_audited`. The context manager
+# pushes a marker on entry and pops it on exit. Compliant sites
+# (``try / finally`` per §1.1, or
+# ``except BaseException: stash; raise`` per §1.2) call
+# :func:`mark_stash_completed` from inside their stash branch BEFORE
+# the block exits — the marker records that the compliance branch
+# fired.
+#
+# At the boundary catch site (``_invoke_internal``'s
+# ``except asyncio.CancelledError`` arm), :func:`assert_stash_invariant`
+# walks the still-open markers (those whose ``__exit__`` hasn't run
+# yet — the cancel propagated through them) and raises
+# :class:`CancellationStashViolation` if any of them never had
+# :func:`mark_stash_completed` called.
+#
+# Default-off: every entry point short-circuits on
+# :func:`is_enabled` so production deploys (env var unset, no pytest
+# loaded) pay one ContextVar read per site enter/exit and nothing
+# more.
+
+
+@dataclass
+class _StashMarker:
+    """Per-audited-site bookkeeping for the cancellation tripwire.
+
+    The ``exited`` flag distinguishes "still inside the ``with``"
+    from "exited via cancellation, retained for boundary inspection".
+    :func:`mark_stash_completed` only flags the innermost
+    not-yet-exited marker — without that filter, a nested cancel
+    would mis-attribute the outer's compliance branch to the inner's
+    retained marker.
+    """
+
+    name: str
+    completed: bool = False
+    exited: bool = False
+
+
+# Stack of currently-open audited sites. A list-valued ContextVar so
+# nested audited sites layer correctly across asyncio task boundaries
+# (a sub-task inherits the parent's stack snapshot at spawn time, so
+# its own ``cancellation_stash_audited`` enters push onto its own
+# private list).
+_open_stash_markers: contextvars.ContextVar[tuple[_StashMarker, ...]] = (
+    contextvars.ContextVar("goldfive_open_stash_markers", default=())
+)
+
+
+class _AuditedSite:
+    """Context manager for a Phase-3.5 audited stash-owning site.
+
+    On entry: pushes a fresh :class:`_StashMarker` onto the
+    open-markers stack.
+
+    On exit:
+
+    * If the block exits normally OR raises a non-cancellation
+      exception, the marker is popped — the audit invariant is
+      moot (the cancel never propagated through this site, so
+      whether the compliance branch ran is irrelevant).
+    * If the block exits via :class:`asyncio.CancelledError` (or any
+      ``BaseException`` that isn't an :class:`Exception`), the
+      marker is RETAINED on the stack so the boundary catch site at
+      :meth:`ADKAdapter._invoke_internal` can inspect its
+      ``completed`` flag. The boundary's
+      :func:`assert_stash_invariant` walks the stack and raises
+      :class:`CancellationStashViolation` for any retained marker
+      whose flag is False — i.e. the site started but never called
+      :func:`mark_stash_completed`.
+
+    Implementation note. We don't use ``ContextVar.reset(token)``
+    because reset would always pop the marker, defeating the
+    "retain on cancel" behaviour. Instead we rebuild the stack
+    tuple ourselves, locating our marker by identity (the
+    :class:`_StashMarker` instance is unique per ``__enter__``).
+    Nested audited sites layer correctly because each
+    ``_AuditedSite`` owns its own marker instance and only removes
+    that instance from the stack.
+    """
+
+    __slots__ = ("_marker", "_active")
+
+    def __init__(self, name: str) -> None:
+        self._marker = _StashMarker(name=name, completed=False)
+        self._active = False
+
+    def __enter__(self) -> None:
+        if not is_enabled():
+            return
+        self._active = True
+        _open_stash_markers.set((*_open_stash_markers.get(), self._marker))
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: Any,
+    ) -> bool:
+        if not self._active:
+            return False
+        # Retain the marker on the stack only when the block exits
+        # via an asyncio cancellation (or any ``BaseException`` that
+        # isn't an ``Exception`` — the contract is about the
+        # ``except Exception`` blind spot). The boundary catch site
+        # consumes retained markers via :func:`assert_stash_invariant`.
+        retain = exc is not None and isinstance(exc, BaseException) and not isinstance(
+            exc, Exception
+        )
+        if retain:
+            # Leave the marker in place but flag it as exited so a
+            # parent site's :func:`mark_stash_completed` call
+            # (e.g. from its ``except BaseException`` arm) does not
+            # mis-attribute to our retained marker.
+            self._marker.exited = True
+            return False
+        # Normal / Exception path: pop ourselves off the stack so
+        # subsequent (unrelated) sites don't see a stale marker.
+        # We rebuild by identity — robust against any nesting that
+        # snuck in between enter and exit (shouldn't happen, but
+        # cheap to do correctly).
+        current = _open_stash_markers.get()
+        rebuilt = tuple(m for m in current if m is not self._marker)
+        if rebuilt != current:
+            _open_stash_markers.set(rebuilt)
+        return False
+
+
+def cancellation_stash_audited(name: str) -> _AuditedSite:
+    """Mark the wrapped block as a Phase-3.5 audited stash-owning site.
+
+    Returns a context manager (:class:`_AuditedSite`) wrapping the
+    ``try / except / finally`` (or
+    ``try / except Exception ... except BaseException: stash; raise``)
+    that owns a state-stash duty across an ``await``. The wrapped
+    block MUST call :func:`mark_stash_completed` from inside its
+    stash branch (the ``finally`` block, or the
+    ``except BaseException`` arm before ``raise``) so the boundary
+    catch site can verify the invariant.
+
+    Default-off: when :func:`is_enabled` returns False the
+    context manager is a pass-through (one ContextVar read on
+    ``__enter__`` and nothing else).
+
+    Example::
+
+        async def _refine(...):
+            with cancellation_stash_audited("ParallelDAGExecutor._refine"):
+                try:
+                    refined = await planner.refine(...)
+                except BaseException:
+                    await self._emit_refine_failure(...)
+                    mark_stash_completed()
+                    raise
+    """
+    return _AuditedSite(name)
+
+
+def mark_stash_completed() -> None:
+    """Mark the innermost open audited site as having run its stash branch.
+
+    Called from inside an audited site's compliance branch
+    (the ``finally`` block per §1.1, or the
+    ``except BaseException: stash; raise`` arm per §1.2) BEFORE the
+    block exits / re-raises. The boundary catch site reads the
+    ``completed`` flag to verify the invariant.
+
+    No-op when :func:`is_enabled` returns False or no audited site is
+    currently open. Safe to call from non-cancellation paths (e.g.
+    from a normal ``finally`` block — the marker just records that
+    the stash fired regardless of exit shape).
+    """
+    if not is_enabled():
+        return
+    stack = _open_stash_markers.get()
+    if not stack:
+        return
+    # Walk from innermost to outermost looking for the first marker
+    # whose audited block is still active (``exited == False``).
+    # Skipping retained-but-exited markers prevents nested cancels
+    # from mis-attributing a parent's compliance branch to a child's
+    # retained marker.
+    for marker in reversed(stack):
+        if not marker.exited:
+            marker.completed = True
+            return
+
+
+def assert_stash_invariant(*, cause: BaseException | None = None) -> None:
+    """Raise :class:`CancellationStashViolation` if any open site bypassed its stash.
+
+    Called from the boundary catch site at
+    :meth:`ADKAdapter._invoke_internal`'s
+    ``except asyncio.CancelledError`` arm — by the time control
+    reaches the catch, every audited site whose ``await`` was
+    interrupted by the cancel should have either:
+
+    * exited normally before the cancel hit (popped off the stack
+      by the ``__exit__`` machinery — not visible here), or
+    * had :func:`mark_stash_completed` called from its compliance
+      branch BEFORE the cancel propagated past it (visible here as
+      ``marker.completed == True``).
+
+    If any open marker has ``completed == False``, the cancel
+    propagated past the site without entering the compliance branch
+    — the bug Phase 3.5 was created to surface.
+
+    No-op when :func:`is_enabled` returns False — production deploys
+    with the env var unset never raise from this function.
+
+    The optional ``cause`` is chained onto the violation as
+    ``__cause__`` so the original ``CancelledError`` traceback is
+    preserved alongside the violation.
+    """
+    if not is_enabled():
+        return
+    stack = _open_stash_markers.get()
+    if not stack:
+        return
+    bad = [m.name for m in stack if not m.completed]
+    # Drain the retained markers regardless of outcome. The catch
+    # site has now inspected them; leaving them around would let a
+    # subsequent unrelated cancel inherit stale state from this
+    # one. (Production deploys never re-enter ``_invoke_internal``
+    # on the same async task without a fresh ``ContextVar`` snapshot
+    # — but tests + harness scenarios that drive multiple cancels
+    # back-to-back on one task rely on this drain.)
+    if stack:
+        _open_stash_markers.set(())
+    if not bad:
+        return
+    # Stack-walk diagnostic: include the catch-site frame chain so the
+    # operator can see WHICH boundary observed the violation. Cheap —
+    # we only walk when we're already raising, and only up to 16
+    # frames.
+    frames: list[str] = []
+    walker = inspect.currentframe()
+    if walker is not None:
+        walker = walker.f_back  # skip ourselves
+    seen = 0
+    while walker is not None and seen < 16:
+        code = getattr(walker, "f_code", None)
+        if code is not None:
+            qual = getattr(code, "co_qualname", None) or getattr(code, "co_name", "")
+            fname = str(getattr(code, "co_filename", ""))
+            frames.append(f"  {fname}:{walker.f_lineno} {qual}")
+        walker = walker.f_back
+        seen += 1
+    msg = (
+        "CancelledError propagated past Phase-3.5 audited stash "
+        "site(s) without entering the compliance branch:\n"
+        + "\n".join(f"  - {n}" for n in bad)
+        + "\n\nCatch-site frame chain:\n"
+        + "\n".join(frames)
+        + "\n\nEach audited site MUST call "
+        "goldfive._state_audit.mark_stash_completed() from its "
+        "``finally`` block (CANCELLATION-CONTRACT.md §1.1) or its "
+        "``except BaseException: stash; raise`` arm "
+        "(CANCELLATION-CONTRACT.md §1.2) BEFORE the cancel "
+        "propagates. See docs/design/CANCELLATION-CONTRACT.md."
+    )
+    violation = CancellationStashViolation(msg)
+    if cause is not None:
+        raise violation from cause
+    raise violation

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -54,6 +54,7 @@ import uuid
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
+from goldfive import _state_audit
 from goldfive.adapters._adk_plugin import (
     SESSION_CONTEXT_STATE_KEY,
     SessionContext,
@@ -2056,7 +2057,7 @@ class ADKAdapter:
                 if task is not None and _task_is_terminal(task, session):
                     stop_reason = "task_terminal"
                     break
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as cancelled_exc:
             was_cancelled = True
             stop_reason = "cancelled"
             # Goldfive boundary catch site (goldfive#271 Phase 3.5
@@ -2078,6 +2079,22 @@ class ADKAdapter:
                         "ADKAdapter.invoke: close_open_boundaries(cancelled) raised: %s",
                         exc,
                     )
+            # Phase 3.5 component 2 (goldfive#271): assert every
+            # audited stash-owning site (CANCELLATION-CONTRACT.md
+            # §C1-C6) ran its compliance branch before the cancel
+            # propagated past it. Default-off — short-circuits when
+            # ``GOLDFIVE_STRICT_STATE_OWNERSHIP`` is unset. Raises
+            # :class:`CancellationStashViolation` (a ``BaseException``
+            # so ``except Exception`` blocks can't swallow it) when
+            # an audited site started but never called
+            # :func:`mark_stash_completed`. We invoke this BEFORE
+            # the heal / plugin-notify steps so the violation
+            # surfaces at the earliest possible point in the catch
+            # arm; the heal calls themselves wouldn't suppress the
+            # violation (they catch ``Exception``, not
+            # ``BaseException``) but raising early keeps the
+            # diagnostic close to the cancel that triggered it.
+            _state_audit.assert_stash_invariant(cause=cancelled_exc)
             # Consume the tag the steerer / executor stashed on us before
             # triggering the cancel (see goldfive#139). An unset tag
             # falls through to the legacy generic reason so existing

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -29,6 +29,7 @@ import logging
 import warnings
 from typing import TYPE_CHECKING, Any, Literal
 
+from goldfive import _state_audit
 from goldfive.events import (
     emit as emit_event,
 )
@@ -800,44 +801,51 @@ class ParallelDAGExecutor:
         attempt_id: str = ""
         if observe_refine is not None and callable(observe_refine):
             cm = observe_refine(session, drift)
-            try:
-                async with cm as ctx_attempt_id:
-                    attempt_id = ctx_attempt_id
-                    refined = await planner.refine(
-                        plan=plan, drift=drift, goals=list(session.goals)
+            with _state_audit.cancellation_stash_audited(
+                "ParallelDAGExecutor._refine.observed"
+            ):
+                try:
+                    async with cm as ctx_attempt_id:
+                        attempt_id = ctx_attempt_id
+                        refined = await planner.refine(
+                            plan=plan, drift=drift, goals=list(session.goals)
+                        )
+                except Exception as exc:  # noqa: BLE001
+                    # observe_refine has already emitted refine_failed; we
+                    # ALSO emit the CRITICAL DriftDetected mirror so the
+                    # legacy operator-visible signal still lands.
+                    log.warning("ParallelDAGExecutor: planner.refine raised: %s", exc)
+                    await self._emit_refine_failure(
+                        session=session,
+                        sinks=sinks,
+                        source=drift,
+                        reason=f"refine raised: {exc}",
                     )
-            except Exception as exc:  # noqa: BLE001
-                # observe_refine has already emitted refine_failed; we
-                # ALSO emit the CRITICAL DriftDetected mirror so the
-                # legacy operator-visible signal still lands.
-                log.warning("ParallelDAGExecutor: planner.refine raised: %s", exc)
-                await self._emit_refine_failure(
-                    session=session,
-                    sinks=sinks,
-                    source=drift,
-                    reason=f"refine raised: {exc}",
-                )
-                return None, attempt_id
-            except BaseException as exc:  # noqa: BLE001
-                # Phase 3.5 (CANCELLATION-CONTRACT.md §C2): ``CancelledError``
-                # bypasses ``except Exception`` (since Py 3.8 it is a
-                # ``BaseException``). The CRITICAL drift mirror is the
-                # operator-visible "refine failed" signal; without this
-                # branch a refine cancelled mid-flight would leave
-                # sinks observing only the original drift, with no
-                # follow-up explaining why the plan didn't change.
-                # Re-raise so cancellation continues to propagate.
-                log.warning(
-                    "ParallelDAGExecutor: planner.refine cancelled: %s",
-                    type(exc).__name__,
-                )
-                await self._emit_refine_failure(
-                    session=session,
-                    sinks=sinks,
-                    source=drift,
-                    reason=f"refine cancelled: {type(exc).__name__}",
-                )
-                raise
+                    return None, attempt_id
+                except BaseException as exc:  # noqa: BLE001
+                    # Phase 3.5 (CANCELLATION-CONTRACT.md §C2): ``CancelledError``
+                    # bypasses ``except Exception`` (since Py 3.8 it is a
+                    # ``BaseException``). The CRITICAL drift mirror is the
+                    # operator-visible "refine failed" signal; without this
+                    # branch a refine cancelled mid-flight would leave
+                    # sinks observing only the original drift, with no
+                    # follow-up explaining why the plan didn't change.
+                    # Re-raise so cancellation continues to propagate.
+                    log.warning(
+                        "ParallelDAGExecutor: planner.refine cancelled: %s",
+                        type(exc).__name__,
+                    )
+                    await self._emit_refine_failure(
+                        session=session,
+                        sinks=sinks,
+                        source=drift,
+                        reason=f"refine cancelled: {type(exc).__name__}",
+                    )
+                    # Phase 3.5 tripwire compliance marker: the
+                    # ``except BaseException: stash; raise`` form (§1.2)
+                    # has run its stash (the refine_failure mirror).
+                    _state_audit.mark_stash_completed()
+                    raise
             if refined is None:
                 log.warning(
                     "ParallelDAGExecutor: planner.refine(kind=%s) returned None; plan unchanged",
@@ -890,36 +898,41 @@ class ParallelDAGExecutor:
             # Legacy path — no steerer or no observe_refine. No
             # refine_attempted/refine_failed emission, but the
             # CRITICAL DriftDetected mirror is preserved.
-            try:
-                refined = await planner.refine(
-                    plan=plan, drift=drift, goals=list(session.goals)
-                )
-            except Exception as exc:  # noqa: BLE001
-                log.warning("ParallelDAGExecutor: planner.refine raised: %s", exc)
-                await self._emit_refine_failure(
-                    session=session,
-                    sinks=sinks,
-                    source=drift,
-                    reason=f"refine raised: {exc}",
-                )
-                return None, attempt_id
-            except BaseException as exc:  # noqa: BLE001
-                # Phase 3.5 (CANCELLATION-CONTRACT.md §C2): ``CancelledError``
-                # bypasses ``except Exception``; emit the CRITICAL drift
-                # mirror so the operator-visible "refine cancelled" signal
-                # still lands, then re-raise to preserve cancellation
-                # propagation per the asyncio contract.
-                log.warning(
-                    "ParallelDAGExecutor: planner.refine cancelled (legacy path): %s",
-                    type(exc).__name__,
-                )
-                await self._emit_refine_failure(
-                    session=session,
-                    sinks=sinks,
-                    source=drift,
-                    reason=f"refine cancelled: {type(exc).__name__}",
-                )
-                raise
+            with _state_audit.cancellation_stash_audited(
+                "ParallelDAGExecutor._refine.legacy"
+            ):
+                try:
+                    refined = await planner.refine(
+                        plan=plan, drift=drift, goals=list(session.goals)
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.warning("ParallelDAGExecutor: planner.refine raised: %s", exc)
+                    await self._emit_refine_failure(
+                        session=session,
+                        sinks=sinks,
+                        source=drift,
+                        reason=f"refine raised: {exc}",
+                    )
+                    return None, attempt_id
+                except BaseException as exc:  # noqa: BLE001
+                    # Phase 3.5 (CANCELLATION-CONTRACT.md §C2): ``CancelledError``
+                    # bypasses ``except Exception``; emit the CRITICAL drift
+                    # mirror so the operator-visible "refine cancelled" signal
+                    # still lands, then re-raise to preserve cancellation
+                    # propagation per the asyncio contract.
+                    log.warning(
+                        "ParallelDAGExecutor: planner.refine cancelled (legacy path): %s",
+                        type(exc).__name__,
+                    )
+                    await self._emit_refine_failure(
+                        session=session,
+                        sinks=sinks,
+                        source=drift,
+                        reason=f"refine cancelled: {type(exc).__name__}",
+                    )
+                    # Phase 3.5 tripwire compliance marker.
+                    _state_audit.mark_stash_completed()
+                    raise
             if refined is None:
                 log.warning(
                     "ParallelDAGExecutor: planner.refine(kind=%s) returned None; plan unchanged",

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -24,6 +24,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
+from goldfive import _state_audit
 from goldfive.types import SupersessionKind, TaskStatus
 
 if TYPE_CHECKING:
@@ -955,12 +956,20 @@ async def _handle_task_started(
     # the unadorned instruction. ``report_task_failed`` does NOT clear
     # (failure is not acknowledgment, and a re-invocation still needs
     # the correction).
-    try:
-        await steerer.mark_task_running(
-            task_id, session=session, detail=detail, source=source
-        )
-    finally:
-        _clear_correction_on_started(session, task)
+    with _state_audit.cancellation_stash_audited(
+        "reporting._handle_task_started.mark_task_running"
+    ):
+        try:
+            await steerer.mark_task_running(
+                task_id, session=session, detail=detail, source=source
+            )
+        finally:
+            _clear_correction_on_started(session, task)
+            # Phase 3.5 tripwire compliance marker (§1.1 form): the
+            # GC ran inside ``finally`` regardless of how the await
+            # exited. The boundary catch site can now confirm we
+            # didn't bypass the stash.
+            _state_audit.mark_stash_completed()
     return dict(_ACK)
 
 

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -42,6 +42,7 @@ import warnings
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from goldfive import _state_audit
 from goldfive import orchestration_state as _ostate
 from goldfive._llm import maybe_close_call_llm
 from goldfive.conversation import Conversation
@@ -719,87 +720,101 @@ class Runner:
                 log.debug("steerer.bind_adapter raised: %s", exc)
 
         # 7. Hand off to the executor.
-        try:
-            executor_kwargs: dict[str, Any] = dict(
-                plan=session.plan,
-                session=session,
-                adapter=self.agent,
-                steerer=self.steerer,
-                planner=self.planner,
-                sinks=list(self.sinks),
-            )
-            if self.control is not None:
-                executor_kwargs["control"] = self.control
-            # Overlay model (goldfive#141): pass the original user
-            # request through to the executor so an overlay-capable
-            # :class:`SequentialExecutor` can hand it verbatim to
-            # ``adapter.invoke_passthrough``. Best-effort via
-            # inspection — executors that don't accept
-            # ``user_input=`` keep working with the legacy kwargs.
-            if isinstance(user_input, str):
-                run_sig = inspect.signature(self.executor.run)
-                if "user_input" in run_sig.parameters:
-                    executor_kwargs["user_input"] = user_input
-            outcome = await self.executor.run(**executor_kwargs)
-        except Exception as exc:  # noqa: BLE001
-            reason = f"executor.run raised: {exc}"
-            log.exception("executor.run raised")
-            await self._emit_run_aborted(session, reason)
-            aborted = ExecutionOutcome(success=False, session=session, reason=reason)
-            convo.absorb_turn(
-                aborted,
-                user_input_summary=_initial_goal_summary(user_input),
-                pinned=pinned,
-            )
-            return aborted
-        finally:
-            # planner-gate: snapshot the turn's final plan so the next
-            # turn's planner_gate can classify against it.
-            #
-            # Rationale (Phase 2.X v2 / goldfive#271 Gap 1): the prior
-            # post-success-path stash (PR #282) was bypassed when ADK
-            # closed the runner mid-flight — the executor coroutine was
-            # cancelled, ``CancelledError`` propagated out of
-            # ``await self.executor.run(...)``, and since Py 3.8
-            # ``CancelledError`` is a ``BaseException`` (not an
-            # ``Exception``) the ``except Exception`` handler above did
-            # NOT catch it. Control flowed out of ``run`` entirely and
-            # the stash was skipped, leaving the prior plan empty for
-            # the next turn even though the turn produced a real plan.
-            # The ADK-web user-steer flow hit this on validation v2:
-            # zero stash log lines across 4 turns.
-            #
-            # Putting the stash in ``finally`` runs it regardless of how
-            # the executor exited — normal success, ``Exception`` (e.g.
-            # planner bind error), or ``BaseException`` (e.g.
-            # ``CancelledError`` from ADK closing the runner mid-stream).
-            # The exception still propagates after the stash; this block
-            # does not swallow it.
-            #
-            # The stash itself lives on :class:`Conversation`
-            # (validation v4 Class 1 / goldfive#271 follow-up): scoping
-            # by session id means a turn on a fresh outer ADK session
-            # sharing this Runner does not inherit a prior plan from
-            # another session. :meth:`Conversation.absorb_turn` (called
-            # on every normal-completion / handled-exception return
-            # path below) folds the stash in alongside the goals /
-            # completed_results merge. The explicit ``stash_plan`` call
-            # here covers the ``BaseException`` (e.g. ``CancelledError``
-            # from ADK closing the runner mid-stream) path that bypasses
-            # ``absorb_turn`` entirely — the same rationale as the
-            # original Gap 1 fix that put the stash in ``finally`` to
-            # begin with. ``stash_plan`` is idempotent: a subsequent
-            # ``absorb_turn`` re-stashes the same plan + session id.
-            if session.plan is not None and session.plan.tasks:
-                convo.stash_plan(session, pinned=pinned)
-                log.info(
-                    "Runner.run: stashed prior plan for next turn's "
-                    "handle_turn (plan_id=%s revision_index=%d "
-                    "session_id=%s)",
-                    (session.plan.id or "")[:16] or "<none>",
-                    int(session.plan.revision_index),
-                    (session.id or "")[:16] or "<none>",
+        # Phase 3.5 (goldfive#271): wrap the executor.run call site
+        # in the cancellation-stash audit context so the boundary's
+        # tripwire can verify the prior-plan stash fired before the
+        # cancel propagated past us. The compliance branch lives in
+        # the ``finally`` block below — it calls
+        # ``mark_stash_completed`` after performing the stash.
+        with _state_audit.cancellation_stash_audited("Runner.run.executor_drive"):
+            try:
+                executor_kwargs: dict[str, Any] = dict(
+                    plan=session.plan,
+                    session=session,
+                    adapter=self.agent,
+                    steerer=self.steerer,
+                    planner=self.planner,
+                    sinks=list(self.sinks),
                 )
+                if self.control is not None:
+                    executor_kwargs["control"] = self.control
+                # Overlay model (goldfive#141): pass the original user
+                # request through to the executor so an overlay-capable
+                # :class:`SequentialExecutor` can hand it verbatim to
+                # ``adapter.invoke_passthrough``. Best-effort via
+                # inspection — executors that don't accept
+                # ``user_input=`` keep working with the legacy kwargs.
+                if isinstance(user_input, str):
+                    run_sig = inspect.signature(self.executor.run)
+                    if "user_input" in run_sig.parameters:
+                        executor_kwargs["user_input"] = user_input
+                outcome = await self.executor.run(**executor_kwargs)
+            except Exception as exc:  # noqa: BLE001
+                reason = f"executor.run raised: {exc}"
+                log.exception("executor.run raised")
+                await self._emit_run_aborted(session, reason)
+                aborted = ExecutionOutcome(success=False, session=session, reason=reason)
+                convo.absorb_turn(
+                    aborted,
+                    user_input_summary=_initial_goal_summary(user_input),
+                    pinned=pinned,
+                )
+                return aborted
+            finally:
+                # planner-gate: snapshot the turn's final plan so the next
+                # turn's planner_gate can classify against it.
+                #
+                # Rationale (Phase 2.X v2 / goldfive#271 Gap 1): the prior
+                # post-success-path stash (PR #282) was bypassed when ADK
+                # closed the runner mid-flight — the executor coroutine was
+                # cancelled, ``CancelledError`` propagated out of
+                # ``await self.executor.run(...)``, and since Py 3.8
+                # ``CancelledError`` is a ``BaseException`` (not an
+                # ``Exception``) the ``except Exception`` handler above did
+                # NOT catch it. Control flowed out of ``run`` entirely and
+                # the stash was skipped, leaving the prior plan empty for
+                # the next turn even though the turn produced a real plan.
+                # The ADK-web user-steer flow hit this on validation v2:
+                # zero stash log lines across 4 turns.
+                #
+                # Putting the stash in ``finally`` runs it regardless of how
+                # the executor exited — normal success, ``Exception`` (e.g.
+                # planner bind error), or ``BaseException`` (e.g.
+                # ``CancelledError`` from ADK closing the runner mid-stream).
+                # The exception still propagates after the stash; this block
+                # does not swallow it.
+                #
+                # The stash itself lives on :class:`Conversation`
+                # (validation v4 Class 1 / goldfive#271 follow-up): scoping
+                # by session id means a turn on a fresh outer ADK session
+                # sharing this Runner does not inherit a prior plan from
+                # another session. :meth:`Conversation.absorb_turn` (called
+                # on every normal-completion / handled-exception return
+                # path below) folds the stash in alongside the goals /
+                # completed_results merge. The explicit ``stash_plan`` call
+                # here covers the ``BaseException`` (e.g. ``CancelledError``
+                # from ADK closing the runner mid-stream) path that bypasses
+                # ``absorb_turn`` entirely — the same rationale as the
+                # original Gap 1 fix that put the stash in ``finally`` to
+                # begin with. ``stash_plan`` is idempotent: a subsequent
+                # ``absorb_turn`` re-stashes the same plan + session id.
+                if session.plan is not None and session.plan.tasks:
+                    convo.stash_plan(session, pinned=pinned)
+                    log.info(
+                        "Runner.run: stashed prior plan for next turn's "
+                        "handle_turn (plan_id=%s revision_index=%d "
+                        "session_id=%s)",
+                        (session.plan.id or "")[:16] or "<none>",
+                        int(session.plan.revision_index),
+                        (session.id or "")[:16] or "<none>",
+                    )
+                # Phase 3.5 (goldfive#271) tripwire compliance marker:
+                # the stash above ran (idempotent and unconditional
+                # within this block). The boundary catch site at
+                # ``ADKAdapter._invoke_internal`` will assert this
+                # marker fired before ``CancelledError`` propagated
+                # past us.
+                _state_audit.mark_stash_completed()
 
         # goldfive#152: clear the current_task_* stamp at run end.
         # The plan id + goals summary stay (they remain meaningful

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -56,6 +56,7 @@ import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from goldfive import _state_audit
 from goldfive import orchestration_state as _ostate
 from goldfive.drift import (
     classify_refusal,
@@ -2544,63 +2545,74 @@ class DefaultSteerer:
                     if flat:
                         available_agents = list(flat)
             refine_accepts_registry = _planner_refine_accepts_available_agents(self._planner)
-            try:
-                if refine_accepts_registry:
-                    revised = await self._planner.refine(
-                        plan=session.plan,
-                        drift=drift,
-                        goals=list(session.goals),
-                        available_agents=available_agents,
+            # Phase 3.5 (goldfive#271) tripwire wrapper — the
+            # ``except BaseException: stash; raise`` arm below is the
+            # compliance branch (CANCELLATION-CONTRACT.md §1.2). The
+            # boundary catch site at ``ADKAdapter._invoke_internal``
+            # asserts ``mark_stash_completed()`` fired before the
+            # cancel propagated past us.
+            with _state_audit.cancellation_stash_audited(
+                "DefaultSteerer._handle_drift.refine"
+            ):
+                try:
+                    if refine_accepts_registry:
+                        revised = await self._planner.refine(
+                            plan=session.plan,
+                            drift=drift,
+                            goals=list(session.goals),
+                            available_agents=available_agents,
+                        )
+                    else:
+                        revised = await self._planner.refine(
+                            plan=session.plan,
+                            drift=drift,
+                            goals=list(session.goals),
+                        )
+                except Exception as exc:  # noqa: BLE001 — refine errors must not break the run
+                    # Surface the failure via logging + a synthetic follow-up
+                    # drift so operators don't silently see the same plan loop
+                    # forever. Without this, a refine that raises (e.g. malformed
+                    # LLM JSON after a mid-invocation cancel poisons the session)
+                    # leaves session.plan unchanged and the executor re-enters
+                    # the same state on the next tick.
+                    log.warning(
+                        "DefaultSteerer._handle_drift: planner.refine(kind=%s) raised "
+                        "%s; plan unchanged",
+                        drift.kind.value,
+                        exc,
                     )
-                else:
-                    revised = await self._planner.refine(
-                        plan=session.plan,
-                        drift=drift,
-                        goals=list(session.goals),
+                    await self._emit_refine_failed(
+                        session,
+                        drift,
+                        attempt_id=attempt_id,
+                        failure_kind="llm_error",
+                        reason=str(exc),
+                        detail=type(exc).__name__,
                     )
-            except Exception as exc:  # noqa: BLE001 — refine errors must not break the run
-                # Surface the failure via logging + a synthetic follow-up
-                # drift so operators don't silently see the same plan loop
-                # forever. Without this, a refine that raises (e.g. malformed
-                # LLM JSON after a mid-invocation cancel poisons the session)
-                # leaves session.plan unchanged and the executor re-enters
-                # the same state on the next tick.
-                log.warning(
-                    "DefaultSteerer._handle_drift: planner.refine(kind=%s) raised "
-                    "%s; plan unchanged",
-                    drift.kind.value,
-                    exc,
-                )
-                await self._emit_refine_failed(
-                    session,
-                    drift,
-                    attempt_id=attempt_id,
-                    failure_kind="llm_error",
-                    reason=str(exc),
-                    detail=type(exc).__name__,
-                )
-                await self._emit_refine_failure(session, drift, reason=str(exc))
-                await self._register_refine_failure(session, drift, counter_key)
-                return
-            except BaseException as exc:  # noqa: BLE001
-                # Phase 3.5 (CANCELLATION-CONTRACT.md §C4): ``CancelledError``
-                # bypasses the ``except Exception`` branch (it is a
-                # ``BaseException`` since Py 3.8). Emit the paired
-                # ``refine_failed`` observability event so a refine cancelled
-                # mid-flight does not leave sinks with an unmatched
-                # ``refine_attempted``. The ``finally`` below still resets
-                # ``_active_session_var``; we only own the paired-event
-                # stash here. Re-raise so cancellation continues to
-                # propagate per the asyncio contract.
-                await self._emit_refine_failed(
-                    session,
-                    drift,
-                    attempt_id=attempt_id,
-                    failure_kind="cancelled",
-                    reason=f"refine cancelled: {type(exc).__name__}",
-                    detail=type(exc).__name__,
-                )
-                raise
+                    await self._emit_refine_failure(session, drift, reason=str(exc))
+                    await self._register_refine_failure(session, drift, counter_key)
+                    return
+                except BaseException as exc:  # noqa: BLE001
+                    # Phase 3.5 (CANCELLATION-CONTRACT.md §C4): ``CancelledError``
+                    # bypasses the ``except Exception`` branch (it is a
+                    # ``BaseException`` since Py 3.8). Emit the paired
+                    # ``refine_failed`` observability event so a refine cancelled
+                    # mid-flight does not leave sinks with an unmatched
+                    # ``refine_attempted``. The ``finally`` below still resets
+                    # ``_active_session_var``; we only own the paired-event
+                    # stash here. Re-raise so cancellation continues to
+                    # propagate per the asyncio contract.
+                    await self._emit_refine_failed(
+                        session,
+                        drift,
+                        attempt_id=attempt_id,
+                        failure_kind="cancelled",
+                        reason=f"refine cancelled: {type(exc).__name__}",
+                        detail=type(exc).__name__,
+                    )
+                    # Phase 3.5 tripwire compliance marker (§1.2 form).
+                    _state_audit.mark_stash_completed()
+                    raise
         finally:
             self._active_session_var.reset(_active_session_token)
         if revised is None:
@@ -3643,42 +3655,48 @@ class DefaultSteerer:
         # ``_handle_drift``.
         attempt_id = self._new_attempt_id()
         await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
-        try:
-            revised = await self._dispatch_goldfive_steer_refine(drift, session)
-        except Exception as exc:  # noqa: BLE001
-            log.warning(
-                "DefaultSteerer._promote_drift_to_steer: refine raised %s; "
-                "plan unchanged",
-                exc,
-            )
-            await self._emit_refine_failed(
-                session,
-                drift,
-                attempt_id=attempt_id,
-                failure_kind="llm_error",
-                reason=str(exc),
-                detail=type(exc).__name__,
-            )
-            await self._emit_refine_failure(session, drift, reason=str(exc))
-            await self._register_refine_failure(session, drift, counter_key)
-            return
-        except BaseException as exc:  # noqa: BLE001
-            # Phase 3.5 (CANCELLATION-CONTRACT.md §C4): ``CancelledError``
-            # bypasses the ``except Exception`` branch above. Emit the
-            # paired ``refine_failed`` so cancelled goldfive-steer refines
-            # do not leave sinks with an unmatched ``refine_attempted``.
-            # Re-raise to preserve asyncio cancellation propagation.
-            await self._emit_refine_failed(
-                session,
-                drift,
-                attempt_id=attempt_id,
-                failure_kind="cancelled",
-                reason=f"refine cancelled: {type(exc).__name__}",
-                detail=type(exc).__name__,
-            )
-            raise
-        finally:
-            self._active_session_var.reset(_active_session_token)
+        # Phase 3.5 (goldfive#271) tripwire wrapper — see §C4.
+        with _state_audit.cancellation_stash_audited(
+            "DefaultSteerer._promote_drift_to_steer.refine"
+        ):
+            try:
+                revised = await self._dispatch_goldfive_steer_refine(drift, session)
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "DefaultSteerer._promote_drift_to_steer: refine raised %s; "
+                    "plan unchanged",
+                    exc,
+                )
+                await self._emit_refine_failed(
+                    session,
+                    drift,
+                    attempt_id=attempt_id,
+                    failure_kind="llm_error",
+                    reason=str(exc),
+                    detail=type(exc).__name__,
+                )
+                await self._emit_refine_failure(session, drift, reason=str(exc))
+                await self._register_refine_failure(session, drift, counter_key)
+                return
+            except BaseException as exc:  # noqa: BLE001
+                # Phase 3.5 (CANCELLATION-CONTRACT.md §C4): ``CancelledError``
+                # bypasses the ``except Exception`` branch above. Emit the
+                # paired ``refine_failed`` so cancelled goldfive-steer refines
+                # do not leave sinks with an unmatched ``refine_attempted``.
+                # Re-raise to preserve asyncio cancellation propagation.
+                await self._emit_refine_failed(
+                    session,
+                    drift,
+                    attempt_id=attempt_id,
+                    failure_kind="cancelled",
+                    reason=f"refine cancelled: {type(exc).__name__}",
+                    detail=type(exc).__name__,
+                )
+                # Phase 3.5 tripwire compliance marker (§1.2 form).
+                _state_audit.mark_stash_completed()
+                raise
+            finally:
+                self._active_session_var.reset(_active_session_token)
         if revised is None:
             log.warning(
                 "DefaultSteerer._promote_drift_to_steer: refine returned None; "
@@ -4329,45 +4347,53 @@ class DefaultSteerer:
         # validator computes orphans, logs the WARNING, but no sink event
         # lands — exactly the symptom Bug A describes.
         _active_session_token = self._active_session_var.set(session)
-        try:
-            await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
+        # Phase 3.5 (goldfive#271) tripwire wrapper — see §C4. The
+        # ``except BaseException: stash; raise`` arm below is the
+        # compliance branch (CANCELLATION-CONTRACT.md §1.2).
+        with _state_audit.cancellation_stash_audited(
+            "DefaultSteerer.observe_refine"
+        ):
             try:
-                yield attempt_id
-            except Exception as exc:  # noqa: BLE001 — refine errors must not break observability
-                # Emit failure event with the same attempt_id so consumers
-                # can pair attempted ↔ failed. We do NOT swallow the
-                # exception — re-raise so the caller's existing error path
-                # (e.g. _emit_refine_failure / fallback plans) runs.
-                await self._emit_refine_failed(
-                    session,
-                    drift,
-                    attempt_id=attempt_id,
-                    failure_kind="llm_error",
-                    reason=str(exc),
-                    detail=type(exc).__name__,
-                )
-                raise
-            except BaseException as exc:  # noqa: BLE001
-                # Phase 3.5 (CANCELLATION-CONTRACT.md §C4): ``CancelledError``
-                # is a ``BaseException`` (not ``Exception``) since Py 3.8, so
-                # the ``except Exception`` branch above does NOT catch it. If
-                # a refine is cancelled mid-flight (e.g. ADK closes the
-                # runner, harness interrupts the loop) the paired
-                # ``refine_failed`` observability event would be skipped,
-                # leaving sinks with an unmatched ``refine_attempted``.
-                # Emit the pair-completing failure event AND re-raise so
-                # cancellation still propagates per the asyncio contract.
-                await self._emit_refine_failed(
-                    session,
-                    drift,
-                    attempt_id=attempt_id,
-                    failure_kind="cancelled",
-                    reason=f"refine cancelled: {type(exc).__name__}",
-                    detail=type(exc).__name__,
-                )
-                raise
-        finally:
-            self._active_session_var.reset(_active_session_token)
+                await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
+                try:
+                    yield attempt_id
+                except Exception as exc:  # noqa: BLE001 — refine errors must not break observability
+                    # Emit failure event with the same attempt_id so consumers
+                    # can pair attempted ↔ failed. We do NOT swallow the
+                    # exception — re-raise so the caller's existing error path
+                    # (e.g. _emit_refine_failure / fallback plans) runs.
+                    await self._emit_refine_failed(
+                        session,
+                        drift,
+                        attempt_id=attempt_id,
+                        failure_kind="llm_error",
+                        reason=str(exc),
+                        detail=type(exc).__name__,
+                    )
+                    raise
+                except BaseException as exc:  # noqa: BLE001
+                    # Phase 3.5 (CANCELLATION-CONTRACT.md §C4): ``CancelledError``
+                    # is a ``BaseException`` (not ``Exception``) since Py 3.8, so
+                    # the ``except Exception`` branch above does NOT catch it. If
+                    # a refine is cancelled mid-flight (e.g. ADK closes the
+                    # runner, harness interrupts the loop) the paired
+                    # ``refine_failed`` observability event would be skipped,
+                    # leaving sinks with an unmatched ``refine_attempted``.
+                    # Emit the pair-completing failure event AND re-raise so
+                    # cancellation still propagates per the asyncio contract.
+                    await self._emit_refine_failed(
+                        session,
+                        drift,
+                        attempt_id=attempt_id,
+                        failure_kind="cancelled",
+                        reason=f"refine cancelled: {type(exc).__name__}",
+                        detail=type(exc).__name__,
+                    )
+                    # Phase 3.5 tripwire compliance marker (§1.2 form).
+                    _state_audit.mark_stash_completed()
+                    raise
+            finally:
+                self._active_session_var.reset(_active_session_token)
 
     async def _emit_plan_revised_correlation(
         self,

--- a/tests/test_cancellation_stash_tripwire.py
+++ b/tests/test_cancellation_stash_tripwire.py
@@ -1,0 +1,321 @@
+"""Phase 3.5 component 2 (goldfive#271): the cancellation-stash tripwire.
+
+PR #290 added the :class:`goldfive._state_audit.CancellationStashViolation`
+exception class but deferred the runtime check. PR #307 landed the
+canonical ``CancelledError`` catch site at
+:meth:`ADKAdapter._invoke_internal`. Phase 3.5 component 2 (this PR)
+ties the two together: every audited stash-owning site listed in
+:doc:`docs/design/CANCELLATION-CONTRACT.md` §C1-C6 is wrapped in
+:func:`goldfive._state_audit.cancellation_stash_audited`, and the
+catch site invokes :func:`assert_stash_invariant` so a site that
+bypasses its compliance branch raises
+:class:`CancellationStashViolation` (a ``BaseException`` so
+``except Exception`` cannot swallow it).
+
+These tests exercise the tripwire itself with synthetic audited
+sites — the production C1-C5 instrumentation is exercised
+end-to-end by :file:`tests/test_cancellation_stash_audit.py`. Here
+we drive ``CancelledError`` at a synthetic ``await`` to verify:
+
+* a synthetic site that DOES call :func:`mark_stash_completed`
+  (compliant) lets the cancel propagate without raising the violation;
+* a synthetic site that does NOT call :func:`mark_stash_completed`
+  (bypass) raises :class:`CancellationStashViolation` chained onto
+  the original ``CancelledError`` as ``__cause__``;
+* the strict-mode default-off contract is preserved: with
+  ``GOLDFIVE_STRICT_STATE_OWNERSHIP=0`` the tripwire never fires
+  regardless of whether the audited site is compliant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from goldfive import _state_audit
+from goldfive._state_audit import (
+    CancellationStashViolation,
+    assert_stash_invariant,
+    cancellation_stash_audited,
+    mark_stash_completed,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture: ensure strict mode is the default for these tests, but let
+# individual tests opt out.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def strict_on() -> Iterator[None]:
+    """Force the tripwire ON for the duration of one test."""
+    prior = os.environ.get("GOLDFIVE_STRICT_STATE_OWNERSHIP")
+    os.environ["GOLDFIVE_STRICT_STATE_OWNERSHIP"] = "1"
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("GOLDFIVE_STRICT_STATE_OWNERSHIP", None)
+        else:
+            os.environ["GOLDFIVE_STRICT_STATE_OWNERSHIP"] = prior
+
+
+@pytest.fixture
+def strict_off() -> Iterator[None]:
+    """Force the tripwire OFF for the duration of one test."""
+    prior = os.environ.get("GOLDFIVE_STRICT_STATE_OWNERSHIP")
+    os.environ["GOLDFIVE_STRICT_STATE_OWNERSHIP"] = "0"
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("GOLDFIVE_STRICT_STATE_OWNERSHIP", None)
+        else:
+            os.environ["GOLDFIVE_STRICT_STATE_OWNERSHIP"] = prior
+
+
+# ---------------------------------------------------------------------------
+# Synthetic boundary helper — mimics _invoke_internal's CancelledError
+# catch arm without dragging in the full ADK adapter.
+# ---------------------------------------------------------------------------
+
+
+async def _run_with_boundary(coro_factory):
+    """Run ``coro_factory()`` inside a synthetic boundary.
+
+    Mirrors the catch site at
+    :meth:`ADKAdapter._invoke_internal`: catches ``CancelledError``,
+    invokes :func:`assert_stash_invariant` (chaining the cancel as
+    ``__cause__``), then re-raises whichever exception came out.
+    """
+    try:
+        return await coro_factory()
+    except asyncio.CancelledError as exc:
+        assert_stash_invariant(cause=exc)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — strict mode + bypass site → CancellationStashViolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bypass_site_under_strict_raises_violation(strict_on: None) -> None:
+    """Synthetic site that does NOT mark the stash-completion flag.
+
+    Drives ``CancelledError`` at the inner await; the audit context
+    manager's ``__exit__`` runs and pops the marker, but
+    :func:`mark_stash_completed` is never called. The boundary's
+    :func:`assert_stash_invariant` should observe the bypass and
+    raise :class:`CancellationStashViolation`.
+
+    Note the violation MUST be a :class:`BaseException` (not an
+    ``Exception``) so the existing ``try / except Exception``
+    blocks the audit was created to surface cannot swallow it. We
+    verify the ``isinstance`` shape explicitly.
+    """
+
+    async def bypass_call() -> None:
+        with cancellation_stash_audited("synthetic.bypass"):
+            try:
+                # Simulate a CancelledError raised by the inner
+                # ``await`` — the bug shape that motivated the
+                # contract: a broad ``except Exception`` lets
+                # ``CancelledError`` skate past, but no compliance
+                # branch (no ``finally`` calling
+                # ``mark_stash_completed``, no
+                # ``except BaseException: stash; raise``) ran.
+                raise asyncio.CancelledError("inner-await-cancelled")
+            except Exception:  # noqa: BLE001
+                # Broad catch that does NOT fire on CancelledError —
+                # this body is only here to mirror the bug shape.
+                pytest.fail(  # pragma: no cover — defensive
+                    "except Exception should not catch CancelledError"
+                )
+
+    with pytest.raises(CancellationStashViolation) as exc_info:
+        await _run_with_boundary(bypass_call)
+    # The violation MUST inherit from BaseException, not Exception —
+    # otherwise the defensive blocks the contract surfaces would
+    # swallow it silently.
+    assert isinstance(exc_info.value, BaseException)
+    assert not isinstance(exc_info.value, Exception)
+    # The original CancelledError is chained as __cause__ so the
+    # diagnostic preserves the trigger.
+    assert isinstance(exc_info.value.__cause__, asyncio.CancelledError)
+    # The site's name appears in the violation message.
+    assert "synthetic.bypass" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — strict mode + compliant site → no violation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compliant_site_under_strict_does_not_raise(strict_on: None) -> None:
+    """Synthetic site that DOES call :func:`mark_stash_completed`.
+
+    Mirrors the §1.2 ``except BaseException: stash; raise`` form. The
+    cancel propagates normally; no violation is raised.
+    """
+
+    async def compliant_call() -> None:
+        with cancellation_stash_audited("synthetic.compliant"):
+            try:
+                raise asyncio.CancelledError("inner-await-cancelled")
+            except BaseException:  # noqa: BLE001
+                # Compliance branch fires the marker BEFORE re-raising.
+                mark_stash_completed()
+                raise
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run_with_boundary(compliant_call)
+    # No violation raised; the original CancelledError surfaced
+    # cleanly (pytest.raises above caught CancelledError, not the
+    # tripwire).
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — strict mode + try/finally form → no violation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compliant_finally_form_under_strict_does_not_raise(
+    strict_on: None,
+) -> None:
+    """The §1.1 ``try / finally`` shape also satisfies the tripwire.
+
+    The marker fires from inside the ``finally`` block, regardless of
+    whether the await returned normally or raised ``CancelledError``.
+    """
+
+    async def compliant_call() -> None:
+        with cancellation_stash_audited("synthetic.try_finally"):
+            try:
+                raise asyncio.CancelledError("inner-await-cancelled")
+            finally:
+                # Compliance branch: stash + mark.
+                mark_stash_completed()
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run_with_boundary(compliant_call)
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — strict mode OFF: bypass site is silent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bypass_site_silent_under_strict_off(strict_off: None) -> None:
+    """With ``GOLDFIVE_STRICT_STATE_OWNERSHIP=0`` the tripwire never fires.
+
+    Mirrors the production default contract: deploys with the env var
+    unset (or set to 0/false/off) pay only one ContextVar read per
+    audited site enter/exit and never raise from
+    :func:`assert_stash_invariant`. Even an obviously bypassing site
+    (no compliance branch at all) must surface only the original
+    ``CancelledError`` — never the violation.
+    """
+    assert not _state_audit.is_enabled()
+
+    async def bypass_call() -> None:
+        with cancellation_stash_audited("synthetic.bypass.strict_off"):
+            raise asyncio.CancelledError("inner-await-cancelled")
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run_with_boundary(bypass_call)
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — strict mode OFF: compliant site is also silent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compliant_site_silent_under_strict_off(strict_off: None) -> None:
+    """Strict-off + compliant site → original CancelledError only.
+
+    Defensive symmetry test: the strict-off contract holds whether
+    the site is compliant or not.
+    """
+    assert not _state_audit.is_enabled()
+
+    async def compliant_call() -> None:
+        with cancellation_stash_audited("synthetic.compliant.strict_off"):
+            try:
+                raise asyncio.CancelledError("inner-await-cancelled")
+            except BaseException:
+                mark_stash_completed()
+                raise
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run_with_boundary(compliant_call)
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — nested audited sites: only the bypassing one is reported
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nested_sites_report_only_bypass(strict_on: None) -> None:
+    """Two audited sites stacked; outer is compliant, inner bypasses.
+
+    The violation message names the bypassing site only — the
+    compliant site already cleared its flag before the cancel
+    reached it. Verifies the marker stack tracks per-site flags
+    independently.
+    """
+
+    async def nested_call() -> None:
+        with cancellation_stash_audited("outer.compliant"):
+            try:
+                with cancellation_stash_audited("inner.bypass"):
+                    # Inner CancelledError — neither branch
+                    # marks the inner stash, so it bypasses.
+                    raise asyncio.CancelledError("inner")
+            except BaseException:
+                # Outer compliance fires before re-raise.
+                mark_stash_completed()
+                raise
+
+    with pytest.raises(CancellationStashViolation) as exc_info:
+        await _run_with_boundary(nested_call)
+    msg = str(exc_info.value)
+    assert "inner.bypass" in msg
+    # Outer was compliant — must NOT appear in the bypass list.
+    # (It can appear elsewhere in the message — the catch-site
+    # frame chain — but not in the "- name" bullet list.)
+    assert "- outer.compliant" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — non-cancel exceptions still propagate normally
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_normal_exception_does_not_trigger_tripwire(strict_on: None) -> None:
+    """Non-``CancelledError`` exceptions never reach the boundary's check.
+
+    The boundary catches only ``asyncio.CancelledError``; a plain
+    ``RuntimeError`` raised from inside an audited site flows through
+    its caller's normal exception handling without any tripwire
+    machinery firing.
+    """
+
+    async def raising_call() -> None:
+        with cancellation_stash_audited("synthetic.raises_runtime_error"):
+            raise RuntimeError("boom")
+
+    # The boundary helper only catches CancelledError, so the
+    # RuntimeError propagates directly — no tripwire involvement.
+    with pytest.raises(RuntimeError, match="boom"):
+        await _run_with_boundary(raising_call)


### PR DESCRIPTION
## Summary

- Closes the last piece of goldfive#271. PR #290 added the `CancellationStashViolation` `BaseException` class but deferred the runtime check; PR #307 landed the canonical `CancelledError` catch site at `ADKAdapter._invoke_internal`. This PR ties the two together with a contextvar-based marker stack.
- Every audited stash-owning site (CANCELLATION-CONTRACT.md §C1-C5) is now wrapped in `goldfive._state_audit.cancellation_stash_audited(name)`. The compliance branch calls `mark_stash_completed()` before exit / re-raise. The boundary at `_invoke_internal`'s `except asyncio.CancelledError` arm invokes `assert_stash_invariant(cause=...)` which walks the open-marker stack and raises `CancellationStashViolation` (chained on the original `CancelledError` as `__cause__`) for any site whose compliance flag is False.
- Default-off via the same `GOLDFIVE_STRICT_STATE_OWNERSHIP` env gate as `StateOwnershipViolation`. Production deploys pay one ContextVar push/pop per audited site enter/exit; the boundary check itself short-circuits when strict mode is off.

## Sites instrumented

| ID | Site | Form |
|---|---|---|
| C1 | `Runner.run` executor.run | `try/finally` (§1.1) |
| C2 | `ParallelDAGExecutor._refine` (observed + legacy) | `except BaseException: stash; raise` (§1.2) |
| C4 | `DefaultSteerer._handle_drift` / `_promote_drift_to_steer` / `observe_refine` | `except BaseException: stash; raise` (§1.2) |
| C5 | `reporting._handle_task_started.mark_task_running` | `try/finally` (§1.1) |

C3 was FIXED transitively via C4 (no direct site). C6 needed no instrumentation (sequence cursor advances before the await by construction).

## Pattern choice

Option B from the spec — per-site context manager that records a compliance flag — was chosen over Option A (static (file, function) catalog) because the audit catalog is small (5 instrumented sites), the marker model handles nested cancels cleanly, and the production code already had the compliance branches; only the marker calls needed to be added. The `_AuditedSite` context manager retains its marker on cancellation exit (flagged `exited=True`) so the boundary can inspect it; `mark_stash_completed()` only flags the innermost not-yet-exited marker so nested cancels never mis-attribute a parent's compliance branch to a child's retained marker.

## Test plan

- [x] `tests/test_cancellation_stash_tripwire.py` — 7 synthetic-site tests covering: bypass under strict raises violation; compliant under strict (both §1.1 and §1.2 forms) does not raise; strict-off never raises regardless of compliance; nested sites report only the bypassing one; non-cancel exceptions propagate without involving the tripwire.
- [x] `tests/test_cancellation_stash_audit.py` — existing end-to-end C1-C6 audit coverage continues to pass (7 tests).
- [x] `tests/test_state_audit.py` — existing state-ownership audit coverage continues to pass (11 tests).
- [x] Full suite: 1822 passed, 49 skipped.
- [x] `ruff check` clean on every touched file.