### PR TITLE
fix(planner): heuristic backstop for pivot detection (R1, #322 follow-up)

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -64,6 +64,74 @@ _EMPTY_RESPONSE_ERROR: str = "empty or non-string LLM response"
 
 
 # ---------------------------------------------------------------------------
+# Pivot heuristic (R1, goldfive#322 follow-up)
+# ---------------------------------------------------------------------------
+#
+# Tier 2 (#323) added an LLM-side ``replaces_prior: bool`` field that
+# ``handle_turn`` is supposed to set when the user is replacing prior
+# intent (e.g. "forget X, do Y instead"). v20 validation showed Qwen
+# 35B Q4 thinking is unreliable about this — turn 2 of session
+# 61ddf449-8ea3-470e-b175-c38211b81220 was a textbook pivot ("Forget
+# solar panels, tell me about solar flares instead") yet the LLM left
+# ``replaces_prior`` unset and the runner re-used the prior plan id,
+# bypassing the pivot route.
+#
+# This regex is a deterministic backstop. ``handle_turn`` OR's the
+# heuristic with the LLM flag — either signal triggers pivot routing
+# through ``install_initial_plan``. Keyword matching is intentionally
+# conservative: false positives are acceptable (the new initial plan
+# can still preserve relevant tasks if the planner thinks they're
+# useful), false negatives — the v20 failure mode — are not.
+_PIVOT_OPENERS_RE = re.compile(
+    r"""(?xi)
+    \b(?:
+        forget(?:\s+about)?                                  # forget / forget about
+        | instead\s+of                                       # instead of solar panels
+        | switch(?:ing)?\s+to                                # switch to / switching to
+        | scratch\s+that                                     # scratch that
+        | actually,?\s+(?:let'?s|let\s+me|do|tell)           # actually let's / actually do X
+        | no,?\s+(?:do|tell|let)                             # no, do X / no tell me
+        | wait,?\s+(?:do|tell|let|i)                         # wait, do X / wait, I want
+        | change\s+(?:the\s+)?topic                          # change topic / change the topic
+        | new\s+topic                                        # new topic
+        | replace\s+that                                     # replace that
+        | do\s+(?:something|this)\s+instead                  # do something instead
+    )\b
+    """
+)
+
+
+def detect_pivot_intent(user_input: str | None) -> bool:
+    """Heuristic backstop for pivot detection (goldfive#322 / R1).
+
+    Returns ``True`` when ``user_input`` contains language that
+    strongly signals "replace prior intent" rather than "build on
+    prior plan." Used in addition to the LLM-side ``replaces_prior``
+    flag — either signal triggers pivot routing through
+    :meth:`DefaultSteerer.install_initial_plan`.
+
+    Why heuristic + LLM flag (not LLM flag alone):
+
+    * Qwen 35B Q4 thinking does not reliably output the structured
+      flag even when the system prompt explicitly covers the case
+      (see Example B in the PIVOT vs REVISION block of the
+      ``handle_turn`` system prompt).
+    * Keyword matching catches the most common explicit-pivot
+      openers ("forget X", "instead of X", "scratch that", ...).
+      False positives are acceptable: routing through
+      ``install_initial_plan`` mints a fresh plan id but the new
+      plan can still preserve relevant tasks if the planner
+      decides to keep them.
+
+    Returns ``False`` for non-string / empty inputs (defensive —
+    the caller may pass ``None`` when no user input is available).
+    """
+    if not isinstance(user_input, str) or not user_input.strip():
+        return False
+    return bool(_PIVOT_OPENERS_RE.search(user_input))
+
+
+# ---------------------------------------------------------------------------
 # System prompts (goal-oriented variants ported from harmonograf_client)
 # ---------------------------------------------------------------------------
 
@@ -3450,6 +3518,7 @@ SUMMARY POLICY (applies to ``plan.summary``):
                 raw=raw,
                 prior_plan=prior_plan,
                 context=context,
+                user_input=text,
             )
             if candidate is None:
                 # Conversational verdict OR unparseable response. Either
@@ -3586,6 +3655,7 @@ SUMMARY POLICY (applies to ``plan.summary``):
         raw: Any,
         prior_plan: Plan | None,
         context: Mapping[str, Any] | None,
