### PR TITLE
fix(adk-plugin): topic-mismatch check on AgentTool delegation (R2, closes #205)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -638,6 +638,278 @@ def _maybe_redirect_completed_agent(
         return None
 
 
+# R2 (#205) — topic-mismatch helpers.
+#
+# F3 (#324) caught the "all tasks terminal" loop by refusing AgentTool
+# dispatches onto agents whose plan tasks were all done. The remaining
+# gap: F3 says nothing about *what* is being asked. A coordinator can
+# still call ``research_agent`` with an off-topic request while the
+# agent has a PENDING / RUNNING task — F3 lets it through, the agent
+# runs off-plan, and the post-hoc PLAN_DIVERGENCE detector fires only
+# *after* the wasted dispatch (v20 validation: 2 sev=1 PLAN_DIVERGENCE
+# drifts on debugger_agent + web_developer_agent for exactly this
+# pattern). R2 closes the gap with a keyword-overlap topic check at
+# the same dispatch boundary.
+#
+# The check is OPTIMISTIC by design: false negatives (allowing an
+# off-topic call through) are preferred over false positives (blocking
+# legitimate work). A single shared meaningful word between the
+# AgentTool's ``request`` and the assigned plan task's
+# ``title + description`` is enough to consider the call on-topic.
+# The post-hoc PLAN_DIVERGENCE detector remains as the safety net for
+# misses; the goal here is to PREVENT the obvious off-plan dispatches.
+
+# Stop-words filtered out before the overlap check. Hand-curated to the
+# tokens that produce false matches in real plans:
+#
+# * articles + prepositions ("the", "of", "for") — saturate every pair,
+# * verbs that show up in *every* delegation request ("research",
+#   "draft", "write", "build") — they're the genre, not the topic,
+# * pronouns / filler ("please", "just", "you") — request-side noise.
+#
+# We keep the list small: aggressive pruning here flips false-negatives
+# into false-positives (every word looks topic-bearing once enough are
+# stripped), and the 4-character minimum already filters most short
+# noise tokens. Synced with :func:`_tokenize_for_matching` style: lowercase
+# alphanumeric tokens of length ≥4 (consistent with the delegation-pin
+# scorer) so the same intuition applies to both.
+_OVERLAP_STOP_WORDS: frozenset[str] = frozenset(
+    {
+        # articles / prepositions / conjunctions ≥4 chars
+        "this",
+        "that",
+        "these",
+        "those",
+        "with",
+        "from",
+        "into",
+        "onto",
+        "upon",
+        "over",
+        "under",
+        "about",
+        # auxiliary verbs / copulas
+        "been",
+        "being",
+        "have",
+        "having",
+        "does",
+        "doing",
+        # delegation filler
+        "please",
+        "just",
+        "make",
+        "create",
+        "write",
+        "research",
+        "draft",
+        "review",
+        "build",
+        "help",
+        # generic pronouns / addressers
+        "your",
+        "yours",
+    }
+)
+
+
+def _normalize_for_overlap(text: Any) -> set[str]:
+    """Return a set of meaningful tokens from ``text`` for overlap checks.
+
+    Lowercases, strips non-alphanumeric to whitespace, drops stop-words
+    and tokens shorter than 4 characters. Mirrors the
+    :func:`_tokenize_for_matching` shape used by the delegation-pin
+    scorer so the two surfaces apply consistent rules.
+    """
+    if not isinstance(text, str):
+        text = str(text or "")
+    if not text:
+        return set()
+    tokens: set[str] = set()
+    buf: list[str] = []
+    for ch in text.lower():
+        if ch.isalnum():
+            buf.append(ch)
+        else:
+            if buf:
+                tok = "".join(buf)
+                if len(tok) >= 4 and tok not in _OVERLAP_STOP_WORDS:
+                    tokens.add(tok)
+                buf.clear()
+    if buf:
+        tok = "".join(buf)
+        if len(tok) >= 4 and tok not in _OVERLAP_STOP_WORDS:
+            tokens.add(tok)
+    return tokens
+
+
+def _extract_agent_tool_request_text(tool_args: Any) -> str:
+    """Pull the LLM's free-form request text out of an AgentTool args dict.
+
+    ADK's ``AgentTool`` packs the parent's prose under
+    ``tool_args["request"]``; defensively support a few alternate keys
+    seen in custom AgentTool wrappers. Falls back to the joined string
+    form of the args mapping so the caller still has *something* to
+    overlap-check on. Non-mapping inputs (rare) are stringified.
+    """
+    if isinstance(tool_args, Mapping):
+        for key in ("request", "input", "query", "prompt", "message"):
+            value = tool_args.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+        # Last resort: concatenate every string-shaped value so a
+        # custom shape (e.g. ``{"topic": "raccoons"}``) still lights
+        # the overlap check.
+        parts: list[str] = []
+        for v in tool_args.values():
+            if isinstance(v, str) and v.strip():
+                parts.append(v)
+        return " ".join(parts)
+    if isinstance(tool_args, str):
+        return tool_args
+    return ""
+
+
+def _delegation_args_off_topic(
+    *,
+    tool_request_text: str,
+    plan_tasks: list[Any],
+    overlap_threshold: float = 0.0,
+) -> bool:
+    """Return True iff ``tool_request_text`` shares no meaningful keywords
+    with ANY of the candidate plan tasks.
+
+    ``plan_tasks`` should be the non-terminal assigned tasks for the
+    target agent. Multi-task agents pass: a request that matches at
+    least one candidate task is on-topic. Optimistic edge cases all
+    return ``False`` (allow):
+
+    * empty ``plan_tasks`` — caller decides whether off-plan dispatch
+      is its problem,
+    * a candidate with no checkable content (empty title + description),
+    * an empty / stop-word-only request — no signal to block on.
+
+    ``overlap_threshold`` of ``0.0`` (default) means "at least one
+    shared meaningful word". A positive threshold gates on the share of
+    the task's keywords that are present in the request.
+    """
+    if not plan_tasks:
+        return False
+    request_words = _normalize_for_overlap(tool_request_text)
+    if not request_words:
+        # No checkable content in the request — let it through.
+        return False
+    for task in plan_tasks:
+        title = _safe_attr(task, "title", "")
+        description = _safe_attr(task, "description", "")
+        task_words = _normalize_for_overlap(title) | _normalize_for_overlap(description)
+        if not task_words:
+            # Task has no checkable content — can't classify; assume on-topic.
+            return False
+        overlap = task_words & request_words
+        if overlap_threshold <= 0:
+            if overlap:
+                return False
+        else:
+            if (len(overlap) / max(len(task_words), 1)) >= overlap_threshold:
+                return False
+    # No candidate matched.
+    return True
+
+
+def _maybe_refuse_topic_mismatch(
+    *,
+    ctx: Any,
+    target_agent: str,
+    tool_args: Any,
+) -> dict[str, Any] | None:
+    """R2 / #205: pre-dispatch topic-mismatch refusal.
+
+    Refuses an AgentTool dispatch when the invocation args don't share
+    keywords with any of the target agent's non-terminal assigned plan
+    tasks. Returns ``None`` (allow) when:
+
+    * the target agent has no assigned plan task at all (off-plan —
+      the existing PLAN_DIVERGENCE drift detector handles it; we do
+      not double-flag),
+    * the agent has only terminal tasks (F3 already handles that),
+    * the request shares ≥1 meaningful keyword with at least one
+      non-terminal task (on-topic),
+    * the request text is empty or stop-word-only (no signal),
+    * any internal failure (defensive — never break dispatch).
+
+    The refusal payload mirrors F3's tool-error shape so the LLM
+    receives a uniform "go elsewhere" signal at this surface.
+    """
+    if not target_agent:
+        return None
+    try:
+        plan = _safe_attr(ctx, "session", None)
+        plan = _safe_attr(plan, "plan", None) if plan is not None else None
+        if plan is None:
+            return None
+        tasks = list(_safe_attr(plan, "tasks", None) or ())
+        if not tasks:
+            return None
+        from goldfive.types import TERMINAL_TASK_STATUSES
+
+        def _bare(name: str) -> str:
+            n = (name or "").strip()
+            return n.rsplit(".", 1)[-1] if "." in n else n
+
+        target_bare = _bare(target_agent)
+        non_terminal: list[Any] = []
+        for task in tasks:
+            assignee = _bare(str(_safe_attr(task, "assignee_agent_id", "") or ""))
+            if assignee != target_bare:
+                continue
+            if _safe_attr(task, "status", None) in TERMINAL_TASK_STATUSES:
+                continue
+            non_terminal.append(task)
+
+        if not non_terminal:
+            # Either off-plan (PLAN_DIVERGENCE handles it) or all
+            # terminal (F3 handles it). Don't double-flag.
+            return None
+
+        request_text = _extract_agent_tool_request_text(tool_args)
+        if not _delegation_args_off_topic(
+            tool_request_text=request_text,
+            plan_tasks=non_terminal,
+        ):
+            return None
+
+        # Build a redirect string. We surface the first non-terminal
+        # task's title as the "expected topic" — picking a single
+        # representative is enough; the LLM only needs to know the call
+        # was off-topic and what the assigned task actually is.
+        assigned_titles = [
+            str(_safe_attr(t, "title", "") or "") for t in non_terminal
+        ]
+        assigned_titles = [t for t in assigned_titles if t]
+        expected_topic = assigned_titles[0] if assigned_titles else ""
+        expected_blob = "; ".join(assigned_titles) or "(no titled task)"
+        snippet = (request_text or "").strip().replace("\n", " ")
+        if len(snippet) > 80:
+            snippet = snippet[:80] + "..."
+        return {
+            "error": (
+                f"Topic mismatch: the request '{snippet}' does not match "
+                f"the assigned plan task(s) for {target_bare}: "
+                f"'{expected_blob}'. Either rephrase the request to match "
+                f"the assigned task or invoke the agent whose plan task "
+                f"covers the requested topic."
+            ),
+            "topic_mismatch": True,
+            "expected_topic": expected_topic,
+        }
+    except Exception as exc:  # noqa: BLE001 — defensive; never break dispatch
+        log.debug(
+            "_maybe_refuse_topic_mismatch: classification raised: %s", exc
+        )
+        return None
+
+
 def _inject_task_id_from_state(
     *,
     tool_name: str,
@@ -4748,6 +5020,31 @@ def make_adk_plugin(
                         redirect.get("redirect_to") or "?",
                     )
                     return redirect
+
+                # R2 (#205): topic-mismatch check. F3 covered the
+                # "agent is done" loop; this covers the orthogonal
+                # "agent has work but the request is off-topic" case
+                # (v20 validation: 2 sev=1 PLAN_DIVERGENCE drifts on
+                # debugger / web_developer firing for unrelated topics).
+                # Refusal is OPTIMISTIC — at least one shared keyword
+                # is enough to consider the call on-topic, so legitimate
+                # rephrasings still pass. Operator visibility for the
+                # post-hoc miss case continues to flow through the
+                # PLAN_DIVERGENCE drift detector.
+                topic_refusal = _maybe_refuse_topic_mismatch(
+                    ctx=ctx,
+                    target_agent=to_agent,
+                    tool_args=tool_args,
+                )
+                if topic_refusal is not None:
+                    log.info(
+                        "before_tool_callback: R2 topic-mismatch — "
+                        "request to %s did not overlap assigned task "
+                        "keywords (expected_topic=%r); refusing dispatch",
+                        to_agent,
+                        topic_refusal.get("expected_topic") or "?",
+                    )
+                    return topic_refusal
                 # Fall through: AgentTool still runs, we're just observing.
 
             # Tool-level approval (Flow B). If the tool opts into

--- a/tests/test_r2_delegation_topic_mismatch.py
+++ b/tests/test_r2_delegation_topic_mismatch.py
@@ -1,0 +1,411 @@
+"""Regression tests for R2 (#205): topic-mismatch refusal on AgentTool dispatch.
+
+Tier 1's F3 (#324) caught the "agent's tasks are all terminal" loop by
+refusing AgentTool dispatches with a redirect error. The remaining gap
+this suite covers: F3 says nothing about *what* the coordinator is
+asking for. A coordinator can still call ``research_agent`` with an
+off-topic request while the agent has a PENDING / RUNNING task — F3
+lets it through and the post-hoc PLAN_DIVERGENCE drift detector fires
+only after the wasted dispatch (v20 validation: 2 sev=1 PLAN_DIVERGENCE
+drifts fired on debugger_agent + web_developer_agent for exactly this
+shape).
+
+R2 closes the gap with a keyword-overlap topic check at the same
+dispatch boundary. The check is optimistic (false negatives preferred
+over false positives — one shared meaningful word is enough to consider
+the call on-topic). These tests exercise the public helper and the
+five required edge cases from the design brief.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    _delegation_args_off_topic,
+    _extract_agent_tool_request_text,
+    _maybe_refuse_topic_mismatch,
+    _normalize_for_overlap,
+)
+from goldfive.types import (  # noqa: E402
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx_for_plan(plan: Plan) -> Any:
+    """Stub the SessionContext shape ``_maybe_refuse_topic_mismatch`` reads."""
+
+    class _Ctx:
+        def __init__(self, plan: Plan) -> None:
+            self.session = Session(
+                run_id="r1", goals=[Goal(id="g1", summary="x")], plan=plan
+            )
+
+    return _Ctx(plan)
+
+
+def _plan_with(tasks: list[Task]) -> Plan:
+    return Plan(id="p1", run_id="r1", goal_ids=["g1"], tasks=tasks, edges=[])
+
+
+# ---------------------------------------------------------------------------
+# normalisation primitives
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_lowercases_and_drops_punctuation() -> None:
+    assert _normalize_for_overlap("Solar Panels, Roof-mounted!") == {
+        "solar",
+        "panels",
+        "roof",
+        "mounted",
+    }
+
+
+def test_normalize_drops_short_tokens() -> None:
+    """3-character tokens are filtered (the ≥4 minimum)."""
+    out = _normalize_for_overlap("the cat sat on a roof")
+    # "cat", "sat", "the", "roof" — only "roof" survives the ≥4 + stop-word filter.
+    assert out == {"roof"}
+
+
+def test_normalize_drops_stop_words() -> None:
+    """The stop-word list strips delegation filler so plans don't trivially
+    match every request on shared verbs."""
+    out = _normalize_for_overlap("Please research and draft the report")
+    # "please" / "research" / "draft" are stop-words. "report" survives.
+    assert "research" not in out
+    assert "draft" not in out
+    assert "please" not in out
+    assert "report" in out
+
+
+def test_normalize_handles_non_string_input() -> None:
+    assert _normalize_for_overlap(None) == set()
+    assert _normalize_for_overlap(12345) == {"12345"}
+
+
+def test_extract_request_prefers_request_key() -> None:
+    assert (
+        _extract_agent_tool_request_text({"request": "do thing", "input": "ignore"})
+        == "do thing"
+    )
+
+
+def test_extract_request_falls_back_to_alt_keys() -> None:
+    assert _extract_agent_tool_request_text({"prompt": "go"}) == "go"
+    assert _extract_agent_tool_request_text({"query": "x"}) == "x"
+
+
+def test_extract_request_concatenates_strings_when_no_known_key() -> None:
+    out = _extract_agent_tool_request_text({"topic": "raccoons", "depth": "deep"})
+    assert "raccoons" in out and "deep" in out
+
+
+def test_extract_request_handles_string_args() -> None:
+    assert _extract_agent_tool_request_text("just a string") == "just a string"
+
+
+def test_extract_request_empty_for_empty_inputs() -> None:
+    assert _extract_agent_tool_request_text({}) == ""
+    assert _extract_agent_tool_request_text(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# _delegation_args_off_topic — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_off_topic_when_no_overlap() -> None:
+    """Plan task 'Research solar panels', request 'Research raccoons' — no
+    overlap on meaningful tokens, so the call is off-topic."""
+    task = Task(id="t1", title="Research solar panels", assignee_agent_id="r")
+    assert _delegation_args_off_topic(
+        tool_request_text="research raccoons",
+        plan_tasks=[task],
+    )
+
+
+def test_on_topic_when_single_keyword_overlaps() -> None:
+    """One shared meaningful word is enough — the check is optimistic."""
+    task = Task(id="t1", title="Research solar panels", assignee_agent_id="r")
+    assert not _delegation_args_off_topic(
+        tool_request_text="research solar generation rates",
+        plan_tasks=[task],
+    )
+
+
+def test_on_topic_when_match_is_in_description() -> None:
+    """The description text contributes alongside the title."""
+    task = Task(
+        id="t1",
+        title="Phase 1",
+        description="Investigate quarterly revenue trends",
+        assignee_agent_id="r",
+    )
+    assert not _delegation_args_off_topic(
+        tool_request_text="please look at quarterly revenue",
+        plan_tasks=[task],
+    )
+
+
+def test_multi_task_agent_matches_one() -> None:
+    """If any candidate plan task overlaps, the dispatch is on-topic."""
+    tasks = [
+        Task(id="t1", title="Research solar panels", assignee_agent_id="r"),
+        Task(id="t2", title="Research raccoons", assignee_agent_id="r"),
+    ]
+    # request matches t2 — must NOT be flagged off-topic just because t1 didn't match.
+    assert not _delegation_args_off_topic(
+        tool_request_text="study raccoons habitat patterns",
+        plan_tasks=tasks,
+    )
+
+
+def test_empty_request_text_is_allowed() -> None:
+    """Empty request: optimistic pass — we have no signal to block on."""
+    task = Task(id="t1", title="Research solar panels", assignee_agent_id="r")
+    assert not _delegation_args_off_topic(
+        tool_request_text="",
+        plan_tasks=[task],
+    )
+
+
+def test_stop_word_only_request_is_allowed() -> None:
+    """All-stop-word request normalises to the empty set — optimistic pass."""
+    task = Task(id="t1", title="Research solar panels", assignee_agent_id="r")
+    assert not _delegation_args_off_topic(
+        tool_request_text="please do this for me",
+        plan_tasks=[task],
+    )
+
+
+def test_no_plan_tasks_is_allowed() -> None:
+    """Empty candidate list — caller decides; this helper says 'allow'."""
+    assert not _delegation_args_off_topic(
+        tool_request_text="solar panels rooftop",
+        plan_tasks=[],
+    )
+
+
+def test_task_with_no_checkable_content_is_allowed() -> None:
+    """A task whose title + description normalise to empty cannot be
+    classified — optimistic pass."""
+    task = Task(id="t1", title="", description="", assignee_agent_id="r")
+    assert not _delegation_args_off_topic(
+        tool_request_text="solar panels rooftop",
+        plan_tasks=[task],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _maybe_refuse_topic_mismatch — wired-in helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_refuses_off_topic_dispatch() -> None:
+    """v20-style scenario: research_agent has 'Research solar panels' as
+    its PENDING task, but the coordinator calls it with 'Research raccoons'.
+    Refusal must fire with topic_mismatch=True and the expected_topic set."""
+    task = Task(
+        id="t1",
+        title="Research solar panels",
+        assignee_agent_id="research_agent",
+        status=TaskStatus.PENDING,
+    )
+    ctx = _ctx_for_plan(_plan_with([task]))
+
+    out = _maybe_refuse_topic_mismatch(
+        ctx=ctx,
+        target_agent="research_agent",
+        tool_args={"request": "Research raccoons"},
+    )
+
+    assert out is not None
+    assert out["topic_mismatch"] is True
+    assert out["expected_topic"] == "Research solar panels"
+    assert "Research raccoons"[:30] in out["error"]
+    assert "Research solar panels" in out["error"]
+
+
+def test_allows_on_topic_dispatch() -> None:
+    """Topic-overlap >0 — call goes through (returns None)."""
+    task = Task(
+        id="t1",
+        title="Research solar panels",
+        assignee_agent_id="research_agent",
+        status=TaskStatus.PENDING,
+    )
+    ctx = _ctx_for_plan(_plan_with([task]))
+
+    out = _maybe_refuse_topic_mismatch(
+        ctx=ctx,
+        target_agent="research_agent",
+        tool_args={"request": "Research solar panels for the presentation"},
+    )
+
+    assert out is None
+
+
+def test_multi_task_agent_one_match_allowed() -> None:
+    """Two PENDING tasks; request matches one — allowed."""
+    tasks = [
+        Task(
+            id="t1",
+            title="Research solar panels",
+            assignee_agent_id="research_agent",
+            status=TaskStatus.PENDING,
+        ),
+        Task(
+            id="t2",
+            title="Research raccoon populations",
+            assignee_agent_id="research_agent",
+            status=TaskStatus.PENDING,
+        ),
+    ]
+    ctx = _ctx_for_plan(_plan_with(tasks))
+
+    out = _maybe_refuse_topic_mismatch(
+        ctx=ctx,
+        target_agent="research_agent",
+        tool_args={"request": "study raccoons populations and habitat"},
+    )
+
+    assert out is None
+
+
+def test_empty_request_text_allowed_through_helper() -> None:
+    """Edge case: AgentTool fired with no explicit request body — optimistic
+    pass through the dispatch boundary."""
+    task = Task(
+        id="t1",
+        title="Research solar panels",
+        assignee_agent_id="research_agent",
+        status=TaskStatus.PENDING,
+    )
+    ctx = _ctx_for_plan(_plan_with([task]))
+
+    out = _maybe_refuse_topic_mismatch(
+        ctx=ctx,
+        target_agent="research_agent",
+        tool_args={"request": ""},
+    )
+
+    assert out is None
+
+
+def test_stop_word_only_request_allowed_through_helper() -> None:
+    """Request like 'please do this for me' has no checkable content — pass."""
+    task = Task(
+        id="t1",
+        title="Research solar panels",
+        assignee_agent_id="research_agent",
+        status=TaskStatus.PENDING,
+    )
+    ctx = _ctx_for_plan(_plan_with([task]))
+
+    out = _maybe_refuse_topic_mismatch(
+        ctx=ctx,
+        target_agent="research_agent",
+        tool_args={"request": "please do this for me"},
+    )
+
+    assert out is None
+
+
+def test_off_plan_agent_not_double_flagged() -> None:
+    """An agent with no assigned plan task is off-plan — that's
+    PLAN_DIVERGENCE territory, not R2's problem. Must return None so the
+    drift detector remains the single source of truth for off-plan flags."""
+    task = Task(
+        id="t1",
+        title="Research solar panels",
+        assignee_agent_id="research_agent",
+        status=TaskStatus.PENDING,
+    )
+    ctx = _ctx_for_plan(_plan_with([task]))
+
+    out = _maybe_refuse_topic_mismatch(
+        ctx=ctx,
+        target_agent="off_plan_agent",
+        tool_args={"request": "totally unrelated content"},
+    )
+
+    assert out is None
+
+
+def test_all_terminal_tasks_not_double_flagged() -> None:
+    """When every assigned task is terminal, F3 owns the refusal.
+    R2's helper must return None so the two surfaces don't double-fire."""
+    task = Task(
+        id="t1",
+        title="Research solar panels",
+        assignee_agent_id="research_agent",
+        status=TaskStatus.COMPLETED,
+    )
+    ctx = _ctx_for_plan(_plan_with([task]))
+
+    out = _maybe_refuse_topic_mismatch(
+        ctx=ctx,
+        target_agent="research_agent",
+        tool_args={"request": "research raccoons"},
+    )
+
+    # F3 territory — R2 abstains.
+    assert out is None
+
+
+def test_qualified_agent_name_matches_bare_assignee() -> None:
+    """ADK passes fully-qualified agent paths like 'coordinator.research_agent';
+    the F3-style bare-name match must round-trip here too."""
+    task = Task(
+        id="t1",
+        title="Research solar panels",
+        assignee_agent_id="research_agent",
+        status=TaskStatus.PENDING,
+    )
+    ctx = _ctx_for_plan(_plan_with([task]))
+
+    out = _maybe_refuse_topic_mismatch(
+        ctx=ctx,
+        target_agent="coordinator.research_agent",
+        tool_args={"request": "Research raccoons"},
+    )
+
+    assert out is not None
+    assert out["topic_mismatch"] is True
+
+
+def test_no_plan_returns_none() -> None:
+    """No plan installed on the session — defensive pass."""
+
+    class _Ctx:
+        def __init__(self) -> None:
+            self.session = Session(
+                run_id="r1", goals=[Goal(id="g1", summary="x")], plan=None
+            )
+
+    out = _maybe_refuse_topic_mismatch(
+        ctx=_Ctx(),
+        target_agent="research_agent",
+        tool_args={"request": "anything"},
+    )
+
+    assert out is None


### PR DESCRIPTION
## Summary

Closes #205. Extends Tier 1's F3 pre-dispatch interception (#324) with a topic-mismatch check on AgentTool delegation arguments.

F3 only looks at task status: it refuses dispatches onto agents whose every plan task is terminal. The complementary gap is **off-topic dispatch onto an agent that still has work**. The coordinator can call `research_agent` with `request="research raccoons"` while the agent's PENDING task is `"Research solar panels"` — F3 lets it through, the agent runs, and PLAN_DIVERGENCE only fires *after* the wasted dispatch.

**v20 validation evidence:** 2 sev=1 PLAN_DIVERGENCE drifts fired on `debugger_agent` and `web_developer_agent` for exactly this shape — agent had pending work, request didn't match the assigned topic, drift surfaced post-hoc.

R2 closes the loop at the same dispatch boundary using a keyword-overlap check on the AgentTool's `request` text vs the non-terminal assigned plan tasks' `title + description`. The check is **optimistic** by design: a single shared meaningful word makes the call on-topic. False negatives (allowing off-topic through) are preferred over false positives — PLAN_DIVERGENCE remains the safety net for misses.

### What's added

- `_normalize_for_overlap` — lowercase + 4-char-min + curated stop-word filter. Style-aligned with the existing `_tokenize_for_matching` used by the delegation-pin scorer so both surfaces apply consistent rules.
- `_extract_agent_tool_request_text` — pulls `request` (with `input` / `query` / `prompt` / `message` fallbacks + last-resort string-value concatenation for custom AgentTool wrappers).
- `_delegation_args_off_topic` — pure overlap classifier; multi-task agents pass if any candidate matches.
- `_maybe_refuse_topic_mismatch` — wired into `before_tool_callback` immediately after the existing F3 call, defensive against missing plan / non-iterable tasks; **explicitly abstains** when the agent has no assigned tasks (PLAN_DIVERGENCE territory) or when all tasks are terminal (F3 territory) so we don't double-flag.

Refusal payload mirrors F3's tool-error shape with `topic_mismatch: True` + `expected_topic` so the LLM gets a uniform "go elsewhere" signal at this boundary.

### Files changed

- `goldfive/adapters/_adk_plugin.py` — helpers + F3 wire-in.
- `tests/test_r2_delegation_topic_mismatch.py` — 26 new tests.

## Test plan

- [x] `uv run --extra dev pytest tests/test_r2_delegation_topic_mismatch.py -q` — 26 passed
- [x] `uv run --extra dev pytest tests -k "delegation or topic_mismatch or off_topic or tier1 or before_tool" -q` — 59 passed, 34 skipped
- [x] Full suite: `uv run --extra dev pytest tests -q` — 1619 passed, 114 skipped
- [x] `uv run --extra dev ruff check .` — All checks passed
- [x] All five required edge cases from the design brief covered: topic-match, topic-mismatch, multi-task agent, empty request, stop-word-only request
- [x] Off-plan agent abstention test (PLAN_DIVERGENCE not double-flagged)
- [x] All-terminal agent abstention test (F3 not double-flagged)
- [x] Qualified agent name (`coordinator.research_agent`) round-trip test