### PR TITLE
cleanup: remove dead observed_actions plumbing (#235)

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -236,7 +236,6 @@ def compose_corrective_user_message(
     *,
     drift: DriftEvent,
     refined_plan: Plan | None,
-    observed_actions: list[Any] | None = None,  # noqa: ARG001
 ) -> str:
     """Build a short directive user message for Level 3 re-invoke.
 
@@ -244,12 +243,6 @@ def compose_corrective_user_message(
     message is deliberately short, action-focused, and avoids goldfive
     jargon -- the consumer is the agent's LLM, which should read a
     natural instruction rather than a framework postmortem.
-
-    ``observed_actions`` is accepted for forward-compat with
-    goldfive#144 (PLAN_DIVERGENCE refine with observed_actions=...) but
-    is NOT interpolated today -- the planner owns action summarization
-    and the composer just stitches drift + refined plan. Adding the
-    parameter now keeps the signature stable when #144 lands.
     """
     current = drift.current_task_id or "the current task"
     next_title = _next_pending_task_title(refined_plan) or "the next planned step"

--- a/tests/test_corrective_message.py
+++ b/tests/test_corrective_message.py
@@ -188,16 +188,3 @@ def test_unknown_drift_kind_uses_generic_fallback() -> None:
     assert "Move forward" in msg
     # Still action-focused: ends with a directive.
     assert msg.lower().endswith(".") or "proceed" in msg.lower()
-
-
-def test_observed_actions_parameter_is_accepted() -> None:
-    """goldfive#144 will feed observed_actions into the composer. The
-    parameter must be accepted today (kwarg-only) even if it doesn't
-    yet influence the shape, so #144 can land without a signature
-    conflict."""
-    msg = compose_corrective_user_message(
-        drift=_drift(DriftKind.PLAN_DIVERGENCE),
-        refined_plan=_plan_with_next("Summarize findings"),
-        observed_actions=[{"action": "search", "query": "foo"}],
-    )
-    assert "Summarize findings" in msg


### PR DESCRIPTION
## Summary

After iter-12 #220 (PR #355) made refine prompt selection by drift
kind alone, the forward-compat `observed_actions` parameter on
`compose_corrective_user_message` (steerer.py, marked `noqa: ARG001`
since the #144 forward-compat plumbing was scoped) is definitively
dead. Production callers in `_handle_drift` (Level 3 CANCEL_REINVOKE
and post-ABSORB nudge) and `_dispatch_nudge` only pass `drift=` and
`refined_plan=`; the planner owns observed-action summarization on the
refine side, and the composer just stitches drift + refined plan into
the corrective user message.

## What was removed

- `observed_actions: list[Any] | None = None  # noqa: ARG001`
  parameter on `compose_corrective_user_message` (`goldfive/steerer.py`).
- The docstring paragraph that documented the parameter as
  forward-compat with goldfive#144.
- `test_observed_actions_parameter_is_accepted` in
  `tests/test_corrective_message.py` -- the test existed only to pin
  the dead forward-compat signature.

## Why it is safe

- The parameter carried `noqa: ARG001` because it was never read
  inside the function. Pre-#220 it would have been threaded into the
  prompt later; post-#220 prompt selection routes by drift kind alone,
  so the forward-compat plumbing has no future caller.
- Grep confirms zero non-test call sites (`_handle_drift`,
  `_dispatch_nudge`, both inside `goldfive/steerer.py`) pass
  `observed_actions=` to `compose_corrective_user_message`. All other
  test call sites in `test_corrective_message.py` and
  `test_tier1_loop_prevention.py` already use the two-kwarg form.
- Out of scope (intentionally untouched): the still-live
  `observed_actions` plumbing on `LLMPlanner.refine` /
  `_build_refine_prompt` (renders the OBSERVED AGENT ACTIVITY block
  when supplied, exercised by `test_planner_observed_actions.py` and
  `test_planner_goal_aware_refine.py`) and on `classify_goal_drift`
  (`goldfive/drift/goals.py`, the goal-drift judge invoked from
  `steerer.maybe_run_goal_drift_check`). Both still read the
  parameter in live code paths.

## Test plan

- [x] `uv run pytest -q` -- 2218 passed, 54 skipped, 1 failed.
  The single failure (`test_rate_limit_resets_on_task_transition`)
  reproduces on clean `origin/main` and is unrelated to this change.
- [x] `uv run ruff check goldfive/ tests/` -- all checks passed.
- [x] `uv run mypy goldfive/steerer.py goldfive/planner.py` -- 7
  errors, identical set to `origin/main` (just line-shifted by the
  7-line removal in steerer.py). No new errors introduced.
- [x] `uv run pytest tests/test_corrective_message.py
  tests/test_tier1_loop_prevention.py -q` -- 26 passed.

Closes #235.