### PR TITLE
feat(steerer, adapter): pin runtime-reasoning agent + observe task lineage

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -2638,6 +2638,30 @@ def make_adk_plugin(
                     )
                 return None
 
+            # Pin the runtime-reasoning agent on the goldfive Session
+            # so the reasoning-drift judge can attribute reasoning to
+            # the agent that actually produced it (rather than the
+            # static plan assignee). When a coordinator delegates to a
+            # child via AgentTool the child reasons under the parent's
+            # task pin; reading ``task.assignee_agent_id`` on the
+            # judge dispatch path mis-attributed every drift to the
+            # coordinator. Last writer wins — reasoning is sequential
+            # within an invocation, so by the time the model-response
+            # callback fires the most recent ``before_agent_callback``
+            # is the agent producing the reasoning. Pre-pin races
+            # (the LLM judge calling before this fires for the first
+            # time) read empty and the consumer falls back to
+            # ``task.assignee_agent_id`` for back-compat.
+            try:
+                gf_session = self._active_ctx.session if self._active_ctx else None
+                if gf_session is not None and agent_name:
+                    gf_session.current_agent_id = agent_name
+            except Exception as exc:  # noqa: BLE001 — pinning must never raise
+                log.debug(
+                    "before_agent_callback: current_agent_id pin raised: %s",
+                    exc,
+                )
+
             # Layer 1: pin the starting sub-agent's task_id so its
             # reporting-tool calls can default the arg from state
             # (goldfive#191). Best-effort: a raise here must never
@@ -4915,6 +4939,29 @@ def make_adk_plugin(
                     task_id=task_id,
                     invocation_id=inv_id,
                 )
