### PR TITLE
feat(reporting, examples): structural artifact verification at report_task_completed (iter-11E PR2+3)

### DIFF
--- a/examples/presentation_agent/agent.py
+++ b/examples/presentation_agent/agent.py
@@ -327,7 +327,16 @@ class _MockLlm(BaseLlm):
 
 
 def _mock_planner_call_llm(topic: str) -> Callable[[str, str, str], Any]:
-    """Canned ``LLMPlanner.call_llm`` — one task per specialist subagent."""
+    """Canned ``LLMPlanner.call_llm`` — one task per specialist subagent.
+
+    iter-11E PR 3: artifact-producing tasks declare
+    ``required_tool_calls`` so the verification at
+    ``report_task_completed`` time (PR 2) catches false-success
+    reports — an agent that fires the report without actually
+    invoking the artifact tool. ``research`` has no requirement
+    (the researcher's deliverable is reasoning, not a file artifact)
+    and is intentionally left at the empty-list default.
+    """
     plan = {
         "summary": f"Build a slideshow presentation on '{topic}'.",
         "tasks": [
@@ -342,18 +351,21 @@ def _mock_planner_call_llm(topic: str) -> Callable[[str, str, str], Any]:
                 "title": "Generate HTML/CSS/JS slideshow",
                 "description": "Produce the presentation files and save them.",
                 "assignee_agent_id": "web_developer_agent",
+                "required_tool_calls": ["write_webpage"],
             },
             {
                 "id": "review",
                 "title": "Review the generated presentation",
                 "description": "Critique the generated slideshow for issues.",
                 "assignee_agent_id": "reviewer_agent",
+                "required_tool_calls": ["read_presentation_files"],
             },
             {
                 "id": "debug",
                 "title": "Patch any critical issues the reviewer flagged",
                 "description": "Apply fixes to the presentation files.",
                 "assignee_agent_id": "debugger_agent",
+                "required_tool_calls": ["patch_file"],
             },
         ],
         "edges": [

--- a/goldfive/reporting.py
+++ b/goldfive/reporting.py
@@ -25,7 +25,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from goldfive import _state_audit
-from goldfive.types import SupersessionKind, TaskStatus
+from goldfive.types import DriftEvent, DriftKind, DriftSeverity, SupersessionKind, TaskStatus
 
 if TYPE_CHECKING:
     from goldfive.protocols import Steerer
@@ -852,6 +852,116 @@ def _invalid_transition_response(
     }
 
 
+def _verify_required_tool_calls(
+    task: Task,
+    session: Session,
+    task_id: str,
+) -> DriftEvent | None:
+    """Check that every tool in ``task.required_tool_calls`` was observed.
+
+    iter-11E PR 2 — structural artifact verification at
+    ``report_task_completed`` time. The plan declares the artifact-
+    producing tools each task must call (``Task.required_tool_calls``)
+    and the verification rejects a completion report whose execution
+    span did not include those tool calls. Catches false-success
+    reports — agents (notably Qwen3.6-32B-A3B-FP8 in our traces) that
+    skip the actual write but still fire ``report_task_succeeded``.
+
+    Scoping: ``Session.recent_tool_observations`` is a global ring
+    buffer (every agent + every task), so this filter narrows to
+    entries pinned to ``task_id`` before checking membership. An
+    observation of ``write_webpage_tool`` produced under a different
+    task does NOT satisfy the requirement on this task — the
+    artefact-producing call must have happened in the failing task's
+    own execution span.
+
+    Returns
+    -------
+    A ``DriftEvent`` with kind ``INCOMPLETE_TOOL_CALLS`` and
+    ``CRITICAL`` severity when one or more required tools are missing.
+    The drift carries the missing-tool list (and the per-task observed
+    set) on its ``detail`` so the planner's goal-aware refine prompt
+    can render them via ``_render_off_topic_reasoning_block``. The
+    same lists also flow into the agent-facing rejection response so
+    the call site does not have to recompute them.
+
+    ``None`` when the task has no requirements or every requirement
+    was satisfied. The completion report proceeds normally in that
+    case.
+    """
+    required = list(task.required_tool_calls or [])
+    if not required:
+        return None
+
+    observed_tools: set[str] = set()
+    for obs in session.recent_tool_observations or []:
+        if not isinstance(obs, dict):
+            continue
+        if obs.get("task_id") != task_id:
+            continue
+        tool_name = obs.get("tool_name")
+        if tool_name:
+            observed_tools.add(str(tool_name))
+
+    missing = [t for t in required if t not in observed_tools]
+    if not missing:
+        return None
+
+    observed_sorted = sorted(observed_tools)
+    detail = (
+        f"task {task_id!r} reported succeeded but required tools "
+        f"were not observed during execution: missing={missing}, "
+        f"observed={observed_sorted}"
+    )
+    drift = DriftEvent(
+        kind=DriftKind.INCOMPLETE_TOOL_CALLS,
+        severity=DriftSeverity.CRITICAL,
+        detail=detail,
+        current_task_id=task_id,
+        current_agent_id=str(getattr(task, "assignee_agent_id", "") or ""),
+    )
+    # Stash the structured missing/observed lists on ``raw`` so the
+    # caller can build the rejection response without re-walking
+    # ``recent_tool_observations``. Sinks read ``detail`` (which
+    # already carries the rendered list); ``raw`` is the call-site-
+    # friendly machine-readable shape.
+    drift.raw = {"missing": list(missing), "observed": list(observed_sorted)}
+    return drift
+
+
+def _incomplete_tool_calls_response(
+    *,
+    task_id: str,
+    missing: list[str],
+    observed: list[str],
+    detail: str,
+) -> dict[str, Any]:
+    """Canonical rejection shape for a completion report missing required tools.
+
+    Mirrors :func:`_invalid_transition_response` and
+    :func:`_missing_required_field_response`: ``acknowledged=False``,
+    a stable ``error`` string the LLM can branch on, and a
+    human-readable ``message`` it can act on. The agent should call
+    the missing tools and only then re-report completion.
+
+    The dispatched ``INCOMPLETE_TOOL_CALLS`` drift handles the
+    plan-side correction (goal-aware refine via
+    ``_PLAN_DIVERGENCE_SYSTEM_PROMPT``); this response handles the
+    LLM-side correction (the agent that issued the false report
+    learns its report did not take effect and the task remains
+    RUNNING).
+    """
+    return {
+        "acknowledged": False,
+        "error": "incomplete_tool_calls",
+        "tool": "report_task_completed",
+        "task_id": task_id,
+        "missing_tool_calls": list(missing),
+        "observed_tool_calls": list(observed),
+        "message": detail,
+    }
+
+
 def _classify_transition(
     *,
     tool_name: str,
@@ -1241,6 +1351,46 @@ async def _handle_task_completed(
                 current_status=task.status,
                 attempted=TaskStatus.COMPLETED,
                 task_id=task_id,
+            )
+        # iter-11E PR 2: structural artifact verification. Reject the
+        # completion when the task declared ``required_tool_calls`` but
+        # those tools weren't observed in this task's execution span.
+        # The dispatched INCOMPLETE_TOOL_CALLS drift drives the
+        # plan-side correction via goal-aware refine; the rejection
+        # response tells the calling agent its report did not take
+        # effect so it can call the missing tools and re-report.
+        incomplete_drift = _verify_required_tool_calls(task, session, task_id)
+        if incomplete_drift is not None:
+            log.warning(
+                "reporting: report_task_completed REJECTED for task_id=%s "
+                "(missing required tool calls); dispatching "
+                "INCOMPLETE_TOOL_CALLS drift",
+                task_id,
+            )
+            # Dispatch via the same fire-and-forget cascade that
+            # ``mark_task_failed`` / ``mark_task_blocked`` use post
+            # iter-11A. The reporting tool returns the rejection
+            # immediately; the planner.refine round-trip lands
+            # asynchronously on the sink bus.
+            spawner = getattr(steerer, "_spawn_drift_handler_background", None)
+            if callable(spawner):
+                spawner(incomplete_drift, session)
+            else:
+                # Custom Steerer / test stub without the iter-11A
+                # spawner: fall back to inline ``_handle_drift`` so the
+                # drift still flows through the ladder.
+                handler = getattr(steerer, "_handle_drift", None)
+                if callable(handler):
+                    await handler(incomplete_drift, session)
+            # ``_verify_required_tool_calls`` already computed both
+            # lists for the drift detail; reuse them via ``drift.raw``
+            # so we don't re-walk the ring buffer.
+            raw = incomplete_drift.raw if isinstance(incomplete_drift.raw, dict) else {}
+            return _incomplete_tool_calls_response(
+                task_id=task_id,
+                missing=list(raw.get("missing") or []),
+                observed=list(raw.get("observed") or []),
+                detail=incomplete_drift.detail,
             )
     await steerer.mark_task_completed(
         task_id, session=session, summary=summary, artifacts=artifacts, source=source

--- a/tests/examples/test_presentation_agent.py
+++ b/tests/examples/test_presentation_agent.py
@@ -107,3 +107,37 @@ def test_adk_web_wrapped_app_name_is_identifier() -> None:
 
     assert app.name == "goldfive_wrapped_demo"
     assert app.name.isidentifier()
+
+
+def test_mock_plan_declares_required_tool_calls_for_artifact_tasks() -> None:
+    """iter-11E PR 3 regression — artifact-producing tasks declare the
+    tools that must be observed during their execution span.
+
+    Pins:
+
+    * ``build`` (web_developer_agent) declares ``write_webpage``.
+    * ``review`` (reviewer_agent) declares ``read_presentation_files``.
+    * ``debug`` (debugger_agent) declares ``patch_file``.
+    * ``research`` is intentionally NOT declared — the researcher's
+      deliverable is reasoning, not a file artifact.
+
+    Without these declarations the verification at
+    ``report_task_completed`` time (PR 2) cannot tell a real
+    artefact-producing run from an agent that fires a false-success
+    report; the example doubles as the canonical opt-in shape for
+    downstream callers.
+    """
+    import json
+
+    from examples.presentation_agent.agent import _mock_planner_call_llm
+
+    call = _mock_planner_call_llm("waffles")
+    raw = asyncio.run(call("system", "user", "model"))
+    plan = json.loads(raw)
+    by_id = {t["id"]: t for t in plan["tasks"]}
+
+    assert by_id["build"].get("required_tool_calls") == ["write_webpage"]
+    assert by_id["review"].get("required_tool_calls") == ["read_presentation_files"]
+    assert by_id["debug"].get("required_tool_calls") == ["patch_file"]
+    # Research has no file artifact — must NOT carry a requirement.
+    assert "required_tool_calls" not in by_id["research"]

--- a/tests/test_artifact_verification.py
+++ b/tests/test_artifact_verification.py
@@ -1,0 +1,458 @@
+"""iter-11E PR 2 — structural artifact verification at ``report_task_completed``.
+
+PR 1 shipped the scaffolding (``Task.required_tool_calls``,
+``DriftKind.INCOMPLETE_TOOL_CALLS``, ladder entry, planner prompt
+selection). PR 2 wires the verification into
+``goldfive.reporting._handle_task_completed`` so a completion report
+on a task with declared ``required_tool_calls`` is rejected when one
+or more of those tools were not observed during the task's execution
+span (per ``Session.recent_tool_observations`` filtered to the
+matching ``task_id``). The rejection
+  * dispatches an ``INCOMPLETE_TOOL_CALLS`` drift through the
+    standard pipeline (refine via the goal-aware system prompt),
+  * returns a structured ``incomplete_tool_calls`` rejection payload
+    so the agent learns its report did not take effect, and
+  * leaves the task in its pre-call status (no transition).
+
+These tests pin those properties.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.reporting import (  # noqa: E402
+    BUILTIN_REPORTING_TOOLS,
+    ReportingToolSpec,
+    _verify_required_tool_calls,
+)
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class StubPlanner:
+    def __init__(self, revised: Plan | None = None) -> None:
+        self.revised = revised
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return self.revised
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        self.refine_calls.append(kwargs)
+        return self.revised
+
+
+def _plan_with_required_tools() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="draft_slides",
+                title="Draft slide deck",
+                assignee_agent_id="presenter",
+                status=TaskStatus.RUNNING,
+                required_tool_calls=["write_webpage_tool"],
+            ),
+            Task(
+                id="review",
+                title="Review slide deck",
+                assignee_agent_id="reviewer",
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="draft_slides", to_task_id="review")],
+    )
+
+
+def _plan_no_required() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research",
+                title="Research the topic",
+                assignee_agent_id="researcher",
+                status=TaskStatus.RUNNING,
+            ),
+        ],
+        edges=[],
+    )
+
+
+def _fresh(plan: Plan) -> tuple[DefaultSteerer, Session, ListSink, StubPlanner]:
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="produce a slide deck")],
+        plan=plan,
+    )
+    sink = ListSink()
+    planner = StubPlanner()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    return steerer, session, sink, planner
+
+
+def _tool(name: str) -> ReportingToolSpec:
+    for t in BUILTIN_REPORTING_TOOLS:
+        if t.name == name:
+            return t
+    raise AssertionError(f"builtin tool {name!r} missing")
+
+
+def _push_observation(
+    session: Session,
+    *,
+    task_id: str,
+    tool_name: str,
+    agent_name: str = "presenter",
+) -> None:
+    """Append a recent_tool_observations entry as an adapter would."""
+    session.recent_tool_observations.append(
+        {
+            "ts_ms": 0,
+            "agent_name": agent_name,
+            "task_id": task_id,
+            "tool_name": tool_name,
+            "args_preview": "(args)",
+            "result_preview": "(ok)",
+            "is_error": False,
+            "error_message": "",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: _verify_required_tool_calls
+# ---------------------------------------------------------------------------
+
+
+def test_verify_returns_none_when_no_required_tools() -> None:
+    """A task with empty ``required_tool_calls`` short-circuits."""
+    plan = _plan_no_required()
+    session = Session(run_id="r1", plan=plan)
+    task = plan.tasks[0]
+    assert _verify_required_tool_calls(task, session, task.id) is None
+
+
+def test_verify_returns_none_when_all_required_observed() -> None:
+    plan = _plan_with_required_tools()
+    session = Session(run_id="r1", plan=plan)
+    task = plan.tasks[0]
+    _push_observation(session, task_id=task.id, tool_name="write_webpage_tool")
+    assert _verify_required_tool_calls(task, session, task.id) is None
+
+
+def test_verify_returns_critical_drift_when_missing() -> None:
+    plan = _plan_with_required_tools()
+    session = Session(run_id="r1", plan=plan)
+    task = plan.tasks[0]
+    drift = _verify_required_tool_calls(task, session, task.id)
+    assert drift is not None
+    assert drift.kind is DriftKind.INCOMPLETE_TOOL_CALLS
+    assert drift.severity is DriftSeverity.CRITICAL
+    assert "write_webpage_tool" in drift.detail
+    assert drift.current_task_id == "draft_slides"
+    assert drift.current_agent_id == "presenter"
+
+
+def test_verify_scopes_observations_per_task() -> None:
+    """An observation pinned to a different task does NOT satisfy this task."""
+    plan = _plan_with_required_tools()
+    session = Session(run_id="r1", plan=plan)
+    task = plan.tasks[0]
+    # Tool observed, but pinned to a sibling task — must NOT count.
+    _push_observation(session, task_id="some_other_task", tool_name="write_webpage_tool")
+    drift = _verify_required_tool_calls(task, session, task.id)
+    assert drift is not None
+    assert "write_webpage_tool" in drift.detail
+
+
+def test_verify_partial_observations_cite_missing_only() -> None:
+    """When some required tools are observed and others aren't, only the
+    missing ones land in the drift detail's ``missing=`` list."""
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="draft_and_save",
+                title="Draft + save",
+                assignee_agent_id="presenter",
+                status=TaskStatus.RUNNING,
+                required_tool_calls=["write_webpage_tool", "read_files_tool"],
+            ),
+        ],
+        edges=[],
+    )
+    session = Session(run_id="r1", plan=plan)
+    task = plan.tasks[0]
+    _push_observation(session, task_id=task.id, tool_name="write_webpage_tool")
+    drift = _verify_required_tool_calls(task, session, task.id)
+    assert drift is not None
+    assert "read_files_tool" in drift.detail
+    # write_webpage_tool was observed; it must not show up in missing=
+    # (it may still show up in observed=).
+    # The exact rendering is "missing=['read_files_tool'], observed=[...]".
+    assert "missing=['read_files_tool']" in drift.detail
+    assert "write_webpage_tool" in drift.detail  # in observed=[...]
+
+
+# ---------------------------------------------------------------------------
+# Wiring: _handle_task_completed
+# ---------------------------------------------------------------------------
+
+
+async def test_report_succeeded_accepted_when_no_required_tools() -> None:
+    """A task with no required_tool_calls retains pre-PR2 behaviour."""
+    steerer, session, sink, planner = _fresh(_plan_no_required())
+    out = await _tool("report_task_completed").handler(
+        {"task_id": "research", "summary": "did the research"},
+        session,
+        steerer,
+    )
+    assert out["acknowledged"] is True
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+    completed = [
+        e for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "task_completed"
+    ]
+    assert len(completed) == 1
+    # No drift was dispatched.
+    await steerer._wait_background_drifts_idle()
+    assert planner.refine_calls == []
+
+
+async def test_report_succeeded_accepted_when_all_required_observed() -> None:
+    """All declared tools observed in this task's span -> completion accepted."""
+    steerer, session, sink, planner = _fresh(_plan_with_required_tools())
+    _push_observation(session, task_id="draft_slides", tool_name="write_webpage_tool")
+    out = await _tool("report_task_completed").handler(
+        {"task_id": "draft_slides", "summary": "all done"},
+        session,
+        steerer,
+    )
+    assert out["acknowledged"] is True
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+    completed = [
+        e for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "task_completed"
+    ]
+    assert len(completed) == 1
+    await steerer._wait_background_drifts_idle()
+    # No INCOMPLETE_TOOL_CALLS refine.
+    incomplete_refines = [
+        c for c in planner.refine_calls
+        if c["drift"].kind is DriftKind.INCOMPLETE_TOOL_CALLS
+    ]
+    assert incomplete_refines == []
+
+
+async def test_report_succeeded_rejected_when_required_tool_missing() -> None:
+    """No observation -> completion rejected with structured payload + drift."""
+    steerer, session, sink, planner = _fresh(_plan_with_required_tools())
+    out = await _tool("report_task_completed").handler(
+        {"task_id": "draft_slides", "summary": "claims done"},
+        session,
+        steerer,
+    )
+    # Rejection shape — mirrors invalid_transition / missing_required_field.
+    assert out["acknowledged"] is False
+    assert out["error"] == "incomplete_tool_calls"
+    assert out["tool"] == "report_task_completed"
+    assert out["task_id"] == "draft_slides"
+    assert out["missing_tool_calls"] == ["write_webpage_tool"]
+    assert out["observed_tool_calls"] == []
+    assert "write_webpage_tool" in out["message"]
+    # Task did NOT transition.
+    assert session.plan.tasks[0].status is TaskStatus.RUNNING
+    # No TaskCompleted on the wire.
+    completed = [
+        e for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "task_completed"
+    ]
+    assert completed == []
+    # Drift dispatched and reaches planner.refine via the ladder's ABSORB
+    # path. CRITICAL severity → CANCEL_REINVOKE on first occurrence,
+    # which still fires planner.refine before the cancel.
+    await steerer._wait_background_drifts_idle()
+    incomplete = [
+        c for c in planner.refine_calls
+        if c["drift"].kind is DriftKind.INCOMPLETE_TOOL_CALLS
+    ]
+    assert len(incomplete) == 1
+    assert incomplete[0]["drift"].current_task_id == "draft_slides"
+    assert "write_webpage_tool" in incomplete[0]["drift"].detail
+
+
+async def test_report_succeeded_rejected_with_partial_tools() -> None:
+    """Drift detail names the missing tool specifically, not the satisfied one."""
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="draft_and_save",
+                title="Draft + save",
+                assignee_agent_id="presenter",
+                status=TaskStatus.RUNNING,
+                required_tool_calls=["write_webpage_tool", "read_files_tool"],
+            ),
+        ],
+        edges=[],
+    )
+    steerer, session, _sink, planner = _fresh(plan)
+    _push_observation(session, task_id="draft_and_save", tool_name="write_webpage_tool")
+    out = await _tool("report_task_completed").handler(
+        {"task_id": "draft_and_save", "summary": "claims done"},
+        session,
+        steerer,
+    )
+    assert out["acknowledged"] is False
+    assert out["error"] == "incomplete_tool_calls"
+    assert out["missing_tool_calls"] == ["read_files_tool"]
+    assert "write_webpage_tool" in out["observed_tool_calls"]
+    await steerer._wait_background_drifts_idle()
+    incomplete = [
+        c for c in planner.refine_calls
+        if c["drift"].kind is DriftKind.INCOMPLETE_TOOL_CALLS
+    ]
+    assert len(incomplete) == 1
+    assert "read_files_tool" in incomplete[0]["drift"].detail
+
+
+async def test_observations_for_other_tasks_not_counted() -> None:
+    """Per-task scoping: a write_webpage_tool observation pinned to a
+    sibling task does not satisfy the requirement on the task being
+    reported."""
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="task_a",
+                title="A",
+                assignee_agent_id="agent_a",
+                status=TaskStatus.RUNNING,
+                required_tool_calls=["write_webpage_tool"],
+            ),
+            Task(
+                id="task_b",
+                title="B",
+                assignee_agent_id="agent_b",
+            ),
+        ],
+        edges=[],
+    )
+    steerer, session, _sink, planner = _fresh(plan)
+    # write_webpage_tool was observed, but pinned to task_b.
+    _push_observation(session, task_id="task_b", tool_name="write_webpage_tool")
+    out = await _tool("report_task_completed").handler(
+        {"task_id": "task_a", "summary": "claims done"},
+        session,
+        steerer,
+    )
+    assert out["acknowledged"] is False
+    assert out["error"] == "incomplete_tool_calls"
+    assert out["missing_tool_calls"] == ["write_webpage_tool"]
+    # The cross-task observation does NOT show up in observed_tool_calls
+    # for task_a — the filter is per-task.
+    assert out["observed_tool_calls"] == []
+    assert session.plan.tasks[0].status is TaskStatus.RUNNING
+    await steerer._wait_background_drifts_idle()
+    incomplete = [
+        c for c in planner.refine_calls
+        if c["drift"].kind is DriftKind.INCOMPLETE_TOOL_CALLS
+    ]
+    assert len(incomplete) == 1
+
+
+async def test_drift_routes_through_goal_aware_refine() -> None:
+    """The PR1-wired prompt selection still picks goal-aware refine
+    when the verification dispatches INCOMPLETE_TOOL_CALLS.
+
+    Re-validates that PR 1's planner.refine prompt-selection branch is
+    actually exercised end-to-end from a verification rejection — not
+    just by direct construction of the drift in scaffolding tests.
+    Mocks the planner's ``call_llm`` so we can assert on the system
+    prompt selected.
+    """
+    from goldfive.planner import LLMPlanner
+
+    captured: dict[str, str] = {}
+
+    async def _stub_llm(system: str, user: str, model: str) -> str:
+        captured["system"] = system
+        captured["user"] = user
+        # Return a no-op plan so refine doesn't blow up on parse.
+        return (
+            '{"summary": "still drafting via write_webpage_tool", '
+            '"tasks": [{"id": "draft_slides", "title": "Draft slide deck", '
+            '"assignee_agent_id": "presenter", "status": "RUNNING"}], '
+            '"edges": []}'
+        )
+
+    planner = LLMPlanner(call_llm=_stub_llm)
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="produce a slide deck")],
+        plan=_plan_with_required_tools(),
+    )
+    out = await _tool("report_task_completed").handler(
+        {"task_id": "draft_slides", "summary": "claims done"},
+        session,
+        steerer,
+    )
+    assert out["acknowledged"] is False
+    await steerer._wait_background_drifts_idle()
+    # The goal-aware divergence prompt has the ABSORB / REJECT
+    # decision contract; the generic refine prompt does not.
+    assert "ABSORB" in captured.get("system", "")
+    assert "REJECT" in captured.get("system", "")
+    # The user prompt renders the missing tools via the OFF-TOPIC
+    # reasoning block (PR1 reuses _render_off_topic_reasoning_block
+    # for INCOMPLETE_TOOL_CALLS).
+    assert "OFF-TOPIC REASONING" in captured.get("user", "")
+    assert "write_webpage_tool" in captured.get("user", "")


