### PR TITLE
fix(planner): require LLM supersedes on replacement tasks (closes #214)

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -129,6 +129,79 @@ markdown fences. Schema:
 """
 
 
+# goldfive#214 (iter-7): the canonical SUPERSESSION INVARIANT block.
+# Embedded verbatim in the user-facing refine / steer / looping system
+# prompts so the planner LLM receives one consistent instruction
+# regardless of drift kind. Backstops at the merge layer:
+#   * _backfill_retry_supersedes covers retry_X / X_v2 patterns when
+#     the LLM forgets supersedes (legacy goldfive-emitted patterns).
+#   * _normalize_supersession_kinds coerces wrong supersedes_kind based
+#     on old-task status.
+#   * _has_live_replacement causal tier consumes the supersedes link.
+# These run unchanged. Prompt strengthening reduces how often the
+# safety nets need to fire — it does NOT replace them.
+_SUPERSESSION_INVARIANT = (
+    "SUPERSESSION INVARIANT — REUSE-OR-SUPERSEDE (mutually exclusive):\n"
+    "\n"
+    "Whenever a task in your response carries forward, retries, fixes, or\n"
+    "re-does work from a prior task, you MUST pick exactly one of these two\n"
+    "shapes — never both, never neither:\n"
+    "\n"
+    "  (a) REUSE THE PRIOR ID. The continuing task keeps the prior task's\n"
+    "      `id`. Retitle / rewrite / reassign as needed; identity is the id.\n"
+    "      Do NOT set `supersedes` (id reuse already encodes continuity).\n"
+    "      A COMPLETED task cannot regress to PENDING under a reused id —\n"
+    "      if you need to redo completed work, use shape (b) with\n"
+    "      `supersedes_kind: CORRECT`, not id reuse.\n"
+    "\n"
+    "  (b) MINT A NEW ID + SUPERSEDES. The continuing task gets a fresh `id`\n"
+    "      AND `\"supersedes\": \"<prior_id>\"` AND `\"supersedes_kind\"`. Use this\n"
+    "      whenever the new id differs from the prior id for ANY reason —\n"
+    "      terminal failure (FAILED/CANCELLED), terminal cancellation,\n"
+    "      structural retry (`retry_X`, `X_v2`), corrective fix\n"
+    "      (`fix_X`, `redo_X`, `revised_X`, etc.), renamed evolution, or\n"
+    "      replacement under a different agent. The naming convention does\n"
+    "      NOT matter; if a new task semantically replaces an older one and\n"
+    "      its `id` is different, `supersedes` is REQUIRED.\n"
+    "\n"
+    "`supersedes_kind` rule:\n"
+    "  * REPLACE — superseded task is PENDING / RUNNING / BLOCKED /\n"
+    "    FAILED / CANCELLED (the new task takes its slot).\n"
+    "  * CORRECT — superseded task is COMPLETED but its output is\n"
+    "    drift-contaminated (the old task stays in the plan as a historical\n"
+    "    COMPLETED node; an edge old -> new is added).\n"
+    "\n"
+    "Forgetting `supersedes` on a renamed replacement is a runtime bug: the\n"
+    "executor cannot link the new task to the old one, the predecessor is\n"
+    "treated as fatally-failed, and the run aborts even though the\n"
+    "replacement is healthy."
+)
+
+# Few-shot examples paired (positive REPLACE + negative EVOLUTION) to
+# anchor the mutual-exclusivity framing. Without the negative example,
+# the LLM tends to over-apply supersedes on legitimate id-reuse-with-
+# evolved-title cases — the iter-7 reviewer's risk-mitigation note.
+_SUPERSESSION_EXAMPLES = (
+    "EXAMPLES:\n"
+    "\n"
+    "  Reused id (evolution; no supersedes):\n"
+    '    Prior: {"id": "research_solar", "title": "Research solar panels"}\n'
+    '    New:   {"id": "research_solar", "title": "Research solar + battery\n'
+    '            costs", "assignee_agent_id": "researcher"}\n'
+    "    No supersedes — id reuse already encodes that this is the same\n"
+    "    logical step.\n"
+    "\n"
+    "  New id with supersedes (replacement; ANY name shape):\n"
+    '    Prior: {"id": "review_slides", "status": "FAILED"}\n'
+    '    New:   {"id": "fix_review_slides", "title": "Re-do slide review\n'
+    '            with cleaner outline", "supersedes": "review_slides",\n'
+    '            "supersedes_kind": "REPLACE"}\n'
+    "    The id `fix_review_slides` is fresh; supersedes is REQUIRED. The\n"
+    "    same applies to `redo_review_slides`, `review_slides_again`,\n"
+    "    `slide_review_2`, etc."
+)
+
+
 _LOOPING_TOOL_CALL_SYSTEM_PROMPT = """\
 You are a task-planning assistant for a multi-agent system. The
 adapter's loop detector has just flagged a task whose agent is stuck
@@ -190,7 +263,7 @@ Respond with a single JSON object and NOTHING ELSE:
   ],
   "edges": [{"from_task_id": "...", "to_task_id": "..."}]
 }
