### PR TITLE
refactor: centralize prompt-shaping gates in PromptShaper

### DIFF
--- a/goldfive/adapters/_adk_dynainst.py
+++ b/goldfive/adapters/_adk_dynainst.py
@@ -27,7 +27,7 @@ specific agent invocation via
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import Any
 
 from goldfive.adapters import _adk_state_protocol as _sp
@@ -281,26 +281,6 @@ def _goldfive_session_context_from_readonly_context(readonly_ctx: Any) -> Any:
     return legacy_ctx
 
 
-def _observation_only_active(readonly_ctx: Any) -> bool:
-    """Return True when the steerer reachable through ``readonly_ctx``
-    has ``observation_only=True`` (goldfive#271 strict-passive).
-
-    Used by the dynamic-instruction resolver to skip system-prompt
-    rewriting under strict-passive observation_only — the operator
-    must see the RAW caller-supplied ``instruction`` string, not the
-    goldfive-augmented "Current assigned task:" / pending-correction
-    block. Mirrors the gate :func:`_observation_only_active` in
-    :mod:`goldfive.adapters._adk_plugin`.
-    """
-    ctx = _goldfive_session_context_from_readonly_context(readonly_ctx)
-    if ctx is None:
-        return False
-    steerer = getattr(ctx, "steerer", None)
-    if steerer is None:
-        return False
-    return bool(getattr(steerer, "_observation_only", False))
-
-
 def _task_title_description_from_session(session: Any, task_id: str) -> tuple[str, str]:
     """Look up ``(title, description)`` for ``task_id`` in ``session.plan``.
 
@@ -327,130 +307,6 @@ def _task_title_description_from_session(session: Any, task_id: str) -> tuple[st
             description = str(getattr(task, "description", "") or "")
             return title, description
     return "", ""
-
-
-def make_dynamic_instruction(
-    original_instruction: str,
-    agent_name: str,
-) -> Callable[[Any], str]:
-    """Return a resolver matching ADK's ``InstructionProvider`` signature.
-
-    The returned callable:
-
-    * Reads ``session.state`` off the ``ReadonlyContext`` to reach the
-      :class:`~goldfive.adapters._adk_plugin.SessionContext` stash and
-      from there the goldfive :class:`~goldfive.types.Session`.
-    * Reads the current-task pin via
-      :class:`~goldfive.state_store.StateStore`. If
-      no pin is set, returns the ``original_instruction`` verbatim
-      (pre-plan turns stay unchanged).
-    * Looks up the task in ``Session.plan.tasks`` for ``title`` /
-      ``description`` (the typed :class:`~goldfive.types.Task` is the
-      source of truth — the resolver does not consult de-normalised
-      ADK-state keys).
-    * If a pending correction exists for ``(agent_name, current_task_id)``
-      the block is appended (Stream D writes; the store reads).
-
-    The resolver is pure: given the same Session.state it returns the
-    same string. No side effects, no persistence.
-
-    Phase 2.0 of goldfive#271 — the bridge from goldfive Session.state
-    onto ADK session.state is gone. The resolver reads goldfive
-    Session directly via the SessionContext stash, eliminating the
-    callback-time write to ADK state that raced with ADK's
-    optimistic-concurrency contract (see goldfive#275).
-
-    Legacy fallback: when the SessionContext stash is unreachable (a
-    unit test drives the resolver against a plain state dict without
-    the stash), the resolver reads the pin / title / description /
-    correction directly off ADK state. Production paths always carry
-    the stash.
-    """
-
-    def resolver(readonly_ctx: Any) -> str:
-        try:
-            # goldfive#271 strict-passive carve-out: under
-            # ``observation_only=True`` return the caller's
-            # ``original_instruction`` verbatim. The dynamic resolver's
-            # job is to append a goldfive-shaped "Current assigned task"
-            # / pending-correction block to every wrapped LlmAgent's
-            # system prompt every turn — that's structural prompt-
-            # shaping the operator is trying to observe AROUND under
-            # strict-passive. With this gate, the agent's LLM sees
-            # exactly the ``instruction`` string the caller passed to
-            # the ``LlmAgent`` constructor, nothing more.
-            if _observation_only_active(readonly_ctx):
-                log.info(
-                    "dynamic_instruction resolver: observation_only=True — "
-                    "SKIPPING goldfive prompt augmentation for agent=%r "
-                    "(returning original instruction verbatim)",
-                    agent_name,
-                )
-                return original_instruction
-
-            state = _state_from_readonly_context(readonly_ctx)
-            session = _goldfive_session_from_readonly_context(readonly_ctx)
-
-            if session is not None:
-                from goldfive.state_store import StateStore
-
-                store = StateStore.for_session(session)
-                current_task_id = store.pin_current_task()
-            else:
-                current_task_id = str(state.get(_sp.KEY_CURRENT_TASK_ID, "") or "")
-
-            if not current_task_id:
-                # No pin — pre-plan turn, or an agent that doesn't need
-                # plan-causal augmentation this turn. Return the caller's
-                # instruction verbatim.
-                return original_instruction
-
-            if session is not None:
-                current_task_title, current_task_description = (
-                    _task_title_description_from_session(session, current_task_id)
-                )
-            else:
-                # Legacy ADK-state fallback path.
-                current_task_title = str(
-                    state.get(_sp.KEY_CURRENT_TASK_TITLE, "") or ""
-                )
-                current_task_description = str(
-                    state.get(_sp.KEY_CURRENT_TASK_DESCRIPTION, "") or ""
-                )
-
-            pending_correction = _read_pending_correction(
-                session=session,
-                state=state,
-                agent_name=agent_name,
-                current_task_id=current_task_id,
-            )
-
-            return _compose_instruction(
-                original=original_instruction,
-                task_id=current_task_id,
-                task_title=current_task_title,
-                task_description=current_task_description,
-                pending_correction=pending_correction,
-            )
-        except Exception as exc:  # noqa: BLE001
-            # Instrumentation path — any failure here degrades to the
-            # original instruction so the agent still runs. ADK's own
-            # pipeline would otherwise surface this as an InternalError
-            # mid-turn, which is the worst possible failure mode.
-            log.debug(
-                "dynamic_instruction resolver raised for agent=%r: %s "
-                "(falling back to original instruction)",
-                agent_name,
-                exc,
-            )
-            return original_instruction
-
-    # Stamp provenance on the closure so test code and tree-walk
-    # idempotency checks can recognise it without relying on repr.
-    resolver._goldfive_dynamic_instruction = True  # type: ignore[attr-defined]
-    resolver._goldfive_agent_name = agent_name  # type: ignore[attr-defined]
-    resolver._goldfive_original_instruction = original_instruction  # type: ignore[attr-defined]
-    return resolver
 
 
 def is_dynamic_instruction(value: Any) -> bool:
@@ -540,7 +396,15 @@ def install_dynamic_instructions(root_agent: Any) -> int:
         original = existing if isinstance(existing, str) else ""
 
         agent_name = str(getattr(cur, "name", "") or "")
-        resolver = make_dynamic_instruction(
+        # Wave B1 (refactor/prompt-shaper): the resolver factory lives
+        # on :class:`~goldfive.prompt_shaper.PromptShaper` so the four
+        # prompt-shape injection sites share one ``observation_only``
+        # gate. The closure shape (provenance attrs, ADK
+        # ``InstructionProvider`` signature) is preserved
+        # byte-identically.
+        from goldfive.prompt_shaper import PromptShaper
+
+        resolver = PromptShaper().make_dynamic_instruction(
             original_instruction=original,
             agent_name=agent_name,
         )
@@ -600,6 +464,5 @@ __all__ = [
     "install_dynamic_instructions",
     "is_dynamic_instruction",
     "log_dynamic_instruction_opt_out",
-    "make_dynamic_instruction",
     "pending_correction_key",
 ]

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -430,32 +430,6 @@ def _session_context_from_callback(ctx: Any) -> SessionContext | None:
     return None
 
 
-def _observation_only_active(ctx: Any) -> bool:
-    """Return True when the steerer reachable through ``ctx`` has
-    ``observation_only=True`` (goldfive#271 strict-passive).
-
-    Reads ``ctx.steerer._observation_only`` if present. Tolerant of
-    ``ctx is None`` (no live SessionContext — treat as not-passive so
-    pre-#271 behaviour is preserved on paths where the plugin runs
-    without a bound steerer, e.g. unit-test stubs that never call
-    :meth:`_GoldfiveADKPlugin.set_active_context`).
-
-    Used by :meth:`_GoldfiveADKPlugin.before_model_callback` to gate
-    the two ``system_instruction`` injection sites — the
-    GoldfivePlanner request-side instruction and the runtime tool-
-    surface hint. Mirrors the :meth:`DefaultSteerer._should_inject`
-    gate used at every other dispatch site (steerer.py:4004 /
-    :4073 / :4470, executors/sequential.py:703 / :794 / :1252 /
-    :1403 / :1576).
-    """
-    if ctx is None:
-        return False
-    steerer = getattr(ctx, "steerer", None)
-    if steerer is None:
-        return False
-    return bool(getattr(steerer, "_observation_only", False))
-
-
 # --------------------------------------------------------------------------
 # goldfive#191 — Layer 3: task_id arg injection for reporting tools
 # --------------------------------------------------------------------------
@@ -1666,140 +1640,6 @@ def _tool_approval_prompt(tool: Any, tool_name: str, tool_args: Any) -> str:
     return f"Run {tool_name}()?"
 
 
-async def _inject_goldfive_planner_instruction(
-    *,
-    callback_context: Any,
-    llm_request: Any,
-) -> None:
-    """Append :class:`GoldfivePlanner` output to ``llm_request.config.system_instruction``.
-
-    ADK's ``flows/llm_flows/_nl_planning.py`` request-side processor
-    gates instruction injection on ``isinstance(planner,
-    PlanReActPlanner)`` — so a ``BasePlanner`` subclass that is NOT a
-    PlanReAct subclass gets its ``build_planning_instruction`` called
-    on the RESPONSE side (via ``process_planning_response``) but never
-    on the REQUEST side. That's fine for response filtering but it
-    starves the model of goldfive's orchestration context block on
-    the turn that matters.
-
-    This helper is the workaround: it detects when the running
-    agent's ``.planner`` is a :class:`~goldfive.planners.goldfive_planner.GoldfivePlanner`
-    (NOT a ``PlanReActPlanner`` or ``BuiltInPlanner`` — ADK handles
-    those on its own via ``_nl_planning``) and appends the planner's
-    :meth:`build_planning_instruction` output to the request's system
-    instruction using ADK's own ``append_instructions`` method.
-
-    Silent fall-throughs in priority order:
-
-    * ADK not installed or ``BasePlanner`` import fails → skip.
-    * Running agent has no ``planner`` attribute or planner is None
-      → skip (plain ADK LlmAgent with no goldfive attachment).
-    * Planner is a ``PlanReActPlanner`` / ``BuiltInPlanner`` subclass
-      → skip (ADK will handle it natively).
-    * ``build_planning_instruction`` returns ``None`` / empty →
-      skip (planner opted out for this turn).
-    * ``llm_request`` lacks ``append_instructions`` → skip (unit-test
-      request stubs).
-    """
-    try:
-        from goldfive.planners.goldfive_planner import GoldfivePlanner
-    except ImportError:  # pragma: no cover — ADK not installed
-        return
-    try:
-        from google.adk.planners.base_planner import BasePlanner  # type: ignore
-        from google.adk.planners.built_in_planner import BuiltInPlanner  # type: ignore
-        from google.adk.planners.plan_re_act_planner import (  # type: ignore
-            PlanReActPlanner,
-        )
-    except ImportError:  # pragma: no cover — ADK not installed
-        return
-
-    # Find the running agent on the callback_context. ADK exposes it
-    # through the invocation context; tests may supply a context that
-    # carries ``.agent`` directly.
-    inv_ctx = _safe_attr(callback_context, "_invocation_context", None) or _safe_attr(
-        callback_context, "invocation_context", None
-    )
-    agent = _safe_attr(inv_ctx, "agent", None)
-    if agent is None:
-        agent = _safe_attr(callback_context, "agent", None)
-    if agent is None:
-        return
-
-    planner = _safe_attr(agent, "planner", None)
-    if planner is None:
-        return
-    # If ADK itself will inject for this planner type, skip. ``BuiltInPlanner``
-    # never emits a text instruction (it configures thinking on the
-    # request instead), ``PlanReActPlanner`` is the one ADK gates on.
-    if isinstance(planner, (PlanReActPlanner, BuiltInPlanner)):
-        return
-    if not isinstance(planner, BasePlanner):
-        return
-    # Narrow further: the adapter attaches GoldfivePlanner specifically.
-    # A custom BasePlanner subclass that is not GoldfivePlanner should
-    # be respected by ADK's own (response-side) dispatch only, not
-    # re-injected here. This keeps the hook behaviour predictable for
-    # users who subclass BasePlanner themselves.
-    if not isinstance(planner, GoldfivePlanner):
-        return
-
-    # Build the ReadonlyContext ADK expects. When invocation_context
-    # is available we use ADK's real class; otherwise we fall back to
-    # ``callback_context`` itself (test stubs carrying ``.state`` work
-    # through GoldfivePlanner's tolerant _extract_state).
-    readonly = callback_context
-    try:
-        from google.adk.agents.readonly_context import ReadonlyContext  # type: ignore
-
-        if inv_ctx is not None:
-            readonly = ReadonlyContext(inv_ctx)
-    except Exception as exc:  # noqa: BLE001 — use fallback
-        log.debug(
-            "_inject_goldfive_planner_instruction: ReadonlyContext unavailable: %s",
-            exc,
-        )
-
-    instruction = planner.build_planning_instruction(readonly, llm_request)
-    if not instruction:
-        return
-
-    append = getattr(llm_request, "append_instructions", None)
-    if not callable(append):
-        # Best-effort write directly into ``config.system_instruction``
-        # when the test stub doesn't carry the helper. Preserves the
-        # existing value if it's a string.
-        config = getattr(llm_request, "config", None)
-        if config is None:
-            return
-        existing = getattr(config, "system_instruction", None)
-        if not existing:
-            try:
-                config.system_instruction = instruction
-            except Exception as exc:  # noqa: BLE001
-                log.debug(
-                    "_inject_goldfive_planner_instruction: could not set system_instruction: %s",
-                    exc,
-                )
-        elif isinstance(existing, str):
-            try:
-                config.system_instruction = existing + "\n\n" + instruction
-            except Exception as exc:  # noqa: BLE001
-                log.debug(
-                    "_inject_goldfive_planner_instruction: could not append system_instruction: %s",
-                    exc,
-                )
-        return
-
-    try:
-        append([instruction])
-    except Exception as exc:  # noqa: BLE001
-        log.debug(
-            "_inject_goldfive_planner_instruction: append_instructions raised: %s",
-            exc,
-        )
-
-
 # R3 (F2 alternative) — runtime tool-surface hint.
 #
 # Tier 1's F2 wanted to mutate ``llm_request.config.tools`` mid-callback
@@ -1914,79 +1754,6 @@ def _strip_prior_runtime_tools_hint(existing: str) -> str:
     while "\n\n\n" in cleaned:
         cleaned = cleaned.replace("\n\n\n", "\n\n")
     return cleaned.strip("\n")
-
-
-def _inject_runtime_tools_hint(
-    *,
-    callback_context: Any,
-    llm_request: Any,
-    session: Any,
-) -> None:
-    """Inject (or refresh) the runtime tool-surface hint on ``llm_request``.
-
-    R3 (F2 alternative). Builds the current plan-state hint via
-    :func:`_build_runtime_tools_hint` and writes it to
-    ``llm_request.config.system_instruction``. If a prior goldfive
-    hint is present (detected by :data:`_RUNTIME_TOOLS_HINT_PREFIX`),
-    it is stripped first so we don't accumulate snapshots across calls.
-
-    Best-effort: never raises. A None hint (no plan, or plan with no
-    informative groups) is a no-op so we don't pollute the prompt with
-    empty markers.
-    """
-    hint = _build_runtime_tools_hint(session)
-
-    config = _safe_attr(llm_request, "config", None)
-    if config is None:
-        return
-    existing = getattr(config, "system_instruction", None)
-
-    # Strip any prior hint regardless of whether we'll re-inject. A
-    # None ``hint`` (plan disappeared or all groups empty) should still
-    # remove the stale marker block from the request.
-    if isinstance(existing, str) and _RUNTIME_TOOLS_HINT_PREFIX in existing:
-        try:
-            config.system_instruction = _strip_prior_runtime_tools_hint(existing) or None
-        except Exception as exc:  # noqa: BLE001
-            log.debug(
-                "_inject_runtime_tools_hint: could not strip prior hint: %s",
-                exc,
-            )
-            return
-        existing = getattr(config, "system_instruction", None)
-
-    if not hint:
-        return
-
-    append = getattr(llm_request, "append_instructions", None)
-    if callable(append):
-        try:
-            append([hint])
-            return
-        except Exception as exc:  # noqa: BLE001
-            log.debug(
-                "_inject_runtime_tools_hint: append_instructions raised: %s",
-                exc,
-            )
-            # fall through to direct write
-
-    # Fallback for stubs that lack ``append_instructions`` (unit tests).
-    if not existing:
-        try:
-            config.system_instruction = hint
-        except Exception as exc:  # noqa: BLE001
-            log.debug(
-                "_inject_runtime_tools_hint: could not set system_instruction: %s",
-                exc,
-            )
-    elif isinstance(existing, str):
-        try:
-            config.system_instruction = existing + "\n\n" + hint
-        except Exception as exc:  # noqa: BLE001
-            log.debug(
-                "_inject_runtime_tools_hint: could not append system_instruction: %s",
-                exc,
-            )
 
 
 #: Default per-LLM-call wall-clock budget (milliseconds) enforced by
@@ -2389,6 +2156,19 @@ def make_adk_plugin(
             # Per-invocation pin ensures the pair is exactly-once even
             # when ADK skips ``after_agent_callback`` on cancel.
             self._boundary_entered_invocations: set[str] = set()
+            # Wave B1 (refactor/prompt-shaper): centralised prompt-shape
+            # injection helpers. The plugin reaches the two
+            # ``before_model_callback`` injection sites
+            # (:meth:`PromptShaper.inject_goldfive_planner_instruction`
+            # and :meth:`PromptShaper.inject_runtime_tools_hint`) via
+            # this instance. ``observation_only`` gating lives inside
+            # the shaper so this module no longer needs its own
+            # ``_observation_only_active`` helper. Stateless — owned
+            # per-plugin so future per-runner shaper configuration is
+            # one attribute away.
+            from goldfive.prompt_shaper import PromptShaper
+
+            self._prompt_shaper = PromptShaper()
 
         def set_active_context(self, ctx: SessionContext) -> None:
             """Attach the ``SessionContext`` for the running invocation.
@@ -5304,30 +5084,22 @@ def make_adk_plugin(
             # goldfive Session directly so no callback-time write
             # is required.
             #
-            # goldfive#271 strict-passive carve-out: under
-            # ``observation_only=True`` skip the injection. The
-            # planner's instruction block is goldfive's coaching of
-            # the coordinator's planning behaviour — mutating
-            # ``system_instruction`` to nudge the model toward a
-            # specific orchestration shape is exactly the kind of
-            # silent prompt-shaping strict-passive exists to surface.
-            if _observation_only_active(ctx):
-                log.info(
-                    "before_model_callback: observation_only=True — "
-                    "SKIPPING GoldfivePlanner request-side instruction "
-                    "injection (system_instruction unchanged)"
+            # goldfive#271 strict-passive carve-out + Wave B1: the
+            # injection + ``observation_only`` gate live in
+            # :class:`~goldfive.prompt_shaper.PromptShaper`. The shaper
+            # short-circuits when ``ctx.steerer._observation_only`` is
+            # True; otherwise the byte-identical pre-#271 inject runs.
+            try:
+                await self._prompt_shaper.inject_goldfive_planner_instruction(
+                    callback_context=callback_context,
+                    llm_request=llm_request,
+                    session_context=ctx,
                 )
-            else:
-                try:
-                    await _inject_goldfive_planner_instruction(
-                        callback_context=callback_context,
-                        llm_request=llm_request,
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    log.debug(
-                        "before_model_callback: goldfive planner injection raised: %s",
-                        exc,
-                    )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "before_model_callback: goldfive planner injection raised: %s",
+                    exc,
+                )
 
             # Structural ``max_output_tokens`` ceiling for sub-agent
             # LLM calls (goldfive#256). Applied AFTER GoldfivePlanner
@@ -5374,32 +5146,24 @@ def make_adk_plugin(
             # strip the stale block before appending the fresh one
             # (per-call, not accumulated).
             #
-            # goldfive#271 strict-passive carve-out: under
-            # ``observation_only=True`` skip injection. The hint is
-            # directive ("Choose the agent whose tasks are still
-            # PENDING. Do not re-invoke agents whose tasks are
-            # already complete.") — exactly the kind of silent
-            # coaching strict-passive exists to surface. Operators
-            # observe the RAW coordinator's tool-choice behaviour.
-            if _observation_only_active(ctx):
-                log.info(
-                    "before_model_callback: observation_only=True — "
-                    "SKIPPING runtime tool-surface hint injection "
-                    "(system_instruction unchanged)"
-                )
-            else:
-                try:
-                    if ctx is not None and ctx.session is not None:
-                        _inject_runtime_tools_hint(
-                            callback_context=callback_context,
-                            llm_request=llm_request,
-                            session=ctx.session,
-                        )
-                except Exception as exc:  # noqa: BLE001
-                    log.debug(
-                        "before_model_callback: runtime tools hint injection raised: %s",
-                        exc,
+            # goldfive#271 strict-passive carve-out + Wave B1: the
+            # hint + ``observation_only`` gate live in
+            # :class:`~goldfive.prompt_shaper.PromptShaper`. The shaper
+            # short-circuits when ``ctx.steerer._observation_only`` is
+            # True; otherwise the byte-identical pre-#271 inject runs.
+            try:
+                if ctx is not None and ctx.session is not None:
+                    self._prompt_shaper.inject_runtime_tools_hint(
+                        callback_context=callback_context,
+                        llm_request=llm_request,
+                        session=ctx.session,
+                        session_context=ctx,
                     )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "before_model_callback: runtime tools hint injection raised: %s",
+                    exc,
+                )
 
             # Per-LLM-call instrumentation (goldfive#172). Measure the
             # request AFTER GoldfivePlanner has appended its

--- a/goldfive/prompt_shaper.py
+++ b/goldfive/prompt_shaper.py
@@ -1,0 +1,630 @@
+"""Centralised gate + injection sites for goldfive prompt-shaping.
+
+Goldfive's runtime augments the prompt the underlying LLM sees in four
+distinct places. Each site is a different mechanism with a different
+caller — but all four share the same enforcement contract:
+:class:`~goldfive.config.SteeringConfig.observation_only` must suppress
+*every* prompt-shape injection so the operator observes the RAW
+caller-supplied prompt the coordinator was constructed with.
+
+Before this module the gate logic was hand-rolled at each of the four
+sites: a ``_observation_only_active`` helper in
+:mod:`goldfive.adapters._adk_plugin`, a near-identical one in
+:mod:`goldfive.adapters._adk_dynainst`, and an inline check in
+:meth:`goldfive.runner.Runner.run`. The duplication invited drift — a
+future site added without remembering the gate would silently leak the
+shaping under ``observation_only=True``. :class:`PromptShaper`
+collapses the four gates into a single :meth:`should_inject` predicate
+and owns the four injection bodies.
+
+Sites
+-----
+
+1. **Conversational follow-up wrap** —
+   :meth:`PromptShaper.wrap_conversational_input`. Frames the user's
+   raw input as a "[CONVERSATIONAL FOLLOW-UP — reuse prior plan]"
+   directive (closes goldfive#277). Used by
+   :meth:`goldfive.runner.Runner.run` on a conversational follow-up
+   turn (``handle_turn`` returned ``None`` on a turn with a real prior
+   plan).
+
+2. **GoldfivePlanner request-side instruction** —
+   :meth:`PromptShaper.inject_goldfive_planner_instruction`. Appends
+   the planner's :meth:`build_planning_instruction` output to
+   ``llm_request.config.system_instruction`` (workaround for ADK's
+   ``_nl_planning`` request-side gating on ``PlanReActPlanner``;
+   goldfive#153).
+
+3. **Runtime tool-surface hint** —
+   :meth:`PromptShaper.inject_runtime_tools_hint`. Appends a
+   ``[GOLDFIVE PLAN-STATE HINT — …]`` block listing each agent's
+   PENDING / DONE task summary so the coordinator has structural
+   guidance about which sub-agent to call next (R3 / F2-alternative).
+
+4. **Dynamic instruction resolver** —
+   :meth:`PromptShaper.make_dynamic_instruction`. Returns an ADK
+   ``InstructionProvider`` callable that resolves the current pinned
+   task + pending-correction block on every turn and appends them to
+   the agent's ``original_instruction`` (goldfive#251).
+
+Each method first asks :meth:`should_inject` whether the gate is open
+for its context. When :meth:`should_inject` returns ``False`` the
+method is a no-op (no-op = "return the raw / pre-existing value" for
+each site's contract).
+
+Note on shape: the four sites have intentionally different signatures
+because the underlying injection mechanisms are different (message-
+body rewrite, ``system_instruction`` append, callable closure). They
+are NOT collapsed into one ``inject(...)`` method.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from goldfive.types import Session
+
+
+log = logging.getLogger("goldfive.prompt_shaper")
+
+
+class PromptShaper:
+    """Stateless namespace for goldfive's prompt-shaping injection sites.
+
+    The class holds no instance state — methods are organised on a class
+    so call sites read naturally (``PromptShaper().wrap_conversational_input(...)``
+    or ``shaper.inject_runtime_tools_hint(...)``) and so a future
+    extension can carry per-runner configuration without a signature
+    change. The four methods correspond to the four injection sites in
+    goldfive's runtime; :meth:`should_inject` is the single
+    ``observation_only`` gate they all consult.
+    """
+
+    # ----------------------------------------------------------------
+    # Gate
+    # ----------------------------------------------------------------
+
+    @staticmethod
+    def should_inject(steerer: Any) -> bool:
+        """Return True when prompt-shaping injections are permitted.
+
+        Reads ``steerer._observation_only`` and returns its logical
+        complement: under strict-passive (``observation_only=True``)
+        injections are suppressed; otherwise the active-steering path
+        runs.
+
+        Tolerant of ``steerer is None`` and steerers that don't carry
+        a ``_observation_only`` attribute — both cases return ``True``
+        so pre-#271 paths and minimal test stubs (which never set up a
+        steerer) keep working byte-identically.
+
+        This is the single source of truth the four inject methods
+        consult. Mirrors :meth:`DefaultSteerer._should_inject` in
+        intent — that predicate gates enforcement-side dispatch (steer,
+        pause-escalate, cancel); this one gates prompt-shape
+        injections.
+        """
+        if steerer is None:
+            return True
+        return not bool(getattr(steerer, "_observation_only", False))
+
+    # ----------------------------------------------------------------
+    # Site 1 — conversational follow-up wrap
+    # ----------------------------------------------------------------
+
+    def wrap_conversational_input(
+        self,
+        *,
+        user_input: str,
+        session: Session,
+        steerer: Any,
+    ) -> str:
+        """Return either the wrapped follow-up directive or the raw input.
+
+        F6 (closes goldfive#277). When :meth:`Planner.handle_turn`
+        returns ``None`` on a turn with a real prior plan, the runner
+        reuses ``session.plan`` but still drives the executor over the
+        input — without this wrapper the coordinator typically treats
+        the question as a fresh task and re-delegates to sub-agents,
+        wasting an invocation. The wrapper:
+
+        * tags the message as a conversational follow-up,
+        * gives the coordinator the plan summary + completed task
+          context so it can answer from history,
+        * asks it explicitly NOT to delegate.
+
+        Lives in the message body (no system-prompt contract). A
+        parallel layer (the ADK plugin's pre-dispatch interceptor,
+        keyed off ``session._conversational_turn``) tightens the
+        tool surface so the coordinator literally cannot delegate
+        even if it tried; this wrapper is the cooperative half.
+
+        Under ``observation_only=True`` (:meth:`should_inject` →
+        ``False``) the wrapper is skipped and ``user_input`` is
+        returned verbatim. The strict-passive operator sees the RAW
+        coordinator behaviour on a follow-up turn — which may include
+        re-delegation; that's the diagnostic value of strict-passive,
+        not a regression.
+        """
+        if not self.should_inject(steerer):
+            log.info(
+                "PromptShaper.wrap_conversational_input: observation_only=True — "
+                "SKIPPING conversational-follow-up wrap "
+                "(user_input passes through raw); session_id=%s",
+                (session.id or "")[:16] or "<none>",
+            )
+            return user_input
+
+        from goldfive.types import TaskStatus
+
+        plan = session.plan
+        plan_summary = (plan.summary if plan is not None else "") or "(no summary)"
+        completed_lines: list[str] = []
+        if plan is not None:
+            for t in plan.tasks:
+                if t.status is TaskStatus.COMPLETED:
+                    title = t.title or t.description or t.id
+                    assignee = t.assignee_agent_id or "(no-assignee)"
+                    completed_lines.append(f"  - [{t.id}] {title} (by {assignee})")
+        completed_block = (
+            "\n".join(completed_lines) if completed_lines else "  (none yet)"
+        )
+        return (
+            "[CONVERSATIONAL FOLLOW-UP — reuse prior plan, don't delegate "
+            "to sub-agents]\n\n"
+            "The user is asking a follow-up question about prior work. "
+            "Answer briefly using the conversation history and existing "
+            "artifacts. Do NOT call any AgentTool — answer directly.\n\n"
+            f"Plan summary: {plan_summary}\n"
+            f"Completed tasks:\n{completed_block}\n\n"
+            f"User question: {user_input}"
+        )
+
+    # ----------------------------------------------------------------
+    # Site 2 — GoldfivePlanner request-side system_instruction
+    # ----------------------------------------------------------------
+
+    async def inject_goldfive_planner_instruction(
+        self,
+        *,
+        callback_context: Any,
+        llm_request: Any,
+        session_context: Any = None,
+    ) -> None:
+        """Append :class:`GoldfivePlanner` output to ``llm_request.config.system_instruction``.
+
+        ADK's ``flows/llm_flows/_nl_planning.py`` request-side processor
+        gates instruction injection on ``isinstance(planner,
+        PlanReActPlanner)`` — so a ``BasePlanner`` subclass that is NOT
+        a PlanReAct subclass gets its ``build_planning_instruction``
+        called on the RESPONSE side (via
+        ``process_planning_response``) but never on the REQUEST side.
+        That's fine for response filtering but it starves the model of
+        goldfive's orchestration context block on the turn that
+        matters.
+
+        This helper is the workaround: detect when the running agent's
+        ``.planner`` is a :class:`~goldfive.planners.goldfive_planner.GoldfivePlanner`
+        (NOT a ``PlanReActPlanner`` or ``BuiltInPlanner`` — ADK handles
+        those on its own via ``_nl_planning``) and append the planner's
+        :meth:`build_planning_instruction` output to the request's
+        system instruction using ADK's own ``append_instructions``
+        method.
+
+        Silent fall-throughs in priority order:
+
+        * ADK not installed or ``BasePlanner`` import fails → skip.
+        * Running agent has no ``planner`` attribute or planner is
+          ``None`` → skip (plain ADK LlmAgent with no goldfive
+          attachment).
+        * Planner is a ``PlanReActPlanner`` / ``BuiltInPlanner``
+          subclass → skip (ADK will handle it natively).
+        * ``build_planning_instruction`` returns ``None`` / empty →
+          skip (planner opted out for this turn).
+        * ``llm_request`` lacks ``append_instructions`` → fall back to
+          writing directly into ``config.system_instruction``.
+
+        Under ``observation_only=True`` (:meth:`should_inject` →
+        ``False``) the injection is suppressed and
+        ``llm_request.config.system_instruction`` is left untouched.
+        The strict-passive operator sees whatever ``system_instruction``
+        ADK / the caller stamped, with no goldfive augmentation.
+
+        ``session_context`` carries the live
+        :class:`~goldfive.adapters._adk_plugin.SessionContext` from the
+        plugin so the gate can reach the steerer. May be ``None`` on
+        unit-test stubs that never wire one up — those paths default
+        to the active-steering branch (pre-#271 behaviour).
+        """
+        steerer = getattr(session_context, "steerer", None) if session_context is not None else None
+        if not self.should_inject(steerer):
+            log.info(
+                "PromptShaper.inject_goldfive_planner_instruction: "
+                "observation_only=True — SKIPPING GoldfivePlanner "
+                "request-side instruction injection "
+                "(system_instruction unchanged)"
+            )
+            return
+
+        try:
+            from goldfive.planners.goldfive_planner import GoldfivePlanner
+        except ImportError:  # pragma: no cover — ADK not installed
+            return
+        try:
+            from google.adk.planners.base_planner import BasePlanner  # type: ignore
+            from google.adk.planners.built_in_planner import BuiltInPlanner  # type: ignore
+            from google.adk.planners.plan_re_act_planner import (  # type: ignore
+                PlanReActPlanner,
+            )
+        except ImportError:  # pragma: no cover — ADK not installed
+            return
+
+        # Find the running agent on the callback_context. ADK exposes
+        # it through the invocation context; tests may supply a context
+        # that carries ``.agent`` directly.
+        inv_ctx = _safe_attr(callback_context, "_invocation_context", None) or _safe_attr(
+            callback_context, "invocation_context", None
+        )
+        agent = _safe_attr(inv_ctx, "agent", None)
+        if agent is None:
+            agent = _safe_attr(callback_context, "agent", None)
+        if agent is None:
+            return
+
+        planner = _safe_attr(agent, "planner", None)
+        if planner is None:
+            return
+        # If ADK itself will inject for this planner type, skip.
+        # ``BuiltInPlanner`` never emits a text instruction (it
+        # configures thinking on the request instead),
+        # ``PlanReActPlanner`` is the one ADK gates on.
+        if isinstance(planner, (PlanReActPlanner, BuiltInPlanner)):
+            return
+        if not isinstance(planner, BasePlanner):
+            return
+        # Narrow further: the adapter attaches GoldfivePlanner
+        # specifically. A custom BasePlanner subclass that is not
+        # GoldfivePlanner should be respected by ADK's own (response-
+        # side) dispatch only, not re-injected here.
+        if not isinstance(planner, GoldfivePlanner):
+            return
+
+        # Build the ReadonlyContext ADK expects. When invocation_context
+        # is available we use ADK's real class; otherwise we fall back
+        # to ``callback_context`` itself (test stubs carrying ``.state``
+        # work through GoldfivePlanner's tolerant _extract_state).
+        readonly = callback_context
+        try:
+            from google.adk.agents.readonly_context import ReadonlyContext  # type: ignore
+
+            if inv_ctx is not None:
+                readonly = ReadonlyContext(inv_ctx)
+        except Exception as exc:  # noqa: BLE001 — use fallback
+            log.debug(
+                "PromptShaper.inject_goldfive_planner_instruction: "
+                "ReadonlyContext unavailable: %s",
+                exc,
+            )
+
+        instruction = planner.build_planning_instruction(readonly, llm_request)
+        if not instruction:
+            return
+
+        append = getattr(llm_request, "append_instructions", None)
+        if not callable(append):
+            # Best-effort write directly into
+            # ``config.system_instruction`` when the test stub doesn't
+            # carry the helper. Preserves the existing value if it's a
+            # string.
+            config = getattr(llm_request, "config", None)
+            if config is None:
+                return
+            existing = getattr(config, "system_instruction", None)
+            if not existing:
+                try:
+                    config.system_instruction = instruction
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "PromptShaper.inject_goldfive_planner_instruction: "
+                        "could not set system_instruction: %s",
+                        exc,
+                    )
+            elif isinstance(existing, str):
+                try:
+                    config.system_instruction = existing + "\n\n" + instruction
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "PromptShaper.inject_goldfive_planner_instruction: "
+                        "could not append system_instruction: %s",
+                        exc,
+                    )
+            return
+
+        try:
+            append([instruction])
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "PromptShaper.inject_goldfive_planner_instruction: "
+                "append_instructions raised: %s",
+                exc,
+            )
+
+    # ----------------------------------------------------------------
+    # Site 3 — runtime tool-surface hint
+    # ----------------------------------------------------------------
+
+    def inject_runtime_tools_hint(
+        self,
+        *,
+        callback_context: Any,
+        llm_request: Any,
+        session: Any,
+        session_context: Any = None,
+    ) -> None:
+        """Inject (or refresh) the runtime tool-surface hint on ``llm_request``.
+
+        R3 (F2 alternative). Builds the current plan-state hint via
+        :func:`goldfive.adapters._adk_plugin._build_runtime_tools_hint`
+        and writes it to ``llm_request.config.system_instruction``. If
+        a prior goldfive hint is present (detected by
+        :data:`goldfive.adapters._adk_plugin._RUNTIME_TOOLS_HINT_PREFIX`),
+        it is stripped first so we don't accumulate snapshots across
+        calls.
+
+        Best-effort: never raises. A ``None`` hint (no plan, or plan
+        with no informative groups) is a no-op so we don't pollute the
+        prompt with empty markers.
+
+        Under ``observation_only=True`` (:meth:`should_inject` →
+        ``False``) the injection (and stale-hint strip) is suppressed
+        — the strict-passive operator sees the unaltered
+        ``system_instruction`` ADK / the caller set.
+
+        ``session_context`` carries the live
+        :class:`~goldfive.adapters._adk_plugin.SessionContext` from the
+        plugin so the gate can reach the steerer. May be ``None`` on
+        unit-test stubs that never wire one up.
+        """
+        steerer = getattr(session_context, "steerer", None) if session_context is not None else None
+        if not self.should_inject(steerer):
+            log.info(
+                "PromptShaper.inject_runtime_tools_hint: "
+                "observation_only=True — SKIPPING runtime tool-surface "
+                "hint injection (system_instruction unchanged)"
+            )
+            return
+
+        # Defer to the helpers that still live in _adk_plugin so the
+        # marker constants + hint composition stay in one place (they
+        # are also publicly imported by the runtime-tool-surface-hint
+        # unit tests).
+        from goldfive.adapters._adk_plugin import (
+            _RUNTIME_TOOLS_HINT_PREFIX,
+            _build_runtime_tools_hint,
+            _strip_prior_runtime_tools_hint,
+        )
+
+        hint = _build_runtime_tools_hint(session)
+
+        config = _safe_attr(llm_request, "config", None)
+        if config is None:
+            return
+        existing = getattr(config, "system_instruction", None)
+
+        # Strip any prior hint regardless of whether we'll re-inject. A
+        # None ``hint`` (plan disappeared or all groups empty) should
+        # still remove the stale marker block from the request.
+        if isinstance(existing, str) and _RUNTIME_TOOLS_HINT_PREFIX in existing:
+            try:
+                config.system_instruction = _strip_prior_runtime_tools_hint(existing) or None
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "PromptShaper.inject_runtime_tools_hint: "
+                    "could not strip prior hint: %s",
+                    exc,
+                )
+                return
+            existing = getattr(config, "system_instruction", None)
+
+        if not hint:
+            return
+
+        append = getattr(llm_request, "append_instructions", None)
+        if callable(append):
+            try:
+                append([hint])
+                return
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "PromptShaper.inject_runtime_tools_hint: "
+                    "append_instructions raised: %s",
+                    exc,
+                )
+                # fall through to direct write
+
+        # Fallback for stubs that lack ``append_instructions`` (unit
+        # tests).
+        if not existing:
+            try:
+                config.system_instruction = hint
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "PromptShaper.inject_runtime_tools_hint: "
+                    "could not set system_instruction: %s",
+                    exc,
+                )
+        elif isinstance(existing, str):
+            try:
+                config.system_instruction = existing + "\n\n" + hint
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "PromptShaper.inject_runtime_tools_hint: "
+                    "could not append system_instruction: %s",
+                    exc,
+                )
+
+    # ----------------------------------------------------------------
+    # Site 4 — dynamic instruction resolver
+    # ----------------------------------------------------------------
+
+    def make_dynamic_instruction(
+        self,
+        original_instruction: str,
+        agent_name: str,
+    ) -> Callable[[Any], str]:
+        """Return a resolver matching ADK's ``InstructionProvider`` signature.
+
+        The returned callable:
+
+        * Reads ``session.state`` off the ``ReadonlyContext`` to reach
+          the :class:`~goldfive.adapters._adk_plugin.SessionContext`
+          stash and from there the goldfive
+          :class:`~goldfive.types.Session`.
+        * Reads the current-task pin via
+          :class:`~goldfive.state_store.StateStore`. If
+          no pin is set, returns the ``original_instruction`` verbatim
+          (pre-plan turns stay unchanged).
+        * Looks up the task in ``Session.plan.tasks`` for ``title`` /
+          ``description`` (the typed :class:`~goldfive.types.Task` is
+          the source of truth — the resolver does not consult
+          de-normalised ADK-state keys).
+        * If a pending correction exists for
+          ``(agent_name, current_task_id)`` the block is appended
+          (Stream D writes; the store reads).
+
+        The resolver is pure: given the same Session.state it returns
+        the same string. No side effects, no persistence.
+
+        Phase 2.0 of goldfive#271 — the bridge from goldfive
+        Session.state onto ADK session.state is gone. The resolver
+        reads goldfive Session directly via the SessionContext stash,
+        eliminating the callback-time write to ADK state that raced
+        with ADK's optimistic-concurrency contract (see
+        goldfive#275).
+
+        Under ``observation_only=True`` (:meth:`should_inject` →
+        ``False``) the resolver returns ``original_instruction``
+        verbatim — no "Current assigned task" block, no pending-
+        correction block, no goldfive augmentation of any kind.
+
+        Legacy fallback: when the SessionContext stash is unreachable
+        (a unit test drives the resolver against a plain state dict
+        without the stash), the resolver reads the pin / title /
+        description / correction directly off ADK state. Production
+        paths always carry the stash.
+        """
+        # Capture ``self`` so the closure can consult the gate via the
+        # shaper's :meth:`should_inject` predicate.
+        shaper = self
+
+        def resolver(readonly_ctx: Any) -> str:
+            try:
+                # Reach the goldfive SessionContext to read the
+                # steerer + session. The same walk supplies both the
+                # gate's steerer and the resolver's session.
+                from goldfive.adapters import _adk_state_protocol as _sp
+                from goldfive.adapters._adk_dynainst import (
+                    _compose_instruction,
+                    _goldfive_session_context_from_readonly_context,
+                    _read_pending_correction,
+                    _state_from_readonly_context,
+                    _task_title_description_from_session,
+                )
+
+                ctx = _goldfive_session_context_from_readonly_context(readonly_ctx)
+                steerer = getattr(ctx, "steerer", None) if ctx is not None else None
+
+                if not shaper.should_inject(steerer):
+                    log.info(
+                        "PromptShaper.make_dynamic_instruction resolver: "
+                        "observation_only=True — SKIPPING goldfive "
+                        "prompt augmentation for agent=%r "
+                        "(returning original instruction verbatim)",
+                        agent_name,
+                    )
+                    return original_instruction
+
+                state = _state_from_readonly_context(readonly_ctx)
+                session = getattr(ctx, "session", None) if ctx is not None else None
+
+                if session is not None:
+                    from goldfive.state_store import StateStore
+
+                    store = StateStore.for_session(session)
+                    current_task_id = store.pin_current_task()
+                else:
+                    current_task_id = str(state.get(_sp.KEY_CURRENT_TASK_ID, "") or "")
+
+                if not current_task_id:
+                    # No pin — pre-plan turn, or an agent that doesn't
+                    # need plan-causal augmentation this turn. Return
+                    # the caller's instruction verbatim.
+                    return original_instruction
+
+                if session is not None:
+                    current_task_title, current_task_description = (
+                        _task_title_description_from_session(session, current_task_id)
+                    )
+                else:
+                    # Legacy ADK-state fallback path.
+                    current_task_title = str(
+                        state.get(_sp.KEY_CURRENT_TASK_TITLE, "") or ""
+                    )
+                    current_task_description = str(
+                        state.get(_sp.KEY_CURRENT_TASK_DESCRIPTION, "") or ""
+                    )
+
+                pending_correction = _read_pending_correction(
+                    session=session,
+                    state=state,
+                    agent_name=agent_name,
+                    current_task_id=current_task_id,
+                )
+
+                return _compose_instruction(
+                    original=original_instruction,
+                    task_id=current_task_id,
+                    task_title=current_task_title,
+                    task_description=current_task_description,
+                    pending_correction=pending_correction,
+                )
+            except Exception as exc:  # noqa: BLE001
+                # Instrumentation path — any failure here degrades to
+                # the original instruction so the agent still runs.
+                # ADK's own pipeline would otherwise surface this as an
+                # InternalError mid-turn, which is the worst possible
+                # failure mode.
+                log.debug(
+                    "PromptShaper.make_dynamic_instruction resolver "
+                    "raised for agent=%r: %s "
+                    "(falling back to original instruction)",
+                    agent_name,
+                    exc,
+                )
+                return original_instruction
+
+        # Stamp provenance on the closure so test code and tree-walk
+        # idempotency checks can recognise it without relying on repr.
+        resolver._goldfive_dynamic_instruction = True  # type: ignore[attr-defined]
+        resolver._goldfive_agent_name = agent_name  # type: ignore[attr-defined]
+        resolver._goldfive_original_instruction = original_instruction  # type: ignore[attr-defined]
+        return resolver
+
+
+def _safe_attr(obj: Any, name: str, default: Any = None) -> Any:
+    """Local copy of the defensive attribute reader used by the ADK plugin.
+
+    Keeps this module independent of an optional google-adk install —
+    callers that pass ADK objects get attribute access; stubs that
+    don't carry the attribute degrade to ``default``.
+    """
+    try:
+        return getattr(obj, name, default)
+    except Exception:  # noqa: BLE001
+        return default
+
+
+__all__ = ["PromptShaper"]

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -315,6 +315,16 @@ class Runner:
         self.executor = executor
         self.goal_deriver: GoalDeriver = goal_deriver or PassthroughGoalDeriver("run")
         self.steerer: Steerer = steerer or DefaultSteerer()
+        # Wave B1 (refactor/prompt-shaper): centralised prompt-shaping
+        # injection sites + ``observation_only`` gate. The Runner only
+        # uses :meth:`PromptShaper.wrap_conversational_input` directly;
+        # the ADK plugin holds its own instance for the three
+        # request-side sites. Stateless — instantiation here keeps the
+        # gate predicate co-located with the runner's other dispatch
+        # helpers.
+        from goldfive.prompt_shaper import PromptShaper
+
+        self._prompt_shaper = PromptShaper()
         # goldfive#143: opt-in gate for the trajectory-level GOAL_DRIFT
         # periodic check. ``True`` (default) is a no-op -- the steerer's
         # own ``goal_drift_call_llm`` wiring governs whether the check
@@ -1073,40 +1083,25 @@ class Runner:
                 # so absorb_turn / event summaries above still see the
                 # user's actual question.
                 #
-                # goldfive#271 strict-passive carve-out: under
-                # ``observation_only=True`` skip the wrap. The whole
-                # point of strict-passive is to surface the RAW
-                # coordinator behaviour — wrapping mutates the input
-                # the agent's LLM sees verbatim (it's prompt-shaping
-                # masquerading as a user message) and would coach the
-                # coordinator into the "don't delegate" behaviour the
-                # operator is trying to observe. Without the wrap, a
-                # follow-up turn may cause the operator's coordinator
-                # to re-delegate; that's the diagnostic value of
-                # strict-passive.
+                # goldfive#271 strict-passive carve-out + Wave B1: the
+                # wrap + ``observation_only`` gate live in
+                # :class:`~goldfive.prompt_shaper.PromptShaper` so the
+                # four prompt-shaping sites share one gate. Under
+                # ``observation_only=True`` ``wrap_conversational_input``
+                # returns the raw input unchanged; otherwise it returns
+                # the composed F6 directive.
                 if isinstance(user_input, str):
                     run_sig = inspect.signature(self.executor.run)
                     if "user_input" in run_sig.parameters:
                         executor_user_input = user_input
-                        is_conversational = (
+                        if (
                             getattr(session, "_conversational_turn", False)
-                            and bool(user_input.strip())
-                        )
-                        passive = bool(
-                            getattr(self.steerer, "_observation_only", False)
-                        )
-                        if is_conversational and not passive:
-                            executor_user_input = self._wrap_conversational_input(
+                            and user_input.strip()
+                        ):
+                            executor_user_input = self._prompt_shaper.wrap_conversational_input(
                                 user_input=user_input,
                                 session=session,
-                            )
-                        elif is_conversational and passive:
-                            log.info(
-                                "Runner.run: observation_only=True — "
-                                "SKIPPING conversational-follow-up wrap "
-                                "(user_input passes through raw); "
-                                "session_id=%s",
-                                (session.id or "")[:16] or "<none>",
+                                steerer=self.steerer,
                             )
                         executor_kwargs["user_input"] = executor_user_input
                 outcome = await self.executor.run(**executor_kwargs)
@@ -1720,58 +1715,6 @@ class Runner:
             )
             return False
         return bool(installed)
-
-    @staticmethod
-    def _wrap_conversational_input(
-        *,
-        user_input: str,
-        session: Session,
-    ) -> str:
-        """Compose a directive that frames the user's input as a
-        conversational follow-up (F6, closes goldfive#277).
-
-        When :meth:`Planner.handle_turn` returns ``None`` on a turn
-        with a real prior plan, the runner reuses ``session.plan``
-        but still drives the executor over the input — without this
-        wrapper the coordinator typically treats the question as a
-        fresh task and re-delegates to sub-agents, wasting an
-        invocation. The wrapper:
-
-        * tags the message as a conversational follow-up,
-        * gives the coordinator the plan summary + completed task
-          context so it can answer from history,
-        * asks it explicitly NOT to delegate.
-
-        Lives in the message body (no system-prompt contract). A
-        parallel layer (the ADK plugin's pre-dispatch interceptor,
-        keyed off ``session._conversational_turn``) tightens the
-        tool surface so the coordinator literally cannot delegate
-        even if it tried; this wrapper is the cooperative half.
-        """
-        from goldfive.types import TaskStatus
-
-        plan = session.plan
-        plan_summary = (plan.summary if plan is not None else "") or "(no summary)"
-        completed_lines: list[str] = []
-        if plan is not None:
-            for t in plan.tasks:
-                if t.status is TaskStatus.COMPLETED:
-                    title = t.title or t.description or t.id
-                    assignee = t.assignee_agent_id or "(no-assignee)"
-                    completed_lines.append(f"  - [{t.id}] {title} (by {assignee})")
-        completed_block = (
-            "\n".join(completed_lines) if completed_lines else "  (none yet)"
-        )
-        return (
-            "[CONVERSATIONAL FOLLOW-UP — reuse prior plan, don't delegate "
-            "to sub-agents]\n\n"
-            "The user is asking a follow-up question about prior work. "
-            "Answer briefly using the conversation history and existing "
-            "artifacts. Do NOT call any AgentTool — answer directly.\n\n"
-            f"Plan summary: {plan_summary}\n"
-            f"Completed tasks:\n{completed_block}\n\n"
-            f"User question: {user_input}"
-        )
 
     async def _resolve_goals(
         self,

--- a/tests/test_correction_injection.py
+++ b/tests/test_correction_injection.py
@@ -588,9 +588,11 @@ def test_format_correction_block_is_directive_not_diagnostic() -> None:
 
 def test_dynamic_resolver_picks_up_correction_dict() -> None:
     pytest.importorskip("google.adk")
-    from goldfive.adapters._adk_dynainst import make_dynamic_instruction
+    # Wave B1 (refactor/prompt-shaper): the factory moved to
+    # :class:`~goldfive.prompt_shaper.PromptShaper`.
+    from goldfive.prompt_shaper import PromptShaper
 
-    resolver = make_dynamic_instruction(
+    resolver = PromptShaper().make_dynamic_instruction(
         original_instruction="you are the researcher",
         agent_name="research_agent",
     )

--- a/tests/test_dynamic_instruction.py
+++ b/tests/test_dynamic_instruction.py
@@ -28,10 +28,23 @@ from goldfive.adapters import _adk_state_protocol as _sp
 from goldfive.adapters._adk_dynainst import (
     install_dynamic_instructions,
     is_dynamic_instruction,
-    make_dynamic_instruction,
     pending_correction_key,
 )
+from goldfive.prompt_shaper import PromptShaper
 from goldfive.types import Plan, Task
+
+
+def make_dynamic_instruction(
+    original_instruction: str,
+    agent_name: str,
+):
+    """Local shim: Wave B1 moved this factory onto
+    :class:`PromptShaper`. Kept as a free function here so the existing
+    test bodies (which pre-date the move) read unchanged."""
+    return PromptShaper().make_dynamic_instruction(
+        original_instruction=original_instruction,
+        agent_name=agent_name,
+    )
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_goldfive_planner.py
+++ b/tests/test_goldfive_planner.py
@@ -17,9 +17,29 @@ pytest.importorskip("google.adk")
 from goldfive.adapters._adk_plugin import (  # noqa: E402
     SESSION_CONTEXT_STATE_KEY,
     SessionContext,
-    _inject_goldfive_planner_instruction,
     make_adk_plugin,
 )
+from goldfive.prompt_shaper import PromptShaper  # noqa: E402
+
+
+async def _inject_goldfive_planner_instruction(
+    *, callback_context: Any, llm_request: Any
+) -> None:
+    """Wave B1 shim: forward to
+    :meth:`PromptShaper.inject_goldfive_planner_instruction`.
+
+    The pre-refactor signature took only ``(callback_context,
+    llm_request)``; the shaper additionally accepts a
+    ``session_context`` to read the steerer. These tests don't exercise
+    the strict-passive gate (they predate it and pass no SessionContext),
+    so we pin ``session_context=None`` — the gate then defaults to
+    "inject" (matches pre-refactor behaviour byte-identically).
+    """
+    await PromptShaper().inject_goldfive_planner_instruction(
+        callback_context=callback_context,
+        llm_request=llm_request,
+        session_context=None,
+    )
 from goldfive.adapters._adk_state_protocol import (  # noqa: E402
     KEY_CURRENT_TASK_ID,
     KEY_CURRENT_TASK_TITLE,

--- a/tests/test_observation_only_strict_passive.py
+++ b/tests/test_observation_only_strict_passive.py
@@ -10,29 +10,35 @@ making the operator's observation be of a goldfive-coached coordinator
 rather than the raw one:
 
 1. **Runner conversational-follow-up wrap**
-   (:meth:`Runner._wrap_conversational_input`, runner.py ~1701).
-   On a follow-up turn the runner rewrote the user's plain input into a
+   (:meth:`goldfive.prompt_shaper.PromptShaper.wrap_conversational_input`,
+   called from :meth:`goldfive.runner.Runner.run`). On a follow-up turn
+   the runner rewrote the user's plain input into a
    ``[CONVERSATIONAL FOLLOW-UP — reuse prior plan, don't delegate]``
    directive. Under strict-passive that wrap is skipped: the executor
    receives the raw ``user_input``.
 
 2. **ADK plugin ``before_model_callback`` ``system_instruction``
-   injections** (:func:`_inject_goldfive_planner_instruction`,
-   :func:`_inject_runtime_tools_hint` in
-   :mod:`goldfive.adapters._adk_plugin`). Both append goldfive-shaped
-   directive blocks to every LLM call's ``system_instruction``. Under
-   strict-passive both are skipped at the callback gate; the
-   coordinator's ``system_instruction`` is whatever ADK / the caller
-   set it to, with no goldfive augmentation.
+   injections**
+   (:meth:`PromptShaper.inject_goldfive_planner_instruction`,
+   :meth:`PromptShaper.inject_runtime_tools_hint`). Both append
+   goldfive-shaped directive blocks to every LLM call's
+   ``system_instruction``. Under strict-passive both are skipped at the
+   shaper's :meth:`should_inject` gate; the coordinator's
+   ``system_instruction`` is whatever ADK / the caller set it to, with
+   no goldfive augmentation.
 
 3. **Dynamic instruction resolver**
-   (:func:`goldfive.adapters._adk_dynainst.make_dynamic_instruction`,
-   installed at :func:`goldfive.wrap` time). The resolver replaces every
-   wrapped ``LlmAgent.instruction`` with a closure that appends
-   "Current assigned task: id/title/description" + any pending-correction
+   (:meth:`PromptShaper.make_dynamic_instruction`, installed at
+   :func:`goldfive.wrap` time). The resolver replaces every wrapped
+   ``LlmAgent.instruction`` with a closure that appends "Current
+   assigned task: id/title/description" + any pending-correction
    block on every turn. Under strict-passive the resolver returns the
    ``original_instruction`` verbatim — the caller-supplied string the
    ``LlmAgent`` was constructed with.
+
+Wave B1 (refactor/prompt-shaper) consolidated the four gate checks
+into :meth:`PromptShaper.should_inject` — the four call sites no
+longer carry duplicated ``observation_only`` predicates.
 
 Live reproduction context: typewriters / kikuchi session
 ``1c3602f8-3810-4158-ad8a-3c8f0b79dfdb`` (2026-05-12) showed the
@@ -260,7 +266,9 @@ async def test_conversational_wrap_log_emitted_under_observation_only(
     """
     import logging
 
-    caplog.set_level(logging.INFO, logger="goldfive.runner")
+    # Wave B1 (refactor/prompt-shaper): the skip log is now emitted by
+    # :mod:`goldfive.prompt_shaper`, not :mod:`goldfive.runner`.
+    caplog.set_level(logging.INFO, logger="goldfive.prompt_shaper")
     runner, _captured = _make_runner(observation_only=True)
     out1 = await runner.run("make a presentation about solar panels")
     assert out1.success
@@ -284,54 +292,64 @@ async def test_conversational_wrap_log_emitted_under_observation_only(
 # Site 2 — ADK plugin ``before_model_callback`` system_instruction injections
 # ---------------------------------------------------------------------------
 #
-# The two injection helpers live in goldfive.adapters._adk_plugin:
-#   * ``_inject_goldfive_planner_instruction`` — appends
+# The two injection methods live on :class:`PromptShaper`:
+#   * ``inject_goldfive_planner_instruction`` — appends
 #     ``GoldfivePlanner.build_planning_instruction`` output
-#   * ``_inject_runtime_tools_hint`` — appends "[GOLDFIVE PLAN-STATE HINT…]"
+#   * ``inject_runtime_tools_hint`` — appends "[GOLDFIVE PLAN-STATE HINT…]"
 #     block listing pending agents
 #
 # Both fire inside ``_GoldfiveADKPlugin.before_model_callback``. The
 # strict-passive gate is a single check on
-# ``ctx.steerer._observation_only`` at the callback entry — the same
-# shape DefaultSteerer._should_inject uses elsewhere. The unit test
-# below drives the gate predicate directly (the full ADK callback
-# requires google-adk + a live LlmRequest; the predicate is the
-# behaviour-defining surface).
+# ``ctx.steerer._observation_only`` via :meth:`PromptShaper.should_inject`
+# — the same shape DefaultSteerer._should_inject uses elsewhere. The
+# unit test below drives the gate predicate directly (the full ADK
+# callback requires google-adk + a live LlmRequest; the predicate is
+# the behaviour-defining surface).
 
 
-def test_observation_only_active_helper_returns_false_when_no_ctx() -> None:
-    """The plugin's ``_observation_only_active`` helper degrades safely
-    when no SessionContext is reachable — the pre-#271 paths (unit-test
-    stubs that never call ``set_active_context``) keep working."""
-    from goldfive.adapters._adk_plugin import _observation_only_active
+def test_should_inject_returns_true_when_no_steerer() -> None:
+    """:meth:`PromptShaper.should_inject` degrades safely to ``True``
+    when no steerer is reachable — pre-#271 paths (unit-test stubs that
+    never call ``set_active_context``) keep working byte-identically."""
+    from goldfive.prompt_shaper import PromptShaper
 
-    assert _observation_only_active(None) is False
-
-
-def test_observation_only_active_helper_true_when_steerer_passive() -> None:
-    """The plugin's ``_observation_only_active`` helper returns True
-    when ``ctx.steerer._observation_only`` is True."""
-    from goldfive.adapters._adk_plugin import _observation_only_active
-
-    class _Ctx:
-        steerer = DefaultSteerer(
-            steering_config=SteeringConfig(observation_only=True)
-        )
-
-    assert _observation_only_active(_Ctx()) is True
+    assert PromptShaper.should_inject(None) is True
 
 
-def test_observation_only_active_helper_false_when_steerer_active() -> None:
-    """The plugin's ``_observation_only_active`` helper returns False
-    when ``ctx.steerer._observation_only`` is False (active steering)."""
-    from goldfive.adapters._adk_plugin import _observation_only_active
+def test_should_inject_returns_false_when_steerer_passive() -> None:
+    """:meth:`PromptShaper.should_inject` returns ``False`` (gate
+    closed → suppress injection) when ``steerer._observation_only`` is
+    ``True``."""
+    from goldfive.prompt_shaper import PromptShaper
 
-    class _Ctx:
-        steerer = DefaultSteerer(
-            steering_config=SteeringConfig(observation_only=False)
-        )
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(observation_only=True)
+    )
+    assert PromptShaper.should_inject(steerer) is False
 
-    assert _observation_only_active(_Ctx()) is False
+
+def test_should_inject_returns_true_when_steerer_active() -> None:
+    """:meth:`PromptShaper.should_inject` returns ``True`` (gate open →
+    run the inject) when ``steerer._observation_only`` is ``False``
+    (active steering)."""
+    from goldfive.prompt_shaper import PromptShaper
+
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(observation_only=False)
+    )
+    assert PromptShaper.should_inject(steerer) is True
+
+
+def test_should_inject_returns_true_when_steerer_lacks_attribute() -> None:
+    """A duck-typed steerer that doesn't carry ``_observation_only``
+    (custom :class:`~goldfive.protocols.Steerer` impls predating #254)
+    returns ``True`` so pre-#254 paths keep working."""
+    from goldfive.prompt_shaper import PromptShaper
+
+    class _LegacySteerer:
+        pass
+
+    assert PromptShaper.should_inject(_LegacySteerer()) is True
 
 
 # ---------------------------------------------------------------------------
@@ -379,7 +397,7 @@ def test_dynamic_instruction_returns_original_under_observation_only() -> None:
     ``original_instruction`` verbatim — no "Current assigned task" block,
     no pending-correction block, no goldfive augmentation of any kind.
     """
-    from goldfive.adapters._adk_dynainst import make_dynamic_instruction
+    from goldfive.prompt_shaper import PromptShaper
     from goldfive.types import Goal, Plan, TaskStatus
 
     # Session with a real pinned task, so the non-strict path WOULD
@@ -411,7 +429,7 @@ def test_dynamic_instruction_returns_original_under_observation_only() -> None:
     store = StateStore.for_session(sess)
     store.set_pin_current_task("t1", title="Draft slide")
 
-    resolver = make_dynamic_instruction(
+    resolver = PromptShaper().make_dynamic_instruction(
         original_instruction="You are a friendly slide-drafting agent.",
         agent_name="writer",
     )
@@ -432,7 +450,7 @@ def test_dynamic_instruction_augments_under_observation_disabled() -> None:
     appends the "Current assigned task" block to the original
     instruction — byte-identical to pre-#271 behaviour.
     """
-    from goldfive.adapters._adk_dynainst import make_dynamic_instruction
+    from goldfive.prompt_shaper import PromptShaper
     from goldfive.state_store import StateStore
     from goldfive.types import Goal, Plan, TaskStatus
 
@@ -458,7 +476,7 @@ def test_dynamic_instruction_augments_under_observation_disabled() -> None:
     store = StateStore.for_session(sess)
     store.set_pin_current_task("t1", title="Draft slide")
 
-    resolver = make_dynamic_instruction(
+    resolver = PromptShaper().make_dynamic_instruction(
         original_instruction="You are a friendly slide-drafting agent.",
         agent_name="writer",
     )

--- a/tests/test_prompt_shaper.py
+++ b/tests/test_prompt_shaper.py
@@ -1,0 +1,508 @@
+"""Unit tests for :class:`goldfive.prompt_shaper.PromptShaper`.
+
+Wave B1 of the modularisation plan extracted the four prompt-shape
+injection sites + the centralised :meth:`PromptShaper.should_inject`
+gate out of :mod:`goldfive.runner`, :mod:`goldfive.adapters._adk_plugin`,
+and :mod:`goldfive.adapters._adk_dynainst`. These tests cover:
+
+1. :meth:`should_inject` returns ``False`` when ``observation_only=True``
+   (gate closed → suppress every site).
+2. Each inject method is a no-op under
+   ``observation_only=True`` — the input value is returned (or, for
+   side-effecting methods, ``llm_request`` is left unchanged).
+3. Each inject method matches the byte-output of the pre-refactor
+   helper under ``observation_only=False``.
+
+The behavioural strict-passive coverage lives in
+``test_observation_only_strict_passive.py``; this module exercises
+:class:`PromptShaper` directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from goldfive.config import SteeringConfig
+from goldfive.prompt_shaper import PromptShaper
+from goldfive.steerer import DefaultSteerer
+from goldfive.types import Goal, Plan, Session, Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_steerer(*, observation_only: bool) -> DefaultSteerer:
+    return DefaultSteerer(
+        steering_config=SteeringConfig(observation_only=observation_only)
+    )
+
+
+def _make_session_with_completed_plan() -> Session:
+    """A session whose plan has one COMPLETED task, used by the
+    conversational-wrap site to render the "Completed tasks:" block."""
+    sess = Session(run_id="r-prompt-shaper-test")
+    sess.goals = [Goal(id="g1", summary="solar")]
+    sess.plan = Plan(
+        id="plan-1",
+        run_id="r-prompt-shaper-test",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Draft slides",
+                description="Write slides",
+                assignee_agent_id="writer",
+                status=TaskStatus.COMPLETED,
+            )
+        ],
+        edges=[],
+        summary="presentation about solar panels",
+        revision_index=1,
+    )
+    return sess
+
+
+# ---------------------------------------------------------------------------
+# should_inject
+# ---------------------------------------------------------------------------
+
+
+def test_should_inject_true_when_steerer_active() -> None:
+    """``observation_only=False`` → gate open → inject."""
+    assert PromptShaper.should_inject(_make_steerer(observation_only=False)) is True
+
+
+def test_should_inject_false_when_steerer_passive() -> None:
+    """``observation_only=True`` → gate closed → suppress."""
+    assert PromptShaper.should_inject(_make_steerer(observation_only=True)) is False
+
+
+def test_should_inject_true_when_steerer_is_none() -> None:
+    """Defensive: a missing steerer (unit-test stubs without a wired
+    DefaultSteerer) must not flip the gate closed — pre-#271 paths
+    keep working byte-identically."""
+    assert PromptShaper.should_inject(None) is True
+
+
+def test_should_inject_true_when_steerer_lacks_attribute() -> None:
+    """A duck-typed steerer that doesn't carry ``_observation_only``
+    (custom impls predating #254) returns True so pre-#254 paths keep
+    working."""
+
+    class _LegacySteerer:
+        pass
+
+    assert PromptShaper.should_inject(_LegacySteerer()) is True
+
+
+# ---------------------------------------------------------------------------
+# Site 1 — wrap_conversational_input
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_conversational_input_noop_when_passive() -> None:
+    """Under ``observation_only=True`` the wrapper returns ``user_input``
+    verbatim — no ``[CONVERSATIONAL FOLLOW-UP]`` framing."""
+    shaper = PromptShaper()
+    sess = _make_session_with_completed_plan()
+    steerer = _make_steerer(observation_only=True)
+
+    out = shaper.wrap_conversational_input(
+        user_input="where will the slides be saved?",
+        session=sess,
+        steerer=steerer,
+    )
+    assert out == "where will the slides be saved?"
+    assert "CONVERSATIONAL FOLLOW-UP" not in out
+
+
+def test_wrap_conversational_input_byte_identical_when_active() -> None:
+    """Under ``observation_only=False`` the wrapper reproduces the
+    pre-refactor format: a directive header, plan summary, completed
+    tasks list, and the verbatim user question."""
+    shaper = PromptShaper()
+    sess = _make_session_with_completed_plan()
+    steerer = _make_steerer(observation_only=False)
+
+    out = shaper.wrap_conversational_input(
+        user_input="where will the slides be saved?",
+        session=sess,
+        steerer=steerer,
+    )
+    # Header fingerprint — must match the canonical wording so an
+    # operator grepping for the directive sees it stable across
+    # releases.
+    assert out.startswith(
+        "[CONVERSATIONAL FOLLOW-UP — reuse prior plan, don't delegate "
+        "to sub-agents]\n\n"
+    )
+    assert "Do NOT call any AgentTool" in out
+    assert "Plan summary: presentation about solar panels" in out
+    assert "Completed tasks:" in out
+    assert "[t1] Draft slides (by writer)" in out
+    assert out.endswith("User question: where will the slides be saved?")
+
+
+def test_wrap_conversational_input_no_plan_uses_placeholder() -> None:
+    """A session without a plan still renders cleanly — the wrapper
+    uses ``(no summary)`` and ``(none yet)`` placeholders. This mirrors
+    the pre-refactor behaviour for the (rare) follow-up turn that
+    fires before any plan has been installed."""
+    shaper = PromptShaper()
+    sess = Session(run_id="r-no-plan")
+    steerer = _make_steerer(observation_only=False)
+
+    out = shaper.wrap_conversational_input(
+        user_input="hi?",
+        session=sess,
+        steerer=steerer,
+    )
+    assert "Plan summary: (no summary)" in out
+    assert "Completed tasks:\n  (none yet)" in out
+    assert out.endswith("User question: hi?")
+
+
+# ---------------------------------------------------------------------------
+# Site 2 — inject_goldfive_planner_instruction
+# ---------------------------------------------------------------------------
+#
+# The full inject pipeline requires google.adk + GoldfivePlanner; we
+# unit-test the gate behaviour with a minimal stub here. The byte-
+# identity check on the active path runs in
+# ``test_goldfive_planner.py`` against the live ADK install.
+
+
+class _FakeConfig:
+    def __init__(self) -> None:
+        self.system_instruction: Any = None
+
+
+class _FakeLlmRequest:
+    def __init__(self) -> None:
+        self.config = _FakeConfig()
+        self.append_calls: list[list[str]] = []
+
+    def append_instructions(self, instructions: list[str]) -> list:
+        self.append_calls.append(list(instructions))
+        return []
+
+
+class _Ctx:
+    """Minimal ``SessionContext``-shaped stub carrying just ``.steerer``."""
+
+    def __init__(self, *, observation_only: bool) -> None:
+        self.steerer = _make_steerer(observation_only=observation_only)
+        self.session = None
+
+
+def test_inject_goldfive_planner_instruction_noop_when_passive() -> None:
+    """Under ``observation_only=True`` the inject is short-circuited
+    BEFORE the ADK / GoldfivePlanner imports — ``llm_request`` is left
+    untouched even if the rest of the pipeline would have run."""
+    shaper = PromptShaper()
+    llm_request = _FakeLlmRequest()
+
+    asyncio.run(
+        shaper.inject_goldfive_planner_instruction(
+            callback_context=None,
+            llm_request=llm_request,
+            session_context=_Ctx(observation_only=True),
+        )
+    )
+
+    assert llm_request.append_calls == []
+    assert llm_request.config.system_instruction is None
+
+
+def test_inject_goldfive_planner_instruction_no_agent_when_active() -> None:
+    """Under ``observation_only=False`` with no reachable agent
+    (callback_context has no ``_invocation_context.agent``) the inject
+    is still a no-op — the pre-refactor silent-fall-through behaviour
+    is preserved byte-identically."""
+    shaper = PromptShaper()
+    llm_request = _FakeLlmRequest()
+
+    asyncio.run(
+        shaper.inject_goldfive_planner_instruction(
+            callback_context=None,
+            llm_request=llm_request,
+            session_context=_Ctx(observation_only=False),
+        )
+    )
+
+    # Pipeline silently returned — no agent reachable → nothing to
+    # inject. Same shape as pre-refactor.
+    assert llm_request.append_calls == []
+    assert llm_request.config.system_instruction is None
+
+
+# ---------------------------------------------------------------------------
+# Site 3 — inject_runtime_tools_hint
+# ---------------------------------------------------------------------------
+
+
+def test_inject_runtime_tools_hint_noop_when_passive() -> None:
+    """Under ``observation_only=True`` the hint is suppressed — the
+    request's ``system_instruction`` and any prior marker block are
+    left untouched (no strip, no append)."""
+    shaper = PromptShaper()
+    sess = Session(
+        run_id="r-test",
+        plan=Plan(
+            id="plan-1",
+            run_id="r-test",
+            goal_ids=[],
+            tasks=[
+                Task(
+                    id="t1",
+                    title="draft",
+                    description="",
+                    assignee_agent_id="writer",
+                    status=TaskStatus.PENDING,
+                )
+            ],
+            edges=[],
+        ),
+    )
+    llm_request = _FakeLlmRequest()
+    # Pre-stamp a prior hint so we can verify the strict-passive path
+    # does NOT strip it (the gate is BEFORE the strip).
+    from goldfive.adapters._adk_plugin import (
+        _RUNTIME_TOOLS_HINT_END,
+        _RUNTIME_TOOLS_HINT_PREFIX,
+    )
+
+    prior = (
+        f"{_RUNTIME_TOOLS_HINT_PREFIX} stale]\n  writer: PENDING — old\n"
+        f"{_RUNTIME_TOOLS_HINT_END}"
+    )
+    llm_request.config.system_instruction = prior
+
+    shaper.inject_runtime_tools_hint(
+        callback_context=None,
+        llm_request=llm_request,
+        session=sess,
+        session_context=_Ctx(observation_only=True),
+    )
+
+    # Untouched: no append, no strip.
+    assert llm_request.append_calls == []
+    assert llm_request.config.system_instruction == prior
+
+
+def test_inject_runtime_tools_hint_byte_identical_when_active() -> None:
+    """Under ``observation_only=False`` the inject reproduces the
+    pre-refactor write: a single ``append_instructions([hint])`` call
+    whose payload is bracketed by the canonical marker tags."""
+    from goldfive.adapters._adk_plugin import (
+        _RUNTIME_TOOLS_HINT_END,
+        _RUNTIME_TOOLS_HINT_PREFIX,
+        _build_runtime_tools_hint,
+    )
+
+    shaper = PromptShaper()
+    sess = Session(
+        run_id="r-test",
+        plan=Plan(
+            id="plan-1",
+            run_id="r-test",
+            goal_ids=[],
+            tasks=[
+                Task(
+                    id="t1",
+                    title="draft",
+                    description="",
+                    assignee_agent_id="writer",
+                    status=TaskStatus.PENDING,
+                )
+            ],
+            edges=[],
+        ),
+    )
+    llm_request = _FakeLlmRequest()
+
+    shaper.inject_runtime_tools_hint(
+        callback_context=None,
+        llm_request=llm_request,
+        session=sess,
+        session_context=_Ctx(observation_only=False),
+    )
+
+    expected = _build_runtime_tools_hint(sess)
+    assert expected is not None
+    assert llm_request.append_calls == [[expected]]
+    # Marker fingerprints present.
+    assert _RUNTIME_TOOLS_HINT_PREFIX in expected
+    assert _RUNTIME_TOOLS_HINT_END in expected
+
+
+def test_inject_runtime_tools_hint_gate_open_with_no_session_context() -> None:
+    """Without a ``SessionContext`` (test stubs) the gate defaults to
+    open — the inject runs. This preserves the pre-#271 paths that
+    drove the helper without ever wiring a steerer."""
+    from goldfive.adapters._adk_plugin import _RUNTIME_TOOLS_HINT_PREFIX
+
+    shaper = PromptShaper()
+    sess = Session(
+        run_id="r-test",
+        plan=Plan(
+            id="plan-1",
+            run_id="r-test",
+            goal_ids=[],
+            tasks=[
+                Task(
+                    id="t1",
+                    title="draft",
+                    description="",
+                    assignee_agent_id="writer",
+                    status=TaskStatus.PENDING,
+                )
+            ],
+            edges=[],
+        ),
+    )
+    llm_request = _FakeLlmRequest()
+
+    shaper.inject_runtime_tools_hint(
+        callback_context=None,
+        llm_request=llm_request,
+        session=sess,
+        session_context=None,
+    )
+
+    assert llm_request.append_calls, "inject must run when no SessionContext"
+    assert _RUNTIME_TOOLS_HINT_PREFIX in llm_request.append_calls[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Site 4 — make_dynamic_instruction
+# ---------------------------------------------------------------------------
+
+
+def _make_readonly_ctx(*, observation_only: bool, session: Session | None) -> Any:
+    """Build a fake ReadonlyContext carrying the goldfive SessionContext
+    stash via the legacy ``state["goldfive._session_context"]`` path."""
+    from goldfive.adapters._adk_plugin import SessionContext
+
+    steerer = _make_steerer(observation_only=observation_only)
+    sess = session or Session(run_id="r-resolver-test")
+    ctx_stash = SessionContext(
+        session=sess,
+        steerer=steerer,
+        task=None,
+        tool_handlers={},
+        host_agent_name="coordinator",
+    )
+
+    class _ReadonlyCtx:
+        state = {"goldfive._session_context": ctx_stash}
+        _invocation_context = None
+
+    return _ReadonlyCtx()
+
+
+def test_make_dynamic_instruction_returns_original_when_passive() -> None:
+    """Under ``observation_only=True`` the resolver returns
+    ``original_instruction`` verbatim — no augmentation."""
+    from goldfive.state_store import StateStore
+
+    sess = Session(run_id="r-resolver-test")
+    sess.goals = [Goal(id="g1", summary="x")]
+    sess.plan = Plan(
+        id="plan-1",
+        run_id="r-resolver-test",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Draft slide",
+                description="d",
+                assignee_agent_id="writer",
+                status=TaskStatus.RUNNING,
+            )
+        ],
+        edges=[],
+        summary="x",
+        revision_index=1,
+    )
+    store = StateStore.for_session(sess)
+    store.set_pin_current_task("t1", title="Draft slide")
+
+    resolver = PromptShaper().make_dynamic_instruction(
+        original_instruction="you are a writer",
+        agent_name="writer",
+    )
+    ctx = _make_readonly_ctx(observation_only=True, session=sess)
+
+    out = resolver(ctx)
+    assert out == "you are a writer"
+    assert "Current assigned task" not in out
+
+
+def test_make_dynamic_instruction_augments_when_active() -> None:
+    """Under ``observation_only=False`` the resolver appends the
+    "Current assigned task" block to the original instruction."""
+    from goldfive.state_store import StateStore
+
+    sess = Session(run_id="r-resolver-test")
+    sess.goals = [Goal(id="g1", summary="x")]
+    sess.plan = Plan(
+        id="plan-1",
+        run_id="r-resolver-test",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Draft slide",
+                description="d",
+                assignee_agent_id="writer",
+                status=TaskStatus.RUNNING,
+            )
+        ],
+        edges=[],
+        summary="x",
+        revision_index=1,
+    )
+    store = StateStore.for_session(sess)
+    store.set_pin_current_task("t1", title="Draft slide")
+
+    resolver = PromptShaper().make_dynamic_instruction(
+        original_instruction="you are a writer",
+        agent_name="writer",
+    )
+    ctx = _make_readonly_ctx(observation_only=False, session=sess)
+
+    out = resolver(ctx)
+    assert out.startswith("you are a writer")
+    assert "Current assigned task:" in out
+    assert "id: t1" in out
+    assert "Draft slide" in out
+
+
+def test_make_dynamic_instruction_provenance_attrs() -> None:
+    """The resolver must carry the legacy provenance attrs used by
+    ``install_dynamic_instructions`` for idempotency checks."""
+    resolver = PromptShaper().make_dynamic_instruction(
+        original_instruction="hello",
+        agent_name="writer",
+    )
+
+    assert getattr(resolver, "_goldfive_dynamic_instruction", False) is True
+    assert getattr(resolver, "_goldfive_agent_name", "") == "writer"
+    assert getattr(resolver, "_goldfive_original_instruction", "") == "hello"
+
+
+def test_make_dynamic_instruction_no_pin_returns_original() -> None:
+    """When no task is pinned the resolver returns
+    ``original_instruction`` (regardless of the gate). Mirrors the
+    pre-refactor "no augmentation when there's nothing to augment with"
+    behaviour."""
+    sess = Session(run_id="r-no-pin")
+    resolver = PromptShaper().make_dynamic_instruction(
+        original_instruction="raw",
+        agent_name="writer",
+    )
+    ctx = _make_readonly_ctx(observation_only=False, session=sess)
+    assert resolver(ctx) == "raw"

--- a/tests/test_runtime_tool_surface_hint.py
+++ b/tests/test_runtime_tool_surface_hint.py
@@ -1,13 +1,18 @@
 """Tests for the R3 runtime tool-surface hint (Tier 1 F2 alternative).
 
 Covers :func:`goldfive.adapters._adk_plugin._build_runtime_tools_hint`
-and :func:`goldfive.adapters._adk_plugin._inject_runtime_tools_hint`
+and :meth:`goldfive.prompt_shaper.PromptShaper.inject_runtime_tools_hint`
 plus the wiring through ``before_model_callback`` such that the hint
 lands on ``llm_request.config.system_instruction`` without clobbering
 prior instructions and without accumulating across calls.
 
 Runs without ADK installed because the helpers are pure-Python and do
 not import ADK at module load. Wiring tests skip when ADK is missing.
+
+Wave B1 (refactor/prompt-shaper): the inject helper moved off
+:mod:`goldfive.adapters._adk_plugin` and onto :class:`PromptShaper`.
+A thin module-local shim preserves the legacy ``_inject_runtime_tools_hint(...)``
+call shape so the test bodies below read unchanged.
 """
 
 from __future__ import annotations
@@ -20,10 +25,27 @@ from goldfive.adapters._adk_plugin import (
     _RUNTIME_TOOLS_HINT_END,
     _RUNTIME_TOOLS_HINT_PREFIX,
     _build_runtime_tools_hint,
-    _inject_runtime_tools_hint,
     _strip_prior_runtime_tools_hint,
 )
+from goldfive.prompt_shaper import PromptShaper
 from goldfive.types import Plan, Session, Task, TaskStatus
+
+
+def _inject_runtime_tools_hint(
+    *, callback_context: Any, llm_request: Any, session: Any
+) -> None:
+    """Wave B1 shim: forward to :meth:`PromptShaper.inject_runtime_tools_hint`.
+
+    These unit tests drive the helper without a ``SessionContext`` so the
+    gate falls back to "inject" (steerer is None → ``should_inject`` →
+    True) — exactly the pre-refactor behaviour.
+    """
+    PromptShaper().inject_runtime_tools_hint(
+        callback_context=callback_context,
+        llm_request=llm_request,
+        session=session,
+        session_context=None,
+    )
 
 # ---------------------------------------------------------------------------
 # Fakes


### PR DESCRIPTION
## Motivation

Goldfive's runtime augments the prompt the underlying LLM sees in four
distinct places. After #271 all four are correctly gated on
``SteeringConfig.observation_only`` — but the gate logic is duplicated
across three files (an ``_observation_only_active`` helper in
``_adk_plugin.py``, a near-identical one in ``_adk_dynainst.py``, and
an inline check in ``runner.py``).

The duplication invites drift: a future inject site added without
remembering the gate would silently leak the shaping under
``observation_only=True``. This is exactly the failure mode that
produced #271 in the first place (live evidence: typewriters/kikuchi
session ``1c3602f8-3810-4158-ad8a-3c8f0b79dfdb`` showed the
conversational wrap firing under strict-passive).

This PR extracts the four functions into a new
``goldfive.prompt_shaper`` module exposing a ``PromptShaper`` class
with a single ``should_inject(steerer)`` predicate. Future sites added
to PromptShaper inherit the gate by construction.

## The four sites

| Site | Old location | New location |
| --- | --- | --- |
| Conversational follow-up wrap | ``Runner._wrap_conversational_input`` | ``PromptShaper.wrap_conversational_input`` |
| GoldfivePlanner request-side instruction | ``_inject_goldfive_planner_instruction`` (``_adk_plugin.py``) | ``PromptShaper.inject_goldfive_planner_instruction`` |
| Runtime tool-surface hint | ``_inject_runtime_tools_hint`` (``_adk_plugin.py``) | ``PromptShaper.inject_runtime_tools_hint`` |
| Dynamic instruction resolver | ``make_dynamic_instruction`` (``_adk_dynainst.py``) | ``PromptShaper.make_dynamic_instruction`` |

The four functions kept their distinct signatures — the underlying
injection mechanisms are different (message-body rewrite,
``system_instruction`` append, callable closure). Collapsing them into
a single ``inject(...)`` method would obscure that and was deliberately
NOT done.

## ``observation_only`` contract preservation

* ``observation_only=True`` → none of the four inject; each method
  returns the raw / unchanged value (byte-identical to post-#271
  behaviour).
* ``observation_only=False`` → byte-identical output to each
  pre-refactor function. Each inject method internally consults
  ``PromptShaper.should_inject(steerer)`` — the single source of truth
  the gate now lives in.
* The three module-local ``_observation_only_active`` helpers are
  REMOVED. The four-site gate is one predicate now, not three.

## Out of scope (still in their original files)

* ``_build_runtime_tools_hint`` / ``_strip_prior_runtime_tools_hint``
  / ``_RUNTIME_TOOLS_HINT_PREFIX`` (in ``_adk_plugin.py``) — these are
  supporting helpers, not entrypoints. External test imports continue
  to resolve unchanged.
* ``_compose_instruction`` / ``_read_pending_correction`` /
  ``_task_title_description_from_session`` /
  ``format_correction_block`` (in ``_adk_dynainst.py``) — same
  rationale; ``format_correction_block`` is also publicly imported.
* All non-prompt-shaping ``observation_only`` checks (steerer dispatch
  gates, executor abort carve-outs, supersedes-integration writer
  gates) stay where they live. The audit confirmed the four removed
  checks are the ONLY prompt-shape gates in the three source files.

## Test plan

- [x] New ``tests/test_prompt_shaper.py`` — 16 unit cases covering
      ``should_inject`` over four steerer shapes (active / passive /
      None / legacy-no-attr), each inject method's no-op path under
      ``observation_only=True``, and each method's byte-output under
      ``observation_only=False``.
- [x] Updated ``tests/test_observation_only_strict_passive.py`` to
      drive ``PromptShaper.should_inject`` (replacing the removed
      ``_observation_only_active`` helpers) + the new
      ``make_dynamic_instruction`` factory location.
- [x] Updated ``tests/test_runtime_tool_surface_hint.py`` +
      ``tests/test_goldfive_planner.py`` +
      ``tests/test_dynamic_instruction.py`` +
      ``tests/test_correction_injection.py`` with thin module-local
      shims so existing test bodies read unchanged.
- [x] Full suite: ``2463 passed, 59 skipped`` (no regressions vs main).
- [x] Self-review pass: no remaining ``observation_only`` checks in
      the four source files' entrypoint paths; no dead-code imports;
      docstring cross-references updated.
- [x] State-ownership audit (``tests/test_state_audit.py``) still
      passes — the shaper holds no ADK state and routes through the
      same callers as before.

## Coordination

* **Wave A** (parallel agents on different files) — does not overlap.
* **Wave C** (steerer split) — does not overlap.
* **Wave B2** (ADK LLM instrumentation consolidation) — held until
  this PR merges. The removal of ``make_dynamic_instruction`` from
  ``_adk_dynainst.py`` is a precondition for B2's planned merge of
  ``_adk_dynainst.py`` + ``_adk_state_protocol.py``.