### PR TITLE
feat(adapters): ReentryKind contract for plugin re-entry observers

### DIFF
--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -60,6 +60,7 @@ from goldfive.adapters._adk_plugin import (
     SessionContext,
     make_adk_plugin,
 )
+from goldfive.adapters.adk_reentry import ReentryKind, reentry
 from goldfive.results import InvocationResult
 from goldfive.types import TERMINAL_TASK_STATUSES
 
@@ -1869,13 +1870,28 @@ class ADKAdapter:
         Returns an :class:`InvocationResult` whose ``task_id`` is
         empty (no single task owns the whole invocation) and
         ``text`` is the final assistant text.
+
+        Re-entry contract (harmonograf#234)
+        -----------------------------------
+
+        Pins :data:`~goldfive.adapters.adk_reentry.current_reentry_kind`
+        to :attr:`~goldfive.adapters.adk_reentry.ReentryKind.OVERLAY_REPLAY`
+        for the lifetime of the inner ``runner.run_async`` call. This
+        signals plugins observing the inner runner's
+        ``on_user_message_callback`` that the user-message they are
+        about to see is goldfive re-feeding the operator's input — the
+        outer (adk-web) runner already observed it as a USER_TURN. A
+        more-specific NUDGE_REPLAY / STEER_REPLAY pinned by the executor
+        BEFORE we are entered survives the nesting (see
+        :func:`~goldfive.adapters.adk_reentry.reentry` semantics).
         """
-        return await self._invoke_internal(
-            task=None,
-            session=session,
-            new_message=_passthrough_message_parts(user_message),
-            reconciler=reconciler,
-        )
+        with reentry(ReentryKind.OVERLAY_REPLAY):
+            return await self._invoke_internal(
+                task=None,
+                session=session,
+                new_message=_passthrough_message_parts(user_message),
+                reconciler=reconciler,
+            )
 
     async def invoke_follow_up(self, task: Task, session: Session) -> InvocationResult:
         """Drive a gentle follow-up for a plan ``task`` missed during passthrough.

--- a/goldfive/adapters/adk_reentry.py
+++ b/goldfive/adapters/adk_reentry.py
@@ -1,0 +1,129 @@
+"""Re-entry contract for ADK plugins observing a goldfive-wrapped tree.
+
+When goldfive's overlay calls into ADK's Runner with the operator's
+verbatim input (or a goldfive-composed nudge/steer message), the
+``on_user_message_callback`` (and similar plugin hooks) fire against
+the inner runner — but the outer runner already fired them for the
+operator's actual input. Plugins observing both sides will see
+duplicates unless they can distinguish "user turn" from "framework
+re-entry."
+
+Goldfive pins :data:`current_reentry_kind` to a non-default value
+when re-entering. Plugins read the var and short-circuit duplicate
+side-effect emissions. Default is :attr:`ReentryKind.USER_TURN` so
+plain ADK use is unchanged.
+
+Background — harmonograf#234 root cause
+---------------------------------------
+
+gRPC ground truth for a 4-turn session showed 6 ``UserMessageReceived``
+envelopes: turns that completed emitted twice, turns that aborted
+mid-invocation emitted once. The duplicate fire originates from the
+goldfive overlay re-entering ADK via :meth:`ADKAdapter.invoke_passthrough`
+which calls ``self._runner.run_async(new_message=<operator input>)``.
+ADK's ``_handle_new_message`` then triggers the plugin manager's
+``on_user_message_callback`` a second time, against the same operator
+input that was already observed and emitted by the outer adk-web
+runner. The harmonograf-client plugin's existing
+``_maybe_disable_as_duplicate`` guard only catches multiple plugin
+*instances* on the same plugin manager — here we have ONE plugin
+instance fired twice in two distinct invocation contexts.
+
+Contract
+--------
+
+Goldfive promises:
+
+* The default value (``USER_TURN``) is what every plain-ADK code path
+  observes — there is no behaviour change for non-goldfive callers.
+* When goldfive re-enters ADK with a message that did NOT originate
+  from a fresh operator turn, ``current_reentry_kind`` is set to a
+  non-default :class:`ReentryKind` for the duration of the inner
+  ``run_async`` call (and any callbacks dispatched from it).
+* The contextvar is reset on exit, including on exception.
+
+Plugins observing this contract may suppress duplicate side effects
+(e.g. dedup user-message envelope emission). Plugins that only care
+about agent-level events (before/after_agent_callback) generally do
+NOT need to consult the contextvar — those events are not duplicated
+because the outer runner has no inner agents of its own.
+"""
+from __future__ import annotations
+
+import contextlib
+import enum
+from collections.abc import Iterator
+from contextvars import ContextVar
+
+
+class ReentryKind(enum.Enum):
+    """Discriminator for ``on_user_message_callback`` re-entry shape."""
+
+    #: A fresh operator turn — the message is new user input. Default.
+    USER_TURN = "user_turn"
+
+    #: Goldfive overlay re-feeding the operator's verbatim user input
+    #: through the inner ADK runner so the wrapped tree sees it in its
+    #: session history. Triggered by :meth:`ADKAdapter.invoke_passthrough`.
+    OVERLAY_REPLAY = "overlay_replay"
+
+    #: Goldfive-composed nudge replay: the steerer queued a
+    #: ``session.pending_nudges`` entry (e.g. after a LOOPING_REASONING
+    #: drift caused refine to spawn a replacement task) and the executor
+    #: re-invokes passthrough with the composed nudge as the new user
+    #: message. Content is goldfive-authored, not operator-typed.
+    NUDGE_REPLAY = "nudge_replay"
+
+    #: Goldfive-composed steer-restart replay: the operator issued a
+    #: STEER mid-invocation, the executor cancelled the in-flight
+    #: invocation, fed the steer through the planner refine, and then
+    #: re-invokes passthrough with the steer body wrapped in a
+    #: ``USER STEERING CONTROL`` override header. Header-wrapped content
+    #: is goldfive-authored framing around operator text.
+    STEER_REPLAY = "steer_replay"
+
+
+current_reentry_kind: ContextVar[ReentryKind] = ContextVar(
+    "goldfive_reentry_kind", default=ReentryKind.USER_TURN
+)
+
+
+@contextlib.contextmanager
+def reentry(kind: ReentryKind) -> Iterator[ReentryKind]:
+    """Pin :data:`current_reentry_kind` to ``kind`` for the duration of the block.
+
+    Stack-precedence semantics
+    --------------------------
+
+    A more-specific kind nested inside a less-specific one keeps the
+    more-specific value visible. Concretely: a STEER_REPLAY *or*
+    NUDGE_REPLAY layered inside an OVERLAY_REPLAY (the natural shape
+    when the executor composes a steer/nudge message and then calls
+    :meth:`ADKAdapter.invoke_passthrough`, which itself pins
+    OVERLAY_REPLAY) keeps the steer/nudge label visible to plugins.
+    Plugins thus see the *cause* of the replay, not the mechanism.
+
+    The reverse — entering OVERLAY_REPLAY while already inside a
+    STEER_REPLAY or NUDGE_REPLAY — does NOT downgrade the visible
+    kind. It yields the prior (more-specific) kind unchanged.
+
+    Yielding from a USER_TURN context ALWAYS pins ``kind`` regardless
+    of value, so the first re-entry boundary always wins from the
+    default state.
+
+    The contextvar is reset on exit, including on exception, via the
+    standard ``ContextVar.reset(token)`` protocol.
+    """
+    prior = current_reentry_kind.get()
+    if prior is ReentryKind.USER_TURN or kind in (
+        ReentryKind.STEER_REPLAY,
+        ReentryKind.NUDGE_REPLAY,
+    ):
+        token = current_reentry_kind.set(kind)
+        try:
+            yield kind
+        finally:
+            current_reentry_kind.reset(token)
+    else:
+        # Already in a more-specific re-entry; don't downgrade.
+        yield prior

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -39,6 +39,7 @@ import re
 import warnings
 from typing import TYPE_CHECKING, Any
 
+from goldfive.adapters.adk_reentry import ReentryKind, reentry
 from goldfive.events import (
     emit,
     new_event,
@@ -857,16 +858,46 @@ class SequentialExecutor(Executor):
         current_user_input = user_input
         failure_reason = ""
         nudge_replays = 0
+        # Re-entry contract (harmonograf#234). The very first iteration
+        # of this loop carries the operator's verbatim user_input — for
+        # plugins observing the inner runner that's still a goldfive
+        # OVERLAY_REPLAY (the outer adk-web runner already emitted the
+        # USER_TURN); ADKAdapter.invoke_passthrough pins OVERLAY_REPLAY
+        # itself, so the default value here is "no executor-level pin".
+        # Subsequent iterations triggered by a STEER or queued nudge
+        # MUST carry the more-specific kind so plugins can attribute
+        # the replay to the correct cause (operator-issued steer vs
+        # autonomous drift-driven nudge); see ReentryKind.reentry()
+        # for stack-precedence rules.
+        next_reentry_kind: ReentryKind | None = None
         while True:
-            kind, payload = await self._invoke_passthrough_with_control(
-                adapter=adapter,
-                session=session,
-                steerer=steerer,
-                sinks=sinks,
-                control=control,
-                reconciler=reconciler,
-                user_input=current_user_input,
-            )
+            # ContextVars snapshot at ``asyncio.create_task`` time
+            # (which happens inside _invoke_passthrough_with_control),
+            # so the ``reentry()`` block must wrap the call site here.
+            if next_reentry_kind is None:
+                kind, payload = await self._invoke_passthrough_with_control(
+                    adapter=adapter,
+                    session=session,
+                    steerer=steerer,
+                    sinks=sinks,
+                    control=control,
+                    reconciler=reconciler,
+                    user_input=current_user_input,
+                )
+            else:
+                with reentry(next_reentry_kind):
+                    kind, payload = await self._invoke_passthrough_with_control(
+                        adapter=adapter,
+                        session=session,
+                        steerer=steerer,
+                        sinks=sinks,
+                        control=control,
+                        reconciler=reconciler,
+                        user_input=current_user_input,
+                    )
+                # One-shot: clear after consumption so the next iteration
+                # falls back to whatever the next branch decides.
+                next_reentry_kind = None
             if kind == "cancelled":
                 failure_reason = str(payload) or "cancelled by control"
                 # goldfive#205: overlay path doesn't have a single
@@ -922,6 +953,13 @@ class SequentialExecutor(Executor):
                 # tasks map fresh — stale task_id → agent claims from
                 # the pre-steer plan must not leak into the replay.
                 reconciler.reset_for_new_plan(session.plan)
+                # Re-entry contract (harmonograf#234): the next iteration
+                # re-feeds a goldfive-composed steer-restart message
+                # wrapped in USER STEERING CONTROL framing. Plugins
+                # observing the inner runner's user_message hook should
+                # see STEER_REPLAY, not USER_TURN, to suppress duplicate
+                # emission.
+                next_reentry_kind = ReentryKind.STEER_REPLAY
                 # Restart the invocation with the steer body as the
                 # new user input.
                 continue
@@ -957,6 +995,14 @@ class SequentialExecutor(Executor):
                 # likely added new PENDING tasks that reconciler-side
                 # agent claims should re-match against.
                 reconciler.reset_for_new_plan(session.plan)
+                # Re-entry contract (harmonograf#234): the next iteration
+                # re-feeds a goldfive-composed nudge body that the
+                # steerer authored in response to autonomous drift +
+                # plan revision (e.g. LOOPING_REASONING → refine spawned
+                # ``<task>_v2``). Plugins observing the inner runner's
+                # user_message hook should see NUDGE_REPLAY, not
+                # USER_TURN.
+                next_reentry_kind = ReentryKind.NUDGE_REPLAY
                 continue
             break
 

--- a/tests/test_adk_reentry.py
+++ b/tests/test_adk_reentry.py
@@ -1,0 +1,228 @@
+"""Tests for the goldfive plugin re-entry contract.
+
+Covers (harmonograf#234):
+
+* :data:`current_reentry_kind` defaults to ``USER_TURN``.
+* :func:`reentry` pins the kind for the duration of the block and
+  resets it on exit, including on exception.
+* Stack precedence: more-specific kinds (STEER/NUDGE) survive nesting
+  inside OVERLAY; OVERLAY does NOT downgrade an inner STEER/NUDGE.
+* :meth:`ADKAdapter.invoke_passthrough` pins ``OVERLAY_REPLAY`` across
+  the inner ``runner.run_async`` call.
+* :meth:`SequentialExecutor._run_overlay`'s nudge-replay path pins
+  ``NUDGE_REPLAY`` for the next iteration's invoke.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from goldfive.adapters.adk_reentry import (
+    ReentryKind,
+    current_reentry_kind,
+    reentry,
+)
+
+
+def test_default_is_user_turn() -> None:
+    assert current_reentry_kind.get() is ReentryKind.USER_TURN
+
+
+def test_reentry_sets_and_resets() -> None:
+    assert current_reentry_kind.get() is ReentryKind.USER_TURN
+    with reentry(ReentryKind.OVERLAY_REPLAY) as kind:
+        assert kind is ReentryKind.OVERLAY_REPLAY
+        assert current_reentry_kind.get() is ReentryKind.OVERLAY_REPLAY
+    assert current_reentry_kind.get() is ReentryKind.USER_TURN
+
+
+def test_reentry_resets_on_exception() -> None:
+    assert current_reentry_kind.get() is ReentryKind.USER_TURN
+    with pytest.raises(RuntimeError):
+        with reentry(ReentryKind.STEER_REPLAY):
+            assert current_reentry_kind.get() is ReentryKind.STEER_REPLAY
+            raise RuntimeError("boom")
+    assert current_reentry_kind.get() is ReentryKind.USER_TURN
+
+
+def test_steer_inside_overlay_keeps_steer_visible() -> None:
+    """Natural shape: executor pins STEER, then ADKAdapter.invoke_passthrough
+    pins OVERLAY around the inner runner — plugins see STEER, not OVERLAY.
+    """
+    with reentry(ReentryKind.STEER_REPLAY):
+        assert current_reentry_kind.get() is ReentryKind.STEER_REPLAY
+        with reentry(ReentryKind.OVERLAY_REPLAY) as nested:
+            # The nested call observes the prior, more-specific kind.
+            assert nested is ReentryKind.STEER_REPLAY
+            assert current_reentry_kind.get() is ReentryKind.STEER_REPLAY
+        assert current_reentry_kind.get() is ReentryKind.STEER_REPLAY
+    assert current_reentry_kind.get() is ReentryKind.USER_TURN
+
+
+def test_nudge_inside_overlay_keeps_nudge_visible() -> None:
+    with reentry(ReentryKind.NUDGE_REPLAY):
+        with reentry(ReentryKind.OVERLAY_REPLAY) as nested:
+            assert nested is ReentryKind.NUDGE_REPLAY
+            assert current_reentry_kind.get() is ReentryKind.NUDGE_REPLAY
+
+
+def test_overlay_inside_steer_does_not_downgrade() -> None:
+    """OVERLAY entered after STEER must not clobber the more-specific kind."""
+    with reentry(ReentryKind.STEER_REPLAY):
+        with reentry(ReentryKind.OVERLAY_REPLAY):
+            assert current_reentry_kind.get() is ReentryKind.STEER_REPLAY
+        assert current_reentry_kind.get() is ReentryKind.STEER_REPLAY
+
+
+def test_steer_inside_nudge_promotes_steer() -> None:
+    """STEER and NUDGE are both 'specific'; the inner one wins for that block.
+
+    This shape is unlikely in practice (the executor only pins one of
+    the two before each iteration) but the contract should be predictable.
+    """
+    with reentry(ReentryKind.NUDGE_REPLAY):
+        with reentry(ReentryKind.STEER_REPLAY):
+            assert current_reentry_kind.get() is ReentryKind.STEER_REPLAY
+        assert current_reentry_kind.get() is ReentryKind.NUDGE_REPLAY
+
+
+def test_nested_user_turn_from_user_turn_is_a_noop() -> None:
+    with reentry(ReentryKind.USER_TURN):
+        assert current_reentry_kind.get() is ReentryKind.USER_TURN
+    assert current_reentry_kind.get() is ReentryKind.USER_TURN
+
+
+# ---------------------------------------------------------------------------
+# ADKAdapter.invoke_passthrough pin site
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("google.adk")
+
+from goldfive.types import Plan, Session, Task  # noqa: E402
+
+
+def _make_agent() -> Any:
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    return LlmAgent(
+        name="reentry_test_agent",
+        model="fake-model",
+        description="Test",
+        instruction="x",
+    )
+
+
+@dataclass
+class _ReentryProbingRunner:
+    """Runner stub that records ``current_reentry_kind`` at run_async time."""
+
+    observed_kind: ReentryKind | None = None
+    session_service: Any = None
+    plugin_manager: Any = field(default=None)
+
+    async def run_async(self, **_kwargs: Any):
+        self.observed_kind = current_reentry_kind.get()
+        if False:  # pragma: no cover -- generator shape
+            yield None
+
+
+async def test_invoke_passthrough_pins_overlay_replay() -> None:
+    from goldfive.adapters.adk import ADKAdapter
+
+    adapter = ADKAdapter(_make_agent())
+    runner = _ReentryProbingRunner()
+    adapter._runner = runner
+    adapter._session_id = "stub-session"
+
+    session = Session(
+        run_id="r1",
+        plan=Plan(id="p0", run_id="r1", goal_ids=[], tasks=[], edges=[]),
+    )
+
+    # Outer scope is USER_TURN.
+    assert current_reentry_kind.get() is ReentryKind.USER_TURN
+    await adapter.invoke_passthrough("hello world", session=session)
+
+    # Inside the inner runner, the contextvar saw OVERLAY_REPLAY.
+    assert runner.observed_kind is ReentryKind.OVERLAY_REPLAY
+    # Outer scope is restored.
+    assert current_reentry_kind.get() is ReentryKind.USER_TURN
+
+
+async def test_invoke_passthrough_preserves_outer_steer_replay() -> None:
+    """Executor wraps the next-iteration invoke in ``reentry(STEER_REPLAY)``
+    and ``invoke_passthrough`` itself nests ``OVERLAY_REPLAY``. The inner
+    runner must observe STEER_REPLAY (the more-specific cause).
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    adapter = ADKAdapter(_make_agent())
+    runner = _ReentryProbingRunner()
+    adapter._runner = runner
+    adapter._session_id = "stub-session"
+
+    session = Session(
+        run_id="r1",
+        plan=Plan(id="p0", run_id="r1", goal_ids=[], tasks=[], edges=[]),
+    )
+
+    with reentry(ReentryKind.STEER_REPLAY):
+        await adapter.invoke_passthrough("steer body", session=session)
+
+    assert runner.observed_kind is ReentryKind.STEER_REPLAY
+
+
+async def test_invoke_does_not_pin_overlay_replay() -> None:
+    """Legacy per-task ``invoke`` is goldfive's own dispatch with task
+    framing — not a re-entry of the operator's user_input. It must not
+    pin OVERLAY_REPLAY.
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    adapter = ADKAdapter(_make_agent())
+    runner = _ReentryProbingRunner()
+    adapter._runner = runner
+    adapter._session_id = "stub-session"
+
+    task = Task(id="t0", title="do work", description="x")
+    session = Session(
+        run_id="r1",
+        plan=Plan(id="p0", run_id="r1", goal_ids=[], tasks=[task], edges=[]),
+    )
+    await adapter.invoke(task=task, session=session)
+
+    # The legacy invoke path runs in the default USER_TURN context.
+    assert runner.observed_kind is ReentryKind.USER_TURN
+
+
+# ---------------------------------------------------------------------------
+# SequentialExecutor nudge-replay pin site
+# ---------------------------------------------------------------------------
+
+
+async def test_executor_nudge_replay_pins_nudge_replay() -> None:
+    """A queued nudge causes the next iteration's invoke to be wrapped
+    in ``reentry(NUDGE_REPLAY)``. The adapter sees NUDGE_REPLAY (more
+    specific than the OVERLAY_REPLAY pin invoke_passthrough adds).
+    """
+    from goldfive.adapters.adk import ADKAdapter
+
+    adapter = ADKAdapter(_make_agent())
+    runner = _ReentryProbingRunner()
+    adapter._runner = runner
+    adapter._session_id = "stub-session"
+
+    session = Session(
+        run_id="r1",
+        plan=Plan(id="p0", run_id="r1", goal_ids=[], tasks=[], edges=[]),
+    )
+
+    # Simulate the executor's nudge-replay branch: it sets
+    # ``next_reentry_kind = NUDGE_REPLAY`` and re-enters the loop, which
+    # wraps the call to invoke_passthrough in ``reentry(...)``.
+    with reentry(ReentryKind.NUDGE_REPLAY):
+        await adapter.invoke_passthrough("nudge body", session=session)
+
+    assert runner.observed_kind is ReentryKind.NUDGE_REPLAY


### PR DESCRIPTION
## Summary

- Adds `goldfive.adapters.adk_reentry` exposing `ReentryKind` (USER_TURN / OVERLAY_REPLAY / NUDGE_REPLAY / STEER_REPLAY), `current_reentry_kind` ContextVar (default USER_TURN), and a `reentry(kind)` context manager with stack-precedence semantics.
- `ADKAdapter.invoke_passthrough` pins `OVERLAY_REPLAY` around the inner `runner.run_async` call. The legacy per-task `invoke` path is intentionally NOT pinned (it sends task framing, not a duplicate of operator input).
- `SequentialExecutor._run_overlay`'s while-True loop tracks a one-shot `next_reentry_kind` set to `STEER_REPLAY` before the steer-restart `continue` and `NUDGE_REPLAY` before the queued-nudge replay `continue`. The next iteration wraps the call in `reentry(...)` so the ContextVar is captured into `asyncio.create_task` at the moment the inner `invoke_passthrough` is dispatched.

## Why

Goldfive's overlay re-enters ADK's Runner with the operator's verbatim input via `ADKAdapter.invoke_passthrough` — and again with composed nudge / steer-restart bodies when the executor's overlay loop iterates. Each re-entry fires the inner runner's `on_user_message_callback`, which plugins observing both the outer (adk-web) and inner runners see as a duplicate of the `user_message` they already emitted on the outer side.

Confirmed via gRPC ground truth on harmonograf#234: 6 `UserMessageReceived` envelopes for 4 user turns; turns that completed emitted twice, turns that aborted before reaching `invoke_passthrough` emitted once. The existing `_maybe_disable_as_duplicate` guard only catches multiple plugin *instances* on the same plugin manager — here we have ONE plugin instance fired twice in two distinct invocation contexts.

Plugins cannot bypass `_append_new_message_to_session` (the inner agent needs the input in its session history), so suppression has to happen at the plugin layer with goldfive providing a discriminator.

## Contract details

* Default value (`USER_TURN`) is what every plain-ADK code path observes — no behaviour change for non-goldfive callers.
* Stack precedence: more-specific kind nested inside a less-specific one keeps the more-specific value visible. Concretely: a `STEER_REPLAY` or `NUDGE_REPLAY` layered inside an `OVERLAY_REPLAY` (the natural shape — executor pins steer/nudge, then `invoke_passthrough` nests OVERLAY around the inner runner) keeps the steer/nudge label visible to plugins. Plugins thus see the *cause* of the replay, not the mechanism.
* The reverse — entering `OVERLAY_REPLAY` while already inside `STEER_REPLAY` / `NUDGE_REPLAY` — does NOT downgrade.
* Reset on exit, including on exception, via the standard `ContextVar.reset(token)` protocol.

The contract is also a foundation for future re-entry shapes (e.g. internal heartbeat replay, plan-revision echo) without further plumbing.

## Follow-up

The harmonograf-client plugin honors the contract in a follow-up PR (closes harmonograf#234 — the symptom of this gap).

## Test plan

- [x] `pytest tests/test_adk_reentry.py` (12 new tests — defaults, set/reset, exception path, stack-precedence cases for STEER/NUDGE/OVERLAY in every nesting order, `invoke_passthrough` pin, executor-style outer pin survives `invoke_passthrough` nesting, legacy `invoke` does NOT pin)
- [x] Full `pytest tests/` (1921 passed, 51 skipped — no regressions)
- [x] `ruff check .` clean
- [x] `mypy goldfive/adapters/adk_reentry.py goldfive/adapters/adk.py goldfive/executors/sequential.py` — zero new errors (12 pre-existing baseline errors unchanged)