### PR TITLE
fix(executor,planner): causality-driven replacement detection (closes #213)

### DIFF
--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -1812,35 +1812,83 @@ def _has_live_pending_or_running(plan: Plan) -> bool:
 def _has_live_replacement(plan: Plan, failed: Task) -> bool:
     """Return True iff ``failed`` has a *live* replacement task in ``plan``.
 
-    A replacement task is one the planner spawned to supersede
-    ``failed`` — a forward-progress successor, not a predecessor. We
-    require it to be PENDING or RUNNING (never COMPLETED) so a
-    COMPLETED sibling lineage peer (``t0`` when ``retry_retry_t0`` is
-    the failure) does NOT mask the failure — that's a predecessor, not
-    a replacement. See goldfive#202.
+    Two-tier match (goldfive#213): causal first, name-pattern fallback.
 
-    Matched via one of two id conventions goldfive's refine path
-    produces (structural inference; no proto ``replaces`` field):
+    **Tier 1 — causal (primary).** Walks the ``Task.supersedes`` link
+    chain. Build a ``{task.id → task.supersedes}`` map over the plan;
+    for each non-FAILED / non-CANCELLED candidate ``r``, follow
+    ``r.supersedes`` (with cycle protection capped at 16 hops, matching
+    :func:`_lineage_root`'s loop bound). If the chain transitively
+    reaches ``failed.id``, ``r`` is a live replacement at *any* status
+    (PENDING / RUNNING / COMPLETED). The chain link is unambiguous
+    about predecessor-vs-replacement direction — ``r.supersedes ==
+    failed.id`` means ``r`` was spawned to supersede ``failed``, never
+    the reverse — so a COMPLETED ``r`` that already finished its work
+    correctly satisfies the FAILED predecessor.
 
-    * Shared retry lineage: ``_lineage_root(R.id) == _lineage_root(failed.id)``.
-      Catches ``retry_<id>``, ``retry2_<id>`` etc. — the pattern the
-      refine system prompt historically emitted (see PLAN-LIFECYCLE.md
-      §7.3).
+    **Chain-of-retries case** (``t0 → retry_t0 → retry_retry_t0`` with
+    ``retry_retry_t0`` FAILED): walking forward from ``retry_retry_t0``,
+    no causal candidate links back to it (the chain points the other
+    way: ``retry_retry_t0.supersedes == retry_t0`` etc.). So
+    ``retry_retry_t0`` correctly remains fatally_failed regardless of
+    earlier links' status — only the LATEST link's outcome matters,
+    which is what the supersedes chain encodes.
+
+    **Tier 2 — name-pattern (fallback).** Used only when Tier 1 found
+    no match. Preserves backward compat with plans where the planner
+    LLM didn't populate ``supersedes`` and there was no auto-backfill:
+
     * Versioned replacement: ``R.id`` starts with ``<failed.id>_``
-      (``define_structure`` → ``define_structure_v2``, ``..._retry``,
-      etc.). Empirically the shape LLM planners emit when the refine
-      prompt does NOT encode a ``retry_`` convention.
+      (e.g. ``define_structure`` → ``define_structure_v2``). Live at
+      any non-FAILED / non-CANCELLED status (a planner would not emit
+      ``..._v2`` before ``v1`` had run, so chronology is
+      unambiguous).
+    * Shared retry lineage: ``_lineage_root(R.id) == _lineage_root(failed.id)``.
+      Catches ``retry_<id>``, ``retry2_<id>`` etc. CHRONOLOGY-AMBIGUOUS
+      under name-pattern alone (``t0`` COMPLETED could be a predecessor
+      of ``retry_retry_t0`` FAILED), so we only count peers at PENDING
+      or RUNNING here — the conservative legacy semantic.
 
-    Additionally require ``R.assignee_agent_id == failed.assignee_agent_id``
-    when both are populated, so a task owned by a different agent doesn't
-    accidentally mask a genuine failure.
-
-    Lives in the executor (not a proto field on :class:`Task`) to avoid
-    a cross-cutting contract change through planner JSON shapes and
-    prompt templates. Structural inference is adequate: the refine
-    output is always validated against :meth:`Plan.validate`, so the
-    shapes here are the shapes the planner actually emits.
+    **Assignee scoping** applies to both tiers but only when *both*
+    ids carry a populated ``assignee_agent_id`` — empty assignees mean
+    no scoping is enforced.
     """
+    # ----- Tier 1: causal supersedes-chain match -----
+    # Build the chain map once. Empty supersedes treated as no link.
+    chain: dict[str, str] = {
+        t.id: (t.supersedes or "").strip() for t in plan.tasks if t.id
+    }
+    for r in plan.tasks:
+        if not r.id or r.id == failed.id:
+            continue
+        if r.status in (TaskStatus.FAILED, TaskStatus.CANCELLED):
+            continue
+        # Walk r.supersedes chain with bounded hops + visited-set
+        # cycle protection. Bound matches _lineage_root: 16 hops is
+        # well above any realistic refine depth and bounds pathology.
+        visited: set[str] = set()
+        cursor = chain.get(r.id, "")
+        hit = False
+        for _ in range(16):
+            if not cursor or cursor in visited:
+                break
+            if cursor == failed.id:
+                hit = True
+                break
+            visited.add(cursor)
+            cursor = chain.get(cursor, "")
+        if not hit:
+            continue
+        # Assignee scoping when both are populated.
+        if (
+            failed.assignee_agent_id
+            and r.assignee_agent_id
+            and r.assignee_agent_id != failed.assignee_agent_id
+        ):
+            continue
+        return True
+
+    # ----- Tier 2: name-pattern fallback -----
     failed_root = _lineage_root(failed.id)
     for r in plan.tasks:
         if r.id == failed.id or not r.id:

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -2255,6 +2255,17 @@ class LLMPlanner:
                     if attempt < attempts:
                         user_prompt = self._build_correction_prompt(base_user_prompt, last_error)
                     continue
+            # goldfive#213: backfill ``Task.supersedes`` for retry-named
+            # tasks the LLM emitted without an explicit causal link.
+            # Mirrors the call in ``_user_steer_one_attempt``'s merge
+            # so that LOOPING_TOOL_CALL / LOOPING_REASONING refines (and
+            # any other path through ``_call_and_validate_refine``)
+            # benefit from causal replacement detection identically to
+            # the user-steer path. Must run BEFORE
+            # ``_normalize_supersession_kinds`` so the kind coercion
+            # sees the backfilled link.
+            if prior_plan is not None:
+                _backfill_retry_supersedes(revised, prior=prior_plan)
             # goldfive#251: Option B validator -- coerce supersedes_kind
             # on every task based on old-task status. Runs before
             # ``revised.validate`` so the structural validator sees

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -607,6 +607,11 @@ def _normalize_supersession_kinds(revised: Plan, *, prior: Plan | None) -> None:
 
     goldfive#251 Option B validator. Rules, in order:
 
+    0. (goldfive#213) If ``task.supersedes == task.id`` (self-reference
+       — the v27 rev-2 anomaly where an LLM mis-applied supersedes to
+       an id-reused task), clear the link. A task cannot be its own
+       predecessor; the empty-target case (Rule 1) then clears any
+       lingering kind.
     1. If ``task.supersedes`` is empty, clear ``supersedes_kind`` to
        ``UNSPECIFIED`` — a kind without a target is dangling.
     2. If the supersedes target does not resolve against either
@@ -635,6 +640,19 @@ def _normalize_supersession_kinds(revised: Plan, *, prior: Plan | None) -> None:
     revised_by_id: dict[str, Task] = {t.id: t for t in revised.tasks if t.id}
     for task in revised.tasks:
         sup_id = (task.supersedes or "").strip()
+        # Rule 0 (goldfive#213): a task can never supersede itself. The
+        # v27 rev-2 anomaly was the LLM emitting ``supersedes == self.id``
+        # on an id-reused task (a structural impossibility — a task
+        # is not its own predecessor). Strip the link and fall through
+        # so Rule 1's empty-target handling clears any kind.
+        if sup_id and task.id and sup_id == task.id:
+            log.warning(
+                "planner: task %r has supersedes pointing at itself; "
+                "clearing self-reference (a task cannot supersede itself)",
+                task.id,
+            )
+            task.supersedes = ""
+            sup_id = ""
         if not sup_id:
             # Rule 1: dangling kind with no target.
             if task.supersedes_kind is not SupersessionKind.UNSPECIFIED:
@@ -684,6 +702,141 @@ def _normalize_supersession_kinds(revised: Plan, *, prior: Plan | None) -> None:
                 expected.value,
             )
             task.supersedes_kind = expected
