### PR TITLE
feat(steerer, runner): user-steer L2 contract + configurable abort policy on revision rejection

### DIFF
--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -280,6 +280,28 @@ dropped set, so the plan lands in a consistent terminal-only shape
 with `success=False` and a clear `revision_reason`. This is
 implemented by the cascade semantics in §6.3.
 
+### 4.2.1 User-steer rejection is structurally impossible
+
+A USER_STEER drift NEVER produces a rejected revision. The
+`install_user_steer` API (`steerer.py`) returns `Plan` (not `Plan | None`)
+and never raises `ValueError`. When the LLM-produced revision fails
+`Plan.validate(for_revision=True, prior=...)`, the steerer falls back
+to a deterministic minimum evolution: preserve every terminal task
+verbatim (§3.1), cancel every PENDING/RUNNING/BLOCKED task, drop every
+edge incident to a cancelled task. The minimum is provably valid by
+construction.
+
+This is a contract, not a heuristic. The principle "user-provided
+steering is never rejected by the validator" is enforced at the type
+level (return type `Plan`), at the API level (no failure path), at the
+implementation level (deterministic fallback always validates), at the
+test level (property-based invariant in
+`tests/test_user_steer_invariant.py`), and at the doc level (here).
+
+Any change to `Plan.validate`, `_apply_revision`, or `install_user_steer`
+that could cause a user steer to abort the turn is a contract violation
+and MUST be reverted.
+
 ### 4.3 Fail-and-route (LOOPING_TOOL_CALL / LOOPING_REASONING)
 
 **Triggers:** `LOOPING_TOOL_CALL`, `LOOPING_REASONING`.
@@ -338,6 +360,29 @@ The steerer handles it in three layers (see TASK-LIFECYCLE.md §4):
    CANCEL dependents so the plan lands in a consistent shape.
 
 Successful refine resets the counter for that `(kind, task_id)`.
+
+### 4.5.1 Goldfive-authored revision rejection is non-fatal by default
+
+When `Plan.validate(for_revision=True)` rejects a goldfive-authored
+revision (autonomous refine output), the run does NOT abort by default.
+The existing plan is retained on `session.plan`, a
+HUMAN_INTERVENTION_REQUIRED INFO drift is emitted for observability,
+and execution continues. The next refine cycle (if the underlying drift
+persists) gets another attempt; the existing REFINE_FAILURE_THRESHOLD=2
+escalation (§4.5) still fires after two consecutive failures of the
+same (kind, task_id).
+
+Operators wanting strict abort-on-rejection — useful for CI, regression
+testing, or debugging refine logic — opt in via:
+
+- `Runner(fail_fast_on_revision_rejection=True)`
+- env var `GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1`
+
+Default is non-fatal because plan-revision rejection is recoverable: the
+existing plan is still installed and valid, agents can still make
+progress, and aborting on transient LLM output unreliability is
+user-hostile. Loud aborts are a debugging affordance, not a default
+user contract.
 
 ---
 

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -41,6 +41,7 @@ import asyncio
 import dataclasses
 import inspect
 import logging
+import os
 import warnings
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any
@@ -185,6 +186,33 @@ class Runner:
         ``report_new_work_discovered`` is intentionally NOT a drift
         tool — there is no observation analog for an agent surfacing
         genuinely new work, so it stays default-on.
