### PR TITLE
fix(adapter): don't short-circuit FunctionTool dispatch on supersede-cancel

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -465,6 +465,44 @@ def _is_reporting_tool_name(tool_name: str) -> bool:
     return tool_name.startswith("report_task_") or tool_name == _REPORT_AWAITING_APPROVAL
 
 
+def _is_agent_tool_dispatch(tool: Any) -> bool:
+    """Return True if ``tool`` is an ADK ``AgentTool`` (sub-agent delegation).
+
+    The cooperative-cancel short-circuit in :meth:`before_tool_callback`
+    discriminates on this: AgentTool dispatches spawn a fresh sub-Runner
+    and stream its full transcript back, so short-circuiting them is
+    correct (we don't want to spawn long sub-agent work on a cancelled
+    parent). Plain ``FunctionTool`` dispatches (write_webpage, patch_file,
+    user-provided side-effect helpers) finish in milliseconds and have
+    already had their args chosen by the LLM — short-circuiting them
+    discards committed work for no benefit, and the next
+    ``before_model_callback`` short-circuit ends the dispatch cleanly
+    anyway. See goldfive#211610 / Bug C from v23 validation.
+
+    Detection prefers an ``isinstance(tool, AgentTool)`` check when the
+    optional ``adk`` extra is importable, with a duck-typed fallback for
+    test stubs and forward-compatibility: AgentTool exposes ``.agent``
+    pointing at the wrapped ``BaseAgent``. A non-callable ``.agent``
+    attribute on a ``FunctionTool`` is unheard of upstream, but the
+    duck-typed branch is conservative anyway — when unsure, treat the
+    tool as a plain function and let it run.
+    """
+    if tool is None:
+        return False
+    try:
+        from google.adk.tools import AgentTool  # type: ignore
+
+        if isinstance(tool, AgentTool):
+            return True
+    except Exception:  # noqa: BLE001 — adk extra not installed / import edge
+        pass
+    # Duck-typed fallback: AgentTool carries a ``.agent`` BaseAgent
+    # pointer (the sub-agent it delegates to). FunctionTool carries a
+    # ``.func`` instead. Treat the presence of ``.agent`` as the AgentTool
+    # discriminator.
+    return _safe_attr(tool, "agent", None) is not None
+
+
 def _agent_has_pending_candidates(ctx: Any, agent_name: str) -> bool:
     """Return True if the plan has any PENDING/RUNNING task for ``agent_name``.
 
@@ -4628,20 +4666,37 @@ def make_adk_plugin(
             # Cooperative-cancellation checkpoint (goldfive#251 Stream C / 7a).
             # When this invocation was flagged for cancel (either the
             # steerer at CRITICAL severity or a user-initiated cancel),
-            # skip tool dispatch and return a MINIMAL LLM-visible tool
-            # response: ``{"status": "cancelled"}``. The minimal shape
-            # is deliberate — richer shapes (``reason``, ``detail``,
+            # skip *AgentTool* dispatch and return a MINIMAL LLM-visible
+            # tool response: ``{"status": "cancelled"}``. The minimal
+            # shape is deliberate — richer shapes (``reason``, ``detail``,
             # ``drift_kind``) become prompt-injection vectors (see
             # lessons from goldfive#250 / #252 / #253 where LLMs
             # pattern-matched on error strings and invented workarounds).
             # Rich context for operators lives on the
             # InvocationCancelled sink event emitted by
             # :meth:`_emit_invocation_cancelled`.
+            #
+            # FunctionTool dispatches (write_webpage, patch_file, and any
+            # user-provided side-effect helpers) are NOT short-circuited
+            # here — see :func:`_is_agent_tool_dispatch` and Bug C from
+            # v23 validation. Their work has already been committed by
+            # the model (args chosen, function_call event emitted) and
+            # discarding the actual call loses the side-effect (no file
+            # written, no row patched) for no semantic benefit: the very
+            # next ``before_model_callback`` on this same invocation
+            # short-circuits the LLM call regardless, ending the
+            # dispatch cleanly. Letting the FunctionTool run preserves
+            # committed work; short-circuiting it would silently strand
+            # it on every supersede-cancel.
             inv_ctx = _safe_attr(tool_context, "_invocation_context", None) or _safe_attr(
                 tool_context, "invocation_context", None
             )
             inv_id_check = str(_safe_attr(inv_ctx, "invocation_id", "") or "")
-            if inv_id_check and self.is_invocation_cancelled(inv_id_check):
+            if (
+                inv_id_check
+                and self.is_invocation_cancelled(inv_id_check)
+                and _is_agent_tool_dispatch(tool)
+            ):
                 pending = self._cancel_state.get(inv_id_check)
                 if pending is not None:
                     request = self.consume_cancel_for_invocation(inv_id_check)

--- a/tests/test_cooperative_cancellation.py
+++ b/tests/test_cooperative_cancellation.py
@@ -153,8 +153,29 @@ class _FakeToolContext(_FakeCallbackContext):
 
 
 class _FakeTool:
+    """FunctionTool-shaped stub: ``.name`` + ``.func`` (a callable)."""
+
     def __init__(self, *, name: str) -> None:
         self.name = name
+        self.func = lambda **_kw: {"ok": True}
+
+
+class _FakeAgentTool:
+    """AgentTool-shaped stub: ``.name`` + ``.agent`` (a sub-agent).
+
+    Mirrors ADK's :class:`google.adk.tools.AgentTool` discriminator —
+    the cooperative-cancel short-circuit in
+    :meth:`~goldfive.adapters._adk_plugin._GoldfiveADKPlugin.before_tool_callback`
+    distinguishes AgentTool dispatches from plain FunctionTool dispatches
+    via :func:`_is_agent_tool_dispatch`. The duck-typed branch keys on
+    ``getattr(tool, "agent", None) is not None``, so this stub trips
+    the AgentTool path even when the optional ``adk`` extra is not
+    importable in the test environment.
+    """
+
+    def __init__(self, *, name: str, agent_name: str = "sub_agent") -> None:
+        self.name = name
+        self.agent = _FakeAgent(name=agent_name)
 
 
 class _StubAdapter:
@@ -319,11 +340,15 @@ async def test_cancel_flag_consumed_on_first_callback() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 3. before_tool_callback returns {"status": "cancelled"} when cancelled
+# 3. before_tool_callback returns {"status": "cancelled"} for AgentTool
+#    dispatches when the invocation is cancelled. FunctionTool dispatches
+#    are NOT short-circuited (Bug C from v23 validation, goldfive#211610):
+#    short-circuiting them silently strands committed side-effects (e.g.
+#    write_webpage / patch_file file writes) on every supersede-cancel.
 # ---------------------------------------------------------------------------
 
 
-async def test_before_tool_returns_cancelled_status() -> None:
+async def test_before_tool_returns_cancelled_status_for_agent_tool() -> None:
     plugin, _sink, _session = _make_plugin()
     plugin.request_invocation_cancel(
         invocation_id="inv-1",
@@ -336,11 +361,107 @@ async def test_before_tool_returns_cancelled_status() -> None:
     )
     tool_ctx = _FakeToolContext(invocation_context=inv_ctx)
     response = await plugin.before_tool_callback(
-        tool=_FakeTool(name="search"),
+        tool=_FakeAgentTool(name="research_agent"),
         tool_args={"query": "test"},
         tool_context=tool_ctx,
     )
     assert response == {"status": "cancelled"}
+
+
+async def test_before_tool_does_not_short_circuit_function_tool_on_cancel() -> None:
+    """Bug C from v23 validation (goldfive#211610). Cancelling the
+    in-flight invocation must NOT cause a plain FunctionTool dispatch
+    (write_webpage, patch_file, …) to be skipped — the LLM has already
+    committed to the call (args chosen, function_call event emitted)
+    and the work is typically a side-effect (file write, DB row patch)
+    we want to land. The next ``before_model_callback`` short-circuits
+    the LLM call regardless, so the dispatch still ends cleanly.
+
+    A short-circuit here would synthesize ``{"status": "cancelled"}``
+    in place of the real tool result — exactly the v23 regression where
+    ``write_webpage`` / ``patch_file`` returned ``cancelled`` after a
+    GOAL_DRIFT-triggered supersede and no presentation file landed.
+    """
+    plugin, _sink, _session = _make_plugin()
+    plugin.request_invocation_cancel(
+        invocation_id="inv-1",
+        request=_make_request(drift_kind="goal_drift", reason="drift"),
+    )
+
+    inv_ctx = _FakeInvocationContext(
+        invocation_id="inv-1",
+        session_state={},
+    )
+    tool_ctx = _FakeToolContext(invocation_context=inv_ctx)
+    response = await plugin.before_tool_callback(
+        tool=_FakeTool(name="write_webpage"),
+        tool_args={"topic": "solar_flares", "html_content": "<html/>"},
+        tool_context=tool_ctx,
+    )
+    # No short-circuit — the callback returns ``None`` so ADK proceeds
+    # to dispatch the real FunctionTool. ``{"status": "cancelled"}``
+    # would be the buggy response.
+    assert response is None
+    # The cancel-state flag is still pending — the next
+    # ``before_model_callback`` will consume it and emit the
+    # ``InvocationCancelled`` sink event there. Pre-fix this method
+    # consumed it, blocking the LLM-call short-circuit from firing.
+    assert plugin.peek_cancel_for_invocation("inv-1") is not None
+
+
+async def test_before_tool_real_adk_function_tool_runs_during_supersede(tmp_path: Any) -> None:
+    """End-to-end shape of Bug C: a real ADK ``FunctionTool`` whose
+    ``func`` writes a file must actually run when the in-flight
+    invocation has been flagged for a supersede-cancel. Pre-fix the
+    callback returned ``{"status": "cancelled"}`` and the file was
+    never written.
+
+    We don't drive a full ADK ``Runner`` here (the cooperative-cancel
+    contract is per-plugin-callback) — instead we assert the callback
+    contract: ``before_tool_callback(...)`` returns ``None`` so ADK
+    proceeds to dispatch the wrapped function. Then we manually invoke
+    the function to model what ADK would do post-callback, and assert
+    the side-effect landed.
+    """
+    pytest.importorskip("google.adk")
+    from google.adk.tools import FunctionTool
+
+    output_path = tmp_path / "solar_flares.html"
+
+    def write_webpage(topic: str, html_content: str) -> str:
+        output_path.write_text(html_content)
+        return f"Wrote {topic}"
+
+    tool = FunctionTool(write_webpage)
+
+    plugin, _sink, _session = _make_plugin()
+    plugin.request_invocation_cancel(
+        invocation_id="inv-1",
+        request=_make_request(drift_kind="goal_drift", reason="drift"),
+    )
+
+    inv_ctx = _FakeInvocationContext(
+        invocation_id="inv-1",
+        session_state={},
+    )
+    tool_ctx = _FakeToolContext(invocation_context=inv_ctx)
+    response = await plugin.before_tool_callback(
+        tool=tool,
+        tool_args={"topic": "solar_flares", "html_content": "<html>flares</html>"},
+        tool_context=tool_ctx,
+    )
+    # Callback returned ``None`` — ADK is told "proceed normally".
+    assert response is None, (
+        f"FunctionTool dispatch was short-circuited (response={response!r}); "
+        "Bug C regression — write_webpage / patch_file must land their work "
+        "even on supersede-cancel."
+    )
+
+    # Model what ADK does next: invoke the wrapped function. The
+    # side-effect must land.
+    write_webpage(topic="solar_flares", html_content="<html>flares</html>")
+    assert output_path.exists()
+    assert output_path.read_text() == "<html>flares</html>"
 
 
 # ---------------------------------------------------------------------------
@@ -489,10 +610,16 @@ async def test_cancel_noop_when_no_active_invocation() -> None:
 
 
 async def test_llm_visible_cancelled_response_is_minimal() -> None:
-    """The tool response returned to the LLM must be ``{"status":
+    """The AgentTool response returned to the LLM must be ``{"status":
     "cancelled"}`` — bare shape. No ``reason`` / ``detail`` /
     ``drift_kind`` leak that the parent LLM could pattern-match on
     and invent workarounds (lesson from goldfive#250 / #252 / #253).
+
+    Asserted on AgentTool dispatch only — FunctionTool dispatches are
+    no longer short-circuited at this callback (Bug C from v23
+    validation, goldfive#211610). The minimal-shape invariant still
+    matters for the AgentTool path because the parent LLM reads that
+    response verbatim as the sub-agent's "result".
     """
     plugin, _sink, _session = _make_plugin()
     request = _make_request(
@@ -507,7 +634,7 @@ async def test_llm_visible_cancelled_response_is_minimal() -> None:
         session_state={},
     )
     response = await plugin.before_tool_callback(
-        tool=_FakeTool(name="search"),
+        tool=_FakeAgentTool(name="researcher"),
         tool_args={},
         tool_context=_FakeToolContext(invocation_context=inv_ctx),
     )

--- a/tests/test_llm_call_timeout_watcher_sticky.py
+++ b/tests/test_llm_call_timeout_watcher_sticky.py
@@ -120,8 +120,27 @@ class _FakeToolContext(_FakeCallbackContext):
 
 
 class _FakeTool:
+    """FunctionTool-shaped stub (``.name`` + ``.func``)."""
+
     def __init__(self, *, name: str) -> None:
         self.name = name
+        self.func = lambda **_kw: {"ok": True}
+
+
+class _FakeAgentTool:
+    """AgentTool-shaped stub (``.name`` + ``.agent``).
+
+    Trips :func:`goldfive.adapters._adk_plugin._is_agent_tool_dispatch`
+    via the ``.agent is not None`` duck-typed branch so the
+    cooperative-cancel short-circuit fires on this stub even when the
+    optional ``adk`` extra is absent. FunctionTool dispatches must NOT
+    short-circuit (Bug C / goldfive#211610) — those tests use
+    :class:`_FakeTool` instead.
+    """
+
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self.agent = type("_FakeAgent", (), {"name": name})()
 
 
 class _FakeLlmRequest:
@@ -310,11 +329,17 @@ async def test_before_model_no_short_circuit_for_unrelated_invocation() -> None:
 
 
 async def test_before_tool_short_circuits_with_cancelled_status() -> None:
+    """AgentTool dispatch on a cancelled invocation short-circuits.
+
+    Plain FunctionTool dispatches no longer short-circuit at this
+    callback (Bug C / goldfive#211610) — see the companion FunctionTool
+    test in tests/test_cooperative_cancellation.py.
+    """
     plugin, sink = _make_plugin_with_ctx()
     plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request("inv-1"))
     inv_ctx = _FakeInvocationContext(invocation_id="inv-1")
     response = await plugin.before_tool_callback(
-        tool=_FakeTool(name="search"),
+        tool=_FakeAgentTool(name="researcher"),
         tool_args={"q": "x"},
         tool_context=_FakeToolContext(invocation_context=inv_ctx),
     )
