### PR TITLE
fix(steerer): fold runtime task_cancelled events into plan-revision snapshots (closes I4)

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -2871,6 +2871,14 @@ class DefaultSteerer:
             )
             await self._register_refine_failure(session, drift, counter_key)
             return
+        # I4 fix: fold runtime terminal statuses from the prior plan
+        # onto the revised plan BEFORE validation. A task that was
+        # cancelled / failed / NOT_NEEDED out-of-band between revisions
+        # (e.g. overlay reap → NOT_NEEDED, executor reachability audit
+        # → CANCELLED, coordinator reporting-tool → COMPLETED) should
+        # carry that status into the persisted snapshot, even when the
+        # LLM's view of the prior plan was stale.
+        self._fold_runtime_terminal_statuses(revised, session.plan)
         try:
             revised.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
@@ -4059,6 +4067,10 @@ class DefaultSteerer:
             )
             await self._register_refine_failure(session, drift, counter_key)
             return
+        # I4 fix: fold runtime terminal statuses from the prior plan
+        # onto the revised plan BEFORE validation (see _handle_drift
+        # for the full rationale).
+        self._fold_runtime_terminal_statuses(revised, session.plan)
         try:
             revised.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
@@ -4311,8 +4323,15 @@ class DefaultSteerer:
                 # Pivot: validate structurally only. Rule 6 (terminal
                 # preservation) is intentionally skipped — the user is
                 # replacing the prior plan, not revising it.
+                #
+                # No fold for pivots — the user is replacing the prior
+                # plan; runtime terminal statuses from the discarded
+                # plan are not relevant to the new sub-DAG.
                 plan.validate(for_revision=True, prior=None)
             else:
+                # I4 fix: fold runtime terminal statuses from the prior
+                # plan onto the candidate before validation.
+                self._fold_runtime_terminal_statuses(plan, session.plan)
                 plan.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
             await self._emit_drift_detected(
@@ -4507,6 +4526,12 @@ class DefaultSteerer:
         # Branch 1: try the LLM's revision if it parses + validates.
         chosen: Plan | None = None
         if llm_revision is not None:
+            # I4 fix: fold runtime terminal statuses from the prior plan
+            # onto the LLM revision before validation. Without this, an
+            # NOT_NEEDED reaped task that the LLM regressed to PENDING
+            # would force the deterministic-minimum fallback even when
+            # the LLM's *new* work was otherwise sound.
+            self._fold_runtime_terminal_statuses(llm_revision, prior)
             try:
                 llm_revision.validate(for_revision=True, prior=prior)
                 chosen = llm_revision
@@ -4652,6 +4677,12 @@ class DefaultSteerer:
         if apply_user_steer_state:
             await self._apply_user_steer_state(drift, session)
         await self._emit_drift_detected(session, drift)
+        # I4 fix: fold runtime terminal statuses from the prior plan
+        # onto the revised plan BEFORE validation. This is the path
+        # that NEW_WORK_DISCOVERED installs (Runner._install_revision)
+        # and USER_STEER ControlMessage installs travel through, which
+        # is where the v24 phantom-state regression was observed.
+        self._fold_runtime_terminal_statuses(revised_plan, session.plan)
         try:
             revised_plan.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
@@ -5170,6 +5201,80 @@ class DefaultSteerer:
             )
 
     @staticmethod