+                # Extend the per-task observed-agent lineage with the
+                # delegated child. Idempotent ``set.add`` so repeat
+                # delegations to the same child do not balloon the set.
+                # No-op when there is no current task pin (race with
+                # task in_progress) or no delegated agent name — those
+                # are best-effort observability signals, not invariants.
+                try:
+                    gf_session = ctx.session if ctx is not None else None
+                    pinned_task_id = (
+                        gf_session.current_task_id if gf_session is not None else ""
+                    )
+                    if (
+                        gf_session is not None
+                        and pinned_task_id
+                        and to_agent
+                        and pinned_task_id in gf_session.task_lineage
+                    ):
+                        gf_session.task_lineage[pinned_task_id].add(to_agent)
+                except Exception as exc:  # noqa: BLE001 — observability is best-effort
+                    log.debug(
+                        "before_tool_callback: task_lineage update raised: %s",
+                        exc,
+                    )
                 if self._reconciler is not None:
                     try:
                         await self._reconciler.on_delegation_observed(

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -135,6 +135,7 @@ REASONING_DRIFT_USER_PROMPT_TEMPLATE: str = (
     "is on task.\n\n"
     "PLAN TASKS (id -> title):\n{plan_tasks_summary}\n\n"
     "CURRENTLY BOUND TASK:\n{task_block}\n\n"
+    "Currently reasoning agent: {current_agent_id}\n\n"
     "GOALS:\n{goals_block}\n\n"
     "REASONING (the agent's most recent chain-of-thought block):\n"
     "{reasoning_block}\n\n"
@@ -505,6 +506,7 @@ async def classify_reasoning_drift_with_focus(
         goals_block=_format_goals(goals),
         task_block=_format_task(task),
         reasoning_block=_format_reasoning(reasoning),
+        current_agent_id=current_agent_id or "(unknown)",
     )
     started = time.monotonic()
     call_failed = False

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -864,6 +864,15 @@ class DefaultSteerer:
         # considered productively iterating; outside that window, the
         # next drift escalates to HUMAN_INTERVENTION_REQUIRED.
         session.task_last_progress_at[task_id] = time.monotonic()
+        # Seed the observed-agent lineage with the static plan
+        # assignee. ``before_tool_callback`` extends the set with each
+        # delegated child agent so consumers (e.g. the reasoning judge)
+        # can distinguish "child of a delegation chain rooted at the
+        # assignee" from "off-plan agent". Cleared on every terminal
+        # transition.
+        session.task_lineage[task_id] = (
+            {task.assignee_agent_id} if task.assignee_agent_id else set()
+        )
         await self._emit_task_started(session, task_id, detail)
         await self._emit_task_transitioned(
             session,
@@ -927,6 +936,8 @@ class DefaultSteerer:
             session.completed_results[task_id] = summary
         # goldfive#152: clear current_task_* if we were the active task.
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.COMPLETED)
+        # Drop the observed-agent lineage now the task is terminal.
+        session.task_lineage.pop(task_id, None)
         await self._emit_task_completed(session, task_id, summary, artifacts or {})
         await self._emit_task_transitioned(
             session,
@@ -975,6 +986,8 @@ class DefaultSteerer:
         from_status = task.status
         task.status = TaskStatus.FAILED
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.FAILED)
+        # Drop the observed-agent lineage now the task is terminal.
+        session.task_lineage.pop(task_id, None)
         await self._emit_task_failed(session, task_id, reason, recoverable)
         await self._emit_task_transitioned(
             session,
@@ -1079,6 +1092,8 @@ class DefaultSteerer:
         from_status = task.status
         task.status = TaskStatus.CANCELLED
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.CANCELLED)
+        # Drop the observed-agent lineage now the task is terminal.
+        session.task_lineage.pop(task_id, None)
         await self._emit_task_cancelled(session, task_id, reason)
         await self._emit_task_transitioned(
             session,
@@ -1127,6 +1142,8 @@ class DefaultSteerer:
         from_status = task.status
         task.status = TaskStatus.NOT_NEEDED
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.NOT_NEEDED)
+        # Drop the observed-agent lineage now the task is terminal.
+        session.task_lineage.pop(task_id, None)
         # There is no dedicated ``TaskNotNeeded`` proto message;
         # reuse TaskCancelled with the reason prefix so sinks that
         # inspect reason can differentiate if they wish. The live
@@ -1221,6 +1238,11 @@ class DefaultSteerer:
             # emission count stay deterministic.
             dep_from = dep.status
             dep.status = TaskStatus.CANCELLED
+            # Drop the observed-agent lineage now the task is terminal —
+            # mirrors the cleanup that ``mark_task_cancelled`` performs
+            # for the initiator (this BFS does not recurse through that
+            # method so the cleanup is duplicated explicitly).
+            session.task_lineage.pop(next_id, None)
             await self._emit_task_cancelled(session, next_id, cascade_reason)
             await self._emit_task_transitioned(
                 session,
@@ -1926,6 +1948,14 @@ class DefaultSteerer:
             conf_val = float(confidence) if confidence is not None else 0.0
         except (TypeError, ValueError):
             conf_val = 0.0
+        # Prefer the runtime-reasoning agent pin (set by the ADK
+        # plugin's ``before_agent_callback``) over the static plan
+        # assignee — when a coordinator delegates to a child the
+        # child's reasoning produced this drift, not the assignee's.
+        # Fall back to ``task.assignee_agent_id`` when the session
+        # pin is empty (pre-pin race or non-ADK adapter that doesn't
+        # populate it) so we keep back-compat.
+        agent_id_for_drift = session.current_agent_id or task.assignee_agent_id
         if not making_progress:
             drift = DriftEvent(
                 kind=DriftKind.SELF_REPORTED_STUCK,
@@ -1936,7 +1966,7 @@ class DefaultSteerer:
                     + f" (confidence={conf_val:.2f})"
                 ),
                 current_task_id=task.id,
-                current_agent_id=task.assignee_agent_id,
+                current_agent_id=agent_id_for_drift,
             )
             await self._handle_drift(drift, session)
             return
@@ -1949,7 +1979,7 @@ class DefaultSteerer:
                     f"(confidence={conf_val:.2f})" + (f": {reason}" if reason else "")
                 ),
                 current_task_id=task.id,
-                current_agent_id=task.assignee_agent_id,
+                current_agent_id=agent_id_for_drift,
             )
             await self._handle_drift(drift, session)
             return

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -961,6 +961,25 @@ class Session:
     # call ids so prompt templates / refine paths / downstream planners
     # can read a single, framework-agnostic source of truth.
     state: dict[str, Any] = dataclasses.field(default_factory=dict)
