### PR TITLE
fix(steerer): stop cancelling background judges at adk-web turn boundary

### DIFF
--- a/goldfive/adapters/adk_wrap.py
+++ b/goldfive/adapters/adk_wrap.py
@@ -386,67 +386,19 @@ class GoldfiveADKAgent(BaseAgent):
                 ):
                     yield adk_event
         finally:
-            # Drain any background reasoning-judge tasks the steerer
-            # scheduled during this run (goldfive#251). The judge is
-            # fire-and-forget so ADK tool dispatch isn't blocked behind
-            # a slow LLM; this is the paired run-end drain so judges
-            # don't leak into subsequent runs and so ``CancelledError``
-            # from an adk-web disconnect doesn't orphan the tasks.
-            # Bounded timeout keeps a hung judge from stalling exit.
-            await self._drain_steerer_background_judges()
+            # Background reasoning-judge tasks (goldfive#251) intentionally
+            # OUTLIVE the per-turn ``_run_async_impl`` boundary. They are
+            # fire-and-forget so ADK tool dispatch isn't blocked behind a
+            # slow LLM; the matching drain happens once per Runner at
+            # :meth:`Runner.close` (goldfive#319). Cancelling at every
+            # adk-web outer-turn boundary killed slow judges that hadn't
+            # completed within 0.5s, dropping their drift verdicts on the
+            # floor — even when the same Runner had many more turns ahead
+            # of it. Each judge's ``done_callback`` already removes its
+            # entry from ``DefaultSteerer._background_judges`` so there
+            # is no per-turn leak; the only thing the previous drain
+            # accomplished beyond that callback was the unwanted cancel.
             self._notify_plugins_on_run_end()
