### PR TITLE
fix(steerer): async drift cascade + pair activity events (iter-11A+11B)

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -631,6 +631,17 @@ class DefaultSteerer:
         # at run end. Tasks auto-discard themselves via
         # ``add_done_callback(self._background_judges.discard)``.
         self._background_judges: set[asyncio.Task[Any]] = set()
+        # Background drift-handler tasks (iter-11A). The drift cascade
+        # triggered from ``mark_task_failed`` / ``mark_task_blocked``
+        # awaits ``planner.refine`` (an LLM round-trip) plus its
+        # cancellation / supersedes side effects. Awaiting that inline
+        # from a reporting-tool call site (e.g. ``report_task_failed``)
+        # blocked the tool from returning for ~minutes on slow local
+        # LLMs, which in turn blocked the agent's next ADK turn. We
+        # now spawn the cascade fire-and-forget through this set,
+        # mirroring :attr:`_background_judges`. ``shutdown`` drains
+        # both sets symmetrically.
+        self._background_drifts: set[asyncio.Task[None]] = set()
         # Per-session plan-state mutation lock. Held only across the
         # consistency-critical region of ``_emit_plan_revised`` (revision
         # index bump + supersedes integration + correction GC + repin +
@@ -922,6 +933,20 @@ class DefaultSteerer:
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.COMPLETED)
         # Drop the observed-agent lineage now the task is terminal.
         session.task_lineage.pop(task_id, None)
+        # iter-11B: pair the prior ``agent_invocation_started`` entry
+        # so the GOAL_DRIFT judge does not see an orphan-start +
+        # task-COMPLETED shape and false-positive on "looping".
+        # ``after_run_callback`` will append the real
+        # ``agent_invocation_completed`` slightly later when the agent
+        # actually returns; duplicate completed entries are harmless
+        # (each is benign and the ring buffer trims naturally).
+        if task.assignee_agent_id:
+            self.note_agent_activity(
+                session,
+                kind="agent_invocation_completed",
+                agent_name=task.assignee_agent_id,
+                task_id=task_id,
+            )
         await self._emit_task_completed(session, task_id, summary, artifacts or {})
         await self._emit_task_transitioned(
             session,
@@ -972,6 +997,17 @@ class DefaultSteerer:
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.FAILED)
         # Drop the observed-agent lineage now the task is terminal.
         session.task_lineage.pop(task_id, None)
+        # iter-11B: pair the prior ``agent_invocation_started`` entry
+        # so the GOAL_DRIFT judge does not see an orphan-start +
+        # task-FAILED shape and false-positive on "looping".  See the
+        # matching write in :meth:`mark_task_completed` for rationale.
+        if task.assignee_agent_id:
+            self.note_agent_activity(
+                session,
+                kind="agent_invocation_completed",
+                agent_name=task.assignee_agent_id,
+                task_id=task_id,
+            )
         await self._emit_task_failed(session, task_id, reason, recoverable)
         await self._emit_task_transitioned(
             session,
@@ -999,7 +1035,13 @@ class DefaultSteerer:
             detail=f"task {task_id} failed: {reason}" if reason else f"task {task_id} failed",
             current_task_id=task_id,
         )
-        await self._handle_drift(drift, session)
+        # iter-11A: spawn the drift cascade fire-and-forget so the
+        # reporting tool that triggered us (``report_task_failed``)
+        # can return immediately. The cascade
+        # (refine → supersedes → cancellation) lands asynchronously;
+        # tests that need the post-cascade plan state await
+        # :meth:`_wait_background_drifts_idle`.
+        self._spawn_drift_handler_background(drift, session)
 
     async def mark_task_blocked(
         self,
@@ -1043,7 +1085,11 @@ class DefaultSteerer:
             detail=detail,
             current_task_id=task_id,
         )
-        await self._handle_drift(drift, session)
+        # iter-11A: spawn the drift cascade fire-and-forget so the
+        # reporting tool that triggered us (``report_task_blocked``)
+        # can return immediately. See :meth:`mark_task_failed` for
+        # the matching call-site comment.
+        self._spawn_drift_handler_background(drift, session)
 
     async def mark_task_cancelled(
         self,
@@ -1601,24 +1647,47 @@ class DefaultSteerer:
             )
 
     async def shutdown(self, *, timeout: float = 5.0) -> None:
