### PR TITLE
refactor: centralize drift detector boilerplate in registry

### DIFF
--- a/goldfive/drift/capability_check.py
+++ b/goldfive/drift/capability_check.py
@@ -435,3 +435,24 @@ def _rule_c_dag_order(
             current_agent_id=invoked_agent_name,
         )
     return None
+
+
+# ---------------------------------------------------------------------------
+# Registry self-registration
+# ---------------------------------------------------------------------------
+#
+# CAPABILITY_MISMATCH is a purely structural detector — no LLM call, no
+# JSON parsing, no observability truncation. The config is therefore
+# all-default (``uses_llm=False``); we register so callers that
+# discover detectors via the registry can dispatch by kind uniformly.
+
+
+from goldfive.drift.registry import DetectorConfig as _DetectorConfig  # noqa: E402
+from goldfive.drift.registry import register as _register  # noqa: E402
+
+_register(
+    DriftKind.CAPABILITY_MISMATCH,
+    detect_capability_mismatch,
+    _DetectorConfig(uses_llm=False),
+    is_async=False,
+)

--- a/goldfive/drift/goals.py
+++ b/goldfive/drift/goals.py
@@ -30,12 +30,23 @@ parse logic.
 
 from __future__ import annotations
 
-import json
 import logging
-import re
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from typing import Any
 
+from goldfive.drift.registry import (
+    DetectorConfig,
+    truncate_for_observability,
+)
+from goldfive.drift.registry import (
+    format_goals_block as _format_goals,
+)
+from goldfive.drift.registry import (
+    parse_json_response as _parse_response,
+)
+from goldfive.drift.registry import (
+    register as _register,
+)
 from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Goal, Plan
 
 log = logging.getLogger(__name__)
@@ -102,47 +113,12 @@ GOAL_DRIFT_USER_PROMPT_TEMPLATE: str = (
 )
 
 
-# Liberal JSON extractor: real LLMs emit markdown code fences and prose
-# even with strong "reply JSON only" instructions. Mirrors the extractor
-# used by the reflective-check path.
-_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
-
-
-def _parse_response(raw: Any) -> dict[str, Any] | None:
-    """Extract the first JSON object from ``raw`` or return ``None``."""
-    if not isinstance(raw, str) or not raw.strip():
-        return None
-    stripped = raw.strip()
-    try:
-        decoded = json.loads(stripped)
-    except (json.JSONDecodeError, ValueError):
-        match = _JSON_OBJECT_RE.search(stripped)
-        if match is None:
-            return None
-        try:
-            decoded = json.loads(match.group(0))
-        except (json.JSONDecodeError, ValueError):
-            return None
-    if not isinstance(decoded, dict):
-        return None
-    return decoded
-
-
-def _format_goals(goals: Sequence[Goal] | Iterable[Any] | None) -> str:
-    if not goals:
-        return "(no goals recorded)"
-    lines: list[str] = []
-    for i, g in enumerate(goals, start=1):
-        gid = str(getattr(g, "id", "") or "")
-        summary = str(getattr(g, "summary", "") or "")
-        if not summary and isinstance(g, str):
-            summary = g
-        prefix = f"{i}."
-        if gid:
-            lines.append(f"{prefix} [{gid}] {summary}")
-        else:
-            lines.append(f"{prefix} {summary}")
-    return "\n".join(lines) if lines else "(no goals recorded)"
+# Liberal JSON extraction + goals rendering live in
+# :mod:`goldfive.drift.registry` so the goal-drift judge and the
+# per-reasoning judge share one implementation. The aliased imports at
+# the top of this module preserve the historical private names (so
+# external test suites mocking ``goals._parse_response`` continue to
+# work) without re-declaring the function bodies here.
 
 
 def _format_tasks(plan: Plan | Any | None) -> str:
@@ -509,14 +485,40 @@ async def classify_goal_drift(
     )
 
 
+# The trigger-input cap is goal-drift-specific (the activity block is
+# wider than a reasoning-judge prompt), so the *limit* lives here but
+# the truncation itself uses the shared registry helper so the
+# " … [truncated]" suffix stays consistent.
 _GOAL_DRIFT_TRIGGER_INPUT_MAX_CHARS: int = 2048
-_GOAL_DRIFT_TRUNCATE_SUFFIX: str = " … [truncated]"
 
 
 def _truncate_trigger_input(text: str) -> str:
     """Cap the observability ``trigger_input`` at a bounded length."""
-    if not isinstance(text, str):
-        return ""
-    if len(text) <= _GOAL_DRIFT_TRIGGER_INPUT_MAX_CHARS:
-        return text
-    return text[:_GOAL_DRIFT_TRIGGER_INPUT_MAX_CHARS] + _GOAL_DRIFT_TRUNCATE_SUFFIX
+    return truncate_for_observability(text, _GOAL_DRIFT_TRIGGER_INPUT_MAX_CHARS)
+
+
+# ---------------------------------------------------------------------------
+# Registry self-registration
+# ---------------------------------------------------------------------------
+#
+# Goal-drift is one of the two LLM-as-a-judge detectors. The config
+# pins the per-callsite output cap (16384, mirrors
+# :data:`GOAL_DRIFT_MAX_OUTPUT_TOKENS`) and the trigger-input cap
+# (2048, mirrors :data:`_GOAL_DRIFT_TRIGGER_INPUT_MAX_CHARS`). The
+# judge enters :func:`call_llm_thinking_disabled` for every dispatch.
+
+
+_GOAL_DRIFT_CONFIG: DetectorConfig = DetectorConfig(
+    uses_llm=True,
+    max_input_chars=_GOAL_DRIFT_TRIGGER_INPUT_MAX_CHARS,
+    max_output_tokens=GOAL_DRIFT_MAX_OUTPUT_TOKENS,
+    disable_thinking=True,
+)
+
+
+_register(
+    DriftKind.GOAL_DRIFT,
+    classify_goal_drift,
+    _GOAL_DRIFT_CONFIG,
+    is_async=True,
+)

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -41,13 +41,24 @@ it back as a real signal.
 from __future__ import annotations
 
 import dataclasses
