### PR TITLE
fix(judge): record shutdown-cancel as CANCELLED, not FAILED (closes #266)

### DIFF
--- a/goldfive/_llm_span.py
+++ b/goldfive/_llm_span.py
@@ -80,10 +80,20 @@ Design notes
   callers that set them before the raise get retrospective context on
   the failure event; callers that don't see empty strings. The
   exception is re-raised.
+* Special case (goldfive#266): when the wrapped body raises
+  :class:`asyncio.CancelledError` AND the current task carries
+  :data:`DRAIN_INITIATED_ATTR` (stamped by the steerer's drain path at
+  run boundary), the ``SpanEnd`` is emitted with ``status="cancelled"``
+  + a benign reason ("drained at run boundary") instead of
+  ``status="failed"``. This distinguishes routine shutdown-initiated
+  teardowns from genuine errors so harmonograf renders the span
+  neutrally on the Gantt rather than red with a CancelledError stack.
+  The cancel BEHAVIOUR is unchanged — only the observability axis.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import uuid
@@ -93,6 +103,30 @@ from dataclasses import dataclass, field
 from typing import Any
 
 log = logging.getLogger(__name__)
+
+# goldfive#266 — task-attribute marker that the steerer's drain path stamps
+# onto in-flight background judge / drift tasks before issuing
+# ``task.cancel()`` at run boundary. ``goldfive_llm_span`` reads this off
+# ``asyncio.current_task()`` on its ``CancelledError`` path so the resulting
+# ``GoldfiveLLMCallEnd`` reports ``status="cancelled"`` with a benign reason
+# instead of ``status="failed"`` with a ``CancelledError`` traceback. The
+# cancel BEHAVIOUR is unchanged — only the observability is corrected so
+# operators stop seeing red ``judge_reasoning`` spans for routine
+# shutdown-initiated teardowns. See ``_drain_background_set`` for the
+# producer side. Public-ish (single underscore, exported through __all__)
+# so the steerer can reference it without resorting to a magic string.
+DRAIN_INITIATED_ATTR = "_goldfive_drain_initiated"
+
+# Wire-level status string emitted when a drain-initiated cancel is
+# detected. Distinct from ``"failed"`` (genuine error) and ``"completed"``
+# (normal exit) so harmonograf can map it to ``SPAN_STATUS_CANCELLED``.
+_STATUS_CANCELLED = "cancelled"
+_STATUS_FAILED = "failed"
+_STATUS_COMPLETED = "completed"
+# Reason text stamped onto ``GoldfiveLLMCallEnd.error`` for drain-initiated
+# cancels. Benign — operators reading the field see the lifecycle reason
+# instead of a CancelledError traceback fragment.
+_CANCEL_REASON_DRAIN = "drained at run boundary"
 
 # Error text on ``GoldfiveLLMCallEnd.error`` is capped so a pathological
 # traceback can't blow the event wire budget. Matches the truncation
@@ -115,6 +149,31 @@ def _truncate(s: str, limit: int = _MAX_ERROR_CHARS) -> str:
     if len(s) <= limit:
         return s
     return s[: max(0, limit - len(_TRUNC_SUFFIX))] + _TRUNC_SUFFIX
+
+
+def _is_drain_initiated_cancel() -> bool:
+    """Return True when the currently-running task was tagged by the
+    steerer's drain path before its ``task.cancel()`` arrived.
+
+    The steerer's :meth:`DefaultSteerer._drain_background_set` stamps
+    :data:`DRAIN_INITIATED_ATTR` onto each background judge / drift task
+    immediately before calling :meth:`task.cancel()`. Reading the
+    attribute off :func:`asyncio.current_task` lets the span helper —
+    which lives several frames inside the cancelled task — distinguish
+    a lifecycle-initiated teardown from a genuine cancel without
+    plumbing a flag through every classifier call signature.
+
+    Returns False when no task is current (rare; only synchronous test
+    harnesses) so the legacy ``failed`` branch wins by default — the
+    cancel obviously didn't come from goldfive's drain in that case.
+    """
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:
+        return False
+    if task is None:
+        return False
+    return bool(getattr(task, DRAIN_INITIATED_ATTR, False))
 
 
 @dataclass
@@ -273,6 +332,15 @@ async def goldfive_llm_span(
     ``decision_summary`` are still read — a caller that partially
     populated them before the raise gets that context on the failure
     event; a caller that didn't populate them sees empty strings.
+
+    goldfive#266 — drain-initiated CancelledError exception (the
+    steerer's :meth:`drain_session_background_tasks` stamps
+    :data:`DRAIN_INITIATED_ATTR` on the task before issuing
+    ``task.cancel()``) is special-cased: ``status="cancelled"`` +
+    a benign reason replaces the ``failed`` classification so live
+    sessions don't render routine run-boundary teardowns of
+    in-flight judge calls as red error spans. Cancel BEHAVIOUR is
+    unchanged; this is an observability-only refinement.
     """
     span_id = uuid.uuid4().hex
     start_ns = time.time_ns()
@@ -316,13 +384,27 @@ async def goldfive_llm_span(
                     exc,
                 )
 
-    status = "completed"
+    status = _STATUS_COMPLETED
     error_text = ""
     try:
         yield handle
     except BaseException as exc:
-        status = "failed"
-        error_text = _truncate(f"{type(exc).__name__}: {exc}")
+        # goldfive#266 — when a CancelledError is raised AND the current
+        # task carries the drain-initiated marker the steerer stamped on
+        # before cancelling us, classify the span as ``cancelled`` rather
+        # than ``failed``. Live sessions used to surface routine
+        # run-boundary teardowns as red ``judge_reasoning`` spans with
+        # CancelledError stack traces; this preserves the cancel
+        # behaviour and only corrects the observability. Genuine
+        # cancels from elsewhere (caller-driven asyncio.CancelledError,
+        # USER_CANCEL flow) keep the ``failed`` classification so
+        # operators can still spot real cancel-induced aborts.
+        if isinstance(exc, asyncio.CancelledError) and _is_drain_initiated_cancel():
+            status = _STATUS_CANCELLED
+            error_text = _CANCEL_REASON_DRAIN
+        else:
+            status = _STATUS_FAILED
+            error_text = _truncate(f"{type(exc).__name__}: {exc}")
         raise
     finally:
         end_ns = time.time_ns()
@@ -362,4 +444,4 @@ async def goldfive_llm_span(
                     )
 
 
-__all__ = ["GoldfiveLLMSpanHandle", "goldfive_llm_span"]
+__all__ = ["DRAIN_INITIATED_ATTR", "GoldfiveLLMSpanHandle", "goldfive_llm_span"]

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -1885,6 +1885,32 @@ class DefaultSteerer:
         pending = list(bg_set)
         if not pending:
             return
+        # goldfive#266 — tag every pending task BEFORE the bounded wait
+        # so the in-flight ``goldfive_llm_span`` context manager (e.g.
+        # inside a ``judge_reasoning`` call) can read the marker off
+        # ``asyncio.current_task()`` on its CancelledError path and emit
+        # ``status="cancelled"`` with a benign reason rather than
+        # ``status="failed"`` with a CancelledError traceback. We stamp
+        # upfront — not just on the post-timeout straggler-cancel branch
+        # — because :func:`asyncio.wait_for` itself cancels its inner
+        # awaitable on timeout, and that cancellation can race ahead of
+        # the explicit ``task.cancel()`` below; tagging before the wait
+        # makes the marker race-free. Tasks that complete naturally
+        # within the timeout never observe a CancelledError so the
+        # attribute is harmless on them. The cancel BEHAVIOUR is
+        # unchanged; only the span-status observability is corrected so
+        # live sessions stop showing red judge spans for routine
+        # run-boundary teardowns.
+        from goldfive._llm_span import DRAIN_INITIATED_ATTR
+
+        for task in pending:
+            try:
+                setattr(task, DRAIN_INITIATED_ATTR, True)
+            except (AttributeError, TypeError):  # noqa: PERF203 — defensive
+                # asyncio.Task allows arbitrary attribute writes in
+                # CPython today; the try/except is purely defensive
+                # against future hardening / alternate implementations.
+                pass
         try:
             await asyncio.wait_for(
                 asyncio.gather(*pending, return_exceptions=True),
@@ -1892,7 +1918,9 @@ class DefaultSteerer:
             )
         except TimeoutError:
             # Cancel the stragglers and give them a beat to unwind so
-            # we don't leave "pending task" warnings on loop close.
+            # we don't leave "pending task" warnings on loop close. The
+            # drain-initiated marker is already on each task from the
+            # tagging loop above.
             still_pending = [t for t in pending if not t.done()]
             for task in still_pending:
                 task.cancel()

--- a/tests/test_llm_span.py
+++ b/tests/test_llm_span.py
@@ -394,3 +394,152 @@ async def test_planner_without_span_context_provider_noops() -> None:
 
     planner = LLMPlanner(call_llm=fake_call_llm, model="gpt-x")
     assert planner._span_kwargs() == {"sinks": [], "model": "gpt-x"}
+
+
+# ---------------------------------------------------------------------------
+# goldfive#266 — shutdown-initiated cancel surfaces as ``cancelled``, not
+# ``failed``. Live session 4538863f-0dea-4fe8-97b4-5f660ee2cb7f surfaced
+# routine ``_drain_steerer_at_run_boundary`` teardowns as red
+# ``judge_reasoning`` spans with CancelledError stack traces. The fix
+# threads a per-task marker the drain stamps before issuing
+# ``task.cancel()`` so the span helper can emit
+# ``status="cancelled"`` with a benign reason — preserving the cancel
+# BEHAVIOUR, correcting only the observability. Genuine cancels (caller-
+# driven asyncio.CancelledError from outside the drain) still surface as
+# ``failed`` so operators can spot real cancel-induced aborts.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_inside_drain_marker_surfaces_as_cancelled() -> None:
+    """When the steerer-drain marker is on the current task, a CancelledError
+    inside the span body produces ``status="cancelled"``."""
+    from goldfive._llm_span import DRAIN_INITIATED_ATTR
+
+    sink = InMemorySink()
+    started = asyncio.Event()
+
+    async def body() -> None:
+        # Simulate the drain having marked us BEFORE issuing the cancel.
+        # In production this is set by ``_drain_background_set`` on the
+        # judge task object; in this unit test we stamp the same marker
+        # on the current task so the span helper observes the same
+        # signal.
+        current = asyncio.current_task()
+        assert current is not None
+        setattr(current, DRAIN_INITIATED_ATTR, True)
+        async with goldfive_llm_span(
+            sinks=[sink], name="judge_reasoning", model="gpt-judge"
+        ):
+            started.set()
+            # Sleep until cancelled — the drain-issued cancel arrives
+            # here, propagates into the span helper, and the helper
+            # detects the marker.
+            await asyncio.sleep(60)
+
+    task = asyncio.create_task(body())
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    events = _span_events(sink)
+    assert len(events) == 2, f"expected start+end, got {events}"
+    end = events[1].goldfive_llm_call_end
+    assert end.status == "cancelled", (
+        f"drain-initiated cancel should surface as status=cancelled, "
+        f"got status={end.status!r}, error={end.error!r}"
+    )
+    assert "drained" in end.error.lower() or "boundary" in end.error.lower(), (
+        f"cancelled span should carry a benign drain reason; "
+        f"got error={end.error!r}"
+    )
+    # Genuine error indicators MUST be absent — operators must not see
+    # ``CancelledError`` or a stack-trace fragment for routine drains.
+    assert "CancelledError" not in end.error
+    assert "Traceback" not in end.error
+
+
+@pytest.mark.asyncio
+async def test_cancel_outside_drain_preserves_failed() -> None:
+    """A CancelledError WITHOUT the drain marker still surfaces as
+    ``status="failed"`` — the legacy behaviour for genuine cancels
+    (e.g. caller-driven asyncio.CancelledError, USER_CANCEL) is
+    preserved."""
+    sink = InMemorySink()
+    started = asyncio.Event()
+
+    async def body() -> None:
+        # No DRAIN_INITIATED_ATTR set on the current task.
+        async with goldfive_llm_span(
+            sinks=[sink], name="judge_reasoning", model="gpt-judge"
+        ):
+            started.set()
+            await asyncio.sleep(60)
+
+    task = asyncio.create_task(body())
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    events = _span_events(sink)
+    assert len(events) == 2
+    end = events[1].goldfive_llm_call_end
+    assert end.status == "failed", (
+        f"non-drain cancel should preserve status=failed; "
+        f"got status={end.status!r}"
+    )
+    # The error text still carries the CancelledError diagnostic for
+    # genuine cancels — that's the back-compat behaviour the negative
+    # case relies on.
+    assert "CancelledError" in end.error
+
+
+@pytest.mark.asyncio
+async def test_drain_marker_tags_judge_task_and_span_records_cancelled() -> None:
+    """End-to-end: the steerer's drain stamps the marker on the
+    in-flight judge task, the cancellation propagates into the
+    ``judge_reasoning`` span body, and the resulting
+    ``GoldfiveLLMCallEnd`` reports ``status="cancelled"``.
+
+    This is the goldfive#266 fix exercised through the actual drain
+    code path — not just the span helper unit. Pins the integration
+    between :meth:`DefaultSteerer._drain_background_set` and the
+    span's CancelledError handler."""
+    from goldfive._llm_span import DRAIN_INITIATED_ATTR, goldfive_llm_span
+
+    sink = InMemorySink()
+    started = asyncio.Event()
+    saw_cancel: dict[str, bool] = {"hit": False}
+
+    async def judge_body() -> None:
+        # Reproduce the reasoning-judge body shape: open the
+        # judge_reasoning span and block on a long await that
+        # ``task.cancel()`` will interrupt — exactly the live-session
+        # symptom shape.
+        try:
+            async with goldfive_llm_span(
+                sinks=[sink], name="judge_reasoning", model="m"
+            ):
+                started.set()
+                await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            saw_cancel["hit"] = True
+            raise
+
+    task = asyncio.create_task(judge_body(), name="goldfive-reasoning-judge:s-fix")
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+    # Reproduce ``_drain_background_set``'s tag-then-cancel pattern.
+    setattr(task, DRAIN_INITIATED_ATTR, True)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert saw_cancel["hit"] is True
+
+    events = _span_events(sink)
+    assert len(events) == 2
+    end = events[1].goldfive_llm_call_end
+    assert end.name == "judge_reasoning"
+    assert end.status == "cancelled"
+    assert "drained" in end.error.lower() or "boundary" in end.error.lower()


### PR DESCRIPTION
## Summary

Live session 4538863f-0dea-4fe8-97b4-5f660ee2cb7f surfaced routine
`judge_reasoning` teardowns at run boundary as red **FAILED** spans with
`CancelledError` stack traces. The cancel itself is correct lifecycle —
only the observability was wrong.

## Mechanism

`DefaultSteerer._drain_background_set` (called from
`_drain_steerer_at_run_boundary`) cancels in-flight background judge /
drift tasks at run boundary. The in-flight `judge_reasoning` span helper
(`goldfive_llm_span`) caught the `CancelledError` under its
`except BaseException` arm and emitted `status="failed"` indistinguishable
from a genuine error.

## Surgical change

- `_drain_background_set` stamps `_goldfive_drain_initiated = True` on
  each pending task **before** the bounded wait (race-free vs.
  `asyncio.wait_for`'s own cancellation of the gather).
- `goldfive_llm_span`, on `CancelledError`, reads the marker off
  `asyncio.current_task()`. When set: `status="cancelled"`,
  `error="drained at run boundary"`. When **not** set: existing
  `status="failed"` preserved so genuine cancels (caller-driven
  `asyncio.CancelledError`, `USER_CANCEL` path) still surface as errors.
- Cancel **behaviour** is unchanged. Only the span-status axis.

## Test plan

- [x] Unit: drain-marker present → `status="cancelled"`, benign reason
  text, **no** `CancelledError` / `Traceback` fragments leak.
- [x] Negative: no drain marker (genuine cancel) → `status="failed"` is
  preserved with the `CancelledError` diagnostic intact.
- [x] Integration: tag-then-cancel through the actual drain-shaped
  pattern with a `judge_reasoning` span body.
- [x] Full goldfive test suite (2405 tests) still passes.

Companion harmonograf PR extends `harmonograf_client/sink.py` to map
`wire_status == "cancelled"` onto `SPAN_STATUS_CANCELLED` end-to-end.