### PR TITLE
feat: recent_tool_observations buffer for reasoning judge (iter-10 PR 2)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -5282,6 +5282,39 @@ def make_adk_plugin(
                 await ctx.steerer.observe(observation, ctx.session)
             except Exception as exc:  # noqa: BLE001
                 log.debug("on_tool_error_callback: steerer.observe raised: %s", exc)
+            # Iter-10 PR 2: also record the raised-error path on
+            # ``session.recent_tool_observations`` so the three-state
+            # reasoning judge (PR 3) can recognise a provoked
+            # deviation rooted in a hard tool exception. The one-shot
+            # ``Observation`` above is consumed for drift dispatch
+            # (e.g. ``classify_tool_error``) but never persisted on
+            # the session.
+            try:
+                note_obs = getattr(ctx.steerer, "note_tool_observation", None)
+                if note_obs is not None:
+                    gf_session = ctx.session
+                    pinned_agent = (
+                        str(_safe_attr(gf_session, "current_agent_id", "") or "")
+                        or self._host_agent_name
+                    )
+                    pinned_task = (
+                        str(_safe_attr(gf_session, "current_task_id", "") or "")
+                        or str(_safe_attr(ctx.task, "id", "") or "")
+                    )
+                    note_obs(
+                        gf_session,
+                        agent_name=pinned_agent,
+                        task_id=pinned_task,
+                        tool_name=tool_name,
+                        args=tool_args,
+                        result=None,
+                        error=error,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "on_tool_error_callback: note_tool_observation raised: %s",
+                    exc,
+                )
             return None
 
         # --- Tool-loop drift detection (goldfive#181) ------------------
@@ -5371,6 +5404,48 @@ def make_adk_plugin(
                     exc,
                 )
                 return None
+
+            # Iter-10 PR 2: record the call in the session-scoped
+            # ``recent_tool_observations`` ring buffer so the
+            # three-state reasoning judge (PR 3) can distinguish a
+            # provoked deviation (the agent saw a tool error or
+            # surprising result and pivoted) from an unprovoked one.
+            # We capture both successful calls and acknowledged
+            # failures (``result`` is a dict with shape
+            # ``{"error": ...}``); raised exceptions are captured by
+            # ``on_tool_error_callback`` instead. The live agent /
+            # task pin set by iter-9's ``before_agent_callback`` is
+            # the authoritative source — fall back to the ADK-resolved
+            # agent_name and the ctx-task id when those are empty.
+            try:
+                note_obs = getattr(ctx.steerer, "note_tool_observation", None)
+                if note_obs is not None:
+                    gf_session = ctx.session
+                    pinned_agent = (
+                        str(_safe_attr(gf_session, "current_agent_id", "") or "")
+                        or agent_name
+                        or self._host_agent_name
+                    )
+                    pinned_task = (
+                        str(_safe_attr(gf_session, "current_task_id", "") or "")
+                        or task_id
+                    )
+                    note_obs(
+                        gf_session,
+                        agent_name=pinned_agent,
+                        task_id=pinned_task,
+                        tool_name=tool_name,
+                        args=tool_args,
+                        result=result,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                # Defensive — observability must never break tool
+                # dispatch. The steerer method already swallows its
+                # own internals; this catches the lookup path.
+                log.debug(
+                    "after_tool_callback: note_tool_observation raised: %s",
+                    exc,
+                )
 
             # Post-observation: reset the window only on acknowledged
             # success for progress-reporting tools. An errored report

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -2014,6 +2014,100 @@ class DefaultSteerer:
         if overflow > 0:
             del hist[:overflow]
 
+    def note_tool_observation(
+        self,
+        session: Session,
+        *,
+        agent_name: str,
+        task_id: str,
+        tool_name: str,
+        args: Any,
+        result: Any,
+        error: Exception | str | None = None,
+    ) -> None:
+        """Append a bounded tool-observation entry to ``session.recent_tool_observations``.
+
+        Iter-10 PR 2. Population path for the three-state reasoning
+        judge (PR 3 reads this buffer to distinguish a provoked
+        deviation from an unprovoked one). Adapters call this from
+        their ``after_tool_callback`` (success + acknowledged-failure)
+        and ``on_tool_error_callback`` hooks.
+
+        Push-only and trim-on-write — mirrors
+        :meth:`note_agent_activity`. The buffer is bounded by
+        ``session.recent_tool_observations_max`` (default 16) so the
+        prompt the judge eventually reads stays small regardless of
+        run length. Per-task filtering happens at READ time in the
+        judge's prompt renderer; this writer captures every call.
+
+        Always swallow internal errors. Observability must never break
+        tool dispatch — a malformed ``args`` / ``result`` repr, a
+        broken clock, or a pathological session must not raise out of
+        an ADK callback. The catch is intentionally broad.
+        """
+        try:
+            ts_ms = time.monotonic_ns() // 1_000_000
+            try:
+                args_preview = repr(args)[:240]
+            except Exception:  # noqa: BLE001
+                args_preview = "(unrepresentable args)"
+            if result is None:
+                result_preview = "(none)"
+            else:
+                try:
+                    result_preview = repr(result)[:480]
+                except Exception:  # noqa: BLE001
+                    result_preview = "(unrepresentable result)"
+            # Error detection: an explicit ``error=`` from the caller
+            # (the on_tool_error path) wins; otherwise look for the
+            # acknowledged-failure shape ``{"error": ...}`` in the
+            # tool result. The reporting tools and most goldfive
+            # tools return that shape on a soft failure.
+            is_error = False
+            error_message = ""
+            if error is not None:
+                is_error = True
+                try:
+                    error_message = str(error)[:240]
+                except Exception:  # noqa: BLE001
+                    error_message = "(unrepresentable error)"
+            elif isinstance(result, dict) and "error" in result:
+                is_error = True
+                try:
+                    error_message = str(result.get("error", ""))[:240]
+                except Exception:  # noqa: BLE001
+                    error_message = "(unrepresentable error)"
+            entry: dict[str, Any] = {
+                "ts_ms": ts_ms,
+                "agent_name": agent_name,
+                "task_id": task_id,
+                "tool_name": tool_name,
+                "args_preview": args_preview,
+                "result_preview": result_preview,
+                "is_error": is_error,
+                "error_message": error_message,
+            }
+            hist = session.recent_tool_observations
+            hist.append(entry)
+            # Cap defaults to 16 (§3.1) but honour any session-local
+            # override; clamp to >=1 so a pathological 0 / negative
+            # value doesn't disable the buffer entirely (we always
+            # want at least the most-recent entry).
+            try:
+                cap_raw = int(session.recent_tool_observations_max)
+            except (TypeError, ValueError):
+                cap_raw = 16
+            cap = max(1, cap_raw)
+            overflow = len(hist) - cap
+            if overflow > 0:
+                # Slice-delete is amortized O(1) on average for the
+                # bounded ``overflow == 1`` case (the steady state once
+                # the buffer is full), and is the same pattern
+                # ``note_agent_activity`` uses.
+                del hist[:overflow]
+        except Exception as exc:  # noqa: BLE001
+            log.debug("note_tool_observation: swallowed: %s", exc)
+
     async def note_agent_turn(self, session: Session) -> None:
         """Record one agent invocation against ``session``.
 

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1026,6 +1026,28 @@ class Session:
     # the reasoning judge) can use this to distinguish "child of a
     # delegation chain rooted at the assignee" from "off-plan agent".
     task_lineage: dict[str, set[str]] = dataclasses.field(default_factory=dict)
+    # Ring buffer of recent tool-call observations consumed by the
+    # iter-10 three-state reasoning judge so it can distinguish a
+    # provoked deviation (the agent saw a tool error / surprising
+    # result and pivoted) from an unprovoked one. Adapters push
+    # entries via ``DefaultSteerer.note_tool_observation`` from their
+    # ``after_tool_callback`` / ``on_tool_error_callback`` hooks; the
+    # steerer trims to ``recent_tool_observations_max`` so the prompt
+    # stays bounded regardless of run length. Each entry is a small
+    # dict (``ts_ms``, ``agent_name``, ``task_id``, ``tool_name``,
+    # ``args_preview``, ``result_preview``, ``is_error``,
+    # ``error_message``) — framework-neutral, no protos, so sinks /
+    # tests can introspect cheaply. Per-task scoping is applied at
+    # READ time by the judge's prompt renderer (PR 3): writers store
+    # everything so a deviation rooted in an earlier task's artefact
+    # remains visible.
+    recent_tool_observations: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+    # Cap for ``recent_tool_observations``. Default 16 covers a couple
+    # of agent invocations on typical traces while keeping the prompt
+    # block under ~1.5KB even before the per-entry truncation. Tunable
+    # via the ``Steerer`` config so operators on tight context budgets
+    # can drop it.
+    recent_tool_observations_max: int = 16
     # Monotonic event sequence counter for sinks. When this Session was
     # built by :meth:`Conversation.next_turn_session`, the seed value is
     # the Conversation's running cursor (lifted from the previous turn's

--- a/tests/test_adk_plugin_tool_observations.py
+++ b/tests/test_adk_plugin_tool_observations.py
@@ -1,0 +1,382 @@
+"""Integration tests for ADK plugin tool-observation wiring.
+
+iter-10 PR 2. Pins the contract that
+:func:`goldfive.adapters._adk_plugin._GoldfiveADKPlugin.after_tool_callback`
+and :meth:`_GoldfiveADKPlugin.on_tool_error_callback` write into
+``session.recent_tool_observations`` via the steerer's
+``note_tool_observation`` method.
+
+Three integration cases:
+
+* Successful tool dispatch -> entry with ``is_error=False``.
+* Acknowledged-failure dispatch (``result == {"error": ...}``) ->
+  entry with ``is_error=True``.
+* Hard tool exception (``on_tool_error_callback``) -> entry with
+  ``is_error=True``.
+
+Plus a robustness case: if ``note_tool_observation`` raises, tool
+dispatch must still complete -- observability never breaks the agent.
+
+The fixture mirrors ``tests/test_tool_loop_exemption_tightening.py`` so
+the plugin entry point is exercised exactly the way the live ADK
+runtime drives it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+pytest.importorskip("google.adk")
+
+from goldfive.types import DriftEvent, Session, Task  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Stubs — minimal surface that mirrors what the live ADK runtime gives us.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSteerer:
+    """Async-capable steerer stub that captures every drift + every observation entry.
+
+    Holds a real ``DefaultSteerer.note_tool_observation`` so the
+    integration test exercises the steerer's writer end-to-end. Tests
+    that want to override the writer (e.g. to assert dispatch survives
+    a writer failure) can monkeypatch ``note_tool_observation`` after
+    construction.
+    """
+
+    def __init__(self) -> None:
+        self.observations: list[Any] = []
+        self.drifts: list[DriftEvent] = []
+        # Defer import until inside __init__ so the protobuf-stubs
+        # gate at module import time is honoured.
+        from goldfive.steerer import DefaultSteerer
+
+        self._real_steerer = DefaultSteerer()
+
+    async def observe(self, event: Any, session: Any) -> None:
+        self.observations.append(event)
+
+    async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+        self.drifts.append(drift)
+
+    def note_tool_observation(self, *args: Any, **kwargs: Any) -> None:
+        # Delegate to the real implementation under test.
+        self._real_steerer.note_tool_observation(*args, **kwargs)
+
+
+def _plugin_with_ctx(task: Task, session: Session, steerer: Any):
+    """Build a goldfive ADK plugin + state-context for tool-observation tests."""
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session,
+            steerer=steerer,
+            task=task,
+            tool_handlers={},
+            host_agent_name="test_agent",
+        )
+    }
+    plugin.set_active_context(state[SESSION_CONTEXT_STATE_KEY])
+    return plugin, state
+
+
+class _ToolStub:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _InvCtxStub:
+    def __init__(self, invocation_id: str, agent_name: str) -> None:
+        self.invocation_id = invocation_id
+        self.agent = type("_A", (), {"name": agent_name})()
+
+
+class _ToolCtxStub:
+    """Minimal ADK tool_context shape exposing ``_invocation_context``."""
+
+    def __init__(self, invocation_id: str, agent_name: str) -> None:
+        self._invocation_context = _InvCtxStub(invocation_id, agent_name)
+
+
+# ---------------------------------------------------------------------------
+# after_tool_callback — success path
+# ---------------------------------------------------------------------------
+
+
+async def test_after_tool_callback_records_observation() -> None:
+    """A successful tool call appends an ``is_error=False`` entry."""
+    steerer = _RecordingSteerer()
+    session = Session(run_id="run-iter10-pr2-after-success")
+    task = Task(id="t1", title="Fetch data", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    tool = _ToolStub("web_search")
+    tool_ctx = _ToolCtxStub("inv-1", "worker")
+    args = {"q": "raccoon facts"}
+    result = {"results": ["fact a"]}
+
+    await plugin.after_tool_callback(
+        tool=tool, tool_args=args, tool_context=tool_ctx, result=result
+    )
+
+    assert len(session.recent_tool_observations) == 1
+    entry = session.recent_tool_observations[0]
+    assert entry["tool_name"] == "web_search"
+    assert entry["is_error"] is False
+    assert entry["error_message"] == ""
+    assert entry["task_id"] == "t1"
+    # Agent name falls back to ADK-resolved name when current_agent_id
+    # is empty (which it is on a bare Session for these tests).
+    assert entry["agent_name"] == "worker"
+    assert "raccoon" in entry["args_preview"]
+    assert "fact a" in entry["result_preview"]
+
+
+async def test_after_tool_callback_uses_pinned_agent_id_when_set() -> None:
+    """``session.current_agent_id`` (iter-9 pin) wins over ADK-resolved name."""
+    steerer = _RecordingSteerer()
+    session = Session(run_id="run-iter10-pr2-pin")
+    session.current_agent_id = "delegated_child"
+    session.current_task_id = "t-pinned"
+    task = Task(id="t1", title="Fetch", assignee_agent_id="parent")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    await plugin.after_tool_callback(
+        tool=_ToolStub("get_url"),
+        tool_args={"url": "https://x"},
+        tool_context=_ToolCtxStub("inv-2", "parent"),
+        result={"ok": True},
+    )
+
+    assert len(session.recent_tool_observations) == 1
+    entry = session.recent_tool_observations[0]
+    # Pin wins over the ADK-resolved ``parent`` name.
+    assert entry["agent_name"] == "delegated_child"
+    # And the task pin from iter-9 wins over ctx.task.id.
+    assert entry["task_id"] == "t-pinned"
+
+
+# ---------------------------------------------------------------------------
+# after_tool_callback — acknowledged-failure path
+# ---------------------------------------------------------------------------
+
+
+async def test_after_tool_callback_records_error_result() -> None:
+    """``result={"error": "..."}`` -> entry with ``is_error=True``.
+
+    The acknowledged-failure shape from the reporting tools and most
+    custom goldfive tools. The buffer must capture these so the
+    three-state judge (PR 3) can recognise a provoked deviation.
+    """
+    steerer = _RecordingSteerer()
+    session = Session(run_id="run-iter10-pr2-after-error")
+    task = Task(id="t-err", title="Task", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    err_result = {"acknowledged": False, "error": "missing_task_id"}
+
+    await plugin.after_tool_callback(
+        tool=_ToolStub("report_task_started"),
+        tool_args={"task_id": "bogus"},
+        tool_context=_ToolCtxStub("inv-err", "worker"),
+        result=err_result,
+    )
+
+    assert len(session.recent_tool_observations) == 1
+    entry = session.recent_tool_observations[0]
+    assert entry["is_error"] is True
+    assert entry["error_message"] == "missing_task_id"
+    assert entry["tool_name"] == "report_task_started"
+
+
+# ---------------------------------------------------------------------------
+# on_tool_error_callback — raised-exception path
+# ---------------------------------------------------------------------------
+
+
+async def test_on_tool_error_callback_records_observation() -> None:
+    """A raised tool exception appends an ``is_error=True`` entry."""
+    steerer = _RecordingSteerer()
+    session = Session(run_id="run-iter10-pr2-on-err")
+    task = Task(id="t-raise", title="Task", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    await plugin.on_tool_error_callback(
+        tool=_ToolStub("web_search"),
+        tool_args={"q": "x"},
+        tool_context=_ToolCtxStub("inv-raise", "worker"),
+        error=RuntimeError("upstream 500"),
+    )
+
+    assert len(session.recent_tool_observations) == 1
+    entry = session.recent_tool_observations[0]
+    assert entry["is_error"] is True
+    assert "upstream 500" in entry["error_message"]
+    assert entry["tool_name"] == "web_search"
+    # ``on_tool_error`` doesn't get a result -- writer marks it as none.
+    assert entry["result_preview"] == "(none)"
+    # The existing one-shot ``Observation`` for steerer.observe still
+    # fires alongside the new buffer write.
+    assert len(steerer.observations) == 1
+
+
+async def test_on_tool_error_callback_uses_pinned_agent_id_when_set() -> None:
+    """The on-error path also honours iter-9's runtime-reasoning pin."""
+    steerer = _RecordingSteerer()
+    session = Session(run_id="run-iter10-pr2-on-err-pin")
+    session.current_agent_id = "child"
+    task = Task(id="t-raise", title="Task", assignee_agent_id="parent")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    await plugin.on_tool_error_callback(
+        tool=_ToolStub("net_call"),
+        tool_args={"u": "https://x"},
+        tool_context=_ToolCtxStub("inv", "parent"),
+        error=RuntimeError("boom"),
+    )
+
+    entry = session.recent_tool_observations[0]
+    assert entry["agent_name"] == "child"
+
+
+# ---------------------------------------------------------------------------
+# Robustness — observability must never break dispatch.
+# ---------------------------------------------------------------------------
+
+
+async def test_observation_does_not_break_on_buffer_failure_after_tool() -> None:
+    """A raising ``note_tool_observation`` must not break ``after_tool_callback``."""
+    steerer = _RecordingSteerer()
+
+    def _raise(*_a: Any, **_kw: Any) -> None:
+        raise RuntimeError("buffer broken")
+
+    steerer.note_tool_observation = _raise  # type: ignore[assignment]
+
+    session = Session(run_id="run-iter10-pr2-broken")
+    task = Task(id="t1", title="Task", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    # Must not raise.
+    await plugin.after_tool_callback(
+        tool=_ToolStub("web_search"),
+        tool_args={"q": "x"},
+        tool_context=_ToolCtxStub("inv", "worker"),
+        result={"ok": True},
+    )
+
+    # Buffer is empty (the writer raised before appending) but no
+    # exception escaped the callback.
+    assert session.recent_tool_observations == []
+
+
+async def test_observation_does_not_break_on_buffer_failure_on_error() -> None:
+    """A raising ``note_tool_observation`` must not break ``on_tool_error_callback``."""
+    steerer = _RecordingSteerer()
+
+    def _raise(*_a: Any, **_kw: Any) -> None:
+        raise RuntimeError("buffer broken")
+
+    steerer.note_tool_observation = _raise  # type: ignore[assignment]
+
+    session = Session(run_id="run-iter10-pr2-broken-on-err")
+    task = Task(id="t1", title="Task", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    # Must not raise.
+    await plugin.on_tool_error_callback(
+        tool=_ToolStub("web_search"),
+        tool_args={"q": "x"},
+        tool_context=_ToolCtxStub("inv", "worker"),
+        error=RuntimeError("upstream 500"),
+    )
+
+    assert session.recent_tool_observations == []
+    # The original ``observe(observation, session)`` path still fires.
+    assert len(steerer.observations) == 1
+
+
+async def test_after_tool_callback_no_observation_when_steerer_lacks_writer() -> None:
+    """A steerer stub without ``note_tool_observation`` is tolerated.
+
+    Some legacy steerer stubs in the wild (e.g. older
+    ``_RecordingToolLoopSteerer`` shapes) don't expose
+    ``note_tool_observation``. The plugin must check for the method
+    via ``getattr`` and skip when absent — never raise ``AttributeError``.
+    """
+
+    class _OldSteerer:
+        async def observe(self, event: Any, session: Any) -> None:
+            pass
+
+        async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+            pass
+
+    session = Session(run_id="run-iter10-pr2-old-steerer")
+    task = Task(id="t1", title="Task", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_ctx(task, session, _OldSteerer())
+
+    await plugin.after_tool_callback(
+        tool=_ToolStub("web_search"),
+        tool_args={"q": "x"},
+        tool_context=_ToolCtxStub("inv", "worker"),
+        result={"ok": True},
+    )
+    # Buffer untouched, no exception.
+    assert session.recent_tool_observations == []
+
+
+# ---------------------------------------------------------------------------
+# Capture-everything semantics — multiple tasks land in the same buffer.
+# ---------------------------------------------------------------------------
+
+
+async def test_after_tool_callback_writes_across_task_boundaries() -> None:
+    """Tool calls under two distinct tasks both land in the buffer.
+
+    Locked decision (§3.1): per-task filtering is a READ-time concern.
+    The writer captures everything so a deviation rooted in an earlier
+    task's artefact remains visible to the judge.
+    """
+    steerer = _RecordingSteerer()
+    session = Session(run_id="run-iter10-pr2-multi-task")
+    task_a = Task(id="ta", title="A", assignee_agent_id="worker")
+    plugin_a, _state_a = _plugin_with_ctx(task_a, session, steerer)
+
+    await plugin_a.after_tool_callback(
+        tool=_ToolStub("tool_a"),
+        tool_args={"a": 1},
+        tool_context=_ToolCtxStub("inv", "worker"),
+        result={"ok": True},
+    )
+
+    # Re-use the same session under a new task ctx.
+    task_b = Task(id="tb", title="B", assignee_agent_id="worker")
+    plugin_b, _state_b = _plugin_with_ctx(task_b, session, steerer)
+    await plugin_b.after_tool_callback(
+        tool=_ToolStub("tool_b"),
+        tool_args={"b": 2},
+        tool_context=_ToolCtxStub("inv", "worker"),
+        result={"ok": True},
+    )
+
+    task_ids = [e["task_id"] for e in session.recent_tool_observations]
+    tool_names = [e["tool_name"] for e in session.recent_tool_observations]
+    assert task_ids == ["ta", "tb"]
+    assert tool_names == ["tool_a", "tool_b"]

--- a/tests/test_session_recent_tool_observations.py
+++ b/tests/test_session_recent_tool_observations.py
@@ -1,0 +1,524 @@
+"""Unit tests for ``Session.recent_tool_observations`` + steerer writer.
+
+iter-10 PR 2. The buffer feeds the three-state reasoning judge (PR 3)
+so it can distinguish a provoked deviation (the agent saw a tool error
+or surprising result and pivoted) from an unprovoked one.
+
+These tests pin the writer contract:
+
+* :meth:`DefaultSteerer.note_tool_observation` appends one entry per
+  call.
+* The buffer is bounded by ``session.recent_tool_observations_max``
+  with trim-on-write — newest wins, oldest dropped.
+* The error path is detected from either an explicit ``error=`` kwarg
+  (the ``on_tool_error_callback`` shape) or from a ``{"error": ...}``
+  dict ``result`` (the acknowledged-failure shape).
+* Internal failures are swallowed — observability must never break
+  tool dispatch.
+* Unhashable / unrepresentable args + results are repr-shaped and do
+  not raise out of the writer.
+
+PR 3 wires the judge prompt to read from this buffer; this PR ships
+only the population path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import Session  # noqa: E402
+
+
+def _make_session() -> Session:
+    return Session(run_id="r-iter10-pr2")
+
+
+# ---------------------------------------------------------------------------
+# Append + shape
+# ---------------------------------------------------------------------------
+
+
+def test_note_tool_observation_appends() -> None:
+    """One call -> one entry with the full §3.1 shape."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.note_tool_observation(
+        session,
+        agent_name="planner",
+        task_id="t1",
+        tool_name="web_search",
+        args={"q": "raccoon facts"},
+        result={"results": ["fact a", "fact b"]},
+    )
+
+    assert len(session.recent_tool_observations) == 1
+    entry = session.recent_tool_observations[0]
+    # Spec-mandated keys.
+    assert set(entry.keys()) == {
+        "ts_ms",
+        "agent_name",
+        "task_id",
+        "tool_name",
+        "args_preview",
+        "result_preview",
+        "is_error",
+        "error_message",
+    }
+    assert isinstance(entry["ts_ms"], int)
+    assert entry["agent_name"] == "planner"
+    assert entry["task_id"] == "t1"
+    assert entry["tool_name"] == "web_search"
+    # repr-shaped previews.
+    assert "raccoon facts" in entry["args_preview"]
+    assert "fact a" in entry["result_preview"]
+    assert entry["is_error"] is False
+    assert entry["error_message"] == ""
+
+
+def test_note_tool_observation_records_none_result_as_marker() -> None:
+    """``result=None`` -> ``result_preview == "(none)"`` per §3.1."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.note_tool_observation(
+        session,
+        agent_name="planner",
+        task_id="t1",
+        tool_name="report_task_started",
+        args={"task_id": "t1"},
+        result=None,
+    )
+
+    entry = session.recent_tool_observations[0]
+    assert entry["result_preview"] == "(none)"
+    # No error signal in this path — None is just an absent result.
+    assert entry["is_error"] is False
+
+
+# ---------------------------------------------------------------------------
+# Trim-on-write
+# ---------------------------------------------------------------------------
+
+
+def test_note_tool_observation_trims_to_max() -> None:
+    """``len(hist) > max`` after writes -> oldest dropped, newest retained.
+
+    The default ``recent_tool_observations_max`` is 16. Push 21 calls
+    and assert the buffer holds the most-recent 16 in order.
+    """
+    steerer = DefaultSteerer()
+    session = _make_session()
+    cap = session.recent_tool_observations_max
+    assert cap == 16  # default per §3.1
+
+    for i in range(cap + 5):
+        steerer.note_tool_observation(
+            session,
+            agent_name=f"a{i}",
+            task_id="t1",
+            tool_name="some_tool",
+            args={"i": i},
+            result={"i": i},
+        )
+
+    hist = session.recent_tool_observations
+    assert len(hist) == cap
+    # Oldest five (a0..a4) dropped; a5..a20 retained, oldest first.
+    assert [e["agent_name"] for e in hist] == [f"a{i}" for i in range(5, cap + 5)]
+
+
+def test_note_tool_observation_respects_session_local_max_override() -> None:
+    """A session may set a smaller ``recent_tool_observations_max``."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+    session.recent_tool_observations_max = 3
+
+    for i in range(8):
+        steerer.note_tool_observation(
+            session,
+            agent_name=f"a{i}",
+            task_id="t1",
+            tool_name="t",
+            args={},
+            result={},
+        )
+
+    assert len(session.recent_tool_observations) == 3
+    assert [e["agent_name"] for e in session.recent_tool_observations] == ["a5", "a6", "a7"]
+
+
+# ---------------------------------------------------------------------------
+# Error detection
+# ---------------------------------------------------------------------------
+
+
+def test_note_tool_observation_records_error_path() -> None:
+    """Explicit ``error=Exception(...)`` -> is_error=True, error_message set."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.note_tool_observation(
+        session,
+        agent_name="worker",
+        task_id="t2",
+        tool_name="http_get",
+        args={"url": "https://example.com"},
+        result=None,
+        error=Exception("boom"),
+    )
+
+    entry = session.recent_tool_observations[0]
+    assert entry["is_error"] is True
+    assert entry["error_message"] == "boom"
+
+
+def test_note_tool_observation_records_error_dict_result() -> None:
+    """Acknowledged-failure ``{"error": "..."}`` -> is_error=True."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.note_tool_observation(
+        session,
+        agent_name="worker",
+        task_id="t3",
+        tool_name="report_task_started",
+        args={"task_id": "bogus"},
+        result={"acknowledged": False, "error": "tool failed: 503"},
+    )
+
+    entry = session.recent_tool_observations[0]
+    assert entry["is_error"] is True
+    assert entry["error_message"] == "tool failed: 503"
+
+
+def test_note_tool_observation_record_error_string() -> None:
+    """``error=`` may be a bare string (some adapters stringify upstream)."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.note_tool_observation(
+        session,
+        agent_name="worker",
+        task_id="t",
+        tool_name="x",
+        args={},
+        result=None,
+        error="upstream 500",
+    )
+
+    entry = session.recent_tool_observations[0]
+    assert entry["is_error"] is True
+    assert entry["error_message"] == "upstream 500"
+
+
+def test_note_tool_observation_truncates_long_error_messages() -> None:
+    """``error_message`` is bounded at 240 chars per §3.2."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+    long = "x" * 1000
+
+    steerer.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t",
+        tool_name="x",
+        args={},
+        result=None,
+        error=long,
+    )
+
+    entry = session.recent_tool_observations[0]
+    assert len(entry["error_message"]) == 240
+
+
+# ---------------------------------------------------------------------------
+# Truncation: previews
+# ---------------------------------------------------------------------------
+
+
+def test_note_tool_observation_truncates_args_preview() -> None:
+    """``args_preview`` clamped at 240 chars per §3.1."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t",
+        tool_name="x",
+        args={"q": "a" * 500},
+        result={"ok": True},
+    )
+
+    entry = session.recent_tool_observations[0]
+    assert len(entry["args_preview"]) <= 240
+
+
+def test_note_tool_observation_truncates_result_preview() -> None:
+    """``result_preview`` clamped at 480 chars per §3.1."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t",
+        tool_name="x",
+        args={},
+        result={"data": "a" * 1000},
+    )
+
+    entry = session.recent_tool_observations[0]
+    assert len(entry["result_preview"]) <= 480
+
+
+# ---------------------------------------------------------------------------
+# Robustness: unhashable / unrepresentable inputs
+# ---------------------------------------------------------------------------
+
+
+def test_note_tool_observation_handles_unhashable_args() -> None:
+    """Args containing un-hashable but repr-able objects must not raise."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    # ``{"x": object()}`` is unhashable but ``repr`` works.
+    steerer.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t",
+        tool_name="x",
+        args={"x": object()},
+        result={"ok": True},
+    )
+
+    assert len(session.recent_tool_observations) == 1
+    entry = session.recent_tool_observations[0]
+    # repr of object() shape is "<object object at 0x...>" — sanity-check
+    # that we ran repr at all.
+    assert entry["args_preview"].startswith("{")
+
+
+def test_note_tool_observation_handles_repr_failure_in_args() -> None:
+    """An object whose ``repr`` raises -> placeholder, no propagation."""
+
+    class _BadRepr:
+        def __repr__(self) -> str:  # pragma: no cover - exercised via writer
+            raise RuntimeError("nope")
+
+    steerer = DefaultSteerer()
+    session = _make_session()
+    steerer.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t",
+        tool_name="x",
+        args=_BadRepr(),
+        result={"ok": True},
+    )
+
+    assert len(session.recent_tool_observations) == 1
+    entry = session.recent_tool_observations[0]
+    assert entry["args_preview"] == "(unrepresentable args)"
+
+
+# ---------------------------------------------------------------------------
+# Internal-error swallowing
+# ---------------------------------------------------------------------------
+
+
+def test_note_tool_observation_swallows_internal_errors() -> None:
+    """A broken clock must not propagate out of the writer.
+
+    Patches ``time.monotonic_ns`` (read inside the steerer module) to
+    raise. The writer's broad try/except is the contract — observability
+    code must never break tool dispatch.
+    """
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    with mock.patch("goldfive.steerer.time.monotonic_ns", side_effect=RuntimeError("clock dead")):
+        # Must not raise.
+        steerer.note_tool_observation(
+            session,
+            agent_name="w",
+            task_id="t",
+            tool_name="x",
+            args={},
+            result={},
+        )
+
+    # And: the buffer is left untouched (no half-written entry).
+    assert session.recent_tool_observations == []
+
+
+def test_note_tool_observation_zero_max_clamps_to_one() -> None:
+    """A pathological ``max=0`` must not fast-loop trim or crash.
+
+    The writer floors to 1 so the buffer always retains the most-recent
+    entry — useful because ``0`` would silently drop everything.
+    """
+    steerer = DefaultSteerer()
+    session = _make_session()
+    session.recent_tool_observations_max = 0
+
+    for i in range(3):
+        steerer.note_tool_observation(
+            session,
+            agent_name=f"a{i}",
+            task_id="t",
+            tool_name="x",
+            args={},
+            result={},
+        )
+
+    assert len(session.recent_tool_observations) == 1
+    assert session.recent_tool_observations[0]["agent_name"] == "a2"
+
+
+# ---------------------------------------------------------------------------
+# Session dataclass back-compat
+# ---------------------------------------------------------------------------
+
+
+def test_session_default_recent_tool_observations_is_empty_list() -> None:
+    """Bare ``Session(run_id=...)`` constructions get an empty buffer."""
+    session = Session(run_id="r")
+    assert session.recent_tool_observations == []
+    assert session.recent_tool_observations_max == 16
+
+
+def test_two_sessions_have_independent_buffers() -> None:
+    """The mutable-default-list classic gotcha must not bite us."""
+    s1 = Session(run_id="r1")
+    s2 = Session(run_id="r2")
+    s1.recent_tool_observations.append({"sentinel": True})
+    assert s2.recent_tool_observations == []
+
+
+def test_note_tool_observation_per_task_filter_left_to_reader() -> None:
+    """Writer captures every task; per-task filtering happens at READ time.
+
+    Locked decision (§3.1): the buffer is global-per-session; the
+    judge's prompt renderer in PR 3 filters by ``task_id``. This test
+    pins that contract — observations from two distinct tasks both
+    land in the same buffer.
+    """
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t1",
+        tool_name="x",
+        args={},
+        result={},
+    )
+    steerer.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t2",
+        tool_name="x",
+        args={},
+        result={},
+    )
+
+    task_ids = [e["task_id"] for e in session.recent_tool_observations]
+    assert task_ids == ["t1", "t2"]
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+def test_note_tool_observation_ts_ms_is_monotonic() -> None:
+    """``ts_ms`` is monotonic across writes (relative ordering only)."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    for i in range(5):
+        steerer.note_tool_observation(
+            session,
+            agent_name=f"a{i}",
+            task_id="t",
+            tool_name="x",
+            args={},
+            result={},
+        )
+
+    ts_values: list[int] = [int(e["ts_ms"]) for e in session.recent_tool_observations]
+    assert ts_values == sorted(ts_values)
+
+
+# ---------------------------------------------------------------------------
+# Misc — defensive against odd ``Any`` inputs
+# ---------------------------------------------------------------------------
+
+
+def test_note_tool_observation_handles_none_args() -> None:
+    """``args=None`` (some adapter edge cases) -> repr-shaped, no raise."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+    steerer.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t",
+        tool_name="x",
+        args=None,
+        result={"ok": True},
+    )
+    assert len(session.recent_tool_observations) == 1
+    assert session.recent_tool_observations[0]["args_preview"] == "None"
+
+
+def test_note_tool_observation_with_string_result() -> None:
+    """Bare string ``result`` is repr-encoded, not flagged as error."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+    steerer.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t",
+        tool_name="x",
+        args={},
+        result="hello world",
+    )
+    entry = session.recent_tool_observations[0]
+    assert "hello world" in entry["result_preview"]
+    assert entry["is_error"] is False
+
+
+# ---------------------------------------------------------------------------
+# Explicit Any/typing pin so reviewers can see the writer accepts opaque
+# types (it really does have to — tool args / results from arbitrary
+# adapters are untyped).
+# ---------------------------------------------------------------------------
+
+
+def test_writer_accepts_arbitrary_any_types() -> None:
+    arbitrary: Any = object()
+    steerer = DefaultSteerer()
+    session = _make_session()
+    steerer.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t",
+        tool_name="x",
+        args=arbitrary,
+        result=arbitrary,
+    )
+    assert len(session.recent_tool_observations) == 1


