### PR TITLE
fix(steerer): gate refine_steer on condition_id lifecycle (closes I5)

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -2720,6 +2720,18 @@ class DefaultSteerer:
         # ``_is_plan_revision_cooldown_exempt``).
         if self._is_plan_revision_gated(drift, session):
             return
+        # Per-condition refine gate (goldfive I5 — iter_1 escalation
+        # report). The drift-as-stateful-condition refactor (#271 PR1 /
+        # #318) already minted a ``condition_id`` + ``lifecycle`` for
+        # this emit via :meth:`_stamp_drift_lifecycle` (called above
+        # inside ``_emit_drift_detected``). We read that lifecycle and
+        # skip the refine when the condition is being re-detected
+        # without change — same severity ``ESCALATING`` re-emits or
+        # terminal lifecycles. Structural gate on lifecycle state, not a
+        # numerical cap; complements the time-based ``_is_plan_revision_gated``
+        # cooldown by catching same-tick re-emits the cooldown lets through.
+        if self._is_refine_gated_by_lifecycle(drift, session):
+            return
         # Progress-based escalation (goldfive#271 — replaces the deleted
         # count cap). If the drift fires on a task that has had no
         # progress signal (``mark_task_running`` / ``mark_task_progress``
@@ -3965,6 +3977,12 @@ class DefaultSteerer:
         if self._planner is None or session.plan is None:
             return
         if self._is_plan_revision_gated(drift, session):
+            return
+        # Per-condition refine gate (goldfive I5). Mirror of the gate in
+        # ``_handle_drift``: skip ``refine_steer`` on a same-severity
+        # ``ESCALATING`` re-emit of an active condition or a terminal
+        # lifecycle. See :meth:`_is_refine_gated_by_lifecycle`.
+        if self._is_refine_gated_by_lifecycle(drift, session):
             return
         # Progress-based escalation (goldfive#271 — replaces the deleted
         # count cap). See the parallel check in ``_handle_drift`` and
@@ -5809,6 +5827,121 @@ class DefaultSteerer:
             cooldown,
         )
         return True