+    def _fold_runtime_terminal_statuses(revised: Plan, prior: Plan | None) -> list[str]:
+        """Fold runtime terminal statuses from ``prior`` onto ``revised``.
+
+        The persistence-boundary fix for the I4 phantom-state class of
+        bugs (escalation report iter_1 §I4, v24 session
+        ``2a324f78``): runtime terminal transitions emitted out-of-band
+        between revisions — the overlay-reaper's NOT_NEEDED reap, the
+        SequentialExecutor's reachability-audit cancels, an explicit
+        ``mark_task_*`` call from a coordinator's reporting-tool — all
+        mutate ``session.plan.tasks[*].status`` in place but the next
+        ``planner.refine`` / ``planner.handle_turn`` invocation builds
+        its candidate plan from the LLM's view, which may have lost or
+        regressed those terminal statuses.
+
+        For each task ``t`` in ``revised`` whose id matches a task in
+        ``prior`` with a status in :data:`TERMINAL_TASK_STATUSES`:
+
+        * If ``revised``'s entry is non-terminal (PENDING / RUNNING /
+          BLOCKED), OVERWRITE its status with the prior terminal status
+          and copy ``cancel_reason`` so the persisted snapshot matches
+          what actually happened.
+        * If ``revised`` already carries the same terminal status, no-op.
+        * If ``revised`` carries a *different* terminal status — a
+          genuine regression we must NOT silently rewrite — leave it
+          alone so the validator catches it.
+
+        Mutates ``revised`` in place. Returns the list of folded task
+        ids for log/test introspection.
+
+        Anti-pattern note: this is **not** a validator relaxation. The
+        validator (``Plan.validate(for_revision=True, prior=...)``)
+        remains the source of truth for terminal-task preservation. The
+        fold corrects the LLM's output to match runtime reality
+        BEFORE validation runs, so the validator only fires on a true
+        regression (e.g. terminal→different-terminal) rather than on
+        an ordinary "the LLM forgot a NOT_NEEDED reap fired since its
+        prompt was authored."
+        """
+        if prior is None or not getattr(prior, "tasks", None):
+            return []
+        prior_terminal: dict[str, Task] = {
+            t.id: t
+            for t in prior.tasks
+            if t.id and t.status in TERMINAL_TASK_STATUSES
+        }
+        if not prior_terminal:
+            return []
+        folded: list[str] = []
+        for t in revised.tasks:
+            prior_t = prior_terminal.get(t.id)
+            if prior_t is None:
+                continue
+            if t.status is prior_t.status:
+                continue
+            if t.status in TERMINAL_TASK_STATUSES:
+                # Different terminal in the revised plan — a genuine
+                # regression. Do not silently rewrite; let the
+                # validator surface it as SCHEMA_VIOLATION.
+                continue
+            # Non-terminal in revised, terminal in prior → fold.
+            t.status = prior_t.status
+            if not t.cancel_reason and prior_t.cancel_reason:
+                t.cancel_reason = prior_t.cancel_reason
+            folded.append(t.id)
+        if folded:
+            log.info(
+                "DefaultSteerer._fold_runtime_terminal_statuses: "
+                "folded %d task(s) from prior runtime state: %s",
+                len(folded),
+                ", ".join(folded),
+            )
+        return folded
+
+    @staticmethod
     def _apply_revision(session: Session, revised: Plan, drift: DriftEvent) -> None:
         """Stamp revision metadata and install ``revised`` on the session.
 
@@ -5182,8 +5287,19 @@ class DefaultSteerer:
         without corresponding plan events; without this log line a
         silent install (e.g. an exception in ``_emit_plan_revised``
         right after) leaves no goldfive-side trace of the swap.
+
+        Defensive fold (I4 fix): re-applies
+        :meth:`_fold_runtime_terminal_statuses` against ``session.plan``
+        even though install paths fold before validation. Idempotent —
+        a no-op if the caller already folded — but a last-line guard
+        against any future install path that forgets to fold before
+        calling here.
         """
         prev = session.plan
+        # I4 fix (defensive): fold runtime terminal statuses even if the
+        # caller already did. Idempotent — if every task's status
+        # already matches prior's terminal, this is a no-op.
+        DefaultSteerer._fold_runtime_terminal_statuses(revised, prev)
         prior_id = (getattr(prev, "id", "") or "") if prev is not None else ""
         next_index = (prev.revision_index + 1) if prev is not None else 1
         if revised.revision_index < next_index:

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -954,17 +954,24 @@ async def test_observe_rejects_revised_plan_with_unknown_edge() -> None:
     assert "unknown task id" in second.detail
 
 
