### PR TITLE
fix(judges,planner): disable thinking on goldfive-internal LLM dispatches (#271 follow-up to #311)

### DIFF
--- a/goldfive/_llm.py
+++ b/goldfive/_llm.py
@@ -90,6 +90,83 @@ def get_max_output_tokens() -> int:
     return int(cap)
 
 
+# ---------------------------------------------------------------------------
+# Per-callsite "disable thinking" signal (goldfive#271 follow-up to #311)
+# ---------------------------------------------------------------------------
+#
+# Goldfive's judges / goal_deriver / planner refines ask small JSON-shaped
+# questions ("is this on-task?", "is the trajectory progressing?", "extract
+# the goal"). Running them through Qwen 3.5 / Gemini "thinking" mode wastes
+# the entire ``max_output_tokens`` ceiling on internal ``<think>`` reasoning
+# and leaves nothing for the JSON answer — the v16 / Qwen 35B failure mode
+# fixed by #311's 16k cap was the *symptom*; the *cause* is that judge
+# dispatches don't need thinking at all.
+#
+# Thinking mode is the user's model behaviour for their own agents
+# (coordinator / research / web_developer / ...) — we do NOT change that.
+# This ContextVar narrowly scopes "disable thinking" to goldfive's internal
+# meta-cognition dispatches. The default ADK / OpenAI builders read it and
+# attach the SDK-specific opt-out (``ThinkingConfig(thinking_budget=0)`` for
+# google.genai; ``extra_body={"enable_thinking": False}`` for Qwen-via-litellm
+# / OpenAI-compatible endpoints).
+
+#: ContextVar carrying the per-callsite disable-thinking flag. ``None`` /
+#: ``False`` means "use the model's natural thinking behaviour" — the
+#: default. ``True`` means "ask the SDK to suppress thinking for this
+#: dispatch".
+THINKING_DISABLED_VAR: contextvars.ContextVar[bool | None] = contextvars.ContextVar(
+    "goldfive_call_llm_thinking_disabled", default=None
+)
+
+
+def get_thinking_disabled() -> bool:
+    """Return whether the per-callsite disable-thinking signal is set.
+
+    ``False`` by default — agent-side LLM calls (coordinator / research /
+    web_developer / etc.) keep their natural thinking behaviour. The
+    judges / goal_deriver / planner refine call sites enter
+    :func:`call_llm_thinking_disabled` to flip this on for the duration
+    of a single ``await call_llm(...)``.
+    """
+    flag = THINKING_DISABLED_VAR.get()
+    return bool(flag)
+
+
+@contextmanager
+def call_llm_thinking_disabled() -> Iterator[None]:
+    """Disable thinking-mode on the ``call_llm`` dispatch inside the with-block.
+
+    Used by goldfive consumers that ask small JSON-shaped questions
+    (judges / goal_deriver / planner refine / reflective check) to avoid
+    burning the ``max_output_tokens`` budget on ``<think>`` reasoning
+    that nobody reads. Restores the prior value on exit even if the body
+    raises.
+
+    Reads + writes :data:`THINKING_DISABLED_VAR`. The default ADK and
+    OpenAI builders inspect ``get_thinking_disabled()`` and attach the
+    SDK-specific opt-out:
+
+    * ``google.genai.types.ThinkingConfig(include_thoughts=False,
+      thinking_budget=0)`` on ``GenerateContentConfig`` for ADK / Gemini.
+    * ``extra_body={"enable_thinking": False}`` on
+      ``client.chat.completions.create`` for Qwen via litellm / OpenAI-
+      compatible endpoints. Vendors that don't recognise the field
+      ignore it (we also include ``/no_think`` in the system prompt as a
+      Qwen-prompt-level fallback when the SDK shape doesn't accept the
+      kwarg).
+
+    User-supplied ``call_llm`` callables can opt in by reading
+    :func:`get_thinking_disabled` themselves; they are not required to.
+    The cost of ignoring it is "the model thinks anyway" — exactly the
+    pre-fix behaviour that wasted the token budget in v16 evidence.
+    """
+    token = THINKING_DISABLED_VAR.set(True)
+    try:
+        yield
+    finally:
+        THINKING_DISABLED_VAR.reset(token)
+
+
 @contextmanager
 def call_llm_budget(max_output_tokens: int | None) -> Iterator[None]:
     """Set :data:`MAX_OUTPUT_TOKENS_VAR` for the duration of the with-block.
@@ -169,7 +246,10 @@ __all__ = [
     "ClosableCallLLM",
     "DEFAULT_MAX_OUTPUT_TOKENS",
     "MAX_OUTPUT_TOKENS_VAR",
+    "THINKING_DISABLED_VAR",
     "call_llm_budget",
+    "call_llm_thinking_disabled",
     "get_max_output_tokens",
+    "get_thinking_disabled",
     "maybe_close_call_llm",
 ]

--- a/goldfive/_llm_detect.py
+++ b/goldfive/_llm_detect.py
@@ -113,9 +113,44 @@ def make_default_adk_call_llm(model: Any) -> CallLLM | None:
         # goldfive#271 follow-up — pre-fix evidence in demo-v8.log
         # showed unbounded calls reaching 9961 completion tokens (9.6
         # minutes wall) on a Qwen Q4 endpoint.
-        from goldfive._llm import get_max_output_tokens
+        from goldfive._llm import get_max_output_tokens, get_thinking_disabled
 
         max_output_tokens = get_max_output_tokens()
+        # Pull the per-callsite "disable thinking" signal (goldfive#271
+        # follow-up to #311). When goldfive's judges / goal_deriver /
+        # planner-refine dispatch through this builder they enter
+        # :func:`goldfive._llm.call_llm_thinking_disabled` first, which
+        # flips this flag on. We then attach
+        # ``ThinkingConfig(include_thoughts=False, thinking_budget=0)``
+        # to the genai config so the SDK suppresses the ``<think>``
+        # prelude entirely. Without this, the 16k cap from #311 ends up
+        # spent inside ``<think>`` and the JSON answer comes back
+        # truncated — the cause v16 was failing for, not the symptom
+        # #311 patched.
+        thinking_disabled = get_thinking_disabled()
+        thinking_config: Any = None
+        if thinking_disabled:
+            try:
+                thinking_config = genai_types.ThinkingConfig(
+                    include_thoughts=False,
+                    thinking_budget=0,
+                )
+            except Exception as exc:  # noqa: BLE001
+                # Older google.genai shapes may not expose ThinkingConfig.
+                # Fall through silently — the model just keeps thinking,
+                # the same as it did before this fix.
+                log.debug(
+                    "goldfive._llm_detect: ThinkingConfig unavailable (%s); "
+                    "continuing without thinking-disabled hint",
+                    exc,
+                )
+                thinking_config = None
+        config_kwargs: dict[str, Any] = {
+            "system_instruction": system,
+            "max_output_tokens": max_output_tokens,
+        }
+        if thinking_config is not None:
+            config_kwargs["thinking_config"] = thinking_config
         req = LlmRequest(
             contents=[
                 genai_types.Content(
@@ -123,23 +158,49 @@ def make_default_adk_call_llm(model: Any) -> CallLLM | None:
                     parts=[genai_types.Part(text=user)],
                 ),
             ],
-            config=genai_types.GenerateContentConfig(
-                system_instruction=system,
-                max_output_tokens=max_output_tokens,
-            ),
+            config=genai_types.GenerateContentConfig(**config_kwargs),
         )
         chunks: list[str] = []
+        # Diagnostic counters (goldfive#271 follow-up to #311). When the
+        # final answer text comes back empty AND we received only
+        # ``thought=True`` parts, we want to surface "model returned all
+        # thinking, no answer" rather than the indistinguishable
+        # ``raw=''`` that caused two days of misdiagnosis. Counted on
+        # every dispatch so observability is symmetric (success and
+        # failure both expose the same shape).
+        thought_part_count = 0
+        answer_part_count = 0
         async for resp in llm.generate_content_async(req, stream=False):
             content = getattr(resp, "content", None)
             if content is None:
                 continue
             for part in getattr(content, "parts", None) or ():
                 if getattr(part, "thought", False):
+                    thought_part_count += 1
                     continue
                 text = getattr(part, "text", "") or ""
                 if text:
+                    answer_part_count += 1
                     chunks.append(str(text))
-        return "".join(chunks).strip()
+        result = "".join(chunks).strip()
+        # Stash the part counts on the function so the caller's span /
+        # log path can surface "empty answer (N thought parts)" instead
+        # of just ``raw=''``. Closure-attached so we don't need to break
+        # the ``(system, user, model) -> str`` contract. Read by the
+        # judge call sites via ``getattr(call_llm, 'last_thought_count', 0)``.
+        _call_llm.last_thought_count = thought_part_count  # type: ignore[attr-defined]
+        _call_llm.last_answer_count = answer_part_count  # type: ignore[attr-defined]
+        if not result and thought_part_count > 0:
+            log.info(
+                "goldfive._llm_detect._call_llm: model returned %d thought "
+                "part(s), %d answer part(s), answer text empty — check "
+                "thinking-mode config or max_output_tokens (the model spent "
+                "its budget thinking and emitted no answer). Goldfive's "
+                "judges should run with call_llm_thinking_disabled() entered.",
+                thought_part_count,
+                answer_part_count,
+            )
+        return result
 
     async def _close() -> None:
         # ADK's BaseLlm doesn't pin a uniform close protocol, but several
@@ -207,9 +268,7 @@ def detect_llm(agent: Any) -> tuple[CallLLM, str] | None:
         call_llm = make_default_adk_call_llm(model)
         if call_llm is None:
             return None
-        model_name = getattr(model, "model", None) or (
-            model if isinstance(model, str) else ""
-        )
+        model_name = getattr(model, "model", None) or (model if isinstance(model, str) else "")
         return call_llm, str(model_name or "")
     except Exception as exc:  # noqa: BLE001
         log.warning(

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -72,8 +72,7 @@ def _build_judge_call_llm(config: JudgeConfig) -> tuple[CallLLM, str] | None:
         from openai import AsyncOpenAI  # type: ignore[import-not-found]
     except Exception as exc:  # noqa: BLE001
         log.debug(
-            "goldfive.wrap: openai SDK not importable for JudgeConfig "
-            "(base_url=%r): %s",
+            "goldfive.wrap: openai SDK not importable for JudgeConfig (base_url=%r): %s",
             base_url,
             exc,
         )
@@ -109,21 +108,84 @@ def _build_judge_call_llm(config: JudgeConfig) -> tuple[CallLLM, str] | None:
         # large enough for plan refines while bounding the worst case
         # under typical Q4 throughput. Pre-fix: unbounded → 9961-token
         # responses (goldfive#271 demo-v8.log).
-        from goldfive._llm import get_max_output_tokens
+        from goldfive._llm import get_max_output_tokens, get_thinking_disabled
 
-        resp = await client.chat.completions.create(
-            model=effective_model,
-            messages=[
-                {"role": "system", "content": system},
+        # Pull the per-callsite "disable thinking" signal (goldfive#271
+        # follow-up to #311). When goldfive's judges / goal_deriver /
+        # planner-refine dispatch we set ``enable_thinking=False`` via
+        # ``extra_body`` (the Qwen-via-litellm convention) AND prepend
+        # ``/no_think`` to the system prompt as a model-prompt-level
+        # fallback. Vendors that don't recognise the kwarg drop it
+        # server-side; vendors that don't recognise ``/no_think`` ignore
+        # the line. Belt-and-suspenders so a misconfigured endpoint
+        # still exits the think prelude.
+        thinking_disabled = get_thinking_disabled()
+        effective_system = system
+        extra_body: dict[str, Any] = {}
+        if thinking_disabled:
+            extra_body["enable_thinking"] = False
+            # ``/no_think`` is the Qwen prompt-level toggle. Cheap to
+            # include for non-Qwen models — they treat it as ordinary
+            # text and ignore it.
+            if "/no_think" not in (system or ""):
+                effective_system = f"/no_think\n{system}" if system else "/no_think"
+
+        create_kwargs: dict[str, Any] = {
+            "model": effective_model,
+            "messages": [
+                {"role": "system", "content": effective_system},
                 {"role": "user", "content": user},
             ],
-            max_tokens=get_max_output_tokens(),
-        )
+            "max_tokens": get_max_output_tokens(),
+        }
+        if extra_body:
+            create_kwargs["extra_body"] = extra_body
+        try:
+            resp = await client.chat.completions.create(**create_kwargs)
+        except TypeError as exc:
+            # Older OpenAI client versions don't accept ``extra_body``.
+            # Retry without it — the ``/no_think`` system-prompt prefix
+            # still does its job for Qwen. Other TypeErrors are real
+            # failures; fall through.
+            if "extra_body" not in create_kwargs:
+                raise
+            log.debug(
+                "goldfive.wrap: AsyncOpenAI rejected extra_body=%r (%s); retrying without it",
+                extra_body,
+                exc,
+            )
+            create_kwargs.pop("extra_body", None)
+            resp = await client.chat.completions.create(**create_kwargs)
         try:
             content = resp.choices[0].message.content or ""
         except Exception:  # noqa: BLE001
             return ""
-        return str(content)
+        # Diagnostic for empty-content + non-empty reasoning_content
+        # (the OpenAI-compatible analogue of "all-thought, no-answer").
+        # Qwen-via-litellm returns reasoning text on a sibling field
+        # (``reasoning_content``); when ``content == ""`` but reasoning
+        # is present, the model spent its budget thinking and produced
+        # no answer. Surface this rather than letting the parser see an
+        # indistinguishable empty string.
+        result = str(content)
+        reasoning_content = ""
+        try:
+            reasoning_content = getattr(resp.choices[0].message, "reasoning_content", "") or ""
+        except Exception:  # noqa: BLE001
+            reasoning_content = ""
+        _call_llm.last_thought_count = (  # type: ignore[attr-defined]
+            1 if reasoning_content else 0
+        )
+        _call_llm.last_answer_count = 1 if result else 0  # type: ignore[attr-defined]
+        if not result and reasoning_content:
+            log.info(
+                "goldfive.wrap._build_judge_call_llm: model returned "
+                "reasoning_content (%d chars) with empty content — check "
+                "thinking-mode config or max_output_tokens (the model spent "
+                "its budget thinking and emitted no answer).",
+                len(reasoning_content),
+            )
+        return result
 
     async def _close() -> None:
         for attr_name in ("aclose", "close"):
@@ -305,9 +367,7 @@ def wrap(
     # reasoning-drift module is installed later inside ``DefaultSteerer``
     # when the steerer-default branch runs (so callers who pass their
     # own ``steerer=`` can make their own installation decisions).
-    resolved_runtime: RuntimeConfig = (
-        runtime if runtime is not None else RuntimeConfig.from_env()
-    )
+    resolved_runtime: RuntimeConfig = runtime if runtime is not None else RuntimeConfig.from_env()
     from goldfive.drift import _embed as _embed_module
     from goldfive.drift import reasoning as _reasoning_module
     from goldfive.drift import tool_loops as _tool_loops_module

--- a/goldfive/drift/goals.py
+++ b/goldfive/drift/goals.py
@@ -303,40 +303,48 @@ async def classify_goal_drift(
             input_preview=activity_block,
         ) as span:
             # Bound the dispatch — see ``GOAL_DRIFT_MAX_OUTPUT_TOKENS``.
-            from goldfive._llm import call_llm_budget
+            # Also disable thinking (goldfive#271 follow-up to #311):
+            # this is meta-cognition asking a small JSON progress
+            # question, not deep reasoning. See `call_llm_thinking_disabled`
+            # docstring for why we don't want to share the 16k cap with
+            # ``<think>`` reasoning here.
+            from goldfive._llm import call_llm_budget, call_llm_thinking_disabled
 
-            with call_llm_budget(GOAL_DRIFT_MAX_OUTPUT_TOKENS):
+            with call_llm_budget(GOAL_DRIFT_MAX_OUTPUT_TOKENS), call_llm_thinking_disabled():
                 raw = await call_llm(system, user, model)
             # Parse inside the with-block so span.decision_summary /
             # output_preview see the verdict before the End emission.
             parsed = _parse_response(raw)
             if parsed is None:
-                span.output_preview = "(unparseable verdict)"
-                span.decision_summary = (
-                    "judged trajectory: unparseable verdict (no drift emitted)"
-                )
+                # Distinguish "model returned all thinking, no answer"
+                # from "model returned garbage". The default ADK /
+                # OpenAI builders stash part counts on the call_llm
+                # closure; surface them when the raw text is empty.
+                _thought_n = int(getattr(call_llm, "last_thought_count", 0) or 0)
+                _raw_str = raw if isinstance(raw, str) else ""
+                if not _raw_str.strip() and _thought_n > 0:
+                    span.output_preview = (
+                        f"empty answer ({_thought_n} thought part(s); "
+                        f"the model spent its budget thinking and emitted "
+                        f"no JSON)"
+                    )
+                else:
+                    span.output_preview = "(unparseable verdict)"
+                span.decision_summary = "judged trajectory: unparseable verdict (no drift emitted)"
             else:
                 progressing_inline = parsed.get("progressing")
                 reason_inline = str(parsed.get("reason", "") or "").strip()
                 if isinstance(progressing_inline, bool):
                     span.output_preview = (
-                        f"progressing={progressing_inline}, "
-                        f"reason={reason_inline or '(none)'}"
+                        f"progressing={progressing_inline}, reason={reason_inline or '(none)'}"
                     )
-                    progressing_str = (
-                        "on-track" if progressing_inline else "off-track"
-                    )
-                    span.decision_summary = (
-                        f"judged trajectory: {progressing_str}"
-                        + (f" ({reason_inline})" if reason_inline else "")
+                    progressing_str = "on-track" if progressing_inline else "off-track"
+                    span.decision_summary = f"judged trajectory: {progressing_str}" + (
+                        f" ({reason_inline})" if reason_inline else ""
                     )
                 else:
-                    span.output_preview = (
-                        f"missing boolean 'progressing'; raw={parsed!r}"
-                    )
-                    span.decision_summary = (
-                        "judged trajectory: verdict missing 'progressing'"
-                    )
+                    span.output_preview = f"missing boolean 'progressing'; raw={parsed!r}"
+                    span.decision_summary = "judged trajectory: verdict missing 'progressing'"
     except Exception as exc:  # noqa: BLE001 - never break the run
         log.warning("classify_goal_drift: call_llm raised %s; no drift emitted", exc)
         return None
@@ -361,8 +369,7 @@ async def classify_goal_drift(
     progressing = parsed.get("progressing")
     if not isinstance(progressing, bool):
         log.debug(
-            "classify_goal_drift: parsed=%r lacks boolean 'progressing' key; "
-            "no drift emitted",
+            "classify_goal_drift: parsed=%r lacks boolean 'progressing' key; no drift emitted",
             parsed,
         )
         return None

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -550,9 +550,14 @@ async def classify_reasoning_drift_with_focus(
             target_task_id=current_task_id,
         ) as span:
             # Bound the dispatch — see ``REASONING_JUDGE_MAX_OUTPUT_TOKENS``.
-            from goldfive._llm import call_llm_budget
+            # Also disable thinking (goldfive#271 follow-up to #311):
+            # this is meta-cognition asking a small JSON question, not
+            # deep reasoning. Letting the model burn the 16k budget on
+            # ``<think>`` was the v16 / Qwen 35B failure mode — the cap
+            # bump was the symptom-fix, this is the cause-fix.
+            from goldfive._llm import call_llm_budget, call_llm_thinking_disabled
 
-            with call_llm_budget(REASONING_JUDGE_MAX_OUTPUT_TOKENS):
+            with call_llm_budget(REASONING_JUDGE_MAX_OUTPUT_TOKENS), call_llm_thinking_disabled():
                 raw = await call_llm(system, user, model)
             # Parse inside the with-block so we can stamp
             # decision-context onto the span before the End event fires
@@ -567,9 +572,7 @@ async def classify_reasoning_drift_with_focus(
                     on_task_parsed = on_task_raw
                     reason = str(parsed.get("reason", "") or "").strip()
                     if not on_task_raw:
-                        severity_str = _severity_from_verdict(
-                            parsed.get("severity")
-                        ).value.lower()
+                        severity_str = _severity_from_verdict(parsed.get("severity")).value.lower()
                 # Extended attribution fields — extracted regardless of
                 # the on_task verdict. The judge can name a focused
                 # task whether or not it considers the reasoning on the
@@ -586,9 +589,7 @@ async def classify_reasoning_drift_with_focus(
                     focus_confidence_parsed = 0.0
                 # Clamp to [0.0, 1.0]; the prompt asks for 0.0-1.0 but
                 # we don't trust the LLM not to drift outside.
-                focus_confidence_parsed = max(
-                    0.0, min(1.0, focus_confidence_parsed)
-                )
+                focus_confidence_parsed = max(0.0, min(1.0, focus_confidence_parsed))
                 intent_raw = parsed.get("stated_intent", "")
                 if isinstance(intent_raw, str):
                     stated_intent_parsed = intent_raw.strip()
@@ -596,9 +597,22 @@ async def classify_reasoning_drift_with_focus(
             # verdict so harmonograf can render "judged agent/task:
             # on-task" inline.
             if on_task_parsed is None:
-                span.output_preview = (
-                    f"unparseable verdict; raw={raw_str_inline[:200]!r}"
-                )
+                # Distinguish "model returned all thinking, no answer"
+                # from "model returned garbage" (goldfive#271 follow-up
+                # to #311). The default ADK / OpenAI builders stash the
+                # part counts on the call_llm closure; when the answer
+                # is empty AND we saw ``thought=True`` parts the
+                # diagnostic should say so rather than show an
+                # indistinguishable ``raw=''``.
+                _thought_n = int(getattr(call_llm, "last_thought_count", 0) or 0)
+                if not raw_str_inline.strip() and _thought_n > 0:
+                    span.output_preview = (
+                        f"empty answer ({_thought_n} thought part(s); "
+                        f"the model spent its budget thinking and emitted "
+                        f"no JSON)"
+                    )
+                else:
+                    span.output_preview = f"unparseable verdict; raw={raw_str_inline[:200]!r}"
                 span.decision_summary = (
                     f"reasoning-judge call on "
                     f"{current_agent_id or '(no-agent)'}"
@@ -615,9 +629,7 @@ async def classify_reasoning_drift_with_focus(
                     verdict_str = "on-task"
                 else:
                     verdict_str = (
-                        f"off-task ({severity_str.upper()})"
-                        if severity_str
-                        else "off-task"
+                        f"off-task ({severity_str.upper()})" if severity_str else "off-task"
                     )
                 span.decision_summary = (
                     f"judged {current_agent_id or '(no-agent)'}'s reasoning "
@@ -640,15 +652,13 @@ async def classify_reasoning_drift_with_focus(
         )
     if parsed is None and not call_failed:
         log.debug(
-            "classify_reasoning_drift: response was not JSON (raw=%r); "
-            "no drift emitted",
+            "classify_reasoning_drift: response was not JSON (raw=%r); no drift emitted",
             raw_str[:200],
         )
     elif parsed is not None:
         if on_task_parsed is None:
             log.debug(
-                "classify_reasoning_drift: parsed=%r lacks boolean 'on_task' "
-                "key; no drift emitted",
+                "classify_reasoning_drift: parsed=%r lacks boolean 'on_task' key; no drift emitted",
                 parsed,
             )
         elif on_task_parsed:
@@ -696,7 +706,9 @@ async def classify_reasoning_drift_with_focus(
             elapsed_ms=elapsed_ms,
             reasoning_input=reasoning,
             raw_response=raw_str,
-            on_task=bool(on_task_parsed) if on_task_parsed is not None else True
+            on_task=bool(on_task_parsed)
+            if on_task_parsed is not None
+            else True
             if drift is None
             else False,
             severity=severity_str,
@@ -763,7 +775,6 @@ async def _emit_judge_invoked(
         await sink.emit(evt)
     except Exception as exc:  # noqa: BLE001 - observability must never break
         log.warning(
-            "classify_reasoning_drift: sink.emit raised %s; "
-            "ReasoningJudgeInvoked dropped",
+            "classify_reasoning_drift: sink.emit raised %s; ReasoningJudgeInvoked dropped",
             exc,
         )

--- a/goldfive/goal_deriver.py
+++ b/goldfive/goal_deriver.py
@@ -149,9 +149,7 @@ def _coerce_goals(goals: str | list[str] | list[Goal]) -> list[Goal]:
             out.append(item)
         elif isinstance(item, str):
             if not item.strip():
-                raise ValueError(
-                    f"PassthroughGoalDeriver: empty summary string at index {i - 1}"
-                )
+                raise ValueError(f"PassthroughGoalDeriver: empty summary string at index {i - 1}")
             out.append(Goal(id=f"g{i}", summary=item))
         else:
             raise TypeError(
@@ -280,9 +278,16 @@ class LLMGoalDeriver:
                 input_preview=user_input,
             ) as span:
                 # Bound the dispatch — see ``LLMGoalDeriver.MAX_OUTPUT_TOKENS``.
-                from goldfive._llm import call_llm_budget
+                # Also disable thinking (goldfive#271 follow-up to #311):
+                # goal extraction is a small JSON dispatch ("what is the
+                # user asking for?"), not deep reasoning. Sharing the 8k
+                # cap with ``<think>`` produced empty responses in v16.
+                from goldfive._llm import call_llm_budget, call_llm_thinking_disabled
 
-                with call_llm_budget(self.MAX_OUTPUT_TOKENS):
+                with (
+                    call_llm_budget(self.MAX_OUTPUT_TOKENS),
+                    call_llm_thinking_disabled(),
+                ):
                     raw = await self._call_llm(self._system_prompt, prompt, self._model)
                 try:
                     parsed_goals = _parse_goals_response(raw)
@@ -292,16 +297,13 @@ class LLMGoalDeriver:
                         f"raw={raw[:200] if isinstance(raw, str) else '(non-str)'}"
                     )
                     span.decision_summary = (
-                        "goal-derive failed to parse LLM response; "
-                        "fell back to passthrough goal"
+                        "goal-derive failed to parse LLM response; fell back to passthrough goal"
                     )
                     raise
                 if parsed_goals:
                     goals = parsed_goals
                     parsed_ok = True
-                    titles = [
-                        (g.summary or g.id or "(no-summary)") for g in goals
-                    ]
+                    titles = [(g.summary or g.id or "(no-summary)") for g in goals]
                     span.output_preview = "goals=[" + ", ".join(titles) + "]"
                     span.decision_summary = (
                         f"derived {len(goals)} goal"
@@ -311,13 +313,11 @@ class LLMGoalDeriver:
                 else:
                     span.output_preview = "goals=[]"
                     span.decision_summary = (
-                        "goal-derive returned zero goals; "
-                        "fell back to passthrough goal"
+                        "goal-derive returned zero goals; fell back to passthrough goal"
                     )
         except Exception as e:  # pragma: no cover - exercised via tests w/ stub
             logger.warning(
-                "LLMGoalDeriver: call_llm or parse raised %s; "
-                "falling back to passthrough goal",
+                "LLMGoalDeriver: call_llm or parse raised %s; falling back to passthrough goal",
                 e,
             )
             return [Goal(id="g1", summary=user_input)]
@@ -346,9 +346,7 @@ class LLMGoalDeriver:
             except (TypeError, ValueError):
                 ctx_json = str(context)
             parts.append(f"Context:\n{ctx_json}")
-        parts.append(
-            'Return JSON: {"goals": [{"id": "g1", "summary": "..."}, ...]}.'
-        )
+        parts.append('Return JSON: {"goals": [{"id": "g1", "summary": "..."}, ...]}.')
         return "\n\n".join(parts)
 
 

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -447,7 +447,7 @@ still as a complete JSON plan, not an empty object).
 # path that can reshape the plan in response to a drift.
 _REFINEMENT_GUIDANCE_BLOCK = (
     "REFINEMENT GUIDANCE:\n"
-    "- The drift you're correcting is usually \"small\" — a single "
+    '- The drift you\'re correcting is usually "small" — a single '
     "agent produced off-topic or flawed output on a task it's "
     "otherwise capable of. Default pattern: replace the drifted task "
     "with a corrected variant, KEEP THE SAME `assignee_agent_id`, "
@@ -711,9 +711,7 @@ def _check_supersedes_coverage(
         return []
     new_ids = {t.id for t in revised.tasks if t.id}
     supersedes_targets = {
-        (t.supersedes or "").strip()
-        for t in revised.tasks
-        if (t.supersedes or "").strip()
+        (t.supersedes or "").strip() for t in revised.tasks if (t.supersedes or "").strip()
     }
     orphans: list[Task] = []
     for old in prior.tasks:
@@ -1038,9 +1036,7 @@ class LLMPlanner:
         """
         self._drift_emitter = emitter
 
-    def set_span_context_provider(
-        self, provider: Callable[[], Any] | None
-    ) -> None:
+    def set_span_context_provider(self, provider: Callable[[], Any] | None) -> None:
         """Install (or remove) the callable that supplies span-emission context.
 
         The callable is invoked at every ``call_llm`` site to snapshot
@@ -1115,10 +1111,7 @@ class LLMPlanner:
         tasks = getattr(plan, "tasks", None) or []
         plan_line = f"current plan: rev{plan.revision_index}, {len(tasks)} task(s)"
         if tasks:
-            titles = [
-                f"{t.id} ({str(getattr(t, 'status', '') or '').lower()})"
-                for t in tasks[:8]
-            ]
+            titles = [f"{t.id} ({str(getattr(t, 'status', '') or '').lower()})" for t in tasks[:8]]
             plan_line += ": " + ", ".join(titles)
         parts.append(plan_line)
         return "\n".join(parts)
@@ -1132,11 +1125,7 @@ class LLMPlanner:
             f"tasks={len(tasks)}",
         ]
         assignees = sorted(
-            {
-                str(t.assignee_agent_id or "")
-                for t in tasks
-                if getattr(t, "assignee_agent_id", "")
-            }
+            {str(t.assignee_agent_id or "") for t in tasks if getattr(t, "assignee_agent_id", "")}
         )
         if assignees:
             parts.append("assignees=[" + ", ".join(assignees) + "]")
@@ -1822,8 +1811,7 @@ class LLMPlanner:
             from goldfive.events import emit, make_event  # noqa: PLC0415 — lazy
         except Exception as exc:  # noqa: BLE001
             log.debug(
-                "LLMPlanner: events module unavailable; dropping "
-                "refine_orphaned_tasks signal (%s)",
+                "LLMPlanner: events module unavailable; dropping refine_orphaned_tasks signal (%s)",
                 exc,
             )
             return
@@ -1847,8 +1835,7 @@ class LLMPlanner:
             seq = seq_fn()
         except Exception as exc:  # noqa: BLE001
             log.debug(
-                "LLMPlanner: sequence_fn raised; dropping "
-                "refine_orphaned_tasks signal (%s)",
+                "LLMPlanner: sequence_fn raised; dropping refine_orphaned_tasks signal (%s)",
                 exc,
             )
             return
@@ -1863,8 +1850,7 @@ class LLMPlanner:
             await emit(list(sinks), evt)
         except Exception as exc:  # noqa: BLE001
             log.warning(
-                "LLMPlanner: failed to emit refine_orphaned_tasks event "
-                "(%s); dropping signal",
+                "LLMPlanner: failed to emit refine_orphaned_tasks event (%s); dropping signal",
                 exc,
             )
 
@@ -1937,13 +1923,21 @@ class LLMPlanner:
                     # Cap the underlying LLM dispatch so a runaway
                     # generation (Qwen Q4 thinking-token explosion)
                     # cannot wedge the run for minutes. See
-                    # ``LLMPlanner.MAX_OUTPUT_TOKENS``.
-                    from goldfive._llm import call_llm_budget
+                    # ``LLMPlanner.MAX_OUTPUT_TOKENS``. Also disable
+                    # thinking (goldfive#271 follow-up to #311): refine
+                    # is a structured JSON revision call, not deep
+                    # reasoning — burning 16k on ``<think>`` produced
+                    # empty responses in v16 evidence.
+                    from goldfive._llm import (
+                        call_llm_budget,
+                        call_llm_thinking_disabled,
+                    )
 
-                    with call_llm_budget(self.MAX_OUTPUT_TOKENS):
-                        raw = await self._call_llm(
-                            system_prompt, user_prompt, self._model
-                        )
+                    with (
+                        call_llm_budget(self.MAX_OUTPUT_TOKENS),
+                        call_llm_thinking_disabled(),
+                    ):
+                        raw = await self._call_llm(system_prompt, user_prompt, self._model)
                     span.output_preview = (
                         raw[:4096] if isinstance(raw, str) else "(non-str response)"
                     )
@@ -2262,9 +2256,7 @@ class LLMPlanner:
         user_request = ""
         if context is not None:
             user_request = str(context.get("user_request") or "")
-        goal_lines = [
-            f"- [{g.id or '(no-id)'}] {g.summary or '(no summary)'}" for g in goals
-        ]
+        goal_lines = [f"- [{g.id or '(no-id)'}] {g.summary or '(no summary)'}" for g in goals]
         generate_input_preview = (
             (f"user_request: {user_request}\n\n" if user_request else "")
             + "goals:\n"
@@ -2281,12 +2273,18 @@ class LLMPlanner:
                     input_preview=generate_input_preview,
                 ) as span:
                     # Bound the dispatch — see ``LLMPlanner.MAX_OUTPUT_TOKENS``.
-                    from goldfive._llm import call_llm_budget
+                    # Disable thinking — plan_generate emits structured
+                    # JSON describing tasks, not deep reasoning.
+                    from goldfive._llm import (
+                        call_llm_budget,
+                        call_llm_thinking_disabled,
+                    )
 
-                    with call_llm_budget(self.MAX_OUTPUT_TOKENS):
-                        raw = await self._call_llm(
-                            self._system_prompt, user_prompt, self._model
-                        )
+                    with (
+                        call_llm_budget(self.MAX_OUTPUT_TOKENS),
+                        call_llm_thinking_disabled(),
+                    ):
+                        raw = await self._call_llm(self._system_prompt, user_prompt, self._model)
                     span.output_preview = (
                         raw[:4096] if isinstance(raw, str) else "(non-str response)"
                     )
@@ -2422,9 +2420,7 @@ class LLMPlanner:
         if plan is None:
             return None
         if drift.kind is DriftKind.USER_STEER:
-            return await self._refine_steer(
-                plan, drift, goals, available_agents, source="user"
-            )
+            return await self._refine_steer(plan, drift, goals, available_agents, source="user")
         if drift.kind in (
             DriftKind.LOOPING_TOOL_CALL,
             DriftKind.LOOPING_REASONING,
@@ -2874,8 +2870,7 @@ class LLMPlanner:
                 # same way as exhausted retries (keep prior plan,
                 # increment backoff) but without the escalation noise.
                 log.info(
-                    "LLMPlanner._refine_steer(source=%s): attempt %d/%d: %s; "
-                    "not retrying",
+                    "LLMPlanner._refine_steer(source=%s): attempt %d/%d: %s; not retrying",
                     effective_source,
                     attempt,
                     attempts,
@@ -2907,9 +2902,7 @@ class LLMPlanner:
         goals: list[Goal],
         available_agents: list[str] | list[dict[str, Any]] | None = None,
     ) -> Plan | None:
-        return await self._refine_steer(
-            plan, drift, goals, available_agents, source="user"
-        )
+        return await self._refine_steer(plan, drift, goals, available_agents, source="user")
 
     async def _user_steer_one_attempt(
         self,
@@ -2947,15 +2940,21 @@ class LLMPlanner:
                 target_task_id=drift.current_task_id or "",
             ) as span:
                 # Bound the dispatch — see ``LLMPlanner.MAX_OUTPUT_TOKENS``.
-                from goldfive._llm import call_llm_budget
+                # Disable thinking — user_steer is a structured JSON
+                # revision call, not deep reasoning.
+                from goldfive._llm import (
+                    call_llm_budget,
+                    call_llm_thinking_disabled,
+                )
 
-                with call_llm_budget(self.MAX_OUTPUT_TOKENS):
+                with (
+                    call_llm_budget(self.MAX_OUTPUT_TOKENS),
+                    call_llm_thinking_disabled(),
+                ):
                     raw = await self._call_llm(
                         self._user_steer_system_prompt, user_prompt, self._model
                     )
-                span.output_preview = (
-                    raw[:4096] if isinstance(raw, str) else "(non-str response)"
-                )
+                span.output_preview = raw[:4096] if isinstance(raw, str) else "(non-str response)"
                 decision_prefix = (
                     "refined plan (goldfive steer) in response to"
                     if source == "goldfive"
@@ -3011,9 +3010,7 @@ class LLMPlanner:
             merged_edges.append(e)
 
         if (source or "user").strip().lower() == "goldfive":
-            revision_reason = (
-                f"goldfive steer ({drift.kind.value}): {drift.detail}"
-            )
+            revision_reason = f"goldfive steer ({drift.kind.value}): {drift.detail}"
             # Preserve the underlying drift kind on the revision so sinks
             # see the ladder-promoted source, not a synthesised USER_STEER.
             revision_kind_value = drift.kind.value
@@ -3340,12 +3337,8 @@ PLAN SHAPE (when plan is non-null):
         # goes through planning at all), so ``target_agent_id`` /
         # ``target_task_id`` stay empty. A compact rendering of the
         # user input + prior plan summary doubles as ``input_preview``.
-        prior_id = (
-            (prior_plan.id or "") if prior_plan is not None else ""
-        )[:16] or "<none>"
-        gate_input_preview = (
-            f"user_input: {text}\nprior_plan_id: {prior_id}"
-        )
+        prior_id = ((prior_plan.id or "") if prior_plan is not None else "")[:16] or "<none>"
+        gate_input_preview = f"user_input: {text}\nprior_plan_id: {prior_id}"
         try:
             async with goldfive_llm_span(
                 **self._span_kwargs(),
@@ -3353,15 +3346,22 @@ PLAN SHAPE (when plan is non-null):
                 input_preview=gate_input_preview,
             ) as span:
                 # Bound the dispatch — see ``LLMPlanner.MAX_OUTPUT_TOKENS``.
-                from goldfive._llm import call_llm_budget
+                # Disable thinking — handle_turn is a small JSON gate
+                # call ("does this user input need a re-plan?"), not
+                # deep reasoning.
+                from goldfive._llm import (
+                    call_llm_budget,
+                    call_llm_thinking_disabled,
+                )
 
-                with call_llm_budget(self.MAX_OUTPUT_TOKENS):
+                with (
+                    call_llm_budget(self.MAX_OUTPUT_TOKENS),
+                    call_llm_thinking_disabled(),
+                ):
                     raw = await self._call_llm(
                         self._HANDLE_TURN_SYSTEM_PROMPT, user_prompt, self._model
                     )
-                span.output_preview = (
-                    raw[:4096] if isinstance(raw, str) else "(non-str response)"
-                )
+                span.output_preview = raw[:4096] if isinstance(raw, str) else "(non-str response)"
         except Exception as exc:  # noqa: BLE001
             log.warning(
                 "LLMPlanner.handle_turn: call_llm raised %s; "
@@ -3407,13 +3407,11 @@ PLAN SHAPE (when plan is non-null):
         chunks.append(self._render_prior_plan_block(prior_plan))
         if prior_goals:
             goal_lines = [
-                f"- [{g.id or '(no-id)'}] {g.summary or '(no summary)'}"
-                for g in prior_goals
+                f"- [{g.id or '(no-id)'}] {g.summary or '(no summary)'}" for g in prior_goals
             ]
             chunks.append(
                 "PRIOR GOALS (preserve their persistent qualifications "
-                "unless the user explicitly removes them):\n"
-                + "\n".join(goal_lines)
+                "unless the user explicitly removes them):\n" + "\n".join(goal_lines)
             )
         if conversation_history:
             # Cap to the most recent few entries — older context lives
@@ -3429,8 +3427,7 @@ PLAN SHAPE (when plan is non-null):
         if agents_block:
             chunks.append(agents_block)
         chunks.append(
-            'Decide and respond. Reply JSON only: '
-            '{"reasoning": "...", "plan": ... | null}'
+            'Decide and respond. Reply JSON only: {"reasoning": "...", "plan": ... | null}'
         )
         return "\n\n".join(chunks)
 
@@ -3512,12 +3509,8 @@ PLAN SHAPE (when plan is non-null):
         # Reuse the prior plan's id so the steerer's _apply_revision
         # bumps revision_index cleanly. This holds for the empty seed
         # (revision 0 → revision 1) AND for every subsequent revision.
-        plan_id_override = (
-            prior_plan.id if prior_plan is not None and prior_plan.id else None
-        )
-        prior_goal_ids = (
-            list(prior_plan.goal_ids) if prior_plan is not None else []
-        )
+        plan_id_override = prior_plan.id if prior_plan is not None and prior_plan.id else None
+        prior_goal_ids = list(prior_plan.goal_ids) if prior_plan is not None else []
         plan = _plan_from_json(
             plan_raw,
             run_id=run_id,
@@ -3526,8 +3519,7 @@ PLAN SHAPE (when plan is non-null):
         )
         if plan is None:
             log.warning(
-                "LLMPlanner.handle_turn: 'plan' failed structural parse; "
-                "treating as conversational"
+                "LLMPlanner.handle_turn: 'plan' failed structural parse; treating as conversational"
             )
             return None
         return plan

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -544,15 +544,11 @@ class DefaultSteerer:
             _conf_threshold = float(reasoning_binding_confidence_threshold)
         except (TypeError, ValueError):
             _conf_threshold = 0.7
-        self._reasoning_binding_confidence_threshold: float = max(
-            0.0, min(1.0, _conf_threshold)
-        )
+        self._reasoning_binding_confidence_threshold: float = max(0.0, min(1.0, _conf_threshold))
         # Drift-triggered plan-revision cooldown (goldfive#227).
         # Clamped to a non-negative float; ``0.0`` disables the gate
         # so callers can opt out without subclassing.
-        self._plan_revision_cooldown_seconds = max(
-            0.0, float(plan_revision_cooldown_seconds)
-        )
+        self._plan_revision_cooldown_seconds = max(0.0, float(plan_revision_cooldown_seconds))
         # goldfive-steer-unification: policy knob + freshness window for
         # promoting goldfive-detected drifts into the USER_STEER-style
         # cancel+refine+restart machinery. Precedence mirrors the other
@@ -567,8 +563,7 @@ class DefaultSteerer:
             _threshold = "warning"
         if _threshold not in {"off", "warning", "critical"}:
             log.warning(
-                "DefaultSteerer: unknown goldfive_steer_threshold=%r; "
-                "falling back to 'warning'",
+                "DefaultSteerer: unknown goldfive_steer_threshold=%r; falling back to 'warning'",
                 _threshold,
             )
             _threshold = "warning"
@@ -752,9 +747,7 @@ class DefaultSteerer:
         if to is TaskStatus.RUNNING:
             await self.mark_task_running(task_id, session=session, detail=detail, source=source)
         elif to is TaskStatus.COMPLETED:
-            await self.mark_task_completed(
-                task_id, summary=detail, session=session, source=source
-            )
+            await self.mark_task_completed(task_id, summary=detail, session=session, source=source)
         elif to is TaskStatus.FAILED:
             reason = cancel_reason or detail
             await self.mark_task_failed(task_id, reason=reason, session=session, source=source)
@@ -1295,9 +1288,7 @@ class DefaultSteerer:
         # Historically this awaited ``analyze_reasoning`` inline; as of
         # goldfive#251 the judge is fire-and-forget so the
         # model-response callback can return immediately.
-        rl_call_llm = self._maybe_take_reasoning_judge_slot(
-            session, agent_name=agent_name
-        )
+        rl_call_llm = self._maybe_take_reasoning_judge_slot(session, agent_name=agent_name)
         # Fast-exit when there's nothing for ``analyze_reasoning`` to
         # do: ``mode="off"``, or ``mode="judge"`` with no judge slot
         # (rate-limited or globally disabled). Embedding and "both"
@@ -1433,8 +1424,7 @@ class DefaultSteerer:
             raise
         except Exception as exc:  # noqa: BLE001 — background task
             log.warning(
-                "DefaultSteerer: background reasoning-judge raised "
-                "(swallowed): %s",
+                "DefaultSteerer: background reasoning-judge raised (swallowed): %s",
                 exc,
             )
 
@@ -1499,8 +1489,7 @@ class DefaultSteerer:
                 )
         except Exception as exc:  # noqa: BLE001 — never break the run
             log.warning(
-                "DefaultSteerer: record_reasoning_extracted_binding raised "
-                "(swallowed): %s",
+                "DefaultSteerer: record_reasoning_extracted_binding raised (swallowed): %s",
                 exc,
             )
 
@@ -1757,9 +1746,18 @@ class DefaultSteerer:
                 target_task_id=task.id,
             ) as span:
                 # Bound the dispatch — see ``REFLECTIVE_MAX_OUTPUT_TOKENS``.
-                from goldfive._llm import call_llm_budget
+                # Also disable thinking (goldfive#271 follow-up to #311):
+                # this is meta-cognition asking the agent if it's making
+                # progress, not deep reasoning.
+                from goldfive._llm import (
+                    call_llm_budget,
+                    call_llm_thinking_disabled,
+                )
 
-                with call_llm_budget(self.REFLECTIVE_MAX_OUTPUT_TOKENS):
+                with (
+                    call_llm_budget(self.REFLECTIVE_MAX_OUTPUT_TOKENS),
+                    call_llm_thinking_disabled(),
+                ):
                     raw = await call_llm(
                         self.REFLECTIVE_SYSTEM_PROMPT,
                         user_prompt,
@@ -1767,12 +1765,23 @@ class DefaultSteerer:
                     )
                 parsed = self._parse_reflective_response(raw)
                 if parsed is None:
-                    span.output_preview = (
-                        f"unparseable verdict; raw={raw!r:.200}"
-                    )
-                    span.decision_summary = (
-                        f"reflective check on {task.id}: unparseable verdict"
-                    )
+                    # Distinguish "model returned all thinking, no
+                    # answer" from "model returned garbage" — see
+                    # goldfive#271 follow-up to #311. ``call_llm`` is
+                    # the closure built by ``make_default_adk_call_llm``
+                    # / ``_build_judge_call_llm`` which stashes part
+                    # counts on itself.
+                    _thought_n = int(getattr(call_llm, "last_thought_count", 0) or 0)
+                    _raw_str = raw if isinstance(raw, str) else ""
+                    if not _raw_str.strip() and _thought_n > 0:
+                        span.output_preview = (
+                            f"empty answer ({_thought_n} thought "
+                            f"part(s); the model spent its budget thinking "
+                            f"and emitted no JSON)"
+                        )
+                    else:
+                        span.output_preview = f"unparseable verdict; raw={raw!r:.200}"
+                    span.decision_summary = f"reflective check on {task.id}: unparseable verdict"
                 else:
                     making_progress_inline = parsed.get("making_progress")
                     conf_inline = parsed.get("confidence")
@@ -1783,14 +1792,10 @@ class DefaultSteerer:
                         f"reason={reason_inline or '(none)'}"
                     )
                     if isinstance(making_progress_inline, bool):
-                        verdict_str = (
-                            "progressing" if making_progress_inline else "stuck"
-                        )
+                        verdict_str = "progressing" if making_progress_inline else "stuck"
                     else:
                         verdict_str = "malformed"
-                    span.decision_summary = (
-                        f"reflective check on {task.id}: {verdict_str}"
-                    )
+                    span.decision_summary = f"reflective check on {task.id}: {verdict_str}"
         except Exception as exc:  # noqa: BLE001 - never break the run
             log.warning("DefaultSteerer.maybe_run_reflective_check: call_llm raised %s", exc)
             await self._emit_reflective_failure(
@@ -2442,8 +2447,7 @@ class DefaultSteerer:
                 await self.request_invocation_cancel(drift=drift, session=session)
             except Exception as exc:  # noqa: BLE001 — cancel is best-effort
                 log.debug(
-                    "DefaultSteerer._handle_drift: "
-                    "request_invocation_cancel raised: %s",
+                    "DefaultSteerer._handle_drift: request_invocation_cancel raised: %s",
                     exc,
                 )
         if promote_to_steer:
@@ -2553,9 +2557,7 @@ class DefaultSteerer:
             # boundary catch site at ``ADKAdapter._invoke_internal``
             # asserts ``mark_stash_completed()`` fired before the
             # cancel propagated past us.
-            with _state_audit.cancellation_stash_audited(
-                "DefaultSteerer._handle_drift.refine"
-            ):
+            with _state_audit.cancellation_stash_audited("DefaultSteerer._handle_drift.refine"):
                 try:
                     if refine_accepts_registry:
                         revised = await self._planner.refine(
@@ -3048,9 +3050,7 @@ class DefaultSteerer:
         return reason
 
     @staticmethod
-    def _write_adapter_cancel_reason(
-        adapter: Any, reason: str, session: Session | None
-    ) -> None:
+    def _write_adapter_cancel_reason(adapter: Any, reason: str, session: Session | None) -> None:
         """Route the cancel-reason tag through the session-aware helper.
 
         Falls back to the legacy bare-attribute write for adapters /
@@ -3063,9 +3063,7 @@ class DefaultSteerer:
                 setter(session, reason)
                 return
             except Exception as exc:  # noqa: BLE001
-                log.debug(
-                    "DefaultSteerer: set_next_cancel_reason raised: %s", exc
-                )
+                log.debug("DefaultSteerer: set_next_cancel_reason raised: %s", exc)
         try:
             adapter._next_cancel_reason = reason
         except Exception as exc:  # noqa: BLE001
@@ -3107,8 +3105,7 @@ class DefaultSteerer:
                 await result
         except Exception as exc:  # noqa: BLE001
             log.debug(
-                "DefaultSteerer._request_adapter_cancel(reason=%r): "
-                "adapter raised: %s",
+                "DefaultSteerer._request_adapter_cancel(reason=%r): adapter raised: %s",
                 reason,
                 exc,
             )
@@ -3117,9 +3114,7 @@ class DefaultSteerer:
     # Cooperative cancellation (goldfive#251 Stream C / 7a)
     # ------------------------------------------------------------------
 
-    def _resolve_active_invocation_ids(
-        self, drift: DriftEvent, session: Session
-    ) -> list[str]:
+    def _resolve_active_invocation_ids(self, drift: DriftEvent, session: Session) -> list[str]:
         """Resolve which invocation_id(s) a cancel should target.
 
         Returns an ordered list of invocation ids that are "active"
@@ -3156,8 +3151,7 @@ class DefaultSteerer:
                             candidates.append(str(inv_id))
             except Exception as exc:  # noqa: BLE001
                 log.debug(
-                    "DefaultSteerer._resolve_active_invocation_ids: "
-                    "reconciler lookup raised: %s",
+                    "DefaultSteerer._resolve_active_invocation_ids: reconciler lookup raised: %s",
                     exc,
                 )
         # Fallback: the adapter's plugin pins a top-level invocation_id
@@ -3379,9 +3373,7 @@ class DefaultSteerer:
         """
         return drift.kind is DriftKind.USER_STEER and getattr(drift, "raw", None) is None
 
-    async def _cancel_inflight_for_revision(
-        self, drift: DriftEvent, session: Session
-    ) -> list[str]:
+    async def _cancel_inflight_for_revision(self, drift: DriftEvent, session: Session) -> list[str]:
         """Cancel the in-flight invocation(s) that produced ``drift``.
 
         Called from every PlanRevised emission path right after the
@@ -3521,9 +3513,7 @@ class DefaultSteerer:
                     return False
         return True
 
-    async def _promote_drift_to_steer(
-        self, drift: DriftEvent, session: Session
-    ) -> None:
+    async def _promote_drift_to_steer(self, drift: DriftEvent, session: Session) -> None:
         """Promote a goldfive-detected drift into a full steer.
 
         Ordered side effects (mirrors the USER_STEER path):
@@ -3559,9 +3549,7 @@ class DefaultSteerer:
         semantics identical to USER_STEER.
         """
         # 1. Tag adapter cancel reason.
-        cancel_reason = self._tag_adapter_cancel_reason_for_promotion(
-            drift, session=session
-        )
+        cancel_reason = self._tag_adapter_cancel_reason_for_promotion(drift, session=session)
         # Session-visible cancel prefix so ``_mark_cancelled_if_live``
         # stamps it on any TaskCancelled the executor emits for the
         # in-flight task as part of the promotion.
@@ -3631,8 +3619,7 @@ class DefaultSteerer:
                 _ostate.record_processed_steer_id(session.state, drift_id)
             except Exception as exc:  # noqa: BLE001
                 log.debug(
-                    "DefaultSteerer._promote_drift_to_steer: "
-                    "record_processed_steer_id raised: %s",
+                    "DefaultSteerer._promote_drift_to_steer: record_processed_steer_id raised: %s",
                     exc,
                 )
         # 4. Route to planner.refine_steer (source="goldfive") — falls
@@ -3665,8 +3652,7 @@ class DefaultSteerer:
                 revised = await self._dispatch_goldfive_steer_refine(drift, session)
             except Exception as exc:  # noqa: BLE001
                 log.warning(
-                    "DefaultSteerer._promote_drift_to_steer: refine raised %s; "
-                    "plan unchanged",
+                    "DefaultSteerer._promote_drift_to_steer: refine raised %s; plan unchanged",
                     exc,
                 )
                 await self._emit_refine_failed(
@@ -3701,8 +3687,7 @@ class DefaultSteerer:
                 self._active_session_var.reset(_active_session_token)
         if revised is None:
             log.warning(
-                "DefaultSteerer._promote_drift_to_steer: refine returned None; "
-                "plan unchanged"
+                "DefaultSteerer._promote_drift_to_steer: refine returned None; plan unchanged"
             )
             await self._emit_refine_failed(
                 session,
@@ -4352,9 +4337,7 @@ class DefaultSteerer:
         # Phase 3.5 (goldfive#271) tripwire wrapper — see §C4. The
         # ``except BaseException: stash; raise`` arm below is the
         # compliance branch (CANCELLATION-CONTRACT.md §1.2).
-        with _state_audit.cancellation_stash_audited(
-            "DefaultSteerer.observe_refine"
-        ):
+        with _state_audit.cancellation_stash_audited("DefaultSteerer.observe_refine"):
             try:
                 await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
                 try:
@@ -4905,9 +4888,7 @@ class DefaultSteerer:
         )
         return True
 
-    def _is_plan_revision_count_gated(
-        self, drift: DriftEvent, session: Session
-    ) -> bool:
+    def _is_plan_revision_count_gated(self, drift: DriftEvent, session: Session) -> bool:
         """Return ``True`` iff the (kind, task) revision cap has been hit.
 
         Independent of the time-based cooldown -- consults
@@ -4939,9 +4920,7 @@ class DefaultSteerer:
         )
         return True
 
