### PR TITLE
fix(drift): add capability_check Rule C — agent role-stem vs bound-task mismatch (closes #268)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -43,6 +43,25 @@ from collections.abc import Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any
 
 from goldfive.adapters._tool_invocation import invoke_tool
+
+# goldfive#268 — shared helpers for agent-name stem matching and
+# tokenisation. Lifted out of this module into
+# :mod:`goldfive.drift.capability_check` so the delegation-pin
+# disambiguator (#265 tier 2) and the structural capability detector's
+# Rule C consume one source of truth. Renamed under their historical
+# module-private names so existing in-module references keep working.
+from goldfive.drift.capability_check import (
+    AGENT_NAME_ROLE_SUFFIXES as _AGENT_NAME_ROLE_SUFFIXES_SHARED,
+)
+from goldfive.drift.capability_check import (
+    agent_name_stems as _agent_name_stems_shared,
+)
+from goldfive.drift.capability_check import (
+    stem_token_match as _stem_token_match_shared,
+)
+from goldfive.drift.capability_check import (
+    tokenize_for_matching as _tokenize_for_matching_shared,
+)
 from goldfive.orchestration_store import (
     PENDING_DELEGATIONS_KEY,
     BindingSource,
@@ -918,32 +937,15 @@ def _function_call_id_from_tool_context(tool_context: Any) -> str:
     return ""
 
 
-def _tokenize_for_matching(text: Any) -> set[str]:
-    """Return the set of lowercase alphanumeric tokens of length ≥4.
-
-    Used by :func:`_score_candidates_by_args` to score candidate tasks
-    against AgentTool args. The ≥4 threshold filters out noisy
-    short-word matches ("in", "of", "the") that would otherwise
-    saturate every candidate's score.
-    """
-    if not isinstance(text, str):
-        text = str(text or "")
-    tokens: set[str] = set()
-    buf: list[str] = []
-    for ch in text.lower():
-        if ch.isalnum():
-            buf.append(ch)
-        else:
-            if buf:
-                tok = "".join(buf)
-                if len(tok) >= 4:
-                    tokens.add(tok)
-                buf.clear()
-    if buf:
-        tok = "".join(buf)
-        if len(tok) >= 4:
-            tokens.add(tok)
-    return tokens
+#: Goldfive#268 lifted this helper into
+#: :mod:`goldfive.drift.capability_check` so the structural capability
+#: detector (Rule C) and the delegation-pin disambiguator share one
+#: source of truth. ``_tokenize_for_matching`` remains the
+#: module-private import surface used here (Tier-3 args scorer,
+#: Tier-2 stem match); see
+#: :func:`goldfive.drift.capability_check.tokenize_for_matching` for
+#: the implementation.
+_tokenize_for_matching = _tokenize_for_matching_shared
 
 
 def _score_candidates_by_args(candidates: list[Any], tool_args: Any) -> Any:
@@ -992,55 +994,21 @@ def _score_candidates_by_args(candidates: list[Any], tool_args: Any) -> Any:
     return best
 
 
-#: Trailing role-suffix tokens stripped from an invoked-agent name during
-#: stem extraction for the goldfive#265 tier-2 semantic match. Conservative
-#: by design: only role-marker tokens that almost never carry topic
-#: meaning. Keep small — adding common verbs/nouns here would suppress
-#: legitimate matches (e.g. dropping "researcher" from "researcher_agent"
-#: leaves the empty stem and nothing matches).
-_AGENT_NAME_ROLE_SUFFIXES: frozenset[str] = frozenset(
-    {"agent", "worker", "assistant", "bot", "tool"}
-)
+#: Goldfive#268 lifted this constant into
+#: :mod:`goldfive.drift.capability_check` so the structural capability
+#: detector (Rule C) and the delegation-pin tier-2 disambiguator share
+#: one source of truth. The module-private alias is kept so existing
+#: in-module references and unit tests that patched the symbol on this
+#: module continue to resolve.
+_AGENT_NAME_ROLE_SUFFIXES: frozenset[str] = _AGENT_NAME_ROLE_SUFFIXES_SHARED
 
 
-def _agent_name_stems(agent_name: str) -> tuple[str, ...]:
-    """Return ordered lowercase stem tokens derived from an ADK agent name.
-
-    Goldfive#265 tier-2 semantic match. The invoked agent's display name
-    (e.g. ``reviewer_agent``) is split on underscore/hyphen/space, lower-
-    cased, role-suffix tokens (``agent``, ``worker``, …) trimmed from the
-    tail, and remaining tokens of length >= 4 returned. Length filter
-    matches :func:`_tokenize_for_matching` so the stems are comparable
-    against title/description tokens.
-
-    Examples
-    --------
-    >>> _agent_name_stems("reviewer_agent")
-    ('reviewer',)
-    >>> _agent_name_stems("web_developer_agent")
-    ('developer',)  # 'web' is < 4 chars and filtered out
-    >>> _agent_name_stems("helper_agent")
-    ('helper',)
-    >>> _agent_name_stems("agent")
-    ()
-
-    Deliberately **no regex** — goldfive#166 / #167 retired the regex-
-    based NL classifiers. Pure str ops only.
-    """
-    if not isinstance(agent_name, str) or not agent_name:
-        return ()
-    # Normalise common separators to spaces, then split.
-    norm = agent_name.replace("_", " ").replace("-", " ").lower()
-    raw_tokens = [tok for tok in norm.split() if tok]
-    # Trim role-suffix tokens off the tail (left-to-right) so
-    # ``reviewer_agent`` -> ``reviewer`` and
-    # ``draft_writer_assistant_bot`` -> ``draft writer``.
-    while raw_tokens and raw_tokens[-1] in _AGENT_NAME_ROLE_SUFFIXES:
-        raw_tokens.pop()
-    # Length filter mirrors _tokenize_for_matching's >=4 threshold so
-    # noisy short tokens ("ui", "qa") don't saturate matches.
-    out = tuple(tok for tok in raw_tokens if len(tok) >= 4)
-    return out
+#: Goldfive#268: thin alias over
+#: :func:`goldfive.drift.capability_check.agent_name_stems`. See the
+#: docstring there for behaviour, examples and the rationale for the
+#: role-suffix list. The local symbol stays so call sites in this
+#: module don't need to update import paths.
+_agent_name_stems = _agent_name_stems_shared
 
 
 def _agent_tool_names(invoked_agent: Any) -> tuple[str, ...]:
@@ -1104,30 +1072,11 @@ def _select_by_required_tools(
     return None
 
 
-def _stem_token_match(stem: str, token: str) -> bool:
-    """Return True when ``stem`` and ``token`` share a meaningful root.
-
-    Bi-directional substring match: catches both stem-is-prefix-of-token
-    (``review`` -> ``reviewer``) and token-is-prefix-of-stem
-    (``reviewer`` -> ``review``). This handles the common
-    role-noun/verb pair where the agent name carries the agent-noun
-    form and the task carries the verb form (or vice versa).
-
-    Pure str ops — no regex (goldfive#166 / #167).
-    """
-    if not stem or not token:
-        return False
-    # Short-circuit on exact and direct substring matches; covers the
-    # most common case.
-    if stem == token:
-        return True
-    # Bi-directional containment: ``reviewer`` ⊇ ``review`` AND
-    # ``review`` ⊆ ``reviewer``. Both are length-bounded by the >=4
-    # filter applied upstream so noise like "is" / "of" cannot reach
-    # this check.
-    if stem in token or token in stem:
-        return True
-    return False
+#: Goldfive#268: thin alias over
+#: :func:`goldfive.drift.capability_check.stem_token_match`. See the
+#: docstring there for behaviour (bi-directional substring match
+#: between an agent stem and a task token).
+_stem_token_match = _stem_token_match_shared
 
 
 def _select_by_agent_name_stems(
@@ -4567,11 +4516,32 @@ def make_adk_plugin(
                 return
 
             tool_list = list(_safe_attr(invoked_agent, "tools", None) or [])
+            # goldfive#268 — gather the full PENDING set (DAG-ready and
+            # not) so Rule C can do its cross-task stem lookup. The bound
+            # task may itself be PENDING; the detector's Rule C
+            # excludes it by id. Defensive: never let this introspection
+            # block the detector — fall back to an empty tuple so Rules
+            # A/B still run.
+            pending_tasks: tuple[Any, ...] = ()
+            try:
+                pending_tasks = tuple(
+                    t
+                    for t in tasks
+                    if _safe_attr(t, "status", None) is TaskStatus.PENDING
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_maybe_emit_capability_mismatch: pending-tasks "
+                    "collection raised: %s",
+                    exc,
+                )
+                pending_tasks = ()
             try:
                 drift = detect_capability_mismatch(
                     invoked_agent_name=invoked_agent_name,
                     invoked_agent_tools=tool_list,
                     task=chosen_task,
+                    all_pending_tasks=pending_tasks,
                 )
             except Exception as exc:  # noqa: BLE001 — detector must not block
                 log.debug(

--- a/goldfive/drift/capability_check.py
+++ b/goldfive/drift/capability_check.py
@@ -2,7 +2,7 @@
 
 Fires :class:`~goldfive.types.DriftKind.CAPABILITY_MISMATCH` when the
 agent the coordinator delegated to *structurally* cannot perform the
-bound task. Two narrow rules; false positives are worse than false
+bound task. Three narrow rules; false positives are worse than false
 negatives at this layer because every fire cancels the in-flight
 invocation and triggers a planner refine.
 
@@ -27,7 +27,18 @@ Detection rules (intentionally surgical):
   CRITICAL. Skipped entirely when the advisory is empty (legacy plans
   and planners that don't populate it are a no-op).
 
-Both rules return :class:`~goldfive.types.DriftEvent` carrying the
+* **Rule C — out-of-DAG-order delegation (goldfive#268).** When the
+  invoked agent's *role stem* (the head of its name, with role-suffix
+  tokens like ``agent``/``worker`` trimmed) is absent from the bound
+  task's title+description AND present in some OTHER pending task,
+  the pin has bound the delegation to a structurally-wrong task —
+  typically because the coordinator dispatched a downstream agent
+  before its DAG predecessors completed and the pin had only one
+  eligible candidate to choose from. Fires CRITICAL. Requires the
+  caller to pass ``all_pending_tasks`` so the cross-task lookup can
+  see non-DAG-ready tasks too; otherwise the rule is silent.
+
+All three rules return :class:`~goldfive.types.DriftEvent` carrying the
 agent name + bound task id + the structural gap, suitable for the
 goldfive intervention ladder. The detector is framework-neutral: it
 takes ADK ``Tool`` objects but only reads their attributes (``.agent``
@@ -37,6 +48,7 @@ for AgentTool detection, ``.name`` for the required-tools cover).
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Task
@@ -45,10 +57,124 @@ log = logging.getLogger(__name__)
 
 
 __all__ = [
+    "AGENT_NAME_ROLE_SUFFIXES",
     "DELEGATION_VERB_MARKERS",
+    "agent_name_stems",
     "detect_capability_mismatch",
     "is_agent_tool",
+    "stem_token_match",
+    "tokenize_for_matching",
 ]
+
+
+#: Trailing role-suffix tokens stripped from an invoked-agent name during
+#: stem extraction. Lifted out of :mod:`goldfive.adapters._adk_plugin`
+#: (the goldfive#265 tier-2 disambiguator) so both call sites — the
+#: delegation-pin selector AND the goldfive#268 Rule C detector — share
+#: one definition.
+#:
+#: Conservative by design: only role-marker tokens that almost never
+#: carry topic meaning. Keep small — adding common verbs/nouns here
+#: would suppress legitimate matches (e.g. dropping ``researcher`` from
+#: ``researcher_agent`` leaves the empty stem and nothing matches).
+AGENT_NAME_ROLE_SUFFIXES: frozenset[str] = frozenset(
+    {"agent", "worker", "assistant", "bot", "tool"}
+)
+
+
+def tokenize_for_matching(text: Any) -> set[str]:
+    """Return the set of lowercase alphanumeric tokens of length ≥4.
+
+    Shared with :mod:`goldfive.adapters._adk_plugin` (Tier-3 args
+    scorer + Tier-2 stem match). The ≥4 threshold filters out noisy
+    short-word matches ("in", "of", "the") that would otherwise
+    saturate every comparison. No regex — goldfive#166 / #167.
+    """
+    if not isinstance(text, str):
+        text = str(text or "")
+    tokens: set[str] = set()
+    buf: list[str] = []
+    for ch in text.lower():
+        if ch.isalnum():
+            buf.append(ch)
+        else:
+            if buf:
+                tok = "".join(buf)
+                if len(tok) >= 4:
+                    tokens.add(tok)
+                buf.clear()
+    if buf:
+        tok = "".join(buf)
+        if len(tok) >= 4:
+            tokens.add(tok)
+    return tokens
+
+
+def agent_name_stems(agent_name: str) -> tuple[str, ...]:
+    """Return ordered lowercase stem tokens derived from an ADK agent name.
+
+    Splits on underscore/hyphen/space, lowercases, trims trailing
+    role-suffix tokens (``agent``, ``worker``, …), and keeps tokens of
+    length ≥4. Same surface :mod:`goldfive.adapters._adk_plugin` uses
+    for its goldfive#265 tier-2 disambiguator; lifted here so the #268
+    Rule C detector can share one source of truth.
+
+    Examples
+    --------
+    >>> agent_name_stems("reviewer_agent")
+    ('reviewer',)
+    >>> agent_name_stems("web_developer_agent")
+    ('developer',)
+    >>> agent_name_stems("helper_agent")
+    ('helper',)
+    >>> agent_name_stems("agent")
+    ()
+
+    No regex (goldfive#166 / #167). Pure str ops.
+    """
+    if not isinstance(agent_name, str) or not agent_name:
+        return ()
+    norm = agent_name.replace("_", " ").replace("-", " ").lower()
+    raw_tokens = [tok for tok in norm.split() if tok]
+    while raw_tokens and raw_tokens[-1] in AGENT_NAME_ROLE_SUFFIXES:
+        raw_tokens.pop()
+    return tuple(tok for tok in raw_tokens if len(tok) >= 4)
+
+
+def stem_token_match(stem: str, token: str) -> bool:
+    """Return True when ``stem`` and ``token`` share a meaningful root.
+
+    Bi-directional substring match: ``review`` → ``reviewer`` AND
+    ``reviewer`` → ``review``. Catches the common role-noun/verb pair
+    where the agent name carries the agent-noun form and the task
+    carries the verb form (or vice versa). Pure str ops — no regex
+    (goldfive#166 / #167).
+    """
+    if not stem or not token:
+        return False
+    if stem == token:
+        return True
+    if stem in token or token in stem:
+        return True
+    return False
+
+
+def _task_text_contains_stem(task: Task, stem: str) -> bool:
+    """Return True when ``stem`` appears in task title+description tokens.
+
+    Bi-directional containment via :func:`stem_token_match` against the
+    ≥4-char tokens extracted from the task's title+description, mirror-
+    ing the goldfive#265 Tier-2 selector exactly.
+    """
+    title = str(getattr(task, "title", "") or "")
+    desc = str(getattr(task, "description", "") or "")
+    tokens = tokenize_for_matching(f"{title} {desc}")
+    if not tokens:
+        return False
+    for tok in tokens:
+        if stem_token_match(stem, tok):
+            return True
+    return False
 
 
 #: Phrases that mark a task as *delegation/coordination* shaped rather
@@ -131,6 +257,7 @@ def detect_capability_mismatch(
     invoked_agent_name: str,
     invoked_agent_tools: list[Any],
     task: Task,
+    all_pending_tasks: Sequence[Task] | None = None,
 ) -> DriftEvent | None:
     """Return a CAPABILITY_MISMATCH drift if ``invoked_agent_name`` cannot perform ``task``.
 
@@ -147,14 +274,23 @@ def detect_capability_mismatch(
     task:
         The :class:`~goldfive.types.Task` the coordinator bound to the
         delegation. ``required_tools`` powers Rule B; ``title`` /
-        ``description`` power Rule A's leaf-task heuristic.
+        ``description`` power Rule A's leaf-task heuristic and Rule C's
+        cross-task stem check.
+    all_pending_tasks:
+        Every ``PENDING`` task in the plan (DAG-ready and not). Powers
+        the goldfive#268 Rule C cross-task lookup. ``None`` /empty
+        disables Rule C — legacy callers and tests that don't pass it
+        keep their pre-#268 behaviour exactly.
 
     Returns
     -------
     DriftEvent | None
-        ``None`` when neither rule trips OR when ``invoked_agent_tools``
-        is empty AND ``required_tools`` is empty (no signal). A
-        ``DriftEvent`` with ``severity=CRITICAL`` otherwise.
+        ``None`` when no rule trips OR when ``invoked_agent_tools`` is
+        empty AND ``required_tools`` is empty AND Rule C has no signal.
+        A ``DriftEvent`` with ``severity=CRITICAL`` otherwise. Rules
+        evaluate in order B → A → C; the first to fire wins so the
+        higher-confidence signal (B, then A, then C) takes precedence
+        and the steerer's refine only sees one verdict per delegation.
     """
     if task is None:
         return None
@@ -205,4 +341,97 @@ def detect_capability_mismatch(
                 current_agent_id=invoked_agent_name,
             )
 
+    # Rule C — out-of-DAG-order delegation (goldfive#268). When the
+    # invoked agent's role stem doesn't appear in the bound task but
+    # DOES appear in another PENDING task, the pin has bound the
+    # delegation to a structurally-wrong task. Mirror live evidence:
+    # ``reviewer_agent`` pinned to ``draft_slides`` while
+    # ``review_presentation`` sits PENDING and not-yet-DAG-ready, the
+    # pin's tier-2 stem disambiguator couldn't help because only one
+    # task was eligible. Rule C fires on that exact shape.
+    #
+    # Cross-task signal — needs the full PENDING set (DAG-ready and
+    # not). Silent when the caller didn't pass it, when the agent
+    # name produces no usable stem (generic ``coordinator_agent`` style
+    # names degrade gracefully), or when no other PENDING task
+    # mentions the stem (in which case Rule C has nothing to say — the
+    # pin is just doing its best with a generic agent).
+    drift_c = _rule_c_dag_order(
+        invoked_agent_name=invoked_agent_name,
+        bound_task=task,
+        all_pending_tasks=all_pending_tasks,
+    )
+    if drift_c is not None:
+        return drift_c
+
+    return None
+
+
+def _rule_c_dag_order(
+    *,
+    invoked_agent_name: str,
+    bound_task: Task,
+    all_pending_tasks: Sequence[Task] | None,
+) -> DriftEvent | None:
+    """Rule C: detect out-of-DAG-order delegation (goldfive#268).
+
+    Returns a CAPABILITY_MISMATCH ``DriftEvent`` iff the agent's role
+    stem is *absent* from the bound task's title+description AND
+    *present* in some other PENDING task. Otherwise ``None``.
+
+    Conservative bail-outs (all return ``None``):
+
+    * ``all_pending_tasks`` is ``None`` or empty.
+    * The agent name produces no stem of length ≥4
+      (``coordinator_agent`` → ``coordinator`` is a stem, but a generic
+      ``agent`` / ``worker`` collapses to the empty tuple and we skip).
+    * The stem is already present in the bound task — no conflict, the
+      pin is on the right task.
+    * No other PENDING task mentions the stem either — Rule C has no
+      strong signal of cross-task confusion.
+    """
+    if not all_pending_tasks:
+        return None
+    stems = agent_name_stems(invoked_agent_name)
+    if not stems:
+        return None
+
+    bound_id = str(getattr(bound_task, "id", "") or "")
+
+    # For each stem, check: absent-from-bound AND present-in-other.
+    # Iterate stems so multi-stem names ("draft_writer_agent" -> draft +
+    # writer) get a chance to match. Fire on the first stem that has
+    # the (absent here, present there) shape.
+    for stem in stems:
+        if _task_text_contains_stem(bound_task, stem):
+            # Stem present in bound — no conflict for this stem, try
+            # the next stem before giving up.
+            continue
+        other_match: Task | None = None
+        for other in all_pending_tasks:
+            other_id = str(getattr(other, "id", "") or "")
+            if not other_id or other_id == bound_id:
+                continue
+            if _task_text_contains_stem(other, stem):
+                other_match = other
+                break
+        if other_match is None:
+            continue
+        other_id = str(getattr(other_match, "id", "") or "")
+        other_title = str(getattr(other_match, "title", "") or "")
+        bound_title = str(getattr(bound_task, "title", "") or "")
+        detail = (
+            f"agent {invoked_agent_name!r} bound to task "
+            f"{bound_id!r} ({bound_title[:80]!r}) but agent's role-stem "
+            f"{stem!r} matches PENDING task {other_id!r} "
+            f"({other_title[:80]!r}); the coordinator likely "
+            f"delegated out of DAG order"
+        )
+        return DriftEvent(
+            kind=DriftKind.CAPABILITY_MISMATCH,
+            severity=DriftSeverity.CRITICAL,
+            detail=detail,
+            current_task_id=bound_id,
+            current_agent_id=invoked_agent_name,
+        )
     return None

--- a/tests/test_capability_mismatch.py
+++ b/tests/test_capability_mismatch.py
@@ -1,4 +1,4 @@
-"""Structural capability-mismatch detector (goldfive#253).
+"""Structural capability-mismatch detector (goldfive#253, #268).
 
 Covers :func:`goldfive.drift.capability_check.detect_capability_mismatch`
 plus the integration wiring through the ADK adapter's
@@ -12,6 +12,12 @@ Detection rules under test:
   wrappers; bound task uses leaf-task verbs ("draft", "write", ...).
 * Rule B — task ``required_tools`` is non-empty and the invoked agent
   doesn't cover the required names.
+* Rule C (goldfive#268) — out-of-DAG-order delegation: agent role
+  stem is absent from the bound task's title+description AND present
+  in another PENDING task. Mirrors the live evidence from session
+  ``f0630532-…`` where ``reviewer_agent`` got pinned to ``draft_slides``
+  because ``review_presentation`` wasn't DAG-ready yet and only one
+  task was eligible.
 
 Negative cases mirror each positive: the same shapes WITHOUT the
 trigger condition must return ``None``.
@@ -284,6 +290,245 @@ def test_is_agent_tool_duck_type() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Rule C (goldfive#268) — out-of-DAG-order delegation
+# ---------------------------------------------------------------------------
+
+
+def test_rule_c_positive_reviewer_pinned_to_draft() -> None:
+    """Live evidence from session ``f0630532-…``: ``reviewer_agent``
+    pinned to ``draft_slides`` while ``review_presentation`` sits
+    PENDING. The agent's role stem (``reviewer``) is absent from the
+    bound task's text and present in another pending task — Rule C must
+    fire.
+    """
+    bound = Task(
+        id="draft_slides",
+        title="Draft the presentation slides",
+        description="Author the slide content based on the outline.",
+    )
+    pending = [
+        bound,  # the bound task is itself PENDING; detector ignores by id
+        Task(
+            id="review_presentation",
+            title="Review the presentation",
+            description="Read the slides and flag issues.",
+        ),
+        Task(
+            id="outline_presentation",
+            title="Create outline",
+            description="Sketch the section structure.",
+        ),
+    ]
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="reviewer_agent",
+        invoked_agent_tools=[_FakeFunctionTool("read_presentation_files")],
+        task=bound,
+        all_pending_tasks=pending,
+    )
+
+    assert drift is not None, "Rule C must fire on stem cross-task mismatch"
+    assert drift.kind is DriftKind.CAPABILITY_MISMATCH
+    assert drift.severity is DriftSeverity.CRITICAL
+    assert drift.current_task_id == "draft_slides"
+    assert drift.current_agent_id == "reviewer_agent"
+    # The detail string must point at the structural confusion:
+    # bound id, the stem, and the conflicting PENDING task id.
+    assert "draft_slides" in drift.detail
+    assert "reviewer" in drift.detail
+    assert "review_presentation" in drift.detail
+
+
+def test_rule_c_negative_stem_found_in_bound_task() -> None:
+    """Stem ``reviewer`` is present in the bound task itself
+    ("Review the presentation") — no conflict. Rule C must NOT fire.
+    """
+    bound = Task(
+        id="review_presentation",
+        title="Review the presentation",
+    )
+    pending = [
+        bound,
+        Task(id="draft_slides", title="Draft the presentation slides"),
+    ]
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="reviewer_agent",
+        invoked_agent_tools=[_FakeFunctionTool("read_presentation_files")],
+        task=bound,
+        all_pending_tasks=pending,
+    )
+
+    assert drift is None, "Rule C must not fire when stem is in the bound task"
+
+
+def test_rule_c_negative_stem_found_nowhere() -> None:
+    """Agent ``helper_agent`` (stem ``helper``) bound to ``draft_slides``
+    with no other ``helper``-shaped task — Rule C has no signal of
+    cross-task confusion and must stay silent.
+    """
+    bound = Task(id="draft_slides", title="Draft the presentation slides")
+    pending = [
+        bound,
+        Task(id="review_presentation", title="Review the presentation"),
+        Task(id="outline_presentation", title="Create outline"),
+    ]
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="helper_agent",
+        invoked_agent_tools=[_FakeFunctionTool("noop")],
+        task=bound,
+        all_pending_tasks=pending,
+    )
+
+    assert drift is None, "Rule C must not fire when stem isn't anywhere"
+
+
+def test_rule_c_negative_generic_coordinator_agent_name() -> None:
+    """``coordinator_agent`` has the stem ``coordinator`` — which would
+    typically not appear anywhere in a normal pending plan. Rule C
+    must degrade gracefully (not fire) on generic / orchestration-shaped
+    agent names. Use a FunctionTool to defuse Rule A so this case
+    isolates Rule C's behaviour.
+    """
+    bound = Task(id="draft_slides", title="Draft the presentation slides")
+    pending = [
+        bound,
+        Task(id="review_presentation", title="Review the presentation"),
+    ]
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="coordinator_agent",
+        invoked_agent_tools=[_FakeFunctionTool("noop")],
+        task=bound,
+        all_pending_tasks=pending,
+    )
+
+    assert drift is None, (
+        "Rule C must not fire on generic agent names with no stem match"
+    )
+
+
+def test_rule_c_negative_short_stem_skipped() -> None:
+    """Agent named ``qa_agent`` has stem ``qa`` (length 2) which is
+    below the ≥4 length filter; ``agent_name_stems`` returns an empty
+    tuple and Rule C silently no-ops.
+    """
+    bound = Task(id="draft_slides", title="Draft the presentation slides")
+    pending = [
+        bound,
+        Task(id="review_presentation", title="Review the presentation"),
+    ]
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="qa_agent",
+        invoked_agent_tools=[_FakeFunctionTool("noop")],
+        task=bound,
+        all_pending_tasks=pending,
+    )
+
+    assert drift is None, "Short stems must skip Rule C cleanly"
+
+
+def test_rule_c_negative_no_all_pending_tasks_passed() -> None:
+    """Legacy callers that don't pass ``all_pending_tasks`` get the
+    pre-#268 behaviour: Rules A/B still run, Rule C is silent.
+    """
+    bound = Task(id="draft_slides", title="Draft the presentation slides")
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="reviewer_agent",
+        invoked_agent_tools=[_FakeFunctionTool("noop")],
+        task=bound,
+        # all_pending_tasks omitted on purpose
+    )
+
+    assert drift is None, "Rule C silent when caller doesn't pass pending set"
+
+
+def test_rule_c_precedence_rule_a_still_wins() -> None:
+    """When Rule A also fires (all AgentTool wrappers + leaf task) AND
+    Rule C would also fire (stem mismatch), Rule A's verdict wins. The
+    detector returns one drift; the detail string identifies Rule A
+    by mentioning "AgentTool".
+    """
+    bound = Task(
+        id="draft_slides",
+        title="Draft the presentation slides",
+    )
+    pending = [
+        bound,
+        Task(id="review_presentation", title="Review the presentation"),
+    ]
+    agent_tools: list[Any] = [_FakeAgentTool("inner")]
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="reviewer_agent",
+        invoked_agent_tools=agent_tools,
+        task=bound,
+        all_pending_tasks=pending,
+    )
+
+    assert drift is not None
+    assert drift.kind is DriftKind.CAPABILITY_MISMATCH
+    # Rule A's signature wording is in the detail; Rule C's is not.
+    assert "AgentTool" in drift.detail
+    assert "role-stem" not in drift.detail
+
+
+def test_rule_c_precedence_rule_b_still_wins() -> None:
+    """Rule B (required_tools advisory) takes priority over Rule C.
+    Same agent/task confusion shape as the positive case, but the
+    bound task also has an unmet required_tools — Rule B fires first.
+    """
+    bound = Task(
+        id="draft_slides",
+        title="Draft the presentation slides",
+        required_tools=("write_webpage",),
+    )
+    pending = [
+        bound,
+        Task(id="review_presentation", title="Review the presentation"),
+    ]
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="reviewer_agent",
+        invoked_agent_tools=[_FakeFunctionTool("read_presentation_files")],
+        task=bound,
+        all_pending_tasks=pending,
+    )
+
+    assert drift is not None
+    assert drift.kind is DriftKind.CAPABILITY_MISMATCH
+    assert "write_webpage" in drift.detail
+    # Rule C's signature wording must not appear when Rule B fires.
+    assert "role-stem" not in drift.detail
+
+
+def test_rule_c_excludes_bound_task_by_id() -> None:
+    """Even when the bound task itself appears in ``all_pending_tasks``
+    (the natural shape — every pending task in the plan, including the
+    one we just pinned), Rule C must exclude it from the "other task"
+    sweep so a bound task with stem-matching text doesn't self-trigger.
+    """
+    # Bound task has the stem in its text — but only itself is pending.
+    bound = Task(
+        id="review_presentation",
+        title="Review the presentation",
+    )
+    pending = [bound]
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="reviewer_agent",
+        invoked_agent_tools=[_FakeFunctionTool("noop")],
+        task=bound,
+        all_pending_tasks=pending,
+    )
+
+    assert drift is None
+
+
+# ---------------------------------------------------------------------------
 # Integration — ADK adapter wires the detector through ``_handle_drift``
 # ---------------------------------------------------------------------------
 
@@ -453,6 +698,102 @@ async def test_integration_capability_mismatch_flows_through_handle_drift() -> N
     assert drift.severity is DriftSeverity.CRITICAL
     assert drift.current_task_id == "t-draft"
     assert drift.current_agent_id == "underqualified"
+
+
+async def test_integration_rule_c_dag_order_mismatch_through_pin() -> None:
+    """End-to-end Rule C (goldfive#268): mirror the live evidence
+    where ``reviewer_agent`` got delegated while only ``draft_slides``
+    was DAG-ready. The delegation pin (#259) binds reviewer_agent ->
+    draft_slides (only eligible), capability_check Rule C catches the
+    stem mismatch against the still-PENDING ``review_presentation``,
+    and the drift lands on the steerer's ``_handle_drift``.
+
+    To isolate Rule C from Rule A, give the reviewer a real
+    FunctionTool — Rule A would otherwise fire first on the
+    AgentTool-only shape.
+    """
+    from google.adk.agents import Agent
+    from google.adk.tools import FunctionTool
+    from google.adk.tools.agent_tool import AgentTool
+
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.types import Plan, Session, Task, TaskEdge
+
+    def read_presentation_files(path: str) -> dict[str, Any]:  # noqa: ARG001
+        return {"ok": True}
+
+    # The reviewer agent — has a real read tool so Rule A is OUT, and
+    # its name ("reviewer_agent") yields stem "reviewer" for Rule C.
+    reviewer = Agent(
+        name="reviewer_agent",
+        model=_make_quiet_llm()(),
+        instruction="",
+        tools=[FunctionTool(read_presentation_files)],
+    )
+    coord = Agent(
+        name="coord",
+        model=_make_one_shot_delegating_llm("reviewer_agent")(),
+        instruction="",
+        tools=[AgentTool(reviewer)],
+    )
+    adapter = ADKAdapter(coord)
+    steerer = _RecordingSteerer()
+    adapter.bind_steerer(steerer)
+
+    # Plan shape from the live evidence:
+    #   draft_slides (PENDING, DAG-ready) -> review_presentation
+    #   (PENDING, NOT DAG-ready until draft_slides completes).
+    # The pin will see only draft_slides as eligible and bind
+    # reviewer_agent -> draft_slides. Rule C must fire.
+    draft_task = Task(
+        id="draft_slides",
+        title="Draft the presentation slides",
+        description="Author the slide content.",
+    )
+    review_task = Task(
+        id="review_presentation",
+        title="Review the presentation",
+        description="Read the slides and flag issues.",
+    )
+    coord_task = Task(
+        id="t-coord",
+        title="Coordinate the work",
+        assignee_agent_id="coord",
+        status=TaskStatus.RUNNING,
+    )
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=(),
+        tasks=(coord_task, draft_task, review_task),
+        edges=(
+            TaskEdge(
+                from_task_id="draft_slides",
+                to_task_id="review_presentation",
+            ),
+        ),
+    )
+    session = Session(run_id="r1", plan=plan)
+
+    await adapter.invoke(task=coord_task, session=session)
+
+    capability_drifts = [
+        d for d in steerer.drifts if d.kind is DriftKind.CAPABILITY_MISMATCH
+    ]
+    assert len(capability_drifts) >= 1, (
+        f"expected at least one CAPABILITY_MISMATCH drift from Rule C; "
+        f"got {[d.kind for d in steerer.drifts]}"
+    )
+    drift = capability_drifts[0]
+    assert drift.severity is DriftSeverity.CRITICAL
+    # The pin bound reviewer_agent to draft_slides (only eligible).
+    assert drift.current_task_id == "draft_slides"
+    assert drift.current_agent_id == "reviewer_agent"
+    # The detail string identifies Rule C: agent stem + the conflicting
+    # PENDING task id.
+    assert "role-stem" in drift.detail
+    assert "reviewer" in drift.detail
+    assert "review_presentation" in drift.detail
 
 
 async def test_integration_no_capability_mismatch_when_agent_has_leaf_tool() -> None:


### PR DESCRIPTION
## Summary

- **Rule C — out-of-DAG-order delegation.** When the invoked agent's role-stem is absent from the bound task's title+description but present in another PENDING task, fire CRITICAL `CAPABILITY_MISMATCH`. Catches the live failure mode where a downstream agent (e.g. `reviewer_agent`) gets pinned to an upstream task (e.g. `draft_slides`) because only one task was DAG-ready and `#265` tier-2 stem disambiguation couldn't help (`len(eligible) == 1`).
- **Detector signature extended.** `detect_capability_mismatch` now accepts `all_pending_tasks: Sequence[Task] | None = None`. Legacy callers and tests that don't pass it keep their pre-#268 behaviour exactly. The ADK plugin's `_maybe_emit_capability_mismatch` collects the full PENDING set off the plan and passes it through.
- **Shared helpers lifted.** `AGENT_NAME_ROLE_SUFFIXES`, `agent_name_stems`, `stem_token_match`, `tokenize_for_matching` moved from `goldfive/adapters/_adk_plugin.py` into `goldfive/drift/capability_check.py` so the delegation-pin disambiguator (#265 tier-2) and Rule C share one source of truth. Module-private names in the plugin remain as thin aliases.

No regex — pure str-ops bi-directional substring match (#166 / #167 ban respected).

## Live evidence

Session `f0630532-7dc3-4008-8faa-ada7edc89806` (walnuts run, 2026-05-12 18:05–18:06):
- Plan DAG: `research → outline → draft → review`
- At delegation 3 only `draft_slides` was DAG-ready.
- Coordinator dispatched `reviewer_agent`; pin bound `reviewer_agent → draft_slides`.
- The reviewer did review work, reported COMPLETED, attribution went to `draft_slides`.
- `review_presentation` stayed PENDING; `run_completed` fired anyway.

Rule C now fires CRITICAL at `delegation_observed` time — BEFORE the silent success — so the steerer's intervention ladder (cancel + refine) runs. Under `observation_only=True` the drift still flows to sinks for visibility without intervening.

## Test plan

- [x] Primary case mirroring live evidence: `reviewer_agent` pinned to `draft_slides` with `review_presentation` in `all_pending_tasks` → fires; detail names the bound id, agent stem, and conflicting task id.
- [x] Stem found in bound task → silent.
- [x] Stem found nowhere → silent.
- [x] Generic `coordinator_agent` stem → silent.
- [x] Short stem (`qa_agent` → stem length 2) → skipped cleanly.
- [x] Legacy caller without `all_pending_tasks` → silent (Rules A/B still run).
- [x] Rule A precedence (AgentTool-only + leaf task + stem mismatch) → Rule A's verdict wins, no double-fire.
- [x] Rule B precedence (`required_tools` unmet + stem mismatch) → Rule B's verdict wins.
- [x] Bound task self-exclusion: even with the bound task in `all_pending_tasks`, Rule C excludes it by id.
- [x] Integration through ADK adapter: draft→review DAG; pin binds `reviewer_agent` to `draft_slides`; Rule C drift lands on `_handle_drift` with the right kind/severity/detail.
- [x] Full suite green: `2433 passed, 59 skipped` (no regressions in Rule A/B/integration cases or in the #265 tier-2 stem-helper consumers).
- [x] `ruff check` clean.