### PR TITLE
fix(pin): agent-name + required_tools semantic match before topo-order (closes #265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
 
 ## Unreleased — 2026-05-11
 
+### Delegation pin
+
+- **[#265](https://github.com/pedapudi/goldfive/issues/265) — agent-name
+  and required-tools semantic match before topo-order in
+  `_maybe_pin_delegation_task`.** The observational pin (#259) used
+  topo-next DAG-ready PENDING plus a topic-args scorer to disambiguate
+  multi-eligible candidates. When the coordinator's autonomous
+  delegation order does not match the planner's DAG order
+  (e.g. delegating to `reviewer_agent` while `draft_presentation` is
+  topo-first), the pin chose the wrong task and the reasoning judge
+  fired `OFF_TOPIC` drift. The fix adds two structural tiers before the
+  topo-order fallback: **Tier 1** picks the unique candidate whose
+  non-empty `Task.required_tools` is fully covered by the invoked
+  agent's live tool names; **Tier 2** picks the unique candidate whose
+  title+description contains a stem extracted from the invoked agent's
+  name (e.g. `reviewer_agent` -> stem `reviewer`, bi-directional
+  substring match against title/description tokens). **Tier 3**
+  (existing scorer + topo-order) is unchanged. Both new tiers use only
+  pure `str` ops (no regex; see #166 / #167). The pin call site now
+  passes the nested ADK agent to enable Tier 1 introspection;
+  `invoked_agent` is an optional kwarg so legacy callers fall through
+  to Tier 2 + Tier 3.
+
 ### Steering
 
 - **BREAKING:

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -992,6 +992,190 @@ def _score_candidates_by_args(candidates: list[Any], tool_args: Any) -> Any:
     return best
 
 
+#: Trailing role-suffix tokens stripped from an invoked-agent name during
+#: stem extraction for the goldfive#265 tier-2 semantic match. Conservative
+#: by design: only role-marker tokens that almost never carry topic
+#: meaning. Keep small — adding common verbs/nouns here would suppress
+#: legitimate matches (e.g. dropping "researcher" from "researcher_agent"
+#: leaves the empty stem and nothing matches).
+_AGENT_NAME_ROLE_SUFFIXES: frozenset[str] = frozenset(
+    {"agent", "worker", "assistant", "bot", "tool"}
+)
+
+
+def _agent_name_stems(agent_name: str) -> tuple[str, ...]:
+    """Return ordered lowercase stem tokens derived from an ADK agent name.
+
+    Goldfive#265 tier-2 semantic match. The invoked agent's display name
+    (e.g. ``reviewer_agent``) is split on underscore/hyphen/space, lower-
+    cased, role-suffix tokens (``agent``, ``worker``, …) trimmed from the
+    tail, and remaining tokens of length >= 4 returned. Length filter
+    matches :func:`_tokenize_for_matching` so the stems are comparable
+    against title/description tokens.
+
+    Examples
+    --------
+    >>> _agent_name_stems("reviewer_agent")
+    ('reviewer',)
+    >>> _agent_name_stems("web_developer_agent")
+    ('developer',)  # 'web' is < 4 chars and filtered out
+    >>> _agent_name_stems("helper_agent")
+    ('helper',)
+    >>> _agent_name_stems("agent")
+    ()
+
+    Deliberately **no regex** — goldfive#166 / #167 retired the regex-
+    based NL classifiers. Pure str ops only.
+    """
+    if not isinstance(agent_name, str) or not agent_name:
+        return ()
+    # Normalise common separators to spaces, then split.
+    norm = agent_name.replace("_", " ").replace("-", " ").lower()
+    raw_tokens = [tok for tok in norm.split() if tok]
+    # Trim role-suffix tokens off the tail (left-to-right) so
+    # ``reviewer_agent`` -> ``reviewer`` and
+    # ``draft_writer_assistant_bot`` -> ``draft writer``.
+    while raw_tokens and raw_tokens[-1] in _AGENT_NAME_ROLE_SUFFIXES:
+        raw_tokens.pop()
+    # Length filter mirrors _tokenize_for_matching's >=4 threshold so
+    # noisy short tokens ("ui", "qa") don't saturate matches.
+    out = tuple(tok for tok in raw_tokens if len(tok) >= 4)
+    return out
+
+
+def _agent_tool_names(invoked_agent: Any) -> tuple[str, ...]:
+    """Return the public tool names exposed by an ADK agent object.
+
+    Best-effort introspection used by goldfive#265 tier-1
+    required-tools cover. Walks ``invoked_agent.tools`` and pulls
+    ``.name`` (or ``.func.__name__`` for FunctionTool stand-ins), the
+    same name surface :mod:`goldfive.drift.capability_check` consumes.
+    Returns empty tuple on any failure so the caller falls through.
+    """
+    if invoked_agent is None:
+        return ()
+    tools = _safe_attr(invoked_agent, "tools", None)
+    if not tools:
+        return ()
+    names: list[str] = []
+    try:
+        for tool in tools:
+            name = getattr(tool, "name", None)
+            if isinstance(name, str) and name:
+                names.append(name)
+                continue
+            func = getattr(tool, "func", None)
+            if func is not None:
+                fname = getattr(func, "__name__", None)
+                if isinstance(fname, str) and fname:
+                    names.append(fname)
+    except Exception:  # noqa: BLE001 — introspection must not block pinning
+        return ()
+    return tuple(names)
+
+
+def _select_by_required_tools(
+    candidates: list[Any],
+    agent_tool_names: tuple[str, ...],
+) -> Any:
+    """Tier-1 selector for goldfive#265: required-tools cover.
+
+    Returns the unique candidate whose non-empty ``required_tools`` is
+    fully covered by ``agent_tool_names``. Returns ``None`` when zero or
+    multiple candidates match — the caller falls through to tier 2.
+
+    Candidates with empty ``required_tools`` are skipped entirely: an
+    empty advisory is "no opinion" (matching the
+    :func:`detect_capability_mismatch` Rule B contract), not a match
+    against every agent.
+    """
+    if not candidates or not agent_tool_names:
+        return None
+    available = set(agent_tool_names)
+    matched: list[Any] = []
+    for cand in candidates:
+        required = tuple(_safe_attr(cand, "required_tools", ()) or ())
+        if not required:
+            continue
+        if all(name in available for name in required):
+            matched.append(cand)
+    if len(matched) == 1:
+        return matched[0]
+    return None
+
+
+def _stem_token_match(stem: str, token: str) -> bool:
+    """Return True when ``stem`` and ``token`` share a meaningful root.
+
+    Bi-directional substring match: catches both stem-is-prefix-of-token
+    (``review`` -> ``reviewer``) and token-is-prefix-of-stem
+    (``reviewer`` -> ``review``). This handles the common
+    role-noun/verb pair where the agent name carries the agent-noun
+    form and the task carries the verb form (or vice versa).
+
+    Pure str ops — no regex (goldfive#166 / #167).
+    """
+    if not stem or not token:
+        return False
+    # Short-circuit on exact and direct substring matches; covers the
+    # most common case.
+    if stem == token:
+        return True
+    # Bi-directional containment: ``reviewer`` ⊇ ``review`` AND
+    # ``review`` ⊆ ``reviewer``. Both are length-bounded by the >=4
+    # filter applied upstream so noise like "is" / "of" cannot reach
+    # this check.
+    if stem in token or token in stem:
+        return True
+    return False
+
+
+def _select_by_agent_name_stems(
+    candidates: list[Any],
+    agent_name: str,
+) -> Any:
+    """Tier-2 selector for goldfive#265: agent-name semantic match.
+
+    Returns the unique candidate whose title+description contains a
+    token that semantically matches a stem extracted from
+    ``agent_name`` (bi-directional substring; see
+    :func:`_stem_token_match`). Returns ``None`` on zero or multiple
+    matches so the caller falls through to the existing topo-order
+    tier-3 fallback.
+
+    The matching is intentionally narrow: tokenise the candidate's
+    title+description into >= 4-char tokens (same threshold as
+    :func:`_tokenize_for_matching`), then compare each agent stem to
+    each task token by bi-directional containment. No regex
+    (goldfive#166 / #167), no LLM call, no embedding — this is a
+    pure structural disambiguation step that runs before the weaker
+    topic-args scorer.
+    """
+    stems = _agent_name_stems(agent_name)
+    if not stems or not candidates:
+        return None
+    matched: list[Any] = []
+    for cand in candidates:
+        title = str(_safe_attr(cand, "title", "") or "")
+        desc = str(_safe_attr(cand, "description", "") or "")
+        cand_tokens = _tokenize_for_matching(f"{title} {desc}")
+        if not cand_tokens:
+            continue
+        hit = False
+        for stem in stems:
+            for tok in cand_tokens:
+                if _stem_token_match(stem, tok):
+                    hit = True
+                    break
+            if hit:
+                break
+        if hit:
+            matched.append(cand)
+    if len(matched) == 1:
+        return matched[0]
+    return None
+
+
 def _measure_request_chars(llm_request: Any) -> tuple[int, int]:
     """Return ``(total_chars, messages_count)`` for an ADK ``LlmRequest``.
 
@@ -4060,9 +4244,10 @@ def make_adk_plugin(
             ctx: SessionContext,
             invoked_agent_name: str,
             tool_args: Any,
+            invoked_agent: Any = None,
         ) -> None:
             """Observationally bind a plan task to ``invoked_agent_name`` at
-            delegation_observed time (goldfive#259).
+            delegation_observed time (goldfive#259, refined by #265).
 
             #252 zeroed ``Task.assignee_agent_id`` at plan-parse time so the
             LLM cannot pre-declare which sub-agent will pick up a task; the
@@ -4075,17 +4260,39 @@ def make_adk_plugin(
             :func:`_resolve_pinned_task_id` finds the task without needing a
             pre-declared assignee.
 
-            Selection algorithm:
+            Selection algorithm (multi-eligible disambiguation tiers):
 
             1. Eligible set = PENDING tasks whose every upstream-edge
                predecessor is COMPLETED (DAG-ready).
             2. If exactly one eligible -> bind it.
-            3. If multiple eligible -> topic-match by tokenising
-               ``tool_args`` against each candidate's title+description
-               (same scorer the delegation pin uses). Top non-zero score
-               wins; tie or zero overlap -> fall back to plan-tasks order
-               (first eligible).
+            3. Multi-eligible disambiguation, short-circuiting on first
+               unique pick (goldfive#265):
+
+               * **Tier 1 — required-tools cover.** When ``invoked_agent``
+                 is supplied, pick the unique candidate whose non-empty
+                 :attr:`Task.required_tools` is fully covered by the
+                 agent's live tool names. Highest-confidence signal —
+                 grounded in the same surface
+                 :func:`detect_capability_mismatch` Rule B consumes.
+               * **Tier 2 — agent-name semantic match.** Pick the unique
+                 candidate whose title+description contains a stem
+                 extracted from ``invoked_agent_name``
+                 (e.g. ``reviewer_agent`` -> stem ``reviewer``).
+                 Substring match against a small fixed role-suffix
+                 list — **no regex** (goldfive#166 / #167 retired
+                 regex-based NL classifiers; don't reintroduce).
+               * **Tier 3 — topic-args scorer + topo-order fallback.**
+                 The pre-#265 behaviour: tokenise ``tool_args`` against
+                 each candidate's title+description; top non-zero score
+                 wins; tie or zero overlap -> first eligible by plan
+                 order.
+
             4. If zero eligible -> log DEBUG and return.
+
+            Tier 1 wins on conflict with Tier 2 by construction: it runs
+            first and short-circuits. ``invoked_agent`` is optional so
+            legacy callers (and tests that don't carry an ADK agent
+            object) still get the tier-2 + tier-3 path.
 
             The stamp is a real mutation, not a dry run. Assignee
             repopulation is observational in the same sense that
@@ -4155,8 +4362,25 @@ def make_adk_plugin(
             if len(eligible) == 1:
                 chosen = eligible[0]
             else:
-                scored = _score_candidates_by_args(eligible, tool_args)
-                chosen = scored if scored is not None else eligible[0]
+                # goldfive#265 — structural disambiguation tiers run
+                # BEFORE the topic-args scorer + plan-order fallback.
+                # Order: tier 1 (required-tools cover) -> tier 2
+                # (agent-name semantic match) -> tier 3 (existing
+                # scorer + topo-order). Each tier short-circuits on a
+                # unique pick; ambiguous tiers fall through.
+                chosen = None
+                tier1_agent_tool_names = _agent_tool_names(invoked_agent)
+                if tier1_agent_tool_names:
+                    chosen = _select_by_required_tools(
+                        eligible, tier1_agent_tool_names
+                    )
+                if chosen is None:
+                    chosen = _select_by_agent_name_stems(
+                        eligible, invoked_agent_name
+                    )
+                if chosen is None:
+                    scored = _score_candidates_by_args(eligible, tool_args)
+                    chosen = scored if scored is not None else eligible[0]
 
             chosen_id = str(_safe_attr(chosen, "id", "") or "")
             if not chosen_id:
@@ -5503,6 +5727,11 @@ def make_adk_plugin(
                         ctx=ctx,
                         invoked_agent_name=to_agent,
                         tool_args=tool_args,
+                        # goldfive#265 — pass the nested ADK agent so the
+                        # tier-1 required-tools cover step can introspect
+                        # ``agent.tools``. Optional; falls through to the
+                        # tier-2/3 paths when absent (legacy callers).
+                        invoked_agent=nested_agent,
                     )
                 except Exception as exc:  # noqa: BLE001
                     log.debug(

--- a/tests/test_delegation_pin.py
+++ b/tests/test_delegation_pin.py
@@ -263,6 +263,268 @@ def test_no_eligible_task_leaves_session_unpinned(
     ), f"expected DEBUG log; got {[r.getMessage() for r in caplog.records]}"
 
 
+# ---------------------------------------------------------------------------
+# goldfive#265 — structural disambiguation tiers (required-tools + agent-name)
+# ---------------------------------------------------------------------------
+
+
+class _FakeFunctionToolForCover:
+    """Stand-in for an ADK FunctionTool: carries a ``.name`` attribute.
+
+    Used by goldfive#265 tier-1 tests where the pin introspects
+    ``invoked_agent.tools[*].name`` to compute the required-tools cover.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeInvokedAgent:
+    """Stand-in for an ADK ``BaseAgent``: carries ``.name`` and ``.tools``."""
+
+    def __init__(self, name: str, tools: list[Any] | None = None) -> None:
+        self.name = name
+        self.tools = list(tools or [])
+
+
+def test_tier1_required_tools_cover_wins_over_topo_order() -> None:
+    """goldfive#265 tier 1: required-tools cover picks the matching task
+    even when it is not topo-first.
+
+    Two parallel DAG-ready PENDING tasks A and B. A.required_tools =
+    ("patch_file",); B.required_tools = (). The invoked agent has only
+    a ``patch_file`` tool. Tier 1 picks A; if we had fallen through to
+    tier 3 we'd have picked B (first by plan order). Asserts the tier
+    fired by checking A is bound.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        # B FIRST in plan order so the topo-order fallback would pick B.
+        Task(id="B", title="general task"),
+        Task(
+            id="A",
+            title="apply patch",
+            required_tools=("patch_file",),
+        ),
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    invoked_agent = _FakeInvokedAgent(
+        name="patcher",
+        tools=[_FakeFunctionToolForCover("patch_file")],
+    )
+
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="patcher",
+        tool_args={"x": "go"},
+        invoked_agent=invoked_agent,
+    )
+
+    a = _find_task(session.plan, "A")
+    b = _find_task(session.plan, "B")
+    assert a is not None and b is not None
+    assert a.assignee_agent_id == "patcher", (
+        f"tier-1 should pick A (required_tools=[patch_file] covered by "
+        f"agent); got A={a.assignee_agent_id!r} B={b.assignee_agent_id!r}"
+    )
+    assert b.assignee_agent_id == ""
+    assert session.current_task_id == "A"
+
+
+def test_tier2_agent_name_match_picks_reviewer_task() -> None:
+    """goldfive#265 tier 2: agent name ``reviewer_agent`` picks
+    ``review_presentation`` over ``outline_presentation`` and
+    ``draft_presentation``.
+
+    Reproduces the session-4538863f bug: the coordinator delegated to
+    ``reviewer_agent``, but the old tier-3-only pin picked
+    ``draft_presentation`` because it was DAG-next. With tier 2 the
+    stem ``reviewer`` substring-matches ``review_presentation``'s
+    title and the pin selects it.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    # All three DAG-ready PENDING (no edges between them).
+    plan = _plan(
+        Task(id="outline_presentation", title="Outline the presentation"),
+        Task(id="draft_presentation", title="Draft the presentation"),
+        Task(id="review_presentation", title="Review the presentation"),
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="reviewer_agent",
+        # tool_args carries a generic prompt that does NOT topic-match
+        # any specific candidate — proves tier 2 (not tier 3) fired.
+        tool_args={"request": "please proceed"},
+    )
+
+    outline = _find_task(session.plan, "outline_presentation")
+    draft = _find_task(session.plan, "draft_presentation")
+    review = _find_task(session.plan, "review_presentation")
+    assert outline is not None and draft is not None and review is not None
+    assert review.assignee_agent_id == "reviewer_agent", (
+        f"tier-2 should pick review_presentation for reviewer_agent; got "
+        f"outline={outline.assignee_agent_id!r} "
+        f"draft={draft.assignee_agent_id!r} "
+        f"review={review.assignee_agent_id!r}"
+    )
+    assert outline.assignee_agent_id == ""
+    assert draft.assignee_agent_id == ""
+    assert session.current_task_id == "review_presentation"
+
+
+def test_tier2_works_when_required_tools_empty() -> None:
+    """goldfive#265 tier 2 still picks correctly when no Tier 1 match
+    is possible (all candidates have empty required_tools).
+
+    Same fixture as the reviewer_agent case but explicitly with
+    ``invoked_agent`` passed and no tools — tier 1 returns ``None``
+    (no required_tools on any candidate), tier 2 fires.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        Task(id="outline_presentation", title="Outline the presentation"),
+        Task(id="draft_presentation", title="Draft the presentation"),
+        Task(id="review_presentation", title="Review the presentation"),
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    invoked_agent = _FakeInvokedAgent(name="reviewer_agent", tools=[])
+
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="reviewer_agent",
+        tool_args={"request": "please proceed"},
+        invoked_agent=invoked_agent,
+    )
+
+    review = _find_task(session.plan, "review_presentation")
+    assert review is not None and review.assignee_agent_id == "reviewer_agent"
+    assert session.current_task_id == "review_presentation"
+
+
+def test_tier3_fallback_when_no_name_overlap() -> None:
+    """goldfive#265 tier 3 (existing topo-order fallback) still wins
+    when agent name doesn't match any task title/description and no
+    required_tools are populated.
+
+    Agent ``web_developer_agent``; tasks have titles unrelated to
+    "developer" or "web". Tier 1 vacuous (no required_tools), tier 2
+    vacuous (no stem match), tier 3 picks the first eligible by plan
+    order.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        Task(id="t1", title="Compose the executive summary"),
+        Task(id="t2", title="Format the bibliography"),
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="web_developer_agent",
+        # No useful tokens (all sub-4-char so scorer is a no-op too).
+        tool_args={"x": "go"},
+    )
+
+    t1 = _find_task(session.plan, "t1")
+    t2 = _find_task(session.plan, "t2")
+    assert t1 is not None and t2 is not None
+    # Tier 3 fallback: first eligible by plan order.
+    assert t1.assignee_agent_id == "web_developer_agent"
+    assert t2.assignee_agent_id == ""
+    assert session.current_task_id == "t1"
+
+
+def test_tier2_ambiguous_agent_name_falls_through_to_tier3() -> None:
+    """goldfive#265 negative case: ambiguous agent name (e.g.
+    ``helper_agent``) doesn't match any task — tier 2 returns ``None``
+    and tier 3 (topo-order fallback) takes over cleanly without
+    crashing.
+
+    Also covers the "no stems after role-suffix strip" edge: the agent
+    name ``agent`` alone would strip to an empty stem tuple; ensure no
+    crash.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        Task(id="t1", title="Compose the executive summary"),
+        Task(id="t2", title="Format the bibliography"),
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="helper_agent",
+        tool_args={"x": "go"},
+    )
+
+    # Tier 3 fallback: helper doesn't match t1 or t2 titles, so we
+    # fall through to first-by-plan-order.
+    t1 = _find_task(session.plan, "t1")
+    assert t1 is not None
+    assert t1.assignee_agent_id == "helper_agent"
+    assert session.current_task_id == "t1"
+
+
+def test_tier1_wins_over_tier2_on_conflict() -> None:
+    """goldfive#265: when tier 1 (required_tools) and tier 2 (agent
+    name) would pick different tasks, tier 1 wins.
+
+    Two tasks:
+
+    * ``review_data``: required_tools=("query_db",), title contains
+      "review" so tier 2 would pick it.
+    * ``compile_report``: required_tools=("compile_report_tool",),
+      no agent-name overlap.
+
+    The agent is ``reviewer_agent`` (tier 2 stem ``reviewer``) but
+    only has the ``compile_report_tool`` tool — so tier 1 covers
+    ``compile_report`` uniquely. Tier 1 should win.
+    """
+    plugin = make_adk_plugin(host_agent_name="coord")
+    plan = _plan(
+        Task(
+            id="review_data",
+            title="review the dataset",
+            required_tools=("query_db",),
+        ),
+        Task(
+            id="compile_report",
+            title="produce the report",
+            required_tools=("compile_report_tool",),
+        ),
+    )
+    session = _session_with(plan)
+    ctx = _ctx(session)
+
+    invoked_agent = _FakeInvokedAgent(
+        name="reviewer_agent",
+        tools=[_FakeFunctionToolForCover("compile_report_tool")],
+    )
+
+    plugin._maybe_pin_delegation_task(
+        ctx=ctx,
+        invoked_agent_name="reviewer_agent",
+        tool_args={"x": "go"},
+        invoked_agent=invoked_agent,
+    )
+
+    review = _find_task(session.plan, "review_data")
+    compile_t = _find_task(session.plan, "compile_report")
+    assert review is not None and compile_t is not None
+    # Tier 1 wins on conflict — picked by required_tools cover.
+    assert compile_t.assignee_agent_id == "reviewer_agent"
+    assert review.assignee_agent_id == ""
+
+
 def test_idempotent_on_already_assigned_task() -> None:
     """Re-running the pin with the same agent on the same eligible task
     is a no-op (assignee already matches, no spurious plan swap)."""


### PR DESCRIPTION
## Summary

The observational pin (#259) used topo-next DAG-ready PENDING plus a topic-args token scorer to disambiguate multi-eligible candidates. Live session 4538863f-0dea-4fe8-97b4-5f660ee2cb7f surfaced a real gap: when the coordinator autonomously delegated to `reviewer_agent` while the topo-next DAG-ready task was `draft_presentation`, the pin bound the wrong task and the reasoning judge fired `OFF_TOPIC` drift ("agent is performing review work but its assigned task is draft_presentation").

This PR adds two structural tiers before the existing topo-order fallback in `_maybe_pin_delegation_task`:

- **Tier 1 - required-tools cover.** When the nested ADK agent is available, pick the unique candidate whose non-empty `Task.required_tools` is fully covered by the agent's live `.tools[*].name` surface. Same name surface `detect_capability_mismatch` Rule B consumes.
- **Tier 2 - agent-name semantic match.** Strip role-suffix tokens (`agent`, `worker`, `assistant`, `bot`, `tool`) from the invoked agent's name, filter to >= 4-char stems, and bi-directionally substring-match each stem against each candidate's title+description tokens. Bi-directional containment handles the common noun/verb pair `reviewer` <-> `review`.
- **Tier 3 (unchanged)** - topic-args scorer + first-by-plan-order fallback.

Each tier short-circuits on a unique pick; ambiguity falls through. Tier 1 wins on conflict with Tier 2 by construction (runs first). Both tiers use pure `str` ops; no regex (#166 / #167 retired the regex-based NL classifiers).

`invoked_agent` is an optional kwarg on `_maybe_pin_delegation_task` so legacy callers cleanly fall through to Tier 2 + Tier 3. The `before_tool_callback` call site passes `nested_agent` so the live path enables Tier 1. Behaviour is identical under `observation_only=True` and `observation_only=False`.

## Test plan

- [x] `pytest tests/test_delegation_pin.py -x -q` — 16 passed (10 pre-existing + 6 new)
- [x] `pytest tests/ -q` — 2408 passed, 59 skipped
- [x] `ruff check .` — clean
- [x] Tier-1 wins over topo-order on required_tools cover
- [x] Tier-2 picks `review_presentation` for `reviewer_agent` against outline/draft/review (the session-4538863f case)
- [x] Tier-2 still works with empty required_tools
- [x] Tier-3 fallback when no name overlap
- [x] Ambiguous agent name falls through to tier 3 cleanly
- [x] Tier-1 wins over tier-2 on conflict