### PR TITLE
fix(steerer): isolate background judge tasks from sibling-cancel propagation (v22 regression)

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -2016,6 +2016,16 @@ class DefaultSteerer:
         :meth:`note_llm_call`, the counter is trajectory-level and is
         NOT reset on task transitions -- GOAL_DRIFT is about the whole
         tree's direction, not one task's progress.
+
+        Spawn-and-detach (goldfive v22 regression fix). The judge is
+        dispatched as a fire-and-forget background task — see the
+        rationale on :meth:`_maybe_run_goal_drift_on_task_boundary`.
+        ``after_run_callback`` runs on the agent's invocation task,
+        which is the same cancellable scope a sibling drift can target
+        via :meth:`request_invocation_cancel`; an inline await on the
+        judge would die the same way the v22 ``judge_goal_drift`` span
+        did. Tests that drove the inline path can drain via
+        ``await asyncio.gather(*list(steerer._background_judges))``.
         """
         if self._goal_drift_call_llm is None:
             return
@@ -2025,7 +2035,7 @@ class DefaultSteerer:
         # Reset before running so a check that itself triggers further
         # invocations in the agent loop doesn't double-fire.
         session._agent_turns_since_goal_check = 0
-        await self.maybe_run_goal_drift_check(session)
+        self._spawn_goal_drift_judge_background(session)
 
     # Minimum spacing between two task-boundary-triggered GOAL_DRIFT
     # judge calls, in seconds (goldfive#219). Task transitions can
@@ -2059,6 +2069,24 @@ class DefaultSteerer:
         gate is enforced inside :meth:`maybe_run_goal_drift_check`;
         we short-circuit here only to avoid bumping the timestamp
         when no judge will run.
+
+        Spawn-and-detach (goldfive v22 regression fix). The judge LLM
+        call is dispatched as a fire-and-forget background task on
+        :attr:`_background_judges` rather than awaited inline. The
+        ``mark_task_*`` callers run on the agent's invocation task —
+        which is registered with the ADK plugin's ``_invocation_tasks``
+        for cooperative cancel — so a sibling cancel (supersede,
+        runaway delegation, refine-driven preempt) firing
+        ``task.cancel()`` on the agent's invocation task while the
+        inline judge was awaiting its LLM round-trip would surface a
+        ``CancelledError`` inside ``classify_goal_drift``. The
+        ``judge_goal_drift`` span ended with ``error=CancelledError``
+        and an empty stack, the verdict was lost, and operator-visible
+        evidence (v22 trace) showed the cancel landing the moment the
+        span opened. Detaching the judge from the cancellable task
+        scope — same pattern as the reasoning judge at
+        :meth:`_run_judge_background` — keeps it alive across cancel
+        propagation and drainable at :meth:`shutdown`.
         """
         if self._goal_drift_call_llm is None:
             return
@@ -2070,7 +2098,7 @@ class DefaultSteerer:
         # Reset the turn counter so the next turn-interval check starts
         # fresh rather than firing one more judge call on the next turn.
         session._agent_turns_since_goal_check = 0
