### PR TITLE
feat(integrations/claude_sdk): ClaudeAgentSDKLlm BaseLlm adapter (Phase C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ htmlcov/
 .vscode/
 .DS_Store
 .claude/
+
+# Example run artifacts (generated presentations, ADK session DBs)
+examples/*/output/
+examples/*/.adk/

--- a/examples/presentation_agent/agent.py
+++ b/examples/presentation_agent/agent.py
@@ -766,16 +766,30 @@ async def _run(*, topic: str, mock: bool) -> Any:
     """
     use_claude_sdk = bool(os.environ.get("GOLDFIVE_USE_CLAUDE_SDK"))
     judge_fallback_call_llm: Any | None = None
+    # Hoist the annotation so all branches share the union type — keeps
+    # mypy / pyright from narrowing to ``_MockLlm`` (the value type on
+    # the ``elif mock`` branch) which would lose the ``str`` arm.
+    agent_model: str | BaseLlm
     if use_claude_sdk:
         from goldfive.integrations.claude_sdk import make_call_llm
 
+        if mock:
+            # The Claude SDK branch supersedes ``--mock`` when both are
+            # set. Surface this in logs so a developer who left
+            # ``GOLDFIVE_USE_CLAUDE_SDK=1`` in their shell isn't
+            # confused by ``--mock`` being silently ignored.
+            log.info(
+                "presentation_agent: GOLDFIVE_USE_CLAUDE_SDK=1 set; "
+                "ignoring --mock and routing planner/goal-deriver/judges "
+                "through claude-agent-sdk."
+            )
         # Planner + goal-deriver + judges go through claude-agent-sdk →
         # Max billing. Subagent model uses ``GOLDFIVE_EXAMPLE_MODEL`` and
         # must be one ADK natively routes (litellm string like
         # ``openai/gpt-4o-mini`` or bare Google Gemini name with
         # ``GOOGLE_API_KEY``). A Claude ``BaseLlm`` adapter for subagents
         # is in development — see the PR thread for status.
-        agent_model: str | BaseLlm = os.environ.get(
+        agent_model = os.environ.get(
             "GOLDFIVE_EXAMPLE_MODEL", "gemini-2.5-flash-lite"
         )
         planner_call_llm = make_call_llm("claude-haiku-4-5")

--- a/examples/presentation_agent/agent.py
+++ b/examples/presentation_agent/agent.py
@@ -771,7 +771,10 @@ async def _run(*, topic: str, mock: bool) -> Any:
     # the ``elif mock`` branch) which would lose the ``str`` arm.
     agent_model: str | BaseLlm
     if use_claude_sdk:
-        from goldfive.integrations.claude_sdk import make_call_llm
+        from goldfive.integrations.claude_sdk import (
+            ClaudeAgentSDKLlm,
+            make_call_llm,
+        )
 
         if mock:
             # The Claude SDK branch supersedes ``--mock`` when both are
@@ -783,15 +786,20 @@ async def _run(*, topic: str, mock: bool) -> Any:
                 "ignoring --mock and routing planner/goal-deriver/judges "
                 "through claude-agent-sdk."
             )
-        # Planner + goal-deriver + judges go through claude-agent-sdk →
-        # Max billing. Subagent model uses ``GOLDFIVE_EXAMPLE_MODEL`` and
-        # must be one ADK natively routes (litellm string like
-        # ``openai/gpt-4o-mini`` or bare Google Gemini name with
-        # ``GOOGLE_API_KEY``). A Claude ``BaseLlm`` adapter for subagents
-        # is in development — see the PR thread for status.
-        agent_model = os.environ.get(
-            "GOLDFIVE_EXAMPLE_MODEL", "gemini-2.5-flash-lite"
-        )
+        # Planner + goal-deriver + judges always go through claude-agent-sdk
+        # → Max billing. Subagents use ``GOLDFIVE_EXAMPLE_MODEL`` — if it's
+        # a ``claude-*`` model we wrap with ``ClaudeAgentSDKLlm`` so the
+        # subagent's BaseLlm goes through claude-agent-sdk too; otherwise we
+        # hand the model string to ADK's native routing (litellm style for
+        # ``gemini/...`` / ``openai/...``, or a bare Google Gemini name with
+        # ``GOOGLE_API_KEY``). That way an operator can keep planner/judges
+        # on Max while running subagents on a cheaper / less rate-limited
+        # model.
+        agent_model_name = os.environ.get("GOLDFIVE_EXAMPLE_MODEL", "claude-sonnet-4-6")
+        if agent_model_name.startswith("claude-"):
+            agent_model = ClaudeAgentSDKLlm(model=agent_model_name)
+        else:
+            agent_model = agent_model_name
         planner_call_llm = make_call_llm("claude-haiku-4-5")
         goal_call_llm = planner_call_llm
         judge_fallback_call_llm = planner_call_llm

--- a/examples/presentation_agent/agent.py
+++ b/examples/presentation_agent/agent.py
@@ -719,20 +719,24 @@ def _build_app() -> Any:
     planner = LLMPlanner(call_llm=call_llm, model=planner_model)
     goal_deriver = LLMGoalDeriver(call_llm=goal_call_llm, model=planner_model)
 
-    wrapped = goldfive.wrap(tree, planner=planner, goal_deriver=goal_deriver)
-
+    sinks: list[Any] = [LoggingSink()]
     plugins: list[Any] = []
     client = _get_or_create_harmonograf_client()
     if client is not None:
         try:
-            from harmonograf_client import HarmonografTelemetryPlugin
+            from harmonograf_client import HarmonografSink, HarmonografTelemetryPlugin
         except ImportError as e:
             log.warning(
-                "HarmonografTelemetryPlugin unavailable (%s); running without spans",
+                "HarmonografSink/Plugin unavailable (%s); running without telemetry",
                 e,
             )
         else:
+            sinks.append(HarmonografSink(client))
             plugins.append(HarmonografTelemetryPlugin(client))
+
+    wrapped = goldfive.wrap(
+        tree, planner=planner, goal_deriver=goal_deriver, sinks=sinks
+    )
 
     return App(name="presentation_agent", root_agent=wrapped, plugins=plugins)
 
@@ -760,8 +764,28 @@ async def _run(*, topic: str, mock: bool) -> Any:
     directly (``asyncio.run(_run(topic=..., mock=True))``) without
     scraping argv.
     """
-    if mock:
-        agent_model: str | BaseLlm = _MockLlm(model="mock/presentation-agent")
+    use_claude_sdk = bool(os.environ.get("GOLDFIVE_USE_CLAUDE_SDK"))
+    judge_fallback_call_llm: Any | None = None
+    if use_claude_sdk:
+        from goldfive.integrations.claude_sdk import make_call_llm
+
+        # Planner + goal-deriver + judges go through claude-agent-sdk →
+        # Max billing. Subagent model uses ``GOLDFIVE_EXAMPLE_MODEL`` and
+        # must be one ADK natively routes (litellm string like
+        # ``openai/gpt-4o-mini`` or bare Google Gemini name with
+        # ``GOOGLE_API_KEY``). A Claude ``BaseLlm`` adapter for subagents
+        # is in development — see the PR thread for status.
+        agent_model: str | BaseLlm = os.environ.get(
+            "GOLDFIVE_EXAMPLE_MODEL", "gemini-2.5-flash-lite"
+        )
+        planner_call_llm = make_call_llm("claude-haiku-4-5")
+        goal_call_llm = planner_call_llm
+        judge_fallback_call_llm = planner_call_llm
+        model_tag = os.environ.get(
+            "GOLDFIVE_EXAMPLE_PLANNER_MODEL", "claude-haiku-4-5"
+        )
+    elif mock:
+        agent_model = _MockLlm(model="mock/presentation-agent")
         planner_call_llm = _mock_planner_call_llm(topic)
         goal_call_llm = _mock_goal_call_llm(topic)
         model_tag = "mock/planner"
@@ -783,13 +807,19 @@ async def _run(*, topic: str, mock: bool) -> Any:
         except ImportError as e:
             log.warning("HarmonografSink unavailable (%s)", e)
 
-    runner = goldfive.wrap(
-        tree,
+    wrap_kwargs: dict[str, Any] = dict(
         planner=LLMPlanner(call_llm=planner_call_llm, model=model_tag),
         goal_deriver=LLMGoalDeriver(call_llm=goal_call_llm, model=model_tag),
         executor=SequentialExecutor(max_task_invocations=8),
         sinks=sinks,
     )
+    if judge_fallback_call_llm is not None:
+        # Route judges (goal-drift, reasoning) through the same callable so
+        # they don't inherit the agent's mock model and produce
+        # "unparseable verdict". Per goldfive.wrap precedence:
+        # explicit > JudgeConfig > detected.
+        wrap_kwargs["call_llm"] = judge_fallback_call_llm
+    runner = goldfive.wrap(tree, **wrap_kwargs)
 
     try:
         outcome = await runner.run(f"Make a short presentation about {topic}.")

--- a/examples/presentation_agent/agent.py
+++ b/examples/presentation_agent/agent.py
@@ -795,7 +795,15 @@ async def _run(*, topic: str, mock: bool) -> Any:
         # ``GOOGLE_API_KEY``). That way an operator can keep planner/judges
         # on Max while running subagents on a cheaper / less rate-limited
         # model.
-        agent_model_name = os.environ.get("GOLDFIVE_EXAMPLE_MODEL", "claude-sonnet-4-6")
+        # Default to Haiku: it's the model this PR validated end-to-end
+        # (real research + real ``write_webpage`` tool calls + slide
+        # files land in ``output/``) once the parallel-function-call and
+        # AgentTool schema fixes shipped together with the adapter. Run
+        # with ``GOLDFIVE_EXAMPLE_MODEL=claude-sonnet-4-6`` for stronger
+        # delegation quality on harder topics — that path uses the same
+        # adapter and works identically, it just bills more Max usage
+        # per turn.
+        agent_model_name = os.environ.get("GOLDFIVE_EXAMPLE_MODEL", "claude-haiku-4-5")
         if agent_model_name.startswith("claude-"):
             agent_model = ClaudeAgentSDKLlm(model=agent_model_name)
         else:

--- a/examples/presentation_agent/drift_ab.py
+++ b/examples/presentation_agent/drift_ab.py
@@ -1,0 +1,306 @@
+"""Drift-fidelity A/B harness — native subagent routing vs ``ClaudeAgentSDKLlm``.
+
+Why this exists
+---------------
+``ClaudeAgentSDKLlm`` (PR #383) reaches a Claude model through a
+*text-replay* transport: on every ADK turn it spins up a fresh
+``ClaudeSDKClient`` and re-renders the prior conversation as a
+descriptive text transcript. A reviewer's standing concern is that this
+representation might *manufacture* the very drift goldfive exists to
+detect — e.g. a serialised transcript could read as looping/off-topic to
+the reasoning judge even when the underlying agent behaviour is fine.
+
+The only honest way to answer that is an apples-to-apples A/B: run the
+**same tree** on the **same task** twice, holding everything constant
+except the subagent's transport, and compare the *profile of
+``DriftDetected`` events* (count and kind) the two arms emit. If the
+adapter's profile is not materially worse than the native baseline, the
+text-replay transport is not inventing drift.
+
+What this isolates (and what it does not)
+-----------------------------------------
+The single variable under test is the **subagent transport**:
+
+* ``adapter`` arm — subagent model is ``ClaudeAgentSDKLlm(model=...)``
+  (text-replay through claude-agent-sdk).
+* ``native`` arm — subagent model is a plain model string handed to
+  ADK's own routing (LiteLLM / Gemini message-array transport, no
+  text replay).
+
+Everything else is held identical across both arms:
+
+* the agent tree (``_build_agent_tree``),
+* the planner / goal-deriver / judge ``call_llm`` (a single shared
+  ``make_call_llm`` callable, so the *judges that mint drift* are byte
+  for byte the same in both arms),
+* the executor, the task, and the number of repetitions.
+
+The **most rigorous** baseline points the native arm at the *same Claude
+model* via LiteLLM (``GOLDFIVE_AB_NATIVE_MODEL=anthropic/claude-haiku-4-5``
+with ``ANTHROPIC_API_KEY`` set). Then the model weights are identical and
+*only* the transport differs — any drift delta is attributable to
+text-replay alone. Pointing the native arm at a different model
+(e.g. ``gemini-2.5-flash``) answers a looser question ("is the adapter's
+drift profile in the same ballpark as a healthy native run?") and
+conflates transport with model behaviour; use it only as a sanity check.
+
+Single runs are noisy: drift detection is stochastic (LLM judges, real
+tool calls). Run several repetitions per arm (``GOLDFIVE_AB_RUNS``,
+default 3) and compare *aggregate* profiles, not one-off runs.
+
+This harness needs the live environment
+---------------------------------------
+Both arms make real LLM calls. The adapter arm needs claude-agent-sdk
+auth (Max/OAuth); the native arm needs whatever its model string
+resolves to (an ``ANTHROPIC_API_KEY`` for LiteLLM Claude, a
+``GOOGLE_API_KEY`` for Gemini, etc.). It cannot run in CI or an offline
+sandbox — run it locally and paste the printed table into the PR.
+
+Usage
+-----
+::
+
+    # Rigorous: same Claude model both ways, only transport differs.
+    ANTHROPIC_API_KEY=sk-ant-... \\
+    GOLDFIVE_AB_NATIVE_MODEL=anthropic/claude-haiku-4-5 \\
+    GOLDFIVE_AB_ADAPTER_MODEL=claude-haiku-4-5 \\
+    GOLDFIVE_AB_RUNS=3 \\
+    uv run --extra adk python examples/presentation_agent/drift_ab.py --topic waffles
+
+    # Looser sanity check: native Gemini vs adapter Claude.
+    GOOGLE_API_KEY=... GOLDFIVE_AB_NATIVE_MODEL=gemini-2.5-flash \\
+    uv run --extra adk python examples/presentation_agent/drift_ab.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from collections import Counter
+from typing import Any
+
+import goldfive
+from goldfive import LLMGoalDeriver, LLMPlanner, SequentialExecutor
+
+# Reuse the canonical tree + the SDK integration from the example module
+# so the A/B exercises exactly the production-shaped agents, not a toy.
+from examples.presentation_agent.agent import _build_agent_tree
+from goldfive.integrations.claude_sdk import ClaudeAgentSDKLlm, make_call_llm
+
+
+# ---------------------------------------------------------------------------
+# Drift-counting sink
+# ---------------------------------------------------------------------------
+
+
+class _DriftCountingSink:
+    """EventSink that tallies ``DriftDetected`` events by kind name.
+
+    Sinks receive pb ``Event`` messages (see ``goldfive.protocols`` and
+    ``LoggingSink``). We only care about the ``drift_detected`` payload;
+    every other event is counted in ``total_events`` for context and
+    otherwise ignored.
+    """
+
+    def __init__(self) -> None:
+        self.kinds: Counter[str] = Counter()
+        self.total_events = 0
+        self._drift_kind_name = _make_drift_kind_namer()
+
+    async def emit(self, event: Any) -> None:
+        self.total_events += 1
+        # pb Event: a oneof named "payload"; drift events set
+        # ``drift_detected``. Guard with getattr/WhichOneof so a dataclass
+        # event (if a future sink path hands one over) degrades instead of
+        # raising.
+        which = None
+        if hasattr(event, "WhichOneof"):
+            which = event.WhichOneof("payload")
+        if which == "drift_detected":
+            kind_val = event.drift_detected.kind
+            self.kinds[self._drift_kind_name(kind_val)] += 1
+        elif hasattr(event, "drift_detected") and getattr(
+            event.drift_detected, "kind", None
+        ):
+            kind_val = event.drift_detected.kind
+            self.kinds[self._drift_kind_name(kind_val)] += 1
+
+    async def close(self) -> None:
+        return None
+
+
+def _make_drift_kind_namer():
+    """Return a fn mapping a DriftKind enum value to its short name.
+
+    Tries the pb enum's ``DriftKind.Name`` first (strips the
+    ``DRIFT_KIND_`` prefix); falls back to ``str(value)`` so the harness
+    never crashes on an unmapped kind.
+    """
+    try:
+        from goldfive.pb.goldfive.v1 import types_pb2 as pb  # type: ignore
+
+        def namer(value: Any) -> str:
+            try:
+                name = pb.DriftKind.Name(int(value))
+            except Exception:
+                return str(value)
+            return name[len("DRIFT_KIND_") :] if name.startswith("DRIFT_KIND_") else name
+
+        return namer
+    except Exception:
+        return lambda value: str(value)
+
+
+# ---------------------------------------------------------------------------
+# One arm = N repetitions of (build tree → wrap → run), drift tallied
+# ---------------------------------------------------------------------------
+
+
+async def _run_arm(
+    *,
+    arm: str,
+    subagent_model: Any,
+    topic: str,
+    runs: int,
+    shared_call_llm: Any,
+    planner_model_tag: str,
+) -> _DriftCountingSink:
+    """Run one arm ``runs`` times, accumulating drift counts in one sink.
+
+    The judges/planner/goal-deriver all route through ``shared_call_llm``
+    so the drift-minting machinery is identical across arms — only
+    ``subagent_model`` (the transport under test) differs.
+    """
+    sink = _DriftCountingSink()
+    for i in range(runs):
+        tree = _build_agent_tree(subagent_model)
+        runner = goldfive.wrap(
+            tree,
+            planner=LLMPlanner(call_llm=shared_call_llm, model=planner_model_tag),
+            goal_deriver=LLMGoalDeriver(
+                call_llm=shared_call_llm, model=planner_model_tag
+            ),
+            executor=SequentialExecutor(max_task_invocations=8),
+            sinks=[sink],
+            # Route judges (reasoning, goal-drift) through the same callable
+            # in BOTH arms so drift detection is held constant.
+            call_llm=shared_call_llm,
+        )
+        try:
+            outcome = await runner.run(f"Make a short presentation about {topic}.")
+            print(
+                f"  [{arm}] run {i + 1}/{runs}: "
+                f"success={outcome.success} reason={outcome.reason!r}"
+            )
+        finally:
+            await runner.close()
+    return sink
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def _print_report(
+    native: _DriftCountingSink,
+    adapter: _DriftCountingSink,
+    *,
+    runs: int,
+) -> None:
+    all_kinds = sorted(set(native.kinds) | set(adapter.kinds))
+    print("\n" + "=" * 64)
+    print(f"DRIFT-FIDELITY A/B  ({runs} run(s) per arm)")
+    print("=" * 64)
+    print(f"{'DriftKind':<34}{'native':>10}{'adapter':>10}{'Δ':>8}")
+    print("-" * 64)
+    if not all_kinds:
+        print("  (no DriftDetected events in either arm)")
+    for kind in all_kinds:
+        n = native.kinds.get(kind, 0)
+        a = adapter.kinds.get(kind, 0)
+        print(f"{kind:<34}{n:>10}{a:>10}{a - n:>+8}")
+    print("-" * 64)
+    nt, at = sum(native.kinds.values()), sum(adapter.kinds.values())
+    print(f"{'TOTAL drift events':<34}{nt:>10}{at:>10}{at - nt:>+8}")
+    print(
+        f"{'events seen (all kinds)':<34}"
+        f"{native.total_events:>10}{adapter.total_events:>10}"
+    )
+    print("=" * 64)
+    # A plain-language verdict the operator can paste into the PR. The bar
+    # the reviewer set: the adapter's drift profile must not be
+    # *materially worse* than native.
+    delta = at - nt
+    per_run = delta / runs if runs else 0.0
+    print(
+        "\nVerdict heuristic: the adapter adds "
+        f"{delta:+d} total drift events vs native "
+        f"({per_run:+.1f} per run). Inspect the per-kind rows above — a "
+        "spike concentrated in LOOPING_REASONING / OFF_TOPIC / "
+        "CONFABULATION_RISK is the signature of the text-replay transport "
+        "manufacturing drift; a roughly flat profile means it is not.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+async def _main_async(topic: str, runs: int) -> None:
+    native_model = os.environ.get("GOLDFIVE_AB_NATIVE_MODEL", "anthropic/claude-haiku-4-5")
+    adapter_model = os.environ.get("GOLDFIVE_AB_ADAPTER_MODEL", "claude-haiku-4-5")
+    planner_model = os.environ.get("GOLDFIVE_AB_PLANNER_MODEL", "claude-haiku-4-5")
+
+    # One shared planner/goal/judge callable, used by BOTH arms so the
+    # drift-minting path is constant and the subagent transport is the
+    # sole independent variable.
+    shared_call_llm = make_call_llm(planner_model)
+
+    print(
+        f"native arm subagent model : {native_model!r} (ADK native routing)\n"
+        f"adapter arm subagent model: {adapter_model!r} (ClaudeAgentSDKLlm text-replay)\n"
+        f"shared planner/judge model: {planner_model!r}\n"
+        f"topic={topic!r}  runs/arm={runs}\n"
+    )
+
+    print("Running NATIVE arm ...")
+    native = await _run_arm(
+        arm="native",
+        subagent_model=native_model,
+        topic=topic,
+        runs=runs,
+        shared_call_llm=shared_call_llm,
+        planner_model_tag=planner_model,
+    )
+
+    print("Running ADAPTER arm ...")
+    adapter = await _run_arm(
+        arm="adapter",
+        subagent_model=ClaudeAgentSDKLlm(model=adapter_model),
+        topic=topic,
+        runs=runs,
+        shared_call_llm=shared_call_llm,
+        planner_model_tag=planner_model,
+    )
+
+    _print_report(native, adapter, runs=runs)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--topic", default="waffles", help="Presentation topic.")
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=int(os.environ.get("GOLDFIVE_AB_RUNS", "3")),
+        help="Repetitions per arm (drift is stochastic; average several).",
+    )
+    args = parser.parse_args()
+    asyncio.run(_main_async(args.topic, args.runs))
+
+
+if __name__ == "__main__":
+    main()

--- a/goldfive/integrations/__init__.py
+++ b/goldfive/integrations/__init__.py
@@ -1,0 +1,12 @@
+"""Optional integrations between goldfive and external SDKs.
+
+Each submodule here wires an external LLM SDK to goldfive's
+``CallLLM = Callable[[str, str, str], Awaitable[str]]`` contract so it
+can be passed to :func:`goldfive.wrap`, :class:`LLMPlanner`,
+:class:`LLMGoalDeriver`, or judges.
+
+These imports are intentionally not re-exported at package level:
+each integration has its own optional dependency (e.g. ``claude-agent-sdk``
+for :mod:`goldfive.integrations.claude_sdk`) which we don't want to
+force on goldfive's core users.
+"""

--- a/goldfive/integrations/claude_sdk.py
+++ b/goldfive/integrations/claude_sdk.py
@@ -625,6 +625,24 @@ def make_claude_agent_sdk_llm_class() -> type:
         async def generate_content_async(
             self, llm_request: LlmRequest, stream: bool = False
         ) -> AsyncGenerator[LlmResponse, None]:
+            # Surface the text-replay cost curve once per adapter instance
+            # so operators see it in logs before the Anthropic invoice
+            # does. Each turn re-sends the full prior transcript, so input
+            # tokens grow linearly with turn count and cumulative spend is
+            # O(N^2) over an N-turn subagent run (the docstring explains
+            # why we accept this trade-off). Pair with the per-call
+            # ``usage_metadata`` now plumbed onto every ``LlmResponse`` to
+            # watch the curve climb.
+            if not getattr(self, "_warned_token_cost", False):
+                self._warned_token_cost = True
+                log.info(
+                    "goldfive.integrations.claude_sdk.ClaudeAgentSDKLlm: "
+                    "text-replay transport re-sends the full transcript "
+                    "each turn (model=%s); input tokens grow linearly and "
+                    "cumulative cost is ~O(N^2) over an N-turn subagent "
+                    "run. Watch per-call usage_metadata to track spend.",
+                    llm_request.model or self.model,
+                )
             system = _extract_system_instruction(llm_request.config)
             transcript = _render_contents_as_transcript(llm_request.contents)
             user_prompt = (

--- a/goldfive/integrations/claude_sdk.py
+++ b/goldfive/integrations/claude_sdk.py
@@ -1,25 +1,40 @@
-"""Claude Agent SDK adapter for goldfive's ``CallLLM`` contract.
+"""Claude Agent SDK adapter for goldfive's two LLM call-site shapes.
 
-Provides :func:`make_call_llm` — an async
-``(system, prompt, model) -> str`` callable that satisfies the
-``CallLLM`` contract. Routes through ``claude_agent_sdk.query``, which
-uses the local ``claude`` CLI's login (Max plan, API key, etc.) — no
-separate ``ANTHROPIC_API_KEY`` needed when the user is already
-authenticated via ``claude /login``.
+Two shapes covered:
 
-Drop in at:
+1. ``make_call_llm`` — an async ``(system, prompt, model) -> str`` that
+   plugs into goldfive's ``CallLLM`` contract: ``LLMPlanner.call_llm``,
+   ``LLMGoalDeriver.call_llm``, judge fallback via
+   ``goldfive.wrap(call_llm=...)``.
 
-* ``LLMPlanner(call_llm=...)``
-* ``LLMGoalDeriver(call_llm=...)``
-* ``goldfive.wrap(call_llm=...)`` (judge fallback per the precedence
-  chain documented on :func:`goldfive.wrap`)
+2. ``ClaudeAgentSDKLlm`` — an ADK ``BaseLlm`` subclass for use as an
+   agent ``model=``. Translates ADK ``LlmRequest`` → fresh
+   ``ClaudeSDKClient`` per call → ADK ``LlmResponse``. ADK tools from
+   ``LlmRequest.tools_dict`` are exposed as MCP-prefixed schemas
+   (``mcp__adk__<name>``); a ``PreToolUse`` hook returns
+   ``permissionDecision: "defer"`` so Claude's tool calls are
+   *captured* and returned to ADK as ``function_call`` parts rather
+   than executed inside the adapter. ADK then runs the tool through
+   its normal pipeline and the goldfive plugin observes every call
+   (``CONFABULATION_RISK`` / ``CAPABILITY_MISMATCH`` detectors fire
+   correctly, tool args / results land in the harmonograf inspector).
+
+Both routes go through claude-agent-sdk which uses the local
+``claude`` CLI's login (Max plan, API key, etc.) — no separate
+``ANTHROPIC_API_KEY`` needed when the user is already authenticated via
+``claude /login``.
 
 Usage::
 
     from goldfive import wrap, LLMPlanner, LLMGoalDeriver
-    from goldfive.integrations.claude_sdk import make_call_llm
+    from goldfive.integrations.claude_sdk import (
+        ClaudeAgentSDKLlm,
+        make_call_llm,
+    )
 
     call_llm = make_call_llm("claude-haiku-4-5")
+    agent_model = ClaudeAgentSDKLlm(model="claude-haiku-4-5")
+    # build agent tree using ``agent_model`` as the ``model=`` for each Agent
     runner = wrap(
         agent_tree,
         planner=LLMPlanner(call_llm=call_llm, model="claude-haiku-4-5"),
@@ -53,10 +68,6 @@ double that. Operators on Max should expect modest per-run quota burn
 on Haiku; bumping to Sonnet/Opus or running tight loops in
 production should plan for paid-tier billing instead.
 
-A companion ADK ``BaseLlm`` adapter for using Claude on subagents is in
-development — see the PR thread for the observability/architecture
-trade-offs being worked through.
-
 The integration is gated on the optional ``claude-agent-sdk``
 dependency. Install via ``uv pip install claude-agent-sdk`` (or add to
 your project's extras) before importing this module.
@@ -64,7 +75,7 @@ your project's extras) before importing this module.
 from __future__ import annotations
 
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -154,3 +165,479 @@ def make_call_llm(
         return "".join(chunks)
 
     return _call
+
+
+# ---------------------------------------------------------------------------
+# ADK BaseLlm adapter
+# ---------------------------------------------------------------------------
+
+
+def _extract_system_instruction(config: Any) -> str:
+    """Pull a plain-string system prompt out of ADK's GenerateContentConfig.
+
+    ``GenerateContentConfig.system_instruction`` may be ``None``, a bare
+    string, or a ``Content`` proto (parts list). Reduce to a single
+    string by concatenating any text parts.
+    """
+    if config is None:
+        return ""
+    si = getattr(config, "system_instruction", None)
+    if si is None:
+        return ""
+    if isinstance(si, str):
+        return si
+    parts = getattr(si, "parts", None) or []
+    return "".join(getattr(p, "text", "") or "" for p in parts)
+
+
+def _render_contents_as_transcript(contents: list[Any]) -> str:
+    """Render ADK ``contents`` into a single descriptive prompt string.
+
+    Used by the BaseLlm adapter's text-replay strategy: each
+    ``generate_content_async`` call spawns a fresh ``query()`` and we
+    can't pass prior assistant messages with real ``tool_use`` blocks,
+    so we describe the prior turns as a text transcript instead.
+
+    Translation rules per ``Content``:
+
+    * ``role="user"`` + text part → ``"User: <text>"``
+    * ``role="user"`` + ``function_response`` part →
+      ``"Tool result (<name>): <response>"``
+    * ``role="model"`` + text part → ``"Assistant: <text>"``
+    * ``role="model"`` + ``function_call`` part →
+      ``"Assistant called tool <name> with args <args>"``
+
+    Adjacent same-role text parts are concatenated. Empty contents
+    returns an empty string. The output is intended to be wrapped as
+    *the* user message to a fresh Claude call; the actual tools are
+    registered separately via MCP.
+    """
+    import json as _json
+
+    lines: list[str] = []
+    for content in contents or ():
+        role = getattr(content, "role", "") or "user"
+        parts = getattr(content, "parts", None) or []
+        for part in parts:
+            text = getattr(part, "text", None)
+            fcall = getattr(part, "function_call", None)
+            fresp = getattr(part, "function_response", None)
+            if text:
+                if role == "model":
+                    lines.append(f"Assistant: {text}")
+                else:
+                    lines.append(f"User: {text}")
+            elif fcall is not None and getattr(fcall, "name", None):
+                args = getattr(fcall, "args", None) or {}
+                try:
+                    args_repr = _json.dumps(dict(args), default=str)
+                except (TypeError, ValueError):
+                    args_repr = str(args)
+                lines.append(
+                    f"Assistant called tool `{fcall.name}` with args {args_repr}"
+                )
+            elif fresp is not None and getattr(fresp, "name", None):
+                resp = getattr(fresp, "response", None)
+                try:
+                    resp_repr = _json.dumps(resp, default=str)
+                except (TypeError, ValueError):
+                    resp_repr = str(resp)
+                lines.append(f"Tool result (`{fresp.name}`): {resp_repr}")
+    return "\n".join(lines)
+
+
+# Back-compat alias — older import sites may still reach for the prior name.
+_flatten_contents_to_prompt = _render_contents_as_transcript
+
+
+_PY_TYPE_TO_JSON: dict[type, str] = {
+    str: "string", int: "integer", float: "number", bool: "boolean",
+    list: "array", dict: "object",
+}
+
+
+def _genai_schema_to_json_schema(schema: Any) -> dict[str, Any]:
+    """Convert a ``google.genai.types.Schema`` into a JSON-Schema dict.
+
+    Used to translate ADK's ``FunctionDeclaration.parameters`` (a Schema
+    proto) into the dict shape claude-agent-sdk's ``@tool`` decorator
+    accepts. Handles the subset of Schema fields ADK tools actually
+    populate: ``type``, ``properties``, ``items``, ``required``,
+    ``description``, ``enum``. Unknown fields are dropped.
+    """
+    if schema is None:
+        return {"type": "object", "properties": {}, "required": []}
+
+    type_str: str = ""
+    raw_type = getattr(schema, "type", None) or getattr(schema, "type_", None)
+    if raw_type is not None:
+        type_str = str(getattr(raw_type, "name", raw_type)).lower()
+
+    out: dict[str, Any] = {}
+    if type_str:
+        out["type"] = type_str
+    description = getattr(schema, "description", None)
+    if description:
+        out["description"] = description
+    enum_vals = getattr(schema, "enum", None)
+    if enum_vals:
+        out["enum"] = list(enum_vals)
+    properties = getattr(schema, "properties", None)
+    if properties:
+        out["properties"] = {
+            k: _genai_schema_to_json_schema(v) for k, v in dict(properties).items()
+        }
+    items = getattr(schema, "items", None)
+    if items is not None:
+        out["items"] = _genai_schema_to_json_schema(items)
+    required = getattr(schema, "required", None)
+    if required:
+        out["required"] = list(required)
+
+    if "type" not in out:
+        out["type"] = "object"
+    if out.get("type") == "object" and "properties" not in out:
+        out["properties"] = {}
+    return out
+
+
+def _build_input_schema_from_signature(func: Any) -> dict[str, Any]:
+    """Build a JSON-schema dict from a Python callable's signature.
+
+    Fallback path for tools where :func:`_extract_input_schema_from_adk_tool`
+    cannot recover a declaration (e.g. plain callables without ADK
+    wrapping). We map basic Python annotations to JSON Schema types;
+    unknown annotations default to ``string``.
+    """
+    import inspect
+
+    schema: dict[str, Any] = {"type": "object", "properties": {}, "required": []}
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return schema
+    for pname, param in sig.parameters.items():
+        if pname in ("self", "tool_context"):
+            continue
+        ann = param.annotation
+        json_type = _PY_TYPE_TO_JSON.get(ann, "string")
+        schema["properties"][pname] = {"type": json_type}
+        if param.default is inspect.Parameter.empty:
+            schema["required"].append(pname)
+    return schema
+
+
+def _extract_input_schema_from_adk_tool(adk_tool: Any) -> dict[str, Any]:
+    """Recover a JSON-Schema dict for any ADK ``BaseTool``.
+
+    Strategy: prefer ``_get_declaration()`` since it works uniformly for
+    ``FunctionTool``, ``AgentTool``, and anything else conforming to
+    ``BaseTool``. For ``AgentTool`` this is the only path that yields
+    the required ``request`` parameter — using
+    :func:`_build_input_schema_from_signature` on ``tool.func`` returns
+    an empty schema because ``AgentTool`` has no ``func`` attribute,
+    which then makes Claude call the tool with empty args and ADK
+    raises ``KeyError('request')``.
+
+    Falls back to the signature-based path when the declaration isn't
+    available (some tool wrappers may not implement it).
+    """
+    declaration = None
+    getter = getattr(adk_tool, "_get_declaration", None)
+    if callable(getter):
+        try:
+            declaration = getter()
+        except Exception:  # noqa: BLE001 — defensive; fall back below
+            declaration = None
+    if declaration is None:
+        declaration = getattr(adk_tool, "declaration", None)
+    if declaration is not None:
+        parameters = getattr(declaration, "parameters", None)
+        if parameters is not None:
+            return _genai_schema_to_json_schema(parameters)
+
+    func = getattr(adk_tool, "func", None)
+    if func is not None:
+        return _build_input_schema_from_signature(func)
+    return {"type": "object", "properties": {}, "required": []}
+
+
+def _adk_tool_to_sdk_tool_schema(adk_name: str, adk_tool: Any) -> Any:
+    """Declare an ADK tool's schema to claude-agent-sdk for tool-discovery.
+
+    The SDK requires every MCP tool to have a handler, but in the
+    text-replay BaseLlm strategy we never want the handler to run —
+    the ``PreToolUse`` hook defers each call so ADK can execute the
+    real tool through its normal pipeline (preserving goldfive
+    observability). The handler here is a safety stub that returns an
+    explicit "intercepted, should not run" sentinel; if it ever does
+    fire, the surrounding integration has a bug worth surfacing.
+    """
+    from claude_agent_sdk import tool as sdk_tool_decorator
+
+    description = (
+        getattr(adk_tool, "description", None) or f"ADK tool {adk_name}"
+    )
+    input_schema = _extract_input_schema_from_adk_tool(adk_tool)
+
+    async def _stub_handler(args: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "internal error: ClaudeAgentSDKLlm stub handler "
+                        f"reached for tool {adk_name!r}. The PreToolUse "
+                        "hook should have deferred this call to ADK."
+                    ),
+                }
+            ],
+            "is_error": True,
+        }
+
+    return sdk_tool_decorator(adk_name, description, input_schema)(_stub_handler)
+
+
+# Back-compat alias.
+_adk_tool_to_sdk_tool = _adk_tool_to_sdk_tool_schema
+
+
+_MCP_TOOL_PREFIX = "mcp__adk__"
+_TRANSCRIPT_PREAMBLE = (
+    "The following is the conversation so far with this agent and the "
+    "tools it has access to. Continue from the latest turn. If you "
+    "need to use a tool to make progress, call it via the normal tool "
+    "interface; otherwise produce a final answer for the user.\n\n"
+    "--- BEGIN PRIOR TRANSCRIPT ---\n"
+)
+_TRANSCRIPT_EPILOGUE = (
+    "\n--- END PRIOR TRANSCRIPT ---\n\n"
+    "Please produce your next turn."
+)
+
+
+def make_claude_agent_sdk_llm_class() -> type:
+    """Build the ADK ``BaseLlm`` subclass on demand.
+
+    Constructed at call time so ``import goldfive.integrations.claude_sdk``
+    does not require ADK to be installed when only :func:`make_call_llm`
+    is needed.
+    """
+    try:
+        from claude_agent_sdk import (
+            ClaudeAgentOptions,
+            ClaudeSDKClient,
+            create_sdk_mcp_server,
+        )
+        from claude_agent_sdk.types import HookMatcher
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "goldfive.integrations.claude_sdk requires `claude-agent-sdk`. "
+            "Install it with: uv pip install claude-agent-sdk"
+        ) from e
+    try:
+        from google.adk.models.base_llm import BaseLlm
+        from google.adk.models.llm_request import LlmRequest
+        from google.adk.models.llm_response import LlmResponse
+        from google.genai import types as genai_types
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "ClaudeAgentSDKLlm requires `google-adk`. Install via the "
+            "goldfive[adk] extra."
+        ) from e
+
+    class ClaudeAgentSDKLlm(BaseLlm):  # type: ignore[misc]
+        """ADK ``BaseLlm`` routing generation through claude-agent-sdk.
+
+        Implementation strategy (text-encoded replay): on every
+        ``generate_content_async`` call we spawn a fresh Claude run via
+        ``ClaudeSDKClient``, render the entire prior ADK conversation as
+        a descriptive text transcript prepended to the user prompt, and
+        register the ADK tool schemas via the SDK's MCP transport. A
+        ``PreToolUse`` hook returns ``defer`` so Claude's first tool
+        request is *captured* (not executed) and surfaced back to ADK as
+        a ``function_call`` ``Part``. ADK then runs the tool through its
+        normal pipeline (goldfive plugin observes), and the next ADK
+        invocation re-enters this method with the ``function_response``
+        appended to ``contents``.
+
+        Why text replay instead of stateful client reuse: the SDK has
+        no clean API for "given this transcript + tool history, give me
+        the next message." ``query()`` and ``ClaudeSDKClient`` accept
+        only user-message streams. Replaying prior assistant tool_use
+        blocks via a same-client ``query()`` doesn't continue cleanly
+        after a deferred run, and ``resume=<session_id>`` spawns a
+        fresh subprocess anyway. So we accept the quadratic token cost
+        of resending the transcript each turn in exchange for a much
+        simpler implementation and predictable per-turn behaviour.
+
+        Two coercion knobs (same as :func:`make_call_llm`) keep
+        Claude Code's bundled CLI in thin behaviour:
+
+        * ``setting_sources=[]`` — SDK isolation mode; no filesystem
+          settings or CLAUDE.md auto-detection.
+        * ``tools=[allowlist]`` — only our MCP-prefixed ADK tools are
+          visible to Claude. Claude Code's built-ins (TodoWrite, Task,
+          Read, Bash, …) are excluded, which keeps the internal agent
+          loop dormant.
+
+        Observability: tool calls flow through ADK's normal pipeline,
+        so goldfive's plugin sees each one. ``CONFABULATION_RISK`` and
+        ``CAPABILITY_MISMATCH`` drift detectors fire correctly.
+        """
+
+        @classmethod
+        def supported_models(cls) -> list[str]:
+            return [r"claude-.*"]
+
+        async def generate_content_async(
+            self, llm_request: LlmRequest, stream: bool = False
+        ) -> AsyncGenerator[LlmResponse, None]:
+            system = _extract_system_instruction(llm_request.config)
+            transcript = _render_contents_as_transcript(llm_request.contents)
+            user_prompt = (
+                _TRANSCRIPT_PREAMBLE + transcript + _TRANSCRIPT_EPILOGUE
+                if transcript
+                else ""
+            )
+
+            adk_tools_dict = getattr(llm_request, "tools_dict", None) or {}
+            mcp_tool_names: list[str] = []
+            mcp_servers: dict[str, Any] = {}
+            if adk_tools_dict:
+                sdk_tools = [
+                    _adk_tool_to_sdk_tool_schema(name, t)
+                    for name, t in adk_tools_dict.items()
+                ]
+                mcp_servers["adk"] = create_sdk_mcp_server(
+                    name="adk", tools=sdk_tools
+                )
+                mcp_tool_names = [
+                    f"{_MCP_TOOL_PREFIX}{name}" for name in adk_tools_dict.keys()
+                ]
+
+            captured_tool_call: dict[str, Any] = {}
+            valid_tool_names = set(mcp_tool_names)
+
+            async def _defer_hook(
+                input_data: dict[str, Any],
+                tool_use_id: str | None,
+                context: Any,
+            ) -> dict[str, Any]:
+                name = input_data.get("tool_name", "")
+                # Only defer ADK tools (registered via our ``adk`` MCP
+                # server). Tools outside this allowlist are usually
+                # user-account-bound MCP servers (Gmail, Drive, etc.)
+                # leaking through Claude Code's CLI process at the
+                # network level — these aren't disabled by
+                # ``setting_sources=[]`` because they come from the
+                # cloud account, not local filesystem. Deny them so
+                # Claude retries with a tool that ADK actually has.
+                if name not in valid_tool_names:
+                    return {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": (
+                                f"Tool {name!r} is not available in this "
+                                "run. Only the tools declared on the "
+                                "current agent may be used. Choose one of: "
+                                + ", ".join(sorted(valid_tool_names)) + "."
+                            ),
+                        }
+                    }
+                # Capture first ADK tool defer; ignore any subsequent
+                # calls in the same run (we'll only return the first to
+                # ADK and let it loop back for the next one).
+                if not captured_tool_call:
+                    captured_tool_call.update(
+                        name=name,
+                        args=input_data.get("tool_input", {}) or {},
+                        tool_use_id=tool_use_id or "",
+                    )
+                return {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "defer",
+                        "permissionDecisionReason": (
+                            "ADK will execute this tool through its normal "
+                            "pipeline and feed the result back."
+                        ),
+                    }
+                }
+
+            opts = ClaudeAgentOptions(
+                system_prompt=system or None,
+                model=llm_request.model or self.model,
+                tools=mcp_tool_names if mcp_tool_names else [],
+                mcp_servers=mcp_servers,
+                allowed_tools=mcp_tool_names,
+                setting_sources=[],
+                max_turns=5,
+                hooks={"PreToolUse": [HookMatcher(hooks=[_defer_hook])]},
+            )
+
+            text_chunks: list[str] = []
+            async with ClaudeSDKClient(options=opts) as client:
+                await client.query(user_prompt or "Please continue.")
+                async for msg in client.receive_response():
+                    # Pull plain text content; track tool_use via the
+                    # hook (captured_tool_call) rather than mid-stream
+                    # so we don't double-handle.
+                    for block in getattr(msg, "content", []) or []:
+                        btype = type(block).__name__
+                        if btype == "TextBlock":
+                            text = getattr(block, "text", None)
+                            if text:
+                                text_chunks.append(text)
+                    # Stop iterating once Claude has acknowledged the
+                    # deferred call (stop_reason=tool_deferred) — the
+                    # rest of the stream is the SDK winding down and
+                    # may include Claude's pre-defer apology text we
+                    # want to discard.
+                    stop_reason = getattr(msg, "stop_reason", None)
+                    if stop_reason == "tool_deferred":
+                        break
+
+            parts: list[Any] = []
+            # When we defer a tool, Claude often emits an apology text
+            # block before the defer registers (e.g. "I apologize, the
+            # tool was unavailable…"). That's an artifact of the defer
+            # mechanism — discard it and surface only the function_call.
+            if not captured_tool_call:
+                joined = "".join(text_chunks).strip()
+                if joined:
+                    parts.append(genai_types.Part(text=joined))
+            else:
+                parts.append(
+                    genai_types.Part(
+                        function_call=genai_types.FunctionCall(
+                            name=captured_tool_call["name"].removeprefix(
+                                _MCP_TOOL_PREFIX
+                            ),
+                            args=captured_tool_call["args"],
+                        )
+                    )
+                )
+
+            if not parts:
+                parts.append(genai_types.Part(text=""))
+
+            yield LlmResponse(
+                content=genai_types.Content(role="model", parts=parts),
+                partial=False,
+                turn_complete=True,
+            )
+
+    return ClaudeAgentSDKLlm
+
+
+# Module-level alias for convenience: ``ClaudeAgentSDKLlm = ...``. Built
+# lazily on first attribute access so that ``import
+# goldfive.integrations.claude_sdk`` stays cheap and dependency-light.
+def __getattr__(name: str) -> Any:
+    if name == "ClaudeAgentSDKLlm":
+        cls = make_claude_agent_sdk_llm_class()
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/goldfive/integrations/claude_sdk.py
+++ b/goldfive/integrations/claude_sdk.py
@@ -31,6 +31,28 @@ Short, structured prompts (plan generation, goal extraction, drift
 verdicts) run cleanly: claude-agent-sdk's internal agent loop does not
 engage for one-shot structured outputs.
 
+Quota / billing visibility
+--------------------------
+
+The callable bills against whichever auth the local ``claude`` CLI is
+logged into — a Max plan in the typical setup. A single steered
+goldfive run can issue multiple calls through this factory:
+
+* one ``LLMPlanner`` call for the initial plan;
+* one ``LLMPlanner.refine`` call per drift that produces a plan
+  revision (rate-limited, but bursty runs can fire several);
+* one ``LLMGoalDeriver`` call per ``run_started``;
+* one ``judge_goal_drift`` call per task-boundary judge fire and per
+  ``goal_drift_check_interval`` agent turn (rate-limited to ~10s
+  between task-boundary fires);
+* one ``judge_reasoning`` call per reasoning-judge fire.
+
+Anecdotal: the ``presentation_agent`` example issues ~5–15 calls
+through this factory on a clean run; failing runs (drift cascades) can
+double that. Operators on Max should expect modest per-run quota burn
+on Haiku; bumping to Sonnet/Opus or running tight loops in
+production should plan for paid-tier billing instead.
+
 A companion ADK ``BaseLlm`` adapter for using Claude on subagents is in
 development — see the PR thread for the observability/architecture
 trade-offs being worked through.
@@ -41,7 +63,16 @@ your project's extras) before importing this module.
 """
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# Module-level so the test suite can assert on it without reaching
+# into ``_call``'s closure.
+_DEFAULT_MAX_TURNS = 5
 
 
 def make_call_llm(
@@ -49,8 +80,12 @@ def make_call_llm(
 ) -> Callable[[str, str, str], Awaitable[str]]:
     """Build an async ``(system, prompt, model) -> str`` callable.
 
-    Goldfive plumbs the configured model through on every call. Empty/
-    falsy ``model`` falls back to ``default_model``.
+    Goldfive plumbs the configured model through on every call. Falsy
+    ``model`` (``""`` or ``None``) falls back to ``default_model`` —
+    matches the rest of goldfive's call-site convention where an empty
+    model string means "use whatever the integration picked." Callers
+    that need to bypass the default (e.g. to assert a specific model
+    string in tests) should pass a sentinel non-empty value instead.
 
     Raises :class:`ImportError` (with an install hint) on first call if
     ``claude_agent_sdk`` is not importable. We import lazily so simply
@@ -65,18 +100,57 @@ def make_call_llm(
         ) from e
 
     async def _call(system: str, prompt: str, model: str) -> str:
+        # Two SDK-isolation knobs (must agree with the BaseLlm adapter
+        # in a follow-up PR):
+        #
+        # * ``setting_sources=[]`` — disables the SDK's default
+        #   discovery chain (``~/.claude/settings.json``, project
+        #   ``.claude/settings.json``, project ``CLAUDE.md``). Without
+        #   it, operator-local Claude config leaks into every
+        #   planner / judge prompt — e.g. a personal CLAUDE.md
+        #   ("respond in YAML", "be terse") would silently corrupt the
+        #   structured-JSON output goldfive parsers expect, surfacing
+        #   downstream as "unparseable verdict" with no obvious cause.
+        # * ``tools=[]`` — strips Claude Code's built-in tools
+        #   (TodoWrite, Task, Read, Bash, …) from Claude's view, which
+        #   keeps the internal agent loop dormant for these short
+        #   structured prompts. ``allowed_tools=[]`` is NOT the right
+        #   knob here: it only suppresses permission prompts; the tools
+        #   stay visible to the model.
         opts = ClaudeAgentOptions(
             system_prompt=system or None,
             model=model or default_model,
-            allowed_tools=[],
-            max_turns=5,
+            tools=[],
+            setting_sources=[],
+            max_turns=_DEFAULT_MAX_TURNS,
         )
         chunks: list[str] = []
+        last_stop_reason: Any = None
         async for msg in query(prompt=prompt, options=opts):
+            stop_reason = getattr(msg, "stop_reason", None)
+            if stop_reason is not None:
+                last_stop_reason = stop_reason
             for block in getattr(msg, "content", []) or []:
                 text = getattr(block, "text", None)
                 if text:
                     chunks.append(text)
+
+        if not chunks:
+            # Silent zero-output is the classic "unparseable verdict"
+            # diagnostic dead-end — downstream JSON parsers
+            # (``LLMPlanner._parse_plan_response``,
+            # ``judge_goal_drift._parse_verdict``) see ``""`` with no
+            # breadcrumb pointing at the cause. Log loudly so operators
+            # can correlate empty returns with model / turn settings.
+            log.warning(
+                "goldfive.integrations.claude_sdk.make_call_llm: "
+                "claude-agent-sdk produced no text "
+                "(model=%s, stop_reason=%s, max_turns=%d); "
+                "downstream parsers will see an empty string",
+                model or default_model,
+                last_stop_reason,
+                _DEFAULT_MAX_TURNS,
+            )
         return "".join(chunks)
 
     return _call

--- a/goldfive/integrations/claude_sdk.py
+++ b/goldfive/integrations/claude_sdk.py
@@ -1,0 +1,82 @@
+"""Claude Agent SDK adapter for goldfive's ``CallLLM`` contract.
+
+Provides :func:`make_call_llm` — an async
+``(system, prompt, model) -> str`` callable that satisfies the
+``CallLLM`` contract. Routes through ``claude_agent_sdk.query``, which
+uses the local ``claude`` CLI's login (Max plan, API key, etc.) — no
+separate ``ANTHROPIC_API_KEY`` needed when the user is already
+authenticated via ``claude /login``.
+
+Drop in at:
+
+* ``LLMPlanner(call_llm=...)``
+* ``LLMGoalDeriver(call_llm=...)``
+* ``goldfive.wrap(call_llm=...)`` (judge fallback per the precedence
+  chain documented on :func:`goldfive.wrap`)
+
+Usage::
+
+    from goldfive import wrap, LLMPlanner, LLMGoalDeriver
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm("claude-haiku-4-5")
+    runner = wrap(
+        agent_tree,
+        planner=LLMPlanner(call_llm=call_llm, model="claude-haiku-4-5"),
+        goal_deriver=LLMGoalDeriver(call_llm=call_llm, model="claude-haiku-4-5"),
+        call_llm=call_llm,  # judges inherit this fallback
+    )
+
+Short, structured prompts (plan generation, goal extraction, drift
+verdicts) run cleanly: claude-agent-sdk's internal agent loop does not
+engage for one-shot structured outputs.
+
+A companion ADK ``BaseLlm`` adapter for using Claude on subagents is in
+development — see the PR thread for the observability/architecture
+trade-offs being worked through.
+
+The integration is gated on the optional ``claude-agent-sdk``
+dependency. Install via ``uv pip install claude-agent-sdk`` (or add to
+your project's extras) before importing this module.
+"""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+
+def make_call_llm(
+    default_model: str = "claude-haiku-4-5",
+) -> Callable[[str, str, str], Awaitable[str]]:
+    """Build an async ``(system, prompt, model) -> str`` callable.
+
+    Goldfive plumbs the configured model through on every call. Empty/
+    falsy ``model`` falls back to ``default_model``.
+
+    Raises :class:`ImportError` (with an install hint) on first call if
+    ``claude_agent_sdk`` is not importable. We import lazily so simply
+    importing this module does not require the SDK to be installed.
+    """
+    try:
+        from claude_agent_sdk import ClaudeAgentOptions, query
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "goldfive.integrations.claude_sdk requires `claude-agent-sdk`. "
+            "Install it with: uv pip install claude-agent-sdk"
+        ) from e
+
+    async def _call(system: str, prompt: str, model: str) -> str:
+        opts = ClaudeAgentOptions(
+            system_prompt=system or None,
+            model=model or default_model,
+            allowed_tools=[],
+            max_turns=5,
+        )
+        chunks: list[str] = []
+        async for msg in query(prompt=prompt, options=opts):
+            for block in getattr(msg, "content", []) or []:
+                text = getattr(block, "text", None)
+                if text:
+                    chunks.append(text)
+        return "".join(chunks)
+
+    return _call

--- a/goldfive/integrations/claude_sdk.py
+++ b/goldfive/integrations/claude_sdk.py
@@ -441,6 +441,71 @@ _TRANSCRIPT_EPILOGUE = (
 )
 
 
+def _defer_in_permission_decision(sdk_types: Any) -> bool | None:
+    """Whether ``"defer"`` is a permitted ``permissionDecision`` value.
+
+    Returns ``True``/``False`` when the ``permissionDecision`` ``Literal``
+    can be located and inspected on any TypedDict in
+    ``claude_agent_sdk.types``; returns ``None`` when the field or its
+    ``Literal`` can't be found/parsed (caller treats ``None`` as
+    "cannot verify — don't fail", to avoid false alarms on SDK layout
+    changes that don't actually drop the feature).
+    """
+    import typing
+
+    for obj in vars(sdk_types).values():
+        ann = getattr(obj, "__annotations__", None)
+        if not isinstance(ann, dict) or "permissionDecision" not in ann:
+            continue
+        # Walk the (possibly ``NotRequired[...]``-wrapped) hint looking
+        # for a nested ``Literal[...]`` and collect its string members.
+        found_literal = False
+        seen: set[str] = set()
+        stack = [ann["permissionDecision"]]
+        while stack:
+            cur = stack.pop()
+            if typing.get_origin(cur) is typing.Literal:
+                found_literal = True
+                seen.update(a for a in typing.get_args(cur) if isinstance(a, str))
+            else:
+                stack.extend(typing.get_args(cur))
+        return "defer" in seen if found_literal else None
+    return None
+
+
+def _verify_defer_contract() -> None:
+    """Fail loudly at the seam if the installed ``claude-agent-sdk`` no
+    longer exposes the ``defer`` PreToolUse contract this adapter is
+    built on.
+
+    The adapter pins ``claude-agent-sdk>=0.1.80`` with no upper bound and
+    keys its runtime behaviour on two SDK affordances that aren't visible
+    to the test suite (the SDK isn't a test dependency): the
+    ``permissionDecision="defer"`` value and the ``DeferredToolUse`` /
+    ``ResultMessage.deferred_tool_use`` envelope (``stop_reason ==
+    "tool_deferred"``). A future release that renames or drops these
+    would otherwise turn into a silent mid-run hang. This check converts
+    that into a clear error at class-build time.
+    """
+    from claude_agent_sdk import types as sdk_types
+
+    missing: list[str] = []
+    if not hasattr(sdk_types, "DeferredToolUse"):
+        missing.append("the DeferredToolUse type")
+    if _defer_in_permission_decision(sdk_types) is False:
+        missing.append('"defer" in the PreToolUse permissionDecision literal')
+    if missing:
+        raise RuntimeError(
+            "Installed claude-agent-sdk no longer exposes the defer "
+            "contract ClaudeAgentSDKLlm depends on (missing: "
+            + "; ".join(missing)
+            + "). The adapter pins claude-agent-sdk>=0.1.80 with no "
+            "upper bound; a newer release appears to have changed the "
+            "PreToolUse defer API. Pin a compatible version or update "
+            "the adapter."
+        )
+
+
 def make_claude_agent_sdk_llm_class() -> type:
     """Build the ADK ``BaseLlm`` subclass on demand.
 
@@ -460,6 +525,9 @@ def make_claude_agent_sdk_llm_class() -> type:
             "goldfive.integrations.claude_sdk requires `claude-agent-sdk`. "
             "Install it with: uv pip install claude-agent-sdk"
         ) from e
+    # Fail loudly now (not mid-run) if the installed SDK dropped the
+    # defer contract this adapter keys on.
+    _verify_defer_contract()
     try:
         from google.adk.models.base_llm import BaseLlm
         from google.adk.models.llm_request import LlmRequest
@@ -480,13 +548,30 @@ def make_claude_agent_sdk_llm_class() -> type:
         a descriptive text transcript prepended to the user prompt, and
         register the ADK tool schemas via the SDK's MCP transport. A
         ``PreToolUse`` hook returns ``defer`` so each tool request is
-        *captured* (not executed) and surfaced back to ADK as one
-        ``function_call`` ``Part`` per call (parallel tool_use blocks
-        from Claude are preserved as parallel ``function_call`` parts —
-        matching ADK's native Gemini path). ADK then runs each tool
-        through its normal pipeline (goldfive plugin observes), and the
-        next ADK invocation re-enters this method with the
-        ``function_response``\\ s appended to ``contents``.
+        *captured* (not executed) and surfaced back to ADK as a
+        ``function_call`` ``Part``. ADK then runs the tool through its
+        normal pipeline (goldfive plugin observes), and the next ADK
+        invocation re-enters this method with the
+        ``function_response`` appended to ``contents``.
+
+        One tool call per turn (parallel fan-out is serialised). Per the
+        ``DeferredToolUse`` contract below, returning ``defer`` *stops
+        the run* and the terminating ``ResultMessage`` carries a single
+        deferred tool call, so even when Claude emits several
+        ``tool_use`` blocks in one assistant message the SDK halts at
+        the first defer and the hook captures only one call before
+        ``generate_content_async`` breaks. The capture is kept as a
+        ``list`` so that *if* a future SDK fires several ``PreToolUse``
+        hooks before halting we surface them all (one ``function_call``
+        ``Part`` each; append-order == emission-order is best-effort),
+        but we do **not** claim that happens on ``>=0.1.80`` — it does
+        not, and a live two-tools-in-one-turn trace proving simultaneous
+        N-capture was not reproduced. When the model attempts to fan out
+        (more ADK ``tool_use`` blocks observed in the stream than were
+        captured) we ``log.warning`` so the serialisation is visible
+        rather than silent; ADK loops back and Claude re-issues the
+        remaining call(s) next turn, so the end state matches the native
+        Gemini path even though intra-turn parallelism is flattened.
 
         The ``defer`` mechanism is SDK-supported as of
         ``claude-agent-sdk>=0.1.80`` — see ``claude_agent_sdk/types.py``:
@@ -563,14 +648,17 @@ def make_claude_agent_sdk_llm_class() -> type:
                     f"{_MCP_TOOL_PREFIX}{name}" for name in adk_tools_dict.keys()
                 ]
 
-            # Capture *all* deferred tool calls (not just the first).
-            # ADK's ``BaseLlm`` contract permits multiple ``function_call``
-            # parts per ``LlmResponse`` and dispatches them in parallel —
-            # matching the native ADK + Gemini path. The earlier
-            # "first call wins" shape silently dropped parallel tool_use
-            # blocks (e.g. ``[get_weather(Tokyo), get_weather(NYC)]``)
-            # which diverged from the Gemini behaviour.
+            # Append (don't overwrite) each deferred ADK tool call. The
+            # SDK halts the run on the *first* ``defer`` (see the class
+            # docstring + the ``DeferredToolUse`` contract), so in
+            # practice this holds at most one entry per turn; the list
+            # shape is forward-compatible if a future SDK fires several
+            # ``PreToolUse`` hooks before halting. ``attempted_adk_calls``
+            # counts ADK ``tool_use`` blocks seen in the stream so we can
+            # warn when the model tried to fan out but only one call was
+            # captured (the rest serialise across ADK turns).
             captured_tool_calls: list[dict[str, Any]] = []
+            attempted_adk_calls = 0
             valid_tool_names = set(mcp_tool_names)
 
             async def _defer_hook(
@@ -618,6 +706,19 @@ def make_claude_agent_sdk_llm_class() -> type:
                     }
                 }
 
+            # ``tools`` and ``allowed_tools`` are intentionally *both*
+            # the ADK allowlist, and they do different jobs:
+            #   * ``tools`` is the visibility allowlist — only our
+            #     MCP-prefixed ADK tools are shown to the model, which
+            #     strips Claude Code's built-ins (TodoWrite/Task/…) so
+            #     the internal agent loop stays dormant.
+            #   * ``allowed_tools`` suppresses the interactive permission
+            #     ``ask`` the SDK would otherwise raise on each ADK tool
+            #     before our ``PreToolUse`` hook gets to ``defer`` it.
+            # ``setting_sources=[]`` is the SDK isolation knob (no
+            # CLAUDE.md / settings discovery). ``max_turns`` reuses the
+            # module constant so this path can't drift from
+            # ``make_call_llm``.
             opts = ClaudeAgentOptions(
                 system_prompt=system or None,
                 model=llm_request.model or self.model,
@@ -625,7 +726,7 @@ def make_claude_agent_sdk_llm_class() -> type:
                 mcp_servers=mcp_servers,
                 allowed_tools=mcp_tool_names,
                 setting_sources=[],
-                max_turns=5,
+                max_turns=_DEFAULT_MAX_TURNS,
                 hooks={"PreToolUse": [HookMatcher(hooks=[_defer_hook])]},
             )
 
@@ -637,6 +738,7 @@ def make_claude_agent_sdk_llm_class() -> type:
             preamble_chunks: list[str] = []
             saw_tool_use_inline = False
             last_usage: dict[str, Any] | None = None
+            last_stop_reason: Any = None
             async with ClaudeSDKClient(options=opts) as client:
                 await client.query(user_prompt or "Please continue.")
                 async for msg in client.receive_response():
@@ -646,6 +748,9 @@ def make_claude_agent_sdk_llm_class() -> type:
                     msg_usage = getattr(msg, "usage", None)
                     if msg_usage:
                         last_usage = msg_usage
+                    stop_reason = getattr(msg, "stop_reason", None)
+                    if stop_reason is not None:
+                        last_stop_reason = stop_reason
                     for block in getattr(msg, "content", []) or []:
                         btype = type(block).__name__
                         if btype == "TextBlock" and not saw_tool_use_inline:
@@ -656,8 +761,31 @@ def make_claude_agent_sdk_llm_class() -> type:
                             # Flip the gate so subsequent text in *this*
                             # stream goes to the discard bucket.
                             saw_tool_use_inline = True
-                    if getattr(msg, "stop_reason", None) == "tool_deferred":
+                            # Count ADK tool_use blocks the model emitted
+                            # so we can detect attempted fan-out the SDK
+                            # serialised by halting on the first defer.
+                            if getattr(block, "name", None) in valid_tool_names:
+                                attempted_adk_calls += 1
+                    if stop_reason == "tool_deferred":
                         break
+
+            # The model emitted more ADK tool calls than the SDK let us
+            # capture before halting on the first defer. ADK will loop
+            # back and Claude re-issues the rest next turn, but flag the
+            # serialisation so it's not a silent divergence from the
+            # native (parallel) Gemini path.
+            if attempted_adk_calls > len(captured_tool_calls):
+                log.warning(
+                    "goldfive.integrations.claude_sdk.ClaudeAgentSDKLlm: "
+                    "model emitted %d ADK tool calls in one turn but the "
+                    "SDK deferred only %d before halting (model=%s); the "
+                    "remaining %d will be re-issued on subsequent ADK "
+                    "turns (intra-turn parallelism is serialised)",
+                    attempted_adk_calls,
+                    len(captured_tool_calls),
+                    llm_request.model or self.model,
+                    attempted_adk_calls - len(captured_tool_calls),
+                )
 
             parts: list[Any] = []
             preamble = "".join(preamble_chunks).strip()
@@ -673,9 +801,22 @@ def make_claude_agent_sdk_llm_class() -> type:
                     )
                 )
             if not parts:
-                # Always emit at least one part so ADK has something to
-                # walk. Empty-text ``Part`` keeps the response shape
-                # well-formed.
+                # Neither preamble text nor a captured tool call — a bare
+                # empty model turn. To ADK this is indistinguishable from
+                # a legitimately empty response and is a prime suspect
+                # when a subagent stalls, so log loudly (mirrors the
+                # zero-output WARNING in ``make_call_llm``). We still
+                # emit one empty-text ``Part`` so the response shape
+                # stays well-formed for ADK to walk.
+                log.warning(
+                    "goldfive.integrations.claude_sdk.ClaudeAgentSDKLlm: "
+                    "claude-agent-sdk produced no text and no tool call "
+                    "(model=%s, stop_reason=%s, max_turns=%d); ADK will "
+                    "see an empty model turn",
+                    llm_request.model or self.model,
+                    last_stop_reason,
+                    _DEFAULT_MAX_TURNS,
+                )
                 parts.append(genai_types.Part(text=""))
 
             # Translate the SDK's ``usage`` (Anthropic's

--- a/goldfive/integrations/claude_sdk.py
+++ b/goldfive/integrations/claude_sdk.py
@@ -261,9 +261,19 @@ def _genai_schema_to_json_schema(schema: Any) -> dict[str, Any]:
 
     Used to translate ADK's ``FunctionDeclaration.parameters`` (a Schema
     proto) into the dict shape claude-agent-sdk's ``@tool`` decorator