+
+
+#: Statuses that warrant a retry/replace — i.e. the old task did NOT
+#: succeed. Used by :func:`_backfill_retry_supersedes` to gate the
+#: structural inference: only retries that follow a non-success outcome
+#: get an inferred supersedes link. COMPLETED / PENDING / RUNNING /
+#: BLOCKED are intentionally excluded — those represent either durable
+#: provenance (don't quietly clobber) or work in flight (a "retry"
+#: spawned alongside a healthy in-flight task is a confused emit, not
+#: a structural successor).
+_RETRY_WARRANTING_OLD_STATUSES: frozenset[TaskStatus] = frozenset(
+    {TaskStatus.FAILED, TaskStatus.CANCELLED}
+)
+
+
+# Precompiled prefix patterns matching goldfive's id conventions for
+# retry / version successor tasks. Mirrors
+# :data:`goldfive.executors.sequential._RETRY_PREFIX_RE` but lives here
+# to avoid an executor → planner import cycle (planner is a dependency
+# of executors via :class:`LLMPlanner`). These patterns are STRUCTURAL
+# inference over goldfive-emitted ids, not over user-content text — so
+# they don't violate the no-regex-heuristics-on-NL contract
+# (``feedback_no_regex_heuristics``).
+_RETRY_PREFIX_RE = re.compile(r"^retry(?:\d+)?_")
+#: Match a trailing ``_v<N>`` suffix on a task id (``t0_v2`` ⇒ root ``t0``).
+_VERSION_SUFFIX_RE = re.compile(r"_v\d+$")
+
+
+def _strip_retry_prefix_once(task_id: str) -> str:
+    """Strip exactly one ``retry_`` / ``retry<N>_`` prefix if present.
+
+    Returns the original id when no prefix is present. Differs from
+    :func:`goldfive.executors.sequential._lineage_root` in that this
+    is single-shot (one peel) — used by backfill to find the immediate
+    predecessor candidate of a single retry name. The full lineage
+    root is still useful for executor budgeting; the single-step peel
+    is the right granularity for "retry of WHICH task."
+    """
+    if not task_id:
+        return task_id
+    return _RETRY_PREFIX_RE.sub("", task_id, count=1)
+
+
+def _candidate_predecessor_id(task_id: str) -> str:
+    """Return the most likely predecessor id for a retry/version name.
+
+    Two patterns, tried in order:
+
+    * ``retry_<root>`` / ``retry<N>_<root>`` ⇒ ``<root>``.
+    * ``<root>_v<N>`` ⇒ ``<root>``.
+
+    Returns ``""`` when neither pattern matches (no inference). This is
+    deterministic structural inference — the candidate must still
+    resolve against the prior plan AND have a retry-warranting status
+    before backfill happens; see :func:`_backfill_retry_supersedes`.
+    """
+    if not task_id:
+        return ""
+    stripped = _strip_retry_prefix_once(task_id)
+    if stripped != task_id:
+        return stripped
+    # Try _v<N> suffix.
+    suffix_stripped = _VERSION_SUFFIX_RE.sub("", task_id)
+    if suffix_stripped != task_id and suffix_stripped:
+        return suffix_stripped
+    return ""
+
+
+def _backfill_retry_supersedes(revised: Plan, *, prior: Plan) -> None:
+    """In-place backfill ``Task.supersedes`` for retry-named tasks.
+
+    Goldfive#213 — when a planner LLM emits a retry-shaped task name
+    (``retry_t0``, ``t0_v2``) but forgets to populate the structural
+    ``supersedes`` link, replacement detection in
+    :func:`goldfive.executors.sequential._has_live_replacement` falls
+    through to the conservative name-pattern fallback. That makes a
+    COMPLETED retry incapable of satisfying the FAILED predecessor
+    (predecessors-as-replacements are chronologically ambiguous under
+    name-pattern alone). The fix is to make the structural link
+    deterministic at merge time so the executor's causal tier can use
+    it — no LLM trust, no prompt contract.
+
+    Backfill rule (per task in ``revised`` whose ``supersedes`` is
+    empty):
+
+    * Compute candidate predecessor id by stripping a leading
+      ``retry_`` / ``retry<N>_`` prefix OR a trailing ``_v<N>``
+      suffix (see :func:`_candidate_predecessor_id`).
+    * If the candidate exists in ``prior.tasks`` AND its status is
+      FAILED or CANCELLED (the retry-warranting set), set
+      ``task.supersedes = candidate``. Don't backfill against
+      COMPLETED, PENDING, RUNNING, or absent candidates — those would
+      be spurious links.
+    * Self-references (``task.supersedes == task.id``) are cleared
+      regardless. This is the v27 rev-2 anomaly where the LLM
+      mis-applied supersedes to an id-reused task. Empty-target
+      cleanup runs in :func:`_normalize_supersession_kinds` as a
+      defence in depth.
+
+    The post-backfill plan is still passed through
+    :func:`_normalize_supersession_kinds` to derive the right
+    ``supersedes_kind`` from old-task status — backfill ONLY sets the
+    target id; the kind is still status-driven.
+    """
+    if prior is None:
+        return
+    prior_by_id: dict[str, Task] = {t.id: t for t in prior.tasks if t.id}
+    for task in revised.tasks:
+        if not task.id:
+            continue
+        sup = (task.supersedes or "").strip()
+        # Self-reference cleanup runs unconditionally (defence in
+        # depth before normalize_supersession_kinds also runs).
+        if sup and sup == task.id:
+            task.supersedes = ""
+            sup = ""
+        if sup:
+            # LLM intent wins: never override an explicit link.
+            continue
+        candidate = _candidate_predecessor_id(task.id)
+        if not candidate or candidate == task.id:
+            continue
+        old = prior_by_id.get(candidate)
+        if old is None:
+            continue
+        if old.status not in _RETRY_WARRANTING_OLD_STATUSES:
+            continue
+        log.debug(
+            "planner: backfilling supersedes %r → %r on %r (prior status %s)",
+            task.id,
+            candidate,
+            task.id,
+            old.status.value,
+        )
+        task.supersedes = candidate
 
 
 #: Old-task statuses that don't require a supersedes link when dropped.
