### PR TITLE
refactor(types): freeze Plan + Task; channel-processor single-writer for session.plan (goldfive#247)

### DIFF
--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -655,6 +655,86 @@ Violating any of them is a bug in goldfive.
    PENDING, RUNNING, or BLOCKED tasks remaining.
 9. **Success is not the default verdict.** `Outcome.success = True`
    is computed from §6.1's conjunction, not "did anything fail?"
+10. **Plan and Task are immutable; the channel processor is the
+    sole writer onto `session.plan` (goldfive#247).** See §7.1
+    below.
+
+### 7.1 Immutable Plan/Task and the single-writer rule (goldfive#247)
+
+`Plan` and `Task` are `@dataclasses.dataclass(frozen=True)` (see
+`goldfive/types.py`). Every "mutation" — flipping a task's status,
+appending tasks, replacing the edge list, bumping `revision_index` —
+constructs a NEW object via the helpers in `goldfive.types`:
+
+| helper | purpose |
+|---|---|
+| `replace_task(plan, task_id, **changes)` | Return a new Plan with one task replaced via `dataclasses.replace`. |
+| `with_task_status(plan, task_id, status)` | Sugar over `replace_task` for the common status-transition path. |
+| `add_tasks(plan, new_tasks)` | Return a new Plan with tasks appended; preserves order. |
+| `replace_edges(plan, edges)` | Return a new Plan with the edge list replaced. |
+| `bump_revision(plan, *, revision_index=..., revision_kind=..., ...)` | Return a new Plan with revision metadata updated. |
+
+These helpers NEVER mutate the input. They are pure functions over
+`Plan`/`Task`.
+
+**Why the freeze fixes a bug class.** Pre-#247, judges and sinks
+read `session.plan` / `task.status`, awaited an LLM, and produced a
+verdict against a snapshot the live state had mutated past. The
+brussels-sprouts and tomato e2e sessions surfaced this as the
+"torn-read" symptom: the reconciler's `mark_task_completed` flipped
+`task.status` in place, `_apply_revision` swapped `session.plan`
+whole-cloth, and both happened DURING a judge's LLM round-trip. With
+frozen types the bug class is impossible: anyone who captured a
+`Plan` reference keeps operating on that snapshot for the duration
+of their work; the live `session.plan` may move, but their snapshot
+doesn't.
+
+**Single-writer enforcement.** The pointer swap onto `session.plan`
+is owned by the steerer's channel processor — `mark_task_*`,
+`_apply_revision`, `cascade_cancel_downstream`, and the executor
+install paths. Every blessed swap site goes through:
+
+```python
+from goldfive.types import channel_processor_active, set_session_plan, with_task_status
+
+with channel_processor_active():
+    set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.RUNNING))
+```
+
+`set_session_plan` checks the `_CHANNEL_PROCESSOR_ACTIVE` contextvar
+on every call. Outside the contextvar:
+
+* **Default (production):** logs a `WARNING` and proceeds. The
+  runtime stays defensive — a sink that accidentally writes to
+  `session.plan` does not crash the run, but the smell is recorded.
+* **`GOLDFIVE_STRICT_STATE_OWNERSHIP=1` (CI / dev):** raises
+  `goldfive.types.PlanOwnershipViolation`. Pytest auto-enables this
+  unless explicitly disabled, mirroring the existing
+  `goldfive._state_audit` opt-in tripwire.
+
+This is structural enforcement of "single writer onto session.plan"
+without forcing every reader to defensively copy. Sinks and judges
+read freely; the steerer's channel processor is the only path that
+swaps the pointer.
+
+**Cross-references.**
+
+* Phase 1 (#245) adds `observed_revision_index` to `DriftEvent` so
+  drift handlers can detect when a drift was minted against an
+  earlier plan. The frozen Plan refactor makes this signal honest:
+  the drift's `observed_revision_index` is forever associated with
+  the plan revision the drift was minted from, even if `session.plan`
+  has moved on.
+* Phase 2 (#246) routes drift handling through `ControlMessage`. The
+  ControlMessage routing site enters `channel_processor_active`
+  before delegating into the steerer's mutation helpers.
+* Phase 4 (#248) adds `Task.supersedes` validation. The
+  `supersedes: tuple[str, ...] = ()`-style default is in place from
+  Phase 3 so Phase 4 only has to wire the validator + prompt + tests.
+  (Note: in this revision the field stays `str = ""` for back-compat
+  with the existing supersedes-by-id design; Phase 4 may evolve it.)
+* Phase 5 (#249) is the top-level design doc; orthogonal to the
+  type-level fix here.
 
 ---
 

--- a/goldfive/executors/_control.py
+++ b/goldfive/executors/_control.py
@@ -62,7 +62,14 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from goldfive.types import Session, TaskStatus
+from goldfive.types import (
+    Session,
+    Task,
+    TaskStatus,
+    channel_processor_active,
+    set_session_plan,
+    with_task_status,
+)
 
 if TYPE_CHECKING:
     from goldfive.control import ControlAck, ControlChannel, ControlMessage
@@ -513,7 +520,7 @@ async def _resolve_approval(
 
 def _rewind_plan(
     session: Session, target_task_id: str
-) -> list[tuple[Any, TaskStatus]] | None:
+) -> list[tuple[Task, TaskStatus]] | None:
     """Reset ``target`` and every downstream task back to ``PENDING``.
 
     Any task transitively reachable from ``target`` via ``plan.edges``
@@ -523,6 +530,15 @@ def _rewind_plan(
     actually changed (i.e. was non-PENDING before the rewind). The
     caller uses this list to emit one ``TaskTransitioned`` event per
     affected task with ``source="control_rewind"``.
+
+    goldfive#247: :class:`Plan` and :class:`Task` are frozen — the
+    rewind no longer mutates ``task.status`` in place. Each affected
+    task is replaced via :func:`with_task_status`; the resulting
+    plan is swapped onto :attr:`Session.plan` under
+    :func:`channel_processor_active` (this is a control-plane
+    mutation, hence channel-processor-owned). The ``Task`` objects
+    in the returned tuples are the **post-swap** instances so the
+    dispatcher's downstream emit reads consistent fields.
 
     F10 / goldfive#251 R4: emitting from the dispatcher (rather than
     here) keeps this helper sync + dependency-free, while still giving
@@ -553,13 +569,29 @@ def _rewind_plan(
             if child not in affected:
                 stack.append(child)
 
-    transitions: list[tuple[Any, TaskStatus]] = []
+    # Build a single new Plan with every affected task transitioned to
+    # PENDING; capture the (task, prev_status) pairs for the dispatcher's
+    # emission. The fold runs over the *new* plan after each
+    # ``with_task_status`` so the post-swap Task instance is what we
+    # return to the caller.
+    transitions: list[tuple[Task, TaskStatus]] = []
+    new_plan = plan
     for tid in affected:
-        task = tasks_by_id[tid]
-        prev = task.status
-        if prev is not TaskStatus.PENDING:
-            transitions.append((task, prev))
-        task.status = TaskStatus.PENDING
+        prev_task = tasks_by_id[tid]
+        prev = prev_task.status
+        if prev is TaskStatus.PENDING:
+            session.completed_results.pop(tid, None)
+            session.task_progress.pop(tid, None)
+            continue
+        new_plan = with_task_status(new_plan, tid, TaskStatus.PENDING)
+        # The freshly-replaced task lives in ``new_plan.tasks``; resolve
+        # it once per fold so the caller emits transitions against the
+        # post-swap instance.
+        new_task = next((t for t in new_plan.tasks if t.id == tid), prev_task)
+        transitions.append((new_task, prev))
         session.completed_results.pop(tid, None)
         session.task_progress.pop(tid, None)
+    if new_plan is not plan:
+        with channel_processor_active():
+            set_session_plan(session, new_plan)
     return transitions

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -61,7 +61,11 @@ from goldfive.types import (
     Session,
     Task,
     TaskStatus,
+    bump_revision,
+    channel_processor_active,
+    set_session_plan,
     severity_rank,
+    with_task_status,
 )
 
 if TYPE_CHECKING:
@@ -197,7 +201,14 @@ class ParallelDAGExecutor:
         sinks: list[EventSink],
         control: ControlChannel | None = None,
     ) -> ExecutionOutcome:
-        session.plan = plan
+        # goldfive#247: even the initial pin runs through the
+        # channel-processor primitive so the runtime check stays
+        # consistent. ``set_session_plan`` warns (or, in strict
+        # mode, raises) when called outside
+        # :func:`channel_processor_active` — that's the structural
+        # enforcement of "single writer onto session.plan".
+        with channel_processor_active():
+            set_session_plan(session, plan)
 
         # Bind sinks + planner into the steerer so its own observe/
         # transition calls fan out alongside ours.
@@ -281,8 +292,19 @@ class ParallelDAGExecutor:
                 # tools (status is terminal), leave it alone. Otherwise
                 # auto-transition on its behalf so clean returns count as
                 # COMPLETED, not silently PENDING/RUNNING.
+                # goldfive#247: ``task`` is the pre-mutation snapshot;
+                # the framework auto-start via ``steerer.transition(...
+                # RUNNING)`` produced a NEW Plan, so the captured ``task``
+                # reference still says PENDING. Refresh status from the
+                # live ``session.plan`` so terminal-task detection (set
+                # by reporting tools through the steerer) is honoured.
+                live_plan = session.plan
+                live_status_by_id: dict[str, TaskStatus] = (
+                    {t.id: t.status for t in live_plan.tasks} if live_plan is not None else {}
+                )
                 for task, inv, _task_drift, error in stage_results:
-                    already_terminal = task.status in _TERMINAL_TASK_STATUSES
+                    live_status = live_status_by_id.get(task.id, task.status)
+                    already_terminal = live_status in _TERMINAL_TASK_STATUSES
                     if error is not None and not isinstance(error, asyncio.CancelledError):
                         if not already_terminal:
                             await steerer.transition(
@@ -371,7 +393,8 @@ class ParallelDAGExecutor:
                         session.refine_outcomes[
                             (drift.kind.value, drift.current_task_id or "")
                         ] = RefineOutcome(state="succeeded", fail_count=0)
-                        session.plan = refined
+                        with channel_processor_active():
+                            set_session_plan(session, refined)
                         await emit_event(
                             sinks,
                             plan_revised_event(
@@ -537,15 +560,48 @@ class ParallelDAGExecutor:
                 # Emit BEFORE the adapter invoke so the transition row
                 # lands in the wire order operators expect (transition
                 # then activity).
+                # F10 / goldfive#251 R4: framework auto-start of a task
+                # is a real PENDING -> RUNNING transition; emit
+                # TaskTransitioned with source="executor_dispatch" so
+                # operators distinguish it from LLM reporting-tool
+                # (handler_default) and other (catch-all). goldfive#247:
+                # the in-place ``task.status = RUNNING`` mutation is
+                # gone; we derive a NEW Plan via :func:`with_task_status`
+                # and swap, then emit. The captured ``task`` reference
+                # used by the surrounding fold-back stays stale (it's a
+                # Task snapshot) but the live ``session.plan.tasks[*]``
+                # carries the new status — :meth:`_run_stage`'s caller
+                # consults the live plan post-fold for terminal
+                # detection.
                 prev_status = task.status
-                task.status = TaskStatus.RUNNING
-                if prev_status is not TaskStatus.RUNNING:
+                if prev_status is not TaskStatus.RUNNING and prev_status not in (
+                    TaskStatus.COMPLETED,
+                    TaskStatus.FAILED,
+                    TaskStatus.CANCELLED,
+                    TaskStatus.NOT_NEEDED,
+                ):
+                    if session.plan is not None and any(
+                        t.id == task.id for t in session.plan.tasks
+                    ):
+                        with channel_processor_active():
+                            set_session_plan(
+                                session,
+                                with_task_status(session.plan, task.id, TaskStatus.RUNNING),
+                            )
                     emit_transition = getattr(steerer, "_emit_task_transitioned", None)
                     if callable(emit_transition):
+                        # Refresh the task reference so the emit reads
+                        # the new status from the swapped plan.
+                        live_task = task
+                        if session.plan is not None:
+                            live_task = next(
+                                (t for t in session.plan.tasks if t.id == task.id),
+                                task,
+                            )
                         try:
                             await emit_transition(
                                 session,
-                                task,
+                                live_task,
                                 from_status=prev_status,
                                 to_status=TaskStatus.RUNNING,
                                 source="executor_dispatch",
@@ -969,12 +1025,18 @@ class ParallelDAGExecutor:
         # inline here. Resolution mirrors steerer._apply_revision: source
         # annotation_id (user-control) → drift.id (autonomous). Preserves
         # any pre-existing stamp from the planner path.
+        # goldfive#247: Plan is frozen — derive a new instance via
+        # :func:`bump_revision` rather than mutating in place.
         if not refined.revision_trigger_event_id:
             from goldfive.events import _trigger_id_from_drift
 
             trig_id = _trigger_id_from_drift(drift)
             if trig_id:
-                refined.revision_trigger_event_id = trig_id
+                refined = bump_revision(
+                    refined,
+                    revision_index=refined.revision_index,
+                    revision_trigger_event_id=trig_id,
+                )
         return refined, attempt_id
 
     @staticmethod

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -55,7 +55,16 @@ from goldfive.executors._control import (
 )
 from goldfive.protocols import AgentAdapter, EventSink, Executor, Planner, Steerer
 from goldfive.results import ExecutionOutcome, evaluate_goal_predicates
-from goldfive.types import DriftKind, DriftSeverity, Plan, Session, Task, TaskStatus
+from goldfive.types import (
+    DriftKind,
+    DriftSeverity,
+    Plan,
+    Session,
+    Task,
+    TaskStatus,
+    channel_processor_active,
+    set_session_plan,
+)
 
 if TYPE_CHECKING:
     from goldfive.control import ControlChannel
@@ -345,8 +354,13 @@ class SequentialExecutor(Executor):
         False.
         """
         # Pin the plan onto the session so the steerer / reporting handlers
-        # see the same object the executor is iterating.
-        session.plan = plan
+        # see the same object the executor is iterating. goldfive#247:
+        # routed through :func:`set_session_plan` for the
+        # single-writer enforcement; the initial pin is a legitimate
+        # channel-processor write so we wrap in
+        # :func:`channel_processor_active`.
+        with channel_processor_active():
+            set_session_plan(session, plan)
 
         # Wire sinks + planner into the steerer so reporting-tool handlers
         # can emit events and trigger planner.refine on drift.

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -21,6 +21,7 @@ is logged and becomes ``None``.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 import re
@@ -41,6 +42,8 @@ from goldfive.types import (
     Task,
     TaskEdge,
     TaskStatus,
+    bump_revision,
+    replace_task,
 )
 
 # Task statuses that are "done" from a steering perspective — they are
@@ -713,8 +716,8 @@ _REPLACE_ELIGIBLE_OLD_STATUSES: frozenset[TaskStatus] = frozenset(
 )
 
 
-def _normalize_supersession_kinds(revised: Plan, *, prior: Plan | None) -> None:
-    """In-place coerce ``supersedes_kind`` on every task in ``revised``.
+def _normalize_supersession_kinds(revised: Plan, *, prior: Plan | None) -> Plan:
+    """Return a Plan with ``supersedes_kind`` normalised on every task.
 
     goldfive#251 Option B validator. Rules, in order:
 
@@ -742,77 +745,93 @@ def _normalize_supersession_kinds(revised: Plan, *, prior: Plan | None) -> None:
 
     The coercion honours Option B's contract: the LLM's semantic signal
     is preserved when it aligns with status; when it disagrees, old-
-    task status is ground truth. Writes proceed in place so callers can
-    pass the revised plan straight through to ``validate``.
+    task status is ground truth.
+
+    goldfive#247: returns a NEW :class:`Plan` (Plan is frozen). When no
+    coercion is needed the input is returned unchanged so callers can
+    keep their reference.
     """
     prior_by_id: dict[str, Task] = (
         {t.id: t for t in getattr(prior, "tasks", ()) or () if t.id} if prior is not None else {}
     )
     revised_by_id: dict[str, Task] = {t.id: t for t in revised.tasks if t.id}
+    new_tasks: list[Task] = []
+    changed = False
     for task in revised.tasks:
+        new_supersedes = task.supersedes
+        new_supersedes_kind = task.supersedes_kind
         sup_id = (task.supersedes or "").strip()
-        # Rule 0 (goldfive#213): a task can never supersede itself. The
-        # v27 rev-2 anomaly was the LLM emitting ``supersedes == self.id``
-        # on an id-reused task (a structural impossibility — a task
-        # is not its own predecessor). Strip the link and fall through
-        # so Rule 1's empty-target handling clears any kind.
+        # Rule 0 (goldfive#213): a task can never supersede itself.
         if sup_id and task.id and sup_id == task.id:
             log.warning(
                 "planner: task %r has supersedes pointing at itself; "
                 "clearing self-reference (a task cannot supersede itself)",
                 task.id,
             )
-            task.supersedes = ""
+            new_supersedes = ""
             sup_id = ""
         if not sup_id:
             # Rule 1: dangling kind with no target.
-            if task.supersedes_kind is not SupersessionKind.UNSPECIFIED:
+            if new_supersedes_kind is not SupersessionKind.UNSPECIFIED:
                 log.warning(
                     "planner: task %r has supersedes_kind=%s without a "
                     "supersedes target; clearing to UNSPECIFIED",
                     task.id,
-                    task.supersedes_kind.value,
+                    new_supersedes_kind.value,
                 )
-                task.supersedes_kind = SupersessionKind.UNSPECIFIED
-            continue
-        old = prior_by_id.get(sup_id) or revised_by_id.get(sup_id)
-        if old is None:
-            # Rule 2: unresolved target — clear the kind; the plan's
-            # structural validator (step 3) will reject the dangling
-            # edge separately.
-            if task.supersedes_kind is not SupersessionKind.UNSPECIFIED:
-                log.warning(
-                    "planner: task %r supersedes %r which is not in the plan; "
-                    "clearing supersedes_kind from %s to UNSPECIFIED",
-                    task.id,
-                    sup_id,
-                    task.supersedes_kind.value,
-                )
-                task.supersedes_kind = SupersessionKind.UNSPECIFIED
-            continue
-        # Rule 3: resolve based on old-task status.
-        if old.status is TaskStatus.COMPLETED:
-            expected = SupersessionKind.CORRECT
-        elif old.status in _REPLACE_ELIGIBLE_OLD_STATUSES:
-            expected = SupersessionKind.REPLACE
+                new_supersedes_kind = SupersessionKind.UNSPECIFIED
         else:
-            # Defensive: any unknown / future status falls through to
-            # REPLACE (the pre-#251 behaviour), which preserves the old
-            # topology rewrite path.
-            expected = SupersessionKind.REPLACE
-        if task.supersedes_kind is SupersessionKind.UNSPECIFIED:
-            task.supersedes_kind = expected
-        elif task.supersedes_kind is not expected:
-            log.warning(
-                "planner: task %r supersedes %r (status=%s) with kind=%s; "
-                "coercing to %s based on old-task status (Option B)",
-                task.id,
-                sup_id,
-                old.status.value,
-                task.supersedes_kind.value,
-                expected.value,
+            old = prior_by_id.get(sup_id) or revised_by_id.get(sup_id)
+            if old is None:
+                # Rule 2: unresolved target — clear the kind; the plan's
+                # structural validator (step 3) will reject the dangling
+                # edge separately.
+                if new_supersedes_kind is not SupersessionKind.UNSPECIFIED:
+                    log.warning(
+                        "planner: task %r supersedes %r which is not in the plan; "
+                        "clearing supersedes_kind from %s to UNSPECIFIED",
+                        task.id,
+                        sup_id,
+                        new_supersedes_kind.value,
+                    )
+                    new_supersedes_kind = SupersessionKind.UNSPECIFIED
+            else:
+                # Rule 3: resolve based on old-task status.
+                if old.status is TaskStatus.COMPLETED:
+                    expected = SupersessionKind.CORRECT
+                elif old.status in _REPLACE_ELIGIBLE_OLD_STATUSES:
+                    expected = SupersessionKind.REPLACE
+                else:
+                    # Defensive: any unknown / future status falls through
+                    # to REPLACE (pre-#251 behaviour).
+                    expected = SupersessionKind.REPLACE
+                if new_supersedes_kind is SupersessionKind.UNSPECIFIED:
+                    new_supersedes_kind = expected
+                elif new_supersedes_kind is not expected:
+                    log.warning(
+                        "planner: task %r supersedes %r (status=%s) with kind=%s; "
+                        "coercing to %s based on old-task status (Option B)",
+                        task.id,
+                        sup_id,
+                        old.status.value,
+                        new_supersedes_kind.value,
+                        expected.value,
+                    )
+                    new_supersedes_kind = expected
+        if new_supersedes != task.supersedes or new_supersedes_kind != task.supersedes_kind:
+            changed = True
+            new_tasks.append(
+                dataclasses.replace(
+                    task,
+                    supersedes=new_supersedes,
+                    supersedes_kind=new_supersedes_kind,
+                )
             )
-            task.supersedes_kind = expected
+        else:
+            new_tasks.append(task)
+    if not changed:
+        return revised
+    return dataclasses.replace(revised, tasks=tuple(new_tasks))
 
 
 #: Statuses that warrant a retry/replace — i.e. the old task did NOT
@@ -881,8 +900,8 @@ def _candidate_predecessor_id(task_id: str) -> str:
     return ""
 
 
-def _backfill_retry_supersedes(revised: Plan, *, prior: Plan) -> None:
-    """In-place backfill ``Task.supersedes`` for retry-named tasks.
+def _backfill_retry_supersedes(revised: Plan, *, prior: Plan) -> Plan:
+    """Backfill ``Task.supersedes`` for retry-named tasks.
 
     Goldfive#213 — when a planner LLM emits a retry-shaped task name
     (``retry_t0``, ``t0_v2``) but forgets to populate the structural
@@ -916,29 +935,48 @@ def _backfill_retry_supersedes(revised: Plan, *, prior: Plan) -> None:
     :func:`_normalize_supersession_kinds` to derive the right
     ``supersedes_kind`` from old-task status — backfill ONLY sets the
     target id; the kind is still status-driven.
+
+    goldfive#247: returns a NEW :class:`Plan` (Plan is frozen). When
+    no backfill is needed the input is returned unchanged.
     """
     if prior is None:
-        return
+        return revised
     prior_by_id: dict[str, Task] = {t.id: t for t in prior.tasks if t.id}
+    new_tasks: list[Task] = []
+    changed = False
     for task in revised.tasks:
         if not task.id:
+            new_tasks.append(task)
             continue
         sup = (task.supersedes or "").strip()
         # Self-reference cleanup runs unconditionally (defence in
-        # depth before normalize_supersession_kinds also runs).
-        if sup and sup == task.id:
-            task.supersedes = ""
+        # depth before normalize_supersession_kinds also runs). Pre-#247
+        # this was an in-place clear that fell through to the candidate
+        # backfill; we mirror the same logic by clearing ``sup`` and
+        # tracking that the task already changed (so the final emit
+        # always uses the cleaned variant rather than the raw input).
+        cleared_self_ref = bool(sup and sup == task.id)
+        if cleared_self_ref:
             sup = ""
         if sup:
             # LLM intent wins: never override an explicit link.
+            new_tasks.append(task)
             continue
         candidate = _candidate_predecessor_id(task.id)
         if not candidate or candidate == task.id:
+            if cleared_self_ref:
+                new_tasks.append(dataclasses.replace(task, supersedes=""))
+                changed = True
+            else:
+                new_tasks.append(task)
             continue
         old = prior_by_id.get(candidate)
-        if old is None:
-            continue
-        if old.status not in _RETRY_WARRANTING_OLD_STATUSES:
+        if old is None or old.status not in _RETRY_WARRANTING_OLD_STATUSES:
+            if cleared_self_ref:
+                new_tasks.append(dataclasses.replace(task, supersedes=""))
+                changed = True
+            else:
+                new_tasks.append(task)
             continue
         log.debug(
             "planner: backfilling supersedes %r → %r on %r (prior status %s)",
@@ -947,7 +985,11 @@ def _backfill_retry_supersedes(revised: Plan, *, prior: Plan) -> None:
             task.id,
             old.status.value,
         )
-        task.supersedes = candidate
+        new_tasks.append(dataclasses.replace(task, supersedes=candidate))
+        changed = True
+    if not changed:
+        return revised
+    return dataclasses.replace(revised, tasks=tuple(new_tasks))
 
 
 #: Old-task statuses that don't require a supersedes link when dropped.
@@ -2450,14 +2492,18 @@ class LLMPlanner:
             # ``_normalize_supersession_kinds`` so the kind coercion
             # sees the backfilled link.
             if prior_plan is not None:
-                _backfill_retry_supersedes(revised, prior=prior_plan)
+                # goldfive#247: returns a NEW Plan; rebind so subsequent
+                # validator + normalize sees the backfilled tasks.
+                revised = _backfill_retry_supersedes(revised, prior=prior_plan)
             # goldfive#251: Option B validator -- coerce supersedes_kind
             # on every task based on old-task status. Runs before
             # ``revised.validate`` so the structural validator sees
-            # self-consistent kinds. In-place; warnings only, never
-            # rejects (Option B is about making the LLM's intent
-            # survive rather than blocking a structurally-valid plan).
-            _normalize_supersession_kinds(revised, prior=prior_plan)
+            # self-consistent kinds. Warnings only, never rejects
+            # (Option B is about making the LLM's intent survive rather
+            # than blocking a structurally-valid plan). goldfive#247:
+            # returns a NEW Plan; rebind so the validator sees the
+            # coerced kinds.
+            revised = _normalize_supersession_kinds(revised, prior=prior_plan)
             try:
                 revised.validate(for_revision=True, prior=prior_plan)
             except ValueError as exc:
@@ -2982,11 +3028,15 @@ class LLMPlanner:
                 await self._emit_refine_validation_failed(plan, drift, last_error)
             return None
         # Stamp revision metadata so downstream sinks can render it.
-        revised.revision_reason = drift.detail
-        revised.revision_kind = str(drift.kind)
-        revised.revision_severity = str(drift.severity)
-        revised.revision_index = plan.revision_index + 1
-        return revised
+        # goldfive#247: Plan is frozen — derive a new instance with the
+        # stamped metadata via :func:`bump_revision`.
+        return bump_revision(
+            revised,
+            revision_index=plan.revision_index + 1,
+            revision_reason=drift.detail,
+            revision_kind=str(drift.kind),
+            revision_severity=str(drift.severity),
+        )
 
     def _build_looping_tool_call_prompt(
         self,
@@ -3100,32 +3150,41 @@ class LLMPlanner:
 
             The protocol contract is that the looper cannot survive its
             own drift, so even if the LLM forgot we force the status.
+
+            goldfive#247: Plan + Task are frozen — produce a NEW plan
+            with the looper transitioned via :func:`replace_task` (or,
+            when the looper was missing, prepended via dataclass
+            replace + tuple concat).
             """
             if not loop_id:
                 return revised
-            for t in revised.tasks:
-                if t.id == loop_id and t.status not in _TERMINAL_STATUSES:
-                    t.status = TaskStatus.FAILED
+            # Step 1: flip the looper if it's still in the plan.
+            existing = next((t for t in revised.tasks if t.id == loop_id), None)
+            if existing is not None and existing.status not in _TERMINAL_STATUSES:
+                revised = replace_task(revised, loop_id, status=TaskStatus.FAILED)
+            # Step 2: prepend a synthetic FAILED looper if the LLM
+            # dropped it and we have a snapshot to re-inject.
             if not any(t.id == loop_id for t in revised.tasks) and looping_task is not None:
-                revised.tasks.insert(
-                    0,
-                    Task(
-                        id=looping_task.id,
-                        title=looping_task.title,
-                        description=looping_task.description,
-                        assignee_agent_id=looping_task.assignee_agent_id,
-                        status=TaskStatus.FAILED,
-                        # goldfive#251: preserve the supersession provenance
-                        # when re-inserting the looping task into the
-                        # revised plan. Dropping these fields here turned a
-                        # CORRECT-kind chain into an orphan, which the
-                        # downstream supersedes-coverage validator would
-                        # then flag as a regression (or, worse, the steerer
-                        # would re-pin to the wrong successor). See the
-                        # paired regression in test_planner.py.
-                        supersedes=looping_task.supersedes,
-                        supersedes_kind=looping_task.supersedes_kind,
-                    ),
+                synthetic = Task(
+                    id=looping_task.id,
+                    title=looping_task.title,
+                    description=looping_task.description,
+                    assignee_agent_id=looping_task.assignee_agent_id,
+                    status=TaskStatus.FAILED,
+                    # goldfive#251: preserve the supersession provenance
+                    # when re-inserting the looping task into the
+                    # revised plan. Dropping these fields here turned a
+                    # CORRECT-kind chain into an orphan, which the
+                    # downstream supersedes-coverage validator would
+                    # then flag as a regression (or, worse, the steerer
+                    # would re-pin to the wrong successor). See the
+                    # paired regression in test_planner.py.
+                    supersedes=looping_task.supersedes,
+                    supersedes_kind=looping_task.supersedes_kind,
+                )
+                revised = dataclasses.replace(
+                    revised,
+                    tasks=(synthetic,) + tuple(revised.tasks),
                 )
             return revised
 
@@ -3156,11 +3215,14 @@ class LLMPlanner:
             if last_error != _EMPTY_RESPONSE_ERROR:
                 await self._emit_refine_validation_failed(plan, drift, last_error)
             return self._fallback_fail_loop_plan(plan, drift, looping_task)
-        revised.revision_reason = drift.detail
-        revised.revision_kind = drift.kind.value
-        revised.revision_severity = str(drift.severity)
-        revised.revision_index = plan.revision_index + 1
-        return revised
+        # goldfive#247: Plan is frozen — stamp via :func:`bump_revision`.
+        return bump_revision(
+            revised,
+            revision_index=plan.revision_index + 1,
+            revision_reason=drift.detail,
+            revision_kind=drift.kind.value,
+            revision_severity=str(drift.severity),
+        )
 
     @staticmethod
     def _fallback_fail_loop_plan(
@@ -3490,8 +3552,9 @@ class LLMPlanner:
         # plan (including completed tasks that were dropped from
         # ``fresh``). This makes the executor's causal-tier
         # replacement detection work even for plans where the LLM
-        # didn't populate ``supersedes``.
-        _backfill_retry_supersedes(fresh, prior=plan)
+        # didn't populate ``supersedes``. goldfive#247: returns a NEW
+        # Plan; rebind so downstream merge sees the backfilled tasks.
+        fresh = _backfill_retry_supersedes(fresh, prior=plan)
 
         # Prepend completed tasks verbatim; drop any new task whose id
         # collides with a completed id so lineage ids stay stable.
@@ -3547,8 +3610,9 @@ class LLMPlanner:
         # against a prior PENDING is coerced to ``REPLACE`` so the
         # executor's pin-redirect runs. Runs AFTER the goldfive#213
         # backfill (above) so the kind is derived against any
-        # freshly-populated retry link.
-        _normalize_supersession_kinds(merged_plan, prior=plan)
+        # freshly-populated retry link. goldfive#247: returns a NEW
+        # Plan; rebind so the validator below sees the coerced kinds.
+        merged_plan = _normalize_supersession_kinds(merged_plan, prior=plan)
         try:
             merged_plan.validate(for_revision=True, prior=plan)
         except ValueError as exc:
@@ -4174,10 +4238,13 @@ SUMMARY POLICY (applies to ``plan.summary``):
         # F5: stamp the pivot flag onto the Plan so the runner's
         # ``_install_revision`` can route to ``install_initial_plan``.
         # Plain attribute on the dataclass instance (Plan is mutable);
-        # the runner reads via ``getattr(plan, "_goldfive_pivot", False)``
+        # the runner reads via ``getattr(plan, "_goldfive_pivot", False)``.
+        # goldfive#247: ``_goldfive_pivot`` is a declared field on the
+        # frozen ``Plan`` dataclass; we derive a new instance with the
+        # flag set rather than dynamically adding the attribute.
         # so older Plans (no flag) trivially route as revisions.
         if replaces_prior:
-            plan._goldfive_pivot = True  # type: ignore[attr-defined]
+            plan = dataclasses.replace(plan, _goldfive_pivot=True)
         return plan
 
 

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -74,6 +74,8 @@ from goldfive.types import (
     Plan,
     Session,
     TaskStatus,
+    channel_processor_active,
+    set_session_plan,
 )
 
 if TYPE_CHECKING:
@@ -637,11 +639,20 @@ class Runner:
         # Conversation-level continuity the original ``_last_plan``
         # field provided.
         prior_plan = convo.prior_plan_for(session.id, pinned=pinned)
-        if prior_plan is not None:
-            prior_plan.run_id = session.run_id
-            session.plan = prior_plan
-        else:
-            session.plan = Plan.empty(run_id=session.run_id)
+        # goldfive#247: Plan is frozen — derive a stamped variant via
+        # ``dataclasses.replace`` rather than mutating in place. The
+        # initial pin onto ``session.plan`` is the run-setup phase of
+        # the channel-processor's mutation lifecycle, so we wrap in
+        # :func:`channel_processor_active` to satisfy the runtime
+        # single-writer check.
+        with channel_processor_active():
+            if prior_plan is not None:
+                set_session_plan(
+                    session,
+                    dataclasses.replace(prior_plan, run_id=session.run_id),
+                )
+            else:
+                set_session_plan(session, Plan.empty(run_id=session.run_id))
         _ostate.set_current_plan(session.state, session.plan)
 
         # 4. Derive (or accept) goals for this turn. Cross-turn state
@@ -1614,9 +1625,11 @@ class Runner:
             log.warning("Runner._install_revision: steerer/adapter bind raised: %s", exc)
             return False
         # Stamp run_id on the revised plan so sink emissions correlate
-        # with this turn.
+        # with this turn. goldfive#247: Plan is frozen — derive a new
+        # instance with the run_id stamped rather than mutating in
+        # place.
         if not revised_plan.run_id:
-            revised_plan.run_id = session.run_id
+            revised_plan = dataclasses.replace(revised_plan, run_id=session.run_id)
         # Branch on first-turn vs pivot vs replan.
         #
         # * First turn — ``session.plan`` is the empty seed (no tasks);

--- a/goldfive/sinks/persistence.py
+++ b/goldfive/sinks/persistence.py
@@ -190,7 +190,13 @@ def reconstruct_session(events: list[Any]) -> Any:
     # which is fine, but keeping the import local matches the lazy proto
     # import above).
     from goldfive.conv import from_pb_goal, from_pb_plan
-    from goldfive.types import Session, TaskStatus
+    from goldfive.types import (
+        Session,
+        TaskStatus,
+        channel_processor_active,
+        set_session_plan,
+        with_task_status,
+    )
 
     session = Session(run_id="")
 
@@ -198,12 +204,19 @@ def reconstruct_session(events: list[Any]) -> Any:
     max_seq = -1
 
     def _update_task_status(task_id: str, status: TaskStatus) -> None:
+        # goldfive#247: Plan + Task are frozen — derive a new Plan via
+        # :func:`with_task_status` and swap it onto the session under
+        # :func:`channel_processor_active`. ``reconstruct_session`` is a
+        # crash-recovery synthetic writer (no live channel processor),
+        # but it IS the sole writer for the duration of replay so the
+        # contextvar is the right scope.
         if session.plan is None or not task_id:
             return
-        for t in session.plan.tasks:
-            if t.id == task_id:
-                t.status = status
-                return
+        # Fast path: skip if no task with this id is in the plan.
+        if not any(t.id == task_id for t in session.plan.tasks):
+            return
+        with channel_processor_active():
+            set_session_plan(session, with_task_status(session.plan, task_id, status))
 
     for evt in events:
         seq = int(getattr(evt, "sequence", 0) or 0)
@@ -222,9 +235,11 @@ def reconstruct_session(events: list[Any]) -> Any:
         elif payload == "goal_derived":
             session.goals = [from_pb_goal(g) for g in evt.goal_derived.goals]
         elif payload == "plan_submitted":
-            session.plan = from_pb_plan(evt.plan_submitted.plan)
+            with channel_processor_active():
+                set_session_plan(session, from_pb_plan(evt.plan_submitted.plan))
         elif payload == "plan_revised":
-            session.plan = from_pb_plan(evt.plan_revised.plan)
+            with channel_processor_active():
+                set_session_plan(session, from_pb_plan(evt.plan_revised.plan))
         elif payload == "task_started":
             ts = evt.task_started
             session.current_task_id = ts.task_id

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -84,6 +84,11 @@ from goldfive.types import (
     Task,
     TaskEdge,
     TaskStatus,
+    bump_revision,
+    channel_processor_active,
+    replace_edges,
+    set_session_plan,
+    with_task_status,
 )
 
 if TYPE_CHECKING:
@@ -893,7 +898,15 @@ class DefaultSteerer:
         if task.status in _TERMINAL_TASK_STATUSES:
             return
         from_status = task.status
-        task.status = TaskStatus.RUNNING
+        # goldfive#247: Plan + Task are frozen. Mutate by deriving a new
+        # plan via :func:`with_task_status` and swapping the pointer
+        # under :func:`channel_processor_active`. The local ``task``
+        # reference becomes stale; refresh from the live plan so
+        # downstream side-effects see the new status.
+        with channel_processor_active():
+            assert session.plan is not None
+            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.RUNNING))
+        task = self._find_task(session, task_id) or task
         session.current_task_id = task_id
         if detail:
             session.agent_notes[task_id] = detail
@@ -973,7 +986,11 @@ class DefaultSteerer:
         if task.status in _TERMINAL_TASK_STATUSES:
             return
         from_status = task.status
-        task.status = TaskStatus.COMPLETED
+        # goldfive#247: derive a new immutable Plan and swap the pointer.
+        with channel_processor_active():
+            assert session.plan is not None
+            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.COMPLETED))
+        task = self._find_task(session, task_id) or task
         if summary:
             session.completed_results[task_id] = summary
         # goldfive#152: clear current_task_* if we were the active task.
@@ -1040,7 +1057,11 @@ class DefaultSteerer:
         if task.status in _TERMINAL_TASK_STATUSES:
             return
         from_status = task.status
-        task.status = TaskStatus.FAILED
+        # goldfive#247: derive a new immutable Plan and swap the pointer.
+        with channel_processor_active():
+            assert session.plan is not None
+            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.FAILED))
+        task = self._find_task(session, task_id) or task
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.FAILED)
         # Drop the observed-agent lineage now the task is terminal.
         session.task_lineage.pop(task_id, None)
@@ -1112,7 +1133,11 @@ class DefaultSteerer:
         # BLOCKED is not a terminal status but we still guard against
         # re-blocking a task that's already blocked (idempotent).
         from_status = task.status
-        task.status = TaskStatus.BLOCKED
+        # goldfive#247: derive a new immutable Plan and swap the pointer.
+        with channel_processor_active():
+            assert session.plan is not None
+            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.BLOCKED))
+        task = self._find_task(session, task_id) or task
         if blocker or needed:
             session.agent_notes[task_id] = f"blocked: {blocker}" + (
                 f" (needed: {needed})" if needed else ""
@@ -1167,7 +1192,11 @@ class DefaultSteerer:
             # TaskCancelled events for downstream tasks on every call.
             return
         from_status = task.status
-        task.status = TaskStatus.CANCELLED
+        # goldfive#247: derive a new immutable Plan and swap the pointer.
+        with channel_processor_active():
+            assert session.plan is not None
+            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.CANCELLED))
+        task = self._find_task(session, task_id) or task
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.CANCELLED)
         # Drop the observed-agent lineage now the task is terminal.
         session.task_lineage.pop(task_id, None)
@@ -1217,7 +1246,14 @@ class DefaultSteerer:
         if task.status in _TERMINAL_TASK_STATUSES:
             return
         from_status = task.status
-        task.status = TaskStatus.NOT_NEEDED
+        # goldfive#247: derive a new immutable Plan and swap the pointer.
+        assert session.plan is not None
+        with channel_processor_active():
+            set_session_plan(
+                session,
+                with_task_status(session.plan, task_id, TaskStatus.NOT_NEEDED),
+            )
+        task = self._find_task(session, task_id) or task
         _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.NOT_NEEDED)
         # Drop the observed-agent lineage now the task is terminal.
         session.task_lineage.pop(task_id, None)
@@ -1309,21 +1345,36 @@ class DefaultSteerer:
                 # completion; cascading past it would mean cancelling
                 # tasks whose preserved prerequisite is still valid.
                 continue
-            # Transition in place and emit. We deliberately do NOT
-            # recurse through ``mark_task_cancelled`` here; we fan out
-            # via our own BFS queue so the surrounding summary log and
-            # emission count stay deterministic.
+            # Transition by deriving a new plan and swapping it in. We
+            # deliberately do NOT recurse through ``mark_task_cancelled``
+            # here; we fan out via our own BFS queue so the surrounding
+            # summary log and emission count stay deterministic.
+            #
+            # goldfive#247: the local ``dep`` reference becomes stale
+            # after the swap (frozen Task) — re-resolve from the live
+            # plan so the emit reads the new status. Note that
+            # ``tasks_by_id`` was built from the *original* plan; the
+            # iteration loop only inspects ``status`` for terminal
+            # gating which is monotonic (a task that wasn't terminal
+            # at loop start is the one we're cancelling).
             dep_from = dep.status
-            dep.status = TaskStatus.CANCELLED
+            assert session.plan is not None
+            with channel_processor_active():
+                set_session_plan(
+                    session,
+                    with_task_status(session.plan, next_id, TaskStatus.CANCELLED),
+                )
             # Drop the observed-agent lineage now the task is terminal —
             # mirrors the cleanup that ``mark_task_cancelled`` performs
             # for the initiator (this BFS does not recurse through that
             # method so the cleanup is duplicated explicitly).
             session.task_lineage.pop(next_id, None)
             await self._emit_task_cancelled(session, next_id, cascade_reason)
+            # Re-fetch so the transition emit reads the swapped task.
+            updated_dep = self._find_task(session, next_id) or dep
             await self._emit_task_transitioned(
                 session,
-                dep,
+                updated_dep,
                 from_status=dep_from,
                 to_status=TaskStatus.CANCELLED,
                 source=source,
@@ -3409,7 +3460,8 @@ class DefaultSteerer:
         # → CANCELLED, coordinator reporting-tool → COMPLETED) should
         # carry that status into the persisted snapshot, even when the
         # LLM's view of the prior plan was stale.
-        self._fold_runtime_terminal_statuses(revised, session.plan)
+        # goldfive#247: fold returns a NEW Plan (Plan is frozen).
+        revised = self._fold_runtime_terminal_statuses(revised, session.plan)
         try:
             revised.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
@@ -3483,7 +3535,8 @@ class DefaultSteerer:
         # revised one; _emit_plan_revised diffs the two to populate the
         # PlanRevisionDiff sidecar (PLAN-LIFECYCLE.md §2, §8 gap #4).
         prev_plan = session.plan
-        self._apply_revision(session, revised, drift)
+        # goldfive#247: _apply_revision returns the stamped instance.
+        revised = self._apply_revision(session, revised, drift)
         # Cancel the in-flight coordinator invocation now that the plan
         # it was reasoning against has been superseded (goldfive#271
         # follow-up — v15 concurrent-invocation bug). Order: cancel
@@ -4859,8 +4912,8 @@ class DefaultSteerer:
             return
         # I4 fix: fold runtime terminal statuses from the prior plan
         # onto the revised plan BEFORE validation (see _handle_drift
-        # for the full rationale).
-        self._fold_runtime_terminal_statuses(revised, session.plan)
+        # for the full rationale). goldfive#247: returns a NEW Plan.
+        revised = self._fold_runtime_terminal_statuses(revised, session.plan)
         try:
             revised.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
@@ -4915,7 +4968,8 @@ class DefaultSteerer:
             return
         await self._record_refine_outcome(session, drift, succeeded=True)
         prev_plan = session.plan
-        self._apply_revision(session, revised, drift)
+        # goldfive#247: rebind to the stamped instance.
+        revised = self._apply_revision(session, revised, drift)
         # Cancel the in-flight coordinator invocation now that
         # ``refine_steer`` produced a superseding plan (goldfive#271
         # follow-up — v15 concurrent-invocation bug). This is the
@@ -5079,7 +5133,9 @@ class DefaultSteerer:
             else:
                 # I4 fix: fold runtime terminal statuses from the prior
                 # plan onto the candidate before validation.
-                self._fold_runtime_terminal_statuses(plan, session.plan)
+                # goldfive#247: returns a NEW Plan; assign so the caller
+                # uses the folded variant downstream.
+                plan = self._fold_runtime_terminal_statuses(plan, session.plan)
                 plan.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
             await self._emit_drift_detected(
@@ -5103,7 +5159,8 @@ class DefaultSteerer:
             authored_by="goldfive",
         )
         prev_plan = session.plan
-        self._apply_revision(session, plan, placeholder)
+        # goldfive#247: rebind to the stamped instance.
+        plan = self._apply_revision(session, plan, placeholder)
         # No cancel-in-flight: nothing is running yet on the very
         # first install.
         await self._emit_plan_revised(
@@ -5279,7 +5336,9 @@ class DefaultSteerer:
             # NOT_NEEDED reaped task that the LLM regressed to PENDING
             # would force the deterministic-minimum fallback even when
             # the LLM's *new* work was otherwise sound.
-            self._fold_runtime_terminal_statuses(llm_revision, prior)
+            # goldfive#247: fold returns a NEW Plan; rebind so the
+            # validator + downstream selection see the folded variant.
+            llm_revision = self._fold_runtime_terminal_statuses(llm_revision, prior)
             try:
                 llm_revision.validate(for_revision=True, prior=prior)
                 chosen = llm_revision
@@ -5312,7 +5371,8 @@ class DefaultSteerer:
         prev_plan = session.plan
         attempt_id = self._new_attempt_id()
         await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
-        self._apply_revision(session, chosen, drift)
+        # goldfive#247: rebind to the stamped instance.
+        chosen = self._apply_revision(session, chosen, drift)
         await self._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
             session,
@@ -5399,9 +5459,9 @@ class DefaultSteerer:
         return Plan(
             id=prior.id,
             run_id=prior.run_id,
-            goal_ids=list(prior.goal_ids),
-            tasks=new_tasks,
-            edges=new_edges,
+            goal_ids=tuple(prior.goal_ids),
+            tasks=tuple(new_tasks),
+            edges=tuple(new_edges),
             summary=prior.summary,
         )
 
@@ -5429,7 +5489,9 @@ class DefaultSteerer:
         # that NEW_WORK_DISCOVERED installs (Runner._install_revision)
         # and USER_STEER ControlMessage installs travel through, which
         # is where the v24 phantom-state regression was observed.
-        self._fold_runtime_terminal_statuses(revised_plan, session.plan)
+        # goldfive#247: returns a NEW Plan; rebind so validation +
+        # _apply_revision below see the folded variant.
+        revised_plan = self._fold_runtime_terminal_statuses(revised_plan, session.plan)
         try:
             revised_plan.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
@@ -5465,7 +5527,8 @@ class DefaultSteerer:
         prev_plan = session.plan
         attempt_id = self._new_attempt_id()
         await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
-        self._apply_revision(session, revised_plan, drift)
+        # goldfive#247: rebind to the stamped instance.
+        revised_plan = self._apply_revision(session, revised_plan, drift)
         await self._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
             session,
@@ -6003,7 +6066,7 @@ class DefaultSteerer:
             )
 
     @staticmethod
-    def _fold_runtime_terminal_statuses(revised: Plan, prior: Plan | None) -> list[str]:
+    def _fold_runtime_terminal_statuses(revised: Plan, prior: Plan | None) -> Plan:
         """Fold runtime terminal statuses from ``prior`` onto ``revised``.
 
         The persistence-boundary fix for the I4 phantom-state class of
@@ -6012,7 +6075,7 @@ class DefaultSteerer:
         between revisions — the overlay-reaper's NOT_NEEDED reap, the
         SequentialExecutor's reachability-audit cancels, an explicit
         ``mark_task_*`` call from a coordinator's reporting-tool — all
-        mutate ``session.plan.tasks[*].status`` in place but the next
+        flip the live plan's task status, but the next
         ``planner.refine`` / ``planner.handle_turn`` invocation builds
         its candidate plan from the LLM's view, which may have lost or
         regressed those terminal statuses.
@@ -6029,8 +6092,10 @@ class DefaultSteerer:
           genuine regression we must NOT silently rewrite — leave it
           alone so the validator catches it.
 
-        Mutates ``revised`` in place. Returns the list of folded task
-        ids for log/test introspection.
+        Returns a NEW :class:`Plan` (goldfive#247: Plan is frozen). When
+        no folds are needed the input is returned unchanged so callers
+        can share the reference. The fold list is logged at INFO when
+        non-empty for downstream observability.
 
         Anti-pattern note: this is **not** a validator relaxation. The
         validator (``Plan.validate(for_revision=True, prior=...)``)
@@ -6042,46 +6107,63 @@ class DefaultSteerer:
         prompt was authored."
         """
         if prior is None or not getattr(prior, "tasks", None):
-            return []
+            return revised
         prior_terminal: dict[str, Task] = {
             t.id: t
             for t in prior.tasks
             if t.id and t.status in TERMINAL_TASK_STATUSES
         }
         if not prior_terminal:
-            return []
+            return revised
+        new_tasks: list[Task] = []
         folded: list[str] = []
         for t in revised.tasks:
             prior_t = prior_terminal.get(t.id)
             if prior_t is None:
+                new_tasks.append(t)
                 continue
             if t.status is prior_t.status:
+                new_tasks.append(t)
                 continue
             if t.status in TERMINAL_TASK_STATUSES:
                 # Different terminal in the revised plan — a genuine
                 # regression. Do not silently rewrite; let the
                 # validator surface it as SCHEMA_VIOLATION.
+                new_tasks.append(t)
                 continue
             # Non-terminal in revised, terminal in prior → fold.
-            t.status = prior_t.status
-            if not t.cancel_reason and prior_t.cancel_reason:
-                t.cancel_reason = prior_t.cancel_reason
-            folded.append(t.id)
-        if folded:
-            log.info(
-                "DefaultSteerer._fold_runtime_terminal_statuses: "
-                "folded %d task(s) from prior runtime state: %s",
-                len(folded),
-                ", ".join(folded),
+            replacement = dataclasses.replace(
+                t,
+                status=prior_t.status,
+                cancel_reason=t.cancel_reason or prior_t.cancel_reason,
             )
-        return folded
+            new_tasks.append(replacement)
+            folded.append(t.id)
+        if not folded:
+            return revised
+        log.info(
+            "DefaultSteerer._fold_runtime_terminal_statuses: "
+            "folded %d task(s) from prior runtime state: %s",
+            len(folded),
+            ", ".join(folded),
+        )
+        return dataclasses.replace(revised, tasks=tuple(new_tasks))
 
     @staticmethod
-    def _apply_revision(session: Session, revised: Plan, drift: DriftEvent) -> None:
+    def _apply_revision(session: Session, revised: Plan, drift: DriftEvent) -> Plan:
         """Stamp revision metadata and install ``revised`` on the session.
 
         Preserves the existing ``revision_index`` monotonicity: the new
         plan's index is at least ``old.revision_index + 1``.
+
+        goldfive#247: returns the post-stamp Plan that was actually
+        installed onto :attr:`Session.plan`. Pre-#247 the function
+        mutated ``revised`` in place AND ``session.plan = revised``, so
+        callers who reused their local ``revised`` reference saw the
+        stamped metadata. With frozen Plan, the stamp produces a NEW
+        instance; the helper returns it so callers can rebind their
+        local variable and pass the same instance to
+        :meth:`_emit_plan_revised`.
 
         Phase 2.X / goldfive#271 Gap 2: log the install at INFO so the
         prior_plan_id → revised_plan_id transition is grep-able in the
@@ -6100,26 +6182,19 @@ class DefaultSteerer:
         prev = session.plan
         # I4 fix (defensive): fold runtime terminal statuses even if the
         # caller already did. Idempotent — if every task's status
-        # already matches prior's terminal, this is a no-op.
-        DefaultSteerer._fold_runtime_terminal_statuses(revised, prev)
+        # already matches prior's terminal, this is a no-op. Returns a
+        # NEW Plan (goldfive#247: Plan is frozen).
+        revised = DefaultSteerer._fold_runtime_terminal_statuses(revised, prev)
         prior_id = (getattr(prev, "id", "") or "") if prev is not None else ""
         next_index = (prev.revision_index + 1) if prev is not None else 1
-        if revised.revision_index < next_index:
-            revised.revision_index = next_index
-        if not revised.revision_kind:
-            revised.revision_kind = drift.kind.value
-        if not revised.revision_severity:
-            revised.revision_severity = drift.severity.value
-        if not revised.revision_reason:
-            revised.revision_reason = drift.detail
-        log.info(
-            "DefaultSteerer._apply_revision: prior_plan_id=%s "
-            "revised_plan_id=%s revision_index=%d drift_kind=%s",
-            prior_id[:16] or "<none>",
-            (revised.id or "")[:16] or "<empty>",
-            int(revised.revision_index),
-            drift.kind.value,
-        )
+        # goldfive#247: Plan is frozen — derive a new instance with the
+        # stamped revision metadata via :func:`bump_revision`. Preserves
+        # caller-supplied non-empty values (matches the legacy
+        # "only set if blank" guards).
+        new_index = max(int(revised.revision_index), next_index)
+        new_kind = revised.revision_kind or drift.kind.value
+        new_severity = revised.revision_severity or drift.severity.value
+        new_reason = revised.revision_reason or drift.detail
         # goldfive#199: stamp the trigger_event_id from the drift onto the
         # plan so out-of-band PlanRevised emitters (the SequentialExecutor's
         # plan-swap detector) can thread it through without needing the
@@ -6130,13 +6205,29 @@ class DefaultSteerer:
         # dataclass defaults to a UUID4 ``id``. Preserves any pre-existing
         # stamp (e.g. validator-retry chains that re-use the original
         # attempt's trigger id).
-        if not revised.revision_trigger_event_id:
-            trig_id = DefaultSteerer._drift_annotation_id(drift) or str(
+        new_trigger_id = revised.revision_trigger_event_id
+        if not new_trigger_id:
+            new_trigger_id = DefaultSteerer._drift_annotation_id(drift) or str(
                 getattr(drift, "id", "") or ""
             )
-            if trig_id:
-                revised.revision_trigger_event_id = trig_id
-        session.plan = revised
+        revised = bump_revision(
+            revised,
+            revision_index=new_index,
+            revision_kind=new_kind,
+            revision_severity=new_severity,
+            revision_reason=new_reason,
+            revision_trigger_event_id=new_trigger_id,
+        )
+        log.info(
+            "DefaultSteerer._apply_revision: prior_plan_id=%s "
+            "revised_plan_id=%s revision_index=%d drift_kind=%s",
+            prior_id[:16] or "<none>",
+            (revised.id or "")[:16] or "<empty>",
+            int(revised.revision_index),
+            drift.kind.value,
+        )
+        with channel_processor_active():
+            set_session_plan(session, revised)
         # goldfive#245 follow-up — stamp the per-(kind, target) addressed
         # watermark so the verdict-freshness gate in :meth:`_handle_drift`
         # can drop subsequent same-(kind, target) verdicts observed at
@@ -6150,6 +6241,7 @@ class DefaultSteerer:
         # goldfive#152: refresh the orchestration-state current plan id
         # so downstream reads see the revised id, not the stale one.
         _ostate.set_current_plan(session.state, revised)
+        return revised
 
     # --- Event construction ------------------------------------------
 
@@ -6855,7 +6947,7 @@ class DefaultSteerer:
         return True
 
     @staticmethod
-    def _integrate_correction_supersedes(revised: Plan) -> None:
+    def _integrate_correction_supersedes(revised: Plan) -> Plan:
         """Rewire DAG edges for every ``CORRECT``-kind supersedes link.
 
         goldfive#251 Option B topology. For a new task
@@ -6880,11 +6972,17 @@ class DefaultSteerer:
         downstream edges rewritten to the replacement) was already
         correct and this method does not touch that path.
 
+        goldfive#247: Plan.edges is an immutable tuple of frozen
+        :class:`TaskEdge`. The rewrite builds a fresh edge list and
+        returns a new :class:`Plan` via :func:`replace_edges`. When no
+        rewrite is needed the original is returned unchanged so callers
+        can keep their reference.
+
         Runs BEFORE :meth:`_repin_current_task_on_supersedes` so that
         helper's downstream rewrites see the already-correct DAG.
         """
         if revised is None:
-            return
+            return revised
         tasks_by_id: dict[str, Task] = {t.id: t for t in revised.tasks if t.id}
         corrections: list[tuple[str, str]] = []  # (old_id, new_id)
         for task in revised.tasks:
@@ -6899,46 +6997,45 @@ class DefaultSteerer:
                 continue
             corrections.append((old_id, new_id))
         if not corrections:
-            return
-        # Index existing edges as a set for idempotence checks.
-        existing_edges: set[tuple[str, str]] = {
-            (e.from_task_id, e.to_task_id) for e in revised.edges
-        }
+            return revised
+        # Build a fresh edge list as plain tuples; coerce to TaskEdges
+        # at the end via :func:`replace_edges` (which also handles
+        # dedup-while-preserving-order).
+        edges: list[tuple[str, str]] = [(e.from_task_id, e.to_task_id) for e in revised.edges]
+        existing_edges: set[tuple[str, str]] = set(edges)
         for old_id, new_id in corrections:
             # 1. Ensure old -> new edge exists.
             if (old_id, new_id) not in existing_edges:
-                revised.edges.append(TaskEdge(from_task_id=old_id, to_task_id=new_id))
+                edges.append((old_id, new_id))
                 existing_edges.add((old_id, new_id))
             # 2. Rewrite outgoing edges of the old task to originate
             #    from the new (correction) task. Skip the old -> new
             #    edge we just ensured.
-            for edge in revised.edges:
-                if edge.from_task_id != old_id:
+            for i, edge in enumerate(edges):
+                frm, to = edge
+                if frm != old_id:
                     continue
-                if edge.to_task_id == new_id:
+                if to == new_id:
                     continue
                 # Avoid duplicating an edge that already exists from the
                 # new task to the same downstream.
-                if (new_id, edge.to_task_id) in existing_edges:
-                    # Mark for removal by setting a sentinel; we
-                    # prune the duplicates after the loop.
-                    edge.from_task_id = new_id  # same content as existing; dedup below
+                if (new_id, to) in existing_edges:
+                    # Mark for dedup below; same content as existing.
+                    edges[i] = (new_id, to)
                     continue
-                existing_edges.discard((old_id, edge.to_task_id))
-                edge.from_task_id = new_id
-                existing_edges.add((new_id, edge.to_task_id))
+                existing_edges.discard((old_id, to))
+                edges[i] = (new_id, to)
+                existing_edges.add((new_id, to))
         # Final dedup: rewriting may have produced structurally-duplicate
         # edges. Preserve insertion order while dropping repeats.
         seen: set[tuple[str, str]] = set()
-        deduped: list[TaskEdge] = []
-        for e in revised.edges:
-            key = (e.from_task_id, e.to_task_id)
-            if key in seen:
+        deduped: list[tuple[str, str]] = []
+        for e in edges:
+            if e in seen:
                 continue
-            seen.add(key)
+            seen.add(e)
             deduped.append(e)
-        if len(deduped) != len(revised.edges):
-            revised.edges = deduped
+        return replace_edges(revised, deduped)
 
     def _repin_current_task_on_supersedes(
         self,
@@ -7090,7 +7187,16 @@ class DefaultSteerer:
             # the old task are rewritten so work flows through the
             # correction. No-op for REPLACE-kind (existing behaviour is
             # preserved) and for plans without supersedes.
-            self._integrate_correction_supersedes(revised)
+            # goldfive#247: returns a NEW Plan (Plan is frozen). The
+            # pre-frozen code mutated ``revised`` in place; with frozen
+            # types, we swap the new variant onto ``session.plan`` so
+            # the live pointer matches the rewired DAG that's about to
+            # be emitted as PlanRevised.
+            integrated = self._integrate_correction_supersedes(revised)
+            if integrated is not revised:
+                revised = integrated
+                with channel_processor_active():
+                    set_session_plan(session, revised)
 
             # goldfive#251 Stream D: GC corrections for tasks superseded by
             # this revision BEFORE queuing new ones. A task whose correction

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -2,17 +2,48 @@
 
 Pinned by ``docs/design/PROTOCOLS.md`` (v0.1). Types in this module are
 pure data — mutation of live state happens only through a ``Steerer``.
+
+**Plan and Task immutability (goldfive#247).** :class:`Plan` and
+:class:`Task` are ``frozen=True`` dataclasses. Their list fields
+(``tasks``, ``edges``, ``goal_ids``) are tuples. The bug class this
+fix targets is "torn read": a judge or sink reads ``session.plan`` /
+``task.status``, awaits an LLM, and produces a verdict against a
+snapshot the live state has mutated past. With frozen types, every
+"mutation" constructs a NEW object. ``session.plan`` is a pointer that
+swaps atomically; readers who captured a ``Plan`` reference keep
+operating on that snapshot for the duration of their work.
+
+The ONLY blessed way to "mutate" a plan is via the helper functions in
+this module: :func:`replace_task`, :func:`with_task_status`,
+:func:`add_tasks`, :func:`replace_edges`, :func:`bump_revision`. Each
+returns a new :class:`Plan` and never touches the input.
+
+The single-writer invariant on ``session.plan`` is enforced at runtime
+by :func:`set_session_plan` paired with the
+:data:`_CHANNEL_PROCESSOR_ACTIVE` contextvar (see
+:func:`channel_processor_active`). Channel-processor paths in
+:mod:`goldfive.steerer` enter the contextvar before swapping
+``session.plan``; sites that swap from outside the channel processor
+emit a WARNING (or, under ``GOLDFIVE_STRICT_STATE_OWNERSHIP=1``, raise
+:class:`PlanOwnershipViolation`).
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import contextvars
 import dataclasses
+import logging
+import os
+import sys
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator, Sequence
 from datetime import datetime
 from enum import StrEnum
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 
 class TaskStatus(StrEnum):
@@ -321,8 +352,21 @@ class CancellationRequest:
     drift_kind: str = ""
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Task:
+    """Immutable task record (goldfive#247).
+
+    ``frozen=True`` is structural enforcement of the "no torn read"
+    invariant: a judge or sink that captures a ``Task`` reference
+    cannot have its snapshot mutated underneath it. Every status
+    transition in the framework constructs a NEW :class:`Task` (via
+    ``dataclasses.replace`` or one of the :mod:`goldfive.types`
+    helpers); the live :class:`Plan` is rebuilt with the new task and
+    swapped onto :attr:`Session.plan` atomically. Readers who got an
+    older :class:`Task` keep operating on it; they can compare ids
+    against the live plan if they need to follow the transition.
+    """
+
     id: str
     title: str
     description: str = ""
@@ -368,19 +412,40 @@ class Task:
     supersedes_kind: SupersessionKind = SupersessionKind.UNSPECIFIED
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class TaskEdge:
+    """Immutable directed edge in a :class:`Plan` DAG (goldfive#247)."""
+
     from_task_id: str
     to_task_id: str
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Plan:
+    """Immutable DAG of :class:`Task` vertices (goldfive#247).
+
+    ``frozen=True`` so every "edit" — adding tasks, marking a task
+    completed, replacing the edge set, bumping the revision index —
+    constructs a NEW :class:`Plan`. The live plan reference is held by
+    :attr:`Session.plan`; swap it via :func:`set_session_plan` (which
+    enforces the single-writer invariant via the
+    :data:`_CHANNEL_PROCESSOR_ACTIVE` contextvar). Use the helpers
+    :func:`replace_task`, :func:`with_task_status`, :func:`add_tasks`,
+    :func:`replace_edges`, :func:`bump_revision` to derive a revision
+    without hand-rolling ``dataclasses.replace`` at the call site.
+
+    The list fields ``goal_ids`` / ``tasks`` / ``edges`` are tuples (an
+    invariant of frozen-and-shareable types — a frozen dataclass that
+    holds mutable lists is a footgun). Constructors accept any
+    :class:`Sequence` and coerce to tuples in ``__post_init__`` so
+    legacy call sites that pass lists keep working.
+    """
+
     id: str
     run_id: str
-    goal_ids: list[str]
-    tasks: list[Task]
-    edges: list[TaskEdge]
+    goal_ids: tuple[str, ...]
+    tasks: tuple[Task, ...]
+    edges: tuple[TaskEdge, ...]
     summary: str = ""
     revision_reason: str = ""
     revision_kind: str = ""  # DriftKind value (str) or ""
@@ -401,6 +466,36 @@ class Plan:
     # See goldfive#199 / harmonograf#95 (rescope). Replaces the narrower
     # ``revision_annotation_id`` from #196/#197 which was user-control only.
     revision_trigger_event_id: str = ""
+    #: F5 / goldfive#322 Layer 2 pivot marker. Set by
+    #: :meth:`LLMPlanner.handle_turn` to ``True`` when the turn's
+    #: classification was ``pivot`` so :meth:`Runner._install_revision`
+    #: routes through ``install_initial_plan`` (no Rule 6 binding).
+    #: Pre-#247 this was a dynamically-attached attribute (``plan._goldfive_pivot``);
+    #: with :class:`Plan` ``frozen=True`` (goldfive#247) the slot has
+    #: to be a declared dataclass field. Default ``False`` keeps every
+    #: legacy / non-pivot install path unchanged.
+    _goldfive_pivot: bool = False
+
+    def __post_init__(self) -> None:
+        """Coerce list-typed inputs into tuples (goldfive#247).
+
+        :class:`Plan` stores ``goal_ids`` / ``tasks`` / ``edges`` as
+        tuples to match the frozen-and-shareable contract. Many call
+        sites (tests, the planner's JSON parser, persistence-sink
+        round-trips) construct a Plan with the legacy ``list[...]``
+        shape; coercing here keeps those sites working without
+        forcing every caller to wrap in ``tuple(...)``. Equivalent
+        ``tuple`` inputs are passed through unchanged. Frozen
+        dataclasses cannot use plain attribute assignment; we go
+        through ``object.__setattr__`` per the standard library's
+        documented frozen-dataclass coercion pattern.
+        """
+        if not isinstance(self.goal_ids, tuple):
+            object.__setattr__(self, "goal_ids", tuple(self.goal_ids))
+        if not isinstance(self.tasks, tuple):
+            object.__setattr__(self, "tasks", tuple(self.tasks))
+        if not isinstance(self.edges, tuple):
+            object.__setattr__(self, "edges", tuple(self.edges))
 
     def validate(self, for_revision: bool = False, *, prior: Plan | None = None) -> None:
         """Structurally validate this plan. Raise ``ValueError`` on failure.
@@ -768,9 +863,9 @@ class Plan:
         return cls(
             id=uuid.uuid4().hex,
             run_id=run_id,
-            goal_ids=[],
-            tasks=[],
-            edges=[],
+            goal_ids=(),
+            tasks=(),
+            edges=(),
             summary="",
         )
 
@@ -866,6 +961,218 @@ def task_upstream_ready(plan: Plan, task_id: str) -> bool:
         if upstream.status is not TaskStatus.COMPLETED:
             return False
     return True
+
+
+# ---------------------------------------------------------------------------
+# Plan / Task derivation helpers (goldfive#247)
+# ---------------------------------------------------------------------------
+#
+# :class:`Plan` and :class:`Task` are frozen — every "mutation" produces a
+# new object. The helpers below give framework code a small, named
+# vocabulary for the common derivation patterns so the call sites stay
+# readable. Each returns a new :class:`Plan`; the input is never touched.
+#
+# Helpers DELIBERATELY do not swap the new plan onto a session — that
+# remains the caller's responsibility (via :func:`set_session_plan`,
+# which performs the single-writer enforcement on :attr:`Session.plan`
+# under the :data:`_CHANNEL_PROCESSOR_ACTIVE` contextvar). Separating
+# "build a derived plan" from "install it on the session" preserves
+# the snapshot-vs-pointer split that motivates the freeze in the first
+# place.
+
+
+def replace_task(plan: Plan, task_id: str, **changes: Any) -> Plan:
+    """Return a new :class:`Plan` with ``task_id`` replaced via ``dataclasses.replace``.
+
+    Walks ``plan.tasks``, finds the entry whose id matches ``task_id``,
+    and rebuilds the tasks tuple with that entry replaced by
+    ``dataclasses.replace(task, **changes)``. Other tasks are preserved
+    by reference (they're frozen — sharing is safe). Order is preserved.
+
+    Raises :class:`KeyError` when ``task_id`` is not in the plan; callers
+    that want a no-op semantics should check ``task_id`` first.
+    """
+    new_tasks: list[Task] = []
+    found = False
+    for t in plan.tasks:
+        if t.id == task_id and not found:
+            new_tasks.append(dataclasses.replace(t, **changes))
+            found = True
+        else:
+            new_tasks.append(t)
+    if not found:
+        raise KeyError(f"task_id {task_id!r} not in plan {plan.id!r}")
+    return dataclasses.replace(plan, tasks=tuple(new_tasks))
+
+
+def with_task_status(plan: Plan, task_id: str, status: TaskStatus) -> Plan:
+    """Sugar over :func:`replace_task` for the common status-transition path.
+
+    Returns a new :class:`Plan` with ``task_id``'s status set to
+    ``status``; every other field on the task and on the plan is
+    preserved. The most common derivation in the framework — e.g.
+    :meth:`DefaultSteerer.mark_task_completed` flips PENDING/RUNNING →
+    COMPLETED through this helper.
+    """
+    return replace_task(plan, task_id, status=status)
+
+
+def add_tasks(plan: Plan, new_tasks: Sequence[Task]) -> Plan:
+    """Return a new :class:`Plan` with ``new_tasks`` appended.
+
+    Existing tasks are preserved in their original order; ``new_tasks``
+    is appended after them. No de-duplication is performed — callers are
+    expected to validate id uniqueness via :meth:`Plan.validate` after
+    the merge if their input might collide with the plan's existing ids.
+    """
+    return dataclasses.replace(plan, tasks=tuple(plan.tasks) + tuple(new_tasks))
+
+
+def replace_edges(plan: Plan, edges: Sequence[tuple[str, str] | TaskEdge]) -> Plan:
+    """Return a new :class:`Plan` with the edge list replaced.
+
+    Accepts either :class:`TaskEdge` instances or ``(from_id, to_id)``
+    tuples for caller convenience; both shapes are normalised to
+    :class:`TaskEdge`. Order is preserved.
+    """
+    coerced: list[TaskEdge] = []
+    for e in edges:
+        if isinstance(e, TaskEdge):
+            coerced.append(e)
+        else:
+            frm, to = e  # type: ignore[misc]
+            coerced.append(TaskEdge(from_task_id=frm, to_task_id=to))
+    return dataclasses.replace(plan, edges=tuple(coerced))
+
+
+def bump_revision(
+    plan: Plan,
+    *,
+    revision_index: int | None = None,
+    revision_kind: str | None = None,
+    revision_severity: str | None = None,
+    revision_reason: str | None = None,
+    revision_trigger_event_id: str | None = None,
+) -> Plan:
+    """Return a new :class:`Plan` with revision metadata updated.
+
+    Every parameter except ``plan`` is keyword-only; ``None`` means
+    "leave that field unchanged". When ``revision_index`` is omitted, the
+    helper returns a plan whose ``revision_index`` is the input plan's
+    value plus one. Used by :meth:`DefaultSteerer._apply_revision` to
+    stamp the new plan's revision metadata before installation.
+    """
+    next_index = plan.revision_index + 1 if revision_index is None else revision_index
+    fields: dict[str, Any] = {"revision_index": next_index}
+    if revision_kind is not None:
+        fields["revision_kind"] = revision_kind
+    if revision_severity is not None:
+        fields["revision_severity"] = revision_severity
+    if revision_reason is not None:
+        fields["revision_reason"] = revision_reason
+    if revision_trigger_event_id is not None:
+        fields["revision_trigger_event_id"] = revision_trigger_event_id
+    return dataclasses.replace(plan, **fields)
+
+
+# ---------------------------------------------------------------------------
+# Single-writer enforcement on Session.plan (goldfive#247)
+# ---------------------------------------------------------------------------
+
+
+class PlanOwnershipViolation(RuntimeError):
+    """A ``Session.plan`` swap fired outside the channel-processor.
+
+    Raised by :func:`set_session_plan` only when
+    ``GOLDFIVE_STRICT_STATE_OWNERSHIP=1``. In production the same
+    condition logs a WARNING and proceeds — the runtime stays
+    defensive. The strict mode is a developer / CI tripwire.
+    """
+
+
+_CHANNEL_PROCESSOR_ACTIVE: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "goldfive_channel_processor_active",
+    default=False,
+)
+
+
+@contextlib.contextmanager
+def channel_processor_active() -> Iterator[None]:
+    """Mark a region as the channel-processor's exclusive plan-writer scope.
+
+    The single writer onto :attr:`Session.plan` is the steerer's
+    channel processor (:meth:`DefaultSteerer._invoke_passthrough_with_control`,
+    :meth:`DefaultSteerer._handle_drift`, :meth:`DefaultSteerer._apply_revision`,
+    and the executor install paths they delegate to). Any
+    :func:`set_session_plan` swap originating outside this region is a
+    structural smell — it means a sink, judge, or out-of-band caller
+    has reached past the channel processor into the steady-state plan.
+
+    Implemented via a :class:`contextvars.ContextVar` so concurrent
+    Sessions (parallel sub-Runners) each maintain an independent flag
+    without cross-talk. The value is set to ``True`` on entry and
+    reset on exit — exception-safe via the contextlib decorator.
+
+    Tests can drive this context manually to simulate the
+    channel-processor envelope around a synthesised plan swap.
+    """
+    token = _CHANNEL_PROCESSOR_ACTIVE.set(True)
+    try:
+        yield
+    finally:
+        _CHANNEL_PROCESSOR_ACTIVE.reset(token)
+
+
+def _strict_state_ownership_enabled() -> bool:
+    """Return whether ``GOLDFIVE_STRICT_STATE_OWNERSHIP`` is on.
+
+    Mirrors the resolution in :mod:`goldfive._state_audit`: explicit
+    1/0 wins; otherwise default-on under pytest, default-off in
+    production. We intentionally don't ``import _state_audit`` here to
+    avoid a typing-time circular import (state-audit imports
+    Session). The duplication is a few lines and bracketed by a unit
+    test in ``tests/test_immutable_plan.py``.
+    """
+    raw = os.environ.get("GOLDFIVE_STRICT_STATE_OWNERSHIP", "").strip().lower()
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return "pytest" in sys.modules
+
+
+def set_session_plan(session: Session, plan: Plan | None) -> None:
+    """Atomically swap ``session.plan`` to ``plan``, with single-writer guard.
+
+    The blessed mutation primitive for :attr:`Session.plan`. Performs
+    the runtime channel-processor check from goldfive#247 step 5: when
+    :data:`_CHANNEL_PROCESSOR_ACTIVE` is ``False`` (i.e. we're outside
+    the steerer's mutation region), log a WARNING with a one-line
+    stack hint. Under ``GOLDFIVE_STRICT_STATE_OWNERSHIP=1`` the same
+    condition raises :class:`PlanOwnershipViolation` so CI / dev
+    environments fail fast on the architectural violation.
+
+    The check is intentionally a runtime smell-test, not a type-system
+    guarantee — the type system already prevents `task.status = X`
+    style mutations via the ``frozen=True`` dataclass. This helper
+    catches the remaining axis: who owns the *pointer* swap. Callers
+    inside the steerer / executor channel-processor paths wrap their
+    region in :func:`channel_processor_active`; sinks and judges are
+    expected to read ``session.plan`` and never write to it.
+    """
+    if not _CHANNEL_PROCESSOR_ACTIVE.get(False):
+        if _strict_state_ownership_enabled():
+            raise PlanOwnershipViolation(
+                "set_session_plan called outside channel_processor_active(). "
+                "Plan swaps are owned exclusively by the steerer's channel "
+                "processor (see docs/design/PLAN-LIFECYCLE.md §7)."
+            )
+        log.warning(
+            "set_session_plan called outside channel_processor_active(); "
+            "the channel-processor is the single owner of session.plan swaps "
+            "(goldfive#247). Caller should wrap mutation in channel_processor_active()."
+        )
+    session.plan = plan
 
 
 #: Conventional value for :attr:`Goal.source` indicating a goal was added

--- a/tests/_immutable_plan_helpers.py
+++ b/tests/_immutable_plan_helpers.py
@@ -1,0 +1,83 @@
+"""Shared test helpers for migrating to the goldfive#247 frozen-Plan world.
+
+Tests built before the freeze used the in-place mutation idioms:
+
+* ``session.plan.tasks[i].status = TaskStatus.X``
+* ``session.plan.tasks.append(Task(...))``
+* ``session.plan.edges.append(TaskEdge(...))``
+
+Under :class:`goldfive.types.Plan` ``frozen=True`` those raise
+:class:`dataclasses.FrozenInstanceError`. The helpers below give tests
+a one-call equivalent that derives a new :class:`Plan` and swaps it
+onto the session inside :func:`channel_processor_active`, satisfying
+the runtime single-writer check.
+
+Use these helpers rather than re-importing the underlying primitives
+in every test — keeps the migration churn small and consistent.
+"""
+
+from __future__ import annotations
+
+from goldfive.types import (
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+    add_tasks,
+    channel_processor_active,
+    replace_edges,
+    replace_task,
+    set_session_plan,
+    with_task_status,
+)
+
+
+def force_task_status(session: Session, task_id: str, status: TaskStatus) -> None:
+    """Synchronously force ``task_id``'s status on ``session.plan``.
+
+    Test-only equivalent of the pre-#247 ``task.status = X`` setup
+    pattern. Wraps the swap in :func:`channel_processor_active` so
+    the runtime single-writer check (which fires on every
+    :func:`set_session_plan` call) treats this as a legitimate
+    channel-processor write — tests are the sole writer here.
+    """
+    assert session.plan is not None
+    with channel_processor_active():
+        set_session_plan(session, with_task_status(session.plan, task_id, status))
+
+
+def force_task_replace(session: Session, task_id: str, **changes: object) -> None:
+    """Replace ``task_id``'s fields with ``changes`` (e.g. ``status=...``,
+    ``cancel_reason=...``). See :func:`force_task_status` for rationale.
+    """
+    assert session.plan is not None
+    with channel_processor_active():
+        set_session_plan(session, replace_task(session.plan, task_id, **changes))
+
+
+def append_tasks(session: Session, tasks: list[Task]) -> None:
+    """Append ``tasks`` onto ``session.plan.tasks``."""
+    assert session.plan is not None
+    with channel_processor_active():
+        set_session_plan(session, add_tasks(session.plan, tasks))
+
+
+def append_edge(session: Session, frm: str, to: str) -> None:
+    """Append a single edge onto ``session.plan.edges``."""
+    assert session.plan is not None
+    new_edges = list(session.plan.edges) + [TaskEdge(from_task_id=frm, to_task_id=to)]
+    with channel_processor_active():
+        set_session_plan(session, replace_edges(session.plan, new_edges))
+
+
+def force_plan(session: Session, plan: Plan | None) -> None:
+    """Swap ``session.plan`` to ``plan`` under the channel processor.
+
+    Test-only — production code paths route through the steerer's
+    :meth:`_apply_revision`. Tests sometimes need to install a
+    pre-built plan directly (no steerer hooked up); this is the
+    one-call form.
+    """
+    with channel_processor_active():
+        set_session_plan(session, plan)

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -980,7 +980,10 @@ async def test_invoke_breaks_when_task_reported_terminal_mid_stream() -> None:
                 observed.append(i)
                 if i == 2:
                     # Simulate a reporting-tool handler marking the task terminal.
-                    session.plan.tasks[0].status = TaskStatus.FAILED
+                    # goldfive#247: Plan + Task are frozen — derive via helper.
+                    from tests._immutable_plan_helpers import force_task_status
+
+                    force_task_status(session, session.plan.tasks[0].id, TaskStatus.FAILED)
                 yield _Event(marker=i)
 
     task = Task(id="t1", title="do the thing")
@@ -1812,12 +1815,23 @@ async def test_reporting_tool_duplicate_returns_idempotent_ack(state_ctx_cls) ->
 
         async def mark_task_running(self, task_id: str, *, session: Any, **kwargs: Any) -> None:
             self.running_calls += 1
-            task = next(
-                (t for t in session.plan.tasks if t.id == task_id),
-                None,
+            # goldfive#247: Plan + Task are frozen — derive a new plan
+            # via with_task_status. This stub mimics what the real
+            # DefaultSteerer.mark_task_running does.
+            from goldfive.types import (
+                channel_processor_active,
+                set_session_plan,
+                with_task_status,
             )
-            if task is not None:
-                task.status = TaskStatus.RUNNING
+            if session.plan is None:
+                return
+            if not any(t.id == task_id for t in session.plan.tasks):
+                return
+            with channel_processor_active():
+                set_session_plan(
+                    session,
+                    with_task_status(session.plan, task_id, TaskStatus.RUNNING),
+                )
 
     spec = next(t for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_started")
 

--- a/tests/test_callable_adapter.py
+++ b/tests/test_callable_adapter.py
@@ -48,11 +48,20 @@ class _StubSteerer:
     ) -> None:
         self.transitions.append((task_id, to, detail))
         # Mirror real steerer behaviour: update session state.
+        # goldfive#247: Plan + Task are frozen — derive a new Plan via
+        # with_task_status and swap onto the session.
         session.current_task_id = task_id
-        if session.plan is not None:
-            for t in session.plan.tasks:
-                if t.id == task_id:
-                    t.status = to
+        if session.plan is None:
+            return
+        if not any(t.id == task_id for t in session.plan.tasks):
+            return
+        from goldfive.types import (
+            channel_processor_active,
+            set_session_plan,
+            with_task_status,
+        )
+        with channel_processor_active():
+            set_session_plan(session, with_task_status(session.plan, task_id, to))
 
     # Unused in these tests but kept so the stub is Steerer-shaped.
     async def observe(self, event: Any, session: Session) -> None:  # pragma: no cover
@@ -232,7 +241,12 @@ async def test_tool_routing_drives_session_transitions() -> None:
 
     assert result.task_id == "t1"
     assert result.text == "done deal"
-    assert task.status == TaskStatus.COMPLETED
+    # goldfive#247: Task is frozen — the local ``task`` reference is
+    # the pre-mutation snapshot. The live status sits on the post-swap
+    # plan in session.plan.
+    assert session.plan is not None
+    live_task = next(t for t in session.plan.tasks if t.id == task.id)
+    assert live_task.status == TaskStatus.COMPLETED
     assert session.completed_results == {"t1": "done deal"}
     assert steerer.transitions == [
         ("t1", TaskStatus.RUNNING, "kicking off"),

--- a/tests/test_cancel_inflight_on_refine.py
+++ b/tests/test_cancel_inflight_on_refine.py
@@ -568,4 +568,5 @@ async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> Non
     assert cancelled.is_set()
     # Plan was actually revised — the cancel did not preempt the
     # PlanRevised emit (the deferral contract is upheld).
-    assert session.plan is revised
+    # goldfive#247: identity check replaced with id check (Plan is frozen)
+    assert session.plan is not None and session.plan.id == revised.id

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -36,6 +36,7 @@ from goldfive import (
     StaticPlanner,
     Task,
     TaskEdge,
+    TaskStatus,
     TurnRecord,
 )
 from goldfive.conversation import Conversation as _ConversationClass  # noqa: F401
@@ -132,9 +133,12 @@ def test_conversation_absorb_turn_merges_goals_and_results() -> None:
     # Turn adds a new goal and one completed result.
     session.goals.append(Goal(id="g2", summary="second"))
     session.completed_results["task1"] = "researched"
-    session.plan = _linear_plan()
+    # goldfive#247: Plan is frozen — install via helper.
+    from tests._immutable_plan_helpers import force_plan, force_task_status
+
+    force_plan(session, _linear_plan())
     # Mark one task completed so the record reflects it.
-    session.plan.tasks[0].status = session.plan.tasks[0].status.COMPLETED
+    force_task_status(session, session.plan.tasks[0].id, TaskStatus.COMPLETED)
 
     outcome = ExecutionOutcome(success=True, session=session)
     record = conv.absorb_turn(outcome, user_input_summary="write a haiku")

--- a/tests/test_correction_injection.py
+++ b/tests/test_correction_injection.py
@@ -173,7 +173,7 @@ async def _emit(
     steerer: DefaultSteerer, session: Session, revised: Plan, drift: DriftEvent
 ) -> None:
     prev = session.plan
-    steerer._apply_revision(session, revised, drift)
+    revised = steerer._apply_revision(session, revised, drift)  # goldfive#247: rebind
     await steerer._emit_plan_revised(session, revised, drift, prev_plan=prev)
 
 
@@ -378,9 +378,11 @@ async def test_correction_cleared_on_report_task_started() -> None:
 async def test_correction_not_cleared_on_report_task_failed() -> None:
     plan = _revised_with_one_correct()
     # Mark the correction task RUNNING so failed is a legal transition.
-    for t in plan.tasks:
-        if t.id == "research_solar_corrected":
-            t.status = TaskStatus.RUNNING
+    # goldfive#247: Plan + Task are frozen — derive a new plan via
+    # with_task_status.
+    from goldfive.types import with_task_status as _wts
+
+    plan = _wts(plan, "research_solar_corrected", TaskStatus.RUNNING)
     session = _session(plan)
     key = pending_correction_key("research_agent", "research_solar_corrected")
     session.state[key] = {

--- a/tests/test_drift_async_dispatch.py
+++ b/tests/test_drift_async_dispatch.py
@@ -200,9 +200,13 @@ async def test_mark_task_completed_skips_pairing_when_no_assignee() -> None:
     """
     steerer, session, _sink, _planner = _bind(_NullPlanner())
     # Wipe the assignee on the test session's tasks.
+    # goldfive#247: Plan + Task are frozen — derive a new plan with
+    # every task's assignee cleared.
     assert session.plan is not None
-    for t in session.plan.tasks:
-        t.assignee_agent_id = ""
+    from tests._immutable_plan_helpers import force_task_replace
+
+    for t in list(session.plan.tasks):
+        force_task_replace(session, t.id, assignee_agent_id="")
     # Pre-existing started entry from a prior agent's run.
     steerer.note_agent_activity(
         session,
@@ -223,8 +227,11 @@ async def test_mark_task_failed_skips_pairing_when_no_assignee() -> None:
     """Mirror of the completed-path "no assignee" guard."""
     steerer, session, _sink, _planner = _bind(_NullPlanner())
     assert session.plan is not None
-    for t in session.plan.tasks:
-        t.assignee_agent_id = ""
+    # goldfive#247: derive a new plan with every task's assignee cleared.
+    from tests._immutable_plan_helpers import force_task_replace
+
+    for t in list(session.plan.tasks):
+        force_task_replace(session, t.id, assignee_agent_id="")
 
     await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
     await steerer._wait_background_drifts_idle()

--- a/tests/test_drift_version_pin.py
+++ b/tests/test_drift_version_pin.py
@@ -48,6 +48,9 @@ from goldfive.types import (  # noqa: E402
     Session,
     Task,
     TaskStatus,
+    bump_revision,
+    channel_processor_active,
+    set_session_plan,
 )
 
 # ---------------------------------------------------------------------------
@@ -573,8 +576,10 @@ async def test_end_to_end_redundant_drift_emits_but_does_not_refine() -> None:
     # Now a refine for the SAME (kind, target) lands externally —
     # watermark advances to revision 3 BEFORE the detector's drift
     # reaches dispatch. (In production this happens via _apply_revision
-    # stamping; we simulate it here by setting the dict directly.)
-    session.plan.revision_index = 3
+    # stamping; we simulate it here via the channel-processor primitive
+    # since Plan is frozen post-#247.)
+    with channel_processor_active():
+        set_session_plan(session, bump_revision(session.plan, revision_index=3))
     session.last_addressed_revision_by_drift_key[
         (DriftKind.OFF_TOPIC.value, "t-draft")
     ] = 3

--- a/tests/test_e2e_plan_causal_correction.py
+++ b/tests/test_e2e_plan_causal_correction.py
@@ -345,7 +345,7 @@ async def _drive_refine_cycle(
     steerer.bind(sinks=[sink], planner=planner)
 
     prev = session.plan
-    steerer._apply_revision(session, revised, drift)
+    revised = steerer._apply_revision(session, revised, drift)  # goldfive#247: rebind
     await steerer._emit_plan_revised(session, revised, drift, prev_plan=prev)
     return steerer, planner, sink
 
@@ -664,7 +664,7 @@ async def test_critical_drift_composes_cancel_with_correction() -> None:
     # correction lands unperturbed by the cancel. This is the
     # composition claim.
     revised = _revised_with_correct_supersedes()
-    steerer._apply_revision(session, revised, drift)
+    revised = steerer._apply_revision(session, revised, drift)  # goldfive#247: rebind
     await steerer._emit_plan_revised(
         session, revised, drift, prev_plan=_presentation_style_plan()
     )

--- a/tests/test_executor_control.py
+++ b/tests/test_executor_control.py
@@ -83,6 +83,10 @@ class StubSteerer:
         self.observed: list[Any] = []
         self.refine_result = refine_result
         self.last_cancel_reason: str = ""
+        # goldfive#247: per-transition record for tests that need to
+        # verify cancellation happened even when the refine swap
+        # produces a plan that doesn't include the cancelled task id.
+        self.transitions: list[tuple[str, TaskStatus, str]] = []
 
     def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
         self._sinks = sinks
@@ -98,7 +102,13 @@ class StubSteerer:
             and kind is not None
             and str(getattr(kind, "value", kind)).upper() == "STEER"
         ):
-            session.plan = self.refine_result
+            # goldfive#247: route through the channel-processor primitive.
+            from goldfive.types import (
+                channel_processor_active,
+                set_session_plan,
+            )
+            with channel_processor_active():
+                set_session_plan(session, self.refine_result)
 
     async def transition(
         self,
@@ -109,16 +119,27 @@ class StubSteerer:
         session: Session,
         cancel_reason: str = "",
     ) -> None:
+        # goldfive#247: record the transition before any plan-shape
+        # check so tests can verify cancellation fired even when the
+        # refine swap that follows replaces the plan without the
+        # cancelled task id.
+        self.transitions.append((task_id, to, detail))
         if session.plan is None:
             return
-        for t in session.plan.tasks:
-            if t.id == task_id:
-                t.status = to
-                if to == TaskStatus.COMPLETED and detail:
-                    session.completed_results[task_id] = detail
-                if to == TaskStatus.CANCELLED:
-                    self.last_cancel_reason = cancel_reason or detail
-                return
+        # goldfive#247: Plan + Task are frozen — derive new plan + swap.
+        if not any(t.id == task_id for t in session.plan.tasks):
+            return
+        from goldfive.types import (
+            channel_processor_active,
+            set_session_plan,
+            with_task_status,
+        )
+        with channel_processor_active():
+            set_session_plan(session, with_task_status(session.plan, task_id, to))
+        if to == TaskStatus.COMPLETED and detail:
+            session.completed_results[task_id] = detail
+        if to == TaskStatus.CANCELLED:
+            self.last_cancel_reason = cancel_reason or detail
 
     def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
         return None
@@ -257,8 +278,10 @@ async def test_sequential_cancel_mid_task_aborts_run() -> None:
     assert sink.payload_kinds()[-1] == "run_aborted"
     # Second task never ran.
     assert adapter.invocations == ["t0"]
-    # Task was marked CANCELLED.
-    assert plan.tasks[0].status == TaskStatus.CANCELLED
+    # Task was marked CANCELLED. goldfive#247: read from the live
+    # session.plan because the local ``plan`` reference is the
+    # pre-mutation snapshot.
+    assert session.plan.tasks[0].status == TaskStatus.CANCELLED
     # Ack published.
     acks = await _drain_acks(channel, count=1, timeout=1.0)
     assert len(acks) == 1 and acks[0].result == AckResult.SUCCESS
@@ -303,10 +326,11 @@ async def test_sequential_steer_mid_task_cancels_and_replans() -> None:
             except asyncio.CancelledError:
                 raise
         # Subsequent tasks: complete immediately.
-        for t in session.plan.tasks:
-            if t.id == task.id:
-                t.status = TaskStatus.COMPLETED
-                break
+        # goldfive#247: derive new plan via helper
+
+        from tests._immutable_plan_helpers import force_task_status
+
+        force_task_status(session, task.id, TaskStatus.COMPLETED)
         return InvocationResult(task_id=task.id, text=f"done:{task.id}")
 
     adapter = StubAdapter(on_invoke=_handler)
@@ -346,9 +370,16 @@ async def test_sequential_steer_mid_task_cancels_and_replans() -> None:
         if str(getattr(getattr(o, "kind", None), "value", "")).upper() == "STEER"
     ]
     assert len(steer_obs) == 1
-    # Original t0 was marked CANCELLED.
-    original_t0 = next(t for t in plan.tasks if t.id == "t0")
-    assert original_t0.status == TaskStatus.CANCELLED
+    # Original t0 was marked CANCELLED. goldfive#247: with frozen
+    # Plan, the refined plan installed in session.plan no longer
+    # contains t0 (the LLM dropped it). Verify the cancel via the
+    # steerer's recorded transitions instead — that's the authoritative
+    # signal that t0 transitioned to CANCELLED before the swap.
+    cancel_transitions = [
+        (tid, st) for (tid, st, _detail) in steerer.transitions
+        if tid == "t0" and st == TaskStatus.CANCELLED
+    ]
+    assert cancel_transitions, steerer.transitions
 
 
 # ---------------------------------------------------------------------------
@@ -369,17 +400,16 @@ async def test_sequential_pause_blocks_next_task_until_resume() -> None:
     t1_started = asyncio.Event()
 
     async def _handler(task: Task, session: Session) -> InvocationResult:
+        # goldfive#247: derive via helper (frozen Plan).
+        from tests._immutable_plan_helpers import force_task_status
+
         if task.id == "t0":
-            for t in session.plan.tasks:
-                if t.id == "t0":
-                    t.status = TaskStatus.COMPLETED
+            force_task_status(session, "t0", TaskStatus.COMPLETED)
             t0_done.set()
             return InvocationResult(task_id=task.id, text="done:t0")
         if task.id == "t1":
             t1_started.set()
-        for t in session.plan.tasks:
-            if t.id == task.id:
-                t.status = TaskStatus.COMPLETED
+        force_task_status(session, task.id, TaskStatus.COMPLETED)
         return InvocationResult(task_id=task.id, text=f"done:{task.id}")
 
     adapter = StubAdapter(on_invoke=_handler)
@@ -442,9 +472,10 @@ async def test_sequential_rewind_between_tasks_re_executes_target() -> None:
 
     async def _handler(task: Task, session: Session) -> InvocationResult:
         counts[task.id] += 1
-        for t in session.plan.tasks:
-            if t.id == task.id:
-                t.status = TaskStatus.COMPLETED
+        # goldfive#247: derive via helper (frozen Plan).
+        from tests._immutable_plan_helpers import force_task_status
+
+        force_task_status(session, task.id, TaskStatus.COMPLETED)
         # After t0's first run, queue PAUSE / REWIND t0 / RESUME so the
         # next pre-task drain reinstates t0 as PENDING before picking.
         if task.id == "t0" and counts["t0"] == 1:
@@ -477,7 +508,10 @@ async def test_sequential_rewind_between_tasks_re_executes_target() -> None:
     # t0 re-executed once after the rewind; t1 ran once (since rewind
     # was to t0, t1 was also downstream and re-set to PENDING).
     assert counts == {"t0": 2, "t1": 1}
-    for t in plan.tasks:
+    # goldfive#247: read from the live session.plan; the local ``plan``
+    # reference is the pre-mutation snapshot.
+    assert session.plan is not None
+    for t in session.plan.tasks:
         assert t.status == TaskStatus.COMPLETED
 
 
@@ -486,10 +520,16 @@ async def test_rewind_helper_resets_target_and_downstream_only() -> None:
     from goldfive.executors._control import dispatch_control
 
     plan = _linear_plan(["t0", "t1", "t2"])
-    for t in plan.tasks:
-        t.status = TaskStatus.COMPLETED
+    # goldfive#247: Plan is frozen — derive a new plan with all
+    # tasks COMPLETED before pinning to the session.
+    from goldfive.types import with_task_status as _wts
+
+    for t in list(plan.tasks):
+        plan = _wts(plan, t.id, TaskStatus.COMPLETED)
     session = _fresh_session()
-    session.plan = plan
+    from tests._immutable_plan_helpers import force_plan
+
+    force_plan(session, plan)
     session.completed_results = {"t0": "a", "t1": "b", "t2": "c"}
     steerer = StubSteerer()
 
@@ -501,9 +541,10 @@ async def test_rewind_helper_resets_target_and_downstream_only() -> None:
     assert outcome.ack.result == AckResult.SUCCESS
     assert outcome.rewind_task_id == "t1"
     # t0 unchanged; t1 and t2 reset to PENDING with completed_results cleared.
-    assert plan.tasks[0].status == TaskStatus.COMPLETED
-    assert plan.tasks[1].status == TaskStatus.PENDING
-    assert plan.tasks[2].status == TaskStatus.PENDING
+    # goldfive#247: read from the live session.plan after the rewind.
+    assert session.plan.tasks[0].status == TaskStatus.COMPLETED
+    assert session.plan.tasks[1].status == TaskStatus.PENDING
+    assert session.plan.tasks[2].status == TaskStatus.PENDING
     assert "t0" in session.completed_results
     assert "t1" not in session.completed_results
     assert "t2" not in session.completed_results
@@ -552,9 +593,10 @@ async def test_sequential_status_query_emits_no_drift_and_returns_snapshot_in_ac
                 )
             status_sent.set()
             await asyncio.sleep(0.1)
-        for t in session.plan.tasks:
-            if t.id == task.id:
-                t.status = TaskStatus.COMPLETED
+        # goldfive#247: derive via helper (frozen Plan).
+        from tests._immutable_plan_helpers import force_task_status
+
+        force_task_status(session, task.id, TaskStatus.COMPLETED)
         return InvocationResult(task_id=task.id, text=f"done:{task.id}")
 
     adapter = StubAdapter(on_invoke=_handler)

--- a/tests/test_executor_supersede_cancel_nonfatal.py
+++ b/tests/test_executor_supersede_cancel_nonfatal.py
@@ -125,10 +125,16 @@ class _MinimalStubSteerer:
     ) -> None:
         if session.plan is None:
             return
-        for t in session.plan.tasks:
-            if t.id == task_id:
-                t.status = to
-                return
+        # goldfive#247: Plan + Task are frozen — derive new plan + swap.
+        if not any(t.id == task_id for t in session.plan.tasks):
+            return
+        from goldfive.types import (
+            channel_processor_active,
+            set_session_plan,
+            with_task_status,
+        )
+        with channel_processor_active():
+            set_session_plan(session, with_task_status(session.plan, task_id, to))
 
     def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:  # noqa: ARG002
         return None
@@ -232,7 +238,9 @@ async def test_overlay_supersede_cancel_restarts_loop_by_default() -> None:
     """
     plan = _two_task_plan()
     session = Session(run_id="r1")
-    session.plan = plan
+    # goldfive#247: route through helper
+    from tests._immutable_plan_helpers import force_plan as _fp_helper
+    _fp_helper(session, plan)
     refined = _revised_plan()
     steerer = _MinimalStubSteerer()
     sink = RecordingSink()
@@ -251,7 +259,9 @@ async def test_overlay_supersede_cancel_restarts_loop_by_default() -> None:
         # 3. raise CancelledError (mirrors the plugin firing
         #    task.cancel() on the registered asyncio.Task).
         if len(adapter.passthrough_calls) == 1:
-            session.plan = refined
+            # goldfive#247: route through helper
+            from tests._immutable_plan_helpers import force_plan as _fp_helper
+            _fp_helper(session, refined)
             session._supersede_pending = True  # type: ignore[attr-defined]
             raise asyncio.CancelledError()
         # Second invocation: run the revised plan to completion. The
@@ -300,8 +310,11 @@ async def test_overlay_supersede_cancel_restarts_loop_by_default() -> None:
     # Final event is run_completed.
     assert sink.payload_kinds()[-1] == "run_completed"
     # session.plan is the revised plan and its tasks are terminal.
-    assert session.plan is refined
-    for t in refined.tasks:
+    # goldfive#247: identity check replaced with id check (Plan is frozen).
+    # Read tasks from session.plan (live) — the local ``refined`` is
+    # the pre-mutation snapshot.
+    assert session.plan is not None and session.plan.id == refined.id
+    for t in session.plan.tasks:
         assert t.status in (TaskStatus.COMPLETED, TaskStatus.NOT_NEEDED), (
             f"revised task {t.id} ended in {t.status}"
         )
@@ -323,7 +336,9 @@ async def test_overlay_external_cancel_still_aborts() -> None:
     """
     plan = _two_task_plan()
     session = Session(run_id="r1")
-    session.plan = plan
+    # goldfive#247: route through helper
+    from tests._immutable_plan_helpers import force_plan as _fp_helper
+    _fp_helper(session, plan)
     steerer = _MinimalStubSteerer()
     sink = RecordingSink()
     channel = ControlChannel()
@@ -381,7 +396,9 @@ async def test_overlay_external_cancel_still_aborts() -> None:
 async def test_overlay_supersede_cancel_aborts_when_fail_fast_kwarg_set() -> None:
     plan = _two_task_plan()
     session = Session(run_id="r1")
-    session.plan = plan
+    # goldfive#247: route through helper
+    from tests._immutable_plan_helpers import force_plan as _fp_helper
+    _fp_helper(session, plan)
     steerer = _MinimalStubSteerer()
     sink = RecordingSink()
     channel = ControlChannel()
@@ -434,7 +451,9 @@ async def test_overlay_env_var_enables_fail_fast(
 
     plan = _two_task_plan()
     session = Session(run_id="r1")
-    session.plan = plan
+    # goldfive#247: route through helper
+    from tests._immutable_plan_helpers import force_plan as _fp_helper
+    _fp_helper(session, plan)
     steerer = _MinimalStubSteerer()
     sink = RecordingSink()
     channel = ControlChannel()
@@ -510,7 +529,9 @@ async def test_overlay_supersede_then_external_cancel_aborts() -> None:
     (it has no supersede marker)."""
     plan = _two_task_plan()
     session = Session(run_id="r1")
-    session.plan = plan
+    # goldfive#247: route through helper
+    from tests._immutable_plan_helpers import force_plan as _fp_helper
+    _fp_helper(session, plan)
     refined = _revised_plan()
     steerer = _MinimalStubSteerer()
     sink = RecordingSink()
@@ -524,7 +545,9 @@ async def test_overlay_supersede_then_external_cancel_aborts() -> None:
         reconciler: Any,  # noqa: ARG001
     ) -> InvocationResult | None:
         if len(adapter.passthrough_calls) == 1:
-            session.plan = refined
+            # goldfive#247: route through helper
+            from tests._immutable_plan_helpers import force_plan as _fp_helper
+            _fp_helper(session, refined)
             session._supersede_pending = True  # type: ignore[attr-defined]
             raise asyncio.CancelledError()
         # Second invocation: signal then block. The test will then
@@ -595,7 +618,9 @@ async def test_overlay_stale_supersede_flag_cleared_per_iteration() -> None:
     """
     plan = _two_task_plan()
     session = Session(run_id="r1")
-    session.plan = plan
+    # goldfive#247: route through helper
+    from tests._immutable_plan_helpers import force_plan as _fp_helper
+    _fp_helper(session, plan)
     # Pre-stamp the flag as if some prior side-effect set it. The
     # executor's per-iteration clear at the top of the while loop must
     # wipe this before the first invocation completes.

--- a/tests/test_immutable_plan.py
+++ b/tests/test_immutable_plan.py
@@ -1,0 +1,409 @@
+"""Coverage for the goldfive#247 frozen :class:`Plan` / :class:`Task` refactor.
+
+These tests are the new-test surface for Phase 3 of the structural fix
+documented at the top of ``goldfive/types.py``:
+
+* :class:`Plan` and :class:`Task` are ``frozen=True``; in-place mutation
+  raises :class:`dataclasses.FrozenInstanceError`.
+* The blessed mutation primitives — :func:`replace_task`,
+  :func:`with_task_status`, :func:`add_tasks`, :func:`replace_edges`,
+  :func:`bump_revision` — return NEW Plan instances and never mutate
+  the input.
+* Multiple readers see independent snapshots: capturing a
+  :class:`Plan` reference and then triggering a revision via the
+  helpers leaves the captured reference at the old shape.
+* :func:`set_session_plan` enforces the single-writer invariant via
+  :data:`_CHANNEL_PROCESSOR_ACTIVE`. Outside the contextvar it warns
+  (production) or raises :class:`PlanOwnershipViolation` (under
+  ``GOLDFIVE_STRICT_STATE_OWNERSHIP=1``).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+from unittest import mock
+
+import pytest
+
+from goldfive.types import (
+    Plan,
+    PlanOwnershipViolation,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+    add_tasks,
+    bump_revision,
+    channel_processor_active,
+    replace_edges,
+    replace_task,
+    set_session_plan,
+    with_task_status,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _plan(*task_ids: str) -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=("g1",),
+        tasks=tuple(Task(id=tid, title=tid.upper()) for tid in task_ids),
+        edges=tuple(
+            TaskEdge(from_task_id=task_ids[i], to_task_id=task_ids[i + 1])
+            for i in range(len(task_ids) - 1)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Frozen-dataclass enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_task_is_frozen() -> None:
+    """``task.status = X`` raises :class:`FrozenInstanceError`."""
+    t = Task(id="t1", title="T1")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        t.status = TaskStatus.RUNNING  # type: ignore[misc]
+
+
+def test_plan_is_frozen() -> None:
+    """``plan.tasks = ...`` and ``plan.id = ...`` both raise."""
+    p = _plan("t1", "t2")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        p.id = "p2"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        p.tasks = ()  # type: ignore[misc]
+
+
+def test_taskedge_is_frozen() -> None:
+    e = TaskEdge(from_task_id="a", to_task_id="b")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        e.from_task_id = "c"  # type: ignore[misc]
+
+
+def test_plan_coerces_list_inputs_to_tuples() -> None:
+    """Back-compat: callers may pass lists; ``__post_init__`` coerces.
+
+    Test fixtures and the planner's JSON parser construct Plans with
+    list-typed ``goal_ids`` / ``tasks`` / ``edges``. The frozen
+    refactor stores them as tuples, so the dataclass coerces in
+    ``__post_init__``.
+    """
+    p = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1", "g2"],  # type: ignore[arg-type]
+        tasks=[Task(id="t1", title="T1")],  # type: ignore[arg-type]
+        edges=[],  # type: ignore[arg-type]
+    )
+    assert isinstance(p.goal_ids, tuple)
+    assert isinstance(p.tasks, tuple)
+    assert isinstance(p.edges, tuple)
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def test_replace_task_returns_new_plan_with_input_unchanged() -> None:
+    """``replace_task`` is pure: input plan and tasks are not mutated."""
+    p = _plan("t1", "t2")
+    new = replace_task(p, "t1", title="renamed", description="x")
+    assert new is not p
+    # Input plan unchanged.
+    assert p.tasks[0].title == "T1"
+    assert p.tasks[0].description == ""
+    # New plan has the change.
+    new_t1 = next(t for t in new.tasks if t.id == "t1")
+    assert new_t1.title == "renamed"
+    assert new_t1.description == "x"
+    # Other tasks preserved by reference (sharing is safe — they're
+    # frozen).
+    assert new.tasks[1] is p.tasks[1]
+
+
+def test_replace_task_raises_when_id_missing() -> None:
+    p = _plan("t1")
+    with pytest.raises(KeyError):
+        replace_task(p, "nope", status=TaskStatus.RUNNING)
+
+
+def test_with_task_status_preserves_other_fields() -> None:
+    """``with_task_status`` only flips the status; everything else is preserved."""
+    p = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=("g1",),
+        tasks=(
+            Task(
+                id="t1",
+                title="The task",
+                description="long description",
+                assignee_agent_id="agent_a",
+                predicted_duration_ms=1234,
+                cancel_reason="prior",
+                supersedes="t0",
+            ),
+        ),
+        edges=(),
+    )
+    new = with_task_status(p, "t1", TaskStatus.RUNNING)
+    new_t1 = new.tasks[0]
+    assert new_t1.status is TaskStatus.RUNNING
+    assert new_t1.title == "The task"
+    assert new_t1.description == "long description"
+    assert new_t1.assignee_agent_id == "agent_a"
+    assert new_t1.predicted_duration_ms == 1234
+    assert new_t1.cancel_reason == "prior"
+    assert new_t1.supersedes == "t0"
+    # Plan id / run_id / revision metadata preserved.
+    assert new.id == p.id
+    assert new.run_id == p.run_id
+    assert new.revision_index == p.revision_index
+
+
+def test_add_tasks_preserves_order_and_input() -> None:
+    """``add_tasks`` appends; original order is preserved; input untouched."""
+    p = _plan("t1", "t2")
+    new = add_tasks(p, [Task(id="t3", title="T3"), Task(id="t4", title="T4")])
+    # Input unchanged.
+    assert [t.id for t in p.tasks] == ["t1", "t2"]
+    # Output is original + new in order.
+    assert [t.id for t in new.tasks] == ["t1", "t2", "t3", "t4"]
+    # Existing tasks shared by reference.
+    for old, new_t in zip(p.tasks, new.tasks[: len(p.tasks)], strict=True):
+        assert old is new_t
+
+
+def test_replace_edges_accepts_tuples_and_taskedges() -> None:
+    """``replace_edges`` normalises both shapes."""
+    p = _plan("t1", "t2", "t3")
+    new = replace_edges(p, [("t1", "t3"), TaskEdge(from_task_id="t2", to_task_id="t3")])
+    assert new is not p
+    assert len(new.edges) == 2
+    assert all(isinstance(e, TaskEdge) for e in new.edges)
+    assert (new.edges[0].from_task_id, new.edges[0].to_task_id) == ("t1", "t3")
+    assert (new.edges[1].from_task_id, new.edges[1].to_task_id) == ("t2", "t3")
+    # Input edges preserved.
+    assert len(p.edges) == 2
+    assert (p.edges[0].from_task_id, p.edges[0].to_task_id) == ("t1", "t2")
+
+
+def test_bump_revision_default_increments_by_one() -> None:
+    p = _plan("t1")
+    new = bump_revision(p)
+    assert new.revision_index == p.revision_index + 1
+    # Other revision metadata preserved (no override given).
+    assert new.revision_kind == p.revision_kind
+    assert new.revision_severity == p.revision_severity
+
+
+def test_bump_revision_with_explicit_index_and_metadata() -> None:
+    p = _plan("t1")
+    new = bump_revision(
+        p,
+        revision_index=5,
+        revision_kind="tool_error",
+        revision_severity="warning",
+        revision_reason="api 500",
+        revision_trigger_event_id="evt-42",
+    )
+    assert new.revision_index == 5
+    assert new.revision_kind == "tool_error"
+    assert new.revision_severity == "warning"
+    assert new.revision_reason == "api 500"
+    assert new.revision_trigger_event_id == "evt-42"
+    # Input untouched.
+    assert p.revision_index == 0
+    assert p.revision_kind == ""
+
+
+# ---------------------------------------------------------------------------
+# Snapshot semantics — readers see independent views
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_readers_see_independent_snapshots() -> None:
+    """A reader who captured ``plan_v1`` keeps seeing v1 after the swap.
+
+    The bug class goldfive#247 targets: a judge / sink reads
+    ``session.plan`` (call this ``plan_v1``), awaits an LLM, and
+    produces a verdict. While the judge was awaiting, the live state
+    swapped to ``plan_v2``. Pre-#247 — when Plan was mutable — the
+    judge's ``plan_v1`` reference saw the v2 mutations. With frozen
+    Plan, the reader's reference still points at v1 and only the
+    pointer on the session has moved.
+    """
+    plan_v1 = _plan("t1", "t2")
+    session = Session(run_id="r1", plan=plan_v1)
+    captured = session.plan  # reader's snapshot reference
+
+    # Live state advances: t1 marked COMPLETED.
+    with channel_processor_active():
+        set_session_plan(session, with_task_status(session.plan, "t1", TaskStatus.COMPLETED))
+
+    # Captured snapshot is unchanged.
+    assert captured is plan_v1
+    assert captured.tasks[0].status is TaskStatus.PENDING
+    # Session.plan moved.
+    assert session.plan is not None
+    assert session.plan is not plan_v1
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Channel-processor enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_set_session_plan_inside_contextvar_no_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The blessed path: swap inside the contextvar is silent."""
+    plan = _plan("t1")
+    session = Session(run_id="r1")
+    with caplog.at_level(logging.WARNING, logger="goldfive.types"):
+        with channel_processor_active():
+            set_session_plan(session, plan)
+    assert session.plan is plan
+    assert all(
+        "channel_processor_active" not in r.message for r in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+def test_set_session_plan_outside_contextvar_warns_in_non_strict_mode(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Calling :func:`set_session_plan` outside the contextvar logs a WARNING.
+
+    Production-defaults behaviour: the runtime stays defensive — we
+    log and proceed. Strict mode (separate test) escalates to an
+    exception. The check is the structural enforcement of the
+    "single writer onto session.plan" invariant from the goldfive#247
+    architectural fix.
+    """
+    plan = _plan("t1")
+    session = Session(run_id="r1")
+    # Force non-strict mode regardless of the test runner's pytest
+    # auto-on default.
+    with mock.patch.dict(os.environ, {"GOLDFIVE_STRICT_STATE_OWNERSHIP": "0"}):
+        with caplog.at_level(logging.WARNING, logger="goldfive.types"):
+            set_session_plan(session, plan)
+    # Plan still installed — defensive, not blocking.
+    assert session.plan is plan
+    assert any(
+        "channel_processor_active" in r.message for r in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+def test_set_session_plan_outside_contextvar_raises_in_strict_mode() -> None:
+    """Strict mode (``GOLDFIVE_STRICT_STATE_OWNERSHIP=1``) raises.
+
+    The CI / dev tripwire — same env gate the existing
+    :class:`StateOwnershipViolation` audit uses. Production deploys
+    with the variable unset never pay the penalty; tests pay because
+    pytest auto-enables strict mode (mirrored from
+    :mod:`goldfive._state_audit`).
+    """
+    plan = _plan("t1")
+    session = Session(run_id="r1")
+    with mock.patch.dict(os.environ, {"GOLDFIVE_STRICT_STATE_OWNERSHIP": "1"}):
+        with pytest.raises(PlanOwnershipViolation):
+            set_session_plan(session, plan)
+
+
+def test_channel_processor_active_is_per_contextvar_token() -> None:
+    """Nested entries / exits restore the prior value cleanly."""
+    plan = _plan("t1")
+    session = Session(run_id="r1", plan=plan)
+    # Outer CM enters; inner CM enters; exits; outer is still active.
+    with channel_processor_active():
+        with channel_processor_active():
+            set_session_plan(session, plan)  # inner: silent
+        # Outer still active — this should also be silent.
+        set_session_plan(session, plan)
+    # Outside both: now strict-mode would raise.
+    with mock.patch.dict(os.environ, {"GOLDFIVE_STRICT_STATE_OWNERSHIP": "1"}):
+        with pytest.raises(PlanOwnershipViolation):
+            set_session_plan(session, plan)
+
+
+# ---------------------------------------------------------------------------
+# Helper interaction with the channel-processor primitive
+# ---------------------------------------------------------------------------
+
+
+def test_helpers_do_not_swap_session_plan_on_their_own() -> None:
+    """The derivation helpers are pure — they never touch a Session.
+
+    A regression here would mean the helpers are entangled with the
+    single-writer enforcement, which would re-couple the structural
+    fix to a global. They must stay pure functions over Plan/Task.
+    """
+    plan = _plan("t1")
+    session = Session(run_id="r1", plan=plan)
+    # None of these touch session.
+    _ = with_task_status(plan, "t1", TaskStatus.RUNNING)
+    _ = add_tasks(plan, [Task(id="t2", title="T2")])
+    _ = replace_edges(plan, [("t1", "t2")])
+    _ = bump_revision(plan)
+    _ = replace_task(plan, "t1", title="x")
+    # session.plan still the original — the helpers didn't swap it.
+    assert session.plan is plan
+
+
+def test_post_helper_install_keeps_old_snapshot_intact() -> None:
+    """End-to-end snapshot proof: derive + install via the helper +
+    contextvar pair; the captured reference remains pointed at the
+    old shape.
+
+    This is the architectural goal of #247 demonstrated as a single
+    test: torn-read elimination via type-system-enforced
+    immutability.
+    """
+    plan_v1 = _plan("t1", "t2", "t3")
+    session = Session(run_id="r1", plan=plan_v1)
+    snapshot_a = session.plan  # judge captures here
+    snapshot_b = session.plan  # second judge captures the same
+
+    # While both judges await an LLM, the steerer-equivalent path
+    # marks t1 COMPLETED, then add_tasks(t4), then bump_revision.
+    with channel_processor_active():
+        new = with_task_status(session.plan, "t1", TaskStatus.COMPLETED)
+        new = add_tasks(new, [Task(id="t4", title="T4")])
+        new = bump_revision(new, revision_index=1, revision_kind="tool_error")
+        set_session_plan(session, new)
+
+    # Snapshots A and B see plan_v1 — torn-read is structurally
+    # impossible.
+    assert snapshot_a is plan_v1
+    assert snapshot_b is plan_v1
+    assert snapshot_a.tasks[0].status is TaskStatus.PENDING
+    assert {t.id for t in snapshot_a.tasks} == {"t1", "t2", "t3"}
+    # Session has the new plan with the new shape.
+    assert session.plan is not None
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+    assert {t.id for t in session.plan.tasks} == {"t1", "t2", "t3", "t4"}
+    assert session.plan.revision_index == 1
+    assert session.plan.revision_kind == "tool_error"
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 (#248) compatibility: Task.supersedes default is in place.
+# ---------------------------------------------------------------------------
+
+
+def test_task_supersedes_default_is_empty_string() -> None:
+    """Phase 4 (#248) ships ``Task.supersedes`` validation; the field's
+    default must be in place from Phase 3 so the wiring lands cleanly.
+    """
+    t = Task(id="t1", title="T1")
+    assert t.supersedes == ""

--- a/tests/test_judge_lifetime_v22_regression.py
+++ b/tests/test_judge_lifetime_v22_regression.py
@@ -273,7 +273,17 @@ async def test_two_back_to_back_task_transitions_do_not_clobber_running_judge() 
     # should NOT spawn a second judge AND must not cancel the first.
     plan = session.plan
     assert plan is not None
-    plan.tasks.append(Task(id="t2", title="t2", description=""))
+    # goldfive#247: Plan is frozen — extend via add_tasks.
+    from goldfive.types import (
+        add_tasks,
+        channel_processor_active,
+        set_session_plan,
+    )
+    with channel_processor_active():
+        set_session_plan(
+            session,
+            add_tasks(plan, [Task(id="t2", title="t2", description="")]),
+        )
     await steerer.mark_task_completed("t2", session=session, summary="also done")
     # First judge still pending.
     assert len(steerer._background_judges) == 1

--- a/tests/test_overlay_forward_progress.py
+++ b/tests/test_overlay_forward_progress.py
@@ -91,10 +91,17 @@ class StubSteerer:
         self.transitions.append((task_id, to))
         if session.plan is None:
             return
-        for t in session.plan.tasks:
-            if t.id == task_id:
-                t.status = to
-                return
+        # goldfive#247: Plan + Task are frozen — derive a new Plan
+        # via with_task_status and swap.
+        if not any(t.id == task_id for t in session.plan.tasks):
+            return
+        from goldfive.types import (
+            channel_processor_active,
+            set_session_plan,
+            with_task_status,
+        )
+        with channel_processor_active():
+            set_session_plan(session, with_task_status(session.plan, task_id, to))
 
     def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:  # noqa: ARG002
         return None
@@ -488,19 +495,38 @@ async def test_level_2_nudge_triggers_overlay_replay() -> None:
         # replacement, and queue a nudge.
         if replay_count == 0:
             replay_count += 1
-            session.plan.tasks[0].status = TaskStatus.FAILED
-            session.plan.tasks.append(
-                Task(
-                    id="define_structure_v2",
-                    title="define (v2)",
-                    status=TaskStatus.PENDING,
-                    assignee_agent_id="planner",
-                )
+            # goldfive#247: Plan + Task are frozen — derive a new plan
+            # via the helpers and swap. The fake path simulates a refine
+            # so we wrap in :func:`channel_processor_active` to satisfy
+            # the runtime single-writer check on session.plan swaps.
+            from goldfive.types import (
+                add_tasks,
+                channel_processor_active,
+                replace_edges,
+                set_session_plan,
+                with_task_status,
             )
-            # Wire replacement into the DAG so draft_slide_1 depends on it.
-            session.plan.edges.append(
-                TaskEdge(from_task_id="define_structure_v2", to_task_id="draft_slide_1")
+            new_plan = with_task_status(
+                session.plan, session.plan.tasks[0].id, TaskStatus.FAILED
             )
+            new_plan = add_tasks(
+                new_plan,
+                [
+                    Task(
+                        id="define_structure_v2",
+                        title="define (v2)",
+                        status=TaskStatus.PENDING,
+                        assignee_agent_id="planner",
+                    )
+                ],
+            )
+            new_plan = replace_edges(
+                new_plan,
+                list(new_plan.edges)
+                + [TaskEdge(from_task_id="define_structure_v2", to_task_id="draft_slide_1")],
+            )
+            with channel_processor_active():
+                set_session_plan(session, new_plan)
             session.pending_nudges.append(
                 "The prior attempt looped on define_structure. Refined plan: "
                 "define (v2). Please try a different approach."
@@ -663,8 +689,13 @@ async def test_absorb_on_looping_reasoning_queues_nudge() -> None:
     )
     await steerer._handle_drift(drift, session)
 
-    # Refine applied (plan swapped in).
-    assert session.plan is revised
+    # Refine applied (plan swapped in). goldfive#247: _apply_revision
+    # builds a NEW Plan via bump_revision; identity is no longer the
+    # right check. Verify the plan id is preserved (revision lineage)
+    # and the revised content landed.
+    assert session.plan is not None
+    assert session.plan.id == revised.id
+    assert session.plan.revision_index == 1
     # Nudge queued for consumption by the overlay.
     assert len(session.pending_nudges) == 1
     nudge = session.pending_nudges[0]

--- a/tests/test_overlay_steer.py
+++ b/tests/test_overlay_steer.py
@@ -117,16 +117,29 @@ class SteerAwareStubSteerer:
             current_task_id=session.current_task_id,
         )
         self.drift_events.append(drift)
+        # goldfive#247: Plan + Task are frozen — derive a new plan
+        # via the helpers and swap. The fold cascade-cancels every
+        # PENDING/RUNNING task in one rebuild.
+        from goldfive.types import (
+            channel_processor_active,
+            set_session_plan,
+            with_task_status,
+        )
         if session.plan is not None:
-            for t in session.plan.tasks:
+            new_plan = session.plan
+            for t in list(session.plan.tasks):
                 if t.status in (TaskStatus.PENDING, TaskStatus.RUNNING):
-                    t.status = TaskStatus.CANCELLED
+                    new_plan = with_task_status(new_plan, t.id, TaskStatus.CANCELLED)
                     self.cascade_cancelled.append(t.id)
+            if new_plan is not session.plan:
+                with channel_processor_active():
+                    set_session_plan(session, new_plan)
         # Emulate planner.refine being called by the intervention ladder.
         if session.plan is not None:
             self.planner_refine_calls.append((session.plan, drift))
         if self._refined_plans:
-            session.plan = self._refined_plans.pop(0)
+            with channel_processor_active():
+                set_session_plan(session, self._refined_plans.pop(0))
 
     async def _handle_drift(self, drift: DriftEvent, session: Session) -> None:  # noqa: ARG002
         self.drift_events.append(drift)
@@ -142,10 +155,16 @@ class SteerAwareStubSteerer:
     ) -> None:
         if session.plan is None:
             return
-        for t in session.plan.tasks:
-            if t.id == task_id:
-                t.status = to
-                return
+        # goldfive#247: Plan + Task are frozen — derive new plan + swap.
+        if not any(t.id == task_id for t in session.plan.tasks):
+            return
+        from goldfive.types import (
+            channel_processor_active,
+            set_session_plan,
+            with_task_status,
+        )
+        with channel_processor_active():
+            set_session_plan(session, with_task_status(session.plan, task_id, to))
 
     def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:  # noqa: ARG002
         return None
@@ -340,13 +359,17 @@ async def test_overlay_steer_triggers_user_steer_drift_and_refine() -> None:
     assert len(steerer.planner_refine_calls) == 1
     assert steerer.planner_refine_calls[0][1].kind is DriftKind.USER_STEER
 
-    # session.plan is now the revised plan.
-    assert session.plan is refined
+    # session.plan is now the revised plan. goldfive#247: Plan is
+    # frozen — the executor's transitions build NEW Plan instances,
+    # so identity is no longer the right check. Verify the plan id
+    # matches the LLM revision and tasks reached terminal.
+    assert session.plan is not None
+    assert session.plan.id == refined.id
 
     # The run completed successfully on the revised plan.
     assert outcome.success is True
-    # Revised tasks are terminal.
-    for t in refined.tasks:
+    # Revised tasks are terminal — read from the live (post-swap) plan.
+    for t in session.plan.tasks:
         assert t.status in (
             TaskStatus.COMPLETED,
             TaskStatus.NOT_NEEDED,
@@ -654,8 +677,11 @@ async def test_overlay_steer_after_steer() -> None:
     ]
     assert len(user_steer_drifts) == 2
     assert len(steerer.planner_refine_calls) == 2
-    # Final plan is the v2 revision.
-    assert session.plan is refined2
+    # Final plan is the v2 revision. goldfive#247: identity check
+    # replaced with id check (Plan is frozen — every transition
+    # rebuilds a Plan).
+    assert session.plan is not None
+    assert session.plan.id == refined2.id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_parallel_executor.py
+++ b/tests/test_parallel_executor.py
@@ -293,14 +293,21 @@ async def test_drift_in_parallel_task_finish_stage_then_refine() -> None:
     # logs a PlanRevised event and advances. Because B/C/D all share
     # the same stage, finish_stage must let B and D complete before
     # refine is called.
+    # goldfive#247: Plan is frozen — derive via helpers.
+    from goldfive.types import bump_revision as _bump
+    from goldfive.types import with_task_status as _wts
+
     revised = _diamond_plan()
-    revised.revision_reason = "observed drift in C"
-    revised.revision_kind = DriftKind.PLAN_DIVERGENCE.value
-    revised.revision_severity = DriftSeverity.WARNING.value
-    revised.revision_index = 1
+    revised = _bump(
+        revised,
+        revision_index=1,
+        revision_reason="observed drift in C",
+        revision_kind=DriftKind.PLAN_DIVERGENCE.value,
+        revision_severity=DriftSeverity.WARNING.value,
+    )
     # Mark A as already completed so the refined plan resumes at the
     # drifted stage; otherwise the walker would replay A.
-    revised.tasks[0].status = TaskStatus.COMPLETED
+    revised = _wts(revised, revised.tasks[0].id, TaskStatus.COMPLETED)
     planner = RecordingPlanner(refined_plan=revised)
 
     executor = ParallelDAGExecutor(
@@ -363,9 +370,13 @@ async def test_drift_cancel_stage_cancels_siblings() -> None:
 
     adapter = VariableDelayAdapter(drift_for={"C": drift})
     steerer = RecordingSteerer()
+    # goldfive#247: Plan is frozen — derive via helpers.
+    from goldfive.types import bump_revision as _bump
+    from goldfive.types import with_task_status as _wts
+
     revised = _diamond_plan()
-    revised.revision_index = 1
-    revised.tasks[0].status = TaskStatus.COMPLETED
+    revised = _bump(revised, revision_index=1)
+    revised = _wts(revised, revised.tasks[0].id, TaskStatus.COMPLETED)
     planner = RecordingPlanner(refined_plan=revised)
     executor = ParallelDAGExecutor(
         max_concurrency=0, drift_policy="cancel_stage"
@@ -429,9 +440,13 @@ async def test_cancel_stage_no_task_leak() -> None:
     adapter = BDriftsQuicklyAdapter(drift_for={"B": drift})
     before_tasks = {t for t in asyncio.all_tasks()}
 
+    # goldfive#247: Plan is frozen — derive via helpers.
+    from goldfive.types import bump_revision as _bump
+    from goldfive.types import with_task_status as _wts
+
     revised = _diamond_plan()
-    revised.revision_index = 1
-    revised.tasks[0].status = TaskStatus.COMPLETED
+    revised = _bump(revised, revision_index=1)
+    revised = _wts(revised, revised.tasks[0].id, TaskStatus.COMPLETED)
     executor = ParallelDAGExecutor(
         max_concurrency=0, drift_policy="cancel_stage"
     )

--- a/tests/test_pin_versioning.py
+++ b/tests/test_pin_versioning.py
@@ -577,8 +577,12 @@ async def test_handler_waits_for_plan_stable_during_concurrent_refine() -> None:
 
     async def _bump_during_wait(_session: Any) -> None:
         # Simulate the refine landing while the handler is parked at
-        # the barrier — increments revision_index in place.
-        plan.revision_index = 1
+        # the barrier — bumps revision_index. goldfive#247: Plan is
+        # frozen — derive a new instance and swap onto session.plan.
+        from goldfive.types import bump_revision
+        from tests._immutable_plan_helpers import force_plan
+
+        force_plan(_session, bump_revision(_session.plan, revision_index=1))
 
     steerer = _SinkingSteerer(sinks, on_wait=_bump_during_wait)
 

--- a/tests/test_plan_reconciler.py
+++ b/tests/test_plan_reconciler.py
@@ -54,13 +54,17 @@ class _RecordingSteerer:
         self.transitions.append((task_id, to, detail))
         if session.plan is None:
             return
-        for t in session.plan.tasks:
-            if t.id == task_id:
-                # Treat every recorded transition as authoritative —
-                # the reconciler doesn't re-emit already-terminal
-                # transitions so duplicate writes are fine.
-                t.status = to
-                return
+        # goldfive#247: Plan + Task are frozen — derive a new Plan via
+        # with_task_status and swap. Mirrors what DefaultSteerer does.
+        from goldfive.types import (
+            channel_processor_active,
+            set_session_plan,
+            with_task_status,
+        )
+        if not any(t.id == task_id for t in session.plan.tasks):
+            return
+        with channel_processor_active():
+            set_session_plan(session, with_task_status(session.plan, task_id, to))
 
     async def observe(self, event: Any, session: Session) -> None:
         if isinstance(event, DriftEvent):

--- a/tests/test_plan_refinement.py
+++ b/tests/test_plan_refinement.py
@@ -28,6 +28,8 @@ def _mk_plan(
     edges: list[Any] | None = None,
     revision_index: int = 0,
     revision_reason: str = "",
+    revision_kind: str = "",
+    revision_severity: str = "",
 ) -> Any:
     return types.Plan(
         id=f"plan-{revision_index}",
@@ -37,6 +39,8 @@ def _mk_plan(
         edges=edges or [],
         revision_index=revision_index,
         revision_reason=revision_reason,
+        revision_kind=revision_kind,
+        revision_severity=revision_severity,
     )
 
 
@@ -57,7 +61,8 @@ def test_refined_plan_preserves_completed_task_ids() -> None:
 
     run_id = "refine-preserve"
     original = _mk_plan(run_id=run_id, tasks=[_mk_task("t1"), _mk_task("t2")])
-    original.tasks[0].status = types.TaskStatus.COMPLETED
+    # goldfive#247: Plan is frozen — derive via with_task_status.
+    original = types.with_task_status(original, "t1", types.TaskStatus.COMPLETED)
 
     refined = _mk_plan(
         run_id=run_id,
@@ -99,8 +104,12 @@ async def test_planner_refine_increments_revision_and_preserves_completed() -> N
         goals=[types.Goal(id="g1", summary="do things")],
         available_agents=["default"],
     )
-    session.plan = p0
-    p0.tasks[0].status = types.TaskStatus.COMPLETED
+    # goldfive#247: install via the test helper so the channel-processor
+    # gate is satisfied; flip t1 COMPLETED via with_task_status.
+    p0 = types.with_task_status(p0, "t1", types.TaskStatus.COMPLETED)
+    from tests._immutable_plan_helpers import force_plan
+
+    force_plan(session, p0)
 
     drift = types.DriftEvent(
         kind=types.DriftKind.NEW_WORK_DISCOVERED,
@@ -163,15 +172,16 @@ async def test_revision_reason_and_kind_propagate() -> None:
             return _mk_plan(run_id="tag", tasks=[_mk_task("t1")])
 
         async def refine(self, *, plan, drift, goals):
-            refined = _mk_plan(
+            # goldfive#247: Plan is frozen — pass all metadata at
+            # construction.
+            return _mk_plan(
                 run_id=plan.run_id,
                 tasks=[*plan.tasks, _mk_task("t2")],
                 revision_index=plan.revision_index + 1,
                 revision_reason=drift.detail,
+                revision_kind=drift.kind.value,
+                revision_severity=drift.severity.value,
             )
-            refined.revision_kind = drift.kind.value
-            refined.revision_severity = drift.severity.value
-            return refined
 
     planner = _TaggingPlanner()
     plan = await planner.generate(goals=[], available_agents=["default"])

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -155,7 +155,7 @@ def test_plan_from_json_happy_path() -> None:
     )
     assert plan is not None
     assert plan.run_id == "run-abc"
-    assert plan.goal_ids == ["g1", "g2"]
+    assert plan.goal_ids == ("g1", "g2")
     assert [t.id for t in plan.tasks] == ["research", "draft", "review"]
     assert all(t.status == TaskStatus.PENDING for t in plan.tasks)
     assert plan.summary == "Draft and review a goldfish blog post."
@@ -211,7 +211,7 @@ async def test_llm_planner_generate_parses_canned_json() -> None:
     )
     assert plan is not None
     assert plan.run_id == "run-xyz"
-    assert plan.goal_ids == ["g1", "g2"]
+    assert plan.goal_ids == ("g1", "g2")
     assert [t.id for t in plan.tasks] == ["research", "draft", "review"]
 
     # Sanity: the prompt the LLM saw mentioned the goals and agents.
@@ -542,7 +542,7 @@ async def test_llm_planner_refine_preserves_completed_tasks() -> None:
     # Plan envelope identity is preserved across refinement.
     assert revised.id == plan.id
     assert revised.run_id == plan.run_id
-    assert revised.goal_ids == ["g1", "g2"]
+    assert revised.goal_ids == ("g1", "g2")
 
     # Revision metadata stamped from the drift.
     assert revised.revision_reason == "Reviewer asked for citations before review"
@@ -619,8 +619,10 @@ async def test_llm_planner_refine_increments_revision_index() -> None:
     planner = LLMPlanner(call_llm=stub)
     drift = DriftEvent(kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.WARNING)
 
-    plan = _running_plan()
-    plan.revision_index = 3
+    # goldfive#247: Plan is frozen — derive via bump_revision.
+    from goldfive.types import bump_revision
+
+    plan = bump_revision(_running_plan(), revision_index=3)
     revised = await planner.refine(plan=plan, drift=drift, goals=_goals())
     assert revised is not None
     assert revised.revision_index == 4

--- a/tests/test_planner_goal_aware_refine.py
+++ b/tests/test_planner_goal_aware_refine.py
@@ -423,9 +423,12 @@ async def test_user_steer_refine_preserves_prior_user_steer_goals() -> None:
     )
     # Start from a plan where draft is COMPLETED so the USER_STEER
     # merge path has something to preserve.
+    # goldfive#247: Plan is frozen — derive via with_task_status.
+    from goldfive.types import with_task_status as _wts
+
     plan = _running_plan()
-    plan.tasks[1].status = TaskStatus.COMPLETED  # draft done
-    plan.tasks[2].status = TaskStatus.COMPLETED  # review done
+    plan = _wts(plan, plan.tasks[1].id, TaskStatus.COMPLETED)  # draft done
+    plan = _wts(plan, plan.tasks[2].id, TaskStatus.COMPLETED)  # review done
 
     revised = await planner.refine(
         plan=plan,

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -417,7 +417,14 @@ async def test_rate_limit_resets_on_task_transition() -> None:
     # Task transition: add a fresh task and bind it as current.
     new_task = Task(id="t2", title="Different task", description="...")
     assert session.plan is not None
-    session.plan.tasks.append(new_task)
+    # goldfive#247: Plan is frozen — extend via add_tasks.
+    from goldfive.types import (
+        add_tasks,
+        channel_processor_active,
+        set_session_plan,
+    )
+    with channel_processor_active():
+        set_session_plan(session, add_tasks(session.plan, [new_task]))
     session.current_task_id = "t2"
 
     # First reasoning on t2 -> fresh judge call (the counter for t2 is 0).

--- a/tests/test_reasoning_keyword_detector.py
+++ b/tests/test_reasoning_keyword_detector.py
@@ -123,9 +123,20 @@ def test_one_shot_per_task() -> None:
     second = dreason.detect_unreferenced_keyword(text, session)
     assert second is None
     # Switching to a new task re-enables firing.
-    session.plan.tasks.append(
-        Task(id="t2", title="Research solar panels", description="Slideshow")
+    # goldfive#247: Plan is frozen — extend via add_tasks.
+    from goldfive.types import (
+        add_tasks,
+        channel_processor_active,
+        set_session_plan,
     )
+    with channel_processor_active():
+        set_session_plan(
+            session,
+            add_tasks(
+                session.plan,
+                [Task(id="t2", title="Research solar panels", description="Slideshow")],
+            ),
+        )
     session.current_task_id = "t2"
     third = dreason.detect_unreferenced_keyword(text, session)
     assert third is not None

--- a/tests/test_refine_atomicity_events.py
+++ b/tests/test_refine_atomicity_events.py
@@ -50,6 +50,7 @@ from goldfive.types import (  # noqa: E402
     Task,
     TaskEdge,
     TaskStatus,
+    bump_revision,
 )
 
 # ---------------------------------------------------------------------------
@@ -213,8 +214,8 @@ async def test_successful_refine_emits_attempted_and_correlation_with_same_attem
     # Structurally-distinct revised plan so the steerer's no-op
     # revision rejection (goldfive#271) doesn't short-circuit refine
     # success — this test exercises the success path.
-    revised = _make_plan(("t1", "t2", "t3"))
-    revised.revision_index = 1
+    # goldfive#247: Plan is frozen — derive via bump_revision.
+    revised = bump_revision(_make_plan(("t1", "t2", "t3")), revision_index=1)
     planner = StubPlanner(revised=revised)
     sink = ListSink()
     steerer = DefaultSteerer()
@@ -330,8 +331,8 @@ async def test_validator_rejection_emits_failed_with_validator_kind() -> None:
 
 async def test_attempt_id_is_unique_per_attempt() -> None:
     """Two consecutive refines mint two distinct ``attempt_id`` values."""
-    revised = _make_plan(("t1", "t2", "t3"))
-    revised.revision_index = 1
+    # goldfive#247: Plan is frozen — derive via bump_revision.
+    revised = bump_revision(_make_plan(("t1", "t2", "t3")), revision_index=1)
     planner = StubPlanner(revised=revised)
     sink = ListSink()
     steerer = DefaultSteerer()
@@ -355,8 +356,8 @@ async def test_refine_attempted_carries_drift_kind_and_severity() -> None:
     triggering drift's kind / severity / drift_id so harmonograf can
     render an intervention timeline without re-fetching the drift.
     """
-    revised = _make_plan(("t1", "t2", "t3"))
-    revised.revision_index = 1
+    # goldfive#247: Plan is frozen — derive via bump_revision.
+    revised = bump_revision(_make_plan(("t1", "t2", "t3")), revision_index=1)
     planner = StubPlanner(revised=revised)
     sink = ListSink()
     steerer = DefaultSteerer()
@@ -400,8 +401,8 @@ async def test_wait_plan_stable_blocks_until_emit_plan_revised_completes() -> No
     mutation region releases. The barrier observes a stable plan: the
     revised one (post-mutation), never a partial state.
     """
-    revised = _make_plan(("t1", "t2", "t3"))
-    revised.revision_index = 1
+    # goldfive#247: Plan is frozen — derive via bump_revision.
+    revised = bump_revision(_make_plan(("t1", "t2", "t3")), revision_index=1)
     planner = StubPlanner(revised=revised)
     sink = ListSink()
     steerer = DefaultSteerer()
@@ -544,14 +545,18 @@ async def test_report_handler_invokes_wait_plan_stable() -> None:
     """
     from goldfive.reporting import BUILTIN_REPORTING_TOOLS
 
+    # goldfive#247: Plan is frozen — derive via helpers.
+    from goldfive.types import bump_revision as _bump
+    from tests._immutable_plan_helpers import force_task_status
+
     revised = _make_plan(("t1", "t2", "t3"))
-    revised.revision_index = 1
+    revised = _bump(revised, revision_index=1)
     planner = StubPlanner(revised=revised)
     sink = ListSink()
     steerer = DefaultSteerer()
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
-    session.plan.tasks[0].status = TaskStatus.RUNNING
+    force_task_status(session, "t1", TaskStatus.RUNNING)
     session.current_task_id = "t1"
 
     # Spy on _wait_plan_stable.
@@ -591,7 +596,10 @@ async def test_report_handler_tolerates_steerer_without_wait_plan_stable() -> No
             pass
 
     session = _make_session()
-    session.plan.tasks[0].status = TaskStatus.RUNNING
+    # goldfive#247: Plan + Task are frozen — derive via helper.
+    from tests._immutable_plan_helpers import force_task_status
+
+    force_task_status(session, "t1", TaskStatus.RUNNING)
     handler = next(
         t.handler for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_completed"
     )
@@ -609,9 +617,12 @@ async def test_proto_plan_revised_event_unchanged_on_success() -> None:
     fields it always has. The a4 attempt_id sidecar is purely additive;
     existing consumers don't observe any field change on the proto.
     """
-    revised = _make_plan(("t1", "t2", "t3"))
-    revised.revision_index = 1
-    revised.revision_reason = ""
+    # goldfive#247: Plan is frozen — derive via bump_revision.
+    revised = bump_revision(
+        _make_plan(("t1", "t2", "t3")),
+        revision_index=1,
+        revision_reason="",
+    )
     planner = StubPlanner(revised=revised)
     sink = ListSink()
     steerer = DefaultSteerer()

--- a/tests/test_refine_emit_parity.py
+++ b/tests/test_refine_emit_parity.py
@@ -493,7 +493,30 @@ class _ScriptedRefinePlanner:
         self.refine_calls.append(drift)
         if self._raise is not None:
             raise self._raise
-        return self._revised
+        if self._revised is None:
+            return None
+        # goldfive#247: pre-#247 this returned the cached
+        # ``self._revised`` instance verbatim; the parallel executor's
+        # fold-back mutated its tasks in place, and successive refines
+        # observed an "already-COMPLETED" view that satisfied the
+        # terminal-preservation validator on the second hop. With
+        # frozen :class:`Plan` the cached instance never changes — so
+        # we hand the planner a fresh derivation that copies the prior
+        # plan's terminal statuses onto the cached template's task
+        # ids. The behaviour matches what the real LLMPlanner.refine
+        # contract requires (preserve prior terminal status) and what
+        # the test was implicitly relying on pre-#247.
+        from goldfive.types import TERMINAL_TASK_STATUSES
+        from goldfive.types import with_task_status as _wts
+
+        out = self._revised
+        prior_terms = {
+            t.id: t.status for t in plan.tasks if t.status in TERMINAL_TASK_STATUSES
+        }
+        for tid, status in prior_terms.items():
+            if any(t.id == tid for t in out.tasks):
+                out = _wts(out, tid, status)
+        return out
 
     def set_drift_emitter(self, emitter: Any) -> None:
         pass

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -146,7 +146,10 @@ async def test_report_task_progress_records_progress() -> None:
     # goldfive#201: progress ticks are only valid on RUNNING tasks —
     # transition t1 first so the handler actually records progress
     # instead of returning invalid_transition.
-    session.plan.tasks[0].status = TaskStatus.RUNNING
+    # goldfive#247: Plan + Task are frozen — derive via helper.
+    from tests._immutable_plan_helpers import force_task_status
+
+    force_task_status(session, "t1", TaskStatus.RUNNING)
     await _tool("report_task_progress").handler(
         {"task_id": "t1", "fraction": 0.75, "detail": "three of four done"},
         session,
@@ -289,10 +292,20 @@ async def test_report_task_started_reroutes_to_replacement() -> None:
     """A report_task_started against a terminal+superseded id lands on the replacement."""
     steerer, session, sink, _ = _fresh()
     # Mark t1 FAILED and add a replacement superseding it.
-    session.plan.tasks[0].status = TaskStatus.FAILED
-    session.plan.tasks.append(
-        Task(id="t1_retry", title="A retry", supersedes="t1"),
+    # goldfive#247: Plan + Task are frozen — derive via helpers.
+    from goldfive.types import (
+        add_tasks,
+        channel_processor_active,
+        set_session_plan,
+        with_task_status,
     )
+    new_plan = with_task_status(session.plan, "t1", TaskStatus.FAILED)
+    new_plan = add_tasks(
+        new_plan,
+        [Task(id="t1_retry", title="A retry", supersedes="t1")],
+    )
+    with channel_processor_active():
+        set_session_plan(session, new_plan)
     out = await _tool("report_task_started").handler(
         {"task_id": "t1", "detail": "starting retry"}, session, steerer
     )

--- a/tests/test_reporting_declarations.py
+++ b/tests/test_reporting_declarations.py
@@ -160,7 +160,9 @@ async def test_declare_task_skipped_does_not_mutate_plan() -> None:
     steerer, session, sink = _fresh()
     plan_before = session.plan
     statuses_before = [t.status for t in session.plan.tasks]
-    edges_before = list(session.plan.edges)
+    # goldfive#247: Plan.edges is a tuple — capture as tuple so the
+    # equality check below compares like-for-like.
+    edges_before = tuple(session.plan.edges)
     await _tool("declare_task_skipped").handler(
         {"task_id": "t1", "reason": "skip me"}, session, steerer
     )

--- a/tests/test_reporting_tool_required_validation.py
+++ b/tests/test_reporting_tool_required_validation.py
@@ -433,7 +433,10 @@ async def test_task_started_no_required_fields_accepts_minimal_call() -> None:
     rejection."""
     steerer, session, _sink, _planner = _fresh()
     # Reset t1 to PENDING so the started transition is legal.
-    session.plan.tasks[0].status = TaskStatus.PENDING
+    # goldfive#247: Plan is frozen — derive new plan via helper.
+    from tests._immutable_plan_helpers import force_task_status
+
+    force_task_status(session, "t1", TaskStatus.PENDING)
     out = await _tool("report_task_started").handler({"task_id": "t1"}, session, steerer)
     # F1: directive ack on a real transition / accepted call.
     assert out["acknowledged"] is True

--- a/tests/test_runner_close_orphan_audit.py
+++ b/tests/test_runner_close_orphan_audit.py
@@ -118,7 +118,15 @@ class StubSteerer:
         if task is None or task.status in self._TERMINAL:
             return
         self.transitions.append((task_id, to, cancel_reason))
-        task.status = to
+        # goldfive#247: Plan + Task are frozen — derive a new plan via
+        # with_task_status and swap. Mirrors what DefaultSteerer does.
+        from goldfive.types import (
+            channel_processor_active,
+            set_session_plan,
+            with_task_status,
+        )
+        with channel_processor_active():
+            set_session_plan(session, with_task_status(session.plan, task_id, to))
         # Emit a synthetic envelope on every bound sink so tests can
         # verify event order. We don't depend on the goldfive.events
         # factory here — a dict is enough for ordering / payload-kind
@@ -310,7 +318,11 @@ async def test_close_cancels_orphan_pending_at_session_end() -> None:
     )
 
     # Plan now has both PENDING tasks flipped to CANCELLED.
-    by_id = {t.id: t.status for t in plan.tasks}
+    # goldfive#247: read from the live session.plan; the local
+    # ``plan`` reference is the pre-mutation snapshot.
+    live_session = runner._last_session_by_key.get("")
+    assert live_session is not None and live_session.plan is not None
+    by_id = {t.id: t.status for t in live_session.plan.tasks}
     assert by_id["a"] is TaskStatus.COMPLETED
     assert by_id["b"] is TaskStatus.CANCELLED
     assert by_id["c"] is TaskStatus.CANCELLED
@@ -410,7 +422,10 @@ async def test_close_with_failed_task_having_live_replacement_only_cancels_pendi
     )
     # b stays FAILED — the steerer's terminal guard prevented a
     # double-transition even if the audit had asked.
-    by_id = {t.id: t.status for t in plan.tasks}
+    # goldfive#247: read from the live session.plan after the swap.
+    live_session = runner._last_session_by_key.get("")
+    assert live_session is not None and live_session.plan is not None
+    by_id = {t.id: t.status for t in live_session.plan.tasks}
     assert by_id["a"] is TaskStatus.COMPLETED
     assert by_id["b"] is TaskStatus.FAILED, (
         f"b must remain FAILED (terminal); got {by_id['b']}"

--- a/tests/test_runner_integration.py
+++ b/tests/test_runner_integration.py
@@ -152,7 +152,7 @@ async def test_runner_drives_goal_plan_parallel_dag_and_persists(tmp_path: Path)
     assert outcome.success is True
     session = outcome.session
     assert session.plan is not None
-    assert session.plan.goal_ids == ["g1"]
+    assert session.plan.goal_ids == ("g1",)
 
     # All four tasks should have reached COMPLETED.
     statuses = {t.id: t.status for t in session.plan.tasks}

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -90,10 +90,16 @@ class StubSteerer:
     ) -> None:
         if session.plan is None:
             return
-        for t in session.plan.tasks:
-            if t.id == task_id:
-                t.status = to
-                return
+        # goldfive#247: derive new plan + swap (frozen Plan).
+        if not any(t.id == task_id for t in session.plan.tasks):
+            return
+        from goldfive.types import (
+            channel_processor_active,
+            set_session_plan,
+            with_task_status,
+        )
+        with channel_processor_active():
+            set_session_plan(session, with_task_status(session.plan, task_id, to))
 
     def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
         return None
@@ -218,7 +224,9 @@ async def test_linear_plan_runs_to_completion() -> None:
     assert outcome.success is True
     assert outcome.session is session
     assert adapter.invocations == ["t0", "t1", "t2"]
-    for t in plan.tasks:
+    # goldfive#247: read from session.plan (live).
+    assert session.plan is not None
+    for t in session.plan.tasks:
         assert t.status == TaskStatus.COMPLETED
 
     # The executor itself owns only the terminal RunCompleted (Runner
@@ -474,7 +482,7 @@ async def test_fail_fast_false_continues_past_failure() -> None:
     # Terminal event is RunAborted with a fail_fast=False reason.
     assert sink.payload_kinds()[-1] == "run_aborted"
     # Remaining tasks a and c are COMPLETED, b stayed FAILED.
-    by_id = {t.id: t.status for t in plan.tasks}
+    by_id = {t.id: t.status for t in (outcome.session.plan or plan).tasks}
     assert by_id == {
         "a": TaskStatus.COMPLETED,
         "b": TaskStatus.FAILED,
@@ -844,7 +852,7 @@ async def test_retry_lineage_cap_collapses_nested_retry_prefixes() -> None:
     # lineage cap and marked FAILED without hitting the adapter.
     assert adapter.invocations == ["t0", "retry_t0"]
     assert outcome.success is False  # one task ended FAILED (retry_retry_t0)
-    by_id = {t.id: t.status for t in plan.tasks}
+    by_id = {t.id: t.status for t in (outcome.session.plan or plan).tasks}
     assert by_id["t0"] == TaskStatus.COMPLETED
     assert by_id["retry_t0"] == TaskStatus.COMPLETED
     assert by_id["retry_retry_t0"] == TaskStatus.FAILED
@@ -904,7 +912,7 @@ async def test_executor_run_with_orphaned_pending_reports_failure() -> None:
     # ended the run as failure. Without the audit, outcome.success
     # would be True and t1 would stay PENDING forever.
     assert outcome.success is False
-    by_id = {t.id: t.status for t in plan.tasks}
+    by_id = {t.id: t.status for t in (outcome.session.plan or plan).tasks}
     assert by_id["t0"] == TaskStatus.CANCELLED
     assert by_id["t1"] == TaskStatus.CANCELLED
     # Terminal event is RunAborted (not RunCompleted).
@@ -1198,7 +1206,10 @@ async def test_max_task_invocations_unbounded_default_completes_large_plan() -> 
 
     assert outcome.success is True
     assert len(adapter.invocations) == n
-    for t in plan.tasks:
+    # goldfive#247: read from session.plan (live) — local ``plan`` is
+    # the pre-mutation snapshot.
+    assert outcome.session.plan is not None
+    for t in outcome.session.plan.tasks:
         assert t.status == TaskStatus.COMPLETED
     assert sink.payload_kinds()[-1] == "run_completed"
 

--- a/tests/test_sequential_executor_overlay.py
+++ b/tests/test_sequential_executor_overlay.py
@@ -95,10 +95,16 @@ class StubSteerer:
         self.transition_details.append((task_id, to, detail, cancel_reason))
         if session.plan is None:
             return
-        for t in session.plan.tasks:
-            if t.id == task_id:
-                t.status = to
-                return
+        # goldfive#247: derive new plan + swap (frozen Plan).
+        if not any(t.id == task_id for t in session.plan.tasks):
+            return
+        from goldfive.types import (
+            channel_processor_active,
+            set_session_plan,
+            with_task_status,
+        )
+        with channel_processor_active():
+            set_session_plan(session, with_task_status(session.plan, task_id, to))
 
     def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:  # noqa: ARG002
         return None
@@ -235,7 +241,7 @@ async def test_overlay_mode_single_passthrough_no_missed_tasks() -> None:
     assert outcome.success is True
     assert adapter.passthrough_calls == ["make it"]
     assert adapter.follow_up_calls == [], "no follow-ups should ever fire under #163"
-    for t in plan.tasks:
+    for t in (outcome.session.plan or plan).tasks:  # goldfive#247
         assert t.status is TaskStatus.COMPLETED
     assert sink.payload_kinds()[-1] == "run_completed"
 
@@ -289,7 +295,7 @@ async def test_overlay_does_not_dispatch_follow_ups() -> None:
     # predecessor t0 just COMPLETED so t1 is reachable next turn; t2's
     # predecessor t1 is still PENDING (not broken). The overlay leaves
     # both alone for the next turn to drive.
-    by_id = {t.id: t.status for t in plan.tasks}
+    by_id = {t.id: t.status for t in (outcome.session.plan or plan).tasks}  # goldfive#247
     assert by_id["t0"] is TaskStatus.COMPLETED
     assert by_id["t1"] is TaskStatus.PENDING, (
         f"reachable t1 should remain PENDING for next turn, got {by_id['t1']}"
@@ -341,7 +347,7 @@ async def test_overlay_pending_stays_pending_when_predecessors_pending() -> None
     assert [tid for tid, to in steerer.transitions if to is TaskStatus.NOT_NEEDED] == []
     assert [tid for tid, to in steerer.transitions if to is TaskStatus.CANCELLED] == []
     # All tasks remain PENDING for the next turn.
-    for t in plan.tasks:
+    for t in (outcome.session.plan or plan).tasks:  # goldfive#247
         assert t.status is TaskStatus.PENDING
     # And of course: no follow-up dispatch.
     assert adapter.follow_up_calls == []
@@ -680,7 +686,9 @@ async def test_overlay_goldfive_pause_leaves_unreachable_pending() -> None:
         "goldfive_pause must trigger structural early return before "
         f"orphan sweep, got {steerer.transitions!r}"
     )
-    by_id = {t.id: t.status for t in plan.tasks}
+    # goldfive#247: read from session.plan (live).
+    live_plan = session.plan or plan
+    by_id = {t.id: t.status for t in live_plan.tasks}
     assert by_id["downstream"] is TaskStatus.PENDING
 
 
@@ -729,9 +737,18 @@ async def test_overlay_no_pending_tasks_no_not_needed_transitions() -> None:
         reconciler: Any,  # noqa: ARG001
     ) -> InvocationResult:
         # Simulate the tree completing every task directly.
+        # goldfive#247: derive new plan via helpers (frozen Plan).
         if session.plan is not None:
-            for t in session.plan.tasks:
-                t.status = TaskStatus.COMPLETED
+            from goldfive.types import (
+                channel_processor_active,
+                set_session_plan,
+                with_task_status,
+            )
+            new_plan = session.plan
+            for t in list(session.plan.tasks):
+                new_plan = with_task_status(new_plan, t.id, TaskStatus.COMPLETED)
+            with channel_processor_active():
+                set_session_plan(session, new_plan)
         return InvocationResult(task_id="", text="")
 
     adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
@@ -825,9 +842,18 @@ async def test_overlay_steer_restart_still_works() -> None:
             )()
             return ("steer", msg)
         # Second invocation: mark every task COMPLETED directly.
+        # goldfive#247: derive new plan via helpers (frozen Plan).
         if session.plan is not None:
-            for t in session.plan.tasks:
-                t.status = TaskStatus.COMPLETED
+            from goldfive.types import (
+                channel_processor_active,
+                set_session_plan,
+                with_task_status,
+            )
+            new_plan = session.plan
+            for t in list(session.plan.tasks):
+                new_plan = with_task_status(new_plan, t.id, TaskStatus.COMPLETED)
+            with channel_processor_active():
+                set_session_plan(session, new_plan)
         return ("result", InvocationResult(task_id="", text="done"))
 
     executor._invoke_passthrough_with_control = _fake_invoke_passthrough_with_control  # type: ignore[assignment]
@@ -896,7 +922,7 @@ async def test_overlay_cancel_still_works() -> None:
     # No follow-ups, no NOT_NEEDED sweep on cancel — we exit early.
     assert adapter.follow_up_calls == []
     # Tasks remain PENDING (we aborted; didn't reach the sweep).
-    for t in plan.tasks:
+    for t in (outcome.session.plan or plan).tasks:  # goldfive#247
         assert t.status is TaskStatus.PENDING
 
 
@@ -957,10 +983,21 @@ class LegacyStubAdapter:
 
     async def invoke(self, task: Task, session: Session) -> InvocationResult:
         self.invocations.append(task.id)
-        for t in session.plan.tasks:
-            if t.id == task.id:
-                t.status = TaskStatus.COMPLETED
-                return InvocationResult(task_id=task.id, text=f"done:{task.id}")
+        # goldfive#247: derive new plan + swap (frozen Plan).
+        if session.plan is not None and any(
+            t.id == task.id for t in session.plan.tasks
+        ):
+            from goldfive.types import (
+                channel_processor_active,
+                set_session_plan,
+                with_task_status,
+            )
+            with channel_processor_active():
+                set_session_plan(
+                    session,
+                    with_task_status(session.plan, task.id, TaskStatus.COMPLETED),
+                )
+            return InvocationResult(task_id=task.id, text=f"done:{task.id}")
         return InvocationResult(task_id=task.id, text="")
 
 

--- a/tests/test_state_rotation.py
+++ b/tests/test_state_rotation.py
@@ -110,8 +110,10 @@ def test_rotate_with_one_pending_pins_the_next_task() -> None:
     state: dict[str, Any] = {"goldfive.current_task_id": "t1"}
 
     # Mark t1 terminal externally (the helper's job is rotation, not
-    # transition).
-    plan.tasks[0].status = TaskStatus.COMPLETED
+    # transition). goldfive#247: Plan is frozen — derive new plan.
+    from goldfive.types import with_task_status as _wts
+
+    plan = _wts(plan, plan.tasks[0].id, TaskStatus.COMPLETED)
 
     out = _ostate.rotate_current_task_id(state, plan, "worker")
 

--- a/tests/test_steer_unification.py
+++ b/tests/test_steer_unification.py
@@ -204,8 +204,9 @@ async def test_goldfive_steer_promotes_at_warning_severity() -> None:
     assert session.state[_ostate.KEY_ACTIVE_STEER_SOURCE] == "goldfive"
     # Adapter cancel reason tagged.
     assert adapter._next_cancel_reason == "goldfive_off_topic"
-    # Revised plan installed.
-    assert session.plan is planner.revised
+    # Revised plan installed. goldfive#247: identity check replaced
+    # with id check (Plan is frozen).
+    assert session.plan is not None and session.plan.id == planner.revised.id
 
 
 async def test_goldfive_steer_does_not_promote_at_info_severity() -> None:

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -34,6 +34,9 @@ from goldfive.types import (  # noqa: E402
     Task,
     TaskEdge,
     TaskStatus,
+    channel_processor_active,
+    set_session_plan,
+    with_task_status,
 )
 
 # ---------------------------------------------------------------------------
@@ -196,7 +199,13 @@ async def test_mark_task_running_transitions_and_emits() -> None:
 
 async def test_mark_task_running_no_op_on_terminal() -> None:
     steerer, session, sink, _ = _fresh()
-    _task(session, "t1").status = TaskStatus.COMPLETED
+    # goldfive#247: Plan + Task are frozen — derive a new plan via
+    # with_task_status and swap. The contextvar wrap is the
+    # structural envelope every plan-pointer swap goes through.
+    with channel_processor_active():
+        set_session_plan(
+            session, with_task_status(session.plan, "t1", TaskStatus.COMPLETED)
+        )
     await steerer.mark_task_running("t1", session=session)
     assert _task(session, "t1").status is TaskStatus.COMPLETED
     assert sink.events == []
@@ -513,9 +522,11 @@ def test_detect_drift_prefers_tool_error_then_refusal_then_stop_reason() -> None
 async def test_observe_emits_drift_and_refines() -> None:
     from goldfive.pb.goldfive.v1 import types_pb2
 
+    # _make_plan already sets id="p1" and run_id="r1". Pre-#247 the
+    # test then reassigned them; with frozen Plan (goldfive#247) those
+    # reassigns would FrozenInstanceError, and they were redundant
+    # anyway, so they're dropped here.
     revised = _make_plan(("t1", "t2", "t3"))
-    revised.id = "p1"
-    revised.run_id = "r1"
     planner = StubPlanner(revised=revised)
     sink = ListSink()
     steerer = DefaultSteerer()
@@ -528,8 +539,12 @@ async def test_observe_emits_drift_and_refines() -> None:
     assert kinds == ["drift_detected", "plan_revised"]
     assert sink.events[0].drift_detected.kind == types_pb2.DRIFT_KIND_TOOL_ERROR
     assert len(planner.refine_calls) == 1
-    # Session's plan is replaced with revised, and revision metadata stamped.
-    assert session.plan is revised
+    # goldfive#247: Plan is frozen — _apply_revision builds a NEW Plan
+    # via bump_revision; identity is no longer the assertion. Verify
+    # the same plan_id is preserved across the swap and metadata is
+    # stamped.
+    assert session.plan is not None
+    assert session.plan.id == revised.id
     assert session.plan.revision_kind == DriftKind.TOOL_ERROR.value
     assert session.plan.revision_severity == DriftSeverity.WARNING.value
     assert session.plan.revision_index >= 1
@@ -1108,8 +1123,13 @@ async def test_apply_revision_silently_folds_terminal_regression(
         await steerer.observe({"error": "trigger refine"}, session)
 
     # Plan was installed (revision_index advanced) and t1 is still
-    # COMPLETED — the fold corrected the regression.
-    assert session.plan is stale_revised
+    # COMPLETED — the fold corrected the regression. goldfive#247: the
+    # frozen-Plan refactor made the install path build a NEW Plan via
+    # `_fold_runtime_terminal_statuses`, so identity is no longer the
+    # check; we assert the post-install plan id matches the LLM
+    # revision (same id is preserved across the swap).
+    assert session.plan is not None
+    assert session.plan.id == stale_revised.id
     assert session.plan.revision_index == prior.revision_index + 1
     new_by_id = {t.id: t for t in session.plan.tasks}
     assert new_by_id["t1"].status is TaskStatus.COMPLETED
@@ -1762,7 +1782,11 @@ async def test_mark_task_cancelled_does_not_cascade_to_completed() -> None:
     steerer = DefaultSteerer()
     plan = _make_plan(("t1", "t2"))
     session = _make_session(plan)
-    _task(session, "t2").status = TaskStatus.COMPLETED
+    # goldfive#247: derive a new plan with t2 marked COMPLETED.
+    with channel_processor_active():
+        set_session_plan(
+            session, with_task_status(session.plan, "t2", TaskStatus.COMPLETED)
+        )
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=StubPlanner())
 

--- a/tests/test_steerer_fold_runtime_terminal.py
+++ b/tests/test_steerer_fold_runtime_terminal.py
@@ -52,6 +52,24 @@ from goldfive.types import (  # noqa: E402
     TaskStatus,
 )
 
+
+def _fold_ids(revised: Plan, prior: Plan | None) -> tuple[list[str], Plan]:
+    """Compatibility shim around the goldfive#247-changed fold signature.
+
+    Pre-#247 ``_fold_runtime_terminal_statuses`` mutated ``revised`` in
+    place and returned the folded task ids as a list. With the frozen
+    Plan refactor it returns a NEW Plan; this helper computes the
+    folded-id list by diffing input vs output so the existing test
+    assertions ``folded == [...]`` keep working.
+    """
+    folded_plan = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+    if folded_plan is revised:
+        return [], folded_plan
+    before = {t.id: t.status for t in revised.tasks}
+    after = {t.id: t.status for t in folded_plan.tasks}
+    folded_ids = [tid for tid, status in after.items() if before.get(tid) is not status]
+    return folded_ids, folded_plan
+
 # ---------------------------------------------------------------------------
 # Local stubs (mirrored from test_steerer.py for self-containment)
 # ---------------------------------------------------------------------------
@@ -164,7 +182,9 @@ def test_fold_overwrites_pending_with_prior_not_needed() -> None:
         ],
     )
 
-    folded = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+    # goldfive#247: fold returns a NEW Plan; use the shim to recover
+    # the folded-id list and bind to the post-fold plan.
+    folded, revised = _fold_ids(revised, prior)
 
     assert folded == ["correct_research"], folded
     new_by_id = {t.id: t for t in revised.tasks}
@@ -199,7 +219,9 @@ def test_fold_no_op_when_revised_already_matches_prior_terminal() -> None:
         edges=[],
     )
 
-    folded = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+    # goldfive#247: fold returns a NEW Plan; use the shim to recover
+    # the folded-id list and bind to the post-fold plan.
+    folded, revised = _fold_ids(revised, prior)
 
     assert folded == []
     assert revised.tasks[0].status is TaskStatus.CANCELLED
@@ -231,7 +253,9 @@ def test_fold_preserves_genuine_terminal_to_terminal_regression() -> None:
         edges=[],
     )
 
-    folded = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+    # goldfive#247: fold returns a NEW Plan; use the shim to recover
+    # the folded-id list and bind to the post-fold plan.
+    folded, revised = _fold_ids(revised, prior)
 
     # No fold — the validator owns this rejection.
     assert folded == []
@@ -247,9 +271,11 @@ def test_fold_handles_none_or_empty_prior() -> None:
         edges=[],
     )
 
-    assert DefaultSteerer._fold_runtime_terminal_statuses(revised, None) == []
+    # goldfive#247: fold returns the input unchanged on no-op; verify
+    # via _fold_ids shim which yields the empty folded-id list.
+    assert _fold_ids(revised, None)[0] == []
     empty = Plan(id="p1", run_id="r1", goal_ids=["g1"], tasks=[], edges=[])
-    assert DefaultSteerer._fold_runtime_terminal_statuses(revised, empty) == []
+    assert _fold_ids(revised, empty)[0] == []
 
 
 def test_fold_skips_tasks_present_only_in_prior() -> None:
@@ -278,7 +304,9 @@ def test_fold_skips_tasks_present_only_in_prior() -> None:
         edges=[],
     )
 
-    folded = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+    # goldfive#247: fold returns a NEW Plan; use the shim to recover
+    # the folded-id list and bind to the post-fold plan.
+    folded, revised = _fold_ids(revised, prior)
 
     assert folded == []
     assert {t.id for t in revised.tasks} == {"t1", "t2"}
@@ -324,7 +352,10 @@ async def test_install_with_drift_folds_runtime_not_needed_into_snapshot() -> No
         edges=[TaskEdge("research", "correct_research")],
     )
     # Bump the prior's revision_index so we can see monotonic advance.
-    prior.revision_index = 3
+    # goldfive#247: Plan is frozen — derive via bump_revision.
+    from goldfive.types import bump_revision
+
+    prior = bump_revision(prior, revision_index=3)
     session = _make_session(plan=prior)
 
     revised = Plan(
@@ -374,7 +405,8 @@ async def test_install_with_drift_folds_runtime_not_needed_into_snapshot() -> No
         "install must succeed: the fold corrects the regression before "
         "validation runs"
     )
-    assert session.plan is revised
+    # goldfive#247: identity check replaced with id check (Plan is frozen)
+    assert session.plan is not None and session.plan.id == revised.id
     assert session.plan.revision_index == 4
     new_by_id = {t.id: t for t in session.plan.tasks}
     assert new_by_id["correct_research"].status is TaskStatus.NOT_NEEDED, (
@@ -448,7 +480,8 @@ async def test_install_with_drift_genuine_terminal_regression_still_rejected() -
 
     assert installed is False
     # Plan unchanged.
-    assert session.plan is prior
+    # goldfive#247: identity check replaced with id check (Plan is frozen)
+    assert session.plan is not None and session.plan.id == prior.id
     assert prior.tasks[0].status is TaskStatus.CANCELLED
     # SCHEMA_VIOLATION drift surfaced.
     schema_violations = [
@@ -520,8 +553,12 @@ async def test_install_user_steer_folds_before_validating_llm_revision() -> None
     )
 
     # The LLM revision was used (not the deterministic minimum) because
-    # the fold corrected the regression before validation.
-    assert returned is llm_revision
+    # the fold corrected the regression before validation. goldfive#247:
+    # _apply_revision returns a NEW Plan (frozen Plan); identity is no
+    # longer the right check — verify the plan id matches and the
+    # post-fold contents.
+    assert returned is not None
+    assert returned.id == llm_revision.id
     new_by_id = {t.id: t for t in session.plan.tasks}
     assert new_by_id["correct_research"].status is TaskStatus.NOT_NEEDED
     assert new_by_id["finalize"].status is TaskStatus.PENDING
@@ -614,7 +651,9 @@ async def test_apply_revision_defensive_fold_idempotent_when_caller_already_fold
     session = _make_session(plan=prior)
 
     # First fold (caller-equivalent): no-op.
-    folded_first = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+    # goldfive#247: shim to compute the folded-id list from the new
+    # Plan-returning signature.
+    folded_first, _ = _fold_ids(revised, prior)
     assert folded_first == []
 
     # _apply_revision's internal defensive fold: also no-op.
@@ -623,9 +662,10 @@ async def test_apply_revision_defensive_fold_idempotent_when_caller_already_fold
         severity=DriftSeverity.INFO,
         detail="x",
     )
-    DefaultSteerer._apply_revision(session, revised, drift)
+    revised = DefaultSteerer._apply_revision(session, revised, drift)  # goldfive#247: rebind
 
-    assert session.plan is revised
+    # goldfive#247: identity check replaced with id check (Plan is frozen)
+    assert session.plan is not None and session.plan.id == revised.id
     new_by_id = {t.id: t for t in session.plan.tasks}
     assert new_by_id["t1"].status is TaskStatus.NOT_NEEDED
     assert new_by_id["t2"].status is TaskStatus.PENDING

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -878,9 +878,11 @@ async def test_apply_revision_stamps_trigger_event_id_from_annotation(
         ],
         edges=[TaskEdge(from_task_id="t1", to_task_id="t2b")],
     )
-    DefaultSteerer._apply_revision(session, revised, drift)
+    # goldfive#247: _apply_revision returns the stamped Plan; the
+    # input Plan stays unchanged (frozen).
+    revised = DefaultSteerer._apply_revision(session, revised, drift)
 
-    assert session.plan is revised
+    assert session.plan is not None and session.plan.id == revised.id
     assert revised.revision_trigger_event_id == "ann_ar_77"
 
 
@@ -911,7 +913,9 @@ async def test_apply_revision_stamps_drift_id_on_autonomous_drift(
         tasks=[Task(id="t1", title="T1", status=TaskStatus.COMPLETED)],
         edges=[],
     )
-    DefaultSteerer._apply_revision(session, revised, drift)
+    # goldfive#247: _apply_revision returns the stamped Plan; the input
+    # stays unchanged (frozen).
+    revised = DefaultSteerer._apply_revision(session, revised, drift)
     assert revised.revision_trigger_event_id == drift.id
 
 

--- a/tests/test_task_binding_follows_revision.py
+++ b/tests/test_task_binding_follows_revision.py
@@ -168,7 +168,7 @@ async def test_current_task_id_repins_on_revision() -> None:
     planner = _StubPlanner(revised=revised)
     steerer = DefaultSteerer()
     steerer.bind(sinks=[ListSink()], planner=planner)
-    steerer._apply_revision(session, revised, _drift())
+    revised = steerer._apply_revision(session, revised, _drift())  # goldfive#247: rebind
     await steerer._emit_plan_revised(session, revised, _drift(), prev_plan=None)
 
     assert session.current_task_id == "research_solar_corrected"
@@ -182,10 +182,10 @@ async def test_report_task_progress_routes_to_replacement() -> None:
         plan=_revised_with_replacement(),
     )
     # Transition the replacement into RUNNING so the progress tick is
-    # a legal transition target.
-    for t in session.plan.tasks:
-        if t.id == "research_solar_corrected":
-            t.status = TaskStatus.RUNNING
+    # a legal transition target. goldfive#247: derive via helper.
+    from tests._immutable_plan_helpers import force_task_status
+
+    force_task_status(session, "research_solar_corrected", TaskStatus.RUNNING)
 
     sink = ListSink()
     planner = _StubPlanner()
@@ -436,7 +436,7 @@ async def test_integrate_correction_supersedes_keeps_old_task() -> None:
         revision_index=1,
     )
 
-    DefaultSteerer._integrate_correction_supersedes(revised)
+    revised = DefaultSteerer._integrate_correction_supersedes(revised)
 
     by_id = {t.id: t for t in revised.tasks}
     # Old task preserved with its COMPLETED status intact.
@@ -461,7 +461,7 @@ async def test_integrate_correction_supersedes_replace_kind_no_dag_rewrite() -> 
     """
     revised = _revised_with_replacement()
     original_edges = [(e.from_task_id, e.to_task_id) for e in revised.edges]
-    DefaultSteerer._integrate_correction_supersedes(revised)
+    revised = DefaultSteerer._integrate_correction_supersedes(revised)
     # No edge mutations.
     assert [(e.from_task_id, e.to_task_id) for e in revised.edges] == original_edges
 
@@ -495,7 +495,7 @@ async def test_validator_coerces_replace_to_correct_on_completed() -> None:
         edges=[],
         revision_index=1,
     )
-    _normalize_supersession_kinds(revised, prior=prior)
+    revised = _normalize_supersession_kinds(revised, prior=prior)
     by_id = {t.id: t for t in revised.tasks}
     assert by_id["research_solar_corrected"].supersedes_kind is SupersessionKind.CORRECT
 
@@ -506,7 +506,10 @@ async def test_validator_coerces_correct_to_replace_on_pending() -> None:
 
     prior = _plan_with_failed_research()
     # Swap research_solar back to PENDING for this scenario.
-    prior.tasks[0].status = TaskStatus.PENDING
+    # goldfive#247: Plan is frozen — derive a new prior via with_task_status.
+    from goldfive.types import with_task_status as _wts
+
+    prior = _wts(prior, prior.tasks[0].id, TaskStatus.PENDING)
     revised = Plan(
         id="p1",
         run_id="r1",
@@ -530,7 +533,7 @@ async def test_validator_coerces_correct_to_replace_on_pending() -> None:
         edges=[],
         revision_index=1,
     )
-    _normalize_supersession_kinds(revised, prior=prior)
+    revised = _normalize_supersession_kinds(revised, prior=prior)
     by_id = {t.id: t for t in revised.tasks}
     assert by_id["research_solar_v2"].supersedes_kind is SupersessionKind.REPLACE
 
@@ -556,7 +559,7 @@ async def test_validator_clears_kind_with_empty_target() -> None:
         edges=[],
         revision_index=1,
     )
-    _normalize_supersession_kinds(revised, prior=prior)
+    revised = _normalize_supersession_kinds(revised, prior=prior)
     assert revised.tasks[0].supersedes_kind is SupersessionKind.UNSPECIFIED
 
 
@@ -586,7 +589,7 @@ async def test_validator_unspecified_resolves_from_status() -> None:
         edges=[],
         revision_index=1,
     )
-    _normalize_supersession_kinds(revised, prior=prior)
+    revised = _normalize_supersession_kinds(revised, prior=prior)
     by_id = {t.id: t for t in revised.tasks}
     assert by_id["research_solar_corrected"].supersedes_kind is SupersessionKind.CORRECT
 
@@ -636,7 +639,7 @@ async def test_downstream_edge_rewrite_on_correct_chain() -> None:
         revision_index=1,
     )
 
-    DefaultSteerer._integrate_correction_supersedes(revised)
+    revised = DefaultSteerer._integrate_correction_supersedes(revised)
 
     edges_set = {(e.from_task_id, e.to_task_id) for e in revised.edges}
     # Chain is now a -> a_prime -> b -> c.
@@ -816,7 +819,7 @@ async def test_correct_integration_via_emit_plan_revised_end_to_end() -> None:
     planner = _StubPlanner(revised=revised)
     steerer = DefaultSteerer()
     steerer.bind(sinks=[sink], planner=planner)
-    steerer._apply_revision(session, revised, _drift())
+    revised = steerer._apply_revision(session, revised, _drift())  # goldfive#247: rebind
     await steerer._emit_plan_revised(session, revised, _drift(), prev_plan=None)
 
     # Session plan now has the corrected topology.

--- a/tests/test_task_id_wiring.py
+++ b/tests/test_task_id_wiring.py
@@ -458,7 +458,14 @@ async def test_pin_supersedes_redirection_tracks_replacement() -> None:
     assert session.state[KEY_CURRENT_TASK_ID] == "C"
 
     # Flip B to COMPLETED; now C is DAG-ready -> signal 2 binds.
-    plan.tasks[1].status = TaskStatus.COMPLETED
+    # goldfive#247: Plan is frozen — derive via helper. ``session.plan``
+    # is the same Plan object as the local ``plan`` variable, but since
+    # ``_session_with(plan)`` doesn't copy, swapping ``session.plan``
+    # to the new derivation also serves the plugin's reads.
+    from tests._immutable_plan_helpers import force_task_status
+
+    force_task_status(session, "B", TaskStatus.COMPLETED)
+    plan = session.plan
     await plugin.before_agent_callback(
         agent=_Agent("research_agent"),
         callback_context=ctx,

--- a/tests/test_task_lineage.py
+++ b/tests/test_task_lineage.py
@@ -202,17 +202,17 @@ async def test_lineage_clears_on_cascade_cancel_downstream() -> None:
     """
     upstream = Task(id="u", title="Upstream", assignee_agent_id="a1")
     downstream = Task(id="d", title="Downstream", assignee_agent_id="a2")
+    # goldfive#247: build the plan with edges at construction (Plan
+    # is frozen — no in-place mutation).
+    from goldfive.types import TaskEdge
+
     plan = Plan(
         id="p1",
         run_id="r1",
         goal_ids=["g1"],
         tasks=[upstream, downstream],
-        edges=[],
+        edges=[TaskEdge(from_task_id="u", to_task_id="d")],
     )
-    # Edge "upstream → downstream" so the cascade reaches d.
-    from goldfive.types import TaskEdge
-
-    plan.edges = [TaskEdge(from_task_id="u", to_task_id="d")]
     session = Session(
         run_id="r1",
         goals=[Goal(id="g1", summary="demo")],
@@ -231,7 +231,11 @@ async def test_lineage_clears_on_cascade_cancel_downstream() -> None:
     await steerer.mark_task_failed("u", session=session, recoverable=False)
     assert "u" not in session.task_lineage
     assert "d" not in session.task_lineage
-    assert downstream.status is TaskStatus.CANCELLED
+    # goldfive#247: read live status from session.plan; the local
+    # ``downstream`` reference is the pre-mutation snapshot.
+    assert session.plan is not None
+    live_d = next(t for t in session.plan.tasks if t.id == "d")
+    assert live_d.status is TaskStatus.CANCELLED
 
 
 async def test_delegation_observed_with_no_pinned_task_is_noop() -> None:

--- a/tests/test_task_transitioned_events.py
+++ b/tests/test_task_transitioned_events.py
@@ -332,7 +332,7 @@ async def test_refine_replace_supersedes_emits_plan_revision_transition() -> Non
     # Mirror the live order: _apply_revision installs ``revised`` on the
     # session, then _emit_plan_revised diffs prev_plan vs. revised and
     # emits the proto + per-transition envelopes.
-    steerer._apply_revision(session, revised, drift)
+    revised = steerer._apply_revision(session, revised, drift)  # goldfive#247: rebind
     await steerer._emit_plan_revised(session, revised, drift, prev_plan=prev_plan)
 
     transitions = _transition_events(sink)
@@ -796,11 +796,13 @@ async def test_control_rewind_emits_control_rewind_transition() -> None:
         msg, session=session, steerer=steerer, sinks=[sink]
     )
 
-    # Sanity: rewind succeeded.
+    # Sanity: rewind succeeded. goldfive#247: read from session.plan
+    # since the local ``plan`` reference is the pre-rewind snapshot.
     assert outcome.rewind_task_id == "t1"
-    assert plan.tasks[0].status == TaskStatus.COMPLETED  # t0 unchanged
-    assert plan.tasks[1].status == TaskStatus.PENDING
-    assert plan.tasks[2].status == TaskStatus.PENDING
+    assert session.plan is not None
+    assert session.plan.tasks[0].status == TaskStatus.COMPLETED  # t0 unchanged
+    assert session.plan.tasks[1].status == TaskStatus.PENDING
+    assert session.plan.tasks[2].status == TaskStatus.PENDING
 
     transitions = _transition_events(sink)
     rewind_transitions = [

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -806,6 +806,9 @@ class TestTaskUpstreamReady:
         # as ready).
         assert task_upstream_ready(plan, "C") is False
 
-        # Flip B to COMPLETED — C becomes ready.
-        plan.tasks[1].status = TaskStatus.COMPLETED
+        # Flip B to COMPLETED — C becomes ready. goldfive#247: Plan is
+        # frozen — derive a new plan via with_task_status.
+        from goldfive.types import with_task_status as _wts
+
+        plan = _wts(plan, "B", TaskStatus.COMPLETED)
         assert task_upstream_ready(plan, "C") is True


### PR DESCRIPTION
## Summary

Phase 3 of 5 in the goldfive#247 structural fix: eliminate the
**torn-read** bug class surfaced by the brussels-sprouts and tomato
e2e sessions. Judges read `session.plan` / `task.status`, await an
LLM, and produce a verdict against a snapshot the live state has
mutated past. Pre-#247, `mark_task_completed` flipped `task.status`
in place and `_apply_revision` swapped `session.plan` whole-cloth —
both happening DURING a judge's LLM round-trip.

The structural fix at the type level: **`Plan` and `Task` are
immutable**. Every "mutation" constructs a new object; `session.plan`
is a pointer that swaps atomically; readers who captured a `Plan`
reference keep operating on that snapshot for the duration of their
work.

## What changed

- **`Plan`, `Task`, `TaskEdge`** are `@dataclass(frozen=True)`. List
  fields become tuples (`tasks: tuple[Task, ...]`, etc.); back-compat
  list inputs are coerced in `Plan.__post_init__`.
- **Helpers** (the blessed mutation primitives, all in
  `goldfive.types`):
  - `replace_task(plan, task_id, **changes)`
  - `with_task_status(plan, task_id, status)`
  - `add_tasks(plan, new_tasks)`
  - `replace_edges(plan, edges)`
  - `bump_revision(plan, *, revision_index=..., revision_kind=..., ...)`
- **Single-writer enforcement**: `set_session_plan(session, plan)`
  checks the `_CHANNEL_PROCESSOR_ACTIVE` contextvar. Outside the
  context manager (`channel_processor_active()`), it logs a WARNING
  in production and raises `PlanOwnershipViolation` under
  `GOLDFIVE_STRICT_STATE_OWNERSHIP=1` (mirrors the existing
  `_state_audit` opt-in tripwire; pytest auto-enables strict).
- **37 mutation sites converted** in `goldfive/`:
  - `DefaultSteerer.mark_task_*` (6 paths) + `cascade_cancel_downstream`
  - `DefaultSteerer._apply_revision` (now returns the stamped Plan;
    callers rebind their local `revised` reference)
  - `DefaultSteerer._fold_runtime_terminal_statuses` (now returns a
    new Plan; 5 call sites updated)
  - `DefaultSteerer._integrate_correction_supersedes`
  - `ParallelDAGExecutor.run` / `run_one` / `_refine`
  - `SequentialExecutor.run`
  - `executors/_control.py::_rewind_plan`
  - `Runner._install_revision`, `Runner.run`
  - `LLMPlanner.refine` / `_refine_looping_tool_call`
  - `planner._normalize_supersession_kinds` /
    `_backfill_retry_supersedes`
  - `sinks/persistence.py::reconstruct_session`
- **`docs/design/PLAN-LIFECYCLE.md`** gains §7.1 "Immutable Plan/Task
  and the single-writer rule" with the helper table, the channel-
  processor pattern, and Phase-1 / 2 / 4 / 5 cross-references.

## Test plan

- [x] New `tests/test_immutable_plan.py` (19 tests) covers frozen
  enforcement, helper purity, snapshot semantics, and the
  contextvar gate (warn vs strict).
- [x] `tests/_immutable_plan_helpers.py` — shared shim
  (`force_task_status`, `append_tasks`, etc.) for the test fixtures
  that previously mutated in place.
- [x] 27 test files updated; identity asserts
  (`session.plan is X`) replaced with id asserts where the swap
  produces a fresh Plan.
- [x] `uv run pytest tests/` — 1892 passed, 120 skipped.
- [x] `uv run ruff check goldfive/ tests/` — clean.
- [x] `uv run mypy goldfive/types.py goldfive/steerer.py` — 1 error
  (preexisting on main, unrelated to this change).

## Coordination

- **Phase 1 (#245)** — `DriftEvent.observed_revision_index` becomes
  honest because the captured plan revision can no longer drift under
  the drift handler's feet.
- **Phase 2 (#246)** — ControlMessage routing should enter
  `channel_processor_active` before delegating into mutation helpers.
- **Phase 4 (#248)** — `Task.supersedes` field stays in place from
  this phase; Phase 4 wires the validator + prompt + tests on top.
- **Phase 5 (#249)** — orthogonal top-level design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)