### PR TITLE
fix(types): wrap field declaration to satisfy ruff E501

### DIFF
--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1123,7 +1123,9 @@ class Session:
     # drifts bypass the gate so they don't need to stamp). Key is
     # ``(drift.kind.value, drift.current_task_id or "")`` — empty target
     # captures trajectory-level drifts that coalesce on a single key.
-    last_addressed_revision_by_drift_key: dict[tuple[str, str], int] = dataclasses.field(default_factory=dict)
+    last_addressed_revision_by_drift_key: dict[tuple[str, str], int] = (
+        dataclasses.field(default_factory=dict)
+    )
     # Per-task ``time.monotonic()`` timestamp of the most recent
     # task-progress signal — set on ``mark_task_running``,
     # ``mark_task_progress``, and every ``_emit_task_transitioned`` call.


### PR DESCRIPTION
Hot-fix for ruff E501 on line 1126 introduced by #368 (Phase 1 of structural fix). The field declaration was 110 chars; ruff's 100-char limit caught it on PR #369 (Phase 2)'s merge-commit CI. I missed running ruff after the per-(kind, target) refinement edit before pushing #368.

Pure formatting; behavior unchanged.