-    accepts. Handles the subset of Schema fields ADK tools actually
-    populate: ``type``, ``properties``, ``items``, ``required``,
-    ``description``, ``enum``. Unknown fields are dropped.
+    accepts. Pass-through fields:
+
+    * ``type``, ``properties``, ``items``, ``required``,
+      ``description``, ``enum`` — the structural backbone.
+    * ``nullable``, ``format``, ``default``, ``pattern`` —
+      constraint hints that downstream consumers (Claude when
+      constructing tool calls, ADK when validating returns) actually
+      use. Dropping these produces malformed tool calls that ADK then
+      rejects, triggering a retry loop noisy in logs and chewing into
+      the per-call ``max_turns`` budget. Pass them through.
+
+    Other Schema fields are dropped (intentional — we only translate
+    the surface ADK tools populate today).
     """
     if schema is None:
         return {"type": "object", "properties": {}, "required": []}
@@ -293,6 +303,12 @@ def _genai_schema_to_json_schema(schema: Any) -> dict[str, Any]:
     required = getattr(schema, "required", None)
     if required:
         out["required"] = list(required)
+
+    # Constraint hints — pass through when ADK populated them.
+    for attr in ("nullable", "format", "default", "pattern"):
+        val = getattr(schema, attr, None)
+        if val is not None:
+            out[attr] = val
 
     if "type" not in out:
         out["type"] = "object"
@@ -352,6 +368,15 @@ def _extract_input_schema_from_adk_tool(adk_tool: Any) -> dict[str, Any]:
     if declaration is None:
         declaration = getattr(adk_tool, "declaration", None)
     if declaration is not None:
+        # Check ``parameters_json_schema`` first. ADK gates which field
+        # is populated via ``FeatureName.JSON_SCHEMA_FOR_FUNC_DECL``;
+        # today ``parameters`` is the populated one, but if that flag
+        # flips in a future ADK upgrade and we don't read both, this
+        # extractor silently returns ``{"type": "object", "properties": {}}``
+        # — the same failure mode the PR's ``AgentTool`` fix addresses.
+        parameters_json = getattr(declaration, "parameters_json_schema", None)
+        if parameters_json:
+            return dict(parameters_json)
         parameters = getattr(declaration, "parameters", None)
         if parameters is not None:
             return _genai_schema_to_json_schema(parameters)
@@ -454,12 +479,34 @@ def make_claude_agent_sdk_llm_class() -> type:
         ``ClaudeSDKClient``, render the entire prior ADK conversation as
         a descriptive text transcript prepended to the user prompt, and
         register the ADK tool schemas via the SDK's MCP transport. A
-        ``PreToolUse`` hook returns ``defer`` so Claude's first tool
-        request is *captured* (not executed) and surfaced back to ADK as
-        a ``function_call`` ``Part``. ADK then runs the tool through its
-        normal pipeline (goldfive plugin observes), and the next ADK
-        invocation re-enters this method with the ``function_response``
-        appended to ``contents``.
+        ``PreToolUse`` hook returns ``defer`` so each tool request is
+        *captured* (not executed) and surfaced back to ADK as one
+        ``function_call`` ``Part`` per call (parallel tool_use blocks
+        from Claude are preserved as parallel ``function_call`` parts —
+        matching ADK's native Gemini path). ADK then runs each tool
+        through its normal pipeline (goldfive plugin observes), and the
+        next ADK invocation re-enters this method with the
+        ``function_response``\\ s appended to ``contents``.
+
+        The ``defer`` mechanism is SDK-supported as of
+        ``claude-agent-sdk>=0.1.80`` — see ``claude_agent_sdk/types.py``:
+
+        * ``PreToolUseHookSpecificOutput.permissionDecision``: the
+          literal includes ``"defer"`` (alongside ``allow``, ``deny``,
+          ``ask``);
+        * ``DeferredToolUse`` dataclass: docstring reads *"Tool use
+          that was deferred by a PreToolUse hook returning ``defer``.
+          The run stops and the result message carries the deferred
+          tool call here so the caller can inspect it and decide
+          whether to resume."*;
+        * ``ResultMessage.deferred_tool_use`` field + ``stop_reason ==
+          "tool_deferred"`` on the terminating message.
+
+        We rely on the ``stop_reason`` + the hook-captured calls, not
+        on ``ResultMessage.deferred_tool_use`` itself, because the hook
+        sees the call earlier in the stream (before SDK synthesises the
+        deferred-tool envelope on the closing ``ResultMessage``). Pin
+        is enforced via the ``goldfive[claude_sdk]`` extra.
 
         Why text replay instead of stateful client reuse: the SDK has
         no clean API for "given this transcript + tool history, give me
@@ -516,7 +563,14 @@ def make_claude_agent_sdk_llm_class() -> type:
                     f"{_MCP_TOOL_PREFIX}{name}" for name in adk_tools_dict.keys()
                 ]
 
-            captured_tool_call: dict[str, Any] = {}
+            # Capture *all* deferred tool calls (not just the first).
+            # ADK's ``BaseLlm`` contract permits multiple ``function_call``
+            # parts per ``LlmResponse`` and dispatches them in parallel —
+            # matching the native ADK + Gemini path. The earlier
+            # "first call wins" shape silently dropped parallel tool_use
+            # blocks (e.g. ``[get_weather(Tokyo), get_weather(NYC)]``)
+            # which diverged from the Gemini behaviour.
+            captured_tool_calls: list[dict[str, Any]] = []
             valid_tool_names = set(mcp_tool_names)
 
             async def _defer_hook(
@@ -546,15 +600,13 @@ def make_claude_agent_sdk_llm_class() -> type:
                             ),
                         }
                     }
-                # Capture first ADK tool defer; ignore any subsequent
-                # calls in the same run (we'll only return the first to
-                # ADK and let it loop back for the next one).
-                if not captured_tool_call:
-                    captured_tool_call.update(
-                        name=name,
-                        args=input_data.get("tool_input", {}) or {},
-                        tool_use_id=tool_use_id or "",
-                    )
+                captured_tool_calls.append(
+                    {
+                        "name": name,
+                        "args": input_data.get("tool_input", {}) or {},
+                        "tool_use_id": tool_use_id or "",
+                    }
+                )
                 return {
                     "hookSpecificOutput": {
                         "hookEventName": "PreToolUse",
@@ -577,56 +629,78 @@ def make_claude_agent_sdk_llm_class() -> type:
                 hooks={"PreToolUse": [HookMatcher(hooks=[_defer_hook])]},
             )
 
-            text_chunks: list[str] = []
+            # Text bookkeeping: we keep the *preamble* (text emitted
+            # before any ``tool_use`` block) as a real ``Part`` because
+            # it's Claude's "let me check the weather first" framing.
+            # Text emitted *after* the first ``tool_use`` is the SDK's
+            # synthetic apology / "tool was deferred" artifact — discard.
+            preamble_chunks: list[str] = []
+            saw_tool_use_inline = False
+            last_usage: dict[str, Any] | None = None
             async with ClaudeSDKClient(options=opts) as client:
                 await client.query(user_prompt or "Please continue.")
                 async for msg in client.receive_response():
-                    # Pull plain text content; track tool_use via the
-                    # hook (captured_tool_call) rather than mid-stream
-                    # so we don't double-handle.
+                    # Surface usage from whichever ``AssistantMessage``
+                    # most recently reported it (per
+                    # ``claude_agent_sdk.types.AssistantMessage.usage``).
+                    msg_usage = getattr(msg, "usage", None)
+                    if msg_usage:
+                        last_usage = msg_usage
                     for block in getattr(msg, "content", []) or []:
                         btype = type(block).__name__
-                        if btype == "TextBlock":
+                        if btype == "TextBlock" and not saw_tool_use_inline:
                             text = getattr(block, "text", None)
                             if text:
-                                text_chunks.append(text)
-                    # Stop iterating once Claude has acknowledged the
-                    # deferred call (stop_reason=tool_deferred) — the
-                    # rest of the stream is the SDK winding down and
-                    # may include Claude's pre-defer apology text we
-                    # want to discard.
-                    stop_reason = getattr(msg, "stop_reason", None)
-                    if stop_reason == "tool_deferred":
+                                preamble_chunks.append(text)
+                        elif btype == "ToolUseBlock":
+                            # Flip the gate so subsequent text in *this*
+                            # stream goes to the discard bucket.
+                            saw_tool_use_inline = True
+                    if getattr(msg, "stop_reason", None) == "tool_deferred":
                         break
 
             parts: list[Any] = []
-            # When we defer a tool, Claude often emits an apology text
-            # block before the defer registers (e.g. "I apologize, the
-            # tool was unavailable…"). That's an artifact of the defer
-            # mechanism — discard it and surface only the function_call.
-            if not captured_tool_call:
-                joined = "".join(text_chunks).strip()
-                if joined:
-                    parts.append(genai_types.Part(text=joined))
-            else:
+            preamble = "".join(preamble_chunks).strip()
+            if preamble:
+                parts.append(genai_types.Part(text=preamble))
+            for call in captured_tool_calls:
                 parts.append(
                     genai_types.Part(
                         function_call=genai_types.FunctionCall(
-                            name=captured_tool_call["name"].removeprefix(
-                                _MCP_TOOL_PREFIX
-                            ),
-                            args=captured_tool_call["args"],
+                            name=call["name"].removeprefix(_MCP_TOOL_PREFIX),
+                            args=call["args"],
                         )
                     )
                 )
-
             if not parts:
+                # Always emit at least one part so ADK has something to
+                # walk. Empty-text ``Part`` keeps the response shape
+                # well-formed.
                 parts.append(genai_types.Part(text=""))
+
+            # Translate the SDK's ``usage`` (Anthropic's
+            # ``{input_tokens, output_tokens, ...}`` dict) into ADK's
+            # ``GenerateContentResponseUsageMetadata`` so the
+            # ``goldfive#172`` per-call instrumentation can log
+            # ``llm.usage.*`` instead of ``?``. Operators on Max care
+            # about this metric — without it, quota burn per goldfive
+            # run is invisible until the invoice arrives.
+            usage_metadata: Any = None
+            if last_usage:
+                input_tokens = last_usage.get("input_tokens")
+                output_tokens = last_usage.get("output_tokens")
+                total = (input_tokens or 0) + (output_tokens or 0)
+                usage_metadata = genai_types.GenerateContentResponseUsageMetadata(
+                    prompt_token_count=input_tokens,
+                    candidates_token_count=output_tokens,
+                    total_token_count=total or None,
+                )
 
             yield LlmResponse(
                 content=genai_types.Content(role="model", parts=parts),
                 partial=False,
                 turn_complete=True,
+                usage_metadata=usage_metadata,
             )
 
     return ClaudeAgentSDKLlm
@@ -635,6 +709,21 @@ def make_claude_agent_sdk_llm_class() -> type:
 # Module-level alias for convenience: ``ClaudeAgentSDKLlm = ...``. Built
 # lazily on first attribute access so that ``import
 # goldfive.integrations.claude_sdk`` stays cheap and dependency-light.
+#
+# Error contract:
+#
+# * Unknown attribute names → :class:`AttributeError` (standard
+#   Python protocol; lets ``hasattr`` answer ``False`` cleanly).
+# * Attribute is ``"ClaudeAgentSDKLlm"`` but ``claude-agent-sdk`` (or
+#   ``google-adk``) is not importable → the underlying
+#   :class:`ImportError` propagates with the install hint baked in by
+#   :func:`make_claude_agent_sdk_llm_class`. Surfacing the more
+#   informative ImportError is intentional: a generic
+#   ``AttributeError`` would point the caller at the *symbol* when the
+#   actual problem is a *missing dependency*. The trade-off is that
+#   ``hasattr(module, "ClaudeAgentSDKLlm")`` raises rather than
+#   returning ``False`` when the SDK is uninstalled — callers who need
+#   the soft-check semantics should catch ``ImportError`` explicitly.
 def __getattr__(name: str) -> Any:
     if name == "ClaudeAgentSDKLlm":
         cls = make_claude_agent_sdk_llm_class()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,17 @@ adk = [
 claude = [
     "anthropic>=0.39.0",
 ]
+# claude-agent-sdk integration (``goldfive.integrations.claude_sdk``).
+# Min version 0.1.80 is the first that ships the documented
+# ``permissionDecision="defer"`` + ``ResultMessage.deferred_tool_use``
+# contract the ``ClaudeAgentSDKLlm`` BaseLlm adapter relies on
+# (claude_agent_sdk/types.py:415 for the literal; types.py:1131 for
+# ``DeferredToolUse``). Earlier 0.1.x versions silently ignored
+# unknown ``permissionDecision`` values, which would surface as
+# "tool stuck pending permission" instead of the clean defer path.
+claude_sdk = [
+    "claude-agent-sdk>=0.1.80",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/tests/integrations/test_claude_sdk_baselm.py
+++ b/tests/integrations/test_claude_sdk_baselm.py
@@ -1013,6 +1013,39 @@ class TestGenerateContentAsync:
         assert [p.text for p in parts if p.text] == ["the answer is 42"]
         assert all(p.function_call is None for p in parts)
 
+    @pytest.mark.asyncio
+    async def test_token_cost_info_logged_once_per_instance(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The O(N^2) text-replay cost is surfaced via a one-shot INFO log
+        on the first call, and not repeated on subsequent calls of the
+        same adapter instance."""
+        from goldfive.integrations.claude_sdk import (
+            make_claude_agent_sdk_llm_class,
+        )
+
+        env = _install_baselm_env(
+            monkeypatch,
+            messages=[
+                _SdkMessage(content=[TextBlock("ok")], stop_reason="end_turn")
+            ],
+        )
+        cls = make_claude_agent_sdk_llm_class()
+        llm = cls(model="claude-haiku-4-5")
+        with caplog.at_level(
+            logging.INFO, logger="goldfive.integrations.claude_sdk"
+        ):
+            async for _ in llm.generate_content_async(_FakeLlmReq(tools_dict={})):
+                pass
+            async for _ in llm.generate_content_async(_FakeLlmReq(tools_dict={})):
+                pass
+        cost_logs = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.INFO and "O(N^2)" in r.getMessage()
+        ]
+        assert len(cost_logs) == 1, [r.getMessage() for r in caplog.records]
+
 
 # Module-level fixture: a clean import slate per test, like the
 # companion ``test_claude_sdk_call_llm.py`` file.