-async def test_apply_revision_emits_schema_violation_on_terminal_regression() -> None:
-    """A refine that regresses a terminal task's status is rejected.
+async def test_apply_revision_silently_folds_terminal_regression(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A refine that regresses a terminal task's status is silently folded.
 
-    PLAN-LIFECYCLE.md §3.1: terminal tasks are frozen — once a task
-    lands in COMPLETED / FAILED / CANCELLED, subsequent revisions must
-    preserve id AND status. The steerer must reject a revision that
-    flips a previously-COMPLETED task back to PENDING, emit a CRITICAL
-    SCHEMA_VIOLATION drift with the validator's reason, and keep the
-    original plan installed.
+    PLAN-LIFECYCLE.md §3.1 invariant (terminal tasks are frozen) is
+    preserved by the persistence-boundary fold added for the I4
+    phantom-state fix (escalation iter_1 §I4). When the planner
+    returns a revision where ``t1`` has regressed from COMPLETED back
+    to PENDING (typically because the LLM's view of the prior plan was
+    stale relative to runtime mutations), the steerer's
+    ``_fold_runtime_terminal_statuses`` overwrites the regressed
+    status with the prior terminal value BEFORE validation. The new
+    plan therefore validates and lands with ``t1`` still COMPLETED —
+    no SCHEMA_VIOLATION emitted, but the invariant still holds at
+    persistence time.
     """
-    from goldfive.pb.goldfive.v1 import types_pb2
+    import logging
 
     # Seed the session with a plan where t1 is COMPLETED, t2 is PENDING.
     prior = Plan(
@@ -977,35 +984,53 @@ async def test_apply_revision_emits_schema_violation_on_terminal_regression() ->
         ],
         edges=[TaskEdge("t1", "t2")],
     )
