### PR TITLE
feat(adapter): observational task pin at delegation_observed (closes #259)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -4018,6 +4018,174 @@ def make_adk_plugin(
                     exc,
                 )
 
+        def _maybe_pin_delegation_task(
+            self,
+            *,
+            ctx: SessionContext,
+            invoked_agent_name: str,
+            tool_args: Any,
+        ) -> None:
+            """Observationally bind a plan task to ``invoked_agent_name`` at
+            delegation_observed time (goldfive#259).
+
+            #252 zeroed ``Task.assignee_agent_id`` at plan-parse time so the
+            LLM cannot pre-declare which sub-agent will pick up a task; the
+            assignment is supposed to be observational (described as what
+            actually happened, not predicted). This hook is the observational
+            re-population — when the coordinator dispatches an AgentTool, we
+            walk the plan, pick the eligible plan task this delegation is
+            enacting, stamp ``task.assignee_agent_id`` and
+            ``session.current_task_id`` so the reporting-tool pin lookup in
+            :func:`_resolve_pinned_task_id` finds the task without needing a
+            pre-declared assignee.
+
+            Selection algorithm:
+
+            1. Eligible set = PENDING tasks whose every upstream-edge
+               predecessor is COMPLETED (DAG-ready).
+            2. If exactly one eligible -> bind it.
+            3. If multiple eligible -> topic-match by tokenising
+               ``tool_args`` against each candidate's title+description
+               (same scorer the delegation pin uses). Top non-zero score
+               wins; tie or zero overlap -> fall back to plan-tasks order
+               (first eligible).
+            4. If zero eligible -> log DEBUG and return.
+
+            The stamp is a real mutation, not a dry run. Assignee
+            repopulation is observational in the same sense that
+            ``NEW_WORK_DISCOVERED`` is — describing observed reality, not a
+            revision — so it does NOT emit ``PlanRevised``.
+
+            Silent on every failure mode.
+            """
+            if not invoked_agent_name:
+                return
+            plan = _safe_attr(ctx.session, "plan", None)
+            if plan is None:
+                return
+            tasks = tuple(_safe_attr(plan, "tasks", None) or ())
+            if not tasks:
+                return
+            try:
+                from goldfive.types import (  # noqa: PLC0415 — lazy
+                    TaskStatus,
+                    channel_processor_active,
+                    replace_task,
+                    set_session_plan,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_maybe_pin_delegation_task: cannot import deps: %s",
+                    exc,
+                )
+                return
+
+            edges = tuple(_safe_attr(plan, "edges", None) or ())
+            completed_ids: set[str] = set()
+            for t in tasks:
+                if _safe_attr(t, "status", None) is TaskStatus.COMPLETED:
+                    tid = str(_safe_attr(t, "id", "") or "")
+                    if tid:
+                        completed_ids.add(tid)
+
+            def _upstream_ok(task_id: str) -> bool:
+                for e in edges:
+                    to_id = str(_safe_attr(e, "to_task_id", "") or "")
+                    if to_id != task_id:
+                        continue
+                    from_id = str(_safe_attr(e, "from_task_id", "") or "")
+                    if from_id and from_id not in completed_ids:
+                        return False
+                return True
+
+            eligible: list[Any] = []
+            for task in tasks:
+                if _safe_attr(task, "status", None) is not TaskStatus.PENDING:
+                    continue
+                tid = str(_safe_attr(task, "id", "") or "")
+                if not tid or not _upstream_ok(tid):
+                    continue
+                eligible.append(task)
+
+            if not eligible:
+                log.debug(
+                    "_maybe_pin_delegation_task: no eligible PENDING task "
+                    "to bind for delegation to %s; leaving unpinned",
+                    invoked_agent_name,
+                )
+                return
+
+            chosen: Any
+            if len(eligible) == 1:
+                chosen = eligible[0]
+            else:
+                scored = _score_candidates_by_args(eligible, tool_args)
+                chosen = scored if scored is not None else eligible[0]
+
+            chosen_id = str(_safe_attr(chosen, "id", "") or "")
+            if not chosen_id:
+                return
+
+            # Stamp assignee onto the chosen task by deriving a new Plan
+            # under the channel-processor envelope. Skip when the assignee
+            # already matches (idempotent on parallel same-agent calls).
+            current_assignee = str(
+                _safe_attr(chosen, "assignee_agent_id", "") or ""
+            )
+            try:
+                if current_assignee != invoked_agent_name:
+                    with channel_processor_active():
+                        new_plan = replace_task(
+                            plan,
+                            chosen_id,
+                            assignee_agent_id=invoked_agent_name,
+                        )
+                        set_session_plan(ctx.session, new_plan)
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_maybe_pin_delegation_task: assignee stamp raised: %s",
+                    exc,
+                )
+                return
+
+            # Pin the chosen task as session.current_task_id via the
+            # OrchestrationStore so the reporting-tool pin lookup
+            # (:func:`_resolve_pinned_task_id`) resolves on the
+            # delegated sub-invocation's tool calls.
+            try:
+                store = OrchestrationStore.for_session(ctx.session)
+                live_plan = _safe_attr(ctx.session, "plan", None)
+                try:
+                    pin_revision = int(
+                        _safe_attr(live_plan, "revision_index", 0) or 0
+                    )
+                except (TypeError, ValueError):
+                    pin_revision = 0
+                store.set_pin_current_task(
+                    chosen_id,
+                    source=BindingSource.DELEGATION_PIN,
+                    revision=pin_revision,
+                    title=str(_safe_attr(chosen, "title", "") or ""),
+                )
+                try:
+                    ctx.session.current_task_id = chosen_id
+                except Exception:  # noqa: BLE001
+                    pass
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_maybe_pin_delegation_task: current_task pin raised: %s",
+                    exc,
+                )
+                return
+
+            log.info(
+                "goldfive.delegation.assignee_observed: task_id=%s "
+                "agent=%s eligible=%d",
+                chosen_id,
+                invoked_agent_name,
+                len(eligible),
+            )
+
         async def _maybe_emit_capability_mismatch(
             self,
             *,
@@ -5320,6 +5488,27 @@ def make_adk_plugin(
                             "before_tool_callback: reconciler.on_delegation_observed raised: %s",
                             exc,
                         )
+
+                # goldfive#259 — observational assignee re-population.
+                # #252 zeroed Task.assignee_agent_id at parse time; this
+                # hook stamps the chosen plan task's assignee with the
+                # invoked agent and pins session.current_task_id so the
+                # reporting-tool pin lookup resolves on the delegated
+                # sub-invocation's tool calls. Runs BEFORE the capability
+                # check so the latter's Strategy 1 (assignee-based) can
+                # find the bound task instead of falling through to the
+                # weaker Strategy 2 (current_task_id only).
+                try:
+                    self._maybe_pin_delegation_task(
+                        ctx=ctx,
+                        invoked_agent_name=to_agent,
+                        tool_args=tool_args,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "before_tool_callback: delegation_pin hook raised: %s",
+                        exc,
+                    )
 
                 # goldfive#253 — structural capability check at delegation
                 # time. Replaces the planner-LLM PLAN_DIVERGENCE

--- a/tests/test_capability_mismatch.py
+++ b/tests/test_capability_mismatch.py
@@ -32,6 +32,7 @@ from goldfive.types import (
     DriftKind,
     DriftSeverity,
     Task,
+    TaskStatus,
 )
 
 # ---------------------------------------------------------------------------
@@ -412,6 +413,12 @@ async def test_integration_capability_mismatch_flows_through_handle_drift() -> N
 
     # Plan task is the leaf authoring task assigned to the
     # underqualified sub-agent — exactly the structural mismatch.
+    # goldfive#259: the coord task is marked RUNNING (not PENDING) so
+    # the observational delegation-time pin (#259) only treats the leaf
+    # task as eligible. Otherwise the pin would pick the
+    # delegation-shaped coord_task by plan order (zero-overlap topic
+    # match falls back to first) and Rule A's "Coordinate" delegation
+    # marker would suppress the drift.
     leaf_task = Task(
         id="t-draft",
         title="Draft a presentation about LLM observability",
@@ -421,6 +428,7 @@ async def test_integration_capability_mismatch_flows_through_handle_drift() -> N
         id="t-coord",
         title="Coordinate the presentation",
         assignee_agent_id="coord",
+        status=TaskStatus.RUNNING,
     )
     plan = Plan(
         id="p1",
@@ -478,6 +486,11 @@ async def test_integration_no_capability_mismatch_when_agent_has_leaf_tool() -> 
     steerer = _RecordingSteerer()
     adapter.bind_steerer(steerer)
 
+    # goldfive#259: mark coord_task RUNNING (not PENDING) so only the
+    # leaf task is eligible for the observational delegation-time pin.
+    # Otherwise the pin would pick coord_task by plan order (zero-
+    # overlap topic match → first eligible), and Rule A would be
+    # suppressed by the "Coordinate" delegation marker anyway.
     leaf_task = Task(
         id="t-draft",
         title="Draft a presentation",
@@ -487,6 +500,7 @@ async def test_integration_no_capability_mismatch_when_agent_has_leaf_tool() -> 
         id="t-coord",
         title="Coordinate the work",
         assignee_agent_id="coord",
+        status=TaskStatus.RUNNING,
     )
     plan = Plan(
         id="p1",

--- a/tests/test_delegation_pin.py
+++ b/tests/test_delegation_pin.py
@@ -1,0 +1,429 @@
+"""Observational delegation-time task pinning (goldfive#259).
+
+#252 zeroed ``Task.assignee_agent_id`` at plan-parse time so the LLM
+cannot pre-declare which sub-agent will pick up a task. The follow-up
+in #259 wires the observational re-population: at ``delegation_observed``
+time the plugin walks the plan, picks the eligible PENDING task this
+delegation is enacting, stamps ``task.assignee_agent_id`` with the
+invoked agent's name and pins ``session.current_task_id`` so the
+reporting-tool pin lookup in :func:`_resolve_pinned_task_id` resolves
+on the delegated sub-invocation's tool calls.
+
+This file pins the selection algorithm and the end-to-end reporting-
+tool resolution behaviour:
+
+  * Linear plan A -> B -> C; first delegation binds A and pins it.
+  * Sequential delegations: after A completes, the next delegation
+    binds B.
+  * Multi-eligible (two parallel PENDING tasks): topic-match in tool
+    args picks the matching task.
+  * Multi-eligible without topic-match in args: first by plan order
+    wins (no guessing).
+  * No eligible task (all PENDING tasks have non-COMPLETED predecessors)
+    -> no pin, DEBUG log, no exception.
+  * Integration: after the pin, ``before_tool_callback`` resolves
+    ``report_task_started`` to the bound task (not the silent-ack
+    no-op).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    SESSION_CONTEXT_STATE_KEY,
+    SessionContext,
+    make_adk_plugin,
+)
+from goldfive.orchestration_store import OrchestrationStore  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _plan(*tasks: Task, edges: list[TaskEdge] | None = None) -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=[],
+        tasks=list(tasks),
+        edges=list(edges or []),
+        summary="",
+    )
+
+
+def _session_with(plan: Plan) -> Session:
+    return Session(run_id="r1", plan=plan)
+
+
+def _ctx(session: Session, host_agent_name: str = "coord") -> SessionContext:
+    return SessionContext(
+        session=session,
+        steerer=None,
+        task=None,
+        tool_handlers={},
+        host_agent_name=host_agent_name,
+    )
+
+
+def _find_task(plan: Plan, task_id: str) -> Task | None:
+    for t in plan.tasks:
+        if t.id == task_id:
+            return t
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Selection algorithm
+# ---------------------------------------------------------------------------
+
+
+def test_linear_plan_first_delegation_binds_first_task() -> None:
+    """3-task linear plan A->B->C, all PENDING, no pre-declared assignees.
+
+    Delegation to agent X picks task A (only DAG-ready PENDING task),
+    stamps assignee, pins current_task_id. The other two tasks remain
+    untouched.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        Task(id="A", title="Research the topic"),
+        Task(id="B", title="Write the draft"),
+        Task(id="C", title="Review the draft"),
+        edges=[
+            TaskEdge(from_task_id="A", to_task_id="B"),
+            TaskEdge(from_task_id="B", to_task_id="C"),
+        ],
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="X",
+        tool_args={"request": "go"},
+    )
+
+    a = _find_task(session.plan, "A")
+    b = _find_task(session.plan, "B")
+    c = _find_task(session.plan, "C")
+    assert a is not None and b is not None and c is not None
+    assert a.assignee_agent_id == "X"
+    assert b.assignee_agent_id == ""
+    assert c.assignee_agent_id == ""
+    assert session.current_task_id == "A"
+    store = OrchestrationStore.for_session(session)
+    assert store.pin_current_task() == "A"
+
+
+def test_sequential_delegations_bind_next_task_after_completion() -> None:
+    """After A completes, delegating to a fresh agent binds B (the new
+    DAG-ready PENDING task)."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        Task(id="A", title="Research the topic", status=TaskStatus.COMPLETED),
+        Task(id="B", title="Write the draft"),
+        Task(id="C", title="Review the draft"),
+        edges=[
+            TaskEdge(from_task_id="A", to_task_id="B"),
+            TaskEdge(from_task_id="B", to_task_id="C"),
+        ],
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="Y",
+        tool_args={"request": "draft"},
+    )
+
+    b = _find_task(session.plan, "B")
+    assert b is not None
+    assert b.assignee_agent_id == "Y"
+    assert session.current_task_id == "B"
+
+
+def test_multi_eligible_topic_match_wins() -> None:
+    """Two parallel PENDING tasks (no edge between them) and tool args
+    contain a token that overlaps with one task's title — the matching
+    task wins."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        Task(
+            id="t1",
+            title="solar telemetry research",
+            description="gather solar telemetry",
+        ),
+        Task(
+            id="t2",
+            title="quarterly invoice review",
+            description="reconcile quarterly invoices",
+        ),
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="researcher",
+        tool_args={"topic": "please research solar telemetry"},
+    )
+
+    t1 = _find_task(session.plan, "t1")
+    t2 = _find_task(session.plan, "t2")
+    assert t1 is not None and t2 is not None
+    assert t1.assignee_agent_id == "researcher"
+    assert t2.assignee_agent_id == ""
+    assert session.current_task_id == "t1"
+
+
+def test_multi_eligible_no_topic_match_falls_back_to_first() -> None:
+    """Two parallel PENDING tasks, tool args have no overlapping tokens
+    with either title -> fall back to the first task by plan order."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        Task(id="t1", title="solar telemetry research"),
+        Task(id="t2", title="quarterly invoice review"),
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    # Tool args contain only sub-4-char tokens (the scorer filter
+    # threshold) so no candidate scores > 0 and the fallback kicks in.
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="researcher",
+        tool_args={"x": "go on"},
+    )
+
+    t1 = _find_task(session.plan, "t1")
+    t2 = _find_task(session.plan, "t2")
+    assert t1 is not None and t2 is not None
+    assert t1.assignee_agent_id == "researcher"
+    assert t2.assignee_agent_id == ""
+    assert session.current_task_id == "t1"
+
+
+def test_no_eligible_task_leaves_session_unpinned(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """All PENDING tasks have non-COMPLETED predecessors -> no pin, no
+    exception, DEBUG log fires."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        # A is PENDING (not COMPLETED) so B's predecessor isn't satisfied.
+        Task(id="A", title="Plan the work"),
+        Task(id="B", title="Execute the work"),
+        edges=[TaskEdge(from_task_id="A", to_task_id="B")],
+    )
+    # Mark A non-PENDING (e.g. RUNNING) so A is not eligible either
+    # (only PENDING tasks count) — that matches the brief's "no
+    # eligible task" case.
+    import dataclasses
+
+    plan = dataclasses.replace(
+        plan,
+        tasks=(
+            dataclasses.replace(plan.tasks[0], status=TaskStatus.RUNNING),
+            plan.tasks[1],
+        ),
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    with caplog.at_level(logging.DEBUG, logger="goldfive.adapters.adk"):
+        plugin._maybe_pin_delegation_task(
+            ctx=ctx,
+            invoked_agent_name="Z",
+            tool_args={"request": "go"},
+        )
+
+    a = _find_task(session.plan, "A")
+    b = _find_task(session.plan, "B")
+    assert a is not None and b is not None
+    assert a.assignee_agent_id == ""
+    assert b.assignee_agent_id == ""
+    assert session.current_task_id == ""
+    assert any(
+        "no eligible PENDING task" in r.getMessage() for r in caplog.records
+    ), f"expected DEBUG log; got {[r.getMessage() for r in caplog.records]}"
+
+
+def test_idempotent_on_already_assigned_task() -> None:
+    """Re-running the pin with the same agent on the same eligible task
+    is a no-op (assignee already matches, no spurious plan swap)."""
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        Task(id="A", title="Research the topic"),
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="X",
+        tool_args={},
+    )
+    first_plan = session.plan
+    assert first_plan is not None
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="X",
+        tool_args={},
+    )
+    # Second call kept the same plan pointer (idempotent).
+    assert session.plan is first_plan
+    a = _find_task(session.plan, "A")
+    assert a is not None and a.assignee_agent_id == "X"
+
+
+# ---------------------------------------------------------------------------
+# Integration with the reporting-tool pin lookup
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgent:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeAgentTool:
+    """ADK AgentTool stand-in: has both ``.agent`` and ``.name``."""
+
+    def __init__(self, agent_name: str) -> None:
+        self.agent = _FakeAgent(agent_name)
+        self.name = agent_name
+
+
+class _FakeFunctionTool:
+    """Stand-in for a reporting tool (FunctionTool with a ``func``)."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+        def _func() -> None:
+            return None
+
+        _func.__name__ = name
+        self.func = _func
+
+
+class _FakeInvocationContext:
+    def __init__(self, session_state: dict, agent_name: str) -> None:
+        class _ADKSession:
+            def __init__(self, state: dict) -> None:
+                self.state = state
+
+        self.session = _ADKSession(session_state)
+        self.invocation_id = "inv-1"
+        self.agent = _FakeAgent(agent_name)
+
+
+class _FakeToolContext:
+    def __init__(self, inv_ctx: Any, function_call_id: str = "fc-1") -> None:
+        self._invocation_context = inv_ctx
+        self.function_call_id = function_call_id
+
+
+async def test_after_pin_report_task_started_resolves_bound_task() -> None:
+    """End-to-end: drive ``before_tool_callback`` through an AgentTool
+    dispatch (which triggers the pin) followed by a ``report_task_started``
+    call from the sub-agent. The reporting-tool lookup must find the
+    bound task and short-circuit through the reporting handler — not
+    the "no task pinned" silent ack.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        Task(id="A", title="Research the topic"),
+        Task(id="B", title="Write the draft"),
+        edges=[TaskEdge(from_task_id="A", to_task_id="B")],
+    )
+    session = _session_with(plan)
+
+    # Build a SessionContext that exposes the reporting-tool spec list
+    # so the plugin's ``before_tool_callback`` routes
+    # ``report_task_started`` through ``invoke_tool`` (not the silent
+    # ack). Reuse the canonical spec list from goldfive.reporting so
+    # we get the real handler.
+    from goldfive.reporting import select_reporting_tools
+
+    specs = select_reporting_tools(False)
+    ctx_obj = SessionContext(
+        session=session,
+        steerer=None,
+        task=None,
+        tools=specs,
+        host_agent_name="coord",
+    )
+    # Set the plugin's active ctx so the live-run path reaches the
+    # SessionContext via ``session_context_from_invocation``.
+    plugin.set_active_context(ctx_obj)
+
+    # Stash the SessionContext on ADK state too so the legacy / unit-test
+    # resolver path also finds it (defensive belt-and-braces).
+    adk_state: dict[str, Any] = {SESSION_CONTEXT_STATE_KEY: ctx_obj}
+    coord_inv = _FakeInvocationContext(adk_state, "coord")
+    coord_tool_context = _FakeToolContext(coord_inv, function_call_id="fc-dispatch")
+
+    # Phase 1: coord fires AgentTool(researcher) — triggers the pin.
+    agent_tool = _FakeAgentTool("researcher")
+    res = await plugin.before_tool_callback(
+        tool=agent_tool,
+        tool_args={"request": "please research the topic"},
+        tool_context=coord_tool_context,
+    )
+    # AgentTool dispatch is not short-circuited (no runaway-cap).
+    assert res is None or (isinstance(res, dict) and not res.get("skipped"))
+
+    # The pin landed.
+    a = _find_task(session.plan, "A")
+    assert a is not None
+    assert a.assignee_agent_id == "researcher"
+    assert session.current_task_id == "A"
+
+    # Phase 2: researcher (sub-agent) fires report_task_started. With
+    # the pin in place, the reporting handler runs (returns a dict
+    # describing the transition) rather than the silent ack.
+    sub_inv = _FakeInvocationContext(adk_state, "researcher")
+    sub_tool_context = _FakeToolContext(sub_inv, function_call_id="fc-report")
+    report_tool = _FakeFunctionTool("report_task_started")
+
+    res = await plugin.before_tool_callback(
+        tool=report_tool,
+        tool_args={},  # task_id is hidden from the LLM; the pin supplies it.
+        tool_context=sub_tool_context,
+    )
+
+    # The reporting handler executed (or attempted to execute), which
+    # means the pin lookup resolved — the response carries either the
+    # handler's success payload or the handler's error payload (when
+    # the test's stub steerer can't drive the real transition). What
+    # MUST NOT happen is the no-task-pinned silent ack: the silent-ack
+    # branch returns EXACTLY ``{"acknowledged": True}`` with no other
+    # keys. Anything else means the pin resolved and the dispatch path
+    # reached invoke_tool.
+    assert isinstance(res, dict)
+    assert res != {"acknowledged": True}, (
+        f"reporting handler did not run; got silent ack: {res}"
+    )
+    # The task_id from the pin was injected into tool_args before the
+    # dispatch (visible because the handler's response either succeeds
+    # against task A or surfaces an error that references A). Either
+    # way, the pin-resolution loop did not fall through to no-op.
+    assert "missing_task_id" not in str(res), (
+        f"task_id was not injected from the pin: {res}"
+    )