-import json
 import logging
-import re
 import time
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from typing import Any
 
+from goldfive.drift.registry import (
+    DetectorConfig,
+    truncate_for_observability,
+)
+from goldfive.drift.registry import (
+    format_goals_block as _format_goals,
+)
+from goldfive.drift.registry import (
+    parse_json_response as _parse_response,
+)
+from goldfive.drift.registry import (
+    register as _register,
+)
 from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Goal, Plan, Task
 
 log = logging.getLogger(__name__)
@@ -86,7 +97,6 @@ __all__ = [
 # sinks (in-memory lists, SQLite rows, gRPC message size caps).
 REASONING_JUDGE_MAX_REASONING_INPUT_CHARS: int = 4096
 REASONING_JUDGE_MAX_RAW_RESPONSE_CHARS: int = 2048
-_TRUNCATE_SUFFIX: str = " … [truncated]"
 
 # Per-callsite ``max_output_tokens`` budget (goldfive#271 follow-up).
 # The judge returns a small JSON verdict ({"on_task": bool, "reason":
@@ -99,18 +109,10 @@ _TRUNCATE_SUFFIX: str = " … [truncated]"
 REASONING_JUDGE_MAX_OUTPUT_TOKENS: int = 16384
 
 
-def truncate_for_observability(text: str, limit: int) -> str:
-    """Cap ``text`` at ``limit`` chars, appending ``"… [truncated]"`` when cut.
-
-    Shared by the observability emission path on every judge call so both
-    the reasoning input and the raw response use the same truncation
-    convention. Callers that need a different limit pass it explicitly.
-    """
-    if not isinstance(text, str):
-        return ""
-    if len(text) <= limit:
-        return text
-    return text[:limit] + _TRUNCATE_SUFFIX
+# ``truncate_for_observability`` lives in :mod:`goldfive.drift.registry`
+# (shared with the goal-drift detector via the same suffix); re-exported
+# here under the historical name so the public ``__all__`` contract and
+# downstream importers continue to work.
 
 
 # Shape matches :mod:`goldfive.drift.goals` / ``LLMPlanner`` so operators
@@ -229,47 +231,12 @@ REASONING_DRIFT_USER_PROMPT_TEMPLATE: str = (
 )
 
 
-# Liberal JSON extractor. Real LLMs emit markdown code fences and prose
-# even with strong "reply JSON only" instructions. Mirrors the extractor
-# in :mod:`goldfive.drift.goals`.
-_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
-
-
-def _parse_response(raw: Any) -> dict[str, Any] | None:
-    """Extract the first JSON object from ``raw`` or return ``None``."""
-    if not isinstance(raw, str) or not raw.strip():
-        return None
-    stripped = raw.strip()
-    try:
-        decoded = json.loads(stripped)
-    except (json.JSONDecodeError, ValueError):
-        match = _JSON_OBJECT_RE.search(stripped)
-        if match is None:
-            return None
-        try:
-            decoded = json.loads(match.group(0))
-        except (json.JSONDecodeError, ValueError):
-            return None
-    if not isinstance(decoded, dict):
-        return None
-    return decoded
-
-
-def _format_goals(goals: Sequence[Goal] | Iterable[Any] | None) -> str:
-    if not goals:
-        return "(no goals recorded)"
-    lines: list[str] = []
-    for i, g in enumerate(goals, start=1):
-        gid = str(getattr(g, "id", "") or "")
-        summary = str(getattr(g, "summary", "") or "")
-        if not summary and isinstance(g, str):
-            summary = g
-        prefix = f"{i}."
-        if gid:
-            lines.append(f"{prefix} [{gid}] {summary}")
-        else:
-            lines.append(f"{prefix} {summary}")
-    return "\n".join(lines) if lines else "(no goals recorded)"
+# Liberal JSON extraction + goals rendering live in
+# :mod:`goldfive.drift.registry` so this judge and the goal-drift judge
+# share one implementation. The aliased imports at the top of this
+# module preserve the historical private names (so external test
+# fixtures mocking ``reasoning_judge._parse_response`` continue to work)
+# without re-declaring the function bodies here.
 
 
 def _format_task(task: Task | Any | None) -> str:
@@ -1374,3 +1341,38 @@ async def _emit_judge_invoked(
             "classify_reasoning_drift: sink.emit raised %s; ReasoningJudgeInvoked dropped",
             exc,
         )
+
+
+# ---------------------------------------------------------------------------
+# Registry self-registration
+# ---------------------------------------------------------------------------
+#
+# The reasoning judge emits TWO drift kinds: ``OFF_TOPIC`` (the
+# pre-iter-10 verdict, also the destination for ``erroneous_deviation``
+# classifications) and ``JUSTIFIED_DEVIATION`` (iter-10 PR 3, fired when
+# the judge attributes a deviation to a recent tool observation or
+# user-input signal). Both share the same classifier function, the
+# same config, and the same caller-facing entry point — we register
+# both for completeness so dispatch lookup by kind works for either.
+
+
+_REASONING_JUDGE_CONFIG: DetectorConfig = DetectorConfig(
+    uses_llm=True,
+    max_input_chars=REASONING_JUDGE_MAX_REASONING_INPUT_CHARS,
+    max_output_tokens=REASONING_JUDGE_MAX_OUTPUT_TOKENS,
+    disable_thinking=True,
+)
+
+
+_register(
+    DriftKind.OFF_TOPIC,
+    classify_reasoning_drift,
+    _REASONING_JUDGE_CONFIG,
+    is_async=True,
+)
+_register(
+    DriftKind.JUSTIFIED_DEVIATION,
+    classify_reasoning_drift,
+    _REASONING_JUDGE_CONFIG,
+    is_async=True,
+)

--- a/goldfive/drift/registry.py
+++ b/goldfive/drift/registry.py
@@ -1,0 +1,410 @@
+"""Drift-detector registry + shared LLM-judge boilerplate.
+
+Wave A piece 2 of the goldfive modularisation plan. Centralises the
+*genuinely-shared* boilerplate across the five drift detectors so each
+detector contributes only its classifier-specific logic.
+
+What lives here (truly shared across detectors)
+-----------------------------------------------
+
+* :class:`DetectorConfig` — per-detector knobs (output-token cap,
+  input/output truncation limits, whether the detector dispatches an LLM
+  call). Pinned per-detector via :func:`register`.
+* :func:`parse_json_response` — liberal JSON extractor that tolerates
+  markdown fences / prose preludes. Used by every LLM-as-a-judge
+  detector (currently :mod:`reasoning_judge` and :mod:`goals`).
+* :func:`truncate_for_observability` — bounded-length text truncation
+  with a uniform ``" … [truncated]"`` suffix, shared by every detector
+  that stamps a long string onto an event payload.
+* :func:`format_goals_block` — render
+  :class:`~goldfive.types.Goal` sequences as a human-readable block.
+  Identical between the goal-drift and reasoning-judge prompts.
+* :func:`register` / :func:`classify` — the registry API. Each detector
+  registers a ``(DriftKind, classifier_fn, DetectorConfig)`` triple;
+  callers can dispatch by kind via :func:`classify` without importing
+  the detector module directly.
+
+What stays in the detector modules (deliberately not centralised)
+-----------------------------------------------------------------
+
+* **Prompt construction** — every detector has its own template + its
+  own helper functions (``_format_task``, ``_format_activity``,
+  ``_format_task_lineage``, ``_format_tool_observations``,
+  ``format_plan_tasks_summary``, ``format_available_agents_block``,
+  …). Moving these here would be churn for no real reuse.
+* **Span ``decision_summary`` / ``output_preview`` strings** — each
+  detector produces a verdict-shaped span tail (``"judged trajectory:
+  on-track"`` vs ``"judged X's reasoning on Y: justified_deviation
+  (tool_error)"``). Centralising those would obscure the very tail
+  strings operators grep for in production logs.
+* **Sink emission** — only :func:`classify_reasoning_drift` emits a
+  ``ReasoningJudgeInvoked`` event; centralising the emitter would force
+  the abstraction onto detectors that don't have an observability
+  channel.
+* **Post-LLM re-read / staleness gates** — only the goal-drift judge
+  re-reads ``session.plan`` after the LLM round-trip. Detector-specific.
+* **DriftEvent construction** — each kind has its own ``detail`` shape
+  and severity logic.
+
+Honest scope note (PR delta)
+----------------------------
+
+The Wave-A brief anticipated ~500 LOC reduction across all five
+detectors. In practice only two of the five (``reasoning_judge`` and
+``goals``) actually wrap an LLM call + parse JSON; the other three
+(``capability_check``, ``tool_loops``, ``reasoning``) are structural
+or embedding-based and have no LLM/JSON boilerplate to share. The
+real LOC reduction is modest — the value of this module is the single
+source of truth for the JSON extractor, the goals renderer, and the
+truncation helper, plus a uniform registry-dispatch API for callers
+that want to look up detectors by ``DriftKind``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable, Iterable, Sequence
+from typing import Any
+
+from goldfive.types import DriftEvent, DriftKind, Goal
+
+log = logging.getLogger(__name__)
+
+
+__all__ = [
+    "DetectorConfig",
+    "TRUNCATE_SUFFIX",
+    "JSON_OBJECT_RE",
+    "classify",
+    "format_goals_block",
+    "get_config",
+    "list_registered",
+    "parse_json_response",
+    "register",
+    "truncate_for_observability",
+]
+
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+
+#: Uniform truncation marker used by every detector's observability-bound
+#: string. Lifted here from the per-detector copies so a future change to
+#: the suffix only happens in one place.
+TRUNCATE_SUFFIX: str = " … [truncated]"
+
+
+#: Liberal JSON-object extractor. Real LLMs emit markdown code fences
+#: and prose even with strong "reply JSON only" instructions; this
+#: matches the *first* ``{...}`` span in the response, leaving the
+#: per-detector parser to validate the dict shape. Used by every
+#: LLM-as-a-judge detector.
+JSON_OBJECT_RE: re.Pattern[str] = re.compile(r"\{.*\}", re.DOTALL)
+
+
+# ---------------------------------------------------------------------------
+# DetectorConfig
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class DetectorConfig:
+    """Per-detector boilerplate knobs.
+
+    Each detector registers a config via :func:`register`. Callers can
+    look up the config via :func:`get_config` to read the per-detector
+    caps without having to know which detector module owns the kind.
+
+    Attributes
+    ----------
+    uses_llm:
+        ``True`` when the detector dispatches an LLM call. The two
+        currently-registered LLM detectors are ``OFF_TOPIC`` (the
+        reasoning judge) and ``GOAL_DRIFT``. Purely structural detectors
+        (``CAPABILITY_MISMATCH``, ``TOOL_ERROR``, ``CONFABULATION_RISK``,
+        the loop trackers, the embedding-based reasoning detectors) set
+        this to ``False``.
+    max_input_chars:
+        Hard cap on the *prompt* / *trigger_input* observability payload
+        the detector emits. Reasoning judge: 4096. Goal drift: 2048.
+        Pure-structural detectors with no observability payload set
+        this to ``0`` and the helper is a no-op.
+    max_output_tokens:
+        Per-callsite ``max_output_tokens`` budget bound around
+        ``await call_llm(...)`` via
+        :func:`goldfive._llm.call_llm_budget`. Both LLM detectors
+        currently use 16384 (Qwen 3.5 thinking-mode headroom — see
+        :data:`goldfive._llm.DEFAULT_MAX_OUTPUT_TOKENS` for the
+        rationale).
+    disable_thinking:
+        When ``True``, the LLM dispatch enters
+        :func:`goldfive._llm.call_llm_thinking_disabled`. Both LLM
+        detectors set this — they ask small JSON-shaped meta-cognition
+        questions and don't need ``<think>`` reasoning preludes.
+    timeout_seconds:
+        Soft wall-clock budget the detector advertises. Goldfive's
+        ``call_llm`` callables already have a wall-clock backstop
+        (``DEFAULT_LLM_CALL_TIMEOUT_MS`` in the ADK plugin); this is a
+        per-detector advisory limit that downstream observability can
+        surface but is not enforced here.
+    """
+
+    uses_llm: bool = False
+    max_input_chars: int = 0
+    max_output_tokens: int = 0
+    disable_thinking: bool = False
+    timeout_seconds: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Shared utilities
+# ---------------------------------------------------------------------------
+
+
+def truncate_for_observability(text: Any, limit: int) -> str:
+    """Cap ``text`` at ``limit`` chars, appending :data:`TRUNCATE_SUFFIX` when cut.
+
+    Returns the empty string when ``text`` is not a ``str`` (consistent
+    with the historical per-detector helpers in
+    :mod:`reasoning_judge` and the goal-drift trigger-input helper).
+    A ``limit`` of ``0`` or below is treated as "no truncation"
+    (returns the input unchanged when it's a string).
+    """
+    if not isinstance(text, str):
+        return ""
+    if limit <= 0 or len(text) <= limit:
+        return text
+    return text[:limit] + TRUNCATE_SUFFIX
+
+
+def parse_json_response(raw: Any) -> dict[str, Any] | None:
+    """Extract the first JSON object from ``raw`` or return ``None``.
+
+    The shared LLM-judge response parser. Matches the byte-for-byte
+    behaviour of the previous per-detector copies in
+    :mod:`goldfive.drift.goals` and
+    :mod:`goldfive.drift.reasoning_judge`:
+
+    1. If ``raw`` is not a non-empty string, return ``None``.
+    2. Try :func:`json.loads` on the stripped text.
+    3. On failure, search for the first ``{...}`` span via
+       :data:`JSON_OBJECT_RE` and try :func:`json.loads` on that.
+    4. Return the decoded dict, or ``None`` if either the response
+       wasn't valid JSON or the top-level value isn't a dict.
+
+    The "return ``None`` on any failure" contract is deliberate — both
+    LLM judges quiet-fail on malformed responses to avoid false-
+    positive drifts (goldfive#143 / #226 / #244).
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    stripped = raw.strip()
+    try:
+        decoded = json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        match = JSON_OBJECT_RE.search(stripped)
+        if match is None:
+            return None
+        try:
+            decoded = json.loads(match.group(0))
+        except (json.JSONDecodeError, ValueError):
+            return None
+    if not isinstance(decoded, dict):
+        return None
+    return decoded
+
+
+def format_goals_block(goals: Sequence[Goal] | Iterable[Any] | None) -> str:
+    """Render ``goals`` as a numbered ``[id] summary`` block.
+
+    Shared by every LLM-judge prompt that needs to surface
+    ``session.goals``. Byte-for-byte identical to the per-detector
+    helpers it replaces in :mod:`goldfive.drift.goals` and
+    :mod:`goldfive.drift.reasoning_judge` (the two previous copies
+    were literally identical).
+
+    Empty / ``None`` goals render as ``"(no goals recorded)"`` so the
+    prompt template can interpolate the block without conditional
+    formatting.
+    """
+    if not goals:
+        return "(no goals recorded)"
+    lines: list[str] = []
+    for i, g in enumerate(goals, start=1):
+        gid = str(getattr(g, "id", "") or "")
+        summary = str(getattr(g, "summary", "") or "")
+        if not summary and isinstance(g, str):
+            summary = g
+        prefix = f"{i}."
+        if gid:
+            lines.append(f"{prefix} [{gid}] {summary}")
+        else:
+            lines.append(f"{prefix} {summary}")
+    return "\n".join(lines) if lines else "(no goals recorded)"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+#: Type alias for a registered classifier. Each detector exposes its
+#: own positional/keyword shape; the registry stores them as ``**kwargs``
+#: callables so :func:`classify` can dispatch without knowing the per-
+#: detector signature.
+ClassifierFn = Callable[..., Any]
+
+
+@dataclasses.dataclass(frozen=True)
+class _Registration:
+    """Internal record stored by :func:`register`."""
+
+    classifier: ClassifierFn
+    config: DetectorConfig
+    is_async: bool
+
+
+_REGISTRY: dict[DriftKind, _Registration] = {}
+
+
+def register(
+    kind: DriftKind,
+    classifier_fn: ClassifierFn,
+    config: DetectorConfig,
+    *,
+    is_async: bool = False,
+) -> None:
+    """Register a classifier for ``kind`` with the given ``config``.
+
+    Re-registration overwrites a prior entry (and logs a debug line)
+    so test fixtures that swap classifiers in and out don't accumulate
+    stale registrations.
+
+    Parameters
+    ----------
+    kind:
+        The :class:`~goldfive.types.DriftKind` the classifier emits.
+        Note that one detector module may register multiple kinds
+        (e.g. the reasoning judge emits both ``OFF_TOPIC`` and
+        ``JUSTIFIED_DEVIATION``); the per-kind classifier in that case
+        points to the same underlying function and the dispatcher just
+        forwards by kind.
+    classifier_fn:
+        The detector entry point. May be sync or async — set
+        ``is_async`` accordingly so :func:`classify` can ``await`` it
+        when appropriate. The classifier owns its own kwargs shape; the
+        registry forwards ``**observation`` verbatim.
+    config:
+        The :class:`DetectorConfig` pinning per-detector knobs.
+    is_async:
+        ``True`` when ``classifier_fn`` is a coroutine function. The
+        registry does not introspect; the caller passes the flag
+        explicitly so wrappers around an async function (e.g. a
+        ``functools.partial``) register correctly.
+    """
+    prior = _REGISTRY.get(kind)
+    _REGISTRY[kind] = _Registration(
+        classifier=classifier_fn, config=config, is_async=is_async
+    )
+    if prior is not None:
+        log.debug(
+            "drift.registry.register: overwrote prior registration for %r", kind
+        )
+
+
+def get_config(kind: DriftKind) -> DetectorConfig | None:
+    """Return the :class:`DetectorConfig` registered for ``kind``, or ``None``.
+
+    Useful for callers that want to read the per-detector caps (e.g.
+    ``max_input_chars`` for an observability payload) without invoking
+    the classifier.
+    """
+    reg = _REGISTRY.get(kind)
+    return reg.config if reg is not None else None
+
+
+def list_registered() -> tuple[DriftKind, ...]:
+    """Return the currently-registered :class:`DriftKind` set.
+
+    Order is insertion-order (Python ``dict`` semantics). Primarily for
+    tests and diagnostics.
+    """
+    return tuple(_REGISTRY.keys())
+
+
+def classify(*, kind: DriftKind, **observation: Any) -> Any:
+    """Dispatch to the classifier registered for ``kind``.
+
+    Forwards ``**observation`` verbatim to the registered classifier.
+    Returns the classifier's return value as-is — typically a
+    :class:`~goldfive.types.DriftEvent` or ``None``, but the reasoning
+    judge returns a :class:`~goldfive.drift.reasoning_judge.ReasoningJudgeVerdict`,
+    which is wider than ``DriftEvent | None``. Callers that prefer the
+    narrow shape can ignore the extra fields or call the detector
+    entry point directly.
+
+    Raises :class:`KeyError` when no detector is registered for ``kind``
+    so a typo at the call site is loud rather than silent.
+
+    When the registered classifier is async (``is_async=True`` at
+    registration time), the function returns the awaitable from the
+    classifier — callers must ``await`` the result. Sync classifiers
+    return their value directly. Mixing in one call site is rare
+    enough that auto-detection isn't worth the runtime cost; pass
+    ``is_async`` explicitly at registration.
+    """
+    reg = _REGISTRY.get(kind)
+    if reg is None:
+        raise KeyError(
+            f"no drift detector registered for kind={kind!r}; "
+            f"registered kinds: {list_registered()!r}"
+        )
+    return reg.classifier(**observation)
+
+
+# ---------------------------------------------------------------------------
+# Auto-registration entry point
+# ---------------------------------------------------------------------------
+#
+# Each detector module is responsible for calling :func:`register` at
+# import time. We expose a thin :func:`_ensure_registered` entry point
+# that imports every detector module once so the registry is fully
+# populated when callers introspect via :func:`list_registered`. Lazy
+# by design: the import is cheap (the detector modules are already
+# imported by the steerer in any realistic runtime), and tests that
+# only exercise a subset of detectors don't need to pull in
+# everything.
+
+
+_AUTO_REGISTERED: bool = False
+
+
+def _ensure_registered() -> None:
+    """Import every detector module so its registration runs.
+
+    Idempotent — safe to call multiple times. The drift module's
+    public ``__init__.py`` calls this on first non-attribute access
+    via the lazy ``__getattr__`` hook.
+    """
+    global _AUTO_REGISTERED
+    if _AUTO_REGISTERED:
+        return
+    # Local imports (avoid top-of-module import cycles via drift/__init__).
+    from goldfive.drift import (  # noqa: F401 — side-effect import for registration
+        capability_check,
+        goals,
+        reasoning_judge,
+        tool_loops,
+    )
+
+    _AUTO_REGISTERED = True
+
+
+# Define typed Awaitable alias for documentation only (not exported).
+_DriftEventOr = DriftEvent | None  # noqa: F841 — referenced by docstrings/type hints
+_AsyncClassifier = Callable[..., Awaitable[Any]]  # noqa: F841

--- a/goldfive/drift/registry.py
+++ b/goldfive/drift/registry.py
@@ -66,10 +66,10 @@ import dataclasses
 import json
 import logging
 import re
-from collections.abc import Awaitable, Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
-from goldfive.types import DriftEvent, DriftKind, Goal
+from goldfive.types import DriftKind, Goal
 
 log = logging.getLogger(__name__)
 
@@ -403,8 +403,3 @@ def _ensure_registered() -> None:
     )
 
     _AUTO_REGISTERED = True
-
-
-# Define typed Awaitable alias for documentation only (not exported).
-_DriftEventOr = DriftEvent | None  # noqa: F841 — referenced by docstrings/type hints
-_AsyncClassifier = Callable[..., Awaitable[Any]]  # noqa: F841

--- a/tests/test_drift_registry.py
+++ b/tests/test_drift_registry.py
@@ -1,0 +1,345 @@
+"""Unit tests for :mod:`goldfive.drift.registry`.
+
+The registry centralises three pieces of boilerplate previously
+duplicated across the goal-drift and reasoning-judge detectors:
+
+* :func:`parse_json_response` — liberal JSON extractor.
+* :func:`format_goals_block` — numbered ``[id] summary`` renderer.
+* :func:`truncate_for_observability` — bounded text truncation with
+  the uniform ``" … [truncated]"`` suffix.
+
+The registry itself stores ``(DriftKind, classifier_fn, DetectorConfig)``
+triples so callers can dispatch by kind via :func:`classify` without
+importing the detector module directly. These tests cover the helper
+behaviour (parity with the byte-identical pre-Wave-A copies) and the
+register/dispatch contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from goldfive.drift import registry
+from goldfive.drift.registry import (
+    TRUNCATE_SUFFIX,
+    DetectorConfig,
+    classify,
+    format_goals_block,
+    get_config,
+    list_registered,
+    parse_json_response,
+    register,
+    truncate_for_observability,
+)
+from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+
+# ---------------------------------------------------------------------------
+# parse_json_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseJsonResponse:
+    """Parity checks against the per-detector copies the registry replaces."""
+
+    def test_plain_json_object(self) -> None:
+        assert parse_json_response('{"a": 1, "b": "two"}') == {"a": 1, "b": "two"}
+
+    def test_whitespace_trimmed_before_parse(self) -> None:
+        assert parse_json_response('   {"x": true}\n') == {"x": True}
+
+    def test_markdown_fence_falls_back_to_first_object(self) -> None:
+        raw = """Here is the verdict:
+```json
+{"on_task": false, "reason": "off-topic"}
+```
+"""
+        assert parse_json_response(raw) == {
+            "on_task": False,
+            "reason": "off-topic",
+        }
+
+    def test_prose_prefix_extracts_object(self) -> None:
+        assert parse_json_response("verdict: {\"progressing\": true}") == {
+            "progressing": True
+        }
+
+    def test_non_string_returns_none(self) -> None:
+        assert parse_json_response(None) is None
+        assert parse_json_response(42) is None
+        assert parse_json_response({"already": "dict"}) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_json_response("") is None
+        assert parse_json_response("   ") is None
+
+    def test_garbage_returns_none(self) -> None:
+        assert parse_json_response("not json at all") is None
+
+    def test_top_level_non_object_returns_none(self) -> None:
+        # The pre-Wave-A parser explicitly rejected lists/strings at the
+        # top level — only dicts pass the type check. The "first ``{...}``"
+        # fallback fires when ``json.loads`` of the entire string fails,
+        # so a bare list never reaches the fallback path; we still want
+        # the contract to hold.
+        assert parse_json_response("[1, 2, 3]") is None
+
+    def test_malformed_json_in_object_returns_none(self) -> None:
+        assert parse_json_response("{not valid json}") is None
+
+
+# ---------------------------------------------------------------------------
+# format_goals_block
+# ---------------------------------------------------------------------------
+
+
+class _Goal:
+    """Minimal duck-typed goal stand-in for parity checks."""
+
+    def __init__(self, id: str = "", summary: str = "") -> None:
+        self.id = id
+        self.summary = summary
+
+
+class TestFormatGoalsBlock:
+    def test_empty_renders_placeholder(self) -> None:
+        assert format_goals_block(None) == "(no goals recorded)"
+        assert format_goals_block([]) == "(no goals recorded)"
+
+    def test_ids_are_bracketed(self) -> None:
+        goals = [_Goal(id="g-1", summary="ship feature"), _Goal(id="g-2", summary="write docs")]
+        assert format_goals_block(goals) == "1. [g-1] ship feature\n2. [g-2] write docs"
+
+    def test_missing_id_omits_brackets(self) -> None:
+        goals = [_Goal(summary="ship feature")]
+        assert format_goals_block(goals) == "1. ship feature"
+
+    def test_string_goal_is_used_verbatim(self) -> None:
+        assert format_goals_block(["just a string"]) == "1. just a string"
+
+    def test_mixed_shape_renders(self) -> None:
+        goals = [_Goal(id="g-1", summary="A"), "B"]
+        assert format_goals_block(goals) == "1. [g-1] A\n2. B"
+
+
+# ---------------------------------------------------------------------------
+# truncate_for_observability
+# ---------------------------------------------------------------------------
+
+
+class TestTruncate:
+    def test_short_text_unchanged(self) -> None:
+        assert truncate_for_observability("hi", 100) == "hi"
+
+    def test_long_text_truncated_with_suffix(self) -> None:
+        text = "x" * 50
+        out = truncate_for_observability(text, 10)
+        assert out == "x" * 10 + TRUNCATE_SUFFIX
+        assert TRUNCATE_SUFFIX in out
+
+    def test_non_string_returns_empty(self) -> None:
+        assert truncate_for_observability(None, 100) == ""
+        assert truncate_for_observability(42, 100) == ""
+        assert truncate_for_observability(["x"], 100) == ""
+
+    def test_zero_limit_returns_input(self) -> None:
+        # Per docstring: limit <= 0 → no truncation.
+        assert truncate_for_observability("hello", 0) == "hello"
+        assert truncate_for_observability("hello", -5) == "hello"
+
+    def test_at_limit_unchanged(self) -> None:
+        assert truncate_for_observability("xxxxx", 5) == "xxxxx"
+
+    def test_suffix_is_pinned(self) -> None:
+        # Pinning the literal value catches accidental edits to
+        # ``TRUNCATE_SUFFIX`` since downstream UIs (harmonograf) match
+        # against it as a sentinel.
+        assert TRUNCATE_SUFFIX == " … [truncated]"
+
+
+# ---------------------------------------------------------------------------
+# register / classify
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_registry(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Isolate registry state from the auto-registered detector entries.
+
+    The detector modules register on import; we don't want to clobber
+    those for tests that share the same process. This fixture swaps in
+    a fresh dict for the duration of the test and restores on teardown.
+    """
+    saved = dict(registry._REGISTRY)
+    registry._REGISTRY.clear()
+    try:
+        yield registry._REGISTRY
+    finally:
+        registry._REGISTRY.clear()
+        registry._REGISTRY.update(saved)
+
+
+class TestRegisterAndClassify:
+    def test_sync_classifier_dispatches(self, fresh_registry: dict) -> None:
+        called: list[dict] = []
+
+        def stub(**kwargs):
+            called.append(kwargs)
+            return DriftEvent(
+                kind=DriftKind.TOOL_ERROR,
+                severity=DriftSeverity.WARNING,
+                detail="stub",
+            )
+
+        register(
+            DriftKind.TOOL_ERROR,
+            stub,
+            DetectorConfig(uses_llm=False),
+            is_async=False,
+        )
+        event = classify(kind=DriftKind.TOOL_ERROR, alpha=1, beta="two")
+        assert isinstance(event, DriftEvent)
+        assert event.kind is DriftKind.TOOL_ERROR
+        assert called == [{"alpha": 1, "beta": "two"}]
+
+    def test_async_classifier_returns_awaitable(self, fresh_registry: dict) -> None:
+        async def stub(**_kwargs) -> DriftEvent | None:
+            return None
+
+        register(
+            DriftKind.OFF_TOPIC,
+            stub,
+            DetectorConfig(uses_llm=True),
+            is_async=True,
+        )
+        result = classify(kind=DriftKind.OFF_TOPIC, reasoning="x")
+        # Async classifiers return a coroutine; the caller awaits it.
+        import inspect
+
+        assert inspect.iscoroutine(result)
+        result.close()
+
+    def test_unregistered_kind_raises(self, fresh_registry: dict) -> None:
+        with pytest.raises(KeyError) as excinfo:
+            classify(kind=DriftKind.TOOL_ERROR)
+        assert "no drift detector registered" in str(excinfo.value)
+
+    def test_get_config_returns_registered_config(
+        self, fresh_registry: dict
+    ) -> None:
+        cfg = DetectorConfig(
+            uses_llm=True,
+            max_input_chars=512,
+            max_output_tokens=4096,
+            disable_thinking=True,
+        )
+        register(DriftKind.GOAL_DRIFT, lambda **_: None, cfg, is_async=False)
+        assert get_config(DriftKind.GOAL_DRIFT) is cfg
+
+    def test_get_config_returns_none_for_unknown_kind(
+        self, fresh_registry: dict
+    ) -> None:
+        assert get_config(DriftKind.CAPABILITY_MISMATCH) is None
+
+    def test_re_registration_overwrites(self, fresh_registry: dict) -> None:
+        a = DetectorConfig(uses_llm=False, max_input_chars=1)
+        b = DetectorConfig(uses_llm=False, max_input_chars=2)
+        register(DriftKind.TOOL_ERROR, lambda **_: None, a, is_async=False)
+        register(DriftKind.TOOL_ERROR, lambda **_: None, b, is_async=False)
+        assert get_config(DriftKind.TOOL_ERROR) is b
+
+    def test_list_registered_returns_insertion_order(
+        self, fresh_registry: dict
+    ) -> None:
+        register(
+            DriftKind.GOAL_DRIFT,
+            lambda **_: None,
+            DetectorConfig(),
+            is_async=False,
+        )
+        register(
+            DriftKind.OFF_TOPIC,
+            lambda **_: None,
+            DetectorConfig(),
+            is_async=False,
+        )
+        assert list_registered() == (DriftKind.GOAL_DRIFT, DriftKind.OFF_TOPIC)
+
+
+class TestAutoRegistration:
+    """Detector modules self-register at import time."""
+
+    def test_ensure_registered_populates_all_known_detectors(self) -> None:
+        registry._ensure_registered()
+        kinds = set(list_registered())
+        # Every LLM-judge detector + the structural CAPABILITY_MISMATCH
+        # rule should be discoverable via the registry after the
+        # idempotent ``_ensure_registered`` call.
+        assert DriftKind.GOAL_DRIFT in kinds
+        assert DriftKind.OFF_TOPIC in kinds
+        assert DriftKind.JUSTIFIED_DEVIATION in kinds
+        assert DriftKind.CAPABILITY_MISMATCH in kinds
+
+    def test_config_for_reasoning_judge_pins_input_cap(self) -> None:
+        registry._ensure_registered()
+        cfg = get_config(DriftKind.OFF_TOPIC)
+        assert cfg is not None
+        # Pinned by the reasoning-judge detector — bus contract that
+        # observability emissions stay at 4096 chars.
+        assert cfg.max_input_chars == 4096
+        assert cfg.uses_llm is True
+        assert cfg.disable_thinking is True
+
+    def test_config_for_goal_drift_pins_trigger_input_cap(self) -> None:
+        registry._ensure_registered()
+        cfg = get_config(DriftKind.GOAL_DRIFT)
+        assert cfg is not None
+        assert cfg.max_input_chars == 2048
+        assert cfg.uses_llm is True
+
+    def test_config_for_capability_mismatch_is_structural(self) -> None:
+        registry._ensure_registered()
+        cfg = get_config(DriftKind.CAPABILITY_MISMATCH)
+        assert cfg is not None
+        assert cfg.uses_llm is False
+        # Structural rules do not have an observability payload —
+        # ``max_input_chars`` is therefore zero so the truncation helper
+        # is a no-op for these detectors.
+        assert cfg.max_input_chars == 0
+
+
+# ---------------------------------------------------------------------------
+# Parity check — the registry helpers must produce byte-identical output
+# vs the per-detector copies they replaced
+# ---------------------------------------------------------------------------
+
+
+class TestSharedHelpersParityWithDetectors:
+    """Sanity-check that goals/reasoning_judge still expose the helpers
+    under the historical private names so external test fixtures that
+    mock ``goals._parse_response`` etc. continue to work.
+    """
+
+    def test_goals_module_reexports_parse_response(self) -> None:
+        from goldfive.drift import goals
+
+        assert goals._parse_response is parse_json_response
+
+    def test_goals_module_reexports_format_goals(self) -> None:
+        from goldfive.drift import goals
+
+        assert goals._format_goals is format_goals_block
+
+    def test_reasoning_judge_reexports_parse_response(self) -> None:
+        from goldfive.drift import reasoning_judge
+
+        assert reasoning_judge._parse_response is parse_json_response
+
+    def test_reasoning_judge_reexports_format_goals(self) -> None:
+        from goldfive.drift import reasoning_judge
+
+        assert reasoning_judge._format_goals is format_goals_block
+
+    def test_reasoning_judge_reexports_truncate(self) -> None:
+        from goldfive.drift import reasoning_judge
+
+        assert reasoning_judge.truncate_for_observability is truncate_for_observability


### PR DESCRIPTION
## Motivation

Wave A piece 2 of 3 of the goldfive modularisation. Centralise the
genuinely-shared boilerplate across drift detectors so each detector
contributes only its classifier-specific logic, and give callers a
single place to look up detectors by `DriftKind`.

## What landed

New module `goldfive/drift/registry.py`:

- `DetectorConfig` dataclass — per-detector knobs (`uses_llm`,
  `max_input_chars`, `max_output_tokens`, `disable_thinking`,
  `timeout_seconds`).
- `parse_json_response` — liberal JSON extractor; previous copies in
  `goals.py` and `reasoning_judge.py` were byte-identical.
- `format_goals_block` — numbered `[id] summary` renderer; previous
  copies were byte-identical.
- `truncate_for_observability` — bounded text truncation with the
  uniform `" … [truncated]"` suffix.
- `register` / `classify` / `get_config` / `list_registered` —
  registry API. Detectors self-register at import time; callers can
  dispatch by kind without importing each detector module directly.

## Scope honesty note

The Wave-A brief anticipated ~500 LOC reduction. In practice **only
two of the five detectors** (`goals`, `reasoning_judge`) actually wrap
an LLM call + parse JSON. The other three (`capability_check`,
`tool_loops`, `reasoning`) are structural or embedding-based and have
no LLM/JSON boilerplate to share. `ToolLoopTracker` is also a stateful
class, not a stateless classifier, so it doesn't fit the registry's
`(kind, fn, config)` shape.

The value of this PR is single-source-of-truth for the JSON parser +
goals renderer + truncation helper, plus the registry-dispatch API.
Raw LOC savings inside the detector bodies are modest because the
duplicated code was small to begin with.

## LOC delta per detector

| File | Before | After | Delta |
| --- | --- | --- | --- |
| `goldfive/drift/registry.py` (new) | 0 | 410 | +410 |
| `tests/test_drift_registry.py` (new) | 0 | 345 | +345 |
| `goldfive/drift/goals.py` | 522 | 518 | -4 |
| `goldfive/drift/reasoning_judge.py` | 1376 | 1372 | -4 |
| `goldfive/drift/capability_check.py` | 437 | 458 | +21 (registration) |
| `goldfive/drift/reasoning.py` | 1286 | 1286 | 0 (no LLM boilerplate) |
| `goldfive/drift/tool_loops.py` | 761 | 761 | 0 (stateful tracker) |

## Contracts preserved (non-negotiable)

- `DriftKind` / `DriftEvent` enums unchanged.
- All prompts (`REASONING_DRIFT_USER_PROMPT_TEMPLATE`,
  `GOAL_DRIFT_USER_PROMPT_TEMPLATE`) unchanged.
- Per-detector caps unchanged: `REASONING_JUDGE_MAX_REASONING_INPUT_CHARS`
  still 4096; `REASONING_JUDGE_MAX_OUTPUT_TOKENS` still 16384;
  `GOAL_DRIFT_MAX_OUTPUT_TOKENS` still 16384.
- Public symbols (`truncate_for_observability`,
  `classify_reasoning_drift`, `classify_goal_drift`, etc.) preserved.
- `goals._parse_response`, `goals._format_goals`,
  `reasoning_judge._parse_response`, `reasoning_judge._format_goals`,
  `reasoning_judge.truncate_for_observability` all still importable
  for back-compat with external fixtures.
- **Output is byte-for-byte equivalent**: the new helpers ARE the old
  bodies, moved verbatim. Five identity tests in
  `tests/test_drift_registry.py::TestSharedHelpersParityWithDetectors`
  pin the re-exports so any future divergence shows up as a unit-test
  failure, not silent behavioural drift.

## Test plan

- [x] New: 36 registry unit tests (`tests/test_drift_registry.py`)
  cover `parse_json_response`, `format_goals_block`,
  `truncate_for_observability`, `register/classify/get_config`, and
  auto-registration.
- [x] Existing drift suite (`test_drift_classifiers.py`,
  `test_goal_drift_classifier.py`, `test_reasoning_judge*.py`,
  `test_drift_reasoning.py`, `test_capability_mismatch.py`,
  `test_tool_loops.py`) all green: **229 passed / 4 skipped / 0
  failed**.
- [x] Full repo: `pytest tests/ --tb=short` → **2024 passed / 126
  skipped / 0 failed** in 21.88s.
- [x] `ruff check goldfive/ tests/test_drift_registry.py` → clean.
- [x] Autouse `_state_audit_enabled` fixture from
  `tests/conftest.py` does not trip on any of the new code.

## Notes / decisions

- The reasoning judge registers under TWO `DriftKind`s
  (`OFF_TOPIC` and `JUSTIFIED_DEVIATION`) because its single
  classifier can emit either; the registry forwards by kind.
- The `classify(*, kind, **observation)` dispatcher forwards
  `**observation` verbatim — each detector keeps its own kwargs
  shape rather than being forced through a unified observation
  envelope (would have leaked detector-specific keys into the
  registry contract).
- Reasoning judge prompt construction (the 8+ `_format_*` helpers
  including `_format_task`, `_format_task_lineage`,
  `_format_tool_observations`, `format_plan_tasks_summary`,
  `format_available_agents_block`) deliberately **stays in the
  detector**. Same for `goal_drift`'s post-LLM re-read /
  staleness gate and `reasoning_judge`'s classification demotion
  logic. Centralising any of those would have hit the "do not
  touch classifier-specific logic" constraint.
- One out-of-scope item flagged for awareness: the four classifier
  helpers in `goldfive/drift/__init__.py` (`classify_tool_error`,
  `classify_refusal`, `classify_confabulation_risk`,
  `classify_stop_reason`) are structural detectors that could
  also self-register if the team wants every kind in the registry.
  Not done in this PR because they aren't in the "5 detectors" the
  brief listed; happy to follow up if useful.