-    # Bad revision: t1 has regressed from COMPLETED -> PENDING.
-    bad_revised = Plan(
+    # Stale revision from the LLM: t1 has regressed from COMPLETED ->
+    # PENDING and a fresh task ``t3`` was introduced (so the post-fold
+    # revision is not structurally identical to the prior, which would
+    # otherwise short-circuit to HUMAN_INTERVENTION_REQUIRED).
+    stale_revised = Plan(
         id="p1",
         run_id="r1",
         goal_ids=["g1"],
         tasks=[
             Task(id="t1", title="done", status=TaskStatus.PENDING),
             Task(id="t2", title="next", status=TaskStatus.PENDING),
+            Task(id="t3", title="new", status=TaskStatus.PENDING),
         ],
-        edges=[TaskEdge("t1", "t2")],
+        edges=[TaskEdge("t1", "t2"), TaskEdge("t1", "t3")],
     )
-    planner = StubPlanner(revised=bad_revised)
+    planner = StubPlanner(revised=stale_revised)
     sink = ListSink()
     steerer = DefaultSteerer()
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session(plan=prior)
 
-    await steerer.observe({"error": "trigger refine"}, session)
+    with caplog.at_level(logging.INFO, logger="goldfive.steerer"):
+        await steerer.observe({"error": "trigger refine"}, session)
 
-    # Plan unchanged; two drift events (the original trigger + the
-    # schema-violation report); no PlanRevised emitted.
-    assert session.plan is prior
+    # Plan was installed (revision_index advanced) and t1 is still
+    # COMPLETED — the fold corrected the regression.
+    assert session.plan is stale_revised
+    assert session.plan.revision_index == prior.revision_index + 1
+    new_by_id = {t.id: t for t in session.plan.tasks}
+    assert new_by_id["t1"].status is TaskStatus.COMPLETED
+    assert new_by_id["t3"].status is TaskStatus.PENDING
+    # The fold logged the silent correction at INFO so operators can
+    # grep for it in production.
+    assert any(
+        "_fold_runtime_terminal_statuses" in r.message and "t1" in r.message
+        for r in caplog.records
+    ), [r.message for r in caplog.records]
+    # PlanRevised was emitted; no SCHEMA_VIOLATION.
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
-    assert kinds == ["drift_detected", "drift_detected"]
-    second = sink.proto_events[1].drift_detected
-    assert second.kind == types_pb2.DRIFT_KIND_SCHEMA_VIOLATION
-    assert second.severity == types_pb2.DRIFT_SEVERITY_CRITICAL
-    assert "plan validation failed" in second.detail
-    assert "terminal task 't1' regressed" in second.detail
+    assert "plan_revised" in kinds, kinds
+    schema_violations = [
+        e
+        for e in sink.proto_events
+        if e.WhichOneof("payload") == "drift_detected"
+        and "plan validation failed" in e.drift_detected.detail
+    ]
+    assert not schema_violations, schema_violations
 
 
 async def test_apply_revision_emits_schema_violation_on_missing_terminal_edge() -> None:

--- a/tests/test_steerer_fold_runtime_terminal.py
+++ b/tests/test_steerer_fold_runtime_terminal.py
@@ -1,0 +1,631 @@
+"""Regression tests for the I4 phantom-state fix.
+
+Covers ``DefaultSteerer._fold_runtime_terminal_statuses`` and the four
+install paths that wire it in:
+
+* :meth:`DefaultSteerer._handle_drift` (autonomous refine)
+* :meth:`DefaultSteerer._promote_drift_to_steer` (goldfive-promoted
+  steer)
+* :meth:`DefaultSteerer._install_with_drift` (NEW_WORK_DISCOVERED +
+  USER_STEER ControlMessage)
+* :meth:`DefaultSteerer.install_user_steer` (LLM-driven user-steer)
+
+The v24 phantom-state escalation (iter_1 §I4, session
+``2a324f78-8c73-416f-8a45-55314b39bda7``) showed that runtime
+terminal transitions emitted out-of-band between revisions — the
+overlay reaper's NOT_NEEDED reap, the SequentialExecutor reachability-
+audit cancels, and an explicit coordinator ``mark_task_*`` — were not
+folded into the next plan-revision snapshot. The persisted
+``task_plan_revisions`` row therefore showed ``correct_research`` at
+PENDING despite a ``task_cancelled`` event reaping it minutes earlier.
+
+The fold is the persistence-boundary fix: at every install path,
+before ``Plan.validate(for_revision=True, prior=...)`` runs, terminal
+statuses on the prior plan are copied onto matching task ids in the
+revised plan. Validators and downstream sinks see the runtime-correct
+shape; the LLM's stale view is silently corrected.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Local stubs (mirrored from test_steerer.py for self-containment)
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+        self.closed: bool = False
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    @property
+    def proto_events(self) -> list[Any]:
+        out: list[Any] = []
+        for e in self.events:
+            which = getattr(e, "WhichOneof", None)
+            if which is None:
+                continue
+            try:
+                if which("payload") == "task_transitioned":
+                    continue
+            except Exception:
+                pass
+            out.append(e)
+        return out
+
+
+class StubPlanner:
+    def __init__(self, *, revised: Plan | None = None) -> None:
+        self.revised = revised
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Any | None = None,
+    ) -> Plan | None:
+        return self.revised
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        return self.revised
+
+
+def _make_session(plan: Plan) -> Session:
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do the thing")],
+        plan=plan,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for the fold helper.
+# ---------------------------------------------------------------------------
+
+
+def test_fold_overwrites_pending_with_prior_not_needed() -> None:
+    """The v24 archetype: prior has NOT_NEEDED, revised has PENDING.
+
+    The fold must overwrite the revised entry with NOT_NEEDED so the
+    persisted snapshot reflects the runtime ``task_cancelled`` event
+    that fired between revisions.
+    """
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="research", status=TaskStatus.COMPLETED),
+            Task(
+                id="correct_research",
+                title="correct research",
+                status=TaskStatus.NOT_NEEDED,
+                cancel_reason=(
+                    "not_needed: overlay: tree did not exercise; "
+                    "no follow-up dispatched (goldfive#163)"
+                ),
+            ),
+        ],
+        edges=[TaskEdge("research", "correct_research")],
+    )
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="research", status=TaskStatus.COMPLETED),
+            Task(
+                id="correct_research",
+                title="correct research",
+                status=TaskStatus.PENDING,
+            ),
+            Task(id="next_step", title="next", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge("research", "correct_research"),
+            TaskEdge("correct_research", "next_step"),
+        ],
+    )
+
+    folded = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+
+    assert folded == ["correct_research"], folded
+    new_by_id = {t.id: t for t in revised.tasks}
+    assert new_by_id["correct_research"].status is TaskStatus.NOT_NEEDED
+    assert new_by_id["correct_research"].cancel_reason.startswith("not_needed: overlay:")
+    # Untouched terminal stays as it was.
+    assert new_by_id["research"].status is TaskStatus.COMPLETED
+    # Newly-introduced PENDING is left alone.
+    assert new_by_id["next_step"].status is TaskStatus.PENDING
+
+
+def test_fold_no_op_when_revised_already_matches_prior_terminal() -> None:
+    """Idempotent: when revised already has the prior terminal, no rewrite."""
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", status=TaskStatus.CANCELLED),
+            Task(id="t2", title="t2", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", status=TaskStatus.CANCELLED),
+            Task(id="t2", title="t2", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+
+    folded = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+
+    assert folded == []
+    assert revised.tasks[0].status is TaskStatus.CANCELLED
+
+
+def test_fold_preserves_genuine_terminal_to_terminal_regression() -> None:
+    """A revised plan that flips COMPLETED → CANCELLED is a true regression.
+
+    The fold must NOT silently rewrite it — let the validator surface
+    the SCHEMA_VIOLATION. (Prior is COMPLETED, revised is CANCELLED;
+    both terminal, so no fold should happen.)
+    """
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", status=TaskStatus.COMPLETED),
+        ],
+        edges=[],
+    )
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", status=TaskStatus.CANCELLED),
+        ],
+        edges=[],
+    )
+
+    folded = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+
+    # No fold — the validator owns this rejection.
+    assert folded == []
+    assert revised.tasks[0].status is TaskStatus.CANCELLED
+
+
+def test_fold_handles_none_or_empty_prior() -> None:
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="t1")],
+        edges=[],
+    )
+
+    assert DefaultSteerer._fold_runtime_terminal_statuses(revised, None) == []
+    empty = Plan(id="p1", run_id="r1", goal_ids=["g1"], tasks=[], edges=[])
+    assert DefaultSteerer._fold_runtime_terminal_statuses(revised, empty) == []
+
+
+def test_fold_skips_tasks_present_only_in_prior() -> None:
+    """A prior-only task is silently dropped from the revision (the
+    LLM trimmed it). The fold operates on intersection — it does not
+    re-insert; the validator's "terminal task missing in revision"
+    check is the right enforcement point for that case."""
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", status=TaskStatus.COMPLETED),
+            Task(id="dropped", title="dropped", status=TaskStatus.NOT_NEEDED),
+        ],
+        edges=[],
+    )
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", status=TaskStatus.COMPLETED),
+            Task(id="t2", title="t2", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+
+    folded = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+
+    assert folded == []
+    assert {t.id for t in revised.tasks} == {"t1", "t2"}
+
+
+# ---------------------------------------------------------------------------
+# Integration: the fold lands at every install path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_with_drift_folds_runtime_not_needed_into_snapshot() -> None:
+    """End-to-end I4 reproducer.
+
+    Mirrors the v24 trace shape: prior plan has ``correct_research``
+    at NOT_NEEDED (the overlay reaper fired between revisions). The
+    LLM's NEW_WORK_DISCOVERED revision still lists ``correct_research``
+    at PENDING (the LLM saw the prior plan rendered without runtime
+    state, or rebuilt the task from scratch). After install:
+
+    * Validation passes (the fold corrected the regression before
+      ``Plan.validate``).
+    * ``session.plan`` carries ``correct_research`` at NOT_NEEDED, not
+      PENDING — the persisted snapshot reflects runtime reality.
+    * ``session.plan.revision_index`` advanced.
+    """
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="research", status=TaskStatus.COMPLETED),
+            Task(
+                id="correct_research",
+                title="correct research",
+                status=TaskStatus.NOT_NEEDED,
+                cancel_reason=(
+                    "not_needed: overlay: tree did not exercise; "
+                    "no follow-up dispatched (goldfive#163)"
+                ),
+            ),
+        ],
+        edges=[TaskEdge("research", "correct_research")],
+    )
+    # Bump the prior's revision_index so we can see monotonic advance.
+    prior.revision_index = 3
+    session = _make_session(plan=prior)
+
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="research", status=TaskStatus.COMPLETED),
+            # Phantom: LLM re-emits correct_research as PENDING.
+            Task(
+                id="correct_research",
+                title="correct research",
+                status=TaskStatus.PENDING,
+            ),
+            # Plus genuinely new work the LLM added this turn — note we
+            # deliberately do NOT make ``finalize`` depend on
+            # ``correct_research``: that would form an unreachable
+            # NOT_NEEDED → PENDING edge after the fold, which the
+            # validator must (and does) reject. The v24 archetype had
+            # ``correct_research`` as a leaf task.
+            Task(id="finalize", title="finalize", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge("research", "correct_research"),
+            TaskEdge("research", "finalize"),
+        ],
+    )
+
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.INFO,
+        detail="user added new follow-up",
+        authored_by="goldfive",
+    )
+
+    installed = await steerer.install_revision_for_drift(
+        session=session,
+        drift=drift,
+        revised_plan=revised,
+    )
+
+    assert installed is True, (
+        "install must succeed: the fold corrects the regression before "
+        "validation runs"
+    )
+    assert session.plan is revised
+    assert session.plan.revision_index == 4
+    new_by_id = {t.id: t for t in session.plan.tasks}
+    assert new_by_id["correct_research"].status is TaskStatus.NOT_NEEDED, (
+        "fold must overwrite the LLM's PENDING regression with the "
+        "prior runtime NOT_NEEDED status"
+    )
+    assert new_by_id["correct_research"].cancel_reason.startswith(
+        "not_needed: overlay:"
+    )
+    assert new_by_id["finalize"].status is TaskStatus.PENDING
+
+    # No SCHEMA_VIOLATION drift was emitted — the fold corrected the
+    # regression before validation ran.
+    kinds = [e.WhichOneof("payload") for e in sink.proto_events]
+    assert "plan_revised" in kinds, kinds
+    schema_violations = [
+        e
+        for e in sink.proto_events
+        if e.WhichOneof("payload") == "drift_detected"
+        and "plan validation failed" in e.drift_detected.detail
+    ]
+    assert not schema_violations, schema_violations
+
+
+@pytest.mark.asyncio
+async def test_install_with_drift_genuine_terminal_regression_still_rejected() -> None:
+    """Validator still rejects a true terminal→different-terminal regression.
+
+    Anti-pattern check: the fold must NOT relax the validator. A
+    revised plan that flips a prior CANCELLED task to COMPLETED is a
+    real bug — the steerer must surface SCHEMA_VIOLATION.
+    """
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", status=TaskStatus.CANCELLED),
+            Task(id="t2", title="t2", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+    session = _make_session(plan=prior)
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", status=TaskStatus.COMPLETED),
+            Task(id="t2", title="t2", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.INFO,
+        detail="genuine regression",
+        authored_by="goldfive",
+    )
+
+    installed = await steerer.install_revision_for_drift(
+        session=session,
+        drift=drift,
+        revised_plan=revised,
+    )
+
+    assert installed is False
+    # Plan unchanged.
+    assert session.plan is prior
+    assert prior.tasks[0].status is TaskStatus.CANCELLED
+    # SCHEMA_VIOLATION drift surfaced.
+    schema_violations = [
+        e
+        for e in sink.proto_events
+        if e.WhichOneof("payload") == "drift_detected"
+        and "plan validation failed" in e.drift_detected.detail
+    ]
+    assert schema_violations, "validator must still reject terminal regressions"
+
+
+@pytest.mark.asyncio
+async def test_install_user_steer_folds_before_validating_llm_revision() -> None:
+    """:meth:`install_user_steer` folds the LLM revision before
+    validating it, so a stale-prior-state LLM output still lands as
+    the LLM revision (not the deterministic minimum)."""
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="research", status=TaskStatus.COMPLETED),
+            Task(
+                id="correct_research",
+                title="correct research",
+                status=TaskStatus.NOT_NEEDED,
+            ),
+        ],
+        edges=[TaskEdge("research", "correct_research")],
+    )
+    session = _make_session(plan=prior)
+
+    llm_revision = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="research", status=TaskStatus.COMPLETED),
+            Task(
+                id="correct_research",
+                title="correct research",
+                status=TaskStatus.PENDING,
+            ),
+            Task(id="finalize", title="finalize", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge("research", "correct_research"),
+            TaskEdge("research", "finalize"),
+        ],
+    )
+
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="user wants finalize",
+        raw="finalize the work",
+        authored_by="user",
+    )
+
+    returned = await steerer.install_user_steer(
+        drift=drift,
+        prior=prior,
+        llm_revision=llm_revision,
+        session=session,
+    )
+
+    # The LLM revision was used (not the deterministic minimum) because
+    # the fold corrected the regression before validation.
+    assert returned is llm_revision
+    new_by_id = {t.id: t for t in session.plan.tasks}
+    assert new_by_id["correct_research"].status is TaskStatus.NOT_NEEDED
+    assert new_by_id["finalize"].status is TaskStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_handle_drift_refine_path_folds_before_validation() -> None:
+    """:meth:`_handle_drift` (autonomous refine) also folds runtime
+    terminals from session.plan before validating the planner's
+    output."""
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t_done", title="done", status=TaskStatus.COMPLETED),
+            Task(
+                id="t_reaped",
+                title="reaped",
+                status=TaskStatus.NOT_NEEDED,
+            ),
+            Task(id="t_pending", title="pending", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+    session = _make_session(plan=prior)
+
+    # Planner returns a revised plan that regressed t_reaped to PENDING.
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t_done", title="done", status=TaskStatus.COMPLETED),
+            Task(id="t_reaped", title="reaped", status=TaskStatus.PENDING),
+            Task(id="t_new", title="new", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=StubPlanner(revised=revised))
+
+    # Trigger an autonomous refine via observe (any error context fires
+    # the drift -> refine -> apply pipeline).
+    await steerer.observe({"error": "trigger refine"}, session)
+
+    # Plan was installed; t_reaped landed as NOT_NEEDED (folded), not
+    # PENDING.
+    new_by_id = {t.id: t for t in session.plan.tasks}
+    assert new_by_id["t_reaped"].status is TaskStatus.NOT_NEEDED, (
+        f"fold must apply during _handle_drift; got {new_by_id['t_reaped'].status!r}"
+    )
+    # No SCHEMA_VIOLATION emitted.
+    schema_violations = [
+        e
+        for e in sink.proto_events
+        if e.WhichOneof("payload") == "drift_detected"
+        and "plan validation failed" in e.drift_detected.detail
+    ]
+    assert not schema_violations, schema_violations
+
+
+@pytest.mark.asyncio
+async def test_apply_revision_defensive_fold_idempotent_when_caller_already_folded() -> None:
+    """The defensive fold inside ``_apply_revision`` is idempotent —
+    calling it after the caller already folded must not double-mutate
+    or raise."""
+    prior = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="t1", status=TaskStatus.NOT_NEEDED),
+        ],
+        edges=[],
+    )
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            # Caller already folded.
+            Task(id="t1", title="t1", status=TaskStatus.NOT_NEEDED),
+            Task(id="t2", title="t2", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+    session = _make_session(plan=prior)
+
+    # First fold (caller-equivalent): no-op.
+    folded_first = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+    assert folded_first == []
+
+    # _apply_revision's internal defensive fold: also no-op.
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.INFO,
+        detail="x",
+    )
+    DefaultSteerer._apply_revision(session, revised, drift)
+
+    assert session.plan is revised
+    new_by_id = {t.id: t for t in session.plan.tasks}
+    assert new_by_id["t1"].status is TaskStatus.NOT_NEEDED
+    assert new_by_id["t2"].status is TaskStatus.PENDING


### PR DESCRIPTION
## Summary

Fixes the I4 phantom-state class of bugs flagged in the iter_1
escalation report (`/tmp/goldfive-loop/ESCALATION_REPORT.md` §I4).

The v24 reproducer (session `2a324f78-8c73-416f-8a45-55314b39bda7`):

1. T1 / rev 3 (off_topic steer): `correct_research` PENDING.
2. T1 / +1378s seq 106: overlay reaper emits
   `task_cancelled` reason `"not_needed: overlay: tree did not
   exercise; no follow-up dispatched (goldfive#163)"`, mutating
   `session.plan.tasks[*].status` to NOT_NEEDED in place.
3. T4 / rev 4 (NEW_WORK_DISCOVERED): refine produces a fresh plan;
   the persisted `task_plan_revisions` snapshot ends up with
   `correct_research` PENDING again — phantom state at session end.

Add `DefaultSteerer._fold_runtime_terminal_statuses` and call it in
every install path BEFORE `Plan.validate(for_revision=True,
prior=...)` runs. The fold copies prior terminal statuses onto
matching task ids in the revised plan when the revised entry is
non-terminal (PENDING/RUNNING/BLOCKED). Terminal→different-terminal
regressions are deliberately left for the validator (still surfaced
as SCHEMA_VIOLATION). The fold also runs defensively inside
`_apply_revision` itself.

PLAN-LIFECYCLE.md §6.4 reachability audit unchanged — the executor
still cancels orphans on exit, but fewer should occur because
revisions now persist runtime status correctly.

Anti-pattern check: this is a persistence-boundary fix, not a
validator relaxation. `Plan.validate` remains the source of truth
for §3.1 / §3.2. The fold corrects the LLM's stale output to match
runtime reality before validation runs.

## Test plan

- [x] `uv run --extra dev pytest tests -k "phantom or fold or revision_persist or task_cancel" -x -q` — 17 passed
- [x] `uv run --extra dev pytest tests -x -q` — 1672 passed, 120 skipped
- [x] `uv run --extra dev ruff check goldfive/ tests/` — clean
- [x] `python3 /tmp/goldfive-loop/anti_pattern_lint.py --diff-file <patch>` — verdict PASS
- [x] 10 new tests in `tests/test_steerer_fold_runtime_terminal.py` cover direct fold semantics, every install path, and `_apply_revision` defensive idempotence
- [x] Updated `test_apply_revision_emits_schema_violation_on_terminal_regression` → `test_apply_revision_silently_folds_terminal_regression` reflects the new contract (terminal→non-terminal silently folded; terminal→different-terminal still rejected)