--- a/tests/integrations/test_claude_sdk_baselm.py
+++ b/tests/integrations/test_claude_sdk_baselm.py
@@ -12,8 +12,10 @@ spinning up Claude Code.
 """
 from __future__ import annotations
 
+import logging
 import sys
 import types
+import typing
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -460,6 +462,556 @@ class TestLazyClassBuild:
         with pytest.raises(ImportError) as excinfo:
             mod.ClaudeAgentSDKLlm  # type: ignore[attr-defined]
         assert "claude-agent-sdk" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# SDK ``defer`` contract guard (_defer_in_permission_decision /
+# _verify_defer_contract)
+# ---------------------------------------------------------------------------
+#
+# These pin the "fail loudly at the seam" check: the adapter pins
+# ``claude-agent-sdk>=0.1.80`` with no ceiling and keys runtime behaviour
+# on the ``permissionDecision="defer"`` literal + the ``DeferredToolUse``
+# envelope. A future SDK that drops either should fail at class-build
+# time, not as a silent mid-run hang.
+
+
+def _ns_with_permission_decision(literal: Any) -> Any:
+    """Build a namespace holding one TypedDict-shaped object whose
+    ``permissionDecision`` annotation is ``literal`` (a real typing
+    object, not a stringized annotation — this module uses
+    ``from __future__ import annotations`` so we assign ``__annotations__``
+    directly to dodge stringization)."""
+    hook_out = type("PreToolUseHookSpecificOutput", (), {})
+    hook_out.__annotations__ = {"permissionDecision": literal}
+    return types.SimpleNamespace(PreToolUseHookSpecificOutput=hook_out)
+
+
+class TestDeferContractGuard:
+    def setup_method(self) -> None:
+        from goldfive.integrations.claude_sdk import (
+            _defer_in_permission_decision,
+            _verify_defer_contract,
+        )
+        self.detect = _defer_in_permission_decision
+        self.verify = _verify_defer_contract
+
+    def test_literal_with_defer_detected(self) -> None:
+        ns = _ns_with_permission_decision(
+            typing.Literal["allow", "deny", "ask", "defer"]
+        )
+        assert self.detect(ns) is True
+
+    def test_literal_wrapped_in_not_required_detected(self) -> None:
+        ns = _ns_with_permission_decision(
+            typing.Optional[typing.Literal["allow", "deny", "defer"]]
+        )
+        assert self.detect(ns) is True
+
+    def test_literal_without_defer_is_false(self) -> None:
+        ns = _ns_with_permission_decision(typing.Literal["allow", "deny", "ask"])
+        assert self.detect(ns) is False
+
+    def test_no_permission_decision_field_returns_none(self) -> None:
+        """Can't locate the field → ``None`` (cannot verify), so the
+        guard stays lenient rather than false-failing on layout drift."""
+        assert self.detect(types.SimpleNamespace(Unrelated=object())) is None
+
+    def test_verify_raises_when_deferredtooluse_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_types = types.ModuleType("claude_agent_sdk.types")
+        fake_types.PreToolUseHookSpecificOutput = (  # type: ignore[attr-defined]
+            _ns_with_permission_decision(
+                typing.Literal["allow", "deny", "ask", "defer"]
+            ).PreToolUseHookSpecificOutput
+        )
+        # No DeferredToolUse attribute.
+        fake_pkg = types.ModuleType("claude_agent_sdk")
+        fake_pkg.types = fake_types  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_pkg)
+        monkeypatch.setitem(sys.modules, "claude_agent_sdk.types", fake_types)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            self.verify()
+        assert "DeferredToolUse" in str(excinfo.value)
+
+    def test_verify_raises_when_defer_dropped_from_literal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_types = types.ModuleType("claude_agent_sdk.types")
+        fake_types.PreToolUseHookSpecificOutput = (  # type: ignore[attr-defined]
+            _ns_with_permission_decision(
+                typing.Literal["allow", "deny", "ask"]
+            ).PreToolUseHookSpecificOutput
+        )
+        fake_types.DeferredToolUse = type("DeferredToolUse", (), {})  # type: ignore[attr-defined]
+        fake_pkg = types.ModuleType("claude_agent_sdk")
+        fake_pkg.types = fake_types  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_pkg)
+        monkeypatch.setitem(sys.modules, "claude_agent_sdk.types", fake_types)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            self.verify()
+        assert "permissionDecision" in str(excinfo.value)
+
+    def test_verify_passes_with_full_contract(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_types = types.ModuleType("claude_agent_sdk.types")
+        fake_types.PreToolUseHookSpecificOutput = (  # type: ignore[attr-defined]
+            _ns_with_permission_decision(
+                typing.Literal["allow", "deny", "ask", "defer"]
+            ).PreToolUseHookSpecificOutput
+        )
+        fake_types.DeferredToolUse = type("DeferredToolUse", (), {})  # type: ignore[attr-defined]
+        fake_pkg = types.ModuleType("claude_agent_sdk")
+        fake_pkg.types = fake_types  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_pkg)
+        monkeypatch.setitem(sys.modules, "claude_agent_sdk.types", fake_types)
+
+        # Should not raise.
+        self.verify()
+
+
+# ---------------------------------------------------------------------------
+# generate_content_async — the high-risk runtime path. Fakes both the SDK
+# (ClaudeSDKClient + the PreToolUse hook dispatch) and the ADK / genai
+# surface via sys.modules injection so we can drive real message streams
+# through the adapter and assert on the emitted ``LlmResponse`` parts,
+# the defer-vs-deny hook branch, the preamble/post-tool-use text split,
+# the empty-output WARNING, the parallel-fan-out WARNING, and
+# usage_metadata translation.
+# ---------------------------------------------------------------------------
+
+
+# Block stubs — the adapter dispatches on ``type(block).__name__`` so the
+# class names here MUST be exactly ``TextBlock`` / ``ToolUseBlock``.
+class TextBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class ToolUseBlock:
+    def __init__(self, name: str, input: dict[str, Any] | None = None) -> None:
+        self.name = name
+        self.input = input or {}
+
+
+class _SdkMessage:
+    """Stand-in for AssistantMessage / ResultMessage. ``usage`` is read
+    off whichever message reports it; ``stop_reason == 'tool_deferred'``
+    terminates the adapter's receive loop."""
+
+    def __init__(
+        self,
+        content: list[Any] | None = None,
+        stop_reason: str | None = None,
+        usage: dict[str, Any] | None = None,
+    ) -> None:
+        self.content = content or []
+        self.stop_reason = stop_reason
+        self.usage = usage
+
+
+def _install_baselm_env(
+    monkeypatch: pytest.MonkeyPatch, *, messages: list[_SdkMessage]
+) -> dict[str, Any]:
+    """Inject fake ``claude_agent_sdk`` (+ ``.types``) and the ADK / genai
+    modules the BaseLlm adapter imports. The fake ``ClaudeSDKClient``
+    replays ``messages`` and, for each ``ToolUseBlock``, invokes the
+    registered ``PreToolUse`` hook until one returns ``defer`` (mirroring
+    the SDK halting the run on the first defer). Returns a recorder."""
+    recorder: dict[str, Any] = {"hook_decisions": [], "options": None}
+
+    class _FakeOptions:
+        def __init__(self, **kwargs: Any) -> None:
+            self.__dict__.update(kwargs)
+
+    class _FakeHookMatcher:
+        def __init__(self, hooks: list[Any]) -> None:
+            self.hooks = hooks
+
+    def _fake_create_sdk_mcp_server(name: str, tools: list[Any]) -> Any:
+        return {"name": name, "tools": tools}
+
+    def _fake_tool(name: str, description: str, input_schema: Any) -> Any:
+        def _wrap(handler: Any) -> Any:
+            return handler
+        return _wrap
+
+    class _FakeClient:
+        def __init__(self, options: Any) -> None:
+            self.options = options
+            recorder["options"] = options
+
+        async def __aenter__(self) -> Any:
+            return self
+
+        async def __aexit__(self, *exc: Any) -> bool:
+            return False
+
+        async def query(self, prompt: str) -> None:
+            recorder["prompt"] = prompt
+
+        async def receive_response(self) -> Any:
+            hook = None
+            hooks_cfg = getattr(self.options, "hooks", {}) or {}
+            matchers = hooks_cfg.get("PreToolUse", [])
+            if matchers:
+                hook = matchers[0].hooks[0]
+            for msg in messages:
+                halted = False
+                if hook is not None:
+                    for block in msg.content:
+                        if type(block).__name__ != "ToolUseBlock":
+                            continue
+                        decision = await hook(
+                            {
+                                "tool_name": block.name,
+                                "tool_input": getattr(block, "input", {}),
+                            },
+                            f"tu_{block.name}",
+                            None,
+                        )
+                        recorder["hook_decisions"].append(decision)
+                        pd = (
+                            decision.get("hookSpecificOutput", {})
+                            .get("permissionDecision")
+                        )
+                        if pd == "defer":
+                            # SDK halts the run on the first defer; do not
+                            # fire hooks for subsequent blocks this turn.
+                            halted = True
+                            break
+                yield msg
+                if halted:
+                    break
+
+    fake_sdk = types.ModuleType("claude_agent_sdk")
+    fake_sdk.ClaudeAgentOptions = _FakeOptions  # type: ignore[attr-defined]
+    fake_sdk.ClaudeSDKClient = _FakeClient  # type: ignore[attr-defined]
+    fake_sdk.create_sdk_mcp_server = _fake_create_sdk_mcp_server  # type: ignore[attr-defined]
+    fake_sdk.tool = _fake_tool  # type: ignore[attr-defined]
+
+    fake_sdk_types = types.ModuleType("claude_agent_sdk.types")
+    fake_sdk_types.HookMatcher = _FakeHookMatcher  # type: ignore[attr-defined]
+    fake_sdk_types.DeferredToolUse = type("DeferredToolUse", (), {})  # type: ignore[attr-defined]
+    _hook_out = type("PreToolUseHookSpecificOutput", (), {})
+    _hook_out.__annotations__ = {
+        "permissionDecision": typing.Literal["allow", "deny", "ask", "defer"]
+    }
+    fake_sdk_types.PreToolUseHookSpecificOutput = _hook_out  # type: ignore[attr-defined]
+    fake_sdk.types = fake_sdk_types  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_sdk)
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk.types", fake_sdk_types)
+
+    # --- ADK + genai surface ------------------------------------------------
+    class _FakeBaseLlm:
+        def __init__(self, model: str | None = None, **kwargs: Any) -> None:
+            self.model = model
+
+    class _FakeLlmResponse:
+        def __init__(self, **kwargs: Any) -> None:
+            self.__dict__.update(kwargs)
+
+    class _FakeLlmRequest:  # only used as a type symbol in the adapter
+        pass
+
+    class _GFunctionCall:
+        def __init__(self, name: str, args: dict[str, Any]) -> None:
+            self.name = name
+            self.args = args
+
+    class _GPart:
+        def __init__(
+            self, text: str | None = None, function_call: Any = None
+        ) -> None:
+            self.text = text
+            self.function_call = function_call
+
+    class _GContent:
+        def __init__(self, role: str, parts: list[Any]) -> None:
+            self.role = role
+            self.parts = parts
+
+    class _GUsage:
+        def __init__(
+            self,
+            prompt_token_count: Any = None,
+            candidates_token_count: Any = None,
+            total_token_count: Any = None,
+        ) -> None:
+            self.prompt_token_count = prompt_token_count
+            self.candidates_token_count = candidates_token_count
+            self.total_token_count = total_token_count
+
+    genai_types = types.ModuleType("google.genai.types")
+    genai_types.Part = _GPart  # type: ignore[attr-defined]
+    genai_types.FunctionCall = _GFunctionCall  # type: ignore[attr-defined]
+    genai_types.Content = _GContent  # type: ignore[attr-defined]
+    genai_types.GenerateContentResponseUsageMetadata = _GUsage  # type: ignore[attr-defined]
+
+    google_mod = types.ModuleType("google")
+    google_genai = types.ModuleType("google.genai")
+    google_genai.types = genai_types  # type: ignore[attr-defined]
+    google_adk = types.ModuleType("google.adk")
+    google_adk_models = types.ModuleType("google.adk.models")
+    base_llm_mod = types.ModuleType("google.adk.models.base_llm")
+    base_llm_mod.BaseLlm = _FakeBaseLlm  # type: ignore[attr-defined]
+    llm_request_mod = types.ModuleType("google.adk.models.llm_request")
+    llm_request_mod.LlmRequest = _FakeLlmRequest  # type: ignore[attr-defined]
+    llm_response_mod = types.ModuleType("google.adk.models.llm_response")
+    llm_response_mod.LlmResponse = _FakeLlmResponse  # type: ignore[attr-defined]
+
+    for name, mod in {
+        "google": google_mod,
+        "google.genai": google_genai,
+        "google.genai.types": genai_types,
+        "google.adk": google_adk,
+        "google.adk.models": google_adk_models,
+        "google.adk.models.base_llm": base_llm_mod,
+        "google.adk.models.llm_request": llm_request_mod,
+        "google.adk.models.llm_response": llm_response_mod,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    recorder["genai_types"] = genai_types
+    return recorder
+
+
+@dataclass
+class _FakeTool:
+    """Minimal ADK tool: a description + a declaration so schema
+    extraction succeeds. Schema content is irrelevant to these tests."""
+
+    description: str = "a tool"
+
+    def _get_declaration(self) -> Any:
+        return _StubFunctionDeclaration(
+            parameters=_StubGenaiSchema(
+                type="OBJECT",
+                properties={"city": _StubGenaiSchema(type="STRING")},
+                required=["city"],
+            )
+        )
+
+
+@dataclass
+class _FakeLlmReq:
+    """Duck-typed ``LlmRequest`` the adapter reads from."""
+
+    contents: list[Any] = field(default_factory=list)
+    tools_dict: dict[str, Any] = field(default_factory=dict)
+    model: str = ""
+    config: Any = None
+
+
+async def _run_adapter(
+    recorder_env: Any, req: _FakeLlmReq, *, model: str = "claude-haiku-4-5"
+) -> list[Any]:
+    from goldfive.integrations.claude_sdk import make_claude_agent_sdk_llm_class
+
+    cls = make_claude_agent_sdk_llm_class()
+    llm = cls(model=model)
+    return [r async for r in llm.generate_content_async(req)]
+
+
+class TestGenerateContentAsync:
+    """Drive real message streams through ``generate_content_async``."""
+
+    @pytest.mark.asyncio
+    async def test_single_tool_call_becomes_function_call_part(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env = _install_baselm_env(
+            monkeypatch,
+            messages=[
+                _SdkMessage(
+                    content=[
+                        ToolUseBlock("mcp__adk__get_weather", {"city": "SF"})
+                    ],
+                    stop_reason="tool_deferred",
+                )
+            ],
+        )
+        req = _FakeLlmReq(tools_dict={"get_weather": _FakeTool()})
+        responses = await _run_adapter(env, req)
+        assert len(responses) == 1
+        parts = responses[0].content.parts
+        fcs = [p for p in parts if p.function_call is not None]
+        assert len(fcs) == 1
+        # ``mcp__adk__`` prefix stripped back to the ADK tool name.
+        assert fcs[0].function_call.name == "get_weather"
+        assert fcs[0].function_call.args == {"city": "SF"}
+        # Hook deferred exactly once.
+        decisions = env["hook_decisions"]
+        assert len(decisions) == 1
+        assert (
+            decisions[0]["hookSpecificOutput"]["permissionDecision"] == "defer"
+        )
+
+    @pytest.mark.asyncio
+    async def test_preamble_text_kept_post_tool_text_discarded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env = _install_baselm_env(
+            monkeypatch,
+            messages=[
+                _SdkMessage(
+                    content=[
+                        TextBlock("Let me check the weather."),
+                        ToolUseBlock("mcp__adk__get_weather", {"city": "SF"}),
+                        TextBlock("(tool was deferred)"),  # post-tool: discard
+                    ],
+                    stop_reason="tool_deferred",
+                )
+            ],
+        )
+        req = _FakeLlmReq(tools_dict={"get_weather": _FakeTool()})
+        responses = await _run_adapter(env, req)
+        parts = responses[0].content.parts
+        texts = [p.text for p in parts if p.text]
+        assert texts == ["Let me check the weather."]
+        assert any(p.function_call is not None for p in parts)
+
+    @pytest.mark.asyncio
+    async def test_deny_branch_for_non_adk_tool(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A tool outside the ADK allowlist (e.g. a leaked cloud-account
+        MCP server) is denied, not captured; the run continues and the
+        real ADK tool is deferred."""
+        env = _install_baselm_env(
+            monkeypatch,
+            messages=[
+                _SdkMessage(
+                    content=[ToolUseBlock("mcp__claude_ai_Drive__create_file")]
+                ),
+                _SdkMessage(
+                    content=[
+                        ToolUseBlock("mcp__adk__get_weather", {"city": "SF"})
+                    ],
+                    stop_reason="tool_deferred",
+                ),
+            ],
+        )
+        req = _FakeLlmReq(tools_dict={"get_weather": _FakeTool()})
+        responses = await _run_adapter(env, req)
+        decisions = env["hook_decisions"]
+        kinds = [
+            d["hookSpecificOutput"]["permissionDecision"] for d in decisions
+        ]
+        assert kinds == ["deny", "defer"]
+        # Denied tool names the valid options in its reason.
+        assert "get_weather" in decisions[0]["hookSpecificOutput"][
+            "permissionDecisionReason"
+        ]
+        parts = responses[0].content.parts
+        fcs = [p for p in parts if p.function_call is not None]
+        assert len(fcs) == 1
+        assert fcs[0].function_call.name == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_parallel_attempt_warns_and_serialises(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Two ADK tool calls in one assistant message: the SDK halts at
+        the first defer so only one is captured. The adapter still counts
+        both ``tool_use`` blocks and WARNs that the model fanned out and
+        the rest serialise across ADK turns."""
+        env = _install_baselm_env(
+            monkeypatch,
+            messages=[
+                _SdkMessage(
+                    content=[
+                        ToolUseBlock("mcp__adk__get_weather", {"city": "Tokyo"}),
+                        ToolUseBlock("mcp__adk__get_weather", {"city": "NYC"}),
+                    ],
+                    stop_reason="tool_deferred",
+                )
+            ],
+        )
+        req = _FakeLlmReq(tools_dict={"get_weather": _FakeTool()})
+        with caplog.at_level(
+            logging.WARNING, logger="goldfive.integrations.claude_sdk"
+        ):
+            responses = await _run_adapter(env, req)
+        # Only the first call captured (one defer before halt).
+        fcs = [p for p in responses[0].content.parts if p.function_call]
+        assert len(fcs) == 1
+        assert fcs[0].function_call.args == {"city": "Tokyo"}
+        assert any(
+            "emitted 2 ADK tool calls in one turn" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        ), [r.getMessage() for r in caplog.records]
+
+    @pytest.mark.asyncio
+    async def test_empty_output_warns_and_emits_empty_part(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No preamble, no tool call → one empty-text Part AND a WARNING
+        (parity with ``make_call_llm``'s zero-output diagnostic)."""
+        env = _install_baselm_env(
+            monkeypatch,
+            messages=[_SdkMessage(content=[], stop_reason="end_turn")],
+        )
+        req = _FakeLlmReq(tools_dict={})
+        with caplog.at_level(
+            logging.WARNING, logger="goldfive.integrations.claude_sdk"
+        ):
+            responses = await _run_adapter(env, req)
+        parts = responses[0].content.parts
+        assert len(parts) == 1
+        assert parts[0].text == ""
+        assert any(
+            "no text and no tool call" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        ), [r.getMessage() for r in caplog.records]
+
+    @pytest.mark.asyncio
+    async def test_usage_metadata_translated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env = _install_baselm_env(
+            monkeypatch,
+            messages=[
+                _SdkMessage(
+                    content=[TextBlock("final answer")],
+                    stop_reason="end_turn",
+                    usage={"input_tokens": 10, "output_tokens": 5},
+                )
+            ],
+        )
+        req = _FakeLlmReq(tools_dict={})
+        responses = await _run_adapter(env, req)
+        um = responses[0].usage_metadata
+        assert um is not None
+        assert um.prompt_token_count == 10
+        assert um.candidates_token_count == 5
+        assert um.total_token_count == 15
+
+    @pytest.mark.asyncio
+    async def test_plain_text_answer_no_tools(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env = _install_baselm_env(
+            monkeypatch,
+            messages=[
+                _SdkMessage(
+                    content=[TextBlock("the answer is 42")],
+                    stop_reason="end_turn",
+                )
+            ],
+        )
+        req = _FakeLlmReq(tools_dict={})
+        responses = await _run_adapter(env, req)
+        parts = responses[0].content.parts
+        assert [p.text for p in parts if p.text] == ["the answer is 42"]
+        assert all(p.function_call is None for p in parts)
 
 
 # Module-level fixture: a clean import slate per test, like the

--- a/tests/integrations/test_claude_sdk_baselm.py
+++ b/tests/integrations/test_claude_sdk_baselm.py
@@ -1,0 +1,469 @@
+"""Unit tests for the ``ClaudeAgentSDKLlm`` adapter helpers.
+
+These exercise the three non-trivial pure-function translators —
+``_render_contents_as_transcript``, ``_extract_input_schema_from_adk_tool``,
+``_genai_schema_to_json_schema`` — and the lazy ``__getattr__`` build
+path for ``ClaudeAgentSDKLlm``.
+
+None of these tests need a live ``claude-agent-sdk`` subprocess. The
+SDK and (where relevant) ADK pieces are stubbed via ``sys.modules``
+injection so we can assert on the actual translator outputs without
+spinning up Claude Code.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared genai-types stub. The real ``google.genai.types`` module is a thin
+# pydantic-wrapping shim; the helpers under test only use it via the
+# ``type``/``properties``/``items``/``required`` attribute surface, so a
+# dataclass façade is plenty.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubGenaiSchema:
+    """Minimal ``google.genai.types.Schema`` look-alike."""
+
+    type: str | None = None
+    type_: str | None = None
+    description: str | None = None
+    properties: dict[str, Any] | None = None
+    items: Any = None
+    required: list[str] | None = None
+    enum: list[Any] | None = None
+    nullable: bool | None = None
+    format: str | None = None
+    default: Any = None
+    pattern: str | None = None
+
+
+@dataclass
+class _StubFunctionDeclaration:
+    parameters: Any = None
+    parameters_json_schema: Any = None
+
+
+@dataclass
+class _StubFunctionCall:
+    name: str
+    args: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _StubFunctionResponse:
+    name: str
+    response: Any = None
+
+
+@dataclass
+class _StubPart:
+    text: str | None = None
+    function_call: _StubFunctionCall | None = None
+    function_response: _StubFunctionResponse | None = None
+
+
+@dataclass
+class _StubContent:
+    role: str
+    parts: list[_StubPart] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# _render_contents_as_transcript
+# ---------------------------------------------------------------------------
+
+
+class TestRenderContentsAsTranscript:
+    """Branch coverage on the conversation-to-transcript translator.
+
+    Every shape this function emits feeds Claude as its prior-history
+    description; if any branch silently drops content the agent loses
+    state across turns.
+    """
+
+    def setup_method(self) -> None:
+        # Lazy import so a missing ``claude_agent_sdk`` doesn't block
+        # tests that only touch the pure-function translators.
+        from goldfive.integrations.claude_sdk import _render_contents_as_transcript
+        self.render = _render_contents_as_transcript
+
+    def test_user_text_renders_with_user_prefix(self) -> None:
+        contents = [_StubContent(role="user", parts=[_StubPart(text="hello")])]
+        assert self.render(contents) == "User: hello"
+
+    def test_model_text_renders_with_assistant_prefix(self) -> None:
+        contents = [_StubContent(role="model", parts=[_StubPart(text="hi back")])]
+        assert self.render(contents) == "Assistant: hi back"
+
+    def test_function_call_renders_as_descriptive_line(self) -> None:
+        contents = [
+            _StubContent(
+                role="model",
+                parts=[
+                    _StubPart(
+                        function_call=_StubFunctionCall(
+                            name="get_weather", args={"city": "SF"}
+                        )
+                    )
+                ],
+            )
+        ]
+        rendered = self.render(contents)
+        # JSON dict args, named tool — operator can read it in logs.
+        assert "Assistant called tool `get_weather`" in rendered
+        assert '"city": "SF"' in rendered
+
+    def test_function_response_renders_as_tool_result_line(self) -> None:
+        contents = [
+            _StubContent(
+                role="user",
+                parts=[
+                    _StubPart(
+                        function_response=_StubFunctionResponse(
+                            name="get_weather", response={"output": "sunny"}
+                        )
+                    )
+                ],
+            )
+        ]
+        rendered = self.render(contents)
+        assert "Tool result (`get_weather`):" in rendered
+        assert '"output": "sunny"' in rendered
+
+    def test_empty_contents_returns_empty_string(self) -> None:
+        """A first-turn ``LlmRequest`` has no prior history yet — must
+        not emit a spurious transcript line."""
+        assert self.render([]) == ""
+        assert self.render(None) == ""  # type: ignore[arg-type]
+
+    def test_mixed_sequence_preserves_order(self) -> None:
+        """User → model+tool_call → user+tool_response — Claude has to
+        see them in chronological order to continue the conversation."""
+        contents = [
+            _StubContent(role="user", parts=[_StubPart(text="ask")]),
+            _StubContent(
+                role="model",
+                parts=[
+                    _StubPart(text="thinking..."),
+                    _StubPart(
+                        function_call=_StubFunctionCall(name="t", args={"a": 1})
+                    ),
+                ],
+            ),
+            _StubContent(
+                role="user",
+                parts=[
+                    _StubPart(
+                        function_response=_StubFunctionResponse(
+                            name="t", response={"ok": True}
+                        )
+                    )
+                ],
+            ),
+        ]
+        rendered = self.render(contents)
+        lines = rendered.splitlines()
+        assert lines[0] == "User: ask"
+        assert lines[1] == "Assistant: thinking..."
+        assert "Assistant called tool `t`" in lines[2]
+        assert "Tool result (`t`):" in lines[3]
+
+
+# ---------------------------------------------------------------------------
+# _genai_schema_to_json_schema
+# ---------------------------------------------------------------------------
+
+
+class TestGenaiSchemaToJsonSchema:
+    """Schema-proto → JSON-Schema-dict conversion.
+
+    The fidelity here matters: dropped fields surface as Claude
+    constructing tool calls that ADK's real schema then rejects,
+    triggering retry loops noisy in logs and chewing into the
+    per-call ``max_turns`` budget.
+    """
+
+    def setup_method(self) -> None:
+        from goldfive.integrations.claude_sdk import _genai_schema_to_json_schema
+        self.convert = _genai_schema_to_json_schema
+
+    def test_nested_object_properties(self) -> None:
+        inner = _StubGenaiSchema(type="STRING", description="inner field")
+        outer = _StubGenaiSchema(
+            type="OBJECT",
+            properties={"inner": inner},
+            required=["inner"],
+        )
+        result = self.convert(outer)
+        assert result["type"] == "object"
+        assert result["required"] == ["inner"]
+        assert result["properties"]["inner"]["type"] == "string"
+        assert result["properties"]["inner"]["description"] == "inner field"
+
+    def test_array_of_objects(self) -> None:
+        item = _StubGenaiSchema(
+            type="OBJECT",
+            properties={"name": _StubGenaiSchema(type="STRING")},
+            required=["name"],
+        )
+        arr = _StubGenaiSchema(type="ARRAY", items=item)
+        result = self.convert(arr)
+        assert result["type"] == "array"
+        assert result["items"]["type"] == "object"
+        assert result["items"]["required"] == ["name"]
+        assert result["items"]["properties"]["name"]["type"] == "string"
+
+    def test_enum_pass_through(self) -> None:
+        s = _StubGenaiSchema(type="STRING", enum=["low", "medium", "high"])
+        result = self.convert(s)
+        assert result["enum"] == ["low", "medium", "high"]
+
+    def test_type_underscore_attr_is_honored(self) -> None:
+        """Some genai proto bindings expose ``type_`` (trailing
+        underscore) instead of ``type``. The translator should handle
+        both — Schema bindings vary across protobuf versions."""
+        s = _StubGenaiSchema(type=None, type_="STRING")
+        result = self.convert(s)
+        assert result["type"] == "string"
+
+    def test_constraint_hints_pass_through(self) -> None:
+        """``nullable``, ``format``, ``default``, ``pattern`` are
+        constraint hints Claude and ADK both use. Dropping them
+        produces malformed values ADK rejects."""
+        s = _StubGenaiSchema(
+            type="STRING",
+            nullable=True,
+            format="uri",
+            default="https://example.com",
+            pattern=r"^https?://",
+        )
+        result = self.convert(s)
+        assert result["nullable"] is True
+        assert result["format"] == "uri"
+        assert result["default"] == "https://example.com"
+        assert result["pattern"] == r"^https?://"
+
+    def test_none_schema_returns_empty_object(self) -> None:
+        """Defensive: ADK occasionally hands us ``parameters=None``."""
+        result = self.convert(None)
+        assert result == {"type": "object", "properties": {}, "required": []}
+
+    def test_object_type_always_has_properties_key(self) -> None:
+        """JSON-Schema convention: an ``object`` always has a
+        ``properties`` key even when empty. Keeps downstream consumers
+        from having to special-case missing keys."""
+        s = _StubGenaiSchema(type="OBJECT")
+        result = self.convert(s)
+        assert result["type"] == "object"
+        assert result["properties"] == {}
+
+
+# ---------------------------------------------------------------------------
+# _extract_input_schema_from_adk_tool
+# ---------------------------------------------------------------------------
+
+
+class _FakeFunctionTool:
+    """``FunctionTool`` look-alike: has ``.func`` and
+    ``_get_declaration`` returning a Schema."""
+
+    def __init__(self, func: Any, declaration: Any | None = None) -> None:
+        self.func = func
+        self._declaration = declaration
+
+    def _get_declaration(self) -> Any:
+        return self._declaration
+
+
+class _FakeAgentTool:
+    """``AgentTool`` look-alike: NO ``.func`` attribute (this is the
+    regression the PR's schema extractor fixes — falling back to
+    signature would produce an empty schema)."""
+
+    def __init__(self, declaration: Any) -> None:
+        self._declaration = declaration
+
+    def _get_declaration(self) -> Any:
+        return self._declaration
+
+
+class _FakeRaisingTool:
+    """Tool whose ``_get_declaration`` raises — the extractor must
+    fall back to the signature path instead of bubbling the error."""
+
+    def __init__(self, func: Any) -> None:
+        self.func = func
+
+    def _get_declaration(self) -> Any:
+        raise RuntimeError("declaration unavailable")
+
+
+class TestExtractInputSchemaFromAdkTool:
+    """Schema extraction for both common ADK ``BaseTool`` shapes.
+
+    The ``AgentTool`` branch is the regression pin for PR #383's fix —
+    without the declaration-first path, Claude calls the AgentTool
+    with empty args and ADK raises ``KeyError('request')``.
+    """
+
+    def setup_method(self) -> None:
+        from goldfive.integrations.claude_sdk import (
+            _extract_input_schema_from_adk_tool,
+        )
+        self.extract = _extract_input_schema_from_adk_tool
+
+    def test_function_tool_with_declaration_uses_schema_path(self) -> None:
+        def my_func(topic: str) -> str:
+            return ""
+
+        declaration = _StubFunctionDeclaration(
+            parameters=_StubGenaiSchema(
+                type="OBJECT",
+                properties={"topic": _StubGenaiSchema(type="STRING")},
+                required=["topic"],
+            )
+        )
+        result = self.extract(_FakeFunctionTool(my_func, declaration))
+        assert result["type"] == "object"
+        assert result["properties"]["topic"]["type"] == "string"
+        assert result["required"] == ["topic"]
+
+    def test_agent_tool_uses_declaration_request_parameter(self) -> None:
+        """The exact regression that motivated this PR's fix — without
+        going through ``_get_declaration`` we'd return ``{}`` and ADK
+        would raise ``KeyError('request')``."""
+        declaration = _StubFunctionDeclaration(
+            parameters=_StubGenaiSchema(
+                type="OBJECT",
+                properties={"request": _StubGenaiSchema(type="STRING")},
+                required=["request"],
+            )
+        )
+        result = self.extract(_FakeAgentTool(declaration))
+        assert result["required"] == ["request"]
+        assert result["properties"]["request"]["type"] == "string"
+
+    def test_parameters_json_schema_preferred_over_proto_schema(self) -> None:
+        """If ADK populates ``parameters_json_schema`` instead of the
+        proto Schema (gated on ``FeatureName.JSON_SCHEMA_FOR_FUNC_DECL``),
+        the extractor must read it directly. Otherwise a future flag
+        flip silently breaks every AgentTool — same failure mode as
+        the bug we just fixed."""
+        json_schema = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        }
+        declaration = _StubFunctionDeclaration(parameters_json_schema=json_schema)
+        result = self.extract(_FakeAgentTool(declaration))
+        assert result == json_schema
+
+    def test_raising_declaration_falls_back_to_signature(self) -> None:
+        def takes_count(count=5):  # type: ignore[no-untyped-def]
+            return ""
+
+        result = self.extract(_FakeRaisingTool(takes_count))
+        # Signature-path schema: ``count`` is optional (default=5), so
+        # not in ``required``. Type defaults to ``string`` since the
+        # signature has no concrete annotation (the signature
+        # extractor's pre-existing behaviour for non-annotated params).
+        assert "count" in result["properties"]
+        assert "count" not in result.get("required", [])
+
+    def test_bare_callable_without_declaration_uses_signature(self) -> None:
+        """Some operator-supplied tools may be raw callables — the
+        extractor should still build a usable schema from inspection."""
+
+        class _BareTool:
+            def __init__(self, func: Any) -> None:
+                self.func = func
+
+            # No _get_declaration / declaration / parameters at all.
+
+        def echo(message: str) -> str:
+            return message
+
+        result = self.extract(_BareTool(echo))
+        assert result["properties"]["message"]["type"] == "string"
+        assert result["required"] == ["message"]
+
+    def test_completely_opaque_tool_returns_empty_object(self) -> None:
+        """Last-resort fallback. Should never silently corrupt the
+        downstream call — but if a caller hands us a tool we can't
+        introspect at all, we return a well-formed empty object
+        schema rather than raising."""
+
+        class _Opaque:
+            pass
+
+        result = self.extract(_Opaque())
+        assert result == {"type": "object", "properties": {}, "required": []}
+
+
+# ---------------------------------------------------------------------------
+# __getattr__ lazy build
+# ---------------------------------------------------------------------------
+
+
+class TestLazyClassBuild:
+    """The module's ``__getattr__`` builds ``ClaudeAgentSDKLlm`` on
+    first request. Two failure modes worth pinning:
+
+    1. Unknown attribute → ``AttributeError`` (so ``hasattr`` works
+       cleanly for any unrelated probing).
+    2. Known attribute but the SDK is missing → ``ImportError``
+       propagates with the install hint. This is the documented
+       trade-off; ``hasattr`` callers who want soft-check semantics
+       have to catch ``ImportError`` explicitly.
+    """
+
+    def test_unknown_attribute_raises_attribute_error(self) -> None:
+        import goldfive.integrations.claude_sdk as mod
+
+        with pytest.raises(AttributeError):
+            mod.SomeNonExistentName  # type: ignore[attr-defined]
+
+    def test_known_attribute_with_sdk_missing_raises_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ``claude-agent-sdk`` isn't importable, the lazy build
+        of ``ClaudeAgentSDKLlm`` raises ``ImportError`` (not
+        ``AttributeError``) — the more informative error pointing the
+        operator at the actual missing dependency."""
+        import builtins
+
+        # Force the lazy build to run again on this access (any prior
+        # successful build would have cached the class onto the module
+        # globals, hiding the import path).
+        sys.modules.pop("goldfive.integrations.claude_sdk", None)
+        monkeypatch.setitem(sys.modules, "claude_agent_sdk", None)
+
+        real_import = builtins.__import__
+
+        def _blocking_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "claude_agent_sdk" or name.startswith("claude_agent_sdk."):
+                raise ImportError("No module named 'claude_agent_sdk'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _blocking_import)
+
+        import goldfive.integrations.claude_sdk as mod
+
+        with pytest.raises(ImportError) as excinfo:
+            mod.ClaudeAgentSDKLlm  # type: ignore[attr-defined]
+        assert "claude-agent-sdk" in str(excinfo.value)
+
+
+# Module-level fixture: a clean import slate per test, like the
+# companion ``test_claude_sdk_call_llm.py`` file.
+@pytest.fixture(autouse=True)
+def _reset_module_cache() -> None:
+    sys.modules.pop("goldfive.integrations.claude_sdk", None)

--- a/tests/integrations/test_claude_sdk_call_llm.py
+++ b/tests/integrations/test_claude_sdk_call_llm.py
@@ -1,0 +1,291 @@
+"""Unit tests for :func:`goldfive.integrations.claude_sdk.make_call_llm`.
+
+The factory feeds three goldfive call-sites (``LLMPlanner.call_llm``,
+``LLMGoalDeriver.call_llm``, judge fallback via
+``goldfive.wrap(call_llm=...)``) whose downstream parsers all assume
+a well-formed string return — silent failures here surface much later
+as "unparseable verdict" with no obvious cause. These tests pin the
+contract:
+
+1. ``ImportError`` propagates with the install hint when
+   ``claude_agent_sdk`` is missing.
+2. Multiple text content blocks across multiple yielded messages
+   concatenate in stream order (the goldfive parser is
+   position-sensitive when JSON wrappers span chunks).
+3. Empty ``model`` (``""``) falls back to ``default_model`` —
+   matches the convention used elsewhere in goldfive.
+4. Empty ``system`` produces ``system_prompt=None`` (not ``""``) on
+   the SDK options object.
+5. An empty SDK stream returns ``""`` AND logs a WARNING so the
+   silent-empty diagnostic case is observable.
+6. ``setting_sources=[]`` and ``tools=[]`` are passed on every call —
+   prevents operator-local Claude config (``CLAUDE.md``,
+   ``~/.claude/settings.json``) from leaking into planner / judge
+   prompts.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+import types
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake ``claude_agent_sdk`` module — injected via ``monkeypatch.setitem`` so
+# the lazy import inside ``make_call_llm`` resolves to our stub, recording
+# the exact ``ClaudeAgentOptions`` that goldfive constructs and feeding back
+# whatever async-iterable of messages the test parameterised.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeOptions:
+    """Recorder for the ``ClaudeAgentOptions`` ctor — captures everything
+    goldfive passed so tests can assert on the actual ctor arguments."""
+
+    system_prompt: Any = None
+    model: Any = None
+    tools: Any = None
+    allowed_tools: Any = None
+    setting_sources: Any = None
+    max_turns: Any = None
+    extra: dict[str, Any] = None  # type: ignore[assignment]
+
+    def __init__(self, **kwargs: Any) -> None:
+        # ``ClaudeAgentOptions`` in the real SDK is a dataclass with many
+        # fields; capture the ones we care about and stash the rest so
+        # tests can introspect.
+        self.system_prompt = kwargs.pop("system_prompt", None)
+        self.model = kwargs.pop("model", None)
+        self.tools = kwargs.pop("tools", None)
+        self.allowed_tools = kwargs.pop("allowed_tools", None)
+        self.setting_sources = kwargs.pop("setting_sources", None)
+        self.max_turns = kwargs.pop("max_turns", None)
+        self.extra = kwargs
+
+
+@dataclass
+class _FakeTextBlock:
+    text: str
+
+
+@dataclass
+class _FakeMessage:
+    content: list[_FakeTextBlock]
+    stop_reason: str | None = None
+
+
+def _install_fake_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    messages: list[_FakeMessage] | None = None,
+) -> dict[str, Any]:
+    """Inject a stub ``claude_agent_sdk`` module that records the last
+    ``ClaudeAgentOptions`` ctor and yields ``messages`` (or none) from
+    ``query``. Returns a recorder dict the test can inspect.
+
+    Recorder keys:
+        ``"options"``   — the most recent :class:`_FakeOptions` ctor call
+        ``"prompt"``    — the most recent ``query()`` prompt argument
+        ``"call_count"`` — number of times ``query()`` was iterated
+    """
+    recorder: dict[str, Any] = {"options": None, "prompt": None, "call_count": 0}
+
+    async def _query(*, prompt: Any, options: Any) -> Any:  # type: ignore[no-redef]
+        recorder["prompt"] = prompt
+        recorder["options"] = options
+        recorder["call_count"] += 1
+        for msg in messages or ():
+            yield msg
+
+    fake_module = types.ModuleType("claude_agent_sdk")
+    fake_module.ClaudeAgentOptions = _FakeOptions  # type: ignore[attr-defined]
+    fake_module.query = _query  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_module)
+    return recorder
+
+
+# Drop any stale ``goldfive.integrations.claude_sdk`` import so each test
+# re-runs the lazy import from a clean slate. Otherwise ``make_call_llm``'s
+# closure captures whichever ``claude_agent_sdk`` was first imported.
+@pytest.fixture(autouse=True)
+def _reset_integration_module() -> None:
+    sys.modules.pop("goldfive.integrations.claude_sdk", None)
+
+
+# ---------------------------------------------------------------------------
+# 1. ImportError on missing SDK
+# ---------------------------------------------------------------------------
+
+
+def test_make_call_llm_raises_import_error_when_sdk_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``claude_agent_sdk`` is not installed, ``make_call_llm``
+    raises :class:`ImportError` with the install-hint message. The hint
+    is what tells users which package to pip install."""
+    # Ensure no stale import — and also block any real import attempt.
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", None)  # forces ImportError
+    real_import = builtins.__import__
+
+    def _blocking_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "claude_agent_sdk" or name.startswith("claude_agent_sdk."):
+            raise ImportError("No module named 'claude_agent_sdk'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocking_import)
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    with pytest.raises(ImportError) as excinfo:
+        make_call_llm()
+    assert "uv pip install claude-agent-sdk" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# 2. Chunks concatenate in stream order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_make_call_llm_concatenates_chunks_in_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text content across multiple yielded messages and multiple
+    blocks-per-message concatenates in stream order. Important because
+    goldfive's JSON parsers sometimes see brace-balanced JSON spanning
+    several content blocks."""
+    _install_fake_sdk(
+        monkeypatch,
+        messages=[
+            _FakeMessage(content=[_FakeTextBlock("alpha-"), _FakeTextBlock("beta-")]),
+            _FakeMessage(content=[_FakeTextBlock("gamma")]),
+        ],
+    )
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm()
+    result = await call_llm("sys", "user prompt", "claude-haiku-4-5")
+    assert result == "alpha-beta-gamma"
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty model falls back to default_model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_model_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``model=""`` (or ``None``) → ``default_model`` is passed to the
+    SDK. Goldfive's call-sites pass the configured model verbatim;
+    this fallback is the integration's contract for "unspecified."""
+    recorder = _install_fake_sdk(
+        monkeypatch,
+        messages=[_FakeMessage(content=[_FakeTextBlock("ok")])],
+    )
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm(default_model="claude-haiku-4-5")
+    await call_llm("sys", "prompt", "")
+    assert recorder["options"].model == "claude-haiku-4-5"
+
+
+# ---------------------------------------------------------------------------
+# 4. Empty system → system_prompt=None on the options
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_system_produces_none_system_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``system=""`` → ``system_prompt=None`` on the SDK options. The
+    distinction matters: the SDK treats ``""`` as "use my empty system
+    prompt" (which the bundled CLI may not honor) versus ``None`` which
+    means "no override, use the SDK default" — and we explicitly want
+    the latter for short structured prompts."""
+    recorder = _install_fake_sdk(
+        monkeypatch,
+        messages=[_FakeMessage(content=[_FakeTextBlock("ok")])],
+    )
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm()
+    await call_llm("", "prompt", "claude-haiku-4-5")
+    assert recorder["options"].system_prompt is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Empty stream returns "" AND logs WARNING
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_returns_empty_string_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An SDK stream that yields no text blocks returns ``""`` from the
+    callable AND emits a WARNING log. The empty return is the classic
+    "unparseable verdict" diagnostic dead-end pre-fix; the WARNING makes
+    it observable so operators can correlate with model / turn config."""
+    _install_fake_sdk(monkeypatch, messages=[])  # no messages at all
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm()
+
+    with caplog.at_level(logging.WARNING, logger="goldfive.integrations.claude_sdk"):
+        result = await call_llm("sys", "prompt", "claude-haiku-4-5")
+    assert result == ""
+    warning_records = [
+        r for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any(
+        "claude-agent-sdk produced no text" in r.getMessage()
+        for r in warning_records
+    ), f"expected zero-output WARNING, saw: {[r.getMessage() for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# 6. setting_sources=[] and tools=[] passed on every call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_isolation_knobs_passed_on_every_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setting_sources=[]`` and ``tools=[]`` must be on the
+    ``ClaudeAgentOptions`` ctor for every invocation. Together they
+    prevent operator-local Claude config (``CLAUDE.md`` / settings
+    files / Claude Code built-in tools) from leaking into planner /
+    judge prompts. Regression test: PR #378 originally shipped without
+    ``setting_sources=[]`` and with ``allowed_tools=[]`` (the wrong
+    knob); reviewer flagged it and that's now part of the contract."""
+    recorder = _install_fake_sdk(
+        monkeypatch,
+        messages=[_FakeMessage(content=[_FakeTextBlock("ok")])],
+    )
+
+    from goldfive.integrations.claude_sdk import make_call_llm
+
+    call_llm = make_call_llm()
+    await call_llm("sys", "prompt", "claude-haiku-4-5")
+    opts = recorder["options"]
+    assert opts.setting_sources == [], (
+        f"setting_sources must be [] (SDK isolation), got {opts.setting_sources!r}"
+    )
+    assert opts.tools == [], (
+        f"tools must be [] (strips Claude Code built-ins), got {opts.tools!r}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -396,6 +396,24 @@ wheels = [
 ]
 
 [[package]]
+name = "claude-agent-sdk"
+version = "0.2.82"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/3d/f75aaecf476c2b2a903dbba6042171b6683eb91c1f97f3ad894784cec270/claude_agent_sdk-0.2.82.tar.gz", hash = "sha256:3e907b7d2bf52a5917d96a3ce336b8aa5546ea31e29ce826a7f346622cf7f4bf", size = 252053, upload-time = "2026-05-15T03:45:34.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/bc/27cf3aec2a24f2ed1f60277de795496b808a761d2a7a3fd34602a2fec37d/claude_agent_sdk-0.2.82-py3-none-macosx_11_0_arm64.whl", hash = "sha256:24ad8ccbcee9afe206ae5d621a9e40a5022ca3eb8c2c672b36916d3e70746e42", size = 61473506, upload-time = "2026-05-15T03:45:38.745Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/95a83f018dbc8c113233eb542bccf17c1a3f5f689448700daf950602bf5e/claude_agent_sdk-0.2.82-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:13e54d5163d9d4f899c4e2a3f14df597f4e050d5afa104618ccf7bb37b372ad1", size = 63541975, upload-time = "2026-05-15T03:45:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/be/07/9356fe0e30f988bade6b116ecc602b4a9ae4df34fa055305187a835e36e0/claude_agent_sdk-0.2.82-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:3b0a0e3f0927737f1fc91ee4549185172243a4e8f135d4c1e4f1f1eba91373e1", size = 71212904, upload-time = "2026-05-15T03:45:51.121Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d9/e2920b4b6c75cf79ec87ebfb4cc4447c78a4f26317cb3fed77e79fcc804e/claude_agent_sdk-0.2.82-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:b05873f9df01c5894930b87f6ca9315f0d97f1563bc2e4dc0fafe0d4a1e31997", size = 71381948, upload-time = "2026-05-15T03:45:56.153Z" },
+    { url = "https://files.pythonhosted.org/packages/89/80/c3ec5a89c735a96d35fe12b6262517169b396ff366149a3b9f4387f797c1/claude_agent_sdk-0.2.82-py3-none-win_amd64.whl", hash = "sha256:71e85e4f50d04cd95e687898092f03648e74e1cd2537583de93370d2da1c0586", size = 71990462, upload-time = "2026-05-15T03:46:01.646Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -677,6 +695,9 @@ adk = [
 claude = [
     { name = "anthropic" },
 ]
+claude-sdk = [
+    { name = "claude-agent-sdk" },
+]
 dev = [
     { name = "grpcio-tools" },
     { name = "mypy" },
@@ -700,6 +721,7 @@ proto = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", marker = "extra == 'claude'", specifier = ">=0.39.0" },
+    { name = "claude-agent-sdk", marker = "extra == 'claude-sdk'", specifier = ">=0.1.80" },
     { name = "google-adk", marker = "extra == 'adk'", specifier = ">=0.1.0" },
     { name = "grpcio", marker = "extra == 'proto'", specifier = ">=1.60" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.60" },
@@ -713,7 +735,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "sentence-transformers", marker = "extra == 'embedding'", specifier = ">=3.0" },
 ]
-provides-extras = ["adk", "claude", "dev", "embedding", "examples", "proto"]
+provides-extras = ["adk", "claude", "claude-sdk", "dev", "embedding", "examples", "proto"]
 
 [[package]]
 name = "google-adk"


### PR DESCRIPTION
## Summary

Adds `ClaudeAgentSDKLlm` — an ADK `BaseLlm` subclass that lets goldfive
subagents run on Claude via `claude-agent-sdk` (Max-billed) while
preserving full goldfive observability. Completes the trio of LLM
call-sites enabled in #378 (planner / goal-deriver / judges via
`make_call_llm`).

Builds on `feat/claude-agent-sdk-callable`. With this PR, setting
`GOLDFIVE_USE_CLAUDE_SDK=1` + `GOLDFIVE_EXAMPLE_MODEL=claude-haiku-4-5`
puts **every LLM call** in the presentation_agent example on Claude
via Max billing.

## Architecture: text-encoded replay + PreToolUse defer

Each `generate_content_async` call:

1. Renders the full ADK conversation (incl. prior `function_call` /
   `function_response` pairs) as a text transcript
2. Spawns a fresh `ClaudeSDKClient` with ADK tool schemas registered
   as MCP tools (`mcp__adk__<name>`)
3. A `PreToolUse` hook returns `permissionDecision: "defer"` for ADK
   tools, captures the first one
4. Adapter returns the captured tool_use as a `function_call` Part
   in `LlmResponse`
5. ADK runs the tool through its normal pipeline → goldfive plugin
   observes → next ADK invocation re-enters this method with the
   `function_response` appended to `contents`

This preserves ADK's normal tool execution pipeline, so goldfive's
`delegation_observed`, `tool_call_*`, `CONFABULATION_RISK`, and
`CAPABILITY_MISMATCH` detectors all fire correctly.

## Why text replay, not stateful client reuse

I attempted stateful `ClaudeSDKClient` (one client per conversation,
fed user / tool_result messages incrementally) first. Three SDK
constraints made it impractical:

- No `messages.create(messages=[...])`-style API — both `query()` and
  `ClaudeSDKClient` accept only user-message streams. There's no way
  to inject prior assistant `tool_use` blocks to "tell" Claude what
  happened.
- After a `permissionDecision: "defer"` run completes, sending a
  tool_result via the same client's `query()` doesn't continue —
  Claude reads the empty user message as a new conversation.
- `resume=<session_id>` works but spawns a fresh subprocess per
  invocation anyway, so the "stateful" win evaporates.

Text replay trades quadratic token cost for predictable per-turn
behaviour and a much simpler implementation (~250 lines vs an
estimated 200-300 for stateful + lifecycle management).

## How agent-loop suppression works (same as #378)

Two knobs keep Claude Code's bundled CLI in thin LLM behaviour:

- `setting_sources=[]` — SDK isolation mode; no filesystem settings,
  no CLAUDE.md auto-detection.
- `tools=[mcp__adk__<name>, …]` — allowlist of just our ADK tools.
  Claude Code's built-ins (`TodoWrite`, `Task`, `Read`, `Bash`, …) are
  excluded, which keeps the internal `TodoWrite`/`Task` agent loop
  from firing.

`allowed_tools` is not the same as `tools` — the former is permission-
prompt control; the latter is the actual visibility allowlist. See
the in-code comment for the verification trail.

## Two issues found and fixed during testing

1. **AgentTool schema extraction**. The previous helper
   `_build_input_schema_from_signature(tool.func)` returned an empty
   schema for `AgentTool` (no `.func` attribute), causing Claude to
   call it with empty args and ADK to raise `KeyError('request')`.
   Fixed by `_extract_input_schema_from_adk_tool`, which prefers
   `tool._get_declaration()` → works uniformly for `FunctionTool`,
   `AgentTool`, and any subclass conforming to `BaseTool`.

2. **User-account MCP server leakage**. Claude Code's bundled CLI
   surfaces cloud-account-bound MCP servers (Gmail, Drive, Calendar)
   to the model **regardless of `setting_sources=[]`** — those are
   loaded from the Claude.ai profile, not local settings. Claude saw
   them in its tool list and tried to call e.g.
   `mcp__claude_ai_Google_Drive__create_file`, which then errored
   inside ADK (`Tool not found`). The `PreToolUse` hook now denies
   any tool not in our `mcp__adk__*` allowlist with a clear message,
   so Claude retries with an ADK tool inside the same Claude run.

## What was validated

- `GOLDFIVE_USE_CLAUDE_SDK=1 GOLDFIVE_EXAMPLE_MODEL=claude-haiku-4-5 uv run --extra adk python examples/presentation_agent/agent.py --topic octopus`
  → `success=True, 3/3 tasks completed`. All three LLM call-sites on
  Claude Haiku via Max.
- `delegation_observed: coordinator_agent → research_agent` events
  fire correctly — ADK sees the AgentTool delegation, goldfive plugin
  records it.
- `judge_goal_drift` returns real parseable verdicts via Claude (no
  more `unparseable verdict` / `CancelledError` from the mock-mode
  era). Example verdict surfaced in the test run: *"Research task is
  already marked COMPLETED, but agents are re-initiating research
  work, suggesting looping rather than advancing to the
  draft_presentation stage."*
- All four `presentation_agent` example modes still work unchanged:
  - `--mock` (no env): canned 4-task plan + `_MockLlm`
  - Original OpenAI live mode (with `OPENAI_API_KEY`)
  - Hybrid (`GOLDFIVE_USE_CLAUDE_SDK=1` + `GOLDFIVE_EXAMPLE_MODEL=gemini-2.5-flash-lite`)
  - **All-Claude (this PR)** — `GOLDFIVE_USE_CLAUDE_SDK=1` + `GOLDFIVE_EXAMPLE_MODEL=claude-haiku-4-5`

## Known limitation (not adapter-related)

Agent semantic quality on Haiku: in the test run, the coordinator
misdelegated `draft_presentation` to `research_agent` instead of
`web_developer_agent`, so no slide files got written. The adapter
plumbing is correct (`success=True 3/3` plumbing-wise) but the
example's coordinator prompt assumes stronger delegation reasoning
than Haiku reliably provides. Bumping `GOLDFIVE_EXAMPLE_MODEL=claude-sonnet-4-6`
would likely fix the misdelegation; that's an example-tuning issue,
not an adapter issue.

## Test plan

- [x] `uv run python examples/presentation_agent/agent.py --mock --topic baseline` — unchanged byte-identical mock path
- [x] `GOLDFIVE_USE_CLAUDE_SDK=1 GOLDFIVE_EXAMPLE_MODEL=claude-haiku-4-5 uv run python examples/presentation_agent/agent.py --topic octopus` — success=True 3/3, real judge verdicts, real delegations
- [x] Isolated probe: `LlmRequest` with `function_call` history → adapter returns next `function_call`, no handler execution
- [x] Schema extraction for `AgentTool` returns `{"request": {"type": "string"}, "required": ["request"]}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)