### PR TITLE
feat: three-state reasoning-judge verdict + JUSTIFIED_DEVIATION routing (iter-10 PR 3+4)

### DIFF
--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -1012,6 +1012,12 @@ async def _run_judge_with_focus(
     reasoning-judge delegated coverage.
     """
     task = _current_task(session)
+    # iter-10 PR 3: surface lineage + recent tool observations to the
+    # judge as additional context. ``task_lineage`` was added in iter-9
+    # (#344); ``recent_tool_observations`` was added in iter-10 PR 2
+    # (#347). Both are passed by attribute lookup so older Session
+    # snapshots without the fields still parse cleanly (the helpers
+    # treat None as "no data").
     return await classify_reasoning_drift_with_focus(
         reasoning=text,
         task=task,
@@ -1025,6 +1031,8 @@ async def _run_judge_with_focus(
         run_id=session.run_id,
         session_id=session.id,
         sequence_fn=session.next_sequence,
+        task_lineage=getattr(session, "task_lineage", None),
+        recent_tool_observations=getattr(session, "recent_tool_observations", None),
     )
 
 

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -61,6 +61,8 @@ __all__ = [
     "REASONING_JUDGE_MAX_RAW_RESPONSE_CHARS",
     "REASONING_DRIFT_MAX_REASONING_CHARS",
     "REASONING_DRIFT_SYSTEM_PROMPT",
+    "REASONING_DRIFT_TOOL_OBS_MAX_CHARS",
+    "REASONING_DRIFT_TOOL_OBS_MAX_ENTRIES",
     "REASONING_DRIFT_USER_PROMPT_TEMPLATE",
     "ReasoningJudgeVerdict",
     "classify_reasoning_drift",
@@ -130,42 +132,78 @@ REASONING_DRIFT_SYSTEM_PROMPT: str = (
     "single JSON object and nothing else."
 )
 
+# iter-10 PR 3: three-state classification + lineage / tool-observation
+# context. The template asks the judge for THREE decisions (classify,
+# attribute, name provenance) instead of TWO. Sections in order:
+# 1. PLAN TASKS               (existing)
+# 2. CURRENTLY BOUND TASK     (existing)
+# 3. Currently reasoning agent line  (existing — added in iter-9)
+# 4. Task lineage line        (NEW — _format_task_lineage)
+# 5. GOALS                    (existing)
+# 6. RECENT TOOL OBSERVATIONS (NEW — _format_tool_observations)
+# 7. REASONING                (existing, ≤1500 chars)
+# 8. "Decide THREE things"    (NEW — classification, attribution, provenance)
+# 9. JSON shape spec          (UPDATED — adds classification + provenance fields)
+# 10. GUIDANCE block          (NEW — per-provenance criteria)
+# 11. Severity guidance       (UPDATED for non-on_task)
 REASONING_DRIFT_USER_PROMPT_TEMPLATE: str = (
     "You are assessing whether an autonomous agent's chain-of-thought "
     "is on task.\n\n"
     "PLAN TASKS (id -> title):\n{plan_tasks_summary}\n\n"
     "CURRENTLY BOUND TASK:\n{task_block}\n\n"
-    "Currently reasoning agent: {current_agent_id}\n\n"
+    "Currently reasoning agent: {current_agent_id}\n"
+    "Task lineage: {task_lineage_block}\n\n"
     "GOALS:\n{goals_block}\n\n"
+    "RECENT TOOL OBSERVATIONS (last {tool_obs_count}, oldest first):\n"
+    "{tool_obs_block}\n\n"
     "REASONING (the agent's most recent chain-of-thought block):\n"
     "{reasoning_block}\n\n"
-    "Decide TWO things:\n"
-    "1. Does the reasoning stay focused on the explicit task and "
-    "goals above? (the on-task verdict)\n"
-    "2. Which task in the PLAN TASKS list above is the reasoning "
-    "actually working on right now? (the attribution verdict — answer "
-    "with a task id from the list, or '' when the reasoning is not "
-    "working on any plan task / is off-plan)\n\n"
+    "Decide THREE things:\n"
+    "1. CLASSIFICATION. Which best describes the reasoning?\n"
+    "   - on_task: it advances the BOUND TASK or the GOALS.\n"
+    "   - justified_deviation: it departs from the BOUND TASK, but a recent\n"
+    "     tool observation, surprising result, discovered dependency, or new\n"
+    "     information visible above plausibly provoked the departure.\n"
+    "   - erroneous_deviation: it departs from the BOUND TASK with no such\n"
+    "     provoking signal in the context above.\n"
+    "2. ATTRIBUTION. Which task in the PLAN TASKS list is the reasoning\n"
+    "   actually working on right now? Use the literal id, or '' when the\n"
+    "   reasoning is off-plan.\n"
+    "3. PROVENANCE. ONLY when classification is justified_deviation, name the\n"
+    "   signal that justifies the deviation. Pick exactly one of:\n"
+    "     tool_error | surprising_result | discovered_dependency | new_information\n"
+    "   When classification is on_task or erroneous_deviation, set\n"
+    '   provenance to "none".\n\n'
     "Reply with a single JSON object and nothing else, in this shape:\n"
     "{{\n"
-    '  "on_task": true|false,\n'
-    '  "severity": "info"|"warning"|"critical",\n'
+    '  "classification": "on_task" | "justified_deviation" | "erroneous_deviation",\n'
+    '  "severity": "info" | "warning" | "critical",\n'
     '  "reason": "one-sentence explanation",\n'
+    '  "provenance": "tool_error" | "surprising_result" | '
+    '"discovered_dependency" | "new_information" | "none",\n'
     '  "focused_task_id": "<id from PLAN TASKS, or \'\' if off-plan>",\n'
     '  "focus_confidence": 0.0-1.0,\n'
     '  "stated_intent": "one-sentence summary of what the agent says it '
     'is doing"\n'
     "}}\n\n"
-    "on_task=true = reasoning is working toward the bound task / goals "
-    "(clarifying sub-steps, exploring tradeoffs, working through a "
-    "calculation all count as on_task). When on_task=true, severity / "
-    "reason may be omitted or empty.\n"
-    "on_task=false = reasoning has drifted to an unrelated topic, is "
-    "proposing to abandon the task, or is otherwise off-course.\n"
-    "Severity guidance when on_task=false:\n"
-    "- info = mild tangent that may self-correct next turn.\n"
-    "- warning = clear off-topic content that deserves a nudge.\n"
-    "- critical = proposing to abandon or replace the task/goal.\n\n"
+    "GUIDANCE:\n"
+    "- on_task includes clarifying sub-steps, exploring tradeoffs, and\n"
+    "  working through calculations.\n"
+    "- A tool_error provenance requires a recent tool observation with\n"
+    "  is_error=true OR an error_message.\n"
+    "- A surprising_result provenance requires a tool observation whose\n"
+    "  result contradicts the reasoning's prior assumption.\n"
+    "- A discovered_dependency provenance requires the reasoning to name a\n"
+    "  prerequisite that was not in the plan or task description.\n"
+    "- A new_information provenance requires the reasoning to cite a fact\n"
+    "  surfaced by a recent tool result.\n"
+    "- If you cannot point to a specific signal in the RECENT TOOL\n"
+    "  OBSERVATIONS or REASONING above to justify a deviation, classify it\n"
+    "  as erroneous_deviation.\n\n"
+    "Severity guidance when classification is non-on_task:\n"
+    "  info     = mild deviation that may self-correct next turn.\n"
+    "  warning  = clear deviation that deserves a refine.\n"
+    "  critical = proposing to abandon the goal entirely.\n\n"
     "focused_task_id MUST be the literal id of one of the listed plan "
     "tasks, or an empty string when the reasoning is not working on "
     "any plan task. focus_confidence is your subjective certainty in "
@@ -239,6 +277,113 @@ def _format_reasoning(reasoning: str) -> str:
     if len(reasoning) <= REASONING_DRIFT_MAX_REASONING_CHARS:
         return reasoning
     return reasoning[:REASONING_DRIFT_MAX_REASONING_CHARS] + " ... [truncated]"
+
+
+# ---------------------------------------------------------------------------
+# iter-10 PR 3: lineage + recent-tool-observation prompt blocks
+# ---------------------------------------------------------------------------
+#
+# Lineage and recent tool observations are surfaced to the judge as
+# additional CONTEXT, never as a structural pre-gate. The LLM still
+# decides; the new context just lets it distinguish a provoked
+# deviation (justified_deviation) from an unprovoked one
+# (erroneous_deviation). See iter10-design.md §3.3 / §5 for the
+# rationale.
+
+
+def _format_task_lineage(
+    task_id: str,
+    lineage: dict[str, set[str]] | None,
+    current_agent_id: str,
+) -> str:
+    """Render the task-lineage block for the judge prompt.
+
+    ``lineage`` is the per-task ``{task_id: set(agent_id)}`` map kept
+    on :class:`~goldfive.types.Session` and populated by the ADK plugin
+    (assignee + every observed AgentTool ``to_agent`` for the task).
+    The empty / missing case renders ``"(no task lineage observed)"``
+    so the prompt shape is invariant for tests; populated cases render
+    a one-line set with a suffix indicating whether the currently
+    reasoning agent is structurally inside the bound task's delegation
+    tree.
+
+    The judge uses this as one signal among several — never as the
+    sole basis for an on-task vs deviation decision (per §5 of the
+    design doc).
+    """
+    if not task_id or not lineage:
+        return "(no task lineage observed)"
+    raw = lineage.get(task_id)
+    if not raw:
+        return "(no task lineage observed)"
+    agents = sorted(str(a) for a in raw if a)
+    if not agents:
+        return "(no task lineage observed)"
+    line = ", ".join(agents)
+    in_lineage = current_agent_id in agents
+    suffix = (
+        f" — {current_agent_id} IS in this lineage"
+        if in_lineage
+        else f" — {current_agent_id} is NOT in this lineage"
+    )
+    return f"observed agents for this task: {line}{suffix}"
+
+
+# Cap the rendered tool-observations block at 1500 chars (matches the
+# REASONING block cap). Per-entry truncation is already enforced at
+# write time by ``DefaultSteerer.note_tool_observation`` (args_preview
+# 240 chars / result_preview 480 chars), so this helper only bounds
+# the total block size.
+REASONING_DRIFT_TOOL_OBS_MAX_CHARS: int = 1500
+REASONING_DRIFT_TOOL_OBS_MAX_ENTRIES: int = 8
+
+
+def _format_tool_observations(
+    obs: list[dict[str, Any]] | None,
+    *,
+    task_id: str,
+    max_entries: int = REASONING_DRIFT_TOOL_OBS_MAX_ENTRIES,
+    max_chars: int = REASONING_DRIFT_TOOL_OBS_MAX_CHARS,
+) -> tuple[str, int]:
+    """Render the recent-tool-observations prompt block.
+
+    Returns ``(rendered_block, count_used)`` where ``count_used`` is the
+    number of entries that actually made it into the block (so the
+    template can stamp it onto the "(last N, oldest first)" header).
+
+    Filters to the current task's observations first; falls back to a
+    global slice when the per-task slice is empty (the §3.4 design
+    decision: per-task is more relevant on average, but a deviation
+    rooted in an earlier task's tool result remains useful context, so
+    don't drop it entirely). Per-entry truncation is already done at
+    write time; this helper enforces the total ``max_chars`` cap so
+    the prompt stays bounded.
+    """
+    if not obs:
+        return "(no recent tool observations)", 0
+    scoped = [e for e in obs if isinstance(e, dict) and e.get("task_id") == task_id]
+    if not scoped:
+        scoped = [e for e in obs if isinstance(e, dict)]
+    if not scoped:
+        return "(no recent tool observations)", 0
+    tail = scoped[-max_entries:]
+    lines: list[str] = []
+    rendered_chars = 0
+    for e in tail:
+        marker = "ERROR" if e.get("is_error") else "ok"
+        agent = str(e.get("agent_name", "") or "?")
+        tool = str(e.get("tool_name", "") or "?")
+        args_preview = str(e.get("args_preview", "") or "")
+        result_preview = str(e.get("result_preview", "") or "")
+        line = f"- {marker} {agent} {tool}({args_preview}) -> {result_preview}"
+        # +1 for the join newline between lines.
+        if rendered_chars + len(line) + 1 > max_chars and lines:
+            break
+        lines.append(line)
+        rendered_chars += len(line) + 1
+    if not lines:
+        return "(no recent tool observations)", 0
+    return "\n".join(lines), len(lines)
 
 
 # Hard cap on the plan-tasks-summary section of the prompt. Phase-1
@@ -369,6 +514,17 @@ def _severity_from_verdict(raw: Any) -> DriftSeverity:
     return _SEVERITY_MAP.get(raw.strip().lower(), DriftSeverity.WARNING)
 
 
+# iter-10 PR 3: three-state classification + provenance enums. Keep
+# these as frozenset literals so misspellings are caught at parse
+# time (the parser strips + lowercases before membership-checking).
+_VALID_CLASSIFICATIONS: frozenset[str] = frozenset(
+    {"on_task", "justified_deviation", "erroneous_deviation"}
+)
+_VALID_PROVENANCES: frozenset[str] = frozenset(
+    {"tool_error", "surprising_result", "discovered_dependency", "new_information"}
+)
+
+
 async def classify_reasoning_drift(
     *,
     reasoning: str,
@@ -385,6 +541,8 @@ async def classify_reasoning_drift(
     session_id: str = "",
     sequence_fn: Callable[[], int] | None = None,
     plan: Plan | None = None,
+    task_lineage: dict[str, set[str]] | None = None,
+    recent_tool_observations: list[dict[str, Any]] | None = None,
 ) -> DriftEvent | None:
     """Ask an LLM-judge whether ``reasoning`` is on-task.
 
@@ -416,6 +574,8 @@ async def classify_reasoning_drift(
         session_id=session_id,
         sequence_fn=sequence_fn,
         plan=plan,
+        task_lineage=task_lineage,
+        recent_tool_observations=recent_tool_observations,
     )
     return verdict.drift
 
@@ -436,6 +596,8 @@ async def classify_reasoning_drift_with_focus(
     session_id: str = "",
     sequence_fn: Callable[[], int] | None = None,
     plan: Plan | None = None,
+    task_lineage: dict[str, set[str]] | None = None,
+    recent_tool_observations: list[dict[str, Any]] | None = None,
 ) -> ReasoningJudgeVerdict:
     """Ask an LLM-judge whether ``reasoning`` is on-task AND which task it works on.
 
@@ -525,12 +687,23 @@ async def classify_reasoning_drift_with_focus(
         return ReasoningJudgeVerdict(drift=None)
     system = system_prompt or REASONING_DRIFT_SYSTEM_PROMPT
     template = user_prompt_template or REASONING_DRIFT_USER_PROMPT_TEMPLATE
+    # iter-10 PR 3: lineage + recent tool observations are passed as
+    # CONTEXT to the LLM (per §3.3 / §5 — never as a structural pre-gate).
+    task_lineage_block = _format_task_lineage(
+        current_task_id, task_lineage, current_agent_id or "(unknown)"
+    )
+    tool_obs_block, tool_obs_count = _format_tool_observations(
+        recent_tool_observations, task_id=current_task_id
+    )
     user = template.format(
         plan_tasks_summary=format_plan_tasks_summary(plan),
         goals_block=_format_goals(goals),
         task_block=_format_task(task),
         reasoning_block=_format_reasoning(reasoning),
         current_agent_id=current_agent_id or "(unknown)",
+        task_lineage_block=task_lineage_block,
+        tool_obs_block=tool_obs_block,
+        tool_obs_count=tool_obs_count,
     )
     started = time.monotonic()
     call_failed = False
@@ -562,6 +735,12 @@ async def classify_reasoning_drift_with_focus(
     focused_task_id_parsed: str = ""
     focus_confidence_parsed: float = 0.0
     stated_intent_parsed: str = ""
+    # iter-10 PR 3 — three-state classification + provenance. Empty
+    # strings are the quiet-fail sentinel (call raised, malformed JSON,
+    # neither classification nor legacy on_task readable). The parser
+    # below populates these post-call.
+    classification_parsed: str = ""
+    provenance_parsed: str = ""
     try:
         async with goldfive_llm_span(
             sinks=span_sinks,
@@ -593,12 +772,71 @@ async def classify_reasoning_drift_with_focus(
             raw_str_inline = raw if isinstance(raw, str) else ""
             parsed = _parse_response(raw)
             if parsed is not None:
-                on_task_raw = parsed.get("on_task")
-                if isinstance(on_task_raw, bool):
-                    on_task_parsed = on_task_raw
+                # iter-10 PR 3: three-state classification (§2.4 rules
+                # 1 + 2). Read ``classification`` first; fall back to
+                # the legacy ``on_task`` boolean when it's missing or
+                # unrecognised. Both paths converge on a populated
+                # ``classification_parsed`` (or "" for quiet-fail).
+                classification_raw = parsed.get("classification", "")
+                if isinstance(classification_raw, str):
+                    candidate = classification_raw.strip().lower()
+                    if candidate in _VALID_CLASSIFICATIONS:
+                        classification_parsed = candidate
+                if not classification_parsed:
+                    # Legacy fallback — the pre-iter-10 prompt only
+                    # asked for a bool. Custom prompt-template
+                    # overrides operators ship may still produce that
+                    # shape, and we promised back-compat in §2.4 rule 2.
+                    on_task_legacy = parsed.get("on_task")
+                    if isinstance(on_task_legacy, bool):
+                        classification_parsed = (
+                            "on_task" if on_task_legacy else "erroneous_deviation"
+                        )
+                # ``on_task_parsed`` mirrors the classification for the
+                # legacy proto event payload AND for the span
+                # output_preview / decision_summary below — set it as
+                # soon as we have a classification (success path), or
+                # leave it None (quiet-fail path).
+                if classification_parsed == "on_task":
+                    on_task_parsed = True
+                elif classification_parsed in (
+                    "justified_deviation",
+                    "erroneous_deviation",
+                ):
+                    on_task_parsed = False
+                # Reason + severity are useful regardless of which
+                # branch we're on (the prompt allows them empty on
+                # on_task; the parser below treats empty reason
+                # gracefully when constructing drift detail).
+                if classification_parsed:
                     reason = str(parsed.get("reason", "") or "").strip()
-                    if not on_task_raw:
-                        severity_str = _severity_from_verdict(parsed.get("severity")).value.lower()
+                    if classification_parsed != "on_task":
+                        severity_str = _severity_from_verdict(
+                            parsed.get("severity")
+                        ).value.lower()
+                # iter-10 PR 3 §2.4 rule 3: provenance validation +
+                # demotion. justified_deviation REQUIRES one of the
+                # four enum values (tool_error | surprising_result |
+                # discovered_dependency | new_information). Anything
+                # else (missing key, "none", unknown free-text) demotes
+                # the verdict to erroneous_deviation. Doing this inside
+                # the span scope so ``span.output_preview`` /
+                # ``decision_summary`` reflect the post-demotion shape.
+                # The actual INFO-level demotion log fires below in
+                # the drift-construction branch.
+                if classification_parsed == "justified_deviation":
+                    provenance_raw = parsed.get("provenance", "")
+                    candidate = ""
+                    if isinstance(provenance_raw, str):
+                        candidate = provenance_raw.strip().lower()
+                    if candidate in _VALID_PROVENANCES:
+                        provenance_parsed = candidate
+                    else:
+                        # Demote — keep raw value around for the
+                        # post-with-block log message.
+                        classification_parsed = "erroneous_deviation"
+                        provenance_parsed = ""
+                        on_task_parsed = False
                 # Extended attribution fields — extracted regardless of
                 # the on_task verdict. The judge can name a focused
                 # task whether or not it considers the reasoning on the
@@ -646,12 +884,39 @@ async def classify_reasoning_drift_with_focus(
                     "unparseable verdict"
                 )
             else:
+                # iter-10 PR 3: span's output_preview + decision_summary
+                # surface the three-state classification (post-demotion,
+                # since the §2.4 rule-3 check ran above inside this
+                # span scope). For justified_deviation the verdict
+                # string carries the provenance suffix so the
+                # harmonograf Gantt shows the provoking signal at a
+                # glance.
                 span.output_preview = (
+                    f"classification={classification_parsed or '(none)'}, "
+                    f"provenance={provenance_parsed or '(none)'}, "
                     f"on_task={on_task_parsed}, "
                     f"severity={severity_str or '(none)'}, "
                     f"reason={reason or '(none)'}"
                 )
-                if on_task_parsed:
+                if classification_parsed == "on_task":
+                    # Keep the legacy "on-task" wording so existing
+                    # observability assertions (and harmonograf's
+                    # display-string scrapers) continue to match. The
+                    # output_preview above already exposes the
+                    # canonical ``classification=on_task`` axis for
+                    # callers that prefer the new field.
+                    verdict_str = "on-task"
+                elif classification_parsed == "justified_deviation":
+                    verdict_str = f"justified_deviation ({provenance_parsed})"
+                elif classification_parsed == "erroneous_deviation":
+                    sev_suffix = (
+                        f" [{severity_str.upper()}]" if severity_str else ""
+                    )
+                    verdict_str = f"erroneous_deviation{sev_suffix}"
+                elif on_task_parsed:
+                    # Defensive: only reached if classification fell
+                    # through to a falsy string but on_task_parsed was
+                    # set — keep legacy text for the proto event mirror.
                     verdict_str = "on-task"
                 else:
                     verdict_str = (
@@ -682,21 +947,84 @@ async def classify_reasoning_drift_with_focus(
             raw_str[:200],
         )
     elif parsed is not None:
-        if on_task_parsed is None:
+        # iter-10 PR 3 §2.4: three-state classification routing. The
+        # parser inside the with-block populated
+        # ``classification_parsed`` (legacy fallback applied) and ran
+        # the §2.4 rule-3 provenance demotion when needed. This branch
+        # only logs + builds the drift event.
+        if not classification_parsed:
+            # Quiet-fail: neither a recognised ``classification`` nor a
+            # boolean ``on_task`` legacy field. Empty verdict, no drift.
             log.debug(
-                "classify_reasoning_drift: parsed=%r lacks boolean 'on_task' key; no drift emitted",
+                "classify_reasoning_drift: parsed=%r lacks both "
+                "'classification' and boolean 'on_task' keys; no drift emitted",
                 parsed,
             )
-        elif on_task_parsed:
+        elif classification_parsed == "on_task":
             log.debug(
                 "classify_reasoning_drift: judge says on-track (reason=%r)",
                 reason,
             )
-        else:
+        elif classification_parsed == "justified_deviation":
             severity_enum = _severity_from_verdict(parsed.get("severity"))
             log.info(
-                "classify_reasoning_drift: drift detected (severity=%s, "
-                "reason=%r); emitting OFF_TOPIC event",
+                "classify_reasoning_drift: justified deviation "
+                "(provenance=%s, severity=%s, reason=%r); emitting "
+                "JUSTIFIED_DEVIATION event",
+                provenance_parsed,
+                severity_enum.value,
+                reason,
+            )
+            detail_body = reason or "(judge returned no reason)"
+            detail = f"justified deviation ({provenance_parsed}): {detail_body}"
+            drift = DriftEvent(
+                kind=DriftKind.JUSTIFIED_DEVIATION,
+                severity=severity_enum,
+                detail=detail,
+                current_task_id=current_task_id,
+                current_agent_id=current_agent_id,
+                raw=reasoning,
+                trigger_input=truncate_for_observability(
+                    reasoning, REASONING_JUDGE_MAX_REASONING_INPUT_CHARS
+                ),
+            )
+        else:
+            # erroneous_deviation — same wire shape as the pre-iter-10
+            # OFF_TOPIC path. This branch ALSO catches a
+            # justified_deviation that was demoted by the §2.4 rule-3
+            # check above; in that case the original raw provenance
+            # value is gone (we logged the demotion when it fired), and
+            # the rendered drift looks identical to a model-emitted
+            # erroneous_deviation. That's intentional — once demoted,
+            # the verdict IS erroneous_deviation by every downstream
+            # surface.
+            assert classification_parsed == "erroneous_deviation", (
+                classification_parsed
+            )
+            severity_enum = _severity_from_verdict(parsed.get("severity"))
+            # Surface the demotion at INFO so operators can grep the
+            # rate of "model claimed justified but couldn't name a
+            # provenance" in production logs. The branch above
+            # (provenance check inside the with-block) intentionally
+            # does NOT log so the message contains the original raw
+            # value and the parsed-after-demotion classification — both
+            # readable here.
+            raw_classification = ""
+            if isinstance(parsed.get("classification"), str):
+                raw_classification = parsed["classification"].strip().lower()
+            if raw_classification == "justified_deviation":
+                provenance_raw_log = parsed.get("provenance", "")
+                log.info(
+                    "classify_reasoning_drift: justified_deviation "
+                    "demoted to erroneous_deviation — provenance=%r is "
+                    "missing or not in the allowed enum "
+                    "(tool_error|surprising_result|"
+                    "discovered_dependency|new_information)",
+                    provenance_raw_log,
+                )
+            log.info(
+                "classify_reasoning_drift: drift detected "
+                "(severity=%s, reason=%r); emitting OFF_TOPIC event",
                 severity_enum.value,
                 reason,
             )
@@ -721,6 +1049,17 @@ async def classify_reasoning_drift_with_focus(
     # parsed outcome but independent of it — on-task, off-task, and
     # plumbing-failure paths all produce an observability event.
     if sink is not None:
+        # iter-10 PR 3: pass the post-demotion classification onto the
+        # ReasoningJudgeInvoked event payload. ``on_task`` is the
+        # legacy mirror — kept for back-compat with existing harmonograf
+        # columns. The mirror is computed from the final
+        # ``classification_parsed`` so it stays consistent with the new
+        # field even after a §2.4 rule-3 demotion.
+        on_task_for_event = (
+            classification_parsed == "on_task"
+            if classification_parsed
+            else (drift is None)
+        )
         await _emit_judge_invoked(
             sink=sink,
             run_id=run_id,
@@ -732,19 +1071,18 @@ async def classify_reasoning_drift_with_focus(
             elapsed_ms=elapsed_ms,
             reasoning_input=reasoning,
             raw_response=raw_str,
-            on_task=bool(on_task_parsed)
-            if on_task_parsed is not None
-            else True
-            if drift is None
-            else False,
+            on_task=on_task_for_event,
             severity=severity_str,
             reason=reason,
+            classification=classification_parsed,
         )
     return ReasoningJudgeVerdict(
         drift=drift,
         focused_task_id=focused_task_id_parsed,
         focus_confidence=focus_confidence_parsed,
         stated_intent=stated_intent_parsed,
+        classification=classification_parsed,
+        provenance=provenance_parsed,
     )
 
 

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -2502,16 +2502,19 @@ class LLMPlanner:
                 'return a JSON object of the form {"reject": true, "reason": '
                 '"..."} (the caller will escalate to human intervention).\n\n'
             )
-        elif drift.kind is DriftKind.OFF_TOPIC:
-            # OFF_TOPIC has no observed-actions channel — the deviation
-            # is in the agent's reasoning, surfaced by the reasoning
-            # judge. Render an analogous "what the agent did" block from
-            # the drift's reasoning context (``trigger_input`` is the
+        elif drift.kind in (DriftKind.OFF_TOPIC, DriftKind.JUSTIFIED_DEVIATION):
+            # OFF_TOPIC and JUSTIFIED_DEVIATION (iter-10 PR 4) have no
+            # observed-actions channel — the deviation is in the
+            # agent's reasoning, surfaced by the reasoning judge.
+            # Render an analogous "what the agent did" block from the
+            # drift's reasoning context (``trigger_input`` is the
             # truncated reasoning text the judge saw; ``raw`` is the
             # original, when set; ``detail`` is the judge's free-form
-            # reason). Frame it with the same ABSORB/REJECT contract so
-            # the goal-aware system prompt's decision shape carries
-            # through.
+            # reason — for JUSTIFIED_DEVIATION the detail string
+            # already carries the provenance prefix from the parser,
+            # e.g. "justified deviation (tool_error): ..."). Frame it
+            # with the same ABSORB/REJECT contract so the goal-aware
+            # system prompt's decision shape carries through.
             observed_block = (
                 f"{self._render_off_topic_reasoning_block(drift)}\n\n"
                 "The agent's reasoning has drifted from the bound task. "
@@ -2802,8 +2805,15 @@ class LLMPlanner:
         # right shape for "agent reasoning wandered off goal".
         is_plan_divergence = drift.kind is DriftKind.PLAN_DIVERGENCE
         is_off_topic = drift.kind is DriftKind.OFF_TOPIC
+        # iter-10 PR 4: JUSTIFIED_DEVIATION shares the goal-aware
+        # ABSORB/REJECT path with OFF_TOPIC. The drift's ``detail``
+        # already carries the provenance prefix (e.g. "justified
+        # deviation (tool_error): ...") which
+        # ``_render_off_topic_reasoning_block`` surfaces verbatim, so
+        # the LLM sees the provoking signal in the rendered context.
+        is_justified = drift.kind is DriftKind.JUSTIFIED_DEVIATION
         has_observed_actions = is_plan_divergence and observed_actions is not None
-        use_divergence_prompt = has_observed_actions or is_off_topic
+        use_divergence_prompt = has_observed_actions or is_off_topic or is_justified
         try:
             base_user_prompt = self._build_refine_prompt(
                 plan,

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -3222,6 +3222,33 @@ class DefaultSteerer:
             InterventionLevel.ABSORB,
             (InterventionLevel.CANCEL_REINVOKE, InterventionLevel.PAUSE_ESCALATE),
         ),
+        # JUSTIFIED_DEVIATION (iter-10 PR 3+4) is plan-context drift
+        # WITH provenance — the agent saw a real provoking signal (tool
+        # error, surprising result, discovered dependency, new
+        # information) that pulled it off the bound task. The refine
+        # path is identical to OFF_TOPIC (goal-aware ABSORB/REJECT via
+        # ``_PLAN_DIVERGENCE_SYSTEM_PROMPT``), but we never escalate:
+        # CRITICAL repeat does NOT escalate to PAUSE_ESCALATE because a
+        # provoked deviation is the right input for plan-extension at
+        # every severity. Penalising it would punish the agent for
+        # responding to reality.
+        #
+        # Backstops against runaway justified_deviation are upstream of
+        # the ladder, not on it (per design §7.3):
+        #
+        # * The per-(kind, task_id) refine cooldown ``_is_plan_revision_
+        #   gated`` collapses a cluster of JUSTIFIED_DEVIATION drifts on
+        #   the same task to one refine attempt; subsequent ones drop.
+        # * The ``task_last_progress_at`` stall gate
+        #   (``_is_task_progress_stalled``) catches the pathological
+        #   case where the agent KEEPS justifying drift on the same
+        #   task without making progress, escalating to
+        #   HUMAN_INTERVENTION_REQUIRED.
+        DriftKind.JUSTIFIED_DEVIATION: (
+            InterventionLevel.OBSERVE,
+            InterventionLevel.ABSORB,
+            (InterventionLevel.ABSORB, InterventionLevel.ABSORB),
+        ),
         DriftKind.INTENT_DIVERGENCE: (
             InterventionLevel.OBSERVE,
             InterventionLevel.ABSORB,

--- a/tests/test_intervention_ladder.py
+++ b/tests/test_intervention_ladder.py
@@ -137,6 +137,36 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         2,
         InterventionLevel.PAUSE_ESCALATE,
     ),
+    # JUSTIFIED_DEVIATION (iter-10 PR 4): provoked deviation. Always-
+    # ABSORB at every severity; CRITICAL repeat does NOT escalate
+    # because the deviation is a response to a real provoking signal.
+    # Backstops upstream of the ladder (per-(kind, task_id) refine
+    # cooldown + task_last_progress_at stall gate) catch runaway
+    # justified_deviation without involving PAUSE_ESCALATE.
+    (
+        DriftKind.JUSTIFIED_DEVIATION,
+        DriftSeverity.INFO,
+        0,
+        InterventionLevel.OBSERVE,
+    ),
+    (
+        DriftKind.JUSTIFIED_DEVIATION,
+        DriftSeverity.WARNING,
+        0,
+        InterventionLevel.ABSORB,
+    ),
+    (
+        DriftKind.JUSTIFIED_DEVIATION,
+        DriftSeverity.CRITICAL,
+        0,
+        InterventionLevel.ABSORB,
+    ),
+    (
+        DriftKind.JUSTIFIED_DEVIATION,
+        DriftSeverity.CRITICAL,
+        2,
+        InterventionLevel.ABSORB,
+    ),
     # INTENT_DIVERGENCE: CRITICAL -> pause-escalate even on first occurrence.
     (DriftKind.INTENT_DIVERGENCE, DriftSeverity.WARNING, 0, InterventionLevel.ABSORB),
     (
@@ -313,4 +343,82 @@ def test_ladder_covers_goal_drift() -> None:
             DefaultSteerer.REFINE_FAILURE_THRESHOLD,
         )
         is InterventionLevel.CANCEL_REINVOKE
+    )
+
+
+def test_justified_deviation_routes_to_absorb_at_all_severities() -> None:
+    """iter-10 PR 4: JUSTIFIED_DEVIATION always-ABSORBs.
+
+    A provoked deviation is the right input for plan-extension at
+    every severity — penalising it with a PAUSE_ESCALATE on CRITICAL
+    repeat would punish the agent for responding to reality. The
+    backstops are upstream (per-(kind, task_id) refine cooldown +
+    task_last_progress_at stall gate), not on the ladder.
+    """
+    steerer = DefaultSteerer()
+    assert (
+        steerer._ladder_level_for(
+            DriftKind.JUSTIFIED_DEVIATION, DriftSeverity.INFO, 0
+        )
+        is InterventionLevel.OBSERVE
+    )
+    assert (
+        steerer._ladder_level_for(
+            DriftKind.JUSTIFIED_DEVIATION, DriftSeverity.WARNING, 0
+        )
+        is InterventionLevel.ABSORB
+    )
+    # CRITICAL first occurrence — ABSORB, NOT cancel-reinvoke.
+    assert (
+        steerer._ladder_level_for(
+            DriftKind.JUSTIFIED_DEVIATION, DriftSeverity.CRITICAL, 0
+        )
+        is InterventionLevel.ABSORB
+    )
+    # CRITICAL repeat — STILL ABSORB. Specifically NOT pause_escalate.
+    assert (
+        steerer._ladder_level_for(
+            DriftKind.JUSTIFIED_DEVIATION,
+            DriftSeverity.CRITICAL,
+            DefaultSteerer.REFINE_FAILURE_THRESHOLD,
+        )
+        is InterventionLevel.ABSORB
+    )
+    # And way past the repeat threshold for paranoia.
+    assert (
+        steerer._ladder_level_for(
+            DriftKind.JUSTIFIED_DEVIATION, DriftSeverity.CRITICAL, 99
+        )
+        is InterventionLevel.ABSORB
+    )
+
+
+def test_off_topic_unchanged_by_justified_deviation_addition() -> None:
+    """Regression: #345's OFF_TOPIC ladder row didn't move.
+
+    iter-10 PR 4 adds a sibling JUSTIFIED_DEVIATION row but must not
+    perturb OFF_TOPIC routing. Pin the four key cells.
+    """
+    steerer = DefaultSteerer()
+    assert (
+        steerer._ladder_level_for(DriftKind.OFF_TOPIC, DriftSeverity.INFO, 0)
+        is InterventionLevel.OBSERVE
+    )
+    assert (
+        steerer._ladder_level_for(DriftKind.OFF_TOPIC, DriftSeverity.WARNING, 0)
+        is InterventionLevel.ABSORB
+    )
+    assert (
+        steerer._ladder_level_for(
+            DriftKind.OFF_TOPIC, DriftSeverity.CRITICAL, 0
+        )
+        is InterventionLevel.CANCEL_REINVOKE
+    )
+    assert (
+        steerer._ladder_level_for(
+            DriftKind.OFF_TOPIC,
+            DriftSeverity.CRITICAL,
+            DefaultSteerer.REFINE_FAILURE_THRESHOLD,
+        )
+        is InterventionLevel.PAUSE_ESCALATE
     )

--- a/tests/test_llm_span_decision_context.py
+++ b/tests/test_llm_span_decision_context.py
@@ -303,7 +303,12 @@ async def test_classify_reasoning_drift_off_task_decision_wording() -> None:
     assert "on_task=False" in end.output_preview
     assert "warning" in end.output_preview
     assert "tangential" in end.output_preview
-    assert "off-task" in end.decision_summary
+    # iter-10 PR 3: decision_summary now carries the three-state
+    # classification name. A legacy ``{"on_task": false, ...}`` response
+    # routes through the §2.4 rule-2 fallback and is rendered as
+    # ``erroneous_deviation`` — the iter-10 equivalent of
+    # off-task-without-provenance.
+    assert "erroneous_deviation" in end.decision_summary
     # Severity surfaced in UPPERCASE.
     assert "WARNING" in end.decision_summary
     assert "research_agent" in end.decision_summary

--- a/tests/test_planner_observed_actions.py
+++ b/tests/test_planner_observed_actions.py
@@ -676,3 +676,155 @@ async def test_refine_repeated_failure_keeps_generic_prompt() -> None:
         assert "OFF-TOPIC REASONING" not in user_prompt
         # No OBSERVED AGENT ACTIVITY block (no observed_actions provided).
         assert "OBSERVED AGENT ACTIVITY" not in user_prompt
+
+
+# ---------------------------------------------------------------------------
+# 9. JUSTIFIED_DEVIATION (iter-10 PR 4) routes to the goal-aware refine prompt
+# ---------------------------------------------------------------------------
+
+
+async def test_refine_justified_deviation_uses_goal_aware_prompt() -> None:
+    """JUSTIFIED_DEVIATION (iter-10) shares OFF_TOPIC's refine path.
+
+    The drift's ``detail`` carries the provenance prefix from the
+    parser ("justified deviation (tool_error): ...") which the
+    existing ``_render_off_topic_reasoning_block`` surfaces verbatim
+    so the LLM sees the provoking signal.
+    """
+    stub = _StubLLM(_absorbed_revision_json())
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(
+        kind=DriftKind.JUSTIFIED_DEVIATION,
+        severity=DriftSeverity.WARNING,
+        detail=(
+            "justified deviation (tool_error): tool 503; falling back "
+            "to a different fact source"
+        ),
+        current_task_id="draft",
+        trigger_input=(
+            "The fact API returned 503; let me retry against the "
+            "alternate endpoint."
+        ),
+    )
+
+    revised = await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+
+    assert revised is not None
+    system, user_prompt, _model = stub.calls[0]
+    # Goal-aware system prompt selected (ABSORB / REJECT framing).
+    assert "ABSORB" in system
+    assert "REJECT" in system
+    # The user prompt carries the OFF-TOPIC reasoning context block —
+    # _render_off_topic_reasoning_block is shared with OFF_TOPIC by
+    # design (the drift detail / trigger_input shape is identical).
+    assert "OFF-TOPIC REASONING" in user_prompt
+    # Provenance prefix from the parser appears verbatim in the
+    # rendered context, so the LLM sees the exact provoking signal
+    # rather than a generic "agent drifted" framing.
+    assert "justified deviation (tool_error)" in user_prompt
+    assert "alternate endpoint" in user_prompt
+    # Not the observed_actions channel.
+    assert "OBSERVED AGENT ACTIVITY" not in user_prompt
+
+
+async def test_refine_justified_deviation_honours_reject_sentinel() -> None:
+    """When the LLM judges the justified deviation to actually contradict
+    a sticky goal, it returns ``{"reject": true, ...}`` and refine
+    returns None (caller escalates via the ladder)."""
+    stub = _StubLLM(json.dumps({"reject": True, "reason": "off-goal even with provenance"}))
+    planner = LLMPlanner(call_llm=stub)
+    drift = DriftEvent(
+        kind=DriftKind.JUSTIFIED_DEVIATION,
+        severity=DriftSeverity.WARNING,
+        detail=(
+            "justified deviation (surprising_result): the source disagrees "
+            "with the sticky goal"
+        ),
+        current_task_id="draft",
+    )
+
+    revised = await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+
+    assert revised is None
+    # Reject is final — no retry on the goal-aware path.
+    assert len(stub.calls) == 1
+
+
+async def test_refine_repeated_failure_does_not_pull_in_justified_deviation() -> None:
+    """Regression: JUSTIFIED_DEVIATION must not pull REPEATED_FAILURE /
+    BLOCKED into the goal-aware path.
+
+    The prompt-selection condition expanded in iter-10 PR 4 must NOT
+    accidentally light up structural-recovery drifts — they continue
+    to use the generic refine prompt.
+    """
+    payload = {
+        "summary": "same",
+        "tasks": [
+            {
+                "id": "research",
+                "title": "Research",
+                "assignee_agent_id": "researcher",
+                "status": "COMPLETED",
+            },
+            {
+                "id": "draft",
+                "title": "Draft",
+                "assignee_agent_id": "writer",
+                "status": "RUNNING",
+            },
+            {
+                "id": "review",
+                "title": "Review",
+                "assignee_agent_id": "editor",
+                "status": "PENDING",
+            },
+        ],
+        "edges": [
+            {"from_task_id": "research", "to_task_id": "draft"},
+            {"from_task_id": "draft", "to_task_id": "review"},
+        ],
+    }
+    for kind in (DriftKind.REPEATED_FAILURE, DriftKind.BLOCKED):
+        stub = _StubLLM(json.dumps(payload))
+        planner = LLMPlanner(call_llm=stub)
+        drift = DriftEvent(
+            kind=kind,
+            severity=DriftSeverity.WARNING,
+            detail="recovery",
+            current_task_id="draft",
+        )
+        await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+        system, user_prompt, _model = stub.calls[0]
+        assert "ABSORB" not in system, (
+            f"{kind.value} accidentally migrated to the goal-aware prompt"
+        )
+        assert "maintaining an ACTIVE plan" in system
+        # Neither reasoning block leaks.
+        assert "OFF-TOPIC REASONING" not in user_prompt
+        assert "justified deviation" not in user_prompt
+
+
+async def test_refine_justified_deviation_drift_detail_carries_provenance() -> None:
+    """The drift the parser builds from a justified-deviation verdict
+    carries the provenance string in ``detail`` — the refine prompt
+    renders it verbatim. Pinned end-to-end.
+    """
+    # Build a JUSTIFIED_DEVIATION drift the way the parser does.
+    drift = DriftEvent(
+        kind=DriftKind.JUSTIFIED_DEVIATION,
+        severity=DriftSeverity.WARNING,
+        detail=(
+            "justified deviation (discovered_dependency): the writer needs "
+            "the editor's style guide first"
+        ),
+        current_task_id="draft",
+        trigger_input="The plan didn't list the style guide as a dep",
+    )
+    stub = _StubLLM(_absorbed_revision_json())
+    planner = LLMPlanner(call_llm=stub)
+    await planner.refine(plan=_running_plan(), drift=drift, goals=_goals())
+
+    _system, user_prompt, _model = stub.calls[0]
+    assert "justified deviation (discovered_dependency)" in user_prompt
+    assert "style guide" in user_prompt

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -258,8 +258,11 @@ async def test_missing_on_task_key_returns_none_with_debug_log(
             call_llm=call_llm,
         )
     assert drift is None
+    # iter-10 PR 3 retitled the log line: now mentions BOTH the
+    # three-state ``classification`` key and the legacy ``on_task``
+    # bool, since the parser tries both before quiet-failing.
     assert any(
-        "lacks boolean 'on_task'" in r.getMessage()
+        "lacks both 'classification' and boolean 'on_task'" in r.getMessage()
         and r.name == "goldfive.drift.reasoning_judge"
         for r in caplog.records
     )
@@ -1020,8 +1023,665 @@ def test_classify_with_focus_renders_plan_tasks_into_prompt() -> None:
         task_block="(no task bound)",
         reasoning_block="thinking",
         current_agent_id="(unknown)",
+        task_lineage_block="(no task lineage observed)",
+        tool_obs_block="(no recent tool observations)",
+        tool_obs_count=0,
     )
     assert "PLAN TASKS" in rendered
     assert "t1 -> Alpha" in rendered
     assert "focused_task_id" in rendered
     assert "focus_confidence" in rendered
+
+
+# ---------------------------------------------------------------------------
+# iter-10 PR 3 — three-state classification parser
+# ---------------------------------------------------------------------------
+
+
+async def test_parser_accepts_on_task_classification() -> None:
+    """``classification: "on_task"`` (no legacy on_task field) → no drift."""
+    call_llm = _stub_call_llm([{"classification": "on_task", "reason": "ok"}])
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thought",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is None
+    assert verdict.classification == "on_task"
+    assert verdict.provenance == ""
+
+
+@pytest.mark.parametrize(
+    "provenance",
+    ["tool_error", "surprising_result", "discovered_dependency", "new_information"],
+)
+async def test_parser_accepts_justified_deviation_with_each_provenance(
+    provenance: str,
+) -> None:
+    """All four provenance enum values produce a JUSTIFIED_DEVIATION drift."""
+    call_llm = _stub_call_llm(
+        [
+            {
+                "classification": "justified_deviation",
+                "severity": "warning",
+                "reason": "Got a surprise",
+                "provenance": provenance,
+            }
+        ]
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="reasoning that pivots after a tool result",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+        current_task_id="t1",
+        current_agent_id="a1",
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.kind is DriftKind.JUSTIFIED_DEVIATION
+    assert verdict.drift.severity is DriftSeverity.WARNING
+    assert verdict.classification == "justified_deviation"
+    assert verdict.provenance == provenance
+    # Detail prefix carries the provenance string so the refine prompt
+    # surfaces it via _render_off_topic_reasoning_block.
+    assert f"justified deviation ({provenance})" in verdict.drift.detail
+
+
+async def test_parser_accepts_erroneous_deviation_classification() -> None:
+    """``classification: "erroneous_deviation"`` produces an OFF_TOPIC drift."""
+    call_llm = _stub_call_llm(
+        [
+            {
+                "classification": "erroneous_deviation",
+                "severity": "warning",
+                "reason": "drifted to raccoons",
+            }
+        ]
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="raccoons have stripes; let me look those up",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+        current_task_id="t1",
+        current_agent_id="a1",
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.kind is DriftKind.OFF_TOPIC
+    assert verdict.classification == "erroneous_deviation"
+    assert verdict.provenance == ""
+    assert "raccoons" in verdict.drift.detail
+
+
+async def test_parser_demotes_justified_deviation_with_none_provenance(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``provenance: "none"`` on a justified verdict → demote to OFF_TOPIC.
+
+    Per §2.4 rule 3: ``"none"`` is a legal value only on the on_task
+    or erroneous branches. On a justified_deviation it is treated as
+    "model couldn't name a signal" → demote.
+    """
+    call_llm = _stub_call_llm(
+        [
+            {
+                "classification": "justified_deviation",
+                "severity": "warning",
+                "reason": "claimed-justified-but-unsourced",
+                "provenance": "none",
+            }
+        ]
+    )
+    with caplog.at_level(logging.INFO, logger="goldfive.drift.reasoning_judge"):
+        verdict = await rjudge.classify_reasoning_drift_with_focus(
+            reasoning="thought",
+            task=_task(),
+            goals=_goals(),
+            plan=None,
+            model="fake",
+            call_llm=call_llm,
+        )
+    assert verdict.drift is not None
+    assert verdict.drift.kind is DriftKind.OFF_TOPIC
+    assert verdict.classification == "erroneous_deviation"
+    assert verdict.provenance == ""
+    # Demotion is audited at INFO so operators can grep the rate.
+    assert any(
+        "demoted to erroneous_deviation" in r.getMessage()
+        and r.name == "goldfive.drift.reasoning_judge"
+        for r in caplog.records
+    )
+
+
+async def test_parser_demotes_justified_deviation_with_unknown_provenance() -> None:
+    """An unrecognised provenance string → demote to erroneous_deviation."""
+    call_llm = _stub_call_llm(
+        [
+            {
+                "classification": "justified_deviation",
+                "severity": "warning",
+                "reason": "claimed-justified-with-bogus-provenance",
+                "provenance": "guesswork",
+            }
+        ]
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thought",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.kind is DriftKind.OFF_TOPIC
+    assert verdict.classification == "erroneous_deviation"
+    assert verdict.provenance == ""
+
+
+async def test_parser_demotes_justified_deviation_with_missing_provenance() -> None:
+    """Missing ``provenance`` key on a justified verdict → demote."""
+    call_llm = _stub_call_llm(
+        [
+            {
+                "classification": "justified_deviation",
+                "severity": "warning",
+                "reason": "no-provenance-key",
+            }
+        ]
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thought",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.kind is DriftKind.OFF_TOPIC
+    assert verdict.classification == "erroneous_deviation"
+    assert verdict.provenance == ""
+
+
+async def test_parser_legacy_on_task_true_yields_on_task() -> None:
+    """Legacy ``{"on_task": true}`` (no classification) → on_task / no drift.
+
+    §2.4 rule 2: back-compat for custom prompt-template overrides.
+    """
+    call_llm = _stub_call_llm([{"on_task": True}])
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thought",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is None
+    assert verdict.classification == "on_task"
+
+
+async def test_parser_legacy_on_task_false_yields_erroneous() -> None:
+    """Legacy ``{"on_task": false, ...}`` → erroneous_deviation / OFF_TOPIC."""
+    call_llm = _stub_call_llm(
+        [{"on_task": False, "severity": "warning", "reason": "drifted"}]
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thought",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.kind is DriftKind.OFF_TOPIC
+    assert verdict.classification == "erroneous_deviation"
+
+
+async def test_parser_quiet_fail_on_missing_classification_and_on_task() -> None:
+    """Neither ``classification`` nor a boolean ``on_task`` → quiet-fail."""
+    call_llm = _stub_call_llm([{"severity": "warning"}])
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thought",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is None
+    assert verdict.classification == ""
+    assert verdict.provenance == ""
+
+
+async def test_parser_tolerates_markdown_fences_three_state() -> None:
+    """Three-state JSON wrapped in ```json fences``` parses cleanly."""
+    raw = (
+        "```json\n"
+        '{"classification": "justified_deviation", '
+        '"severity": "warning", '
+        '"reason": "tool 503", '
+        '"provenance": "tool_error"}\n'
+        "```"
+    )
+    call_llm = _stub_call_llm([raw])
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="retrying after 503",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.kind is DriftKind.JUSTIFIED_DEVIATION
+    assert verdict.classification == "justified_deviation"
+    assert verdict.provenance == "tool_error"
+
+
+async def test_parser_unknown_classification_falls_back_to_legacy_on_task() -> None:
+    """Half-correct ``classification`` (not in the enum) → legacy fallback.
+
+    Defensive: if the model returns ``classification: "drift"`` or
+    similar, the parser must still fall through to the legacy
+    ``on_task`` field. This protects custom-prompt operators who may
+    inadvertently trigger novel verdict shapes.
+    """
+    call_llm = _stub_call_llm(
+        [{"classification": "drift", "on_task": False, "severity": "warning", "reason": "x"}]
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thought",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.kind is DriftKind.OFF_TOPIC
+    assert verdict.classification == "erroneous_deviation"
+
+
+# ---------------------------------------------------------------------------
+# iter-10 PR 3 — prompt rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def test_format_task_lineage_empty() -> None:
+    """No lineage → ``(no task lineage observed)``."""
+    assert (
+        rjudge._format_task_lineage("t1", None, "a1") == "(no task lineage observed)"
+    )
+    assert (
+        rjudge._format_task_lineage("t1", {}, "a1") == "(no task lineage observed)"
+    )
+    # Task not in lineage map → also empty.
+    assert (
+        rjudge._format_task_lineage("t1", {"t2": {"a1"}}, "a1")
+        == "(no task lineage observed)"
+    )
+    # Empty set for task → also empty.
+    assert (
+        rjudge._format_task_lineage("t1", {"t1": set()}, "a1")
+        == "(no task lineage observed)"
+    )
+
+
+def test_format_task_lineage_includes_agent_when_in_lineage() -> None:
+    rendered = rjudge._format_task_lineage("t1", {"t1": {"a1", "b1"}}, "a1")
+    # Sorted membership-list, with "IS in this lineage" suffix.
+    assert "observed agents for this task: a1, b1" in rendered
+    assert "a1 IS in this lineage" in rendered
+
+
+def test_format_task_lineage_when_agent_not_in_lineage() -> None:
+    rendered = rjudge._format_task_lineage("t1", {"t1": {"a1", "b1"}}, "c1")
+    assert "observed agents for this task: a1, b1" in rendered
+    assert "c1 is NOT in this lineage" in rendered
+
+
+def test_format_tool_observations_empty() -> None:
+    block, count = rjudge._format_tool_observations(None, task_id="t1")
+    assert block == "(no recent tool observations)"
+    assert count == 0
+    block, count = rjudge._format_tool_observations([], task_id="t1")
+    assert block == "(no recent tool observations)"
+    assert count == 0
+
+
+def test_format_tool_observations_filters_by_task() -> None:
+    """Per-task filtering: when current task has obs, render ONLY those."""
+    obs = [
+        {
+            "task_id": "t_other",
+            "agent_name": "a1",
+            "tool_name": "fetch",
+            "args_preview": "{}",
+            "result_preview": "ok",
+            "is_error": False,
+        },
+        {
+            "task_id": "t1",
+            "agent_name": "a2",
+            "tool_name": "search",
+            "args_preview": '{"q": "x"}',
+            "result_preview": "[]",
+            "is_error": False,
+        },
+    ]
+    block, count = rjudge._format_tool_observations(obs, task_id="t1")
+    assert count == 1
+    assert "search" in block
+    assert "fetch" not in block
+
+
+def test_format_tool_observations_falls_back_to_global() -> None:
+    """When current task has no obs, fall back to the global slice."""
+    obs = [
+        {
+            "task_id": "t_other",
+            "agent_name": "a1",
+            "tool_name": "fetch",
+            "args_preview": "{}",
+            "result_preview": "ok",
+            "is_error": False,
+        },
+        {
+            "task_id": "t_other2",
+            "agent_name": "a2",
+            "tool_name": "search",
+            "args_preview": "{}",
+            "result_preview": "[]",
+            "is_error": True,
+        },
+    ]
+    block, count = rjudge._format_tool_observations(obs, task_id="t_missing")
+    assert count == 2
+    assert "fetch" in block
+    assert "search" in block
+    # Error marker rendered for the failing entry.
+    assert "ERROR" in block
+    assert "ok" in block  # the success marker prefix
+
+
+def test_format_tool_observations_caps_at_max_chars() -> None:
+    """Block stays ≤ 1500 chars even when fed many observations.
+
+    Each entry's args_preview / result_preview are already bounded at
+    write time (240 / 480 chars). The helper enforces total block
+    size as the second-line defence.
+    """
+    big_arg = "x" * 240
+    big_result = "y" * 480
+    obs = [
+        {
+            "task_id": "t1",
+            "agent_name": f"a{i}",
+            "tool_name": "tool",
+            "args_preview": big_arg,
+            "result_preview": big_result,
+            "is_error": False,
+        }
+        for i in range(50)
+    ]
+    block, count = rjudge._format_tool_observations(obs, task_id="t1")
+    assert len(block) <= rjudge.REASONING_DRIFT_TOOL_OBS_MAX_CHARS
+    # Count must be > 0 (we got at least one entry rendered) and < 50
+    # (the cap kicked in before we ran out of entries).
+    assert 0 < count < 50
+
+
+def test_prompt_includes_lineage_block_when_set() -> None:
+    """Render lineage with two agents into the user prompt."""
+    rendered = rjudge.REASONING_DRIFT_USER_PROMPT_TEMPLATE.format(
+        plan_tasks_summary="(no plan tasks)",
+        goals_block="(no goals)",
+        task_block="(no task bound)",
+        reasoning_block="thinking",
+        current_agent_id="a1",
+        task_lineage_block=rjudge._format_task_lineage(
+            "t1", {"t1": {"a1", "b1"}}, "a1"
+        ),
+        tool_obs_block="(no recent tool observations)",
+        tool_obs_count=0,
+    )
+    assert "Task lineage:" in rendered
+    assert "observed agents for this task: a1, b1" in rendered
+    assert "a1 IS in this lineage" in rendered
+
+
+def test_prompt_lineage_block_when_absent() -> None:
+    rendered = rjudge.REASONING_DRIFT_USER_PROMPT_TEMPLATE.format(
+        plan_tasks_summary="(no plan tasks)",
+        goals_block="(no goals)",
+        task_block="(no task bound)",
+        reasoning_block="thinking",
+        current_agent_id="a1",
+        task_lineage_block=rjudge._format_task_lineage("t1", None, "a1"),
+        tool_obs_block="(no recent tool observations)",
+        tool_obs_count=0,
+    )
+    assert "Task lineage: (no task lineage observed)" in rendered
+
+
+def test_prompt_lineage_block_when_agent_not_in_set() -> None:
+    rendered = rjudge.REASONING_DRIFT_USER_PROMPT_TEMPLATE.format(
+        plan_tasks_summary="(no plan tasks)",
+        goals_block="(no goals)",
+        task_block="(no task bound)",
+        reasoning_block="thinking",
+        current_agent_id="c1",
+        task_lineage_block=rjudge._format_task_lineage(
+            "t1", {"t1": {"a1", "b1"}}, "c1"
+        ),
+        tool_obs_block="(no recent tool observations)",
+        tool_obs_count=0,
+    )
+    assert "c1 is NOT in this lineage" in rendered
+
+
+def test_prompt_renders_three_state_decision_section() -> None:
+    """The user prompt template carries the iter-10 'Decide THREE things' block.
+
+    Snapshot-style contains-check: pins the literal markers so a
+    well-meaning prompt edit that drops one of the three decisions
+    fails this test.
+    """
+    rendered = rjudge.REASONING_DRIFT_USER_PROMPT_TEMPLATE.format(
+        plan_tasks_summary="(no plan tasks)",
+        goals_block="(no goals)",
+        task_block="(no task bound)",
+        reasoning_block="thinking",
+        current_agent_id="a1",
+        task_lineage_block="(no task lineage observed)",
+        tool_obs_block="(no recent tool observations)",
+        tool_obs_count=0,
+    )
+    assert "Decide THREE things:" in rendered
+    # The three decisions are listed.
+    assert "1. CLASSIFICATION." in rendered
+    assert "2. ATTRIBUTION." in rendered
+    assert "3. PROVENANCE." in rendered
+    # Provenance enum literals appear verbatim (the LLM's output must
+    # match these strings; the parser strip+lowercases before
+    # comparison but the prompt asks for the canonical names).
+    for token in (
+        "tool_error",
+        "surprising_result",
+        "discovered_dependency",
+        "new_information",
+    ):
+        assert token in rendered, token
+    # Three-state classification literals also appear verbatim.
+    for token in ("on_task", "justified_deviation", "erroneous_deviation"):
+        assert token in rendered, token
+    # GUIDANCE block is present (LLM behaviour depends on its specifics).
+    assert "GUIDANCE:" in rendered
+
+
+# ---------------------------------------------------------------------------
+# iter-10 PR 3 — verdict propagation through the legacy wrapper
+# ---------------------------------------------------------------------------
+
+
+async def test_classify_reasoning_drift_legacy_wrapper_threads_lineage() -> None:
+    """The back-compat wrapper accepts and threads the new kwargs.
+
+    Pins the API surface — external callers who upgrade to iter-10
+    can pass lineage / tool observations through the legacy wrapper
+    too without switching to ``classify_reasoning_drift_with_focus``.
+    """
+    call_llm = _stub_call_llm(
+        [
+            {
+                "classification": "justified_deviation",
+                "severity": "warning",
+                "reason": "tool 503",
+                "provenance": "tool_error",
+            }
+        ]
+    )
+    drift = await rjudge.classify_reasoning_drift(
+        reasoning="retrying after 503",
+        task=_task(),
+        goals=_goals(),
+        model="fake",
+        call_llm=call_llm,
+        task_lineage={"t1": {"a1"}},
+        recent_tool_observations=[
+            {
+                "task_id": "t1",
+                "agent_name": "a1",
+                "tool_name": "fetch",
+                "args_preview": "{}",
+                "result_preview": "503",
+                "is_error": True,
+            }
+        ],
+    )
+    assert drift is not None
+    assert drift.kind is DriftKind.JUSTIFIED_DEVIATION
+
+
+# ---------------------------------------------------------------------------
+# iter-10 PR 3 — span / observability event
+# ---------------------------------------------------------------------------
+
+
+async def test_reasoning_judge_invoked_carries_classification_three_state() -> None:
+    """ReasoningJudgeInvoked event payload populates ``classification`` for each
+    of the three states.
+
+    Pins the proto-event wiring: PR 1 added the field; PR 3 starts
+    populating it from the parser. on_task / justified_deviation /
+    erroneous_deviation must all surface their canonical
+    classification name on the wire.
+    """
+    cases: list[tuple[dict[str, Any], str]] = [
+        ({"classification": "on_task", "reason": "ok"}, "on_task"),
+        (
+            {
+                "classification": "justified_deviation",
+                "severity": "warning",
+                "reason": "503",
+                "provenance": "tool_error",
+            },
+            "justified_deviation",
+        ),
+        (
+            {
+                "classification": "erroneous_deviation",
+                "severity": "warning",
+                "reason": "drifted",
+            },
+            "erroneous_deviation",
+        ),
+    ]
+    for response, expected in cases:
+        sink = ListSink()
+        call_llm = _stub_call_llm([response])
+        await rjudge.classify_reasoning_drift_with_focus(
+            reasoning="thinking",
+            task=_task(),
+            goals=_goals(),
+            plan=None,
+            model="fake",
+            call_llm=call_llm,
+            current_task_id="t1",
+            current_agent_id="a1",
+            sink=sink,
+            run_id="r1",
+            session_id="s1",
+        )
+        # Pull the ReasoningJudgeInvoked event out of the sink stream.
+        invoked: list[Any] = []
+        for evt in sink.events:
+            payload = getattr(evt, "reasoning_judge_invoked", None)
+            if payload is None:
+                continue
+            # Distinguish between an unset oneof (returns the default
+            # message but the envelope's WhichOneof is something else)
+            # and a real RJI envelope by checking model is set.
+            if getattr(payload, "model", "") == "fake":
+                invoked.append(payload)
+        assert len(invoked) == 1, (expected, invoked)
+        assert invoked[0].classification == expected, (expected, invoked[0])
+
+
+async def test_judge_span_decision_summary_three_state() -> None:
+    """Span ``decision_summary`` carries the three-state classification.
+
+    For justified_deviation, the provenance is rendered alongside
+    (e.g. ``"justified_deviation (tool_error)"``).
+    """
+    sink = ListSink()
+    call_llm = _stub_call_llm(
+        [
+            {
+                "classification": "justified_deviation",
+                "severity": "warning",
+                "reason": "503",
+                "provenance": "tool_error",
+            }
+        ]
+    )
+    await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="retrying after 503",
+        task=_task(),
+        goals=_goals(),
+        plan=None,
+        model="fake",
+        call_llm=call_llm,
+        current_task_id="t1",
+        current_agent_id="a1",
+        sink=sink,
+        run_id="r1",
+        session_id="s1",
+    )
+    # Span end events are emitted onto the sink; find the
+    # judge_reasoning span end and check its decision_summary.
+    decision_summaries: list[str] = []
+    for evt in sink.events:
+        end = getattr(evt, "goldfive_llm_call_end", None)
+        if end is None:
+            continue
+        # Distinguish unset oneof from a real End — only consider
+        # envelopes whose ``span_id`` is populated (the End helper
+        # always sets it).
+        if not getattr(end, "span_id", ""):
+            continue
+        if getattr(end, "decision_summary", ""):
+            decision_summaries.append(end.decision_summary)
+    assert any(
+        "justified_deviation (tool_error)" in s for s in decision_summaries
+    ), decision_summaries

--- a/tests/test_reasoning_judge_classification_table.py
+++ b/tests/test_reasoning_judge_classification_table.py
@@ -1,0 +1,268 @@
+"""Fixture-driven classification-table tests for the iter-10 reasoning judge.
+
+Per the iter-10 design doc §8: each trace exercises one of the three
+states (on_task / justified_deviation / erroneous_deviation) with a
+deterministic mock ``call_llm`` keyed by trace id. The point is NOT to
+test the LLM — it's to lock in the prompt-shape expectation and the
+parser's reading of representative responses.
+
+Three traces:
+
+* Trace A — on-task reasoning. Mock returns
+  ``{"classification": "on_task", ...}``. Asserts no drift.
+* Trace B — provoked deviation with a matching tool observation in
+  ``recent_tool_observations``. Mock returns
+  ``{"classification": "justified_deviation", "provenance": "tool_error", ...}``.
+  Asserts ``drift.kind == DriftKind.JUSTIFIED_DEVIATION`` and the
+  provenance is preserved on the verdict.
+* Trace C — unprovoked deviation with no relevant tool observations.
+  Mock returns
+  ``{"classification": "erroneous_deviation", "severity": "warning", ...}``.
+  Asserts ``drift.kind == DriftKind.OFF_TOPIC``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.drift.reasoning_judge import (  # noqa: E402
+    classify_reasoning_drift_with_focus,
+)
+from goldfive.types import (  # noqa: E402
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Task,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class _Trace:
+    """One trace + the canned mock-LLM response that should classify it."""
+
+    trace_id: str
+    reasoning: str
+    recent_tool_observations: list[dict[str, Any]]
+    canned_response: dict[str, Any]
+    expected_drift_kind: DriftKind | None
+    expected_classification: str
+    expected_provenance: str
+
+
+def _task() -> Task:
+    return Task(
+        id="t_post",
+        title="Draft a memo on solar panel ROI",
+        description="One-page memo with citations",
+    )
+
+
+def _goals() -> list[Goal]:
+    return [Goal(id="g1", summary="Publish a one-page memo on solar panel ROI")]
+
+
+def _plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[_task()],
+        edges=[],
+    )
+
+
+_TRACES: list[_Trace] = [
+    _Trace(
+        trace_id="A_on_task",
+        reasoning=(
+            "I should look up commercial-rooftop solar panel efficiency "
+            "ratings and pull together a quick comparison for the memo."
+        ),
+        recent_tool_observations=[],
+        canned_response={
+            "classification": "on_task",
+            "reason": "researching the bound task",
+            "focused_task_id": "t_post",
+            "focus_confidence": 0.9,
+            "stated_intent": "researching solar efficiency for the memo",
+        },
+        expected_drift_kind=None,
+        expected_classification="on_task",
+        expected_provenance="",
+    ),
+    _Trace(
+        trace_id="B_justified_deviation_tool_error",
+        reasoning=(
+            "The pricing API returned 503 again; I'll fall back to "
+            "scraping the public datasheet PDF instead so the memo "
+            "still has a citation."
+        ),
+        recent_tool_observations=[
+            {
+                "ts_ms": 1000,
+                "agent_name": "researcher",
+                "task_id": "t_post",
+                "tool_name": "fetch_pricing_api",
+                "args_preview": '{"sku":"sp-100"}',
+                "result_preview": '{"error":"503 Service Unavailable"}',
+                "is_error": True,
+                "error_message": "503 Service Unavailable",
+            }
+        ],
+        canned_response={
+            "classification": "justified_deviation",
+            "severity": "warning",
+            "reason": (
+                "agent pivoted to a fallback source after a real tool "
+                "failure recorded in the recent tool observations"
+            ),
+            "provenance": "tool_error",
+            "focused_task_id": "t_post",
+            "focus_confidence": 0.85,
+            "stated_intent": "scraping the datasheet as a fallback citation",
+        },
+        expected_drift_kind=DriftKind.JUSTIFIED_DEVIATION,
+        expected_classification="justified_deviation",
+        expected_provenance="tool_error",
+    ),
+    _Trace(
+        trace_id="C_erroneous_deviation",
+        reasoning=(
+            "Actually, raccoons are surprisingly clever animals — I "
+            "should look up some raccoon facts before continuing."
+        ),
+        recent_tool_observations=[],  # No provoking tool signal.
+        canned_response={
+            "classification": "erroneous_deviation",
+            "severity": "warning",
+            "reason": (
+                "the reasoning pivoted to raccoons with no provoking "
+                "signal in the prompt context"
+            ),
+            "focused_task_id": "",
+            "focus_confidence": 0.0,
+            "stated_intent": "looking up raccoon facts",
+        },
+        expected_drift_kind=DriftKind.OFF_TOPIC,
+        expected_classification="erroneous_deviation",
+        expected_provenance="",
+    ),
+]
+
+
+def _make_call_llm(canned: dict[str, Any]):
+    """Async ``CallLLM``-shaped stub that always returns the same JSON.
+
+    The stub also records what it saw in ``calls`` so the test can
+    assert the prompt actually contained the provoking tool
+    observation (for trace B).
+    """
+
+    calls: list[tuple[str, str, str]] = []
+
+    async def _call_llm(system: str, user: str, model: str) -> str:
+        calls.append((system, user, model))
+        return json.dumps(canned)
+
+    _call_llm.calls = calls  # type: ignore[attr-defined]
+    return _call_llm
+
+
+@pytest.mark.parametrize(
+    "trace",
+    _TRACES,
+    ids=[t.trace_id for t in _TRACES],
+)
+async def test_classification_table_round_trip(trace: _Trace) -> None:
+    """Each trace round-trips through the parser to its expected drift shape."""
+    call_llm = _make_call_llm(trace.canned_response)
+    verdict = await classify_reasoning_drift_with_focus(
+        reasoning=trace.reasoning,
+        task=_task(),
+        goals=_goals(),
+        plan=_plan(),
+        model="fake",
+        call_llm=call_llm,
+        current_task_id="t_post",
+        current_agent_id="researcher",
+        recent_tool_observations=trace.recent_tool_observations,
+        task_lineage={"t_post": {"researcher"}},
+    )
+    if trace.expected_drift_kind is None:
+        assert verdict.drift is None, trace.trace_id
+    else:
+        assert verdict.drift is not None, trace.trace_id
+        assert verdict.drift.kind is trace.expected_drift_kind, (
+            trace.trace_id,
+            verdict.drift.kind,
+        )
+        # Severity is WARNING in every non-on_task trace.
+        assert verdict.drift.severity is DriftSeverity.WARNING, trace.trace_id
+    assert verdict.classification == trace.expected_classification, trace.trace_id
+    assert verdict.provenance == trace.expected_provenance, trace.trace_id
+
+
+async def test_trace_b_prompt_includes_tool_observation() -> None:
+    """Trace B's user prompt carries the provoking tool error.
+
+    Pins the prompt-rendering wiring: the recent_tool_observations
+    actually make it into the LLM's context window for the judge to
+    use as evidence.
+    """
+    trace = _TRACES[1]  # B
+    call_llm = _make_call_llm(trace.canned_response)
+    await classify_reasoning_drift_with_focus(
+        reasoning=trace.reasoning,
+        task=_task(),
+        goals=_goals(),
+        plan=_plan(),
+        model="fake",
+        call_llm=call_llm,
+        current_task_id="t_post",
+        current_agent_id="researcher",
+        recent_tool_observations=trace.recent_tool_observations,
+        task_lineage={"t_post": {"researcher"}},
+    )
+    assert len(call_llm.calls) == 1
+    _system, user, _model = call_llm.calls[0]
+    assert "RECENT TOOL OBSERVATIONS" in user
+    assert "fetch_pricing_api" in user
+    assert "ERROR" in user
+    assert "503" in user
+
+
+async def test_trace_a_prompt_includes_empty_tool_obs_marker() -> None:
+    """Trace A has no tool observations → empty-marker placeholder.
+
+    The prompt shape is invariant — the section header is always
+    present and the body is the canonical "(no recent tool
+    observations)" placeholder when nothing has been observed.
+    """
+    trace = _TRACES[0]  # A
+    call_llm = _make_call_llm(trace.canned_response)
+    await classify_reasoning_drift_with_focus(
+        reasoning=trace.reasoning,
+        task=_task(),
+        goals=_goals(),
+        plan=_plan(),
+        model="fake",
+        call_llm=call_llm,
+        current_task_id="t_post",
+        current_agent_id="researcher",
+        recent_tool_observations=trace.recent_tool_observations,
+    )
+    _system, user, _model = call_llm.calls[0]
+    assert "RECENT TOOL OBSERVATIONS" in user
+    assert "(no recent tool observations)" in user


### PR DESCRIPTION
## Summary

iter-10 core: wire the three-state reasoning-judge verdict (on_task /
justified_deviation / erroneous_deviation) end-to-end on top of Wave 1
scaffolding (#346 / #347).

- Judge prompt extended with **THREE decisions** (classification,
  attribution, provenance), a Task lineage line, and a RECENT TOOL
  OBSERVATIONS block sourced from `Session.task_lineage` (iter-9 #344)
  and `Session.recent_tool_observations` (iter-10 PR 2 #347).
- Parser populates `ReasoningJudgeVerdict.classification` +
  `.provenance`. Legacy `{"on_task": bool}` responses still parse via
  the §2.4 rule-2 fallback. `justified_deviation` with missing /
  "none" / unrecognised provenance demotes to `erroneous_deviation`
  per §2.4 rule 3 (logged at INFO).
- New `DriftKind.JUSTIFIED_DEVIATION` ladder row: always-ABSORB at
  every severity (CRITICAL repeat does NOT escalate to PAUSE_ESCALATE
  — provoked deviations should be absorbed into the plan, not
  penalised). Backstops are upstream of the ladder: per-(kind,
  task_id) refine cooldown + `task_last_progress_at` stall gate.
- Planner `refine()` prompt-selection extended so JUSTIFIED_DEVIATION
  uses the goal-aware `_PLAN_DIVERGENCE_SYSTEM_PROMPT`. The existing
  `_render_off_topic_reasoning_block` works as-is because the parser
  stamps the provenance prefix onto `drift.detail` (e.g. `"justified
  deviation (tool_error): ..."`).
- Observability: `ReasoningJudgeInvoked.classification` populated;
  span `decision_summary` carries the three-state verdict (and
  provenance for `justified_deviation`).

## Test plan

- [x] 43 new tests, 2198 total passing (baseline 2155). Coverage:
  parser unit tests for each classification + provenance + the §2.4
  fallbacks, prompt rendering helpers, intervention-ladder
  JUSTIFIED_DEVIATION cases + OFF_TOPIC regression, planner refine
  with goal-aware prompt + reject sentinel + REPEATED_FAILURE
  regression, fixture-driven classification table covering all three
  states, span / proto event population.
- [x] `ruff check` clean.
- [x] Prompt size growth ~1.2KB (template body 1850 → 3094 chars),
  within the design's ~2KB cap.

## Notes / deviations

- The `_GOLDFIVE_STEER_ELIGIBLE_KINDS` set was deliberately NOT
  extended for JUSTIFIED_DEVIATION. Promotion would conflict with the
  always-ABSORB / never-escalate ladder design (§7.3); the default
  ladder routing already gives the right behavior.
- Span `decision_summary` for legacy `{"on_task": false}` responses
  now reads `erroneous_deviation [WARNING]` instead of
  `off-task (WARNING)` (the legacy fallback maps to the new
  classification name). One existing observability test was updated
  to match. The new wording is consistent with iter-10's design
  intent that `decision_summary` "includes the classification".