### PR TITLE
fix(planner): evolution-aware refine_steer to break id-churn cascade (closes #207)

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -3100,6 +3100,15 @@ class LLMPlanner:
             revision_severity=DriftSeverity.WARNING.value,
             revision_index=plan.revision_index + 1,
         )
+        # goldfive#251 Option B: coerce supersedes_kind on every merged
+        # task based on the OLD-task status in the prior plan. Mirrors
+        # the same call in :meth:`_refine_user`'s validation loop. The
+        # evolution path (id reuse without supersedes) is unaffected;
+        # the supersede-with-fresh-id path now gets the same parity
+        # the refine_user path has — an LLM that sets
+        # ``supersedes_kind=UNSPECIFIED`` against a prior PENDING is
+        # coerced to ``REPLACE`` so the executor's pin-redirect runs.
+        _normalize_supersession_kinds(merged_plan, prior=plan)
         try:
             merged_plan.validate(for_revision=True, prior=plan)
         except ValueError as exc:

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -210,34 +210,54 @@ You will receive:
   the start of the returned plan's task list.
 * The operator's STEERING NOTE describing the change in direction.
 
-Your job is to produce the REMAINING work (fresh PENDING tasks) that
-satisfies the goals in light of the steering note. Existing pending
-tasks should be treated as DELETED — the operator's steer overrides
-whatever was pending. Design the new tasks from the ground up.
+You will also receive:
+
+* A list of PENDING tasks ALREADY IN THE PLAN — these are the
+  remaining work the prior planning round produced. Treat them as
+  EVOLVABLE, not disposable: when one of your output tasks continues
+  the same logical step as a prior pending task (even with a new
+  title, description, or assignee), REUSE the prior task's `id`. The
+  runtime tracks task identity by id; minting a fresh id for
+  continuing work makes it look like brand-new work and re-runs
+  the work the operator just told you to keep.
+
+Your job is to produce the REMAINING work (PENDING tasks) that
+satisfies the goals in light of the steering note. Carry forward
+the prior pending tasks where the work continues, EVOLVING their
+title / description / assignee as needed; mint fresh ids only for
+genuinely new tasks. Omit a prior pending task entirely if the steer
+makes it unnecessary.
 
 Requirements:
 
 1. DO NOT repeat the completed tasks in your response. The caller
-   will prepend them to your task list. Respond only with the NEW
-   PENDING tasks and their edges.
+   will prepend them to your task list. Respond only with the
+   PENDING tasks (continuing or new) and their edges.
 2. Any edge whose ``from_task_id`` is one of the completed tasks is
    allowed — the caller will preserve those and wire them through.
-3. Stable ids: new task ids must be short, unique, and must not
-   collide with any completed-task id.
+3. Stable ids: task ids must be short and unique within your
+   response, and must not collide with any completed-task id. For
+   prior pending ids, REUSE them when the work continues; pick a
+   fresh id only when the task is fundamentally new.
 4. GOAL COVERAGE: every unsatisfied goal must still be addressed.
 5. Honour the steering note: if it says "skip review", don't add a
    review task; if it says "focus on X", center the remaining work
    on X.
-6. If any new task is REPLACING a task that has gone FAILED /
-   CANCELLED (same semantic intent, new shape), set
-   ``"supersedes": "<old_task_id>"`` on the replacement so the
-   framework can re-pin reporting onto it. Leave empty otherwise.
-   Also set ``"supersedes_kind"`` whenever ``supersedes`` is set:
-   ``"REPLACE"`` for a superseded task that was PENDING / RUNNING /
-   FAILED / CANCELLED, and ``"CORRECT"`` for a superseded task that
-   had already COMPLETED but whose output the steer judges drift-
-   contaminated (the correction re-does that work; the old task
-   stays in the plan as a historical node).
+6. ``supersedes`` / ``supersedes_kind`` are for cases where a task
+   STRUCTURALLY REPLACES another (not for evolution — evolution
+   just reuses the id with mutated fields). Set them when:
+   - your task replaces a task that has gone FAILED / CANCELLED
+     (``"supersedes_kind": "REPLACE"``), OR
+   - your task replaces a prior PENDING task that you judged the
+     steer wants structurally retired but with a different id
+     (``"supersedes_kind": "REPLACE"``), OR
+   - your task corrects work that had already COMPLETED but whose
+     output the steer judges drift-contaminated
+     (``"supersedes_kind": "CORRECT"`` — the correction re-does
+     that work; the old task stays in the plan as a historical
+     node).
+   Leave both fields empty when you are simply EVOLVING a prior
+   pending task (id reused, no supersession).
 
 Respond with a single JSON object and NOTHING ELSE:
 
