### PR TITLE
feat(planner): strengthen refine prompt against dropping terminal tasks (Gemma-class models)

### DIFF
--- a/goldfive/planner.py
+++ b/goldfive/planner.py
@@ -1973,8 +1973,22 @@ class LLMPlanner:
             "MUST appear verbatim in your `tasks` array. Same `id`, "
             "`title`, `assignee_agent_id`, and same terminal `status`. "
             "You MUST NOT drop them, rename them, or regress their status "
-            "back to PENDING/RUNNING/BLOCKED.",
+            "back to PENDING/RUNNING/BLOCKED. NOTE: 'terminal' here means "
+            "task STATUS (COMPLETED/FAILED/CANCELLED), NOT graph position "
+            "— a leaf task whose status is PENDING is NOT terminal. A "
+            "terminal task with no downstream successors is still terminal "
+            "and still MUST be kept. The most common failure mode on "
+            "weaker models is silently dropping a terminal task that "
+            "has no downstream consumers because 'it looks done'; the "
+            "validator rejects this with `terminal task '<id>' missing "
+            "in revision` and the run escalates to human intervention. "
+            "DO NOT do this.",
             f"   Terminal tasks in the current plan: {terminal_json}",
+            "   VALID revision shape (terminal tasks preserved verbatim):",
+            '     "tasks": [..., {"id": "<terminal_id>", "title": "...", '
+            '"status": "COMPLETED", "assignee_agent_id": "..."}, ...]',
+            "   INVALID revision shape (terminal task omitted — REJECTED):",
+            '     "tasks": [<new PENDING tasks only; <terminal_id> missing>]',
             "",
             "2. TERMINAL->TERMINAL EDGES (edges where BOTH endpoints are "
             "terminal tasks) MUST appear verbatim in your `edges` array. "

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2355,3 +2355,63 @@ def test_render_structural_invariants_does_NOT_double_carry_supersession() -> No
     # system prompts. Asserting absence here pins the separation of
     # concerns.
     assert "REUSE-OR-SUPERSEDE" not in rendered
+
+
+def test_render_structural_invariants_disambiguates_terminal_status_vs_graph_leaf() -> None:
+    """Weak-model strengthening: the invariants block explicitly
+    distinguishes status-terminal (COMPLETED/FAILED/CANCELLED) from
+    graph-terminal (leaf with no successors). The 2026-05-13 Gemma 26B
+    failure surfaced as a dropped terminal task; the model treated
+    "no downstream consumers" as license to omit the task. The prompt
+    must now spell out that status is the only criterion.
+    """
+    from goldfive.planner import LLMPlanner
+    from goldfive.types import Plan, Task, TaskEdge, TaskStatus
+    plan = Plan(
+        id="p", run_id="r", goal_ids=[],
+        tasks=[
+            Task(id="research", title="Research", status=TaskStatus.COMPLETED),
+            Task(id="draft_presentation", title="Draft", status=TaskStatus.COMPLETED),
+        ],
+        edges=[TaskEdge(from_task_id="research", to_task_id="draft_presentation")],
+    )
+    planner = LLMPlanner(call_llm=None, model="m")
+    rendered = planner._render_structural_invariants_block(plan)
+    # Disambiguation: status, not graph position.
+    assert "task STATUS" in rendered
+    assert "NOT graph position" in rendered
+    # Explicit naming of the leaf-terminal failure mode.
+    assert "no downstream successors is still terminal" in rendered
+    # Explicit naming of the most common weak-model failure pattern,
+    # including the validator error string operators see in logs.
+    assert "terminal task '<id>' missing in revision" in rendered
+    # VALID + INVALID example labels — structural markup weaker models
+    # tend to follow better than free prose.
+    assert "VALID revision shape" in rendered
+    assert "INVALID revision shape" in rendered
+
+
+async def test_refine_prompt_carries_strengthened_terminal_guidance() -> None:
+    """End-to-end: the strengthened terminal-tasks guidance reaches the
+    LLM via the user prompt on the LOOPING_TOOL_CALL refine path (which
+    routes through _render_structural_invariants_block). Mirrors
+    test_refine_prompt_enumerates_terminal_tasks_and_edges but pins the
+    weak-model disambiguation tokens specifically.
+    """
+    scripted = _ScriptedLLM([_good_looping_revision_json()])
+    planner = LLMPlanner(call_llm=scripted, max_refine_attempts=2)
+    drift = DriftEvent(
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        severity=DriftSeverity.WARNING,
+        detail="stuck",
+        current_task_id="draft_slides",
+    )
+
+    await planner.refine(plan=_looping_plan(), drift=drift, goals=_goals())
+
+    _system, user_prompt, _model = scripted.calls[0]
+    # The strengthening lands in the prompt the LLM actually sees.
+    assert "task STATUS" in user_prompt
+    assert "no downstream successors is still terminal" in user_prompt
+    assert "VALID revision shape" in user_prompt
+    assert "INVALID revision shape" in user_prompt


