### PR TITLE
test: clear OrchestrationStore registries between tests (closes #251)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,50 @@ def no_state_audit() -> Iterator[None]:
         else:
             os.environ["GOLDFIVE_STRICT_STATE_OWNERSHIP"] = prior
 
+
+@pytest.fixture(autouse=True)
+def _isolate_orchestration_store_registries() -> Iterator[None]:
+    """Clear OrchestrationStore's per-session registries between tests.
+
+    ``_ACTIVE_INVOCATION_TASKS`` and ``_CANCEL_REQUESTED_INVOCATIONS``
+    are module-level dicts in ``goldfive.orchestration_store`` keyed
+    by ``session.id`` (which is a property aliased to ``run_id``).
+    Many tests share ``run_id="r1"``, so a test that calls
+    ``request_invocation_cancel`` or ``register_invocation_task``
+    without explicit cleanup leaks its bucket into the next test's
+    session and silently flips the late-drift gate
+    (``_is_late_drift_for_terminated_invocation``) — manifesting as a
+    flaky CI-only failure of e.g.
+    ``test_judge_verdict_with_live_invocation_proceeds_normally``
+    where ``planner.refine`` is unexpectedly skipped because a stale
+    cancel-pending entry from an earlier test makes the gate think
+    the verdict is late.
+
+    Clearing both dicts before and after every test makes test
+    ordering irrelevant. Cheap (dict.clear() under the existing
+    module-level lock) and idempotent.
+    """
+    try:
+        from goldfive.orchestration_store import (
+            _ACTIVE_INVOCATION_LOCK,
+            _ACTIVE_INVOCATION_TASKS,
+            _CANCEL_REQUESTED_INVOCATIONS,
+        )
+    except ImportError:
+        # Module not importable yet (pre-Phase-1 worktree) — degrade
+        # to a no-op so this fixture doesn't block other tests.
+        yield
+        return
+    with _ACTIVE_INVOCATION_LOCK:
+        _ACTIVE_INVOCATION_TASKS.clear()
+        _CANCEL_REQUESTED_INVOCATIONS.clear()
+    try:
+        yield
+    finally:
+        with _ACTIVE_INVOCATION_LOCK:
+            _ACTIVE_INVOCATION_TASKS.clear()
+            _CANCEL_REQUESTED_INVOCATIONS.clear()
+
 # ---------------------------------------------------------------------------
 # stub_call_llm factory
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add an autouse pytest fixture that clears `_ACTIVE_INVOCATION_TASKS` and `_CANCEL_REQUESTED_INVOCATIONS` (the module-level dicts in `goldfive/orchestration_store.py`) before and after every test.

## Why this is the root cause of the flake

Both registries are module-level dicts keyed by `session.id`, which is a `@property` aliased to `run_id`. `_session()` in `tests/test_judge_task_lifetime.py` hardcodes `run_id="r1"`, and grep finds **83** test files using the same default. Of those, 4 also touch `request_invocation_cancel` / `register_invocation_task`:

- `test_e2e_plan_causal_correction.py`
- `test_executor_supersede_cancel_nonfatal.py`
- `test_judge_lifetime_v22_regression.py`
- `test_llm_call_timeout_watcher.py`

These run earlier alphabetically than `test_judge_task_lifetime.py`. Any of them leaving a stale entry in `_CANCEL_REQUESTED_INVOCATIONS["r1"]` flips `_is_late_drift_for_terminated_invocation` for the flaky test's verdict — `cancel_pending` non-empty → drift treated as late → `planner.refine` skipped → `assert len(planner.refine_calls) == 1` fails as `0 == 1`. Local runs of just that file pass because no prior pollution exists. CI fails because the suite is collected serially in one process.

Same root cause shape as #194 ("Drive validation tests with ADK-minted UUIDs, not pinned test ids"), just for these two newer registries that were added after that fix landed.

## Fix

The fixture clears both dicts under the existing `_ACTIVE_INVOCATION_LOCK`. Cheap, idempotent, makes test ordering irrelevant, and any other tests that were silently relying on lucky ordering also become deterministic.

## Test plan

- [x] `pytest tests/test_judge_task_lifetime.py tests/test_cooperative_cancellation.py tests/test_e2e_plan_causal_correction.py tests/test_executor_supersede_cancel_nonfatal.py tests/test_iter11d_cancel_race.py tests/test_judge_lifetime_v22_regression.py tests/test_llm_call_timeout_watcher.py tests/test_llm_call_timeout_watcher_sticky.py tests/test_invocation_boundary_wrapper.py tests/test_cancel_inflight_on_refine.py tests/test_state_audit.py` — 102 passed.
- [x] Full suite — 2309 passed, 54 skipped, 0 failed locally.
- [ ] CI green (this PR's run will be the canonical confirmation; #372 / #373 will rebase onto this).

Closes #251.