### PR TITLE
feat(adk-plugin): runtime plan-state hint at before_model_callback (R3, F2 alternative)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -571,9 +571,7 @@ def _maybe_redirect_completed_agent(
             return None
 
         # If any assigned task is non-terminal, the dispatch is legitimate.
-        if any(
-            _safe_attr(t, "status", None) not in TERMINAL_TASK_STATUSES for t in assigned
-        ):
+        if any(_safe_attr(t, "status", None) not in TERMINAL_TASK_STATUSES for t in assigned):
             return None
 
         # All assigned tasks are terminal. Find the next PENDING task
@@ -611,9 +609,7 @@ def _maybe_redirect_completed_agent(
             # plan handling will close out the run.
             return None
 
-        next_assignee = _bare(
-            str(_safe_attr(next_pending, "assignee_agent_id", "") or "")
-        )
+        next_assignee = _bare(str(_safe_attr(next_pending, "assignee_agent_id", "") or ""))
         if next_assignee == target_bare:
             # Next pending is on the same agent — this dispatch is
             # legitimate follow-up work, not a loop.
@@ -632,9 +628,7 @@ def _maybe_redirect_completed_agent(
             "redirect_to": next_assignee,
         }
     except Exception as exc:  # noqa: BLE001 — defensive; never break dispatch
-        log.debug(
-            "_maybe_redirect_completed_agent: classification raised: %s", exc
-        )
+        log.debug("_maybe_redirect_completed_agent: classification raised: %s", exc)
         return None
 
 
@@ -1571,6 +1565,195 @@ async def _inject_goldfive_planner_instruction(
             "_inject_goldfive_planner_instruction: append_instructions raised: %s",
             exc,
         )
+
+
+# R3 (F2 alternative) — runtime tool-surface hint.
+#
+# Tier 1's F2 wanted to mutate ``llm_request.config.tools`` mid-callback
+# to remove agents whose tasks have all completed, but mutating the
+# tool list mid-flight is fragile (ADK caches declarations on
+# ``tools_dict`` and the model API rejects requests where the
+# function declarations don't match the names referenced in
+# ``contents``). R3 takes the non-invasive route: keep all tools
+# available, but pre-emptively tell the LLM — at every model call —
+# which agents still have PENDING work and which agents' work is
+# already DONE. The LLM then has structural guidance to choose the
+# right next action without us having to alter the tool surface.
+#
+# Why a prefix marker: the hint is per-call. Each
+# ``before_model_callback`` invocation must inject the CURRENT plan
+# state, not accumulate prior snapshots. ``system_instruction`` in
+# ADK is a single string, so we detect-and-strip any previous
+# goldfive hint by its ``[GOLDFIVE PLAN-STATE HINT —`` opener before
+# appending the fresh one.
+_RUNTIME_TOOLS_HINT_PREFIX: str = "[GOLDFIVE PLAN-STATE HINT —"
+_RUNTIME_TOOLS_HINT_END: str = "[/GOLDFIVE PLAN-STATE HINT]"
+
+
+def _build_runtime_tools_hint(session: Any) -> str | None:
+    """Compose a 'currently-relevant tools' hint for injection into the LLM context.
+
+    Walks ``session.plan.tasks`` and groups them by ``assignee_agent_id``.
+    For each agent, summarise:
+
+    * tasks already DONE (terminal — COMPLETED / FAILED / CANCELLED / NOT_NEEDED)
+    * tasks PENDING (with their titles, capped at three for brevity)
+    * whether the agent has any remaining work
+
+    Returns a multi-line string suitable for prepending to the LLM
+    request as a system-level guidance message. Returns ``None`` when
+    there's no plan to summarise (turn 1, or pre-plan-install
+    windows), or when the plan groups produce no useful signal.
+
+    The output is bracketed by :data:`_RUNTIME_TOOLS_HINT_PREFIX` and
+    :data:`_RUNTIME_TOOLS_HINT_END` so a follow-up call can detect and
+    strip the previous hint from ``system_instruction`` before
+    appending the fresh one (R3 dedup contract).
+    """
+    plan = _safe_attr(session, "plan", None)
+    if plan is None:
+        return None
+    tasks = _safe_attr(plan, "tasks", None)
+    if not tasks:
+        return None
+
+    try:
+        from goldfive.types import TERMINAL_TASK_STATUSES
+    except ImportError:  # pragma: no cover — should never happen
+        return None
+
+    by_agent: dict[str, dict[str, list[str]]] = {}
+    for t in tasks:
+        agent = _safe_attr(t, "assignee_agent_id", "") or "<unassigned>"
+        bucket = by_agent.setdefault(agent, {"done": [], "remaining": []})
+        status = _safe_attr(t, "status", None)
+        title = _safe_attr(t, "title", "") or _safe_attr(t, "id", "") or "?"
+        if status in TERMINAL_TASK_STATUSES:
+            bucket["done"].append(str(title))
+        else:
+            bucket["remaining"].append(str(title))
+
+    body_lines: list[str] = []
+    for agent in sorted(by_agent):
+        info = by_agent[agent]
+        # Strip any namespace separator so the hint matches what the
+        # LLM sees as the bare tool / sub-agent name.
+        bare = agent.split(":")[-1] if ":" in agent else agent
+        if info["remaining"]:
+            tasks_summary = "; ".join(info["remaining"][:3])
+            body_lines.append(f"  {bare}: PENDING — {tasks_summary}")
+        elif info["done"]:
+            body_lines.append(f"  {bare}: all assigned tasks complete; do NOT re-invoke this agent")
+
+    if not body_lines:
+        return None
+
+    lines: list[str] = [f"{_RUNTIME_TOOLS_HINT_PREFIX} runtime guidance, not user-authored]"]
+    lines.extend(body_lines)
+    lines.append(
+        "Choose the agent whose tasks are still PENDING. Do not re-invoke "
+        "agents whose tasks are already complete."
+    )
+    lines.append(_RUNTIME_TOOLS_HINT_END)
+    return "\n".join(lines)
+
+
+def _strip_prior_runtime_tools_hint(existing: str) -> str:
+    """Remove a previously-injected runtime-tools hint from ``existing``.
+
+    The hint is bracketed by :data:`_RUNTIME_TOOLS_HINT_PREFIX` and
+    :data:`_RUNTIME_TOOLS_HINT_END`. When found, both markers and the
+    text between them are removed; surrounding ``\\n\\n`` separators
+    are normalised so the result has no orphan blank lines.
+
+    Returns the input unchanged when no prior hint marker is present.
+    """
+    if _RUNTIME_TOOLS_HINT_PREFIX not in existing:
+        return existing
+    start = existing.find(_RUNTIME_TOOLS_HINT_PREFIX)
+    end = existing.find(_RUNTIME_TOOLS_HINT_END, start)
+    if end == -1:
+        # Truncated / malformed — drop from prefix to end of string.
+        cleaned = existing[:start]
+    else:
+        cleaned = existing[:start] + existing[end + len(_RUNTIME_TOOLS_HINT_END) :]
+    # Collapse any 3+ consecutive newlines created by the removal.
+    while "\n\n\n" in cleaned:
+        cleaned = cleaned.replace("\n\n\n", "\n\n")
+    return cleaned.strip("\n")
+
+
+def _inject_runtime_tools_hint(
+    *,
+    callback_context: Any,
+    llm_request: Any,
+    session: Any,
+) -> None:
+    """Inject (or refresh) the runtime tool-surface hint on ``llm_request``.
+
+    R3 (F2 alternative). Builds the current plan-state hint via
+    :func:`_build_runtime_tools_hint` and writes it to
+    ``llm_request.config.system_instruction``. If a prior goldfive
+    hint is present (detected by :data:`_RUNTIME_TOOLS_HINT_PREFIX`),
+    it is stripped first so we don't accumulate snapshots across calls.
+
+    Best-effort: never raises. A None hint (no plan, or plan with no
+    informative groups) is a no-op so we don't pollute the prompt with
+    empty markers.
+    """
+    hint = _build_runtime_tools_hint(session)
+
+    config = _safe_attr(llm_request, "config", None)
+    if config is None:
+        return
+    existing = getattr(config, "system_instruction", None)
+
+    # Strip any prior hint regardless of whether we'll re-inject. A
+    # None ``hint`` (plan disappeared or all groups empty) should still
+    # remove the stale marker block from the request.
+    if isinstance(existing, str) and _RUNTIME_TOOLS_HINT_PREFIX in existing:
+        try:
+            config.system_instruction = _strip_prior_runtime_tools_hint(existing) or None
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "_inject_runtime_tools_hint: could not strip prior hint: %s",
+                exc,
+            )
+            return
+        existing = getattr(config, "system_instruction", None)
+
+    if not hint:
+        return
+
+    append = getattr(llm_request, "append_instructions", None)
+    if callable(append):
+        try:
+            append([hint])
+            return
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "_inject_runtime_tools_hint: append_instructions raised: %s",
+                exc,
+            )
+            # fall through to direct write
+
+    # Fallback for stubs that lack ``append_instructions`` (unit tests).
+    if not existing:
+        try:
+            config.system_instruction = hint
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "_inject_runtime_tools_hint: could not set system_instruction: %s",
+                exc,
+            )
+    elif isinstance(existing, str):
+        try:
+            config.system_instruction = existing + "\n\n" + hint
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "_inject_runtime_tools_hint: could not append system_instruction: %s",
+                exc,
+            )
 
 
 #: Default per-LLM-call wall-clock budget (milliseconds) enforced by