### PR DESCRIPTION
## Summary

Iter-10 PR 2 of 4. Ships the session-scoped tool-observation ring buffer that the three-state reasoning judge (PR 3) will read to distinguish a provoked deviation (the agent saw a tool error / surprising result and pivoted) from an unprovoked one. **No judge wiring yet** — this PR ships the buffer + its population path so PR 3 can read from it.

- New ``Session.recent_tool_observations`` (``list[dict]``) + ``recent_tool_observations_max`` (default 16) fields, default_factory-backed (no mutable-default-list trap).
- New ``DefaultSteerer.note_tool_observation`` — public writer mirroring the trim-on-write pattern of ``note_agent_activity``. Captures ``ts_ms``/``agent_name``/``task_id``/``tool_name``/``args_preview`` (240ch)/``result_preview`` (480ch)/``is_error``/``error_message`` per the locked §3.1 entry shape. Detects errors from either an explicit ``error=`` kwarg or a ``{"error": ...}`` result dict. Body wrapped in a broad try/except — observability must never break tool dispatch.
- Adapter wiring at the two ADK plugin sites: ``after_tool_callback`` (success + acknowledged-failure paths) and ``on_tool_error_callback`` (raised-exception path). Both look up ``current_agent_id`` / ``current_task_id`` from the iter-9 pin first, fall back to the ADK-resolved name + ctx.task.id; both wrap the writer call in try/except for layered defense.