+    fail_fast_on_revision_rejection:
+        Strict-abort opt-in for goldfive-authored revisions that fail
+        ``Plan.validate(for_revision=True, prior=...)``. Default
+        (``False``) is non-fatal: when a goldfive-authored autonomous
+        refine produces an invalid revision, the runner keeps the
+        existing ``session.plan``, emits a
+        ``HUMAN_INTERVENTION_REQUIRED`` INFO ``DriftDetected`` for
+        observability, and continues the turn. The next refine cycle
+        gets another attempt; the existing
+        ``REFINE_FAILURE_THRESHOLD=2`` escalation still fires after two
+        consecutive failures of the same ``(kind, task_id)``.
+
+        Operators wanting strict abort-on-rejection — useful for CI,
+        regression testing, or debugging refine logic — opt in by
+        passing ``True`` (or setting the env var
+        ``GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1``). When ``None``
+        (the default), the env var is consulted; explicit ``False`` /
+        ``True`` always wins over the env.
+
+        **User-authored** drifts (``USER_STEER`` from a
+        ``ControlMessage``) are NEVER affected by this flag — the
+        :meth:`DefaultSteerer.install_user_steer` API guarantees a
+        valid ``Plan`` returns even when the LLM revision fails
+        validation (PLAN-LIFECYCLE.md §4.2.1). User-steer rejection is
+        structurally impossible.
+
+        See PLAN-LIFECYCLE.md §4.5.1 for the full rationale.
     """
 
     def __init__(
@@ -202,6 +230,7 @@ class Runner:
         goal_drift_enabled: bool = True,
         planner_gate: Any = "auto",
         drift_self_reporting: bool | list[str] = False,
+        fail_fast_on_revision_rejection: bool | None = None,
         **legacy_kwargs: Any,
     ) -> None:
         if "max_plan_reinvocations" in legacy_kwargs:
@@ -338,6 +367,23 @@ class Runner:
             self.drift_self_reporting: bool | list[str] = drift_self_reporting
         else:
             self.drift_self_reporting = [str(n) for n in drift_self_reporting]
+        # Configurable abort policy on goldfive-authored revision
+        # rejection. See PLAN-LIFECYCLE.md §4.5.1. Default (kwarg
+        # ``None``): consult env var; falsy unless the env explicitly
+        # opts in. Explicit ``True`` / ``False`` from the kwarg wins
+        # over the env so tests can pin behaviour without unsetting the
+        # env first. User-authored drifts (USER_STEER) are never gated
+        # by this flag — see :meth:`DefaultSteerer.install_user_steer`.
+        if fail_fast_on_revision_rejection is None:
+            fail_fast_on_revision_rejection = (
+                os.environ.get(
+                    "GOLDFIVE_FAIL_FAST_REVISION_REJECTION", "0"
+                )
+                == "1"
+            )
+        self._fail_fast_on_revision_rejection: bool = bool(
+            fail_fast_on_revision_rejection
+        )
         # Cross-turn prior-plan stash lives on :class:`Conversation`
         # (keyed by session id) so a Runner shared across multiple
         # outer ADK sessions does not leak one session's plan into
@@ -701,15 +747,89 @@ class Runner:
                 revised_plan=next_plan,
             )
             if not installed:
-                reason = "plan revision rejected by validator"
-                await self._emit_run_aborted(session, reason)
-                outcome = ExecutionOutcome(success=False, session=session, reason=reason)
-                convo.absorb_turn(
-                    outcome,
-                    user_input_summary=_initial_goal_summary(user_input),
-                    pinned=pinned,
+                # Configurable abort policy on goldfive-authored
+                # revision rejection (PLAN-LIFECYCLE.md §4.5.1). The
+                # install path here is always goldfive-authored — it
+                # handles handle_turn-driven NEW_WORK_DISCOVERED
+                # revisions; genuine operator USER_STEER takes the
+                # executor's STEER control loop and routes through the
+                # steerer's user-steer pipeline (which is structurally
+                # incapable of aborting — see PLAN-LIFECYCLE.md
+                # §4.2.1 and ``DefaultSteerer.install_user_steer``).
+                #
+                # Default (``fail_fast_on_revision_rejection=False``):
+                # keep ``session.plan`` unchanged, emit a
+                # HUMAN_INTERVENTION_REQUIRED INFO drift for
+                # observability, and continue the turn. The plan that
+                # was previously valid is still valid; agents can
+                # still make progress; the next refine cycle (if the
+                # underlying drift persists) gets another attempt.
+                # The existing ``REFINE_FAILURE_THRESHOLD=2``
+                # escalation in :meth:`DefaultSteerer._install_with_drift`
+                # still fires after two consecutive failures of the
+                # same ``(kind, task_id)``.
+                #
+                # Opt-in strict mode (``fail_fast_on_revision_rejection
+                # =True`` or ``GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1``):
+                # emit ``run_aborted`` as the pre-PR1 behaviour. Useful
+                # for CI / regression / debugging refine logic.
+                log.warning(
+                    "Runner.run: goldfive-authored revision rejected "
+                    "by validator; keeping existing plan, continuing "
+                    "run (set fail_fast_on_revision_rejection=True or "
+                    "GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1 for "
+                    "strict mode). prior_plan_id=%s revision_index=%d",
+                    (session.plan.id or "")[:16] or "<none>",
+                    int(getattr(session.plan, "revision_index", 0)),
                 )
-                return outcome
+                # Observability drift on the same sinks the steerer
+                # uses, so harmonograf / sinks see the rejection
+                # alongside the surrounding refine activity. Routed
+                # through the steerer's ``_emit_drift_detected`` so
+                # the lifecycle / condition_id stamping fires
+                # consistently.
+                obs_drift = DriftEvent(
+                    kind=DriftKind.HUMAN_INTERVENTION_REQUIRED,
+                    severity=DriftSeverity.INFO,
+                    detail=(
+                        "autonomous refine produced an invalid plan "
+                        "revision; existing plan retained; next "
+                        "refine cycle may try again"
+                    ),
+                    authored_by="goldfive",
+                )
+                emit_helper = getattr(
+                    self.steerer, "_emit_drift_detected", None
+                )
+                if callable(emit_helper):
+                    try:
+                        await emit_helper(session, obs_drift)
+                    except Exception as exc:  # noqa: BLE001
+                        log.warning(
+                            "Runner.run: emitting "
+                            "HUMAN_INTERVENTION_REQUIRED observability "
+                            "drift raised: %s",
+                            exc,
+                        )
+
+                if self._fail_fast_on_revision_rejection:
+                    reason = "plan revision rejected by validator"
+                    await self._emit_run_aborted(session, reason)
+                    outcome = ExecutionOutcome(
+                        success=False, session=session, reason=reason
+                    )
+                    convo.absorb_turn(
+                        outcome,
+                        user_input_summary=_initial_goal_summary(user_input),
+                        pinned=pinned,
+                    )
+                    return outcome
+                # Default: keep existing plan, continue. ``session.plan``
+                # is unchanged because ``_install_revision``'s
+                # rejection path returns False BEFORE applying the
+                # revision (see :meth:`_install_with_drift` —
+                # ``revised_plan.validate`` raises before
+                # ``_apply_revision`` runs).
         elif not session.plan.tasks:
             # First turn AND handle_turn returned None (purely
             # conversational on an empty seed). No plan to drive the

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import contextvars
+import dataclasses
 import enum
 import inspect
 import json
@@ -4307,6 +4308,189 @@ class DefaultSteerer:
             drift=drift,
             revised_plan=revised_plan,
             apply_user_steer_state=True,
+        )
+
+    async def install_user_steer(
+        self,
+        *,
+        drift: DriftEvent,
+        prior: Plan,
+        llm_revision: Plan | None,
+        session: Session,
+    ) -> Plan:
+        """Install a user-authored revision. ALWAYS returns a valid Plan.
+
+        Contract (see ``docs/design/PLAN-LIFECYCLE.md`` §4.2.1): user-steer
+        rejection is **structurally impossible**. The return type is
+        ``Plan`` (never ``None``), and this method does not raise
+        ``ValueError`` from validation. If the LLM-produced revision
+        fails ``Plan.validate(for_revision=True, prior=...)``, this
+        method falls back to the deterministic minimum evolution shape
+        (per §4.2): preserve every terminal task verbatim, cancel every
+        PENDING / RUNNING / BLOCKED task, drop edges incident to the
+        cancelled set. The minimum is provably valid by construction.
+
+        Order of preference:
+
+        1. ``llm_revision`` if non-None and validates against ``prior``.
+        2. :meth:`_build_minimal_steer_evolution` — deterministic, always
+           valid, intentionally produces a plan with no PENDING tasks.
+
+        The deterministic minimum lands the user's pivot as a clean
+        terminal-only frontier; the next refine cycle or coordinator
+        turn can populate the new sub-DAG. This is acceptable
+        degradation — the turn does not abort. The contract sacrifices
+        a bit of "the LLM's first attempt drove forward progress" for
+        the much stronger "the user's intent ALWAYS lands".
+
+        Side effects (regardless of which branch fires):
+
+        * :meth:`_apply_user_steer_state` writes the
+          ``goldfive.active_steer.*`` slot from ``drift``.
+        * :meth:`_emit_drift_detected` emits the ``USER_STEER`` drift.
+        * :meth:`_apply_revision` swaps ``session.plan`` and bumps
+          ``revision_index``.
+        * :meth:`_cancel_inflight_for_revision` preempts in-flight work.
+        * :meth:`_emit_plan_revised` fires ``PlanRevised``.
+
+        The deterministic-fallback branch deliberately does NOT touch
+        ``session.refine_failure_counts`` — that counter governs
+        goldfive-authored autonomous refines (§4.5), not user-driven
+        changes. A USER_STEER never escalates via REPEATED_FAILURE.
+
+        Never raises.
+        """
+        # Normalise the drift's authored_by so downstream observability
+        # (DriftDetected.authored_by) carries the right attribution.
+        if not drift.authored_by:
+            drift.authored_by = "user"
+        # Branch 1: try the LLM's revision if it parses + validates.
+        chosen: Plan | None = None
+        if llm_revision is not None:
+            try:
+                llm_revision.validate(for_revision=True, prior=prior)
+                chosen = llm_revision
+            except ValueError as exc:
+                log.warning(
+                    "DefaultSteerer.install_user_steer: LLM revision rejected "
+                    "by validator (%s); falling back to deterministic minimum "
+                    "evolution shape (PLAN-LIFECYCLE.md §4.2.1)",
+                    exc,
+                )
+        # Branch 2: deterministic minimum. Always valid by construction.
+        if chosen is None:
+            chosen = self._build_minimal_steer_evolution(prior, drift)
+        # Always run the user-steer state bookkeeping — every call to
+        # this method represents a genuine operator action.
+        await self._apply_user_steer_state(drift, session)
+        await self._emit_drift_detected(session, drift)
+        # No-op short-circuit: the deterministic minimum on a prior with
+        # no PENDING/RUNNING/BLOCKED tasks degenerates to a structurally
+        # identical plan. Skip the install (avoids a misleading
+        # PlanRevised with empty diff) but still return ``prior`` so the
+        # contract (always a Plan) holds.
+        if self._plans_structurally_identical(prior, chosen):
+            log.info(
+                "DefaultSteerer.install_user_steer: deterministic minimum "
+                "is structurally identical to prior (no mutable tasks to "
+                "cancel); install skipped, returning prior plan"
+            )
+            return prior
+        prev_plan = session.plan
+        attempt_id = self._new_attempt_id()
+        await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
+        self._apply_revision(session, chosen, drift)
+        await self._cancel_inflight_for_revision(drift, session)
+        await self._emit_plan_revised(
+            session,
+            chosen,
+            drift,
+            prev_plan=prev_plan,
+            attempt_id=attempt_id,
+        )
+        self._record_plan_revision(drift, session)
+        return chosen
+
+    def _build_minimal_steer_evolution(
+        self, prior: Plan, drift: DriftEvent
+    ) -> Plan:
+        """Construct the canonical evolution shape per PLAN-LIFECYCLE.md §4.2.
+
+        Deterministic. Preserves terminal tasks verbatim (§3.1), cancels
+        every PENDING / RUNNING / BLOCKED task (so they enter the
+        absorbing CANCELLED terminal), and drops every edge incident to
+        a cancelled task. The result always passes
+        ``Plan.validate(for_revision=True, prior=prior)`` because:
+
+        * Every prior-terminal task is preserved with the same status →
+          §3.1 holds.
+        * Every prior terminal->terminal edge is preserved verbatim →
+          §3.2 holds.
+        * No PENDING tasks remain → reachability invariant (§5 rule 7,
+          goldfive#137) is vacuously satisfied (no PENDING task can
+          have a CANCELLED predecessor because there ARE no PENDING
+          tasks).
+        * Edges only span surviving terminal endpoints → no dangling
+          edges.
+
+        Uses :func:`dataclasses.replace` so the prior plan and tasks
+        are not mutated. The deriver caches Tasks by identity in a few
+        places (Tier 2 #323 found that mutating shared Task references
+        corrupts the cache); fresh copies sidestep that risk.
+
+        ``drift`` is consulted only for revision metadata (kind /
+        severity / detail go onto the new plan via
+        :meth:`_apply_revision`). It is not strictly required here, but
+        keeping the parameter mirrors the steerer's other revision
+        builders and makes future extensions (e.g. tagging which task
+        the steer named) easier.
+        """
+        _ = drift  # reserved for future per-task framing; see docstring
+        new_tasks: list[Task] = []
+        cancelled_ids: set[str] = set()
+        for t in prior.tasks:
+            if t.status.is_terminal:
+                # Preserve verbatim — fresh copy so callers cannot
+                # accidentally mutate the prior plan's task identity.
+                new_tasks.append(dataclasses.replace(t))
+            else:
+                # PENDING / RUNNING / BLOCKED → CANCELLED. Stamp a
+                # provenance reason so harmonograf's intervention view
+                # can attribute the cancel to a user-steer rollover.
+                cancelled = dataclasses.replace(
+                    t,
+                    status=TaskStatus.CANCELLED,
+                    cancel_reason=f"user_steer_rollover:{drift.id}"
+                    if getattr(drift, "id", "")
+                    else "user_steer_rollover",
+                )
+                new_tasks.append(cancelled)
+                cancelled_ids.add(t.id)
+        # Edges: drop any edge incident to a cancelled task. The
+        # surviving edges are exactly the prior terminal->terminal set
+        # plus any pre-existing terminal->cancelled (now both terminal,
+        # but we still drop those because the to-task transitioned in
+        # this revision and §3.2 only freezes edges that were
+        # terminal->terminal in PRIOR — not in the revision).
+        # Simpler: drop any edge touching a cancelled-this-rev id.
+        new_edges: list[TaskEdge] = []
+        for e in prior.edges:
+            if e.from_task_id in cancelled_ids or e.to_task_id in cancelled_ids:
+                continue
+            new_edges.append(dataclasses.replace(e))
+        # Construct the revised plan. ``revision_index`` is bumped by
+        # :meth:`_apply_revision`; ``revision_*`` metadata stamping
+        # happens there too. We populate ``id`` / ``run_id`` /
+        # ``goal_ids`` / ``summary`` from prior so identity stays
+        # stable across the revision (the plan_id-stable-across-turns
+        # invariant from goldfive#271 Phase 4).
+        return Plan(
+            id=prior.id,
+            run_id=prior.run_id,
+            goal_ids=list(prior.goal_ids),
+            tasks=new_tasks,
+            edges=new_edges,
+            summary=prior.summary,
         )
 
     async def _install_with_drift(

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -32,6 +32,22 @@ class TaskStatus(StrEnum):
     # redundant".
     NOT_NEEDED = "NOT_NEEDED"
 
+    @property
+    def is_terminal(self) -> bool:
+        """True iff this status is terminal (no further transitions allowed).
+
+        Mirrors :data:`TERMINAL_TASK_STATUSES` for ergonomic per-status
+        checks (``task.status.is_terminal``) without forcing callers to
+        import the module-level set. The two sources stay in lock-step:
+        if a new terminal member is added, update both.
+        """
+        return self in (
+            TaskStatus.COMPLETED,
+            TaskStatus.FAILED,
+            TaskStatus.CANCELLED,
+            TaskStatus.NOT_NEEDED,
+        )
+
 
 # Terminal statuses — a task in any of these cannot transition further
 # and must not be re-invoked. This set is the **single source of truth**

--- a/tests/test_runner_revision_rejection_policy.py
+++ b/tests/test_runner_revision_rejection_policy.py
@@ -1,0 +1,498 @@
+"""Tests for the configurable abort policy on revision rejection.
+
+Pin: ``Runner(fail_fast_on_revision_rejection=...)`` (and the env-var
+fallback ``GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1``) controls whether
+a goldfive-authored revision rejected by the validator aborts the
+turn. Default is non-fatal — see ``docs/design/PLAN-LIFECYCLE.md``
+§4.5.1.
+
+User-authored drifts (USER_STEER) are NEVER affected by this flag —
+that contract is enforced structurally by
+:meth:`DefaultSteerer.install_user_steer` (see §4.2.1) and tested in
+``test_user_steer_invariant.py``. The matching assertion here is a
+belt-and-braces: regardless of the flag, a user-steer install does
+not produce a ``run_aborted`` event.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive import (  # noqa: E402, I001
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    Runner,
+    SequentialExecutor,
+    Session,
+    Task,
+)
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    ObservedAction,
+    TaskStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Adapter / planner stubs
+# ---------------------------------------------------------------------------
+
+
+async def _happy_agent(
+    task: Task, session: Session, tools: list[Any]
+) -> InvocationResult:
+    _ = tools, session
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+def _good_first_plan(*, run_id: str) -> Plan:
+    return Plan(
+        id="p1",
+        run_id=run_id,
+        goal_ids=["g"],
+        tasks=[Task(id="t1", title="T1", assignee_agent_id="w")],
+        edges=[],
+        summary="turn 1",
+    )
+
+
+def _invalid_revision(*, run_id: str, prior_id: str) -> Plan:
+    """Revision that drops a prior-COMPLETED task — fails §3.1
+    terminal-task preservation, so :meth:`Plan.validate` raises.
+    """
+    return Plan(
+        id=prior_id,
+        run_id=run_id,
+        goal_ids=["g"],
+        # Note: drops "t1" (COMPLETED in the prior plan after turn 1).
+        tasks=[Task(id="t2", title="T2", assignee_agent_id="w")],
+        edges=[],
+        summary="turn 2 invalid",
+    )
+
+
+class _ProgrammablePlanner:
+    """Planner stub whose ``handle_turn`` returns ``plans[turn_index]``.
+
+    On turn N (1-indexed), returns ``plans[N-1]`` if available, else
+    ``None``. ``generate`` is wired so the first turn falls through
+    cleanly when ``handle_turn`` returns ``None``.
+    """
+
+    def __init__(self, plans: list[Plan | None]) -> None:
+        self._plans = plans
+        self._turn_idx = 0
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: Any,
+        context: Mapping[str, Any] | None = None,
+    ) -> Plan | None:
+        # Only used as fallback when handle_turn returns None on turn 1.
+        run_id = ""
+        if context is not None:
+            run_id = str(context.get("run_id") or "")
+        return _good_first_plan(run_id=run_id or "fallback")
+
+    async def handle_turn(
+        self,
+        *,
+        user_input: str,
+        session: Session,
+        conversation_history: list[Any] | None = None,
+        available_agents: Any = None,
+        context: Mapping[str, Any] | None = None,
+    ) -> Plan | None:
+        idx = self._turn_idx
+        self._turn_idx += 1
+        if idx >= len(self._plans):
+            return None
+        return self._plans[idx]
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+        observed_actions: list[ObservedAction] | None = None,
+        available_agents: Any = None,
+    ) -> Plan | None:
+        return None
+
+
+def _runner(
+    planner: _ProgrammablePlanner,
+    sink: InMemorySink,
+    *,
+    fail_fast: bool | None = None,
+) -> Runner:
+    kwargs: dict[str, Any] = {}
+    if fail_fast is not None:
+        kwargs["fail_fast_on_revision_rejection"] = fail_fast
+    return Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["w"]),
+        planner=planner,
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("demo"),
+        sinks=[sink],
+        **kwargs,
+    )
+
+
+def _payload_kinds(sink: InMemorySink) -> list[str]:
+    out = []
+    for evt in sink.events:
+        which = evt.WhichOneof("payload") if hasattr(evt, "WhichOneof") else None
+        if which:
+            out.append(which)
+    return out
+
+
+def _drift_kinds(sink: InMemorySink) -> list[int]:
+    out = []
+    for evt in sink.events:
+        which = evt.WhichOneof("payload") if hasattr(evt, "WhichOneof") else None
+        if which != "drift_detected":
+            continue
+        out.append(int(evt.drift_detected.kind))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Default behavior: non-fatal on goldfive-authored revision rejection
+# ---------------------------------------------------------------------------
+
+
+async def test_default_revision_rejection_is_non_fatal() -> None:
+    """Default behaviour (no kwarg, no env var):
+    a goldfive-authored revision rejected by the validator does NOT
+    abort the run. The existing plan is retained, a
+    HUMAN_INTERVENTION_REQUIRED INFO drift is emitted for
+    observability, and the executor continues."""
+    sink = InMemorySink()
+
+    # Turn 1: good plan; turn 2: invalid revision (drops the now-COMPLETED t1).
+    plans: list[Plan | None] = []
+    planner = _ProgrammablePlanner(plans)
+    runner = _runner(planner, sink)
+
+    try:
+        # First, run with a good first plan to get t1 COMPLETED.
+        plans.append(_good_first_plan(run_id="r"))
+        out1 = await runner.run("turn 1", session_id="default-policy")
+        assert out1.success, f"turn 1 failed: {out1.reason!r}"
+        plan_id_after_t1 = out1.session.plan.id
+        index_after_t1 = out1.session.plan.revision_index
+
+        # Now turn 2: invalid revision. The runner's handle_turn-driven
+        # install path is goldfive-authored.
+        sink.events.clear()
+        plans.append(_invalid_revision(run_id="r", prior_id=plan_id_after_t1))
+        out2 = await runner.run("turn 2", session_id="default-policy")
+    finally:
+        await runner.close()
+
+    # No run_aborted on the wire from the install rejection.
+    aborted_with_validator_reason = [
+        e
+        for e in sink.events
+        if (e.WhichOneof("payload") if hasattr(e, "WhichOneof") else None)
+        == "run_aborted"
+        and "plan revision rejected" in e.run_aborted.reason
+    ]
+    assert not aborted_with_validator_reason, (
+        "default policy: validator rejection MUST NOT abort the run; "
+        f"got {[e.run_aborted.reason for e in aborted_with_validator_reason]!r}"
+    )
+
+    # HUMAN_INTERVENTION_REQUIRED INFO drift was emitted on the sink.
+    from goldfive.pb.goldfive.v1 import types_pb2 as _tpb
+
+    hir_drifts = [
+        evt.drift_detected
+        for evt in sink.events
+        if (evt.WhichOneof("payload") if hasattr(evt, "WhichOneof") else None)
+        == "drift_detected"
+        and int(evt.drift_detected.kind)
+        == _tpb.DRIFT_KIND_HUMAN_INTERVENTION_REQUIRED
+    ]
+    assert hir_drifts, (
+        "default policy: expected a HUMAN_INTERVENTION_REQUIRED "
+        "observability drift after revision rejection; "
+        f"saw drift_kinds={_drift_kinds(sink)!r}"
+    )
+    # INFO severity, authored_by goldfive.
+    assert int(hir_drifts[0].severity) == _tpb.DRIFT_SEVERITY_INFO
+    assert hir_drifts[0].authored_by == "goldfive"
+
+    # session.plan unchanged from turn 1's revision.
+    assert out2.session.plan.id == plan_id_after_t1
+    assert out2.session.plan.revision_index == index_after_t1
+
+
+# ---------------------------------------------------------------------------
+# Strict opt-in: kwarg
+# ---------------------------------------------------------------------------
+
+
+async def test_strict_kwarg_aborts_on_revision_rejection() -> None:
+    """``Runner(fail_fast_on_revision_rejection=True)`` restores the
+    pre-PR1 abort behaviour: validator rejection emits ``run_aborted``
+    and the turn ends with ``success=False``."""
+    sink = InMemorySink()
+    plans: list[Plan | None] = []
+    planner = _ProgrammablePlanner(plans)
+    runner = _runner(planner, sink, fail_fast=True)
+
+    try:
+        plans.append(_good_first_plan(run_id="r"))
+        out1 = await runner.run("turn 1", session_id="strict-kwarg")
+        assert out1.success
+        plan_id_after_t1 = out1.session.plan.id
+        sink.events.clear()
+        plans.append(_invalid_revision(run_id="r", prior_id=plan_id_after_t1))
+        out2 = await runner.run("turn 2", session_id="strict-kwarg")
+    finally:
+        await runner.close()
+
+    assert not out2.success, "strict mode: invalid revision must fail the turn"
+    assert "plan revision rejected" in (out2.reason or ""), out2.reason
+    payload_kinds = _payload_kinds(sink)
+    assert "run_aborted" in payload_kinds, (
+        f"strict mode: expected run_aborted on the sink; got {payload_kinds!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Env-var fallback: GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1
+# ---------------------------------------------------------------------------
+
+
+async def test_strict_env_var_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the constructor kwarg is omitted (``None``), the env var
+    ``GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1`` opts in to strict mode.
+    """
+    monkeypatch.setenv("GOLDFIVE_FAIL_FAST_REVISION_REJECTION", "1")
+    sink = InMemorySink()
+    plans: list[Plan | None] = []
+    planner = _ProgrammablePlanner(plans)
+    # No fail_fast kwarg — env var should govern.
+    runner = _runner(planner, sink, fail_fast=None)
+
+    try:
+        plans.append(_good_first_plan(run_id="r"))
+        out1 = await runner.run("turn 1", session_id="env-var")
+        assert out1.success
+        plan_id_after_t1 = out1.session.plan.id
+        sink.events.clear()
+        plans.append(_invalid_revision(run_id="r", prior_id=plan_id_after_t1))
+        out2 = await runner.run("turn 2", session_id="env-var")
+    finally:
+        await runner.close()
+
+    assert not out2.success, "env var=1 should opt into strict mode"
+    payload_kinds = _payload_kinds(sink)
+    assert "run_aborted" in payload_kinds
+
+
+async def test_explicit_kwarg_overrides_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit ``fail_fast_on_revision_rejection=False`` wins over
+    ``GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1`` so tests can pin
+    behaviour without unsetting the env first.
+    """
+    monkeypatch.setenv("GOLDFIVE_FAIL_FAST_REVISION_REJECTION", "1")
+    sink = InMemorySink()
+    plans: list[Plan | None] = []
+    planner = _ProgrammablePlanner(plans)
+    runner = _runner(planner, sink, fail_fast=False)
+
+    try:
+        plans.append(_good_first_plan(run_id="r"))
+        out1 = await runner.run("turn 1", session_id="kwarg-override")
+        assert out1.success
+        plan_id_after_t1 = out1.session.plan.id
+        sink.events.clear()
+        plans.append(_invalid_revision(run_id="r", prior_id=plan_id_after_t1))
+        await runner.run("turn 2", session_id="kwarg-override")
+    finally:
+        await runner.close()
+
+    payload_kinds = _payload_kinds(sink)
+    aborted_with_validator_reason = [
+        e
+        for e in sink.events
+        if (e.WhichOneof("payload") if hasattr(e, "WhichOneof") else None)
+        == "run_aborted"
+        and "plan revision rejected" in e.run_aborted.reason
+    ]
+    assert not aborted_with_validator_reason, (
+        "explicit fail_fast=False MUST override env var=1; "
+        f"saw run_aborted with validator reason in {payload_kinds!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# L2 contract: user-steer install never aborts, regardless of the flag
+# ---------------------------------------------------------------------------
+
+
+async def test_user_steer_install_never_aborts_default_flag() -> None:
+    """A user-authored steer routed through
+    :meth:`DefaultSteerer.install_user_steer` MUST NOT emit
+    ``run_aborted`` even when the LLM revision is invalid. The
+    ``fail_fast_on_revision_rejection`` flag does not gate this — the
+    L2 contract (PLAN-LIFECYCLE.md §4.2.1) is structural.
+    """
+    sink = InMemorySink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=None)
+    session = Session(run_id="l2-default")
+    prior = Plan(
+        id="p1",
+        run_id=session.run_id,
+        goal_ids=["g"],
+        tasks=[
+            Task(id="done", title="done", assignee_agent_id="w", status=TaskStatus.COMPLETED),
+            Task(id="pending", title="pending", assignee_agent_id="w"),
+        ],
+        edges=[],
+        summary="prior",
+    )
+    session.plan = prior
+
+    # An invalid LLM revision (drops the COMPLETED task).
+    invalid = Plan(
+        id=prior.id,
+        run_id=session.run_id,
+        goal_ids=["g"],
+        tasks=[Task(id="new", title="new", assignee_agent_id="w")],
+        edges=[],
+        summary="invalid",
+    )
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="pivot",
+        authored_by="user",
+    )
+    returned = await steerer.install_user_steer(
+        drift=drift, prior=prior, llm_revision=invalid, session=session
+    )
+    # The fallback fired — pending was cancelled, done preserved.
+    assert isinstance(returned, Plan)
+    statuses = {t.id: t.status for t in returned.tasks}
+    assert statuses["done"] is TaskStatus.COMPLETED
+    assert statuses["pending"] is TaskStatus.CANCELLED
+    # No run_aborted on the wire.
+    payload_kinds = _payload_kinds(sink)
+    assert "run_aborted" not in payload_kinds, (
+        f"L2 contract: user-steer install must not emit run_aborted; "
+        f"got {payload_kinds!r}"
+    )
+
+
+async def test_user_steer_install_never_aborts_strict_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same contract as the default-flag test, but with the strict env
+    var on. The flag governs goldfive-authored installs only; user-
+    authored installs go through the L2 type-safe path that has no
+    failure mode."""
+    monkeypatch.setenv("GOLDFIVE_FAIL_FAST_REVISION_REJECTION", "1")
+    # Same setup as the default test — the steerer call doesn't
+    # consult the env var.
+    sink = InMemorySink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=None)
+    session = Session(run_id="l2-strict")
+    prior = Plan(
+        id="p1",
+        run_id=session.run_id,
+        goal_ids=["g"],
+        tasks=[
+            Task(id="done", title="done", assignee_agent_id="w", status=TaskStatus.COMPLETED),
+            Task(id="pending", title="pending", assignee_agent_id="w"),
+        ],
+        edges=[],
+        summary="prior",
+    )
+    session.plan = prior
+    invalid = Plan(
+        id=prior.id,
+        run_id=session.run_id,
+        goal_ids=["g"],
+        tasks=[Task(id="new", title="new", assignee_agent_id="w")],
+        edges=[],
+        summary="invalid",
+    )
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="pivot",
+        authored_by="user",
+    )
+    await steerer.install_user_steer(
+        drift=drift, prior=prior, llm_revision=invalid, session=session
+    )
+    payload_kinds = _payload_kinds(sink)
+    assert "run_aborted" not in payload_kinds
+
+
+# ---------------------------------------------------------------------------
+# After a non-fatal rejection, the run continues — executor.run was
+# invoked, the registered ``_happy_agent`` adapter ran, and turn-2 lands
+# with success=True (no work to do because the prior plan's only task
+# completed in turn 1, but the run completes cleanly rather than
+# aborting).
+# ---------------------------------------------------------------------------
+
+
+async def test_default_run_continues_after_rejection() -> None:
+    """After a non-fatal validator rejection on turn N, the executor
+    is still invoked and the turn produces a normal outcome (not the
+    pre-PR1 ``success=False`` from the abort path).
+    """
+    sink = InMemorySink()
+    plans: list[Plan | None] = []
+    planner = _ProgrammablePlanner(plans)
+    runner = _runner(planner, sink)
+
+    try:
+        plans.append(_good_first_plan(run_id="r"))
+        out1 = await runner.run("turn 1", session_id="continues")
+        assert out1.success
+        plan_id_after_t1 = out1.session.plan.id
+        sink.events.clear()
+        plans.append(_invalid_revision(run_id="r", prior_id=plan_id_after_t1))
+        out2 = await runner.run("turn 2", session_id="continues")
+    finally:
+        await runner.close()
+
+    # Outcome is not the pre-PR1 abort one.
+    assert (out2.reason or "") != "plan revision rejected by validator"
+    # session.plan still reflects turn 1's revision (unchanged).
+    assert out2.session.plan.id == plan_id_after_t1

--- a/tests/test_user_steer_invariant.py
+++ b/tests/test_user_steer_invariant.py
@@ -1,0 +1,585 @@
+"""Property-style tests for the L2 user-steer contract.
+
+Pin: ``DefaultSteerer.install_user_steer`` ALWAYS returns a valid
+:class:`Plan`. User-steer rejection is structurally impossible per
+``docs/design/PLAN-LIFECYCLE.md`` §4.2.1.
+
+The invariants under test:
+
+1. The return value is a ``Plan`` instance, never ``None``.
+2. The returned plan validates against ``prior`` via
+   ``Plan.validate(for_revision=True, prior=prior)`` — no
+   ``ValueError`` from the steerer.
+3. ``returned.id == prior.id`` (plan-id stable across revisions —
+   goldfive#271 Phase 4 invariant).
+4. ``returned.revision_index == prior.revision_index + 1``.
+5. Every prior-terminal task appears verbatim in the returned plan
+   (status preserved — §3.1).
+6. When the LLM revision is ``None``, every PENDING / RUNNING / BLOCKED
+   prior task transitions to ``CANCELLED`` in the deterministic
+   minimum (§4.2 delete-and-replan shape).
+
+Inputs varied across the matrix:
+
+* Plan shape: empty, single-task, multi-task with mixed terminals,
+  multi-task all-PENDING, multi-task all-terminal.
+* ``llm_revision``: ``None``, structurally valid revision, invalid
+  revision dropping a terminal, invalid revision with a malformed
+  edge.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.steerer import DefaultSteerer  # noqa: E402, I001
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sink stub
+# ---------------------------------------------------------------------------
+
+
+class _Sink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event: Any) -> None:
+        self.events.append(event)
+
+    async def close(self) -> None:
+        return
+
+
+# ---------------------------------------------------------------------------
+# Plan-shape fixtures
+# ---------------------------------------------------------------------------
+
+
+def _plan_empty(*, run_id: str = "run") -> Plan:
+    return Plan(
+        id="plan-empty",
+        run_id=run_id,
+        goal_ids=["g"],
+        tasks=[],
+        edges=[],
+        summary="empty",
+    )
+
+
+def _plan_single_pending(*, run_id: str = "run") -> Plan:
+    return Plan(
+        id="plan-single",
+        run_id=run_id,
+        goal_ids=["g"],
+        tasks=[Task(id="t1", title="T1", assignee_agent_id="w")],
+        edges=[],
+        summary="single-pending",
+    )
+
+
+def _plan_mixed_terminals(*, run_id: str = "run") -> Plan:
+    """One COMPLETED, one CANCELLED, one PENDING with edges."""
+    return Plan(
+        id="plan-mixed",
+        run_id=run_id,
+        goal_ids=["g"],
+        tasks=[
+            Task(
+                id="t1",
+                title="T1",
+                assignee_agent_id="w",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="t2",
+                title="T2",
+                assignee_agent_id="w",
+                status=TaskStatus.CANCELLED,
+            ),
+            Task(id="t3", title="T3", assignee_agent_id="w"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="t1", to_task_id="t2"),
+        ],
+        summary="mixed-terminals",
+    )
+
+
+def _plan_all_pending(*, run_id: str = "run") -> Plan:
+    return Plan(
+        id="plan-all-pending",
+        run_id=run_id,
+        goal_ids=["g"],
+        tasks=[
+            Task(id="a", title="A", assignee_agent_id="w"),
+            Task(id="b", title="B", assignee_agent_id="w"),
+            Task(id="c", title="C", assignee_agent_id="w"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="a", to_task_id="b"),
+            TaskEdge(from_task_id="b", to_task_id="c"),
+        ],
+        summary="all-pending-chain",
+    )
+
+
+def _plan_all_completed(*, run_id: str = "run") -> Plan:
+    return Plan(
+        id="plan-all-done",
+        run_id=run_id,
+        goal_ids=["g"],
+        tasks=[
+            Task(
+                id="x",
+                title="X",
+                assignee_agent_id="w",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="y",
+                title="Y",
+                assignee_agent_id="w",
+                status=TaskStatus.COMPLETED,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="x", to_task_id="y")],
+        summary="all-completed",
+    )
+
+
+def _plan_blocked_running(*, run_id: str = "run") -> Plan:
+    return Plan(
+        id="plan-blocked-running",
+        run_id=run_id,
+        goal_ids=["g"],
+        tasks=[
+            Task(
+                id="r",
+                title="R",
+                assignee_agent_id="w",
+                status=TaskStatus.RUNNING,
+            ),
+            Task(
+                id="b",
+                title="B",
+                assignee_agent_id="w",
+                status=TaskStatus.BLOCKED,
+            ),
+        ],
+        edges=[],
+        summary="running-and-blocked",
+    )
+
+
+_PLAN_FIXTURES = [
+    _plan_empty,
+    _plan_single_pending,
+    _plan_mixed_terminals,
+    _plan_all_pending,
+    _plan_all_completed,
+    _plan_blocked_running,
+]
+
+
+# ---------------------------------------------------------------------------
+# llm_revision fixtures (parameterised against a chosen prior)
+# ---------------------------------------------------------------------------
+
+
+def _llm_revision_valid(prior: Plan) -> Plan:
+    """A trivially valid revision: preserve terminals, drop mutables,
+    add one fresh PENDING root.
+
+    Mirrors what a well-behaved planner would emit. Distinguishable from
+    the deterministic minimum (which adds NO fresh tasks) so tests can
+    tell which branch ran.
+    """
+    new_tasks: list[Task] = []
+    for t in prior.tasks:
+        if t.status.is_terminal:
+            new_tasks.append(dataclasses.replace(t))
+    new_tasks.append(
+        Task(id="llm-new", title="LLM-added pivot work", assignee_agent_id="w")
+    )
+    new_edges: list[TaskEdge] = []
+    for e in prior.edges:
+        ids = {t.id for t in new_tasks}
+        if e.from_task_id in ids and e.to_task_id in ids:
+            new_edges.append(dataclasses.replace(e))
+    return Plan(
+        id=prior.id,
+        run_id=prior.run_id,
+        goal_ids=list(prior.goal_ids),
+        tasks=new_tasks,
+        edges=new_edges,
+        summary="llm-valid-revision",
+    )
+
+
+def _llm_revision_drops_terminal(prior: Plan) -> Plan | None:
+    """Invalid: drops a prior-terminal task. Validator must reject (§3.1).
+
+    Returns ``None`` when prior has no terminals — the input is then
+    "no terminals to drop", which is structurally valid; the test
+    matrix drops this row.
+    """
+    if not any(t.status.is_terminal for t in prior.tasks):
+        return None
+    new_tasks = [t for t in prior.tasks if not t.status.is_terminal]
+    # Strip edges touching the dropped terminals.
+    surviving = {t.id for t in new_tasks}
+    new_edges = [
+        e
+        for e in prior.edges
+        if e.from_task_id in surviving and e.to_task_id in surviving
+    ]
+    return Plan(
+        id=prior.id,
+        run_id=prior.run_id,
+        goal_ids=list(prior.goal_ids),
+        tasks=new_tasks,
+        edges=new_edges,
+        summary="llm-drops-terminal",
+    )
+
+
+def _llm_revision_malformed_edge(prior: Plan) -> Plan:
+    """Invalid: edge references a task that does not exist."""
+    new_tasks = [dataclasses.replace(t) for t in prior.tasks]
+    bad_edge = TaskEdge(from_task_id="ghost", to_task_id="phantom")
+    return Plan(
+        id=prior.id,
+        run_id=prior.run_id,
+        goal_ids=list(prior.goal_ids),
+        tasks=new_tasks,
+        edges=[*[dataclasses.replace(e) for e in prior.edges], bad_edge],
+        summary="llm-malformed-edge",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _new_steerer() -> tuple[DefaultSteerer, _Sink]:
+    sink = _Sink()
+    steerer = DefaultSteerer()
+    # ``planner=None`` is fine — install_user_steer never calls the
+    # planner; it only consults ``llm_revision`` / falls back to the
+    # deterministic minimum.
+    steerer.bind(sinks=[sink], planner=None)
+    return steerer, sink
+
+
+def _new_session(prior: Plan) -> Session:
+    session = Session(run_id=prior.run_id)
+    session.plan = prior
+    return session
+
+
+def _drift() -> DriftEvent:
+    return DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="user pivot",
+        authored_by="user",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1-5: returned plan is a Plan that validates + identity holds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("prior_factory", _PLAN_FIXTURES, ids=lambda f: f.__name__)
+@pytest.mark.parametrize(
+    "llm_factory_name",
+    ["none", "valid", "drops_terminal", "malformed_edge"],
+)
+async def test_install_user_steer_always_returns_valid_plan(
+    prior_factory: Any, llm_factory_name: str
+) -> None:
+    prior = prior_factory()
+    if llm_factory_name == "none":
+        llm_revision: Plan | None = None
+    elif llm_factory_name == "valid":
+        llm_revision = _llm_revision_valid(prior)
+    elif llm_factory_name == "drops_terminal":
+        llm_revision = _llm_revision_drops_terminal(prior)
+        if llm_revision is None:
+            pytest.skip("prior has no terminals — drops-terminal row N/A")
+    else:
+        llm_revision = _llm_revision_malformed_edge(prior)
+
+    steerer, _sink = _new_steerer()
+    session = _new_session(prior)
+    drift = _drift()
+    prior_index = prior.revision_index
+
+    returned = await steerer.install_user_steer(
+        drift=drift,
+        prior=prior,
+        llm_revision=llm_revision,
+        session=session,
+    )
+
+    # Invariant 1: returned IS a Plan.
+    assert isinstance(returned, Plan), (
+        f"install_user_steer returned non-Plan: {type(returned).__name__}"
+    )
+
+    # Invariant 2: validates without raising.
+    try:
+        returned.validate(for_revision=True, prior=prior)
+    except ValueError as exc:
+        raise AssertionError(
+            f"install_user_steer returned a plan that does NOT validate "
+            f"against prior: {exc}. prior tasks="
+            f"{[(t.id, t.status.value) for t in prior.tasks]} "
+            f"returned tasks={[(t.id, t.status.value) for t in returned.tasks]}"
+        ) from exc
+
+    # Invariant 3: plan_id stable.
+    assert returned.id == prior.id, (
+        f"plan_id changed across user-steer revision: prior={prior.id!r} "
+        f"returned={returned.id!r}"
+    )
+
+    # Invariant 4: revision_index bumped.
+    # Exception: when the deterministic minimum equals the prior plan
+    # structurally (no PENDING/RUNNING/BLOCKED to cancel) AND the
+    # LLM revision wasn't usable, install_user_steer short-circuits
+    # (no PlanRevised emitted) and returns ``prior`` as-is. That's
+    # acceptable degradation: the contract is "always a valid Plan",
+    # not "always a fresh revision". This row covers all-terminal
+    # priors and empty priors when the LLM input is unusable.
+    used_fallback = llm_revision is None or llm_factory_name in (
+        "drops_terminal",
+        "malformed_edge",
+    )
+    no_mutables = not any(not t.status.is_terminal for t in prior.tasks)
+    deterministic_no_op = used_fallback and no_mutables
+    if not deterministic_no_op:
+        assert returned.revision_index == prior_index + 1, (
+            f"revision_index not bumped: prior={prior_index} "
+            f"returned={returned.revision_index}"
+        )
+
+    # Invariant 5: every prior-terminal task is preserved verbatim.
+    returned_by_id = {t.id: t for t in returned.tasks}
+    for t in prior.tasks:
+        if not t.status.is_terminal:
+            continue
+        rt = returned_by_id.get(t.id)
+        assert rt is not None, (
+            f"terminal task {t.id!r} dropped from user-steer revision"
+        )
+        assert rt.status is t.status, (
+            f"terminal task {t.id!r} status regressed: "
+            f"{t.status.value} -> {rt.status.value}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 6: llm_revision=None on a plan with mutables -> mutables
+# transition to CANCELLED in the deterministic minimum
+# ---------------------------------------------------------------------------
+
+
+async def test_deterministic_minimum_cancels_pending_running_blocked() -> None:
+    """When the LLM revision is unavailable, every PENDING / RUNNING /
+    BLOCKED task lands as CANCELLED — that is the §4.2 delete-and-replan
+    shape, deterministic and provably valid."""
+    prior = Plan(
+        id="plan-mix-mutables",
+        run_id="run",
+        goal_ids=["g"],
+        tasks=[
+            Task(
+                id="done",
+                title="done",
+                assignee_agent_id="w",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="pending",
+                title="pending",
+                assignee_agent_id="w",
+                status=TaskStatus.PENDING,
+            ),
+            Task(
+                id="running",
+                title="running",
+                assignee_agent_id="w",
+                status=TaskStatus.RUNNING,
+            ),
+            Task(
+                id="blocked",
+                title="blocked",
+                assignee_agent_id="w",
+                status=TaskStatus.BLOCKED,
+            ),
+        ],
+        edges=[
+            TaskEdge(from_task_id="done", to_task_id="pending"),
+            TaskEdge(from_task_id="running", to_task_id="blocked"),
+        ],
+        summary="mix",
+    )
+    steerer, _sink = _new_steerer()
+    session = _new_session(prior)
+    drift = _drift()
+
+    returned = await steerer.install_user_steer(
+        drift=drift,
+        prior=prior,
+        llm_revision=None,
+        session=session,
+    )
+
+    statuses = {t.id: t.status for t in returned.tasks}
+    assert statuses["done"] is TaskStatus.COMPLETED
+    assert statuses["pending"] is TaskStatus.CANCELLED
+    assert statuses["running"] is TaskStatus.CANCELLED
+    assert statuses["blocked"] is TaskStatus.CANCELLED
+
+
+# ---------------------------------------------------------------------------
+# When the LLM revision IS valid, install_user_steer prefers it (the
+# deterministic minimum is the FALLBACK, not the default).
+# ---------------------------------------------------------------------------
+
+
+async def test_install_user_steer_prefers_valid_llm_revision() -> None:
+    prior = _plan_mixed_terminals()
+    llm_revision = _llm_revision_valid(prior)
+    # The LLM revision adds a task id "llm-new"; the deterministic
+    # minimum does NOT. The returned plan having "llm-new" proves the
+    # LLM branch fired.
+    assert any(t.id == "llm-new" for t in llm_revision.tasks)
+
+    steerer, _sink = _new_steerer()
+    session = _new_session(prior)
+    drift = _drift()
+
+    returned = await steerer.install_user_steer(
+        drift=drift,
+        prior=prior,
+        llm_revision=llm_revision,
+        session=session,
+    )
+    assert any(t.id == "llm-new" for t in returned.tasks), (
+        "valid LLM revision should be preferred over the deterministic "
+        "minimum"
+    )
+
+
+# ---------------------------------------------------------------------------
+# When the LLM revision is INVALID, fallback fires AND the steerer logs
+# a warning (the operator must see WHY the deterministic shape ran).
+# ---------------------------------------------------------------------------
+
+
+async def test_install_user_steer_falls_back_on_invalid_llm_revision(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+
+    prior = _plan_mixed_terminals()
+    invalid = _llm_revision_drops_terminal(prior)
+    assert invalid is not None  # mixed_terminals has terminals to drop
+
+    steerer, _sink = _new_steerer()
+    session = _new_session(prior)
+    drift = _drift()
+
+    caplog.set_level(logging.WARNING, logger="goldfive.steerer")
+    returned = await steerer.install_user_steer(
+        drift=drift,
+        prior=prior,
+        llm_revision=invalid,
+        session=session,
+    )
+    # Deterministic minimum: no LLM-added task; mutables cancelled.
+    assert not any(t.id == "llm-new" for t in returned.tasks)
+    # WARNING log emitted with the validator's error.
+    assert any(
+        "rejected by validator" in rec.message
+        and "deterministic minimum" in rec.message
+        for rec in caplog.records
+    ), f"expected fallback WARNING; got {[r.message for r in caplog.records]!r}"
+
+
+# ---------------------------------------------------------------------------
+# Side-effect contract: ``session.refine_failure_counts`` is NOT touched
+# by the deterministic-fallback path. That counter is for goldfive-
+# authored autonomous refines (§4.5), not user-driven changes.
+# ---------------------------------------------------------------------------
+
+
+async def test_install_user_steer_does_not_touch_refine_failure_counts() -> None:
+    prior = _plan_mixed_terminals()
+    invalid = _llm_revision_drops_terminal(prior)
+    assert invalid is not None
+
+    steerer, _sink = _new_steerer()
+    session = _new_session(prior)
+    # Pre-seed an unrelated counter — invariant: it must NOT be cleared
+    # OR incremented by install_user_steer.
+    session.refine_failure_counts[("user_steer", "")] = 7
+    session.refine_failure_counts[("plan_divergence", "t3")] = 3
+
+    drift = _drift()
+    await steerer.install_user_steer(
+        drift=drift,
+        prior=prior,
+        llm_revision=invalid,
+        session=session,
+    )
+    assert session.refine_failure_counts[("user_steer", "")] == 7
+    assert session.refine_failure_counts[("plan_divergence", "t3")] == 3
+
+
+# ---------------------------------------------------------------------------
+# session.plan is swapped on success.
+# ---------------------------------------------------------------------------
+
+
+async def test_install_user_steer_swaps_session_plan() -> None:
+    prior = _plan_mixed_terminals()
+    steerer, _sink = _new_steerer()
+    session = _new_session(prior)
+    drift = _drift()
+
+    returned = await steerer.install_user_steer(
+        drift=drift,
+        prior=prior,
+        llm_revision=None,
+        session=session,
+    )
+    # Mixed-terminals has a PENDING task; deterministic minimum cancels
+    # it -> structural change -> session.plan is swapped.
+    assert session.plan is returned
+    assert session.plan.revision_index == prior.revision_index + 1


### PR DESCRIPTION
## Principle

**Plan-revision rejection is non-fatal by default.** User-steer rejection is structurally impossible.

Per user directive: validator rejection should NOT abort the turn by default. The existing plan was previously valid; the user's pivot can still land; aborting on transient LLM-output unreliability is user-hostile.

## Layered defenses (user-steer L2 contract)

The principle "user-provided steering is never rejected by the validator" is enforced at:

1. **Type level** — `DefaultSteerer.install_user_steer` returns `Plan` (not `Plan | None`).
2. **API level** — the method has no failure path, never raises.
3. **Implementation level** — when the LLM-produced revision fails `Plan.validate(for_revision=True)`, falls back to a deterministic minimum evolution (PLAN-LIFECYCLE.md §4.2): preserve every terminal task verbatim, cancel every PENDING/RUNNING/BLOCKED, drop edges incident to cancelled. Provably valid by construction.
4. **Test level** — property-style invariants in `tests/test_user_steer_invariant.py` span 6 plan shapes (empty / single-pending / mixed-terminals / all-pending / all-completed / running+blocked) Cartesian-producted with 4 LLM-revision shapes (None / valid / drops-terminal / malformed-edge). 25 parametrised invariant assertions plus targeted side-effect tests.
5. **Doc level** — PLAN-LIFECYCLE.md §4.2.1 documents the contract; any change that could re-introduce abort on user-steer is flagged as a contract violation.

## Goldfive-authored rejection — configurable

When `Plan.validate(for_revision=True)` rejects a goldfive-authored autonomous refine (NEW_WORK_DISCOVERED, GOAL_DRIFT, OFF_TOPIC, …), the run no longer aborts by default. The existing `session.plan` is retained, a `HUMAN_INTERVENTION_REQUIRED` INFO `DriftDetected` fires for observability, and execution continues.

Strict abort-on-rejection (CI / regression / debugging) is opt-in:

- `Runner(fail_fast_on_revision_rejection=True)`
- env var `GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1`

Explicit kwarg wins over the env. The existing `REFINE_FAILURE_THRESHOLD=2` escalation in `_install_with_drift` still fires after two consecutive failures of the same `(kind, task_id)` — the new default does not disable the safety bound, it just stops the *first* failure from being fatal.

## Migration path for existing tests

`grep -rn "plan revision rejected by validator|run_aborted" tests/` showed:

- `tests/test_planner_handle_turn_real_llm.py` — references the reason string in a docstring only; no abort-path assertion. Untouched.
- All `run_aborted` assertions in `tests/test_sequential_executor.py`, `tests/test_executor_control.py`, `tests/test_live_steering_e2e.py`, `tests/test_event_session_id.py` are for cancel / control-driven aborts, not validator rejections. Untouched.
- `tests/test_steerer.py::test_observe_rejects_*` covers the steerer-level `_install_with_drift` path which still returns False on validation failure (the runner branch is what changed). Untouched.

No existing tests required migration to `fail_fast=True`; the abort-on-rejection path was unasserted.

## Files changed

- `goldfive/types.py` — `+16` lines: add `TaskStatus.is_terminal` property (mirrors `TERMINAL_TASK_STATUSES`).
- `goldfive/steerer.py` — `+184` lines: add `install_user_steer` API + `_build_minimal_steer_evolution` helper.
- `goldfive/runner.py` — `+128 -8` lines: add `fail_fast_on_revision_rejection` constructor kwarg + env-var fallback; rewrite the install-rejection branch.
- `docs/design/PLAN-LIFECYCLE.md` — `+45` lines: §4.2.1 (L2 contract) + §4.5.1 (default-non-fatal policy).
- `tests/test_user_steer_invariant.py` — new, 7 test functions including a 24-row parametrised invariant.
- `tests/test_runner_revision_rejection_policy.py` — new, 7 test functions covering default / strict kwarg / env var / kwarg-overrides-env / L2 contract under both flag values / continue-after-rejection.

## Test plan

- [x] `uv run --extra dev pytest tests -k "user_steer or revision_rejection or steer_invariant" -x -q` — 66 passed
- [x] Full suite: `uv run --extra dev pytest tests -x -q` — 1643 passed, 120 skipped
- [x] Ruff: `uv run --extra dev ruff check goldfive/ tests/` — clean