### PR TITLE
feat: user-steer pipeline (F5+F6+F7+F9)

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -3102,6 +3102,7 @@ not, return null for the plan.
 Reply with a single JSON object and NOTHING ELSE:
 {
   "reasoning": "<one-sentence why>",
+  "replaces_prior": <bool — see PIVOT vs REVISION below>,
   "plan": null OR {
     "id": "<short-id>",
     "summary": "<noun phrase describing the GOAL — see SUMMARY POLICY in PLAN SHAPE>",
@@ -3117,6 +3118,35 @@ Reply with a single JSON object and NOTHING ELSE:
     "edges": [{"from_task_id": "...", "to_task_id": "..."}]
   }
 }
+
+PIVOT vs REVISION (the ``replaces_prior`` field):
+
+Set ``replaces_prior: true`` when the user is REPLACING prior intent
+rather than building on it — a topic pivot, an artefact abandonment,
+or any "forget X, do Y instead"-shaped instruction. A pivot is a
+fresh start: the runner mints a new plan id, terminal-task / edge
+preservation does NOT apply, and the new plan does not need to echo
+back COMPLETED tasks from the prior. Examples:
+
+  * "forget the slides, just give me bullet points" — different artefact
+  * "scratch that, do something completely different — translate this poem"
+  * "no, don't do any of that. Tell me about quantum mechanics instead."
+  * "stop, I want to switch topics entirely to dark matter"
+
+Set ``replaces_prior: false`` (the default) when the user is BUILDING
+on the prior plan — additive constraints, partial corrections,
+qualification tweaks, even topic-shifts that keep the same artefact
+shape. The runner installs the result as a revision of the prior
+plan id. Terminal tasks must be preserved verbatim in the new plan.
+Examples:
+
+  * "make it 2 slides instead of 5" — additive constraint
+  * "actually, make it about solar flares not solar panels" — topic
+    shift on the same artefact (still a presentation)
+  * "redo task 3 with the new data" — partial correction
+
+When in doubt, prefer ``false`` — a revision is the safer default;
+the structural-preservation overhead is small.
 
 WHEN TO RETURN A PLAN (plan is non-null):
 
@@ -3351,7 +3381,7 @@ SUMMARY POLICY (applies to ``plan.summary``):
             return None
         prior_plan = session.plan
         prior_goals = list(session.goals)