@@ -4325,6 +4508,34 @@ def make_adk_plugin(
             except Exception as exc:  # noqa: BLE001
                 log.debug(
                     "before_model_callback: goldfive planner injection raised: %s",
+                    exc,
+                )
+
+            # R3 (F2 alternative) — runtime tool-surface hint.
+            #
+            # Tier 1's F1/F3/F4 fire AFTER the LLM has already emitted /
+            # received a tool call. They can't prevent the model's NEXT
+            # inference loop from picking the same already-completed
+            # agent. The hint here is the PRE-EMPTIVE signal: at every
+            # model call we tell the LLM which agents still have
+            # PENDING work and which are DONE, so the model has
+            # structural guidance about what to call next without
+            # needing user-prompt cooperation.
+            #
+            # Best-effort, like the planner injection above. The hint
+            # is bracketed with marker tags so subsequent calls can
+            # strip the stale block before appending the fresh one
+            # (per-call, not accumulated).
+            try:
+                if ctx is not None and ctx.session is not None:
+                    _inject_runtime_tools_hint(
+                        callback_context=callback_context,
+                        llm_request=llm_request,
+                        session=ctx.session,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "before_model_callback: runtime tools hint injection raised: %s",
                     exc,
                 )
 

--- a/tests/test_runtime_tool_surface_hint.py
+++ b/tests/test_runtime_tool_surface_hint.py
@@ -1,0 +1,510 @@
+"""Tests for the R3 runtime tool-surface hint (Tier 1 F2 alternative).
+
+Covers :func:`goldfive.adapters._adk_plugin._build_runtime_tools_hint`
+and :func:`goldfive.adapters._adk_plugin._inject_runtime_tools_hint`
+plus the wiring through ``before_model_callback`` such that the hint
+lands on ``llm_request.config.system_instruction`` without clobbering
+prior instructions and without accumulating across calls.
+
+Runs without ADK installed because the helpers are pure-Python and do
+not import ADK at module load. Wiring tests skip when ADK is missing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from goldfive.adapters._adk_plugin import (
+    _RUNTIME_TOOLS_HINT_END,
+    _RUNTIME_TOOLS_HINT_PREFIX,
+    _build_runtime_tools_hint,
+    _inject_runtime_tools_hint,
+    _strip_prior_runtime_tools_hint,
+)
+from goldfive.types import Plan, Session, Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    def __init__(self) -> None:
+        self.system_instruction: str | None = None
+
+
+class _FakeLlmRequest:
+    """LlmRequest stub mimicking ADK's ``append_instructions`` + ``config``."""
+
+    def __init__(self) -> None:
+        self.config = _FakeConfig()
+        self.append_calls: list[list[str]] = []
+
+    def append_instructions(self, instructions: list[str]) -> list:
+        self.append_calls.append(list(instructions))
+        new_text = "\n\n".join(instructions)
+        if not self.config.system_instruction:
+            self.config.system_instruction = new_text
+        else:
+            self.config.system_instruction += "\n\n" + new_text
+        return []
+
+
+def _make_session(tasks: list[Task] | None, *, run_id: str = "run-1") -> Session:
+    if tasks is None:
+        return Session(run_id=run_id, plan=None)
+    plan = Plan(id="plan-1", run_id=run_id, goal_ids=[], tasks=tasks, edges=[])
+    return Session(run_id=run_id, plan=plan)
+
+
+# ---------------------------------------------------------------------------
+# _build_runtime_tools_hint
+# ---------------------------------------------------------------------------
+
+
+def test_no_plan_returns_none() -> None:
+    """A session with ``plan=None`` produces no hint."""
+    session = _make_session(None)
+    assert _build_runtime_tools_hint(session) is None
+
+
+def test_empty_plan_returns_none() -> None:
+    """A plan with zero tasks produces no hint."""
+    session = _make_session([])
+    assert _build_runtime_tools_hint(session) is None
+
+
+def test_multi_agent_plan_lists_pending_and_done() -> None:
+    """Mixed plan: one PENDING agent, one all-COMPLETED agent."""
+    tasks = [
+        Task(
+            id="t1",
+            title="Research the market",
+            assignee_agent_id="research_agent",
+            status=TaskStatus.PENDING,
+        ),
+        Task(
+            id="t2",
+            title="Build the landing page",
+            assignee_agent_id="web_developer_agent",
+            status=TaskStatus.COMPLETED,
+        ),
+    ]
+    session = _make_session(tasks)
+
+    hint = _build_runtime_tools_hint(session)
+
+    assert hint is not None
+    assert "research_agent: PENDING" in hint
+    assert "Research the market" in hint
+    assert "web_developer_agent: all assigned tasks complete" in hint
+    assert "do NOT re-invoke" in hint
+
+
+def test_all_complete_emits_do_not_re_invoke() -> None:
+    """A plan whose only tasks are all terminal — every line says 'do NOT re-invoke'."""
+    tasks = [
+        Task(
+            id="t1",
+            title="A",
+            assignee_agent_id="research_agent",
+            status=TaskStatus.COMPLETED,
+        ),
+        Task(
+            id="t2",
+            title="B",
+            assignee_agent_id="research_agent",
+            status=TaskStatus.NOT_NEEDED,
+        ),
+    ]
+    session = _make_session(tasks)
+
+    hint = _build_runtime_tools_hint(session)
+
+    assert hint is not None
+    assert "research_agent: all assigned tasks complete" in hint
+    # No PENDING line for that agent
+    assert "research_agent: PENDING" not in hint
+
+
+def test_terminal_statuses_all_recognised() -> None:
+    """COMPLETED, FAILED, CANCELLED, NOT_NEEDED all count as 'done'."""
+    statuses = [
+        TaskStatus.COMPLETED,
+        TaskStatus.FAILED,
+        TaskStatus.CANCELLED,
+        TaskStatus.NOT_NEEDED,
+    ]
+    for st in statuses:
+        tasks = [
+            Task(id="t1", title="X", assignee_agent_id="alpha", status=st),
+        ]
+        hint = _build_runtime_tools_hint(_make_session(tasks))
+        assert hint is not None, f"hint missing for status={st}"
+        assert "alpha: all assigned tasks complete" in hint, f"status={st}"
+
+
+def test_hint_format_marker_present() -> None:
+    """The prefix marker MUST be present so dedup logic can find prior hints."""
+    tasks = [
+        Task(
+            id="t1",
+            title="Anything",
+            assignee_agent_id="a",
+            status=TaskStatus.PENDING,
+        ),
+    ]
+    hint = _build_runtime_tools_hint(_make_session(tasks))
+    assert hint is not None
+    assert hint.startswith(_RUNTIME_TOOLS_HINT_PREFIX)
+    assert _RUNTIME_TOOLS_HINT_END in hint
+    assert "Choose the agent whose tasks are still PENDING" in hint
+
+
+def test_namespaced_agent_id_strips_namespace() -> None:
+    """``ns:agent_name`` agent ids are surfaced as the bare name."""
+    tasks = [
+        Task(
+            id="t1",
+            title="Probe",
+            assignee_agent_id="my.namespace:research_agent",
+            status=TaskStatus.PENDING,
+        ),
+    ]
+    hint = _build_runtime_tools_hint(_make_session(tasks))
+    assert hint is not None
+    assert "research_agent: PENDING" in hint
+    # The full namespaced form should not appear as the line key.
+    assert "my.namespace:research_agent: PENDING" not in hint
+
+
+def test_pending_summary_caps_at_three_titles() -> None:
+    """Long PENDING lists are truncated to three titles for prompt brevity."""
+    tasks = [
+        Task(id=f"t{i}", title=f"Task {i}", assignee_agent_id="a", status=TaskStatus.PENDING)
+        for i in range(5)
+    ]
+    hint = _build_runtime_tools_hint(_make_session(tasks))
+    assert hint is not None
+    # First three present
+    assert "Task 0" in hint and "Task 1" in hint and "Task 2" in hint
+    # 4th + 5th omitted
+    assert "Task 3" not in hint
+    assert "Task 4" not in hint
+
+
+# ---------------------------------------------------------------------------
+# _strip_prior_runtime_tools_hint
+# ---------------------------------------------------------------------------
+
+
+def test_strip_no_marker_is_passthrough() -> None:
+    """Strings without the prefix are returned unchanged."""
+    assert _strip_prior_runtime_tools_hint("hello world") == "hello world"
+
+
+def test_strip_removes_full_marker_block() -> None:
+    """A complete hint block bracketed by both markers is removed cleanly."""
+    body = (
+        "USER PROMPT TEXT\n\n"
+        f"{_RUNTIME_TOOLS_HINT_PREFIX} runtime guidance, not user-authored]\n"
+        "  research_agent: PENDING — Do thing\n"
+        f"{_RUNTIME_TOOLS_HINT_END}\n\n"
+        "TRAILING TEXT"
+    )
+    out = _strip_prior_runtime_tools_hint(body)
+    assert _RUNTIME_TOOLS_HINT_PREFIX not in out
+    assert _RUNTIME_TOOLS_HINT_END not in out
+    assert "USER PROMPT TEXT" in out
+    assert "TRAILING TEXT" in out
+    # No tripled newlines
+    assert "\n\n\n" not in out
+
+
+def test_strip_handles_truncated_marker() -> None:
+    """A prefix without the closing marker is dropped from prefix to end."""
+    body = f"USER\n\n{_RUNTIME_TOOLS_HINT_PREFIX} ...]\n  research_agent: PENDING"
+    out = _strip_prior_runtime_tools_hint(body)
+    assert _RUNTIME_TOOLS_HINT_PREFIX not in out
+    assert "USER" in out
+
+
+# ---------------------------------------------------------------------------
+# _inject_runtime_tools_hint
+# ---------------------------------------------------------------------------
+
+
+def test_injection_appends_when_no_prior_instruction() -> None:
+    """Empty system_instruction gets the hint via append_instructions."""
+    tasks = [
+        Task(
+            id="t1",
+            title="Probe",
+            assignee_agent_id="research_agent",
+            status=TaskStatus.PENDING,
+        ),
+    ]
+    session = _make_session(tasks)
+    req = _FakeLlmRequest()
+
+    _inject_runtime_tools_hint(callback_context=None, llm_request=req, session=session)
+
+    assert req.config.system_instruction is not None
+    assert _RUNTIME_TOOLS_HINT_PREFIX in req.config.system_instruction
+    assert "research_agent: PENDING" in req.config.system_instruction
+    assert req.append_calls == [[req.config.system_instruction]] or len(req.append_calls) == 1
+
+
+def test_injection_preserves_existing_user_system_instruction() -> None:
+    """A pre-existing system_instruction (the user's coordinator prompt) survives."""
+    tasks = [
+        Task(
+            id="t1",
+            title="Probe",
+            assignee_agent_id="research_agent",
+            status=TaskStatus.PENDING,
+        ),
+    ]
+    session = _make_session(tasks)
+    req = _FakeLlmRequest()
+    req.config.system_instruction = "You are a coordinator. Delegate to specialists."
+
+    _inject_runtime_tools_hint(callback_context=None, llm_request=req, session=session)
+
+    instr = req.config.system_instruction
+    assert instr is not None
+    assert "You are a coordinator." in instr
+    assert _RUNTIME_TOOLS_HINT_PREFIX in instr
+    # Hint comes AFTER the user's prompt (append semantics).
+    assert instr.index("You are a coordinator.") < instr.index(_RUNTIME_TOOLS_HINT_PREFIX)
+
+
+def test_injection_replaces_prior_hint_no_accumulation() -> None:
+    """A second injection swaps the stale hint for the fresh one."""
+    req = _FakeLlmRequest()
+    req.config.system_instruction = "USER PROMPT"
+
+    # First call: research_agent has 1 PENDING task.
+    s1 = _make_session(
+        [
+            Task(
+                id="t1",
+                title="First task",
+                assignee_agent_id="research_agent",
+                status=TaskStatus.PENDING,
+            )
+        ]
+    )
+    _inject_runtime_tools_hint(callback_context=None, llm_request=req, session=s1)
+    after_first = req.config.system_instruction
+    assert after_first is not None
+    assert "First task" in after_first
+    assert after_first.count(_RUNTIME_TOOLS_HINT_PREFIX) == 1
+
+    # Second call: same agent, task is now COMPLETED.
+    s2 = _make_session(
+        [
+            Task(
+                id="t1",
+                title="First task",
+                assignee_agent_id="research_agent",
+                status=TaskStatus.COMPLETED,
+            )
+        ]
+    )
+    _inject_runtime_tools_hint(callback_context=None, llm_request=req, session=s2)
+    after_second = req.config.system_instruction
+    assert after_second is not None
+    # User prompt is still present.
+    assert "USER PROMPT" in after_second
+    # Exactly ONE hint block (no accumulation).
+    assert after_second.count(_RUNTIME_TOOLS_HINT_PREFIX) == 1
+    assert after_second.count(_RUNTIME_TOOLS_HINT_END) == 1
+    # The fresh hint reflects the new state.
+    assert "all assigned tasks complete" in after_second
+    # The stale "PENDING — First task" line is gone.
+    assert "PENDING — First task" not in after_second
+
+
+def test_injection_no_plan_strips_stale_hint() -> None:
+    """When the plan disappears, an existing hint should be stripped, not left dangling."""
+    req = _FakeLlmRequest()
+    req.config.system_instruction = (
+        "USER PROMPT\n\n"
+        f"{_RUNTIME_TOOLS_HINT_PREFIX} runtime guidance, not user-authored]\n"
+        "  research_agent: PENDING — Old task\n"
+        f"{_RUNTIME_TOOLS_HINT_END}"
+    )
+
+    session = _make_session(None)
+    _inject_runtime_tools_hint(callback_context=None, llm_request=req, session=session)
+
+    instr = req.config.system_instruction
+    assert instr is not None
+    assert "USER PROMPT" in instr
+    assert _RUNTIME_TOOLS_HINT_PREFIX not in instr
+    assert _RUNTIME_TOOLS_HINT_END not in instr
+
+
+def test_injection_no_plan_no_prior_hint_is_noop() -> None:
+    """No plan AND no prior hint: nothing changes (no accidental polluting)."""
+    req = _FakeLlmRequest()
+    req.config.system_instruction = "USER PROMPT"
+
+    session = _make_session(None)
+    _inject_runtime_tools_hint(callback_context=None, llm_request=req, session=session)
+
+    assert req.config.system_instruction == "USER PROMPT"
+    assert req.append_calls == []
+
+
+def test_injection_handles_missing_config_attr() -> None:
+    """A request without ``config`` is a silent no-op (defensive path)."""
+
+    class _Bare:
+        pass
+
+    bare = _Bare()
+    session = _make_session(
+        [
+            Task(
+                id="t1",
+                title="X",
+                assignee_agent_id="a",
+                status=TaskStatus.PENDING,
+            )
+        ]
+    )
+    # Should not raise.
+    _inject_runtime_tools_hint(callback_context=None, llm_request=bare, session=session)
+
+
+def test_injection_falls_back_to_direct_write_without_append_helper() -> None:
+    """When LlmRequest lacks ``append_instructions``, write directly to system_instruction."""
+
+    class _BareReq:
+        def __init__(self) -> None:
+            self.config = _FakeConfig()
+
+    req: Any = _BareReq()
+    session = _make_session(
+        [
+            Task(
+                id="t1",
+                title="X",
+                assignee_agent_id="a",
+                status=TaskStatus.PENDING,
+            )
+        ]
+    )
+    _inject_runtime_tools_hint(callback_context=None, llm_request=req, session=session)
+    assert req.config.system_instruction is not None
+    assert _RUNTIME_TOOLS_HINT_PREFIX in req.config.system_instruction
+
+
+# ---------------------------------------------------------------------------
+# before_model_callback wiring (requires ADK)
+# ---------------------------------------------------------------------------
+
+try:  # pragma: no cover — env-dependent
+    import google.adk  # noqa: F401
+
+    _ADK_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _ADK_AVAILABLE = False
+
+skip_without_adk = pytest.mark.skipif(
+    not _ADK_AVAILABLE, reason="ADK wiring tests require google-adk"
+)
+
+if _ADK_AVAILABLE:
+    from goldfive.adapters._adk_plugin import (  # noqa: E402
+        SessionContext,
+        make_adk_plugin,
+    )
+
+
+class _FakeInvocationContext:
+    def __init__(self) -> None:
+        self.invocation_id = "inv-r3"
+        self.agent = None
+        self.session = None
+        self.user_content = None
+        self.user_id = "u"
+        self.branch = None
+        self.run_config = None
+
+
+class _FakeCallbackContext:
+    def __init__(self, inv_ctx: _FakeInvocationContext) -> None:
+        self._invocation_context = inv_ctx
+
+
+@skip_without_adk
+@pytest.mark.asyncio
+async def test_before_model_callback_injects_runtime_tools_hint() -> None:
+    """End-to-end through ``before_model_callback``: hint lands on system_instruction."""
+    plugin = make_adk_plugin()
+
+    tasks = [
+        Task(
+            id="t1",
+            title="Survey",
+            assignee_agent_id="research_agent",
+            status=TaskStatus.PENDING,
+        ),
+        Task(
+            id="t2",
+            title="Build site",
+            assignee_agent_id="web_developer_agent",
+            status=TaskStatus.COMPLETED,
+        ),
+    ]
+    session = _make_session(tasks)
+    ctx = SessionContext(
+        session=session,
+        steerer=None,
+        task=tasks[0],
+        tool_handlers={},
+        host_agent_name="coordinator",
+    )
+    plugin.set_active_context(ctx)
+
+    inv_ctx = _FakeInvocationContext()
+    cb = _FakeCallbackContext(inv_ctx)
+    req = _FakeLlmRequest()
+    req.config.system_instruction = "USER COORDINATOR PROMPT"
+
+    try:
+        result = await plugin.before_model_callback(callback_context=cb, llm_request=req)
+        # Non-None return short-circuits ADK; the hint path must NOT do that.
+        assert result is None
+        instr = req.config.system_instruction
+        assert instr is not None
+        assert "USER COORDINATOR PROMPT" in instr
+        assert _RUNTIME_TOOLS_HINT_PREFIX in instr
+        assert "research_agent: PENDING" in instr
+        assert "web_developer_agent: all assigned tasks complete" in instr
+    finally:
+        plugin.clear_active_context()
+
+
+@skip_without_adk
+@pytest.mark.asyncio
+async def test_before_model_callback_no_session_is_noop_for_hint() -> None:
+    """No active SessionContext: hint injection skips, callback still returns None."""
+    plugin = make_adk_plugin()
+    # Deliberately no set_active_context.
+
+    inv_ctx = _FakeInvocationContext()
+    cb = _FakeCallbackContext(inv_ctx)
+    req = _FakeLlmRequest()
+    req.config.system_instruction = "USER PROMPT"
+
+    result = await plugin.before_model_callback(callback_context=cb, llm_request=req)
+    assert result is None
+    # No hint added.
+    assert req.config.system_instruction == "USER PROMPT"
+    assert _RUNTIME_TOOLS_HINT_PREFIX not in (req.config.system_instruction or "")


### PR DESCRIPTION
## Summary

R3 is the non-invasive alternative to Tier 1's F2. F2 wanted to mutate `llm_request.config.tools` mid-callback to remove agents whose tasks were complete — but that was deemed risky (ADK caches function declarations on `tools_dict`, and the model API rejects requests where the declarations don't line up with the names in `contents`). R3 instead injects a **runtime "currently-relevant tools" hint** as a separate system-instruction block at every model call.