+        user_input: str | None = None,
     ) -> Plan | None:
         """Parse the LLM's JSON response into a :class:`Plan` or ``None``.
 
@@ -3611,6 +3681,13 @@ SUMMARY POLICY (applies to ``plan.summary``):
         (terminal-task / terminal->terminal-edge preservation in
         :meth:`Plan.validate`) does not gate the new plan against
         the prior — a pivot is structurally a fresh start.
+
+        ``user_input`` (R1 backstop, goldfive#322 follow-up): when
+        provided, :func:`detect_pivot_intent` runs against the raw
+        user message and is OR'd with the LLM's ``replaces_prior``
+        flag. The keyword heuristic catches the explicit-pivot
+        openers ("forget X", "instead of X", "scratch that", ...)
+        that small thinking models miss in the structured flag.
         """
         if not isinstance(raw, str) or not raw.strip():
             log.warning("LLMPlanner.handle_turn: empty / non-str response")
@@ -3645,7 +3722,21 @@ SUMMARY POLICY (applies to ``plan.summary``):
         # plan_id and signal the runner to route through
         # ``install_initial_plan``. False/absent (the safe default) →
         # reuse the prior id so revision_index bumps cleanly.
-        replaces_prior = bool(parsed.get("replaces_prior"))
+        #
+        # R1 backstop (goldfive#322 follow-up): OR the LLM flag with
+        # the keyword heuristic against the raw user input. Either
+        # signal triggers pivot routing — the LLM-side flag is
+        # unreliable on small thinking models (Qwen 35B Q4 v20),
+        # the keyword pass catches the explicit-pivot openers the
+        # LLM misses. Either alone is sufficient; both is no-op.
+        llm_flag = bool(parsed.get("replaces_prior"))
+        heuristic_flag = detect_pivot_intent(user_input)
+        replaces_prior = llm_flag or heuristic_flag
+        if replaces_prior and not llm_flag:
+            log.info(
+                "LLMPlanner.handle_turn: pivot detected by heuristic backstop "
+                "(LLM flag was unset); routing through install_initial_plan"
+            )
         if replaces_prior:
             plan_id_override = None  # _plan_from_json mints a fresh uuid
         else:

--- a/tests/test_pivot_heuristic.py
+++ b/tests/test_pivot_heuristic.py
@@ -1,0 +1,456 @@
+"""Heuristic backstop for pivot detection (R1, goldfive#322 follow-up).
+
+The Tier 2 pipeline (#323) added an LLM-side ``replaces_prior: bool``
+field on ``LLMPlanner.handle_turn`` to route pivots ("forget X, do Y
+instead") through :meth:`DefaultSteerer.install_initial_plan` instead
+of ``install_revision_for_drift``. v20 validation found that small
+thinking models (Qwen 35B Q4) do not reliably set the flag even on
+textbook pivot phrasing — session
+``61ddf449-8ea3-470e-b175-c38211b81220`` turn 2 was *"Forget solar
+panels, tell me about solar flares instead."* and the LLM left the
+flag unset. The runner re-used the prior plan id and pivot routing
+was bypassed.
+
+This module covers the deterministic backstop:
+
+* :func:`detect_pivot_intent` — pure regex test against representative
+  positive / negative phrasings (R1 unit coverage).
+* :func:`_parse_handle_turn_response` — heuristic alone (LLM flag
+  absent), LLM flag alone (no keywords), both signals together,
+  neither signal (additive steer).
+* End-to-end runner spy — heuristic-only pivot routes through
+  ``install_initial_plan`` and mints a fresh plan id, mirroring the
+  v20 failure mode.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive import (  # noqa: E402
+    CallableAdapter,
+    Goal,
+    InMemorySink,
+    InvocationResult,
+    LLMPlanner,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+from goldfive.planner import detect_pivot_intent  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror tests/test_tier2_steer_pipeline.py)
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedLLM:
+    """Returns canned responses, optionally per-call from a script."""
+
+    def __init__(self, responses: str | list[str]) -> None:
+        if isinstance(responses, str):
+            responses = [responses]
+        self._responses = list(responses)
+        self._idx = 0
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(self, system: str, user: str, model: str) -> str:
+        self.calls.append((system, user, model))
+        i = min(self._idx, len(self._responses) - 1)
+        self._idx += 1
+        return self._responses[i]
+
+
+def _populated_session(*, plan_id: str = "plan-prior") -> Session:
+    s = Session(run_id="r-test")
+    s.goals = [Goal(id="g1", summary="Make a 2-slide presentation about solar panels.")]
+    s.plan = Plan(
+        id=plan_id,
+        run_id="r-test",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_panels",
+                title="Research solar panels",
+                assignee_agent_id="writer",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="draft_slides",
+                title="Draft the slides",
+                assignee_agent_id="writer",
+                status=TaskStatus.COMPLETED,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research_panels", to_task_id="draft_slides")],
+        summary="Make a 2-slide presentation about solar panels.",
+        revision_index=1,
+    )
+    return s
+
+
+def _plan_dict(
+    *,
+    plan_id: str = "plan-new",
+    summary: str = "x",
+    tasks: list[dict[str, Any]] | None = None,
+    edges: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": plan_id,
+        "summary": summary,
+        "tasks": tasks
+        or [
+            {
+                "id": "t1",
+                "title": "do the thing",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            }
+        ],
+        "edges": edges or [],
+    }
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = tools, session
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+# ---------------------------------------------------------------------------
+# Unit: regex coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        # The v20 case verbatim.
+        "Forget solar panels, tell me about solar flares instead.",
+        # Variants on the same opener.
+        "forget the slides — write me a haiku about cats instead",
+        "Forget about that, do this other thing.",
+        # "instead of X" — replacement framing.
+        "Instead of researching panels, draft a marketing brief.",
+        # "switch to" / "switching to".
+        "Switch to a different topic: dolphins.",
+        "switching to a haiku format please",
+        # "scratch that".
+        "Scratch that — let's do something simpler.",
+        # "actually let's / actually do X" — common reversal opener.
+        "Actually, let's write about birds instead.",
+        "actually do the marketing brief first",
+        # "no, do X" / "no tell me" / "no let's".
+        "No, tell me about black holes.",
+        "no, do the haiku version",
+        # "wait, ..." reversal.
+        "Wait, do the slides about clouds instead.",
+        "Wait, I want a different topic.",
+        # "change topic" / "new topic".
+        "Change the topic to weather.",
+        "new topic: oceans",
+        # "replace that".
+        "Replace that with something shorter.",
+        # "do X instead".
+        "Do something instead — write a poem.",
+    ],
+)
+def test_detect_pivot_intent_positive(phrase: str) -> None:
+    assert detect_pivot_intent(phrase) is True, phrase
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        # Additive / refining steers — must NOT trigger pivot routing.
+        "Make sure the slides include a chart.",
+        "Research the topic more thoroughly.",
+        "Add a citation to slide 2.",
+        "Please be concise.",
+        "Where did the data come from?",
+        "Use a different font on slide 1.",
+        # Empty / whitespace / non-string.
+        "",
+        "   ",
+    ],
+)
+def test_detect_pivot_intent_negative(phrase: str) -> None:
+    assert detect_pivot_intent(phrase) is False, phrase
+
+
+def test_detect_pivot_intent_handles_non_string() -> None:
+    assert detect_pivot_intent(None) is False
+    assert detect_pivot_intent(123) is False  # type: ignore[arg-type]
+    assert detect_pivot_intent([]) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Parser: heuristic OR LLM flag
+# ---------------------------------------------------------------------------
+
+
+async def test_heuristic_only_triggers_pivot_routing_in_parser() -> None:
+    """Reproduces v20: LLM omits ``replaces_prior`` but the user said
+    "Forget solar panels, tell me about solar flares instead." The
+    keyword heuristic must trigger pivot routing — fresh plan id +
+    ``_goldfive_pivot`` sentinel — without help from the LLM flag.
+    """
+    scripted = _ScriptedLLM(
+        json.dumps(
+            {
+                "reasoning": "the model failed to set replaces_prior",
+                # NOTE: replaces_prior is intentionally absent.
+                "plan": _plan_dict(plan_id="ignored-by-runner"),
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    session = _populated_session(plan_id="plan-prior-stable")
+    plan = await planner.handle_turn(
+        user_input="Forget solar panels, tell me about solar flares instead.",
+        session=session,
+    )
+    assert plan is not None
+    assert plan.id != "plan-prior-stable", (
+        "heuristic should have minted a fresh plan id"
+    )
+    assert plan.id, "fresh plan id must be non-empty"
+    assert getattr(plan, "_goldfive_pivot", False) is True
+
+
+async def test_llm_flag_only_triggers_pivot_routing() -> None:
+    """LLM sets ``replaces_prior=True`` while user_input has no pivot
+    keywords. Pivot routing still triggers (the LLM-only path remains
+    intact — the heuristic is purely additive).
+    """
+    scripted = _ScriptedLLM(
+        json.dumps(
+            {
+                "reasoning": "structured flag set",
+                "replaces_prior": True,
+                "plan": _plan_dict(plan_id="ignored-by-runner"),
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    session = _populated_session(plan_id="plan-prior-stable")
+    # No pivot keywords in this input — heuristic returns False.
+    user_input = "make it a marketing brief about renewables"
+    assert detect_pivot_intent(user_input) is False
+    plan = await planner.handle_turn(user_input=user_input, session=session)
+    assert plan is not None
+    assert plan.id != "plan-prior-stable"
+    assert getattr(plan, "_goldfive_pivot", False) is True
+
+
+async def test_both_signals_triggers_pivot_routing_no_double() -> None:
+    """Both LLM flag AND keywords present. Pivot routing triggers
+    cleanly — no double-routing or weird state.
+    """
+    scripted = _ScriptedLLM(
+        json.dumps(
+            {
+                "reasoning": "both signals",
+                "replaces_prior": True,
+                "plan": _plan_dict(plan_id="ignored-by-runner"),
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    session = _populated_session(plan_id="plan-prior-stable")
+    plan = await planner.handle_turn(
+        user_input="Forget the slides, do a haiku instead.",
+        session=session,
+    )
+    assert plan is not None
+    assert plan.id != "plan-prior-stable"
+    # Idempotent: the sentinel is True (not "True True" or any other
+    # weirdness), and the parser ran exactly once.
+    assert getattr(plan, "_goldfive_pivot", False) is True
+    assert len(scripted.calls) == 1
+
+
+async def test_neither_signal_preserves_revision_route() -> None:
+    """Additive steer: no LLM flag AND no pivot keywords. The prior
+    plan id must be preserved (revision route — Rule 6 binding still
+    applies via the runner's drift install path).
+    """
+    scripted = _ScriptedLLM(
+        json.dumps(
+            {
+                "reasoning": "additive constraint, no replacement",
+                "replaces_prior": False,
+                "plan": _plan_dict(plan_id="ignored-by-runner"),
+            }
+        )
+    )
+    planner = LLMPlanner(call_llm=scripted)
+    session = _populated_session(plan_id="plan-prior-stable")
+    plan = await planner.handle_turn(
+        user_input="make sure it includes a chart",
+        session=session,
+    )
+    assert plan is not None
+    assert plan.id == "plan-prior-stable", (
+        "additive steer must preserve the prior plan id (revision route)"
+    )
+    assert getattr(plan, "_goldfive_pivot", False) is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: heuristic-only pivot routes through install_initial_plan
+# ---------------------------------------------------------------------------
+
+
+async def test_heuristic_only_pivot_e2e_routes_through_install_initial_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The v20 scenario, end-to-end. Drive turn 1 (initial plan) then
+    turn 2 with a textbook pivot input AND an LLM stub that does NOT
+    set ``replaces_prior``. Assert turn 2 still routes through
+    ``install_initial_plan`` (heuristic backstop) and mints a fresh
+    plan id.
+    """
+    plan_t1 = _plan_dict(
+        plan_id="ignored-by-runner",
+        summary="2-slide presentation about solar panels",
+        tasks=[
+            {
+                "id": "research_panels",
+                "title": "Research solar panels",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            },
+            {
+                "id": "draft_slides",
+                "title": "Draft 2 slides about solar panels",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            },
+        ],
+        edges=[
+            {"from_task_id": "research_panels", "to_task_id": "draft_slides"},
+        ],
+    )
+    plan_t2_pivot = _plan_dict(
+        plan_id="ignored-by-runner",
+        summary="solar flares explainer",
+        tasks=[
+            {
+                "id": "explain_flares",
+                "title": "Explain solar flares",
+                "assignee_agent_id": "writer",
+                "status": "PENDING",
+            }
+        ],
+        edges=[],
+    )
+
+    async def planner_llm(system: str, user: str, model: str) -> str:
+        _ = model
+        if "warrants a plan change" in system or "PIVOT vs REVISION" in system:
+            # handle_turn call. Branch on the user message.
+            #
+            # The pivot turn keys off "flares" — and we INTENTIONALLY
+            # omit ``replaces_prior`` so only the heuristic can rescue
+            # this turn into the pivot route. This mirrors the v20
+            # session.
+            if "flares" in user.lower() or "forget" in user.lower():
+                return json.dumps(
+                    {
+                        "reasoning": "topic shift — solar flares",
+                        # replaces_prior intentionally absent.
+                        "plan": plan_t2_pivot,
+                    }
+                )
+            return json.dumps(
+                {
+                    "reasoning": "first turn",
+                    "replaces_prior": False,
+                    "plan": plan_t1,
+                }
+            )
+        return json.dumps(plan_t1)
+
+    planner = LLMPlanner(call_llm=planner_llm, model="stub")
+    sink = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+    )
+
+    initial_calls: list[tuple[str, bool]] = []
+    drift_calls: list[str] = []
+    real_initial = runner.steerer.install_initial_plan
+    real_drift = runner.steerer.install_revision_for_drift
+
+    async def _spy_initial(
+        *, session: Session, plan: Plan, is_pivot: bool = False
+    ) -> bool:
+        initial_calls.append((plan.id, is_pivot))
+        return await real_initial(session=session, plan=plan, is_pivot=is_pivot)
+
+    async def _spy_drift(*, session: Session, drift: Any, revised_plan: Plan) -> bool:
+        drift_calls.append(revised_plan.id)
+        return await real_drift(
+            session=session, drift=drift, revised_plan=revised_plan
+        )
+
+    monkeypatch.setattr(runner.steerer, "install_initial_plan", _spy_initial)
+    monkeypatch.setattr(runner.steerer, "install_revision_for_drift", _spy_drift)
+
+    out1 = await runner.run("make a 2-slide presentation about solar panels")
+    assert out1.success, out1.reason
+    turn1_plan_id = out1.session.plan.id
+
+    # The v20 input verbatim.
+    out2 = await runner.run(
+        "Forget solar panels, tell me about solar flares instead."
+    )
+    await runner.close()
+    assert out2.success, out2.reason
+    turn2_plan_id = out2.session.plan.id
+
+    # Heuristic-rescued pivot: 2 install_initial_plan calls (turn 1 +
+    # rescued turn 2), zero drift installs.
+    assert len(initial_calls) == 2, (
+        f"expected 2 install_initial_plan calls (turn 1 + heuristic-rescued "
+        f"turn 2); got {len(initial_calls)}"
+    )
+    assert initial_calls[0][1] is False, (
+        f"turn 1 should be first-turn (is_pivot=False); got {initial_calls[0]}"
+    )
+    assert initial_calls[1][1] is True, (
+        f"turn 2 should be flagged as pivot via heuristic backstop "
+        f"(is_pivot=True); got {initial_calls[1]}"
+    )
+    assert len(drift_calls) == 0, (
+        f"heuristic-rescued pivot must NOT route through "
+        f"install_revision_for_drift; got {len(drift_calls)} drift install(s)"
+    )
+    assert turn2_plan_id != turn1_plan_id, (
+        f"heuristic pivot should mint a fresh plan id; both turns got {turn1_plan_id}"
+    )