+    # Runtime-reasoning agent pin. Set by the ADK plugin's
+    # ``before_agent_callback`` to the agent that is about to reason
+    # (``last writer wins`` — reasoning is sequential within an
+    # invocation). Distinct from ``Task.assignee_agent_id`` which
+    # encodes the static plan intent: when a coordinator (assignee)
+    # delegates to a child via ``AgentTool``, the child reasons under
+    # the parent's task pin; ``current_agent_id`` reflects the actual
+    # reasoner so the reasoning judge attributes drift correctly.
+    # Defaults to ``""`` for legacy callers / pre-pin races; consumers
+    # should fall back to ``task.assignee_agent_id`` when empty.
+    current_agent_id: str = ""
+    # Observed delegation lineage per-task. Keyed by ``task.id`` →
+    # set of ``agent_id`` strings observed reasoning under that task
+    # (initialised to ``{task.assignee_agent_id}`` on RUNNING and
+    # extended by each ``delegation_observed`` whose pinned task_id
+    # matches). Cleared on task terminal transition. Consumers (e.g.
+    # the reasoning judge) can use this to distinguish "child of a
+    # delegation chain rooted at the assignee" from "off-plan agent".
+    task_lineage: dict[str, set[str]] = dataclasses.field(default_factory=dict)
     # Monotonic event sequence counter for sinks. When this Session was
     # built by :meth:`Conversation.next_turn_session`, the seed value is
     # the Conversation's running cursor (lifted from the previous turn's

