### PR TITLE
fix(judges,watcher): raise judge max_output_tokens to 16k + watcher to 30min for Qwen 3.5 thinking models (#271)

### DIFF
--- a/goldfive/_llm.py
+++ b/goldfive/_llm.py
@@ -99,6 +99,20 @@ def call_llm_budget(max_output_tokens: int | None) -> Iterator[None]:
     ``await call_llm(...)``. ``None`` resets to no-cap (default applied
     by the builders). Restores the prior value on exit even if the body
     raises.
+
+    Sizing note (Qwen 3.5 thinking models)
+    --------------------------------------
+    Qwen 3.5 thinking models combine ``<think>`` reasoning and the final
+    answer under a single ``max_output_tokens`` ceiling. A judge prompt
+    that returns a ~100-300 token JSON verdict still requires several
+    thousand tokens of reasoning headroom on the 35B variant; capping
+    at 2048 produced empty (``raw=''``) responses on v16 because the
+    model exhausted its budget inside the think block before emitting
+    a single JSON byte. Goldfive's consumer caps therefore budget 16k
+    (judges / reflective check / planner) or 8k (goal deriver) to
+    leave ample room for both the think prelude and the structured
+    answer. The wall-clock backstop lives in
+    :data:`goldfive.adapters._adk_plugin.DEFAULT_LLM_CALL_TIMEOUT_MS`.
     """
     token = MAX_OUTPUT_TOKENS_VAR.set(max_output_tokens)
     try:

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1453,12 +1453,14 @@ async def _inject_goldfive_planner_instruction(
 #: ADK LLM dispatch exceeds this budget, the plugin emits a CRITICAL
 #: ``LLM_CALL_TIMEOUT`` drift and flags the invocation for cancel so
 #: subsequent callbacks short-circuit. Set to ``0`` (or any negative
-#: int) to disable the watcher entirely. Default 120000ms (2 minutes)
-#: matches the user-visible spec on goldfive#271 — a Q4 model emitting
-#: at ~17 tok/sec for 2 min produces ~2000 tokens, which is more than
-#: enough headroom for legitimate large responses while bounding the
-#: 9.6-minute pathology observed in demo-v8.log.
-DEFAULT_LLM_CALL_TIMEOUT_MS: int = 120_000
+#: int) to disable the watcher entirely. Default 1800000ms (30 minutes)
+#: is the pathological-hang ceiling for slow local models on
+#: compute-bound generation (e.g. Qwen 35B on slide generation or
+#: multi-step research synthesis). The watcher's job is catching wedged
+#: invocations, not enforcing latency SLOs — operators who want a
+#: tighter SLO pass an explicit ``llm_call_timeout_ms`` to
+#: :func:`make_adk_plugin`.
+DEFAULT_LLM_CALL_TIMEOUT_MS: int = 1_800_000
 
 
 def _make_cancelled_llm_response() -> Any:
@@ -1537,7 +1539,9 @@ def make_adk_plugin(
     explosions (Qwen Q4 emitting 9961 completion tokens in 9.6 minutes,
     demo-v8.log) — without it a single bad turn can wedge the run for
     minutes. Set to ``0`` or any negative int to disable the watcher.
-    Default ``DEFAULT_LLM_CALL_TIMEOUT_MS`` (120000 / 2 minutes).
+    Default ``DEFAULT_LLM_CALL_TIMEOUT_MS`` (1800000 / 30 minutes) —
+    sized as the pathological-hang ceiling for slow local models on
+    compute-bound generation, not an SLO.
     """
     try:
         from google.adk.plugins.base_plugin import BasePlugin  # type: ignore

--- a/goldfive/drift/goals.py
+++ b/goldfive/drift/goals.py
@@ -61,9 +61,12 @@ GOAL_DRIFT_IDLE_SECONDS: int = 300
 
 # Per-callsite ``max_output_tokens`` budget (goldfive#271 follow-up).
 # The judge returns a small JSON verdict ({"progressing": bool, "reason":
-# "..."}); 2048 leaves room for thinking-token preludes on Q4 endpoints
-# without permitting unbounded essays.
-GOAL_DRIFT_MAX_OUTPUT_TOKENS: int = 2048
+# "..."}); 16384 covers Qwen 3.5 thinking-model preludes (think +
+# answer share the same ceiling) without permitting unbounded essays.
+# Empirical: v16 on Qwen 35B exhausted a 2048 budget inside ``<think>``
+# and returned ``raw=''``, so no drift fired — see ``call_llm_budget``
+# docstring for sizing rationale.
+GOAL_DRIFT_MAX_OUTPUT_TOKENS: int = 16384
 
 
 # Type alias for the async callable this classifier takes. Matches the

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -85,9 +85,13 @@ _TRUNCATE_SUFFIX: str = " … [truncated]"
 
 # Per-callsite ``max_output_tokens`` budget (goldfive#271 follow-up).
 # The judge returns a small JSON verdict ({"on_task": bool, "reason":
-# "...", "severity": "...", ...}); 2048 leaves room for thinking-token
-# preludes on Q4 endpoints without permitting unbounded essays.
-REASONING_JUDGE_MAX_OUTPUT_TOKENS: int = 2048
+# "...", "severity": "...", ...}); 16384 covers Qwen 3.5 thinking-model
+# preludes (think + answer share the same ceiling) without permitting
+# unbounded essays. Empirical: v16 on Qwen 35B exhausted a 2048 budget
+# inside ``<think>`` and returned ``raw=''``, so no drift fired and the
+# cascade never started — see ``call_llm_budget`` docstring for sizing
+# rationale.
+REASONING_JUDGE_MAX_OUTPUT_TOKENS: int = 16384
 
 
 def truncate_for_observability(text: str, limit: int) -> str:

--- a/goldfive/goal_deriver.py
+++ b/goldfive/goal_deriver.py
@@ -210,10 +210,12 @@ class LLMGoalDeriver:
     """
 
     # Per-callsite ``max_output_tokens`` budget (goldfive#271 follow-up).
-    # Goal extraction returns a small JSON object with one or two goals
-    # — 1024 tokens is generous and bounds wall-clock at ~60s on a
-    # Q4 endpoint.
-    MAX_OUTPUT_TOKENS: int = 1024
+    # Goal extraction returns a small JSON object with one or two goals,
+    # but Qwen 3.5 thinking models share think+answer under one ceiling
+    # — 8192 leaves headroom for the think prelude on the 35B variant
+    # without permitting unbounded essays. See ``call_llm_budget``
+    # docstring for sizing rationale.
+    MAX_OUTPUT_TOKENS: int = 8192
 
     def __init__(
         self,

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -963,14 +963,16 @@ class LLMPlanner:
 
     # Per-callsite ``max_output_tokens`` budget for the underlying
     # ``call_llm`` (goldfive#271 follow-up). All planner LLM calls return
-    # a JSON plan structure; 4096 covers typical refines and large
-    # multi-task generates while bounding wall-clock at ~4 minutes
-    # against a Q4 Qwen endpoint at ~17 tok/sec. Pre-fix evidence
-    # (demo-v8.log): unbounded → 9961-token / 9.6-minute calls.
+    # a JSON plan structure; 16384 covers typical refines and large
+    # multi-task generates while leaving ample headroom for Qwen 3.5
+    # thinking-model preludes (think + answer share the same ceiling).
+    # Pre-fix evidence (demo-v8.log): unbounded → 9961-token / 9.6-minute
+    # calls; the wall-clock backstop now lives in
+    # :data:`goldfive.adapters._adk_plugin.DEFAULT_LLM_CALL_TIMEOUT_MS`.
     # Subclasses may override; the value is read once per call into
     # :func:`goldfive._llm.call_llm_budget` so per-instance overrides
     # propagate without restart.
-    MAX_OUTPUT_TOKENS: int = 4096
+    MAX_OUTPUT_TOKENS: int = 16384
 
     def __init__(
         self,

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -1650,10 +1650,12 @@ class DefaultSteerer:
     )
 
     # Per-callsite ``max_output_tokens`` budget (goldfive#271 follow-up).
-    # The reflective check returns a small JSON verdict; 2048 covers
-    # thinking-token preludes on Q4 endpoints without permitting
-    # unbounded essays.
-    REFLECTIVE_MAX_OUTPUT_TOKENS: int = 2048
+    # The reflective check returns a small JSON verdict, but Qwen 3.5
+    # thinking models share think+answer under one ceiling — 16384
+    # covers the think prelude on the 35B variant without permitting
+    # unbounded essays. See
+    # :func:`goldfive._llm.call_llm_budget` docstring for sizing rationale.
+    REFLECTIVE_MAX_OUTPUT_TOKENS: int = 16384
 
     async def note_llm_call(self, session: Session) -> None:
         """Record one LLM invocation against ``session``.

--- a/tests/test_judge_token_caps.py
+++ b/tests/test_judge_token_caps.py
@@ -25,7 +25,6 @@ import pytest
 
 from goldfive._llm import get_max_output_tokens
 
-
 # ---------------------------------------------------------------------------
 # Constant pins — fail loudly if anyone halves the cap and reintroduces
 # the v16 / Qwen 35B empty-judge regression.

--- a/tests/test_judge_token_caps.py
+++ b/tests/test_judge_token_caps.py
@@ -1,0 +1,172 @@
+"""Judge token caps for Qwen 3.5 thinking models (goldfive#271 follow-up).
+
+Empirical context (v16 on Qwen 35B): the reasoning + goal-drift judges
+returned ``raw=''`` because Qwen 3.5 thinking models share ``<think>``
++ answer under one ``max_output_tokens`` ceiling. A 2048-token cap was
+exhausted inside the think block before any JSON was emitted, so
+goldfive's parser fell through to "no drift" and the cascade never
+fired.
+
+These tests pin the post-fix caps (16k for the judges / planner /
+reflective check, 8k for the goal deriver) AND assert each call site
+threads the cap through :func:`goldfive._llm.call_llm_budget` so a
+wrapping ``call_llm`` shim sees the per-callsite value.
+
+Each consumer's ``call_llm`` is replaced with a stub that captures
+``get_max_output_tokens()`` at the moment the judge dispatches. That is
+the only thing the underlying SDK builders ever see, so it is the only
+contract we need to pin — the actual SDK plumbing is exercised by
+:mod:`tests.test_llm_call_budget_integration`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from goldfive._llm import get_max_output_tokens
+
+
+# ---------------------------------------------------------------------------
+# Constant pins — fail loudly if anyone halves the cap and reintroduces
+# the v16 / Qwen 35B empty-judge regression.
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_judge_cap_is_16k():
+    from goldfive.drift.reasoning_judge import REASONING_JUDGE_MAX_OUTPUT_TOKENS
+
+    assert REASONING_JUDGE_MAX_OUTPUT_TOKENS == 16384
+
+
+def test_goal_drift_judge_cap_is_16k():
+    from goldfive.drift.goals import GOAL_DRIFT_MAX_OUTPUT_TOKENS
+
+    assert GOAL_DRIFT_MAX_OUTPUT_TOKENS == 16384
+
+
+def test_llm_planner_cap_is_16k():
+    from goldfive.planner import LLMPlanner
+
+    assert LLMPlanner.MAX_OUTPUT_TOKENS == 16384
+
+
+def test_reflective_check_cap_is_16k():
+    from goldfive.steerer import DefaultSteerer
+
+    assert DefaultSteerer.REFLECTIVE_MAX_OUTPUT_TOKENS == 16384
+
+
+def test_goal_deriver_cap_is_8k():
+    from goldfive.goal_deriver import LLMGoalDeriver
+
+    assert LLMGoalDeriver.MAX_OUTPUT_TOKENS == 8192
+
+
+# ---------------------------------------------------------------------------
+# Threading: each call site must set the ContextVar around its
+# ``await call_llm(...)``. We replace ``call_llm`` with a stub that
+# captures ``get_max_output_tokens()`` at invocation time and assert the
+# captured value matches the consumer's class-attribute cap.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reasoning_judge_threads_16k_budget():
+    """``classify_reasoning_drift`` must set ``call_llm_budget(16384)``
+    around its ``await call_llm(...)`` so a wrapping shim — which is
+    what ADK / OpenAI builders are — applies the cap to the SDK call."""
+    from goldfive.drift.reasoning_judge import (
+        REASONING_JUDGE_MAX_OUTPUT_TOKENS,
+        classify_reasoning_drift,
+    )
+    from goldfive.types import Task
+
+    seen_budgets: list[int] = []
+
+    async def stub_call_llm(system: str, user: str, model: str) -> str:
+        seen_budgets.append(get_max_output_tokens())
+        # Quiet-on-failure: an empty response means no drift emitted
+        # (matches the v16 / 35B observation), but the call itself
+        # still happened so we capture the budget.
+        return ""
+
+    drift = await classify_reasoning_drift(
+        reasoning="some reasoning to judge",
+        task=Task(id="t1", title="Ship the feature"),
+        goals=None,
+        model="x",
+        call_llm=stub_call_llm,
+    )
+    assert drift is None
+    assert seen_budgets == [REASONING_JUDGE_MAX_OUTPUT_TOKENS]
+    assert seen_budgets == [16384]
+
+
+@pytest.mark.asyncio
+async def test_goal_drift_judge_threads_16k_budget():
+    """``classify_goal_drift`` must set ``call_llm_budget(16384)``."""
+    from goldfive.drift.goals import (
+        GOAL_DRIFT_MAX_OUTPUT_TOKENS,
+        classify_goal_drift,
+    )
+    from goldfive.types import Goal
+
+    seen_budgets: list[int] = []
+
+    async def stub_call_llm(system: str, user: str, model: str) -> str:
+        seen_budgets.append(get_max_output_tokens())
+        return '{"progressing": true, "reason": "looks fine"}'
+
+    drift = await classify_goal_drift(
+        goals=[Goal(id="g1", summary="ship")],
+        plan=None,
+        observed_actions=[
+            {"kind": "tool_call", "agent_name": "agent", "detail": "ran a tool"}
+        ],
+        call_llm=stub_call_llm,
+        model="x",
+        run_id="r",
+        session_id="s",
+    )
+    assert drift is None  # progressing=True → no drift
+    assert seen_budgets == [GOAL_DRIFT_MAX_OUTPUT_TOKENS]
+    assert seen_budgets == [16384]
+
+
+@pytest.mark.asyncio
+async def test_planner_handle_turn_threads_16k_budget():
+    """``LLMPlanner.handle_turn`` must set ``call_llm_budget(16384)``."""
+    from goldfive.planner import LLMPlanner
+    from goldfive.types import Plan, Session
+
+    seen_budgets: list[int] = []
+
+    async def stub_call_llm(system: str, user: str, model: str) -> str:
+        seen_budgets.append(get_max_output_tokens())
+        return ""
+
+    planner = LLMPlanner(call_llm=stub_call_llm, model="x")
+    session = Session(run_id="r1")
+    session.plan = Plan.empty(run_id="r1")
+    result = await planner.handle_turn(user_input="hello", session=session)
+    assert result is None
+    assert seen_budgets == [LLMPlanner.MAX_OUTPUT_TOKENS]
+    assert seen_budgets == [16384]
+
+
+@pytest.mark.asyncio
+async def test_goal_deriver_threads_8k_budget():
+    """``LLMGoalDeriver.derive`` must set ``call_llm_budget(8192)``."""
+    from goldfive.goal_deriver import LLMGoalDeriver
+
+    seen_budgets: list[int] = []
+
+    async def stub_call_llm(system: str, user: str, model: str) -> str:
+        seen_budgets.append(get_max_output_tokens())
+        return '{"goals": [{"id": "g1", "summary": "test"}]}'
+
+    deriver = LLMGoalDeriver(stub_call_llm)
+    goals = await deriver.derive("hello world")
+    assert len(goals) == 1
+    assert seen_budgets == [LLMGoalDeriver.MAX_OUTPUT_TOKENS]
+    assert seen_budgets == [8192]

--- a/tests/test_llm_call_budget.py
+++ b/tests/test_llm_call_budget.py
@@ -91,34 +91,34 @@ def test_call_llm_budget_zero_or_negative_falls_back():
 # ---------------------------------------------------------------------------
 
 
-def test_llm_planner_cap_is_4096():
+def test_llm_planner_cap_is_16384():
     from goldfive.planner import LLMPlanner
 
-    assert LLMPlanner.MAX_OUTPUT_TOKENS == 4096
+    assert LLMPlanner.MAX_OUTPUT_TOKENS == 16384
 
 
-def test_llm_goal_deriver_cap_is_1024():
+def test_llm_goal_deriver_cap_is_8192():
     from goldfive.goal_deriver import LLMGoalDeriver
 
-    assert LLMGoalDeriver.MAX_OUTPUT_TOKENS == 1024
+    assert LLMGoalDeriver.MAX_OUTPUT_TOKENS == 8192
 
 
-def test_goal_drift_cap_is_2048():
+def test_goal_drift_cap_is_16384():
     from goldfive.drift.goals import GOAL_DRIFT_MAX_OUTPUT_TOKENS
 
-    assert GOAL_DRIFT_MAX_OUTPUT_TOKENS == 2048
+    assert GOAL_DRIFT_MAX_OUTPUT_TOKENS == 16384
 
 
-def test_reasoning_judge_cap_is_2048():
+def test_reasoning_judge_cap_is_16384():
     from goldfive.drift.reasoning_judge import REASONING_JUDGE_MAX_OUTPUT_TOKENS
 
-    assert REASONING_JUDGE_MAX_OUTPUT_TOKENS == 2048
+    assert REASONING_JUDGE_MAX_OUTPUT_TOKENS == 16384
 
 
-def test_reflective_check_cap_is_2048():
+def test_reflective_check_cap_is_16384():
     from goldfive.steerer import DefaultSteerer
 
-    assert DefaultSteerer.REFLECTIVE_MAX_OUTPUT_TOKENS == 2048
+    assert DefaultSteerer.REFLECTIVE_MAX_OUTPUT_TOKENS == 16384
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +169,7 @@ async def test_goal_deriver_threads_budget():
     goals = await deriver.derive("hello world")
     assert len(goals) == 1
     assert seen_budgets == [LLMGoalDeriver.MAX_OUTPUT_TOKENS]
-    assert seen_budgets == [1024]
+    assert seen_budgets == [8192]
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_call_timeout_watcher.py
+++ b/tests/test_llm_call_timeout_watcher.py
@@ -60,11 +60,12 @@ def _make_session_context(steerer: Any) -> Any:
     )
 
 
-def test_default_llm_call_timeout_is_120_seconds():
-    """120000 ms (2 min) is the user-spec default — generous enough for
-    legitimate long generations, tight enough to catch the 9.6-min Qwen
-    pathology."""
-    assert adk_plugin.DEFAULT_LLM_CALL_TIMEOUT_MS == 120_000
+def test_default_llm_call_timeout_is_30_minutes():
+    """1800000 ms (30 min) is the pathological-hang ceiling for slow
+    local models on compute-bound generation (Qwen 35B on slide
+    generation, multi-step research synthesis). Tight latency SLOs are
+    the operator's responsibility via ``llm_call_timeout_ms``."""
+    assert adk_plugin.DEFAULT_LLM_CALL_TIMEOUT_MS == 1_800_000
 
 
 def test_make_adk_plugin_accepts_llm_call_timeout_ms():


### PR DESCRIPTION
## Summary

Two related config issues exposed by v16 on Qwen 35B (thinking model):

**Issue A — judges return empty ``raw=''`` on Qwen 35B → no drift detection.** Reasoning + goal-drift judges observed off-topic content (their ``goldfive.input_preview`` span attribute confirms it) but returned ``raw=''`` because Qwen 3.5 thinking models share ``<think>`` + answer under one ``max_output_tokens`` ceiling. The 2048-token cap was exhausted inside the think block before any JSON was emitted. Goldfive's parser fell through to "no drift", the cascade never started, and the agent freely produced raccoon content.

**Issue B — LLM call wall-clock watcher too tight for slow local models.** ``DEFAULT_LLM_CALL_TIMEOUT_MS`` raised from 120000 (2 min) → 1800000 (30 min). The watcher's job is catching pathological hangs, not enforcing latency SLOs; 30 minutes is the right ceiling for slow local models on compute-bound generation. Operators wanting tighter SLOs pass an explicit ``llm_call_timeout_ms`` to ``make_adk_plugin``.

**Constant changes:**
- ``REASONING_JUDGE_MAX_OUTPUT_TOKENS``: 2048 → **16384**
- ``GOAL_DRIFT_MAX_OUTPUT_TOKENS``: 2048 → **16384**
- ``LLMPlanner.MAX_OUTPUT_TOKENS``: 4096 → **16384**
- ``DefaultSteerer.REFLECTIVE_MAX_OUTPUT_TOKENS``: 2048 → **16384**
- ``LLMGoalDeriver.MAX_OUTPUT_TOKENS``: 1024 → **8192**
- ``DEFAULT_LLM_CALL_TIMEOUT_MS``: 120000 → **1800000**

Sizing rationale documented in ``call_llm_budget`` docstring (Qwen 3.5 think+answer share one ceiling; judges return ~100-300 tokens of JSON but need several thousand of think headroom).

## Test plan

- [x] New ``tests/test_judge_token_caps.py``: each call site is asserted to set ``call_llm_budget()`` ContextVar, introspected via a stub ``call_llm`` capturing ``get_max_output_tokens()`` at invocation time (9 new test cases).
- [x] Existing ``tests/test_llm_call_budget.py`` updated to the new pinned values.
- [x] Existing ``tests/test_llm_call_timeout_watcher.py`` renamed default-timeout test from ``_120_seconds`` → ``_30_minutes``.
- [x] Full suite: **1864 passed, 49 skipped** under ``GOLDFIVE_STRICT_STATE_OWNERSHIP=1`` (no regressions).