### PR DESCRIPTION
## Summary

Closes the deferred follow-up from #377 (#252): when the planner stopped declaring `assignee_agent_id` (now always `""` at plan-parse time), the existing task-pinning lookup in `before_tool_callback` could no longer resolve which plan task an invoked sub-agent was working on, and every `report_task_*` call no-opped with `"no task pinned for ...; returning no-op acknowledgment"`. Per-task lifecycle (PENDING → RUNNING → COMPLETED) never transitioned on live runs.

Live e2e 2026-05-11 (session `b7823b3c`, gemma-4-26B): coordinator's autonomous flow ran end-to-end in 51s with successful recovery via `debugger_agent.find_presentation_files`, but harmonograf showed all 4 tasks PENDING because none of the tool-reported transitions could find a bound task.

## Fix

At `delegation_observed` time, pick the single DAG-ready PENDING task and **observationally stamp**:

1. `task.assignee_agent_id = invoked_agent_name` — via `replace_task` + `set_session_plan` under `channel_processor_active()` (the canonical frozen-Plan mutation).
2. `session.current_task_id = task.id` — via `OrchestrationStore.set_pin_current_task`.

**Task-selection strategy**:
1. Pending tasks whose predecessors are all `COMPLETED` — the DAG-eligible set.
2. If 1 eligible → bind it.
3. If multiple → case-insensitive substring topic-match against the delegation tool args.
4. If still multiple → first by `plan.tasks` order.
5. If 0 eligible → DEBUG log; leave unpinned (existing behavior).

The pin mutation does NOT emit a `PlanRevised` event — assignee population is a description of what happened, not a plan revision. Conceptually the same class as the `NEW_WORK_DISCOVERED` carve-out from #382.

## Test plan

- [x] 7 new tests in `tests/test_delegation_pin.py`:
  - linear plan / sequential delegations / multi-eligible topic-match / multi-eligible plan-order fallback / no-eligible no-op / idempotent re-delegation / end-to-end `report_task_started` resolution.
- [x] All 7 verified to FAIL on `origin/main` (stash plugin diff, re-run) and PASS with the fix — real regression guards.
- [x] `pytest tests/ -q` — 2380 passed, 59 skipped, 0 failed (baseline 2373 + 7 new).
- [x] `ruff check goldfive/ tests/` — clean.

## Net effect on live runs

- `report_task_*` resolves to the bound task; harmonograf gets real task transitions.
- Reasoning judge has `task.title` / `description` context to ground on_task checks.
- Capability detector's Strategy-1 (assignee match) fires correctly; Strategy-2 (current_task_id) remains as defense-in-depth.

Closes #259.