-
-    #: Per-turn drain timeout. Bounds how long ``_run_async_impl``'s
-    #: ``finally`` block can block ADK's iterator exit. Phase 2.X
-    #: (goldfive#271 Gap 3): the previous default of 5.0s was inherited
-    #: from :meth:`Steerer.shutdown` and was the root of the residual
-    #: #275-style stale-session race — while the per-turn drain held
-    #: ADK's outer loop for 5s, a concurrent ``/run_sse`` invocation on
-    #: the same outer session could advance the SQLite session's
-    #: ``last_update_time``, leaving the blocked turn's deferred event
-    #: appends behind. 0.5s is plenty for judges that are about to
-    #: complete; stragglers get cancelled and resume drift emit on
-    #: :meth:`Runner.close` (which keeps the longer 5s timeout for
-    #: programmatic teardown).
-    _PER_TURN_DRAIN_TIMEOUT_S: float = 0.5
-
-    async def _drain_steerer_background_judges(self) -> None:
-        """Call ``steerer.shutdown()`` on the bound runner's steerer, if any.
-
-        Duck-typed so custom ``Steerer`` implementations (or stubs used
-        in tests) without the method fall through cleanly. Exceptions
-        are swallowed: teardown must never mask the run's real outcome.
-
-        Uses a tight :data:`_PER_TURN_DRAIN_TIMEOUT_S` bound so the
-        ``finally`` block doesn't stall ADK's iterator exit when a
-        slow LLM judge is still in flight at run end. The default
-        :meth:`Steerer.shutdown` timeout (5s) survives on
-        :meth:`Runner.close`, where blocking is acceptable.
-        """
-        steerer = getattr(self._runner, "steerer", None)
-        shutdown = getattr(steerer, "shutdown", None)
-        if shutdown is None:
-            return
-        try:
-            await shutdown(timeout=self._PER_TURN_DRAIN_TIMEOUT_S)
-        except TypeError:
-            # Custom Steerers without the timeout kwarg get the legacy
-            # default. Best-effort fallthrough so we don't break third-
-            # party steerers that haven't been updated.
-            try:
-                await shutdown()
-            except Exception as exc:  # noqa: BLE001 — defensive
-                log.debug(
-                    "GoldfiveADKAgent: steerer.shutdown raised "
-                    "(swallowed): %s",
-                    exc,
-                )
-        except Exception as exc:  # noqa: BLE001 — defensive
-            log.debug(
-                "GoldfiveADKAgent: steerer.shutdown raised "
-                "(swallowed): %s",
-                exc,
-            )
 
     def _notify_plugins_on_run_end(self) -> None:
         """Fire ``on_run_end()`` on every adapter plugin that defines it.

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -1448,6 +1448,34 @@ class DefaultSteerer:
                 return
             if not drift.trigger_input:
                 drift.trigger_input = self._truncate_trigger_input(text)
+            # Late-drift tolerance (goldfive#319). The judge is
+            # fire-and-forget so its verdict can land after the
+            # invocation that produced the reasoning has already
+            # terminated — adk-web outer-turn boundary crossed, agent
+            # moved on. Routing such a verdict through the cancel +
+            # ladder dispatch would either cancel an unrelated next
+            # invocation or refine against a plan whose offending step
+            # is already complete. We still want the drift on the wire
+            # for observability ("from past turn"), so we emit it
+            # directly via :meth:`_emit_drift_detected` and skip the
+            # rest of the dispatch. The guard is scoped to the
+            # background-judge path because only that path produces
+            # verdicts that may outlive the originating invocation —
+            # synchronous detectors run inline on the model-response
+            # callback and always see a live invocation.
+            if self._is_late_drift_for_terminated_invocation(drift, session):
+                log.info(
+                    "DefaultSteerer: stale judge verdict; invocation for "
+                    "agent=%r task=%r already terminated; drift kind=%s "
+                    "recorded but refine skipped",
+                    drift.current_agent_id or "-",
+                    drift.current_task_id or "-",
+                    drift.kind.value,
+                )
+                if not drift.authored_by:
+                    drift.authored_by = self._resolve_authored_by(drift)
+                await self._emit_drift_detected(session, drift)
+                return
             await self._handle_drift(drift, session)
         except asyncio.CancelledError:
             # Propagate cancellation so :meth:`shutdown` / event-loop
@@ -3210,6 +3238,49 @@ class DefaultSteerer:
     # ------------------------------------------------------------------
     # Cooperative cancellation (goldfive#251 Stream C / 7a)
     # ------------------------------------------------------------------
+
+    def _is_late_drift_for_terminated_invocation(
+        self, drift: DriftEvent, session: Session
+    ) -> bool:
+        """Return True iff a goldfive-authored drift's target is gone (goldfive#319).
+
+        Background reasoning-judge tasks (goldfive#251) run off the
+        critical path so the adapter's model-response callback can return
+        before the LLM judge finishes. With goldfive#319's removal of the
+        per-turn cancel-drain, a slow judge spawned in turn N may now
+        produce its verdict in turn N+1 — well after the original agent
+        invocation has terminated. Routing such a verdict through the
+        cancel + ladder dispatch is a category error: it could cancel an
+        unrelated invocation or trigger a refine against a plan whose
+        offending step is already complete. The drift is still emitted
+        on the sink (observability preserved); this guard short-circuits
+        the dispatch.
+
+        The check uses :class:`OrchestrationStore` as the live registry
+        of in-flight invocations (Phase 3.5 component 1, goldfive#271).
+        When the per-session bucket is empty, every agent has finished
+        its turn and any drift currently being handled is by definition
+        stale. User-authored drifts (USER_STEER / USER_CANCEL /
+        USER_PAUSE) always bypass this guard — they are forward-looking
+        operator directives, not tied to a specific in-flight invocation.
+        """
+        # User-authored drifts always pass through. ``authored_by`` was
+        # normalised at the top of :meth:`_handle_drift`.
+        if (drift.authored_by or "").lower() == "user":
+            return False
+        try:
+            from goldfive.orchestration_store import OrchestrationStore
+
+            store = OrchestrationStore.for_session(session)
+            active = store.active_invocation_ids()
+        except Exception as exc:  # noqa: BLE001 — defensive
+            log.debug(
+                "DefaultSteerer._is_late_drift_for_terminated_invocation: "
+                "active_invocation_ids lookup raised (treating as not-late): %s",
+                exc,
+            )
+            return False
+        return not active
 
     def _resolve_active_invocation_ids(self, drift: DriftEvent, session: Session) -> list[str]:
         """Resolve which invocation_id(s) a cancel should target.

--- a/tests/test_judge_task_lifetime.py
+++ b/tests/test_judge_task_lifetime.py
@@ -1,0 +1,362 @@
+"""Regression tests for goldfive#319: background reasoning-judge tasks
+must not be cancelled at the per-turn boundary.
+
+The fire-and-forget reasoning judge (goldfive#251) runs off the critical
+path so the adapter's model-response callback can return before the
+slow LLM judge completes. Pre-fix, ``GoldfiveADKAgent._run_async_impl``
+called ``steerer.shutdown(timeout=0.5)`` in its per-turn ``finally``
+block, which fired ``task.cancel()`` on every still-running judge — the
+verdict was dropped on the floor whenever the LLM was slower than 0.5s,
+even when the same Runner had many more turns ahead of it.
+
+The fix removes the per-turn drain so background judges live for the
+lifetime of the :class:`~goldfive.runner.Runner`. The canonical drain
+runs only at :meth:`Runner.close`. A late verdict that arrives after
+its target invocation has already terminated is still recorded on the
+sink (observability preserved); the steerer skips the cancel + ladder
+dispatch via :meth:`DefaultSteerer._is_late_drift_for_terminated_invocation`
+inside :meth:`DefaultSteerer._run_judge_background`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Test stubs (mirrors of test_reasoning_judge.py — kept local so this
+# file is self-contained as a regression bundle for #319).
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class NullPlanner:
+    """Non-None planner whose ``refine`` records every call. The
+    presence-check in :meth:`DefaultSteerer._handle_drift` requires a
+    non-None planner before refine is reached, so the late-drift
+    tolerance test wires this in to confirm refine is *not* invoked.
+    """
+
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        self.refine_calls.append(kwargs)
+        return None
+
+
+def _session(run_id: str = "r1", task_id: str = "t1") -> Session:
+    task = Task(
+        id=task_id, title="Research solar panels", description="Find specs"
+    )
+    plan = Plan(
+        id="p1",
+        run_id=run_id,
+        goal_ids=["g1"],
+        tasks=[task],
+        edges=[],
+    )
+    return Session(
+        run_id=run_id,
+        goals=[Goal(id="g1", summary="Publish a memo on solar panels")],
+        plan=plan,
+        current_task_id=task_id,
+    )
+
+
+def _task_status(session: Session, task_id: str) -> TaskStatus:
+    plan = session.plan
+    assert plan is not None
+    for t in plan.tasks:
+        if t.id == task_id:
+            return t.status
+    raise AssertionError(f"task {task_id!r} not found on plan")
+
+
+# ---------------------------------------------------------------------------
+# Slow-judge survival across turn boundaries (goldfive#319 core regression)
+# ---------------------------------------------------------------------------
+
+
+async def test_slow_judge_completes_when_per_turn_drain_is_removed() -> None:
+    """A judge slower than the deleted 0.5s drain budget completes cleanly.
+
+    The pre-fix ``_drain_steerer_background_judges`` cancelled judges
+    whose LLM round-trip exceeded 0.5s; this test simulates that exact
+    scenario. With the fix, the judge runs to completion and emits its
+    drift verdict to the sink.
+    """
+
+    async def slow_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        # Well past the 0.5s the previous per-turn drain allowed. We
+        # keep it modest so the test is fast on CI.
+        await asyncio.sleep(0.7)
+        return json.dumps(
+            {"on_task": False, "severity": "info", "reason": "slightly off"}
+        )
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=slow_call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    await steerer.observe_reasoning(
+        "raccoons are nocturnal", session=session
+    )
+    assert len(steerer._background_judges) == 1, (
+        "observe_reasoning must schedule the judge as a background task"
+    )
+
+    # Wait for completion — no cancel was applied.
+    pending = list(steerer._background_judges)
+    results = await asyncio.gather(*pending, return_exceptions=True)
+    for r in results:
+        assert not isinstance(r, BaseException), (
+            f"background judge raised {r!r}; expected clean completion"
+        )
+
+    drifts = [
+        e for e in sink.events if e.WhichOneof("payload") == "drift_detected"
+    ]
+    assert len(drifts) == 1, (
+        f"slow judge must produce its drift verdict; got {len(drifts)} drift "
+        "events on the sink"
+    )
+
+
+async def test_done_callback_removes_from_background_judges() -> None:
+    """The ``add_done_callback`` registered at spawn must clear the set."""
+
+    async def fast_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        return json.dumps({"on_task": True})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=fast_call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    await steerer.observe_reasoning("clean reasoning", session=session)
+    assert len(steerer._background_judges) == 1
+
+    # Drain the task; the done_callback fires synchronously when the
+    # task completes.
+    pending = list(steerer._background_judges)
+    await asyncio.gather(*pending, return_exceptions=True)
+    # Yield once so the done_callback is invoked.
+    await asyncio.sleep(0)
+
+    assert steerer._background_judges == set(), (
+        "done_callback must remove the completed task from "
+        "_background_judges; got "
+        f"{len(steerer._background_judges)} stragglers"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Late-drift tolerance (goldfive#319): a verdict produced by the
+# fire-and-forget background judge whose target invocation has already
+# terminated must record the drift but skip refine.
+# ---------------------------------------------------------------------------
+#
+# Scoped to ``_run_judge_background`` — only the background judge path
+# can emit verdicts that outlive their originating invocation.
+# Synchronous detectors fire inline on the model-response callback and
+# always see a live invocation, so they never need this guard.
+
+
+async def test_late_judge_verdict_records_drift_but_skips_refine(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A judge verdict produced when no invocations are active is
+    recorded on the sink but does NOT trigger planner.refine.
+    """
+
+    async def call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        return json.dumps(
+            {
+                "on_task": False,
+                "severity": "warning",
+                "reason": "drifted to raccoons",
+            }
+        )
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session()
+    sink = ListSink()
+    planner = NullPlanner()
+    steerer.bind(sinks=[sink], planner=planner)
+
+    # No invocations registered on the OrchestrationStore for this
+    # session — the agent has moved on. The fire-and-forget judge
+    # treats this as a stale verdict.
+    with caplog.at_level(logging.INFO, logger="goldfive.steerer"):
+        await steerer.observe_reasoning(
+            "raccoons are nocturnal", session=session
+        )
+        pending = list(steerer._background_judges)
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    # The drift was emitted on the sink (observability preserved).
+    drift_events = [
+        e
+        for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "drift_detected"
+    ]
+    assert len(drift_events) == 1, (
+        "late judge verdict must still be recorded on the sink for "
+        f"observability; got {len(drift_events)} drift event(s)"
+    )
+
+    # planner.refine was NOT called.
+    assert planner.refine_calls == [], (
+        "late judge verdict whose target invocation is gone must NOT "
+        f"trigger planner.refine; got {len(planner.refine_calls)} call(s)"
+    )
+
+    # The structural log line was emitted at INFO so operators can see
+    # late verdicts in the run log.
+    info_records = [
+        r
+        for r in caplog.records
+        if r.name == "goldfive.steerer"
+        and r.levelno == logging.INFO
+        and "stale judge verdict" in r.getMessage()
+    ]
+    assert len(info_records) == 1, (
+        f"stale-judge-verdict log line must fire at INFO; got "
+        f"{len(info_records)} matching record(s)"
+    )
+
+
+async def test_judge_verdict_with_live_invocation_proceeds_normally() -> None:
+    """When an invocation is registered, the judge's verdict reaches
+    the refine path normally.
+
+    Confirms the late-drift guard is not over-broad — a WARNING drift
+    on a live agent must still reach planner.refine (Level 1 ABSORB).
+    """
+    from goldfive.orchestration_store import OrchestrationStore
+
+    async def call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        return json.dumps(
+            {
+                "on_task": False,
+                "severity": "warning",
+                "reason": "drifted to raccoons",
+            }
+        )
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session()
+    sink = ListSink()
+    planner = NullPlanner()
+    steerer.bind(sinks=[sink], planner=planner)
+
+    # Register a fake live invocation. The task itself is irrelevant —
+    # only the registry's non-emptiness gates the late-drift guard.
+    store = OrchestrationStore.for_session(session)
+
+    async def _placeholder() -> None:
+        await asyncio.sleep(0.5)
+
+    fake_task = asyncio.create_task(_placeholder())
+    store.register_invocation_task("inv-live", fake_task)
+    try:
+        await steerer.observe_reasoning(
+            "raccoons are nocturnal", session=session
+        )
+        pending = list(steerer._background_judges)
+        await asyncio.gather(*pending, return_exceptions=True)
+
+        # planner.refine WAS called (Level 1 ABSORB on first WARNING).
+        assert len(planner.refine_calls) == 1, (
+            "WARNING drift on a live invocation must reach planner.refine; "
+            f"got {len(planner.refine_calls)} call(s)"
+        )
+    finally:
+        store.deregister_invocation_task("inv-live")
+        fake_task.cancel()
+        await asyncio.gather(fake_task, return_exceptions=True)
+
+
+async def test_synchronous_tool_flow_unaffected_by_late_drift_guard() -> None:
+    """Synchronous tool-flow drifts (mark_task_failed -> TASK_FAILED_*)
+    fire inline through ``_handle_drift`` and must NOT be gated by the
+    late-drift guard.
+
+    Regression bound: the guard is scoped to ``_run_judge_background``
+    only; broadening it to every ``_handle_drift`` call would skip
+    refine for tool-callback flows whose invocation registry isn't
+    necessarily populated in test setups (and shouldn't be: those
+    callers ARE the live agent reporting status).
+    """
+    steerer = DefaultSteerer()
+    session = _session()
+    sink = ListSink()
+    planner = NullPlanner()
+    steerer.bind(sinks=[sink], planner=planner)
+
+    # Drive a tool-flow drift (mark_task_failed -> TASK_FAILED_RECOVERABLE
+    # -> Level 1 ABSORB) without any registered invocation. The guard
+    # must not fire because this isn't the background-judge path.
+    await steerer.mark_task_failed(
+        "t1", session=session, reason="boom", recoverable=True
+    )
+
+    assert _task_status(session, "t1") is TaskStatus.FAILED
+    # planner.refine WAS called: synchronous tool-flow drifts route
+    # through ``_handle_drift`` directly and are not gated.
+    assert len(planner.refine_calls) >= 1, (
+        "synchronous tool-flow drift on a non-registered session must "
+        "still reach planner.refine; got "
+        f"{len(planner.refine_calls)} call(s)"
+    )

--- a/tests/test_wrap_adk.py
+++ b/tests/test_wrap_adk.py
@@ -419,23 +419,25 @@ async def test_run_async_impl_without_on_run_end_plugins_still_works(
 
 
 # ---------------------------------------------------------------------------
-# Phase 2.X / goldfive#271 Gap 3: per-turn judge drain is bounded tightly
+# goldfive#319: per-turn boundary must NOT cancel background judge tasks
 # ---------------------------------------------------------------------------
 
 
-async def test_per_turn_drain_uses_short_timeout_not_runner_close_default(
+async def test_per_turn_boundary_does_not_call_steerer_shutdown(
     stub_call_llm: Any,
 ) -> None:
-    """``_drain_steerer_background_judges`` passes the
-    :data:`GoldfiveADKAgent._PER_TURN_DRAIN_TIMEOUT_S` to
-    ``Steerer.shutdown`` so a slow judge can't stall ADK's iterator
-    exit for the full :meth:`Steerer.shutdown` default (5s).
+    """``_run_async_impl``'s ``finally`` MUST NOT invoke
+    ``steerer.shutdown`` (goldfive#319).
 
-    Validation E2E (session 95ecda4c) saw the residual #275-style
-    stale-session race after the per-turn drain held ADK's outer
-    loop for 5s while a concurrent ``/run_sse`` invocation advanced
-    the SQLite session. Tightening the per-turn timeout to 0.5s
-    bounds the race window.
+    The previous Phase 2.X drain called ``shutdown(timeout=0.5)`` at
+    every adk-web outer-turn boundary, which fired ``task.cancel()`` on
+    every in-flight reasoning-judge task. That dropped slow judges'
+    drift verdicts on the floor whenever the judge took longer than
+    0.5s — even when the same Runner had many more turns ahead of it
+    and would have happily awaited the verdict on the next observe.
+
+    The fix is structural: judges live for the lifetime of the
+    :class:`Runner`, and the only canonical drain is :meth:`Runner.close`.
     """
     from unittest.mock import AsyncMock
 
@@ -454,78 +456,26 @@ async def test_per_turn_drain_uses_short_timeout_not_runner_close_default(
     wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
     wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
 
-    # Spy the steerer's shutdown to capture the timeout argument.
-    captured_timeouts: list[float | None] = []
+    # Spy on ``shutdown`` and assert it is NEVER invoked during the
+    # per-turn run. ``Runner.close`` is the only path that should
+    # drain background judges, and it isn't called by
+    # ``_run_async_impl``.
+    shutdown_call_count = 0
 
     async def _spy_shutdown(*args: Any, **kwargs: Any) -> None:
-        captured_timeouts.append(kwargs.get("timeout"))
+        nonlocal shutdown_call_count
+        shutdown_call_count += 1
 
     wrapped.runner.steerer.shutdown = _spy_shutdown  # type: ignore[method-assign]
 
     ctx = _FakeCtx("do a thing")
     [evt async for evt in wrapped._run_async_impl(ctx)]
 
-    assert captured_timeouts, (
-        "_drain_steerer_background_judges did not call steerer.shutdown"
+    assert shutdown_call_count == 0, (
+        "per-turn ``_run_async_impl`` must not call ``steerer.shutdown`` "
+        "(goldfive#319 regression: that cancels in-flight background "
+        f"judges). Got {shutdown_call_count} call(s)."
     )
-    timeout = captured_timeouts[0]
-    assert timeout is not None, (
-        "per-turn drain must pass an explicit timeout (got None)"
-    )
-    # Tight enough that a 5s shutdown can't blow it open. We assert
-    # well under 1s as the regression bound.
-    assert timeout <= 1.0, (
-        f"per-turn drain timeout regressed to {timeout!r}; expected <= 1s"
-    )
-
-
-async def test_per_turn_drain_falls_back_when_steerer_shutdown_lacks_timeout(
-    stub_call_llm: Any,
-) -> None:
-    """Custom Steerers without the ``timeout=`` kwarg fall through to
-    the legacy default-call shape. This is the back-compat path for
-    third-party Steerers that haven't been updated for the per-turn
-    timeout knob.
-    """
-    from unittest.mock import AsyncMock
-
-    from goldfive import InvocationResult, SequentialExecutor
-
-    inner = _mk_inner()
-    wrapped = goldfive.wrap(
-        inner,
-        planner=_one_task_planner(),
-        sinks=[InMemorySink()],
-    )
-
-    async def _fake_invoke(task: Task, session: Any) -> InvocationResult:
-        return InvocationResult(task_id=task.id, text="ok")
-
-    wrapped.runner.agent.invoke = AsyncMock(side_effect=_fake_invoke)
-    wrapped.runner.executor = SequentialExecutor(max_task_invocations=3)
-
-    # Old-shape shutdown: no timeout kwarg, raises TypeError when one
-    # is passed. The drain helper must catch the TypeError and retry
-    # with no kwargs.
-    call_log: list[str] = []
-
-    async def _legacy_shutdown() -> None:
-        call_log.append("no-kwargs")
-
-    async def _entry_shutdown(*args: Any, **kwargs: Any) -> None:
-        if kwargs:
-            raise TypeError("legacy shutdown takes no kwargs")
-        call_log.append("entry")
-        await _legacy_shutdown()
-
-    wrapped.runner.steerer.shutdown = _entry_shutdown  # type: ignore[method-assign]
-
-    ctx = _FakeCtx("do a thing")
-    [evt async for evt in wrapped._run_async_impl(ctx)]
-
-    # The fallthrough call shape (no kwargs) was reached after the
-    # initial timeout-kwarg call raised TypeError.
-    assert "entry" in call_log
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #319.

The fire-and-forget reasoning judge (goldfive#251) was getting cancelled at every adk-web outer-turn boundary because `GoldfiveADKAgent._run_async_impl`'s `finally` block called `DefaultSteerer.shutdown(timeout=0.5)`, which fires `task.cancel()` on every judge that hasn't completed within 0.5s. Slow verdicts produced in turn N got killed when turn N's outer driver exited — even when the same Runner had many more turns ahead.

The fix is structural. Background judges are scoped to the Runner, not the per-turn dispatch:

- **Drop the per-turn drain entirely.** Each judge's `done_callback` already removes its entry from `DefaultSteerer._background_judges`, so the cancel had no resource-leak justification beyond the cancel itself. `Runner.close()` remains the canonical drain, where the default 5s `shutdown()` timeout blocks during programmatic teardown.
- **Add late-drift tolerance in `_run_judge_background`.** A verdict that arrives after every invocation has terminated still gets a `DriftDetected` sink emit (operators see "verdict from past turn") but the cancel + ladder dispatch is skipped — there is no live invocation to cancel, and refining against a plan whose offending step is gone would just thrash. The guard is scoped to the background-judge path; synchronous detectors and tool-flow drifts (`mark_task_*`) are unaffected because they always run with a live caller.

## Cross-turn state audit

The judge captures `Session` by reference and reads `session.goals`, `session.current_task_id`, `session.plan` when it eventually runs. The Session is Runner-scoped so the longer judge lifetime carries no UAF risk. `session.reasoning_history` is already snapshotted at schedule time inside `_run_judge_background`.

**Pre-existing nuance** (not introduced by this PR, not blocking): `session.current_task_id` can shift between schedule and run — the judge's prompt would then be framed against the new task while the reasoning text it analyses came from the old one. This was already true under the previous behaviour for any judge that completed within 0.5s but after the agent moved on. Worth a follow-up issue (snapshot `current_task_id` at schedule time, pass as kwarg into `_run_judge_background`) but kept out of this PR to keep the change minimal.

## Test plan

- [x] `pytest tests/test_judge_task_lifetime.py` — 5 new regression tests (slow judge survives, done_callback cleanup, late-drift records-but-skips-refine, late-drift bypass when invocation is live, sync tool flows unaffected)
- [x] `pytest tests/test_wrap_adk.py` — replaced the two Phase 2.X `_drain_steerer_background_judges` tests with a single assertion that `_run_async_impl` never invokes `steerer.shutdown`
- [x] Full suite: `pytest tests/` — 1565 passed, 113 skipped
- [x] `ruff check goldfive/ tests/` — clean
- [x] mypy on changed files — only pre-existing errors (verified by stashing the change and re-running)