### PR TITLE
test: harden test_rate_limit_resets_on_task_transition against embedding-based looping detector

### DIFF
--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -409,8 +409,18 @@ async def test_rate_limit_resets_on_task_transition() -> None:
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
     # Two thinking messages on t1 -> one judge call (1st fires, 2nd skips).
-    await steerer.observe_reasoning("t1 turn 1", session=session)
-    await steerer.observe_reasoning("t1 turn 2", session=session)
+    # NB: the strings must be semantically distinct so the always-on
+    # ``detect_looping_reasoning`` embedding detector does NOT classify
+    # them as a near-duplicate cluster (which would short-circuit
+    # ``observe_reasoning`` before the judge dispatches and break this
+    # test under any venv that has sentence-transformers installed).
+    await steerer.observe_reasoning(
+        "investigating solar panel efficiency curves", session=session
+    )
+    await steerer.observe_reasoning(
+        "comparing inverter topologies for residential rooftops",
+        session=session,
+    )
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
 
@@ -428,7 +438,12 @@ async def test_rate_limit_resets_on_task_transition() -> None:
     session.current_task_id = "t2"
 
     # First reasoning on t2 -> fresh judge call (the counter for t2 is 0).
-    await steerer.observe_reasoning("t2 turn 1", session=session)
+    # Use a topic that's semantically far from the two t1 strings above
+    # so the looping detector does not flag this as a continuation.
+    await steerer.observe_reasoning(
+        "examining hydroponic tomato yield variance under LED grow lights",
+        session=session,
+    )
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
 


### PR DESCRIPTION
## Summary

The strings used in `test_rate_limit_resets_on_task_transition` (`'t1 turn 1'`, `'t1 turn 2'`, `'t2 turn 1'`) are near-byte-identical, so the always-on `detect_looping_reasoning` embedding detector classifies them as a near-duplicate cluster whenever `sentence-transformers` is installed in the venv (e.g. after `uv sync --all-extras`). The resulting drift short-circuits `observe_reasoning` before the judge dispatches; the test's expected second judge call never fires; assertion `len(call_llm.calls) == 2` fails as `1 == 2`.

The CI workflow today doesn't install the embedding extra, so main appears clean — but local `uv sync --all-extras` runs (the default in our parallel agent worktrees) trip the flake, and surfaced it via #252 / #253 work.

## Fix

Replace the placeholder strings with three semantically distinct topic descriptions whose embeddings sit in different clusters:
- `'investigating solar panel efficiency curves'`
- `'comparing inverter topologies for residential rooftops'`
- `'examining hydroponic tomato yield variance under LED grow lights'`

The test's contract — first reasoning on a fresh task fires a judge call regardless of prior task's rate-limit window — is preserved; the input strings just no longer accidentally exercise the looping detector.

## Test plan

- [x] `uv sync --all-extras` (sentence-transformers 5.4.1 installed)
- [x] `pytest tests/test_reasoning_judge.py -q` — 64 passed (was: 1 fail, 63 pass)
- [x] `pytest tests/test_reasoning_judge.py::test_rate_limit_resets_on_task_transition -q` in isolation — passes

Net: pure test fragility fix, no production code changes. Unblocks #252 + #253 from spurious failures.