### PR DESCRIPTION
## Summary

Combines iter-11E PR 2 (verification at ``report_task_completed`` time) with PR 3 (example agent declarations).

PR 2 alone has no observable behavioral effect on existing plans (no task declares ``required_tool_calls`` until PR 3 lands), and PR 3 alone is dead code without PR 2's verification path. Shipping them together avoids a half-wired feature on main between merges.

### PR 2 — verification at ``report_task_completed``

* New ``_verify_required_tool_calls`` helper in ``goldfive/reporting.py`` reads ``Task.required_tool_calls`` and filters ``Session.recent_tool_observations`` per-``task_id`` (an observation produced under a sibling task does NOT satisfy this task's requirement).
* On miss, ``_handle_task_completed`` dispatches a CRITICAL ``INCOMPLETE_TOOL_CALLS`` drift via ``_spawn_drift_handler_background`` — same fire-and-forget cascade ``mark_task_failed`` / ``_blocked`` use post iter-11A — and returns a structured ``incomplete_tool_calls`` rejection payload (mirrors ``_invalid_transition_response`` / ``_missing_required_field_response``). Falls back to inline ``_handle_drift`` for stub Steerers.
* The task stays in its pre-call status; no ``TaskCompleted`` event is emitted. The agent can call the missing tools and re-report.
* The drift carries the missing/observed lists on ``raw`` so the call site builds the rejection payload without re-walking the ring buffer.

### PR 3 — example agent declarations

In ``examples/presentation_agent/agent.py::_mock_planner_call_llm``:

* ``build`` (web_developer_agent) declares ``write_webpage``.
* ``review`` (reviewer_agent) declares ``read_presentation_files``.
* ``debug`` (debugger_agent) declares ``patch_file``.
* ``research`` intentionally has no declaration — the deliverable is reasoning, not a file artifact.

Tool names match the ADK function ``__name__`` written into ``recent_tool_observations``, not the FunctionTool variable name.

``adk_presentation`` and ``harmonograf_observed`` have no artifact-producing tools and are intentionally untouched.

## Test plan

* [x] ``tests/test_artifact_verification.py`` (11 new tests) — pure-helper coverage (empty / all-satisfied / all-missing / partial / per-task scoping) + handler wiring (accept paths preserve pre-PR2 behaviour; reject path leaves task RUNNING, returns structured rejection, dispatches drift, drift hits goal-aware refine prompt).
* [x] ``tests/examples/test_presentation_agent.py`` — added regression pinning the new declarations on the example mock plan.
* [x] Full goldfive test suite passes locally (2243 passed, 55 skipped).
* [x] ``ruff check`` clean.
* [x] ``mypy goldfive/reporting.py`` reports the same 9 pre-existing errors as ``origin/main`` — no new errors introduced.