-        user_prompt = self._build_handle_turn_prompt(
+        base_user_prompt = self._build_handle_turn_prompt(
             user_input=text,
             prior_plan=prior_plan,
             prior_goals=prior_goals,
@@ -3366,45 +3396,111 @@ SUMMARY POLICY (applies to ``plan.summary``):
         # user input + prior plan summary doubles as ``input_preview``.
         prior_id = ((prior_plan.id or "") if prior_plan is not None else "")[:16] or "<none>"
         gate_input_preview = f"user_input: {text}\nprior_plan_id: {prior_id}"
-        try:
-            async with goldfive_llm_span(
-                **self._span_kwargs(),
-                name="planner_handle_turn",
-                input_preview=gate_input_preview,
-            ) as span:
-                # Bound the dispatch — see ``LLMPlanner.MAX_OUTPUT_TOKENS``.
-                # Disable thinking — handle_turn is a small JSON gate
-                # call ("does this user input need a re-plan?"), not
-                # deep reasoning.
-                from goldfive._llm import (
-                    call_llm_budget,
-                    call_llm_thinking_disabled,
-                )
 
-                with (
-                    call_llm_budget(self.MAX_OUTPUT_TOKENS),
-                    call_llm_thinking_disabled(),
-                ):
-                    raw = await self._call_llm(
-                        self._HANDLE_TURN_SYSTEM_PROMPT, user_prompt, self._model
+        # F7 (closes part of goldfive#322): validator-feedback retry.
+        # Mirrors the retry pattern in ``_call_and_validate_refine``
+        # (planner.py:1870+) but inlined for handle_turn so a one-off
+        # validation failure on the first LLM attempt — almost always
+        # a Rule 6 terminal-task / terminal->terminal-edge regression
+        # — gets a second chance with an explicit error message
+        # appended to the prompt. Capped at 2 attempts (one retry)
+        # so a misbehaving LLM doesn't burn the per-turn budget.
+        user_prompt = base_user_prompt
+        plan: Plan | None = None
+        last_error = ""
+        max_attempts = 2
+        for attempt in range(1, max_attempts + 1):
+            try:
+                async with goldfive_llm_span(
+                    **self._span_kwargs(),
+                    name="planner_handle_turn",
+                    input_preview=gate_input_preview,
+                ) as span:
+                    # Bound the dispatch — see ``LLMPlanner.MAX_OUTPUT_TOKENS``.
+                    # Disable thinking — handle_turn is a small JSON gate
+                    # call ("does this user input need a re-plan?"), not
+                    # deep reasoning.
+                    from goldfive._llm import (
+                        call_llm_budget,
+                        call_llm_thinking_disabled,
                     )
-                span.output_preview = raw[:4096] if isinstance(raw, str) else "(non-str response)"
-        except Exception as exc:  # noqa: BLE001
-            log.warning(
-                "LLMPlanner.handle_turn: call_llm raised %s; "
-                "treating as conversational (no plan change)",
-                exc,
+
+                    with (
+                        call_llm_budget(self.MAX_OUTPUT_TOKENS),
+                        call_llm_thinking_disabled(),
+                    ):
+                        raw = await self._call_llm(
+                            self._HANDLE_TURN_SYSTEM_PROMPT,
+                            user_prompt,
+                            self._model,
+                        )
+                    span.output_preview = (
+                        raw[:4096] if isinstance(raw, str) else "(non-str response)"
+                    )
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "LLMPlanner.handle_turn: attempt %d/%d: call_llm raised %s; "
+                    "treating as conversational (no plan change)",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                return None
+            candidate = self._parse_handle_turn_response(
+                raw=raw,
+                prior_plan=prior_plan,
+                context=context,
             )
-            return None
-        plan = self._parse_handle_turn_response(
-            raw=raw,
-            prior_plan=prior_plan,
-            context=context,
-        )
+            if candidate is None:
+                # Conversational verdict OR unparseable response. Either
+                # way, no plan to validate. Return None — the runner
+                # treats this as "reuse prior plan".
+                log.info(
+                    "LLMPlanner.handle_turn: attempt %d/%d: produced_plan=no "
+                    "prior_plan_id=%s",
+                    attempt,
+                    max_attempts,
+                    prior_id,
+                )
+                return None
+            # Validate now (mirrors what the steerer's install path
+            # would otherwise check) so a Rule-6 regression triggers
+            # the retry rather than the runner aborting the turn.
+            # Pivot installs go through ``install_initial_plan`` which
+            # validates against the empty seed — skip the prior here.
+            is_pivot = bool(getattr(candidate, "_goldfive_pivot", False))
+            try:
+                if is_pivot or prior_plan is None or not prior_plan.tasks:
+                    candidate.validate(for_revision=True, prior=None)
+                else:
+                    candidate.validate(for_revision=True, prior=prior_plan)
+            except ValueError as exc:
+                last_error = str(exc)
+                log.warning(
+                    "LLMPlanner.handle_turn: attempt %d/%d: validator rejected "
+                    "produced plan: %s",
+                    attempt,
+                    max_attempts,
+                    last_error,
+                )
+                if attempt < max_attempts:
+                    user_prompt = self._build_correction_prompt(
+                        base_user_prompt, last_error
+                    )
+                    continue
+                # Final attempt failed validation. Return the candidate
+                # anyway — the runner's install path will surface the
+                # validation error via SCHEMA_VIOLATION drift, matching
+                # the prior behaviour for callers that disable retry.
+                plan = candidate
+                break
+            plan = candidate
+            break
         log.info(
-            "LLMPlanner.handle_turn: produced_plan=%s prior_plan_id=%s",
+            "LLMPlanner.handle_turn: produced_plan=%s prior_plan_id=%s%s",
             "yes" if plan is not None else "no",
             prior_id,
+            f" (after {attempt} attempt(s))" if attempt > 1 else "",
         )
         return plan
 
@@ -3497,12 +3593,24 @@ SUMMARY POLICY (applies to ``plan.summary``):
         conversational by the Runner). The contract: this method MUST
         NOT raise.
 
-        When the LLM produces a plan, ALWAYS install the prior plan's
-        id verbatim — the steerer's ``_apply_revision`` then bumps
+        When the LLM produces a plan AND ``replaces_prior`` is False
+        (or absent — the safe default), install the prior plan's id
+        verbatim — the steerer's ``_apply_revision`` then bumps
         ``revision_index`` cleanly. Validation v3 confirmed
-        refine/replace collapse: even a topic-shift steer like
-        "forget solar panels, tell me about solar flares" lands as a
-        same-id revision_index bump rather than a fresh plan id.
+        refine/replace collapse for that path.
+
+        When ``replaces_prior`` is True (F5 — pivot routing,
+        goldfive#322 Layer 2 / #204), the LLM has signalled an
+        artefact-replacement intent. Mint a FRESH plan id (drop the
+        prior's id) and stash the pivot flag on the Plan via the
+        sentinel attribute :attr:`Plan._goldfive_pivot` so the
+        Runner's ``_install_revision`` routes through
+        ``install_initial_plan`` rather than
+        ``install_revision_for_drift``. The fresh id +
+        non-revision install path mean Rule 6
+        (terminal-task / terminal->terminal-edge preservation in
+        :meth:`Plan.validate`) does not gate the new plan against
+        the prior — a pivot is structurally a fresh start.
         """
         if not isinstance(raw, str) or not raw.strip():
             log.warning("LLMPlanner.handle_turn: empty / non-str response")
@@ -3533,10 +3641,17 @@ SUMMARY POLICY (applies to ``plan.summary``):
         run_id = ""
         if context is not None:
             run_id = str(context.get("run_id") or "")
-        # Reuse the prior plan's id so the steerer's _apply_revision
-        # bumps revision_index cleanly. This holds for the empty seed
-        # (revision 0 → revision 1) AND for every subsequent revision.
-        plan_id_override = prior_plan.id if prior_plan is not None and prior_plan.id else None
+        # F5: pivot detection. ``replaces_prior=true`` → mint a fresh
+        # plan_id and signal the runner to route through
+        # ``install_initial_plan``. False/absent (the safe default) →
+        # reuse the prior id so revision_index bumps cleanly.
+        replaces_prior = bool(parsed.get("replaces_prior"))
+        if replaces_prior:
+            plan_id_override = None  # _plan_from_json mints a fresh uuid
+        else:
+            plan_id_override = (
+                prior_plan.id if prior_plan is not None and prior_plan.id else None
+            )
         prior_goal_ids = list(prior_plan.goal_ids) if prior_plan is not None else []
         plan = _plan_from_json(
             plan_raw,
@@ -3549,6 +3664,13 @@ SUMMARY POLICY (applies to ``plan.summary``):
                 "LLMPlanner.handle_turn: 'plan' failed structural parse; treating as conversational"
             )
             return None
+        # F5: stamp the pivot flag onto the Plan so the runner's
+        # ``_install_revision`` can route to ``install_initial_plan``.
+        # Plain attribute on the dataclass instance (Plan is mutable);
+        # the runner reads via ``getattr(plan, "_goldfive_pivot", False)``
+        # so older Plans (no flag) trivially route as revisions.
+        if replaces_prior:
+            plan._goldfive_pivot = True  # type: ignore[attr-defined]
         return plan
 
 

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -38,6 +38,7 @@ and are loaded lazily by callers.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import inspect
 import logging
 import warnings
@@ -545,13 +546,40 @@ class Runner:
             )
             return outcome
 
+        # F9 (closes goldfive#322 Layer 4): mint fresh goal ids when
+        # the deriver's LLM-supplied id collides with an existing
+        # session goal. The deriver's prompt prompts ``g1`` every
+        # turn; the prior dedup-on-collision path silently dropped
+        # legitimate new goals, so multi-turn sessions accumulated
+        # only the first turn's goals. Renumber the new goal so it
+        # lands in ``session.goals`` instead of being discarded.
+        #
+        # Renumbering is done by replacing the Goal with a fresh
+        # ``dataclasses.replace`` copy so we never mutate the
+        # deriver's stored list in place — some derivers (e.g.
+        # :class:`PassthroughGoalDeriver`) return shallow copies
+        # that share Goal objects with their internal cache; an
+        # in-place mutation would silently rewrite the deriver's
+        # state for subsequent turns.
         existing_ids = {g.id for g in session.goals if g.id}
+        next_seq = len(session.goals) + 1
         for g in new_goals:
             if g.id and g.id in existing_ids:
-                continue
+                while True:
+                    candidate = f"g{next_seq}"
+                    next_seq += 1
+                    if candidate not in existing_ids:
+                        break
+                log.info(
+                    "Runner.run: goal id collision (%r) — renumbering to %r",
+                    g.id,
+                    candidate,
+                )
+                g = dataclasses.replace(g, id=candidate)
             session.goals.append(g)
             if g.id:
                 existing_ids.add(g.id)
+                next_seq = max(next_seq, len(session.goals) + 1)
 
         # goldfive#152: refresh the orchestration-state goals summary
         # so prompt templates / handle_turn / downstream planners see
@@ -699,11 +727,24 @@ class Runner:
             # Conversational follow-up on a real prior plan. Reuse
             # session.plan unchanged. No PlanRevised — the prior
             # revision is still the right one for this turn.
+            #
+            # F6 (closes goldfive#277): wrap ``user_input`` with a
+            # directive that tells the coordinator to answer briefly
+            # from history rather than re-delegating to sub-agents.
+            # The directive lives in the message body — NOT the system
+            # prompt — to preserve the no-prompt-contract principle:
+            # users bring their own coordinator prompts; goldfive must
+            # not require them to honour a specific system-prompt
+            # contract. The session flag below lets a parallel
+            # adapter-plugin layer (e.g. the ADK plugin's pre-dispatch
+            # interceptor) tighten the tool surface for this turn
+            # without coordinating through the message body.
             log.info(
                 "Runner.run: conversational turn — reusing prior plan_id=%s revision_index=%d",
                 (session.plan.id or "")[:16] or "<none>",
                 int(session.plan.revision_index),
             )
+            session._conversational_turn = True  # type: ignore[attr-defined]
 
         # 5. Register the canonical reporting tools on the adapter.
         # goldfive#196: ``drift_self_reporting`` decides whether the
@@ -807,10 +848,26 @@ class Runner:
                 # ``adapter.invoke_passthrough``. Best-effort via
                 # inspection — executors that don't accept
                 # ``user_input=`` keep working with the legacy kwargs.
+                #
+                # F6 (goldfive#277): on a conversational turn, hand the
+                # executor the wrapped directive (frames the input as a
+                # follow-up question, asks the coordinator not to
+                # delegate). The wrapping lives at the executor handoff
+                # so absorb_turn / event summaries above still see the
+                # user's actual question.
                 if isinstance(user_input, str):
                     run_sig = inspect.signature(self.executor.run)
                     if "user_input" in run_sig.parameters:
-                        executor_kwargs["user_input"] = user_input
+                        executor_user_input = user_input
+                        if (
+                            getattr(session, "_conversational_turn", False)
+                            and user_input.strip()
+                        ):
+                            executor_user_input = self._wrap_conversational_input(
+                                user_input=user_input,
+                                session=session,
+                            )
+                        executor_kwargs["user_input"] = executor_user_input
                 outcome = await self.executor.run(**executor_kwargs)
             except Exception as exc:  # noqa: BLE001
                 reason = f"executor.run raised: {exc}"
@@ -1336,14 +1393,40 @@ class Runner:
         # with this turn.
         if not revised_plan.run_id:
             revised_plan.run_id = session.run_id
-        # Branch on first-turn vs replan. ``session.plan`` is non-None
-        # on every turn (the Runner seeds Plan.empty on turn 1); the
-        # absence of tasks is the unambiguous "first install" signal.
+        # Branch on first-turn vs pivot vs replan.
+        #
+        # * First turn — ``session.plan`` is the empty seed (no tasks);
+        #   route through ``install_initial_plan`` (no Rule 6 binding).
+        # * Pivot turn (F5, goldfive#322 Layer 2 / #204) — the planner's
+        #   ``handle_turn`` set ``_goldfive_pivot`` on the revised plan
+        #   to signal that the user is replacing prior intent rather
+        #   than building on it. The plan already carries a fresh
+        #   plan_id (minted in ``_parse_handle_turn_response``); route
+        #   through ``install_initial_plan`` so Rule 6 doesn't reject
+        #   the legitimate pivot for "dropping" the prior's terminal
+        #   tasks.
+        # * Otherwise — replan via ``install_revision_for_drift`` with
+        #   a NEW_WORK_DISCOVERED drift (the existing path).
+        #
+        # ``session.plan`` is non-None on every turn (the Runner seeds
+        # Plan.empty on turn 1); the absence of tasks is the
+        # unambiguous "first install" signal.
         first_turn = session.plan is None or not session.plan.tasks
+        is_pivot = bool(getattr(revised_plan, "_goldfive_pivot", False))
         try:
-            if first_turn:
+            if first_turn or is_pivot:
+                if is_pivot:
+                    log.info(
+                        "Runner._install_revision: pivot detected — routing "
+                        "through install_initial_plan (fresh plan_id=%s, "
+                        "prior_plan_id=%s)",
+                        (revised_plan.id or "")[:16] or "<none>",
+                        (session.plan.id or "")[:16]
+                        if session.plan is not None
+                        else "<none>",
+                    )
                 installed = await self.steerer.install_initial_plan(
-                    session=session, plan=revised_plan
+                    session=session, plan=revised_plan, is_pivot=is_pivot
                 )
             else:
                 # Turn N+1 replan: the user's fresh message caused
@@ -1376,6 +1459,58 @@ class Runner:
             )
             return False
         return bool(installed)
+
+    @staticmethod
+    def _wrap_conversational_input(
+        *,
+        user_input: str,
+        session: Session,
+    ) -> str:
+        """Compose a directive that frames the user's input as a
+        conversational follow-up (F6, closes goldfive#277).
+
+        When :meth:`Planner.handle_turn` returns ``None`` on a turn
+        with a real prior plan, the runner reuses ``session.plan``
+        but still drives the executor over the input — without this
+        wrapper the coordinator typically treats the question as a
+        fresh task and re-delegates to sub-agents, wasting an
+        invocation. The wrapper:
+
+        * tags the message as a conversational follow-up,
+        * gives the coordinator the plan summary + completed task
+          context so it can answer from history,
+        * asks it explicitly NOT to delegate.
+
+        Lives in the message body (no system-prompt contract). A
+        parallel layer (the ADK plugin's pre-dispatch interceptor,
+        keyed off ``session._conversational_turn``) tightens the
+        tool surface so the coordinator literally cannot delegate
+        even if it tried; this wrapper is the cooperative half.
+        """
+        from goldfive.types import TaskStatus
+
+        plan = session.plan
+        plan_summary = (plan.summary if plan is not None else "") or "(no summary)"
+        completed_lines: list[str] = []
+        if plan is not None:
+            for t in plan.tasks:
+                if t.status is TaskStatus.COMPLETED:
+                    title = t.title or t.description or t.id
+                    assignee = t.assignee_agent_id or "(no-assignee)"
+                    completed_lines.append(f"  - [{t.id}] {title} (by {assignee})")
+        completed_block = (
+            "\n".join(completed_lines) if completed_lines else "  (none yet)"
+        )
+        return (
+            "[CONVERSATIONAL FOLLOW-UP — reuse prior plan, don't delegate "
+            "to sub-agents]\n\n"
+            "The user is asking a follow-up question about prior work. "
+            "Answer briefly using the conversation history and existing "
+            "artifacts. Do NOT call any AgentTool — answer directly.\n\n"
+            f"Plan summary: {plan_summary}\n"
+            f"Completed tasks:\n{completed_block}\n\n"
+            f"User question: {user_input}"
+        )
 
     async def _resolve_goals(
         self,

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -4080,6 +4080,7 @@ class DefaultSteerer:
         *,
         session: Session,
         plan: Plan,
+        is_pivot: bool = False,
     ) -> bool:
         """Install ``plan`` as the very first revision (rev 1) of ``session.plan``.
 
@@ -4089,6 +4090,16 @@ class DefaultSteerer:
         installing the first plan is not a corrective intervention,
         and stamping a USER_STEER drift here was the category error
         Option A (goldfive#271 follow-up) eliminates.
+
+        ``is_pivot`` (F5, goldfive#322 Layer 2 / #204): when ``True``,
+        the caller has classified the user's intent as a PIVOT —
+        replacement of the prior plan rather than a revision of it.
+        The validator runs WITHOUT ``prior`` so Rule 6
+        (terminal-task / terminal->terminal-edge preservation) does
+        not gate the new plan against a structurally-unrelated
+        predecessor. The runner sets this when
+        :meth:`Planner.handle_turn` flagged ``replaces_prior`` on the
+        produced plan.
 
         The internal ``DriftEvent`` placeholder this method passes to
         :meth:`_apply_revision` and :meth:`_emit_plan_revised` carries
@@ -4103,7 +4114,13 @@ class DefaultSteerer:
         Never raises.
         """
         try:
-            plan.validate(for_revision=True, prior=session.plan)
+            if is_pivot:
+                # Pivot: validate structurally only. Rule 6 (terminal
+                # preservation) is intentionally skipped — the user is
+                # replacing the prior plan, not revising it.
+                plan.validate(for_revision=True, prior=None)
+            else:
+                plan.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
             await self._emit_drift_detected(
                 session,

--- a/tests/test_tier2_steer_pipeline.py
+++ b/tests/test_tier2_steer_pipeline.py
@@ -1,0 +1,698 @@
+"""Regression tests for the Tier 2 user-steer pipeline (F5+F6+F7+F9).
+
+Closes goldfive#322 (Layer 2 + Layer 4) and references #277, #204.
+
+The four fixes covered here:
+
+* **F5 — Pivot routing.** When the planner's ``handle_turn`` flags
+  ``replaces_prior=true`` on a steer like "forget X, do Y instead",
+  the runner installs the result through
+  :meth:`DefaultSteerer.install_initial_plan` (fresh plan_id,
+  no Rule 6 binding) instead of
+  :meth:`DefaultSteerer.install_revision_for_drift`.
+* **F6 — Conversational dispatch path.** When ``handle_turn`` returns
+  ``None`` on a real prior plan, the runner wraps the user_input with
+  a directive that frames it as a follow-up question and asks the
+  coordinator not to delegate. ``session._conversational_turn`` is
+  set so a parallel adapter-plugin layer can tighten the tool surface.
+* **F7 — handle_turn validator-feedback retry.** When the first LLM
+  attempt produces a Rule 6-violating revision, ``handle_turn`` retries
+  once with the validator's error message appended to the prompt
+  (mirrors the ``_call_and_validate_refine`` pattern).
+* **F9 — Goal id collision.** When the goal deriver mints a colliding
+  ``g1`` on a follow-up turn, the runner renumbers it instead of
+  silently dropping the new goal.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive import (  # noqa: E402
+    CallableAdapter,
+    Goal,
+    InMemorySink,
+    InvocationResult,
+    LLMPlanner,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers (model on tests/test_planner_handle_turn.py + test_runner_multi_turn.py)
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedLLM:
+    """Returns canned responses, optionally per-call from a script.
+
+    A list of responses lets a single LLM stub answer multiple
+    handle_turn calls in sequence (one per turn).
+    """
+
+    def __init__(self, responses: str | list[str]) -> None:
+        if isinstance(responses, str):
+            responses = [responses]
+        self._responses = list(responses)
+        self._idx = 0
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        self.calls.append((system, user, model))
+        # Repeat the last response if the script is exhausted.
+        i = min(self._idx, len(self._responses) - 1)
+        self._idx += 1
+        return self._responses[i]
+
+
+def _populated_session(*, plan_id: str = "plan-prior") -> Session:
+    """Session with a one-completed-task prior plan."""
+    s = Session(run_id="r-test")
+    s.goals = [Goal(id="g1", summary="Make a 2-slide presentation about solar panels.")]
+    s.plan = Plan(
+        id=plan_id,
+        run_id="r-test",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_panels",
+                title="Research solar panels",
+                assignee_agent_id="writer",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="draft_slides",
+                title="Draft the slides",
+                assignee_agent_id="writer",
+                status=TaskStatus.COMPLETED,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research_panels", to_task_id="draft_slides")],
+        summary="Make a 2-slide presentation about solar panels.",
+        revision_index=1,
+    )
+    return s
+
+
+def _plan_dict(
+    *,
+    plan_id: str = "plan-new",
+    summary: str = "x",
+    tasks: list[dict[str, Any]] | None = None,
+    edges: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": plan_id,
+        "summary": summary,
+        "tasks": tasks
+        or [
+            {
+                "id": "t1",
+                "title": "do the thing",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            }
+        ],
+        "edges": edges or [],
+    }
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = tools, session
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+# ---------------------------------------------------------------------------
+# F5 — Pivot routing
+# ---------------------------------------------------------------------------
+
+
+async def test_f5_pivot_flag_mints_fresh_plan_id() -> None:
+    """When the LLM emits ``replaces_prior: true``, the parser drops
+    the prior plan id and mints a fresh one.
+    """
+    scripted = _ScriptedLLM(
+        json.dumps(
+            {
+                "reasoning": "user pivoted to a different artefact entirely",
+                "replaces_prior": True,
+                "plan": _plan_dict(plan_id="ignored", summary="haiku draft"),
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    session = _populated_session(plan_id="plan-prior-stable")
+    plan = await planner.handle_turn(
+        user_input="forget the slides — write me a haiku about cats instead",
+        session=session,
+    )
+    assert plan is not None
+    # Pivot path: id is freshly minted, NOT inherited from the prior.
+    assert plan.id != "plan-prior-stable"
+    assert plan.id, "fresh plan id should be non-empty"
+    # The pivot sentinel is set so the runner routes through
+    # install_initial_plan instead of install_revision_for_drift.
+    assert getattr(plan, "_goldfive_pivot", False) is True
+
+
+async def test_f5_replaces_prior_false_preserves_plan_id() -> None:
+    """When ``replaces_prior`` is False (or absent), the prior plan id
+    is preserved verbatim — the existing revision path.
+    """
+    scripted = _ScriptedLLM(
+        json.dumps(
+            {
+                "reasoning": "additive constraint",
+                "replaces_prior": False,
+                "plan": _plan_dict(plan_id="ignored"),
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    session = _populated_session(plan_id="plan-prior-stable")
+    plan = await planner.handle_turn(
+        user_input="make sure the slides are 2 slides max",
+        session=session,
+    )
+    assert plan is not None
+    assert plan.id == "plan-prior-stable"
+    assert getattr(plan, "_goldfive_pivot", False) is False
+
+
+async def test_f5_pivot_routes_through_install_initial_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: drive turn 1 (initial plan) then turn 2 with a pivot
+    input. Assert turn 2 lands a NEW plan_id (Rule 6 NOT applied) by
+    checking that ``install_initial_plan`` was called for both turns
+    and ``install_revision_for_drift`` was never called.
+    """
+    plan_t1 = _plan_dict(
+        plan_id="ignored-by-runner",
+        summary="2-slide presentation about solar panels",
+        tasks=[
+            {
+                "id": "research_panels",
+                "title": "Research solar panels",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            },
+            {
+                "id": "draft_slides",
+                "title": "Draft 2 slides about solar panels",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            },
+        ],
+        edges=[
+            {"from_task_id": "research_panels", "to_task_id": "draft_slides"},
+        ],
+    )
+    # Turn 2: pivot — drop the prior tasks entirely (which would
+    # violate Rule 6 if routed as a revision), with replaces_prior=true.
+    plan_t2_pivot = _plan_dict(
+        plan_id="ignored-by-runner",
+        summary="haiku about cats",
+        tasks=[
+            {
+                "id": "write_haiku",
+                "title": "Write a haiku about cats",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            }
+        ],
+        edges=[],
+    )
+
+    async def planner_llm(system: str, user: str, model: str) -> str:
+        _ = model
+        if (
+            "warrants a plan change" in system
+            or "PIVOT vs REVISION" in system
+        ):
+            # handle_turn call. Decide based on the user message.
+            if "haiku" in user.lower() or "forget" in user.lower():
+                return json.dumps(
+                    {
+                        "reasoning": "pivot to a different artefact",
+                        "replaces_prior": True,
+                        "plan": plan_t2_pivot,
+                    }
+                )
+            return json.dumps(
+                {
+                    "reasoning": "first turn",
+                    "replaces_prior": False,
+                    "plan": plan_t1,
+                }
+            )
+        # Plan-generate fall-through (first turn against empty seed).
+        return json.dumps(plan_t1)
+
+    planner = LLMPlanner(call_llm=planner_llm, model="stub")
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    # Spy on the steerer's install paths.
+    initial_calls: list[tuple[str, bool]] = []
+    drift_calls: list[str] = []
+    real_initial = runner.steerer.install_initial_plan
+    real_drift = runner.steerer.install_revision_for_drift
+
+    async def _spy_initial(
+        *, session: Session, plan: Plan, is_pivot: bool = False
+    ) -> bool:
+        initial_calls.append((plan.id, is_pivot))
+        return await real_initial(session=session, plan=plan, is_pivot=is_pivot)
+
+    async def _spy_drift(*, session: Session, drift: Any, revised_plan: Plan) -> bool:
+        drift_calls.append(revised_plan.id)
+        return await real_drift(
+            session=session, drift=drift, revised_plan=revised_plan
+        )
+
+    monkeypatch.setattr(runner.steerer, "install_initial_plan", _spy_initial)
+    monkeypatch.setattr(
+        runner.steerer, "install_revision_for_drift", _spy_drift
+    )
+
+    out1 = await runner.run("make a 2-slide presentation about solar panels")
+    assert out1.success, out1.reason
+    turn1_plan_id = out1.session.plan.id
+
+    out2 = await runner.run("forget the slides — write a haiku about cats")
+    await runner.close()
+    assert out2.success, out2.reason
+    turn2_plan_id = out2.session.plan.id
+
+    # F5 invariant: pivot routed through install_initial_plan, NOT
+    # install_revision_for_drift. Turn 1 also goes through
+    # install_initial_plan (first-turn path), so we expect 2 calls.
+    # Turn 1 is_pivot=False (genuine first turn); turn 2 is_pivot=True.
+    assert len(initial_calls) == 2, (
+        f"expected 2 install_initial_plan calls (turn 1 + pivot turn 2); "
+        f"got {len(initial_calls)}"
+    )
+    assert initial_calls[0][1] is False, (
+        f"turn 1 should be first-turn (is_pivot=False); got {initial_calls[0]}"
+    )
+    assert initial_calls[1][1] is True, (
+        f"turn 2 should be flagged as pivot (is_pivot=True); got {initial_calls[1]}"
+    )
+    assert len(drift_calls) == 0, (
+        f"pivot must NOT route through install_revision_for_drift; "
+        f"got {len(drift_calls)} drift install(s)"
+    )
+    # Plan id changed across the pivot.
+    assert turn2_plan_id != turn1_plan_id, (
+        f"pivot should mint a fresh plan id; both turns got {turn1_plan_id}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F6 — Conversational dispatch path
+# ---------------------------------------------------------------------------
+
+
+async def test_f6_conversational_turn_wraps_user_input_for_executor() -> None:
+    """When handle_turn returns None on a real prior plan, the runner
+    wraps the user_input with a CONVERSATIONAL FOLLOW-UP directive
+    before handing it to the executor, AND sets
+    ``session._conversational_turn = True``.
+    """
+    plan_t1 = _plan_dict(
+        plan_id="ignored",
+        summary="presentation about solar panels",
+        tasks=[
+            {
+                "id": "draft_slides",
+                "title": "Draft slides",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            }
+        ],
+    )
+
+    async def planner_llm(system: str, user: str, model: str) -> str:
+        _ = model
+        if "warrants a plan change" in system or "PIVOT vs REVISION" in system:
+            # Turn 2 conversational — return null plan.
+            if "where" in user.lower():
+                return json.dumps(
+                    {
+                        "reasoning": "factual question about prior",
+                        "replaces_prior": False,
+                        "plan": None,
+                    }
+                )
+            return json.dumps(
+                {"reasoning": "first turn", "replaces_prior": False, "plan": plan_t1}
+            )
+        return json.dumps(plan_t1)
+
+    planner = LLMPlanner(call_llm=planner_llm, model="stub")
+    sink = InMemorySink()
+
+    # Capture user_inputs handed to the agent.
+    seen_inputs: list[str] = []
+
+    async def _capture_agent(
+        task: Task,
+        session: Session,
+        tools: list[ReportingToolSpec],
+    ) -> InvocationResult:
+        _ = tools
+        # SequentialExecutor passes user_input through invoke_passthrough
+        # for the overlay path; the per-task invoke surface here only
+        # sees the task. We instead capture via the executor's
+        # passthrough invocation below — this branch covers the
+        # legacy invocation surface so the test still exercises the
+        # plan execution.
+        return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+    runner = Runner(
+        agent=CallableAdapter(_capture_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    # Wrap the executor.run to snapshot the user_input it receives.
+    # Preserve the wrapped function's signature so the runner's
+    # ``inspect.signature(executor.run)`` parameter probe (which gates
+    # whether the runner passes ``user_input=`` at all) still sees a
+    # ``user_input`` parameter.
+    import functools
+
+    real_executor_run = runner.executor.run
+    captured_user_inputs: list[str] = []
+
+    @functools.wraps(real_executor_run)
+    async def _spy_run(*args: Any, **kwargs: Any) -> Any:
+        captured_user_inputs.append(kwargs.get("user_input", ""))
+        return await real_executor_run(*args, **kwargs)
+
+    runner.executor.run = _spy_run  # type: ignore[method-assign]
+
+    out1 = await runner.run("make a presentation about solar panels")
+    assert out1.success, out1.reason
+
+    out2 = await runner.run("where will the slides be saved?")
+    await runner.close()
+    assert out2.success, out2.reason
+
+    # Turn 1: user_input is the raw user request (no wrapping).
+    assert captured_user_inputs[0] == "make a presentation about solar panels"
+    # Turn 2: user_input is wrapped with the conversational directive.
+    wrapped = captured_user_inputs[1]
+    assert "CONVERSATIONAL FOLLOW-UP" in wrapped, wrapped
+    assert "Do NOT call any AgentTool" in wrapped, wrapped
+    assert "where will the slides be saved?" in wrapped, wrapped
+    # Plan summary is threaded through.
+    assert "presentation about solar panels" in wrapped, wrapped
+
+    # Session flag set so a parallel plugin layer can tighten the tool
+    # surface for this turn.
+    assert getattr(out2.session, "_conversational_turn", False) is True
+    _ = seen_inputs  # silence unused — captured via _spy_run
+
+
+# ---------------------------------------------------------------------------
+# F7 — handle_turn validator-feedback retry
+# ---------------------------------------------------------------------------
+
+
+async def test_f7_handle_turn_retries_on_rule6_validation_failure() -> None:
+    """First LLM attempt drops a terminal task (Rule 6 violation);
+    second attempt preserves it. handle_turn must succeed via retry
+    AND the second attempt's prompt must include the validator's error
+    message.
+    """
+    # Attempt 1: drops the COMPLETED ``research_panels`` task →
+    # Plan.validate(for_revision=True, prior=...) raises Rule 6.
+    bad_plan = _plan_dict(
+        plan_id="ignored",
+        summary="solar flares",
+        tasks=[
+            {
+                "id": "draft_slides",
+                "title": "Draft slides about solar flares",
+                "assignee_agent_id": "writer",
+                "status": "COMPLETED",
+            },
+        ],
+        edges=[],
+    )
+    # Attempt 2: preserves both terminal tasks AND their edge.
+    good_plan = _plan_dict(
+        plan_id="ignored",
+        summary="2-slide presentation about solar flares",
+        tasks=[
+            {
+                "id": "research_panels",
+                "title": "Research solar panels",
+                "assignee_agent_id": "writer",
+                "status": "COMPLETED",
+            },
+            {
+                "id": "draft_slides",
+                "title": "Draft the slides",
+                "assignee_agent_id": "writer",
+                "status": "COMPLETED",
+            },
+            {
+                "id": "research_flares",
+                "title": "Research solar flares",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            },
+        ],
+        edges=[
+            {"from_task_id": "research_panels", "to_task_id": "draft_slides"},
+        ],
+    )
+    scripted = _ScriptedLLM(
+        [
+            json.dumps(
+                {
+                    "reasoning": "topic shift to flares",
+                    "replaces_prior": False,
+                    "plan": bad_plan,
+                }
+            ),
+            json.dumps(
+                {
+                    "reasoning": "preserved terminal tasks this time",
+                    "replaces_prior": False,
+                    "plan": good_plan,
+                }
+            ),
+        ]
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    session = _populated_session(plan_id="plan-prior-id")
+    plan = await planner.handle_turn(
+        user_input="actually, also cover solar flares",
+        session=session,
+    )
+    assert plan is not None, "retry should produce a valid plan"
+    # Two LLM calls: first failed validation, second succeeded.
+    assert len(scripted.calls) == 2, scripted.calls
+    # Second call's user prompt carries the validator's error message.
+    _sys2, user2, _model2 = scripted.calls[1]
+    assert "PREVIOUS ATTEMPT FAILED" in user2, user2
+    assert "terminal task" in user2 or "missing in revision" in user2, user2
+
+
+async def test_f7_handle_turn_succeeds_on_first_attempt_when_valid() -> None:
+    """No retry when the first attempt validates."""
+    good_plan = _plan_dict(
+        plan_id="ignored",
+        summary="2-slide presentation about solar panels",
+        tasks=[
+            {
+                "id": "research_panels",
+                "title": "Research solar panels",
+                "assignee_agent_id": "writer",
+                "status": "COMPLETED",
+            },
+            {
+                "id": "draft_slides",
+                "title": "Draft the slides",
+                "assignee_agent_id": "writer",
+                "status": "COMPLETED",
+            },
+            {
+                "id": "review",
+                "title": "Review the slides",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            },
+        ],
+        edges=[
+            {"from_task_id": "research_panels", "to_task_id": "draft_slides"},
+        ],
+    )
+    scripted = _ScriptedLLM(
+        json.dumps(
+            {
+                "reasoning": "additive review task",
+                "replaces_prior": False,
+                "plan": good_plan,
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    session = _populated_session(plan_id="plan-prior-id")
+    plan = await planner.handle_turn(
+        user_input="also have someone review the slides",
+        session=session,
+    )
+    assert plan is not None
+    assert len(scripted.calls) == 1, "no retry needed when validation passes"
+
+
+# ---------------------------------------------------------------------------
+# F9 — Goal id collision
+# ---------------------------------------------------------------------------
+
+
+class _FixedIdGoalDeriver:
+    """Deriver that mints ``g1`` every turn — mirrors the LLM-deriver
+    bug where the prompt elicits the same id on every call.
+    """
+
+    def __init__(self, summaries_by_input: dict[str, str]) -> None:
+        self._map = summaries_by_input
+
+    async def derive(
+        self,
+        user_input: str,
+        *,
+        context: Any = None,
+    ) -> list[Goal]:
+        summary = self._map.get(user_input, user_input)
+        return [Goal(id="g1", summary=summary)]
+
+
+async def test_f9_goal_id_collision_renumbers_instead_of_dropping() -> None:
+    """Two consecutive turns whose deriver mints the same ``g1`` id
+    must both end up in ``session.goals`` (the second renumbered to
+    ``g2``).
+    """
+    plan_t1 = _plan_dict(
+        plan_id="ignored",
+        summary="presentation about solar panels",
+        tasks=[
+            {
+                "id": "draft",
+                "title": "Draft slides",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            }
+        ],
+    )
+    # Turn 2 revision must preserve the COMPLETED ``draft`` from turn 1
+    # (Rule 6) and add a delta task for the funnier tone.
+    plan_t2 = _plan_dict(
+        plan_id="ignored",
+        summary="presentation about solar panels with funny tone",
+        tasks=[
+            {
+                "id": "draft",
+                "title": "Draft slides",
+                "assignee_agent_id": "writer",
+                "status": "COMPLETED",
+            },
+            {
+                "id": "tone_pass",
+                "title": "Rewrite slides with a funnier tone",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            },
+        ],
+        edges=[{"from_task_id": "draft", "to_task_id": "tone_pass"}],
+    )
+
+    async def planner_llm(system: str, user: str, model: str) -> str:
+        _ = model
+        if "warrants a plan change" in system or "PIVOT vs REVISION" in system:
+            # Distinguish turn 1 (initial plan) from turn 2 (revision)
+            # off the user prompt — turn 2's input contains "funnier".
+            if "funnier" in user.lower():
+                return json.dumps(
+                    {
+                        "reasoning": "tone tweak",
+                        "replaces_prior": False,
+                        "plan": plan_t2,
+                    }
+                )
+            return json.dumps(
+                {"reasoning": "first turn", "replaces_prior": False, "plan": plan_t1}
+            )
+        return json.dumps(plan_t1)
+
+    planner = LLMPlanner(call_llm=planner_llm, model="stub")
+    deriver = _FixedIdGoalDeriver(
+        {
+            "make a presentation about solar panels": (
+                "Make a presentation about solar panels."
+            ),
+            "make it funnier": "Make the tone funnier.",
+        }
+    )
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=deriver,
+        sinks=[sink],
+    )
+
+    out1 = await runner.run("make a presentation about solar panels")
+    assert out1.success, out1.reason
+
+    out2 = await runner.run("make it funnier")
+    await runner.close()
+    assert out2.success, out2.reason
+
+    # F9 invariant: BOTH goals are in session.goals; the second was
+    # renumbered to g2 instead of being silently dropped.
+    summaries = [g.summary for g in out2.session.goals]
+    assert len(out2.session.goals) == 2, (
+        f"expected 2 goals after collision; got {len(out2.session.goals)}: "
+        f"{summaries}"
+    )
+    assert "Make a presentation about solar panels." in summaries, summaries
+    assert "Make the tone funnier." in summaries, summaries
+    ids = sorted(g.id for g in out2.session.goals)
+    assert ids == ["g1", "g2"], ids


### PR DESCRIPTION
## Summary

Tier 2 of the structural-fix push — four targeted fixes for the multi-turn user-steer path.

* **F5 — Pivot routing.** `LLMPlanner.handle_turn` extends its JSON schema with `replaces_prior`; pivots mint a fresh `plan_id` and route through `install_initial_plan(is_pivot=True)` so Rule 6 doesn't reject legitimate artefact-replacement steers like "forget X, do Y instead". Closes goldfive#322 Layer 2 / #204.
* **F6 — Conversational dispatch path.** When `handle_turn` returns null on a real prior plan, the runner wraps `user_input` with a `[CONVERSATIONAL FOLLOW-UP — reuse prior plan, don't delegate]` directive and sets `session._conversational_turn = True`. Wrapping happens at the executor handoff (preserves absorb_turn semantics) and lives in the message body to honour the no-prompt-contract principle. Closes goldfive#277.
* **F7 — handle_turn validator-feedback retry.** Mirrors the existing `_call_and_validate_refine` retry: on a Rule 6 / structural failure, retry once with the validator error appended via `_build_correction_prompt`. Caps at 2 attempts.
* **F9 — Goal id collision.** Runner now renumbers colliding LLM-supplied goal ids via `dataclasses.replace` (avoids mutating the deriver's stored Goal references, which broke `PassthroughGoalDeriver`-style derivers in turn 2). Closes goldfive#322 Layer 4.

## Files changed

* `goldfive/planner.py` — `replaces_prior` schema + prompt section, retry loop in `handle_turn`, pivot id minting + `_goldfive_pivot` sentinel in `_parse_handle_turn_response`.
* `goldfive/runner.py` — pivot routing in `_install_revision`, conversational `_wrap_conversational_input` helper at executor handoff, F9 goal-id renumbering.
* `goldfive/steerer.py` — `install_initial_plan` gains `is_pivot: bool = False` kwarg (validates without `prior` when set).
* `tests/test_tier2_steer_pipeline.py` — 7 new regression tests.

## Test plan

- [x] `uv run --extra dev pytest tests -q` — 1572 passed, 113 skipped (was 1565+113 on origin/main; +7 new tests, no regressions)
- [x] `uv run --extra dev ruff check goldfive/ tests/` — clean
- [x] F5: turn 2 with "forget the slides — write a haiku about cats" routes through `install_initial_plan(is_pivot=True)` and lands a fresh `plan_id`; `install_revision_for_drift` is never called
- [x] F6: factual question "where will the slides be saved?" gets wrapped with the directive before the executor sees it; original question still surfaced through `absorb_turn`
- [x] F7: scripted-LLM stub returning a Rule-6 violating revision then a valid one succeeds via retry; second-attempt prompt carries `PREVIOUS ATTEMPT FAILED` + the specific validator error
- [x] F9: two consecutive turns whose deriver mints `g1` both end up in `session.goals` (`g1`, `g2`)

## Coordination

Tier 1 is editing `steerer.py:155-219`, `~2966-2970`, plus `reporting.py` and `adapters/_adk_plugin.py`. This PR's `steerer.py` edit is at line 4078+ (`install_initial_plan`) — no overlap. Tier 1 will merge cleanly on top.

References #277 (conversational dispatch), #322 (steer pipeline rollup), #204 (pivot routing).