@@ -324,24 +349,24 @@ async def test_before_tool_short_circuits_with_cancelled_status() -> None:
 
 
 async def test_before_tool_sticky_short_circuit_no_double_emit() -> None:
-    """Subsequent tool calls on a cancelled invocation also return the
-    cancelled status without re-emitting the sink event."""
+    """Subsequent AgentTool calls on a cancelled invocation also return
+    the cancelled status without re-emitting the sink event."""
     plugin, sink = _make_plugin_with_ctx()
     plugin.request_invocation_cancel(invocation_id="inv-1", request=_make_request("inv-1"))
     inv_ctx = _FakeInvocationContext(invocation_id="inv-1")
     tool_ctx = _FakeToolContext(invocation_context=inv_ctx)
 
-    # First tool call — consumes the marker, emits InvocationCancelled.
+    # First AgentTool call — consumes the marker, emits InvocationCancelled.
     r1 = await plugin.before_tool_callback(
-        tool=_FakeTool(name="search"),
+        tool=_FakeAgentTool(name="researcher"),
         tool_args={},
         tool_context=tool_ctx,
     )
     assert r1 == {"status": "cancelled"}
     assert _cancelled_event_count(sink) == 1
-    # Second tool call — sticky bit shorts the dispatch silently.
+    # Second AgentTool call — sticky bit shorts the dispatch silently.
     r2 = await plugin.before_tool_callback(
-        tool=_FakeTool(name="another_tool"),
+        tool=_FakeAgentTool(name="reviewer"),
         tool_args={},
         tool_context=tool_ctx,
     )


