### PR TITLE
feat(validator): enforce corrective-predecessor topology via supersedes (closes #248)

### DIFF
--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -183,6 +183,78 @@ On validation failure, the revision is discarded, a CRITICAL
 `SCHEMA_VIOLATION` drift is emitted, and `session.plan` is
 unchanged. The refine-failure counter (§4.5) is also incremented.
 
+### 3.6 Corrective predecessors via `supersedes` (non-terminal)
+
+**Motivation (goldfive#248 — tomato e2e false-positive).** When the
+planner-LLM produces a corrective revision (e.g. `fix_research_X`
+correcting a hallucinated research task), it sometimes attaches the
+new task as an *independent root* rather than wiring it in as a
+predecessor of the existing PENDING tasks that depended on the
+contaminated work. The pre-#248 validator only enforced terminal
+preservation (§3.1, §3.2), so this shape passed validation. The
+empirical consequence: with REV 2 carrying both `fix_research_X`
+(corrective) and `draft_slides` (PENDING, still reachable from
+COMPLETED `research_X`), the reconciler claimed `draft_slides` for
+the in-flight coordinator's drafting work while `fix_research_X`
+sat unrun — out-of-order plan execution, with the slides being
+drafted from the very output the correction was meant to fix.
+
+**Contract.** Whenever a revised task `X` declares
+`X.supersedes == Y` and `Y` exists in `prior` AND `Y.status` is
+*non-terminal* (PENDING / RUNNING / BLOCKED), the revision must
+take exactly one of these two shapes:
+
+- **Shape A — keep Y, prepend X.** `Y` stays in the revision with
+  status PENDING and the revision contains an edge `X -> Y`. The
+  corrective `X` runs first; `Y`'s eventual execution is gated on
+  `X`'s output. Y's prior downstream edges (`Y -> Z`) carry forward
+  unchanged: the ordering chain becomes `X -> Y -> Z`.
+- **Shape B — re-edge consumers through X.** Every prior edge
+  `Y -> Z` (where `Z` is non-terminal in the revision) is replaced
+  by `X -> Z`. `Y` may stay or be dropped; if it stays, its
+  remaining downstream edges to terminal tasks are preserved per
+  §3.2. The corrective `X` becomes the new gating predecessor for
+  every consumer that previously waited on `Y`.
+
+Inserting `X` as an independent root while leaving `Y` (and its
+PENDING downstreams) reachable without going through `X` first is
+REJECTED with:
+
+```
+task 'X' supersedes 'Y' but downstream consumers of 'Y' not
+re-edged through 'X': missing edges [...]. Either add an edge
+'X' -> Z for every prior consumer Z of 'Y', OR re-mark 'Y'
+PENDING in the revision and add an edge 'X' -> 'Y'.
+```
+
+**Interaction with #214 REPLACE / CORRECT.** When `Y` is *terminal*
+in the prior plan (COMPLETED / FAILED / CANCELLED / NOT_NEEDED),
+this §3.6 check is a no-op — the existing #214 REPLACE path
+(failed/cancelled task replaced by a new PENDING successor) and
+CORRECT path (completed-but-drift-contaminated task corrected by
+an inserted child) already handle the topology correctly via §3.1
+/ §3.2's terminal-preservation rules and the planner's
+`_emit_plan_revised` re-pinning logic. §3.6 specifically addresses
+the gap: superseding work that has not yet finished.
+
+**Self-supersedes and mutual supersedes are rejected.** A task
+cannot be its own predecessor (`X.supersedes == X.id`) and a pair
+cannot mutually supersede each other (`X.supersedes == Y.id` and
+`Y.supersedes == X.id`) — both shapes are structurally meaningless
+for a corrective predecessor and surface a confused emit at the
+LLM layer (the safety-net `_normalize_supersession_kinds` pass
+also clears self-references at parse time, but the validator
+catches the pair-cycle case the parser cannot reason about).
+
+**Field shape.** `Task.supersedes` is a single string id (the
+existing goldfive#237 field). The §3.6 invariant treats one
+target per task; planner LLM prompts ask for one supersedes id
+per X. (A future evolution to `tuple[str, ...]` for multi-target
+supersession was scoped against the existing single-string proto
+schema and the broad reach of the field across reporting,
+executor causal-tier matching, and steerer routing — out of scope
+for #248.)
+
 ---
 
 ## 4. Refinement modes

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -477,6 +477,44 @@ You MUST:
        child: an edge ``old -> new`` is added and any downstream
        edges are rewired so work flows through the correction.
 
+3a. CORRECTIVE PREDECESSORS (goldfive#248). When you insert a NEW
+   PENDING task X meant to RUN BEFORE an existing non-terminal task
+   Y (so Y's eventual execution depends on X's output — e.g.
+   ``fix_research_tomatoes`` correcting a hallucinated research
+   task that was already COMPLETED, or a clarifying step that must
+   precede a still-PENDING ``draft_slides``), set
+   ``"supersedes": "<Y_id>"`` on X. The validator then enforces
+   corrective topology: every downstream Z of Y in the prior plan
+   must now depend on X (i.e. add an edge X -> Z), OR the plan
+   must keep Y as PENDING and add an edge X -> Y so Y itself
+   waits on X. Inserting X as an independent root while leaving
+   Y still root-eligible against COMPLETED predecessors is a
+   structural bug: the executor will pick whichever happens to
+   match first, producing out-of-order plan execution. The
+   validator REJECTS that shape.
+
+   Example. Prior plan: research_X (COMPLETED) -> draft_slides
+   (PENDING). Drift: research_X output was off-topic. Correct
+   revision (Shape B — re-edge consumers through X):
+
+     tasks:
+       research_X      (COMPLETED, preserved)
+       fix_research_X  (PENDING, supersedes=research_X,
+                        supersedes_kind=CORRECT)
+       draft_slides    (PENDING, unchanged title/assignee)
+     edges:
+       research_X      -> fix_research_X
+       fix_research_X  -> draft_slides   <-- re-edged via X
+       (drop the prior research_X -> draft_slides edge or keep it
+        — both forms are accepted as long as fix_research_X ->
+        draft_slides exists)
+
+   Wrong revision (rejected by validator): adding fix_research_X
+   as an independent root with no edge to draft_slides. The
+   validator emits "task 'fix_research_X' supersedes
+   'research_X' but downstream consumers of 'research_X' not
+   re-edged through 'fix_research_X'".
+
 4. DROP OBSOLETE PENDING TASKS. If the drift makes a PENDING task
    unnecessary (e.g., a goal has been satisfied early, a dependency
    collapsed), you may omit it from the returned plan. Never drop
@@ -1909,6 +1947,20 @@ class LLMPlanner:
             "that exists in your `tasks` array.",
             "",
             "5. The task graph must be ACYCLIC. Do not introduce edges that would create a cycle.",
+            "",
+            "6. CORRECTIVE PREDECESSORS (goldfive#248). When you insert "
+            "a new PENDING task X with `supersedes: <Y_id>` and Y is "
+            "non-terminal in the current plan (PENDING / RUNNING / "
+            "BLOCKED — Y's status above is one of those), X must be "
+            "wired as a structural predecessor of Y's downstreams. "
+            "Either: (a) add edges from X to every prior consumer of "
+            "Y so the corrective work runs before any task that "
+            "depended on Y, OR (b) keep Y as PENDING in your plan and "
+            "add a single edge X -> Y so Y itself waits on X. "
+            "Inserting X as an independent root while leaving Y's "
+            "downstreams reachable without going through X first is "
+            "REJECTED — the executor would race the corrective work "
+            "against the work it was meant to correct.",
         ]
         return "\n".join(lines)
 

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -443,6 +443,33 @@ class Plan:
            that is the natural in-flight DAG shape: a finished stage
            feeding into a still-PENDING next stage.
 
+        8. **Corrective-predecessor topology (PLAN-LIFECYCLE.md §3.6,
+           goldfive#248).** When a revised task ``X`` declares
+           ``X.supersedes == Y`` and ``Y`` exists in ``prior`` AND
+           ``Y.status`` is *non-terminal* (PENDING / RUNNING / BLOCKED),
+           the revision must wire ``X`` in as a structural predecessor
+           of every task that previously depended on ``Y``. Concretely,
+           for every ``prior`` edge ``Y -> Z`` (where ``Z`` exists in
+           the revision and is non-terminal), the revision must contain
+           an edge ``X -> Z`` (the edge is re-routed through ``X``);
+           OR the revision must contain ``Y`` re-marked PENDING with an
+           edge ``X -> Y`` so ``Y`` itself waits on ``X``. The
+           validator rejects any revision that inserts ``X`` as an
+           independent root while ``Y`` (and its downstreams) remain
+           reachable without going through ``X`` first. Motivation:
+           the tomato e2e (#248) showed a corrective ``fix_research_X``
+           landing as an independent root while the original
+           ``draft_slides`` stayed PENDING and root-eligible against
+           ``research_X``; the reconciler picked whichever happened to
+           match first, producing out-of-order plan execution. When
+           ``Y`` is *terminal* in ``prior`` the existing #214 REPLACE/
+           CORRECT path (§3.5) governs and this check is a no-op
+           — supersedes-of-terminal does not require re-edging.
+           Self-supersedes (``X.supersedes == X.id``) and mutual
+           supersedes (``X.supersedes == Y.id`` and
+           ``Y.supersedes == X.id``) are rejected by this step as
+           structurally meaningless.
+
         This is a pure-data validator: it does not mutate the plan. It
         is intended to be called at plan creation (``LLMPlanner.generate``)
         and at plan revision (``LLMPlanner.refine`` /
@@ -577,6 +604,151 @@ class Plan:
                     f"FAILED tasks (their status never transitions to COMPLETED, "
                     f"so downstream PENDING tasks can never become eligible)."
                 )
+
+        # 8. corrective-predecessor topology (PLAN-LIFECYCLE.md §3.6,
+        # goldfive#248). When a revised task X has ``supersedes = Y``
+        # and Y is non-terminal in the prior plan, X must be wired in
+        # as a true predecessor of Y's downstream consumers — otherwise
+        # X lands as an independent root and the prior PENDING work
+        # downstream of Y stays root-eligible against the (still
+        # non-terminal) Y, producing out-of-order plan execution.
+        #
+        # See ``Plan.validate`` step 8 in the docstring above for the
+        # full motivation; the tomato-e2e false-positive (#248) is the
+        # canonical failure shape.
+        #
+        # Only runs on the revision path with a prior — creation-time
+        # plans (``for_revision=False``) cannot have supersedes against
+        # non-terminal prior tasks because there is no prior.
+        if for_revision and prior is not None:
+            prior_by_id: dict[str, Task] = {t.id: t for t in prior.tasks if t.id}
+            new_by_id_step8: dict[str, Task] = {t.id: t for t in self.tasks if t.id}
+            new_edge_set: set[tuple[str, str]] = {
+                (e.from_task_id, e.to_task_id) for e in self.edges
+            }
+
+            # Pre-compute prior outgoing edges keyed by source task.
+            prior_outgoing: dict[str, list[str]] = {}
+            for e in prior.edges:
+                prior_outgoing.setdefault(e.from_task_id, []).append(e.to_task_id)
+
+            for x in self.tasks:
+                sup_id = (x.supersedes or "").strip()
+                if not sup_id:
+                    continue
+
+                # 8a. Self-supersedes is structurally meaningless.
+                if sup_id == x.id:
+                    raise ValueError(
+                        f"task {x.id!r} supersedes itself; a task cannot be its "
+                        f"own predecessor / replacement"
+                    )
+
+                # 8b. supersedes must reference a known task — either in
+                # the revision (forward chain like C.supersedes=B with B
+                # added in the same rev) or in the prior (the typical
+                # backward reference). A target that resolves nowhere is
+                # a dangling reference.
+                resolves_in_prior = sup_id in prior_by_id
+                resolves_in_revised = sup_id in new_by_id_step8
+                if not resolves_in_prior and not resolves_in_revised:
+                    raise ValueError(
+                        f"task {x.id!r} supersedes unknown task {sup_id!r} "
+                        f"(not present in prior plan or in revision)"
+                    )
+
+                # 8c. mutual supersedes (X->Y and Y->X) is a structural
+                # cycle in the supersession graph regardless of where it
+                # is observed. Check both directions in the revision.
+                other = new_by_id_step8.get(sup_id)
+                if other is not None:
+                    other_sup = (other.supersedes or "").strip()
+                    if other_sup == x.id:
+                        raise ValueError(
+                            f"mutual supersedes between {x.id!r} and {sup_id!r}; "
+                            f"a supersession chain must be acyclic"
+                        )
+
+                # 8d. corrective-topology check: only enforced when Y is
+                # in prior AND Y is non-terminal in prior. Terminal-
+                # supersedes (REPLACE / CORRECT in #214 semantics) is
+                # already governed by the §3.1 / §3.2 preservation rules
+                # and the existing terminal-edge invariant — this step
+                # is a no-op for that path.
+                y_prior = prior_by_id.get(sup_id)
+                if y_prior is None or y_prior.status in TERMINAL_TASK_STATUSES:
+                    continue
+
+                # Y is also accepted as a no-op when the *revision* has
+                # advanced Y to terminal: the corrective ordering has
+                # already been resolved in time (X ran before Y) so the
+                # revision-time graph is legitimate even without an X->Z
+                # re-edge. This handles the chained-revision case where
+                # a prior valid Shape A becomes Y-COMPLETED in a later
+                # revision (the X->Y edge from prior_v2 is the §3.2
+                # frozen historical edge that survives; downstream
+                # PENDING consumers now wait on Y's terminal status as
+                # they always did).
+                y_revised = new_by_id_step8.get(sup_id)
+                if y_revised is not None and y_revised.status in TERMINAL_TASK_STATUSES:
+                    continue
+
+                # Y was non-terminal in prior. The revision must satisfy
+                # one of two shapes:
+                #
+                # Shape A: Y stays in the revision (re-marked PENDING)
+                #   AND there is an edge X -> Y.
+                # Shape B: every prior consumer Z of Y (i.e. every
+                #   prior edge Y -> Z) where Z still exists in the
+                #   revision and is non-terminal must now have an
+                #   edge X -> Z.
+                shape_a_ok = (
+                    sup_id in new_by_id_step8
+                    and new_by_id_step8[sup_id].status is TaskStatus.PENDING
+                    and (x.id, sup_id) in new_edge_set
+                )
+
+                downstream_consumers = prior_outgoing.get(sup_id, [])
+                # Filter to consumers that survive into the revision
+                # and remain non-terminal (terminal Z's edge would be a
+                # frozen historical edge governed by §3.2, not a new
+                # routing decision).
+                live_consumers: list[str] = []
+                for z_id in downstream_consumers:
+                    z_new = new_by_id_step8.get(z_id)
+                    if z_new is None:
+                        # Z was dropped by the revision; no re-edge
+                        # obligation for this consumer.
+                        continue
+                    if z_new.status in TERMINAL_TASK_STATUSES:
+                        # Z already terminal — its edges are frozen
+                        # historical structure; not a routing target
+                        # for the corrective predecessor.
+                        continue
+                    live_consumers.append(z_id)
+
+                # Shape B: every live consumer of Y must be re-edged
+                # through X. Y may stay or be dropped from the revision
+                # — the structural property the validator cares about
+                # is that no PENDING task previously gated on Y is still
+                # gated on Y alone (without going through X first).
+                missing_reedge = [
+                    z_id for z_id in live_consumers if (x.id, z_id) not in new_edge_set
+                ]
+                shape_b_ok = not missing_reedge
+
+                if not (shape_a_ok or shape_b_ok):
+                    raise ValueError(
+                        f"task {x.id!r} supersedes {sup_id!r} but downstream "
+                        f"consumers of {sup_id!r} not re-edged through "
+                        f"{x.id!r}: missing edges "
+                        f"{[(x.id, z) for z in missing_reedge]!r}. Either "
+                        f"add an edge {x.id!r} -> Z for every prior "
+                        f"consumer Z of {sup_id!r}, OR re-mark "
+                        f"{sup_id!r} PENDING in the revision and add an "
+                        f"edge {x.id!r} -> {sup_id!r}. See "
+                        f"PLAN-LIFECYCLE.md §3.6 (goldfive#248)."
+                    )
 
     @classmethod
     def empty(cls, *, run_id: str = "") -> Plan:

--- a/tests/test_task_supersedes_validator.py
+++ b/tests/test_task_supersedes_validator.py
@@ -1,0 +1,546 @@
+"""Validator tests for the corrective-predecessor `supersedes` invariant.
+
+Covers ``Plan.validate(for_revision=True, prior=...)`` step 8
+(``PLAN-LIFECYCLE.md §3.6``, goldfive#248). The motivating bug: a
+corrective task ``fix_research_X`` was inserted as an independent
+root while the prior PENDING ``draft_slides`` stayed reachable from
+the (now-suspect) COMPLETED ``research_X``. The reconciler claimed
+``draft_slides`` for in-flight drafting work while ``fix_research_X``
+sat unrun — out-of-order plan execution.
+
+These tests pin the validator semantics:
+
+* Valid corrective predecessor shapes (Shape A: keep Y + edge X->Y;
+  Shape B: re-edge every Y consumer through X) are accepted.
+* Independent-root insertions (the bug shape) are rejected.
+* The existing #214 REPLACE / CORRECT semantics for *terminal*
+  supersedes targets remain untouched (no-op for §3.6).
+* Self-supersedes and mutual-supersedes pairs are rejected.
+* Empty supersedes (default) imposes no new constraint
+  (back-compat for plans / tests that do not use the link at all).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from goldfive.planner import LLMPlanner
+from goldfive.types import (
+    Plan,
+    SupersessionKind,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+
+def _plan(
+    tasks: list[Task],
+    edges: list[TaskEdge],
+    *,
+    plan_id: str = "p",
+    summary: str = "",
+) -> Plan:
+    return Plan(
+        id=plan_id,
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=tasks,
+        edges=edges,
+        summary=summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 1: valid supersedes of non-terminal task with full re-edge (Shape B)
+# ---------------------------------------------------------------------------
+
+
+def test_supersedes_nonterminal_full_reedge_accepted() -> None:
+    """Shape B: prior Y -> Z, revision X -> Z (with X.supersedes = Y).
+
+    Y stays as PENDING but is no longer the gating predecessor of Z;
+    X is the new gate. This is the canonical corrective-predecessor
+    shape the validator must accept.
+    """
+    prior = _plan(
+        tasks=[
+            Task(id="research_X", title="Research X", status=TaskStatus.PENDING),
+            Task(id="draft_slides", title="Draft slides", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="research_X", to_task_id="draft_slides")],
+    )
+    revised = _plan(
+        tasks=[
+            Task(id="research_X", title="Research X", status=TaskStatus.PENDING),
+            Task(
+                id="fix_research_X",
+                title="Re-research X",
+                status=TaskStatus.PENDING,
+                supersedes="research_X",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+            Task(id="draft_slides", title="Draft slides", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            # Re-edge every prior consumer of research_X through fix_research_X.
+            TaskEdge(from_task_id="fix_research_X", to_task_id="draft_slides"),
+        ],
+    )
+
+    revised.validate(for_revision=True, prior=prior)
+
+
+# ---------------------------------------------------------------------------
+# Case 2: invalid — supersedes set but downstream consumer not re-edged
+# (the tomato-e2e bug shape)
+# ---------------------------------------------------------------------------
+
+
+def test_supersedes_nonterminal_independent_root_rejected() -> None:
+    """The #248 motivating bug: fix_X as independent root, draft_slides
+    still depends on the (now-suspect) X. Validator must REJECT.
+    """
+    prior = _plan(
+        tasks=[
+            Task(id="research_X", title="Research X", status=TaskStatus.PENDING),
+            Task(id="draft_slides", title="Draft slides", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="research_X", to_task_id="draft_slides")],
+    )
+    revised = _plan(
+        tasks=[
+            Task(id="research_X", title="Research X", status=TaskStatus.PENDING),
+            Task(id="draft_slides", title="Draft slides", status=TaskStatus.PENDING),
+            Task(
+                id="fix_research_X",
+                title="Re-research X",
+                status=TaskStatus.PENDING,
+                supersedes="research_X",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+        ],
+        # Prior research_X -> draft_slides edge preserved; fix_research_X
+        # is an independent root with no edge into the rest of the DAG.
+        edges=[TaskEdge(from_task_id="research_X", to_task_id="draft_slides")],
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        revised.validate(for_revision=True, prior=prior)
+
+    msg = str(exc_info.value)
+    assert "fix_research_X" in msg
+    assert "research_X" in msg
+    assert "not re-edged through" in msg
+
+
+# ---------------------------------------------------------------------------
+# Case 3: valid supersedes of TERMINAL task (#214 REPLACEMENT case)
+# ---------------------------------------------------------------------------
+
+
+def test_supersedes_terminal_replacement_accepted() -> None:
+    """Y is terminal (FAILED) → §3.6 is a no-op; the existing #214
+    REPLACEMENT topology is allowed without re-edge requirements."""
+    prior = _plan(
+        tasks=[
+            Task(id="research_X", title="Research X", status=TaskStatus.FAILED),
+            Task(id="draft_slides", title="Draft slides", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+    revised = _plan(
+        tasks=[
+            Task(id="research_X", title="Research X", status=TaskStatus.FAILED),
+            Task(
+                id="fix_research_X",
+                title="Re-research X",
+                status=TaskStatus.PENDING,
+                supersedes="research_X",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+            Task(id="draft_slides", title="Draft slides", status=TaskStatus.PENDING),
+        ],
+        # No edges from FAILED research_X (would violate §137 anyway).
+        # No re-edge required by §3.6 because Y is terminal.
+        edges=[
+            TaskEdge(from_task_id="fix_research_X", to_task_id="draft_slides"),
+        ],
+    )
+
+    revised.validate(for_revision=True, prior=prior)
+
+
+def test_supersedes_terminal_correct_completed_accepted() -> None:
+    """Y is terminal (COMPLETED) with the #214 CORRECT-kind shape:
+    prior research_X COMPLETED -> draft_slides PENDING; revision adds
+    fix_research_X with supersedes=research_X and an edge
+    research_X -> fix_research_X (the historical-completed-then-correct
+    DAG). §3.6 must NOT fire — Y is terminal — so the existing CORRECT
+    path remains untouched.
+    """
+    prior = _plan(
+        tasks=[
+            Task(id="research_X", title="Research X", status=TaskStatus.COMPLETED),
+            Task(id="draft_slides", title="Draft slides", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="research_X", to_task_id="draft_slides")],
+    )
+    revised = _plan(
+        tasks=[
+            Task(id="research_X", title="Research X", status=TaskStatus.COMPLETED),
+            Task(
+                id="fix_research_X",
+                title="Re-research X",
+                status=TaskStatus.PENDING,
+                supersedes="research_X",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+            Task(id="draft_slides", title="Draft slides", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            # CORRECT: research_X COMPLETED stays; new edge research_X -> fix_research_X
+            # injects fix_research_X as a child of the corrected work.
+            TaskEdge(from_task_id="research_X", to_task_id="fix_research_X"),
+            TaskEdge(from_task_id="fix_research_X", to_task_id="draft_slides"),
+        ],
+    )
+
+    # §3.6 must be a no-op (research_X terminal); the existing #214
+    # CORRECT topology validates cleanly.
+    revised.validate(for_revision=True, prior=prior)
+
+
+# ---------------------------------------------------------------------------
+# Case 4: Shape A — keep Y, prepend X via X -> Y
+# ---------------------------------------------------------------------------
+
+
+def test_supersedes_nonterminal_shape_a_prepend_accepted() -> None:
+    """Alternative valid shape: Y stays PENDING, X gates Y via X -> Y.
+    Y's prior downstream edges (Y -> Z) remain unchanged."""
+    prior = _plan(
+        tasks=[
+            Task(id="Y_task", title="Y", status=TaskStatus.PENDING),
+            Task(id="Z_task", title="Z", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="Y_task", to_task_id="Z_task")],
+    )
+    revised = _plan(
+        tasks=[
+            Task(id="Y_task", title="Y", status=TaskStatus.PENDING),
+            Task(id="Z_task", title="Z", status=TaskStatus.PENDING),
+            Task(
+                id="X_task",
+                title="X (clarifying step)",
+                status=TaskStatus.PENDING,
+                supersedes="Y_task",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+        ],
+        edges=[
+            TaskEdge(from_task_id="X_task", to_task_id="Y_task"),
+            TaskEdge(from_task_id="Y_task", to_task_id="Z_task"),
+        ],
+    )
+
+    revised.validate(for_revision=True, prior=prior)
+
+
+# ---------------------------------------------------------------------------
+# Case 5: Multiple downstream consumers of Y — all must be re-edged
+# ---------------------------------------------------------------------------
+
+
+def test_supersedes_nonterminal_partial_reedge_rejected() -> None:
+    """If Y has TWO downstream consumers Z1, Z2 in prior and the
+    revision re-edges only Z1 through X (leaving Z2 still gated on
+    the now-suspect Y), the validator REJECTS."""
+    prior = _plan(
+        tasks=[
+            Task(id="Y_task", title="Y", status=TaskStatus.PENDING),
+            Task(id="Z1", title="Z1", status=TaskStatus.PENDING),
+            Task(id="Z2", title="Z2", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge(from_task_id="Y_task", to_task_id="Z1"),
+            TaskEdge(from_task_id="Y_task", to_task_id="Z2"),
+        ],
+    )
+    revised = _plan(
+        tasks=[
+            Task(id="Y_task", title="Y", status=TaskStatus.PENDING),
+            Task(id="Z1", title="Z1", status=TaskStatus.PENDING),
+            Task(id="Z2", title="Z2", status=TaskStatus.PENDING),
+            Task(
+                id="X_task",
+                title="X corrective",
+                status=TaskStatus.PENDING,
+                supersedes="Y_task",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+        ],
+        # Only Z1 re-edged through X; Z2 still hangs off Y_task only.
+        edges=[
+            TaskEdge(from_task_id="Y_task", to_task_id="Z1"),
+            TaskEdge(from_task_id="Y_task", to_task_id="Z2"),
+            TaskEdge(from_task_id="X_task", to_task_id="Z1"),
+        ],
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        revised.validate(for_revision=True, prior=prior)
+
+    msg = str(exc_info.value)
+    assert "X_task" in msg
+    assert "Y_task" in msg
+    assert "Z2" in msg
+
+
+# ---------------------------------------------------------------------------
+# Case 6: Empty supersedes (default) — no constraint applied (back-compat)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_supersedes_no_constraint() -> None:
+    """A revision that adds new PENDING tasks without using `supersedes`
+    at all must validate cleanly (no false positives on plans that
+    pre-date the link or simply don't need it)."""
+    prior = _plan(
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.PENDING),
+            Task(id="t2", title="T2", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    revised = _plan(
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.PENDING),
+            Task(id="t2", title="T2", status=TaskStatus.PENDING),
+            # Brand-new task, no supersedes, plugged in as a fresh root.
+            Task(id="t3", title="T3", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge(from_task_id="t1", to_task_id="t2"),
+            TaskEdge(from_task_id="t1", to_task_id="t3"),
+        ],
+    )
+
+    revised.validate(for_revision=True, prior=prior)
+
+
+# ---------------------------------------------------------------------------
+# Case 7: supersedes naming a non-existent task — rejected
+# ---------------------------------------------------------------------------
+
+
+def test_supersedes_unknown_target_rejected() -> None:
+    """X.supersedes references a task id that exists in neither
+    `prior` nor the revision — dangling reference, validator rejects."""
+    prior = _plan(
+        tasks=[Task(id="t1", title="T1", status=TaskStatus.PENDING)],
+        edges=[],
+    )
+    revised = _plan(
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.PENDING),
+            Task(
+                id="X_task",
+                title="X",
+                status=TaskStatus.PENDING,
+                supersedes="nonexistent_id",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+        ],
+        edges=[],
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        revised.validate(for_revision=True, prior=prior)
+
+    msg = str(exc_info.value)
+    assert "X_task" in msg
+    assert "nonexistent_id" in msg
+
+
+# ---------------------------------------------------------------------------
+# Case 8: cycle prevention — X.supersedes=Y AND Y.supersedes=X
+# ---------------------------------------------------------------------------
+
+
+def test_mutual_supersedes_rejected() -> None:
+    """Mutual supersession (X<->Y) is structurally meaningless. Both
+    directions seen in the same revision must be rejected."""
+    prior = _plan(
+        tasks=[Task(id="t1", title="T1", status=TaskStatus.PENDING)],
+        edges=[],
+    )
+    revised = _plan(
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.PENDING),
+            Task(
+                id="X_task",
+                title="X",
+                status=TaskStatus.PENDING,
+                supersedes="Y_task",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+            Task(
+                id="Y_task",
+                title="Y",
+                status=TaskStatus.PENDING,
+                supersedes="X_task",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+        ],
+        edges=[],
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        revised.validate(for_revision=True, prior=prior)
+
+    msg = str(exc_info.value)
+    assert "mutual supersedes" in msg
+    assert "X_task" in msg
+    assert "Y_task" in msg
+
+
+def test_self_supersedes_rejected() -> None:
+    """A task cannot supersede itself."""
+    prior = _plan(
+        tasks=[Task(id="t1", title="T1", status=TaskStatus.PENDING)],
+        edges=[],
+    )
+    revised = _plan(
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.PENDING),
+            Task(
+                id="X_task",
+                title="X",
+                status=TaskStatus.PENDING,
+                supersedes="X_task",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+        ],
+        edges=[],
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        revised.validate(for_revision=True, prior=prior)
+
+    msg = str(exc_info.value)
+    assert "X_task" in msg
+    assert "supersedes itself" in msg
+
+
+# ---------------------------------------------------------------------------
+# Case 9: Refine prompt's invariants block surfaces the new contract
+# ---------------------------------------------------------------------------
+
+
+def test_refine_prompt_invariants_block_includes_corrective_predecessor() -> None:
+    """Render the structural-invariants block on a representative plan
+    and assert the §3.6 contract appears as item 6 with the key
+    instructional language."""
+    plan = _plan(
+        tasks=[
+            Task(id="research_X", title="Research X", status=TaskStatus.COMPLETED),
+            Task(id="draft_slides", title="Draft slides", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="research_X", to_task_id="draft_slides")],
+    )
+    block = LLMPlanner._render_structural_invariants_block(plan)
+
+    # The new invariant is item 6 in the rendered block, after the
+    # cycle-free invariant.
+    assert "6. CORRECTIVE PREDECESSORS" in block
+    assert "supersedes" in block
+    # Both shapes are documented to the LLM.
+    assert "structural predecessor" in block
+    assert "every prior consumer" in block.lower() or "every prior consumer" in block
+    # The reject message language matches the validator's phrasing
+    # so retry prompts can correlate.
+    assert "REJECTED" in block
+
+
+# ---------------------------------------------------------------------------
+# Case 10: bonus — Shape B with Y dropped from the revision is accepted
+# ---------------------------------------------------------------------------
+
+
+def test_supersedes_y_advanced_to_terminal_in_revision_accepted() -> None:
+    """Chained-revision case: prior had a valid Shape A (Y stayed
+    PENDING + edge X->Y). The next revision runs further and Y has
+    advanced to COMPLETED (X completed Y's gating work). The
+    revision should validate even though shape_a_ok now fails (Y
+    is no longer PENDING) and shape_b_ok would still require
+    re-edges that the Shape A topology never had — the corrective
+    ordering has been resolved in time and the graph is consistent.
+    """
+    prior = _plan(
+        tasks=[
+            Task(id="research_X", title="Research X", status=TaskStatus.PENDING),
+            Task(
+                id="fix_research_X",
+                title="Fix X",
+                status=TaskStatus.PENDING,
+                supersedes="research_X",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+            Task(id="draft_slides", title="Draft", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge(from_task_id="fix_research_X", to_task_id="research_X"),
+            TaskEdge(from_task_id="research_X", to_task_id="draft_slides"),
+        ],
+    )
+    revised = _plan(
+        tasks=[
+            # Y advanced to COMPLETED in this revision; corrective
+            # X also completed.
+            Task(id="research_X", title="Research X", status=TaskStatus.COMPLETED),
+            Task(
+                id="fix_research_X",
+                title="Fix X",
+                status=TaskStatus.COMPLETED,
+                supersedes="research_X",
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+            Task(id="draft_slides", title="Draft", status=TaskStatus.PENDING),
+        ],
+        edges=[
+            TaskEdge(from_task_id="fix_research_X", to_task_id="research_X"),
+            TaskEdge(from_task_id="research_X", to_task_id="draft_slides"),
+        ],
+    )
+
+    revised.validate(for_revision=True, prior=prior)
+
+
+def test_supersedes_nonterminal_y_dropped_with_full_reedge_accepted() -> None:
+    """A revision may drop Y entirely (X completely subsumes it) so
+    long as every Y-consumer is re-edged through X. Y must not be
+    referenced by the remaining edges."""
+    prior = _plan(
+        tasks=[
+            Task(id="Y_task", title="Y", status=TaskStatus.PENDING),
+            Task(id="Z_task", title="Z", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="Y_task", to_task_id="Z_task")],
+    )
+    revised = _plan(
+        tasks=[
+            # Y_task dropped from the revision.
+            Task(id="Z_task", title="Z", status=TaskStatus.PENDING),
+            Task(
+                id="X_task",
+                title="X corrective",
+                status=TaskStatus.PENDING,
+                supersedes="Y_task",  # Y resolves in prior
+                supersedes_kind=SupersessionKind.REPLACE,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="X_task", to_task_id="Z_task")],
+    )
+
+    revised.validate(for_revision=True, prior=prior)


### PR DESCRIPTION
## Summary

- Adds **Plan.validate step 8** (PLAN-LIFECYCLE.md §3.6): when a revised task X has `supersedes = Y` and Y is non-terminal in the prior plan, X must be wired in as a structural predecessor of Y's downstream consumers — either via Shape A (X -> Y prepend) or Shape B (re-edge every Y consumer through X). Inserting X as an INDEPENDENT ROOT while leaving Y's PENDING downstreams reachable bypasses the corrective work and is now rejected.
- Updates the planner refine prompt (`_REFINE_SYSTEM_PROMPT` §3a + the dynamic structural-invariants block item 6) with a concrete worked example, so the LLM produces the topology the validator demands.
- Documents the contract in `docs/design/PLAN-LIFECYCLE.md` §3.6 with the tomato-e2e false-positive as motivation, the field-shape decision (kept as scalar `str` rather than `tuple[str, ...]` — the brief's hypothesis was a counterfactual; the existing field has broad reach across reporting / executor causal-tier / steerer routing), and the interaction with the existing #214 REPLACE / CORRECT path (no-op for terminal Y, no regression).

## Background

Phase 4 of 5 of a coordinated structural fix. Orthogonal to phases 1, 2, 3 (different file areas / code paths). Merges first per the schedule (smallest, lowest-risk).

The motivating bug (tomato e2e false-positive): REV 2 added `fix_research_tomatoes` (corrective research) but left `draft_slides` PENDING and root-eligible against the contaminated COMPLETED `research_sprouts`. The reconciler claimed `draft_slides` for in-flight drafting work while `fix_research_tomatoes` sat unrun — out-of-order plan execution, with the slides drafted from the very output the correction was meant to fix.

## Validator semantics (Plan.validate step 8)

For each revised task X with non-empty `supersedes` (Y):

- **8a** — self-supersedes rejected.
- **8b** — supersedes target must resolve in `prior` or in the revision.
- **8c** — mutual supersedes (X<->Y) rejected.
- **8d** — when Y is non-terminal in prior AND non-terminal in the revision, the revision must satisfy Shape A (Y stays PENDING + edge X -> Y) OR Shape B (every prior `Y -> Z` re-edged as `X -> Z` for non-terminal Z surviving into the revision). Y advancing to terminal in the revision is also accepted as a no-op (corrective ordering resolved in time).
- Terminal supersedes (Y in {COMPLETED, FAILED, CANCELLED, NOT_NEEDED} in prior) is a **no-op** for §3.6 — the existing #214 REPLACE / CORRECT path governs and is unchanged.

## Test plan

- [x] New `tests/test_task_supersedes_validator.py` (13 cases): valid Shape A / Shape B, the #248 independent-root rejection, terminal REPLACE + CORRECT (no §3.6 fire), partial re-edge rejection with the missing consumer named, empty supersedes back-compat, unknown / self / mutual supersedes rejections, refine-prompt block contains §3.6, chained-revision (Y advances to terminal) accepted, Y-dropped accepted.
- [x] Full suite: `uv run pytest -q` — **1886 passed, 117 skipped** (added 13, no regressions).
- [x] `uv run ruff check` clean.
- [x] `uv run mypy goldfive/types.py goldfive/planner.py tests/test_task_supersedes_validator.py` clean (pre-existing 6 mypy errors in `planner.py:1493+` are unrelated to this change — same on origin/main).
- [x] No `Co-Authored-By: Claude` trailer per repo convention.

## Field shape decision (no proto change)

The brief asked for `supersedes: tuple[str, ...]` (frozen-friendly default). Existing `Task.supersedes: str` (goldfive#237) is already wired across reporting reroute (`reporting._resolve_effective_task_id`), executor causal-tier matching (`executors/sequential.py:1873`), planner post-parse normalisation (`_normalize_supersession_kinds`, #251), and steerer routing (`_emit_plan_revised`). A tuple migration is a multi-PR refactor orthogonal to the §3.6 contract. This PR ships the invariant on the existing scalar; a future tuple migration can layer on top without re-deriving the §3.6 topology rules. Documented in PLAN-LIFECYCLE.md §3.6.