@@ -3054,6 +3207,18 @@ class LLMPlanner:
         if fresh is None:
             return None, "parsed JSON did not contain a usable plan"
 
+        # goldfive#213: backfill ``Task.supersedes`` for retry-named
+        # tasks (``retry_t0``, ``t0_v2``) when the LLM forgot the
+        # structural link. Pure structural inference over goldfive's
+        # own id conventions — no LLM-trust, no prompt contract.
+        # Runs against ``fresh`` (not the post-merge plan) so the
+        # predecessor candidates are resolved against the FULL prior
+        # plan (including completed tasks that were dropped from
+        # ``fresh``). This makes the executor's causal-tier
+        # replacement detection work even for plans where the LLM
+        # didn't populate ``supersedes``.
+        _backfill_retry_supersedes(fresh, prior=plan)
+
         # Prepend completed tasks verbatim; drop any new task whose id
         # collides with a completed id so lineage ids stay stable.
         new_pending = [t for t in fresh.tasks if t.id not in completed_ids]
@@ -3101,13 +3266,14 @@ class LLMPlanner:
             revision_index=plan.revision_index + 1,
         )
         # goldfive#251 Option B: coerce supersedes_kind on every merged
-        # task based on the OLD-task status in the prior plan. Mirrors
-        # the same call in :meth:`_refine_user`'s validation loop. The
+        # task based on the OLD-task status in the prior plan. The
         # evolution path (id reuse without supersedes) is unaffected;
-        # the supersede-with-fresh-id path now gets the same parity
-        # the refine_user path has — an LLM that sets
-        # ``supersedes_kind=UNSPECIFIED`` against a prior PENDING is
-        # coerced to ``REPLACE`` so the executor's pin-redirect runs.
+        # the supersede-with-fresh-id path gets parity with the
+        # refine_user path — an LLM that sets ``supersedes_kind=UNSPECIFIED``
+        # against a prior PENDING is coerced to ``REPLACE`` so the
+        # executor's pin-redirect runs. Runs AFTER the goldfive#213
+        # backfill (above) so the kind is derived against any
+        # freshly-populated retry link.
         _normalize_supersession_kinds(merged_plan, prior=plan)
         try:
             merged_plan.validate(for_revision=True, prior=plan)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -950,6 +950,140 @@ def _good_looping_revision_json() -> str:
     )
 
 