### PR DESCRIPTION
## Summary

- Adds three targeted strengtheners to the terminal-tasks invariant inside `_render_structural_invariants_block` to make it harder for weak models (Gemma 26B class) to drop a status-terminal task whose only "sin" is having no downstream consumers.
- No validator change — `Plan.validate(for_revision=True, prior=...)` already rejects the failure mode. This is purely a prompt-side reduction in the rate the validator needs to fire on weaker models.
- Two new regression tests pin the strengthened prompt content at both the helper-render layer and the user-prompt layer (via the LOOPING_TOOL_CALL refine path).

## Surfaced by

2026-05-13 cherry-tree e2e session `2d27ff4a` ran into a `SCHEMA_VIOLATION` at 0:56 — `terminal task 'draft_presentation' missing in revision` — after Gemma's refine response omitted a COMPLETED task that had no downstream successors. The refine retry loop exhausted and the run escalated to `HUMAN_INTERVENTION_REQUIRED CRITICAL`.

## Weakness vectors identified

1. The existing invariant said `(status in {COMPLETED, FAILED, CANCELLED})` parenthetically, but weak models still conflate "terminal" with "graph leaf" and treat leaf-status-terminal tasks as droppable.
2. No "common failure mode" call-out naming the validator error string operators see; the model had no signal that this specific shape would fail.
3. No copy-paste VALID/INVALID example pair adjacent to the JSON-enumerated terminal tasks — only a prose rule.

## Prompt diff (before -> after)

Before:
```
1. TERMINAL TASKS (status in {COMPLETED, FAILED, CANCELLED}) MUST appear verbatim in your `tasks` array. Same `id`, `title`, `assignee_agent_id`, and same terminal `status`. You MUST NOT drop them, rename them, or regress their status back to PENDING/RUNNING/BLOCKED.
   Terminal tasks in the current plan: <json>
```

After (delta inline; same enumerated-tasks JSON still rendered):
```
1. TERMINAL TASKS (...) MUST appear verbatim ... NOTE: 'terminal' here
   means task STATUS (COMPLETED/FAILED/CANCELLED), NOT graph position
   — a leaf task whose status is PENDING is NOT terminal. A terminal
   task with no downstream successors is still terminal and still
   MUST be kept. The most common failure mode on weaker models is
   silently dropping a terminal task that has no downstream consumers
   because 'it looks done'; the validator rejects this with
   `terminal task '<id>' missing in revision` and the run escalates
   to human intervention. DO NOT do this.
   Terminal tasks in the current plan: <json>
   VALID revision shape (terminal tasks preserved verbatim):
     "tasks": [..., {"id": "<terminal_id>", "title": "...", "status": "COMPLETED", "assignee_agent_id": "..."}, ...]
   INVALID revision shape (terminal task omitted — REJECTED):
     "tasks": [<new PENDING tasks only; <terminal_id> missing>]
```

Net diff: +16 lines (one invariant inside one helper). Per-call token cost is bounded — the helper feeds 2 of the 4 system-prompt sites.

## Regression test scope

- `test_render_structural_invariants_disambiguates_terminal_status_vs_graph_leaf` — pins the disambiguation tokens, the validator-error citation, and the VALID/INVALID example labels on `_render_structural_invariants_block`'s direct output.
- `test_refine_prompt_carries_strengthened_terminal_guidance` — end-to-end via `LLMPlanner.refine()` on a `LOOPING_TOOL_CALL` drift; asserts the strengthened tokens appear in the user prompt the scripted LLM actually sees.
- Real-LLM rate-of-improvement validation requires a live Gemma run; not in scope here.

## What was NOT changed

- `Plan.validate()` rules — untouched; the prompt already matched them.
- `_REFINE_SYSTEM_PROMPT`, `_USER_STEER_SYSTEM_PROMPT`, `_REFINEMENT_GUIDANCE_BLOCK`, `_SUPERSESSION_INVARIANT`, `_SUPERSESSION_EXAMPLES` — already strong; no edit needed.
- The retry-loop copy-paste-ready snippet path (`_build_correction_prompt` + `_structural_correction_snippet`) — already covers the `terminal_missing` rejection class with `KEEP THIS TASK VERBATIM IN YOUR \`tasks\` ARRAY ...`. Confirmed via existing tests in `test_planner_correction_prompt.py`.

## Test plan

- [x] `pytest tests/` — 2095 passed, 126 skipped (full suite)
- [x] Targeted planner suite (`test_planner*`, `test_refine_*`, `test_plan_*`, `test_task_supersedes_validator.py`, `test_cancel_inflight_on_refine.py`) — 199 passed, 3 skipped
- [ ] Real-Gemma e2e validation (out of scope for this PR; needs live run)