--- a/tests/test_judge_uses_real_agent_id.py
+++ b/tests/test_judge_uses_real_agent_id.py
@@ -1,0 +1,200 @@
+"""Tests for the runtime-reasoning agent pin (``Session.current_agent_id``).
+
+The reflective self-progress check (``maybe_run_reflective_check``)
+constructs ``DriftEvent``\\s of kind ``SELF_REPORTED_STUCK`` /
+``UNCERTAIN_PROGRESS``. Pre-fix it stamped ``current_agent_id`` from
+``task.assignee_agent_id`` — the static plan intent. When a coordinator
+delegates to a child via AgentTool the child reasons under the parent's
+task pin but the steerer still attributed the resulting drift to the
+coordinator.
+
+The fix reads ``session.current_agent_id`` (set by the ADK plugin's
+``before_agent_callback``) when non-empty, falling back to
+``task.assignee_agent_id`` for back-compat (pre-pin races, non-ADK
+adapters that don't populate the session pin).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.pb.goldfive.v1 import types_pb2  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Goal,
+    Plan,
+    Session,
+    Task,
+)
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:  # pragma: no cover - convenience
+        return None
+
+
+class _NullPlanner:
+    async def generate(self, **kwargs: Any) -> Plan | None:  # noqa: ARG002
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:  # noqa: ARG002
+        return None
+
+
+def _stub_call_llm(response: dict[str, Any]):
+    """Async ``call_llm``-shaped stub. Captures (system, user, model)."""
+    captured: list[tuple[str, str, str]] = []
+
+    async def _call(system: str, user: str, model: str) -> str:
+        captured.append((system, user, model))
+        return json.dumps(response)
+
+    _call.calls = captured  # type: ignore[attr-defined]
+    return _call
+
+
+def _build_running_session(
+    *,
+    assignee: str,
+    current_agent_id: str = "",
+) -> tuple[Session, Task]:
+    """Build a session whose single task is RUNNING with the given assignee."""
+    task = Task(id="t1", title="Demo", assignee_agent_id=assignee)
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[task],
+        edges=[],
+    )
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="demo")],
+        plan=plan,
+        current_task_id=task.id,
+        current_agent_id=current_agent_id,
+    )
+    return session, task
+
+
+async def _capture_drifts(steerer: DefaultSteerer, sink: _ListSink) -> list[Any]:
+    """Pull the ``DriftDetected`` payloads from the sink."""
+    drifts: list[Any] = []
+    for evt in sink.events:
+        if hasattr(evt, "WhichOneof") and evt.WhichOneof("payload") == "drift_detected":
+            drifts.append(evt.drift_detected)
+    return drifts
+
+
+async def test_reflective_drift_uses_session_current_agent_id_when_set() -> None:
+    """When ``session.current_agent_id`` is set the reflective drift uses it.
+
+    Reproduces the topology: ``task.assignee_agent_id == "coordinator"``
+    but the actual reasoner is ``research_agent`` (delegated via
+    AgentTool). The reflective judge returns ``making_progress=False``;
+    the resulting ``SELF_REPORTED_STUCK`` drift must be attributed to
+    ``research_agent``, not the coordinator.
+    """
+    sink = _ListSink()
+    reflective_call = _stub_call_llm(
+        {"making_progress": False, "confidence": 0.9, "reason": "stuck"}
+    )
+    steerer = DefaultSteerer(reflective_call_llm=reflective_call)
+    steerer.bind(sinks=[sink], planner=_NullPlanner())
+
+    session, task = _build_running_session(
+        assignee="coordinator",
+        current_agent_id="research_agent",
+    )
+
+    await steerer.maybe_run_reflective_check(session)
+
+    drifts = await _capture_drifts(steerer, sink)
+    # ``_handle_drift`` may emit a lifecycle follow-up (ESCALATING) on top
+    # of the initial ENGAGED drift; we only care about the initial event.
+    assert drifts, "reflective check should have emitted at least one drift"
+    assert drifts[0].kind == types_pb2.DRIFT_KIND_SELF_REPORTED_STUCK
+    assert drifts[0].current_agent_id == "research_agent", (
+        "reflective drift must be attributed to the runtime reasoner, "
+        "not the static plan assignee"
+    )
+
+
+async def test_reflective_drift_falls_back_to_assignee_when_pin_empty() -> None:
+    """Empty session pin → falls back to ``task.assignee_agent_id``.
+
+    Back-compat path: a non-ADK adapter (or a pre-pin race during the
+    very first invocation before ``before_agent_callback`` has fired)
+    leaves ``session.current_agent_id`` empty. The drift must still
+    carry an attribution rather than ending up with empty
+    ``current_agent_id`` — fall back to the static plan assignee.
+    """
+    sink = _ListSink()
+    reflective_call = _stub_call_llm(
+        {"making_progress": False, "confidence": 0.9, "reason": "stuck"}
+    )
+    steerer = DefaultSteerer(reflective_call_llm=reflective_call)
+    steerer.bind(sinks=[sink], planner=_NullPlanner())
+
+    session, task = _build_running_session(
+        assignee="coordinator",
+        current_agent_id="",  # empty pin
+    )
+
+    await steerer.maybe_run_reflective_check(session)
+
+    drifts = await _capture_drifts(steerer, sink)
+    assert drifts, "reflective check should have emitted at least one drift"
+    assert drifts[0].current_agent_id == "coordinator", (
+        "empty session pin must fall back to the static assignee"
+    )
+
+
+async def test_uncertain_progress_drift_also_uses_session_pin() -> None:
+    """The ``UNCERTAIN_PROGRESS`` (low-confidence) path carries the pin too.
+
+    The reflective check has two drift exits: ``SELF_REPORTED_STUCK``
+    when ``making_progress=False`` and ``UNCERTAIN_PROGRESS`` when
+    ``making_progress=True`` but ``confidence < 0.5``. Both exits
+    construct a ``DriftEvent`` and must read from the session pin.
+    """
+    sink = _ListSink()
+    reflective_call = _stub_call_llm(
+        {"making_progress": True, "confidence": 0.2, "reason": "vague"}
+    )
+    steerer = DefaultSteerer(reflective_call_llm=reflective_call)
+    steerer.bind(sinks=[sink], planner=_NullPlanner())
+
+    session, task = _build_running_session(
+        assignee="coordinator",
+        current_agent_id="research_agent",
+    )
+
+    await steerer.maybe_run_reflective_check(session)
+
+    drifts = await _capture_drifts(steerer, sink)
+    assert drifts, "reflective check should have emitted at least one drift"
+    assert drifts[0].kind == types_pb2.DRIFT_KIND_UNCERTAIN_PROGRESS
+    assert drifts[0].current_agent_id == "research_agent"
+
+
+def test_session_default_current_agent_id_is_empty_string() -> None:
+    """``Session.current_agent_id`` defaults to ``""`` for legacy callers."""
+    s = Session(run_id="r1")
+    assert s.current_agent_id == ""

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -1019,6 +1019,7 @@ def test_classify_with_focus_renders_plan_tasks_into_prompt() -> None:
         goals_block="(no goals)",
         task_block="(no task bound)",
         reasoning_block="thinking",
+        current_agent_id="(unknown)",
     )
     assert "PLAN TASKS" in rendered
     assert "t1 -> Alpha" in rendered

--- a/tests/test_task_lineage.py
+++ b/tests/test_task_lineage.py
@@ -1,0 +1,255 @@
+"""Tests for the observation-tracked agent lineage on ``Session.task_lineage``.
+
+The reasoning judge identifies the reasoning agent via ``current_agent_id``
+which used to be derived from ``task.assignee_agent_id`` — the static plan
+intent. When a coordinator delegates to a child via AgentTool the child
+reasons under the parent's task pin and the judge mis-attributed every
+drift to the coordinator. The fix tracks the *observed* agent lineage so
+consumers can distinguish "delegated child of the assignee" from
+"off-plan agent".
+
+Lifecycle contract exercised here:
+
+* ``mark_task_running`` initialises ``session.task_lineage[task.id]``
+  with ``{task.assignee_agent_id}``.
+* ``before_tool_callback`` AgentTool path adds ``to_agent`` to that set
+  whenever ``session.current_task_id`` matches the in-progress task.
+* Multiple delegations under the same task accumulate (idempotent
+  ``set.add``).
+* Each terminal transition (``mark_task_completed`` /
+  ``mark_task_failed`` / ``mark_task_cancelled`` /
+  ``mark_task_not_needed``) drops the lineage entry.
+* The cascade path also clears entries for downstream cancelled tasks
+  (it bypasses ``mark_task_cancelled`` and does the cleanup inline).
+* When ``session.current_task_id`` is empty at delegation time the
+  lineage update is a no-op (race with task in-progress is fine).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskStatus,
+)
+
+
+class _NullPlanner:
+    async def generate(self, **kwargs: Any) -> Plan | None:  # noqa: ARG002
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:  # noqa: ARG002
+        return None
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:  # pragma: no cover - convenience
+        return None
+
+
+def _build_session_with_running_task(
+    *, task_id: str = "t1", assignee: str = "coordinator"
+) -> tuple[DefaultSteerer, Session, Task]:
+    task = Task(id=task_id, title="Demo", assignee_agent_id=assignee)
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[task],
+        edges=[],
+    )
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="demo goal")],
+        plan=plan,
+    )
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[_ListSink()], planner=_NullPlanner())
+    return steerer, session, task
+
+
+async def test_lineage_initialises_on_task_running() -> None:
+    """``mark_task_running`` seeds ``task_lineage`` with the assignee."""
+    steerer, session, task = _build_session_with_running_task(assignee="coordinator")
+    assert task.id not in session.task_lineage  # pre-condition
+
+    await steerer.mark_task_running(task.id, session=session)
+
+    assert session.task_lineage[task.id] == {"coordinator"}
+
+
+async def test_lineage_initialises_empty_set_when_no_assignee() -> None:
+    """Plans built without an assignee still get a lineage entry (empty set).
+
+    A blank assignee should not leave ``task_lineage`` keyless on the
+    in-progress task — downstream consumers expect ``task_id in lineage``
+    to be the "is this task running" signal, distinct from "what agents
+    have we observed".
+    """
+    steerer, session, task = _build_session_with_running_task(assignee="")
+    await steerer.mark_task_running(task.id, session=session)
+    assert session.task_lineage[task.id] == set()
+
+
+async def test_delegation_observed_extends_lineage_on_pinned_task() -> None:
+    """Simulating the ``before_tool_callback`` lineage write.
+
+    The plugin calls ``session.task_lineage[current_task_id].add(to_agent)``
+    when an AgentTool dispatch fires. We exercise the contract directly
+    rather than going through the full ADK plugin so the test stays
+    framework-neutral.
+    """
+    steerer, session, task = _build_session_with_running_task(assignee="coordinator")
+    await steerer.mark_task_running(task.id, session=session)
+    assert session.current_task_id == task.id
+
+    # Simulate the plugin's idempotent set.add on a delegated child.
+    session.task_lineage[session.current_task_id].add("research_agent")
+    assert session.task_lineage[task.id] == {"coordinator", "research_agent"}
+
+
+async def test_lineage_accumulates_multiple_delegations() -> None:
+    """Two delegations under the same task end up in one set."""
+    steerer, session, task = _build_session_with_running_task(assignee="coordinator")
+    await steerer.mark_task_running(task.id, session=session)
+
+    session.task_lineage[task.id].add("research_agent")
+    session.task_lineage[task.id].add("writer_agent")
+    # Idempotent re-add is a no-op.
+    session.task_lineage[task.id].add("research_agent")
+
+    assert session.task_lineage[task.id] == {
+        "coordinator",
+        "research_agent",
+        "writer_agent",
+    }
+
+
+async def test_lineage_clears_on_completed() -> None:
+    steerer, session, task = _build_session_with_running_task()
+    await steerer.mark_task_running(task.id, session=session)
+    assert task.id in session.task_lineage
+
+    await steerer.mark_task_completed(task.id, session=session)
+    assert task.id not in session.task_lineage
+
+
+async def test_lineage_clears_on_failed_recoverable() -> None:
+    steerer, session, task = _build_session_with_running_task()
+    await steerer.mark_task_running(task.id, session=session)
+
+    await steerer.mark_task_failed(task.id, session=session, recoverable=True)
+    assert task.id not in session.task_lineage
+
+
+async def test_lineage_clears_on_failed_fatal() -> None:
+    steerer, session, task = _build_session_with_running_task()
+    await steerer.mark_task_running(task.id, session=session)
+
+    await steerer.mark_task_failed(task.id, session=session, recoverable=False)
+    assert task.id not in session.task_lineage
+
+
+async def test_lineage_clears_on_cancelled() -> None:
+    steerer, session, task = _build_session_with_running_task()
+    await steerer.mark_task_running(task.id, session=session)
+
+    await steerer.mark_task_cancelled(task.id, session=session)
+    assert task.id not in session.task_lineage
+
+
+async def test_lineage_clears_on_not_needed() -> None:
+    """``NOT_NEEDED`` is the closest TaskStatus analog to "superseded".
+
+    The reconciler marks redundant pending tasks NOT_NEEDED post-
+    invocation. The lineage entry should be dropped just like any
+    other terminal transition.
+    """
+    steerer, session, task = _build_session_with_running_task()
+    await steerer.mark_task_running(task.id, session=session)
+
+    await steerer.mark_task_not_needed(task.id, session=session)
+    assert task.id not in session.task_lineage
+
+
+async def test_lineage_clears_on_cascade_cancel_downstream() -> None:
+    """The cascade BFS path also clears lineage for downstream tasks.
+
+    ``cascade_cancel_downstream`` deliberately does not recurse through
+    ``mark_task_cancelled``; it transitions tasks in place. We mirror
+    the cleanup so a fatal upstream failure that cancels three
+    downstream tasks leaves no orphaned lineage entries.
+    """
+    upstream = Task(id="u", title="Upstream", assignee_agent_id="a1")
+    downstream = Task(id="d", title="Downstream", assignee_agent_id="a2")
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[upstream, downstream],
+        edges=[],
+    )
+    # Edge "upstream → downstream" so the cascade reaches d.
+    from goldfive.types import TaskEdge
+
+    plan.edges = [TaskEdge(from_task_id="u", to_task_id="d")]
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="demo")],
+        plan=plan,
+    )
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[_ListSink()], planner=_NullPlanner())
+
+    await steerer.mark_task_running("u", session=session)
+    await steerer.mark_task_running("d", session=session)
+    assert "u" in session.task_lineage
+    assert "d" in session.task_lineage
+
+    # Fatal failure on upstream cascades cancellation to downstream;
+    # both lineage entries should be cleared.
+    await steerer.mark_task_failed("u", session=session, recoverable=False)
+    assert "u" not in session.task_lineage
+    assert "d" not in session.task_lineage
+    assert downstream.status is TaskStatus.CANCELLED
+
+
+async def test_delegation_observed_with_no_pinned_task_is_noop() -> None:
+    """If ``current_task_id`` is empty at delegation time, no lineage write.
+
+    The plugin guards on ``current_task_id`` and ``pinned_task_id in
+    session.task_lineage`` before writing, so a delegation observed
+    before any task transitioned to RUNNING (race with task in_progress)
+    is silently dropped.
+    """
+    session = Session(run_id="r1")
+    assert session.current_task_id == ""
+    assert session.task_lineage == {}
+
+    # Mimic the plugin's guarded write — same condition as in
+    # ``before_tool_callback``: only write when both the pin AND the
+    # lineage key are present. With both empty, nothing changes.
+    pinned = session.current_task_id
+    if pinned and pinned in session.task_lineage:  # pragma: no cover - intentional
+        session.task_lineage[pinned].add("research_agent")
+    assert session.task_lineage == {}


