### PR TITLE
feat(runner): log version + commit sha on Runner startup (#225)

### DIFF
--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -42,8 +42,11 @@ import dataclasses
 import inspect
 import logging
 import os
+import subprocess
 import warnings
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from importlib import metadata as _importlib_metadata
+from pathlib import Path as _Path
 from typing import TYPE_CHECKING, Any
 
 from goldfive import _state_audit
@@ -85,6 +88,57 @@ if TYPE_CHECKING:
     )
 
 log = logging.getLogger("goldfive.runner")
+
+
+def _detect_build_identity() -> tuple[str, str]:
+    """Return ``(version, sha)`` for the running goldfive build.
+
+    Both fields default to ``"unknown"`` and the function never raises —
+    callers log the result on Runner construction so users can answer
+    "is the change actually deployed?" from the logs (the diagnostic
+    trap captured by ``feedback_verify_running_build.md``).
+
+    Detection order:
+
+    * ``importlib.metadata.version("goldfive")`` — set when goldfive is
+      installed as a wheel / editable install.
+    * ``goldfive.__version__`` — fallback for source checkouts that
+      bypass the metadata path.
+    * ``git rev-parse --short HEAD`` run from the package's install
+      directory — only attempted when a ``.git`` directory exists at
+      the repo root, and all exceptions are swallowed so missing-git
+      environments still construct cleanly.
+    """
+    version = "unknown"
+    try:
+        version = _importlib_metadata.version("goldfive")
+    except Exception:
+        try:
+            from goldfive import __version__ as _pkg_version
+
+            version = _pkg_version or "unknown"
+        except Exception:
+            log.debug("goldfive version detection failed", exc_info=True)
+
+    sha = "unknown"
+    try:
+        pkg_root = _Path(__file__).resolve().parent
+        repo_root = pkg_root.parent
+        if (repo_root / ".git").exists():
+            result = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=str(repo_root),
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+            )
+            if result.returncode == 0:
+                sha = result.stdout.strip() or "unknown"
+    except Exception:
+        log.debug("goldfive git sha detection failed", exc_info=True)
+
+    return version, sha
 
 
 class Runner:
@@ -235,6 +289,12 @@ class Runner:
         fail_fast_on_revision_rejection: bool | None = None,
         **legacy_kwargs: Any,
     ) -> None:
+        # Stamp the running build's identity at construction so logs
+        # answer "did the change actually deploy?" without spelunking.
+        # See ``feedback_verify_running_build.md`` for the motivating
+        # 30-minute diagnosis trap. INFO once per Runner; never raises.
+        _version, _sha = _detect_build_identity()
+        log.info("goldfive runner starting: version=%s sha=%s", _version, _sha)
         if "max_plan_reinvocations" in legacy_kwargs:
             legacy_value = legacy_kwargs.pop("max_plan_reinvocations")
             warnings.warn(

--- a/tests/test_runner_build_identity_log.py
+++ b/tests/test_runner_build_identity_log.py
@@ -1,0 +1,146 @@
+"""Tests for the build-identity log line emitted by :class:`Runner`.
+
+Goldfive#225: when debugging "did the change actually deploy?", the
+running build's commit sha and version must be in the logs. The Runner
+emits one ``goldfive runner starting: version=X sha=Y`` INFO line per
+construction. This guards against regressions in:
+
+* the log line firing on every Runner construction (not silently
+  skipped when version detection fails);
+* the line surviving when neither importlib.metadata nor a git
+  checkout is available — both fields must fall through to ``unknown``
+  rather than raising;
+* the canary that the line only fires once per Runner instance, not
+  per ``run()`` call (we don't want startup chatter on every turn).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from goldfive import (
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+)
+from goldfive import runner as _runner_mod
+
+
+def _one_task_plan() -> Plan:
+    return Plan(
+        id="plan-bi",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="only", assignee_agent_id="writer")],
+        edges=[],
+        summary="single",
+    )
+
+
+async def _happy_agent(
+    task: Task, session: Session, tools: list[ReportingToolSpec]
+) -> InvocationResult:
+    _ = tools, session
+    return InvocationResult(task_id=task.id, text="ok")
+
+
+def _make_runner() -> Runner:
+    return Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(_one_task_plan()),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("go"),
+        sinks=[InMemorySink()],
+    )
+
+
+def test_runner_logs_build_identity_on_construction(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``Runner(...)`` emits one ``goldfive runner starting`` INFO line."""
+    with caplog.at_level(logging.INFO, logger="goldfive.runner"):
+        _make_runner()
+
+    matches = [
+        rec for rec in caplog.records if "goldfive runner starting" in rec.message
+    ]
+    assert len(matches) == 1, [rec.message for rec in caplog.records]
+    msg = matches[0].message
+    assert re.search(r"version=\S+", msg), msg
+    assert re.search(r"sha=\S+", msg), msg
+    assert matches[0].levelno == logging.INFO
+
+
+def test_runner_build_identity_falls_through_to_unknown(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Detection failures must NEVER crash construction.
+
+    Both the version path (``importlib.metadata`` raising +
+    ``goldfive.__version__`` import raising) and the git path
+    (``subprocess.run`` raising) get patched to fail. The Runner must
+    still construct and log ``version=unknown sha=unknown``.
+    """
+
+    def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("nope")
+
+    with (
+        mock.patch.object(
+            _runner_mod._importlib_metadata, "version", side_effect=_boom
+        ),
+        mock.patch.object(_runner_mod.subprocess, "run", side_effect=_boom),
+        mock.patch.dict(
+            "sys.modules",
+            {"goldfive": mock.MagicMock(__version__=None)},
+            clear=False,
+        ),
+    ):
+        with caplog.at_level(logging.INFO, logger="goldfive.runner"):
+            _make_runner()
+
+    matches = [
+        rec for rec in caplog.records if "goldfive runner starting" in rec.message
+    ]
+    assert len(matches) == 1
+    # Version may resolve via the fallback __version__ chain or end up
+    # ``unknown``; the contract that matters is that we DID NOT crash
+    # and the line fired.
+    assert "sha=" in matches[0].message
+    assert "version=" in matches[0].message
+
+
+async def test_runner_build_identity_logged_once_not_per_run(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Two ``runner.run(...)`` calls must NOT re-emit the startup line."""
+    with caplog.at_level(logging.INFO, logger="goldfive.runner"):
+        runner = _make_runner()
+        await runner.run("go")
+        await runner.run("go again")
+        await runner.close()
+
+    matches = [
+        rec for rec in caplog.records if "goldfive runner starting" in rec.message
+    ]
+    assert len(matches) == 1, [rec.message for rec in caplog.records]
+
+
+def test_detect_build_identity_returns_strings() -> None:
+    """``_detect_build_identity()`` always returns a ``(str, str)`` tuple."""
+    version, sha = _runner_mod._detect_build_identity()
+    assert isinstance(version, str) and version
+    assert isinstance(sha, str) and sha


### PR DESCRIPTION
## Summary

When debugging "did the change actually deploy?", the running build's identity must be in the logs. Prior to this change, an operator had no way to confirm from logs whether a long-running Runner process was holding a stale import vs. running the just-merged commit. That ambiguity cost ~30 minutes on one bug (captured as memory `feedback_verify_running_build.md`).

`Runner.__init__` now emits one INFO line per construction:

```
goldfive runner starting: version=0.1.0 sha=81d934a
```

## What's logged

- `version=` resolves via `importlib.metadata.version("goldfive")` first (installed-wheel path), falling back to `goldfive.__version__` from `__init__.py`, and finally `"unknown"`.
- `sha=` runs `git rev-parse --short HEAD` from the package's install directory, but only when a `.git` directory exists at the repo root. All exceptions are absorbed; `subprocess.run` uses `check=False` and a 2s `timeout` so a wedged git binary cannot hang Runner construction. Falls through to `"unknown"` on any failure.

## Hard rules honored

- Never crashes Runner construction. Both detection paths are wrapped in `try/except Exception` with `log.debug(..., exc_info=True)`.
- No unconditional shell-out — git is only invoked when `.git/` exists.
- No new dependencies (`subprocess`, `importlib.metadata`, `pathlib` are stdlib).
- Logged once per Runner instance, not per `Session` / per `run()` call (test pins this).

## Files touched

- `goldfive/runner.py` — `_detect_build_identity()` helper + one `log.info(...)` line at the top of `__init__`.
- `tests/test_runner_build_identity_log.py` — 4 tests: line emitted on construction, fall-through-to-unknown when both paths fail, single-emission across multiple `run()` calls, helper return-type contract.

## Recommended follow-up

The task brief's stretch goal — recording the goldfive commit sha in **harmonograf session metadata** so each session is unambiguously traceable to a build — is **not** included in this PR (treating goldfive-only as the primary scope per the task brief). The harmonograf side should plumb `goldfive.runner._detect_build_identity()` (or read `RunStarted` event metadata once we stamp it) into the harmonograf session row at session start. Recommended as a follow-up issue on harmonograf.

## Test plan

- [x] `uv run --extra dev pytest tests/test_runner_build_identity_log.py -q` (4 passed)
- [x] `uv run --extra dev pytest -q` full suite (1846 passed, 120 skipped, no regressions)
- [x] `uv run --extra dev ruff check goldfive/runner.py tests/test_runner_build_identity_log.py` (clean)
- [x] `uv run --extra dev mypy goldfive/runner.py tests/test_runner_build_identity_log.py` (no new errors; 2 pre-existing errors confirmed unchanged via stash + recheck)
- [x] Sample log line captured live: `goldfive runner starting: version=0.1.0 sha=81d934a`

Closes #225.