### PR TITLE
fix(steerer): carve bootstrap install + user-authored revisions out of observation_only gate (closes #255)

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -3584,7 +3584,10 @@ class DefaultSteerer:
         # PlanRevisionDiff sidecar (PLAN-LIFECYCLE.md §2, §8 gap #4).
         prev_plan = session.plan
         # goldfive#247: _apply_revision returns the stamped instance.
-        revised = self._apply_revision(session, revised, drift)
+        # goldfive#255: _apply_revision returns ``(revised, was_installed)``
+        # so the caller can thread the install outcome into PlanRevised's
+        # ``dry_run`` marker.
+        revised, was_installed = self._apply_revision(session, revised, drift)
         # Cancel the in-flight coordinator invocation now that the plan
         # it was reasoning against has been superseded (goldfive#271
         # follow-up — v15 concurrent-invocation bug). Order: cancel
@@ -3594,7 +3597,12 @@ class DefaultSteerer:
         # raises — a no-op cancel still leaves the new plan installed.
         await self._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
-            session, revised, drift, prev_plan=prev_plan, attempt_id=attempt_id
+            session,
+            revised,
+            drift,
+            prev_plan=prev_plan,
+            attempt_id=attempt_id,
+            dry_run=not was_installed,
         )
         # Level 3 (CANCEL_REINVOKE) handoff (Phase 2 of the path-
         # duality fix). Pre-Phase-2 this stuffed
@@ -5078,7 +5086,8 @@ class DefaultSteerer:
         await self._record_refine_outcome(session, drift, succeeded=True)
         prev_plan = session.plan
         # goldfive#247: rebind to the stamped instance.
-        revised = self._apply_revision(session, revised, drift)
+        # goldfive#255: thread ``was_installed`` into PlanRevised.dry_run.
+        revised, was_installed = self._apply_revision(session, revised, drift)
         # Cancel the in-flight coordinator invocation now that
         # ``refine_steer`` produced a superseding plan (goldfive#271
         # follow-up — v15 concurrent-invocation bug). This is the
@@ -5096,7 +5105,12 @@ class DefaultSteerer:
         # gantt timeline.
         await self._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
-            session, revised, drift, prev_plan=prev_plan, attempt_id=attempt_id
+            session,
+            revised,
+            drift,
+            prev_plan=prev_plan,
+            attempt_id=attempt_id,
+            dry_run=not was_installed,
         )
 
     @staticmethod
@@ -5269,7 +5283,12 @@ class DefaultSteerer:
         )
         prev_plan = session.plan
         # goldfive#247: rebind to the stamped instance.
-        plan = self._apply_revision(session, plan, placeholder)
+        # goldfive#255: bootstrap installs always land — the carve-out
+        # inside ``_apply_revision`` (``prev is None``) covers the
+        # fresh-session case; the ``Plan.empty`` seed path bypasses the
+        # gate via this method's contract (``install_initial_plan`` is
+        # structural, never a corrective intervention).
+        plan, was_installed = self._apply_revision(session, plan, placeholder)
         # No cancel-in-flight: nothing is running yet on the very
         # first install.
         await self._emit_plan_revised(
@@ -5278,6 +5297,7 @@ class DefaultSteerer:
             placeholder,
             prev_plan=prev_plan,
             attempt_id=None,
+            dry_run=not was_installed,
         )
         return True
 
@@ -5481,7 +5501,10 @@ class DefaultSteerer:
         attempt_id = self._new_attempt_id()
         await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
         # goldfive#247: rebind to the stamped instance.
-        chosen = self._apply_revision(session, chosen, drift)
+        # goldfive#255: user-authored revisions always land (the carve-out
+        # inside ``_apply_revision`` honours ``drift.authored_by == "user"``)
+        # so ``was_installed`` is True even under observation_only.
+        chosen, was_installed = self._apply_revision(session, chosen, drift)
         await self._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
             session,
@@ -5489,6 +5512,7 @@ class DefaultSteerer:
             drift,
             prev_plan=prev_plan,
             attempt_id=attempt_id,
+            dry_run=not was_installed,
         )
         return chosen
 
