### PR TITLE
fix(executor): overlay reaper uses reachability, not blanket NOT_NEEDED (closes #208)

### DIFF
--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -1106,23 +1106,34 @@ class SequentialExecutor(Executor):
                 continue
             break
 
-        # --- PENDING → NOT_NEEDED on invocation end (goldfive#163). ----
-        # The tree finished its natural flow. Any task still PENDING
-        # was not exercised by the tree. Mark terminal so sinks do not
-        # see stale PENDING entries and downstream runs do not wedge.
-        # We deliberately do NOT dispatch a follow-up: flow-prompted
-        # coordinators re-run their full pipeline on every new user
-        # message, which amplifies a ~10 min run into 40+ min. STEER
-        # is the user-driven path for exercising uncovered work.
+        # --- End-of-overlay PENDING disposition (goldfive#163, revised
+        #     by goldfive#208). The tree finished its natural flow; we
+        #     now have to decide what to do with PENDING tasks the tree
+        #     didn't exercise. The legacy policy (#163) was a blanket
+        #     NOT_NEEDED reap, which silently destroyed user intent
+        #     across turn boundaries: a user-pivoted plan whose first
+        #     stage completes but whose downstream stages haven't been
+        #     dispatched yet would have those downstream stages reaped
+        #     before the next turn could pick them up.
         #
-        # Tier 1 / F10 (loop prevention): gate the reap on
-        # ``session.paused_for_human_intervention``. When the steerer
-        # has just emitted ``HUMAN_INTERVENTION_REQUIRED`` (Level 4
-        # PAUSE_ESCALATE), the agents stay PENDING for the next user
-        # turn — sweeping them to NOT_NEEDED here silently lies about
-        # user intent (the user hasn't decided yet whether the work is
-        # still wanted). Skip the sweep so the pending tasks survive
-        # the pause; they're picked up again when control returns.
+        #     The revised policy is structural reachability:
+        #
+        #     * REACHABLE PENDING (every predecessor either COMPLETED
+        #       or itself a still-running PENDING/RUNNING task that can
+        #       reach COMPLETED) — leave PENDING. The Conversation
+        #       carry-forward (`stash_plan` / `prior_plan_for`) will
+        #       seed the next turn with this task still live.
+        #     * UNREACHABLE PENDING (at least one predecessor reached
+        #       a terminal-non-COMPLETED status — CANCELLED / FAILED /
+        #       NOT_NEEDED — with no live replacement in the lineage)
+        #       — CANCEL with the same `run_aborted:orphaned by plan
+        #       revision failure` reason the legacy executor's
+        #       reachability audit uses (`_run` body around L732).
+        #
+        #     Tier 1 / F10 still applies: when paused for human
+        #     intervention, leave EVERY PENDING alone — the operator
+        #     hasn't decided yet whether unreachable work should be
+        #     dropped, so we should not pre-empt that decision.
         live_plan = session.plan or plan
         pending_ids = [
             t.id
@@ -1130,19 +1141,31 @@ class SequentialExecutor(Executor):
             if t.status is TaskStatus.PENDING and t.id
         ]
         if pending_ids and not getattr(session, "paused_for_human_intervention", False):
-            log.info(
-                "SequentialExecutor._run_overlay: marking %d PENDING task(s) "
-                "NOT_NEEDED at invocation end (no soft follow-up per #163): %s",
-                len(pending_ids),
-                ", ".join(pending_ids),
-            )
-            for tid in pending_ids:
-                await steerer.transition(
-                    tid,
-                    TaskStatus.NOT_NEEDED,
-                    detail="overlay: tree did not exercise; no follow-up dispatched (goldfive#163)",
-                    session=session,
+            unreachable = _unreachable_pending_task_ids(live_plan)
+            reachable = [tid for tid in pending_ids if tid not in unreachable]
+            if reachable:
+                log.info(
+                    "SequentialExecutor._run_overlay: leaving %d reachable "
+                    "PENDING task(s) live for next turn: %s",
+                    len(reachable),
+                    ", ".join(reachable),
                 )
+            if unreachable:
+                log.info(
+                    "SequentialExecutor._run_overlay: cancelling %d unreachable "
+                    "PENDING task(s) (predecessor terminal-non-COMPLETED with "
+                    "no live replacement): %s",
+                    len(unreachable),
+                    ", ".join(unreachable),
+                )
+                for tid in unreachable:
+                    await steerer.transition(
+                        tid,
+                        TaskStatus.CANCELLED,
+                        detail="orphaned by plan revision failure",
+                        cancel_reason="run_aborted:orphaned by plan revision failure",
+                        session=session,
+                    )
         elif pending_ids:
             # F10: surface the gated reap so operators see "reap
             # suppressed: escalation pending" in logs rather than a
@@ -1150,8 +1173,9 @@ class SequentialExecutor(Executor):
             # on the next user turn after the human-intervention pause
             # resolves.
             log.info(
-                "SequentialExecutor._run_overlay: NOT_NEEDED reap suppressed "
-                "(paused_for_human_intervention); leaving %d PENDING task(s): %s",
+                "SequentialExecutor._run_overlay: PENDING disposition "
+                "suppressed (paused_for_human_intervention); leaving "
+                "%d PENDING task(s): %s",
                 len(pending_ids),
                 ", ".join(pending_ids),
             )
@@ -1890,6 +1914,75 @@ def _pending_task_ids(plan: Plan) -> list[str]:
     sinks see a coherent plan-end state instead of "stuck PENDING forever."
     """
     return [t.id for t in plan.tasks if t.status == TaskStatus.PENDING and t.id]
+
+
+_TERMINAL_NON_COMPLETED_STATUSES: frozenset[TaskStatus] = frozenset(
+    {TaskStatus.CANCELLED, TaskStatus.FAILED, TaskStatus.NOT_NEEDED}
+)
+
+
+def _unreachable_pending_task_ids(plan: Plan) -> set[str]:
+    """Return the ids of PENDING tasks whose predecessor chain is broken.
+
+    A PENDING task is unreachable iff the transitive predecessor closure
+    contains at least one task in a terminal-non-COMPLETED status
+    (CANCELLED / FAILED / NOT_NEEDED) that has no live replacement in
+    the plan. Reachability propagates: if A → B → C and A is CANCELLED,
+    both B and C are unreachable. A predecessor that is itself PENDING
+    or RUNNING does NOT taint downstream — those can still progress to
+    COMPLETED (this turn or a future one).
+
+    Used by the overlay end-of-invocation policy (goldfive#208): the
+    legacy policy unconditionally NOT_NEEDED-reaped every PENDING at
+    overlay exit, which destroyed cross-turn user intent. The new
+    policy is "leave reachable PENDING alone, cancel only the
+    structurally unreachable PENDING."
+    """
+    tasks_by_id = {t.id: t for t in plan.tasks if t.id}
+    deps_by_task: dict[str, list[str]] = {}
+    for e in plan.edges:
+        deps_by_task.setdefault(e.to_task_id, []).append(e.from_task_id)
+
+    # Seed: every task whose own status is terminal-non-COMPLETED with
+    # no live replacement is "broken." A FAILED task with a live
+    # replacement (goldfive#202) is NOT broken — its successor carries
+    # the work forward.
+    broken: set[str] = set()
+    for tid, t in tasks_by_id.items():
+        if t.status not in _TERMINAL_NON_COMPLETED_STATUSES:
+            continue
+        if t.status == TaskStatus.FAILED and _has_live_replacement(plan, t):
+            continue
+        broken.add(tid)
+
+    # Forward-propagate: any task whose predecessor is broken is itself
+    # unreachable. Iterate to fixed point (plan size is small, O(N*E)
+    # is fine).
+    changed = True
+    while changed:
+        changed = False
+        for tid, t in tasks_by_id.items():
+            if tid in broken:
+                continue
+            if t.status != TaskStatus.PENDING:
+                # Only PENDING tasks can be marked unreachable here —
+                # COMPLETED / RUNNING / terminal statuses already have
+                # their own correct disposition.
+                continue
+            for dep_id in deps_by_task.get(tid, []):
+                if dep_id in broken:
+                    broken.add(tid)
+                    changed = True
+                    break
+
+    # Return only the PENDING-and-unreachable subset: callers want the
+    # ids to cancel, not the seed broken set.
+    return {
+        tid
+        for tid in broken
+        if tasks_by_id.get(tid) is not None
+        and tasks_by_id[tid].status == TaskStatus.PENDING
+    }
 
 
 async def _emit_pipeline_failure_drift(

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -1924,13 +1924,24 @@ _TERMINAL_NON_COMPLETED_STATUSES: frozenset[TaskStatus] = frozenset(
 def _unreachable_pending_task_ids(plan: Plan) -> set[str]:
     """Return the ids of PENDING tasks whose predecessor chain is broken.
 
-    A PENDING task is unreachable iff the transitive predecessor closure
-    contains at least one task in a terminal-non-COMPLETED status
-    (CANCELLED / FAILED / NOT_NEEDED) that has no live replacement in
-    the plan. Reachability propagates: if A → B → C and A is CANCELLED,
-    both B and C are unreachable. A predecessor that is itself PENDING
-    or RUNNING does NOT taint downstream — those can still progress to
-    COMPLETED (this turn or a future one).
+    A PENDING task is unreachable iff at least one transitive predecessor
+    is in a terminal-non-COMPLETED status (CANCELLED / FAILED / NOT_NEEDED)
+    with no live replacement in the plan. Reachability propagates:
+    A → B → C with A=CANCELLED makes both B and C unreachable. A
+    predecessor that is itself PENDING or RUNNING does NOT taint
+    downstream — those can still progress to COMPLETED (this turn or
+    a future one).
+
+    AND-join semantics: when a task has multiple predecessors, ANY
+    broken predecessor is fatal. This matches ``_pick_next_task``'s
+    scheduling rule (every predecessor must be COMPLETED to schedule
+    the task), so a join with one CANCELLED predecessor can never be
+    scheduled — orphan-cancelling it is consistent with the rest of
+    the executor.
+
+    A FAILED task with a live ``retry_<id>`` / ``<id>_v2`` lineage
+    replacement (goldfive#202) is NOT broken — the replacement carries
+    the work forward, so downstream PENDING remains reachable.
 
     Used by the overlay end-of-invocation policy (goldfive#208): the
     legacy policy unconditionally NOT_NEEDED-reaped every PENDING at
@@ -1944,45 +1955,35 @@ def _unreachable_pending_task_ids(plan: Plan) -> set[str]:
         deps_by_task.setdefault(e.to_task_id, []).append(e.from_task_id)
 
     # Seed: every task whose own status is terminal-non-COMPLETED with
-    # no live replacement is "broken." A FAILED task with a live
-    # replacement (goldfive#202) is NOT broken — its successor carries
-    # the work forward.
-    broken: set[str] = set()
+    # no live replacement is "broken" — a structural dead-end that
+    # downstream PENDING work can never get past.
+    seed_broken: set[str] = set()
     for tid, t in tasks_by_id.items():
         if t.status not in _TERMINAL_NON_COMPLETED_STATUSES:
             continue
         if t.status == TaskStatus.FAILED and _has_live_replacement(plan, t):
             continue
-        broken.add(tid)
+        seed_broken.add(tid)
 
-    # Forward-propagate: any task whose predecessor is broken is itself
-    # unreachable. Iterate to fixed point (plan size is small, O(N*E)
-    # is fine).
+    # Forward-propagate to PENDING tasks only (other statuses already
+    # have their own correct disposition). Iterate to fixed point —
+    # plan size is small, O(N*E) is fine.
+    unreachable_pending: set[str] = set()
     changed = True
     while changed:
         changed = False
         for tid, t in tasks_by_id.items():
-            if tid in broken:
+            if tid in unreachable_pending or tid in seed_broken:
                 continue
             if t.status != TaskStatus.PENDING:
-                # Only PENDING tasks can be marked unreachable here —
-                # COMPLETED / RUNNING / terminal statuses already have
-                # their own correct disposition.
                 continue
             for dep_id in deps_by_task.get(tid, []):
-                if dep_id in broken:
-                    broken.add(tid)
+                if dep_id in seed_broken or dep_id in unreachable_pending:
+                    unreachable_pending.add(tid)
                     changed = True
                     break
 
-    # Return only the PENDING-and-unreachable subset: callers want the
-    # ids to cancel, not the seed broken set.
-    return {
-        tid
-        for tid in broken
-        if tasks_by_id.get(tid) is not None
-        and tasks_by_id[tid].status == TaskStatus.PENDING
-    }
+    return unreachable_pending
 
 
 async def _emit_pipeline_failure_drift(

--- a/tests/examples/test_presentation_agent_adk_web.py
+++ b/tests/examples/test_presentation_agent_adk_web.py
@@ -367,9 +367,11 @@ def test_presentation_agent_e2e_under_adk_web(
         # Inspect the run-end PENDING set on the latest plan_revised
         # snapshot. Every non-terminal planned task must be PENDING
         # AND reachable (no broken predecessors).
+        from goldfive.pb.goldfive.v1 import types_pb2  # noqa: PLC0415
+
         latest_plan = plan_events[-1].plan_revised.plan
         plan_tasks_by_id = {t.id: t for t in latest_plan.tasks}
-        plan_edges_to = {}
+        plan_edges_to: dict[str, list[str]] = {}
         for e in latest_plan.edges:
             plan_edges_to.setdefault(e.to_task_id, []).append(e.from_task_id)
         broken_statuses = {
@@ -380,9 +382,9 @@ def test_presentation_agent_e2e_under_adk_web(
         for tid in non_terminal_planned:
             t = plan_tasks_by_id.get(tid)
             assert t is not None, f"planned task {tid} missing from latest plan"
-            status_name = (
-                t.status.name if hasattr(t.status, "name") else str(t.status)
-            )
+            # ``t.status`` is a proto enum int; resolve to name via
+            # ``TaskStatus.Name`` so the assertion message is readable.
+            status_name = types_pb2.TaskStatus.Name(t.status)
             assert "PENDING" in status_name, (
                 f"non-terminal planned task {tid} has unexpected status {status_name}"
             )
@@ -390,9 +392,7 @@ def test_presentation_agent_e2e_under_adk_web(
                 dep = plan_tasks_by_id.get(dep_id)
                 if dep is None:
                     continue
-                dep_status_name = (
-                    dep.status.name if hasattr(dep.status, "name") else str(dep.status)
-                )
+                dep_status_name = types_pb2.TaskStatus.Name(dep.status)
                 assert dep_status_name not in broken_statuses, (
                     f"non-terminal planned task {tid} has broken predecessor "
                     f"{dep_id} (status={dep_status_name}); should have been "

--- a/tests/examples/test_presentation_agent_adk_web.py
+++ b/tests/examples/test_presentation_agent_adk_web.py
@@ -15,11 +15,14 @@ loads ``examples/presentation_agent`` in mock mode, POSTs a prompt via
 ``/run_sse``, and asserts:
 
 * a single ``plan_submitted`` with the expected four-task plan,
-* every planned task reaches a terminal state
-  (``task_completed`` / ``task_failed`` / ``task_cancelled`` — the
-  last covers both real cancellations and NOT_NEEDED tasks, which
-  emit ``task_cancelled`` with a ``not_needed:`` reason prefix per
-  ``Steerer.mark_task_not_needed``),
+* every planned task is either terminal (``task_completed`` /
+  ``task_failed`` / ``task_cancelled`` — the last covers real
+  cancellations AND NOT_NEEDED tasks, which emit ``task_cancelled``
+  with a ``not_needed:`` reason prefix per
+  ``Steerer.mark_task_not_needed``) OR still PENDING with all
+  predecessors reachable (post-#208: PENDING tasks can survive a
+  turn end and carry forward to the next turn rather than being
+  blanket-NOT_NEEDED-reaped),
 * at least one task progressed to a non-NOT_NEEDED terminal state
   (proving dispatch actually worked — the specific pathology we're
   guarding against was "plan submitted, but no task ever completes"),
@@ -303,17 +306,19 @@ def test_presentation_agent_e2e_under_adk_web(
         "debug": "debugger_agent",
     }, f"unexpected plan shape: {planned_tasks}"
 
-    # 2. Every planned task must reach a terminal state. Goldfive's
-    # terminal task events are task_completed / task_failed /
-    # task_cancelled. NOT_NEEDED tasks (goldfive#141) emit
-    # task_cancelled with a ``not_needed:`` reason prefix (no
+    # 2. Every planned task must reach a terminal state OR be a
+    # reachable PENDING that survived turn-end (post-#208).
+    # Goldfive's terminal task events are task_completed /
+    # task_failed / task_cancelled. NOT_NEEDED tasks (goldfive#141)
+    # emit task_cancelled with a ``not_needed:`` reason prefix (no
     # dedicated proto event) — see ``Steerer.mark_task_not_needed``.
     #
-    # Under the goldfive#163 overlay model, tasks the tree did not
-    # naturally exercise are transitioned PENDING → NOT_NEEDED
-    # directly (without going through RUNNING first), so we do NOT
-    # require a task_started event for every planned task — only
-    # that every planned task reaches SOME terminal state.
+    # Pre-#208, the overlay reaper unconditionally NOT_NEEDED-reaped
+    # every PENDING at end-of-turn, so every planned task became
+    # terminal even when the tree didn't exercise it. Post-#208,
+    # reachable PENDING tasks (predecessors COMPLETED or themselves
+    # PENDING/RUNNING) carry forward to the next turn instead of
+    # being reaped — this is the multi-turn carry-forward contract.
     started_ids = {
         e.task_started.task_id for e, k in zip(events, kinds, strict=True) if k == "task_started"
     }
@@ -340,17 +345,59 @@ def test_presentation_agent_e2e_under_adk_web(
 
     # task_started events only fire for tasks the reconciler
     # matched to an observed sub-agent invocation. Unmatched tasks
-    # land in NOT_NEEDED without a RUNNING announcement (#163). The
+    # may stay PENDING (reachable carry-forward) post-#208. The
     # only invariant is: any id with a task_started must also be in
     # terminal_ids (no dangling RUNNING).
     assert started_ids <= terminal_ids, (
         f"some task_started events had no matching terminal event. "
         f"started={started_ids} terminal={terminal_ids}"
     )
-    assert set(planned_tasks) <= terminal_ids, (
-        f"some planned tasks never reached terminal state. "
-        f"planned={set(planned_tasks)} terminal={terminal_ids}"
-    )
+    # Post-#208 invariant: every planned task is terminal OR still
+    # PENDING with reachable predecessors. The legacy "every planned
+    # task reaches terminal" was an artifact of the blanket-reap
+    # policy. The harness's mock LLM doesn't exercise the tree, so
+    # under the new policy all four tasks legitimately remain
+    # PENDING (research is a root task with no predecessors —
+    # reachable; build/review/debug have research as predecessor
+    # which is still PENDING — also reachable). The multi-turn
+    # contract is honoured: these tasks would carry forward to the
+    # next turn for the user (or operator) to drive.
+    non_terminal_planned = set(planned_tasks) - terminal_ids
+    if non_terminal_planned:
+        # Inspect the run-end PENDING set on the latest plan_revised
+        # snapshot. Every non-terminal planned task must be PENDING
+        # AND reachable (no broken predecessors).
+        latest_plan = plan_events[-1].plan_revised.plan
+        plan_tasks_by_id = {t.id: t for t in latest_plan.tasks}
+        plan_edges_to = {}
+        for e in latest_plan.edges:
+            plan_edges_to.setdefault(e.to_task_id, []).append(e.from_task_id)
+        broken_statuses = {
+            "TASK_STATUS_CANCELLED",
+            "TASK_STATUS_FAILED",
+            "TASK_STATUS_NOT_NEEDED",
+        }
+        for tid in non_terminal_planned:
+            t = plan_tasks_by_id.get(tid)
+            assert t is not None, f"planned task {tid} missing from latest plan"
+            status_name = (
+                t.status.name if hasattr(t.status, "name") else str(t.status)
+            )
+            assert "PENDING" in status_name, (
+                f"non-terminal planned task {tid} has unexpected status {status_name}"
+            )
+            for dep_id in plan_edges_to.get(tid, []):
+                dep = plan_tasks_by_id.get(dep_id)
+                if dep is None:
+                    continue
+                dep_status_name = (
+                    dep.status.name if hasattr(dep.status, "name") else str(dep.status)
+                )
+                assert dep_status_name not in broken_statuses, (
+                    f"non-terminal planned task {tid} has broken predecessor "
+                    f"{dep_id} (status={dep_status_name}); should have been "
+                    f"orphan-cancelled"
+                )
 
     # 3. Per-task progression check — informational under mock mode.
     # The original test required "at least one task_completed" to

--- a/tests/test_sequential_executor_overlay.py
+++ b/tests/test_sequential_executor_overlay.py
@@ -238,10 +238,14 @@ async def test_overlay_mode_single_passthrough_no_missed_tasks() -> None:
 
 async def test_overlay_does_not_dispatch_follow_ups() -> None:
     """goldfive#163: even when the reconciler reports missed PENDING
-    tasks, the overlay MUST NOT dispatch ``invoke_follow_up``. The
-    missed tasks end up ``NOT_NEEDED`` instead.
+    tasks, the overlay MUST NOT dispatch ``invoke_follow_up``.
 
-    Regression guard: this is the core contract #163 added.
+    goldfive#208 (revised contract): missed tasks no longer become
+    NOT_NEEDED at end-of-invocation. They remain PENDING and are
+    carried forward to the next turn (Conversation.stash_plan /
+    prior_plan_for) where the next user message can drive them. Only
+    structurally UNREACHABLE PENDING tasks (predecessors broken) are
+    cancelled at overlay end.
     """
     plan = _three_task_plan()
     session = Session(run_id="r1")
@@ -277,26 +281,31 @@ async def test_overlay_does_not_dispatch_follow_ups() -> None:
     assert adapter.follow_up_calls == [], (
         f"overlay must not dispatch follow-ups (goldfive#163); got {adapter.follow_up_calls!r}"
     )
-    # t0 completed via the reconciler; t1 and t2 are NOT_NEEDED (not
-    # PENDING, not COMPLETED-via-follow-up, not FAILED).
+    # t0 completed via the reconciler. t1 and t2 stay PENDING — t1's
+    # predecessor t0 just COMPLETED so t1 is reachable next turn; t2's
+    # predecessor t1 is still PENDING (not broken). The overlay leaves
+    # both alone for the next turn to drive.
     by_id = {t.id: t.status for t in plan.tasks}
     assert by_id["t0"] is TaskStatus.COMPLETED
-    assert by_id["t1"] is TaskStatus.NOT_NEEDED, (
-        f"missed task t1 should be NOT_NEEDED, got {by_id['t1']}"
+    assert by_id["t1"] is TaskStatus.PENDING, (
+        f"reachable t1 should remain PENDING for next turn, got {by_id['t1']}"
     )
-    assert by_id["t2"] is TaskStatus.NOT_NEEDED, (
-        f"missed task t2 should be NOT_NEEDED, got {by_id['t2']}"
+    assert by_id["t2"] is TaskStatus.PENDING, (
+        f"reachable t2 should remain PENDING for next turn, got {by_id['t2']}"
     )
+    # No NOT_NEEDED transitions, no CANCELLED transitions — all
+    # PENDING tasks are reachable.
+    assert [tid for tid, to in steerer.transitions if to is TaskStatus.NOT_NEEDED] == []
+    assert [tid for tid, to in steerer.transitions if to is TaskStatus.CANCELLED] == []
 
 
-async def test_overlay_pending_to_not_needed_on_invocation_end() -> None:
-    """Explicit transition test: every PENDING task at the end of
-    ``invoke_passthrough`` is transitioned via
-    ``steerer.transition(..., TaskStatus.NOT_NEEDED, ...)``.
+async def test_overlay_pending_stays_pending_when_predecessors_pending() -> None:
+    """When the tree does nothing and all tasks remain PENDING with
+    no broken predecessor chain, the overlay leaves every task PENDING.
 
-    Verifies the exact transition API call (not just the terminal
-    status), so future refactors can't silently mutate task.status
-    without going through the steerer.
+    goldfive#208 contract: end-of-overlay alone is NOT a sufficient
+    reason to mark NOT_NEEDED. The next turn (or a USER_STEER) can
+    drive these tasks forward.
     """
     plan = _three_task_plan()
     session = Session(run_id="r1")
@@ -324,16 +333,104 @@ async def test_overlay_pending_to_not_needed_on_invocation_end() -> None:
     )
 
     assert outcome.success is True
-    # Exactly three NOT_NEEDED transitions (one per PENDING task).
-    not_needed_transitions = [tid for tid, to in steerer.transitions if to is TaskStatus.NOT_NEEDED]
-    assert set(not_needed_transitions) == {"t0", "t1", "t2"}, (
-        f"expected NOT_NEEDED transitions for t0/t1/t2, got {not_needed_transitions!r}"
-    )
-    # All tasks terminal.
+    # Zero NOT_NEEDED transitions and zero CANCELLED transitions.
+    assert [tid for tid, to in steerer.transitions if to is TaskStatus.NOT_NEEDED] == []
+    assert [tid for tid, to in steerer.transitions if to is TaskStatus.CANCELLED] == []
+    # All tasks remain PENDING for the next turn.
     for t in plan.tasks:
-        assert t.status is TaskStatus.NOT_NEEDED
+        assert t.status is TaskStatus.PENDING
     # And of course: no follow-up dispatch.
     assert adapter.follow_up_calls == []
+
+
+async def test_overlay_cancels_unreachable_pending_when_predecessor_failed() -> None:
+    """goldfive#208: a PENDING task whose predecessor went CANCELLED
+    (with no live replacement) is structurally unreachable. End-of-
+    overlay should CANCEL it (not NOT_NEEDED) so sinks see a coherent
+    plan-end and the next turn doesn't try to drive a dead task.
+    """
+    plan = Plan(
+        id="p_unreach",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="t0", title="root", assignee_agent_id="agent_a", status=TaskStatus.CANCELLED),
+            Task(id="t1", title="downstream", assignee_agent_id="agent_b"),
+        ],
+        edges=[TaskEdge(from_task_id="t0", to_task_id="t1")],
+    )
+    session = Session(run_id="r1")
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    async def _passthrough(
+        user_message: str,  # noqa: ARG001
+        session: Session,  # noqa: ARG001
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        return InvocationResult(task_id="", text="")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    executor = SequentialExecutor(overlay_mode=True)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="anything",
+    )
+
+    assert outcome.success is True
+    cancelled = [tid for tid, to in steerer.transitions if to is TaskStatus.CANCELLED]
+    assert "t1" in cancelled, (
+        f"unreachable t1 should be CANCELLED, got transitions={steerer.transitions!r}"
+    )
+    # NOT_NEEDED is not the right disposition for unreachable.
+    assert [tid for tid, to in steerer.transitions if to is TaskStatus.NOT_NEEDED] == []
+
+
+async def test_overlay_does_not_emit_legacy_not_needed_reason() -> None:
+    """Regression guard: the legacy reason string ``tree did not
+    exercise; no follow-up dispatched`` must NOT appear post-#208.
+    """
+    plan = _three_task_plan()
+    session = Session(run_id="r1")
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    async def _passthrough(
+        user_message: str,  # noqa: ARG001
+        session: Session,  # noqa: ARG001
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        return InvocationResult(task_id="", text="")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    executor = SequentialExecutor(overlay_mode=True)
+    await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="anything",
+    )
+
+    # No detail field on any recorded transition should mention the
+    # retired phrase.
+    for tid, to, *_rest in (
+        (t.id, t.to, getattr(t, "detail", "")) if hasattr(t, "to") else (None, None, "")
+        for t in []
+    ):
+        # placeholder — StubSteerer's transitions records (id, to_status)
+        del tid, to
+    # The transitions list itself should not contain a NOT_NEEDED with
+    # the legacy reason — the simpler assertion is that no NOT_NEEDED
+    # transition was emitted at all in this scenario.
+    assert [tid for tid, to in steerer.transitions if to is TaskStatus.NOT_NEEDED] == []
 
 
 async def test_overlay_no_pending_tasks_no_not_needed_transitions() -> None:

--- a/tests/test_sequential_executor_overlay.py
+++ b/tests/test_sequential_executor_overlay.py
@@ -68,6 +68,9 @@ class StubSteerer:
         self._planner: Any = None
         self.observed: list[Any] = []
         self.transitions: list[tuple[str, TaskStatus]] = []
+        # Full call record including detail/cancel_reason so tests can
+        # assert on the structured reason strings the executor emits.
+        self.transition_details: list[tuple[str, TaskStatus, str, str]] = []
 
     def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
         self._sinks = sinks
@@ -84,11 +87,12 @@ class StubSteerer:
         task_id: str,
         to: TaskStatus,
         *,
-        detail: str = "",  # noqa: ARG002
+        detail: str = "",
         session: Session,
-        cancel_reason: str = "",  # noqa: ARG002
+        cancel_reason: str = "",
     ) -> None:
         self.transitions.append((task_id, to))
+        self.transition_details.append((task_id, to, detail, cancel_reason))
         if session.plan is None:
             return
         for t in session.plan.tasks:
@@ -394,8 +398,29 @@ async def test_overlay_cancels_unreachable_pending_when_predecessor_failed() -> 
 async def test_overlay_does_not_emit_legacy_not_needed_reason() -> None:
     """Regression guard: the legacy reason string ``tree did not
     exercise; no follow-up dispatched`` must NOT appear post-#208.
+
+    Sets up a plan where end-of-overlay would, under #163, have
+    transitioned every PENDING to NOT_NEEDED with that exact reason.
+    Asserts the literal string is not present in any recorded
+    transition's detail or cancel_reason.
     """
-    plan = _three_task_plan()
+    plan = Plan(
+        id="p_legacy_guard",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            # Mix of reachable + unreachable so we exercise both branches.
+            Task(id="reachable_1", title="A", assignee_agent_id="agent_a"),
+            Task(
+                id="broken_root",
+                title="B",
+                assignee_agent_id="agent_b",
+                status=TaskStatus.CANCELLED,
+            ),
+            Task(id="unreachable_1", title="C", assignee_agent_id="agent_c"),
+        ],
+        edges=[TaskEdge(from_task_id="broken_root", to_task_id="unreachable_1")],
+    )
     session = Session(run_id="r1")
     steerer = StubSteerer()
     sink = RecordingSink()
@@ -419,18 +444,252 @@ async def test_overlay_does_not_emit_legacy_not_needed_reason() -> None:
         user_input="anything",
     )
 
-    # No detail field on any recorded transition should mention the
-    # retired phrase.
-    for tid, to, *_rest in (
-        (t.id, t.to, getattr(t, "detail", "")) if hasattr(t, "to") else (None, None, "")
-        for t in []
-    ):
-        # placeholder — StubSteerer's transitions records (id, to_status)
-        del tid, to
-    # The transitions list itself should not contain a NOT_NEEDED with
-    # the legacy reason — the simpler assertion is that no NOT_NEEDED
-    # transition was emitted at all in this scenario.
+    # No transition's detail or cancel_reason should mention the
+    # retired phrase, and NOT_NEEDED should not be produced by the
+    # overlay-end path at all.
+    legacy_phrase = "tree did not exercise"
+    for tid, to, detail, cancel_reason in steerer.transition_details:
+        assert legacy_phrase not in detail, (
+            f"task {tid} transition to {to} carries retired reason "
+            f"{detail!r} (PR #208 retired this)"
+        )
+        assert legacy_phrase not in cancel_reason, (
+            f"task {tid} transition to {to} carries retired cancel_reason "
+            f"{cancel_reason!r}"
+        )
     assert [tid for tid, to in steerer.transitions if to is TaskStatus.NOT_NEEDED] == []
+
+
+async def test_overlay_unreachable_propagates_through_chain() -> None:
+    """Multi-step propagation: A=CANCELLED -> B -> C -> D should mark
+    B, C, AND D unreachable. The fixed-point iteration must reach D.
+    """
+    plan = Plan(
+        id="p_chain",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="a", title="A", assignee_agent_id="agent_a", status=TaskStatus.CANCELLED),
+            Task(id="b", title="B", assignee_agent_id="agent_b"),
+            Task(id="c", title="C", assignee_agent_id="agent_c"),
+            Task(id="d", title="D", assignee_agent_id="agent_d"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="a", to_task_id="b"),
+            TaskEdge(from_task_id="b", to_task_id="c"),
+            TaskEdge(from_task_id="c", to_task_id="d"),
+        ],
+    )
+    session = Session(run_id="r1")
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    async def _passthrough(
+        user_message: str,  # noqa: ARG001
+        session: Session,  # noqa: ARG001
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        return InvocationResult(task_id="", text="")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    await SequentialExecutor(overlay_mode=True).run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="anything",
+    )
+
+    cancelled = {tid for tid, to in steerer.transitions if to is TaskStatus.CANCELLED}
+    assert cancelled == {"b", "c", "d"}, (
+        f"all three downstream tasks should be CANCELLED via propagation, got {cancelled!r}"
+    )
+
+
+async def test_overlay_diamond_partial_break_marks_join_unreachable() -> None:
+    """AND-join semantics (matching ``_pick_next_task``): when a join
+    task has multiple predecessors and at least one is broken with no
+    live replacement, the join is unreachable. The executor's
+    scheduler requires ALL predecessors COMPLETED to schedule a task,
+    so a join with one CANCELLED predecessor can never be scheduled.
+    """
+    plan = Plan(
+        id="p_diamond",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="a", title="A", assignee_agent_id="agent_a", status=TaskStatus.COMPLETED),
+            Task(id="b", title="B", assignee_agent_id="agent_b", status=TaskStatus.CANCELLED),
+            Task(id="c", title="C", assignee_agent_id="agent_c"),
+            Task(id="d", title="D", assignee_agent_id="agent_d"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="a", to_task_id="b"),
+            TaskEdge(from_task_id="a", to_task_id="c"),
+            TaskEdge(from_task_id="b", to_task_id="d"),
+            TaskEdge(from_task_id="c", to_task_id="d"),
+        ],
+    )
+    session = Session(run_id="r1")
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    async def _passthrough(
+        user_message: str,  # noqa: ARG001
+        session: Session,  # noqa: ARG001
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        return InvocationResult(task_id="", text="")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    await SequentialExecutor(overlay_mode=True).run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="anything",
+    )
+
+    cancelled = {tid for tid, to in steerer.transitions if to is TaskStatus.CANCELLED}
+    # D depends on b (CANCELLED) AND c — AND-join, b's broken status
+    # makes D unreachable. C remains reachable (its only predecessor a
+    # is COMPLETED).
+    assert "d" in cancelled, f"diamond join D should be CANCELLED, got {cancelled!r}"
+    assert "c" not in cancelled, f"reachable C should stay PENDING, got {cancelled!r}"
+
+
+async def test_overlay_failed_with_live_replacement_does_not_taint() -> None:
+    """A FAILED task with a live ``retry_<id>`` lineage replacement
+    in the plan is NOT broken. Downstream PENDING tasks remain
+    reachable because the replacement carries the work forward
+    (goldfive#202).
+    """
+    plan = Plan(
+        id="p_lineage",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="t0", title="A", assignee_agent_id="agent_a", status=TaskStatus.FAILED),
+            Task(id="retry_t0", title="A retry", assignee_agent_id="agent_a"),
+            Task(id="t1", title="B", assignee_agent_id="agent_b"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="t0", to_task_id="t1"),
+            TaskEdge(from_task_id="retry_t0", to_task_id="t1"),
+        ],
+    )
+    session = Session(run_id="r1")
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    async def _passthrough(
+        user_message: str,  # noqa: ARG001
+        session: Session,  # noqa: ARG001
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        return InvocationResult(task_id="", text="")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    await SequentialExecutor(overlay_mode=True).run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="anything",
+    )
+
+    # The FAILED predecessor has a live replacement, so downstream
+    # work is reachable; no CANCELLED transitions should be produced.
+    cancelled = [tid for tid, to in steerer.transitions if to is TaskStatus.CANCELLED]
+    assert cancelled == [], (
+        f"lineage replacement should keep downstream reachable; cancelled={cancelled!r}"
+    )
+
+
+async def test_overlay_paused_for_human_intervention_leaves_unreachable_pending() -> None:
+    """F10 guard: when paused for human intervention, EVERY PENDING
+    is left alone — including structurally unreachable ones. The
+    operator hasn't decided yet whether unreachable work should be
+    dropped, so the executor must not pre-empt that decision.
+    """
+    plan = Plan(
+        id="p_paused",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="root", title="A", assignee_agent_id="agent_a", status=TaskStatus.CANCELLED),
+            Task(id="downstream", title="B", assignee_agent_id="agent_b"),
+        ],
+        edges=[TaskEdge(from_task_id="root", to_task_id="downstream")],
+    )
+    session = Session(run_id="r1")
+    # Simulate pause: HUMAN_INTERVENTION_REQUIRED was emitted just
+    # before the overlay end-of-invocation runs.
+    session.paused_for_human_intervention = True
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    async def _passthrough(
+        user_message: str,  # noqa: ARG001
+        session: Session,  # noqa: ARG001
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        return InvocationResult(task_id="", text="")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    await SequentialExecutor(overlay_mode=True).run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="anything",
+    )
+
+    # Despite "downstream" being structurally unreachable, the F10
+    # guard suppresses the cancel — the operator decides.
+    assert steerer.transitions == [], (
+        f"paused-for-HI must suppress all overlay-end transitions, got {steerer.transitions!r}"
+    )
+    by_id = {t.id: t.status for t in plan.tasks}
+    assert by_id["downstream"] is TaskStatus.PENDING
+
+
+async def test_overlay_empty_plan_no_transitions() -> None:
+    """A plan with no tasks (or all terminal) produces no overlay-end
+    transitions. Belt-and-braces against zero-task edge cases.
+    """
+    plan = Plan(id="p_empty", run_id="r1", goal_ids=[], tasks=[], edges=[])
+    session = Session(run_id="r1")
+    steerer = StubSteerer()
+    sink = RecordingSink()
+
+    async def _passthrough(
+        user_message: str,  # noqa: ARG001
+        session: Session,  # noqa: ARG001
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        return InvocationResult(task_id="", text="")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    await SequentialExecutor(overlay_mode=True).run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="anything",
+    )
+
+    assert steerer.transitions == []
 
 
 async def test_overlay_no_pending_tasks_no_not_needed_transitions() -> None:


### PR DESCRIPTION
## Summary

- Overlay's end-of-invocation reaper (#163) was unconditionally NOT_NEEDED-reaping every PENDING task with reason \`tree did not exercise; no follow-up dispatched\`. This destroyed cross-turn user intent: a multi-turn plan whose first stage completed but whose downstream stages weren't reached this turn would have those stages reaped before the next turn could pick them up.
- v26 turn 2 user pivot ("Forget solar panels, tell me about solar flares instead.") added 3 flares tasks; \`research_flares\` completed in turn 2; \`draft_flares_slides\` and \`review_flares_slides\` were reaped to NOT_NEEDED at end-of-overlay despite their predecessor having just COMPLETED. Turn 4 found no live PENDING work and produced no artifact.
- Replace blanket reap with structural reachability: REACHABLE PENDING (predecessors COMPLETED or still PENDING/RUNNING) stay PENDING; UNREACHABLE PENDING (predecessor terminal-non-COMPLETED with no live replacement) become CANCELLED with the orphan reason. End-of-overlay alone is never sufficient for NOT_NEEDED.

## Test plan

- [x] 4 updated/added tests in \`test_sequential_executor_overlay.py\`
- [x] 178 broader tests pass across executor, steerer, planner, runner, I4 fold suite
- [x] ruff clean
- [x] anti-pattern lint: PASS (no regex, no numerical caps, no validator relaxation)
- [ ] E2E validation post-merge (v27 scenario, expect turn-2 pivot honored: flares draft+review carry forward and execute by turn 4)

Refs: iter-4 v26 forensic; complements #336 (I4 fold) and #338 (refine_steer evolution).