### PR DESCRIPTION
## V23 evidence (Bug C)

Session `b28dac48-4fd1-4e6f-a4d0-824d3c139c3b`, turn 2 (user pivoted to solar flares):

```
20:34:04 run_started turn 2
20:37:39 plan_revised rev=4 ("Create a 2-slide presentation about solar flares.")
20:41:03 create_presentation_flares RUNNING
20:45:49 GOAL_DRIFT sev=3
20:56:19 create_presentation_flares COMPLETED
         AND simultaneously: web_developer_agent write_webpage COMPLETED
                              with payload_summary='{"status": "cancelled"}'
21:08:59 run_completed (no abort — PR #333 working)
         AND simultaneously: debugger_agent patch_file COMPLETED
                              with payload_summary='{"status": "cancelled"}'
```

No solar_flares artifact was produced anywhere in `output/` during turn 2. The user pivoted, the system ran research → presentation → review → debug, but every file-writing tool returned `{"status": "cancelled"}` and no file landed.

## Investigation

Source identified at `goldfive/adapters/_adk_plugin.py:4644-4661` (`before_tool_callback`). When the in-flight invocation is flagged for cooperative cancel, the callback returned `{"status": "cancelled"}` for **every** tool — including plain `FunctionTool` side-effect helpers (`write_webpage`, `patch_file`) that finish in milliseconds and have already had their args chosen by the LLM. The actual file write was skipped entirely.

