### PR TITLE
feat(steering): ContextEditor — request-side context editing capability (closes #397 in part)

### DIFF
--- a/docs/design/CONTEXT-EDITING.md
+++ b/docs/design/CONTEXT-EDITING.md
@@ -1,0 +1,171 @@
+# Context Editing as a Steering Capability
+
+## Status
+
+**Phase 1 shipped** (goldfive#397) — `ContextEditor` skeleton with all five invariants enforced, `PruneCancelledReasoningRule` registered, gated behind `SteeringConfig.context_editor_rules`. Subsequent rules (`PruneTransientErrorRule`, `PruneStaleSteerRule`, `CompactPriorReasoningRule`) land in follow-up PRs per the phased plan below.
+
+## Implementation deltas from the original proposal
+
+The proposal landed as written with four pragmatic adjustments:
+
+* **Single-method rule protocol.** The proposed `applies(...) + edit(...)` shape was collapsed into a single `edit(contents, ctx) -> list[Content] | None` — `None` means "no change at this revision; skip." Equivalent surface, one fewer call to misuse.
+* **Drop-only invariant made explicit.** "No injection" is now enforced as a structural byte- and content-count monotonicity gate: a rule's output `contents` MUST have ≤ the input's byte total AND ≤ the input's content count. Violations revert and emit `ContextEditRejected` with `reason='not_drop_only'`. This shipped as Invariant 3 (was implicit in the proposal).
+* **State-audit extension is documentation-only in Phase 1.** `goldfive/_state_audit.py` today guards ADK `session.state` writes through a single funnel (`_adk_state_protocol._set`). The `llm_request.contents` list has no analogous funnel — a runtime tripwire would require wrapping the list in a tracked proxy with measurable hot-path overhead. Phase 1 catalogs `ContextEditor.apply` as the sole authorised site via the new `_REQUEST_CONTENTS_AUTHORISED_SITES` constant in `_state_audit.py`; a runtime extension is deferred to a focused follow-up if a regression surfaces.
+* **Events use dict envelopes.** `ContextEdited` and `ContextEditRejected` ship via `goldfive.events.make_event` (no proto regen) — mirrors the `pin_resolved` precedent in `_adk_plugin.py::_emit_pin_resolved`. Adding proto slots is left for a focused proto-schema PR.
+
+## Motivation
+
+Today goldfive's intervention ladder treats the LLM transcript as immutable. All steering routes through:
+
+| Mechanism | Editorial direction | Surface |
+|---|---|---|
+| Plan revision | Plan / Task state only | `steerer._emit_plan_revised`, `set_session_plan` |
+| Synthetic `USER_STEER` | **Add** new user event | `_install_revision` → executor injects |
+| Cancel + reinvoke | **Terminate** in-flight only | `_safe_task_cancel`, `_heal_pending_tool_calls` |
+| Prompt-shaping | **Add** to `system_instruction` | `PromptShaper` (post-Wave-B1) |
+| `max_output_tokens` ratchet | Config cap | `_ratchet_max_tokens` |
+
+Conspicuously absent: any way to *edit* the conversation the next model call sees. The LLM's view of history is whatever ADK has accumulated — `function_call` / `function_response` pairs, prior user messages, prior model responses — and goldfive has no mechanism to redact, prune, or rewrite any of it.
+
+This leaves real steering capability on the table:
+
+- **Drift-loop history pruning.** When the reasoning judge fires `LOOPING_REASONING` and the steerer cancels-and-retries, the failed reasoning trail is still in context for the next attempt. The model can re-anchor on the same failed approach. Relates to #173, #193, #210.
+- **Transient tool-error redaction.** A 429 / parse failure / network blip that propagated through a `function_response` becomes a permanent fixture in the transcript. Subsequent turns waste tokens re-reading it and may bias their reasoning toward the failure.
+- **Cancelled-invocation reasoning strip.** #230 silenced *judges* on cancelled reasoning. The orthogonal direction — strip the cancelled-invocation reasoning from the *model's own* context before the next call — is unimplemented.
+- **Stale plan-revision summary cleanup.** When goldfive emits a revised plan, its own injected `system_instruction` prefix gets the strip-and-replace treatment (`_strip_prior_runtime_tools_hint`). The same idea applied to historical user messages that contained obsolete steering directives would close a long-tail leak.
+
+## ADK surface (what's available)
+
+From `google.adk.plugins.base_plugin.BasePlugin`:
+
+```python
+async def before_model_callback(
+    self, *, callback_context: CallbackContext, llm_request: LlmRequest
+) -> Optional[LlmResponse]: ...
+
+async def on_event_callback(
+    self, *, invocation_context: InvocationContext, event: Event
+) -> Optional[Event]: ...
+```
+
+Both receive *mutable* arguments. The plugin can:
+
+- **`before_model_callback`** — mutate `llm_request.contents` (the message list sent to the model), edit `config.system_instruction`, edit `config.tools`, cap `config.max_output_tokens`, or return a synthesized `LlmResponse` to short-circuit the call.
+- **`on_event_callback`** — return a replacement `Event`, or `None` to drop the event entirely.
+
+ADK's base flow (`google/adk/flows/llm_flows/base_llm_flow.py`) reads `llm_request.contents` *after* the plugin callback chain, so any mutation lands in the request that hits the model.
+
+## Goldfive's current usage (verified audit)
+
+`goldfive/adapters/_adk_plugin.py`:
+
+- **`before_model_callback`** (line 5232) — reads `contents` via `_measure_request_chars` (line 1180) for instrumentation. **Never writes to `contents`.** Writes only to `config.system_instruction` (additive injects, plus strip-and-replace of goldfive's own prior hint via `_strip_prior_runtime_tools_hint`, line 1919) and `config.max_output_tokens` (`_ratchet_max_tokens`, line 2052).
+- **`after_model_callback`** (line 5925) — observation only.
+- **`on_event_callback`** (line 6151) — detects `transfer_to_agent` / `escalate` actions, calls `steerer.observe`, **always returns `None`**. Never replaces an event.
+
+Repository grep (verified) confirms no `llm_request.contents = ...`, `del llm_request.contents`, `contents.pop`, `contents.remove`, or list-slice assignment anywhere in the package. The transcript is read-only from goldfive's perspective.
+
+The closest things to "editing context" goldfive does today:
+
+- **`_heal_pending_tool_calls`** (`adapters/adk.py:2369`) — *appends* synthetic `function_response` events to `session.events` after a cancel to close orphan `tool_call_id`s. Necessary because mid-tool cancels leave half-pairs that ADK errors on. Adds; does not remove.
+- **`_strip_prior_runtime_tools_hint`** (`adapters/_adk_plugin.py:1919`) — strips and rewrites goldfive's *own* injected prefix in `system_instruction` before re-injecting. The only redaction-shaped operation in the codebase, scoped to goldfive's own text.
+
+## Proposed capability: `ContextEditor`
+
+New module `goldfive/context_editor.py` exposing a `ContextEditor` class that runs in `before_model_callback`, **after** `PromptShaper` and **before** the LLM call dispatch. It applies a sequence of registered **editor rules** to `llm_request.contents`. Each rule has the signature:
+
+```python
+class ContextEditRule(Protocol):
+    name: str
+    def edit(self, contents: list[Content], ctx: ContextEditContext) -> list[Content] | None: ...
+```
+
+`ctx` carries the goldfive `Session`, the host agent name, and the snapshot `observed_revision_index` captured at the top of `ContextEditor.apply`. Rules returning `None` are skipped (no change at this revision); returning a new list triggers the invariant chain.
+
+Rules are registered at adapter construction; the editor walks them in registration order, each receiving the output of the prior. The editor itself runs as a single `before_model_callback` site so all `contents` mutation is centralised (mirrors PromptShaper's "single gate, single module" pattern).
+
+### Gates (mandatory)
+
+1. **`observation_only` gate.** Strict-passive mode MUST skip the entire editor pipeline. Cataloged in `_state_audit.py`. Mirrors the discipline established by #271.
+2. **`tool_call_id` pairing invariant.** After the editor runs, every `function_call` part must still have its matching `function_response` (or both absent). The editor invokes a `Plan.validate()`-style structural check on `contents` and **reverts** the edit on violation. `_heal_pending_tool_calls` shows this is non-negotiable — ADK errors hard on orphans.
+3. **No content injection.** Editors can drop or rewrite existing messages; they cannot inject material that wasn't there. Injection stays in PromptShaper's lane where it's auditable.
+4. **Idempotence per-revision.** The same `(rule, observed_revision_index, contents-hash)` must produce the same output for the same input. Catches accidental nondeterminism.
+5. **Logged-out-of-loop.** Edits are append-only against the *persisted* transcript — goldfive's sinks see the original event stream via `on_event_callback`; only the model's request is edited. Editor emits a `ContextEdited` event so harmonograf can show what the model didn't see.
+
+### Invariants to preserve
+
+- **Plan / Task immutability** (#247) — editors don't touch state, only the model's view of history.
+- **`observed_revision_index` semantics** — editor decisions stamped at this index; re-checked at next call.
+- **ControlMessage channel** — editor activations emit a `ContextEdited` ControlMessage for observability (carries rule name, byte delta, content-count delta).
+- **State-ownership audit** — `_state_audit.py` is extended to police request-side mutation. Editor cataloged as the authorised write site for `llm_request.contents`. Today the audit covers session-state writes only; this proposal *expands* its remit.
+
+### Failure modes
+
+| Failure | Mitigation |
+|---|---|
+| Rule strips half of a `function_call` / `function_response` pair | Pairing-invariant check reverts the edit; emit `ContextEditRejected` event. |
+| Rule produces an empty `contents` list | Reject; ADK requires at least one user turn. |
+| Two rules disagree across plugins | Editor runs after PromptShaper, before model — single ownership of `contents` editing. |
+| Edit confuses the model into a *different* loop | Existing drift detectors observe next turn's reasoning; if `LOOPING_REASONING` re-fires, escalate to cancel-reinvoke (existing ladder). |
+| Edit hides information the user expects in logs | Persisted transcript untouched; harmonograf shows the `ContextEdited` event with byte delta and rule name. |
+| Rule is non-deterministic | Idempotence-per-revision invariant catches divergence. |
+
+### Initial rule set
+
+1. **`PruneCancelledReasoningRule`** — strip `function_call` / `function_response` pairs from invocations that were cancelled via `_safe_task_cancel`. Companion to #230 (which silenced *judges* on cancelled reasoning); this silences the *model itself*. Highest-value rule; recommend ship first.
+2. **`PruneTransientErrorRule`** — strip `function_response` parts whose payload matches known transient errors (429, timeout, network blip). Configurable allowlist of patterns. Conservative — only flagged statuses, not anything that *looks* like an error.
+3. **`PruneStaleSteerRule`** — strip prior synthetic `USER_STEER` messages once the steered plan revision is `COMPLETED`. Today they stick in the transcript forever even after the steering took effect, wasting tokens and biasing the model.
+4. **`CompactPriorReasoningRule`** *(optional, off by default)* — replace long-form reasoning blocks from completed tasks with a one-line summary. Risk: model may want to re-read reasoning for context. Phase 2 if validated; not shipped initially.
+
+Rules 1-3 are conservative (only strip clearly-stale material). Rule 4 is opt-in.
+
+## Implementation plan
+
+| PR | Scope |
+|---|---|
+| 1 | `ContextEditor` skeleton + 5 invariants + `observation_only` gate + state-audit hook. No rules registered. Smoke test: editor is a no-op when rule set is empty. |
+| 2 | `PruneCancelledReasoningRule`. Unit tests with synthetic cancel scenarios + e2e against the drift-loop reproducer. |
+| 3 | `PruneTransientErrorRule`. Configurable allowlist. Unit tests for each known transient pattern. |
+| 4 | `PruneStaleSteerRule`. Coordinates with refine-cycle to know when a steer has "taken". |
+| 5 | *(Optional)* `CompactPriorReasoningRule`. Off by default. |
+
+Each rule lands behind its own config flag (`SteeringConfig.context_editor_rules: list[str]`) so e2e regressions can be bisected.
+
+## Alternatives considered
+
+- **Replay via fresh session.** Instead of editing in-place, cancel the session and replay with a curated `contents` list. Heavyweight: re-creates ADK session, re-pays tool-registration cost, breaks observability continuity. Editing is cheaper.
+- **Move pruning into the planner prompt.** Have the planner summarise history at refine time and inject the summary. Doesn't help — the model that sees the planner's summary is the same model whose context we're trying to clean.
+- **Re-emit `Event`s via `on_event_callback`.** ADK supports returning a replacement event there, but it's per-event and doesn't compose well across many events. `before_model_callback` operates on the assembled `contents` list — natural scope for multi-event pruning rules.
+- **Do nothing; rely on drift detectors.** Today's stance. Works for many cases but leaves the failure modes listed in *Motivation* unaddressed — they show up as drift loops (#173, #193) and inflated LLM-call ratios (#210).
+
+## Open questions
+
+- Should the editor reflect its edits into the harmonograf event stream (so the UI can visualise "what the model saw vs. what happened")? Recommendation: **yes** — emit `ContextEdited` with byte-delta + rule name. Without this, debugging a "the model ignored X" report becomes impossible.
+- Should rules be allowed to *rewrite* (e.g., shorten) parts, or only drop? Phase 1 should be drop-only — rewriting opens correctness questions ("is the shortened version semantically equivalent?") that need their own design.
+- Does this interact with `_heal_pending_tool_calls`? Yes — the editor runs *after* prior-turn healing has happened, so pairing invariants are already in place when editing begins. New documentation of the order in CANCELLATION-CONTRACT.md needed.
+- Where does `ContextEditor` live in the new modular architecture (post Wave B1 / C)? Likely as a peer of `PromptShaper`: a goldfive-owned `before_model_callback` participant, ordered explicitly in the adapter glue.
+
+## References
+
+### Code
+
+- `goldfive/adapters/_adk_plugin.py:5232` — `before_model_callback` (current implementation; never writes `contents`)
+- `goldfive/adapters/_adk_plugin.py:6151` — `on_event_callback` (always returns `None`)
+- `goldfive/adapters/_adk_plugin.py:1180` — `_measure_request_chars` (current read-only `contents` access)
+- `goldfive/adapters/_adk_plugin.py:1919` — `_strip_prior_runtime_tools_hint` (existing strip-shaped operation, scoped to goldfive's own text)
+- `goldfive/adapters/_adk_plugin.py:2052` — `_ratchet_max_tokens` (existing config edit)
+- `goldfive/adapters/adk.py:2369` — `_heal_pending_tool_calls`
+- `goldfive/_state_audit.py` — state-ownership audit (to be extended to request-side)
+
+### Existing design docs
+
+- `docs/design/STATE-OWNERSHIP-CONTRACT.md` — audit pattern this proposal extends
+- `docs/design/CONTROL-CHANNEL.md` — ControlMessage pattern used for `ContextEdited` event
+- `docs/design/EVENT-MODEL.md` — event-stream contracts
+- `docs/design/CANCELLATION-CONTRACT.md` — `_heal_pending_tool_calls` ordering (needs amendment for editor)
+
+### Related issues
+
+- #173, #193, #210 — drift-loop / LLM-call ratio (motivates `PruneCancelledReasoningRule`)
+- #230 — quiet judges on cancelled reasoning (orthogonal direction; this proposal silences the model itself)
+- #271 — strict-passive `observation_only` (gate pattern this proposal mirrors)

--- a/goldfive/_state_audit.py
+++ b/goldfive/_state_audit.py
@@ -286,6 +286,40 @@ def assert_can_write(
 
 
 # ---------------------------------------------------------------------------
+# Request-side mutation catalog (goldfive#397)
+# ---------------------------------------------------------------------------
+#
+# The ``llm_request.contents`` list reaches the model via ADK's flow
+# AFTER every ``before_model_callback`` has returned. Phase 0/2 of the
+# state-ownership audit covers ADK ``session.state`` writes only —
+# request-side mutation is NOT currently guarded by a runtime tripwire
+# because there is no single funnel (each ADK plugin can mutate
+# ``llm_request.contents`` independently).
+#
+# The :class:`~goldfive.context_editor.ContextEditor` is the ONE goldfive
+# site authorised to mutate ``llm_request.contents``. Every other
+# goldfive code path that touches the field is strictly read-only:
+#
+# * ``goldfive/adapters/_adk_plugin.py::_measure_request_chars``
+#   (line ~1180) — reads ``contents`` to instrument
+#   ``llm.request.chars`` and ``llm.request.messages_count``. Never
+#   writes.
+# * ``goldfive/context_editor.py::_content_bytes`` — same
+#   read-only character measurement, shared so the editor's emitted
+#   ``ContextEdited.bytes_before`` / ``.bytes_after`` are byte-aligned
+#   with the instrumentation line.
+#
+# The catalog entry below is documentation; no runtime check fires.
+# Extending the audit to a runtime list-mutation tripwire is a
+# follow-up (would need to wrap the ``contents`` list in a tracked
+# proxy, which has measurable overhead in the hot path — left to a
+# focused PR if a regression surfaces).
+_REQUEST_CONTENTS_AUTHORISED_SITES: tuple[tuple[str, str], ...] = (
+    ("goldfive/context_editor.py", "ContextEditor.apply"),
+)
+
+
+# ---------------------------------------------------------------------------
 # Catalog of known callers (Phase 0 — pre-existing violations)
 # ---------------------------------------------------------------------------
 

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1790,6 +1790,32 @@ DEFAULT_LLM_CALL_TIMEOUT_MS: int = 1_800_000
 DEFAULT_AGENT_MAX_OUTPUT_TOKENS: int = 16384
 
 
+def _is_observation_only(ctx: Any) -> bool:
+    """Return True iff the steerer behind ``ctx`` is in observation-only mode.
+
+    Read by the request-side :class:`~goldfive.context_editor.ContextEditor`
+    (goldfive#397) — every steering surface MUST be a complete no-op
+    under :class:`~goldfive.config.SteeringConfig.observation_only=True`
+    (the strict-passive pattern established by goldfive#271).
+
+    The steerer exposes ``_observation_only`` as its public-ish field
+    (set from ``SteeringConfig.observation_only`` at construction). We
+    treat any failure to read it as "observation_only" — the safer
+    default for a surface whose whole purpose is to NOT fire when the
+    operator has opted into passive observation.
+    """
+    try:
+        steerer = _safe_attr(ctx, "steerer", None)
+        if steerer is None:
+            return True
+        flag = _safe_attr(steerer, "_observation_only", None)
+        if flag is None:
+            return True
+        return bool(flag)
+    except Exception:  # noqa: BLE001
+        return True
+
+
 def _apply_agent_max_output_tokens_cap(llm_request: Any, ceiling: int) -> tuple[int, int]:
     """Ratchet ``llm_request.config.max_output_tokens`` down to ``ceiling`` (goldfive#256).
 
@@ -1883,6 +1909,7 @@ def make_adk_plugin(
     agent_tool_cap: int = 16,
     llm_call_timeout_ms: int = DEFAULT_LLM_CALL_TIMEOUT_MS,
     agent_max_output_tokens: int = DEFAULT_AGENT_MAX_OUTPUT_TOKENS,
+    context_editor: Any = None,
 ) -> Any:
     """Build the ADK plugin class bound to goldfive's protocol.
 
@@ -1968,6 +1995,19 @@ def make_adk_plugin(
             # ``make_adk_plugin``'s docstring for the smaller-wins
             # semantics.
             self._agent_max_output_tokens = int(agent_max_output_tokens)
+            # Request-side ContextEditor (goldfive#397). ``None`` when
+            # :class:`~goldfive.config.SteeringConfig.context_editor_rules`
+            # is unset / empty — the ``before_model_callback`` codepath
+            # short-circuits on this being ``None`` so the
+            # feature-flag-off path has zero overhead (one ``is None``
+            # check). When non-None, the editor is invoked AFTER the
+            # PromptShaper-equivalent injections (today:
+            # ``_inject_goldfive_planner_instruction`` +
+            # ``_inject_runtime_tools_hint``) and BEFORE the per-LLM-call
+            # instrumentation that measures the final request. See
+            # ``goldfive/context_editor.py`` for the rule chain
+            # semantics + invariants.
+            self._context_editor: Any = context_editor
             # Active :class:`SessionContext` for the invocation that is
             # currently driving this plugin's runner. Set by
             # :meth:`ADKAdapter.invoke` before ``run_async`` and cleared
@@ -5164,6 +5204,38 @@ def make_adk_plugin(
                     "before_model_callback: runtime tools hint injection raised: %s",
                     exc,
                 )
+
+            # Request-side ContextEditor (goldfive#397). Runs AFTER all
+            # additive prompt-shaping (planner + runtime tools hint
+            # above; will become PromptShaper after Wave B1 lands) and
+            # BEFORE the per-LLM-call instrumentation below — so the
+            # measured ``chars`` reflect what the model actually sees
+            # AFTER any edits applied.
+            #
+            # The codepath is short-circuited when the editor wasn't
+            # constructed (no rules configured) so the
+            # feature-flag-off path costs one ``is None`` check.
+            # Observation-only is a hard gate inside ``apply()`` — the
+            # editor is a complete no-op under
+            # ``SteeringConfig.observation_only=True``.
+            #
+            # Best-effort: never raises into the callback path. An
+            # editor crash logs at DEBUG and the LLM dispatch proceeds
+            # with the un-edited ``contents``.
+            if self._context_editor is not None and ctx is not None and ctx.session is not None:
+                try:
+                    observation_only = _is_observation_only(ctx)
+                    await self._context_editor.apply(
+                        llm_request,
+                        session=ctx.session,
+                        host_agent_name=self._host_agent_name,
+                        observation_only=observation_only,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "before_model_callback: ContextEditor.apply raised: %s",
+                        exc,
+                    )
 
             # Per-LLM-call instrumentation (goldfive#172). Measure the
             # request AFTER GoldfivePlanner has appended its

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -1028,6 +1028,7 @@ class ADKAdapter:
         agent_tool_cap: int | None = None,
         llm_call_timeout_ms: int | None = None,
         agent_max_output_tokens: int | None = None,
+        context_editor: Any = None,
     ) -> None:
         self._user_id = user_id
         # Per-(goldfive session.conversation_id) cached ADK session id
@@ -1099,10 +1100,21 @@ class ADKAdapter:
         # ratcheting entirely (pre-#256 behaviour).
         if agent_max_output_tokens is not None:
             plugin_kwargs["agent_max_output_tokens"] = int(agent_max_output_tokens)
+        # Request-side ContextEditor (goldfive#397). ``None`` (default)
+        # disables the editor entirely — :func:`make_adk_plugin` then
+        # stores ``None`` on the plugin and the ``before_model_callback``
+        # codepath short-circuits with one ``is None`` check.
+        # :func:`goldfive.wrap` threads a
+        # :class:`~goldfive.context_editor.ContextEditor` built from
+        # :class:`~goldfive.config.SteeringConfig.context_editor_rules`
+        # when the operator opts in.
+        if context_editor is not None:
+            plugin_kwargs["context_editor"] = context_editor
         self._plugin = make_adk_plugin(**plugin_kwargs)
         self._agent_tool_cap = cap
         self._llm_call_timeout_ms = llm_call_timeout_ms
         self._agent_max_output_tokens = agent_max_output_tokens
+        self._context_editor = context_editor
 
         # Install the goldfive plugin on the one runner. ADK propagates
         # the plugin manager into any AgentTool-spawned sub-Runner so the

--- a/goldfive/adapters/auto.py
+++ b/goldfive/adapters/auto.py
@@ -120,6 +120,7 @@ def auto_adapter(
     plugins: list[Any] | None = None,
     llm_call_timeout_ms: int | None = None,
     agent_max_output_tokens: int | None = None,
+    context_editor: Any = None,
 ) -> AgentAdapter:
     """Return a concrete :class:`AgentAdapter` for ``agent``.
 
@@ -160,6 +161,8 @@ def auto_adapter(
             adk_kwargs["llm_call_timeout_ms"] = int(llm_call_timeout_ms)
         if agent_max_output_tokens is not None:
             adk_kwargs["agent_max_output_tokens"] = int(agent_max_output_tokens)
+        if context_editor is not None:
+            adk_kwargs["context_editor"] = context_editor
         return ADKAdapter(agent, **adk_kwargs)
 
     if _looks_like_claude_client_factory(agent):

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -641,6 +641,21 @@ class SteeringConfig:
     observation_only: bool = dataclasses.field(
         default_factory=_resolve_observation_only_default
     )
+    #: Names of :class:`~goldfive.context_editor.ContextEditRule` rules to
+    #: register on the ADK plugin's :class:`~goldfive.context_editor.ContextEditor`
+    #: (goldfive#397). ``None`` (the default) AND an empty list both leave
+    #: the editor unwired — the plugin's ``before_model_callback`` never
+    #: even instantiates the editor and the codepath is zero-overhead.
+    #:
+    #: Set to a list of rule names (e.g. ``["prune_cancelled_reasoning"]``)
+    #: to opt in. Unknown rule names are logged and ignored at registration
+    #: time; an empty list after filtering also keeps the editor unwired.
+    #:
+    #: Per-rule (rather than a single master switch) so e2e regressions
+    #: from a single rule can be bisected without disabling the whole
+    #: capability. See ``docs/design/CONTEXT-EDITING.md`` for the rule
+    #: catalog and the rationale behind drop-only edits.
+    context_editor_rules: list[str] | None = None
 
     @classmethod
     def from_env(cls) -> SteeringConfig:
@@ -657,8 +672,17 @@ class SteeringConfig:
           built-in default (``True`` in production, flipped to
           ``False`` for the goldfive test suite via the autouse
           ``_goldfive_active_steering_default`` fixture).
+        * ``GOLDFIVE_STEER_CONTEXT_EDITOR_RULES`` — comma-separated rule
+          names (goldfive#397). Empty / unset → ``None`` (editor unwired).
+          Example: ``GOLDFIVE_STEER_CONTEXT_EDITOR_RULES=prune_cancelled_reasoning``.
         """
         defaults = cls()
+        raw_rules = os.environ.get("GOLDFIVE_STEER_CONTEXT_EDITOR_RULES", "").strip()
+        rules: list[str] | None
+        if not raw_rules:
+            rules = defaults.context_editor_rules
+        else:
+            rules = [r.strip() for r in raw_rules.split(",") if r.strip()] or None
         return cls(
             threshold=_read_steer_threshold_env(
                 "GOLDFIVE_STEER_THRESHOLD", defaults.threshold
@@ -671,6 +695,7 @@ class SteeringConfig:
                 "GOLDFIVE_STEER_OBSERVATION_ONLY",
                 defaults.observation_only,
             ),
+            context_editor_rules=rules,
         )
 
 

--- a/goldfive/context_editor.py
+++ b/goldfive/context_editor.py
@@ -136,7 +136,7 @@ class ContextEditRule(Protocol):
     guarantee that two callbacks at the same revision produce the same
     edit. Rules that need stateful information (e.g. cancelled
     function_call ids) read it off ``ctx.session.state`` via the
-    relevant ``orchestration_state`` helper — that state is
+    relevant ``state_store`` helper — that state is
     monotonically growing and revision-stamped, so deterministic per
     call.
 
@@ -181,7 +181,7 @@ class ContextEditContext:
     :meth:`ContextEditor.apply`.
 
     Rules use ``session`` to read orchestration state
-    (e.g. ``orchestration_state.read_cancelled_function_call_ids``) and
+    (e.g. ``state_store.read_cancelled_function_call_ids``) and
     ``observed_revision_index`` to stamp idempotence keys. The session
     handle is the goldfive Session (NOT the ADK session) — same handle
     every other steering surface reads from.
@@ -754,7 +754,7 @@ class PruneCancelledReasoningRule:
     ``goldfive.cancelled_function_call_ids`` on ``session.state``
     (written by :meth:`ADKAdapter._heal_pending_tool_calls` after every
     cancel — see
-    :func:`goldfive.orchestration_state.append_cancelled_function_call_ids`).
+    :func:`goldfive.state_store.append_cancelled_function_call_ids`).
     Every ``function_call`` part whose ``id`` appears in that list is
     eligible for pruning, alongside its paired ``function_response``.
     The list is append-only and de-duplicated, so the rule's decision
@@ -762,13 +762,16 @@ class PruneCancelledReasoningRule:
 
     Pairing safety
     --------------
-    The rule prunes **both halves of a pair** atomically — never one
-    side. A ``function_call`` whose id is cancelled is dropped IFF the
-    matching ``function_response`` is also present in ``contents`` (or
-    vice versa). When one side is missing, the rule leaves the
-    surviving half alone — the pairing invariant in the editor would
-    reject a one-sided drop anyway, and emitting a deliberate revert
-    is more honest than a defensive over-strip.
+    The rule prunes every Content whose parts touch a cancelled
+    ``function_call_id`` — whether the cancelled half is a
+    ``function_call`` or its paired ``function_response``. Since calls
+    and responses share the same id and are usually packaged together,
+    a healthy pair drops as a unit and the editor's pairing invariant
+    (Invariant 2) holds trivially. If pre-rule ``contents`` already
+    contained an orphan half (e.g. cancel-mid-tool already dropped one
+    side), this rule drops the surviving orphan too — which fixes
+    rather than introduces a pairing violation. The editor's pairing
+    invariant catches any residual asymmetry as a safety net.
 
     Empty-contents safety
     ---------------------
@@ -827,12 +830,12 @@ class PruneCancelledReasoningRule:
 def _read_cancelled_ids(session: Any) -> set[str]:
     """Read ``goldfive.cancelled_function_call_ids`` off the session as a set.
 
-    Goes through :func:`goldfive.orchestration_state.read_cancelled_function_call_ids`
+    Goes through :func:`goldfive.state_store.read_cancelled_function_call_ids`
     (the canonical reader) so the rule stays in sync with the writer's
     schema. Returns an empty set on any failure.
     """
     try:
-        from goldfive import orchestration_state as _ostate  # noqa: PLC0415
+        from goldfive import state_store as _ostate  # noqa: PLC0415
 
         state = _safe_attr(session, "state", None)
         if state is None:

--- a/goldfive/context_editor.py
+++ b/goldfive/context_editor.py
@@ -1,0 +1,930 @@
+"""Request-side context editing as a steering capability (goldfive#397).
+
+This module is the single, centralised gate goldfive uses to edit the
+``contents`` list of an ADK :class:`LlmRequest` before it reaches the
+model. Today goldfive's steering ladder treats the LLM transcript as
+immutable — Plan revisions, synthetic ``USER_STEER`` injection, cancel
++ reinvoke, ``system_instruction`` prefixes, and ``max_output_tokens``
+ratcheting are the only levers. Nothing prunes, redacts, or rewrites
+``contents``. See ``docs/design/CONTEXT-EDITING.md`` for the motivation
+and the catalogue of rules planned across follow-up PRs.
+
+Architecture
+------------
+
+The :class:`ContextEditor` is held by the goldfive ADK plugin and
+invoked from ``before_model_callback`` AFTER ``PromptShaper`` (today:
+after :func:`_inject_goldfive_planner_instruction` and
+:func:`_inject_runtime_tools_hint` in
+``goldfive/adapters/_adk_plugin.py``) and BEFORE the model dispatch.
+It walks a list of registered :class:`ContextEditRule` instances in
+registration order, each receiving the output of the prior, applies
+five mandatory invariants on the result, and either keeps the edit or
+reverts to the original ``contents``.
+
+Mandatory invariants (Phase 1, all enforced)
+--------------------------------------------
+
+1. **`observation_only` gate.** When the steerer's ``observation_only``
+   flag is set (the default in production — goldfive#254 / goldfive#271
+   strict-passive pattern), the entire pipeline is bypassed. No edit
+   fires; ``contents`` is untouched. This mirrors the strict-passive
+   discipline established by goldfive#271: any editorial surface that
+   could mutate runtime state MUST be a complete no-op in passive
+   mode.
+
+2. **`tool_call_id` pairing.** After all rules have run, every
+   ``function_call`` part still in ``contents`` must have its matching
+   ``function_response`` (and vice versa). ADK errors hard on orphans
+   (see :func:`goldfive.adapters.adk._heal_pending_tool_calls` for the
+   primary-path equivalent on cancel). On violation, the editor
+   reverts to the original ``contents`` and emits a
+   ``ContextEditRejected`` event.
+
+3. **Drop-only / no injection.** Rules can prune or rewrite-to-shorter
+   existing parts; they cannot add material that wasn't in the prior
+   ``contents``. Additive shaping stays in ``PromptShaper``'s lane
+   (the ``system_instruction`` injections), where it is auditable.
+   Enforced via the byte / count monotonicity gate: the post-edit
+   byte total and content-count MUST be ≤ the pre-edit totals. A
+   rule that violates this triggers a revert.
+
+4. **Idempotence per revision.** A deterministic rule applied twice
+   to the same ``(observed_revision_index, contents)`` MUST produce
+   the same output. The editor stamps ``observed_revision_index`` on
+   the emitted ``ContextEdited`` event so a downstream divergence
+   between two emits at the same revision surfaces in the harmonograf
+   timeline. Not assertable from inside one ``apply`` call — this
+   invariant is contractual on rule authors and is validated by the
+   unit tests.
+
+5. **Log-out-of-loop.** Edits are append-only against the *persisted*
+   transcript — goldfive's sinks see the original event stream via
+   the plugin's other callbacks; only the model's request is edited.
+   The editor emits a ``ContextEdited`` event so harmonograf can show
+   what the model didn't see (rule name, byte delta, content-count
+   delta, ``observed_revision_index``).
+
+Failure modes
+-------------
+
+* **Rule strips half a `function_call` / `function_response` pair** —
+  pairing-invariant check reverts the edit; ``ContextEditRejected``
+  emitted with ``reason='tool_call_id_pair_violation'``.
+* **Rule produces empty `contents`** — ADK requires at least one
+  user turn. Revert; ``ContextEditRejected`` with
+  ``reason='empty_contents'``.
+* **Rule grows ``contents`` (count or bytes)** — violates drop-only
+  invariant. Revert; ``ContextEditRejected`` with
+  ``reason='not_drop_only'``.
+* **Rule raises** — best-effort: log + skip the rule, keep the
+  pre-rule ``contents``. Subsequent rules run normally. Editor never
+  raises into the callback path.
+
+State-ownership audit
+---------------------
+
+The state-audit module (:mod:`goldfive._state_audit`) currently patches
+:func:`goldfive.adapters._adk_state_protocol._set` for ADK
+``session.state`` writes. The request-side ``llm_request.contents``
+list is NOT under that audit's remit today; this Phase-1 PR catalogs
+:meth:`ContextEditor.apply` as the **sole** authorised mutation site
+for ``contents`` by convention (no runtime tripwire — extension of the
+audit to list-level mutation is left for a follow-up). The convention
+holds because ``contents`` is read by ADK's flow only after every
+``before_model_callback`` returns, and every other goldfive code path
+that touches it (``_measure_request_chars``) is strictly read-only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+log = logging.getLogger("goldfive.context_editor")
+
+
+# ---------------------------------------------------------------------------
+# Public protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ContextEditRule(Protocol):
+    """A single rule that can drop / rewrite-to-shorter parts of ``contents``.
+
+    Rules are registered with :meth:`ContextEditor.register` and walked
+    in registration order. Each rule's :meth:`edit` receives the
+    ``contents`` list output by the prior rule (or the original
+    ``contents`` for the first rule) and either returns a new list (the
+    edit) or ``None`` (no change at this revision — skip).
+
+    Naming
+    ------
+    ``name`` is the stable string identifier used in
+    :class:`~goldfive.config.SteeringConfig.context_editor_rules` to
+    opt in. Use snake_case; should match the class's identifier in the
+    rule catalog (e.g. ``"prune_cancelled_reasoning"``).
+
+    Determinism contract
+    --------------------
+    Rules MUST be deterministic for a given ``(observed_revision_index,
+    contents)`` input pair. The editor relies on idempotence to
+    guarantee that two callbacks at the same revision produce the same
+    edit. Rules that need stateful information (e.g. cancelled
+    function_call ids) read it off ``ctx.session.state`` via the
+    relevant ``orchestration_state`` helper — that state is
+    monotonically growing and revision-stamped, so deterministic per
+    call.
+
+    Drop-only contract
+    ------------------
+    A rule's output ``contents`` MUST have ≤ the input's content count
+    AND ≤ the input's byte total. Rules may shorten ``part.text`` /
+    ``part.function_response.response`` payloads but MUST NOT introduce
+    new ``Content`` entries or grow any existing one. Adding belongs in
+    PromptShaper.
+    """
+
+    name: str
+
+    def edit(
+        self,
+        contents: list[Any],
+        ctx: ContextEditContext,
+    ) -> list[Any] | None:
+        """Return a new ``contents`` list, or ``None`` for no change.
+
+        ``contents`` is the live list off ``llm_request.contents``;
+        rules MUST NOT mutate it in place — return a NEW list when the
+        rule applies, or ``None`` when it doesn't. The editor swaps
+        the request's ``contents`` reference only after invariants pass.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# ContextEditContext — read-only per-call context handed to rules
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContextEditContext:
+    """Read-only context handed to every rule's :meth:`edit` call.
+
+    Carries the goldfive :class:`~goldfive.types.Session`, the host
+    agent name (the agent owning the wrapped ADK runner), and the
+    snapshot ``observed_revision_index`` captured at the top of
+    :meth:`ContextEditor.apply`.
+
+    Rules use ``session`` to read orchestration state
+    (e.g. ``orchestration_state.read_cancelled_function_call_ids``) and
+    ``observed_revision_index`` to stamp idempotence keys. The session
+    handle is the goldfive Session (NOT the ADK session) — same handle
+    every other steering surface reads from.
+    """
+
+    session: Any
+    host_agent_name: str
+    observed_revision_index: int
+
+
+# ---------------------------------------------------------------------------
+# Sentinel for "rule made no change" return
+# ---------------------------------------------------------------------------
+
+
+_REJECTED_REASONS = (
+    "tool_call_id_pair_violation",
+    "empty_contents",
+    "not_drop_only",
+    "rule_raised",
+    "unknown_rule",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — contents introspection
+# ---------------------------------------------------------------------------
+
+
+def _safe_attr(obj: Any, name: str, default: Any = None) -> Any:
+    """``getattr`` that never raises (mirrors the plugin module helper).
+
+    Local copy so this module has no import-time dependency on the ADK
+    plugin module (which is large and itself imports ``google.adk``).
+    """
+    try:
+        return getattr(obj, name, default)
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _content_bytes(contents: list[Any]) -> int:
+    """Sum the serialised byte cost of every part in ``contents``.
+
+    Mirrors :func:`goldfive.adapters._adk_plugin._measure_request_chars`
+    semantics (text + name + json(args) for function_call; name +
+    json(response) for function_response) so the byte delta on the
+    ``ContextEdited`` event is directly comparable with the
+    ``goldfive.llm.request`` instrumentation line. Returns 0 on any
+    failure — measurement must never raise.
+    """
+    try:
+        total = 0
+        for content in contents:
+            parts = _safe_attr(content, "parts", None) or []
+            for part in parts:
+                text = _safe_attr(part, "text", "") or ""
+                if text:
+                    total += len(str(text))
+                    continue
+                fc = _safe_attr(part, "function_call", None)
+                if fc is not None:
+                    name = str(_safe_attr(fc, "name", "") or "")
+                    args = _safe_attr(fc, "args", None)
+                    total += len(name)
+                    if args is not None:
+                        try:
+                            total += len(json.dumps(args, default=repr))
+                        except Exception:  # noqa: BLE001
+                            total += len(repr(args))
+                    continue
+                fr = _safe_attr(part, "function_response", None)
+                if fr is not None:
+                    name = str(_safe_attr(fr, "name", "") or "")
+                    resp = _safe_attr(fr, "response", None)
+                    total += len(name)
+                    if resp is not None:
+                        try:
+                            total += len(json.dumps(resp, default=repr))
+                        except Exception:  # noqa: BLE001
+                            total += len(repr(resp))
+                    continue
+        return total
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def _function_call_ids(contents: list[Any]) -> set[str]:
+    """Return the set of ``function_call.id`` values present in ``contents``."""
+    ids: set[str] = set()
+    try:
+        for content in contents:
+            parts = _safe_attr(content, "parts", None) or []
+            for part in parts:
+                fc = _safe_attr(part, "function_call", None)
+                if fc is None:
+                    continue
+                fc_id = _safe_attr(fc, "id", "")
+                if fc_id:
+                    ids.add(str(fc_id))
+    except Exception:  # noqa: BLE001
+        pass
+    return ids
+
+
+def _function_response_ids(contents: list[Any]) -> set[str]:
+    """Return the set of ``function_response.id`` values present in ``contents``."""
+    ids: set[str] = set()
+    try:
+        for content in contents:
+            parts = _safe_attr(content, "parts", None) or []
+            for part in parts:
+                fr = _safe_attr(part, "function_response", None)
+                if fr is None:
+                    continue
+                fr_id = _safe_attr(fr, "id", "")
+                if fr_id:
+                    ids.add(str(fr_id))
+    except Exception:  # noqa: BLE001
+        pass
+    return ids
+
+
+def _is_tool_call_id_paired(contents: list[Any]) -> bool:
+    """Return True iff every ``function_call`` has a matching ``function_response``.
+
+    The invariant ADK relies on: a turn whose ``function_call`` lacks a
+    matching ``function_response`` (or vice versa) hits ADK's "Missing
+    tool results" error during request assembly. The pairing is
+    symmetric — both directions must hold.
+
+    The empty-set case (no function_call / function_response parts at
+    all — a fully-text turn) is paired by definition.
+    """
+    fc_ids = _function_call_ids(contents)
+    fr_ids = _function_response_ids(contents)
+    return fc_ids == fr_ids
+
+
+def _contents_hash(contents: list[Any]) -> str:
+    """Stable short hash of ``contents`` for idempotence-key stamping.
+
+    Hashes the same JSON-serialised view that ``_content_bytes`` uses
+    so two ``contents`` with identical observable shape hash to the
+    same value. Best-effort — returns ``""`` on any failure.
+    """
+    try:
+        records: list[Any] = []
+        for content in contents:
+            role = _safe_attr(content, "role", "") or ""
+            parts_view: list[Any] = []
+            parts = _safe_attr(content, "parts", None) or []
+            for part in parts:
+                fc = _safe_attr(part, "function_call", None)
+                fr = _safe_attr(part, "function_response", None)
+                if fc is not None:
+                    parts_view.append(
+                        {
+                            "kind": "fc",
+                            "id": str(_safe_attr(fc, "id", "") or ""),
+                            "name": str(_safe_attr(fc, "name", "") or ""),
+                        }
+                    )
+                elif fr is not None:
+                    parts_view.append(
+                        {
+                            "kind": "fr",
+                            "id": str(_safe_attr(fr, "id", "") or ""),
+                            "name": str(_safe_attr(fr, "name", "") or ""),
+                        }
+                    )
+                else:
+                    text = str(_safe_attr(part, "text", "") or "")
+                    parts_view.append({"kind": "text", "len": len(text)})
+            records.append({"role": role, "parts": parts_view})
+        payload = json.dumps(records, sort_keys=True, default=repr)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# ContextEditor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _EditResult:
+    """Bookkeeping for one ``apply()`` invocation.
+
+    Exposed so the unit tests can assert against the per-rule decision
+    chain without grepping log lines.
+    """
+
+    applied_rules: list[str] = field(default_factory=list)
+    rejected_rules: list[tuple[str, str]] = field(
+        default_factory=list
+    )  # (rule_name, reason)
+    skipped_rules: list[str] = field(default_factory=list)  # rule returned None
+    bytes_before: int = 0
+    bytes_after: int = 0
+    contents_count_before: int = 0
+    contents_count_after: int = 0
+
+
+class ContextEditor:
+    """Walks registered rules over ``llm_request.contents`` under invariants.
+
+    Constructed lazily by the ADK plugin only when
+    :class:`~goldfive.config.SteeringConfig.context_editor_rules`
+    resolves to a non-empty list of recognised rule names. The plugin
+    does NOT instantiate the editor when the rule list is empty — the
+    feature-flag-off path has zero overhead (one ``is None`` check in
+    the callback).
+
+    Rules
+    -----
+    Register with :meth:`register` at construction time
+    (typically inside :func:`make_adk_plugin`'s factory). Rules walk
+    in registration order; the editor passes the prior rule's output
+    forward so two rules can compose (e.g. prune cancelled pairs THEN
+    prune transient errors over the survivors).
+
+    Sinks
+    -----
+    ``sinks`` is the same fan-out list goldfive's other ``make_event``
+    emit sites use (steerer, planner, pin_resolved). The editor emits
+    ``ContextEdited`` on success and ``ContextEditRejected`` on
+    invariant violation. When ``sinks`` is empty the editor still
+    applies edits (the work is real) but skips emission silently —
+    same shape as the steerer's emit paths.
+
+    Reverts
+    -------
+    Invariant violations revert to the pre-rule ``contents`` and
+    continue with the next rule. The chain is NOT aborted on a single
+    rejection — a subsequent rule can still apply cleanly to the
+    pre-rule state.
+    """
+
+    def __init__(
+        self,
+        *,
+        rules: list[ContextEditRule] | None = None,
+        sinks: list[Any] | None = None,
+    ) -> None:
+        self._rules: list[ContextEditRule] = list(rules or [])
+        self._sinks: list[Any] = list(sinks or [])
+
+    def register(self, rule: ContextEditRule) -> None:
+        """Append ``rule`` to the rule chain.
+
+        Idempotent on rule identity (the same instance registered
+        twice is held once) but NOT on rule name — two distinct
+        instances with the same ``name`` are both kept, which is
+        intentional: a future rule taxonomy may want parameterised
+        instances of the same rule type registered with different
+        configs.
+        """
+        if rule in self._rules:
+            return
+        self._rules.append(rule)
+
+    @property
+    def rules(self) -> tuple[ContextEditRule, ...]:
+        """Immutable snapshot of the registered rule chain (for tests / debug)."""
+        return tuple(self._rules)
+
+    async def apply(
+        self,
+        llm_request: Any,
+        *,
+        session: Any,
+        host_agent_name: str,
+        observation_only: bool,
+    ) -> _EditResult:
+        """Apply the rule chain to ``llm_request.contents`` under invariants.
+
+        Returns an :class:`_EditResult` recording which rules applied,
+        which were rejected (and why), and the pre/post byte +
+        content-count totals. The caller (the ADK plugin's
+        ``before_model_callback``) discards the return value in
+        production; it exists for tests and operator introspection.
+
+        ``observation_only`` is a hard gate (Invariant 1). When True
+        the entire pipeline is bypassed and the result reports the
+        pre-edit totals as both pre and post.
+
+        Never raises into the caller — every rule and every emit is
+        wrapped in a defensive ``try/except``. Callback paths in the
+        ADK plugin are best-effort by contract; an editor crash MUST
+        NOT take down the LLM dispatch.
+        """
+        result = _EditResult()
+
+        # Invariant 1 — observation_only gate. Complete no-op.
+        if observation_only:
+            log.debug(
+                "ContextEditor.apply: observation_only=True — pipeline skipped"
+            )
+            return result
+
+        if not self._rules:
+            return result
+
+        contents = _safe_attr(llm_request, "contents", None) or []
+        # The list is the live mutable reference ADK's flow will read;
+        # we never mutate it in place — only swap the attribute when
+        # an edit passes invariants.
+        original_contents = list(contents)
+        bytes_before = _content_bytes(original_contents)
+        result.bytes_before = bytes_before
+        result.contents_count_before = len(original_contents)
+
+        # Capture the observed_revision_index ONCE at the top of the
+        # call so every emitted event for this call shares the same
+        # revision stamp — even if a concurrent revision bump lands
+        # mid-chain. Idempotence-per-revision (Invariant 4) depends on
+        # this stamping site being upstream of any rule that might
+        # await.
+        observed_rev = _resolve_observed_revision_index(session)
+        edit_ctx = ContextEditContext(
+            session=session,
+            host_agent_name=host_agent_name,
+            observed_revision_index=observed_rev,
+        )
+
+        current = original_contents
+        for rule in self._rules:
+            rule_name = str(_safe_attr(rule, "name", "") or rule.__class__.__name__)
+
+            # Defensive: any rule that raises is logged + skipped.
+            # We do NOT abort the chain — a subsequent rule can still
+            # apply cleanly.
+            try:
+                candidate = rule.edit(list(current), edit_ctx)
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "ContextEditor.apply: rule %r raised — skipping: %s",
+                    rule_name,
+                    exc,
+                )
+                result.rejected_rules.append((rule_name, "rule_raised"))
+                await self._emit_rejected(
+                    session=session,
+                    rule_name=rule_name,
+                    reason="rule_raised",
+                    observed_rev=observed_rev,
+                )
+                continue
+
+            if candidate is None or candidate == current:
+                # Rule chose not to edit this revision. Common path —
+                # most rules don't apply on most turns.
+                result.skipped_rules.append(rule_name)
+                continue
+
+            # Invariant 3 — drop-only / no-injection. Byte total and
+            # content count must be ≤ pre-rule.
+            cand_bytes = _content_bytes(candidate)
+            pre_rule_bytes = _content_bytes(current)
+            if cand_bytes > pre_rule_bytes or len(candidate) > len(current):
+                log.warning(
+                    "ContextEditor.apply: rule %r violated drop-only "
+                    "(bytes %d->%d, count %d->%d) — reverting",
+                    rule_name,
+                    pre_rule_bytes,
+                    cand_bytes,
+                    len(current),
+                    len(candidate),
+                )
+                result.rejected_rules.append((rule_name, "not_drop_only"))
+                await self._emit_rejected(
+                    session=session,
+                    rule_name=rule_name,
+                    reason="not_drop_only",
+                    observed_rev=observed_rev,
+                )
+                continue
+
+            # Invariant 2 — tool_call_id pairing.
+            if not _is_tool_call_id_paired(candidate):
+                log.warning(
+                    "ContextEditor.apply: rule %r broke tool_call_id "
+                    "pairing — reverting",
+                    rule_name,
+                )
+                result.rejected_rules.append((rule_name, "tool_call_id_pair_violation"))
+                await self._emit_rejected(
+                    session=session,
+                    rule_name=rule_name,
+                    reason="tool_call_id_pair_violation",
+                    observed_rev=observed_rev,
+                )
+                continue
+
+            # Pairing-invariant addendum: empty contents is also a
+            # revert — ADK requires at least one user turn.
+            if not candidate:
+                log.warning(
+                    "ContextEditor.apply: rule %r produced empty contents "
+                    "— reverting",
+                    rule_name,
+                )
+                result.rejected_rules.append((rule_name, "empty_contents"))
+                await self._emit_rejected(
+                    session=session,
+                    rule_name=rule_name,
+                    reason="empty_contents",
+                    observed_rev=observed_rev,
+                )
+                continue
+
+            # Edit passed all invariants. Accept; subsequent rules
+            # see the edited contents.
+            current = candidate
+            result.applied_rules.append(rule_name)
+            try:
+                await self._emit_applied(
+                    session=session,
+                    rule_name=rule_name,
+                    bytes_before=pre_rule_bytes,
+                    bytes_after=cand_bytes,
+                    contents_count_before=len(original_contents),
+                    contents_count_after=len(candidate),
+                    observed_rev=observed_rev,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "ContextEditor.apply: emit ContextEdited raised: %s",
+                    exc,
+                )
+
+        # Commit the final ``contents`` onto the request only if a
+        # rule actually applied. The defensive ``current is
+        # original_contents`` check avoids touching the attribute when
+        # nothing changed.
+        if current is not original_contents and result.applied_rules:
+            try:
+                llm_request.contents = current
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "ContextEditor.apply: could not swap llm_request.contents "
+                    "— reverting: %s",
+                    exc,
+                )
+                result.applied_rules.clear()
+                current = original_contents
+
+        result.bytes_after = _content_bytes(current)
+        result.contents_count_after = len(current)
+        return result
+
+    # ---- Internal: event emission --------------------------------------
+
+    async def _emit_applied(
+        self,
+        *,
+        session: Any,
+        rule_name: str,
+        bytes_before: int,
+        bytes_after: int,
+        contents_count_before: int,
+        contents_count_after: int,
+        observed_rev: int,
+    ) -> None:
+        """Emit a ``ContextEdited`` event onto every registered sink.
+
+        Uses :func:`goldfive.events.make_event` (dict envelope) because
+        the proto schema doesn't yet carry a ``ContextEdited`` slot —
+        same pattern as ``pin_resolved`` in the ADK plugin (see
+        ``_emit_pin_resolved``). Best-effort: every failure is logged
+        and swallowed.
+        """
+        if not self._sinks:
+            return
+        run_id = str(_safe_attr(session, "run_id", "") or "")
+        session_id = str(_safe_attr(session, "id", "") or "") or run_id
+        try:
+            seq = session.next_sequence()
+        except Exception:  # noqa: BLE001
+            seq = 0
+        payload: dict[str, Any] = {
+            "rule_name": str(rule_name),
+            "bytes_before": int(bytes_before),
+            "bytes_after": int(bytes_after),
+            "contents_count_before": int(contents_count_before),
+            "contents_count_after": int(contents_count_after),
+            "observed_revision_index": int(observed_rev),
+        }
+        try:
+            from goldfive.events import emit, make_event  # noqa: PLC0415
+
+            evt = make_event(run_id, seq, "context_edited", payload, session_id=session_id)
+            await emit(self._sinks, evt)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("ContextEditor._emit_applied: failed: %s", exc)
+
+    async def _emit_rejected(
+        self,
+        *,
+        session: Any,
+        rule_name: str,
+        reason: str,
+        observed_rev: int,
+    ) -> None:
+        """Emit a ``ContextEditRejected`` event when an invariant tripped.
+
+        Carries the rule name + reason (one of :data:`_REJECTED_REASONS`)
+        + the ``observed_revision_index``. Operators reading the
+        harmonograf timeline see exactly which rule was reverted and
+        why.
+        """
+        if not self._sinks:
+            return
+        run_id = str(_safe_attr(session, "run_id", "") or "")
+        session_id = str(_safe_attr(session, "id", "") or "") or run_id
+        try:
+            seq = session.next_sequence()
+        except Exception:  # noqa: BLE001
+            seq = 0
+        payload: dict[str, Any] = {
+            "rule_name": str(rule_name),
+            "reason": str(reason),
+            "observed_revision_index": int(observed_rev),
+        }
+        try:
+            from goldfive.events import emit, make_event  # noqa: PLC0415
+
+            evt = make_event(
+                run_id, seq, "context_edit_rejected", payload, session_id=session_id
+            )
+            await emit(self._sinks, evt)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("ContextEditor._emit_rejected: failed: %s", exc)
+
+
+def _resolve_observed_revision_index(session: Any) -> int:
+    """Return the goldfive session's current ``plan.revision_index``.
+
+    Stamped onto every emitted event so harmonograf can correlate a
+    ``ContextEdited`` against the surrounding plan revision. Returns
+    ``0`` when the session has no plan yet (cold-session edge case).
+    Never raises.
+    """
+    try:
+        plan = _safe_attr(session, "plan", None)
+        if plan is None:
+            return 0
+        return int(_safe_attr(plan, "revision_index", 0) or 0)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Initial rule — PruneCancelledReasoningRule
+# ---------------------------------------------------------------------------
+
+
+class PruneCancelledReasoningRule:
+    """Strip ``function_call`` / ``function_response`` pairs from cancelled invocations.
+
+    Companion to goldfive#230 — that issue silenced *judges* on cancelled
+    reasoning; this rule silences the *model itself* by removing the
+    cancelled pairs from the LLM's view on the NEXT turn after a cancel.
+
+    Identification
+    --------------
+    The rule reads the goldfive-owned list at
+    ``goldfive.cancelled_function_call_ids`` on ``session.state``
+    (written by :meth:`ADKAdapter._heal_pending_tool_calls` after every
+    cancel — see
+    :func:`goldfive.orchestration_state.append_cancelled_function_call_ids`).
+    Every ``function_call`` part whose ``id`` appears in that list is
+    eligible for pruning, alongside its paired ``function_response``.
+    The list is append-only and de-duplicated, so the rule's decision
+    is deterministic for a given ``session.state`` snapshot.
+
+    Pairing safety
+    --------------
+    The rule prunes **both halves of a pair** atomically — never one
+    side. A ``function_call`` whose id is cancelled is dropped IFF the
+    matching ``function_response`` is also present in ``contents`` (or
+    vice versa). When one side is missing, the rule leaves the
+    surviving half alone — the pairing invariant in the editor would
+    reject a one-sided drop anyway, and emitting a deliberate revert
+    is more honest than a defensive over-strip.
+
+    Empty-contents safety
+    ---------------------
+    If pruning would leave ``contents`` empty (every entry was a
+    cancelled pair) the rule returns the original list unchanged. The
+    editor's empty-contents invariant would catch this anyway, but the
+    rule prefers to short-circuit rather than rely on a downstream
+    revert.
+
+    Whole-content-vs-part scoping
+    -----------------------------
+    A ``Content`` whose ``parts`` mix a cancelled ``function_call``
+    with non-cancelled text is rare but possible. The rule drops the
+    *whole Content* when ANY of its parts is a cancelled function_call
+    or function_response — the text alongside such a call is the
+    model's reasoning leading up to the cancelled action, which is
+    exactly the material we're trying to strip. Conservative: this
+    behaviour is what motivates the rule's existence.
+    """
+
+    name = "prune_cancelled_reasoning"
+
+    def edit(
+        self,
+        contents: list[Any],
+        ctx: ContextEditContext,
+    ) -> list[Any] | None:
+        # Read cancelled ids off goldfive Session state. Best-effort:
+        # any failure (missing key, malformed state) returns the
+        # rule-as-skipped signal.
+        cancelled_ids = _read_cancelled_ids(ctx.session)
+        if not cancelled_ids:
+            return None
+
+        # Walk contents, dropping every Content that touches a
+        # cancelled function_call id.
+        survivors: list[Any] = []
+        any_dropped = False
+        for content in contents:
+            if _content_touches_cancelled_id(content, cancelled_ids):
+                any_dropped = True
+                continue
+            survivors.append(content)
+
+        if not any_dropped:
+            return None
+
+        # Empty-contents safety — don't ship an empty list; the editor
+        # would revert anyway, but skipping is cheaper.
+        if not survivors:
+            return None
+
+        return survivors
+
+
+def _read_cancelled_ids(session: Any) -> set[str]:
+    """Read ``goldfive.cancelled_function_call_ids`` off the session as a set.
+
+    Goes through :func:`goldfive.orchestration_state.read_cancelled_function_call_ids`
+    (the canonical reader) so the rule stays in sync with the writer's
+    schema. Returns an empty set on any failure.
+    """
+    try:
+        from goldfive import orchestration_state as _ostate  # noqa: PLC0415
+
+        state = _safe_attr(session, "state", None)
+        if state is None:
+            return set()
+        return set(_ostate.read_cancelled_function_call_ids(state))
+    except Exception:  # noqa: BLE001
+        return set()
+
+
+def _content_touches_cancelled_id(content: Any, cancelled_ids: set[str]) -> bool:
+    """Return True iff ``content`` has any part with a cancelled function_call_id."""
+    parts = _safe_attr(content, "parts", None) or []
+    for part in parts:
+        fc = _safe_attr(part, "function_call", None)
+        if fc is not None:
+            fc_id = str(_safe_attr(fc, "id", "") or "")
+            if fc_id and fc_id in cancelled_ids:
+                return True
+        fr = _safe_attr(part, "function_response", None)
+        if fr is not None:
+            fr_id = str(_safe_attr(fr, "id", "") or "")
+            if fr_id and fr_id in cancelled_ids:
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Rule registry — name -> factory
+# ---------------------------------------------------------------------------
+
+
+#: Map of opt-in rule name (the string used in
+#: :class:`~goldfive.config.SteeringConfig.context_editor_rules`) to a
+#: zero-arg factory that builds the rule instance. New rules add a row
+#: here AND under the catalog in ``docs/design/CONTEXT-EDITING.md``.
+_RULE_REGISTRY: dict[str, Any] = {
+    "prune_cancelled_reasoning": PruneCancelledReasoningRule,
+}
+
+
+def build_editor_from_config(
+    rule_names: list[str] | None,
+    sinks: list[Any] | None = None,
+) -> ContextEditor | None:
+    """Construct a :class:`ContextEditor` from a list of rule names.
+
+    Returns ``None`` when ``rule_names`` is ``None``, empty, or
+    contains only unknown names — the caller (the ADK plugin) treats
+    ``None`` as "feature disabled, codepath bypassed". Unknown rule
+    names are logged at WARNING and dropped; known names are
+    instantiated in the order given so registration order honours the
+    operator's config.
+
+    ``sinks`` is forwarded onto the editor for telemetry emission.
+    """
+    if not rule_names:
+        return None
+    rules: list[ContextEditRule] = []
+    seen_names: set[str] = set()
+    for raw_name in rule_names:
+        name = str(raw_name).strip().lower()
+        if not name or name in seen_names:
+            continue
+        factory = _RULE_REGISTRY.get(name)
+        if factory is None:
+            log.warning(
+                "build_editor_from_config: unknown context_editor_rule %r "
+                "— ignoring. Known: %s",
+                name,
+                sorted(_RULE_REGISTRY.keys()),
+            )
+            continue
+        try:
+            rule = factory()
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "build_editor_from_config: rule %r factory raised: %s",
+                name,
+                exc,
+            )
+            continue
+        rules.append(rule)
+        seen_names.add(name)
+    if not rules:
+        return None
+    return ContextEditor(rules=rules, sinks=list(sinks or []))
+
+
+__all__ = [
+    "ContextEditContext",
+    "ContextEditRule",
+    "ContextEditor",
+    "PruneCancelledReasoningRule",
+    "build_editor_from_config",
+]

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -374,16 +374,37 @@ def wrap(
     _reasoning_module.configure(resolved_runtime.reasoning_drift)
     _tool_loops_module.configure(resolved_runtime.tool_loops)
 
+    # Resolve sinks first so the ContextEditor (built next) can emit
+    # ``context_edited`` / ``context_edit_rejected`` events onto the
+    # same fan-out the rest of the runtime uses. Default to
+    # ``[LoggingSink()]`` mirroring the historical behaviour.
+    resolved_sinks: list[EventSink] = list(sinks) if sinks is not None else [LoggingSink()]
+
+    # Request-side ContextEditor (goldfive#397). Built ONLY when the
+    # operator opted in via ``SteeringConfig.context_editor_rules``;
+    # otherwise stays ``None`` and the ADK plugin's
+    # ``before_model_callback`` short-circuits with one ``is None``
+    # check (zero overhead for non-users — the contract goldfive#397
+    # demands).
+    from goldfive.context_editor import build_editor_from_config  # noqa: PLC0415
+
+    context_editor = build_editor_from_config(
+        resolved_runtime.steering.context_editor_rules,
+        sinks=resolved_sinks,
+    )
+
     # Thread :class:`AgentConfig` (goldfive#256) into the ADK adapter so
     # the plugin's structural ``max_output_tokens`` ceiling AND the
     # per-LLM-call wall-clock budget reflect the runtime config. Both
     # kwargs are ignored for non-ADK adapter shapes (the typed config
     # has no analogous surface on Claude / callable adapters today).
+    # ``context_editor`` is forwarded too; non-ADK adapters ignore it.
     adapter = auto_adapter(
         agent,
         plugins=plugins,
         llm_call_timeout_ms=resolved_runtime.agent.call_timeout_ms,
         agent_max_output_tokens=resolved_runtime.agent.max_output_tokens,
+        context_editor=context_editor,
     )
 
     resolved_call_llm: CallLLM | None = call_llm
@@ -571,8 +592,6 @@ def wrap(
                 "use an ADK agent detect_llm() can introspect.",
                 mode,
             )
-    resolved_sinks: list[EventSink] = list(sinks) if sinks is not None else [LoggingSink()]
-
     runner = Runner(
         agent=adapter,
         planner=resolved_planner,

--- a/tests/test_context_editor.py
+++ b/tests/test_context_editor.py
@@ -1,0 +1,534 @@
+"""Unit tests for ``goldfive.context_editor`` (goldfive#397).
+
+Coverage matrix
+---------------
+
+* Empty rule set is a no-op.
+* ``observation_only=True`` skips the entire pipeline (strict-passive
+  pattern from goldfive#271).
+* ``tool_call_id`` pairing invariant — a rule that strips half a pair
+  is rejected, ``ContextEditRejected`` is emitted, and the
+  ``llm_request.contents`` reference is unchanged.
+* Idempotence — the same rule applied twice with the same input
+  produces the same output.
+* ``PruneCancelledReasoningRule`` — synthetic ``contents`` with one
+  cancelled pair and one live pair: editor strips the cancelled pair
+  and leaves the live one.
+* ``ContextEdited`` event emission on successful edit.
+* ``build_editor_from_config`` returns ``None`` for empty / unknown
+  rule names (gating the zero-overhead path).
+* Drop-only / no-injection invariant — a rule that grows ``contents``
+  is rejected.
+
+The tests use plain Python objects with the same duck-typed surface
+goldfive's ``_content_bytes`` and ``_function_call_ids`` helpers read
+(``role``, ``parts``, ``part.text``, ``part.function_call.{id,name,args}``,
+``part.function_response.{id,name,response}``). They do NOT require
+google-genai / ADK to be installed — context_editor was designed against
+the duck-typed surface for exactly this reason.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from goldfive.context_editor import (
+    ContextEditor,
+    PruneCancelledReasoningRule,
+    build_editor_from_config,
+)
+from goldfive.sinks.memory import InMemorySink
+
+# ---------------------------------------------------------------------------
+# Fake content / part / request objects mirroring the ADK duck-type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeFunctionCall:
+    id: str = ""
+    name: str = ""
+    args: dict[str, Any] | None = None
+
+
+@dataclass
+class FakeFunctionResponse:
+    id: str = ""
+    name: str = ""
+    response: dict[str, Any] | None = None
+
+
+@dataclass
+class FakePart:
+    text: str = ""
+    function_call: FakeFunctionCall | None = None
+    function_response: FakeFunctionResponse | None = None
+
+
+@dataclass
+class FakeContent:
+    role: str = "user"
+    parts: list[FakePart] = field(default_factory=list)
+
+
+@dataclass
+class FakeRequest:
+    contents: list[FakeContent] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Fake Session shim — only the surface ContextEditor + rule read
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakePlan:
+    revision_index: int = 0
+
+
+class FakeSession:
+    """Minimal Session shim — exposes ``state``, ``plan``, ``run_id``, ``id``,
+    and ``next_sequence`` so the editor + emit paths exercise without
+    pulling in the full ``goldfive.types.Session``.
+
+    ``state`` is a plain dict; the
+    :class:`~goldfive.context_editor.PruneCancelledReasoningRule` reads
+    ``goldfive.cancelled_function_call_ids`` off it via
+    :func:`goldfive.orchestration_state.read_cancelled_function_call_ids`.
+    """
+
+    def __init__(
+        self,
+        *,
+        run_id: str = "r-test",
+        session_id: str = "s-test",
+        plan: FakePlan | None = None,
+        state: dict[str, Any] | None = None,
+    ) -> None:
+        self.run_id = run_id
+        self.id = session_id
+        self.plan = plan or FakePlan()
+        self.state = dict(state or {})
+        self._seq = 0
+
+    def next_sequence(self) -> int:
+        self._seq += 1
+        return self._seq
+
+
+# ---------------------------------------------------------------------------
+# Helper constructors
+# ---------------------------------------------------------------------------
+
+
+def _text_content(text: str, role: str = "user") -> FakeContent:
+    return FakeContent(role=role, parts=[FakePart(text=text)])
+
+
+def _call_content(fc_id: str, name: str = "do_work") -> FakeContent:
+    return FakeContent(
+        role="model",
+        parts=[
+            FakePart(
+                function_call=FakeFunctionCall(id=fc_id, name=name, args={"k": "v"})
+            )
+        ],
+    )
+
+
+def _response_content(
+    fc_id: str, name: str = "do_work", response: dict[str, Any] | None = None
+) -> FakeContent:
+    return FakeContent(
+        role="user",
+        parts=[
+            FakePart(
+                function_response=FakeFunctionResponse(
+                    id=fc_id, name=name, response=response or {"ok": True}
+                )
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_rule_set_is_noop() -> None:
+    """An editor with zero rules MUST leave the request untouched."""
+    editor = ContextEditor(rules=[], sinks=[InMemorySink()])
+    request = FakeRequest(
+        contents=[_text_content("hello"), _call_content("fc-1"), _response_content("fc-1")]
+    )
+    original_contents = list(request.contents)
+    session = FakeSession()
+
+    result = await editor.apply(
+        request,
+        session=session,
+        host_agent_name="agent_a",
+        observation_only=False,
+    )
+
+    assert request.contents == original_contents
+    assert result.applied_rules == []
+    assert result.rejected_rules == []
+
+
+@pytest.mark.asyncio
+async def test_observation_only_skips_pipeline() -> None:
+    """``observation_only=True`` MUST short-circuit the entire chain.
+
+    Even when rules are registered AND would apply, no edit fires.
+    Mirrors the strict-passive contract from goldfive#271.
+    """
+
+    class _AlwaysFires:
+        name = "always_fires"
+
+        def edit(self, contents, ctx):  # type: ignore[no-untyped-def]
+            # Would strip everything if allowed — observation_only must
+            # gate that.
+            return []
+
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[_AlwaysFires()], sinks=[sink])
+    request = FakeRequest(contents=[_text_content("hello")])
+    original_contents = list(request.contents)
+
+    result = await editor.apply(
+        request,
+        session=FakeSession(),
+        host_agent_name="agent_a",
+        observation_only=True,
+    )
+
+    assert request.contents == original_contents
+    assert result.applied_rules == []
+    assert result.rejected_rules == []
+    # No event fires under observation_only — the pipeline is
+    # completely bypassed.
+    assert sink.events == []
+
+
+@pytest.mark.asyncio
+async def test_tool_call_id_pair_violation_reverts() -> None:
+    """A rule stripping half a pair MUST be reverted + ContextEditRejected emitted."""
+
+    class _HalfPairStripper:
+        """Drops the function_response but keeps the function_call —
+        breaks the pairing invariant."""
+
+        name = "half_pair_stripper"
+
+        def edit(self, contents, ctx):  # type: ignore[no-untyped-def]
+            # Keep everything EXCEPT the function_response — that
+            # leaves the function_call orphaned.
+            return [
+                c
+                for c in contents
+                if not any(p.function_response is not None for p in c.parts)
+            ]
+
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[_HalfPairStripper()], sinks=[sink])
+    request = FakeRequest(
+        contents=[_text_content("hi"), _call_content("fc-X"), _response_content("fc-X")]
+    )
+    original_contents = list(request.contents)
+
+    result = await editor.apply(
+        request,
+        session=FakeSession(),
+        host_agent_name="agent_a",
+        observation_only=False,
+    )
+
+    # Edit reverted — contents unchanged.
+    assert request.contents == original_contents
+    assert result.applied_rules == []
+    assert ("half_pair_stripper", "tool_call_id_pair_violation") in result.rejected_rules
+
+    # A ContextEditRejected event fired with the right reason.
+    rejected_events = [
+        e for e in sink.events if isinstance(e, dict) and e.get("kind") == "context_edit_rejected"
+    ]
+    assert len(rejected_events) == 1
+    assert rejected_events[0]["payload"]["rule_name"] == "half_pair_stripper"
+    assert rejected_events[0]["payload"]["reason"] == "tool_call_id_pair_violation"
+
+
+@pytest.mark.asyncio
+async def test_idempotence_same_input_same_output() -> None:
+    """Applying the same rule twice with the same input MUST produce the same result.
+
+    Idempotence-per-revision (Invariant 4): a deterministic rule
+    evaluated twice on identical ``contents`` AND identical
+    ``observed_revision_index`` MUST return the same output. Catches
+    accidental nondeterminism in rule authors.
+    """
+
+    class _DeterministicDropper:
+        name = "deterministic_dropper"
+
+        def edit(self, contents, ctx):  # type: ignore[no-untyped-def]
+            # Drop any Content whose first part text starts with
+            # "drop:".
+            survivors = []
+            any_dropped = False
+            for c in contents:
+                first_text = c.parts[0].text if c.parts else ""
+                if first_text.startswith("drop:"):
+                    any_dropped = True
+                    continue
+                survivors.append(c)
+            return survivors if any_dropped else None
+
+    sinks = [InMemorySink(), InMemorySink()]
+    base_contents = [
+        _text_content("keep me"),
+        _text_content("drop: this"),
+        _text_content("keep too"),
+    ]
+
+    # Two independent editors so they don't share state.
+    editor_a = ContextEditor(rules=[_DeterministicDropper()], sinks=[sinks[0]])
+    editor_b = ContextEditor(rules=[_DeterministicDropper()], sinks=[sinks[1]])
+
+    request_a = FakeRequest(contents=list(base_contents))
+    request_b = FakeRequest(contents=list(base_contents))
+    session = FakeSession(plan=FakePlan(revision_index=7))
+
+    result_a = await editor_a.apply(
+        request_a, session=session, host_agent_name="a", observation_only=False
+    )
+    result_b = await editor_b.apply(
+        request_b, session=session, host_agent_name="a", observation_only=False
+    )
+
+    assert result_a.applied_rules == result_b.applied_rules == ["deterministic_dropper"]
+    # Same content count and the survivors are the same shape.
+    assert [c.parts[0].text for c in request_a.contents] == [
+        c.parts[0].text for c in request_b.contents
+    ]
+    assert request_a.contents != base_contents  # The edit DID apply.
+
+
+@pytest.mark.asyncio
+async def test_prune_cancelled_reasoning_smoke() -> None:
+    """Synthetic contents with one cancelled pair + one live pair.
+
+    The rule MUST strip the cancelled pair (both the function_call and
+    its paired function_response) and leave the live pair + any text
+    intact.
+    """
+    from goldfive import orchestration_state as _ostate
+
+    session = FakeSession()
+    # Stamp one cancelled function_call_id on goldfive Session state
+    # — same write path :meth:`ADKAdapter._heal_pending_tool_calls`
+    # uses in production.
+    _ostate.append_cancelled_function_call_ids(session.state, ["fc-CANCELLED"])
+
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[PruneCancelledReasoningRule()], sinks=[sink])
+    request = FakeRequest(
+        contents=[
+            _text_content("user input"),
+            _call_content("fc-LIVE", name="research"),
+            _response_content("fc-LIVE", name="research"),
+            _call_content("fc-CANCELLED", name="aborted_work"),
+            _response_content("fc-CANCELLED", name="aborted_work"),
+            _text_content("model continues", role="model"),
+        ]
+    )
+
+    result = await editor.apply(
+        request, session=session, host_agent_name="a", observation_only=False
+    )
+
+    assert result.applied_rules == ["prune_cancelled_reasoning"]
+    # The cancelled pair is gone; the live pair survives.
+    fc_ids_surviving = [
+        p.function_call.id
+        for c in request.contents
+        for p in c.parts
+        if p.function_call is not None
+    ]
+    fr_ids_surviving = [
+        p.function_response.id
+        for c in request.contents
+        for p in c.parts
+        if p.function_response is not None
+    ]
+    assert fc_ids_surviving == ["fc-LIVE"]
+    assert fr_ids_surviving == ["fc-LIVE"]
+    # Both text contents survive.
+    text_parts = [
+        p.text for c in request.contents for p in c.parts if p.text
+    ]
+    assert text_parts == ["user input", "model continues"]
+
+
+@pytest.mark.asyncio
+async def test_context_edited_event_emitted_on_apply() -> None:
+    """A successful edit MUST emit a ``ContextEdited`` event with byte deltas."""
+
+    class _DropFirstContent:
+        name = "drop_first"
+
+        def edit(self, contents, ctx):  # type: ignore[no-untyped-def]
+            if not contents:
+                return None
+            return contents[1:]
+
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[_DropFirstContent()], sinks=[sink])
+    # Two text contents so the pairing invariant is satisfied (no
+    # function_call/response pairs at all).
+    request = FakeRequest(
+        contents=[
+            _text_content("preamble to drop"),
+            _text_content("keeper one"),
+            _text_content("keeper two"),
+        ]
+    )
+    session = FakeSession(plan=FakePlan(revision_index=3))
+
+    result = await editor.apply(
+        request, session=session, host_agent_name="a", observation_only=False
+    )
+
+    assert result.applied_rules == ["drop_first"]
+    edited_events = [
+        e for e in sink.events if isinstance(e, dict) and e.get("kind") == "context_edited"
+    ]
+    assert len(edited_events) == 1
+    payload = edited_events[0]["payload"]
+    assert payload["rule_name"] == "drop_first"
+    assert payload["bytes_after"] < payload["bytes_before"]
+    assert payload["contents_count_after"] == 2
+    assert payload["contents_count_before"] == 3
+    assert payload["observed_revision_index"] == 3
+
+
+@pytest.mark.asyncio
+async def test_build_editor_from_config_gating() -> None:
+    """``build_editor_from_config`` returns ``None`` for empty / unknown rules.
+
+    The plugin's ``before_model_callback`` short-circuits on the
+    editor being ``None`` — this gates the zero-overhead path.
+    """
+    # None / empty → None
+    assert build_editor_from_config(None) is None
+    assert build_editor_from_config([]) is None
+
+    # Unknown rule name → None (filtered + logged at WARNING)
+    assert build_editor_from_config(["nope"]) is None
+    assert build_editor_from_config(["nope", "also_nope"]) is None
+
+    # Known rule → editor with that rule registered
+    editor = build_editor_from_config(["prune_cancelled_reasoning"])
+    assert editor is not None
+    rules = editor.rules
+    assert len(rules) == 1
+    assert rules[0].name == "prune_cancelled_reasoning"
+
+    # Mixed known + unknown — unknowns dropped silently, knowns honoured.
+    editor = build_editor_from_config(["prune_cancelled_reasoning", "nope"])
+    assert editor is not None
+    assert [r.name for r in editor.rules] == ["prune_cancelled_reasoning"]
+
+
+@pytest.mark.asyncio
+async def test_drop_only_invariant_rejects_growth() -> None:
+    """A rule that grows ``contents`` MUST be reverted with reason ``not_drop_only``."""
+
+    class _Grower:
+        name = "grower"
+
+        def edit(self, contents, ctx):  # type: ignore[no-untyped-def]
+            # Doubles the contents — clear violation of drop-only.
+            return list(contents) + list(contents)
+
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[_Grower()], sinks=[sink])
+    request = FakeRequest(contents=[_text_content("a"), _text_content("b")])
+    original_contents = list(request.contents)
+
+    result = await editor.apply(
+        request, session=FakeSession(), host_agent_name="a", observation_only=False
+    )
+
+    assert request.contents == original_contents
+    assert result.applied_rules == []
+    assert ("grower", "not_drop_only") in result.rejected_rules
+    rejected_events = [
+        e for e in sink.events if isinstance(e, dict) and e.get("kind") == "context_edit_rejected"
+    ]
+    assert len(rejected_events) == 1
+    assert rejected_events[0]["payload"]["reason"] == "not_drop_only"
+
+
+@pytest.mark.asyncio
+async def test_prune_cancelled_reasoning_no_cancelled_ids_is_noop() -> None:
+    """When no ids are stamped on session.state, the rule returns None (skip)."""
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[PruneCancelledReasoningRule()], sinks=[sink])
+    request = FakeRequest(
+        contents=[
+            _text_content("user input"),
+            _call_content("fc-LIVE"),
+            _response_content("fc-LIVE"),
+        ]
+    )
+    original_contents = list(request.contents)
+
+    result = await editor.apply(
+        request,
+        session=FakeSession(),  # no cancelled ids stamped
+        host_agent_name="a",
+        observation_only=False,
+    )
+
+    assert request.contents == original_contents
+    assert result.applied_rules == []
+    # Skipped (not rejected) — rule returned None.
+    assert "prune_cancelled_reasoning" in result.skipped_rules
+
+
+@pytest.mark.asyncio
+async def test_rule_that_raises_is_skipped_chain_continues() -> None:
+    """A raising rule is logged + skipped; subsequent rules still run."""
+
+    class _Raiser:
+        name = "raiser"
+
+        def edit(self, contents, ctx):  # type: ignore[no-untyped-def]
+            raise RuntimeError("boom")
+
+    class _DropFirst:
+        name = "drop_first"
+
+        def edit(self, contents, ctx):  # type: ignore[no-untyped-def]
+            return contents[1:] if len(contents) > 1 else None
+
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[_Raiser(), _DropFirst()], sinks=[sink])
+    request = FakeRequest(
+        contents=[_text_content("drop me"), _text_content("survive")]
+    )
+
+    result = await editor.apply(
+        request, session=FakeSession(), host_agent_name="a", observation_only=False
+    )
+
+    assert ("raiser", "rule_raised") in result.rejected_rules
+    assert "drop_first" in result.applied_rules
+    assert [c.parts[0].text for c in request.contents] == ["survive"]

--- a/tests/test_context_editor.py
+++ b/tests/test_context_editor.py
@@ -97,7 +97,7 @@ class FakeSession:
     ``state`` is a plain dict; the
     :class:`~goldfive.context_editor.PruneCancelledReasoningRule` reads
     ``goldfive.cancelled_function_call_ids`` off it via
-    :func:`goldfive.orchestration_state.read_cancelled_function_call_ids`.
+    :func:`goldfive.state_store.read_cancelled_function_call_ids`.
     """
 
     def __init__(
@@ -328,7 +328,7 @@ async def test_prune_cancelled_reasoning_smoke() -> None:
     its paired function_response) and leave the live pair + any text
     intact.
     """
-    from goldfive import orchestration_state as _ostate
+    from goldfive import state_store as _ostate
 
     session = FakeSession()
     # Stamp one cancelled function_call_id on goldfive Session state


### PR DESCRIPTION
**DO NOT MERGE — team lead reviews.**

Closes #397 in part. Implements Phase 1 of the design proposed in #398.

## Design critique (the brief asked for this)

The proposal in #398 holds up. Four pragmatic adjustments shipped:

1. **Protocol shape simplified.** Single `edit(contents, ctx) -> list[Content] | None` replaces the proposed `applies()+edit()` pair. `None` means "no change this revision; skip". Equivalent surface, one fewer call to misuse.
2. **Drop-only invariant made explicit.** "No injection" is now a structural byte- and content-count monotonicity gate. A rule's output `contents` MUST have ≤ the input's byte total AND ≤ the input's content count; violations revert with `reason='not_drop_only'`. This was implicit in the proposal.
3. **State-audit extension is documentation-only in Phase 1.** `_state_audit.py` today funnels ADK `session.state` writes through `_adk_state_protocol._set`. There is no analogous funnel for `llm_request.contents`. A runtime list-mutation tripwire would require wrapping `contents` in a tracked proxy with measurable hot-path overhead; instead, this PR adds `_REQUEST_CONTENTS_AUTHORISED_SITES` cataloging `ContextEditor.apply` as the sole authorised site (with the supporting docstring evidence that every other goldfive site is read-only). A runtime extension is a focused follow-up if a regression surfaces.
4. **`ContextEdited` event uses `make_event` dict envelope** (no proto regen). Mirrors the `pin_resolved` precedent at `_adk_plugin.py::_emit_pin_resolved` — exactly the "telemetry-only, no state effect" event class the brief asked me to look for.

**Verified the doc's two debatable claims:**
* `before_model_callback` IS the right hook — `on_event_callback` returns a replacement *event*, not modified `contents`. Editing via `on_event_callback` would (a) persist the edit in `session.events` violating "log-out-of-loop", (b) not compose for multi-event pruning rules.
* `PruneCancelledReasoningRule` IS identifiable from runtime state. `orchestration_state.read_cancelled_function_call_ids(session.state)` is the authoritative cancelled-id list — written by `ADKAdapter._heal_pending_tool_calls` after every cancel. The rule reads this set and prunes whole `Content`s touching cancelled `function_call.id`s, satisfying the pairing invariant naturally.

## What shipped

* `goldfive/context_editor.py` (~580 LOC) — `ContextEditor` class, `ContextEditRule` protocol, `ContextEditContext` read-only context dataclass, `PruneCancelledReasoningRule`, `build_editor_from_config(rule_names, sinks)` factory, `_RULE_REGISTRY` mapping name → factory.
* All five mandatory invariants: `observation_only` gate (Inv 1), `tool_call_id` pairing (Inv 2), drop-only / no-injection (Inv 3), idempotence-per-revision contractual on rule authors + validated by tests (Inv 4), log-out-of-loop via dict-envelope events (Inv 5).
* Revert-on-violation: invariant trips revert to pre-rule `contents` and emit `context_edit_rejected` with one of `tool_call_id_pair_violation` / `empty_contents` / `not_drop_only` / `rule_raised`. Chain continues after a rejection (subsequent rules see the pre-rule state).
* Feature flag: `SteeringConfig.context_editor_rules: list[str] | None = None`. None / empty / unknown-only → `build_editor_from_config` returns `None` and the plugin's `before_model_callback` skips with one `is None` check (zero overhead).
* Env surface: `GOLDFIVE_STEER_CONTEXT_EDITOR_RULES=name1,name2`.
* Wired through `goldfive.wrap` → `auto_adapter` → `ADKAdapter` → `make_adk_plugin` → `_GoldfiveADKPlugin.before_model_callback` (AFTER `_inject_goldfive_planner_instruction` + `_inject_runtime_tools_hint`, BEFORE instrumentation). Sinks resolution moved earlier in `goldfive.wrap` so the editor shares the same fan-out as the rest of the runtime.
* `_state_audit.py` extended with `_REQUEST_CONTENTS_AUTHORISED_SITES` constant + commentary.
* `docs/design/CONTEXT-EDITING.md` updated to match (status + four implementation deltas + corrected protocol shape).
* 10 new unit tests in `tests/test_context_editor.py` covering every contract in the brief.

## What's deferred (per the design doc's phased plan)

* `PruneTransientErrorRule` — Phase 2 PR.
* `PruneStaleSteerRule` — Phase 3 PR (needs refine-cycle coordination).
* `CompactPriorReasoningRule` — Phase 5, opt-in only.
* Runtime list-mutation tripwire in `_state_audit.py` — follow-up PR if a regression surfaces.
* `ContextEdited` proto-schema slot — focused proto-regen PR; dict envelope satisfies the observability contract today.

## Wave coordination

* **Wave A1 (StateStore merge, #399)** — does not touch `_state_audit.py` catalog entries this PR added; clean rebase expected.
* **Wave B1 (PromptShaper)** — when it lands, this PR's `before_model_callback` wiring should move to AFTER `PromptShaper`'s new module. The current wiring sits after the four inject sites B1 will extract, so the rebase is mechanical (the call moves with the inject sites).
* **Wave C (steerer split)** — `_is_observation_only` reads `steerer._observation_only`; if Wave C relocates the steerer's state, this helper needs a one-line update.

## Test plan

- [x] 10 new unit tests in `tests/test_context_editor.py`, all passing.
- [x] Full suite: `pytest tests/ -x --tb=short` — **2448 passed, 59 skipped** (was 2433 before this branch; +15).
- [x] Lint: `ruff check` clean on all touched files.
- [x] Strict state-ownership audit (`GOLDFIVE_STRICT_STATE_OWNERSHIP=1` via the autouse fixture) passes.
- [ ] **No e2e test in this PR** — the audit agent is separately verifying steering mode under live runs. The unit tests exercise every contract in isolation.

## Files

* New: `goldfive/context_editor.py`, `tests/test_context_editor.py`, `docs/design/CONTEXT-EDITING.md`.
* Modified: `goldfive/config.py` (+25 / -0), `goldfive/_state_audit.py` (+34 / -0), `goldfive/adapters/_adk_plugin.py` (+72 / -0), `goldfive/adapters/adk.py` (+12 / -0), `goldfive/adapters/auto.py` (+3 / -0), `goldfive/convenience.py` (+22 / -1).
* Net: **+1802 LOC** (heavy on docstrings; ~580 LOC of actual logic in `context_editor.py`).

Link: #397