+async def test_looping_refine_backfills_supersedes_for_retry_named_replacement() -> None:
+    """goldfive#213: the LOOPING_TOOL_CALL refine path goes through
+    ``_call_and_validate_refine`` (not ``_user_steer_one_attempt``). The
+    backfill helper must run on this path too — otherwise the LOOPING
+    refine path would leave ``Task.supersedes`` empty for retry-named
+    replacement tasks the LLM emits, defeating causal replacement
+    detection in ``_has_live_replacement`` and producing the same
+    false-positive ``run_aborted`` symptom from v27.
+
+    Setup: a plan whose looping task is FAILED (the planner failed it
+    before refining). The LLM emits a ``retry_<id>`` replacement
+    without populating ``supersedes``. Assert backfill set it.
+    """
+    # Adapt _looping_plan but with draft_slides already FAILED (the
+    # state _refine_looping_tool_call sees: it fails the looper before
+    # asking the LLM for a replacement plan).
+    plan = Plan(
+        id="plan-loop-backfill",
+        run_id="run-1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_installation",
+                title="Research installation",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="structure_presentation",
+                title="Structure presentation",
+                assignee_agent_id="writer",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="draft_slides",
+                title="Draft slides",
+                assignee_agent_id="writer",
+                status=TaskStatus.FAILED,
+            ),
+        ],
+        edges=[
+            TaskEdge(
+                from_task_id="research_installation",
+                to_task_id="structure_presentation",
+            ),
+            TaskEdge(
+                from_task_id="structure_presentation",
+                to_task_id="draft_slides",
+            ),
+        ],
+        summary="Build the installation presentation.",
+        revision_index=1,
+    )
+    revision_json = json.dumps(
+        {
+            "summary": "retry the looper",
+            "tasks": [
+                {
+                    "id": "research_installation",
+                    "title": "Research installation",
+                    "assignee_agent_id": "researcher",
+                    "status": "COMPLETED",
+                },
+                {
+                    "id": "structure_presentation",
+                    "title": "Structure presentation",
+                    "assignee_agent_id": "writer",
+                    "status": "COMPLETED",
+                },
+                {
+                    "id": "draft_slides",
+                    "title": "Draft slides",
+                    "assignee_agent_id": "writer",
+                    "status": "FAILED",
+                },
+                {
+                    # Retry-named replacement; LLM omits supersedes — the
+                    # bug this test guards against.
+                    "id": "retry_draft_slides",
+                    "title": "Retry drafting slides with outline",
+                    "assignee_agent_id": "writer",
+                    "status": "PENDING",
+                },
+            ],
+            "edges": [
+                {
+                    "from_task_id": "research_installation",
+                    "to_task_id": "structure_presentation",
+                },
+                # Preserve the terminal->terminal edge (required by
+                # validator step 5 once draft_slides is FAILED).
+                {
+                    "from_task_id": "structure_presentation",
+                    "to_task_id": "draft_slides",
+                },
+                # New retry routes from the LAST COMPLETED predecessor
+                # (avoids the FAILED->PENDING reachability rejection).
+                {
+                    "from_task_id": "structure_presentation",
+                    "to_task_id": "retry_draft_slides",
+                },
+            ],
+        }
+    )
+    scripted = _ScriptedLLM([revision_json])
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=1)
+    drift = DriftEvent(
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        severity=DriftSeverity.WARNING,
+        detail="agent stuck calling read_file",
+        current_task_id="draft_slides",
+    )
+
+    revised = await planner.refine(plan=plan, drift=drift, goals=_goals())
+
+    assert revised is not None
+    by_id = {t.id: t for t in revised.tasks}
+    assert "retry_draft_slides" in by_id, "replacement task missing"
+    retry = by_id["retry_draft_slides"]
+    # Backfill must have run on the LOOPING path: supersedes is populated.
+    assert retry.supersedes == "draft_slides", (
+        f"expected backfill to set supersedes='draft_slides', "
+        f"got {retry.supersedes!r}"
+    )
+    # And _normalize_supersession_kinds derived REPLACE from the
+    # FAILED predecessor status.
+    from goldfive.types import SupersessionKind  # noqa: PLC0415
+
+    assert retry.supersedes_kind is SupersessionKind.REPLACE, (
+        f"expected supersedes_kind=REPLACE for FAILED predecessor, "
+        f"got {retry.supersedes_kind}"
+    )
+
+
 async def test_refine_retries_on_validation_failure_and_succeeds() -> None:
     """Attempt 1 emits a plan missing a terminal->terminal edge; attempt 2
     emits a valid plan. The planner must retry and succeed.

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -1325,3 +1325,249 @@ async def test_refine_steer_id_reuse_preserves_inter_pending_edges() -> None:
     edges = {(e.from_task_id, e.to_task_id) for e in revised.edges}
     assert ("research", "step_a") in edges
     assert ("step_a", "step_b") in edges
+
+
+# ---------------------------------------------------------------------------
+# goldfive#213: structural backfill of Task.supersedes for retry-named tasks.
+# ---------------------------------------------------------------------------
+#
+# When the LLM emits a retry-shaped task name (``retry_t0``, ``t0_v2``)
+# but forgets to populate ``supersedes``, the merge-time backfill
+# infers the link structurally — provided the candidate predecessor
+# exists in the prior plan AND is in a retry-warranting status (FAILED
+# / CANCELLED). Pure deterministic structural inference, no LLM trust.
+
+
+def _retry_steer_json(
+    *,
+    new_task_id: str,
+    supersedes: str | None = None,
+    title: str = "Retry it",
+) -> str:
+    """Build a steer-shaped LLM response that proposes a single retry task.
+
+    ``supersedes`` of None ⇒ key omitted from JSON (LLM didn't populate
+    the link). Pass an empty string to emit the key with empty value
+    (same observable shape after JSON parse).
+    """
+    task: dict[str, Any] = {
+        "id": new_task_id,
+        "title": title,
+        "description": "Retry of failed predecessor.",
+        "assignee_agent_id": "writer",
+    }
+    if supersedes is not None:
+        task["supersedes"] = supersedes
+    return json.dumps(
+        {
+            "summary": "Retry the failure.",
+            "tasks": [task],
+            "edges": [],
+        }
+    )
+
+
+def _plan_with_retry_predecessor(
+    *,
+    predecessor_id: str = "t0",
+    predecessor_status: TaskStatus = TaskStatus.FAILED,
+) -> Plan:
+    """Prior plan with a single predecessor in a configurable status."""
+    return Plan(
+        id="plan-r213",
+        run_id="run-r213",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id=predecessor_id,
+                title="Original",
+                status=predecessor_status,
+                assignee_agent_id="writer",
+            ),
+        ],
+        edges=[],
+        revision_index=0,
+    )
+
+
+def _user_steer_drift() -> DriftEvent:
+    return DriftEvent(
+        kind=DriftKind.USER_STEER,
+        severity=DriftSeverity.WARNING,
+        detail="please retry",
+        current_task_id="t0",
+    )
+
+
+def _find_task(plan: Plan, task_id: str) -> Task:
+    for t in plan.tasks:
+        if t.id == task_id:
+            return t
+    raise AssertionError(f"task {task_id!r} not in plan")
+
+
+async def test_backfill_supersedes_on_retry_name_when_old_failed() -> None:
+    """Prior ``t0 FAILED`` + LLM emits ``retry_t0`` with no
+    supersedes ⇒ backfill sets ``retry_t0.supersedes = "t0"``.
+    """
+    plan = _plan_with_retry_predecessor(predecessor_status=TaskStatus.FAILED)
+    goals = [Goal(id="g1", summary="ship it")]
+    llm = _StubLLM(_retry_steer_json(new_task_id="retry_t0", supersedes=None))
+    planner = LLMPlanner(call_llm=llm, model="test-model")
+
+    revised = await planner.refine(plan=plan, drift=_user_steer_drift(), goals=goals)
+    assert revised is not None
+
+    retry = _find_task(revised, "retry_t0")
+    assert retry.supersedes == "t0", (
+        f"expected backfill to set supersedes='t0', got {retry.supersedes!r}"
+    )
+    # Kind must also have been derived from FAILED status (REPLACE).
+    from goldfive.types import SupersessionKind
+
+    assert retry.supersedes_kind is SupersessionKind.REPLACE
+
+
+async def test_backfill_supersedes_on_retry_name_when_old_cancelled() -> None:
+    """CANCELLED predecessor also warrants backfill — same rationale
+    as FAILED (the old work is conclusively closed without delivering)."""
+    plan = _plan_with_retry_predecessor(predecessor_status=TaskStatus.CANCELLED)
+    goals = [Goal(id="g1", summary="ship it")]
+    llm = _StubLLM(_retry_steer_json(new_task_id="retry_t0", supersedes=None))
+    planner = LLMPlanner(call_llm=llm, model="test-model")
+
+    revised = await planner.refine(plan=plan, drift=_user_steer_drift(), goals=goals)
+    assert revised is not None
+
+    retry = _find_task(revised, "retry_t0")
+    assert retry.supersedes == "t0"
+
+
+async def test_no_backfill_when_old_completed() -> None:
+    """Prior ``t0 COMPLETED`` + LLM emits ``retry_t0`` ⇒ supersedes
+    stays empty (no spurious link over a successful predecessor).
+    """
+    plan = _plan_with_retry_predecessor(predecessor_status=TaskStatus.COMPLETED)
+    goals = [Goal(id="g1", summary="ship it")]
+    llm = _StubLLM(_retry_steer_json(new_task_id="retry_t0", supersedes=None))
+    planner = LLMPlanner(call_llm=llm, model="test-model")
+
+    revised = await planner.refine(plan=plan, drift=_user_steer_drift(), goals=goals)
+    assert revised is not None
+
+    retry = _find_task(revised, "retry_t0")
+    assert retry.supersedes == "", (
+        f"expected supersedes empty (COMPLETED predecessor), got {retry.supersedes!r}"
+    )
+
+
+async def test_no_backfill_when_old_absent() -> None:
+    """LLM emits ``retry_unknown`` with no ``unknown`` task in the
+    prior plan ⇒ supersedes stays empty.
+    """
+    plan = _plan_with_retry_predecessor(predecessor_id="t0")
+    goals = [Goal(id="g1", summary="ship it")]
+    llm = _StubLLM(
+        _retry_steer_json(new_task_id="retry_unknown", supersedes=None)
+    )
+    planner = LLMPlanner(call_llm=llm, model="test-model")
+
+    revised = await planner.refine(plan=plan, drift=_user_steer_drift(), goals=goals)
+    assert revised is not None
+
+    retry = _find_task(revised, "retry_unknown")
+    assert retry.supersedes == ""
+
+
+async def test_backfill_skips_already_populated() -> None:
+    """LLM emits explicit ``supersedes='other'`` ⇒ backfill leaves
+    it alone (LLM intent wins over structural inference).
+    """
+    # Add a second prior task ("other") so the explicit link resolves.
+    plan = Plan(
+        id="plan-r213",
+        run_id="run-r213",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t0", title="t0", status=TaskStatus.FAILED),
+            Task(id="other", title="other", status=TaskStatus.FAILED),
+        ],
+        edges=[],
+        revision_index=0,
+    )
+    goals = [Goal(id="g1", summary="ship it")]
+    llm = _StubLLM(
+        _retry_steer_json(new_task_id="retry_t0", supersedes="other")
+    )
+    planner = LLMPlanner(call_llm=llm, model="test-model")
+
+    revised = await planner.refine(plan=plan, drift=_user_steer_drift(), goals=goals)
+    assert revised is not None
+
+    retry = _find_task(revised, "retry_t0")
+    assert retry.supersedes == "other", (
+        "explicit LLM-supplied supersedes link must not be overridden"
+    )
+
+
+async def test_self_supersede_stripped() -> None:
+    """LLM emits ``t0_v2`` with ``supersedes='t0_v2'`` (self-reference,
+    the v27 rev-2 anomaly). Normalization clears it.
+
+    NOTE: backfill ALSO clears self-references as defence in depth, so
+    this test pins the self-reference cleanup regardless of which
+    layer caught it.
+    """
+    plan = _plan_with_retry_predecessor(predecessor_status=TaskStatus.FAILED)
+    goals = [Goal(id="g1", summary="ship it")]
+    # The LLM emits a self-referencing supersedes on a NEW id (no
+    # collision with prior). Backfill / normalize must strip the
+    # self-reference. Versioned suffix backfill then runs on the
+    # cleared link and points to ``t0`` (the predecessor).
+    llm = _StubLLM(
+        _retry_steer_json(new_task_id="t0_v2", supersedes="t0_v2")
+    )
+    planner = LLMPlanner(call_llm=llm, model="test-model")
+
+    revised = await planner.refine(plan=plan, drift=_user_steer_drift(), goals=goals)
+    assert revised is not None
+
+    new_task = _find_task(revised, "t0_v2")
+    # Self-reference cleared. Backfill ran AFTER (sup was empty), so
+    # the structural inference points to ``t0`` (the FAILED prior).
+    assert new_task.supersedes == "t0", (
+        "self-reference must be cleared then backfill should infer "
+        f"the predecessor; got supersedes={new_task.supersedes!r}"
+    )
+
+
+async def test_versioned_pattern_t0_v2_backfilled() -> None:
+    """Prior ``t0 FAILED`` + LLM emits ``t0_v2`` (no retry_ prefix,
+    just ``_v2`` suffix) ⇒ backfill sets ``supersedes='t0'``.
+    """
+    plan = _plan_with_retry_predecessor(predecessor_status=TaskStatus.FAILED)
+    goals = [Goal(id="g1", summary="ship it")]
+    llm = _StubLLM(_retry_steer_json(new_task_id="t0_v2", supersedes=None))
+    planner = LLMPlanner(call_llm=llm, model="test-model")
+
+    revised = await planner.refine(plan=plan, drift=_user_steer_drift(), goals=goals)
+    assert revised is not None
+
+    versioned = _find_task(revised, "t0_v2")
+    assert versioned.supersedes == "t0"
+
+
+async def test_backfill_skips_unrelated_task_names() -> None:
+    """Tasks with names that don't match retry/version conventions
+    are left alone — the inference is conservative."""
+    plan = _plan_with_retry_predecessor(predecessor_status=TaskStatus.FAILED)
+    goals = [Goal(id="g1", summary="ship it")]
+    # New task id ``brand_new`` doesn't strip to any prior id.
+    llm = _StubLLM(_retry_steer_json(new_task_id="brand_new", supersedes=None))
+    planner = LLMPlanner(call_llm=llm, model="test-model")
+
+    revised = await planner.refine(plan=plan, drift=_user_steer_drift(), goals=goals)
+    assert revised is not None
+
+    new_task = _find_task(revised, "brand_new")
+    assert new_task.supersedes == ""

--- a/tests/test_supersede_causal_replacement.py
+++ b/tests/test_supersede_causal_replacement.py
@@ -1,0 +1,426 @@
+"""Tests for causal (supersedes-driven) replacement detection (goldfive#213).
+
+The executor's :func:`_has_live_replacement` is two-tier as of #213:
+
+1. **Causal tier**: walk ``Task.supersedes`` chains. A non-FAILED /
+   non-CANCELLED task whose chain reaches the failed id satisfies the
+   FAILED predecessor at *any* status (PENDING, RUNNING, COMPLETED).
+   The chain link is unambiguous about chronology — there is no
+   COMPLETED-as-predecessor masking risk.
+2. **Name-pattern tier (fallback)**: only used when the causal tier
+   found nothing. Preserves legacy semantic (PENDING/RUNNING for shared
+   retry lineage, any non-terminal for versioned suffix).
+
+These tests pin both tiers + the assignee scoping rule.
+"""
+
+from __future__ import annotations
+
+from goldfive.executors.sequential import (
+    _fatally_failed_task_ids,
+    _has_live_replacement,
+)
+from goldfive.types import Plan, Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Tier 1: causal (supersedes-chain) replacement detection.
+# ---------------------------------------------------------------------------
+
+
+def test_completed_retry_via_supersedes_satisfies_failed() -> None:
+    """A COMPLETED task with ``supersedes`` pointing at a FAILED
+    predecessor is a live replacement (the v27 bug repro).
+
+    Pre-#213, the COMPLETED status would be treated as a predecessor
+    by the name-pattern fallback's chronology rule, leaving ``t0`` in
+    the fatally_failed list and triggering false-positive
+    ``run_aborted`` events at every overlay-end across subsequent
+    turns. With the causal tier, the supersedes link unambiguously
+    identifies ``retry_t0`` as a SUCCESSOR — chronologically valid
+    regardless of status.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="t0",
+                title="task 0",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="a",
+            ),
+            Task(
+                id="retry_t0",
+                title="retry of task 0",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="a",
+                supersedes="t0",
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is True
+    assert _fatally_failed_task_ids(plan) == []
+
+
+def test_pending_retry_via_supersedes_satisfies_failed() -> None:
+    """Same as the COMPLETED case but PENDING — still a live
+    replacement under the causal tier (matches existing semantic, just
+    via the new path)."""
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="t0",
+                title="task 0",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="a",
+            ),
+            Task(
+                id="retry_t0",
+                title="retry of task 0",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="a",
+                supersedes="t0",
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is True
+    assert _fatally_failed_task_ids(plan) == []
+
+
+def test_completed_retry_via_name_pattern_alone_does_not_satisfy() -> None:
+    """When ``supersedes`` is empty, the name-pattern tier's
+    conservative chronology rule kicks in: a COMPLETED ``retry_<id>``
+    is treated as a *predecessor*, not a replacement.
+
+    NOTE: in real refines, Part 2's backfill would populate
+    ``supersedes`` and the causal tier would catch this. The helper
+    itself does NOT auto-infer — that's the merge-time inference's
+    job. This test pins the legacy fallback behaviour.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="t0",
+                title="task 0",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="a",
+            ),
+            Task(
+                id="retry_t0",
+                title="retry of task 0",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="a",
+                supersedes="",  # explicit: no causal link
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is False
+    assert _fatally_failed_task_ids(plan) == ["t0"]
+
+
+# ---------------------------------------------------------------------------
+# Chain semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_chain_failure_marks_latest_link_fatal() -> None:
+    """Chain ``t0 → retry_t0 → retry_retry_t0`` all linked via
+    ``supersedes`` (each new task supersedes the previous), with
+    ``retry_retry_t0`` FAILED at the leaf.
+
+    Semantic decision (documented): only the LATEST chain link's
+    status drives fatality. Earlier links (t0, retry_t0) carry FAILED
+    too in this scenario but each has a successor in the chain that's
+    a live replacement (retry_t0 via direct supersedes from
+    retry_retry_t0; t0 via the *transitive* chain through retry_t0).
+    The leaf retry_retry_t0 itself has NO successor that supersedes
+    it — so it's fatal.
+
+    This is the correct semantic: the chain encodes "we tried, then
+    we tried again, then the latest attempt failed." The earlier
+    failures are absorbed by the chain.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="t0",
+                title="task 0",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="a",
+            ),
+            Task(
+                id="retry_t0",
+                title="retry 1",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="a",
+                supersedes="t0",
+            ),
+            Task(
+                id="retry_retry_t0",
+                title="retry 2",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="a",
+                supersedes="retry_t0",
+            ),
+        ],
+        edges=[],
+    )
+    # t0: retry_t0 is FAILED so causal tier skips it; retry_retry_t0
+    # transitively supersedes t0 but is also FAILED. Name-pattern
+    # tier: only PENDING/RUNNING peers in the same lineage count, all
+    # are FAILED. So t0 is fatal.
+    assert _has_live_replacement(plan, plan.tasks[0]) is False
+    # retry_t0: retry_retry_t0 supersedes it but is FAILED. Fatal.
+    assert _has_live_replacement(plan, plan.tasks[1]) is False
+    # retry_retry_t0: no successor. Fatal.
+    assert _has_live_replacement(plan, plan.tasks[2]) is False
+    # All three FAILED with no live replacement.
+    assert sorted(_fatally_failed_task_ids(plan)) == sorted(
+        ["t0", "retry_t0", "retry_retry_t0"]
+    )
+
+
+def test_chain_failure_with_live_leaf_satisfies_root() -> None:
+    """``t0 → retry_t0 → retry_retry_t0`` chain where the LEAF is
+    PENDING. The transitive supersedes link from the live leaf
+    satisfies *every* failed predecessor in the chain.
+
+    This is the chain-of-retries forward-progress case: the operator
+    wired three attempts, the latest is still in flight, and the run
+    should not be aborted on any of the earlier failures.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="t0",
+                title="task 0",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="a",
+            ),
+            Task(
+                id="retry_t0",
+                title="retry 1",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="a",
+                supersedes="t0",
+            ),
+            Task(
+                id="retry_retry_t0",
+                title="retry 2",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="a",
+                supersedes="retry_t0",
+            ),
+        ],
+        edges=[],
+    )
+    # PENDING leaf transitively supersedes both earlier failures.
+    assert _has_live_replacement(plan, plan.tasks[0]) is True
+    assert _has_live_replacement(plan, plan.tasks[1]) is True
+    # Leaf itself is not failed.
+    assert _fatally_failed_task_ids(plan) == []
+
+
+# ---------------------------------------------------------------------------
+# Assignee scoping.
+# ---------------------------------------------------------------------------
+
+
+def test_assignee_mismatch_breaks_replacement_in_causal_tier() -> None:
+    """A causal supersedes link with a DIFFERENT assignee does NOT
+    count. Assignee scoping applies to both tiers when both ids carry
+    a populated ``assignee_agent_id``.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="t0",
+                title="task 0",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="agent_a",
+            ),
+            Task(
+                id="retry_t0",
+                title="retry of task 0",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="agent_b",  # different
+                supersedes="t0",
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is False
+
+
+def test_empty_assignee_does_not_block_causal_match() -> None:
+    """When EITHER side has an empty assignee, scoping is bypassed —
+    causal supersedes link alone is enough.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="t0", title="task 0", status=TaskStatus.FAILED),
+            Task(
+                id="retry_t0",
+                title="retry of task 0",
+                status=TaskStatus.PENDING,
+                supersedes="t0",
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is True
+
+
+# ---------------------------------------------------------------------------
+# Cycle protection.
+# ---------------------------------------------------------------------------
+
+
+def test_supersedes_self_loop_does_not_hang() -> None:
+    """A pathological self-supersedes (``t.supersedes == t.id``) should
+    not infinite-loop the chain walk.
+
+    In production this is normalised away by
+    :func:`_normalize_supersession_kinds`'s Rule 0, but the executor
+    helper must still be defensive against malformed plan input.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="t0",
+                title="task 0",
+                status=TaskStatus.FAILED,
+                supersedes="t0",  # self-loop
+            ),
+        ],
+        edges=[],
+    )
+    # Should not hang; chain walk bails on visited cursor.
+    assert _has_live_replacement(plan, plan.tasks[0]) is False
+
+
+def test_supersedes_two_node_cycle_does_not_hang() -> None:
+    """Two-node cycle (``a.supersedes=b, b.supersedes=a``). Chain walk
+    must terminate.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="a",
+                title="a",
+                status=TaskStatus.FAILED,
+                supersedes="b",
+            ),
+            Task(
+                id="b",
+                title="b",
+                status=TaskStatus.PENDING,
+                supersedes="a",
+            ),
+        ],
+        edges=[],
+    )
+    # b transitively reaches a via cycle (a -> b -> a -> ...). Cycle
+    # protection caps the walk; b's chain visits b first then sees a
+    # in chain[a]=b which is already visited; bail. So no transitive
+    # match through the cycle. But b.supersedes == "a" directly so
+    # b satisfies a after 1 hop -- that's fine, that's the link the
+    # LLM explicitly drew.
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is True
+
+
+# ---------------------------------------------------------------------------
+# Name-pattern tier still works when supersedes is empty.
+# ---------------------------------------------------------------------------
+
+
+def test_name_pattern_pending_retry_still_satisfies() -> None:
+    """Backward compat: legacy plans without supersedes still get the
+    PENDING/RUNNING name-pattern fallback.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="t0",
+                title="task 0",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="a",
+            ),
+            Task(
+                id="retry_t0",
+                title="retry",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="a",
+                # no supersedes
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is True
+
+
+def test_name_pattern_versioned_completed_satisfies() -> None:
+    """Backward compat: a COMPLETED ``<id>_v2`` is a SUCCESSOR by
+    naming convention — still counts via name-pattern fallback.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(
+                id="define_structure",
+                title="define",
+                status=TaskStatus.FAILED,
+                assignee_agent_id="planner",
+            ),
+            Task(
+                id="define_structure_v2",
+                title="define (v2)",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="planner",
+                # no supersedes
+            ),
+        ],
+        edges=[],
+    )
+    failed = plan.tasks[0]
+    assert _has_live_replacement(plan, failed) is True


### PR DESCRIPTION
## Summary

- Replacement detection in \`_has_live_replacement\` now reads \`Task.supersedes\` chain first; any non-failed task whose chain transitively reaches \`failed.id\` counts as a replacement at ANY status (including COMPLETED). Falls back to existing name-pattern logic when no causal match.
- Backfill \`supersedes\` structurally in BOTH refine paths: \`_user_steer_one_attempt\` (USER_STEER) and \`_call_and_validate_refine\` (LOOPING/PLAN_DIVERGENCE/etc.). When the LLM emits \`retry_X\`/\`X_v2\` for FAILED/CANCELLED prior task X without setting \`supersedes\`, infer the link deterministically.
- Strip self-supersedes (\`task.supersedes == task.id\`) in both backfill and \`_normalize_supersession_kinds\` — the v27 rev-2 anomaly where the LLM mis-applied supersedes to an id-reused task.
- Cycle protection on chain walk (visited set, terminates on \`A→B→A\`).

## Why

v27 forensic showed a false-positive \`run_aborted\`: \`review_presentation\` FAILED, \`retry_review_presentation\` COMPLETED with empty \`supersedes\` field. \`_has_live_replacement\` had only the name-pattern signal and (per its docstring's chronology-ambiguity rule) excluded COMPLETED retry peers — so the original FAILED task was classified as fatally-failed despite the work having been completed by its retry. The abort then re-emitted on every subsequent turn (\`#211\` symptom).

Causal links eliminate the ambiguity: if \`retry_X.supersedes = X\` and \`retry_X\` is COMPLETED, X's work is done. Walking the chain in either direction is unambiguous about predecessor-vs-replacement.

## Test plan

- [x] 20 new tests across \`test_supersede_causal_replacement.py\`, \`test_steerer_usersteer.py\`, \`test_planner.py\`
- [x] 1698 broader tests pass (was 1678 baseline, +20)
- [x] Zero existing tests required updating (two-tier design preserved name-pattern fallback verbatim)
- [x] ruff clean
- [x] Independent reviewer flagged 3 issues: cycle protection (added), single-prefix-strip (used), backfill on LOOPING path (added in follow-up commit)
- [ ] E2E v28 validation post-merge

Refs: iter-5 #213; complements #337 (lifecycle gate), #338 (refine evolution), #339 (overlay reachability) — same direction of replacing inferential heuristics with structural causality.