### PR TITLE
fix(planner): drop LLM-supplied assignee + disable PLAN_DIVERGENCE drift (closes #252)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -3963,11 +3963,31 @@ def make_adk_plugin(
                 )
                 return
 
-            # Resolve the bound task: prefer a PENDING/RUNNING task whose
-            # ``assignee_agent_id`` matches the invoked agent. Mirrors
-            # ``_pin_delegation_task_id``'s candidate filter without the
-            # tool-args scoring (we don't need tie-breaking — the first
-            # qualifying candidate is enough to feed the detector).
+            # Resolve the bound task. Two-strategy lookup:
+            #
+            # 1. Legacy / explicit-assignee path: prefer a PENDING/RUNNING
+            #    task whose ``assignee_agent_id`` matches the invoked
+            #    agent. This covers test fixtures and any caller that
+            #    still constructs plans with explicit assignees, plus
+            #    cases where an upstream tool (or future planner mode)
+            #    re-introduces declarative binding.
+            # 2. Post-#252 fallback: when no assignee matches (the
+            #    common case now — the goldfive planner zeroes
+            #    ``assignee_agent_id`` at parse time), read the
+            #    currently pinned task id off the goldfive Session.
+            #    ``before_tool_callback`` has already pinned the task
+            #    for the parent agent's turn via
+            #    :meth:`_pin_current_task_id_for_agent` /
+            #    :meth:`_stamp_current_task_id`; that pin describes the
+            #    work this delegation is enacting, which is the
+            #    capability surface we want to validate against the
+            #    invoked sub-agent's tools.
+            #
+            # If neither strategy resolves a task (plan empty, fresh
+            # session, no pin), skip the detector — Rule A wants a task
+            # to consult; without one it would have to invent one.
+            # Best-effort: the detector no-ops, which is fine given the
+            # failure mode it catches is rare.
             plan = _safe_attr(ctx.session, "plan", None)
             if plan is None:
                 return
@@ -3983,9 +4003,45 @@ def make_adk_plugin(
                 chosen_task = task
                 break
             if chosen_task is None:
-                # No plan task names this agent — leave the
-                # planner-side checks to handle the assignee mismatch.
-                # The detector cannot decide capability without a task.
+                # Strategy 2 — read the goldfive Session's current pin.
+                pinned_task_id = ""
+                try:
+                    pinned_task_id = str(
+                        _safe_attr(ctx.session, "current_task_id", "") or ""
+                    )
+                    if not pinned_task_id:
+                        # Fallback to the OrchestrationStore-backed pin
+                        # (the primary single-writer slot post-#271
+                        # Phase 2.1).
+                        from goldfive.orchestration_store import (  # noqa: PLC0415 — lazy
+                            OrchestrationStore,
+                        )
+
+                        store = OrchestrationStore.for_session(ctx.session)
+                        pinned_task_id = store.pin_current_task()
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "_maybe_emit_capability_mismatch: pin lookup raised: %s",
+                        exc,
+                    )
+                    return
+                if not pinned_task_id:
+                    return
+                for task in tasks:
+                    tid = str(_safe_attr(task, "id", "") or "")
+                    if tid != pinned_task_id:
+                        continue
+                    status = _safe_attr(task, "status", None)
+                    if (
+                        status is not TaskStatus.PENDING
+                        and status is not TaskStatus.RUNNING
+                    ):
+                        return
+                    chosen_task = task
+                    break
+            if chosen_task is None:
+                # Pin missing or pinned task not live in the plan. The
+                # detector cannot decide capability without a task.
                 return
 
             tool_list = list(_safe_attr(invoked_agent, "tools", None) or [])

--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -97,12 +97,11 @@ Requirements for the plan:
    may run concurrently. Build a real DAG, not a single linear chain,
    when independent work exists.
 