+
+    def _is_refine_gated_by_lifecycle(self, drift: DriftEvent, session: Session) -> bool:
+        """Return ``True`` iff ``drift``'s active condition does not warrant a refine.
+
+        Per-condition refine gate (goldfive I5 — iter_1 escalation report).
+        The drift-as-stateful-condition refactor (#271 PR1 / #318) gives
+        every emit a stable ``condition_id`` and a ``lifecycle`` stamped
+        on ``session.state``. Without this gate, every re-emit of the
+        same logical condition (``ESCALATING`` at the same severity)
+        triggered another ``planner.refine`` — empirically dominating
+        the LLM-call budget on long runs (V24: 7 ``refine_steer`` calls
+        for 18 theoretical task turns, 2/turn average).
+
+        The structural rule:
+
+        * ``OPENED`` — first emit of this condition; refine runs
+          (current baseline).
+        * ``ESCALATING`` with a severity bump (``prev_severity != severity``)
+          — escalation is real (e.g. INFO -> WARNING), refine runs.
+        * ``ESCALATING`` at the same severity — same condition being
+          re-detected without change; refine is a no-op replay, gate it.
+        * ``RESOLVED`` / ``HUMAN_INTERVENTION_REQUIRED`` — terminal lifecycle
+          for this condition; refine has either already happened or has
+          been lifted to the operator. Gate.
+
+        User / trajectory-level drifts (``USER_STEER`` / ``USER_CANCEL`` /
+        ``GOAL_DRIFT``) bypass the gate — operator intent must be
+        honoured even on a re-emit, and trajectory-wide drifts have
+        their own rate limiters.
+
+        The active-drift entry is read from
+        :func:`orchestration_state.get_active_drift` keyed by the same
+        condition_id :meth:`_stamp_drift_lifecycle` minted on the wire
+        emit. Reads ``session.state`` only — no mutation. Idempotent:
+        called twice for the same drift returns the same answer.
+
+        NB: ``_stamp_drift_lifecycle`` only ever writes ``OPENED`` or
+        ``ESCALATING`` to the active set (the resolving / human-intervention
+        helpers remove the entry rather than store it). So a missing
+        active-drift entry on a fresh ``_handle_drift`` tick means the
+        condition was previously resolved or escalated to a human;
+        treating that as "gate refine" is the correct, conservative
+        default.
+        """
+        # User / trajectory-level drifts bypass the gate (same exemption
+        # set as ``_is_plan_revision_gated``).
+        if drift.kind in self._USER_OR_TRAJECTORY_DRIFT_KINDS:
+            return False
+        # Re-derive the condition_id with the same args
+        # ``_stamp_drift_lifecycle`` used so this gate reads the same
+        # entry it stamped.
+        try:
+            cid = _ostate.compute_condition_id(
+                kind=drift.kind,
+                task_id=str(getattr(drift, "current_task_id", "") or ""),
+                agent_id=str(getattr(drift, "current_agent_id", "") or ""),
+                turn_id=str(getattr(session, "run_id", "") or ""),
+            )
+            tracked = _ostate.get_active_drift(session.state, cid)
+        except Exception as exc:  # noqa: BLE001
+            # Lifecycle bookkeeping is observability-only; never let a
+            # malformed state dict break dispatch. Fall through to the
+            # un-gated behaviour (legacy single-shot refine).
+            log.debug("DefaultSteerer: refine lifecycle gate skipped (%s)", exc)
+            return False
+        if tracked is None:
+            # Condition is no longer in the active set — either resolved
+            # or escalated to human intervention by a prior tick. Don't
+            # re-fire refine on a closed condition.
+            log.debug(
+                "refine gated by lifecycle (kind=%s task=%r): condition resolved/escalated",
+                drift.kind.value,
+                drift.current_task_id,
+            )
+            return True
+        lifecycle = tracked.lifecycle
+        if lifecycle == _ostate.LIFECYCLE_OPENED:
+            # First emit of the condition this turn — refine the baseline.
+            return False
+        if lifecycle == _ostate.LIFECYCLE_ESCALATING:
+            # Escalating: refine ONLY if the severity actually bumped.
+            # Same severity re-emit -> the underlying condition is being
+            # re-detected without change; the prior refine still applies.
+            if tracked.prev_severity != tracked.severity:
+                return False
+            log.debug(
+                "refine gated by lifecycle (kind=%s task=%r): escalating re-emit "
+                "at same severity %s",
+                drift.kind.value,
+                drift.current_task_id,
+                tracked.severity.value if tracked.severity else "",
+            )
+            log.info(
+                "goldfive observed a %s drift on task=%r as a same-severity re-emit "
+                "of an active condition; skipping replan",
+                drift.kind.value,
+                drift.current_task_id,
+            )
+            return True
+        # RESOLVED / HUMAN_INTERVENTION_REQUIRED in the active set is
+        # not normally produced by ``_stamp_drift_lifecycle`` (the helpers
+        # for those lifecycles remove the entry), but guard defensively
+        # so an out-of-tree mutation can't bypass the intent of the gate.
+        if lifecycle in (
+            _ostate.LIFECYCLE_RESOLVED,
+            _ostate.LIFECYCLE_HUMAN_INTERVENTION_REQUIRED,
+        ):
+            log.debug(
+                "refine gated by lifecycle (kind=%s task=%r): terminal lifecycle %s",
+                drift.kind.value,
+                drift.current_task_id,
+                lifecycle,
+            )
+            return True
+        return False
 
     def _is_task_progress_stalled(self, drift: DriftEvent, session: Session) -> bool:
         """Return ``True`` iff the drift's task has had no progress recently.

--- a/tests/test_drift_lifecycle.py
+++ b/tests/test_drift_lifecycle.py
@@ -528,3 +528,291 @@ async def test_emit_drift_detected_preserves_legacy_fields() -> None:
     # Per-event id (#199) is still populated and DISTINCT from condition_id.
     assert payload.id != ""
     assert payload.id != payload.condition_id
+
+
+# ---------------------------------------------------------------------------
+# I5 — per-condition refine gate (lifecycle-driven)
+# ---------------------------------------------------------------------------
+#
+# The drift-as-stateful-condition refactor (#271 PR1 / #318) gives every
+# emit a stable ``condition_id`` and a ``lifecycle``. Without a gate,
+# every re-emit of the same condition (``ESCALATING`` at the same
+# severity) re-fired ``planner.refine`` — empirically dominating the
+# LLM-call budget on long V24 runs. The gate skips refine when:
+#
+# * ``ESCALATING`` at the SAME severity as the prior emit (re-detection
+#   without change — refine would be a no-op replay).
+# * ``RESOLVED`` / ``HUMAN_INTERVENTION_REQUIRED`` (terminal lifecycle
+#   for the condition; refine has either already happened or has been
+#   lifted to the operator).
+#
+# ``OPENED`` and ``ESCALATING`` with a real severity bump still refine
+# (baseline behaviour and genuine escalation).
+
+
+class _RecordingPlanner:
+    """Planner stub that records every ``refine`` call for assertions.
+
+    Returns a structurally-modified plan so the steerer's
+    refine-returned-None cascade (``_emit_refine_failure`` ->
+    CRITICAL re-emit of the source drift) doesn't perturb the lifecycle
+    sequence the gate tests assert on.
+    """
+
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(self, **_: Any) -> Any:
+        return None
+
+    async def refine(self, *, plan: Any, drift: Any, goals: Any, **_: Any) -> Any:
+        self.refine_calls.append({"plan": plan, "drift": drift, "goals": goals})
+        # Return a copy of the plan with revision_index bumped — passes
+        # the post-refine validator and keeps the lifecycle counter
+        # cleanly at OPENED -> ESCALATING (no failure-cascade re-emit).
+        import dataclasses as _dc
+
+        revised = _dc.replace(
+            plan,
+            revision_index=plan.revision_index + 1,
+            revision_kind=drift.kind,
+            revision_severity=drift.severity,
+            revision_reason="test-refine",
+            revision_trigger_event_id=drift.id,
+        )
+        return revised
+
+
+def _drift_event() -> DriftEvent:
+    """Build a fresh WARNING-severity TOOL_ERROR drift on (t1, a1)."""
+    return DriftEvent(
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.WARNING,
+        detail="simulated tool error",
+        current_task_id="t1",
+        current_agent_id="a1",
+    )
+
+
+def _make_session_with_plan() -> Session:
+    from goldfive.types import Goal, Plan, Task
+
+    return Session(
+        run_id="run-001",
+        goals=[Goal(id="g1", summary="do the thing")],
+        plan=Plan(
+            id="p1",
+            run_id="run-001",
+            goal_ids=["g1"],
+            tasks=[Task(id="t1", title="T1"), Task(id="t2", title="T2")],
+            edges=[],
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_refine_gate_opened_lifecycle_fires_refine() -> None:
+    """First emit of a condition (OPENED) -> refine runs (baseline)."""
+    sink = _ListSink()
+    planner = _RecordingPlanner()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session_with_plan()
+
+    await steerer._handle_drift(_drift_event(), session)
+    assert len(planner.refine_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_refine_gate_escalating_same_severity_skips_refine() -> None:
+    """Re-emit at the same severity (ESCALATING, prev==cur) -> NO refine."""
+    sink = _ListSink()
+    planner = _RecordingPlanner()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session_with_plan()
+
+    # First emit: OPENED -> refine runs.
+    await steerer._handle_drift(_drift_event(), session)
+    assert len(planner.refine_calls) == 1
+    # Second emit at the SAME severity: ESCALATING with prev == cur.
+    # Gate skips refine.
+    await steerer._handle_drift(_drift_event(), session)
+    assert len(planner.refine_calls) == 1, (
+        "same-severity ESCALATING re-emit should NOT trigger another refine"
+    )
+    # But the wire emits still landed — observability is preserved.
+    # The first emit is OPENED, the second is ESCALATING (same severity).
+    # (Additional TOOL_ERROR emits may follow as the steerer's refine-
+    # failure cascade re-emits at CRITICAL — those are ESCALATING with
+    # a real bump, which is fine; we only assert on the OPENED+ESCALATING
+    # prefix the test exercises.)
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    tool_error_emits = [
+        e
+        for e in sink.events
+        if hasattr(e, "WhichOneof")
+        and e.WhichOneof("payload") == "drift_detected"
+        and e.drift_detected.kind == types_pb2.DRIFT_KIND_TOOL_ERROR
+    ]
+    assert len(tool_error_emits) >= 2
+    assert tool_error_emits[0].drift_detected.lifecycle == (types_pb2.DRIFT_LIFECYCLE_OPENED)
+    assert tool_error_emits[1].drift_detected.lifecycle == (types_pb2.DRIFT_LIFECYCLE_ESCALATING)
+    # Same-severity re-emit: severity stays WARNING and prev_severity
+    # is also WARNING — this is the exact pattern the gate suppresses.
+    assert tool_error_emits[1].drift_detected.severity == (types_pb2.DRIFT_SEVERITY_WARNING)
+    assert tool_error_emits[1].drift_detected.prev_severity == (types_pb2.DRIFT_SEVERITY_WARNING)
+
+
+@pytest.mark.asyncio
+async def test_refine_gate_escalating_severity_bump_fires_refine() -> None:
+    """Re-emit with prev_severity != severity (real escalation) -> refine fires."""
+    sink = _ListSink()
+    planner = _RecordingPlanner()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session_with_plan()
+
+    # First emit at WARNING.
+    await steerer._handle_drift(_drift_event(), session)
+    assert len(planner.refine_calls) == 1
+    # Bump to CRITICAL: this is a real escalation. The TOOL_ERROR ladder
+    # entry routes CRITICAL-first to CANCEL_REINVOKE which still calls
+    # refine, so the gate must NOT block it.
+    bumped = DriftEvent(
+        kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.CRITICAL,
+        detail="now critical",
+        current_task_id="t1",
+        current_agent_id="a1",
+    )
+    await steerer._handle_drift(bumped, session)
+    assert len(planner.refine_calls) == 2, (
+        "real severity escalation (WARNING -> CRITICAL) must still trigger refine"
+    )
+
+
+@pytest.mark.asyncio
+async def test_refine_gate_resolved_condition_skips_refine() -> None:
+    """A drift whose condition was previously RESOLVED -> NO refine.
+
+    ``resolve_drift`` removes the entry from the active set; the gate
+    treats a missing active entry as "condition closed" and skips
+    refine — protecting against an out-of-band resolution between
+    detection and dispatch.
+    """
+    sink = _ListSink()
+    planner = _RecordingPlanner()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session_with_plan()
+
+    # First emit opens the condition.
+    drift = _drift_event()
+    await steerer._handle_drift(drift, session)
+    assert len(planner.refine_calls) == 1
+    # Resolve the condition out-of-band (sink callback / external
+    # observer marks it cleared).
+    cid = _ostate.compute_condition_id(
+        kind=drift.kind,
+        task_id=drift.current_task_id,
+        agent_id=drift.current_agent_id,
+        turn_id=session.run_id,
+    )
+    resolved = _ostate.resolve_drift(session.state, cid)
+    assert resolved is not None
+    assert resolved.lifecycle == _ostate.LIFECYCLE_RESOLVED
+    # Now construct a NEW drift event that would re-fire on the same
+    # condition. ``_stamp_drift_lifecycle`` will re-open the condition
+    # (active set was empty), so this case naturally re-runs refine.
+    # The gate's RESOLVED-protection is exercised via the get-then-act
+    # race: stamp lifecycle, then resolve before _is_refine_gated_by_lifecycle
+    # reads. We simulate that by directly invoking the gate after a
+    # resolve.
+    next_drift = _drift_event()
+    # Manually stamp lifecycle (opens a fresh condition since the prior
+    # was resolved+removed) then immediately resolve before the gate
+    # check sees it -- this models the race the gate guards against.
+    from goldfive.pb.goldfive.v1 import types_pb2  # noqa: F401
+
+    # Run the gate WITHOUT going through _emit_drift_detected first:
+    # the active set is empty (we just resolved), so the gate should
+    # short-circuit at "tracked is None" -> True (skip).
+    assert steerer._is_refine_gated_by_lifecycle(next_drift, session) is True
+
+
+@pytest.mark.asyncio
+async def test_refine_gate_human_intervention_lifecycle_skips_refine() -> None:
+    """A condition escalated to HUMAN_INTERVENTION_REQUIRED -> NO refine."""
+    sink = _ListSink()
+    planner = _RecordingPlanner()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session_with_plan()
+
+    drift = _drift_event()
+    # Open the condition then escalate to human intervention.
+    cid = _ostate.compute_condition_id(
+        kind=drift.kind,
+        task_id=drift.current_task_id,
+        agent_id=drift.current_agent_id,
+        turn_id=session.run_id,
+    )
+    _ostate.open_or_escalate_drift(
+        session.state,
+        kind=drift.kind,
+        task_id=drift.current_task_id,
+        agent_id=drift.current_agent_id,
+        turn_id=session.run_id,
+        severity=drift.severity,
+    )
+    final = _ostate.escalate_drift_to_human_intervention(session.state, cid)
+    assert final is not None
+    assert final.lifecycle == _ostate.LIFECYCLE_HUMAN_INTERVENTION_REQUIRED
+    # The active entry is gone — the gate treats a missing active drift
+    # as "condition closed" and skips refine.
+    assert steerer._is_refine_gated_by_lifecycle(drift, session) is True
+
+
+@pytest.mark.asyncio
+async def test_refine_gate_user_steer_bypasses_lifecycle_gate() -> None:
+    """USER_STEER bypasses the gate — operator intent always honoured.
+
+    Mirrors the existing ``_is_plan_revision_gated`` exemption for
+    user / trajectory-level drifts. A re-emit of a USER_STEER condition
+    must still flow through the refine path.
+    """
+    sink = _ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=_RecordingPlanner())
+    session = _make_session_with_plan()
+
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="please pivot",
+        current_task_id="t1",
+        current_agent_id="a1",
+    )
+    # Pre-open the condition so a fresh _is_refine_gated_by_lifecycle
+    # would otherwise see an OPENED active entry, then pretend it was
+    # already escalating at the same severity.
+    _ostate.open_or_escalate_drift(
+        session.state,
+        kind=drift.kind,
+        task_id=drift.current_task_id,
+        agent_id=drift.current_agent_id,
+        turn_id=session.run_id,
+        severity=drift.severity,
+    )
+    _ostate.open_or_escalate_drift(
+        session.state,
+        kind=drift.kind,
+        task_id=drift.current_task_id,
+        agent_id=drift.current_agent_id,
+        turn_id=session.run_id,
+        severity=drift.severity,
+    )
+    # Even at ESCALATING-same-severity, USER_STEER must NOT be gated.
+    assert steerer._is_refine_gated_by_lifecycle(drift, session) is False

--- a/tests/test_plan_revision_cooldown.py
+++ b/tests/test_plan_revision_cooldown.py
@@ -119,12 +119,14 @@ def _drift(
     task_id: str = "t1",
     severity: DriftSeverity = DriftSeverity.WARNING,
     detail: str = "drift",
+    agent_id: str = "",
 ) -> DriftEvent:
     return DriftEvent(
         kind=kind,
         severity=severity,
         detail=detail,
         current_task_id=task_id,
+        current_agent_id=agent_id,
     )
 
 
@@ -171,15 +173,24 @@ async def test_two_off_topic_drifts_within_window_emit_one_plan_revised(
 async def test_two_off_topic_drifts_past_cooldown_emit_twice(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Two OFF_TOPIC drifts 35s apart -> both plan_revised emissions fire."""
