### PR TITLE
feat(integrations): claude-agent-sdk callable for planner / goal / judges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ htmlcov/
 .vscode/
 .DS_Store
 .claude/
+
+# Example run artifacts (generated presentations, ADK session DBs)
+examples/*/output/
+examples/*/.adk/

--- a/examples/presentation_agent/agent.py
+++ b/examples/presentation_agent/agent.py
@@ -638,20 +638,24 @@ def _build_app() -> Any:
     planner = LLMPlanner(call_llm=call_llm, model=planner_model)
     goal_deriver = LLMGoalDeriver(call_llm=goal_call_llm, model=planner_model)
 
-    wrapped = goldfive.wrap(tree, planner=planner, goal_deriver=goal_deriver)
-
+    sinks: list[Any] = [LoggingSink()]
     plugins: list[Any] = []
     client = _get_or_create_harmonograf_client()
     if client is not None:
         try:
-            from harmonograf_client import HarmonografTelemetryPlugin
+            from harmonograf_client import HarmonografSink, HarmonografTelemetryPlugin
         except ImportError as e:
             log.warning(
-                "HarmonografTelemetryPlugin unavailable (%s); running without spans",
+                "HarmonografSink/Plugin unavailable (%s); running without telemetry",
                 e,
             )
         else:
+            sinks.append(HarmonografSink(client))
             plugins.append(HarmonografTelemetryPlugin(client))
+
+    wrapped = goldfive.wrap(
+        tree, planner=planner, goal_deriver=goal_deriver, sinks=sinks
+    )
 
     return App(name="presentation_agent", root_agent=wrapped, plugins=plugins)
 
@@ -679,8 +683,28 @@ async def _run(*, topic: str, mock: bool) -> Any:
     directly (``asyncio.run(_run(topic=..., mock=True))``) without
     scraping argv.
     """
-    if mock:
-        agent_model: str | BaseLlm = _MockLlm(model="mock/presentation-agent")
+    use_claude_sdk = bool(os.environ.get("GOLDFIVE_USE_CLAUDE_SDK"))
+    judge_fallback_call_llm: Any | None = None
+    if use_claude_sdk:
+        from goldfive.integrations.claude_sdk import make_call_llm
+
+        # Planner + goal-deriver + judges go through claude-agent-sdk →
+        # Max billing. Subagent model uses ``GOLDFIVE_EXAMPLE_MODEL`` and
+        # must be one ADK natively routes (litellm string like
+        # ``openai/gpt-4o-mini`` or bare Google Gemini name with
+        # ``GOOGLE_API_KEY``). A Claude ``BaseLlm`` adapter for subagents
+        # is in development — see the PR thread for status.
+        agent_model: str | BaseLlm = os.environ.get(
+            "GOLDFIVE_EXAMPLE_MODEL", "gemini-2.5-flash-lite"
+        )
+        planner_call_llm = make_call_llm("claude-haiku-4-5")
+        goal_call_llm = planner_call_llm
+        judge_fallback_call_llm = planner_call_llm
+        model_tag = os.environ.get(
+            "GOLDFIVE_EXAMPLE_PLANNER_MODEL", "claude-haiku-4-5"
+        )
+    elif mock:
+        agent_model = _MockLlm(model="mock/presentation-agent")
         planner_call_llm = _mock_planner_call_llm(topic)
         goal_call_llm = _mock_goal_call_llm(topic)
         model_tag = "mock/planner"
@@ -702,13 +726,19 @@ async def _run(*, topic: str, mock: bool) -> Any:
         except ImportError as e:
             log.warning("HarmonografSink unavailable (%s)", e)
 
-    runner = goldfive.wrap(
-        tree,
+    wrap_kwargs: dict[str, Any] = dict(
         planner=LLMPlanner(call_llm=planner_call_llm, model=model_tag),
         goal_deriver=LLMGoalDeriver(call_llm=goal_call_llm, model=model_tag),
         executor=SequentialExecutor(max_task_invocations=8),
         sinks=sinks,
     )
+    if judge_fallback_call_llm is not None:
+        # Route judges (goal-drift, reasoning) through the same callable so
+        # they don't inherit the agent's mock model and produce
+        # "unparseable verdict". Per goldfive.wrap precedence:
+        # explicit > JudgeConfig > detected.
+        wrap_kwargs["call_llm"] = judge_fallback_call_llm
+    runner = goldfive.wrap(tree, **wrap_kwargs)
 
     try:
         outcome = await runner.run(f"Make a short presentation about {topic}.")

--- a/examples/presentation_agent/agent.py
+++ b/examples/presentation_agent/agent.py
@@ -685,16 +685,30 @@ async def _run(*, topic: str, mock: bool) -> Any:
     """
     use_claude_sdk = bool(os.environ.get("GOLDFIVE_USE_CLAUDE_SDK"))
     judge_fallback_call_llm: Any | None = None