-"""
+""" + "\n" + _SUPERSESSION_INVARIANT + "\n"
 
 
 _USER_STEER_SYSTEM_PROMPT = """\
@@ -275,7 +348,7 @@ Respond with a single JSON object and NOTHING ELSE:
   ],
   "edges": [{"from_task_id": "...", "to_task_id": "..."}]
 }
-"""
+""" + "\n" + _SUPERSESSION_INVARIANT + "\n\n" + _SUPERSESSION_EXAMPLES + "\n"
 
 
 _PLAN_DIVERGENCE_SYSTEM_PROMPT = """\
@@ -453,7 +526,7 @@ Respond with a single JSON object and NOTHING ELSE:
 
 If nothing needs to change, return the current plan unchanged (but
 still as a complete JSON plan, not an empty object).
-"""
+""" + "\n" + _SUPERSESSION_INVARIANT + "\n\n" + _SUPERSESSION_EXAMPLES + "\n"
 
 
 # ---------------------------------------------------------------------------
@@ -1675,7 +1748,8 @@ class LLMPlanner:
             "tracks task identity across revisions; minting a new id for "
             "continuing work makes the runtime treat it as brand-new and "
             "re-runs work the operator just told you to keep. Reusable "
-            f"prior PENDING ids: {prior_pending_ids}"
+            f"prior PENDING ids: {prior_pending_ids}\n"
+            "7. " + _SUPERSESSION_INVARIANT
         )
         if source == "goldfive":
             directive_header = (

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2264,3 +2264,101 @@ def test_static_planner_template_clone_preserves_supersedes() -> None:
     assert isinstance(correction.supersedes, str)
     assert correction.supersedes == "research_solar"
     assert correction.supersedes_kind is SupersessionKind.CORRECT
+
+
+# ---------------------------------------------------------------------------
+# goldfive#214 (iter-7): SUPERSESSION INVARIANT prompt strengthening.
+# ---------------------------------------------------------------------------
+
+
+def test_supersession_invariant_in_user_steer_system_prompt() -> None:
+    """The canonical block lands in _USER_STEER_SYSTEM_PROMPT."""
+    from goldfive.planner import _USER_STEER_SYSTEM_PROMPT
+    assert "REUSE-OR-SUPERSEDE" in _USER_STEER_SYSTEM_PROMPT
+    assert "(b) MINT A NEW ID + SUPERSEDES" in _USER_STEER_SYSTEM_PROMPT
+    assert "fix_X" in _USER_STEER_SYSTEM_PROMPT or "fix_review_slides" in _USER_STEER_SYSTEM_PROMPT
+
+
+def test_supersession_invariant_in_refine_system_prompt() -> None:
+    """The canonical block lands in _REFINE_SYSTEM_PROMPT."""
+    from goldfive.planner import _REFINE_SYSTEM_PROMPT
+    assert "REUSE-OR-SUPERSEDE" in _REFINE_SYSTEM_PROMPT
+    assert "(b) MINT A NEW ID + SUPERSEDES" in _REFINE_SYSTEM_PROMPT
+
+
+def test_supersession_invariant_in_looping_system_prompt() -> None:
+    """The canonical block lands in _LOOPING_TOOL_CALL_SYSTEM_PROMPT."""
+    from goldfive.planner import _LOOPING_TOOL_CALL_SYSTEM_PROMPT
+    assert "REUSE-OR-SUPERSEDE" in _LOOPING_TOOL_CALL_SYSTEM_PROMPT
+    assert "(b) MINT A NEW ID + SUPERSEDES" in _LOOPING_TOOL_CALL_SYSTEM_PROMPT
+
+
+def test_supersession_invariant_NOT_in_plan_divergence_system_prompt() -> None:
+    """PLAN_DIVERGENCE path is about ABSORB/REJECT, not supersession.
+    Skipping the invariant there per iter-7 reviewer's note avoids
+    pulling LLM focus off the absorb-vs-reject decision.
+    """
+    from goldfive.planner import _PLAN_DIVERGENCE_SYSTEM_PROMPT
+    assert "REUSE-OR-SUPERSEDE" not in _PLAN_DIVERGENCE_SYSTEM_PROMPT
+
+
+def test_supersession_examples_present_in_user_steer_and_refine_prompts() -> None:
+    """Few-shot examples (positive + negative) anchor the
+    mutual-exclusivity framing in both user-facing prompts."""
+    from goldfive.planner import _REFINE_SYSTEM_PROMPT, _USER_STEER_SYSTEM_PROMPT
+    for prompt in (_USER_STEER_SYSTEM_PROMPT, _REFINE_SYSTEM_PROMPT):
+        # Negative example: id reuse with no supersedes
+        assert "Reused id (evolution; no supersedes)" in prompt
+        # Positive example: fresh id with supersedes
+        assert "fix_review_slides" in prompt
+        assert "supersedes_kind" in prompt
+
+
+def test_steer_prompt_invariants_block_contains_supersession_invariant() -> None:
+    """_build_steer_prompt's invariants block adds the SUPERSESSION
+    INVARIANT as item 7 (item 6 stays the id-reuse rule)."""
+    from goldfive.planner import LLMPlanner
+    from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Goal, Task, TaskStatus
+
+    class _NoopLLM:
+        async def __call__(self, system: str, user: str, model: str) -> str:
+            return ""
+
+    planner = LLMPlanner(call_llm=_NoopLLM(), model="m")
+    completed = [Task(id="research", title="r", status=TaskStatus.COMPLETED)]
+    prior_pending = [Task(id="draft", title="d", status=TaskStatus.PENDING)]
+    drift = DriftEvent(kind=DriftKind.USER_STEER, severity=DriftSeverity.WARNING, detail="pivot")
+    rendered = planner._build_steer_prompt(
+        completed,
+        drift,
+        [Goal(id="g1", summary="ship")],
+        source="user",
+        prior_pending=prior_pending,
+    )
+    assert "REUSE-OR-SUPERSEDE" in rendered
+    # Invariant 7 numbering preserved (6 = id reuse, 7 = supersession invariant)
+    assert "7. SUPERSESSION INVARIANT" in rendered
+    # Invariant 6 (id reuse) is unchanged
+    assert "6. ID REUSE FOR CONTINUING WORK" in rendered
+
+
+def test_render_structural_invariants_does_NOT_double_carry_supersession() -> None:
+    """Reviewer note (point 9): _render_structural_invariants_block
+    feeds 2 of the 4 system-prompt sites. The system prompts already
+    carry the invariant. Doubling it inflates per-call tokens. The
+    helper should NOT be modified to add the supersession block.
+    """
+    from goldfive.planner import LLMPlanner
+    from goldfive.types import Plan, Task, TaskStatus
+    plan = Plan(
+        id="p", run_id="r", goal_ids=[],
+        tasks=[Task(id="a", title="A", status=TaskStatus.PENDING)],
+        edges=[],
+    )
+    planner = LLMPlanner(call_llm=None, model="m")
+    rendered = planner._render_structural_invariants_block(plan)
+    # The structural invariants helper is concerned with terminal
+    # preservation and DAG shape; supersession semantics live in the
+    # system prompts. Asserting absence here pins the separation of
+    # concerns.
+    assert "REUSE-OR-SUPERSEDE" not in rendered


### PR DESCRIPTION
## Summary

- Add canonical \`_SUPERSESSION_INVARIANT\` constant + \`_SUPERSESSION_EXAMPLES\` (positive REPLACE + negative EVOLUTION) to 3 system prompts (\`_USER_STEER\`, \`_REFINE\`, \`_LOOPING_TOOL_CALL\`) + the \`_build_steer_prompt\` invariants block.
- Goal: have goldfive's own planner LLM emit \`Task.supersedes\` for any semantic replacement, regardless of new-task-id naming, so we don't depend on name-pattern inference.
- v29 forensic: LLM emitted \`fix_review_slides\`, missed by iter-5's \`retry_X\` / \`X_v2\` backfill; \`review_slides\` falsely fatally_failed.
- Reviewer's REQUEST_CHANGES applied: skipped \`_PLAN_DIVERGENCE_SYSTEM_PROMPT\`, did NOT modify \`_render_structural_invariants_block\`, paired examples (positive + negative).

## Test plan

- [x] 7 new tests in \`test_planner.py\`
- [x] 1728 broader tests pass (was 1721 baseline)
- [x] ruff clean
- [x] Anti-pattern check: PASS (goldfive's own planner is fine to instruct; not a user-agent contract)

Refs: iter-7 #214.