+    """Two OFF_TOPIC drifts 35s apart -> both plan_revised emissions fire.
+
+    Distinct ``current_agent_id`` per emit so the I5 per-condition gate
+    (kind+task+agent within a turn) doesn't fold them onto the same
+    condition; the time-based cooldown under test is orthogonal.
+    """
     steerer, session, sink, planner = _build(cooldown=30.0)
 
     clock = [1000.0]
     monkeypatch.setattr("goldfive.steerer.time.monotonic", lambda: clock[0])
 
-    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+    await steerer._handle_drift(
+        _drift(DriftKind.OFF_TOPIC, agent_id="agent-a"), session
+    )
     clock[0] += 35.0
-    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+    await steerer._handle_drift(
+        _drift(DriftKind.OFF_TOPIC, agent_id="agent-b"), session
+    )
 
     assert _plan_revised_count(sink) == 2
     assert len(planner.refine_calls) == 2
@@ -300,16 +311,22 @@ async def test_goal_drift_does_not_consume_cooldown(
 async def test_cooldown_zero_disables_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     """``plan_revision_cooldown_seconds=0.0`` disables the cooldown entirely.
 
-    Two back-to-back identical drifts both replan.
+    Two back-to-back drifts both replan when both the time-based cooldown
+    and the I5 per-condition gate are bypassed (distinct
+    ``current_agent_id`` mints fresh conditions for the latter).
     """
     steerer, session, sink, planner = _build(cooldown=0.0)
 
     clock = [1000.0]
     monkeypatch.setattr("goldfive.steerer.time.monotonic", lambda: clock[0])
 
-    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
-    # Same tick; with cooldown==0 the gate no-ops.
-    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+    await steerer._handle_drift(
+        _drift(DriftKind.OFF_TOPIC, agent_id="agent-a"), session
+    )
+    # Same tick; with cooldown==0 and a fresh agent_id, both gates no-op.
+    await steerer._handle_drift(
+        _drift(DriftKind.OFF_TOPIC, agent_id="agent-b"), session
+    )
 
     assert _plan_revised_count(sink) == 2
     assert len(planner.refine_calls) == 2

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -610,13 +610,28 @@ async def test_observe_surfaces_refine_none_return() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _tool_error_drift(task_id: str = "t1") -> DriftEvent:
-    """Build a canned WARNING-severity drift routed through _handle_drift."""
+def _tool_error_drift(
+    task_id: str = "t1",
+    *,
+    severity: DriftSeverity = DriftSeverity.WARNING,
+    agent_id: str = "",
+) -> DriftEvent:
+    """Build a canned WARNING-severity drift routed through _handle_drift.
+
+    ``severity`` and ``agent_id`` are parameterised so callers exercising
+    the per-condition refine gate (goldfive I5) can mint a DISTINCT
+    drift condition on a re-emit. The gate keys on
+    ``(kind, task, agent, turn)`` — without varying one of these, the
+    second emit collapses onto the same condition_id and is treated as
+    a no-op replay (skipped). The failure-counter, by contrast, keys
+    only on ``(kind, task)`` so the assertions below still trip.
+    """
     return DriftEvent(
         kind=DriftKind.TOOL_ERROR,
-        severity=DriftSeverity.WARNING,
+        severity=severity,
         detail="simulated tool error",
         current_task_id=task_id,
+        current_agent_id=agent_id,
     )
 
 
@@ -633,11 +648,15 @@ async def test_refine_failure_counter_increments_on_exception() -> None:
     # Same drift is classified by detect_drift — use a dict the tool-error
     # classifier picks up and that carries a task via current_task_id.
     # Simpler: drive _handle_drift directly so the drift identity is stable.
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer._handle_drift(_tool_error_drift(agent_id="agent-a"), session)
     assert session.refine_failure_counts[key] == 1
     assert len(planner.refine_calls) == 1
 
-    await steerer._handle_drift(_tool_error_drift(), session)
+    # Second observation must mint a DISTINCT drift condition so the
+    # I5 per-condition refine gate (which keys on kind+task+agent+turn)
+    # doesn't suppress it. Vary ``current_agent_id``: same counter key
+    # (counter only keys on kind+task) but a fresh lifecycle bucket.
+    await steerer._handle_drift(_tool_error_drift(agent_id="agent-b"), session)
     # Second failure hits the threshold: _register_refine_failure calls
     # mark_task_failed, which fires a TASK_FAILED_FATAL drift that routes
     # through _handle_drift and triggers one more refine attempt (keyed
@@ -659,11 +678,14 @@ async def test_refine_failure_counter_increments_on_none_return() -> None:
     key = (DriftKind.TOOL_ERROR.value, "t1")
     assert session.refine_failure_counts.get(key, 0) == 0
 
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer._handle_drift(_tool_error_drift(agent_id="agent-a"), session)
     assert session.refine_failure_counts[key] == 1
     assert len(planner.refine_calls) == 1
 
-    await steerer._handle_drift(_tool_error_drift(), session)
+    # Distinct ``current_agent_id`` mints a fresh drift condition (I5
+    # gate exemption) while preserving the (kind, task) failure-counter
+    # key.
+    await steerer._handle_drift(_tool_error_drift(agent_id="agent-b"), session)
     # Same cascade as the exception case: the TOOL_ERROR counter is
     # clamped at the threshold (2), the cascaded TASK_FAILED_FATAL drift
     # kicks off its own independent counter at 1.
@@ -680,12 +702,13 @@ async def test_two_consecutive_refine_failures_marks_task_failed() -> None:
     session = _make_session()
 
     # First failure: visibility-only, task stays PENDING.
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer._handle_drift(_tool_error_drift(agent_id="agent-a"), session)
     assert _task(session, "t1").status is TaskStatus.PENDING
 
     # Second failure: backoff trips — task marked FAILED, REPEATED_FAILURE
-    # drift emitted.
-    await steerer._handle_drift(_tool_error_drift(), session)
+    # drift emitted. Distinct ``current_agent_id`` so the I5 lifecycle
+    # gate doesn't fold this onto the prior condition.
+    await steerer._handle_drift(_tool_error_drift(agent_id="agent-b"), session)
     assert _task(session, "t1").status is TaskStatus.FAILED
 
     from goldfive.pb.goldfive.v1 import types_pb2
@@ -736,7 +759,7 @@ async def test_successful_refine_resets_failure_counter() -> None:
 
     key = (DriftKind.TOOL_ERROR.value, "t1")
 
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer._handle_drift(_tool_error_drift(agent_id="agent-a"), session)
     assert session.refine_failure_counts[key] == 1
 
     # Flip planner to success mode BEFORE the counter hits the threshold
@@ -744,7 +767,10 @@ async def test_successful_refine_resets_failure_counter() -> None:
     planner.raise_exc = None
     planner.revised = revised
 
-    await steerer._handle_drift(_tool_error_drift(), session)
+    # Distinct ``current_agent_id`` mints a fresh drift condition (I5
+    # gate exemption) so the success path runs and clears the failure
+    # counter.
+    await steerer._handle_drift(_tool_error_drift(agent_id="agent-b"), session)
     # Successful refine clears the key entirely (pop) — the counter is
     # reset, not decremented, so a fresh run of failures starts at 0.
     assert key not in session.refine_failure_counts

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -306,18 +306,18 @@ async def test_observe_dedupe_does_not_affect_heuristic_drifts() -> None:
     content-based classifiers (tool errors, refusals, loops) must
     remain free-running so repeated heuristic signals still escalate.
 
-    This test deliberately fires two identical back-to-back tool-error
-    drifts, which would otherwise be suppressed by the plan-revision
-    cooldown (goldfive feedback-loop fix). The cooldown is an
-    orthogonal rate limit covered by
-    ``tests/test_plan_revision_cooldown.py``; here we disable it so
-    the dedup-set assertion can stand on its own.
+    This test deliberately fires two heuristic tool-error drifts on
+    DIFFERENT current_task_ids so each opens a fresh drift condition
+    (goldfive I5 — same kind+task within a turn now collapses onto one
+    refine; cross-task dispatches still refine independently). The
+    plan-revision cooldown is also hot-patched off so a co-located
+    cluster doesn't shadow the dedupe-set assertion.
     """
     steerer, session, _sink, planner = _bind_fresh()
     # Hot-patch the cooldown off for this test only. ``_bind_fresh``
     # builds a default-configured steerer; we need the cooldown window
-    # at 0 so the two identical tool-error observations below both
-    # trigger refine.
+    # at 0 so the two tool-error observations below both reach the
+    # refine path.
     steerer._plan_revision_cooldown_seconds = 0.0
 
     # A steer populates processed_steer_ids.
@@ -327,11 +327,13 @@ async def test_observe_dedupe_does_not_affect_heuristic_drifts() -> None:
         payload={"note": "go", "annotation_id": "ann_s"},
     )
     await steerer.observe(msg, session)
-    # A tool-error event — classified as TOOL_ERROR, must still emit.
-    await steerer.observe({"error": "boom"}, session)
-    await steerer.observe({"error": "boom"}, session)
+    # Two tool-error events on DIFFERENT pinned tasks — each is its own
+    # drift condition (per-condition gate is keyed on kind+task+agent
+    # within a turn) and therefore gets its own refine.
+    await steerer.observe({"error": "boom", "task_id": "t1"}, session)
+    await steerer.observe({"error": "boom", "task_id": "t2"}, session)
 
-    # planner.refine: 1 steer + 2 tool_error observations.
+    # planner.refine: 1 steer + 2 tool_error observations across distinct tasks.
     assert len(planner.refine_calls) == 3
 
 


### PR DESCRIPTION
## Summary

Per-condition refine gate keyed on `DriftLifecycle` (#318 plumbing).
After `_emit_drift_detected` stamps the lifecycle, `_handle_drift` and
`_promote_drift_to_steer` skip `planner.refine` / `planner.refine_steer`
when the underlying condition is being re-detected without change.

## Evidence (iter_1 escalation report, S5)

V24 ran **113 LLM calls vs 18 theoretical** = 6.28x ratio. The cascade
was dominated by repeated refines on the same condition: 7
`refine_steer` calls (2 per turn average) and 52 judge calls fired on
recurring goldfive-detected drifts. The escalation report
([§I5](file:///tmp/goldfive-loop/ESCALATION_REPORT.md)) called out the
single-line gate that lands here as the right structural fix.

## Lifecycle gate (new helper `_is_refine_gated_by_lifecycle`)

* `OPENED` -> refine runs (baseline; first encounter of this condition).
* `ESCALATING` with `prev_severity != severity` -> refine runs (real
  escalation, e.g. INFO -> WARNING).
* `ESCALATING` with `prev_severity == severity` -> **gate** (same
  condition re-detected without change; prior refine still applies).
* No active entry (`RESOLVED` / `HUMAN_INTERVENTION_REQUIRED` removed
  it) -> **gate** (terminal lifecycle).
* `USER_STEER` / `USER_CANCEL` / `GOAL_DRIFT` -> bypass (operator
  intent always honoured; mirrors `_is_plan_revision_gated` exemption).

Wired into both refine paths:

* `DefaultSteerer._handle_drift` (Level 1 ABSORB / CANCEL_REINVOKE)
* `DefaultSteerer._promote_drift_to_steer` (goldfive-steer-unification)

The gate reads from `session.state` only -- no mutation, no new state
keys. Idempotent: same drift checked twice returns the same answer.

## Anti-pattern check

`anti_pattern_lint.py` verdict: **PASS** (no
detection-without-response, no numerical cap, no validator relaxation).
The gate is structural state-machine logic on existing lifecycle
plumbing -- not a magic number, not a heuristic.

## Part 2 (judge cooldown) -- DEFERRED

The brief proposed a 30s on_task reasoning-judge cooldown as a
secondary win. Deferred for these reasons:

1. The escalation report itself flagged judge over-firing as **harder**
   than the refine gate.
2. `DefaultSteerer` already has `reasoning_drift_rate_limit` (default
   3) gating judge fires per (agent, task) bucket. Layering a
   wall-clock cooldown on top requires care to not double-count.
3. Part 1's test-update fan-out (5 files, 4 pre-existing tests rewired
   onto distinct conditions) was already non-trivial; per the brief's
   guidance ("DEFER if Part 2 is significantly larger than expected"),
   stopping here keeps the change reviewable.

A follow-up PR can layer the on_task cooldown on top of the existing
counter-based rate limit if the V25+ replay still shows judge cost
dominating.

## Test plan

Five new tests in `tests/test_drift_lifecycle.py`:

- [x] `test_refine_gate_opened_lifecycle_fires_refine` -- OPENED still refines (baseline).
- [x] `test_refine_gate_escalating_same_severity_skips_refine` -- the I5 case.
- [x] `test_refine_gate_escalating_severity_bump_fires_refine` -- WARNING -> CRITICAL still refines.
- [x] `test_refine_gate_resolved_condition_skips_refine` -- terminal lifecycle blocks refine.
- [x] `test_refine_gate_human_intervention_lifecycle_skips_refine` -- escalation lifecycle blocks refine.
- [x] `test_refine_gate_user_steer_bypasses_lifecycle_gate` -- USER_STEER honoured.

Existing tests rewired onto distinct conditions so the orthogonal
counter / cooldown semantics still trip:

- [x] `test_refine_failure_counter_increments_on_exception`
- [x] `test_refine_failure_counter_increments_on_none_return`
- [x] `test_two_consecutive_refine_failures_marks_task_failed`
- [x] `test_successful_refine_resets_failure_counter`
- [x] `test_observe_dedupe_does_not_affect_heuristic_drifts`
- [x] `test_two_off_topic_drifts_past_cooldown_emit_twice`
- [x] `test_cooldown_zero_disables_gate`

Full suite: **1668 passed, 120 skipped**. Ruff: clean (no new format
or lint regressions on the touched files).