-        """Drain background reasoning-judge tasks with a bounded wait.
+        """Drain background reasoning-judge + drift tasks with a bounded wait.
 
         Called at run / runner teardown so ``asyncio.create_task``
-        handles scheduled by :meth:`observe_reasoning` do not leak
-        beyond the event loop's lifetime. Waits at most ``timeout``
-        seconds (default 5.0) for all tracked judges to finish; any
-        still-running tasks past the timeout are cancelled and awaited
-        briefly so their ``CancelledError`` propagation settles before
-        we return.
+        handles scheduled by :meth:`observe_reasoning` (judges) and
+        :meth:`mark_task_failed` / :meth:`mark_task_blocked` (drift
+        cascades, iter-11A) do not leak beyond the event loop's
+        lifetime. Waits at most ``timeout`` seconds (default 5.0) for
+        all tracked tasks to finish; any still-running tasks past the
+        timeout are cancelled and awaited briefly so their
+        ``CancelledError`` propagation settles before we return.
 
-        Idempotent: a second call on an empty ``_background_judges``
-        set is a no-op.
+        Idempotent: a second call when both tracking sets are empty
+        is a no-op.
         """
-        if not self._background_judges:
-            return
+        # Drain reasoning-judge tasks.
+        if self._background_judges:
+            await self._drain_background_set(
+                self._background_judges, label="judge", timeout=timeout
+            )
+        # Drain drift-handler tasks (iter-11A).
+        if self._background_drifts:
+            await self._drain_background_set(
+                self._background_drifts, label="drift", timeout=timeout
+            )
+
+    async def _drain_background_set(
+        self,
+        bg_set: set[asyncio.Task[Any]],
+        *,
+        label: str,
+        timeout: float,
+    ) -> None:
+        """Bounded-wait drain for a background-task tracking set.
+
+        Shared between :attr:`_background_judges` and
+        :attr:`_background_drifts` (iter-11A). ``label`` is used in
+        log messages only.
+        """
         # Snapshot: tasks may be removed from the set by their
         # done-callbacks while we're iterating.
-        pending = list(self._background_judges)
+        pending = list(bg_set)
         if not pending:
             return
         try:
@@ -1648,17 +1717,19 @@ class DefaultSteerer:
             # signal.
             if still_pending:
                 log.warning(
-                    "DefaultSteerer.shutdown: %d background judge task(s) "
+                    "DefaultSteerer.shutdown: %d background %s task(s) "
                     "exceeded %.2fs timeout; cancelled",
                     len(still_pending),
+                    label,
                     float(timeout),
                 )
             else:
                 log.debug(
                     "DefaultSteerer.shutdown: %.2fs timeout expired but "
-                    "all judges completed in the same instant; nothing "
+                    "all %s tasks completed in the same instant; nothing "
                     "to cancel",
                     float(timeout),
+                    label,
                 )
 
     @staticmethod
@@ -2334,6 +2405,97 @@ class DefaultSteerer:
                 "(swallowed): %s",
                 exc,
             )
+
+    # ------------------------------------------------------------------
+    # iter-11A: fire-and-forget drift-cascade dispatch.
+    #
+    # ``mark_task_failed`` / ``mark_task_blocked`` previously awaited
+    # ``_handle_drift`` inline. The cascade traverses planner.refine
+    # (an LLM round-trip), supersedes integration, and downstream
+    # cancellation — on a slow local LLM (e.g. Qwen3.6-35B-A3B-FP8) the
+    # full chain can take 60-120s. Awaiting that from the reporting
+    # tool blocked the tool's return, which blocked the agent's next
+    # ADK turn end-to-end. Spawning the cascade lets the tool ack the
+    # transition immediately; the cascade's side effects
+    # (PlanRevised emission, supersedes, follow-up nudges) land on the
+    # sink bus exactly as before, just slightly later.
+    #
+    # Mirrors :meth:`_spawn_goal_drift_judge_background`. ``shutdown``
+    # drains :attr:`_background_drifts` symmetrically with
+    # :attr:`_background_judges`.
+    # ------------------------------------------------------------------
+    def _spawn_drift_handler_background(
+        self, drift: DriftEvent, session: Session
+    ) -> None:
+        """Dispatch :meth:`_handle_drift` off the critical path.
+
+        Mirrors :meth:`_spawn_goal_drift_judge_background`. The
+        reporting tool that triggered this drift returns immediately;
+        the downstream cascade (refine, supersedes, cancellation)
+        happens asynchronously on a tracked task.
+
+        No-op when no event loop is running (defensive — keeps
+        synchronous test harnesses that build a steerer outside an
+        async context from raising; the inline-awaiting callers of
+        ``mark_task_*`` outside an async context are vanishingly rare
+        and cannot drive a refine round-trip anyway).
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop — fall through silently. Same defensive pattern
+            # as :meth:`_spawn_goal_drift_judge_background`.
+            log.debug(
+                "DefaultSteerer._spawn_drift_handler_background: no running "
+                "loop; skipping spawn for kind=%s",
+                drift.kind.value,
+            )
+            return
+        bg_task = asyncio.create_task(
+            self._run_drift_handler_background(drift, session),
+            name=f"goldfive-drift-{drift.kind.value}",
+        )
+        self._background_drifts.add(bg_task)
+        bg_task.add_done_callback(self._background_drifts.discard)
+
+    async def _run_drift_handler_background(
+        self, drift: DriftEvent, session: Session
+    ) -> None:
+        """Body of the fire-and-forget drift handler.
+
+        Mirrors :meth:`_run_goal_drift_judge_background`: swallows
+        every exception so a flaky cascade cannot crash the run, and
+        re-raises ``CancelledError`` cleanly so :meth:`shutdown` can
+        cancel still-running cascades at teardown without a stray
+        ``WARNING`` muddying the signal.
+        """
+        try:
+            await self._handle_drift(drift, session)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — background task
+            log.warning(
+                "DefaultSteerer: background drift handler raised "
+                "(swallowed): kind=%s exc=%s",
+                drift.kind.value,
+                exc,
+            )
+
+    async def _wait_background_drifts_idle(self) -> None:
+        """Wait for every pending background drift task to settle.
+
+        Test helper. Mirrors the goal-drift drain pattern used by
+        :func:`tests.test_goal_drift_classifier._drain_background_judges`.
+        Production callers should never need this — the run-end
+        :meth:`shutdown` drains pending cascades with a bounded wait.
+        """
+        pending = list(self._background_drifts)
+        if not pending:
+            return
+        await asyncio.gather(*pending, return_exceptions=True)
+        # One yield so the ``add_done_callback(...discard)`` has run
+        # and the set is fully empty for the next assertion / spawn.
+        await asyncio.sleep(0)
 
     async def _emit_reflective_failure(
         self, session: Session, *, task_id: str, reason: str

--- a/tests/test_drift_async_dispatch.py
+++ b/tests/test_drift_async_dispatch.py
@@ -1,0 +1,455 @@
+"""Async drift-cascade dispatch + activity-pairing (iter-11A + 11B).
+
+Iter-11A: ``mark_task_failed`` / ``mark_task_blocked`` previously
+awaited ``planner.refine`` inline through :meth:`_handle_drift`. On a
+slow local LLM (e.g. Qwen3.6-35B-A3B-FP8) the resulting
+``report_task_failed`` tool call took ~2 minutes to return, which
+blocked the agent's next ADK turn end-to-end. The fix spawns the
+cascade fire-and-forget on
+:attr:`DefaultSteerer._background_drifts` and drains it at
+:meth:`shutdown`. This module pins:
+
+* The reporting tool ack returns immediately (within 100ms) regardless
+  of how long ``planner.refine`` takes.
+* :meth:`shutdown` drains pending drift cascades within the timeout.
+* No running event loop → spawn no-ops without crashing (synchronous
+  test harnesses).
+
+Iter-11B: ``mark_task_completed`` / ``mark_task_failed`` now write a
+synthetic ``agent_invocation_completed`` entry to
+:attr:`Session.recent_agent_activity` so the GOAL_DRIFT judge does not
+read an orphan-start + task-COMPLETED shape and false-positive on
+"looping". The real ``after_run_callback`` will append another
+``agent_invocation_completed`` slightly later — duplicate completed
+entries are harmless (the goal-drift prompt renders both fine and the
+ring buffer trims naturally).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs (intentionally local to this file — keep the spec self-contained).
+# ---------------------------------------------------------------------------
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class _NullPlanner:
+    """Refine returns ``None`` synchronously and instantly."""
+
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        self.refine_calls.append(kwargs)
+        return None
+
+
+class _SlowPlanner:
+    """Refine sleeps ``delay`` seconds before returning ``None``.
+
+    Used to assert that the reporting tool returns BEFORE refine
+    settles (the iter-11A correctness contract).
+    """
+
+    def __init__(self, *, delay: float) -> None:
+        self.delay = delay
+        self.refine_calls: list[dict[str, Any]] = []
+        self.refine_done = asyncio.Event()
+
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        self.refine_calls.append(kwargs)
+        try:
+            await asyncio.sleep(self.delay)
+            return None
+        finally:
+            self.refine_done.set()
+
+
+def _make_session(*, assignee: str = "worker") -> Session:
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="A", assignee_agent_id=assignee),
+            Task(id="t2", title="B", assignee_agent_id=assignee),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do the thing")],
+        plan=plan,
+    )
+
+
+def _bind(planner: Any) -> tuple[DefaultSteerer, Session, _ListSink, Any]:
+    steerer = DefaultSteerer()
+    session = _make_session()
+    sink = _ListSink()
+    steerer.bind(sinks=[sink], planner=planner)
+    return steerer, session, sink, planner
+
+
+# ---------------------------------------------------------------------------
+# 11B — synthetic activity-pair entry
+# ---------------------------------------------------------------------------
+
+
+async def test_mark_task_completed_appends_synthetic_invocation_completed() -> None:
+    """``mark_task_completed`` pairs a prior ``agent_invocation_started``.
+
+    Reproduces the GOAL_DRIFT judge's "orphan start + task COMPLETED →
+    looping" false positive. After the synthetic write the activity
+    buffer has both the start AND a paired completed keyed on the
+    task's ``assignee_agent_id``.
+    """
+    steerer, session, _sink, _planner = _bind(_NullPlanner())
+    # Adapter would normally write this from ``before_run_callback``.
+    steerer.note_agent_activity(
+        session,
+        kind="agent_invocation_started",
+        agent_name="worker",
+        task_id="t1",
+    )
+    assert len(session.recent_agent_activity) == 1
+
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+
+    # Paired entry appended.
+    completed_entries = [
+        e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
+    ]
+    assert len(completed_entries) == 1
+    assert completed_entries[0]["agent_name"] == "worker"
+    assert completed_entries[0]["task_id"] == "t1"
+
+
+async def test_mark_task_failed_appends_synthetic_invocation_completed() -> None:
+    """Same pairing applies on the failed-task path.
+
+    Same false-positive shape: orphan start + task FAILED would also
+    look like "looping" to the goal-drift judge.
+    """
+    steerer, session, _sink, _planner = _bind(_NullPlanner())
+    steerer.note_agent_activity(
+        session,
+        kind="agent_invocation_started",
+        agent_name="worker",
+        task_id="t1",
+    )
+
+    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    await steerer._wait_background_drifts_idle()
+
+    completed_entries = [
+        e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
+    ]
+    assert len(completed_entries) == 1
+    assert completed_entries[0]["agent_name"] == "worker"
+    assert completed_entries[0]["task_id"] == "t1"
+
+
+async def test_mark_task_completed_skips_pairing_when_no_assignee() -> None:
+    """Tasks without an ``assignee_agent_id`` skip the synthetic write.
+
+    The pairing keys on the agent name; with no assignee the entry
+    would carry an empty agent name and pollute the goal-drift prompt
+    without disambiguating anything.
+    """
+    steerer, session, _sink, _planner = _bind(_NullPlanner())
+    # Wipe the assignee on the test session's tasks.
+    assert session.plan is not None
+    for t in session.plan.tasks:
+        t.assignee_agent_id = ""
+    # Pre-existing started entry from a prior agent's run.
+    steerer.note_agent_activity(
+        session,
+        kind="agent_invocation_started",
+        agent_name="worker",
+        task_id="t1",
+    )
+
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+
+    completed_entries = [
+        e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
+    ]
+    assert completed_entries == []
+
+
+async def test_mark_task_failed_skips_pairing_when_no_assignee() -> None:
+    """Mirror of the completed-path "no assignee" guard."""
+    steerer, session, _sink, _planner = _bind(_NullPlanner())
+    assert session.plan is not None
+    for t in session.plan.tasks:
+        t.assignee_agent_id = ""
+
+    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    await steerer._wait_background_drifts_idle()
+
+    completed_entries = [
+        e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
+    ]
+    assert completed_entries == []
+
+
+async def test_duplicate_completed_entries_are_harmless() -> None:
+    """Real ``after_run_callback`` will also append a completed entry.
+
+    The synthetic + real pair lands two completed entries in the
+    activity buffer. Both are well-formed ``dict``s with the expected
+    keys; the goal-drift prompt renders them fine; the ring buffer
+    trims naturally on overflow.
+    """
+    steerer, session, _sink, _planner = _bind(_NullPlanner())
+    steerer.note_agent_activity(
+        session,
+        kind="agent_invocation_started",
+        agent_name="worker",
+        task_id="t1",
+    )
+
+    await steerer.mark_task_completed("t1", session=session, summary="done")
+    # Simulate the real after_run_callback firing slightly later.
+    steerer.note_agent_activity(
+        session,
+        kind="agent_invocation_completed",
+        agent_name="worker",
+        task_id="t1",
+    )
+
+    completed_entries = [
+        e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
+    ]
+    assert len(completed_entries) == 2
+    # Each entry carries the canonical keys; the goal-drift prompt
+    # renderer reads ``kind``, ``agent_name``, ``task_id`` and is
+    # tolerant of duplicates.
+    for entry in completed_entries:
+        assert entry["kind"] == "agent_invocation_completed"
+        assert entry["agent_name"] == "worker"
+        assert entry["task_id"] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# 11A — async drift dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_mark_task_failed_does_not_block_on_refine() -> None:
+    """``mark_task_failed`` returns immediately even when refine is slow.
+
+    The iter-11A correctness contract: a 30s refine round-trip must
+    NOT block the reporting-tool return. ``mark_task_failed`` returns
+    in well under 100ms; refine eventually runs in the background and
+    is observable via ``_wait_background_drifts_idle``.
+    """
+    slow_planner = _SlowPlanner(delay=30.0)
+    steerer, session, _sink, _planner = _bind(slow_planner)
+
+    t0 = time.monotonic()
+    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    elapsed = time.monotonic() - t0
+
+    # 100ms is generous — the synchronous portion is two event emits +
+    # a status flip. Real measured latency is sub-ms.
+    assert elapsed < 0.1, (
+        f"mark_task_failed blocked for {elapsed * 1000:.1f}ms; "
+        "expected <100ms (iter-11A contract: cascade is fire-and-forget)"
+    )
+    # Refine HAS NOT settled yet — the slow planner is still asleep.
+    assert slow_planner.refine_calls == [] or not slow_planner.refine_done.is_set()
+    # Cancel the spawned task so we don't have to wait the full 30s.
+    pending = list(steerer._background_drifts)
+    for task in pending:
+        task.cancel()
+    await asyncio.gather(*pending, return_exceptions=True)
+
+
+async def test_mark_task_failed_refine_runs_eventually() -> None:
+    """The refine round-trip ALWAYS lands — just asynchronously.
+
+    Pairs with the latency assertion above: the cascade is offloaded,
+    not dropped. Tests that need the post-cascade plan state await
+    ``_wait_background_drifts_idle``.
+    """
+    planner = _NullPlanner()
+    steerer, session, _sink, _ = _bind(planner)
+
+    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    # No refine call yet — handler is still queued.
+    assert planner.refine_calls == []
+    await steerer._wait_background_drifts_idle()
+    # After the drain refine WAS called.
+    assert len(planner.refine_calls) == 1
+    assert planner.refine_calls[0]["drift"].kind is DriftKind.TASK_FAILED_RECOVERABLE
+
+
+async def test_mark_task_blocked_does_not_block_on_refine() -> None:
+    """Same async contract for ``mark_task_blocked``.
+
+    The reporting tool ``report_task_blocked`` shares the same code
+    path; pin it explicitly so a future refactor that re-synchronises
+    just one of the two methods is caught here.
+    """
+    slow_planner = _SlowPlanner(delay=30.0)
+    steerer, session, _sink, _planner = _bind(slow_planner)
+
+    t0 = time.monotonic()
+    await steerer.mark_task_blocked("t1", session=session, blocker="missing input")
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 0.1, (
+        f"mark_task_blocked blocked for {elapsed * 1000:.1f}ms; expected <100ms (iter-11A contract)"
+    )
+    pending = list(steerer._background_drifts)
+    for task in pending:
+        task.cancel()
+    await asyncio.gather(*pending, return_exceptions=True)
+
+
+async def test_shutdown_drains_background_drifts() -> None:
+    """``shutdown`` cancels still-running drift cascades within timeout.
+
+    Mirror of the existing ``_background_judges`` drain. A drift
+    cascade that outlives its run must be cancelled at teardown so
+    ``asyncio.create_task`` handles do not leak past the event
+    loop's lifetime.
+    """
+    slow_planner = _SlowPlanner(delay=30.0)
+    steerer, session, _sink, _ = _bind(slow_planner)
+
+    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    # One pending drift task should be tracked.
+    assert len(steerer._background_drifts) == 1
+
+    t0 = time.monotonic()
+    # Bounded timeout — slow_planner.delay (30s) >> shutdown timeout.
+    await steerer.shutdown(timeout=0.2)
+    elapsed = time.monotonic() - t0
+
+    # Shutdown should land within the timeout window plus the 0.5s
+    # post-cancel grace; not 30s.
+    assert elapsed < 1.5, (
+        f"shutdown blocked for {elapsed:.2f}s; expected <1.5s (timeout=0.2s + 0.5s cancel grace)"
+    )
+    # All tracked tasks discarded by their done-callbacks.
+    assert steerer._background_drifts == set()
+
+
+async def test_shutdown_idempotent_with_no_background_drifts() -> None:
+    """``shutdown`` on an empty drift set is a no-op (matches judge drain)."""
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[_ListSink()], planner=_NullPlanner())
+    await steerer.shutdown(timeout=5.0)
+    # Second call still safe.
+    await steerer.shutdown(timeout=5.0)
+
+
+def test_mark_task_failed_returns_immediately_when_no_loop() -> None:
+    """No running event loop → ``_spawn_drift_handler_background`` no-ops.
+
+    Synchronous test harnesses (or one-shot CLIs) that build a steerer
+    outside ``asyncio.run`` must not crash when a drift would
+    otherwise be spawned. The inline cascade is skipped — those
+    callers couldn't await it anyway, and the production path always
+    has a running loop.
+
+    This test deliberately runs sync (no ``async def``) and uses
+    :meth:`asyncio.new_event_loop` only to drive the
+    ``mark_task_failed`` coroutine to completion — the spawn path
+    itself observes "no running loop" and short-circuits.
+    """
+    steerer, session, _sink, _ = _bind(_NullPlanner())
+    drift = DriftEvent(
+        kind=DriftKind.TASK_FAILED_RECOVERABLE,
+        severity=DriftSeverity.WARNING,
+        detail="test drift",
+        current_task_id="t1",
+    )
+    # Direct test: call the spawner WITHOUT a running loop. It should
+    # log+return rather than raise.
+    steerer._spawn_drift_handler_background(drift, session)
+    assert steerer._background_drifts == set()
+    # Sanity: the same call WITH a loop does spawn a task.
+    loop = asyncio.new_event_loop()
+    try:
+
+        async def _spawn() -> None:
+            steerer._spawn_drift_handler_background(drift, session)
+            assert len(steerer._background_drifts) == 1
+            await steerer._wait_background_drifts_idle()
+            assert steerer._background_drifts == set()
+
+        loop.run_until_complete(_spawn())
+    finally:
+        loop.close()
+
+
+async def test_background_drift_swallows_handler_exception() -> None:
+    """A flaky cascade must not crash the run.
+
+    Mirrors :meth:`_run_goal_drift_judge_background`: handler raises
+    → log warning, swallow, mark task complete on the tracking set.
+    """
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[_ListSink()], planner=_NullPlanner())
+    session = _make_session()
+    drift = DriftEvent(
+        kind=DriftKind.TASK_FAILED_RECOVERABLE,
+        severity=DriftSeverity.WARNING,
+        detail="test drift",
+        current_task_id="t1",
+    )
+
+    async def _raise(_drift: DriftEvent, _session: Session) -> None:
+        raise RuntimeError("simulated handler failure")
+
+    # Patch _handle_drift on the instance for this one test.
+    steerer._handle_drift = _raise  # type: ignore[assignment]
+    steerer._spawn_drift_handler_background(drift, session)
+    assert len(steerer._background_drifts) == 1
+    await steerer._wait_background_drifts_idle()
+    assert steerer._background_drifts == set()

--- a/tests/test_judge_task_lifetime.py
+++ b/tests/test_judge_task_lifetime.py
@@ -353,6 +353,11 @@ async def test_synchronous_tool_flow_unaffected_by_late_drift_guard() -> None:
     )
 
     assert _task_status(session, "t1") is TaskStatus.FAILED
+    # iter-11A: drift cascade is fire-and-forget; drain before
+    # asserting on planner.refine. The late-drift guard rationale
+    # below still applies — what changed is the dispatch mechanism,
+    # not the guard scope.
+    await steerer._wait_background_drifts_idle()
     # planner.refine WAS called: synchronous tool-flow drifts route
     # through ``_handle_drift`` directly and are not gated.
     assert len(planner.refine_calls) >= 1, (

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -185,6 +185,10 @@ async def test_report_task_failed_transitions_and_refines() -> None:
         steerer,
     )
     assert session.plan.tasks[0].status is TaskStatus.FAILED
+    # iter-11A: drift cascade is fire-and-forget so the reporting tool
+    # ack is no longer gated on planner.refine; drain before asserting
+    # on the refine side effects.
+    await steerer._wait_background_drifts_idle()
     # Sequence: TaskFailed, DriftDetected. Planner.refine invoked once.
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     assert "task_failed" in kinds and "drift_detected" in kinds
@@ -204,6 +208,9 @@ async def test_report_task_blocked_transitions_and_refines() -> None:
         steerer,
     )
     assert session.plan.tasks[0].status is TaskStatus.BLOCKED
+    # iter-11A: drift cascade is fire-and-forget; drain before
+    # asserting on planner.refine side effects.
+    await steerer._wait_background_drifts_idle()
     assert len(planner.refine_calls) == 1
     assert planner.refine_calls[0]["drift"].kind is DriftKind.BLOCKED
 
@@ -266,6 +273,9 @@ async def test_handler_recoverable_accepts_string_bool() -> None:
         session,
         steerer,
     )
+    # iter-11A: drift cascade is fire-and-forget; drain before
+    # asserting on planner.refine side effects.
+    await steerer._wait_background_drifts_idle()
     # "false" string → recoverable=False → TASK_FAILED_FATAL
     assert planner.refine_calls[0]["drift"].kind is DriftKind.TASK_FAILED_FATAL
 

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -256,6 +256,9 @@ async def test_mark_task_failed_recoverable_fires_drift() -> None:
     steerer, session, sink, planner = _fresh()
     await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
     assert _task(session, "t1").status is TaskStatus.FAILED
+    # iter-11A: drift cascade is fire-and-forget; drain before
+    # asserting on its observable side effects.
+    await steerer._wait_background_drifts_idle()
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     # TaskFailed + DriftDetected + refine-failure DriftDetected (planner
     # returns None so no PlanRevised; the follow-up drift surfaces that).
@@ -275,6 +278,9 @@ async def test_mark_task_failed_recoverable_fires_drift() -> None:
 async def test_mark_task_failed_fatal_fires_critical_drift() -> None:
     steerer, session, sink, _planner = _fresh()
     await steerer.mark_task_failed("t1", session=session, reason="unrecoverable", recoverable=False)
+    # iter-11A: drift cascade is fire-and-forget; drain before
+    # asserting on its observable side effects.
+    await steerer._wait_background_drifts_idle()
     # Event order: TaskFailed(t1) → TaskCancelled(t2, cascade) → DriftDetected(TASK_FAILED_FATAL) →
     # refine-failure DriftDetected (stub planner returns None). The
     # cascade fires before the fatal drift so planner.refine (if it ran)
@@ -301,6 +307,9 @@ async def test_mark_task_blocked_transitions_and_emits_drift() -> None:
         "t1", session=session, blocker="need API key", needed="credentials.json"
     )
     assert _task(session, "t1").status is TaskStatus.BLOCKED
+    # iter-11A: drift cascade is fire-and-forget; drain before
+    # asserting on its observable side effects.
+    await steerer._wait_background_drifts_idle()
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     # TaskBlocked + DriftDetected + refine-failure DriftDetected (stub
     # planner returns None; the follow-up drift surfaces that).
@@ -661,6 +670,10 @@ async def test_refine_failure_counter_increments_on_exception() -> None:
     # through _handle_drift and triggers one more refine attempt (keyed
     # on a different (kind, task) tuple, so the TOOL_ERROR counter stays
     # at 2 and the TASK_FAILED_FATAL counter reaches 1).
+    # iter-11A: the TASK_FAILED_FATAL refine attempt now lands
+    # asynchronously via mark_task_failed's spawned cascade — drain
+    # before asserting on the fatal-key outcome.
+    await steerer._wait_background_drifts_idle()
     outcome_after_2 = session.refine_outcomes[key]
     assert outcome_after_2.state == "failed"
     assert outcome_after_2.fail_count == 2
@@ -692,6 +705,9 @@ async def test_refine_failure_counter_increments_on_none_return() -> None:
     # Same cascade as the exception case: the TOOL_ERROR counter is
     # clamped at the threshold (2), the cascaded TASK_FAILED_FATAL drift
     # kicks off its own independent counter at 1.
+    # iter-11A: drain the spawned mark_task_failed cascade before
+    # asserting on the fatal-key outcome.
+    await steerer._wait_background_drifts_idle()
     outcome_after_2 = session.refine_outcomes[key]
     assert outcome_after_2.state == "failed"
     assert outcome_after_2.fail_count == 2


### PR DESCRIPTION
## Summary

Two structural fixes in ``goldfive/steerer.py`` surfaced by live e2e on Qwen3.6-35B-A3B-FP8. Shared call sites (``mark_task_failed`` / ``mark_task_blocked`` / ``mark_task_completed``) so combined into one PR to avoid merge conflicts.

- **iter-11A — Async drift cascade.** ``mark_task_failed`` / ``mark_task_blocked`` previously awaited ``planner.refine`` (and the supersedes/cancel side effects) synchronously through ``_handle_drift``. On slow local LLMs the resulting ``report_task_failed`` span ran ~130s and blocked the agent's next ADK turn. The cascade is now spawned fire-and-forget on a new ``_background_drifts`` tracking set, mirroring ``_background_judges``. ``shutdown`` drains both sets via a shared ``_drain_background_set`` helper.
- **iter-11B — Synthetic activity-pair entry.** The GOAL_DRIFT judge read ``Session.recent_agent_activity`` and treated an orphan ``agent_invocation_started`` next to a COMPLETED/FAILED task as "looping". ``mark_task_completed`` / ``mark_task_failed`` now append a paired ``agent_invocation_completed`` entry immediately after the status transition (keyed on ``task.assignee_agent_id``). Duplicate completed entries from the later real ``after_run_callback`` are harmless.

Scope: limited to ``mark_task_failed`` and ``mark_task_blocked`` — the only ``mark_task_*`` methods that currently await ``_handle_drift`` directly. ``mark_task_started`` does not await drift; ``mark_task_completed`` only spawns the goal-drift judge (already async), so neither needs the async-ify treatment.

## Test plan

- [x] New ``tests/test_drift_async_dispatch.py`` (12 tests): activity pairing on completed/failed/no-assignee, duplicate-completed harmlessness, latency contract (mark_task_failed returns <100ms even with 30s refine), refine eventually runs after drain, shutdown drains pending cascades within timeout, idempotent shutdown, no-running-loop defensive path, exception swallowing.
- [x] Existing tests updated with ``_wait_background_drifts_idle`` barriers: ``test_steerer.py`` (5 tests), ``test_reporting.py`` (3 tests), ``test_judge_task_lifetime.py`` (1 test).
- [x] Full suite: 1835 passing, 121 skipped (was 1823 + 121).
- [x] ``ruff check .`` clean.

## Concurrent agents

- Iter-11C (planner.py refine retry) — different file, no conflict.
- Iter-11D (``_adk_plugin.py::after_model_callback``) — different file, no conflict.
- Iter-11E PR 1 (proto + types.py + steerer.py ladder) — touches a different region of steerer.py (``_LADDER`` table). If they merge first, rebase cleanly.