-        await self.maybe_run_goal_drift_check(session)
+        self._spawn_goal_drift_judge_background(session)
 
     async def maybe_run_goal_drift_check(self, session: Session) -> None:
         """Run the trajectory-level GOAL_DRIFT judge once, cost-bounded.
@@ -2116,6 +2144,88 @@ class DefaultSteerer:
         if drift is None:
             return
         await self._handle_drift(drift, session)
+
+    def _spawn_goal_drift_judge_background(self, session: Session) -> None:
+        """Spawn :meth:`maybe_run_goal_drift_check` as a fire-and-forget task.
+
+        Goldfive v22 regression fix. The trajectory-level GOAL_DRIFT
+        judge used to be awaited inline from
+        :meth:`_maybe_run_goal_drift_on_task_boundary` (called from
+        ``mark_task_*``) and from :meth:`note_agent_turn` (called from
+        the ADK plugin's ``after_run_callback``). Both call sites run
+        on the agent's ADK invocation task, which is registered with
+        ``_GoldfiveADKPlugin._invocation_tasks`` for cooperative
+        cancellation. A sibling drift firing
+        :meth:`request_invocation_cancel(cancel_inflight_task=True)`
+        could therefore land a ``CancelledError`` inside the judge's
+        own ``await call_llm(...)`` — the v22 trace
+        (49b0eb10-5636-465d-b96b-9e9d03d91e81) shows exactly that:
+        immediately after research_panels transitioned to COMPLETED
+        the ``judge_goal_drift`` span opened and failed with
+        ``CancelledError`` and an empty stack, no LLM duration
+        recorded.
+
+        Detaching the judge into a separate ``asyncio.Task`` isolates
+        it from the agent invocation's cancel scope: ``task.cancel()``
+        on the agent's task does NOT propagate to children spawned via
+        :func:`asyncio.create_task` (asyncio Tasks do not form a
+        parent-child cancel tree the way ``asyncio.TaskGroup`` does).
+        The judge is tracked on :attr:`_background_judges` so
+        :meth:`shutdown` (called from ``Runner.close``) can drain it
+        with the same bounded wait the reasoning judge uses
+        (goldfive#251). Done-callback removes the entry on completion
+        so there is no per-turn leak.
+
+        No-op when no event loop is running (defensive — keeps
+        synchronous test harnesses that build a steerer outside an
+        async context from raising). No-op when no judge ``call_llm``
+        is configured.
+        """
+        if self._goal_drift_call_llm is None:
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop — fall through silently. The synchronous callers
+            # of ``mark_task_*`` outside an async context (rare; only
+            # tests / synthetic harnesses) won't get a goal-drift
+            # check, but they wouldn't have anywhere to await the
+            # judge anyway.
+            return
+        bg_task = asyncio.create_task(
+            self._run_goal_drift_judge_background(session),
+            name="goldfive-goal-drift-judge",
+        )
+        self._background_judges.add(bg_task)
+        bg_task.add_done_callback(self._background_judges.discard)
+
+    async def _run_goal_drift_judge_background(self, session: Session) -> None:
+        """Body of the fire-and-forget GOAL_DRIFT judge task.
+
+        Mirrors :meth:`_run_judge_background` (the reasoning-judge
+        equivalent): swallows every exception so a flaky judge cannot
+        crash the run, and re-raises ``CancelledError`` cleanly so
+        :meth:`shutdown` can cancel still-running judges at teardown
+        without a stray ``WARNING`` muddying the signal.
+
+        Calls :meth:`maybe_run_goal_drift_check` directly — the public
+        method's synchronous semantics are preserved for operator-side
+        one-shot triggers; this background path just bypasses the
+        cancellable agent task that hosted us.
+        """
+        try:
+            await self.maybe_run_goal_drift_check(session)
+        except asyncio.CancelledError:
+            # Propagate so :meth:`shutdown` / teardown sees a clean
+            # cancel. The shutdown path expects this and counts it
+            # against the still-pending tally without warning.
+            raise
+        except Exception as exc:  # noqa: BLE001 — background task
+            log.warning(
+                "DefaultSteerer: background goal-drift judge raised "
+                "(swallowed): %s",
+                exc,
+            )
 
     async def _emit_reflective_failure(
         self, session: Session, *, task_id: str, reason: str

--- a/tests/test_goal_drift_classifier.py
+++ b/tests/test_goal_drift_classifier.py
@@ -11,10 +11,21 @@ Two layers:
   caller-managed counter fires the judge at the configured interval,
   never more than one LLM call per check, and routes CRITICAL drift
   through ``_handle_drift`` so the #142 ladder can route it to Level 4.
+
+Background-judge handling (v22 regression fix). Goal-drift judges
+spawned by :meth:`note_agent_turn` and the ``mark_task_*`` task-boundary
+helper are now fire-and-forget tasks tracked on
+``DefaultSteerer._background_judges`` (mirroring the reasoning judge,
+goldfive#251 / #319). Tests that previously inspected sink events or
+the call-llm stub's call count immediately after ``await
+note_agent_turn(...)`` / ``mark_task_*`` now drain the background
+tasks first via :func:`_drain_background_judges` so assertions still
+see the same end-state.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -67,6 +78,25 @@ class StubPlanner:
     async def refine(self, *, plan, drift, goals):
         self.refine_calls.append({"plan": plan, "drift": drift, "goals": goals})
         return None
+
+
+async def _drain_background_judges(steerer: DefaultSteerer) -> None:
+    """Wait for every pending background goal-drift judge to settle.
+
+    The steerer spawns the judge LLM call as a fire-and-forget task on
+    :attr:`DefaultSteerer._background_judges` so ``mark_task_*`` /
+    ``note_agent_turn`` callers (which run on cancellable agent
+    invocation tasks) do not host the judge themselves. Tests assert
+    on the post-judge sink state and the stub ``call_llm``'s call
+    count, so they need to wait for the spawned task to complete.
+    """
+    pending = list(steerer._background_judges)
+    if not pending:
+        return
+    await asyncio.gather(*pending, return_exceptions=True)
+    # One yield so the ``add_done_callback(self._background_judges.discard)``
+    # has run and the set is fully empty for the next assertion / spawn.
+    await asyncio.sleep(0)
 
 
 def _stub_call_llm(responses: list[Any]):
@@ -329,14 +359,18 @@ async def test_steerer_counter_fires_at_interval() -> None:
     session = _make_session()
     for _ in range(4):
         await steerer.note_agent_turn(session)
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 0, "should not fire before the 5th turn"  # type: ignore[attr-defined]
     await steerer.note_agent_turn(session)
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1, "should fire on the 5th turn"  # type: ignore[attr-defined]
     # Counter resets after check; next 4 should not re-fire.
     for _ in range(4):
         await steerer.note_agent_turn(session)
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     await steerer.note_agent_turn(session)
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
 
 
@@ -363,6 +397,7 @@ async def test_steerer_off_track_emits_critical_drift_and_nudges() -> None:
     session = _make_session()
     for _ in range(2):
         await steerer.note_agent_turn(session)
+    await _drain_background_judges(steerer)
 
     drifts = [e for e in sink.events if e.WhichOneof("payload") == "drift_detected"]
     assert len(drifts) >= 1
@@ -392,6 +427,9 @@ async def test_steerer_disabled_by_default_no_check_ever_fires() -> None:
     session = _make_session()
     for _ in range(100):
         await steerer.note_agent_turn(session)
+    # Disabled steerer never spawns; nothing to drain. The counter
+    # check below is the same end-state assertion the inline path
+    # carried.
     assert session._agent_turns_since_goal_check == 0
 
 
@@ -407,6 +445,7 @@ async def test_steerer_malformed_response_does_not_crash_run() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
     await steerer.note_agent_turn(session)
+    await _drain_background_judges(steerer)
     drifts = [e for e in sink.events if e.WhichOneof("payload") == "drift_detected"]
     assert drifts == []
     assert planner.refine_calls == []
@@ -443,6 +482,7 @@ async def test_steerer_counter_is_not_task_scoped() -> None:
     session.current_task_id = "t2"
     await steerer.note_agent_turn(session)
     await steerer.note_agent_turn(session)
+    await _drain_background_judges(steerer)
     # Third call should fire the check, not be held back by transition.
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
 
@@ -505,6 +545,7 @@ async def test_runner_goal_drift_enabled_false_detaches_callable() -> None:
     assert steerer._goal_drift_call_llm is None
     session = _make_session()
     await steerer.note_agent_turn(session)
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 0  # type: ignore[attr-defined]
 
 
@@ -560,6 +601,7 @@ async def test_task_boundary_fires_goal_drift_check_on_mark_task_completed() -> 
     session = _make_session()
 
     await steerer.mark_task_completed("t1", session=session, summary="done")
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     # Turn counter is reset on task-boundary fire so we don't double-pay.
     assert session._agent_turns_since_goal_check == 0
@@ -581,11 +623,13 @@ async def test_task_boundary_fires_on_mark_task_failed_and_cancelled() -> None:
     session = _make_session()
 
     await steerer.mark_task_failed("t1", session=session, reason="boom")
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
 
     # Rewind the rate-limit clock so the next boundary fires.
     session._last_goal_drift_check_ts = 0.0
     await steerer.mark_task_cancelled("t2", session=session, reason="no longer needed")
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
 
 
@@ -601,6 +645,7 @@ async def test_task_boundary_fires_independent_of_turn_counter() -> None:
     assert session._agent_turns_since_goal_check == 0
 
     await steerer.mark_task_completed("t1", session=session, summary="done")
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
 
 
@@ -616,12 +661,17 @@ async def test_task_boundary_rate_limited_within_ten_seconds() -> None:
 
     # First transition primes the timestamp.
     await steerer.mark_task_completed("t1", session=session, summary="done")
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     first_ts = session._last_goal_drift_check_ts
     assert first_ts > 0.0
 
     # Second transition <1s later: should be suppressed by the 10s guard.
+    # The rate-limit gate fires synchronously before any spawn so no
+    # drain is needed to observe the no-fire state, but call it anyway
+    # to be defensive (no-op when the set is empty).
     await steerer.mark_task_completed("t2", session=session, summary="done")
+    await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     # Timestamp must NOT advance on a suppressed call.
     assert session._last_goal_drift_check_ts == first_ts

--- a/tests/test_judge_lifetime_v22_regression.py
+++ b/tests/test_judge_lifetime_v22_regression.py
@@ -1,0 +1,414 @@
+"""Regression tests for the v22 GOAL_DRIFT judge cancellation bug.
+
+V22 trace ``49b0eb10-5636-465d-b96b-9e9d03d91e81`` — at 19:17:19,
+``research_panels`` transitioned RUNNING -> COMPLETED, then the
+``judge_goal_drift`` span opened and immediately failed with
+``CancelledError`` (empty stack, no LLM-call duration recorded). No
+``invocation_cancelled`` event fired at that timestamp — the cancel
+came from a different propagation path.
+
+Root cause: :meth:`DefaultSteerer._maybe_run_goal_drift_on_task_boundary`
+and :meth:`DefaultSteerer.note_agent_turn` ``await``-ed the LLM judge
+inline on the agent's ADK invocation task. That task is registered
+with the ADK plugin's ``_invocation_tasks`` for cooperative
+cancellation, so any sibling drift firing
+``request_invocation_cancel(cancel_inflight_task=True)`` could
+``task.cancel()`` the agent's task and surface a ``CancelledError``
+inside the judge's own ``await call_llm(...)``. PR #320 had already
+removed the per-turn drain that was killing reasoning judges; this
+sibling family of cancels needed an analogous fix.
+
+Fix: spawn the goal-drift judge as a fire-and-forget task on
+:attr:`DefaultSteerer._background_judges` (same pattern as the
+reasoning judge in :meth:`_run_judge_background`). asyncio Tasks do
+not form a parent-child cancel tree, so a cancel on the agent's
+invocation task does NOT propagate to the spawned judge child. The
+judge runs to completion regardless; :meth:`shutdown` (driven by
+``Runner.close``) drains it at teardown.
+
+These tests are scoped to the regression FAMILY, not the specific v22
+scenario:
+
+* The judge survives a ``task.cancel()`` on its spawning task,
+  regardless of whether the cancel is fired from a sibling drift's
+  ``request_invocation_cancel`` path or from upstream cancel propagation
+  (adk-web stream close, generator ``aclose()``).
+* The fix preserves PR #320's contract: the judge is still drainable
+  by ``steerer.shutdown()``.
+* Both spawn sites — task-boundary (``mark_task_*``) and turn-counter
+  (``note_agent_turn``) — are covered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Goal,
+    Plan,
+    Session,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs (kept local so this file is self-contained as a regression bundle)
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class StubPlanner:
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(self, *, goals, available_agents, context=None):
+        return None
+
+    async def refine(self, *, plan, drift, goals):
+        self.refine_calls.append({"plan": plan, "drift": drift, "goals": goals})
+        return None
+
+
+def _make_session(task_id: str = "t1") -> Session:
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id=task_id, title="Research solar panels", description="Find specs")],
+        edges=[],
+    )
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="Publish a memo on solar panels")],
+        plan=plan,
+        current_task_id=task_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cancellation-source coverage: a cancel on the spawning agent's task must
+# NOT propagate to the goal-drift judge.
+# ---------------------------------------------------------------------------
+
+
+async def test_judge_survives_cancel_of_spawning_task_at_task_boundary() -> None:
+    """Cancel the task that hosted ``mark_task_completed`` — judge runs.
+
+    Reproduces the v22 mechanism: a sibling drift fires
+    ``request_invocation_cancel(cancel_inflight_task=True)`` on the
+    agent's invocation task while the report-tool handler is still
+    executing the inline goal-drift judge. Pre-fix, the judge died
+    with ``CancelledError`` and an empty stack. Post-fix, the spawn-
+    and-detach pattern keeps it alive.
+    """
+    judge_started = asyncio.Event()
+    judge_complete = asyncio.Event()
+
+    async def slow_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        judge_started.set()
+        # Sleep long enough to make sure the cancel below lands while
+        # the judge is still mid-call. 0.3s is well within CI tolerance.
+        try:
+            await asyncio.sleep(0.3)
+        finally:
+            judge_complete.set()
+        return json.dumps({"progressing": True})
+
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=100,
+        goal_drift_call_llm=slow_call_llm,
+    )
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+    session = _make_session()
+
+    async def host_agent_invocation() -> None:
+        # This task models the ADK agent invocation task that hosts
+        # the report_task_completed tool handler. mark_task_completed
+        # spawns the goal-drift judge as a background task; we then
+        # cancel ourselves to simulate a sibling cancel landing on
+        # this task.
+        await steerer.mark_task_completed(
+            "t1", session=session, summary="research_panels done"
+        )
+        # Wait for the judge to have started before we yield to the
+        # cancel — ensures we are reproducing "cancel lands while
+        # judge is running" rather than "cancel before judge spawned".
+        await judge_started.wait()
+        # Now sleep so the cancel below has time to fire. The judge
+        # runs on a separate task and is unaffected.
+        await asyncio.sleep(1.0)
+
+    host = asyncio.create_task(host_agent_invocation(), name="host-invoke")
+    # Wait for judge to start.
+    await asyncio.wait_for(judge_started.wait(), timeout=2.0)
+    # Cancel the host task — same mechanism as
+    # ``_GoldfiveADKPlugin.request_invocation_cancel(cancel_inflight_task=True)``.
+    host.cancel()
+    try:
+        await host
+    except asyncio.CancelledError:
+        pass
+
+    # Drain the spawned background judge. With the spawn-and-detach
+    # fix, this task is independent of ``host`` and runs to completion.
+    pending = list(steerer._background_judges)
+    assert pending, (
+        "task-boundary trigger must have spawned a background judge "
+        "before the host was cancelled"
+    )
+    results = await asyncio.gather(*pending, return_exceptions=True)
+    for r in results:
+        assert not isinstance(r, BaseException), (
+            f"background judge raised {r!r}; the spawn-and-detach fix "
+            "should have isolated it from the host's cancel"
+        )
+
+    assert judge_complete.is_set(), (
+        "goal-drift judge LLM call must have completed despite the "
+        "host invocation task being cancelled mid-call"
+    )
+
+
+async def test_judge_survives_cancel_of_spawning_task_via_note_agent_turn() -> None:
+    """Same property for the ``note_agent_turn`` (after_run_callback) path.
+
+    The turn-counter trigger fires from the ADK plugin's
+    ``after_run_callback`` which also runs on the agent's invocation
+    task. The spawn site is symmetric with the task-boundary one and
+    must benefit from the same isolation.
+    """
+    judge_started = asyncio.Event()
+    judge_complete = asyncio.Event()
+
+    async def slow_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        judge_started.set()
+        try:
+            await asyncio.sleep(0.3)
+        finally:
+            judge_complete.set()
+        return json.dumps({"progressing": True})
+
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=1,  # fire on every turn
+        goal_drift_call_llm=slow_call_llm,
+    )
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+    session = _make_session()
+
+    async def host_after_run() -> None:
+        await steerer.note_agent_turn(session)
+        await judge_started.wait()
+        await asyncio.sleep(1.0)
+
+    host = asyncio.create_task(host_after_run(), name="host-after-run")
+    await asyncio.wait_for(judge_started.wait(), timeout=2.0)
+    host.cancel()
+    try:
+        await host
+    except asyncio.CancelledError:
+        pass
+
+    pending = list(steerer._background_judges)
+    assert pending, "note_agent_turn must spawn the judge as a background task"
+    results = await asyncio.gather(*pending, return_exceptions=True)
+    for r in results:
+        assert not isinstance(r, BaseException), (
+            f"background judge raised {r!r}; expected clean completion"
+        )
+    assert judge_complete.is_set()
+
+
+async def test_two_back_to_back_task_transitions_do_not_clobber_running_judge() -> None:
+    """A second task transition during the rate-limit window does not
+    cancel the in-flight judge from the first one.
+
+    Generalises the v22 scenario: even if the second mark_task_*
+    happens to share a task with the first (cascading cancel-cancel),
+    the first judge — already running on the background task — must
+    not die when the second call's host returns / is cancelled.
+    """
+    judge_completions: list[bool] = []
+
+    async def call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        await asyncio.sleep(0.2)
+        judge_completions.append(True)
+        return json.dumps({"progressing": True})
+
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=100,
+        goal_drift_call_llm=call_llm,
+    )
+    steerer.bind(sinks=[ListSink()], planner=StubPlanner())
+    session = _make_session()
+
+    # First transition spawns the judge, primes the rate-limit
+    # timestamp. Second transition rate-limits to no-op (timestamp guard).
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+    # Sanity: spawn happened.
+    assert len(steerer._background_judges) == 1
+    # Second transition immediately after — within rate-limit window —
+    # should NOT spawn a second judge AND must not cancel the first.
+    plan = session.plan
+    assert plan is not None
+    plan.tasks.append(Task(id="t2", title="t2", description=""))
+    await steerer.mark_task_completed("t2", session=session, summary="also done")
+    # First judge still pending.
+    assert len(steerer._background_judges) == 1
+
+    pending = list(steerer._background_judges)
+    results = await asyncio.gather(*pending, return_exceptions=True)
+    for r in results:
+        assert not isinstance(r, BaseException), (
+            f"first judge must complete cleanly; got {r!r}"
+        )
+    assert judge_completions == [True], (
+        "first judge must run to completion exactly once; second "
+        "transition was rate-limited"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drainability: PR #320 contract preservation.
+# ---------------------------------------------------------------------------
+
+
+async def test_goal_drift_judge_drainable_at_steerer_shutdown() -> None:
+    """``steerer.shutdown()`` drains a still-running goal-drift judge.
+
+    PR #320's contract — judges live for the lifetime of the Runner,
+    drained at ``Runner.close()`` — must hold for goal-drift judges
+    too. The shutdown path uses :meth:`DefaultSteerer.shutdown` which
+    walks ``_background_judges``; the goal-drift spawn registers
+    there, so this is a structural test.
+    """
+
+    async def slow_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        await asyncio.sleep(2.0)
+        return json.dumps({"progressing": True})
+
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=100,
+        goal_drift_call_llm=slow_call_llm,
+    )
+    steerer.bind(sinks=[ListSink()], planner=StubPlanner())
+    session = _make_session()
+
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+    assert len(steerer._background_judges) == 1
+
+    # shutdown with a tight timeout — the judge is sleeping 2s, so it
+    # will be cancelled by the shutdown path.
+    await steerer.shutdown(timeout=0.1)
+    # Yield once so done-callbacks fire.
+    await asyncio.sleep(0)
+    assert steerer._background_judges == set(), (
+        "shutdown must clear _background_judges; got "
+        f"{len(steerer._background_judges)} stragglers"
+    )
+
+
+async def test_goal_drift_judge_completes_naturally_when_left_alone() -> None:
+    """Bare-baseline: the new spawn path doesn't change happy-path semantics.
+
+    A judge that runs to completion must still emit its drift event
+    on the sink and (if off-track) reach the planner. This guards
+    against the spawn refactor accidentally breaking the wire-up.
+    """
+
+    async def call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        return json.dumps({"progressing": False, "reason": "off the rails"})
+
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=100,
+        goal_drift_call_llm=call_llm,
+    )
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+    session = _make_session()
+
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+    # Drain.
+    pending = list(steerer._background_judges)
+    await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    # GOAL_DRIFT drift was emitted.
+    drifts = [
+        e for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "drift_detected"
+    ]
+    goal_drifts = [d for d in drifts if "off the rails" in d.drift_detected.detail]
+    assert goal_drifts, (
+        "judge that returns progressing=false must still produce a "
+        "GOAL_DRIFT drift via the spawn-and-detach path; got "
+        f"{[d.drift_detected.detail for d in drifts]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spawn-time invariants
+# ---------------------------------------------------------------------------
+
+
+async def test_spawn_helper_is_noop_when_no_judge_is_wired() -> None:
+    """``_spawn_goal_drift_judge_background`` no-ops without a wired call_llm.
+
+    The caller short-circuit at the top of
+    ``_maybe_run_goal_drift_on_task_boundary`` already guards this,
+    but the spawn helper itself must be safe to invoke directly so
+    operator-driven one-shot triggers (or future internal callers)
+    can rely on it.
+    """
+    steerer = DefaultSteerer()  # no goal_drift_call_llm
+    steerer.bind(sinks=[ListSink()], planner=StubPlanner())
+    session = _make_session()
+    steerer._spawn_goal_drift_judge_background(session)
+    assert steerer._background_judges == set(), (
+        "spawn helper must not register a task when no judge is wired"
+    )
+
+
+def test_spawn_helper_is_noop_outside_event_loop() -> None:
+    """The helper degrades to a silent no-op when no event loop is running.
+
+    Synchronous test harnesses / module-import-time wiring must not
+    crash if a call site fires through. Real production paths always
+    run inside an async context (the spawn site is reached via an
+    ``await mark_task_*`` call). This test is intentionally
+    synchronous so :func:`asyncio.get_running_loop` raises
+    ``RuntimeError`` and the spawn helper exercises its degraded path.
+    """
+
+    async def call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        return json.dumps({"progressing": True})
+
+    steerer = DefaultSteerer(goal_drift_call_llm=call_llm)
+    steerer.bind(sinks=[ListSink()], planner=StubPlanner())
+    session = _make_session()
+
+    # No running loop — helper must return cleanly without scheduling.
+    steerer._spawn_goal_drift_judge_background(session)
+    assert steerer._background_judges == set()

--- a/tests/test_wrap_goal_drift_wiring.py
+++ b/tests/test_wrap_goal_drift_wiring.py
@@ -19,6 +19,7 @@ which silently disarmed the trajectory-level GOAL_DRIFT judge
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -546,10 +547,19 @@ async def test_goal_drift_judge_fires_when_wired() -> None:
     # Below interval -- no judge call yet.
     for _ in range(2):
         await steerer.note_agent_turn(session)
+    # Drain any spawned judges (none expected below interval) so the
+    # call-llm count assertion is post-judge.
+    pending = list(steerer._background_judges)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
     assert len(call_llm.calls) == 0  # type: ignore[attr-defined]
 
     # Third turn crosses the interval -> judge fires, drift is emitted.
     await steerer.note_agent_turn(session)
+    pending = list(steerer._background_judges)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
 
     from goldfive.pb.goldfive.v1 import types_pb2


### PR DESCRIPTION
## Bug

V22 session ``49b0eb10-5636-465d-b96b-9e9d03d91e81`` shows
``judge_goal_drift`` spans opening at task transitions and
immediately failing with ``error=CancelledError`` (empty stack, no
LLM-call duration recorded). PR #320 already removed the per-turn
``_drain_steerer_background_judges`` that #319 originally identified
— this is a *different* cancel source in the same regression family.

## Root cause

``_maybe_run_goal_drift_on_task_boundary`` (driven by
``mark_task_completed`` / ``mark_task_failed`` /
``mark_task_cancelled`` via the ``report_task_*`` reporting tools)
and ``note_agent_turn`` (driven by the ADK plugin's
``after_run_callback``) both ``await maybe_run_goal_drift_check``
**inline on the agent's ADK invocation task**.

That task is registered with
``_GoldfiveADKPlugin._invocation_tasks`` for cooperative
cancellation, so anything firing
``request_invocation_cancel(cancel_inflight_task=True)`` against the
invocation can land a ``CancelledError`` inside the judge's
``await call_llm(...)``. Per the v22 evidence the cancel landed the
moment the ``judge_goal_drift`` span opened — well before any LLM
round-trip began.

## Fix

Spawn the goal-drift judge as a fire-and-forget task on
``DefaultSteerer._background_judges``, the same set the reasoning
judge (#251) uses. asyncio Tasks do not form a parent-child cancel
tree, so a ``task.cancel()`` on the agent's invocation task does
NOT propagate to the spawned judge. The drain at
``Runner.close()`` -> ``steerer.shutdown()`` already covers
``_background_judges`` with a bounded timeout.

Public ``maybe_run_goal_drift_check`` keeps its synchronous
semantics for operator-driven one-shot triggers; only the two
internal callers (``_maybe_run_goal_drift_on_task_boundary``,
``note_agent_turn``) switch to the spawn path.

## Test plan

- [x] ``tests/test_judge_lifetime_v22_regression.py`` (new, 7 tests):
  - judge survives ``task.cancel()`` of its spawning task at the
    task-boundary path
  - same for the ``note_agent_turn`` path
  - back-to-back transitions don't clobber a running judge
  - ``steerer.shutdown()`` drains a still-running goal-drift judge
  - happy-path GOAL_DRIFT emission still works through the spawn
  - spawn no-ops without a wired ``call_llm``
  - spawn no-ops outside an event loop
- [x] ``tests/test_goal_drift_classifier.py`` and
  ``tests/test_wrap_goal_drift_wiring.py`` updated to drain
  ``_background_judges`` after spawn-bearing calls so existing
  end-state assertions still pass.
- [x] Full suite: 1650 passed / 120 skipped / 0 failed
- [x] ``ruff check goldfive tests`` clean

## Coordination with Bug A

This change is isolated to ``goldfive/steerer.py`` and does not
touch ``executors/sequential.py`` ``_run_overlay`` or
``request_invocation_cancel`` (Bug A territory).