--- a/tests/test_planner_handle_turn.py
+++ b/tests/test_planner_handle_turn.py
@@ -238,17 +238,23 @@ async def test_handle_turn_empty_user_input_returns_none_without_llm_call() -> N
 
 
 async def test_handle_turn_revision_preserves_prior_plan_id() -> None:
-    """Phase 4 invariant: every plan change is a revision of the same
-    plan_id. The handle_turn parser forces the returned plan's id to
-    match the prior's so the steerer's _apply_revision finds it.
+    """Phase 4 invariant (revision branch): when the user input is an
+    additive / refining steer (no pivot keywords) AND the LLM does not
+    set ``replaces_prior``, the parser forces the returned plan id to
+    match the prior's so the steerer's ``_apply_revision`` finds it.
+
+    Pre-R1 this test used a "forget solar panels..." pivot phrasing,
+    which now correctly trips the heuristic backstop (goldfive#322
+    R1 follow-up). The original revision invariant is unchanged for
+    non-pivot inputs — covered here with an additive steer phrasing.
     """
     scripted = _ScriptedLLM(
         json.dumps(
             {
-                "reasoning": "topic shift",
+                "reasoning": "additive constraint",
                 "plan": _plan_json(
                     plan_id="completely-different-id",
-                    summary="solar flares plan",
+                    summary="solar panel plan with citations",
                 ),
             }
         )
@@ -256,12 +262,12 @@ async def test_handle_turn_revision_preserves_prior_plan_id() -> None:
     planner = LLMPlanner(call_llm=scripted)
     session = _populated_session(plan_id="plan-prior-id")
     plan = await planner.handle_turn(
-        user_input="forget solar panels, tell me about solar flares",
+        user_input="add citations to each slide",
         session=session,
     )
     assert plan is not None
     # Even though the LLM emitted "completely-different-id", the parser
-    # overrides with the prior's id — Phase 4 invariant.
+    # overrides with the prior's id — Phase 4 invariant for revisions.
     assert plan.id == "plan-prior-id"
 
 
@@ -429,15 +435,24 @@ async def test_handle_turn_factual_question_about_prior_returns_none() -> None:
     assert plan is None
 
 
-async def test_handle_turn_topic_pivot_produces_revision_with_carried_qualifications() -> None:
-    """(b) 'forget solar panels, tell me about solar flares' — produces
-    a revision. The prompt threads prior_goals (carrying '2 slides')
-    so the LLM merges the cap into the new plan's summary.
+async def test_handle_turn_topic_pivot_routes_through_pivot_branch() -> None:
+    """(b) 'forget solar panels, tell me about solar flares' — explicit
+    pivot phrasing. Per goldfive#322 R1 (heuristic backstop), this
+    input trips :func:`detect_pivot_intent` regardless of whether the
+    LLM sets ``replaces_prior``. The parser mints a fresh plan id and
+    stamps the ``_goldfive_pivot`` sentinel so the runner routes
+    through ``install_initial_plan``.
+
+    Prior goals (carrying '2 slides') are still threaded into the
+    prompt — the LLM is free to merge them into the new plan's summary.
     """
     scripted = _ScriptedLLM(
         json.dumps(
             {
                 "reasoning": "topic shift; preserve 2-slide cap",
+                # Note: replaces_prior intentionally absent — the R1
+                # heuristic backstop must rescue the pivot route on
+                # its own, mirroring the v20 Qwen failure mode.
                 "plan": _plan_json(
                     summary=(
                         "Create a 2-slide presentation about solar flares."
@@ -453,7 +468,10 @@ async def test_handle_turn_topic_pivot_produces_revision_with_carried_qualificat
         session=session,
     )
     assert plan is not None
-    assert plan.id == "plan-stable"  # revision-of-prior invariant
+    # R1: pivot route — fresh plan id, NOT inherited from the prior.
+    assert plan.id != "plan-stable"
+    assert plan.id, "fresh plan id must be non-empty"
+    assert getattr(plan, "_goldfive_pivot", False) is True
     # The prompt surfaced the 2-slide cap; assert the canned plan kept it.
     assert "2-slide" in plan.summary or "2 slide" in plan.summary
 

--- a/tests/test_runner_install_revision_stall.py
+++ b/tests/test_runner_install_revision_stall.py
@@ -198,9 +198,14 @@ async def test_install_revision_two_turns_stable_session_id_no_stall() -> None:
         plan_id_t1 = out1.session.plan.id
         assert out1.session.plan.revision_index == 1
 
+        # Additive steer (not a pivot — keeps the same artefact). Pivot
+        # phrasings ("forget X, do Y instead") now route through
+        # ``install_initial_plan`` per goldfive#322 R1, which would
+        # mint a fresh plan_id and bypass the revision invariant
+        # this test pins.
         out2 = await asyncio.wait_for(
             runner.run(
-                "Forget solar panels, tell me about solar flares.",
+                "Add a citations slide and make it more thorough.",
                 session_id="adk-pinned-session-A",
             ),
             timeout=10.0,
@@ -386,9 +391,14 @@ async def test_second_turn_install_emits_new_work_discovered_drift() -> None:
             if (evt.WhichOneof("payload") if hasattr(evt, "WhichOneof") else None)
             == "drift_detected"
         )
+        # Additive steer — must route through the drift install path.
+        # A pivot phrasing ("forget X, do Y instead") would route
+        # through ``install_initial_plan`` (goldfive#322 R1) which
+        # does NOT emit a NEW_WORK_DISCOVERED drift, so the assertion
+        # below would fail for the wrong reason.
         out2 = await asyncio.wait_for(
             runner.run(
-                "Forget solar panels, tell me about solar flares.",
+                "Add a citations slide and make it more thorough.",
                 session_id="option-a-replan",
             ),
             timeout=10.0,


### PR DESCRIPTION
## Summary

Tier 2 (#323) added an LLM-side `replaces_prior: bool` on `LLMPlanner.handle_turn` so user pivots (\"forget X, do Y instead\") route through `install_initial_plan` (fresh plan id, no Rule 6 binding) instead of `install_revision_for_drift`.

**v20 caught the LLM-only path failing.** Session `61ddf449-8ea3-470e-b175-c38211b81220` turn 2 was a textbook pivot — *\"Forget solar panels, tell me about solar flares instead.\"* — but Qwen 35B Q4 thinking left `replaces_prior` unset. The runner re-used the prior plan id (`1c3cff296...`) with `revision_index += 1`, bypassing pivot routing entirely. Relying on a small thinking model to emit a structured boolean is fragile; the system-prompt extension guarantees nothing.

## The fix

Deterministic keyword backstop OR'd with the LLM flag. `goldfive.planner.detect_pivot_intent` matches a single case-insensitive verbose regex (`_PIVOT_OPENERS_RE`) covering common explicit-pivot openers:

- `forget` / `forget about`
- `instead of X`
- `switch to` / `switching to`
- `scratch that`
- `actually, let's/do/tell/let me`
- `no, do/tell/let`
- `wait, do/tell/let/I`
- `change topic` / `change the topic` / `new topic`
- `replace that`
- `do something/this instead`

Either signal — LLM flag or heuristic — triggers pivot routing in `_parse_handle_turn_response`. The new plan id is freshly minted and the `_goldfive_pivot` sentinel is stamped, so the runner's existing `_install_revision` branch (`runner.py:1415`) routes through `install_initial_plan` with no further changes.

**False positives are acceptable.** Routing through `install_initial_plan` mints a fresh plan id but the new plan can still preserve relevant tasks if the planner thinks they're useful. **False negatives — the v20 failure mode — are not.**

## Test plan

New file `tests/test_pivot_heuristic.py`:

- [x] `detect_pivot_intent` regex coverage: ~17 positive phrasings (incl. v20 verbatim) + ~8 negative phrasings (additive steers) + non-string defensiveness.
- [x] Parser layer: heuristic-only triggers pivot route (LLM flag absent — the v20 case).
- [x] Parser layer: LLM-only triggers pivot route (heuristic returns False).
- [x] Parser layer: both signals trigger cleanly with no double-routing.
- [x] Parser layer: neither signal preserves the revision route.
- [x] End-to-end runner spy: v20 input routes through `install_initial_plan` with `is_pivot=True` and mints a fresh plan id, even though the stub LLM omits `replaces_prior`.

Two pre-R1 tests had pivot phrasings baked in while asserting the OPPOSITE of the new contract; they were updated:

- `test_handle_turn_topic_pivot_produces_revision_with_carried_qualifications` → `test_handle_turn_topic_pivot_routes_through_pivot_branch` (now asserts the pivot route).
- `test_handle_turn_revision_preserves_prior_plan_id` swapped its user_input from `\"forget solar panels...\"` to `\"add citations to each slide\"` so it continues to pin the revision invariant.
- Two timing/drift tests in `test_runner_install_revision_stall.py` swapped pivot phrasings to additive steers for the same reason.

- [x] Full suite: **1624 passed, 114 skipped** (no behavior changes outside the documented test fixes).
- [x] `ruff check goldfive/ tests/` clean.

## Files changed

- `goldfive/planner.py` — `_PIVOT_OPENERS_RE`, `detect_pivot_intent`, OR-wire in `_parse_handle_turn_response` (+ `user_input` kwarg threaded from `handle_turn`).
- `tests/test_pivot_heuristic.py` — new (31 test cases).
- `tests/test_planner_handle_turn.py` — pre-R1 pivot/revision tests rewritten.
- `tests/test_runner_install_revision_stall.py` — pivot phrasings swapped to additive steers.