### Why this is needed

In v20 validation, four `GOAL_DRIFT` events fired despite F4 NUDGE-routing. The coordinator kept trying to call `research_agent` after it had completed all its work because:
- F1 (directive tool responses) only fires AFTER the LLM has decided to call.
- F3 (re-invocation refusal) only fires AFTER the LLM emits a tool call.
- The LLM's NEXT inference loop sees ALL tools as available and re-picks the same agent.

R3 supplies the missing **pre-emptive** signal: at every `before_model_callback` we tell the LLM which agents still have PENDING tasks and which are DONE.

### No prompt-contract violation

The user's coordinator prompt stays untouched. Goldfive contributes a separate `[GOLDFIVE PLAN-STATE HINT — ...]` block via `LlmRequest.append_instructions` — the same path the GoldfivePlanner already uses.

### Implementation

- `_build_runtime_tools_hint(session)` — walks `session.plan.tasks`, groups by `assignee_agent_id`, renders PENDING (with up to 3 task titles) / DONE lines.
- `_strip_prior_runtime_tools_hint(existing)` — detects the marker prefix and strips the previous block so the hint is **per-call, not accumulated**.
- `_inject_runtime_tools_hint(...)` — strip-then-append via `append_instructions`, preserving the user's existing `system_instruction`. Falls back to direct `config.system_instruction` write for stubs that lack the helper.
- Wired into `before_model_callback` right after the GoldfivePlanner injection. Best-effort; never raises.

### Injection mechanism

`LlmRequest.append_instructions([hint])` — same string-concat path the GoldfivePlanner takes. ADK's `system_instruction` is a single string, so the marker-bracketed block is concatenated on with `\n\n` between segments. Dedup uses substring search for the prefix on each call.

## Test plan

- [x] 20 new tests in `tests/test_runtime_tool_surface_hint.py`:
  - `_build_runtime_tools_hint`: no plan, empty plan, mixed agents, all-complete agent, every terminal status, marker presence, namespace stripping, 3-title cap.
  - `_strip_prior_runtime_tools_hint`: passthrough, full-block removal, truncated marker.
  - `_inject_runtime_tools_hint`: append on empty, preserve user prompt, replace prior hint (no accumulation), strip stale hint when plan disappears, no-op when no plan and no prior hint, missing-config defensive path, fallback when no `append_instructions`.
  - End-to-end via `before_model_callback`: hint lands on `system_instruction`; no-active-context is a clean no-op.
- [x] Targeted: `pytest tests -k "tool_surface or hint or before_model"` — 26 passed, 1 skipped.
- [x] Full suite: `pytest tests` — **1975 passed, 51 skipped**.
- [x] `ruff check` — clean.