### PR TITLE
fix(steerer): observation_only carve-out also exempts NEW_WORK_DISCOVERED revisions (closes #258)

### DIFF
--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -564,6 +564,21 @@ class SteeringConfig:
     * the ``request_invocation_cancel`` plugin call in
       :meth:`~goldfive.steerer.DefaultSteerer.request_invocation_cancel`.
 
+    The plan-install gate suppresses only **corrective**
+    goldfive-authored revisions. Three categories always land as real
+    revisions even under ``observation_only=True``:
+
+    * **bootstrap** — first install on a cold session (``prev is None``);
+    * **user-authored** — operator ``ControlMessage`` STEER deliveries
+      (``drift.authored_by == "user"``);
+    * **discovery** — ``DriftKind.NEW_WORK_DISCOVERED`` revisions
+      (goldfive#258), covering both the runner's turn-1 install through
+      :meth:`install_initial_plan` (where ``session.plan`` was seeded
+      with ``Plan.empty()`` so ``prev is None`` no longer holds) and
+      the turn N+1 replan through :meth:`install_revision_for_drift`.
+      Discovery is the planner / a sub-agent describing observed work,
+      not a framework-driven correction.
+
     Detection still runs in full (reasoning judges, embedding
     detectors, goal-drift, looping detectors, CAPABILITY_MISMATCH, …)
     and ``planner.refine_steer`` still runs — operators can see what

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -6304,19 +6304,42 @@ class DefaultSteerer:
         Preserves the existing ``revision_index`` monotonicity: the new
         plan's index is at least ``old.revision_index + 1``.
 
-        Observation-only mode (goldfive#254 / goldfive#255): when
+        Observation-only mode (goldfive#254 / #255 / #258): when
         ``observation_only`` is set the gate suppresses **only**
-        goldfive-authored corrective drifts. The brief carve-outs:
+        goldfive-authored **corrective** drifts (``OFF_TOPIC``,
+        ``GOAL_DRIFT``, ``LOOPING_*``, ``TASK_FAILED_*``, ``BLOCKED``,
+        ``CAPABILITY_MISMATCH``, etc.). The carve-outs land as **real**
+        revisions even under ``observation_only=True``:
 
-        * **bootstrap** (``prev is None``) — the very first install of
-          a session's plan is structural, not a corrective intervention.
-          Without this carve-out the gate would leave ``session.plan``
-          permanently ``None`` in observation mode and detectors would
-          collapse (goldfive#255 root cause: harmonograf showed an empty
-          DAG because the bootstrap was rendered as dry-run).
+        * **bootstrap** (``prev is None``) — a cold start with no prior
+          plan on the session. Structural, not corrective.
         * **user-authored** (``drift.authored_by == "user"``) — genuine
           operator STEER ``ControlMessage`` deliveries always land. The
           operator has the authority to override observation mode.
+        * **discovery** (``drift.kind is DriftKind.NEW_WORK_DISCOVERED``,
+          goldfive#258) — a description of work the planner or a
+          sub-agent reported / discovered, not a framework-driven
+          correction. This covers two paths the ``prev is None``
+          bootstrap predicate missed:
+
+          - The runner's turn-1 install through
+            :meth:`install_initial_plan`: the runner seeds
+            ``session.plan = Plan.empty(run_id=...)`` before
+            :meth:`Planner.handle_turn` runs, so by the time the
+            placeholder ``NEW_WORK_DISCOVERED`` drift reaches
+            ``_apply_revision`` ``prev`` is the empty seed (non-None).
+          - The runner's turn N+1 replan through
+            :meth:`install_revision_for_drift` with a
+            ``NEW_WORK_DISCOVERED`` drift: the planner integrated new
+            work from the user's fresh message. This is a description
+            of what happened, not a corrective intervention.
+
+          Sub-agent ``report_new_work_discovered`` calls fold into the
+          same kind for the same reason.
+
+        observation-only is about suppressing framework-driven
+        **corrections** — not framework-driven **observability** of
+        what the planner / agents are doing.
 
         When the gate fires, the revision metadata is STILL stamped (so
         the returned Plan accurately reflects the index/kind/severity
@@ -6391,28 +6414,40 @@ class DefaultSteerer:
             revision_reason=new_reason,
             revision_trigger_event_id=new_trigger_id,
         )
-        # goldfive#255: refine the observation-only gate so it captures
-        # ONLY goldfive-authored corrective drifts on an already-bootstrapped
-        # session. ``gate_active`` is True iff this specific revision is
-        # being suppressed; the bootstrap (``prev is None``) and user-
-        # authored (``drift.authored_by == "user"``) carve-outs are named
-        # explicitly so a future reader can grep for the reasons the gate
-        # does NOT fire.
+        # goldfive#255 / #258: refine the observation-only gate so it
+        # captures ONLY goldfive-authored corrective drifts. The three
+        # carve-outs — bootstrap, user-authored, and discovery — are
+        # named explicitly so a future reader can grep for the reasons
+        # the gate does NOT fire:
+        #
+        # * bootstrap (``prev is None``) — cold session.
+        # * user-authored (``drift.authored_by == "user"``) — operator
+        #   STEER deliveries.
+        # * discovery (``drift.kind is DriftKind.NEW_WORK_DISCOVERED``,
+        #   #258) — the planner / a sub-agent describing new work, not
+        #   a framework-driven correction. Covers both turn-1 installs
+        #   through ``install_initial_plan`` (where ``prev`` is the
+        #   ``Plan.empty()`` seed, NOT None) and turn N+1 replans
+        #   through ``install_revision_for_drift``.
         is_bootstrap = prev is None
         is_user_authored = (drift.authored_by or "").lower() == "user"
+        is_discovery = drift.kind is DriftKind.NEW_WORK_DISCOVERED
         gate_active = (
             (not is_bootstrap)
             and (not is_user_authored)
+            and (not is_discovery)
             and (not self._should_inject())
         )
         if gate_active:
             log.info(
                 "DefaultSteerer._apply_revision: observation_only=True — "
-                "SKIPPING plan install (gate_active; bootstrap=%s user=%s). "
-                "prior_plan_id=%s would_have_installed_plan_id=%s "
-                "revision_index=%d drift_kind=%s",
+                "SKIPPING plan install (gate_active; bootstrap=%s user=%s "
+                "discovery=%s). prior_plan_id=%s "
+                "would_have_installed_plan_id=%s revision_index=%d "
+                "drift_kind=%s",
                 is_bootstrap,
                 is_user_authored,
+                is_discovery,
                 prior_id[:16] or "<none>",
                 (revised.id or "")[:16] or "<empty>",
                 int(revised.revision_index),

--- a/tests/test_observation_only.py
+++ b/tests/test_observation_only.py
@@ -921,3 +921,196 @@ async def test_goldfive_corrective_drift_lands_with_observation_only_false() -> 
         "dry_run must be False on a real revision so consumers don't "
         "treat it as a preview"
     )
+
+
+# ---------------------------------------------------------------------------
+# goldfive#258 carve-out: NEW_WORK_DISCOVERED revisions always land
+# ---------------------------------------------------------------------------
+
+
+async def test_discovery_revision_lands_under_observation_only() -> None:
+    """goldfive#258: a goldfive-authored ``NEW_WORK_DISCOVERED`` drift on
+    an already-bootstrapped session must land as a real revision under
+    ``observation_only=True``.
+
+    Discovery represents observed/described work (the planner integrated
+    new work from the user's next-turn message; a sub-agent reported
+    new work via ``report_new_work_discovered``) — NOT a framework-driven
+    correction. The pre-#258 gate fired here because ``prev`` is non-None
+    (an existing plan is on the session) and ``authored_by`` is
+    ``"goldfive"``, leaving the discovery as a dry-run preview.
+    """
+    cfg = SteeringConfig(observation_only=True)
+    steerer = DefaultSteerer(steering_config=cfg)
+    session = _make_session()
+    prior_plan = session.plan
+    assert prior_plan is not None
+    sink = ListSink()
+    planner = RecordingPlanner()
+    control = RecordingControlChannel()
+    adapter = RecordingAdapter()
+    steerer.bind(sinks=[sink], planner=planner)
+    steerer.bind_control_channel(control)
+    steerer.bind_adapter(adapter)
+
+    # Build a structurally-distinct revised plan so the no-op revision
+    # rejection in ``_install_with_drift`` doesn't short-circuit before
+    # the gate decision.
+    revised = _revised_plan(prior_plan)
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.INFO,
+        detail="planner integrated new work from the user's next turn",
+        authored_by="goldfive",
+    )
+
+    installed = await steerer.install_revision_for_drift(
+        session=session,
+        drift=drift,
+        revised_plan=revised,
+    )
+    assert installed is True, "discovery revision must install"
+
+    # session.plan WAS mutated to the revised plan.
+    assert session.plan is not prior_plan, (
+        "NEW_WORK_DISCOVERED revision must land session.plan even under "
+        "observation_only=True — discovery is a description of observed "
+        "work, not a corrective intervention. goldfive#258 carve-out."
+    )
+    assert session.plan is not None and session.plan.id == revised.id
+
+    # PlanRevised emitted with dry_run=False (real revision, not preview).
+    revised_events = _plan_revised_events(sink)
+    assert len(revised_events) == 1
+    assert revised_events[0].plan_revised.dry_run is False, (
+        "dry_run must be False for a NEW_WORK_DISCOVERED revision under "
+        "observation_only — discovery is authoritative, not a preview"
+    )
+
+
+async def test_discovery_revision_lands_under_observation_only_initial_plan_seed() -> (
+    None
+):
+    """goldfive#258 live-bug path: turn-1 ``install_initial_plan`` with a
+    pre-seeded ``Plan.empty()`` must still land under observation_only.
+
+    The runner seeds ``session.plan = Plan.empty(run_id=...)`` before
+    :meth:`Planner.handle_turn` runs (so the planner always sees a
+    non-None ``session.plan``). By the time
+    :meth:`install_initial_plan`'s placeholder
+    ``NEW_WORK_DISCOVERED`` drift reaches ``_apply_revision``, ``prev``
+    is that empty seed — **not** ``None`` — so the original #255
+    ``prev is None`` carve-out did NOT match.
+
+    Pre-#258 reproduction (live session ``793ef00b``, gemma-4-26B):
+
+        DefaultSteerer._apply_revision: observation_only=True —
+        SKIPPING plan install (gate_active; bootstrap=False user=False).
+        ... revision_index=1 drift_kind=new_work_discovered
+
+    The fresh discovery drift on revision 1 was rendered as a dry-run,
+    leaving ``session.plan`` permanently the empty seed. This test is
+    the regression guard.
+    """
+    from goldfive.types import channel_processor_active, set_session_plan
+
+    cfg = SteeringConfig(observation_only=True)
+    steerer = DefaultSteerer(steering_config=cfg)
+
+    # Build the live runner's turn-1 state: session.plan is the
+    # ``Plan.empty()`` seed (non-None, but tasks empty + revision_index 0).
+    session = Session(
+        run_id="r-seed",
+        goals=[Goal(id="g1", summary="Publish a memo on solar panels")],
+        plan=None,
+        current_task_id="",
+    )
+    with channel_processor_active():
+        set_session_plan(session, Plan.empty(run_id="r-seed"))
+    seed = session.plan
+    assert seed is not None, "Plan.empty() seed should populate session.plan"
+    assert seed.tasks == (), "empty seed must have no tasks"
+
+    sink = ListSink()
+    planner = RecordingPlanner()
+    steerer.bind(sinks=[sink], planner=planner)
+
+    # The runner builds a real plan via Planner.handle_turn then routes
+    # through install_initial_plan with first_turn=True (because
+    # session.plan.tasks is empty). install_initial_plan synthesises a
+    # NEW_WORK_DISCOVERED placeholder for _apply_revision metadata
+    # stamping — the same placeholder that fires in the live bug.
+    initial = Plan(
+        id="p-initial",
+        run_id="r-seed",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="Research solar panels")],
+        edges=[],
+    )
+    installed = await steerer.install_initial_plan(session=session, plan=initial)
+    assert installed is True, "initial plan install must succeed"
+
+    # session.plan was swapped from the empty seed onto the real plan.
+    assert session.plan is not seed, (
+        "install_initial_plan must swap the empty seed for the real plan "
+        "even under observation_only — goldfive#258 regression guard"
+    )
+    assert session.plan is not None and session.plan.id == initial.id
+    assert session.plan.tasks, (
+        "post-install session.plan must carry the planner-authored tasks; "
+        "the empty seed leaking past the install is the goldfive#258 bug"
+    )
+
+    # PlanRevised emitted with dry_run=False — the install is
+    # authoritative, not a preview.
+    revised_events = _plan_revised_events(sink)
+    assert len(revised_events) == 1
+    assert revised_events[0].plan_revised.dry_run is False, (
+        "dry_run must be False on the turn-1 install under observation_only "
+        "— the empty-seed -> real-plan transition is a discovery, not a "
+        "corrective intervention. goldfive#258."
+    )
+
+
+async def test_discovery_via_install_revision_for_drift_under_observation_only() -> None:
+    """goldfive#258: turn N+1 replan path with ``NEW_WORK_DISCOVERED``.
+
+    Mirrors the runner's :meth:`Runner._install_revision` non-first-turn
+    branch (``runner.py`` ≈ line 1681): the user's fresh message caused
+    ``Planner.handle_turn`` to surface new work, and the runner installs
+    via ``install_revision_for_drift`` with
+    ``DriftKind.NEW_WORK_DISCOVERED, authored_by="goldfive"``. Under
+    observation_only this must still produce a real revision — the
+    discovery is a description of observed work, not a correction.
+    """
+    cfg = SteeringConfig(observation_only=True)
+    steerer = DefaultSteerer(steering_config=cfg)
+    session = _make_session()
+    prior_plan = session.plan
+    assert prior_plan is not None
+    sink = ListSink()
+    planner = RecordingPlanner()
+    steerer.bind(sinks=[sink], planner=planner)
+
+    revised = _revised_plan(prior_plan)
+    drift = DriftEvent(
+        kind=DriftKind.NEW_WORK_DISCOVERED,
+        severity=DriftSeverity.INFO,
+        detail="the user asked a follow-up that surfaced new work",
+        authored_by="goldfive",
+    )
+    installed = await steerer.install_revision_for_drift(
+        session=session,
+        drift=drift,
+        revised_plan=revised,
+    )
+    assert installed is True
+
+    # session.plan was mutated.
+    assert session.plan is not prior_plan
+    assert session.plan is not None and session.plan.id == revised.id
+
+    # dry_run False on the emitted PlanRevised — the install is real.
+    revised_events = _plan_revised_events(sink)
+    assert len(revised_events) == 1
+    assert revised_events[0].plan_revised.dry_run is False


### PR DESCRIPTION
## Summary

Expands the `observation_only` carve-out introduced in #381 to also exempt `NEW_WORK_DISCOVERED` revisions. Discovery revisions (planner discovering new work; sub-agent calling `report_new_work_discovered`) are descriptions of what's been observed, not framework-driven corrections — they should land as real plan installs regardless of `observation_only`.

## Background — reproduced live 2026-05-11

Session `793ef00b` on gemma-4-26B fired this log line on the very first plan install:

```
DefaultSteerer._apply_revision: observation_only=True — SKIPPING plan install
  (gate_active; bootstrap=False user=False).
  prior_plan_id=53e07cb854ce42a8 would_have_installed_plan_id=53e07cb854ce42a8
  revision_index=1 drift_kind=new_work_discovered
```

`bootstrap=False` because `planner.handle_turn` had already assigned the produced plan to `session.plan` before `_apply_revision` ran for revision-metadata stamping. The #381 carve-out's `prev is None` predicate missed this path. The would-be-first plan got marked `dry_run=True` and never landed, identical bug to what #381 was supposed to fix.

## Fix

```python
is_bootstrap = prev is None
is_user_authored = (drift.authored_by or "").lower() == "user"
is_discovery = drift.kind is DriftKind.NEW_WORK_DISCOVERED   # NEW
gate_active = (
    (not is_bootstrap)
    and (not is_user_authored)
    and (not is_discovery)
    and (not self._should_inject())
)
```

The conceptual model: `observation_only` gates **corrective** framework-driven revisions (OFF_TOPIC / GOAL_DRIFT / LOOPING_* / CAPABILITY_MISMATCH / etc.) only. Discovery, user-steer, and cold-bootstrap revisions always apply. Log message updated to include the new flag (`discovery=False`); docstrings on `_apply_revision` + `SteeringConfig.observation_only` updated to reflect the carve-out set.

## Test plan

- [x] 3 new tests in `tests/test_observation_only.py`:
  - `test_discovery_revision_lands_under_observation_only`
  - `test_discovery_revision_lands_under_observation_only_initial_plan_seed` — explicit regression guard for the live `793ef00b` reproduction
  - `test_discovery_via_install_revision_for_drift_under_observation_only`
- [x] Verified all 3 new tests FAIL on `origin/main` (404d6f0) and pass on this branch — real regression guards.
- [x] `pytest tests/ -q` — 2373 passed, 59 skipped, 0 failed.
- [x] `ruff check goldfive/ tests/` — clean.

Closes #258.