@@ -5637,7 +5661,14 @@ class DefaultSteerer:
         attempt_id = self._new_attempt_id()
         await self._emit_refine_attempted(session, drift, attempt_id=attempt_id)
         # goldfive#247: rebind to the stamped instance.
-        revised_plan = self._apply_revision(session, revised_plan, drift)
+        # goldfive#255: thread ``was_installed`` into PlanRevised.dry_run.
+        # ``install_revision_for_user_steer`` and the user-steer routing
+        # in ``apply_user_steer_with_plan`` enter through here too — the
+        # ``authored_by == "user"`` carve-out inside ``_apply_revision``
+        # makes ``was_installed`` True for those even under observation_only.
+        revised_plan, was_installed = self._apply_revision(
+            session, revised_plan, drift
+        )
         await self._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
             session,
@@ -5645,6 +5676,7 @@ class DefaultSteerer:
             drift,
             prev_plan=prev_plan,
             attempt_id=attempt_id,
+            dry_run=not was_installed,
         )
         return True
 
@@ -6258,20 +6290,41 @@ class DefaultSteerer:
         )
         return dataclasses.replace(revised, tasks=tuple(new_tasks))
 
-    def _apply_revision(self, session: Session, revised: Plan, drift: DriftEvent) -> Plan:
+    def _apply_revision(
+        self, session: Session, revised: Plan, drift: DriftEvent
+    ) -> tuple[Plan, bool]:
         """Stamp revision metadata and install ``revised`` on the session.
+
+        Returns ``(revised, was_installed)``: ``was_installed`` is
+        ``True`` iff the revision was actually swapped onto
+        ``session.plan`` (so the caller — and downstream
+        :meth:`_emit_plan_revised` — can stamp ``dry_run`` on the
+        emitted ``PlanRevised`` faithfully).
 
         Preserves the existing ``revision_index`` monotonicity: the new
         plan's index is at least ``old.revision_index + 1``.
 
-        Observation-only mode (goldfive#254): when
-        :meth:`_should_inject` is ``False`` the revision metadata is
-        STILL stamped (so the returned Plan accurately reflects the
-        index/kind/severity the planner produced and downstream
-        :meth:`_emit_plan_revised` can render a faithful preview), but
-        the actual ``set_session_plan`` write to ``session.plan`` and
-        the ``last_addressed_revision_by_drift_key`` stamp are SKIPPED
-        — the live agent keeps reasoning against the prior plan. The
+        Observation-only mode (goldfive#254 / goldfive#255): when
+        ``observation_only`` is set the gate suppresses **only**
+        goldfive-authored corrective drifts. The brief carve-outs:
+
+        * **bootstrap** (``prev is None``) — the very first install of
+          a session's plan is structural, not a corrective intervention.
+          Without this carve-out the gate would leave ``session.plan``
+          permanently ``None`` in observation mode and detectors would
+          collapse (goldfive#255 root cause: harmonograf showed an empty
+          DAG because the bootstrap was rendered as dry-run).
+        * **user-authored** (``drift.authored_by == "user"``) — genuine
+          operator STEER ``ControlMessage`` deliveries always land. The
+          operator has the authority to override observation mode.
+
+        When the gate fires, the revision metadata is STILL stamped (so
+        the returned Plan accurately reflects the index/kind/severity
+        the planner produced and downstream :meth:`_emit_plan_revised`
+        can render a faithful preview), but the actual
+        ``set_session_plan`` write to ``session.plan`` and the
+        ``last_addressed_revision_by_drift_key`` stamp are SKIPPED —
+        the live agent keeps reasoning against the prior plan. The
         paired ``PlanRevised`` event from :meth:`_emit_plan_revised`
         carries ``dry_run=True`` so consumers can distinguish a
         would-have-applied revision from a real one.
@@ -6338,11 +6391,28 @@ class DefaultSteerer:
             revision_reason=new_reason,
             revision_trigger_event_id=new_trigger_id,
         )
-        if not self._should_inject():
+        # goldfive#255: refine the observation-only gate so it captures
+        # ONLY goldfive-authored corrective drifts on an already-bootstrapped
+        # session. ``gate_active`` is True iff this specific revision is
+        # being suppressed; the bootstrap (``prev is None``) and user-
+        # authored (``drift.authored_by == "user"``) carve-outs are named
+        # explicitly so a future reader can grep for the reasons the gate
+        # does NOT fire.
+        is_bootstrap = prev is None
+        is_user_authored = (drift.authored_by or "").lower() == "user"
+        gate_active = (
+            (not is_bootstrap)
+            and (not is_user_authored)
+            and (not self._should_inject())
+        )
+        if gate_active:
             log.info(
                 "DefaultSteerer._apply_revision: observation_only=True — "
-                "SKIPPING plan install. prior_plan_id=%s "
-                "would_have_installed_plan_id=%s revision_index=%d drift_kind=%s",
+                "SKIPPING plan install (gate_active; bootstrap=%s user=%s). "
+                "prior_plan_id=%s would_have_installed_plan_id=%s "
+                "revision_index=%d drift_kind=%s",
+                is_bootstrap,
+                is_user_authored,
                 prior_id[:16] or "<none>",
                 (revised.id or "")[:16] or "<empty>",
                 int(revised.revision_index),
@@ -6354,7 +6424,7 @@ class DefaultSteerer:
             # ``revised`` instance is still returned so
             # :meth:`_emit_plan_revised` can render the would-have-applied
             # preview into ``PlanRevised`` (with ``dry_run=True``).
-            return revised
+            return revised, False
         log.info(
             "DefaultSteerer._apply_revision: prior_plan_id=%s "
             "revised_plan_id=%s revision_index=%d drift_kind=%s",
@@ -6378,7 +6448,7 @@ class DefaultSteerer:
         # goldfive#152: refresh the orchestration-state current plan id
         # so downstream reads see the revised id, not the stale one.
         _ostate.set_current_plan(session.state, revised)
-        return revised
+        return revised, True
 
     # --- Event construction ------------------------------------------
 
@@ -7297,6 +7367,7 @@ class DefaultSteerer:
         *,
         prev_plan: Plan | None = None,
         attempt_id: str | None = None,
+        dry_run: bool | None = None,
     ) -> None:
         from goldfive._correction_injection import (
             clear_obsolete_corrections_on_revision,
@@ -7409,7 +7480,19 @@ class DefaultSteerer:
             # requested) from a real revision. Wire-default is ``false``
             # so legacy producers and historical events round-trip as
             # "real revision" without surprise.
-            evt.plan_revised.dry_run = not self._should_inject()
+            #
+            # goldfive#255: the caller threads the value through from
+            # :meth:`_apply_revision`'s ``was_installed`` return so the
+            # marker reflects whether this SPECIFIC revision was actually
+            # suppressed (a bootstrap install or user-authored steer
+            # under observation_only is a REAL revision — dry_run False
+            # — even though ``self._should_inject()`` is False). Legacy
+            # callers that don't pass ``dry_run`` fall back to the
+            # pre-#255 behaviour for back-compat.
+            if dry_run is not None:
+                evt.plan_revised.dry_run = bool(dry_run)
+            else:
+                evt.plan_revised.dry_run = not self._should_inject()
             # Phase 2.X / goldfive#271 Gap 2: log the emission so a
             # raise-mid-fire scenario (proto build OK, sink emit raises)
             # leaves a goldfive-side trace before the harmonograf side

--- a/tests/test_correction_injection.py
+++ b/tests/test_correction_injection.py
@@ -173,7 +173,9 @@ async def _emit(
     steerer: DefaultSteerer, session: Session, revised: Plan, drift: DriftEvent
 ) -> None:
     prev = session.plan
-    revised = steerer._apply_revision(session, revised, drift)  # goldfive#247: rebind
+    # goldfive#247: rebind to the stamped instance.
+    # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
+    revised, _was_installed = steerer._apply_revision(session, revised, drift)
     await steerer._emit_plan_revised(session, revised, drift, prev_plan=prev)
 
 

--- a/tests/test_e2e_plan_causal_correction.py
+++ b/tests/test_e2e_plan_causal_correction.py
@@ -345,7 +345,9 @@ async def _drive_refine_cycle(
     steerer.bind(sinks=[sink], planner=planner)
 
     prev = session.plan
-    revised = steerer._apply_revision(session, revised, drift)  # goldfive#247: rebind
+    # goldfive#247: rebind to the stamped instance.
+    # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
+    revised, _was_installed = steerer._apply_revision(session, revised, drift)
     await steerer._emit_plan_revised(session, revised, drift, prev_plan=prev)
     return steerer, planner, sink
 
@@ -664,7 +666,9 @@ async def test_critical_drift_composes_cancel_with_correction() -> None:
     # correction lands unperturbed by the cancel. This is the
     # composition claim.
     revised = _revised_with_correct_supersedes()
-    revised = steerer._apply_revision(session, revised, drift)  # goldfive#247: rebind
+    # goldfive#247: rebind to the stamped instance.
+    # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
+    revised, _was_installed = steerer._apply_revision(session, revised, drift)
     await steerer._emit_plan_revised(
         session, revised, drift, prev_plan=_presentation_style_plan()
     )

--- a/tests/test_observation_only.py
+++ b/tests/test_observation_only.py
@@ -690,3 +690,234 @@ async def test_observe_reasoning_warning_verdict_under_observation_only() -> Non
         store.deregister_invocation_task("inv-live")
         fake_task.cancel()
         await asyncio.gather(fake_task, return_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# goldfive#255 carve-outs: bootstrap install + user-authored revision must
+# always land, even under observation_only=True. Only goldfive-authored
+# corrective drifts on an already-bootstrapped session are gated.
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_session(run_id: str = "r-bootstrap") -> Session:
+    """Build a fresh session with ``session.plan = None``.
+
+    Mirrors the live reproduction in goldfive#255: bootstrap install
+    enters ``_apply_revision`` with ``prev = session.plan = None`` and
+    the pre-fix gate left ``session.plan`` permanently ``None`` under
+    observation_only=True — detectors collapsed, harmonograf rendered
+    an empty DAG.
+    """
+    return Session(
+        run_id=run_id,
+        goals=[Goal(id="g-bootstrap", summary="Publish a memo on solar panels")],
+        plan=None,
+        current_task_id="",
+    )
+
+
+def _initial_plan(run_id: str = "r-bootstrap") -> Plan:
+    """Build a structurally-valid initial plan for the bootstrap test."""
+    return Plan(
+        id="p-bootstrap",
+        run_id=run_id,
+        goal_ids=["g-bootstrap"],
+        tasks=[Task(id="t-bootstrap", title="Research solar panels")],
+        edges=[],
+    )
+
+
+async def test_bootstrap_install_lands_under_observation_only() -> None:
+    """goldfive#255: ``session.plan = None`` install must land even with
+    ``observation_only=True``.
+
+    Bootstrap is structural, not corrective — the gate carve-out for
+    ``prev is None`` keeps the very first install of a session's plan
+    real. Without this, ``session.plan`` would stay ``None`` forever,
+    detectors would collapse, and harmonograf's task_plans dispatch
+    would never see authoritative content (the live reproduction in
+    session ``62dde1a6``).
+    """
+    cfg = SteeringConfig(observation_only=True)
+    steerer = DefaultSteerer(steering_config=cfg)
+    session = _bootstrap_session()
+    assert session.plan is None
+    sink = ListSink()
+    planner = RecordingPlanner()
+    steerer.bind(sinks=[sink], planner=planner)
+
+    initial = _initial_plan()
+    installed = await steerer.install_initial_plan(session=session, plan=initial)
+    assert installed is True, "bootstrap must succeed"
+
+    # session.plan was set (non-None) post-install.
+    assert session.plan is not None, (
+        "bootstrap install must land session.plan even under observation_only; "
+        "the gate carve-out is the goldfive#255 fix"
+    )
+    assert session.plan.id == initial.id
+
+    # PlanRevised emitted with dry_run=False (real revision, not preview).
+    revised_events = _plan_revised_events(sink)
+    assert len(revised_events) == 1
+    assert revised_events[0].plan_revised.dry_run is False, (
+        "dry_run must be False on a bootstrap install — operators should "
+        "see the install as authoritative, not as a would-have-applied "
+        "preview"
+    )
+
+    # Watermark behaviour: the bootstrap placeholder is goldfive-authored
+    # (kind=NEW_WORK_DISCOVERED, authored_by="goldfive") so the existing
+    # stamping site at the end of ``_apply_revision`` will write the
+    # ("new_work_discovered", "") key — the placeholder has empty
+    # current_task_id. This is innocuous (the key collides with no real
+    # drift verdict on the freshness gate), but we assert the install
+    # itself worked rather than relying on watermark absence.
+    # The brief asked to "verify this still behaves correctly" — the
+    # behaviour we care about is the install landing. Watermark stamping
+    # is a secondary effect we leave under the existing
+    # authored_by != "user" rule.
+
+
+async def test_user_authored_revision_lands_under_observation_only() -> None:
+    """goldfive#255: a USER_STEER revision must land even with
+    ``observation_only=True``.
+
+    The carve-out for ``drift.authored_by == "user"`` keeps operator
+    STEER ControlMessage deliveries authoritative even when goldfive
+    is configured to passively observe its own drifts.
+    """
+    cfg = SteeringConfig(observation_only=True)
+    steerer = DefaultSteerer(steering_config=cfg)
+    session = _make_session()
+    prior_plan = session.plan
+    assert prior_plan is not None
+    sink = ListSink()
+    planner = RecordingPlanner()
+    control = RecordingControlChannel()
+    adapter = RecordingAdapter()
+    steerer.bind(sinks=[sink], planner=planner)
+    steerer.bind_control_channel(control)
+    steerer.bind_adapter(adapter)
+
+    # Build a structurally-distinct revised plan (avoids the no-op
+    # revision short-circuit in ``_install_with_drift``).
+    revised = _revised_plan(prior_plan)
+
+    # Drive the canonical user-authored install path. ``raw=None`` is
+    # accepted: ``_unpack_steer_context`` falls back to drift.detail
+    # when raw is absent.
+    installed = await steerer.install_revision_for_user_steer(
+        session=session,
+        raw=None,
+        revised_plan=revised,
+    )
+    assert installed is True, "user-authored revision must install"
+
+    # session.plan mutated to the revised plan.
+    assert session.plan is not prior_plan, (
+        "user-authored revision must land session.plan even under "
+        "observation_only — operator directives override the gate"
+    )
+    assert session.plan is not None and session.plan.id == revised.id
+
+    # PlanRevised emitted with dry_run=False — operator action is
+    # authoritative, not a preview.
+    revised_events = _plan_revised_events(sink)
+    assert len(revised_events) == 1
+    assert revised_events[0].plan_revised.dry_run is False, (
+        "dry_run must be False for a user-authored revision; an operator "
+        "STEER is never a preview"
+    )
+
+
+async def test_goldfive_corrective_drift_is_gated_under_observation_only() -> None:
+    """goldfive#255 regression: OFF_TOPIC (goldfive-authored, non-bootstrap)
+    MUST stay gated under ``observation_only=True``.
+
+    This is the path the refactor must NOT accidentally open. The
+    carve-outs in ``_apply_revision`` are narrow — only bootstrap and
+    user-authored drifts bypass the gate. A goldfive-authored
+    corrective drift on a session with a non-None plan stays gated:
+    no install, dry_run=True on the emitted PlanRevised.
+    """
+    cfg = SteeringConfig(observation_only=True)
+    steerer = DefaultSteerer(steering_config=cfg)
+    session = _make_session()
+    prior_plan = session.plan
+    assert prior_plan is not None
+    sink = ListSink()
+    planner = RecordingPlanner()
+    control = RecordingControlChannel()
+    adapter = RecordingAdapter()
+    steerer.bind(sinks=[sink], planner=planner)
+    steerer.bind_control_channel(control)
+    steerer.bind_adapter(adapter)
+
+    drift = _drift_warning(
+        kind=DriftKind.OFF_TOPIC,
+        authored_by="goldfive",
+    )
+    await steerer._handle_drift(drift, session)
+
+    # session.plan unchanged — gate held.
+    assert session.plan is prior_plan, (
+        "goldfive-authored corrective drift must NOT land session.plan "
+        "under observation_only; the carve-outs apply only to bootstrap "
+        "and user-authored revisions"
+    )
+
+    # PlanRevised emitted with dry_run=True (preview only).
+    revised_events = _plan_revised_events(sink)
+    assert len(revised_events) == 1, (
+        "PlanRevised must still emit so operators see the would-have-"
+        f"applied plan; got {len(revised_events)} event(s)"
+    )
+    assert revised_events[0].plan_revised.dry_run is True, (
+        "dry_run must be True for a gated corrective drift — it's a "
+        "preview, not a real revision"
+    )
+
+
+async def test_goldfive_corrective_drift_lands_with_observation_only_false() -> None:
+    """goldfive#255 positive control: with ``observation_only=False`` the
+    same corrective drift lands.
+
+    Toggling the flag off removes ALL three sources of gating
+    (``gate_active`` becomes False because ``not self._should_inject()``
+    is False). The refactor must not introduce a hidden gate that
+    survives the flag flip.
+    """
+    cfg = SteeringConfig(observation_only=False)
+    steerer = DefaultSteerer(steering_config=cfg)
+    session = _make_session()
+    prior_plan = session.plan
+    assert prior_plan is not None
+    sink = ListSink()
+    planner = RecordingPlanner()
+    control = RecordingControlChannel()
+    adapter = RecordingAdapter()
+    steerer.bind(sinks=[sink], planner=planner)
+    steerer.bind_control_channel(control)
+    steerer.bind_adapter(adapter)
+
+    drift = _drift_warning(
+        kind=DriftKind.OFF_TOPIC,
+        authored_by="goldfive",
+    )
+    await steerer._handle_drift(drift, session)
+
+    # session.plan mutated to the revised plan.
+    assert session.plan is not prior_plan, (
+        "with observation_only=False the corrective drift must land "
+        "session.plan"
+    )
+    assert session.plan is not None and session.plan.id == "p2"
+
+    # PlanRevised emitted with dry_run=False (real revision).
+    revised_events = _plan_revised_events(sink)
+    assert len(revised_events) == 1
+    assert revised_events[0].plan_revised.dry_run is False, (
+        "dry_run must be False on a real revision so consumers don't "
+        "treat it as a preview"
+    )

--- a/tests/test_steerer_fold_runtime_terminal.py
+++ b/tests/test_steerer_fold_runtime_terminal.py
@@ -663,7 +663,8 @@ async def test_apply_revision_defensive_fold_idempotent_when_caller_already_fold
         detail="x",
     )
     # goldfive#254: instance method now.
-    revised = DefaultSteerer()._apply_revision(session, revised, drift)  # goldfive#247: rebind
+    # goldfive#255: _apply_revision returns ``(revised, was_installed)``.
+    revised, _was_installed = DefaultSteerer()._apply_revision(session, revised, drift)
 
     # goldfive#247: identity check replaced with id check (Plan is frozen)
     assert session.plan is not None and session.plan.id == revised.id

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -883,7 +883,8 @@ async def test_apply_revision_stamps_trigger_event_id_from_annotation(
     # method (consults ``self._should_inject()`` to gate the install
     # in observation-only mode); the test-suite fixture flips the
     # default to active-steering so the install lands.
-    revised = DefaultSteerer()._apply_revision(session, revised, drift)
+    # goldfive#255: returns ``(revised, was_installed)``.
+    revised, _was_installed = DefaultSteerer()._apply_revision(session, revised, drift)
 
     assert session.plan is not None and session.plan.id == revised.id
     assert revised.revision_trigger_event_id == "ann_ar_77"
@@ -918,7 +919,8 @@ async def test_apply_revision_stamps_drift_id_on_autonomous_drift(
     )
     # goldfive#247: _apply_revision returns the stamped Plan; the input
     # stays unchanged (frozen). goldfive#254: instance method now.
-    revised = DefaultSteerer()._apply_revision(session, revised, drift)
+    # goldfive#255: returns ``(revised, was_installed)``.
+    revised, _was_installed = DefaultSteerer()._apply_revision(session, revised, drift)
     assert revised.revision_trigger_event_id == drift.id
 
 

--- a/tests/test_task_binding_follows_revision.py
+++ b/tests/test_task_binding_follows_revision.py
@@ -168,7 +168,9 @@ async def test_current_task_id_repins_on_revision() -> None:
     planner = _StubPlanner(revised=revised)
     steerer = DefaultSteerer()
     steerer.bind(sinks=[ListSink()], planner=planner)
-    revised = steerer._apply_revision(session, revised, _drift())  # goldfive#247: rebind
+    # goldfive#247: rebind to the stamped instance.
+    # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
+    revised, _was_installed = steerer._apply_revision(session, revised, _drift())
     await steerer._emit_plan_revised(session, revised, _drift(), prev_plan=None)
 
     assert session.current_task_id == "research_solar_corrected"
@@ -819,7 +821,9 @@ async def test_correct_integration_via_emit_plan_revised_end_to_end() -> None:
     planner = _StubPlanner(revised=revised)
     steerer = DefaultSteerer()
     steerer.bind(sinks=[sink], planner=planner)
-    revised = steerer._apply_revision(session, revised, _drift())  # goldfive#247: rebind
+    # goldfive#247: rebind to the stamped instance.
+    # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
+    revised, _was_installed = steerer._apply_revision(session, revised, _drift())
     await steerer._emit_plan_revised(session, revised, _drift(), prev_plan=None)
 
     # Session plan now has the corrected topology.

--- a/tests/test_task_transitioned_events.py
+++ b/tests/test_task_transitioned_events.py
@@ -332,7 +332,9 @@ async def test_refine_replace_supersedes_emits_plan_revision_transition() -> Non
     # Mirror the live order: _apply_revision installs ``revised`` on the
     # session, then _emit_plan_revised diffs prev_plan vs. revised and
     # emits the proto + per-transition envelopes.
-    revised = steerer._apply_revision(session, revised, drift)  # goldfive#247: rebind
+    # goldfive#247: rebind to the stamped instance.
+    # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
+    revised, _was_installed = steerer._apply_revision(session, revised, drift)
     await steerer._emit_plan_revised(session, revised, drift, prev_plan=prev_plan)
 
     transitions = _transition_events(sink)


### PR DESCRIPTION
## Summary

Fixes the regression introduced by #254 where the `observation_only` gate in `DefaultSteerer._apply_revision` fired for **every** revision — including the initial bootstrap install. Under `observation_only=True` the bootstrap was being skipped, leaving `session.plan = None` and degrading every detector that keys on task context.

Live e2e 2026-05-11 (ice cream session `62dde1a6`): plan_revised events seq=5 (bootstrap) AND seq=21 (OFF_TOPIC dry-run refine) both arrived with `dry_run=True`; harmonograf upserted both into `task_plans` under the same plan_id, so the dry-run plan overwrote the bootstrap content. UI rendered a single collapsed task instead of the planner's four-task initial plan.

## Changes

Replace the simple gate with a more precise predicate:

```python
is_bootstrap = prev is None
is_user_authored = (drift.authored_by or "").lower() == "user"
gate_active = (not is_bootstrap) and (not is_user_authored) and (not self._should_inject())
```

The gate now fires **only** for goldfive-authored corrective revisions arriving in observation-only mode. Bootstrap installs and operator overrides land normally regardless of mode.

`_apply_revision` returns `tuple[Plan, bool]` (the second element is `was_installed`). All 5 production call sites unpack it and thread `dry_run=not was_installed` into `_emit_plan_revised`, so the `PlanRevised.dry_run` proto field accurately reflects what actually happened (real install ↔ `dry_run=False`; gated ↔ `dry_run=True`).

## Test plan

- [x] 4 new tests in `tests/test_observation_only.py`:
  - `test_bootstrap_install_lands_under_observation_only` — `session.plan` populates; `dry_run=False`.
  - `test_user_authored_revision_lands_under_observation_only` — USER_STEER applies; `dry_run=False`.
  - `test_goldfive_corrective_drift_is_gated_under_observation_only` — OFF_TOPIC stays dry-run (regression guard).
  - `test_goldfive_corrective_drift_lands_with_observation_only_false` — positive control.
- [x] Full suite: `pytest tests/ -q` — 2352 passed, 59 skipped, 0 failed.
- [x] `ruff check goldfive/ tests/` — clean.

Pairs with goldfive#380 (agent LLM budget) and harmonograf#267 (server filters dry-run upserts).

Closes #255.