+    # Hoist the annotation so all branches share the union type — keeps
+    # mypy / pyright from narrowing to ``_MockLlm`` (the value type on
+    # the ``elif mock`` branch) which would lose the ``str`` arm.
+    agent_model: str | BaseLlm
     if use_claude_sdk:
         from goldfive.integrations.claude_sdk import make_call_llm
 
+        if mock:
+            # The Claude SDK branch supersedes ``--mock`` when both are
+            # set. Surface this in logs so a developer who left
+            # ``GOLDFIVE_USE_CLAUDE_SDK=1`` in their shell isn't
+            # confused by ``--mock`` being silently ignored.
+            log.info(
+                "presentation_agent: GOLDFIVE_USE_CLAUDE_SDK=1 set; "
+                "ignoring --mock and routing planner/goal-deriver/judges "
+                "through claude-agent-sdk."
+            )
         # Planner + goal-deriver + judges go through claude-agent-sdk →
         # Max billing. Subagent model uses ``GOLDFIVE_EXAMPLE_MODEL`` and
         # must be one ADK natively routes (litellm string like
         # ``openai/gpt-4o-mini`` or bare Google Gemini name with
         # ``GOOGLE_API_KEY``). A Claude ``BaseLlm`` adapter for subagents
         # is in development — see the PR thread for status.