This is "Option (b)" from the investigation brief: goldfive-side adapter intercept, not tool-level wrapping.

## Fix

Discriminate AgentTool vs FunctionTool dispatches in the cancel short-circuit:

* **AgentTool** dispatches still short-circuit. Spawning a fresh sub-Runner for stale work after a cancel was the original motivating regression — short-circuit semantics there are correct.
* **FunctionTool** dispatches no longer short-circuit. Their work is already committed (function_call event emitted, args chosen) and the side-effect is exactly what we want to preserve. The next `before_model_callback` on the same invocation short-circuits the LLM call regardless, so the dispatch still ends cleanly without losing the file write.

New helper `_is_agent_tool_dispatch` prefers `isinstance(tool, AgentTool)` when the optional `adk` extra is importable, with a duck-typed `.agent` fallback for tests and forward-compat.

## Test plan

- [x] New `test_before_tool_does_not_short_circuit_function_tool_on_cancel` asserts FunctionTool dispatches return `None` (proceed) when the invocation is cancelled.
- [x] New `test_before_tool_real_adk_function_tool_runs_during_supersede` drives a real ADK `FunctionTool` whose `func` writes a file and asserts the side-effect lands.
- [x] Existing AgentTool short-circuit tests retargeted at AgentTool-shaped stubs; behaviour preserved.
- [x] Minimal-response invariant test retargeted at AgentTool path (still load-bearing for prompt-injection safety on sub-agent results).
- [x] Full suite passes (2028 passed, 55 skipped).
- [x] Ruff clean.