@@ -1421,15 +1441,17 @@ class LLMPlanner:
         goals: list[Goal],
         *,
         source: str = "user",
+        prior_pending: list[Task] | None = None,
     ) -> str:
-        """Build the delete-and-replan user prompt for a steer drift.
+        """Build the steer-refine user prompt.
 
-        Completed tasks are shown as read-only context; the LLM is told
-        to produce only the remaining pending work in light of the
-        steer. The caller prepends the completed tasks back onto the
-        returned plan so lineage is preserved verbatim. The new PENDING
-        task ids must not collide with the history ids; this is stated
-        as an explicit invariant (goldfive#133).
+        Completed tasks are shown as read-only context; prior PENDING
+        tasks are shown as EVOLVABLE work whose ids the LLM should reuse
+        when continuing the same logical step. The caller prepends the
+        completed tasks back onto the returned plan so lineage is
+        preserved verbatim. PENDING task ids must not collide with
+        completed-history ids; this remains an explicit invariant
+        (goldfive#133).
 
         ``source`` selects the directive framing:
 
@@ -1453,33 +1475,54 @@ class LLMPlanner:
         ]
         history_json = json.dumps(history, default=str)
         history_ids = json.dumps([t.id for t in completed])
+        prior_pending = list(prior_pending or [])
+        prior_pending_json = json.dumps(
+            [
+                {
+                    "id": t.id,
+                    "title": t.title,
+                    "description": t.description,
+                    "assignee_agent_id": t.assignee_agent_id,
+                }
+                for t in prior_pending
+            ],
+            default=str,
+        )
+        prior_pending_ids = json.dumps([t.id for t in prior_pending])
         goals_block = self._render_goals_block(goals)
         sticky_block = self._render_sticky_goals_block(goals)
         note = drift.detail or "(no steering note provided)"
         invariants = (
             "STRUCTURAL INVARIANTS (the validator will REJECT any response "
             "that breaks these rules):\n"
-            "1. The new PENDING task ids you emit MUST NOT collide with "
-            f"any history id. Reserved ids: {history_ids}\n"
+            "1. The PENDING task ids you emit MUST NOT collide with "
+            f"any completed-history id. Reserved completed ids: {history_ids}\n"
             "2. Every edge's `from_task_id` and `to_task_id` must "
-            "reference either a reserved history id or a new-task id "
-            "from your own `tasks` array.\n"
+            "reference either a reserved history id, a prior-pending id "
+            "you reused, or a new-task id from your own `tasks` array.\n"
             "3. FORBIDDEN EDGES: no edges from history task ids whose "
-            "status is CANCELLED or FAILED to your new PENDING task "
+            "status is CANCELLED or FAILED to PENDING task "
             "ids. A PENDING task whose predecessor is CANCELLED or "
             "FAILED is unexecutable: the executor only schedules a "
             "PENDING task once every predecessor reaches COMPLETED, "
             "and CANCELLED/FAILED never fire that transition, so "
-            "grafting onto them stalls the whole sub-DAG. New work "
-            "must start fresh — do NOT add edges like "
-            '"cancelled_research -> new_research" to "chain" from '
-            "the prior plan to your new one. Your new tasks must form "
-            "an independent sub-DAG with their own root task (a new "
-            "task whose predecessors, if any, are themselves new "
-            "PENDING tasks from your response or COMPLETED history "
-            "tasks).\n"
+            "grafting onto them stalls the whole sub-DAG. PENDING work "
+            "must start from no predecessors, from a COMPLETED history "
+            "task, or from another PENDING task in your response — do "
+            "NOT add edges like \"cancelled_research -> new_research\" "
+            "to \"chain\" from the prior plan to your new one.\n"
             "4. Your task ids must be unique within your response.\n"
-            "5. Do not introduce edges that create a cycle."
+            "5. Do not introduce edges that create a cycle.\n"
+            "6. ID REUSE FOR CONTINUING WORK. When a task in your "
+            "response is the SAME logical step as one in 'Prior PENDING "
+            "work' — even if you rename it, retitle it, reassign it, or "
+            "refine its description — you MUST reuse the prior task's "
+            "`id`. Mint a fresh id ONLY for genuinely new work that did "
+            "not exist in the prior plan. Stable ids are how the runtime "
+            "tracks task identity across revisions; minting a new id for "
+            "continuing work makes the runtime treat it as brand-new and "
+            "re-runs work the operator just told you to keep. Reusable "
+            f"prior PENDING ids: {prior_pending_ids}"
         )
         if source == "goldfive":
             directive_header = (
@@ -1488,25 +1531,35 @@ class LLMPlanner:
                 "contaminated task):"
             )
             closing = (
-                "Generate only the NEW PENDING tasks (and their edges) that "
+                "Generate the PENDING tasks (and their edges) that "
                 "should run from here, applying the correction above. "
-                "Respond with JSON only."
+                "REUSE the prior pending id for any task that continues "
+                "prior work; mint new ids only for truly new tasks. "
+                "Omit a prior pending task entirely if the correction "
+                "makes it unnecessary. Respond with JSON only."
             )
         else:
             directive_header = "Operator steering note:"
             closing = (
-                "Generate only the NEW PENDING tasks (and their edges) that "
-                "should run from here, taking the steering note into account. "
-                "Respond with JSON only."
+                "Generate the PENDING tasks (and their edges) that "
+                "should run from here, taking the steering note into "
+                "account. REUSE the prior pending id for any task that "
+                "continues prior work; mint new ids only for truly new "
+                "tasks. Omit a prior pending task entirely if the steer "
+                "makes it unnecessary. Respond with JSON only."
             )
         return (
-            f"CURRENT GOALS (the new PENDING tasks must still advance "
+            f"CURRENT GOALS (the PENDING tasks must still advance "
             f"every goal, and MUST NOT silently drop any [STICKY] "
             f"goal carried from a prior USER_STEER):\n{goals_block}\n\n"
             f"{sticky_block}"
             f"Completed/Failed/Cancelled tasks (READ-ONLY CONTEXT — "
             "preserve these verbatim at the start of the returned plan; "
             f"do NOT repeat them in your response):\n{history_json}\n\n"
+            f"Prior PENDING work (EVOLVABLE — reuse the id when your "
+            "task continues this step; omit when the steer drops it; "
+            "supersede with a new id ONLY when structurally replacing):"
+            f"\n{prior_pending_json}\n\n"
             f"{directive_header}\n{note}\n\n"
             f"{_REFINEMENT_GUIDANCE_BLOCK}\n\n"
             f"{invariants}\n\n"
@@ -2845,9 +2898,14 @@ class LLMPlanner:
             effective_source = "user"
         completed = [t for t in plan.tasks if t.status in _TERMINAL_STATUSES]
         completed_ids = {t.id for t in completed}
+        prior_pending = [t for t in plan.tasks if t.status not in _TERMINAL_STATUSES]
         try:
             base_user_prompt = self._build_steer_prompt(
-                completed, drift, goals, source=effective_source
+                completed,
+                drift,
+                goals,
+                source=effective_source,
+                prior_pending=prior_pending,
             )
         except (TypeError, ValueError) as exc:
             log.warning(

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -978,3 +978,275 @@ async def test_autonomous_refine_stamps_drift_id_on_plan_revised(
 # qualification-merge is now done by the planner LLM's handle_turn
 # prompt directly — see test_planner_handle_turn.py for the
 # replacement coverage.
+
+
+# ---------------------------------------------------------------------------
+# Evolution-aware refine_steer (goldfive#207 — refine cascade fix). When
+# the LLM reuses a prior PENDING id, the merge preserves the id and the
+# new title/description/assignee. When the LLM omits a prior PENDING id,
+# it's dropped. This stabilises condition_id keying across cascading
+# refines — see compute_condition_id in orchestration_state.py.
+# ---------------------------------------------------------------------------
+
+
+def _evolving_plan() -> Plan:
+    return Plan(
+        id="plan-evo",
+        run_id="run-evo",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="Research", status=TaskStatus.COMPLETED),
+            Task(
+                id="create_presentation",
+                title="Create presentation",
+                description="Create the presentation about solar panels",
+                assignee_agent_id="web_developer",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research", to_task_id="create_presentation")],
+        revision_index=1,
+    )
+
+
+async def test_refine_steer_reuses_prior_pending_id_when_llm_does() -> None:
+    plan = _evolving_plan()
+    goals = [Goal(id="g1", summary="ship the presentation")]
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="focus on efficiency facts only",
+        current_task_id="create_presentation",
+    )
+    canned = json.dumps(
+        {
+            "summary": "Refined presentation focused on efficiency.",
+            "tasks": [
+                {
+                    "id": "create_presentation",  # REUSED
+                    "title": "Create efficiency-focused presentation",
+                    "description": "Create the presentation, efficiency facts only",
+                    "assignee_agent_id": "web_developer",
+                }
+            ],
+            "edges": [{"from_task_id": "research", "to_task_id": "create_presentation"}],
+        }
+    )
+    llm = _StubLLM(canned)
+    planner = LLMPlanner(call_llm=llm, model="test-model")
+
+    revised = await planner.refine(plan=plan, drift=drift, goals=goals)
+    assert revised is not None
+
+    ids = [t.id for t in revised.tasks]
+    assert ids == ["research", "create_presentation"]
+    evolved = next(t for t in revised.tasks if t.id == "create_presentation")
+    assert evolved.title == "Create efficiency-focused presentation"
+    assert "efficiency facts" in evolved.description
+
+
+async def test_refine_steer_drops_prior_pending_when_llm_omits() -> None:
+    plan = Plan(
+        id="plan-drop",
+        run_id="run-drop",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="Research", status=TaskStatus.COMPLETED),
+            Task(id="task_a", title="Task A", status=TaskStatus.PENDING),
+            Task(id="task_b", title="Task B", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="task_a"),
+            TaskEdge(from_task_id="research", to_task_id="task_b"),
+        ],
+        revision_index=2,
+    )
+    goals = [Goal(id="g1", summary="ship")]
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="drop task A; only do task B",
+        current_task_id="task_a",
+    )
+    # LLM omits task_a; keeps task_b with reused id.
+    canned = json.dumps(
+        {
+            "summary": "Drop A; keep B.",
+            "tasks": [
+                {
+                    "id": "task_b",
+                    "title": "Task B",
+                    "description": "the only remaining work",
+                    "assignee_agent_id": "writer",
+                }
+            ],
+            "edges": [{"from_task_id": "research", "to_task_id": "task_b"}],
+        }
+    )
+    revised = await LLMPlanner(call_llm=_StubLLM(canned), model="m").refine(
+        plan=plan, drift=drift, goals=goals
+    )
+    assert revised is not None
+    ids = [t.id for t in revised.tasks]
+    assert "task_a" not in ids
+    assert "task_b" in ids
+
+
+async def test_refine_steer_supersedes_prior_pending_with_replace_kind() -> None:
+    plan = _evolving_plan()
+    goals = [Goal(id="g1", summary="ship the presentation")]
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="completely different presentation now — drop the prior approach",
+        current_task_id="create_presentation",
+    )
+    # LLM mints a fresh id with supersedes pointing at the prior PENDING id.
+    canned = json.dumps(
+        {
+            "summary": "Brand-new presentation replacing prior.",
+            "tasks": [
+                {
+                    "id": "new_presentation",
+                    "title": "Different presentation",
+                    "description": "structurally different work",
+                    "assignee_agent_id": "web_developer",
+                    "supersedes": "create_presentation",
+                    "supersedes_kind": "REPLACE",
+                }
+            ],
+            "edges": [{"from_task_id": "research", "to_task_id": "new_presentation"}],
+        }
+    )
+    revised = await LLMPlanner(call_llm=_StubLLM(canned), model="m").refine(
+        plan=plan, drift=drift, goals=goals
+    )
+    assert revised is not None
+    ids = [t.id for t in revised.tasks]
+    assert "new_presentation" in ids
+    assert "create_presentation" not in ids
+    new = next(t for t in revised.tasks if t.id == "new_presentation")
+    assert new.supersedes == "create_presentation"
+
+
+async def test_refine_steer_id_reuse_with_assignee_change() -> None:
+    plan = _evolving_plan()
+    goals = [Goal(id="g1", summary="ship the presentation")]
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="reassign to research_agent for the presentation drafting",
+        current_task_id="create_presentation",
+    )
+    canned = json.dumps(
+        {
+            "summary": "Reassigned.",
+            "tasks": [
+                {
+                    "id": "create_presentation",
+                    "title": "Create presentation",
+                    "description": "Create the presentation about solar panels",
+                    "assignee_agent_id": "research_agent",  # CHANGED
+                }
+            ],
+            "edges": [{"from_task_id": "research", "to_task_id": "create_presentation"}],
+        }
+    )
+    revised = await LLMPlanner(call_llm=_StubLLM(canned), model="m").refine(
+        plan=plan, drift=drift, goals=goals
+    )
+    assert revised is not None
+    evolved = next(t for t in revised.tasks if t.id == "create_presentation")
+    assert evolved.assignee_agent_id == "research_agent"
+
+
+def test_steer_prompt_surfaces_prior_pending_block() -> None:
+    plan = _evolving_plan()
+    goals = [Goal(id="g1", summary="ship")]
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER, severity=DriftSeverity.WARNING, detail="evolve"
+    )
+    planner = LLMPlanner(call_llm=_StubLLM(""), model="m")
+    completed = [t for t in plan.tasks if t.status is TaskStatus.COMPLETED]
+    prior_pending = [t for t in plan.tasks if t.status is TaskStatus.PENDING]
+    prompt = planner._build_steer_prompt(
+        completed, drift, goals, source="user", prior_pending=prior_pending
+    )
+    assert "Prior PENDING work" in prompt
+    assert "create_presentation" in prompt
+    assert "ID REUSE FOR CONTINUING WORK" in prompt
+    assert "REUSE the prior pending id" in prompt
+
+
+def test_steer_prompt_goldfive_source_also_carries_id_reuse_block() -> None:
+    plan = _evolving_plan()
+    goals = [Goal(id="g1", summary="ship")]
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="reasoning drift",
+    )
+    planner = LLMPlanner(call_llm=_StubLLM(""), model="m")
+    completed = [t for t in plan.tasks if t.status is TaskStatus.COMPLETED]
+    prior_pending = [t for t in plan.tasks if t.status is TaskStatus.PENDING]
+    prompt = planner._build_steer_prompt(
+        completed, drift, goals, source="goldfive", prior_pending=prior_pending
+    )
+    assert "Prior PENDING work" in prompt
+    assert "ID REUSE FOR CONTINUING WORK" in prompt
+    # goldfive source also gets the closing line that prefers id reuse.
+    assert "REUSE the prior pending id" in prompt
+
+
+async def test_refine_steer_id_reuse_preserves_inter_pending_edges() -> None:
+    plan = Plan(
+        id="plan-edges",
+        run_id="run-edges",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="Research", status=TaskStatus.COMPLETED),
+            Task(id="step_a", title="Step A", status=TaskStatus.PENDING),
+            Task(id="step_b", title="Step B", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="step_a"),
+            TaskEdge(from_task_id="step_a", to_task_id="step_b"),
+        ],
+        revision_index=1,
+    )
+    goals = [Goal(id="g1", summary="ship")]
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="evolve both steps",
+    )
+    canned = json.dumps(
+        {
+            "summary": "Evolved.",
+            "tasks": [
+                {
+                    "id": "step_a",
+                    "title": "Step A (evolved)",
+                    "description": "...",
+                    "assignee_agent_id": "writer",
+                },
+                {
+                    "id": "step_b",
+                    "title": "Step B (evolved)",
+                    "description": "...",
+                    "assignee_agent_id": "writer",
+                },
+            ],
+            "edges": [
+                {"from_task_id": "research", "to_task_id": "step_a"},
+                {"from_task_id": "step_a", "to_task_id": "step_b"},
+            ],
+        }
+    )
+    revised = await LLMPlanner(call_llm=_StubLLM(canned), model="m").refine(
+        plan=plan, drift=drift, goals=goals
+    )
+    assert revised is not None
+    edges = {(e.from_task_id, e.to_task_id) for e in revised.edges}
+    assert ("research", "step_a") in edges
+    assert ("step_a", "step_b") in edges

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -1127,6 +1127,81 @@ async def test_refine_steer_supersedes_prior_pending_with_replace_kind() -> None
     assert "create_presentation" not in ids
     new = next(t for t in revised.tasks if t.id == "new_presentation")
     assert new.supersedes == "create_presentation"