Per-task filtering is a READ-time concern (the judge's prompt renderer in PR 3); writers capture everything so a deviation rooted in an earlier task's artefact remains visible.

## Test plan

- [x] 21 new unit tests (`tests/test_session_recent_tool_observations.py`) — append, trim-on-write, session-local cap override, error detection from both paths, preview truncation, unhashable / unrepresentable inputs, internal-error swallowing, back-compat / mutable-default safety, monotonic ordering, capture-everything across tasks.
- [x] 9 new integration tests (`tests/test_adk_plugin_tool_observations.py`) — successful dispatch records ``is_error=False``, acknowledged-failure dispatch records ``is_error=True``, raised-exception dispatch records ``is_error=True``, iter-9 runtime-pin priority over ADK-resolved name, broken-writer survival on both callback paths, legacy steerer-stub tolerance (no ``note_tool_observation`` method), capture across task boundaries.
- [x] Full suite: 2173 passed, 55 skipped (no regressions on iter-9 / #345).
- [x] Ruff clean on touched files; mypy: zero new errors (5 pre-existing on these files unaffected).

## What this PR does NOT do

- No judge prompt template change (PR 3).
- No parser / verdict-shape change (PR 3).
- No ladder entry / planner.refine change (PR 4).
- No ``DriftKind.JUSTIFIED_DEVIATION`` enum value or verdict ``classification`` field (concurrent PR 1).
- The judge does not yet READ from the buffer (PR 3 wires that read).

Refs iter-10 design doc §3.1, §3.2, §6 PR 2 row.