### PR TITLE
refactor: split steerer into router + TaskStateMachine (drift_observer + plan_reviser TBD)

### DIFF
--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -682,6 +682,18 @@ class DefaultSteerer:
         # a consistent plan call :meth:`_wait_plan_stable` to acquire +
         # immediately release the lock. Keyed by ``session.id``.
         self._plan_locks: dict[str, asyncio.Lock] = {}
+        # Component construction. The router holds shared mutable state
+        # (sinks, planner, adapter, control_channel, ContextVar,
+        # background-task sets, plan locks, observation_only flag,
+        # config) and each component takes a back-reference to the
+        # router so cross-component calls go through one indirection.
+        # Order matters only insofar as a component constructed first
+        # cannot reference one constructed later inside its own
+        # ``__init__`` — none of them do today; every cross-call lands
+        # at runtime.
+        from goldfive.task_state_machine import TaskStateMachine
+
+        self._task_state_machine: TaskStateMachine = TaskStateMachine(self)
 
     # ------------------------------------------------------------------
     # Protocol-required: wiring
@@ -895,7 +907,12 @@ class DefaultSteerer:
         # here; transitions are always forward in the lifecycle.
 
     # ------------------------------------------------------------------
-    # Task state machine
+    # Task state machine — delegated to :class:`TaskStateMachine`.
+    #
+    # See :mod:`goldfive.task_state_machine` for the implementation.
+    # These thin shims preserve the historical public surface
+    # (``DefaultSteerer.mark_task_*``) so executors / reporting handlers
+    # / tests that bind to the router don't have to change.
     # ------------------------------------------------------------------
 
     async def mark_task_running(
@@ -906,59 +923,8 @@ class DefaultSteerer:
         detail: str = "",
         source: str = "other",
     ) -> None:
-        """Transition ``task_id`` to ``RUNNING`` and emit ``TaskStarted``.
-
-        ``source`` (goldfive#251 R4) is the attribution string emitted on
-        the paired ``TaskTransitioned`` sink event — see
-        :func:`goldfive.events.task_transitioned_event` for the
-        vocabulary. Defaults to ``"other"`` for callers that haven't been
-        threaded through (back-compat); the live LLM-driven path through
-        :mod:`goldfive.reporting` passes ``"llm_report"`` /
-        ``"handler_default"`` / ``"supersedes_reroute"`` as appropriate.
-        """
-        task = self._find_task(session, task_id)
-        if task is None:
-            return
-        if task.status in _TERMINAL_TASK_STATUSES:
-            return
-        from_status = task.status
-        # goldfive#247: Plan + Task are frozen. Mutate by deriving a new
-        # plan via :func:`with_task_status` and swapping the pointer
-        # under :func:`channel_processor_active`. The local ``task``
-        # reference becomes stale; refresh from the live plan so
-        # downstream side-effects see the new status.
-        with channel_processor_active():
-            assert session.plan is not None
-            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.RUNNING))
-        task = self._find_task(session, task_id) or task
-        session.current_task_id = task_id
-        if detail:
-            session.agent_notes[task_id] = detail
-        # goldfive#152: stamp current_task_* on the orchestration-state
-        # dict so downstream prompt templates / refine paths see it.
-        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.RUNNING)
-        # goldfive#271: stamp task progress liveness for the structural
-        # progress-stall escalation. A drift firing on this task within
-        # ``PROGRESS_STALL_THRESHOLD_SECONDS`` of any progress signal is
-        # considered productively iterating; outside that window, the
-        # next drift escalates to HUMAN_INTERVENTION_REQUIRED.
-        session.task_last_progress_at[task_id] = time.monotonic()
-        # Seed the observed-agent lineage with the static plan
-        # assignee. ``before_tool_callback`` extends the set with each
-        # delegated child agent so consumers (e.g. the reasoning judge)
-        # can distinguish "child of a delegation chain rooted at the
-        # assignee" from "off-plan agent". Cleared on every terminal
-        # transition.
-        session.task_lineage[task_id] = (
-            {task.assignee_agent_id} if task.assignee_agent_id else set()
-        )
-        await self._emit_task_started(session, task_id, detail)
-        await self._emit_task_transitioned(
-            session,
-            task,
-            from_status=from_status,
-            to_status=TaskStatus.RUNNING,
-            source=source,
+        await self._task_state_machine.mark_task_running(
+            task_id, session=session, detail=detail, source=source
         )
 
     async def mark_task_progress(
@@ -969,27 +935,9 @@ class DefaultSteerer:
         fraction: float = 0.0,
         detail: str = "",
     ) -> None:
-        """Record mid-task progress and emit ``TaskProgress``.
-
-        No status transition — a progress update is a liveness ping only.
-        ``fraction`` is clamped to ``[0.0, 1.0]``.
-        """
-        task = self._find_task(session, task_id)
-        if task is None:
-            return
-        try:
-            frac = float(fraction)
-        except (TypeError, ValueError):
-            frac = 0.0
-        frac = max(0.0, min(1.0, frac))
-        session.task_progress[task_id] = frac
-        if detail:
-            session.agent_notes[task_id] = detail
-        # goldfive#271: refresh progress liveness so a productively
-        # iterating task is not flagged as stalled by the structural
-        # escalation gate.
-        session.task_last_progress_at[task_id] = time.monotonic()
-        await self._emit_task_progress(session, task_id, frac, detail)
+        await self._task_state_machine.mark_task_progress(
+            task_id, session=session, fraction=fraction, detail=detail
+        )
 
     async def mark_task_completed(
         self,
@@ -1000,51 +948,13 @@ class DefaultSteerer:
         artifacts: dict[str, str] | None = None,
         source: str = "other",
     ) -> None:
-        """Transition ``task_id`` to ``COMPLETED`` and emit ``TaskCompleted``.
-
-        See :meth:`mark_task_running` for the ``source`` contract.
-        """
-        task = self._find_task(session, task_id)
-        if task is None:
-            return
-        if task.status in _TERMINAL_TASK_STATUSES:
-            return
-        from_status = task.status
-        # goldfive#247: derive a new immutable Plan and swap the pointer.
-        with channel_processor_active():
-            assert session.plan is not None
-            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.COMPLETED))
-        task = self._find_task(session, task_id) or task
-        if summary:
-            session.completed_results[task_id] = summary
-        # goldfive#152: clear current_task_* if we were the active task.
-        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.COMPLETED)
-        # Drop the observed-agent lineage now the task is terminal.
-        session.task_lineage.pop(task_id, None)
-        # iter-11B: pair the prior ``agent_invocation_started`` entry
-        # so the GOAL_DRIFT judge does not see an orphan-start +
-        # task-COMPLETED shape and false-positive on "looping".
-        # ``after_run_callback`` will append the real
-        # ``agent_invocation_completed`` slightly later when the agent
-        # actually returns; duplicate completed entries are harmless
-        # (each is benign and the ring buffer trims naturally).
-        if task.assignee_agent_id:
-            self.note_agent_activity(
-                session,
-                kind="agent_invocation_completed",
-                agent_name=task.assignee_agent_id,
-                task_id=task_id,
-            )
-        await self._emit_task_completed(session, task_id, summary, artifacts or {})
-        await self._emit_task_transitioned(
-            session,
-            task,
-            from_status=from_status,
-            to_status=TaskStatus.COMPLETED,
+        await self._task_state_machine.mark_task_completed(
+            task_id,
+            session=session,
+            summary=summary,
+            artifacts=artifacts,
             source=source,
         )
-        # goldfive#219: task boundary is a natural goal-drift checkpoint.
-        await self._maybe_run_goal_drift_on_task_boundary(session)
 
     async def mark_task_failed(
         self,
@@ -1055,85 +965,13 @@ class DefaultSteerer:
         recoverable: bool = True,
         source: str = "other",
     ) -> None:
-        """Transition ``task_id`` to ``FAILED`` and emit ``TaskFailed``.
-
-        Also fires a drift event of kind ``TASK_FAILED_RECOVERABLE`` or
-        ``TASK_FAILED_FATAL``. The drift event is dispatched through the
-        same drift pipeline as observer-detected drift: if severity is
-        ``>= WARNING`` (both of these are) we invoke ``planner.refine``.
-
-        When ``recoverable=False`` the failure is fatal for this task
-        lineage: **cascade-cancel every reachable downstream non-terminal
-        task** via :meth:`cascade_cancel_downstream`, so the plan lands
-        in a consistent terminal-only shape instead of orphaning
-        dependents that would sit PENDING forever. This is the
-        implementation of PLAN-LIFECYCLE.md §6.2 step 3 and it shares
-        its primitive with the §6.3 cancel cascade path
-        (:meth:`mark_task_cancelled`). The downstream cascade fires
-        *before* we dispatch the fatal drift through ``_handle_drift``
-        so that planner.refine sees the post-cascade plan shape and a
-        refine-failure back-off does not leave orphans behind. See
-        ``STATE-MACHINE.md §"Cascade semantics on unrecoverable drift"``.
-        """
-        task = self._find_task(session, task_id)
-        if task is None:
-            return
-        if task.status in _TERMINAL_TASK_STATUSES:
-            return
-        from_status = task.status
-        # goldfive#247: derive a new immutable Plan and swap the pointer.
-        with channel_processor_active():
-            assert session.plan is not None
-            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.FAILED))
-        task = self._find_task(session, task_id) or task
-        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.FAILED)
-        # Drop the observed-agent lineage now the task is terminal.
-        session.task_lineage.pop(task_id, None)
-        # iter-11B: pair the prior ``agent_invocation_started`` entry
-        # so the GOAL_DRIFT judge does not see an orphan-start +
-        # task-FAILED shape and false-positive on "looping".  See the
-        # matching write in :meth:`mark_task_completed` for rationale.
-        if task.assignee_agent_id:
-            self.note_agent_activity(
-                session,
-                kind="agent_invocation_completed",
-                agent_name=task.assignee_agent_id,
-                task_id=task_id,
-            )
-        await self._emit_task_failed(session, task_id, reason, recoverable)
-        await self._emit_task_transitioned(
-            session,
-            task,
-            from_status=from_status,
-            to_status=TaskStatus.FAILED,
+        await self._task_state_machine.mark_task_failed(
+            task_id,
+            session=session,
+            reason=reason,
+            recoverable=recoverable,
             source=source,
         )
-        # goldfive#219: task boundary is a natural goal-drift checkpoint.
-        await self._maybe_run_goal_drift_on_task_boundary(session)
-        # Fatal failures cascade downstream via the same primitive used
-        # by mark_task_cancelled, so both §6.2 and §6.3 produce the
-        # same TaskCancelled event stream and share rejection guards.
-        if not recoverable:
-            # The cascade is a propagation of the same source-attribution
-            # decision (e.g. an LLM-reported fatal failure cascades as
-            # ``"cancellation"`` from the framework's perspective — the
-            # cascaded tasks weren't moved by the LLM directly).
-            await self.cascade_cancel_downstream(session, task_id, source="cancellation")
-        kind = DriftKind.TASK_FAILED_RECOVERABLE if recoverable else DriftKind.TASK_FAILED_FATAL
-        severity = DriftSeverity.WARNING if recoverable else DriftSeverity.CRITICAL
-        drift = DriftEvent(
-            kind=kind,
-            severity=severity,
-            detail=f"task {task_id} failed: {reason}" if reason else f"task {task_id} failed",
-            current_task_id=task_id,
-        )
-        # iter-11A: spawn the drift cascade fire-and-forget so the
-        # reporting tool that triggered us (``report_task_failed``)
-        # can return immediately. The cascade
-        # (refine → supersedes → cancellation) lands asynchronously;
-        # tests that need the post-cascade plan state await
-        # :meth:`_wait_background_drifts_idle`.
-        self._spawn_drift_handler_background(drift, session)
 
     async def mark_task_blocked(
         self,
@@ -1144,48 +982,13 @@ class DefaultSteerer:
         needed: str = "",
         source: str = "other",
     ) -> None:
-        """Transition ``task_id`` to ``BLOCKED`` and emit ``TaskBlocked``.
-
-        Also fires a drift event of kind ``BLOCKED`` which flows through
-        the standard drift pipeline (WARNING severity → refine).
-        """
-        task = self._find_task(session, task_id)
-        if task is None:
-            return
-        if task.status in _TERMINAL_TASK_STATUSES:
-            return
-        # BLOCKED is not a terminal status but we still guard against
-        # re-blocking a task that's already blocked (idempotent).
-        from_status = task.status
-        # goldfive#247: derive a new immutable Plan and swap the pointer.
-        with channel_processor_active():
-            assert session.plan is not None
-            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.BLOCKED))
-        task = self._find_task(session, task_id) or task
-        if blocker or needed:
-            session.agent_notes[task_id] = f"blocked: {blocker}" + (
-                f" (needed: {needed})" if needed else ""
-            )
-        await self._emit_task_blocked(session, task_id, blocker, needed)
-        await self._emit_task_transitioned(
-            session,
-            task,
-            from_status=from_status,
-            to_status=TaskStatus.BLOCKED,
+        await self._task_state_machine.mark_task_blocked(
+            task_id,
+            session=session,
+            blocker=blocker,
+            needed=needed,
             source=source,
         )
-        detail = f"task {task_id} blocked: {blocker}" + (f" (needed: {needed})" if needed else "")
-        drift = DriftEvent(
-            kind=DriftKind.BLOCKED,
-            severity=DriftSeverity.WARNING,
-            detail=detail,
-            current_task_id=task_id,
-        )
-        # iter-11A: spawn the drift cascade fire-and-forget so the
-        # reporting tool that triggered us (``report_task_blocked``)
-        # can return immediately. See :meth:`mark_task_failed` for
-        # the matching call-site comment.
-        self._spawn_drift_handler_background(drift, session)
 
     async def mark_task_cancelled(
         self,
@@ -1195,50 +998,9 @@ class DefaultSteerer:
         reason: str = "",
         source: str = "other",
     ) -> None:
-        """Transition ``task_id`` to ``CANCELLED`` and emit ``TaskCancelled``.
-
-        Also **cascades** the cancellation forward through the plan's
-        edges: every non-terminal task reachable from ``task_id`` is
-        transitioned to ``CANCELLED`` with a "cascade from <task_id>"
-        reason. Without this cascade, downstream PENDING tasks with a
-        CANCELLED predecessor would never satisfy the executor's
-        "all deps COMPLETED" check — they would sit PENDING forever and
-        the executor would report the run as successful while leaving
-        them orphaned. See TASK-LIFECYCLE.md §"Cancellation cascade" and
-        STATE-MACHINE.md §"Cascade semantics on unrecoverable drift".
-        """
-        task = self._find_task(session, task_id)
-        if task is None:
-            return
-        if task.status in _TERMINAL_TASK_STATUSES:
-            # Already terminal (including already CANCELLED) — no-op, and
-            # crucially do NOT re-run the cascade: we would double-emit
-            # TaskCancelled events for downstream tasks on every call.
-            return
-        from_status = task.status
-        # goldfive#247: derive a new immutable Plan and swap the pointer.
-        with channel_processor_active():
-            assert session.plan is not None
-            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.CANCELLED))
-        task = self._find_task(session, task_id) or task
-        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.CANCELLED)
-        # Drop the observed-agent lineage now the task is terminal.
-        session.task_lineage.pop(task_id, None)
-        await self._emit_task_cancelled(session, task_id, reason)
-        await self._emit_task_transitioned(
-            session,
-            task,
-            from_status=from_status,
-            to_status=TaskStatus.CANCELLED,
-            source=source,
+        await self._task_state_machine.mark_task_cancelled(
+            task_id, session=session, reason=reason, source=source
         )
-        # goldfive#219: task boundary is a natural goal-drift checkpoint.
-        # Fire before cascade so the judge sees the initiator's transition;
-        # cascade-cancel downstream tasks share the same rate-limit bucket
-        # and will no-op as subsequent boundary fires fall within the
-        # 10s guard.
-        await self._maybe_run_goal_drift_on_task_boundary(session)
-        await self.cascade_cancel_downstream(session, task_id, source="cancellation")
 
     async def mark_task_not_needed(
         self,
@@ -1248,55 +1010,9 @@ class DefaultSteerer:
         reason: str = "",
         source: str = "other",
     ) -> None:
-        """Transition ``task_id`` to ``NOT_NEEDED`` terminally.
-
-        Introduced by the overlay-model refactor (goldfive#141). Unlike
-        :meth:`mark_task_cancelled` this path does NOT cascade — a task
-        the :class:`~goldfive.reconciler.PlanReconciler` deemed "not
-        needed" post-invocation is an observation about that specific
-        plan entry, not a signal that downstream work is invalid. The
-        reconciler independently evaluates each PENDING task.
-
-        Idempotent on terminal tasks. Emits ``TaskCancelled`` at the
-        proto level (there's no dedicated NOT_NEEDED event — the
-        status lives on the task itself and sinks can distinguish via
-        ``task.status`` on the next ``TaskCancelled`` / ``PlanRevised``
-        envelope). The reason string carries the distinguishing
-        context ("not needed: superseded by ...").
-        """
-        task = self._find_task(session, task_id)
-        if task is None:
-            return
-        if task.status in _TERMINAL_TASK_STATUSES:
-            return
-        from_status = task.status
-        # goldfive#247: derive a new immutable Plan and swap the pointer.
-        assert session.plan is not None
-        with channel_processor_active():
-            set_session_plan(
-                session,
-                with_task_status(session.plan, task_id, TaskStatus.NOT_NEEDED),
-            )
-        task = self._find_task(session, task_id) or task
-        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.NOT_NEEDED)
-        # Drop the observed-agent lineage now the task is terminal.
-        session.task_lineage.pop(task_id, None)
-        # There is no dedicated ``TaskNotNeeded`` proto message;
-        # reuse TaskCancelled with the reason prefix so sinks that
-        # inspect reason can differentiate if they wish. The live
-        # ``task.status`` on the plan is the authoritative signal.
-        await self._emit_task_cancelled(
-            session, task_id, f"not_needed: {reason}" if reason else "not_needed"
+        await self._task_state_machine.mark_task_not_needed(
+            task_id, session=session, reason=reason, source=source
         )
-        await self._emit_task_transitioned(
-            session,
-            task,
-            from_status=from_status,
-            to_status=TaskStatus.NOT_NEEDED,
-            source=source,
-        )
-        # goldfive#219: task boundary is a natural goal-drift checkpoint.
-        await self._maybe_run_goal_drift_on_task_boundary(session)
 
     async def cascade_cancel_downstream(
         self,
@@ -1305,115 +1021,9 @@ class DefaultSteerer:
         *,
         source: str = "cancellation",
     ) -> None:
-        """BFS-cancel every downstream non-terminal task of ``cancelled_id``.
-
-        Shared primitive for both cascade codepaths
-        (PLAN-LIFECYCLE.md §6.2 unrecoverable cascade and §6.3
-        cancellation cascade):
-
-        - The recoverable path
-          (:meth:`mark_task_cancelled`) calls it after transitioning
-          the initiator to ``CANCELLED``.
-        - The unrecoverable path
-          (:meth:`mark_task_failed` with ``recoverable=False``) calls
-          it after transitioning the initiator to ``FAILED``.
-
-        Both paths therefore produce the same ``TaskCancelled`` event
-        stream for the downstream set and share the rejection guards
-        (terminal tasks are skipped; diamond DAGs are de-duplicated).
-        The initiator's own transition-emission is caller-controlled —
-        this method only emits for the *downstream* set.
-
-        Walks ``session.plan.edges`` forward from ``cancelled_id`` and
-        transitions every reachable non-terminal task to ``CANCELLED``
-        in-place, emitting one ``TaskCancelled`` event per transition.
-        Terminal tasks (COMPLETED / FAILED / CANCELLED) are skipped so a
-        diamond DAG does not re-cancel a task through two paths and so
-        already-COMPLETED dependents are preserved verbatim.
-
-        Implemented as an iterative BFS on a precomputed adjacency list
-        (rather than recursing into :meth:`mark_task_cancelled`) so a
-        single top-level cancel produces one summary log line and a
-        predictable number of emitted events, independent of graph shape.
-        """
-        plan = session.plan
-        if plan is None:
-            return
-        # Precompute forward adjacency once.
-        downstream: dict[str, list[str]] = {}
-        for e in plan.edges:
-            downstream.setdefault(e.from_task_id, []).append(e.to_task_id)
-        tasks_by_id: dict[str, Task] = {t.id: t for t in plan.tasks if t.id}
-
-        # goldfive#205: structured reason consumed by harmonograf's
-        # Trajectory view. Old ``cascade from <id>`` form preserved in a
-        # human-readable tail after the colon so sinks that render the
-        # raw reason keep their existing copy; new sinks parse the
-        # ``upstream_failed:`` prefix to categorise the cancel.
-        cascade_reason = f"upstream_failed:{cancelled_id}"
-        cascaded: list[str] = []
-        queue: list[str] = list(downstream.get(cancelled_id, []))
-        visited: set[str] = set()
-        while queue:
-            next_id = queue.pop(0)
-            if next_id in visited:
-                continue
-            visited.add(next_id)
-            dep = tasks_by_id.get(next_id)
-            if dep is None:
-                continue
-            if dep.status in _TERMINAL_TASK_STATUSES:
-                # Already terminal (COMPLETED/FAILED/CANCELLED) — preserve
-                # and do not traverse its children. A COMPLETED task that
-                # sits downstream of a late-cancelled ancestor keeps its
-                # completion; cascading past it would mean cancelling
-                # tasks whose preserved prerequisite is still valid.
-                continue
-            # Transition by deriving a new plan and swapping it in. We
-            # deliberately do NOT recurse through ``mark_task_cancelled``
-            # here; we fan out via our own BFS queue so the surrounding
-            # summary log and emission count stay deterministic.
-            #
-            # goldfive#247: the local ``dep`` reference becomes stale
-            # after the swap (frozen Task) — re-resolve from the live
-            # plan so the emit reads the new status. Note that
-            # ``tasks_by_id`` was built from the *original* plan; the
-            # iteration loop only inspects ``status`` for terminal
-            # gating which is monotonic (a task that wasn't terminal
-            # at loop start is the one we're cancelling).
-            dep_from = dep.status
-            assert session.plan is not None
-            with channel_processor_active():
-                set_session_plan(
-                    session,
-                    with_task_status(session.plan, next_id, TaskStatus.CANCELLED),
-                )
-            # Drop the observed-agent lineage now the task is terminal —
-            # mirrors the cleanup that ``mark_task_cancelled`` performs
-            # for the initiator (this BFS does not recurse through that
-            # method so the cleanup is duplicated explicitly).
-            session.task_lineage.pop(next_id, None)
-            await self._emit_task_cancelled(session, next_id, cascade_reason)
-            # Re-fetch so the transition emit reads the swapped task.
-            updated_dep = self._find_task(session, next_id) or dep
-            await self._emit_task_transitioned(
-                session,
-                updated_dep,
-                from_status=dep_from,
-                to_status=TaskStatus.CANCELLED,
-                source=source,
-            )
-            cascaded.append(next_id)
-            for grandchild in downstream.get(next_id, []):
-                if grandchild not in visited:
-                    queue.append(grandchild)
-        if cascaded:
-            log.info(
-                "DefaultSteerer: cascade-cancelled %d downstream task(s) from %s: %s",
-                len(cascaded),
-                cancelled_id,
-                ", ".join(cascaded),
-            )
+        await self._task_state_machine.cascade_cancel_downstream(
+            session, cancelled_id, source=source
+        )
 
     # ------------------------------------------------------------------
     # Observer: drift detection + refine
@@ -3113,6 +2723,10 @@ class DefaultSteerer:
 
     @staticmethod
     def _find_task(session: Session, task_id: str) -> Task | None:
+        # Identity helper — kept as a router-level staticmethod so the
+        # historical call surface (``DefaultSteerer._find_task``) keeps
+        # working unchanged. Mirrors
+        # :meth:`goldfive.task_state_machine.TaskStateMachine._find_task`.
         if not task_id or session.plan is None:
             return None
         for t in session.plan.tasks:
@@ -6578,21 +6192,20 @@ class DefaultSteerer:
         return getattr(types_pb2, name, getattr(types_pb2, "DRIFT_SEVERITY_UNSPECIFIED", 0))
 
     # --- Concrete emitters -------------------------------------------
+    #
+    # Per-status proto emit helpers — delegated to
+    # :class:`~goldfive.task_state_machine.TaskStateMachine`. Thin shims
+    # so test fixtures that mock ``DefaultSteerer._emit_task_*`` keep
+    # intercepting at the router level and so other components inside
+    # this module can keep calling ``self._emit_task_*`` unchanged.
 
     async def _emit_task_started(self, session: Session, task_id: str, detail: str) -> None:
-        evt = self._new_envelope(session)
-        evt.task_started.task_id = task_id
-        evt.task_started.detail = detail
-        await self._emit(evt)
+        await self._task_state_machine._emit_task_started(session, task_id, detail)
 
     async def _emit_task_progress(
         self, session: Session, task_id: str, fraction: float, detail: str
     ) -> None:
-        evt = self._new_envelope(session)
-        evt.task_progress.task_id = task_id
-        evt.task_progress.fraction = fraction
-        evt.task_progress.detail = detail
-        await self._emit(evt)
+        await self._task_state_machine._emit_task_progress(session, task_id, fraction, detail)
 
     async def _emit_task_completed(
         self,
@@ -6601,36 +6214,26 @@ class DefaultSteerer:
         summary: str,
         artifacts: dict[str, str],
     ) -> None:
-        evt = self._new_envelope(session)
-        evt.task_completed.task_id = task_id
-        evt.task_completed.summary = summary
-        for k, v in artifacts.items():
-            evt.task_completed.artifacts[k] = v
-        await self._emit(evt)
+        await self._task_state_machine._emit_task_completed(
+            session, task_id, summary, artifacts
+        )
 
     async def _emit_task_failed(
         self, session: Session, task_id: str, reason: str, recoverable: bool
     ) -> None:
-        evt = self._new_envelope(session)
-        evt.task_failed.task_id = task_id
-        evt.task_failed.reason = reason
-        evt.task_failed.recoverable = recoverable
-        await self._emit(evt)
+        await self._task_state_machine._emit_task_failed(
+            session, task_id, reason, recoverable
+        )
 
     async def _emit_task_blocked(
         self, session: Session, task_id: str, blocker: str, needed: str
     ) -> None:
-        evt = self._new_envelope(session)
-        evt.task_blocked.task_id = task_id
-        evt.task_blocked.blocker = blocker
-        evt.task_blocked.needed = needed
-        await self._emit(evt)
+        await self._task_state_machine._emit_task_blocked(
+            session, task_id, blocker, needed
+        )
 
     async def _emit_task_cancelled(self, session: Session, task_id: str, reason: str) -> None:
-        evt = self._new_envelope(session)
-        evt.task_cancelled.task_id = task_id
-        evt.task_cancelled.reason = reason
-        await self._emit(evt)
+        await self._task_state_machine._emit_task_cancelled(session, task_id, reason)
 
     async def _emit_task_transitioned(
         self,
@@ -6641,82 +6244,13 @@ class DefaultSteerer:
         to_status: TaskStatus,
         source: str,
     ) -> None:
-        """Emit a ``TaskTransitioned`` envelope (goldfive#251 R4).
-
-        Sink-only observability. Called from every site that mutates a
-        task's status — both the imperative ``mark_task_*`` path and
-        the cascade path inside :meth:`cascade_cancel_downstream`. The
-        LLM never sees this event; the ``report_task_*`` surface still
-        returns ``{"acknowledged": True}``.
-
-        Source attribution is the caller's responsibility (defaults to
-        ``"other"`` on un-threaded callers); see
-        :func:`goldfive.events.task_transitioned_event` for the
-        vocabulary.
-
-        ``agent_name`` resolves to ``task.assignee_agent_id``; that's
-        the most stable surface goldfive owns. ``invocation_id`` is a
-        best-effort lookup against the reconciler's
-        ``_invocation_agent`` map (goldfive#151) when available; empty
-        when no in-flight invocation matches the assignee. Tolerant of
-        missing maps / proto stubs — emission failures are swallowed
-        with a debug log rather than breaking the transition path.
-        """
-        # goldfive#271: stamp task progress liveness on every transition
-        # so the structural progress-stall escalation gate sees the task
-        # as productively iterating. Done BEFORE the sink check because
-        # progress liveness must be tracked even when sinks are missing
-        # (test scenarios) — the gate consults this map regardless.
-        task_id_for_progress = str(getattr(task, "id", "") or "")
-        if task_id_for_progress:
-            session.task_last_progress_at[task_id_for_progress] = time.monotonic()
-        sinks = self._sinks
-        if not sinks:
-            return
-        try:
-            from goldfive.events import emit, task_transitioned_event
-        except Exception as exc:  # noqa: BLE001 — proto stubs may be missing
-            log.debug(
-                "DefaultSteerer._emit_task_transitioned: events module unavailable: %s",
-                exc,
-            )
-            return
-
-        agent_name = str(getattr(task, "assignee_agent_id", "") or "")
-        invocation_id = self._resolve_invocation_id_for_agent(agent_name)
-        revision_stamp = 0
-        plan = getattr(session, "plan", None)
-        if plan is not None:
-            try:
-                revision_stamp = int(getattr(plan, "revision_index", 0) or 0)
-            except (TypeError, ValueError):
-                revision_stamp = 0
-        try:
-            evt = task_transitioned_event(
-                session.run_id,
-                session.next_sequence(),
-                task_id=str(getattr(task, "id", "") or ""),
-                from_status=str(getattr(from_status, "value", from_status) or ""),
-                to_status=str(getattr(to_status, "value", to_status) or ""),
-                source=str(source or "other"),
-                revision_stamp=revision_stamp,
-                agent_name=agent_name,
-                invocation_id=invocation_id,
-                session_id=session.id,
-            )
-        except Exception as exc:  # noqa: BLE001
-            log.debug(
-                "DefaultSteerer._emit_task_transitioned: proto event build failed: %s",
-                exc,
-            )
-            return
-        try:
-            await emit(sinks, evt)
-        except Exception as exc:  # noqa: BLE001
-            log.debug(
-                "DefaultSteerer._emit_task_transitioned: sink emit raised: %s",
-                exc,
-            )
+        await self._task_state_machine._emit_task_transitioned(
+            session,
+            task,
+            from_status=from_status,
+            to_status=to_status,
+            source=source,
+        )
 
     async def _emit_plan_revision_transitions(
         self,
@@ -6724,89 +6258,12 @@ class DefaultSteerer:
         prev_plan: Plan | None,
         revised: Plan,
     ) -> None:
-        """Emit ``TaskTransitioned`` events for status changes carried by a refine.
-
-        Compares ``prev_plan`` vs ``revised`` task-by-task and emits one
-        ``TaskTransitioned`` event per task whose status changed (or
-        whose ``status`` is now non-PENDING and the task didn't exist
-        in ``prev_plan`` — a refine-introduced task that arrived in a
-        non-PENDING state, e.g. a CORRECT-kind successor that the
-        planner pre-stamped).
-
-        Source is always ``"plan_revision"``: the refine is the
-        authoritative driver. Tasks that exist in both plans with the
-        same status are skipped (no transition happened).
-
-        ``prev_plan`` may be ``None`` on the first revision after a run
-        with no initial plan; in that case every task in ``revised``
-        with non-PENDING status emits a "(implicit) PENDING ->
-        actual_status" event so operators see the post-revision state
-        on the wire.
-        """
-        if not self._sinks:
-            return
-        prev_by_id: dict[str, Task] = {}
-        if prev_plan is not None:
-            for t in getattr(prev_plan, "tasks", []) or []:
-                tid = str(getattr(t, "id", "") or "")
-                if tid:
-                    prev_by_id[tid] = t
-        for t in getattr(revised, "tasks", []) or []:
-            tid = str(getattr(t, "id", "") or "")
-            if not tid:
-                continue
-            new_status = getattr(t, "status", None)
-            if not isinstance(new_status, TaskStatus):
-                continue
-            old = prev_by_id.get(tid)
-            if old is None:
-                old_status: TaskStatus = TaskStatus.PENDING
-            else:
-                old_status = getattr(old, "status", TaskStatus.PENDING)
-            if old_status == new_status:
-                continue
-            # No transition to record when the new status is the
-            # default PENDING and the task is brand-new — sinks would
-            # render that as a phantom "started in PENDING" row.
-            if old is None and new_status is TaskStatus.PENDING:
-                continue
-            await self._emit_task_transitioned(
-                session,
-                t,
-                from_status=old_status,
-                to_status=new_status,
-                source="plan_revision",
-            )
+        await self._task_state_machine._emit_plan_revision_transitions(
+            session, prev_plan, revised
+        )
 
     def _resolve_invocation_id_for_agent(self, agent_name: str) -> str:
-        """Best-effort lookup of an active invocation_id for ``agent_name``.
-
-        Mirrors the reconciler-walk pattern in
-        :meth:`_resolve_active_invocation_ids` but scopes the match to a
-        single agent name (the assignee of the transitioning task). The
-        most-recent matching invocation_id wins; empty string when no
-        match (no reconciler, no in-flight invocation under that
-        agent, etc.). Tolerant of every failure mode — never raises.
-        """
-        if not agent_name:
-            return ""
-        adapter = self._adapter
-        plugin = getattr(adapter, "_plugin", None) if adapter is not None else None
-        reconciler = getattr(plugin, "_reconciler", None) if plugin is not None else None
-        if reconciler is None:
-            return ""
-        try:
-            inv_agent = getattr(reconciler, "_invocation_agent", None)
-            if not isinstance(inv_agent, Mapping):
-                return ""
-            # Iterate insertion-order; later writes win.
-            match = ""
-            for inv_id, name in inv_agent.items():
-                if name == agent_name and inv_id:
-                    match = str(inv_id)
-            return match
-        except Exception:  # noqa: BLE001
-            return ""
+        return self._task_state_machine._resolve_invocation_id_for_agent(agent_name)
 
     async def _emit_drift_detected(self, session: Session, drift: DriftEvent) -> None:
         evt = self._new_envelope(session)

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -88,7 +88,6 @@ from goldfive.types import (
     channel_processor_active,
     replace_edges,
     set_session_plan,
-    with_task_status,
 )
 
 if TYPE_CHECKING:

--- a/goldfive/task_state_machine.py
+++ b/goldfive/task_state_machine.py
@@ -57,7 +57,7 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from goldfive import orchestration_state as _ostate
 from goldfive.types import (

--- a/goldfive/task_state_machine.py
+++ b/goldfive/task_state_machine.py
@@ -59,7 +59,7 @@ import time
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
-from goldfive import orchestration_state as _ostate
+from goldfive import state_store as _ostate
 from goldfive.types import (
     TERMINAL_TASK_STATUSES,
     DriftEvent,

--- a/goldfive/task_state_machine.py
+++ b/goldfive/task_state_machine.py
@@ -1,0 +1,874 @@
+"""Task-status transitions + per-status sink emission for :class:`DefaultSteerer`.
+
+Extracted from :mod:`goldfive.steerer` in Wave C of the steerer split.
+This module owns the imperative ``mark_task_*`` family — the canonical
+write path for every task-status transition driven by reporting tools,
+the reconciler, and the executor — plus the shared
+:func:`cascade_cancel_downstream` primitive used by both the
+``mark_task_cancelled`` recoverable path and the ``mark_task_failed``
+unrecoverable path.
+
+Responsibilities
+----------------
+
+* Validate ``(from_status, to_status)`` against the
+  :data:`~goldfive.types.TERMINAL_TASK_STATUSES` set so terminal tasks
+  cannot be reanimated, and so a re-call on an already-terminal task is
+  a no-op (matters for cascade reentry).
+* Derive the new immutable :class:`~goldfive.types.Plan` via
+  :func:`~goldfive.types.with_task_status` and swap it onto
+  ``session.plan`` under :func:`~goldfive.types.channel_processor_active`
+  — the goldfive#247 contract for Plan + Task immutability.
+* Stamp the per-task progress liveness watermark
+  (``session.task_last_progress_at``) so the structural progress-stall
+  gate in :mod:`goldfive.drift_observer` can distinguish productively
+  iterating tasks from stuck ones (goldfive#271).
+* Maintain ``session.task_lineage`` so reasoning-judge attribution can
+  detect "child of a delegation chain rooted at this assignee".
+* Emit one proto ``Task*`` event PLUS one ``TaskTransitioned`` event
+  per transition. Cascade cancellation emits the same pair per
+  downstream task, with a structured ``upstream_failed:<id>`` reason
+  (goldfive#205).
+* Spawn drift cascades fire-and-forget for FAILED / BLOCKED so the
+  reporting tool that triggered the transition returns immediately
+  (iter-11A). The cascade itself is owned by the
+  :class:`~goldfive.drift_observer.DriftObserver`; this module only
+  spawns the task.
+* Fire the per-task-boundary GOAL_DRIFT check (goldfive#219).
+
+The module DOES NOT own:
+
+* Drift classification / dispatch (lives in
+  :class:`~goldfive.drift_observer.DriftObserver`).
+* Plan revision install / supersedes / refine sequencing (lives in
+  :class:`~goldfive.plan_reviser.PlanReviser`).
+* The shared event-emission primitives (``_new_envelope`` / ``_emit``
+  / pb-value helpers) — those live on the :class:`DefaultSteerer`
+  router because every component emits through them.
+
+All cross-component calls go through the router back-reference passed
+to :meth:`TaskStateMachine.__init__` (``self._steerer``). This keeps
+the three components decoupled and lets the router own the shared
+state (sinks, adapter, control channel, background-task tracking).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from goldfive import orchestration_state as _ostate
+from goldfive.types import (
+    TERMINAL_TASK_STATUSES,
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Plan,
+    Session,
+    Task,
+    TaskStatus,
+    channel_processor_active,
+    set_session_plan,
+    with_task_status,
+)
+
+if TYPE_CHECKING:
+    from goldfive.steerer import DefaultSteerer
+
+log = logging.getLogger(__name__)
+
+
+# Re-export for compat with code that imported the private name from
+# :mod:`goldfive.steerer` historically; do NOT redefine.
+_TERMINAL_TASK_STATUSES = TERMINAL_TASK_STATUSES
+
+
+class TaskStateMachine:
+    """Per-task status transitions + cascade + transition-event emission.
+
+    Constructed by :class:`DefaultSteerer` and held on
+    ``DefaultSteerer._task_state_machine``. The router delegates every
+    ``mark_task_*`` protocol method to the matching method on this
+    class. Tests that historically poked the bare-attribute names
+    (``steerer.mark_task_running``, ``steerer._emit_task_started``,
+    etc.) still find them via the router's ``__getattr__`` forwarder.
+    """
+
+    def __init__(self, steerer: DefaultSteerer) -> None:
+        # Back-reference to the router. Used to reach the shared event-
+        # emission primitives (``_new_envelope``, ``_emit``) and the
+        # other two components (``_drift_observer``, ``_plan_reviser``)
+        # when a transition path needs to cross a boundary
+        # (e.g. mark_task_failed spawns a drift cascade owned by the
+        # observer; cascade emits a TaskTransitioned which needs the
+        # invocation-id resolver).
+        self._steerer = steerer
+
+    # ------------------------------------------------------------------
+    # Plan lookup
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _find_task(session: Session, task_id: str) -> Task | None:
+        if not task_id or session.plan is None:
+            return None
+        for t in session.plan.tasks:
+            if t.id == task_id:
+                return t
+        return None
+
+    # ------------------------------------------------------------------
+    # mark_task_* family
+    # ------------------------------------------------------------------
+
+    async def mark_task_running(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        detail: str = "",
+        source: str = "other",
+    ) -> None:
+        """Transition ``task_id`` to ``RUNNING`` and emit ``TaskStarted``.
+
+        ``source`` (goldfive#251 R4) is the attribution string emitted on
+        the paired ``TaskTransitioned`` sink event — see
+        :func:`goldfive.events.task_transitioned_event` for the
+        vocabulary. Defaults to ``"other"`` for callers that haven't been
+        threaded through (back-compat); the live LLM-driven path through
+        :mod:`goldfive.reporting` passes ``"llm_report"`` /
+        ``"handler_default"`` / ``"supersedes_reroute"`` as appropriate.
+        """
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return
+        from_status = task.status
+        # goldfive#247: Plan + Task are frozen. Mutate by deriving a new
+        # plan via :func:`with_task_status` and swapping the pointer
+        # under :func:`channel_processor_active`. The local ``task``
+        # reference becomes stale; refresh from the live plan so
+        # downstream side-effects see the new status.
+        with channel_processor_active():
+            assert session.plan is not None
+            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.RUNNING))
+        task = self._find_task(session, task_id) or task
+        session.current_task_id = task_id
+        if detail:
+            session.agent_notes[task_id] = detail
+        # goldfive#152: stamp current_task_* on the orchestration-state
+        # dict so downstream prompt templates / refine paths see it.
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.RUNNING)
+        # goldfive#271: stamp task progress liveness for the structural
+        # progress-stall escalation. A drift firing on this task within
+        # ``PROGRESS_STALL_THRESHOLD_SECONDS`` of any progress signal is
+        # considered productively iterating; outside that window, the
+        # next drift escalates to HUMAN_INTERVENTION_REQUIRED.
+        session.task_last_progress_at[task_id] = time.monotonic()
+        # Seed the observed-agent lineage with the static plan
+        # assignee. ``before_tool_callback`` extends the set with each
+        # delegated child agent so consumers (e.g. the reasoning judge)
+        # can distinguish "child of a delegation chain rooted at the
+        # assignee" from "off-plan agent". Cleared on every terminal
+        # transition.
+        session.task_lineage[task_id] = (
+            {task.assignee_agent_id} if task.assignee_agent_id else set()
+        )
+        await self._emit_task_started(session, task_id, detail)
+        await self._emit_task_transitioned(
+            session,
+            task,
+            from_status=from_status,
+            to_status=TaskStatus.RUNNING,
+            source=source,
+        )
+
+    async def mark_task_progress(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        fraction: float = 0.0,
+        detail: str = "",
+    ) -> None:
+        """Record mid-task progress and emit ``TaskProgress``.
+
+        No status transition — a progress update is a liveness ping only.
+        ``fraction`` is clamped to ``[0.0, 1.0]``.
+        """
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        try:
+            frac = float(fraction)
+        except (TypeError, ValueError):
+            frac = 0.0
+        frac = max(0.0, min(1.0, frac))
+        session.task_progress[task_id] = frac
+        if detail:
+            session.agent_notes[task_id] = detail
+        # goldfive#271: refresh progress liveness so a productively
+        # iterating task is not flagged as stalled by the structural
+        # escalation gate.
+        session.task_last_progress_at[task_id] = time.monotonic()
+        await self._emit_task_progress(session, task_id, frac, detail)
+
+    async def mark_task_completed(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        summary: str = "",
+        artifacts: dict[str, str] | None = None,
+        source: str = "other",
+    ) -> None:
+        """Transition ``task_id`` to ``COMPLETED`` and emit ``TaskCompleted``.
+
+        See :meth:`mark_task_running` for the ``source`` contract.
+        """
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return
+        from_status = task.status
+        # goldfive#247: derive a new immutable Plan and swap the pointer.
+        with channel_processor_active():
+            assert session.plan is not None
+            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.COMPLETED))
+        task = self._find_task(session, task_id) or task
+        if summary:
+            session.completed_results[task_id] = summary
+        # goldfive#152: clear current_task_* if we were the active task.
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.COMPLETED)
+        # Drop the observed-agent lineage now the task is terminal.
+        session.task_lineage.pop(task_id, None)
+        # iter-11B: pair the prior ``agent_invocation_started`` entry
+        # so the GOAL_DRIFT judge does not see an orphan-start +
+        # task-COMPLETED shape and false-positive on "looping".
+        # ``after_run_callback`` will append the real
+        # ``agent_invocation_completed`` slightly later when the agent
+        # actually returns; duplicate completed entries are harmless
+        # (each is benign and the ring buffer trims naturally).
+        if task.assignee_agent_id:
+            self._steerer.note_agent_activity(
+                session,
+                kind="agent_invocation_completed",
+                agent_name=task.assignee_agent_id,
+                task_id=task_id,
+            )
+        await self._emit_task_completed(session, task_id, summary, artifacts or {})
+        await self._emit_task_transitioned(
+            session,
+            task,
+            from_status=from_status,
+            to_status=TaskStatus.COMPLETED,
+            source=source,
+        )
+        # goldfive#219: task boundary is a natural goal-drift checkpoint.
+        await self._steerer._maybe_run_goal_drift_on_task_boundary(session)
+
+    async def mark_task_failed(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        reason: str = "",
+        recoverable: bool = True,
+        source: str = "other",
+    ) -> None:
+        """Transition ``task_id`` to ``FAILED`` and emit ``TaskFailed``.
+
+        Also fires a drift event of kind ``TASK_FAILED_RECOVERABLE`` or
+        ``TASK_FAILED_FATAL``. The drift event is dispatched through the
+        same drift pipeline as observer-detected drift: if severity is
+        ``>= WARNING`` (both of these are) we invoke ``planner.refine``.
+
+        When ``recoverable=False`` the failure is fatal for this task
+        lineage: **cascade-cancel every reachable downstream non-terminal
+        task** via :meth:`cascade_cancel_downstream`, so the plan lands
+        in a consistent terminal-only shape instead of orphaning
+        dependents that would sit PENDING forever. This is the
+        implementation of PLAN-LIFECYCLE.md §6.2 step 3 and it shares
+        its primitive with the §6.3 cancel cascade path
+        (:meth:`mark_task_cancelled`). The downstream cascade fires
+        *before* we dispatch the fatal drift through ``_handle_drift``
+        so that planner.refine sees the post-cascade plan shape and a
+        refine-failure back-off does not leave orphans behind. See
+        ``STATE-MACHINE.md §"Cascade semantics on unrecoverable drift"``.
+        """
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return
+        from_status = task.status
+        # goldfive#247: derive a new immutable Plan and swap the pointer.
+        with channel_processor_active():
+            assert session.plan is not None
+            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.FAILED))
+        task = self._find_task(session, task_id) or task
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.FAILED)
+        # Drop the observed-agent lineage now the task is terminal.
+        session.task_lineage.pop(task_id, None)
+        # iter-11B: pair the prior ``agent_invocation_started`` entry
+        # so the GOAL_DRIFT judge does not see an orphan-start +
+        # task-FAILED shape and false-positive on "looping".  See the
+        # matching write in :meth:`mark_task_completed` for rationale.
+        if task.assignee_agent_id:
+            self._steerer.note_agent_activity(
+                session,
+                kind="agent_invocation_completed",
+                agent_name=task.assignee_agent_id,
+                task_id=task_id,
+            )
+        await self._emit_task_failed(session, task_id, reason, recoverable)
+        await self._emit_task_transitioned(
+            session,
+            task,
+            from_status=from_status,
+            to_status=TaskStatus.FAILED,
+            source=source,
+        )
+        # goldfive#219: task boundary is a natural goal-drift checkpoint.
+        await self._steerer._maybe_run_goal_drift_on_task_boundary(session)
+        # Fatal failures cascade downstream via the same primitive used
+        # by mark_task_cancelled, so both §6.2 and §6.3 produce the
+        # same TaskCancelled event stream and share rejection guards.
+        if not recoverable:
+            # The cascade is a propagation of the same source-attribution
+            # decision (e.g. an LLM-reported fatal failure cascades as
+            # ``"cancellation"`` from the framework's perspective — the
+            # cascaded tasks weren't moved by the LLM directly).
+            await self.cascade_cancel_downstream(session, task_id, source="cancellation")
+        kind = DriftKind.TASK_FAILED_RECOVERABLE if recoverable else DriftKind.TASK_FAILED_FATAL
+        severity = DriftSeverity.WARNING if recoverable else DriftSeverity.CRITICAL
+        drift = DriftEvent(
+            kind=kind,
+            severity=severity,
+            detail=f"task {task_id} failed: {reason}" if reason else f"task {task_id} failed",
+            current_task_id=task_id,
+        )
+        # iter-11A: spawn the drift cascade fire-and-forget so the
+        # reporting tool that triggered us (``report_task_failed``)
+        # can return immediately. The cascade
+        # (refine → supersedes → cancellation) lands asynchronously;
+        # tests that need the post-cascade plan state await
+        # :meth:`_wait_background_drifts_idle`.
+        self._steerer._spawn_drift_handler_background(drift, session)
+
+    async def mark_task_blocked(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        blocker: str = "",
+        needed: str = "",
+        source: str = "other",
+    ) -> None:
+        """Transition ``task_id`` to ``BLOCKED`` and emit ``TaskBlocked``.
+
+        Also fires a drift event of kind ``BLOCKED`` which flows through
+        the standard drift pipeline (WARNING severity → refine).
+        """
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return
+        # BLOCKED is not a terminal status but we still guard against
+        # re-blocking a task that's already blocked (idempotent).
+        from_status = task.status
+        # goldfive#247: derive a new immutable Plan and swap the pointer.
+        with channel_processor_active():
+            assert session.plan is not None
+            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.BLOCKED))
+        task = self._find_task(session, task_id) or task
+        if blocker or needed:
+            session.agent_notes[task_id] = f"blocked: {blocker}" + (
+                f" (needed: {needed})" if needed else ""
+            )
+        await self._emit_task_blocked(session, task_id, blocker, needed)
+        await self._emit_task_transitioned(
+            session,
+            task,
+            from_status=from_status,
+            to_status=TaskStatus.BLOCKED,
+            source=source,
+        )
+        detail = f"task {task_id} blocked: {blocker}" + (f" (needed: {needed})" if needed else "")
+        drift = DriftEvent(
+            kind=DriftKind.BLOCKED,
+            severity=DriftSeverity.WARNING,
+            detail=detail,
+            current_task_id=task_id,
+        )
+        # iter-11A: spawn the drift cascade fire-and-forget so the
+        # reporting tool that triggered us (``report_task_blocked``)
+        # can return immediately. See :meth:`mark_task_failed` for
+        # the matching call-site comment.
+        self._steerer._spawn_drift_handler_background(drift, session)
+
+    async def mark_task_cancelled(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        reason: str = "",
+        source: str = "other",
+    ) -> None:
+        """Transition ``task_id`` to ``CANCELLED`` and emit ``TaskCancelled``.
+
+        Also **cascades** the cancellation forward through the plan's
+        edges: every non-terminal task reachable from ``task_id`` is
+        transitioned to ``CANCELLED`` with a "cascade from <task_id>"
+        reason. Without this cascade, downstream PENDING tasks with a
+        CANCELLED predecessor would never satisfy the executor's
+        "all deps COMPLETED" check — they would sit PENDING forever and
+        the executor would report the run as successful while leaving
+        them orphaned. See TASK-LIFECYCLE.md §"Cancellation cascade" and
+        STATE-MACHINE.md §"Cascade semantics on unrecoverable drift".
+        """
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            # Already terminal (including already CANCELLED) — no-op, and
+            # crucially do NOT re-run the cascade: we would double-emit
+            # TaskCancelled events for downstream tasks on every call.
+            return
+        from_status = task.status
+        # goldfive#247: derive a new immutable Plan and swap the pointer.
+        with channel_processor_active():
+            assert session.plan is not None
+            set_session_plan(session, with_task_status(session.plan, task_id, TaskStatus.CANCELLED))
+        task = self._find_task(session, task_id) or task
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.CANCELLED)
+        # Drop the observed-agent lineage now the task is terminal.
+        session.task_lineage.pop(task_id, None)
+        await self._emit_task_cancelled(session, task_id, reason)
+        await self._emit_task_transitioned(
+            session,
+            task,
+            from_status=from_status,
+            to_status=TaskStatus.CANCELLED,
+            source=source,
+        )
+        # goldfive#219: task boundary is a natural goal-drift checkpoint.
+        # Fire before cascade so the judge sees the initiator's transition;
+        # cascade-cancel downstream tasks share the same rate-limit bucket
+        # and will no-op as subsequent boundary fires fall within the
+        # 10s guard.
+        await self._steerer._maybe_run_goal_drift_on_task_boundary(session)
+        await self.cascade_cancel_downstream(session, task_id, source="cancellation")
+
+    async def mark_task_not_needed(
+        self,
+        task_id: str,
+        *,
+        session: Session,
+        reason: str = "",
+        source: str = "other",
+    ) -> None:
+        """Transition ``task_id`` to ``NOT_NEEDED`` terminally.
+
+        Introduced by the overlay-model refactor (goldfive#141). Unlike
+        :meth:`mark_task_cancelled` this path does NOT cascade — a task
+        the :class:`~goldfive.reconciler.PlanReconciler` deemed "not
+        needed" post-invocation is an observation about that specific
+        plan entry, not a signal that downstream work is invalid. The
+        reconciler independently evaluates each PENDING task.
+
+        Idempotent on terminal tasks. Emits ``TaskCancelled`` at the
+        proto level (there's no dedicated NOT_NEEDED event — the
+        status lives on the task itself and sinks can distinguish via
+        ``task.status`` on the next ``TaskCancelled`` / ``PlanRevised``
+        envelope). The reason string carries the distinguishing
+        context ("not needed: superseded by ...").
+        """
+        task = self._find_task(session, task_id)
+        if task is None:
+            return
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return
+        from_status = task.status
+        # goldfive#247: derive a new immutable Plan and swap the pointer.
+        assert session.plan is not None
+        with channel_processor_active():
+            set_session_plan(
+                session,
+                with_task_status(session.plan, task_id, TaskStatus.NOT_NEEDED),
+            )
+        task = self._find_task(session, task_id) or task
+        _ostate.sync_current_task_from_transition(session.state, task, TaskStatus.NOT_NEEDED)
+        # Drop the observed-agent lineage now the task is terminal.
+        session.task_lineage.pop(task_id, None)
+        # There is no dedicated ``TaskNotNeeded`` proto message;
+        # reuse TaskCancelled with the reason prefix so sinks that
+        # inspect reason can differentiate if they wish. The live
+        # ``task.status`` on the plan is the authoritative signal.
+        await self._emit_task_cancelled(
+            session, task_id, f"not_needed: {reason}" if reason else "not_needed"
+        )
+        await self._emit_task_transitioned(
+            session,
+            task,
+            from_status=from_status,
+            to_status=TaskStatus.NOT_NEEDED,
+            source=source,
+        )
+        # goldfive#219: task boundary is a natural goal-drift checkpoint.
+        await self._steerer._maybe_run_goal_drift_on_task_boundary(session)
+
+    async def cascade_cancel_downstream(
+        self,
+        session: Session,
+        cancelled_id: str,
+        *,
+        source: str = "cancellation",
+    ) -> None:
+        """BFS-cancel every downstream non-terminal task of ``cancelled_id``.
+
+        Shared primitive for both cascade codepaths
+        (PLAN-LIFECYCLE.md §6.2 unrecoverable cascade and §6.3
+        cancellation cascade):
+
+        - The recoverable path
+          (:meth:`mark_task_cancelled`) calls it after transitioning
+          the initiator to ``CANCELLED``.
+        - The unrecoverable path
+          (:meth:`mark_task_failed` with ``recoverable=False``) calls
+          it after transitioning the initiator to ``FAILED``.
+
+        Both paths therefore produce the same ``TaskCancelled`` event
+        stream for the downstream set and share the rejection guards
+        (terminal tasks are skipped; diamond DAGs are de-duplicated).
+        The initiator's own transition-emission is caller-controlled —
+        this method only emits for the *downstream* set.
+
+        Walks ``session.plan.edges`` forward from ``cancelled_id`` and
+        transitions every reachable non-terminal task to ``CANCELLED``
+        in-place, emitting one ``TaskCancelled`` event per transition.
+        Terminal tasks (COMPLETED / FAILED / CANCELLED) are skipped so a
+        diamond DAG does not re-cancel a task through two paths and so
+        already-COMPLETED dependents are preserved verbatim.
+
+        Implemented as an iterative BFS on a precomputed adjacency list
+        (rather than recursing into :meth:`mark_task_cancelled`) so a
+        single top-level cancel produces one summary log line and a
+        predictable number of emitted events, independent of graph shape.
+        """
+        plan = session.plan
+        if plan is None:
+            return
+        # Precompute forward adjacency once.
+        downstream: dict[str, list[str]] = {}
+        for e in plan.edges:
+            downstream.setdefault(e.from_task_id, []).append(e.to_task_id)
+        tasks_by_id: dict[str, Task] = {t.id: t for t in plan.tasks if t.id}
+
+        # goldfive#205: structured reason consumed by harmonograf's
+        # Trajectory view. Old ``cascade from <id>`` form preserved in a
+        # human-readable tail after the colon so sinks that render the
+        # raw reason keep their existing copy; new sinks parse the
+        # ``upstream_failed:`` prefix to categorise the cancel.
+        cascade_reason = f"upstream_failed:{cancelled_id}"
+        cascaded: list[str] = []
+        queue: list[str] = list(downstream.get(cancelled_id, []))
+        visited: set[str] = set()
+        while queue:
+            next_id = queue.pop(0)
+            if next_id in visited:
+                continue
+            visited.add(next_id)
+            dep = tasks_by_id.get(next_id)
+            if dep is None:
+                continue
+            if dep.status in _TERMINAL_TASK_STATUSES:
+                # Already terminal (COMPLETED/FAILED/CANCELLED) — preserve
+                # and do not traverse its children. A COMPLETED task that
+                # sits downstream of a late-cancelled ancestor keeps its
+                # completion; cascading past it would mean cancelling
+                # tasks whose preserved prerequisite is still valid.
+                continue
+            # Transition by deriving a new plan and swapping it in. We
+            # deliberately do NOT recurse through ``mark_task_cancelled``
+            # here; we fan out via our own BFS queue so the surrounding
+            # summary log and emission count stay deterministic.
+            #
+            # goldfive#247: the local ``dep`` reference becomes stale
+            # after the swap (frozen Task) — re-resolve from the live
+            # plan so the emit reads the new status. Note that
+            # ``tasks_by_id`` was built from the *original* plan; the
+            # iteration loop only inspects ``status`` for terminal
+            # gating which is monotonic (a task that wasn't terminal
+            # at loop start is the one we're cancelling).
+            dep_from = dep.status
+            assert session.plan is not None
+            with channel_processor_active():
+                set_session_plan(
+                    session,
+                    with_task_status(session.plan, next_id, TaskStatus.CANCELLED),
+                )
+            # Drop the observed-agent lineage now the task is terminal —
+            # mirrors the cleanup that ``mark_task_cancelled`` performs
+            # for the initiator (this BFS does not recurse through that
+            # method so the cleanup is duplicated explicitly).
+            session.task_lineage.pop(next_id, None)
+            await self._emit_task_cancelled(session, next_id, cascade_reason)
+            # Re-fetch so the transition emit reads the swapped task.
+            updated_dep = self._find_task(session, next_id) or dep
+            await self._emit_task_transitioned(
+                session,
+                updated_dep,
+                from_status=dep_from,
+                to_status=TaskStatus.CANCELLED,
+                source=source,
+            )
+            cascaded.append(next_id)
+            for grandchild in downstream.get(next_id, []):
+                if grandchild not in visited:
+                    queue.append(grandchild)
+        if cascaded:
+            log.info(
+                "DefaultSteerer: cascade-cancelled %d downstream task(s) from %s: %s",
+                len(cascaded),
+                cancelled_id,
+                ", ".join(cascaded),
+            )
+
+    # ------------------------------------------------------------------
+    # Per-status proto emitters
+    # ------------------------------------------------------------------
+
+    async def _emit_task_started(self, session: Session, task_id: str, detail: str) -> None:
+        evt = self._steerer._new_envelope(session)
+        evt.task_started.task_id = task_id
+        evt.task_started.detail = detail
+        await self._steerer._emit(evt)
+
+    async def _emit_task_progress(
+        self, session: Session, task_id: str, fraction: float, detail: str
+    ) -> None:
+        evt = self._steerer._new_envelope(session)
+        evt.task_progress.task_id = task_id
+        evt.task_progress.fraction = fraction
+        evt.task_progress.detail = detail
+        await self._steerer._emit(evt)
+
+    async def _emit_task_completed(
+        self,
+        session: Session,
+        task_id: str,
+        summary: str,
+        artifacts: dict[str, str],
+    ) -> None:
+        evt = self._steerer._new_envelope(session)
+        evt.task_completed.task_id = task_id
+        evt.task_completed.summary = summary
+        for k, v in artifacts.items():
+            evt.task_completed.artifacts[k] = v
+        await self._steerer._emit(evt)
+
+    async def _emit_task_failed(
+        self, session: Session, task_id: str, reason: str, recoverable: bool
+    ) -> None:
+        evt = self._steerer._new_envelope(session)
+        evt.task_failed.task_id = task_id
+        evt.task_failed.reason = reason
+        evt.task_failed.recoverable = recoverable
+        await self._steerer._emit(evt)
+
+    async def _emit_task_blocked(
+        self, session: Session, task_id: str, blocker: str, needed: str
+    ) -> None:
+        evt = self._steerer._new_envelope(session)
+        evt.task_blocked.task_id = task_id
+        evt.task_blocked.blocker = blocker
+        evt.task_blocked.needed = needed
+        await self._steerer._emit(evt)
+
+    async def _emit_task_cancelled(self, session: Session, task_id: str, reason: str) -> None:
+        evt = self._steerer._new_envelope(session)
+        evt.task_cancelled.task_id = task_id
+        evt.task_cancelled.reason = reason
+        await self._steerer._emit(evt)
+
+    async def _emit_task_transitioned(
+        self,
+        session: Session,
+        task: Task,
+        *,
+        from_status: TaskStatus,
+        to_status: TaskStatus,
+        source: str,
+    ) -> None:
+        """Emit a ``TaskTransitioned`` envelope (goldfive#251 R4).
+
+        Sink-only observability. Called from every site that mutates a
+        task's status — both the imperative ``mark_task_*`` path and
+        the cascade path inside :meth:`cascade_cancel_downstream`. The
+        LLM never sees this event; the ``report_task_*`` surface still
+        returns ``{"acknowledged": True}``.
+
+        Source attribution is the caller's responsibility (defaults to
+        ``"other"`` on un-threaded callers); see
+        :func:`goldfive.events.task_transitioned_event` for the
+        vocabulary.
+
+        ``agent_name`` resolves to ``task.assignee_agent_id``; that's
+        the most stable surface goldfive owns. ``invocation_id`` is a
+        best-effort lookup against the reconciler's
+        ``_invocation_agent`` map (goldfive#151) when available; empty
+        when no in-flight invocation matches the assignee. Tolerant of
+        missing maps / proto stubs — emission failures are swallowed
+        with a debug log rather than breaking the transition path.
+        """
+        # goldfive#271: stamp task progress liveness on every transition
+        # so the structural progress-stall escalation gate sees the task
+        # as productively iterating. Done BEFORE the sink check because
+        # progress liveness must be tracked even when sinks are missing
+        # (test scenarios) — the gate consults this map regardless.
+        task_id_for_progress = str(getattr(task, "id", "") or "")
+        if task_id_for_progress:
+            session.task_last_progress_at[task_id_for_progress] = time.monotonic()
+        sinks = self._steerer._sinks
+        if not sinks:
+            return
+        try:
+            from goldfive.events import emit, task_transitioned_event
+        except Exception as exc:  # noqa: BLE001 — proto stubs may be missing
+            log.debug(
+                "DefaultSteerer._emit_task_transitioned: events module unavailable: %s",
+                exc,
+            )
+            return
+
+        agent_name = str(getattr(task, "assignee_agent_id", "") or "")
+        invocation_id = self._resolve_invocation_id_for_agent(agent_name)
+        revision_stamp = 0
+        plan = getattr(session, "plan", None)
+        if plan is not None:
+            try:
+                revision_stamp = int(getattr(plan, "revision_index", 0) or 0)
+            except (TypeError, ValueError):
+                revision_stamp = 0
+        try:
+            evt = task_transitioned_event(
+                session.run_id,
+                session.next_sequence(),
+                task_id=str(getattr(task, "id", "") or ""),
+                from_status=str(getattr(from_status, "value", from_status) or ""),
+                to_status=str(getattr(to_status, "value", to_status) or ""),
+                source=str(source or "other"),
+                revision_stamp=revision_stamp,
+                agent_name=agent_name,
+                invocation_id=invocation_id,
+                session_id=session.id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "DefaultSteerer._emit_task_transitioned: proto event build failed: %s",
+                exc,
+            )
+            return
+        try:
+            await emit(sinks, evt)
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "DefaultSteerer._emit_task_transitioned: sink emit raised: %s",
+                exc,
+            )
+
+    async def _emit_plan_revision_transitions(
+        self,
+        session: Session,
+        prev_plan: Plan | None,
+        revised: Plan,
+    ) -> None:
+        """Emit ``TaskTransitioned`` events for status changes carried by a refine.
+
+        Compares ``prev_plan`` vs ``revised`` task-by-task and emits one
+        ``TaskTransitioned`` event per task whose status changed (or
+        whose ``status`` is now non-PENDING and the task didn't exist
+        in ``prev_plan`` — a refine-introduced task that arrived in a
+        non-PENDING state, e.g. a CORRECT-kind successor that the
+        planner pre-stamped).
+
+        Source is always ``"plan_revision"``: the refine is the
+        authoritative driver. Tasks that exist in both plans with the
+        same status are skipped (no transition happened).
+
+        ``prev_plan`` may be ``None`` on the first revision after a run
+        with no initial plan; in that case every task in ``revised``
+        with non-PENDING status emits a "(implicit) PENDING ->
+        actual_status" event so operators see the post-revision state
+        on the wire.
+        """
+        if not self._steerer._sinks:
+            return
+        prev_by_id: dict[str, Task] = {}
+        if prev_plan is not None:
+            for t in getattr(prev_plan, "tasks", []) or []:
+                tid = str(getattr(t, "id", "") or "")
+                if tid:
+                    prev_by_id[tid] = t
+        for t in getattr(revised, "tasks", []) or []:
+            tid = str(getattr(t, "id", "") or "")
+            if not tid:
+                continue
+            new_status = getattr(t, "status", None)
+            if not isinstance(new_status, TaskStatus):
+                continue
+            old = prev_by_id.get(tid)
+            if old is None:
+                old_status: TaskStatus = TaskStatus.PENDING
+            else:
+                old_status = getattr(old, "status", TaskStatus.PENDING)
+            if old_status == new_status:
+                continue
+            # No transition to record when the new status is the
+            # default PENDING and the task is brand-new — sinks would
+            # render that as a phantom "started in PENDING" row.
+            if old is None and new_status is TaskStatus.PENDING:
+                continue
+            await self._emit_task_transitioned(
+                session,
+                t,
+                from_status=old_status,
+                to_status=new_status,
+                source="plan_revision",
+            )
+
+    def _resolve_invocation_id_for_agent(self, agent_name: str) -> str:
+        """Best-effort lookup of an active invocation_id for ``agent_name``.
+
+        Mirrors the reconciler-walk pattern in
+        :meth:`_resolve_active_invocation_ids` but scopes the match to a
+        single agent name (the assignee of the transitioning task). The
+        most-recent matching invocation_id wins; empty string when no
+        match (no reconciler, no in-flight invocation under that
+        agent, etc.). Tolerant of every failure mode — never raises.
+        """
+        if not agent_name:
+            return ""
+        adapter = self._steerer._adapter
+        plugin = getattr(adapter, "_plugin", None) if adapter is not None else None
+        reconciler = getattr(plugin, "_reconciler", None) if plugin is not None else None
+        if reconciler is None:
+            return ""
+        try:
+            inv_agent = getattr(reconciler, "_invocation_agent", None)
+            if not isinstance(inv_agent, Mapping):
+                return ""
+            # Iterate insertion-order; later writes win.
+            match = ""
+            for inv_id, name in inv_agent.items():
+                if name == agent_name and inv_id:
+                    match = str(inv_id)
+            return match
+        except Exception:  # noqa: BLE001
+            return ""

--- a/tests/test_task_state_machine.py
+++ b/tests/test_task_state_machine.py
@@ -1,0 +1,341 @@
+"""Unit tests for :class:`goldfive.task_state_machine.TaskStateMachine`.
+
+Wave C of the steerer split (Issue #N/A internal). These tests exercise
+the extracted TSM directly via a tiny stub router so the module's
+contracts are pinned independently of the broader steerer surface:
+
+* The ``mark_task_*`` family preserves the immutable-Plan swap pattern
+  (goldfive#247) and stamps ``session.task_last_progress_at`` on every
+  transition (goldfive#271).
+* Terminal-task guard: a re-call on an already-terminal task is a no-op
+  (no double-emission, no second cascade fan-out).
+* ``cascade_cancel_downstream`` BFSs the forward DAG, skips
+  already-terminal nodes, and emits one ``TaskCancelled`` + one
+  ``TaskTransitioned`` per downstream task with the
+  ``upstream_failed:<id>`` reason prefix (goldfive#205).
+* Cross-component calls (``note_agent_activity``,
+  ``_spawn_drift_handler_background``,
+  ``_maybe_run_goal_drift_on_task_boundary``) route through the
+  router's ``self._steerer`` back-reference and are observed by a
+  minimal mock — TSM never reaches into the drift observer or plan
+  reviser directly.
+
+Coverage of the wider behaviour (drift cascade triggered by
+``mark_task_failed``, the supersedes integration on PlanRevised, etc.)
+lives in the router-level test files
+(``test_steerer_*``, ``test_cancel_propagation``,
+``test_intervention_ladder``, ``test_drift_async_dispatch``); those
+keep exercising the same TSM module via the full ``DefaultSteerer``
+surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.task_state_machine import TaskStateMachine  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+
+class _StubRouter:
+    """Minimal mock router that satisfies :class:`TaskStateMachine`.
+
+    Records every cross-component call so tests can assert the TSM
+    routes them through the router back-reference (rather than
+    importing the sibling components directly).
+    """
+
+    def __init__(self) -> None:
+        self._sink = _ListSink()
+        self._sinks = [self._sink]
+        self._adapter: Any = None
+        # Spy state for cross-component routing.
+        self.note_agent_activity_calls: list[dict[str, Any]] = []
+        self.spawn_drift_calls: list[tuple[DriftEvent, Session]] = []
+        self.goal_drift_boundary_calls: int = 0
+
+    def _new_envelope(self, session: Session) -> Any:
+        from goldfive.events import new_event
+
+        return new_event(session.run_id, session.next_sequence(), session_id=session.id)
+
+    async def _emit(self, event_pb: Any) -> None:
+        from goldfive.events import emit
+
+        await emit(self._sinks, event_pb)
+
+    def note_agent_activity(
+        self,
+        session: Session,
+        *,
+        kind: str,
+        agent_name: str = "",
+        task_id: str = "",
+        detail: str = "",
+    ) -> None:
+        self.note_agent_activity_calls.append(
+            {
+                "kind": kind,
+                "agent_name": agent_name,
+                "task_id": task_id,
+                "detail": detail,
+            }
+        )
+
+    def _spawn_drift_handler_background(
+        self, drift: DriftEvent, session: Session
+    ) -> None:
+        self.spawn_drift_calls.append((drift, session))
+
+    async def _maybe_run_goal_drift_on_task_boundary(self, session: Session) -> None:
+        self.goal_drift_boundary_calls += 1
+
+
+def _seed_session_with_plan() -> Session:
+    plan = Plan(
+        id="plan-1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="A", title="A", assignee_agent_id="alpha"),
+            Task(id="B", title="B", assignee_agent_id="beta"),
+            Task(id="C", title="C", assignee_agent_id="gamma"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="A", to_task_id="B"),
+            TaskEdge(from_task_id="B", to_task_id="C"),
+        ],
+    )
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do the thing")],
+        plan=plan,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mark_task_running_swaps_plan_and_emits_transition() -> None:
+    """``mark_task_running`` derives a new Plan and emits both proto events."""
+    router = _StubRouter()
+    tsm = TaskStateMachine(router)
+    session = _seed_session_with_plan()
+    original_plan_id = id(session.plan)
+
+    await tsm.mark_task_running("A", session=session, detail="kickoff", source="llm_report")
+
+    # goldfive#247: Plan is frozen — the swap produces a new instance.
+    assert id(session.plan) != original_plan_id
+    a = next(t for t in session.plan.tasks if t.id == "A")
+    assert a.status is TaskStatus.RUNNING
+    assert session.current_task_id == "A"
+    # Liveness watermark stamped so the structural progress-stall gate
+    # can distinguish iterating vs stuck tasks.
+    assert "A" in session.task_last_progress_at
+    # Lineage seeded with the assignee for downstream judge attribution.
+    assert session.task_lineage["A"] == {"alpha"}
+    # Two events: TaskStarted + TaskTransitioned.
+    kinds = [evt.WhichOneof("payload") for evt in router._sink.events]
+    assert kinds == ["task_started", "task_transitioned"]
+
+
+@pytest.mark.asyncio
+async def test_mark_task_completed_routes_through_router_notes_and_boundary() -> None:
+    """Completion routes ``note_agent_activity`` + goal-drift boundary via router."""
+    router = _StubRouter()
+    tsm = TaskStateMachine(router)
+    session = _seed_session_with_plan()
+    await tsm.mark_task_running("A", session=session)
+    router._sink.events.clear()
+
+    await tsm.mark_task_completed(
+        "A", session=session, summary="done", source="llm_report"
+    )
+
+    a = next(t for t in session.plan.tasks if t.id == "A")
+    assert a.status is TaskStatus.COMPLETED
+    assert session.completed_results["A"] == "done"
+    # Lineage cleared on terminal.
+    assert "A" not in session.task_lineage
+    # The TSM must route through the router back-reference, NOT reach
+    # for the drift observer directly.
+    assert len(router.note_agent_activity_calls) == 1
+    assert router.note_agent_activity_calls[0]["kind"] == "agent_invocation_completed"
+    assert router.note_agent_activity_calls[0]["agent_name"] == "alpha"
+    assert router.goal_drift_boundary_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_mark_task_failed_spawns_drift_cascade_via_router() -> None:
+    """Recoverable FAILED spawns the drift cascade via the router stub."""
+    router = _StubRouter()
+    tsm = TaskStateMachine(router)
+    session = _seed_session_with_plan()
+    await tsm.mark_task_running("A", session=session)
+
+    await tsm.mark_task_failed(
+        "A", session=session, reason="boom", recoverable=True
+    )
+
+    a = next(t for t in session.plan.tasks if t.id == "A")
+    assert a.status is TaskStatus.FAILED
+    # iter-11A — recoverable failure spawns the cascade fire-and-forget
+    # through the router. Captured by the stub spy.
+    assert len(router.spawn_drift_calls) == 1
+    drift, spawned_session = router.spawn_drift_calls[0]
+    assert drift.kind.value == "task_failed_recoverable"
+    assert spawned_session is session
+    # No cascade on a recoverable failure (cascade is only for
+    # ``recoverable=False``).
+    b = next(t for t in session.plan.tasks if t.id == "B")
+    assert b.status is TaskStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_mark_task_failed_unrecoverable_cascades_downstream() -> None:
+    """Unrecoverable FAILED cascade-cancels the forward closure."""
+    router = _StubRouter()
+    tsm = TaskStateMachine(router)
+    session = _seed_session_with_plan()
+    await tsm.mark_task_running("A", session=session)
+
+    await tsm.mark_task_failed(
+        "A", session=session, reason="fatal", recoverable=False
+    )
+
+    a = next(t for t in session.plan.tasks if t.id == "A")
+    b = next(t for t in session.plan.tasks if t.id == "B")
+    c = next(t for t in session.plan.tasks if t.id == "C")
+    assert a.status is TaskStatus.FAILED
+    assert b.status is TaskStatus.CANCELLED
+    assert c.status is TaskStatus.CANCELLED
+    # The fatal drift is still spawned through the router; cascade is
+    # an additional side effect.
+    assert len(router.spawn_drift_calls) == 1
+    assert router.spawn_drift_calls[0][0].kind.value == "task_failed_fatal"
+
+
+@pytest.mark.asyncio
+async def test_mark_task_running_is_idempotent_on_terminal() -> None:
+    """Terminal-task guard prevents re-emission of transitions."""
+    router = _StubRouter()
+    tsm = TaskStateMachine(router)
+    session = _seed_session_with_plan()
+    await tsm.mark_task_running("A", session=session)
+    await tsm.mark_task_completed("A", session=session)
+    before = len(router._sink.events)
+    note_count_before = len(router.note_agent_activity_calls)
+    boundary_count_before = router.goal_drift_boundary_calls
+
+    # Re-call after COMPLETED — must be a no-op.
+    await tsm.mark_task_running("A", session=session, detail="zombie")
+    await tsm.mark_task_completed("A", session=session)
+    await tsm.mark_task_failed("A", session=session, reason="x")
+    await tsm.mark_task_blocked("A", session=session, blocker="x")
+    await tsm.mark_task_cancelled("A", session=session)
+    await tsm.mark_task_not_needed("A", session=session)
+
+    assert len(router._sink.events) == before
+    assert len(router.note_agent_activity_calls) == note_count_before
+    assert router.goal_drift_boundary_calls == boundary_count_before
+    assert len(router.spawn_drift_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_cascade_cancel_downstream_emits_upstream_failed_reason() -> None:
+    """Cascade uses the goldfive#205 structured reason on every downstream."""
+    router = _StubRouter()
+    tsm = TaskStateMachine(router)
+    session = _seed_session_with_plan()
+    await tsm.mark_task_running("A", session=session)
+    router._sink.events.clear()
+
+    await tsm.cascade_cancel_downstream(session, "A", source="cancellation")
+
+    # Both B and C get cancelled via the BFS; the initiator (A) itself
+    # is NOT transitioned by this primitive (caller-owned).
+    b = next(t for t in session.plan.tasks if t.id == "B")
+    c = next(t for t in session.plan.tasks if t.id == "C")
+    assert b.status is TaskStatus.CANCELLED
+    assert c.status is TaskStatus.CANCELLED
+    # The TaskCancelled events carry the upstream_failed:<id> prefix.
+    cancel_events = [
+        evt for evt in router._sink.events if evt.WhichOneof("payload") == "task_cancelled"
+    ]
+    assert len(cancel_events) == 2
+    for evt in cancel_events:
+        assert evt.task_cancelled.reason == "upstream_failed:A"
+
+
+@pytest.mark.asyncio
+async def test_cascade_cancel_downstream_skips_terminal_dependents() -> None:
+    """A diamond-DAG dependent in COMPLETED is preserved, not re-cancelled."""
+    router = _StubRouter()
+    tsm = TaskStateMachine(router)
+    session = _seed_session_with_plan()
+    # Drive B to COMPLETED out of band; the cascade from A must skip it
+    # and stop the traversal (C depends only on B, so it stays PENDING).
+    await tsm.mark_task_running("A", session=session)
+    await tsm.mark_task_completed("A", session=session)
+    await tsm.mark_task_running("B", session=session)
+    await tsm.mark_task_completed("B", session=session)
+    router._sink.events.clear()
+
+    # Now cascade from a fresh hypothetical fatal on A. B is COMPLETED
+    # so the BFS short-circuits; C must stay PENDING.
+    await tsm.cascade_cancel_downstream(session, "A", source="cancellation")
+
+    b = next(t for t in session.plan.tasks if t.id == "B")
+    c = next(t for t in session.plan.tasks if t.id == "C")
+    assert b.status is TaskStatus.COMPLETED  # preserved
+    assert c.status is TaskStatus.PENDING  # not cascaded past COMPLETED ancestor
+
+
+@pytest.mark.asyncio
+async def test_mark_task_not_needed_does_not_cascade() -> None:
+    """NOT_NEEDED is a per-task observation, not a downstream invalidation."""
+    router = _StubRouter()
+    tsm = TaskStateMachine(router)
+    session = _seed_session_with_plan()
+
+    await tsm.mark_task_not_needed("B", session=session, reason="superseded")
+
+    b = next(t for t in session.plan.tasks if t.id == "B")
+    c = next(t for t in session.plan.tasks if t.id == "C")
+    assert b.status is TaskStatus.NOT_NEEDED
+    assert c.status is TaskStatus.PENDING  # NOT_NEEDED does not cascade
+
+
+@pytest.mark.asyncio
+async def test_find_task_static_helper() -> None:
+    """``_find_task`` matches by id and returns ``None`` for missing inputs."""
+    session = _seed_session_with_plan()
+    assert TaskStateMachine._find_task(session, "A").id == "A"
+    assert TaskStateMachine._find_task(session, "missing") is None
+    assert TaskStateMachine._find_task(session, "") is None
+    session.plan = None
+    assert TaskStateMachine._find_task(session, "A") is None


### PR DESCRIPTION
## Motivation

Wave C of the maintainer-approved modularization plan. `goldfive/steerer.py` is 7800 LOC with ~129 methods mixing three independent concerns: task-state transitions, drift observation + LLM judge spinup, and plan revision dispatch.

The plan was to split into a thin router + three components (TaskStateMachine, DriftObserver, PlanReviser) in 1-2 days. After mapping the surface I found the **cross-component coupling is much denser than the brief suggested** — `_handle_drift` (drift_observer territory) directly calls `_apply_revision` / `_emit_plan_revised` (plan_reviser territory), and `_record_refine_outcome` (drift_observer) calls `mark_task_failed` (task_state). Threading every cross-call through router back-references is mechanical but voluminous, and the file touches several recently-fixed gates (#267 dry_run, #264 PAUSE_ESCALATE, #242/#230 late-drift, #199/#183 synthetic-USER_STEER) where a missed indirection is a subtle gate regression.

**This draft PR delivers the first, lowest-risk extraction (TaskStateMachine) end-to-end with tests** so the team lead can evaluate the approach and decide whether to ship this slice and follow up with B/C separately, or pause and reassign.

## What's in this PR

**TaskStateMachine extracted into `goldfive/task_state_machine.py`** (Wave C bucket 1 of 3):

- The `mark_task_*` family (RUNNING / PROGRESS / COMPLETED / FAILED / BLOCKED / CANCELLED / NOT_NEEDED).
- The shared `cascade_cancel_downstream` BFS primitive.
- The per-status proto emitters (`_emit_task_started` through `_emit_task_cancelled`).
- `_emit_task_transitioned` (goldfive#251 R4) and `_emit_plan_revision_transitions` (refine-driven transitions).
- `_find_task` (kept also as a router-level staticmethod for back-compat).
- `_resolve_invocation_id_for_agent`.

`DefaultSteerer` keeps the historical public surface — every moved method has a thin shim that delegates to `self._task_state_machine`. Tests, executors, reporting handlers, and sinks bind to the router unchanged.

Cross-component calls inside the TSM route through the router back-reference (`self._steerer.note_agent_activity`, `self._steerer._spawn_drift_handler_background`, `self._steerer._maybe_run_goal_drift_on_task_boundary`) so the extraction order is independent of the upcoming drift_observer / plan_reviser splits — the second and third extractions can land in any order and the TSM doesn't need to be touched again.

## Bucket map for the remaining two extractions

Mapped while reading `steerer.py` end-to-end. Recorded here so the next agent picks up where I stopped without re-deriving it.

**DriftObserver (drift_observer.py, ~3000 LOC):**
- `observe`, `observe_reasoning`, `_run_judge_background`, `_maybe_record_reasoning_binding`
- Reflective check: `note_llm_call`, `maybe_run_reflective_check`, `_emit_reflective_failure`, `_parse_reflective_response`, `_summarize_recent_tool_calls/reasoning`
- Goal drift: `note_agent_activity`, `note_tool_observation`, `note_agent_turn`, `_maybe_run_goal_drift_on_task_boundary`, `maybe_run_goal_drift_check`, `_spawn_goal_drift_judge_background`, `_run_goal_drift_judge_background`
- Drift cascade spawn: `_spawn_drift_handler_background`, `_run_drift_handler_background`, `_wait_background_drifts_idle`
- STEER/dedupe: `_steer_dedupe_id`, `_unpack_steer_context`, `_is_duplicate_steer`, `_drift_from_control`
- Classification: `detect_drift`
- Plan-mutation drift hooks: `report_new_work_discovered`, `report_plan_divergence`
- Dispatch: `_handle_drift` (the meat — calls into plan_reviser._apply_revision/_emit_plan_revised)
- Ladder: `_LADDER`, `_ladder_level_for`, `_ABSORB_NUDGE_KINDS`, `_dispatch_nudge`, `_dispatch_goldfive_steer_control`, `_dispatch_goldfive_pause_control` (#264 gate), `_dispatch_pause_escalate`
- Adapter tagging: `_tag_adapter_cancel_reason*`, `_write_adapter_cancel_reason`, `_request_adapter_cancel`
- Cancel/late-drift: `_is_late_drift_for_terminated_invocation` (#242/#230 gate), `_resolve_active_invocation_ids`, `request_invocation_cancel`, `_should_request_cancel_for_drift`, `_cancel_reason_for_drift`, `_cancel_inflight_for_revision`
- Promotion: `_GOLDFIVE_STEER_ELIGIBLE_KINDS`, `_severity_meets_promotion_threshold`, `_should_promote_to_steer`, `_promote_drift_to_steer`, `_compose_goldfive_steer_body`
- USER_STEER state: `_apply_user_steer_state` (#199/#183 path)
- Refine outcome: `_record_refine_outcome`, `reset_for_turn`, `_occurrence_count_for_ladder`, `_escalate_refine_failure_as_critical_drift`, `REFINE_FAILURE_THRESHOLD`
- Progress/handler escalation: `_is_task_progress_stalled`, `_emit_progress_stalled_escalation`, `_emit_handler_exhausted_escalation`
- DriftDetected emit: `_emit_drift_detected`, `_stamp_drift_lifecycle`, `_drift_lifecycle_pb_value`, `_is_terminal_drift`, `_TERMINAL_DRIFT_KINDS`, `_close_open_boundaries_for_terminal_drift`, `_resolve_authored_by`, `_drift_annotation_id`

**PlanReviser (plan_reviser.py, ~1500 LOC):**
- `install_initial_plan`, `install_revision_for_drift`, `install_revision_for_user_steer`, `install_user_steer`, `apply_user_steer_with_plan`, `_install_with_drift`
- `_build_minimal_steer_evolution`
- `_apply_revision` (#267 dry_run gate, #254 observation_only, #255 bootstrap/discovery carve-outs, #258 NEW_WORK)
- `_emit_plan_revised` (the 351-line method, all 3 dry_run sites preserved)
- `_emit_plan_revised_correlation`, `_emit_refine_attempted`, `_emit_refine_failed`, `observe_refine` (CM)
- `_integrate_correction_supersedes`, `_repin_current_task_on_supersedes`
- `_fold_runtime_terminal_statuses` (I4 fix), `_plans_structurally_identical`
- `_build_refine_input_summary`, `_build_refine_output_summary`
- `_get_plan_lock`, `_wait_plan_stable`, `_new_attempt_id`

**Router (steerer.py, target ~1500 LOC):**
- `__init__`, `bind`, `bind_adapter`, `bind_control_channel`, `_dispatch_goldfive_control`
- `transition` (protocol)
- `get_tool_loop_config`, `_span_context_for_planner`, `_emit_planner_refine_validation_failed`
- `shutdown`, `drain_session_background_tasks`, `_drain_background_set`
- `_new_envelope`, `_emit`, `_drift_kind_pb_value`, `_drift_severity_pb_value`, `_truncate_trigger_input` (shared low-level)
- `_should_inject`, `_observation_only` accessor
- Thin shims for the three components' public methods
- `RefineExhausted`, `InterventionLevel`, `compose_corrective_user_message` (module-level)

## LOC delta (so far)

- `steerer.py`: **7800 -> 7257 (-543 LOC)**
- `task_state_machine.py`: +874 LOC (mostly docstring + extracted class)
- `tests/test_task_state_machine.py`: +312 LOC (9 new focused unit tests)

When B+C land, `steerer.py` should reach the ~1500-2000 LOC target from the brief.

## Contract-preservation checklist

For this PR (TSM only):

- [x] DefaultSteerer still implements the Steerer protocol; Runner / executors / sinks see no API change.
- [x] Plan + Task immutability (goldfive#247) preserved verbatim — every transition still derives a new Plan via `with_task_status` under `channel_processor_active`.
- [x] `Plan.validate()` invariants preserved — TSM does not touch validation paths.
- [x] `observed_revision_index` semantics preserved — drift observation paths untouched.
- [x] observation_only mode preserved — TSM does not gate on it (gate lives in plan_reviser / drift_observer territory).
- [x] State-ownership audit unchanged: TSM writes to goldfive `session.state` only via the existing `_ostate.sync_current_task_*` helper, NOT through `_adk_state_protocol._set`. No `_KNOWN_CALLERS` change required.
- [x] Late-drift / synthetic-USER_STEER / #267 dry_run / #264 PAUSE_ESCALATE gates: untouched — those live in drift_observer / plan_reviser territory and TSM does not call them inline.

When B+C land they MUST also preserve:
- [ ] `_emit_plan_revised` 3-site dry_run gate (#267) — preserve in plan_reviser.
- [ ] Late-drift gate (#242, #230) — preserve in drift_observer.
- [ ] Synthetic-USER_STEER suppression (#199, #183) — preserve in drift_observer.
- [ ] `_apply_revision` install gate (lines ~6432-6486 in original) — preserve in plan_reviser.
- [ ] `_dispatch_goldfive_pause_control` (#264) observation_only carve-out — preserve in drift_observer.
- [ ] Reasoning judge `observe` path (#270, #266, #244, #200) — preserve in drift_observer.

## Test plan

- [x] `pytest tests/ -x --tb=short` — **2447 passed, 59 skipped, 0 failed** (was 2438 passed pre-extraction; +9 new TSM unit tests).
- [x] State-ownership audit (`GOLDFIVE_STRICT_STATE_OWNERSHIP=1`, autouse in `tests/conftest.py`) green — no `_KNOWN_CALLERS` update needed since TSM uses the existing `_ostate.sync_current_task_*` helper.
- [x] New focused unit tests (`tests/test_task_state_machine.py`) exercise TSM directly via a stub router so the contracts (frozen-plan swap, terminal-task guard, BFS cascade with `upstream_failed:<id>` reason, cross-component routing through the back-reference) are pinned independently of the broader steerer surface.
- [ ] Operator smoke test on a live ADK run — deferred; brief did not call out a manual smoke and the test suite covers every transition path.

## Honest scoping note for the team lead

I'm reporting this as a partial milestone rather than blocked-and-silent. The TSM extraction is clean and standalone; if you want to merge it as a stepping stone and have me (or another agent) follow up with the drift_observer + plan_reviser extractions in separate PRs, the bucket map above is everything needed to pick up where I stopped. If you'd rather wait for the full split, please reassign — I don't think a single-session full-split lands cleanly under the 1-2 day budget given the cross-component density.

**DO NOT MERGE** until team lead reviews and decides on the full vs partial path.