### PR TITLE
fix(steerer): close iter-11D race between cancel-requested and terminated mark (#242)

### DIFF
--- a/goldfive/orchestration_store.py
+++ b/goldfive/orchestration_store.py
@@ -144,6 +144,20 @@ __all__ = [
 _ACTIVE_INVOCATION_TASKS: dict[str, dict[str, asyncio.Task[Any]]] = {}
 _ACTIVE_INVOCATION_LOCK = threading.Lock()
 
+# Companion registry: per-session set of invocation ids for which a
+# cooperative cancel has been requested (goldfive#242). Stamped
+# synchronously at the top of
+# :meth:`~goldfive.steerer.DefaultSteerer.request_invocation_cancel`
+# so the late-drift gate can short-circuit drifts that fire during the
+# 4-8s window between the cancel-request landing and ADK winding down
+# the cancelled invocations (during which ``active_invocation_ids()``
+# still lists them).
+#
+# Same locking discipline as the active-task registry above. Cleared by
+# :meth:`OrchestrationStore.clear_active_invocations` so a session
+# teardown wipes both registries in one shot.
+_CANCEL_REQUESTED_INVOCATIONS: dict[str, set[str]] = {}
+
 
 # State key for the new reasoning-extracted bindings slot. Lives under
 # the goldfive prefix so :func:`goldfive.orchestration_state.write`
@@ -818,12 +832,67 @@ class OrchestrationStore:
         """Drop every registered task for this session. Idempotent.
 
         Called from the adapter's dispatch teardown so a stale handle
-        cannot target the next invocation.
+        cannot target the next invocation. Also clears the companion
+        cancel-requested registry (goldfive#242) so a fresh dispatch
+        on the same session id starts with a clean slate.
         """
         if not self._session_id:
             return
         with _ACTIVE_INVOCATION_LOCK:
             _ACTIVE_INVOCATION_TASKS.pop(self._session_id, None)
+            _CANCEL_REQUESTED_INVOCATIONS.pop(self._session_id, None)
+
+    # -- Cancel-requested registry (goldfive#242) -----------------------
+    #
+    # Closes the iter-11D race between
+    # :meth:`~goldfive.steerer.DefaultSteerer.request_invocation_cancel`
+    # (synchronous flag flip) and
+    # :meth:`active_invocation_ids` (transitions to empty only AFTER
+    # ADK winds down each cancelled invocation, ~4-8s later). The
+    # late-drift gate consults this set; a drift that fires during that
+    # window sees ``cancel_requested_invocation_ids()`` non-empty and
+    # is treated as late, even though the active-task registry still
+    # lists the cancelled invocation.
+
+    def mark_invocation_cancel_requested(self, invocation_id: str) -> None:
+        """Stamp ``invocation_id`` as having a pending cancel request.
+
+        Called synchronously from the top of
+        :meth:`~goldfive.steerer.DefaultSteerer.request_invocation_cancel`
+        before any plugin / async work. Idempotent; multiple cancel
+        requests for the same id collapse to one entry.
+
+        No-op when ``invocation_id`` is empty or the store has no
+        session id (e.g. tests that construct a bare-state store).
+        """
+        if not invocation_id or not self._session_id:
+            return
+        with _ACTIVE_INVOCATION_LOCK:
+            bucket = _CANCEL_REQUESTED_INVOCATIONS.setdefault(self._session_id, set())
+            bucket.add(str(invocation_id))
+
+    def is_invocation_cancel_requested(self, invocation_id: str) -> bool:
+        """Return True iff a cancel was requested for ``invocation_id``."""
+        if not invocation_id or not self._session_id:
+            return False
+        with _ACTIVE_INVOCATION_LOCK:
+            bucket = _CANCEL_REQUESTED_INVOCATIONS.get(self._session_id)
+        if bucket is None:
+            return False
+        return str(invocation_id) in bucket
+
+    def cancel_requested_invocation_ids(self) -> list[str]:
+        """Return the ids of every invocation with a pending cancel.
+
+        Empty list when no session id or no pending cancels.
+        """
+        if not self._session_id:
+            return []
+        with _ACTIVE_INVOCATION_LOCK:
+            bucket = _CANCEL_REQUESTED_INVOCATIONS.get(self._session_id)
+        if bucket is None:
+            return []
+        return list(bucket)
 
     # -- Active drift conditions (goldfive#271 PR1) ---------------------
 

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -3748,11 +3748,22 @@ class DefaultSteerer:
 
         The check uses :class:`OrchestrationStore` as the live registry
         of in-flight invocations (Phase 3.5 component 1, goldfive#271).
-        When the per-session bucket is empty, every agent has finished
-        its turn and any drift currently being handled is by definition
-        stale. User-authored drifts (USER_STEER / USER_CANCEL /
-        USER_PAUSE) always bypass this guard — they are forward-looking
-        operator directives, not tied to a specific in-flight invocation.
+        Two conditions count as "late":
+
+        * **No active invocations** — every agent has finished its turn
+          and any drift currently being handled is by definition stale.
+        * **Cancel-pending on the session** (goldfive#242) — a previous
+          drift already requested a cooperative cancel for one or more
+          invocations. The active-task registry takes 4-8s to drain
+          while ADK winds those invocations down; during that window
+          any newly-arriving goldfive-authored drift would dispatch a
+          refine against an effectively-dead session. Stamping the
+          cancel-pending flag synchronously at
+          :meth:`request_invocation_cancel` time closes that race.
+
+        User-authored drifts (USER_STEER / USER_CANCEL / USER_PAUSE)
+        always bypass this guard — they are forward-looking operator
+        directives, not tied to a specific in-flight invocation.
         """
         # User-authored drifts always pass through. ``authored_by`` was
         # normalised at the top of :meth:`_handle_drift`.
@@ -3763,6 +3774,7 @@ class DefaultSteerer:
 
             store = OrchestrationStore.for_session(session)
             active = store.active_invocation_ids()
+            cancel_pending = store.cancel_requested_invocation_ids()
         except Exception as exc:  # noqa: BLE001 — defensive
             log.debug(
                 "DefaultSteerer._is_late_drift_for_terminated_invocation: "
@@ -3770,7 +3782,12 @@ class DefaultSteerer:
                 exc,
             )
             return False
-        return not active
+        # Symmetric predicate: late when the active list is empty OR
+        # any cancel is pending on the session. The cancel-pending
+        # branch closes the iter-11D race (goldfive#242) where the
+        # cancel-request has landed but ADK hasn't yet finished
+        # winding down the cancelled invocation.
+        return (not active) or bool(cancel_pending)
 
     def _resolve_active_invocation_ids(self, drift: DriftEvent, session: Session) -> list[str]:
         """Resolve which invocation_id(s) a cancel should target.
@@ -3884,6 +3901,30 @@ class DefaultSteerer:
         if not callable(fn):
             return []
         invocation_ids = self._resolve_active_invocation_ids(drift, session)
+        # Stamp the cancel-pending flag SYNCHRONOUSLY before any
+        # plugin / async work (goldfive#242). The active-task
+        # registry takes 4-8s to drain while ADK winds the cancelled
+        # invocations down; during that window the late-drift gate
+        # would otherwise see ``active_invocation_ids()`` non-empty
+        # and let a freshly-arriving goldfive-authored drift dispatch
+        # a refine against an effectively-dead session. Flipping the
+        # flag here closes the race: any drift handled after this
+        # point sees ``cancel_requested_invocation_ids()`` non-empty
+        # via :meth:`_is_late_drift_for_terminated_invocation` and
+        # short-circuits.
+        if invocation_ids:
+            try:
+                from goldfive.orchestration_store import OrchestrationStore
+
+                store = OrchestrationStore.for_session(session)
+                for inv_id in invocation_ids:
+                    store.mark_invocation_cancel_requested(inv_id)
+            except Exception as exc:  # noqa: BLE001 — defensive
+                log.debug(
+                    "DefaultSteerer.request_invocation_cancel: "
+                    "cancel-pending stamp raised (continuing): %s",
+                    exc,
+                )
         if not invocation_ids:
             # Empty invocation-id guard — drift has no identifiable
             # in-flight invocation. Don't fabricate one; the cancel

--- a/tests/test_iter11d_cancel_race.py
+++ b/tests/test_iter11d_cancel_race.py
@@ -1,0 +1,339 @@
+"""Regression tests for goldfive#242: close the race between
+``request_invocation_cancel`` (synchronous flag flip) and
+``OrchestrationStore.active_invocation_ids()`` (transitions to empty
+only AFTER ADK winds down each cancelled invocation, ~4-8s later).
+
+The bug
+-------
+
+iter-11D introduced
+:meth:`DefaultSteerer._is_late_drift_for_terminated_invocation` to gate
+background-judge drifts that arrive after the originating invocation
+has terminated. The gate consulted ``active_invocation_ids()``: when
+empty, the drift was treated as late and refine was skipped.
+
+Empirically, ``request_invocation_cancel`` only flips a flag — ADK then
+takes several seconds to wind the invocation down and remove it from
+the active-task registry. Live evidence from the brussels-sprouts run:
+
+* 21:49:22 — ``request_invocation_cancel`` fired for 5 invocations on
+  ``goal_drift severity=critical``
+* 21:49:26 — JUSTIFIED_DEVIATION drift fired; gate did NOT skip;
+  refine dispatched
+* 21:49:30 — second JUSTIFIED_DEVIATION; ``active_invocation_ids``
+  is now empty; gate correctly skipped
+
+The 4-second window between the cancel landing and the registry
+draining is when goldfive-authored drifts would mis-dispatch.
+
+The fix
+-------
+
+A companion per-session set of cancel-pending invocation ids on
+:class:`~goldfive.orchestration_store.OrchestrationStore`, stamped
+synchronously at the top of ``request_invocation_cancel``. The gate
+now treats "cancel-pending OR not-active" as late.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.orchestration_store import OrchestrationStore  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Test stubs
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class NullPlanner:
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        self.refine_calls.append(kwargs)
+        return None
+
+
+class _RecordingPlugin:
+    """Stand-in plugin used to validate that
+    ``request_invocation_cancel`` reaches the plugin while the
+    cancel-pending flag is stamped synchronously beforehand. The
+    plugin never removes the invocation from the active-task
+    registry, mirroring the real-world race window where ADK has
+    not yet wound the invocation down.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def request_invocation_cancel(
+        self,
+        *,
+        invocation_id: str,
+        request: Any,
+        cancel_inflight_task: bool = False,
+    ) -> list[str]:
+        self.calls.append(
+            {
+                "invocation_id": invocation_id,
+                "request": request,
+                "cancel_inflight_task": cancel_inflight_task,
+            }
+        )
+        return [invocation_id]
+
+
+class _StubAdapter:
+    def __init__(self, plugin: _RecordingPlugin) -> None:
+        self._plugin = plugin
+
+
+def _session(run_id: str = "r-242", task_id: str = "t-242") -> Session:
+    task = Task(id=task_id, title="Task 242", description="cancel race")
+    plan = Plan(
+        id="p-242",
+        run_id=run_id,
+        goal_ids=["g-242"],
+        tasks=[task],
+        edges=[],
+    )
+    return Session(
+        run_id=run_id,
+        goals=[Goal(id="g-242", summary="goal")],
+        plan=plan,
+        current_task_id=task_id,
+    )
+
+
+def _drift(
+    *,
+    kind: DriftKind = DriftKind.JUSTIFIED_DEVIATION,
+    severity: DriftSeverity = DriftSeverity.WARNING,
+    agent: str = "agent-x",
+    task: str = "t-242",
+    authored_by: str = "goldfive",
+) -> DriftEvent:
+    return DriftEvent(
+        id="d-242",
+        kind=kind,
+        severity=severity,
+        current_agent_id=agent,
+        current_task_id=task,
+        authored_by=authored_by,
+        detail="brussels race",
+        trigger_input="x",
+    )
+
+
+# ---------------------------------------------------------------------------
+# OrchestrationStore: cancel-pending registry primitives
+# ---------------------------------------------------------------------------
+
+
+def test_mark_invocation_cancel_requested_round_trips() -> None:
+    """``mark_*`` then ``is_*`` / ``cancel_requested_invocation_ids`` agree."""
+    session = _session(run_id="r-prim")
+    store = OrchestrationStore.for_session(session)
+    try:
+        assert store.cancel_requested_invocation_ids() == []
+        assert not store.is_invocation_cancel_requested("inv-A")
+
+        store.mark_invocation_cancel_requested("inv-A")
+        store.mark_invocation_cancel_requested("inv-B")
+        # Idempotent — duplicate stamp doesn't grow the set.
+        store.mark_invocation_cancel_requested("inv-A")
+
+        ids = sorted(store.cancel_requested_invocation_ids())
+        assert ids == ["inv-A", "inv-B"]
+        assert store.is_invocation_cancel_requested("inv-A")
+        assert store.is_invocation_cancel_requested("inv-B")
+        assert not store.is_invocation_cancel_requested("inv-C")
+    finally:
+        store.clear_active_invocations()
+
+
+def test_clear_active_invocations_drops_cancel_pending_too() -> None:
+    """Session teardown wipes both registries in one shot."""
+    session = _session(run_id="r-clear")
+    store = OrchestrationStore.for_session(session)
+    store.mark_invocation_cancel_requested("inv-X")
+    assert store.cancel_requested_invocation_ids() == ["inv-X"]
+
+    store.clear_active_invocations()
+    assert store.cancel_requested_invocation_ids() == []
+
+
+# ---------------------------------------------------------------------------
+# Late-drift gate: cancel-pending short-circuits even with active list non-empty
+# ---------------------------------------------------------------------------
+
+
+async def test_gate_skips_drift_when_cancel_pending_with_active_invocations() -> None:
+    """The race-window scenario: cancel was requested, the registry
+    still lists the invocation as active, a goldfive-authored drift
+    fires, and the gate must classify it as late.
+    """
+    steerer = DefaultSteerer()
+    session = _session(run_id="r-race")
+    store = OrchestrationStore.for_session(session)
+
+    async def _placeholder() -> None:
+        await asyncio.sleep(1.0)
+
+    fake_task = asyncio.create_task(_placeholder())
+    store.register_invocation_task("inv-live", fake_task)
+    try:
+        # Sanity: pre-cancel, gate does NOT classify the drift as late.
+        drift = _drift()
+        assert steerer._is_late_drift_for_terminated_invocation(drift, session) is False
+
+        # Synchronous cancel-pending stamp (the part
+        # request_invocation_cancel does at its top).
+        store.mark_invocation_cancel_requested("inv-live")
+
+        # The active-task registry is intentionally still populated —
+        # this is the 4-8s window the bug lived in. The gate must
+        # nonetheless treat the drift as late.
+        assert store.active_invocation_ids() == ["inv-live"]
+        assert steerer._is_late_drift_for_terminated_invocation(drift, session) is True
+    finally:
+        store.deregister_invocation_task("inv-live")
+        store.clear_active_invocations()
+        fake_task.cancel()
+        await asyncio.gather(fake_task, return_exceptions=True)
+
+
+async def test_gate_still_classifies_empty_active_list_as_late() -> None:
+    """Pre-existing semantics preserved: empty active list still gates."""
+    steerer = DefaultSteerer()
+    session = _session(run_id="r-empty")
+    store = OrchestrationStore.for_session(session)
+    try:
+        assert store.active_invocation_ids() == []
+        assert store.cancel_requested_invocation_ids() == []
+        drift = _drift()
+        assert steerer._is_late_drift_for_terminated_invocation(drift, session) is True
+    finally:
+        store.clear_active_invocations()
+
+
+async def test_gate_lets_user_authored_drift_through_even_with_cancel_pending() -> None:
+    """User-authored drifts always bypass the gate — preserved."""
+    steerer = DefaultSteerer()
+    session = _session(run_id="r-user")
+    store = OrchestrationStore.for_session(session)
+    store.mark_invocation_cancel_requested("inv-user")
+    try:
+        for kind in (
+            DriftKind.USER_STEER,
+            DriftKind.USER_CANCEL,
+            DriftKind.USER_PAUSE,
+        ):
+            drift = _drift(kind=kind, authored_by="user")
+            assert (
+                steerer._is_late_drift_for_terminated_invocation(drift, session)
+                is False
+            ), (
+                f"user-authored drift kind={kind!r} must bypass the late-drift "
+                "gate even when cancel-pending is set"
+            )
+    finally:
+        store.clear_active_invocations()
+
+
+# ---------------------------------------------------------------------------
+# Integration: request_invocation_cancel flips the flag synchronously
+# ---------------------------------------------------------------------------
+
+
+async def test_request_invocation_cancel_stamps_cancel_pending_synchronously() -> None:
+    """The flag flip happens at the TOP of ``request_invocation_cancel``,
+    before the plugin call. After the method returns, the gate sees
+    cancel-pending non-empty even though the active-task registry is
+    untouched.
+    """
+    plugin = _RecordingPlugin()
+    adapter = _StubAdapter(plugin)
+    steerer = DefaultSteerer()
+    steerer._adapter = adapter  # type: ignore[assignment]
+
+    session = _session(run_id="r-stamp")
+    store = OrchestrationStore.for_session(session)
+
+    async def _placeholder() -> None:
+        await asyncio.sleep(1.0)
+
+    fake_task = asyncio.create_task(_placeholder())
+    store.register_invocation_task("inv-A", fake_task)
+
+    # Wire the steerer's resolver to find inv-A. The simplest path is to
+    # stamp ``_top_invocation_id`` on the plugin — the resolver's
+    # fallback branch picks it up.
+    plugin._top_invocation_id = "inv-A"  # type: ignore[attr-defined]
+
+    try:
+        cancel_drift = _drift(
+            kind=DriftKind.GOAL_DRIFT,
+            severity=DriftSeverity.CRITICAL,
+        )
+        flagged = await steerer.request_invocation_cancel(
+            drift=cancel_drift, session=session
+        )
+        assert flagged == ["inv-A"]
+        # Plugin was called.
+        assert len(plugin.calls) == 1
+        assert plugin.calls[0]["invocation_id"] == "inv-A"
+
+        # Cancel-pending stamped synchronously.
+        assert store.is_invocation_cancel_requested("inv-A")
+
+        # Active-task registry still populated (mirroring the
+        # real-world race window).
+        assert store.active_invocation_ids() == ["inv-A"]
+
+        # A goldfive-authored drift firing immediately after is gated.
+        late_drift = _drift(kind=DriftKind.JUSTIFIED_DEVIATION)
+        assert (
+            steerer._is_late_drift_for_terminated_invocation(late_drift, session)
+            is True
+        )
+    finally:
+        store.deregister_invocation_task("inv-A")
+        store.clear_active_invocations()
+        fake_task.cancel()
+        await asyncio.gather(fake_task, return_exceptions=True)


### PR DESCRIPTION
## Summary

iter-11D introduced ``_is_late_drift_for_terminated_invocation`` (steerer.py:3732) to gate background-judge drifts that arrive after the originating invocation has terminated. The gate consulted ``OrchestrationStore.active_invocation_ids()`` — when empty, the drift was treated as late and refine was skipped.

Empirically, ``request_invocation_cancel`` only flips a flag synchronously; ADK then takes several seconds to wind the cancelled invocations down and drop them from the active-task registry. Live evidence from the brussels-sprouts e2e run:

- ``21:49:22`` — ``request_invocation_cancel`` fired for 5 invocations on ``goal_drift severity=critical``
- ``21:49:26`` — ``JUSTIFIED_DEVIATION`` drift fired; gate did **NOT** skip; refine dispatched
- ``21:49:30`` — second ``JUSTIFIED_DEVIATION``; ``active_invocation_ids()`` now empty; gate correctly skipped

The ~4s window between the cancel landing and the registry draining is when goldfive-authored drifts mis-dispatch a refine against an effectively-dead session. The leaked refine then runs into the post-abort window — separate task #243 covers the leak side.

## Fix

Adds a per-session cancel-requested registry on ``OrchestrationStore`` (``_CANCEL_REQUESTED_INVOCATIONS``, mirroring the existing module-level active-task registry pattern). Three new accessors:

- ``mark_invocation_cancel_requested(inv_id)``
- ``is_invocation_cancel_requested(inv_id)``
- ``cancel_requested_invocation_ids() -> list[str]``

``request_invocation_cancel`` stamps every resolved invocation id **synchronously at the top of the method**, before any plugin call or async work. The late-drift gate's predicate becomes symmetric:

```python
return (not active) or bool(cancel_pending)
```

User-authored drifts (``USER_STEER`` / ``USER_CANCEL`` / ``USER_PAUSE``) still bypass via the existing ``authored_by == "user"`` early return — the cancel-pending check is purely additive. ``clear_active_invocations`` now wipes both registries so a fresh dispatch on the same session id starts clean.

## Test plan

- [x] New ``tests/test_iter11d_cancel_race.py`` — 6 cases:
  - registry primitives round-trip
  - ``clear_active_invocations`` drops cancel-pending too
  - gate skips when cancel-pending with active invocations (the race window)
  - gate still classifies empty active list as late (existing semantics preserved)
  - user-authored drifts bypass even with cancel-pending set
  - ``request_invocation_cancel`` stamps the flag synchronously while plugin call returns
- [x] Existing ``test_judge_task_lifetime`` / ``test_drift_lifecycle`` / ``test_steerer`` / ``test_cooperative_cancellation`` / ``test_cancel_propagation`` / ``test_cancel_inflight_on_refine`` / ``test_drift_async_dispatch`` pass unchanged
- [x] Full suite: **1851 passed, 120 skipped**
- [x] ``uv run ruff check`` clean
- [x] ``uv run mypy goldfive/steerer.py goldfive/orchestration_store.py`` — zero new errors (pre-existing ``Session._last_cancel_reason_prefix`` attr warning unchanged)

## Coordination

- #243 drains ``_background_drifts`` on session-boundary signals — covers the leak side (refines that already escaped the gate). Independent worktree; merge will sort any adjacency.
- #244 threads ``available_agents`` into reasoning-judge prompt — independent module.

Closes #242.