-    async def _emit_revision_cap_escalation(
-        self, drift: DriftEvent, session: Session
-    ) -> None:
+    async def _emit_revision_cap_escalation(self, drift: DriftEvent, session: Session) -> None:
         """Emit a HUMAN_INTERVENTION_REQUIRED drift + pause the runner.
 
         Called from ``_handle_drift`` / ``_promote_drift_to_steer`` when
@@ -4992,9 +4971,7 @@ class DefaultSteerer:
         # budget. GOAL_DRIFT has its own rate-limit via
         # ``_last_goal_drift_check_ts``.
         if drift.kind not in self._PLAN_REVISION_COOLDOWN_EXEMPT_KINDS:
-            session.plan_revision_counts[key] = (
-                session.plan_revision_counts.get(key, 0) + 1
-            )
+            session.plan_revision_counts[key] = session.plan_revision_counts.get(key, 0) + 1
 
     @staticmethod
     def _integrate_correction_supersedes(revised: Plan) -> None:

--- a/tests/test_call_llm_diagnostic.py
+++ b/tests/test_call_llm_diagnostic.py
@@ -1,0 +1,192 @@
+"""Diagnostic for the all-thought-no-answer LLM-call failure mode
+(goldfive#271 follow-up to #311).
+
+Pre-fix: ``_call_llm`` silently dropped every ``thought=True`` part and
+returned ``"".join(answer_parts).strip()``. When all parts were thought
+parts, the function returned ``""`` — indistinguishable from "the model
+truly produced empty output" or "the network ate the response". Two
+days were lost to that ambiguity in the v16 / Qwen 35B investigation.
+
+Post-fix:
+
+1. The default ADK builder counts ``thought=True`` vs answer parts on
+   every dispatch and stashes the counts on the closure
+   (``_call_llm.last_thought_count`` / ``last_answer_count``).
+2. When the answer is empty AND there were thought parts, the builder
+   logs at INFO with a diagnostic message naming the failure shape so
+   operators can distinguish "model spent its budget thinking" from
+   "real empty response".
+3. The judge call sites (reasoning_judge, classify_goal_drift,
+   reflective check) read the stashed counts when they fail to parse
+   the response and surface ``"empty answer (N thought parts)"`` on the
+   span ``output_preview`` rather than the indistinguishable ``raw=''``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_adk_builder_logs_diagnostic_when_all_thoughts_no_answer(caplog):
+    """ADK ``_call_llm`` logs INFO with thought/answer part counts when
+    the final concatenated answer is empty but ``thought=True`` parts
+    were emitted. This is the exact shape that produced ``raw=''`` on
+    Qwen 35B + a 2048 cap pre-#311."""
+    pytest.importorskip("google.adk")
+    pytest.importorskip("google.genai")
+
+    from google.adk.models.base_llm import BaseLlm  # type: ignore[import-not-found]
+    from google.adk.models.llm_response import (  # type: ignore[import-not-found]
+        LlmResponse,
+    )
+    from google.genai import types as genai_types  # type: ignore[import-not-found]
+
+    from goldfive._llm_detect import make_default_adk_call_llm
+
+    class _AllThoughtNoAnswerLLM(BaseLlm):
+        async def generate_content_async(self, req, stream=False):  # type: ignore[override]
+            # Three thought parts, zero answer parts — the v16 / Qwen
+            # 35B failure shape.
+            yield LlmResponse(
+                content=genai_types.Content(
+                    role="model",
+                    parts=[
+                        genai_types.Part(text="thinking step 1", thought=True),
+                        genai_types.Part(text="thinking step 2", thought=True),
+                        genai_types.Part(text="thinking step 3", thought=True),
+                    ],
+                ),
+            )
+
+    stub = _AllThoughtNoAnswerLLM(model="stub")
+    call_llm = make_default_adk_call_llm(stub)
+    assert call_llm is not None
+
+    with caplog.at_level(logging.INFO, logger="goldfive.llm_detect"):
+        out = await call_llm("system", "user", "stub")
+
+    assert out == "", "all-thought response must produce empty answer"
+    # Part counts stashed on the closure for the caller.
+    assert getattr(call_llm, "last_thought_count", None) == 3
+    assert getattr(call_llm, "last_answer_count", None) == 0
+    # Diagnostic INFO log fired.
+    matching = [
+        rec
+        for rec in caplog.records
+        if "thought part" in rec.message and "answer text empty" in rec.message
+    ]
+    assert matching, (
+        f"expected the all-thought-no-answer diagnostic; got log records: "
+        f"{[r.message for r in caplog.records]}"
+    )
+    msg = matching[0].message
+    assert "3 thought" in msg
+
+
+@pytest.mark.asyncio
+async def test_adk_builder_no_diagnostic_on_normal_response(caplog):
+    """When the model returns a real answer, no diagnostic fires."""
+    pytest.importorskip("google.adk")
+    pytest.importorskip("google.genai")
+
+    from google.adk.models.base_llm import BaseLlm  # type: ignore[import-not-found]
+    from google.adk.models.llm_response import (  # type: ignore[import-not-found]
+        LlmResponse,
+    )
+    from google.genai import types as genai_types  # type: ignore[import-not-found]
+
+    from goldfive._llm_detect import make_default_adk_call_llm
+
+    class _NormalLLM(BaseLlm):
+        async def generate_content_async(self, req, stream=False):  # type: ignore[override]
+            yield LlmResponse(
+                content=genai_types.Content(
+                    role="model",
+                    parts=[
+                        genai_types.Part(text="thinking", thought=True),
+                        genai_types.Part(text='{"on_task": true}'),
+                    ],
+                ),
+            )
+
+    stub = _NormalLLM(model="stub")
+    call_llm = make_default_adk_call_llm(stub)
+    assert call_llm is not None
+
+    with caplog.at_level(logging.INFO, logger="goldfive.llm_detect"):
+        out = await call_llm("system", "user", "stub")
+
+    assert out == '{"on_task": true}'
+    assert getattr(call_llm, "last_thought_count", None) == 1
+    assert getattr(call_llm, "last_answer_count", None) == 1
+    # No diagnostic fired.
+    diag = [rec for rec in caplog.records if "answer text empty" in rec.message]
+    assert not diag
+
+
+@pytest.mark.asyncio
+async def test_reasoning_judge_surfaces_diagnostic_in_span():
+    """``classify_reasoning_drift`` records an "empty answer (N thought
+    parts)" output_preview on the span when the call_llm returned ``""``
+    and stashed a positive thought count. Replaces the previous
+    indistinguishable ``raw=''`` shape."""
+    from goldfive.drift.reasoning_judge import classify_reasoning_drift
+    from goldfive.protocols import EventSink
+    from goldfive.types import Task
+
+    # Stub call_llm returning empty AND advertising 3 thought parts via
+    # the closure-attached attribute (the same shape the default ADK
+    # builder produces).
+    async def stub_call_llm(system: str, user: str, model: str) -> str:
+        return ""
+
+    stub_call_llm.last_thought_count = 3  # type: ignore[attr-defined]
+    stub_call_llm.last_answer_count = 0  # type: ignore[attr-defined]
+
+    captured: list[Any] = []
+
+    class _CaptureSink(EventSink):
+        async def emit(self, event: Any) -> None:
+            captured.append(event)
+
+        async def close(self) -> None:
+            return None
+
+    sink = _CaptureSink()
+
+    drift = await classify_reasoning_drift(
+        reasoning="some reasoning to judge",
+        task=Task(id="t1", title="Ship the feature"),
+        goals=None,
+        model="x",
+        call_llm=stub_call_llm,
+        sink=sink,
+        run_id="r",
+        session_id="s",
+    )
+    assert drift is None
+
+    # Find the LLM span End event and check its output_preview
+    # mentions the thought-part diagnostic. Span emission goes through
+    # ``goldfive_llm_span``; the End event payload is the
+    # ``goldfive_llm_call_end`` oneof case.
+    end_previews: list[str] = []
+    for evt in captured:
+        # WhichOneof returns the active oneof field name; check directly
+        # by looking for the field on the proto message. ``HasField``
+        # works for oneof cases.
+        try:
+            if evt.HasField("goldfive_llm_call_end"):
+                end_previews.append(evt.goldfive_llm_call_end.output_preview)
+        except (AttributeError, ValueError):
+            continue
+    diag_previews = [p for p in end_previews if "thought part" in p]
+    assert diag_previews, (
+        f"expected an 'empty answer (N thought parts)' span preview; "
+        f"saw output_previews: {end_previews}"
+    )
+    assert "3" in diag_previews[0]

--- a/tests/test_judge_thinking_disabled.py
+++ b/tests/test_judge_thinking_disabled.py
@@ -1,0 +1,280 @@
+"""Judge dispatches must run with thinking disabled (goldfive#271 follow-up to #311).
+
+#311 raised the judge / planner / goal-deriver max_output_tokens caps from
+2048 to 16384 because v16 / Qwen 35B was returning ``raw=''`` — the
+*symptom* fix. The *cause* is that goldfive's judges are meta-cognition
+(small JSON questions like "is this on-task?") and have no business
+running through Qwen / Gemini "thinking" mode at all. Letting the model
+share the 16k cap with ``<think>`` reasoning is the same failure mode,
+just one cap-bump away.
+
+These tests pin the contract:
+
+1. ``call_llm_thinking_disabled()`` flips ``THINKING_DISABLED_VAR`` on
+   for the duration of the with-block.
+2. The default ADK builder reads the var and attaches
+   ``ThinkingConfig(include_thoughts=False, thinking_budget=0)`` to the
+   ``GenerateContentConfig`` it sends to ``BaseLlm.generate_content_async``.
+3. The default OpenAI / Qwen-via-litellm judge builder reads the var
+   and sends ``extra_body={"enable_thinking": False}`` plus a
+   ``/no_think`` system-prompt prefix.
+4. Each judge / goal_deriver / planner-refine call site enters
+   :func:`call_llm_thinking_disabled` around its
+   ``await call_llm(...)`` so a wrapping shim sees the flag.
+5. Agent-side dispatches (no enclosing context manager) keep thinking
+   enabled — that's the user's model behaviour, not goldfive's choice.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from goldfive._llm import (
+    call_llm_thinking_disabled,
+    get_thinking_disabled,
+)
+
+# ---------------------------------------------------------------------------
+# ContextVar plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_default_thinking_is_enabled():
+    """Outside any with-block, ``get_thinking_disabled()`` returns ``False``.
+
+    Agent-side LLM calls (coordinator / research / web_developer) keep
+    their natural thinking behaviour. Goldfive only flips the flag for
+    its own meta-cognition dispatches.
+    """
+    assert get_thinking_disabled() is False
+
+
+def test_call_llm_thinking_disabled_flips_var():
+    """``call_llm_thinking_disabled()`` flips the var inside the block."""
+    assert get_thinking_disabled() is False
+    with call_llm_thinking_disabled():
+        assert get_thinking_disabled() is True
+    assert get_thinking_disabled() is False
+
+
+def test_call_llm_thinking_disabled_resets_on_exception():
+    """The var is reset even when the body raises."""
+    with pytest.raises(RuntimeError):
+        with call_llm_thinking_disabled():
+            assert get_thinking_disabled() is True
+            raise RuntimeError("boom")
+    assert get_thinking_disabled() is False
+
+
+# ---------------------------------------------------------------------------
+# ADK builder integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_adk_builder_attaches_thinking_config_when_disabled():
+    """``make_default_adk_call_llm`` must attach a ``ThinkingConfig`` with
+    ``include_thoughts=False, thinking_budget=0`` when the per-callsite
+    disable-thinking flag is set."""
+    pytest.importorskip("google.adk")
+    pytest.importorskip("google.genai")
+
+    from goldfive._llm_detect import make_default_adk_call_llm
+
+    captured_requests: list[Any] = []
+
+    from google.adk.models.base_llm import BaseLlm  # type: ignore[import-not-found]
+    from google.adk.models.llm_response import (  # type: ignore[import-not-found]
+        LlmResponse,
+    )
+    from google.genai import types as genai_types  # type: ignore[import-not-found]
+
+    class _StubLLM(BaseLlm):
+        async def generate_content_async(self, req, stream=False):  # type: ignore[override]
+            captured_requests.append(req)
+            yield LlmResponse(
+                content=genai_types.Content(
+                    role="model",
+                    parts=[genai_types.Part(text="ok")],
+                ),
+            )
+
+    stub = _StubLLM(model="stub")
+    call_llm = make_default_adk_call_llm(stub)
+    assert call_llm is not None
+
+    # Default (no disable-thinking flag) — no ThinkingConfig on the request.
+    out = await call_llm("system", "user", "stub")
+    assert out == "ok"
+    last_config = captured_requests[-1].config
+    assert getattr(last_config, "thinking_config", None) is None, (
+        "agent-side calls must keep their natural thinking behaviour"
+    )
+
+    # With disable-thinking flag — ThinkingConfig must be present and
+    # configured to suppress the think prelude entirely.
+    with call_llm_thinking_disabled():
+        await call_llm("system", "user", "stub")
+    last_config = captured_requests[-1].config
+    tc = getattr(last_config, "thinking_config", None)
+    assert tc is not None, "judge-side dispatches must attach ThinkingConfig"
+    assert tc.include_thoughts is False
+    assert tc.thinking_budget == 0
+
+
+# ---------------------------------------------------------------------------
+# OpenAI / Qwen builder integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_builder_threads_enable_thinking_false_when_disabled():
+    """``_build_judge_call_llm`` must send ``extra_body={"enable_thinking":
+    False}`` and prepend ``/no_think`` to the system prompt when the
+    disable-thinking flag is set."""
+    pytest.importorskip("openai")
+    from goldfive.config import JudgeConfig
+    from goldfive.convenience import _build_judge_call_llm
+
+    config = JudgeConfig(
+        base_url="http://stub-judge.invalid",
+        model="stub-judge",
+        api_key="not-needed",
+    )
+
+    built = _build_judge_call_llm(config)
+    assert built is not None
+    call_llm, _model = built
+
+    captured_kwargs: list[dict[str, Any]] = []
+    fake_response = MagicMock()
+    fake_response.choices = [MagicMock(message=MagicMock(content="ok"))]
+    # No reasoning_content attribute — typical for non-thinking models.
+    type(fake_response.choices[0].message).reasoning_content = ""  # type: ignore[attr-defined]
+
+    async def fake_create(**kwargs: Any) -> Any:
+        captured_kwargs.append(kwargs)
+        return fake_response
+
+    client_cell = None
+    for c in call_llm.__closure__ or ():
+        if hasattr(c.cell_contents, "chat"):
+            client_cell = c
+            break
+    assert client_cell is not None
+    client_cell.cell_contents.chat.completions.create = fake_create
+
+    # Default: no extra_body, no /no_think prefix.
+    out = await call_llm("system", "user", "stub-judge")
+    assert out == "ok"
+    assert "extra_body" not in captured_kwargs[-1]
+    sys_msg = captured_kwargs[-1]["messages"][0]["content"]
+    assert "/no_think" not in sys_msg
+
+    # With disable-thinking flag: extra_body present, /no_think prepended.
+    with call_llm_thinking_disabled():
+        await call_llm("system", "user", "stub-judge")
+    last = captured_kwargs[-1]
+    assert last["extra_body"] == {"enable_thinking": False}
+    sys_msg = last["messages"][0]["content"]
+    assert sys_msg.startswith("/no_think"), "Qwen prompt-level fallback must be prepended"
+
+
+# ---------------------------------------------------------------------------
+# Per-call-site contract: each judge / goal-deriver / planner-refine site
+# must enter ``call_llm_thinking_disabled()`` around its
+# ``await call_llm(...)``. Same shape as ``test_judge_token_caps.py`` but
+# capturing the disable-thinking flag rather than the token cap.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reasoning_judge_disables_thinking():
+    """``classify_reasoning_drift`` must enter
+    ``call_llm_thinking_disabled()`` around its ``await call_llm(...)``."""
+    from goldfive.drift.reasoning_judge import classify_reasoning_drift
+    from goldfive.types import Task
+
+    seen_flags: list[bool] = []
+
+    async def stub_call_llm(system: str, user: str, model: str) -> str:
+        seen_flags.append(get_thinking_disabled())
+        return ""
+
+    drift = await classify_reasoning_drift(
+        reasoning="some reasoning to judge",
+        task=Task(id="t1", title="Ship the feature"),
+        goals=None,
+        model="x",
+        call_llm=stub_call_llm,
+    )
+    assert drift is None
+    assert seen_flags == [True]
+
+
+@pytest.mark.asyncio
+async def test_goal_drift_judge_disables_thinking():
+    """``classify_goal_drift`` must enter
+    ``call_llm_thinking_disabled()``."""
+    from goldfive.drift.goals import classify_goal_drift
+    from goldfive.types import Goal
+
+    seen_flags: list[bool] = []
+
+    async def stub_call_llm(system: str, user: str, model: str) -> str:
+        seen_flags.append(get_thinking_disabled())
+        return '{"progressing": true}'
+
+    drift = await classify_goal_drift(
+        goals=[Goal(id="g1", summary="ship")],
+        plan=None,
+        observed_actions=[{"kind": "tool_call", "agent_name": "agent", "detail": "ran a tool"}],
+        call_llm=stub_call_llm,
+        model="x",
+        run_id="r",
+        session_id="s",
+    )
+    assert drift is None
+    assert seen_flags == [True]
+
+
+@pytest.mark.asyncio
+async def test_planner_handle_turn_disables_thinking():
+    """``LLMPlanner.handle_turn`` must enter
+    ``call_llm_thinking_disabled()``."""
+    from goldfive.planner import LLMPlanner
+    from goldfive.types import Plan, Session
+
+    seen_flags: list[bool] = []
+
+    async def stub_call_llm(system: str, user: str, model: str) -> str:
+        seen_flags.append(get_thinking_disabled())
+        return ""
+
+    planner = LLMPlanner(call_llm=stub_call_llm, model="x")
+    session = Session(run_id="r1")
+    session.plan = Plan.empty(run_id="r1")
+    result = await planner.handle_turn(user_input="hello", session=session)
+    assert result is None
+    assert seen_flags == [True]
+
+
+@pytest.mark.asyncio
+async def test_goal_deriver_disables_thinking():
+    """``LLMGoalDeriver.derive`` must enter
+    ``call_llm_thinking_disabled()``."""
+    from goldfive.goal_deriver import LLMGoalDeriver
+
+    seen_flags: list[bool] = []
+
+    async def stub_call_llm(system: str, user: str, model: str) -> str:
+        seen_flags.append(get_thinking_disabled())
+        return '{"goals": [{"id": "g1", "summary": "test"}]}'
+
+    deriver = LLMGoalDeriver(stub_call_llm)
+    goals = await deriver.derive("hello world")
+    assert len(goals) == 1
+    assert seen_flags == [True]


### PR DESCRIPTION
## Summary

#311 raised judge / planner / goal-deriver `max_output_tokens` caps from 2048 to 16384 to escape v16's empty-verdict failure on Qwen 35B. That was the *symptom*-fix; the *cause* is that goldfive's judges, goal-deriver, and planner refines are meta-cognition asking small JSON-shaped questions ("is this on-task?", "extract the goal", "revise the plan") and have no business sharing their token budget with `<think>` reasoning. Letting Qwen 3.5 split 16k between think + answer is the same failure mode, just one cap-bump away.

### Part 1 - Per-callsite "disable thinking" signal

New `THINKING_DISABLED_VAR` ContextVar + `call_llm_thinking_disabled()` context manager mirror the existing `call_llm_budget` pattern.

- Goldfive's judges (`reasoning_judge`, `classify_goal_drift`, reflective check), goal deriver, and all four planner sites (refine, plan_generate, user_steer, planner_handle_turn) enter the context manager around their `await call_llm(...)`.
- Agent-side dispatches (coordinator / research / web_developer / etc.) keep their natural thinking behaviour - that is the user's model choice, not goldfive's.
- The default ADK builder reads the var and attaches `ThinkingConfig(include_thoughts=False, thinking_budget=0)` on `GenerateContentConfig`.
- The OpenAI / Qwen-via-litellm judge builder sends `extra_body={"enable_thinking": False}` plus a `/no_think` system-prompt prefix as a Qwen prompt-level fallback (vendors that don't recognise either silently ignore them).

### Part 2 - All-thought-no-answer diagnostic

- The default ADK builder counts `thought=True` vs answer parts on every dispatch, stashes the counts on the closure (`call_llm.last_thought_count` / `last_answer_count`), and logs at INFO when the answer is empty AND thought parts were emitted.
- The judge call sites read the stashed counts on parse failure and surface `"empty answer (N thought parts)"` on `span.output_preview` rather than the indistinguishable `raw=''` shape that cost two days in the v16 / Qwen 35B investigation.
- The OpenAI builder applies the same diagnostic against `reasoning_content` (the OpenAI-compatible analogue of "thought" parts).

## Test plan

- [x] `tests/test_judge_thinking_disabled.py`: ContextVar plumbing, ADK builder attaches `ThinkingConfig` only when flag is set, OpenAI builder threads `extra_body` + `/no_think`, each consumer (reasoning judge, goal-drift judge, planner handle_turn, goal deriver) enters the context manager around its `await call_llm(...)`. 8 passing + 1 skipped (no openai installed).
- [x] `tests/test_call_llm_diagnostic.py`: ADK builder logs INFO when 3 thought parts + 0 answer parts arrive, stays quiet on normal responses, and the reasoning-judge surfaces "empty answer (3 thought parts)" on `span.output_preview` instead of `raw=''`. 3 passing.
- [x] Existing related tests still green: `test_llm_call_budget_integration.py`, `test_judge_token_caps.py`, `test_llm_call_budget.py`, `test_wrap_goal_drift_wiring.py`, `test_wrap_runtime_config.py`, `test_reflective_check.py`. (`test_reasoning_judge.py::test_rate_limit_resets_on_task_transition` was already failing on origin/main, unrelated.)
- [x] Full suite `GOLDFIVE_STRICT_STATE_OWNERSHIP=1 pytest`: 1874 passed, 50 skipped, 1 pre-existing failure.