### PR DESCRIPTION
## Summary

Live e2e on apple-presentation (Qwen3.6-35B-A3B-FP8 / kossel.lan) saw 5 false-positive `OFF_TOPIC` drifts whose root cause was the reasoning-drift judge attributing reasoning to the static plan **assignee** (`Task.assignee_agent_id`) rather than the agent that actually produced the reasoning. When a coordinator delegates to a child via `AgentTool`, the child reasons under the parent's task pin; the judge mis-attributed every drift to the coordinator.

This is a structural fix in two parts:

- **Runtime-reasoning agent pin.** New `Session.current_agent_id` set by `before_agent_callback`. The reflective-check drift constructions in `DefaultSteerer.maybe_run_reflective_check` now read from this pin (falling back to `task.assignee_agent_id` when empty for back-compat).
- **Observed delegation lineage.** New `Session.task_lineage` (`task_id` → set of agent ids observed reasoning under that task). Initialised on `mark_task_running` with the assignee, extended by each `before_tool_callback` AgentTool dispatch, cleared on every terminal transition (including the in-place cascade-cancel BFS path that bypasses `mark_task_cancelled`).

Plus a light-touch enrichment of the reasoning-judge prompt: a `Currently reasoning agent: {current_agent_id}` line so the LLM has the data even though no structural gate is added yet (that's a separate, larger change involving three-way verdict reshaping — deferred).

## Out of scope (deferred)

- A hard structural gate on the judge ("skip judge call when current agent is in lineage") — the spec explicitly defers this; this PR makes the data correct and surfaces it to the prompt.
- Migrating the existing `analyze_reasoning(..., agent_name=...)` plumbing to read from the session pin instead. That path already passes the live agent name from the ADK plugin's `_invocation_context` (added by goldfive#271 reasoning-judge delegated coverage), so the bug in this PR's scope was specifically the **reflective-check** drift constructions.

## Files

- `goldfive/types.py` — new `Session.current_agent_id`, `Session.task_lineage` fields with default factories (back-compat-safe for tests reading old session JSON snapshots).
- `goldfive/adapters/_adk_plugin.py` — `before_agent_callback` pins `current_agent_id`; `before_tool_callback` AgentTool path extends `task_lineage` (idempotent set.add).
- `goldfive/steerer.py` — lineage init on RUNNING; lineage clear on COMPLETED / FAILED / CANCELLED / NOT_NEEDED + the cascade BFS path. Reflective drift now reads from session pin with assignee fallback.
- `goldfive/drift/reasoning_judge.py` — prompt template enrichment.
- `tests/test_task_lineage.py` (new) — 11 tests covering the lifecycle.
- `tests/test_judge_uses_real_agent_id.py` (new) — 4 tests for reflective drift agent attribution.
- `tests/test_reasoning_judge.py` — small fix: existing template-formatting test now passes the new `current_agent_id` placeholder.

## Test plan

- [x] `pytest tests/test_task_lineage.py -q` — 11 passed
- [x] `pytest tests/test_judge_uses_real_agent_id.py -q` — 4 passed
- [x] `pytest -q` — 1697 passed, 120 skipped
- [x] `ruff check` clean on touched files