-        agent_model: str | BaseLlm = os.environ.get(
+        agent_model = os.environ.get(
             "GOLDFIVE_EXAMPLE_MODEL", "gemini-2.5-flash-lite"
         )
         planner_call_llm = make_call_llm("claude-haiku-4-5")

--- a/goldfive/integrations/__init__.py
+++ b/goldfive/integrations/__init__.py
@@ -1,0 +1,12 @@
+"""Optional integrations between goldfive and external SDKs.
+
+Each submodule here wires an external LLM SDK to goldfive's
+``CallLLM = Callable[[str, str, str], Awaitable[str]]`` contract so it
+can be passed to :func:`goldfive.wrap`, :class:`LLMPlanner`,
+:class:`LLMGoalDeriver`, or judges.
+
+These imports are intentionally not re-exported at package level:
+each integration has its own optional dependency (e.g. ``claude-agent-sdk``
+for :mod:`goldfive.integrations.claude_sdk`) which we don't want to
+force on goldfive's core users.
+"""

--- a/goldfive/integrations/claude_sdk.py
+++ b/goldfive/integrations/claude_sdk.py
@@ -70,9 +70,74 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
-# Module-level so the test suite can assert on it without reaching
-# into ``_call``'s closure.
+# Module-level so the test suite can assert on it without reaching into
+# ``_call``'s closure, and so the BaseLlm adapter (``ClaudeAgentSDKLlm``)
+# can reuse the same turn budget instead of hardcoding its own.
 _DEFAULT_MAX_TURNS = 5
+
+
+def _import_sdk() -> tuple[Any, Any]:
+    """Lazily import the optional ``claude-agent-sdk``.
+
+    Returns ``(ClaudeAgentOptions, query)``. Raises :class:`ImportError`
+    with an install hint when the package is absent — the single owner of
+    that hint so every call site reports it identically. Imported lazily
+    so merely importing this module does not require the SDK.
+    """
+    try:
+        from claude_agent_sdk import ClaudeAgentOptions, query
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "goldfive.integrations.claude_sdk requires `claude-agent-sdk`. "
+            "Install it with: uv pip install claude-agent-sdk"
+        ) from e
+    return ClaudeAgentOptions, query
+
+
+def _build_agent_options(
+    *,
+    system: str | None,
+    model: str,
+    tools: list[Any],
+    max_turns: int = _DEFAULT_MAX_TURNS,
+    **extra: Any,
+) -> Any:
+    """Single source of truth for the ``ClaudeAgentOptions`` knobs shared
+    by every goldfive call site — ``make_call_llm`` here and the
+    ``ClaudeAgentSDKLlm`` BaseLlm adapter. Centralising them keeps the two
+    call sites from silently drifting on the SDK-isolation settings.
+
+    Fixed here and not overridable by callers:
+
+    * ``setting_sources=[]`` — disables the SDK's default discovery chain
+      (``~/.claude/settings.json``, project ``.claude/settings.json``,
+      project ``CLAUDE.md``). Without it, operator-local Claude config
+      leaks into every planner / judge prompt — e.g. a personal
+      ``CLAUDE.md`` ("respond in YAML", "be terse") would silently
+      corrupt the structured-JSON output goldfive parsers expect,
+      surfacing downstream as "unparseable verdict" with no obvious cause.
+
+    What legitimately varies between call sites is passed in:
+
+    * ``tools`` — ``make_call_llm`` passes ``[]`` to strip Claude Code's
+      built-in tools (TodoWrite, Task, Read, Bash, …) so the internal
+      agent loop stays dormant for short structured prompts. The BaseLlm
+      adapter passes its MCP-prefixed ADK tool allowlist instead.
+      ``allowed_tools=[]`` is NOT the isolation knob: it only suppresses
+      permission prompts; the tools stay visible to the model. Callers
+      needing an ``allowed_tools`` allowlist (plus ``mcp_servers`` /
+      ``hooks``) pass them through ``**extra``.
+    * ``max_turns`` — defaults to :data:`_DEFAULT_MAX_TURNS`.
+    """
+    ClaudeAgentOptions, _ = _import_sdk()
+    return ClaudeAgentOptions(
+        system_prompt=system or None,
+        model=model,
+        tools=tools,
+        setting_sources=[],
+        max_turns=max_turns,
+        **extra,
+    )
 
 
 def make_call_llm(
@@ -91,38 +156,21 @@ def make_call_llm(
     ``claude_agent_sdk`` is not importable. We import lazily so simply
     importing this module does not require the SDK to be installed.
     """
-    try:
-        from claude_agent_sdk import ClaudeAgentOptions, query
-    except ImportError as e:  # pragma: no cover
-        raise ImportError(
-            "goldfive.integrations.claude_sdk requires `claude-agent-sdk`. "
-            "Install it with: uv pip install claude-agent-sdk"
-        ) from e
+    # Validate the optional dependency eagerly so misconfiguration
+    # surfaces at wiring time, not on the first planner / judge call.
+    # ``query`` is captured for the closure below.
+    _, query = _import_sdk()
 
     async def _call(system: str, prompt: str, model: str) -> str:
-        # Two SDK-isolation knobs (must agree with the BaseLlm adapter
-        # in a follow-up PR):
-        #
-        # * ``setting_sources=[]`` — disables the SDK's default
-        #   discovery chain (``~/.claude/settings.json``, project
-        #   ``.claude/settings.json``, project ``CLAUDE.md``). Without
-        #   it, operator-local Claude config leaks into every
-        #   planner / judge prompt — e.g. a personal CLAUDE.md
-        #   ("respond in YAML", "be terse") would silently corrupt the
-        #   structured-JSON output goldfive parsers expect, surfacing
-        #   downstream as "unparseable verdict" with no obvious cause.
-        # * ``tools=[]`` — strips Claude Code's built-in tools
-        #   (TodoWrite, Task, Read, Bash, …) from Claude's view, which
-        #   keeps the internal agent loop dormant for these short
-        #   structured prompts. ``allowed_tools=[]`` is NOT the right
-        #   knob here: it only suppresses permission prompts; the tools
-        #   stay visible to the model.
-        opts = ClaudeAgentOptions(
-            system_prompt=system or None,
+        # ``tools=[]`` gives this call site full isolation — no tools at
+        # all — so the SDK's agent loop stays dormant for short
+        # structured prompts. The isolation knobs (``setting_sources=[]``,
+        # ``max_turns``) live in ``_build_agent_options`` so this call
+        # site and the BaseLlm adapter can't drift.
+        opts = _build_agent_options(
+            system=system,
             model=model or default_model,
             tools=[],
-            setting_sources=[],
-            max_turns=_DEFAULT_MAX_TURNS,
         )
         chunks: list[str] = []
         last_stop_reason: Any = None

--- a/goldfive/integrations/claude_sdk.py
+++ b/goldfive/integrations/claude_sdk.py
@@ -31,6 +31,28 @@ Short, structured prompts (plan generation, goal extraction, drift
 verdicts) run cleanly: claude-agent-sdk's internal agent loop does not
 engage for one-shot structured outputs.
 
+Quota / billing visibility
+--------------------------
+
+The callable bills against whichever auth the local ``claude`` CLI is
+logged into — a Max plan in the typical setup. A single steered
+goldfive run can issue multiple calls through this factory:
+
+* one ``LLMPlanner`` call for the initial plan;
+* one ``LLMPlanner.refine`` call per drift that produces a plan
+  revision (rate-limited, but bursty runs can fire several);
+* one ``LLMGoalDeriver`` call per ``run_started``;
+* one ``judge_goal_drift`` call per task-boundary judge fire and per
+  ``goal_drift_check_interval`` agent turn (rate-limited to ~10s
+  between task-boundary fires);
+* one ``judge_reasoning`` call per reasoning-judge fire.
+
+Anecdotal: the ``presentation_agent`` example issues ~5–15 calls
+through this factory on a clean run; failing runs (drift cascades) can
+double that. Operators on Max should expect modest per-run quota burn
+on Haiku; bumping to Sonnet/Opus or running tight loops in
+production should plan for paid-tier billing instead.
+
 A companion ADK ``BaseLlm`` adapter for using Claude on subagents is in
 development — see the PR thread for the observability/architecture
 trade-offs being worked through.
@@ -41,7 +63,16 @@ your project's extras) before importing this module.
 """
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# Module-level so the test suite can assert on it without reaching
+# into ``_call``'s closure.
+_DEFAULT_MAX_TURNS = 5
 
 
 def make_call_llm(
@@ -49,8 +80,12 @@ def make_call_llm(
 ) -> Callable[[str, str, str], Awaitable[str]]:
     """Build an async ``(system, prompt, model) -> str`` callable.
 
-    Goldfive plumbs the configured model through on every call. Empty/
-    falsy ``model`` falls back to ``default_model``.
+    Goldfive plumbs the configured model through on every call. Falsy
+    ``model`` (``""`` or ``None``) falls back to ``default_model`` —
+    matches the rest of goldfive's call-site convention where an empty
+    model string means "use whatever the integration picked." Callers
+    that need to bypass the default (e.g. to assert a specific model
+    string in tests) should pass a sentinel non-empty value instead.
 
     Raises :class:`ImportError` (with an install hint) on first call if
     ``claude_agent_sdk`` is not importable. We import lazily so simply
@@ -65,18 +100,57 @@ def make_call_llm(
         ) from e
 
     async def _call(system: str, prompt: str, model: str) -> str:
+        # Two SDK-isolation knobs (must agree with the BaseLlm adapter
+        # in a follow-up PR):
+        #
+        # * ``setting_sources=[]`` — disables the SDK's default
+        #   discovery chain (``~/.claude/settings.json``, project
+        #   ``.claude/settings.json``, project ``CLAUDE.md``). Without
+        #   it, operator-local Claude config leaks into every
+        #   planner / judge prompt — e.g. a personal CLAUDE.md
+        #   ("respond in YAML", "be terse") would silently corrupt the
+        #   structured-JSON output goldfive parsers expect, surfacing
+        #   downstream as "unparseable verdict" with no obvious cause.
+        # * ``tools=[]`` — strips Claude Code's built-in tools
+        #   (TodoWrite, Task, Read, Bash, …) from Claude's view, which
+        #   keeps the internal agent loop dormant for these short
+        #   structured prompts. ``allowed_tools=[]`` is NOT the right
+        #   knob here: it only suppresses permission prompts; the tools
+        #   stay visible to the model.
         opts = ClaudeAgentOptions(
             system_prompt=system or None,
             model=model or default_model,
-            allowed_tools=[],
-            max_turns=5,
+            tools=[],
+            setting_sources=[],
+            max_turns=_DEFAULT_MAX_TURNS,
         )
         chunks: list[str] = []
+        last_stop_reason: Any = None
         async for msg in query(prompt=prompt, options=opts):
+            stop_reason = getattr(msg, "stop_reason", None)
+            if stop_reason is not None:
+                last_stop_reason = stop_reason
             for block in getattr(msg, "content", []) or []:
                 text = getattr(block, "text", None)
                 if text:
                     chunks.append(text)
+
+        if not chunks:
+            # Silent zero-output is the classic "unparseable verdict"
+            # diagnostic dead-end — downstream JSON parsers
+            # (``LLMPlanner._parse_plan_response``,
+            # ``judge_goal_drift._parse_verdict``) see ``""`` with no
+            # breadcrumb pointing at the cause. Log loudly so operators
+            # can correlate empty returns with model / turn settings.
+            log.warning(
+                "goldfive.integrations.claude_sdk.make_call_llm: "
+                "claude-agent-sdk produced no text "
+                "(model=%s, stop_reason=%s, max_turns=%d); "
+                "downstream parsers will see an empty string",
+                model or default_model,
+                last_stop_reason,
+                _DEFAULT_MAX_TURNS,
+            )
         return "".join(chunks)
 
     return _call

--- a/goldfive/integrations/claude_sdk.py
+++ b/goldfive/integrations/claude_sdk.py
@@ -1,0 +1,82 @@
+"""Claude Agent SDK adapter for goldfive's ``CallLLM`` contract.
+
+Provides :func:`make_call_llm` — an async
+``(system, prompt, model) -> str`` callable that satisfies the
+``CallLLM`` contract. Routes through ``claude_agent_sdk.query``, which
+uses the local ``claude`` CLI's login (Max plan, API key, etc.) — no
+separate ``ANTHROPIC_API_KEY`` needed when the user is already
+authenticated via ``claude /login``.
+
+Drop in at:
+
+* ``LLMPlanner(call_llm=...)``
+* ``LLMGoalDeriver(call_llm=...)``
+* ``goldfive.wrap(call_llm=...)`` (judge fallback per the precedence
+  chain documented on :func:`goldfive.wrap`)
+
+Usage::
+
+    from goldfive import wrap, LLMPlanner, LLMGoalDeriver
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm("claude-haiku-4-5")
+    runner = wrap(
+        agent_tree,
+        planner=LLMPlanner(call_llm=call_llm, model="claude-haiku-4-5"),
+        goal_deriver=LLMGoalDeriver(call_llm=call_llm, model="claude-haiku-4-5"),
+        call_llm=call_llm,  # judges inherit this fallback
+    )
+
+Short, structured prompts (plan generation, goal extraction, drift
+verdicts) run cleanly: claude-agent-sdk's internal agent loop does not
+engage for one-shot structured outputs.
+
+A companion ADK ``BaseLlm`` adapter for using Claude on subagents is in
+development — see the PR thread for the observability/architecture
+trade-offs being worked through.
+
+The integration is gated on the optional ``claude-agent-sdk``
+dependency. Install via ``uv pip install claude-agent-sdk`` (or add to
+your project's extras) before importing this module.
+"""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+
+def make_call_llm(
+    default_model: str = "claude-haiku-4-5",
+) -> Callable[[str, str, str], Awaitable[str]]:
+    """Build an async ``(system, prompt, model) -> str`` callable.
+
+    Goldfive plumbs the configured model through on every call. Empty/
+    falsy ``model`` falls back to ``default_model``.
+
+    Raises :class:`ImportError` (with an install hint) on first call if
+    ``claude_agent_sdk`` is not importable. We import lazily so simply
+    importing this module does not require the SDK to be installed.
+    """
+    try:
+        from claude_agent_sdk import ClaudeAgentOptions, query
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "goldfive.integrations.claude_sdk requires `claude-agent-sdk`. "
+            "Install it with: uv pip install claude-agent-sdk"
+        ) from e
+
+    async def _call(system: str, prompt: str, model: str) -> str:
+        opts = ClaudeAgentOptions(
+            system_prompt=system or None,
+            model=model or default_model,
+            allowed_tools=[],
+            max_turns=5,
+        )
+        chunks: list[str] = []
+        async for msg in query(prompt=prompt, options=opts):
+            for block in getattr(msg, "content", []) or []:
+                text = getattr(block, "text", None)
+                if text:
+                    chunks.append(text)
+        return "".join(chunks)
+
+    return _call

--- a/tests/integrations/test_claude_sdk_call_llm.py
+++ b/tests/integrations/test_claude_sdk_call_llm.py
@@ -1,0 +1,291 @@
+"""Unit tests for :func:`goldfive.integrations.claude_sdk.make_call_llm`.
+
+The factory feeds three goldfive call-sites (``LLMPlanner.call_llm``,
+``LLMGoalDeriver.call_llm``, judge fallback via
+``goldfive.wrap(call_llm=...)``) whose downstream parsers all assume
+a well-formed string return — silent failures here surface much later
+as "unparseable verdict" with no obvious cause. These tests pin the
+contract:
+
+1. ``ImportError`` propagates with the install hint when
+   ``claude_agent_sdk`` is missing.
+2. Multiple text content blocks across multiple yielded messages
+   concatenate in stream order (the goldfive parser is
+   position-sensitive when JSON wrappers span chunks).
+3. Empty ``model`` (``""``) falls back to ``default_model`` —
+   matches the convention used elsewhere in goldfive.
+4. Empty ``system`` produces ``system_prompt=None`` (not ``""``) on
+   the SDK options object.
+5. An empty SDK stream returns ``""`` AND logs a WARNING so the
+   silent-empty diagnostic case is observable.
+6. ``setting_sources=[]`` and ``tools=[]`` are passed on every call —
+   prevents operator-local Claude config (``CLAUDE.md``,
+   ``~/.claude/settings.json``) from leaking into planner / judge
+   prompts.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+import types
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake ``claude_agent_sdk`` module — injected via ``monkeypatch.setitem`` so
+# the lazy import inside ``make_call_llm`` resolves to our stub, recording
+# the exact ``ClaudeAgentOptions`` that goldfive constructs and feeding back
+# whatever async-iterable of messages the test parameterised.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeOptions:
+    """Recorder for the ``ClaudeAgentOptions`` ctor — captures everything
+    goldfive passed so tests can assert on the actual ctor arguments."""
+
+    system_prompt: Any = None
+    model: Any = None
+    tools: Any = None
+    allowed_tools: Any = None
+    setting_sources: Any = None
+    max_turns: Any = None
+    extra: dict[str, Any] = None  # type: ignore[assignment]
+
+    def __init__(self, **kwargs: Any) -> None:
+        # ``ClaudeAgentOptions`` in the real SDK is a dataclass with many
+        # fields; capture the ones we care about and stash the rest so
+        # tests can introspect.
+        self.system_prompt = kwargs.pop("system_prompt", None)
+        self.model = kwargs.pop("model", None)
+        self.tools = kwargs.pop("tools", None)
+        self.allowed_tools = kwargs.pop("allowed_tools", None)
+        self.setting_sources = kwargs.pop("setting_sources", None)
+        self.max_turns = kwargs.pop("max_turns", None)
+        self.extra = kwargs
+
+
+@dataclass
+class _FakeTextBlock:
+    text: str
+
+
+@dataclass
+class _FakeMessage:
+    content: list[_FakeTextBlock]
+    stop_reason: str | None = None
+
+
+def _install_fake_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    messages: list[_FakeMessage] | None = None,
+) -> dict[str, Any]:
+    """Inject a stub ``claude_agent_sdk`` module that records the last
+    ``ClaudeAgentOptions`` ctor and yields ``messages`` (or none) from
+    ``query``. Returns a recorder dict the test can inspect.
+
+    Recorder keys:
+        ``"options"``   — the most recent :class:`_FakeOptions` ctor call
+        ``"prompt"``    — the most recent ``query()`` prompt argument
+        ``"call_count"`` — number of times ``query()`` was iterated
+    """
+    recorder: dict[str, Any] = {"options": None, "prompt": None, "call_count": 0}
+
+    async def _query(*, prompt: Any, options: Any) -> Any:  # type: ignore[no-redef]
+        recorder["prompt"] = prompt
+        recorder["options"] = options
+        recorder["call_count"] += 1
+        for msg in messages or ():
+            yield msg
+
+    fake_module = types.ModuleType("claude_agent_sdk")
+    fake_module.ClaudeAgentOptions = _FakeOptions  # type: ignore[attr-defined]
+    fake_module.query = _query  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_module)
+    return recorder
+
+
+# Drop any stale ``goldfive.integrations.claude_sdk`` import so each test
+# re-runs the lazy import from a clean slate. Otherwise ``make_call_llm``'s
+# closure captures whichever ``claude_agent_sdk`` was first imported.
+@pytest.fixture(autouse=True)
+def _reset_integration_module() -> None:
+    sys.modules.pop("goldfive.integrations.claude_sdk", None)
+
+
+# ---------------------------------------------------------------------------
+# 1. ImportError on missing SDK
+# ---------------------------------------------------------------------------
+
+
+def test_make_call_llm_raises_import_error_when_sdk_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``claude_agent_sdk`` is not installed, ``make_call_llm``
+    raises :class:`ImportError` with the install-hint message. The hint
+    is what tells users which package to pip install."""
+    # Ensure no stale import — and also block any real import attempt.
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", None)  # forces ImportError
+    real_import = builtins.__import__
+
+    def _blocking_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "claude_agent_sdk" or name.startswith("claude_agent_sdk."):
+            raise ImportError("No module named 'claude_agent_sdk'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocking_import)
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    with pytest.raises(ImportError) as excinfo:
+        make_call_llm()
+    assert "uv pip install claude-agent-sdk" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# 2. Chunks concatenate in stream order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_make_call_llm_concatenates_chunks_in_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text content across multiple yielded messages and multiple
+    blocks-per-message concatenates in stream order. Important because
+    goldfive's JSON parsers sometimes see brace-balanced JSON spanning
+    several content blocks."""
+    _install_fake_sdk(
+        monkeypatch,
+        messages=[
+            _FakeMessage(content=[_FakeTextBlock("alpha-"), _FakeTextBlock("beta-")]),
+            _FakeMessage(content=[_FakeTextBlock("gamma")]),
+        ],
+    )
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm()
+    result = await call_llm("sys", "user prompt", "claude-haiku-4-5")
+    assert result == "alpha-beta-gamma"
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty model falls back to default_model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_model_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``model=""`` (or ``None``) → ``default_model`` is passed to the
+    SDK. Goldfive's call-sites pass the configured model verbatim;
+    this fallback is the integration's contract for "unspecified."""
+    recorder = _install_fake_sdk(
+        monkeypatch,
+        messages=[_FakeMessage(content=[_FakeTextBlock("ok")])],
+    )
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm(default_model="claude-haiku-4-5")
+    await call_llm("sys", "prompt", "")
+    assert recorder["options"].model == "claude-haiku-4-5"
+
+
+# ---------------------------------------------------------------------------
+# 4. Empty system → system_prompt=None on the options
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_system_produces_none_system_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``system=""`` → ``system_prompt=None`` on the SDK options. The
+    distinction matters: the SDK treats ``""`` as "use my empty system
+    prompt" (which the bundled CLI may not honor) versus ``None`` which
+    means "no override, use the SDK default" — and we explicitly want
+    the latter for short structured prompts."""
+    recorder = _install_fake_sdk(
+        monkeypatch,
+        messages=[_FakeMessage(content=[_FakeTextBlock("ok")])],
+    )
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm()
+    await call_llm("", "prompt", "claude-haiku-4-5")
+    assert recorder["options"].system_prompt is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Empty stream returns "" AND logs WARNING
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_returns_empty_string_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An SDK stream that yields no text blocks returns ``""`` from the
+    callable AND emits a WARNING log. The empty return is the classic
+    "unparseable verdict" diagnostic dead-end pre-fix; the WARNING makes
+    it observable so operators can correlate with model / turn config."""
+    _install_fake_sdk(monkeypatch, messages=[])  # no messages at all
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm()
+
+    with caplog.at_level(logging.WARNING, logger="goldfive.integrations.claude_sdk"):
+        result = await call_llm("sys", "prompt", "claude-haiku-4-5")
+    assert result == ""
+    warning_records = [
+        r for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any(
+        "claude-agent-sdk produced no text" in r.getMessage()
+        for r in warning_records
+    ), f"expected zero-output WARNING, saw: {[r.getMessage() for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# 6. setting_sources=[] and tools=[] passed on every call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_isolation_knobs_passed_on_every_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setting_sources=[]`` and ``tools=[]`` must be on the
+    ``ClaudeAgentOptions`` ctor for every invocation. Together they
+    prevent operator-local Claude config (``CLAUDE.md`` / settings
+    files / Claude Code built-in tools) from leaking into planner /
+    judge prompts. Regression test: PR #378 originally shipped without
+    ``setting_sources=[]`` and with ``allowed_tools=[]`` (the wrong
+    knob); reviewer flagged it and that's now part of the contract."""
+    recorder = _install_fake_sdk(
+        monkeypatch,
+        messages=[_FakeMessage(content=[_FakeTextBlock("ok")])],
+    )
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm()
+    await call_llm("sys", "prompt", "claude-haiku-4-5")
+    opts = recorder["options"]
+    assert opts.setting_sources == [], (
+        f"setting_sources must be [] (SDK isolation), got {opts.setting_sources!r}"
+    )
+    assert opts.tools == [], (
+        f"tools must be [] (strips Claude Code built-ins), got {opts.tools!r}"
+    )


### PR DESCRIPTION
## Summary

Adds a `goldfive.integrations.claude_sdk` module with `make_call_llm` —
an async `(system, prompt, model) -> str` callable that lets any
goldfive consumer route the planner / goal-deriver / judge LLM calls
through `claude-agent-sdk` (Max-billed via the local `claude` CLI
login). No `ANTHROPIC_API_KEY` needed.

Plus a fix to `_build_app()` so adk-web users also get the goldfive
event stream in harmonograf (sink was missing — only the ADK plugin
was attached).

Without the env gate, all existing paths in the `presentation_agent`
example are byte-identical to before this PR.

## What's wired

| Goldfive call-site | Wires via | Notes |
|---|---|---|
| `LLMPlanner.call_llm` | `make_call_llm("claude-haiku-4-5")` | Plan JSON converges in 1-2 internal turns |
| `LLMGoalDeriver.call_llm` | same callable | Goal extraction is small structured output |
| `wrap(call_llm=...)` (judge fallback) | same callable | Drift judges (`judge_goal_drift`, `reasoning_judge`) now emit real verdicts instead of "unparseable verdict" / `CancelledError` |

For the BaseLlm side (subagents), this PR does **not** ship an
adapter. The subagent model is whatever `GOLDFIVE_EXAMPLE_MODEL`
resolves to and goes through ADK's native routing (litellm string for
OpenAI, bare Gemini name with `GOOGLE_API_KEY`, etc.). The hybrid
"Claude orchestration + Gemini subagents" pattern works out of the
box; the all-Claude pattern is a follow-up (see below).

## Example usage

Hybrid (Claude planner/judges via Max, Gemini subagents free tier):

```
GOLDFIVE_USE_CLAUDE_SDK=1 \
GOLDFIVE_EXAMPLE_MODEL=gemini-2.5-flash-lite \
GOOGLE_API_KEY=... \
uv run --extra adk python examples/presentation_agent/agent.py --topic waffles
```

End-to-end verified: full goldfive pipeline including real
`write_webpage` tool calls, files written to
`examples/presentation_agent/output/`, drift→refine→retry cycles
exercising under Gemini's free-tier 429s. Goldfive's drift detection
acts as designed because the subagent path uses ADK-native tool routing
(full per-tool observability).

## Related fix: `_build_app()` was missing `HarmonografSink`

The adk-web path only attached `HarmonografTelemetryPlugin` (which
sends ADK invocation spans), so the goldfive event stream — plan
revisions, task transitions, drift detections — never reached the
harmonograf server. The CLI `_run()` wired both; the web app factory
wired one. This PR fixes the asymmetry by adding `HarmonografSink` to
the wrap call when a harmonograf client is available.

## Why this PR doesn't include a BaseLlm Claude adapter

I prototyped one and learned the architecturally clean version is
non-trivial. `claude-agent-sdk` is a wrapper around the bundled
`claude` CLI — a full agent runtime, not a thin API client. Two pain
points:

1. **Coercing it into thin behaviour requires combining knobs**:
   `setting_sources=[]` (the SDK's documented isolation mode) plus
   `tools=[allowlist]` (NOT `allowed_tools=[]` — different semantics)
   to prevent the bundled CLI's internal `TodoWrite`/`Task` agent loop
   from firing on every call. After those, plain LLM behaviour works.
2. **The SDK has no "given this transcript, return next message" API.**
   Both `query()` and `ClaudeSDKClient` accept only user messages /
   user-message streams. ADK's BaseLlm contract is fundamentally
   transcript-driven (every call delivers the full conversation
   including past `function_call`/`function_response` pairs). The two
   shapes don't compose cleanly.

A working "tool execution inside the adapter" version exists locally
(in working-copy / on a follow-up branch). It writes files and
completes the pipeline, but **loses per-tool observability** — ADK and
goldfive only see the final `LlmResponse` text. `CONFABULATION_RISK`
and `CAPABILITY_MISMATCH` drift detectors that key off ADK-visible
tool calls misfire for these runs. That's enough of a goldfive
semantics regression that it isn't worth merging.

## Next steps (separate PR)

The architecturally correct shape for a BaseLlm adapter (what ADK's
Gemini / LiteLLM integrations do natively): adapter receives
`LlmRequest` with full conversation, returns Claude's next `tool_use`
as an ADK `function_call` `Part`; ADK runs the tool via its normal
pipeline (goldfive plugin sees it); ADK loops back with
`function_response` and the adapter resumes the Claude conversation
with that result.

Implementing this against `claude-agent-sdk` requires either:

1. **Stateful `ClaudeSDKClient` per ADK conversation** kept alive
   across `generate_content_async` calls, fed user/tool_result
   messages. Module-level registry keyed on a stable per-conversation
   id, careful lifecycle management. Estimated 200-300 lines.
2. **Hacky text-encoded conversation replay** with `query()` each
   call — quicker but fragile.
3. **Switch the BaseLlm adapter to `anthropic` SDK direct** — gives
   us `messages.create(messages=[...])`, maps 1:1 to ADK's pattern in
   ~50 lines. Loses Max billing for these calls only; planner /
   judges stay on `claude-agent-sdk` → Max via this PR's
   `make_call_llm`.

Going to prototype option 1 next; if it doesn't converge cleanly in
a 2-hour spike, option 3 is the fallback.

## Design notes worth recording

A handful of dead-ends found during the iteration in case anyone
revisits the BaseLlm side:

- `permission_mode='plan'` triggers Claude Code's project-init
  pathway — produces a CLAUDE.md template instead of answering. Don't
  use it for thin-LLM coercion.
- `disallowed_tools=['Task', 'TodoWrite', …]` only partially suppresses
  the agent loop. `tools=[]` (the allowlist) is the actual disable
  knob — `allowed_tools=[]` is unrelated (it suppresses permission
  prompts, not tool availability).
- `claude-agent-sdk` spawns a fresh `claude` subprocess per `query()`.
  Sessions do not appear in the user's interactive `claude` history
  because `setting_sources=[]` disables session persistence. This is
  good for library / programmatic use.
- `make_call_llm` (this PR) works without any of the above coercion
  because short structured prompts (planner JSON, drift verdicts)
  converge in 1-2 internal turns — Claude Code's agent loop doesn't
  engage. The BaseLlm half needs all the knobs because subagent system
  prompts are multi-page mission descriptions that Claude reads as
  agentic work.

## Test plan

- [x] `uv run python examples/presentation_agent/agent.py --mock --topic baseline` — unchanged behaviour, canned 4-task plan, `success=True`
- [x] `GOLDFIVE_USE_CLAUDE_SDK=1 GOLDFIVE_EXAMPLE_MODEL=gemini-2.5-flash-lite GOOGLE_API_KEY=... uv run python examples/presentation_agent/agent.py --topic waffles` — hybrid run; real tool calls fire via Gemini, files written under `examples/presentation_agent/output/`, harmonograf trace shows plan + tasks + drift markers + tool calls
- [x] `adk web examples` with `OPENAI_API_KEY` unset — adk-web mock path; `HarmonografSink` now attached when `HARMONOGRAF_SERVER` is set, so the harmonograf UI shows the goldfive event stream alongside the ADK invocation spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)