-4. ASSIGNMENTS. Every task's `assignee_agent_id` MUST be drawn from
-   the provided available_agents list. If multiple agents could do a
-   task, pick the most specialised one. If no agent fits, assign it
-   to the coordinator/root agent rather than inventing an id.
-   `assignee_agent_id` must be the bare agent name as listed above —
-   do NOT add a namespace, client prefix, or `<something>:` qualifier.
+4. ASSIGNMENTS. Do NOT populate `assignee_agent_id`; leave it as the
+   empty string. The framework will populate it observationally when
+   a delegation actually happens (goldfive#252). The available_agents
+   block is supplied for context only — describe each task in terms of
+   the work that needs doing, not which agent will perform it.
 
 5. STABILITY. Task ids must be short, unique, and stable strings
    (e.g. "research", "draft_intro", "review_final"). Descriptions
@@ -121,8 +120,7 @@ markdown fences. Schema:
     {
       "id": "research",
       "title": "short human-readable title",
-      "description": "one sentence defining 'done' for this task",
-      "assignee_agent_id": "<agent id from available list>"
+      "description": "one sentence defining 'done' for this task"
     }
   ],
   "edges": [
@@ -190,7 +188,7 @@ _SUPERSESSION_EXAMPLES = (
     "  Reused id (evolution; no supersedes):\n"
     '    Prior: {"id": "research_solar", "title": "Research solar panels"}\n'
     '    New:   {"id": "research_solar", "title": "Research solar + battery\n'
-    '            costs", "assignee_agent_id": "researcher"}\n'
+    '            costs"}\n'
     "    No supersedes — id reuse already encodes that this is the same\n"
     "    logical step.\n"
     "\n"
@@ -249,6 +247,11 @@ Requirements:
 5. GOAL COVERAGE: every unsatisfied goal must still be addressed by at
    least one task in the returned plan.
 
+Do NOT populate `assignee_agent_id` on any new or rewritten task; leave
+it as the empty string. The framework populates it observationally
+(goldfive#252). Tasks you preserve verbatim from the prior plan keep
+their existing assignee value.
+
 Respond with a single JSON object and NOTHING ELSE:
 
 {
@@ -258,7 +261,6 @@ Respond with a single JSON object and NOTHING ELSE:
       "id": "...",
       "title": "...",
       "description": "...",
-      "assignee_agent_id": "...",
       "status": "PENDING|RUNNING|COMPLETED|FAILED|CANCELLED|BLOCKED",
       "supersedes": "<optional: id of a terminal task this one replaces>",
       "supersedes_kind": "<REPLACE|CORRECT — required when supersedes is set>"
@@ -300,9 +302,11 @@ You will also receive:
 Your job is to produce the REMAINING work (PENDING tasks) that
 satisfies the goals in light of the steering note. Carry forward
 the prior pending tasks where the work continues, EVOLVING their
-title / description / assignee as needed; mint fresh ids only for
-genuinely new tasks. Omit a prior pending task entirely if the steer
-makes it unnecessary.
+title / description as needed; mint fresh ids only for genuinely
+new tasks. Omit a prior pending task entirely if the steer
+makes it unnecessary. Do NOT populate `assignee_agent_id`; leave
+it as the empty string. The framework populates it observationally
+(goldfive#252).
 
 Requirements:
 
@@ -344,7 +348,6 @@ Respond with a single JSON object and NOTHING ELSE:
       "id": "...",
       "title": "...",
       "description": "...",
-      "assignee_agent_id": "...",
       "supersedes": "<optional: id of a terminal task this one replaces>",
       "supersedes_kind": "<REPLACE|CORRECT — required when supersedes is set>"
     }
@@ -407,6 +410,11 @@ validation):
 6. Every unsatisfied goal must still be addressed by at least one
    task in the returned plan.
 
+Do NOT populate `assignee_agent_id` on new or rewritten tasks; leave it
+as the empty string. The framework populates it observationally
+(goldfive#252). Tasks you preserve verbatim from the prior plan keep
+their existing assignee value.
+
 Respond with a single JSON object and NOTHING else. For ABSORB:
 
 {
@@ -416,7 +424,6 @@ Respond with a single JSON object and NOTHING else. For ABSORB:
       "id": "...",
       "title": "...",
       "description": "...",
-      "assignee_agent_id": "...",
       "status": "PENDING|RUNNING|COMPLETED|FAILED|CANCELLED|BLOCKED"
     }
   ],
@@ -523,8 +530,10 @@ You MUST:
    collapsed), you may omit it from the returned plan. Never drop
    tasks that already ran.
 
-5. REASSIGN. If a task is better handled by a different available
-   agent in light of the drift, update its `assignee_agent_id`.
+5. ASSIGNMENTS. Do NOT populate `assignee_agent_id` on new or
+   rewritten tasks; leave it as the empty string. The framework
+   populates it observationally (goldfive#252). Tasks you preserve
+   verbatim from the prior plan keep their existing assignee value.
 
 6. KEEP IDS STABLE. When the underlying work is the same, keep the
    task id unchanged. Reuse ids only for the same logical task.
@@ -556,7 +565,6 @@ Respond with a single JSON object and NOTHING ELSE:
       "id": "...",
       "title": "...",
       "description": "...",
-      "assignee_agent_id": "...",
       "status": "PENDING|RUNNING|COMPLETED|FAILED|CANCELLED|BLOCKED",
       "supersedes": "<optional: id of a terminal task this one replaces>",
       "supersedes_kind": "<REPLACE|CORRECT — required when supersedes is set>"
@@ -597,15 +605,16 @@ _REFINEMENT_GUIDANCE_BLOCK = (
     '- The drift you\'re correcting is usually "small" — a single '
     "agent produced off-topic or flawed output on a task it's "
     "otherwise capable of. Default pattern: replace the drifted task "
-    "with a corrected variant, KEEP THE SAME `assignee_agent_id`, "
-    "and populate `supersedes: <old_task_id>` on the replacement. "
-    "Preserve the surrounding DAG structure (edges, sibling tasks, "
-    "stage count).\n"
-    "- Only reshape the plan (reassign tasks to different agents, "
-    "collapse stages, drop tasks) when the drift indicates the "
-    "agent is systemically incapable — repeated failures on the "
-    "same task, tool errors it can't recover from, refusal-by-the-"
-    "agent, or a pattern the original agent has already failed at.\n"
+    "with a corrected variant and populate `supersedes: <old_task_id>` "
+    "on the replacement. Leave `assignee_agent_id` empty on the "
+    "replacement — the framework populates it observationally "
+    "(goldfive#252). Preserve the surrounding DAG structure (edges, "
+    "sibling tasks, stage count).\n"
+    "- Only reshape the plan (collapse stages, drop tasks) when the "
+    "drift indicates the work itself needs restructuring — repeated "
+    "failures on the same task, tool errors that can't be recovered "
+    "from, or a pattern the prior shape of the work has already "
+    "failed at.\n"
     "- Do NOT collapse a multi-stage plan to a single task unless "
     "the user request genuinely warrants it.\n"
     "- The `supersedes` field is required on every replacement — "
@@ -1092,12 +1101,14 @@ def _plan_from_json(
         title = str(t.get("title") or "").strip()
         if not tid or not title:
             continue
+        # goldfive#252: assignee is observational, not declarative. Drop
+        # any LLM-supplied value.
         tasks.append(
             Task(
                 id=tid,
                 title=title,
                 description=str(t.get("description") or ""),
-                assignee_agent_id=_normalize_assignee(str(t.get("assignee_agent_id") or "")),
+                assignee_agent_id="",
                 status=_coerce_status(t.get("status")),
                 predicted_start_ms=int(t.get("predicted_start_ms") or 0),
                 predicted_duration_ms=int(t.get("predicted_duration_ms") or 0),
@@ -1712,9 +1723,12 @@ class LLMPlanner:
         goals_block = self._render_goals_block(goals)
         agents_block = self._render_agents_block(available_agents)
         agents_header = (
-            "AGENT TREE (pick assignee_agent_id from this registry):"
+            # goldfive#252: assignee is observational, not declarative.
+            # Render the tree as context only — do NOT instruct the LLM
+            # to pick an assignee from it.
+            "AGENT TREE (context only — do NOT populate assignee_agent_id):"
             if _is_tree_entry_list(available_agents)
-            else "Available agents:"
+            else "Available agents (context only):"
         )
         prior_block = self._render_prior_turns_block(context)
         context_block = ""
@@ -3775,7 +3789,6 @@ Reply with a single JSON object and NOTHING ELSE:
         "id": "<short-id>",
         "title": "<one-sentence what 'done' looks like>",
         "description": "<optional longer description>",
-        "assignee_agent_id": "<bare agent name from registry>",
         "status": "PENDING"
       }
     ],
@@ -3886,11 +3899,11 @@ COMPLETED tasks back in ``tasks`` with the SAME id and SAME status:
       "summary": "Draft and review a 2-slide presentation about solar panels.",
       "tasks": [
         {"id": "research_solar", "title": "Research solar panels",
-         "assignee_agent_id": "research_agent", "status": "COMPLETED"},
+         "status": "COMPLETED"},
         {"id": "draft_slides",   "title": "Draft EXACTLY 2 slides",
-         "assignee_agent_id": "presentation_agent", "status": "PENDING"},
+         "status": "PENDING"},
         {"id": "review",         "title": "Review the 2-slide presentation",
-         "assignee_agent_id": "reviewer_agent", "status": "PENDING"}
+         "status": "PENDING"}
       ],
       "edges": [
         {"from_task_id": "research_solar", "to_task_id": "draft_slides"},
@@ -3922,13 +3935,13 @@ output):
       "summary": "Create a 2-slide presentation about solar flares.",
       "tasks": [
         {"id": "research_solar",   "title": "Research solar panels",
-         "assignee_agent_id": "research_agent", "status": "COMPLETED"},
+         "status": "COMPLETED"},
         {"id": "research_flares",  "title": "Research solar flares",
-         "assignee_agent_id": "research_agent", "status": "PENDING"},
+         "status": "PENDING"},
         {"id": "draft_flares",     "title": "Draft 2-slide presentation about solar flares",
-         "assignee_agent_id": "presentation_agent", "status": "PENDING"},
+         "status": "PENDING"},
         {"id": "review_flares",    "title": "Review the 2-slide solar flares presentation",
-         "assignee_agent_id": "reviewer_agent", "status": "PENDING"}
+         "status": "PENDING"}
       ],
       "edges": [
         {"from_task_id": "research_flares", "to_task_id": "draft_flares"},
@@ -3967,9 +3980,10 @@ PLAN SHAPE (when plan is non-null):
 
   * 5-20 tasks typically. Smaller is OK for trivial follow-ups
     (revisions often add 1-3 delta tasks).
-  * Every task's assignee_agent_id MUST be drawn from the available
-    agents registry passed in the user prompt. Use the bare name only
-    — no namespace, no prefix.
+  * Do NOT populate `assignee_agent_id`; leave it as the empty string.
+    The framework populates it observationally when a delegation
+    actually happens (goldfive#252). The available_agents block in
+    the user prompt is supplied for context only.
   * Task ids: short, unique, stable strings ("research", "draft_intro",
     "review_final"). Reuse prior task ids when the task is the same
     work; mint new ids for delta tasks.

--- a/goldfive/planners/goldfive_planner.py
+++ b/goldfive/planners/goldfive_planner.py
@@ -556,18 +556,21 @@ class GoldfivePlanner(BasePlanner):
 
                 # Stage 2 — name matches an agent in the registry but
                 # wasn't exposed to this agent. Cross-layer delegation.
+                #
+                # goldfive#252: PLAN_DIVERGENCE replaced by
+                # CAPABILITY_MISMATCH (#253) — disabled here. The
+                # detection still runs (so we log the cross-layer
+                # delegation attempt at DEBUG and mark
+                # ``divergence_fired`` so the kept-list returns), but
+                # we no longer construct a ``DriftEvent``. CAPABILITY_
+                # MISMATCH replaces this signal with one grounded in
+                # actual agent tools rather than declared assignees.
                 if self._agent_registry is not None and name in self._agent_registry:
-                    self._emit_tool_call_drift(
+                    log.debug(
+                        "GoldfivePlanner: detector observed cross-layer "
+                        "delegation to %r but PLAN_DIVERGENCE drift is "
+                        "disabled (goldfive#252); no drift fired",
                         name,
-                        callback_context,
-                        kind_name="PLAN_DIVERGENCE",
-                        detail=(
-                            f"LLM emitted function_call to agent "
-                            f"{name!r} which is in the tree registry "
-                            f"but was not exposed as a tool to the "
-                            f"currently-running agent — cross-layer "
-                            f"delegation attempt, call not blocked"
-                        ),
                     )
                     divergence_fired = True
                     continue

--- a/goldfive/reconciler.py
+++ b/goldfive/reconciler.py
@@ -83,9 +83,6 @@ from typing import TYPE_CHECKING
 from goldfive import orchestration_state as _ostate
 from goldfive.types import (
     TERMINAL_TASK_STATUSES,
-    DriftEvent,
-    DriftKind,
-    DriftSeverity,
     Plan,
     Session,
     Task,
@@ -573,13 +570,20 @@ class PlanReconciler:
         agent_name: str,
         invocation_id: str,
     ) -> None:
-        """Emit a PLAN_DIVERGENCE drift via the steerer.
+        """Detector hook for off-plan agents (drift emission disabled).
 
-        INFO severity by default. The steerer's drift pipeline
-        (and, once #142 lands, the intervention ladder) decides
-        whether to escalate. We deliberately do not refine here:
-        an off-plan agent observation is informational until the
-        steerer has enough context to decide.
+        goldfive#252: PLAN_DIVERGENCE replaced by CAPABILITY_MISMATCH
+        (#253) — disabled here. Pre-#252 this fired a PLAN_DIVERGENCE
+        drift comparing the planner-predicted ``assignee_agent_id``
+        against runtime delegation. With #252 the planner no longer
+        declares assignees (assignment is observational), so the
+        comparison's premise is gone. Detection coverage moves to
+        CAPABILITY_MISMATCH, which is grounded in actual agent tools.
+
+        The detector still records the divergence string on
+        ``self.divergence_events`` so existing observers and tests that
+        read the list keep working; we just don't construct a
+        ``DriftEvent`` and we don't dispatch through the steerer.
         """
         detail = (
             f"observed off-plan agent {agent_name!r} "
@@ -587,49 +591,13 @@ class PlanReconciler:
             f"assigned to this agent"
         )
         self.divergence_events.append(detail)
-        # goldfive#245 — stamp observation-time plan revision so the
-        # dispatch-time gate can drop a stale verdict.
-        _gf_plan = getattr(self._session, "plan", None)
-        _observed_rev = (
-            int(getattr(_gf_plan, "revision_index", 0) or 0)
-            if _gf_plan is not None
-            else 0
+        log.debug(
+            "PlanReconciler._emit_divergence: detector observed "
+            "off-plan agent %r but PLAN_DIVERGENCE drift is disabled "
+            "(goldfive#252); no drift fired",
+            agent_name,
         )
-        drift = DriftEvent(
-            kind=DriftKind.PLAN_DIVERGENCE,
-            severity=DriftSeverity.INFO,
-            detail=detail,
-            current_task_id=self._session.current_task_id or "",
-            current_agent_id=agent_name,
-            observed_revision_index=_observed_rev,
-        )
-        # Prefer the steerer's internal _handle_drift (pre-built
-        # DriftEvent → DriftDetected emission + refine policy). The
-        # steerer's ``observe`` path expects a raw event to classify,
-        # not a DriftEvent, so passing the pre-built drift through
-        # ``observe`` would round-trip through detect_drift and
-        # almost certainly return None. ``_handle_drift`` is the
-        # same entry point other plugin-side drifts (CONFABULATION_RISK,
-        # RUNAWAY_DELEGATION) already use.
-        handle = getattr(self._steerer, "_handle_drift", None)
-        if callable(handle):
-            try:
-                await handle(drift, self._session)
-                return
-            except Exception as exc:  # noqa: BLE001
-                log.debug(
-                    "PlanReconciler._emit_divergence: _handle_drift raised: %s",
-                    exc,
-                )
-        # Fallback for steerer stubs without _handle_drift: feed
-        # the DriftEvent through observe() and let custom steerers
-        # decide. Tests that stub the steerer lean on this path.
-        try:
-            observe = getattr(self._steerer, "observe", None)
-            if observe is not None:
-                await observe(drift, self._session)
-        except Exception as exc:  # noqa: BLE001
-            log.debug("PlanReconciler._emit_divergence: observe raised: %s", exc)
+        return
 
 
 __all__ = ["PlanReconciler"]

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -3037,16 +3037,21 @@ class DefaultSteerer:
         note: str,
         suggested_action: str = "",
     ) -> None:
-        """Fire a ``PLAN_DIVERGENCE`` drift event → triggers refine."""
+        """No-op: PLAN_DIVERGENCE drift is disabled (goldfive#252).
+
+        # goldfive#252: PLAN_DIVERGENCE replaced by CAPABILITY_MISMATCH
+        (#253) — disabled here. The detector path still records the
+        ``divergence_flag`` so observers see "something happened", but
+        no drift fires through the steerer pipeline.
+        """
         session.divergence_flag = True
         detail = f"{note} (suggested: {suggested_action})" if suggested_action else note
-        drift = DriftEvent(
-            kind=DriftKind.PLAN_DIVERGENCE,
-            severity=DriftSeverity.WARNING,
-            detail=detail,
-            current_task_id=session.current_task_id,
+        log.debug(
+            "DefaultSteerer.report_plan_divergence: PLAN_DIVERGENCE "
+            "drift disabled (goldfive#252); detector observed %r",
+            detail,
         )
-        await self._handle_drift(drift, session)
+        return
 
     # ==================================================================
     # Internals
@@ -3086,9 +3091,28 @@ class DefaultSteerer:
         CRITICAL ``REPEATED_FAILURE`` drift so sinks see the back-off.
         This bounds the loop that would otherwise re-fire the same
         drift every tick until ``SequentialExecutor.max_task_invocations``
-        tripped (see TASK-LIFECYCLE.md §7.3). The outcome table is
+        tripped (see TASK-LIFECYCLE.md). The outcome table is
         cleared on every ``run_started`` boundary.
+
+        goldfive#252: PLAN_DIVERGENCE replaced by CAPABILITY_MISMATCH
+        (#253) — disabled here. Drop the drift at the very top of the
+        handler so any external producer (legacy callers, replays,
+        sinks that build raw ``DriftEvent`` instances) cannot revive
+        the signal. Detection coverage moves to CAPABILITY_MISMATCH,
+        which is grounded in actual agent tools rather than the
+        planner's declared ``assignee_agent_id``.
         """
+        # goldfive#252: PLAN_DIVERGENCE replaced by CAPABILITY_MISMATCH
+        # (#253) — disabled here. Guard at the very top so any external
+        # producer (legacy callers, replays, sinks) cannot revive it.
+        if drift.kind is DriftKind.PLAN_DIVERGENCE:
+            log.debug(
+                "DefaultSteerer._handle_drift: PLAN_DIVERGENCE drift "
+                "received but handling is disabled (goldfive#252); "
+                "detail=%r",
+                drift.detail,
+            )
+            return
         # Normalise source attribution early so every downstream
         # consumer (sinks, promotion policy, prompt framing) sees a
         # non-empty ``authored_by``. USER_* kinds → "user"; anything

--- a/tests/examples/test_presentation_agent_adk_web.py
+++ b/tests/examples/test_presentation_agent_adk_web.py
@@ -297,14 +297,24 @@ def test_presentation_agent_e2e_under_adk_web(
         f"expected at least one plan_revised; got 0 (kinds: {kinds})"
     )
     # The first plan_revised holds the initial four-task plan.
+    # goldfive#252: planner no longer populates ``assignee_agent_id``;
+    # the framework binds tasks to agents observationally at delegation
+    # time. Assert the planned task IDs only — assignees are now ``""``
+    # on every plan task.
     plan_pb = plan_events[0].plan_revised.plan
+    planned_task_ids = {t.id for t in plan_pb.tasks}
+    assert planned_task_ids == {
+        "research",
+        "build",
+        "review",
+        "debug",
+    }, f"unexpected plan shape: {sorted(planned_task_ids)}"
     planned_tasks = {t.id: t.assignee_agent_id for t in plan_pb.tasks}
-    assert planned_tasks == {
-        "research": "research_agent",
-        "build": "web_developer_agent",
-        "review": "reviewer_agent",
-        "debug": "debugger_agent",
-    }, f"unexpected plan shape: {planned_tasks}"
+    # Every task's assignee is empty post-#252. Document that here so
+    # future test edits don't reintroduce the assignee assertion.
+    assert all(a == "" for a in planned_tasks.values()), (
+        f"planner emitted non-empty assignee_agent_id post-#252: {planned_tasks}"
+    )
 
     # 2. Every planned task must reach a terminal state OR be a
     # reachable PENDING that survived turn-end (post-#208).

--- a/tests/test_cancel_inflight_on_refine.py
+++ b/tests/test_cancel_inflight_on_refine.py
@@ -453,13 +453,13 @@ async def test_cancel_inflight_for_revision_fires_for_real_drift() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 8. End-to-end: PLAN_DIVERGENCE → refine_steer → cancel fires on the
+# 8. End-to-end: WARNING-severity drift → refine_steer → cancel fires on the
 #    coordinator's task before its long sleep finishes
 # ---------------------------------------------------------------------------
 
 
 async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> None:
-    """Regression test for the v15 bug: a PLAN_DIVERGENCE drift fires
+    """Regression test for the v15 bug: a WARNING-severity drift fires
     refine_steer; the coordinator's in-flight asyncio task is cancelled
     within the 1s propagation budget instead of running for the full
     refine duration.
@@ -470,11 +470,17 @@ async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> Non
        run ``refine_steer`` (returning a revised plan).
     2. Pinning a long-running coordinator task in the plugin's
        per-invocation registry.
-    3. Firing a ``PLAN_DIVERGENCE`` (WARNING) drift through
+    3. Firing an ``OFF_TOPIC`` (WARNING) drift through
        ``_handle_drift`` — which routes to ``_promote_drift_to_steer``
        given the goldfive-steer eligibility set.
     4. Asserting the coordinator's task observes ``CancelledError``
        within 1s.
+
+    goldfive#252: this test originally fired PLAN_DIVERGENCE; that kind
+    is now silenced at the top of ``_handle_drift`` (replaced by
+    CAPABILITY_MISMATCH in #253). The cancel-inflight contract is
+    independent of which drift kind triggers it, so we exercise the
+    same code path with ``OFF_TOPIC`` (also WARNING → ABSORB → refine).
     """
 
     revised = Plan(
@@ -486,7 +492,7 @@ async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> Non
             Task(id="t2b", title="Replanned T2"),
         ],
         edges=[TaskEdge(from_task_id="t1", to_task_id="t2b")],
-        revision_kind=DriftKind.PLAN_DIVERGENCE.value,
+        revision_kind=DriftKind.OFF_TOPIC.value,
         revision_severity=DriftSeverity.WARNING.value,
         revision_index=1,
     )
@@ -548,9 +554,9 @@ async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> Non
     plugin._invocation_tasks["inv-coord-1"] = coord_task
 
     drift = DriftEvent(
-        kind=DriftKind.PLAN_DIVERGENCE,
+        kind=DriftKind.OFF_TOPIC,
         severity=DriftSeverity.WARNING,
-        detail="coordinator emitted off-plan tool call",
+        detail="coordinator reasoning off the bound task",
         current_task_id="t1",
         current_agent_id="coordinator",
     )
@@ -562,7 +568,7 @@ async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> Non
         pass
     except TimeoutError:
         pytest.fail(
-            "coordinator task was not cancelled within 1s of PLAN_DIVERGENCE "
+            "coordinator task was not cancelled within 1s of OFF_TOPIC "
             "refine — v15 concurrent-invocation bug regressed"
         )
     assert cancelled.is_set()

--- a/tests/test_drift_version_pin.py
+++ b/tests/test_drift_version_pin.py
@@ -239,14 +239,18 @@ async def test_orthogonal_kind_drift_dispatches_after_unrelated_revision() -> No
     The bug class this guards against: parallel judges fire on
     *orthogonal* concerns. Judge A observes revision N → fires OFF_TOPIC
     on task T_A → refine produces revision N+1 (addresses OFF_TOPIC/T_A).
-    Judge B observes revision N → fires PLAN_DIVERGENCE on task T_B; B's
+    Judge B observes revision N → fires INTENT_DIVERGENCE on task T_B; B's
     verdict returns AFTER A's refine landed. Naive global ``observed <
     live`` gating would drop B; per-(kind, target) gating preserves it
-    because (PLAN_DIVERGENCE, T_B) was never specifically addressed.
+    because (INTENT_DIVERGENCE, T_B) was never specifically addressed.
 
-    Both PLAN_DIVERGENCE and OFF_TOPIC at WARNING severity route to the
-    refine path (CANCEL_REINVOKE), so we assert ``planner.refine_calls``
-    fires for the orthogonal drift.
+    Both INTENT_DIVERGENCE and OFF_TOPIC at WARNING severity route to
+    the refine path, so we assert ``planner.refine_calls`` fires for
+    the orthogonal drift.
+
+    goldfive#252: prior shape used PLAN_DIVERGENCE; that kind is now
+    silenced at the top of ``_handle_drift`` so we use
+    INTENT_DIVERGENCE which has the same routing characteristics.
     """
     sink = _ListSink()
     planner = _NullPlanner()
@@ -259,11 +263,11 @@ async def test_orthogonal_kind_drift_dispatches_after_unrelated_revision() -> No
     session.last_addressed_revision_by_drift_key[
         (DriftKind.OFF_TOPIC.value, "t-draft")
     ] = 4
-    # The drift is PLAN_DIVERGENCE on a different task — orthogonal
+    # The drift is INTENT_DIVERGENCE on a different task — orthogonal
     # concern, also a refine-routing kind so we can assert the
     # dispatch path ran.
     drift = _drift(
-        kind=DriftKind.PLAN_DIVERGENCE,
+        kind=DriftKind.INTENT_DIVERGENCE,
         severity=DriftSeverity.WARNING,
         observed_revision_index=3,
         task="t-other",

--- a/tests/test_goldfive_planner.py
+++ b/tests/test_goldfive_planner.py
@@ -287,6 +287,7 @@ def test_goldfive_planner_process_response_noop_when_no_filters_fire() -> None:
     assert out is None
 
 
+@pytest.mark.skip(reason="goldfive#252: PLAN_DIVERGENCE replaced by CAPABILITY_MISMATCH (#253)")
 async def test_goldfive_planner_process_response_emits_divergence_on_off_registry_agent() -> None:
     """Three-stage classification: cross-layer → PLAN_DIVERGENCE;
     hallucinated → CONFABULATION_RISK; report_ prefix → skipped.
@@ -431,6 +432,7 @@ async def test_own_tool_call_no_drift() -> None:
     assert out is None
 
 
+@pytest.mark.skip(reason="goldfive#252: PLAN_DIVERGENCE replaced by CAPABILITY_MISMATCH (#253)")
 async def test_cross_layer_agent_call_fires_plan_divergence() -> None:
     """Stage 2: name matches a registry agent but is not in this agent's tools.
 
@@ -561,13 +563,19 @@ async def test_cancelled_id_stripped_across_all_stages() -> None:
     assert "fc-cancel-stage2" not in remaining_ids
     assert "fc-cancel-stage3" not in remaining_ids
 
-    # Drifts fired only for the retained cross-layer + hallucinated
-    # parts — the cancelled ones never reach classification because
-    # the cancelled-id filter runs first.
+    # Drifts fired only for the retained hallucinated part — the
+    # cancelled ones never reach classification because the cancelled-id
+    # filter runs first.
+    #
+    # goldfive#252: PLAN_DIVERGENCE is silenced (replaced by
+    # CAPABILITY_MISMATCH in #253); the retained stage-2 cross-layer
+    # part is still classified but produces no drift. Only the stage-3
+    # hallucination still fires CONFABULATION_RISK.
     await asyncio.sleep(0)
     kinds = sorted(d.kind.value for d in steerer.drifts)
-    assert kinds == ["confabulation_risk", "plan_divergence"], (
-        f"expected one PLAN_DIVERGENCE + one CONFABULATION_RISK, got {steerer.drifts!r}"
+    assert kinds == ["confabulation_risk"], (
+        f"expected one CONFABULATION_RISK (PLAN_DIVERGENCE silenced per "
+        f"#252), got {steerer.drifts!r}"
     )
 
 

--- a/tests/test_plan_reconciler.py
+++ b/tests/test_plan_reconciler.py
@@ -316,6 +316,9 @@ async def test_get_missed_tasks_reads_live_plan() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skip(
+    reason="goldfive#252: PLAN_DIVERGENCE replaced by CAPABILITY_MISMATCH (#253)"
+)
 async def test_off_plan_agent_emits_plan_divergence() -> None:
     session = _make_session(
         [
@@ -334,6 +337,9 @@ async def test_off_plan_agent_emits_plan_divergence() -> None:
     assert "stranger_agent" in d.detail
 
 
+@pytest.mark.skip(
+    reason="goldfive#252: PLAN_DIVERGENCE replaced by CAPABILITY_MISMATCH (#253)"
+)
 async def test_off_plan_divergence_deduped_per_agent() -> None:
     """Repeated invocations of the same off-plan agent should fire the
     drift once, not on every observation.
@@ -452,6 +458,11 @@ async def test_task_without_assignee_not_claimed() -> None:
     """A PENDING task with empty ``assignee_agent_id`` must not be
     opportunistically claimed by any agent — the reconciler
     requires explicit assignee matching to avoid over-attribution.
+
+    goldfive#252: the divergence is still recorded on the
+    reconciler's own ``divergence_events`` list for observability,
+    but PLAN_DIVERGENCE drift creation is disabled (the kind is
+    being replaced by CAPABILITY_MISMATCH in #253).
     """
     session = _make_session(
         [
@@ -466,9 +477,10 @@ async def test_task_without_assignee_not_claimed() -> None:
     # No transitions; the unassigned task stays PENDING.
     assert steerer.transitions == []
     assert session.plan.tasks[0].status is TaskStatus.PENDING
-    # And the no-assignee agent is recorded as divergent (there's no
-    # plan task targeting any_agent and no ancestor chain to resolve).
-    assert len(steerer.drifts) == 1
+    # PLAN_DIVERGENCE drift no longer fires (goldfive#252) but the
+    # detector still records the observation.
+    assert steerer.drifts == []
+    assert any("any_agent" in d for d in rec.divergence_events)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -349,7 +349,11 @@ async def test_generate_prompt_renders_agent_tree_when_tree_given() -> None:
 
 
 async def test_generate_prompt_flat_list_renders_legacy_header() -> None:
-    """Legacy ``list[str]`` callers still see the old 'Available agents:' header."""
+    """Legacy ``list[str]`` callers still see an 'Available agents' header.
+
+    goldfive#252: header now flags the block as context-only since the
+    LLM is no longer asked to pick an assignee.
+    """
     stub = _StubLLM(_canned_plan_json())
     planner = LLMPlanner(call_llm=stub)
     await planner.generate(
@@ -357,15 +361,18 @@ async def test_generate_prompt_flat_list_renders_legacy_header() -> None:
         available_agents=["researcher", "writer", "editor"],
     )
     _sys, user, _model = stub.calls[0]
-    assert "Available agents:" in user
+    assert "Available agents" in user
     assert "AGENT TREE" not in user
 
 
-async def test_validator_rejects_off_registry_assignee() -> None:
-    """Plans whose assignees aren't in the registry are rejected on every attempt.
+async def test_off_registry_assignee_dropped_silently() -> None:
+    """goldfive#252: planner output drops any LLM-supplied assignee.
 
-    Exhausts the retry budget because the stub always returns the same
-    off-registry JSON; ``generate`` eventually returns ``None``.
+    Pre-#252 the validator rejected off-registry assignees and the
+    retry loop fed the error back. Now the parser unconditionally
+    drops the value, so off-registry / on-registry / compound names
+    all collapse to the empty string and the plan validates on the
+    first attempt.
     """
 
     class _AlwaysOffRegistry:
@@ -382,20 +389,19 @@ async def test_validator_rejects_off_registry_assignee() -> None:
         goals=_goals(),
         available_agents=_tree_registry(),
     )
-    assert result is None
-    # The retry loop fired the full budget.
-    assert len(stub.calls) == 2
-    # The retry prompt fed the validator error back to the LLM.
-    _sys, retry_user, _ = stub.calls[1]
-    assert "off-registry assignee" in retry_user
+    assert result is not None
+    # First attempt suffices because the parser drops the assignee
+    # before the registry check sees anything to reject.
+    assert len(stub.calls) == 1
+    assert all(t.assignee_agent_id == "" for t in result.tasks)
 
 
-async def test_retry_loop_corrects_off_registry_assignee() -> None:
-    """First attempt uses bogus assignees; second attempt picks the real names.
+async def test_planner_normalization_drops_assignees_unconditionally() -> None:
+    """goldfive#252: the parser drops every LLM-supplied assignee.
 
-    Demonstrates the #133/#136 retry-with-correction loop wired into
-    the #151 registry check: the validator's error message feeds the
-    second prompt, and the second response validates cleanly.
+    Whether or not the LLM picks a registry-legal name, the framework
+    overwrites it with the empty string — assignment is observational,
+    not declarative.
     """
 
     class _Correcting:
@@ -404,8 +410,6 @@ async def test_retry_loop_corrects_off_registry_assignee() -> None:
 
         async def __call__(self, system: str, user: str, model: str) -> str:
             self.calls.append((system, user, model))
-            if len(self.calls) == 1:
-                return _off_registry_plan_json()
             return _canned_plan_json()
 
     stub = _Correcting()
@@ -415,12 +419,9 @@ async def test_retry_loop_corrects_off_registry_assignee() -> None:
         available_agents=_tree_registry(),
     )
     assert plan is not None
-    # Second attempt used the real registry names.
+    # Even on-registry names get dropped to the empty string.
     assignees = {t.assignee_agent_id for t in plan.tasks}
-    assert assignees <= {"researcher", "writer", "editor"}
-    # Correction feedback landed in the retry prompt.
-    _sys, retry_user, _ = stub.calls[1]
-    assert "off-registry assignee" in retry_user
+    assert assignees == {""}
 
 
 async def test_generate_accepts_none_registry_backcompat() -> None:
@@ -1584,9 +1585,12 @@ def test_normalize_assignee_uses_last_colon() -> None:
     assert _normalize_assignee("a:b:c:research_agent") == "research_agent"
 
 
-def test_plan_from_json_normalizes_compound_assignees(
+def test_plan_from_json_drops_compound_assignees(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    # goldfive#252: assignee is observational, not declarative. The
+    # parser unconditionally drops any LLM-supplied value (compound or
+    # bare) so coordinator-style mis-picks never reach the runtime.
     payload = {
         "summary": "s",
         "tasks": [
@@ -1605,16 +1609,15 @@ def test_plan_from_json_normalizes_compound_assignees(
     with caplog.at_level("WARNING", logger="goldfive.planner"):
         plan = _plan_from_json(payload, run_id="r", goal_ids=[])
     assert plan is not None
-    assert [t.assignee_agent_id for t in plan.tasks] == ["research_agent", "writer"]
-    compound_warnings = [
-        r for r in caplog.records if "compound assignee_agent_id" in r.getMessage()
-    ]
-    assert len(compound_warnings) == 2
+    assert [t.assignee_agent_id for t in plan.tasks] == ["", ""]
 
 
-def test_plan_from_json_leaves_bare_assignees_unchanged(
+def test_plan_from_json_drops_bare_assignees(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    # goldfive#252: bare LLM-emitted names are dropped too — the
+    # framework populates assignee observationally regardless of what
+    # the LLM said.
     payload = {
         "summary": "s",
         "tasks": [
@@ -1625,16 +1628,13 @@ def test_plan_from_json_leaves_bare_assignees_unchanged(
     with caplog.at_level("WARNING", logger="goldfive.planner"):
         plan = _plan_from_json(payload, run_id="r", goal_ids=[])
     assert plan is not None
-    assert [t.assignee_agent_id for t in plan.tasks] == ["research_agent", "writer"]
-    compound_warnings = [
-        r for r in caplog.records if "compound assignee_agent_id" in r.getMessage()
-    ]
-    assert compound_warnings == []
+    assert [t.assignee_agent_id for t in plan.tasks] == ["", ""]
 
 
-def test_plan_from_json_normalizes_mixed_assignees(
+def test_plan_from_json_drops_mixed_assignees(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    # goldfive#252: same drop applies regardless of compound/bare mix.
     payload = {
         "summary": "s",
         "tasks": [
@@ -1650,23 +1650,14 @@ def test_plan_from_json_normalizes_mixed_assignees(
     with caplog.at_level("WARNING", logger="goldfive.planner"):
         plan = _plan_from_json(payload, run_id="r", goal_ids=[])
     assert plan is not None
-    assert [t.assignee_agent_id for t in plan.tasks] == [
-        "research_agent",
-        "writer",
-        "reviewer",
-    ]
-    compound_warnings = [
-        r for r in caplog.records if "compound assignee_agent_id" in r.getMessage()
-    ]
-    assert len(compound_warnings) == 1
-    assert "'client-xyz:writer'" in compound_warnings[0].getMessage()
-    assert "'writer'" in compound_warnings[0].getMessage()
+    assert [t.assignee_agent_id for t in plan.tasks] == ["", "", ""]
 
 
-def test_default_system_prompt_forbids_compound_assignee() -> None:
-    # Regression guard against the planner prompt drifting away from the
-    # explicit "bare name only" directive added alongside #214.
-    assert "do NOT add a namespace" in _DEFAULT_SYSTEM_PROMPT
+def test_default_system_prompt_forbids_assignee_population() -> None:
+    # goldfive#252 regression guard: the prompt MUST instruct the LLM
+    # not to populate ``assignee_agent_id`` (the framework owns that
+    # field observationally).
+    assert "Do NOT populate `assignee_agent_id`" in _DEFAULT_SYSTEM_PROMPT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_planner_refine_guidance.py
+++ b/tests/test_planner_refine_guidance.py
@@ -89,14 +89,16 @@ def _plan_with_running_task() -> Plan:
 
 def test_guidance_block_constant_contains_key_instructions() -> None:
     """Sanity-pin the constant's wording so accidental edits that
-    dilute the guidance fail loudly. The three load-bearing phrases
-    are the preserve-assignee rule, the supersedes requirement, and
-    the don't-collapse-stages clause."""
+    dilute the guidance fail loudly. The load-bearing phrases are the
+    leave-assignee-empty rule (goldfive#252), the supersedes
+    requirement, and the don't-collapse-stages clause."""
     text = _REFINEMENT_GUIDANCE_BLOCK
     assert "REFINEMENT GUIDANCE" in text
-    assert "KEEP THE SAME `assignee_agent_id`" in text
+    # goldfive#252: assignee is observational; the prompt now tells the
+    # LLM to leave the field empty rather than to "keep the same"
+    # value the planner previously emitted.
+    assert "Leave `assignee_agent_id` empty" in text
     assert "supersedes" in text
-    assert "systemically incapable" in text
     assert "Do NOT collapse a multi-stage plan to a single task" in text
 
 
@@ -117,7 +119,8 @@ def test_guidance_appears_in_steer_prompt_user_source() -> None:
         source="user",
     )
     assert "REFINEMENT GUIDANCE" in prompt
-    assert "KEEP THE SAME `assignee_agent_id`" in prompt
+    # goldfive#252: prompt now tells the LLM to leave assignee empty.
+    assert "Leave `assignee_agent_id` empty" in prompt
 
 
 def test_guidance_appears_in_steer_prompt_goldfive_source() -> None:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -234,7 +234,14 @@ async def test_report_new_work_discovered_fires_refine() -> None:
     assert planner.refine_calls[0]["drift"].kind is DriftKind.NEW_WORK_DISCOVERED
 
 
-async def test_report_plan_divergence_fires_refine_and_sets_flag() -> None:
+async def test_report_plan_divergence_sets_flag_only() -> None:
+    """goldfive#252: PLAN_DIVERGENCE drift is silenced.
+
+    The reporting tool still flips ``session.divergence_flag`` so
+    observers see "something happened", but no drift fires through
+    the steerer pipeline (the kind is being replaced by
+    CAPABILITY_MISMATCH in #253).
+    """
     steerer, session, _sink, planner = _fresh()
     await _tool("report_plan_divergence").handler(
         {
@@ -245,7 +252,7 @@ async def test_report_plan_divergence_fires_refine_and_sets_flag() -> None:
         steerer,
     )
     assert session.divergence_flag is True
-    assert planner.refine_calls[0]["drift"].kind is DriftKind.PLAN_DIVERGENCE
+    assert planner.refine_calls == []
 
 
 async def test_handler_tolerates_missing_optional_fields() -> None:

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -892,7 +892,14 @@ async def test_report_new_work_discovered_fires_drift() -> None:
     assert planner.refine_calls[0]["drift"].kind is DriftKind.NEW_WORK_DISCOVERED
 
 
-async def test_report_plan_divergence_sets_flag_and_fires_drift() -> None:
+async def test_report_plan_divergence_sets_flag_only() -> None:
+    """goldfive#252: PLAN_DIVERGENCE drift creation is disabled.
+
+    ``report_plan_divergence`` keeps the ``divergence_flag`` write so
+    observers see "something happened", but no drift fires through
+    the steerer pipeline (the kind is being replaced by
+    CAPABILITY_MISMATCH in #253).
+    """
     steerer, session, sink, planner = _fresh()
     await steerer.report_plan_divergence(
         session=session,
@@ -900,10 +907,9 @@ async def test_report_plan_divergence_sets_flag_and_fires_drift() -> None:
         suggested_action="replan from here",
     )
     assert session.divergence_flag is True
-    from goldfive.pb.goldfive.v1 import types_pb2
-
-    assert sink.events[0].drift_detected.kind == types_pb2.DRIFT_KIND_PLAN_DIVERGENCE
-    assert planner.refine_calls[0]["drift"].kind is DriftKind.PLAN_DIVERGENCE
+    # No DriftDetected emitted, no refine called.
+    assert sink.events == []
+    assert planner.refine_calls == []
 
 
 # ---------------------------------------------------------------------------
@@ -1489,8 +1495,12 @@ async def test_refine_returns_none_does_not_cascade_further_drifts() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
 
+    # goldfive#252: PLAN_DIVERGENCE handling is disabled at the top
+    # of ``_handle_drift``, so use OFF_TOPIC (which routes through
+    # the same goal-aware refine path) to exercise the no-cascade
+    # contract this test was filed for (#204).
     drift = DriftEvent(
-        kind=DriftKind.PLAN_DIVERGENCE,
+        kind=DriftKind.OFF_TOPIC,
         severity=DriftSeverity.WARNING,
         detail="reviewer reported BLOCKED",
         current_task_id="t1",
@@ -1514,13 +1524,13 @@ async def test_refine_returns_none_does_not_cascade_further_drifts() -> None:
         if e.WhichOneof("payload") == "drift_detected"
     ]
     # Exactly the original drift + the escalation. No follow-up
-    # PLAN_DIVERGENCE CRITICAL (the pre-fix shape) and no cascade
-    # through TASK_FAILED_FATAL / REPEATED_FAILURE on a single tick.
-    assert types_pb2.DRIFT_KIND_PLAN_DIVERGENCE in drift_kinds
+    # OFF_TOPIC CRITICAL (the pre-fix shape) and no cascade through
+    # TASK_FAILED_FATAL / REPEATED_FAILURE on a single tick.
+    assert types_pb2.DRIFT_KIND_OFF_TOPIC in drift_kinds
     assert types_pb2.DRIFT_KIND_HUMAN_INTERVENTION_REQUIRED in drift_kinds
-    plan_divergence_count = drift_kinds.count(types_pb2.DRIFT_KIND_PLAN_DIVERGENCE)
+    off_topic_count = drift_kinds.count(types_pb2.DRIFT_KIND_OFF_TOPIC)
     # Only the originating drift, no recursing CRITICAL clone.
-    assert plan_divergence_count == 1, drift_kinds
+    assert off_topic_count == 1, drift_kinds
 
 
 async def test_refine_exhausted_path_unchanged() -> None:

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -1207,7 +1207,15 @@ def test_steer_prompt_handles_empty_prior_pending() -> None:
     assert "Reusable prior PENDING ids: []" in prompt
 
 
-async def test_refine_steer_id_reuse_with_assignee_change() -> None:
+async def test_refine_steer_id_reuse_drops_llm_assignee() -> None:
+    """goldfive#252: any LLM-emitted ``assignee_agent_id`` is dropped.
+
+    Pre-#252 the LLM could redirect a task to a different agent by
+    naming the new agent in ``assignee_agent_id`` on the same id-reused
+    task. Post-#252 the parser unconditionally drops the value — the
+    framework will populate the field observationally when a delegation
+    actually happens.
+    """
     plan = _evolving_plan()
     goals = [Goal(id="g1", summary="ship the presentation")]
     drift = DriftEvent(
@@ -1224,7 +1232,7 @@ async def test_refine_steer_id_reuse_with_assignee_change() -> None:
                     "id": "create_presentation",
                     "title": "Create presentation",
                     "description": "Create the presentation about solar panels",
-                    "assignee_agent_id": "research_agent",  # CHANGED
+                    "assignee_agent_id": "research_agent",  # IGNORED post-#252
                 }
             ],
             "edges": [{"from_task_id": "research", "to_task_id": "create_presentation"}],
@@ -1235,7 +1243,8 @@ async def test_refine_steer_id_reuse_with_assignee_change() -> None:
     )
     assert revised is not None
     evolved = next(t for t in revised.tasks if t.id == "create_presentation")
-    assert evolved.assignee_agent_id == "research_agent"
+    # LLM-emitted assignee dropped (goldfive#252).
+    assert evolved.assignee_agent_id == ""
 
 
 def test_steer_prompt_surfaces_prior_pending_block() -> None:

--- a/tests/test_task_id_wiring.py
+++ b/tests/test_task_id_wiring.py
@@ -739,6 +739,14 @@ async def test_missing_task_id_still_rejects_when_state_empty() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skip(
+    reason="goldfive#252: planner-side assignee_agent_id is dropped at parse "
+    "time (always ''); the #214 compound-assignee normalization path no "
+    "longer applies because there is no assignee to normalize. Pin "
+    "resolution at before_agent_callback now relies on observational "
+    "matching (current_task_id, span topology) rather than the planner's "
+    "declared assignee."
+)
 async def test_before_agent_callback_pins_when_plan_came_from_compound_json() -> None:
     """Plans built from compound-form planner JSON still pin the right task.
 


### PR DESCRIPTION
## Summary

Stops the planner LLM from picking `Task.assignee_agent_id` and disables the now-redundant `PLAN_DIVERGENCE` drift creation. The capability-grounded replacement (`CAPABILITY_MISMATCH`, #253) merged in #376; this PR completes the structural pivot from declarative to observational assignment.

### Changes

- **Planner prompt strips**: removed every "assign each task to an agent" clause from `_DEFAULT_SYSTEM_PROMPT`, `_REFINE_SYSTEM_PROMPT`, `_USER_STEER_SYSTEM_PROMPT`, `_LOOPING_TOOL_CALL_SYSTEM_PROMPT`, `_PLAN_DIVERGENCE_SYSTEM_PROMPT`, `_HANDLE_TURN_SYSTEM_PROMPT`, `_SUPERSESSION_EXAMPLES`, `_REFINEMENT_GUIDANCE_BLOCK`, `_build_generate_prompt` / `_build_refine_prompt` agent-tree headers. Replaced with explicit "Do NOT populate `assignee_agent_id`; leave as empty string. The framework will populate it observationally when a delegation actually happens." JSON skeleton lost the field.
- **Parser normalization**: `_plan_from_json` unconditionally writes `assignee_agent_id=""` on every parsed Task, regardless of LLM output. Single line in the helper that all paths (generate / refine / refine_steer / handle_turn) funnel through.
- **PLAN_DIVERGENCE silenced**: every construction site (`reconciler._emit_divergence`, `steerer.report_plan_divergence`, `goldfive_planner._emit_tool_call_drift` cross-layer-delegation branch, plus a top-of-`_handle_drift` guard) is now a no-op + DEBUG log. `DriftKind.PLAN_DIVERGENCE` enum + proto field preserved for back-compat.
- **#253 seam patch in `_adk_plugin.py:_maybe_emit_capability_mismatch`**: two-strategy task resolver — (1) legacy `assignee_agent_id` match (preserved for explicit-fixture callers including #253's integration tests), (2) post-#252 fallback reading `session.current_task_id` then `OrchestrationStore.pin_current_task()`. If neither resolves a PENDING/RUNNING task the detector no-ops.

### Test plan

- [x] `pytest tests/ -q` — 2339 passed, 59 skipped, 0 failed.
- [x] `ruff check goldfive/ tests/` — clean.
- [x] 6 PLAN_DIVERGENCE-dependent tests handled: 3 skipped (pure emission), 3 updated (cancel-inflight rewritten on OFF_TOPIC, cancelled-id-stripping assertion tightened, e2e test asserts post-#252 invariant `all assignee == ""`). No tests deleted.

### Why this completes #252's design rationale

The planner's `assignee_agent_id` field was being treated as authoritative metadata when it was actually an LLM hallucination prone to picking structurally wrong assignees (e.g. live e2e session `bc6c4f6a`: planner picked `coordinator_agent` for `draft_presentation`, an agent with no leaf-execution tools). After this PR + #376, the framework stops asking the LLM to make this decision and instead grounds the same comparison in actual tool capability via `CAPABILITY_MISMATCH`.

Closes #252.