### PR TITLE
feat(reasoning-judge): thread available_agents into prompt to recognize sub-agent delegation (#244)

### DIFF
--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -904,6 +904,7 @@ async def _run_judge(
     model: str,
     sink: Any = None,
     agent_name: str = "",
+    available_agents: list[str] | list[dict[str, Any]] | None = None,
 ) -> DriftEvent | None:
     """Dispatch :func:`classify_reasoning_drift` against the current task.
 
@@ -923,9 +924,23 @@ async def _run_judge(
     a coordinator) is correctly attributed on the resulting
     :class:`DriftEvent` and the ``ReasoningJudgeInvoked`` observability
     event. See goldfive#271 reasoning-judge delegated coverage.
+
+    ``available_agents`` (goldfive#244) is the wrapped agent tree (in
+    the shape exposed by
+    :attr:`goldfive.adapters.adk.ADKAdapter.available_agents_tree`)
+    forwarded into the judge prompt so legitimate coordinator → sub-
+    agent delegation is treated as ON-TASK execution rather than an
+    OFF_TOPIC deviation. ``None`` (the default) preserves the byte-
+    identical pre-#244 prompt.
     """
     verdict = await _run_judge_with_focus(
-        text, session, call_llm=call_llm, model=model, sink=sink, agent_name=agent_name
+        text,
+        session,
+        call_llm=call_llm,
+        model=model,
+        sink=sink,
+        agent_name=agent_name,
+        available_agents=available_agents,
     )
     return verdict.drift
 
@@ -938,6 +953,7 @@ async def _run_judge_with_focus(
     model: str,
     sink: Any = None,
     agent_name: str = "",
+    available_agents: list[str] | list[dict[str, Any]] | None = None,
 ) -> ReasoningJudgeVerdict:
     """Dispatch :func:`classify_reasoning_drift_with_focus` against the current task.
 
@@ -978,6 +994,7 @@ async def _run_judge_with_focus(
         sequence_fn=session.next_sequence,
         task_lineage=getattr(session, "task_lineage", None),
         recent_tool_observations=getattr(session, "recent_tool_observations", None),
+        available_agents=available_agents,
     )
 
 
@@ -990,6 +1007,7 @@ async def analyze_reasoning_with_focus(
     model: str = "",
     sink: Any = None,
     agent_name: str = "",
+    available_agents: list[str] | list[dict[str, Any]] | None = None,
 ) -> ReasoningJudgeVerdict:
     """Phase-1 sibling of :func:`analyze_reasoning` returning a focused verdict.
 
@@ -1031,6 +1049,7 @@ async def analyze_reasoning_with_focus(
             model=model,
             sink=sink,
             agent_name=agent_name,
+            available_agents=available_agents,
         )
     if mode == "both":
         embedding_drift = _embedding_pipeline(text, session)
@@ -1043,6 +1062,7 @@ async def analyze_reasoning_with_focus(
                 model=model,
                 sink=sink,
                 agent_name=agent_name,
+                available_agents=available_agents,
             )
         if judge_verdict is None:
             return ReasoningJudgeVerdict(drift=embedding_drift)
@@ -1086,6 +1106,7 @@ async def analyze_reasoning(
     model: str = "",
     sink: Any = None,
     agent_name: str = "",
+    available_agents: list[str] | list[dict[str, Any]] | None = None,
 ) -> DriftEvent | None:
     """Run the reasoning-drift pipeline against ``text``.
 
@@ -1145,6 +1166,7 @@ async def analyze_reasoning(
             model=model,
             sink=sink,
             agent_name=agent_name,
+            available_agents=available_agents,
         )
     if mode == "both":
         embedding_drift = _embedding_pipeline(text, session)
@@ -1157,6 +1179,7 @@ async def analyze_reasoning(
                 model=model,
                 sink=sink,
                 agent_name=agent_name,
+                available_agents=available_agents,
             )
         if embedding_drift is None:
             return judge_drift

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -54,6 +54,8 @@ log = logging.getLogger(__name__)
 
 
 __all__ = [
+    "AGENT_TREE_BLOCK_MAX_CHARS",
+    "AGENT_TREE_SYSTEM_PROMPT_SUFFIX",
     "CallLLM",
     "PLAN_TASKS_SUMMARY_MAX_CHARS",
     "REASONING_JUDGE_MAX_OUTPUT_TOKENS",
@@ -67,6 +69,7 @@ __all__ = [
     "ReasoningJudgeVerdict",
     "classify_reasoning_drift",
     "classify_reasoning_drift_with_focus",
+    "format_available_agents_block",
     "format_plan_tasks_summary",
     "truncate_for_observability",
 ]
@@ -399,6 +402,7 @@ def format_plan_tasks_summary(
     plan: Plan | None,
     *,
     max_chars: int = PLAN_TASKS_SUMMARY_MAX_CHARS,
+    available_agents: Any = None,
 ) -> str:
     """Render ``plan.tasks`` as a one-per-line ``id -> title`` summary.
 
@@ -411,9 +415,34 @@ def format_plan_tasks_summary(
     head of the list (most recently planned tasks tend to be most
     relevant for a "what is the agent working on right now?" judgement
     — they are at the front of typical refines).
+
+    ``available_agents`` (goldfive#244) is the structured tree (same
+    shape as
+    :attr:`goldfive.adapters.adk.ADKAdapter.available_agents_tree`).
+    When provided AND non-empty, lines are extended with the task's
+    ``assignee_agent_id`` and a comma-separated list of that
+    assignee's known sub-agents — so the judge can see at a glance
+    that a coordinator-style assignee is allowed to delegate to its
+    sub-agents for that task. Default ``None`` produces the byte-
+    identical pre-#244 ``id -> title`` rendering required for back-
+    compat with existing prompt assertions and external callers.
     """
     if plan is None or not getattr(plan, "tasks", None):
         return "(no plan tasks)"
+    # Build a parent -> [child names] index from the agent tree once
+    # so per-line lookup is O(1). Falsy / non-tree inputs short-circuit
+    # to the legacy render (byte-identical pre-#244).
+    children_by_parent: dict[str, list[str]] = {}
+    has_tree = False
+    if available_agents and isinstance(available_agents, (list, tuple)):
+        for entry in available_agents:
+            if isinstance(entry, dict) and "name" in entry:
+                has_tree = True
+                parent = str(entry.get("parent", "") or "")
+                name = str(entry.get("name", "") or "")
+                if not name or not parent:
+                    continue
+                children_by_parent.setdefault(parent, []).append(name)
     lines: list[str] = []
     rendered_chars = 0
     truncated = 0
@@ -421,7 +450,22 @@ def format_plan_tasks_summary(
     for i, task in enumerate(tasks):
         tid = str(getattr(task, "id", "") or "")
         title = str(getattr(task, "title", "") or "(untitled)")
-        line = f"- {tid} -> {title}" if tid else f"- (no id) -> {title}"
+        if has_tree:
+            assignee = str(getattr(task, "assignee_agent_id", "") or "").strip()
+            base = f"- {tid} -> {title}" if tid else f"- (no id) -> {title}"
+            if assignee:
+                kids = children_by_parent.get(assignee, [])
+                if kids:
+                    line = (
+                        f"{base} [assignee={assignee}; "
+                        f"delegates to: {', '.join(kids)}]"
+                    )
+                else:
+                    line = f"{base} [assignee={assignee}]"
+            else:
+                line = base
+        else:
+            line = f"- {tid} -> {title}" if tid else f"- (no id) -> {title}"
         if rendered_chars + len(line) + 1 > max_chars and lines:
             truncated = len(tasks) - i
             break
@@ -431,6 +475,141 @@ def format_plan_tasks_summary(
         lines.append(f"... [{truncated} more task(s) elided]")
     if not lines:
         return "(no plan tasks)"
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# goldfive#244 — agent-tree section
+# ---------------------------------------------------------------------------
+#
+# When the steerer can resolve the wrapped agent tree (typically via
+# :attr:`goldfive.adapters.adk.ADKAdapter.available_agents_tree`), we
+# render a separate "AGENT TREE" section into the judge prompt and append
+# a one-paragraph clarification to the system prompt. Without this
+# context the judge cannot distinguish a coordinator-style agent
+# delegating to its known sub-agent (legitimate goldfive.wrap usage —
+# see ``feedback_goldfive_wrap_contract.md``) from arbitrary off-plan
+# work, and it tends to fire OFF_TOPIC for the legitimate case (see
+# brussels-sprouts session OFF_TOPIC at 0:26: "agent deviates from the
+# plan by invoking an unlisted web_developer_agent instead of proceeding
+# to the draft_slides task" — web_developer_agent was a known sub-agent
+# of coordinator_agent in the wrapped tree).
+#
+# This is purely additional CONTEXT — the judge still decides. We do
+# NOT mutate the existing user-prompt template (existing tests render
+# it via ``.format(...)`` with the current key set; introducing a new
+# placeholder breaks them) and we do NOT add regex / structural pre-
+# gates. The default-``available_agents=None`` path produces the
+# byte-identical pre-#244 prompt so existing tests, classifications,
+# and external callers see no behavioural change.
+
+#: Hard cap on the rendered AGENT TREE section. ~1200 chars (~300
+#: tokens) keeps the prompt bounded for very large trees while leaving
+#: enough room to enumerate ~25-40 named agents at typical name length.
+AGENT_TREE_BLOCK_MAX_CHARS: int = 1200
+
+
+#: System-prompt suffix appended ONLY when ``available_agents`` is
+#: provided. Strengthens the on-task definition so the judge does not
+#: treat sub-agent delegation as an off-plan deviation. Kept as a
+#: separate constant so operators can A/B the wording without forking
+#: :data:`REASONING_DRIFT_SYSTEM_PROMPT`.
+AGENT_TREE_SYSTEM_PROMPT_SUFFIX: str = (
+    " The user prompt may include an AGENT TREE section listing the "
+    "wrapped agents and their parent/child relationships. If the agent "
+    "in question invokes a known sub-agent (per that tree) to perform "
+    "its assigned task, treat that as ON-TASK execution of the bound "
+    "task — delegation is normal coordinator behaviour and is NOT a "
+    "deviation. Mark a deviation only when the agent invokes something "
+    "not in the tree, or when its reasoning wanders semantically away "
+    "from the bound task and goals."
+)
+
+
+def format_available_agents_block(
+    available_agents: Any,
+    *,
+    max_chars: int = AGENT_TREE_BLOCK_MAX_CHARS,
+) -> str:
+    """Render the AGENT TREE section listing parent/child relationships.
+
+    ``available_agents`` mirrors the shape exposed by
+    :attr:`goldfive.adapters.adk.ADKAdapter.available_agents_tree`: a
+    list of dicts with at least a ``name`` key and optionally
+    ``parent``, ``role``, ``kind``, ``depth``. The legacy ``list[str]``
+    form (plain agent names without tree edges) is also accepted for
+    parity with the planner's :func:`LLMPlanner._render_agents_block`;
+    string entries render as bullets without a "delegates to" suffix
+    because we don't have edge data.
+
+    Empty / ``None`` inputs yield ``""`` so the caller can short-circuit
+    on the empty string and skip appending the section entirely (the
+    default-None code path stays byte-identical to pre-#244).
+
+    Truncation: when the rendered text would exceed ``max_chars`` we
+    drop suffix lines and append a ``"... [N more agent(s) elided]"``
+    marker so the judge knows the listing is incomplete. Bounded so a
+    pathologically deep tree cannot blow the prompt budget.
+    """
+    if not available_agents:
+        return ""
+    if not isinstance(available_agents, (list, tuple)):
+        return ""
+    structured: list[dict[str, Any]] = []
+    flat_names: list[str] = []
+    for entry in available_agents:
+        if isinstance(entry, dict) and "name" in entry:
+            structured.append(entry)
+        elif isinstance(entry, str) and entry:
+            flat_names.append(entry)
+    if not structured and not flat_names:
+        return ""
+    lines: list[str] = []
+    truncated = 0
+    rendered_chars = 0
+    if structured:
+        # Index children by parent name (order-preserving).
+        children_by_parent: dict[str, list[str]] = {}
+        for entry in structured:
+            parent = str(entry.get("parent", "") or "")
+            name = str(entry.get("name", "") or "")
+            if not name:
+                continue
+            children_by_parent.setdefault(parent, []).append(name)
+        for i, entry in enumerate(structured):
+            name = str(entry.get("name", "") or "")
+            if not name:
+                continue
+            kids = children_by_parent.get(name, [])
+            role = str(entry.get("role", "") or "")
+            kind = str(entry.get("kind", "") or "")
+            meta_bits: list[str] = []
+            if role:
+                meta_bits.append(f"role={role}")
+            if kind:
+                meta_bits.append(f"kind={kind}")
+            meta = f" ({', '.join(meta_bits)})" if meta_bits else ""
+            if kids:
+                line = f"- {name}{meta} delegates to: {', '.join(kids)}"
+            else:
+                line = f"- {name}{meta}"
+            if rendered_chars + len(line) + 1 > max_chars and lines:
+                truncated = len(structured) - i
+                break
+            lines.append(line)
+            rendered_chars += len(line) + 1
+    else:
+        for i, name in enumerate(flat_names):
+            line = f"- {name}"
+            if rendered_chars + len(line) + 1 > max_chars and lines:
+                truncated = len(flat_names) - i
+                break
+            lines.append(line)
+            rendered_chars += len(line) + 1
+    if truncated > 0:
+        lines.append(f"... [{truncated} more agent(s) elided]")
+    if not lines:
+        return ""
     return "\n".join(lines)
 
 
@@ -543,6 +722,7 @@ async def classify_reasoning_drift(
     plan: Plan | None = None,
     task_lineage: dict[str, set[str]] | None = None,
     recent_tool_observations: list[dict[str, Any]] | None = None,
+    available_agents: list[str] | list[dict[str, Any]] | None = None,
 ) -> DriftEvent | None:
     """Ask an LLM-judge whether ``reasoning`` is on-task.
 
@@ -557,7 +737,10 @@ async def classify_reasoning_drift(
     goldfive#271 added an optional ``plan`` keyword that the extended
     function uses to render the plan-tasks attribution prompt; legacy
     callers can omit it and the prompt renders ``"(no plan tasks)"``
-    for that section.
+    for that section. goldfive#244 added an optional ``available_agents``
+    keyword that, when provided, surfaces the wrapped agent tree
+    (parent → sub-agents) so the judge does not flag legitimate
+    coordinator → sub-agent delegation as off-topic.
     """
     verdict = await classify_reasoning_drift_with_focus(
         reasoning=reasoning,
@@ -576,6 +759,7 @@ async def classify_reasoning_drift(
         plan=plan,
         task_lineage=task_lineage,
         recent_tool_observations=recent_tool_observations,
+        available_agents=available_agents,
     )
     return verdict.drift
 
@@ -598,6 +782,7 @@ async def classify_reasoning_drift_with_focus(
     plan: Plan | None = None,
     task_lineage: dict[str, set[str]] | None = None,
     recent_tool_observations: list[dict[str, Any]] | None = None,
+    available_agents: list[str] | list[dict[str, Any]] | None = None,
 ) -> ReasoningJudgeVerdict:
     """Ask an LLM-judge whether ``reasoning`` is on-task AND which task it works on.
 
@@ -696,7 +881,9 @@ async def classify_reasoning_drift_with_focus(
         recent_tool_observations, task_id=current_task_id
     )
     user = template.format(
-        plan_tasks_summary=format_plan_tasks_summary(plan),
+        plan_tasks_summary=format_plan_tasks_summary(
+            plan, available_agents=available_agents
+        ),
         goals_block=_format_goals(goals),
         task_block=_format_task(task),
         reasoning_block=_format_reasoning(reasoning),
@@ -705,6 +892,23 @@ async def classify_reasoning_drift_with_focus(
         tool_obs_block=tool_obs_block,
         tool_obs_count=tool_obs_count,
     )
+    # goldfive#244: when the steerer can resolve the wrapped agent tree,
+    # append a separate AGENT TREE section to the user prompt and a
+    # one-paragraph clarification to the system prompt. The default-None
+    # path skips both so existing callers / tests see the byte-identical
+    # pre-#244 prompt. We append (vs templating) so existing
+    # ``REASONING_DRIFT_USER_PROMPT_TEMPLATE.format(...)`` call sites
+    # don't need a new key. See module-level rationale at
+    # :data:`AGENT_TREE_SYSTEM_PROMPT_SUFFIX` for why this is purely
+    # additional context, never a structural pre-gate.
+    agent_tree_block = format_available_agents_block(available_agents)
+    if agent_tree_block:
+        user = (
+            f"{user}\n\nAGENT TREE (parent → sub-agents; sub-agent "
+            f"delegation by a listed parent is ON-TASK execution of "
+            f"the bound task):\n{agent_tree_block}"
+        )
+        system = f"{system}{AGENT_TREE_SYSTEM_PROMPT_SUFFIX}"
     started = time.monotonic()
     call_failed = False
     # Wrap the judge call in the shared LLM span helper so harmonograf

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -1491,6 +1491,17 @@ class DefaultSteerer:
                 # :class:`ReasoningJudgeVerdict` instead of just the
                 # drift; legacy callers of ``analyze_reasoning`` keep
                 # their existing return shape.
+                #
+                # goldfive#244 — also forward the wrapped agent tree so
+                # the judge can recognise legitimate coordinator → sub-
+                # agent delegation as ON-TASK rather than OFF_TOPIC.
+                # Reuses the same shape the planner already consumes
+                # (``ADKAdapter.available_agents_tree``); legacy adapters
+                # without the property fall back to a flat
+                # ``available_agents`` list, and adapters with neither
+                # leave ``available_agents=None`` — the judge prompt
+                # then renders byte-identically to pre-#244.
+                judge_available_agents = self._resolve_available_agents()
                 verdict = await analyze_reasoning_with_focus(
                     text,
                     session,
@@ -1499,6 +1510,7 @@ class DefaultSteerer:
                     model=self._reasoning_drift_model,
                     sink=judge_sink,
                     agent_name=agent_name,
+                    available_agents=judge_available_agents,
                 )
             finally:
                 # Restore the live history. Any entries appended by
@@ -1727,6 +1739,35 @@ class DefaultSteerer:
         if len(text) <= limit:
             return text
         return text[:limit] + " … [truncated]"
+
+    def _resolve_available_agents(self) -> list[str] | list[dict[str, Any]] | None:
+        """Return the wrapped agent tree for a downstream prompt.
+
+        Mirrors the resolution used by ``_handle_drift`` when threading
+        ``available_agents`` into ``planner.refine``: prefer the
+        structured ``ADKAdapter.available_agents_tree`` (goldfive#151,
+        list of dicts with name/parent/role/kind/depth); fall back to
+        the flat ``available_agents`` (list[str]) when the structured
+        property is missing or empty; return ``None`` when the adapter
+        is missing or exposes neither surface.
+
+        Used by :meth:`_run_judge_background` to feed the reasoning
+        judge's :data:`~goldfive.drift.reasoning_judge.AGENT_TREE_BLOCK_MAX_CHARS`
+        bounded "AGENT TREE" prompt section (goldfive#244) so the judge
+        can recognise legitimate coordinator → sub-agent delegation as
+        ON-TASK rather than OFF_TOPIC. ``None`` keeps the judge's
+        prompt byte-identical to the pre-#244 shape.
+        """
+        adapter = self._adapter
+        if adapter is None:
+            return None
+        tree = getattr(adapter, "available_agents_tree", None)
+        if isinstance(tree, list) and tree:
+            return list(tree)
+        flat = getattr(adapter, "available_agents", None)
+        if flat:
+            return list(flat)
+        return None
 
     def _maybe_take_reasoning_judge_slot(
         self,

--- a/tests/test_reasoning_judge_agent_tree.py
+++ b/tests/test_reasoning_judge_agent_tree.py
@@ -1,0 +1,630 @@
+"""Regression tests for goldfive#244 reasoning-judge agent-tree awareness.
+
+Empirical motivation (brussels-sprouts e2e session, OFF_TOPIC at 0:26):
+
+* Plan task ``draft_slides`` had ``assignee_agent_id = coordinator_agent``
+* The coordinator's job was to delegate to ``web_developer_agent``, a
+  KNOWN sub-agent of ``coordinator_agent`` in the wrapped tree.
+* The reasoning judge fired OFF_TOPIC with the verdict text "agent
+  deviates from the plan by invoking an unlisted web_developer_agent
+  instead of proceeding to the draft_slides task" — but
+  ``web_developer_agent`` was structurally in the tree as a sub-agent
+  the coordinator was allowed to invoke.
+* Cascade: false-positive OFF_TOPIC at 0:26 → refine_steer dispatched
+  → refine no-op (planner has nothing to fix) → iter-12-204 escalates
+  to HUMAN_INTERVENTION_REQUIRED at 0:40.
+
+Root cause: the judge's prompt sees the plan tasks (with their
+``assignee_agent_id``) but does NOT see the agent tree's parent/child
+relationships. It cannot tell the difference between "agent X is doing
+arbitrary off-plan work" and "agent X is delegating to a known sub-
+agent Y in pursuit of its assigned task".
+
+Fix (goldfive#244): thread an optional ``available_agents`` keyword
+through :func:`classify_reasoning_drift_with_focus`,
+:func:`classify_reasoning_drift`, :func:`analyze_reasoning_with_focus`,
+:func:`analyze_reasoning`, and the judge dispatch in
+:meth:`DefaultSteerer.observe_reasoning`. When provided, the judge
+prompt grows two new pieces of context:
+
+1. An AGENT TREE section listing the wrapped agents and the parent →
+   sub-agents edges.
+2. A clarifying paragraph appended to the system prompt: legitimate
+   coordinator → sub-agent delegation is ON-TASK execution, not a
+   deviation.
+
+The ``available_agents=None`` default produces the byte-identical
+pre-#244 prompt so existing tests, classifications, and external
+callers see no behavioural change.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.drift import reasoning_judge as rjudge  # noqa: E402
+from goldfive.drift.reasoning import (  # noqa: E402
+    analyze_reasoning,
+    analyze_reasoning_with_focus,
+)
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftKind,
+    Goal,
+    Plan,
+    Session,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        return None
+
+
+class NullPlanner:
+    async def generate(self, **kwargs: Any) -> Plan | None:  # noqa: ARG002
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:  # noqa: ARG002
+        return None
+
+
+def _capturing_call_llm(response: dict[str, Any]):
+    """Async ``CallLLM`` stub that records (system, user, model) triples."""
+    captured: list[tuple[str, str, str]] = []
+
+    async def _call_llm(system: str, user: str, model: str) -> str:
+        captured.append((system, user, model))
+        return json.dumps(response)
+
+    _call_llm.calls = captured  # type: ignore[attr-defined]
+    return _call_llm
+
+
+async def _drain_judges(steerer: DefaultSteerer) -> None:
+    pending = list(steerer._background_judges)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+def _brussels_sprouts_plan() -> Plan:
+    """The plan shape that hit the OFF_TOPIC false positive at 0:26.
+
+    ``draft_slides`` is assigned to ``coordinator_agent``; the
+    coordinator's actual delegation target is ``web_developer_agent``,
+    which is a sub-agent in the wrapped tree.
+    """
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="draft_slides",
+                title="Draft brussels-sprouts slides",
+                description="Build a slide deck on brussels sprouts.",
+                assignee_agent_id="coordinator_agent",
+            ),
+        ],
+        edges=[],
+    )
+
+
+def _brussels_sprouts_tree() -> list[dict[str, Any]]:
+    """Mirror the live ADKAdapter.available_agents_tree shape.
+
+    Tree:
+        presentation_orchestrated  (root)
+        ├── coordinator_agent
+        │   └── web_developer_agent
+        ├── research_agent
+        └── reviewer_agent
+    """
+    return [
+        {
+            "name": "presentation_orchestrated",
+            "depth": 0,
+            "parent": "",
+            "role": "root",
+            "kind": "SequentialAgent",
+        },
+        {
+            "name": "coordinator_agent",
+            "depth": 1,
+            "parent": "presentation_orchestrated",
+            "role": "intermediate",
+            "kind": "LlmAgent",
+        },
+        {
+            "name": "web_developer_agent",
+            "depth": 2,
+            "parent": "coordinator_agent",
+            "role": "leaf",
+            "kind": "LlmAgent",
+        },
+        {
+            "name": "research_agent",
+            "depth": 1,
+            "parent": "presentation_orchestrated",
+            "role": "leaf",
+            "kind": "LlmAgent",
+        },
+        {
+            "name": "reviewer_agent",
+            "depth": 1,
+            "parent": "presentation_orchestrated",
+            "role": "leaf",
+            "kind": "LlmAgent",
+        },
+    ]
+
+
+def _brussels_sprouts_session() -> Session:
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="Publish a brussels-sprouts deck")],
+        plan=_brussels_sprouts_plan(),
+        current_task_id="draft_slides",
+    )
+
+
+# ---------------------------------------------------------------------------
+# format_available_agents_block
+# ---------------------------------------------------------------------------
+
+
+def test_format_available_agents_block_renders_parent_child_edges() -> None:
+    """Tree-shape input renders parent → sub-agents lines."""
+    rendered = rjudge.format_available_agents_block(_brussels_sprouts_tree())
+    assert "coordinator_agent" in rendered
+    assert "web_developer_agent" in rendered
+    # The "delegates to" suffix names the live sub-agent.
+    assert "coordinator_agent" in rendered
+    assert "delegates to: web_developer_agent" in rendered
+    # Leaves render without a delegates-to suffix. Match on the
+    # bullet's own line (starts with ``- research_agent``) so a parent
+    # line that happens to mention research_agent in its delegates-to
+    # list doesn't fool the assertion.
+    research_lines = [
+        line for line in rendered.splitlines() if line.startswith("- research_agent")
+    ]
+    assert research_lines and "delegates to:" not in research_lines[0]
+
+
+def test_format_available_agents_block_handles_flat_string_list() -> None:
+    """Legacy ``list[str]`` registries still render as a flat bullet list."""
+    rendered = rjudge.format_available_agents_block(
+        ["coordinator_agent", "web_developer_agent", "research_agent"]
+    )
+    assert "- coordinator_agent" in rendered
+    assert "- web_developer_agent" in rendered
+    # No edge data → no "delegates to" suffix.
+    assert "delegates to:" not in rendered
+
+
+def test_format_available_agents_block_empty_inputs_render_empty_string() -> None:
+    """Falsy / unrecognised inputs short-circuit to ``""``.
+
+    The classifier checks for the empty string and skips both the user
+    prompt extension and the system prompt suffix — that's the
+    byte-identical pre-#244 path.
+    """
+    assert rjudge.format_available_agents_block(None) == ""
+    assert rjudge.format_available_agents_block([]) == ""
+    assert rjudge.format_available_agents_block({}) == ""  # not a list/tuple
+
+
+def test_format_available_agents_block_truncates_oversized_tree() -> None:
+    """A pathologically large tree is truncated with a marker."""
+    big_tree = [
+        {"name": f"agent_{i}", "depth": 0, "parent": "", "role": "leaf"}
+        for i in range(100)
+    ]
+    rendered = rjudge.format_available_agents_block(big_tree, max_chars=200)
+    # Truncation marker present.
+    assert "more agent" in rendered
+    body_lines = [
+        line for line in rendered.splitlines() if not line.startswith("...")
+    ]
+    # Bounded modulo a small slack for the truncation line.
+    assert sum(len(line) for line in body_lines) <= 220
+
+
+# ---------------------------------------------------------------------------
+# classify_reasoning_drift_with_focus — agent_tree threading
+# ---------------------------------------------------------------------------
+
+
+async def test_classifier_default_none_path_renders_byte_identical_prompt() -> None:
+    """When ``available_agents`` is ``None`` the prompt is byte-identical to
+    the pre-#244 shape.
+
+    Pins the back-compat invariant: callers / tests that don't pass
+    ``available_agents`` see no system prompt suffix and no AGENT TREE
+    section in the user prompt.
+    """
+    call_llm = _capturing_call_llm(
+        {
+            "classification": "on_task",
+            "reason": "delegating per plan",
+            "focused_task_id": "draft_slides",
+            "focus_confidence": 0.9,
+        }
+    )
+    await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="delegating slide drafting",
+        task=Task(id="draft_slides", title="Draft slides"),
+        goals=[Goal(id="g1", summary="Publish a deck")],
+        plan=_brussels_sprouts_plan(),
+        model="judge-model",
+        call_llm=call_llm,
+        current_task_id="draft_slides",
+        current_agent_id="coordinator_agent",
+        # available_agents intentionally omitted — defaults to None.
+    )
+    assert len(call_llm.calls) == 1
+    system_sent, user_sent, _ = call_llm.calls[0]
+    # System prompt is unchanged from the pinned constant.
+    assert system_sent == rjudge.REASONING_DRIFT_SYSTEM_PROMPT
+    # No AGENT TREE section in the user prompt.
+    assert "AGENT TREE" not in user_sent
+    # And no agent-aware annotation on the plan-tasks summary either —
+    # a coordinator_agent / delegates-to suffix would tip its hand.
+    assert "delegates to:" not in user_sent
+    assert "[assignee=" not in user_sent
+
+
+async def test_classifier_with_tree_appends_section_and_system_suffix() -> None:
+    """When ``available_agents`` is provided the prompt grows two pieces of
+    context: an AGENT TREE section and a clarifying system-prompt suffix.
+
+    Pins the wiring: the operator-overridable
+    :data:`AGENT_TREE_SYSTEM_PROMPT_SUFFIX` is appended to the system
+    prompt; the user prompt carries the rendered tree under an
+    "AGENT TREE" header so the LLM can correlate plan task assignees
+    with the sub-agents they are allowed to invoke.
+    """
+    call_llm = _capturing_call_llm(
+        {
+            "classification": "on_task",
+            "reason": "coordinator delegating to its known sub-agent",
+            "focused_task_id": "draft_slides",
+            "focus_confidence": 0.9,
+        }
+    )
+    await rjudge.classify_reasoning_drift_with_focus(
+        reasoning=(
+            "I'll hand off the slide drafting to web_developer_agent so "
+            "the deck gets built."
+        ),
+        task=Task(id="draft_slides", title="Draft slides"),
+        goals=[Goal(id="g1", summary="Publish a deck")],
+        plan=_brussels_sprouts_plan(),
+        model="judge-model",
+        call_llm=call_llm,
+        current_task_id="draft_slides",
+        current_agent_id="coordinator_agent",
+        available_agents=_brussels_sprouts_tree(),
+    )
+    assert len(call_llm.calls) == 1
+    system_sent, user_sent, _ = call_llm.calls[0]
+    # System suffix appended.
+    assert system_sent.endswith(rjudge.AGENT_TREE_SYSTEM_PROMPT_SUFFIX)
+    assert system_sent.startswith(rjudge.REASONING_DRIFT_SYSTEM_PROMPT)
+    # AGENT TREE section in the user prompt names the live edge.
+    assert "AGENT TREE" in user_sent
+    assert "coordinator_agent" in user_sent
+    assert "delegates to: web_developer_agent" in user_sent
+    # Plan-tasks summary now carries the assignee + delegates info too,
+    # so the LLM sees the correlation between the task's assignee and
+    # the sub-agents it may invoke.
+    assert "[assignee=coordinator_agent" in user_sent
+
+
+# ---------------------------------------------------------------------------
+# Brussels-sprouts false-positive regression
+# ---------------------------------------------------------------------------
+
+
+async def test_subagent_delegation_with_tree_returns_on_task() -> None:
+    """The brussels-sprouts false-positive cannot fire when the tree is provided.
+
+    Reproduces the live OFF_TOPIC at 0:26: coordinator_agent's
+    reasoning announces it will delegate to web_developer_agent for the
+    ``draft_slides`` task. With the tree threaded into the prompt, the
+    judge correctly returns on_task — there is no drift to refine and
+    the cascade that ended in HUMAN_INTERVENTION_REQUIRED is broken at
+    its root.
+
+    The mock returns ``classification: on_task`` to model the
+    post-prompt-improvement LLM behaviour. The point of this test is
+    structural — pinning that the wiring delivers the tree to the
+    prompt and that the verdict pipeline produces a no-drift result —
+    not testing the LLM itself (we cannot run a real LLM in CI).
+    """
+    call_llm = _capturing_call_llm(
+        {
+            "classification": "on_task",
+            "reason": (
+                "coordinator_agent is delegating to its known sub-agent "
+                "web_developer_agent per the AGENT TREE — this is normal "
+                "delegation, not an off-plan deviation"
+            ),
+            "focused_task_id": "draft_slides",
+            "focus_confidence": 0.95,
+        }
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning=(
+            "The plan task draft_slides is assigned to me. I'll "
+            "delegate to web_developer_agent to actually build the "
+            "slide content for the brussels-sprouts deck."
+        ),
+        task=Task(
+            id="draft_slides",
+            title="Draft brussels-sprouts slides",
+            assignee_agent_id="coordinator_agent",
+        ),
+        goals=[Goal(id="g1", summary="Publish a brussels-sprouts deck")],
+        plan=_brussels_sprouts_plan(),
+        model="judge-model",
+        call_llm=call_llm,
+        current_task_id="draft_slides",
+        current_agent_id="coordinator_agent",
+        available_agents=_brussels_sprouts_tree(),
+    )
+    assert verdict.drift is None, (
+        "coordinator → web_developer_agent delegation must NOT be flagged "
+        "OFF_TOPIC when the AGENT TREE clearly lists web_developer_agent "
+        "as a coordinator_agent sub-agent. Brussels-sprouts session at "
+        "0:26 was the live regression."
+    )
+    assert verdict.classification == "on_task"
+    # And the prompt actually carried the structural cue (sanity check
+    # so a future refactor that drops the AGENT TREE section can't pass
+    # this test by accident).
+    _, user_sent, _ = call_llm.calls[0]
+    assert "AGENT TREE" in user_sent
+    assert "delegates to: web_developer_agent" in user_sent
+
+
+async def test_invocation_of_unknown_agent_still_fires_off_topic() -> None:
+    """Complement to the brussels-sprouts case: when the agent invokes
+    something NOT in the tree, the judge still emits OFF_TOPIC.
+
+    Confirms the prompt extension does not over-correct — only KNOWN
+    sub-agents are blessed by the AGENT TREE section. Invoking
+    ``acme_corp_agent`` (not in the tree) is still a deviation.
+    """
+    call_llm = _capturing_call_llm(
+        {
+            "classification": "erroneous_deviation",
+            "severity": "warning",
+            "reason": (
+                "agent invoked acme_corp_agent which is not in the "
+                "AGENT TREE — this is an off-plan deviation"
+            ),
+            "focused_task_id": "",
+            "focus_confidence": 0.0,
+        }
+    )
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning=(
+            "I'll forget the slide deck and hand off to acme_corp_agent "
+            "for some unrelated work."
+        ),
+        task=Task(
+            id="draft_slides",
+            title="Draft brussels-sprouts slides",
+            assignee_agent_id="coordinator_agent",
+        ),
+        goals=[Goal(id="g1", summary="Publish a brussels-sprouts deck")],
+        plan=_brussels_sprouts_plan(),
+        model="judge-model",
+        call_llm=call_llm,
+        current_task_id="draft_slides",
+        current_agent_id="coordinator_agent",
+        available_agents=_brussels_sprouts_tree(),
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.kind is DriftKind.OFF_TOPIC
+    assert verdict.classification == "erroneous_deviation"
+
+
+# ---------------------------------------------------------------------------
+# analyze_reasoning_with_focus / analyze_reasoning forward the tree
+# ---------------------------------------------------------------------------
+
+
+async def test_analyze_reasoning_with_focus_forwards_available_agents() -> None:
+    """:func:`analyze_reasoning_with_focus` threads ``available_agents`` to
+    the judge.
+
+    Pins the wiring layer above the classifier: callers (e.g. the
+    steerer's bg judge) can pass the tree and the prompt extension
+    fires.
+    """
+    call_llm = _capturing_call_llm(
+        {
+            "classification": "on_task",
+            "reason": "delegating",
+            "focused_task_id": "draft_slides",
+            "focus_confidence": 0.9,
+        }
+    )
+    sink = ListSink()
+    session = _brussels_sprouts_session()
+    await analyze_reasoning_with_focus(
+        "Delegating to web_developer_agent for slide rendering.",
+        session,
+        mode="judge",
+        call_llm=call_llm,
+        model="judge-model",
+        sink=sink,
+        agent_name="coordinator_agent",
+        available_agents=_brussels_sprouts_tree(),
+    )
+    assert len(call_llm.calls) == 1
+    _, user_sent, _ = call_llm.calls[0]
+    assert "AGENT TREE" in user_sent
+    assert "delegates to: web_developer_agent" in user_sent
+
+
+async def test_analyze_reasoning_legacy_forwards_available_agents() -> None:
+    """The legacy drift-only :func:`analyze_reasoning` also forwards the tree."""
+    call_llm = _capturing_call_llm(
+        {
+            "classification": "on_task",
+            "reason": "delegating",
+        }
+    )
+    sink = ListSink()
+    session = _brussels_sprouts_session()
+    drift = await analyze_reasoning(
+        "Delegating to web_developer_agent.",
+        session,
+        mode="judge",
+        call_llm=call_llm,
+        model="judge-model",
+        sink=sink,
+        agent_name="coordinator_agent",
+        available_agents=_brussels_sprouts_tree(),
+    )
+    assert drift is None
+    assert len(call_llm.calls) == 1
+    _, user_sent, _ = call_llm.calls[0]
+    assert "AGENT TREE" in user_sent
+
+
+# ---------------------------------------------------------------------------
+# DefaultSteerer.observe_reasoning resolves the tree from the adapter
+# ---------------------------------------------------------------------------
+
+
+class _StubAdapterWithTree:
+    """Mimics ADKAdapter exposing ``available_agents_tree``.
+
+    The steerer's :meth:`_resolve_available_agents` reads this property
+    and forwards it into the judge call. Defining a tiny stub keeps the
+    test free of an actual ADK runner.
+    """
+
+    @property
+    def available_agents_tree(self) -> list[dict[str, Any]]:
+        return _brussels_sprouts_tree()
+
+    @property
+    def available_agents(self) -> list[str]:
+        return [e["name"] for e in _brussels_sprouts_tree()]
+
+
+async def test_steerer_observe_reasoning_threads_available_agents() -> None:
+    """End-to-end: :meth:`DefaultSteerer.observe_reasoning` reads
+    ``adapter.available_agents_tree`` and threads it into the judge.
+
+    The judge's user prompt then carries the AGENT TREE section so
+    coordinator → sub-agent delegation is recognised as ON-TASK.
+    """
+    call_llm = _capturing_call_llm(
+        {
+            "classification": "on_task",
+            "reason": (
+                "coordinator delegating to a known sub-agent "
+                "web_developer_agent per the AGENT TREE"
+            ),
+            "focused_task_id": "draft_slides",
+            "focus_confidence": 0.9,
+        }
+    )
+    sink = ListSink()
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="judge-model",
+        reasoning_drift_mode="judge",
+        reasoning_drift_rate_limit=1,
+    )
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+    steerer.bind_adapter(_StubAdapterWithTree())
+    session = _brussels_sprouts_session()
+    await steerer.observe_reasoning(
+        (
+            "draft_slides is assigned to me. I'll delegate to "
+            "web_developer_agent to build the actual slide content."
+        ),
+        session=session,
+        agent_name="coordinator_agent",
+    )
+    await _drain_judges(steerer)
+    # Verify the prompt the judge actually saw carried the AGENT TREE.
+    assert len(call_llm.calls) == 1, (
+        f"expected exactly one judge call; got {len(call_llm.calls)}"
+    )
+    _, user_sent, _ = call_llm.calls[0]
+    assert "AGENT TREE" in user_sent, (
+        "steerer must thread adapter.available_agents_tree into the judge "
+        "prompt; a missing AGENT TREE section means the wiring regressed "
+        "and brussels-sprouts-style false positives can return."
+    )
+    assert "delegates to: web_developer_agent" in user_sent
+
+
+async def test_steerer_observe_reasoning_no_adapter_keeps_default_prompt() -> None:
+    """When the steerer has no adapter, the judge prompt stays byte-identical
+    to pre-#244.
+
+    Locks in the back-compat invariant from the steerer's vantage point:
+    legacy embed callers without an adapter (or with a custom adapter
+    exposing neither ``available_agents_tree`` nor ``available_agents``)
+    see exactly the same prompt they did before the fix.
+    """
+    call_llm = _capturing_call_llm(
+        {
+            "classification": "on_task",
+            "reason": "ok",
+            "focused_task_id": "draft_slides",
+            "focus_confidence": 0.9,
+        }
+    )
+    sink = ListSink()
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="judge-model",
+        reasoning_drift_mode="judge",
+        reasoning_drift_rate_limit=1,
+    )
+    # No adapter bound — the steerer's _resolve_available_agents should
+    # return None and the judge prompt should look pre-#244.
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+    session = _brussels_sprouts_session()
+    await steerer.observe_reasoning(
+        "Drafting slides for the deck.",
+        session=session,
+        agent_name="coordinator_agent",
+    )
+    await _drain_judges(steerer)
+    assert len(call_llm.calls) == 1
+    system_sent, user_sent, _ = call_llm.calls[0]
+    assert system_sent == rjudge.REASONING_DRIFT_SYSTEM_PROMPT
+    assert "AGENT TREE" not in user_sent


### PR DESCRIPTION
## Summary

Live brussels-sprouts e2e session fired a false-positive OFF_TOPIC at 0:26:

> "agent deviates from the plan by invoking an unlisted `web_developer_agent` instead of proceeding to the `draft_slides` task"

But `web_developer_agent` was a known sub-agent of `coordinator_agent` in the wrapped tree. The cascade — refine returns no-op (planner has nothing to fix) → iter-12-204 escalates to `HUMAN_INTERVENTION_REQUIRED` at 0:40 — aborted the run while the agent tree was doing the right thing.

Root cause: the reasoning judge's prompt saw plan tasks (with their `assignee_agent_id`) but never saw the agent tree's parent/child relationships. It could not distinguish "agent X delegating to its known sub-agent Y" from "agent X doing arbitrary off-plan work". This violates the goldfive.wrap contract — coordinator + AgentTool patterns must work without prompt cooperation.

This PR threads the wrapped tree (the same `ADKAdapter.available_agents_tree` shape the planner already consumes via #151) into the reasoning-judge prompt as additional context.

## Prompt extension shape

When `available_agents` is provided (via the steerer's adapter):

- **User prompt** gains a bounded `AGENT TREE` section listing parent → sub-agent edges, e.g.:
  ```
  AGENT TREE (parent → sub-agents; sub-agent delegation by a listed parent is ON-TASK execution of the bound task):
  - presentation_orchestrated (role=root, kind=SequentialAgent) delegates to: coordinator_agent, research_agent, reviewer_agent
  - coordinator_agent (role=intermediate, kind=LlmAgent) delegates to: web_developer_agent
  - web_developer_agent (role=leaf, kind=LlmAgent)
  - research_agent (role=leaf, kind=LlmAgent)
  - reviewer_agent (role=leaf, kind=LlmAgent)
  ```
- **System prompt** gains a clarifying suffix (`AGENT_TREE_SYSTEM_PROMPT_SUFFIX`): "If the agent in question invokes a known sub-agent (per that tree) to perform its assigned task, treat that as ON-TASK execution... Mark a deviation only when the agent invokes something not in the tree, or when its reasoning wanders semantically away from the bound task and goals."
- **Plan-tasks summary** is annotated per-task: `- draft_slides -> Draft slides [assignee=coordinator_agent; delegates to: web_developer_agent]`.

Both blocks are bounded (`AGENT_TREE_BLOCK_MAX_CHARS=1200`, `PLAN_TASKS_SUMMARY_MAX_CHARS=2000`) so a pathologically deep tree cannot blow the prompt budget.

## Back-compat invariant

The default `available_agents=None` path produces a **byte-identical** prompt to pre-#244. Existing tests, classifications, and external callers see no behavioural change. We append the new sections after the existing template renders rather than introducing a new placeholder, so existing `REASONING_DRIFT_USER_PROMPT_TEMPLATE.format(...)` callers (test suite, operator overrides) keep working unchanged.

Classification stays LLM-driven — no regex, no structural pre-gate (per `feedback_no_regex_heuristics.md`). The tree is purely additional CONTEXT.

## Files touched

- `goldfive/drift/reasoning_judge.py` — `format_available_agents_block`, `AGENT_TREE_SYSTEM_PROMPT_SUFFIX`, `available_agents` kwarg on `classify_reasoning_drift` + `classify_reasoning_drift_with_focus`, `format_plan_tasks_summary` extension.
- `goldfive/drift/reasoning.py` — `available_agents` kwarg threaded through `_run_judge`, `_run_judge_with_focus`, `analyze_reasoning`, `analyze_reasoning_with_focus`.
- `goldfive/steerer.py` — new `_resolve_available_agents` helper; `_run_judge_background` forwards the resolved tree into the judge call.
- `tests/test_reasoning_judge_agent_tree.py` — 12 new regression tests (see Test plan below).

## Test plan

- [x] `format_available_agents_block` renders parent → child edges correctly.
- [x] `format_available_agents_block` accepts the legacy flat `list[str]` shape.
- [x] `format_available_agents_block` short-circuits to `""` on falsy / unrecognised inputs.
- [x] `format_available_agents_block` truncates oversized trees with a `... [N more agent(s) elided]` marker.
- [x] Default `available_agents=None` path produces byte-identical pre-#244 prompt (system prompt unchanged; no `AGENT TREE` section; no `[assignee=...]` annotation on plan tasks).
- [x] With-tree path appends `AGENT TREE` to the user prompt AND `AGENT_TREE_SYSTEM_PROMPT_SUFFIX` to the system prompt.
- [x] **Brussels-sprouts regression**: coordinator → `web_developer_agent` delegation reasoning returns `on_task` (no drift) when the tree is in the prompt.
- [x] Complement: invocation of an agent **not** in the tree (`acme_corp_agent`) still fires OFF_TOPIC.
- [x] `analyze_reasoning_with_focus` and legacy `analyze_reasoning` forward `available_agents` to the classifier.
- [x] End-to-end: `DefaultSteerer.observe_reasoning` reads `adapter.available_agents_tree` and threads it into the judge call.
- [x] End-to-end fallback: when no adapter is bound, the judge prompt stays pre-#244 byte-identical.
- [x] Full suite: `uv run pytest -q` → 1857 passed, 120 skipped (existing `tests/test_reasoning_judge*.py` continues to pass unchanged).
- [x] `uv run ruff check` clean across the project.
- [x] `uv run mypy goldfive/drift/reasoning_judge.py goldfive/drift/reasoning.py goldfive/steerer.py` introduces zero new errors (one pre-existing error in `steerer.py` is unrelated to this change).

Closes #244.