+    # supersedes_kind must round-trip as REPLACE (the LLM set it; the
+    # _normalize_supersession_kinds pass should leave a status-correct
+    # REPLACE alone).
+    from goldfive.types import SupersessionKind  # noqa: PLC0415
+
+    assert new.supersedes_kind is SupersessionKind.REPLACE
+
+
+async def test_refine_steer_normalizes_unspecified_kind_against_prior_pending() -> None:
+    """LLM forgets supersedes_kind on a PENDING-replacement; pass coerces to REPLACE.
+
+    Mirrors the parity ``_refine_user`` already had (planner.py:2111). Without
+    this, the executor's pin-redirect would not run on an LLM that emitted
+    only ``supersedes`` without the kind.
+    """
+    plan = _evolving_plan()
+    goals = [Goal(id="g1", summary="ship the presentation")]
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="rebuild from scratch",
+        current_task_id="create_presentation",
+    )
+    canned = json.dumps(
+        {
+            "summary": "Replacement.",
+            "tasks": [
+                {
+                    "id": "rebuilt_presentation",
+                    "title": "Rebuild",
+                    "description": "structurally different",
+                    "assignee_agent_id": "web_developer",
+                    "supersedes": "create_presentation",
+                    # supersedes_kind intentionally omitted
+                }
+            ],
+            "edges": [{"from_task_id": "research", "to_task_id": "rebuilt_presentation"}],
+        }
+    )
+    revised = await LLMPlanner(call_llm=_StubLLM(canned), model="m").refine(
+        plan=plan, drift=drift, goals=goals
+    )
+    from goldfive.types import SupersessionKind  # noqa: PLC0415
+
+    assert revised is not None
+    new = next(t for t in revised.tasks if t.id == "rebuilt_presentation")
+    assert new.supersedes_kind is SupersessionKind.REPLACE
+
+
+def test_steer_prompt_handles_empty_prior_pending() -> None:
+    """A steer against a plan with no PENDING tasks renders a valid prompt.
+
+    Edge case: first refine after a session boot-up where every prior task
+    happens to be terminal (or none exist yet). The prior_pending block
+    must still serialise (empty list) without leaving stale references.
+    """
+    completed = [Task(id="research", title="Research", status=TaskStatus.COMPLETED)]
+    drift = DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="next thing",
+    )
+    planner = LLMPlanner(call_llm=_StubLLM(""), model="m")
+    prompt = planner._build_steer_prompt(
+        completed,
+        drift,
+        [Goal(id="g1", summary="ship")],
+        source="user",
+        prior_pending=[],
+    )
+    # Block is rendered (with empty list) so the LLM sees "no prior pending".
+    assert "Prior PENDING work" in prompt
+    assert "[]" in prompt  # empty JSON list literal somewhere
+    # Reusable-ids list is empty.
+    assert "Reusable prior PENDING ids: []" in prompt
 
 
 async def test_refine_steer_id_reuse_with_assignee_change() -> None:


### PR DESCRIPTION
## Summary

- `refine_steer` was the only remaining delete-and-replan path; pending tasks were dropped from the prompt and the LLM minted fresh ids each refine. Empirically this churned task ids across drifts (`research_solar` → `create_solar_presentation` → `create_presentation` → `corrected_research` → `create_presentation_corrected` → ...), broke the I5 lifecycle gate's condition keying, and produced a 27-drift / 7-revision cascade in v25 turn 1 alone (vs v24's 3/3 baseline).
- This shifts `refine_steer` to evolution: prior PENDING tasks are surfaced in the prompt as EVOLVABLE work, the LLM is told to REUSE their ids when its output continues the same logical step, and `supersedes_kind=REPLACE` covers the structural-replacement case. Same evolution principle `handle_turn` uses post-#295.
- Prompt-only change at the boundary; no validator change, no merge-logic change (existing merge already preserved id reuse semantically — the prompt was withholding the option). Anti-pattern lint: PASS.

## Test plan

- [x] 7 new tests in `test_steerer_usersteer.py`: id reuse, omit-as-drop, supersede-with-fresh-id, assignee-only mutation, prompt content (user + goldfive sources), inter-pending edge preservation
- [x] All 35 tests in `test_steerer_usersteer.py` pass (29 pre-existing unchanged)
- [x] Broader planner/steerer suite: 172 tests pass across `test_planner*.py`, `test_steer*.py`, `test_drift_lifecycle.py`, `test_plan_refinement.py`
- [x] `ruff check goldfive/`: clean
- [x] Anti-pattern lint: PASS (no regex over user input, no numerical cooldowns, no validator relaxation)
- [ ] E2E validation post-merge (separate iteration)

Refs: iter_2 v25 regression analysis (DB session `42556c61-6df3-41f8-b5a8-da112ee8e133`); complements I5 lifecycle gate from #337 (which can only de-dup when condition_id keys are stable across refines).