### PR TITLE
fix(planner, steerer): route OFF_TOPIC drift through goal-aware refine

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -1313,6 +1313,28 @@ class LLMPlanner:
         return "\n".join(lines)
 
     @staticmethod
+    def _render_off_topic_reasoning_block(drift: DriftEvent) -> str:
+        """Render the reasoning context for an OFF_TOPIC drift refine.
+
+        OFF_TOPIC drifts come from the reasoning judge (or sentence-level
+        cosine detector); the deviation is in the agent's reasoning, not
+        in the observed agent activity. To give the goal-aware refine
+        prompt an analogue of ``OBSERVED AGENT ACTIVITY`` we render the
+        reason and the truncated reasoning text the judge saw. Falls back
+        to ``"(no reasoning excerpt available)"`` when the drift carries
+        no preview, so the prompt shape is invariant for tests.
+        """
+        header = "OFF-TOPIC REASONING (what the agent has been reasoning about):"
+        reason = drift.detail or "(judge returned no reason)"
+        excerpt = drift.trigger_input or ""
+        if not excerpt and isinstance(drift.raw, str):
+            excerpt = drift.raw
+        excerpt = excerpt.strip()
+        if not excerpt:
+            excerpt = "(no reasoning excerpt available)"
+        return f"{header}\n- judge reason: {reason}\n- excerpt: {excerpt}"
+
+    @staticmethod
     def _render_prior_turns_block(context: Mapping[str, Any] | None) -> str:
         """Render cross-turn context from a Conversation into a prompt block.
 
@@ -2189,6 +2211,31 @@ class LLMPlanner:
                 'return a JSON object of the form {"reject": true, "reason": '
                 '"..."} (the caller will escalate to human intervention).\n\n'
             )
+        elif drift.kind is DriftKind.OFF_TOPIC:
+            # OFF_TOPIC has no observed-actions channel — the deviation
+            # is in the agent's reasoning, surfaced by the reasoning
+            # judge. Render an analogous "what the agent did" block from
+            # the drift's reasoning context (``trigger_input`` is the
+            # truncated reasoning text the judge saw; ``raw`` is the
+            # original, when set; ``detail`` is the judge's free-form
+            # reason). Frame it with the same ABSORB/REJECT contract so
+            # the goal-aware system prompt's decision shape carries
+            # through.
+            observed_block = (
+                f"{self._render_off_topic_reasoning_block(drift)}\n\n"
+                "The agent's reasoning has drifted from the bound task. "
+                "Decide:\n"
+                "- ABSORB: if the new reasoning topic plausibly moves toward "
+                "the GOALS (and preserves every STICKY goal), produce a "
+                "revised plan that reflects the new direction (add or revise "
+                "tasks so the work the agent is now reasoning about has a "
+                "place in the plan).\n"
+                "- REJECT: if the new reasoning topic CONTRADICTS any goal "
+                "-- especially any STICKY goal added by a prior USER_STEER "
+                "-- or simply does not advance any goal, return a JSON "
+                'object of the form {"reject": true, "reason": "..."} '
+                "(the caller will escalate to human intervention).\n\n"
+            )
         return (
             f"{agents_block}"
             f"CURRENT GOALS (the revision must still advance every goal, "
@@ -2449,20 +2496,29 @@ class LLMPlanner:
         # kind; defending here too is a belt-and-braces guard.
         if drift.kind is DriftKind.REFINE_VALIDATION_FAILED:
             return None
-        # PLAN_DIVERGENCE with observed_actions goes through the
-        # reconciler prompt: the LLM must either ABSORB observed agent
-        # activity into a revised plan or REJECT (emit the reject
-        # sentinel). Without observed_actions we fall through to the
-        # generic refine path so callers that wire PLAN_DIVERGENCE the
-        # old way keep working.
+        # Plan-context drifts (PLAN_DIVERGENCE with observed_actions, or
+        # OFF_TOPIC reasoning drift) take the goal-aware ABSORB/REJECT
+        # prompt: the LLM must either revise the plan to reflect / accept
+        # the observed deviation, or emit the reject sentinel when the
+        # deviation contradicts the goals. PLAN_DIVERGENCE without
+        # observed_actions falls through to the generic refine path so
+        # legacy callers that wire PLAN_DIVERGENCE the old way keep
+        # working. OFF_TOPIC has no observed-actions channel — the
+        # reconciler context comes from the drift's ``detail`` /
+        # ``trigger_input`` (the reasoning the judge flagged) which the
+        # generic refine prompt also surfaces in the drift block, but
+        # the goal-aware system prompt's ABSORB/REJECT contract is the
+        # right shape for "agent reasoning wandered off goal".
         is_plan_divergence = drift.kind is DriftKind.PLAN_DIVERGENCE
-        use_divergence_prompt = is_plan_divergence and observed_actions is not None
+        is_off_topic = drift.kind is DriftKind.OFF_TOPIC
+        has_observed_actions = is_plan_divergence and observed_actions is not None
+        use_divergence_prompt = has_observed_actions or is_off_topic
         try:
             base_user_prompt = self._build_refine_prompt(
                 plan,
                 drift,
                 goals,
-                observed_actions=observed_actions if use_divergence_prompt else None,
+                observed_actions=observed_actions if has_observed_actions else None,
                 available_agents=available_agents,
             )
         except (TypeError, ValueError) as exc:

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -3100,6 +3100,21 @@ class DefaultSteerer:
             InterventionLevel.ABSORB,
             (InterventionLevel.CANCEL_REINVOKE, InterventionLevel.PAUSE_ESCALATE),
         ),
+        # OFF_TOPIC is plan-context drift from the reasoning judge — the
+        # agent is reasoning about something that doesn't fit the bound
+        # task. Mirrors PLAN_DIVERGENCE's ladder mapping so the ABSORB
+        # path engages the goal-aware refine prompt (planner.refine
+        # routes both PLAN_DIVERGENCE and OFF_TOPIC through
+        # ``_PLAN_DIVERGENCE_SYSTEM_PROMPT``). Without this entry the
+        # default fallback (WARNING -> ABSORB) still triggered refine
+        # but the planner picked the generic ``_REFINE_SYSTEM_PROMPT``
+        # which has no goal-alignment guidance and could silently
+        # absorb off-goal reasoning into the plan.
+        DriftKind.OFF_TOPIC: (
+            InterventionLevel.OBSERVE,
+            InterventionLevel.ABSORB,
+            (InterventionLevel.CANCEL_REINVOKE, InterventionLevel.PAUSE_ESCALATE),
+        ),
         DriftKind.INTENT_DIVERGENCE: (
             InterventionLevel.OBSERVE,
             InterventionLevel.ABSORB,

--- a/tests/test_intervention_ladder.py
+++ b/tests/test_intervention_ladder.py
@@ -120,6 +120,23 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         2,
         InterventionLevel.PAUSE_ESCALATE,
     ),
+    # OFF_TOPIC: plan-context drift from the reasoning judge. Ladder
+    # mirrors PLAN_DIVERGENCE so the ABSORB path can route to the
+    # goal-aware refine prompt rather than the generic refine prompt.
+    (DriftKind.OFF_TOPIC, DriftSeverity.INFO, 0, InterventionLevel.OBSERVE),
+    (DriftKind.OFF_TOPIC, DriftSeverity.WARNING, 0, InterventionLevel.ABSORB),
+    (
+        DriftKind.OFF_TOPIC,
+        DriftSeverity.CRITICAL,
+        0,
+        InterventionLevel.CANCEL_REINVOKE,
+    ),
+    (
+        DriftKind.OFF_TOPIC,
+        DriftSeverity.CRITICAL,
+        2,
+        InterventionLevel.PAUSE_ESCALATE,
+    ),
     # INTENT_DIVERGENCE: CRITICAL -> pause-escalate even on first occurrence.
     (DriftKind.INTENT_DIVERGENCE, DriftSeverity.WARNING, 0, InterventionLevel.ABSORB),
     (

--- a/tests/test_planner_observed_actions.py
+++ b/tests/test_planner_observed_actions.py
@@ -518,3 +518,161 @@ def test_observed_action_dataclass_shape() -> None:
     assert a.completed_at is None
     assert a.parent_invocation_id == ""
     assert a.status == "running"
+
+
+# ---------------------------------------------------------------------------
+# 8. OFF_TOPIC routes to the goal-aware refine prompt
+# ---------------------------------------------------------------------------
+
+
+async def test_refine_off_topic_uses_plan_divergence_system_prompt() -> None:
+    """OFF_TOPIC drift is plan-context drift from the reasoning judge:
+    the agent is reasoning about something that doesn't fit the bound
+    task. The ABSORB path must use the goal-aware
+    ``_PLAN_DIVERGENCE_SYSTEM_PROMPT`` so the LLM either revises the
+    plan to absorb the new direction (when it advances a goal) or
+    emits the ``{"reject": true, ...}`` sentinel (when it doesn't),
+    rather than silently absorbing off-goal reasoning via the generic
+    ``_REFINE_SYSTEM_PROMPT``.
+    """
+    stub = _StubLLM(_absorbed_revision_json())
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="reasoning drift: agent began researching tropical fish, not goldfish",
+        current_task_id="draft",
+        trigger_input="Let me research tropical fish habitats and breeding patterns...",
+    )
+
+    revised = await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+
+    assert revised is not None
+    system, user_prompt, _model = stub.calls[0]
+    # The divergence (goal-aware) system prompt was selected, NOT the
+    # generic refine prompt. Two structural markers:
+    #   1. Goal-aware prompt frames PLAN_DIVERGENCE / ABSORB / REJECT.
+    #   2. Generic prompt opens with "maintaining an ACTIVE plan" without
+    #      the ABSORB/REJECT contract.
+    assert "ABSORB" in system
+    assert "REJECT" in system
+    # The user prompt carries the OFF_TOPIC reasoning context block —
+    # the analogue of OBSERVED AGENT ACTIVITY for a reasoning-judge
+    # drift — so the system prompt's referenced "what the agent did"
+    # channel is honoured.
+    assert "OFF-TOPIC REASONING" in user_prompt
+    assert "tropical fish" in user_prompt
+    assert "judge reason" in user_prompt
+    # The user prompt should NOT include the OBSERVED AGENT ACTIVITY
+    # header — that's the PLAN_DIVERGENCE+observed_actions channel and
+    # OFF_TOPIC has no observed actions.
+    assert "OBSERVED AGENT ACTIVITY" not in user_prompt
+
+
+async def test_refine_off_topic_honours_reject_sentinel() -> None:
+    """When the LLM judges the off-topic reasoning to be off-goal, it
+    emits ``{"reject": true, "reason": "..."}`` and refine returns
+    ``None`` (so the steerer can escalate via the intervention ladder).
+    No REFINE_VALIDATION_FAILED is emitted because reject is a
+    successful decision, not a parse failure.
+    """
+    stub = _StubLLM(json.dumps({"reject": True, "reason": "off-goal excursion"}))
+    planner = LLMPlanner(call_llm=stub)
+
+    emitted: list[DriftEvent] = []
+
+    async def capture(d: DriftEvent) -> None:
+        emitted.append(d)
+
+    planner.set_drift_emitter(capture)
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="reasoning drifted to unrelated topic",
+        current_task_id="draft",
+    )
+
+    revised = await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+
+    assert revised is None
+    assert emitted == []
+    # Reject is final — no retry.
+    assert len(stub.calls) == 1
+
+
+async def test_refine_off_topic_without_trigger_input_renders_placeholder() -> None:
+    """The OFF_TOPIC reasoning block has invariant shape: when the drift
+    carries no ``trigger_input`` / ``raw`` / ``detail`` excerpt the
+    block still renders with a placeholder so the prompt is well-formed
+    (mirrors the ``(no observed activity)`` fallback on the
+    PLAN_DIVERGENCE path)."""
+    stub = _StubLLM(_absorbed_revision_json())
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="",
+        current_task_id="draft",
+    )
+
+    await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+    _system, user_prompt, _model = stub.calls[0]
+    assert "OFF-TOPIC REASONING" in user_prompt
+    assert "(no reasoning excerpt available)" in user_prompt
+
+
+async def test_refine_repeated_failure_keeps_generic_prompt() -> None:
+    """REPEATED_FAILURE / BLOCKED are structural-recovery drifts, not
+    plan-context drifts. They must continue to use the generic
+    ``_REFINE_SYSTEM_PROMPT`` — accidentally migrating them to the
+    goal-aware ABSORB/REJECT prompt would let the LLM emit
+    ``{"reject": true}`` for what is just a structural recovery and
+    that path is wired to escalate to human intervention.
+    """
+    payload = {
+        "summary": "same",
+        "tasks": [
+            {
+                "id": "research",
+                "title": "Research",
+                "assignee_agent_id": "researcher",
+                "status": "COMPLETED",
+            },
+            {
+                "id": "draft",
+                "title": "Draft",
+                "assignee_agent_id": "writer",
+                "status": "RUNNING",
+            },
+            {
+                "id": "review",
+                "title": "Review",
+                "assignee_agent_id": "editor",
+                "status": "PENDING",
+            },
+        ],
+        "edges": [
+            {"from_task_id": "research", "to_task_id": "draft"},
+            {"from_task_id": "draft", "to_task_id": "review"},
+        ],
+    }
+    for kind in (DriftKind.REPEATED_FAILURE, DriftKind.BLOCKED):
+        stub = _StubLLM(json.dumps(payload))
+        planner = LLMPlanner(call_llm=stub)
+        drift = DriftEvent(
+            kind=kind,
+            severity=DriftSeverity.WARNING,
+            detail="recovery",
+            current_task_id="draft",
+        )
+        await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+        system, user_prompt, _model = stub.calls[0]
+        # Generic refine system prompt selected, NOT the goal-aware one.
+        assert "ABSORB" not in system, (
+            f"{kind.value} accidentally migrated to the goal-aware prompt"
+        )
+        assert "maintaining an ACTIVE plan" in system
+        # No OFF_TOPIC reasoning block leaks onto non-OFF_TOPIC kinds.
+        assert "OFF-TOPIC REASONING" not in user_prompt
+        # No OBSERVED AGENT ACTIVITY block (no observed_actions provided).
+        assert "OBSERVED AGENT ACTIVITY" not in user_prompt


### PR DESCRIPTION
## Summary

OFF_TOPIC drifts from the reasoning judge fell through the steerer ladder to the default fallback (WARNING -> ABSORB), which called \`planner.refine()\` with the generic \`_REFINE_SYSTEM_PROMPT\`. That prompt has no goal-alignment guidance and could silently absorb off-goal reasoning into the plan.

OFF_TOPIC is plan-context drift -- the agent is reasoning about something that doesn't fit the bound task -- so it deserves the goal-aware ABSORB/REJECT contract that PLAN_DIVERGENCE+observed_actions already uses via \`_PLAN_DIVERGENCE_SYSTEM_PROMPT\`. The LLM either revises the plan to reflect the new direction (when it advances a goal) or emits the \`{\"reject\": true, \"reason\": \"...\"}\` sentinel (when it doesn't), so off-goal reasoning escalates via the intervention ladder rather than being silently absorbed.

## Changes

- **\`goldfive/planner.py\`**: extend the prompt-selection condition in \`refine()\` so OFF_TOPIC also picks \`_PLAN_DIVERGENCE_SYSTEM_PROMPT\`. OFF_TOPIC has no observed-actions channel, so render an analogous \"OFF-TOPIC REASONING\" user-prompt block from \`drift.detail\` / \`trigger_input\` / \`raw\` -- same shape and ABSORB/REJECT framing as the observed-actions block. PLAN_DIVERGENCE without observed_actions still uses the generic prompt (back-compat preserved).
- **\`goldfive/steerer.py\`**: add an explicit OFF_TOPIC entry to the \`_LADDER\` table mirroring PLAN_DIVERGENCE so the routing is documented where future readers expect it. REPEATED_FAILURE / BLOCKED / other structural-recovery kinds are unchanged.

## Fix shape

Picked **option B** from the brief (categorize plan-context drifts in the prompt-selection logic). Option A (ladder entry only) wouldn't fix the bug because the prompt is selected inside \`planner.refine\`, not by the ladder. Option C (goal-aware as default) was risky -- REPEATED_FAILURE / BLOCKED structural-recovery drifts don't fit the ABSORB/REJECT contract.

## Test plan

- [x] Pin OFF_TOPIC ladder mapping in \`test_intervention_ladder.py\` (4 new cases: INFO/WARNING/CRITICAL-first/CRITICAL-repeat).
- [x] Assert OFF_TOPIC \`refine\` uses the goal-aware system prompt + OFF-TOPIC REASONING user-prompt block.
- [x] Assert OFF_TOPIC honours the reject sentinel and returns \`None\` (no \`REFINE_VALIDATION_FAILED\` emit on reject).
- [x] Regression: PLAN_DIVERGENCE without observed_actions still uses the generic prompt.
- [x] Regression: REPEATED_FAILURE / BLOCKED still use the generic prompt (didn't accidentally migrate them).
- [x] Full test suite passes (1686 passed, 120 skipped).
- [x] \`ruff check\` clean.