### PR TITLE
refactor(tests): consolidate env fixtures + drop drift_observer sibling logger

### DIFF
--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -169,15 +169,15 @@ if TYPE_CHECKING:
 ReflectiveCallLLM = Callable[[str, str, str], Awaitable[str]]
 
 log = logging.getLogger(__name__)
-# Tests + harmonograf consumers grep for ``"DefaultSteerer."`` prefixes
-# and the ``goldfive.steerer`` logger name across log records the
-# observation + judge surface emits. Keep emitting under that logger
-# name so the contract survives the bucket-3b extraction byte-for-byte
-# (cf. the structural ``"stale judge verdict"`` INFO line asserted by
-# :file:`tests/test_judge_task_lifetime.py`). The module's other logs
-# stay on the ``goldfive.drift_observer`` logger so log-routing /
-# filtering scoped to this component still works.
-_steerer_log = logging.getLogger("goldfive.steerer")
+# Wave C bucket 3b/3c post-cleanup: the module previously kept a
+# sibling ``_steerer_log = logging.getLogger("goldfive.steerer")``
+# because the test corpus asserted on ``record.name == "goldfive.steerer"``.
+# Those assertions have been widened to message-content predicates so
+# we no longer need the sibling — every log line on this module now
+# lands on the natural ``goldfive.drift_observer`` logger (``log``).
+# Operators / harmonograf consumers should grep on message content
+# (``"DefaultSteerer."`` prefixes, ``"stale judge verdict"``, etc.)
+# or on the parent ``goldfive`` logger.
 
 
 class DriftObserver:
@@ -1076,7 +1076,7 @@ class DriftObserver:
         """
         if self._is_duplicate_steer(event, session):
             steer_id = self._steer_dedupe_id(event)
-            _steerer_log.debug("DefaultSteerer.observe: dropping duplicate STEER id=%s", steer_id)
+            log.debug("DefaultSteerer.observe: dropping duplicate STEER id=%s", steer_id)
             return
         drift = self._drift_from_control(event, session)
         if drift is None:
@@ -1331,7 +1331,7 @@ class DriftObserver:
             # synchronous detectors run inline on the model-response
             # callback and always see a live invocation.
             if self._is_late_drift_for_terminated_invocation(drift, session):
-                _steerer_log.info(
+                log.info(
                     "DefaultSteerer: stale judge verdict; invocation for "
                     "agent=%r task=%r already terminated; drift kind=%s "
                     "recorded but refine skipped",
@@ -1350,7 +1350,7 @@ class DriftObserver:
             # the WARNING log below muddying the signal.
             raise
         except Exception as exc:  # noqa: BLE001 — background task
-            _steerer_log.warning(
+            log.warning(
                 "DefaultSteerer: background reasoning-judge raised (swallowed): %s",
                 exc,
             )
@@ -1386,7 +1386,7 @@ class DriftObserver:
         confidence = float(getattr(verdict, "focus_confidence", 0.0) or 0.0)
         threshold = self._steerer._reasoning_binding_confidence_threshold
         if confidence < threshold:
-            _steerer_log.debug(
+            log.debug(
                 "DefaultSteerer: reasoning binding for agent=%r "
                 "task=%r dropped (confidence=%.2f < threshold=%.2f)",
                 agent_name,
@@ -1408,7 +1408,7 @@ class DriftObserver:
                 session_id=session.id,
             )
             if recorded is not None:
-                _steerer_log.info(
+                log.info(
                     "DefaultSteerer: recorded reasoning-extracted binding "
                     "agent=%r task=%r confidence=%.2f",
                     agent_name,
@@ -1416,7 +1416,7 @@ class DriftObserver:
                     confidence,
                 )
         except Exception as exc:  # noqa: BLE001 — never break the run
-            _steerer_log.warning(
+            log.warning(
                 "DefaultSteerer: record_reasoning_extracted_binding raised (swallowed): %s",
                 exc,
             )
@@ -1492,7 +1492,7 @@ class DriftObserver:
         drain — operator intent survives across turns by construction.
         """
         if not session_id:
-            _steerer_log.warning(
+            log.warning(
                 "DefaultSteerer.drain_session_background_tasks: empty "
                 "session_id; refusing to drain (would otherwise match "
                 "every pending background task)",
@@ -1586,7 +1586,7 @@ class DriftObserver:
             # / WARNING reserved for the real "we cancelled work"
             # signal.
             if still_pending:
-                _steerer_log.warning(
+                log.warning(
                     "DefaultSteerer.shutdown: %d background %s task(s) "
                     "exceeded %.2fs timeout; cancelled",
                     len(still_pending),
@@ -1594,7 +1594,7 @@ class DriftObserver:
                     float(timeout),
                 )
             else:
-                _steerer_log.debug(
+                log.debug(
                     "DefaultSteerer.shutdown: %.2fs timeout expired but "
                     "all %s tasks completed in the same instant; nothing "
                     "to cancel",
@@ -1830,7 +1830,7 @@ class DriftObserver:
                         verdict_str = "malformed"
                     span.decision_summary = f"reflective check on {task.id}: {verdict_str}"
         except Exception as exc:  # noqa: BLE001 - never break the run
-            _steerer_log.warning(
+            log.warning(
                 "DefaultSteerer.maybe_run_reflective_check: call_llm raised %s", exc
             )
             await self._emit_reflective_failure(
@@ -2054,7 +2054,7 @@ class DriftObserver:
                 # ``note_agent_activity`` uses.
                 del hist[:overflow]
         except Exception as exc:  # noqa: BLE001
-            _steerer_log.debug("note_tool_observation: swallowed: %s", exc)
+            log.debug("note_tool_observation: swallowed: %s", exc)
 
     async def note_agent_turn(self, session: Session) -> None:
         """Record one agent invocation against ``session``.
@@ -2277,7 +2277,7 @@ class DriftObserver:
             # against the still-pending tally without warning.
             raise
         except Exception as exc:  # noqa: BLE001 — background task
-            _steerer_log.warning(
+            log.warning(
                 "DefaultSteerer: background goal-drift judge raised "
                 "(swallowed): %s",
                 exc,
@@ -2322,7 +2322,7 @@ class DriftObserver:
         except RuntimeError:
             # No loop — fall through silently. Same defensive pattern
             # as :meth:`_spawn_goal_drift_judge_background`.
-            _steerer_log.debug(
+            log.debug(
                 "DefaultSteerer._spawn_drift_handler_background: no running "
                 "loop; skipping spawn for kind=%s",
                 drift.kind.value,
@@ -2355,7 +2355,7 @@ class DriftObserver:
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # noqa: BLE001 — background task
-            _steerer_log.warning(
+            log.warning(
                 "DefaultSteerer: background drift handler raised "
                 "(swallowed): kind=%s exc=%s",
                 drift.kind.value,
@@ -2636,7 +2636,7 @@ class DriftObserver:
                 session.last_addressed_revision_by_drift_key.get(key, 0)
             )
             if last_addressed and drift.observed_revision_index < last_addressed:
-                _steerer_log.info(
+                log.info(
                     "DefaultSteerer._handle_drift: redundant verdict — "
                     "drift kind=%s target=%r observed revision %d but "
                     "same (kind, target) was already addressed at "
@@ -2866,7 +2866,7 @@ class DriftObserver:
                     # produce a meaningful change. Same escalation path
                     # as the structural no-op detector — pause for
                     # human intervention rather than retrying.
-                    _steerer_log.info(
+                    log.info(
                         "DefaultSteerer._handle_drift: planner.refine raised "
                         "RefineExhausted for kind=%s task=%r: %s",
                         drift.kind.value,
@@ -2890,7 +2890,7 @@ class DriftObserver:
                     # LLM JSON after a mid-invocation cancel poisons the session)
                     # leaves session.plan unchanged and the executor re-enters
                     # the same state on the next tick.
-                    _steerer_log.warning(
+                    log.warning(
                         "DefaultSteerer._handle_drift: planner.refine(kind=%s) raised "
                         "%s; plan unchanged",
                         drift.kind.value,
@@ -2941,7 +2941,7 @@ class DriftObserver:
             # recurse through ``_handle_drift`` and eventually abort the
             # run. Mirrors the ``RefineExhausted`` and no-op-revision
             # escalation paths.
-            _steerer_log.warning(
+            log.warning(
                 "DefaultSteerer._handle_drift: planner.refine(kind=%s) returned None; "
                 "plan unchanged — escalating to HUMAN_INTERVENTION_REQUIRED",
                 drift.kind.value,
@@ -3015,7 +3015,7 @@ class DriftObserver:
         # index for a no-op, which would otherwise loop forever on a
         # judge that keeps re-firing on a corrected task.
         if self._steerer._plans_structurally_identical(session.plan, revised):
-            _steerer_log.info(
+            log.info(
                 "no-op revision skipped (kind=%s task=%r); escalating to "
                 "HUMAN_INTERVENTION_REQUIRED",
                 drift.kind.value,
@@ -3193,7 +3193,7 @@ class DriftObserver:
         # No cancel-and-restart fires on the executor; the live invocation
         # continues against the prior plan.
         if not self._steerer._should_inject():
-            _steerer_log.info(
+            log.info(
                 "DefaultSteerer._dispatch_goldfive_steer_control: "
                 "observation_only=True — SKIPPING GOLDFIVE_STEER enqueue. "
                 "would_have_dispatched kind=%s task=%s drift_id=%s "
@@ -3262,7 +3262,7 @@ class DriftObserver:
         from goldfive.control import ControlKind, ControlMessage
 
         if not self._steerer._should_inject():
-            _steerer_log.info(
+            log.info(
                 "DefaultSteerer._dispatch_goldfive_pause_control: "
                 "observation_only=True — SKIPPING GOLDFIVE_PAUSE_ESCALATE "
                 "dispatch. would_have_dispatched kind=%s task=%s "
@@ -3663,7 +3663,7 @@ class DriftObserver:
         live invocation.
         """
         if not self._steerer._should_inject():
-            _steerer_log.info(
+            log.info(
                 "DefaultSteerer.request_invocation_cancel: "
                 "observation_only=True — SKIPPING cancel for "
                 "drift kind=%s severity=%s agent=%s task=%s",
@@ -3771,7 +3771,7 @@ class DriftObserver:
             else:
                 flagged.append(inv_id)
         if flagged:
-            _steerer_log.info(
+            log.info(
                 "DefaultSteerer.request_invocation_cancel: flagged "
                 "invocations=%s for drift kind=%s severity=%s",
                 flagged,
@@ -3990,7 +3990,7 @@ class DriftObserver:
                 age = current_turn - active.at_turn
                 if 0 <= age < window:
                     drift.suppressed_by_user_steer = True
-                    _steerer_log.info(
+                    log.info(
                         "goldfive steer suppressed: user steer %r is active "
                         "(age=%d turns, window=%d)",
                         active.body,
@@ -4204,7 +4204,7 @@ class DriftObserver:
             except RefineExhausted as exc:
                 # goldfive#271: planner explicitly signalled handler
                 # exhaustion. Pause for human intervention.
-                _steerer_log.info(
+                log.info(
                     "DefaultSteerer._promote_drift_to_steer: refine raised "
                     "RefineExhausted for kind=%s task=%r: %s",
                     drift.kind.value,
@@ -4222,7 +4222,7 @@ class DriftObserver:
                 await self._emit_handler_exhausted_escalation(drift, session)
                 return
             except Exception as exc:  # noqa: BLE001
-                _steerer_log.warning(
+                log.warning(
                     "DefaultSteerer._promote_drift_to_steer: refine raised %s; plan unchanged",
                     exc,
                 )
@@ -4265,7 +4265,7 @@ class DriftObserver:
             # HUMAN_INTERVENTION_REQUIRED rather than emitting a
             # recursing CRITICAL follow-up drift that would eventually
             # abort the run.
-            _steerer_log.warning(
+            log.warning(
                 "DefaultSteerer._promote_drift_to_steer: refine returned None; "
                 "plan unchanged — escalating to HUMAN_INTERVENTION_REQUIRED"
             )
@@ -4320,7 +4320,7 @@ class DriftObserver:
         # identical plan means the planner cannot make progress on this
         # drift; escalate to HUMAN_INTERVENTION_REQUIRED.
         if self._steerer._plans_structurally_identical(session.plan, revised):
-            _steerer_log.info(
+            log.info(
                 "no-op refine_steer revision skipped (kind=%s task=%r); "
                 "escalating to HUMAN_INTERVENTION_REQUIRED",
                 drift.kind.value,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,3 +259,203 @@ def in_memory_runner() -> Callable[..., Any]:
 def tmp_jsonl_path(tmp_path):
     """Return a pathlib.Path to a .jsonl file inside pytest tmp_path."""
     return tmp_path / "events.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Env-var fixtures (Wave C bucket 3 cleanup)
+# ---------------------------------------------------------------------------
+#
+# Each ``GOLDFIVE_*`` (and the small ``OPENAI_*``) env-var family that the
+# config / from-env tests poke gets a dedicated fixture below. The fixtures
+# are thin wrappers over ``pytest.MonkeyPatch.setenv`` / ``delenv`` — they
+# do NOT touch ``os.environ`` directly, so the standard pytest
+# monkeypatch-teardown still owns the cleanup. The point of the fixture
+# is to (a) eliminate per-test boilerplate, (b) make the env surface a
+# test consumes visible from the fixture name (``goldfive_agent_env``
+# vs ``goldfive_embedding_env`` etc.), and (c) avoid each test inlining
+# the variable-name string.
+#
+# A fixture is named after the **config domain** rather than the env
+# var: callers ask for ``goldfive_steer_env`` and set
+# ``observation_only="1"`` — never the underlying
+# ``GOLDFIVE_STEER_OBSERVATION_ONLY`` string. The mapping is owned by
+# the fixture; callers must not bypass it.
+#
+# Reset semantics: each fixture pre-clears its variables via
+# ``delenv(..., raising=False)`` before yielding so tests start from a
+# guaranteed clean slate. Teardown is automatic via the underlying
+# monkeypatch fixture.
+
+
+class _EnvController:
+    """Thin controller backing the per-domain env-var fixtures.
+
+    Construction takes an explicit allow-list of env-var names: the
+    controller refuses ``set`` / ``unset`` calls for any other name so
+    a fixture's tests cannot accidentally poke a sibling family's
+    variables and confuse the reader of the fixture name.
+    """
+
+    def __init__(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        names: dict[str, str],
+    ) -> None:
+        self._monkeypatch = monkeypatch
+        # ``names`` maps a short kwarg-style key (``base_url``) to the
+        # underlying env-var name (``GOLDFIVE_EMBEDDING_BASE_URL``).
+        self._names = dict(names)
+
+    def _resolve(self, key: str) -> str:
+        if key not in self._names:
+            raise KeyError(
+                f"{key!r} is not a recognised env-var key for this "
+                f"fixture; expected one of {sorted(self._names)}"
+            )
+        return self._names[key]
+
+    def set(self, **kwargs: str) -> None:
+        """Set one or more env vars by short key.
+
+        Values are str-coerced so callers can pass ``1`` / ``True`` /
+        floats without ceremony.
+        """
+        for key, value in kwargs.items():
+            self._monkeypatch.setenv(self._resolve(key), str(value))
+
+    def unset(self, *keys: str) -> None:
+        """Delete one or more env vars (no-op if absent)."""
+        for key in keys:
+            self._monkeypatch.delenv(self._resolve(key), raising=False)
+
+    def clear(self) -> None:
+        """Delete every env var owned by this fixture."""
+        for env_name in self._names.values():
+            self._monkeypatch.delenv(env_name, raising=False)
+
+    def raw_setenv(self, env_name: str, value: str) -> None:
+        """Escape-hatch for tests that need to set a variant string
+        directly (e.g. the case-insensitivity / whitespace tests).
+
+        Only accepts env-var names this controller owns.
+        """
+        if env_name not in self._names.values():
+            raise KeyError(
+                f"{env_name!r} is not owned by this fixture; "
+                f"owned names: {sorted(self._names.values())}"
+            )
+        self._monkeypatch.setenv(env_name, value)
+
+
+_AGENT_ENV: dict[str, str] = {
+    "max_output_tokens": "GOLDFIVE_AGENT_MAX_OUTPUT_TOKENS",
+    "call_timeout_ms": "GOLDFIVE_AGENT_CALL_TIMEOUT_MS",
+}
+
+_EMBEDDING_ENV: dict[str, str] = {
+    "base_url": "GOLDFIVE_EMBEDDING_BASE_URL",
+    "model": "GOLDFIVE_EMBEDDING_MODEL",
+    "api_key": "GOLDFIVE_EMBEDDING_API_KEY",
+    "timeout_ms": "GOLDFIVE_EMBEDDING_TIMEOUT_MS",
+}
+
+_STEER_ENV: dict[str, str] = {
+    "observation_only": "GOLDFIVE_STEER_OBSERVATION_ONLY",
+    "threshold": "GOLDFIVE_STEER_THRESHOLD",
+    "suppression_window_turns": "GOLDFIVE_STEER_SUPPRESSION_WINDOW_TURNS",
+}
+
+_TOOL_LOOP_ENV: dict[str, str] = {
+    "window": "GOLDFIVE_TOOL_LOOP_WINDOW",
+    "exact_threshold": "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD",
+    "name_threshold": "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD",
+    "alternating_threshold": "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD",
+}
+
+_REASONING_DRIFT_ENV: dict[str, str] = {
+    "mode": "GOLDFIVE_DRIFT_REASONING_MODE",
+    "off_topic_distance": "GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE",
+    "intent_healthy_similarity": "GOLDFIVE_DRIFT_INTENT_HEALTHY_SIMILARITY",
+    "intent_minor_similarity": "GOLDFIVE_DRIFT_INTENT_MINOR_SIMILARITY",
+    "intent_warning_similarity": "GOLDFIVE_DRIFT_INTENT_WARNING_SIMILARITY",
+    "looping_similarity": "GOLDFIVE_DRIFT_LOOPING_SIMILARITY",
+    "cluster_similarity": "GOLDFIVE_DRIFT_CLUSTER_SIMILARITY",
+    "looping_hash_window": "GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW",
+    "fallback_to_content": "GOLDFIVE_DRIFT_FALLBACK_TO_CONTENT",
+}
+
+_GOAL_DRIFT_ENV: dict[str, str] = {
+    "check_interval": "GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL",
+    "activity_window": "GOLDFIVE_GOAL_DRIFT_ACTIVITY_WINDOW",
+}
+
+_JUDGE_ENV: dict[str, str] = {
+    "base_url": "GOLDFIVE_JUDGE_BASE_URL",
+    "model": "GOLDFIVE_JUDGE_MODEL",
+    "api_key": "GOLDFIVE_JUDGE_API_KEY",
+    "timeout_ms": "GOLDFIVE_JUDGE_TIMEOUT_MS",
+}
+
+_FAIL_FAST_ENV: dict[str, str] = {
+    "revision_rejection": "GOLDFIVE_FAIL_FAST_REVISION_REJECTION",
+    "invoke_cancel": "GOLDFIVE_FAIL_FAST_ON_INVOKE_CANCEL",
+}
+
+_EXAMPLES_ENV: dict[str, str] = {
+    "topic": "GOLDFIVE_EXAMPLE_TOPIC",
+    "openai_api_key": "OPENAI_API_KEY",
+    "harmonograf_server": "HARMONOGRAF_SERVER",
+}
+
+
+def _make_env_fixture(env_map: dict[str, str]) -> Callable[..., Iterator[_EnvController]]:
+    """Build a fixture function that yields an ``_EnvController`` over ``env_map``."""
+
+    @pytest.fixture
+    def _fixture(monkeypatch: pytest.MonkeyPatch) -> Iterator[_EnvController]:
+        controller = _EnvController(monkeypatch, env_map)
+        # Start from a clean slate: any of these env vars set in the
+        # ambient environment must not leak into the test.
+        controller.clear()
+        yield controller
+        # No teardown needed — monkeypatch unwinds set/delenv automatically.
+
+    return _fixture
+
+
+goldfive_agent_env = _make_env_fixture(_AGENT_ENV)
+goldfive_embedding_env = _make_env_fixture(_EMBEDDING_ENV)
+goldfive_steer_env = _make_env_fixture(_STEER_ENV)
+goldfive_tool_loop_env = _make_env_fixture(_TOOL_LOOP_ENV)
+goldfive_reasoning_drift_env = _make_env_fixture(_REASONING_DRIFT_ENV)
+goldfive_goal_drift_env = _make_env_fixture(_GOAL_DRIFT_ENV)
+goldfive_judge_env = _make_env_fixture(_JUDGE_ENV)
+goldfive_fail_fast_env = _make_env_fixture(_FAIL_FAST_ENV)
+goldfive_examples_env = _make_env_fixture(_EXAMPLES_ENV)
+
+
+@pytest.fixture
+def goldfive_runtime_env(
+    goldfive_embedding_env: _EnvController,
+    goldfive_tool_loop_env: _EnvController,
+    goldfive_reasoning_drift_env: _EnvController,
+    goldfive_goal_drift_env: _EnvController,
+    goldfive_judge_env: _EnvController,
+    goldfive_steer_env: _EnvController,
+    goldfive_agent_env: _EnvController,
+) -> dict[str, _EnvController]:
+    """Bundle every ``RuntimeConfig`` sub-domain controller for tests
+    that exercise the aggregate ``RuntimeConfig.from_env()`` path.
+
+    Returned as a dict keyed by sub-domain so a single test can poke
+    multiple families without claiming half a dozen named fixtures.
+    """
+    return {
+        "embedding": goldfive_embedding_env,
+        "tool_loop": goldfive_tool_loop_env,
+        "reasoning_drift": goldfive_reasoning_drift_env,
+        "goal_drift": goldfive_goal_drift_env,
+        "judge": goldfive_judge_env,
+        "steer": goldfive_steer_env,
+        "agent": goldfive_agent_env,
+    }

--- a/tests/examples/test_presentation_agent.py
+++ b/tests/examples/test_presentation_agent.py
@@ -82,11 +82,13 @@ def test_mock_run_completes_successfully() -> None:
     assert task_ids == {"research", "build", "review", "debug"}
 
 
-def test_app_is_valid_adk_app(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_app_is_valid_adk_app(goldfive_examples_env) -> None:
     """``app`` must load offline and present a ``BaseAgent`` root."""
     # Force mock-mode App construction — no OPENAI_API_KEY, no harmonograf.
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("HARMONOGRAF_SERVER", raising=False)
+    # The fixture's ``clear()`` pre-step already unset both variables in
+    # the calling environment, so the explicit unsets below are belt-
+    # and-braces for readers; either is sufficient.
+    goldfive_examples_env.unset("openai_api_key", "harmonograf_server")
 
     # Reset the cached app so we build a fresh one under the scrubbed env.
     from examples.presentation_agent import agent as agent_mod

--- a/tests/examples/test_presentation_agent_adk_web.py
+++ b/tests/examples/test_presentation_agent_adk_web.py
@@ -110,7 +110,10 @@ PLUGIN_REGISTRATIONS_MAX = 5
 
 
 @pytest.fixture
-def presentation_agent_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+def presentation_agent_env(
+    monkeypatch: pytest.MonkeyPatch,
+    goldfive_examples_env: Any,
+) -> Iterator[str]:
     """Stage ``examples/presentation_agent`` under a tmp agents_dir.
 
     Copies the example tree into a temp dir so the ADK ``AgentLoader``
@@ -121,12 +124,13 @@ def presentation_agent_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
     Yields the temp agents_dir path. Cleanup is handled by the
     ``TemporaryDirectory`` context manager.
     """
-    # Mock-mode env: no real LLM, no telemetry server.
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("HARMONOGRAF_SERVER", raising=False)
+    # Mock-mode env: no real LLM, no telemetry server. ``clear()`` in
+    # the fixture setup already cleared these; the explicit unsets are
+    # belt-and-braces for readers.
+    goldfive_examples_env.unset("openai_api_key", "harmonograf_server")
     # Pin the topic so plan / goal IDs are stable across reruns. The
     # presentation_agent module reads this at _build_app time.
-    monkeypatch.setenv("GOLDFIVE_EXAMPLE_TOPIC", "solar-panels")
+    goldfive_examples_env.set(topic="solar-panels")
 
     # Reset any cached ``_APP`` so a prior test in the same process
     # doesn't hand back a stale App built under different env vars. The

--- a/tests/test_agent_budget.py
+++ b/tests/test_agent_budget.py
@@ -59,27 +59,26 @@ def test_agent_config_defaults() -> None:
     assert cfg.call_timeout_ms == 120_000
 
 
-def test_agent_config_from_env_max_output_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_agent_config_from_env_max_output_tokens(goldfive_agent_env: Any) -> None:
     """``GOLDFIVE_AGENT_MAX_OUTPUT_TOKENS`` overrides the field default."""
-    monkeypatch.setenv("GOLDFIVE_AGENT_MAX_OUTPUT_TOKENS", "1024")
+    goldfive_agent_env.set(max_output_tokens=1024)
     cfg = AgentConfig.from_env()
     assert cfg.max_output_tokens == 1024
     # Other field unaffected.
     assert cfg.call_timeout_ms == 120_000
 
 
-def test_agent_config_from_env_call_timeout_ms(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_agent_config_from_env_call_timeout_ms(goldfive_agent_env: Any) -> None:
     """``GOLDFIVE_AGENT_CALL_TIMEOUT_MS`` overrides the field default."""
-    monkeypatch.setenv("GOLDFIVE_AGENT_CALL_TIMEOUT_MS", "30000")
+    goldfive_agent_env.set(call_timeout_ms=30000)
     cfg = AgentConfig.from_env()
     assert cfg.call_timeout_ms == 30_000
     assert cfg.max_output_tokens == 16384
 
 
-def test_agent_config_from_env_ignores_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_agent_config_from_env_ignores_invalid(goldfive_agent_env: Any) -> None:
     """Non-integer / non-positive env values fall back to the field default."""
-    monkeypatch.setenv("GOLDFIVE_AGENT_MAX_OUTPUT_TOKENS", "not-an-int")
-    monkeypatch.setenv("GOLDFIVE_AGENT_CALL_TIMEOUT_MS", "0")
+    goldfive_agent_env.set(max_output_tokens="not-an-int", call_timeout_ms="0")
     cfg = AgentConfig.from_env()
     assert cfg.max_output_tokens == 16384
     assert cfg.call_timeout_ms == 120_000
@@ -93,10 +92,9 @@ def test_runtime_config_carries_agent_subconfig() -> None:
     assert runtime.agent.max_output_tokens == 16384
 
 
-def test_runtime_config_from_env_threads_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_runtime_config_from_env_threads_agent(goldfive_agent_env: Any) -> None:
     """``RuntimeConfig.from_env()`` calls :meth:`AgentConfig.from_env`."""
-    monkeypatch.setenv("GOLDFIVE_AGENT_MAX_OUTPUT_TOKENS", "2048")
-    monkeypatch.setenv("GOLDFIVE_AGENT_CALL_TIMEOUT_MS", "90000")
+    goldfive_agent_env.set(max_output_tokens=2048, call_timeout_ms=90000)
     runtime = RuntimeConfig.from_env()
     assert runtime.agent.max_output_tokens == 2048
     assert runtime.agent.call_timeout_ms == 90_000

--- a/tests/test_call_llm_diagnostic.py
+++ b/tests/test_call_llm_diagnostic.py
@@ -66,7 +66,7 @@ async def test_adk_builder_logs_diagnostic_when_all_thoughts_no_answer(caplog):
     call_llm = make_default_adk_call_llm(stub)
     assert call_llm is not None
 
-    with caplog.at_level(logging.INFO, logger="goldfive.llm_detect"):
+    with caplog.at_level(logging.INFO, logger="goldfive"):
         out = await call_llm("system", "user", "stub")
 
     assert out == "", "all-thought response must produce empty answer"
@@ -117,7 +117,7 @@ async def test_adk_builder_no_diagnostic_on_normal_response(caplog):
     call_llm = make_default_adk_call_llm(stub)
     assert call_llm is not None
 
-    with caplog.at_level(logging.INFO, logger="goldfive.llm_detect"):
+    with caplog.at_level(logging.INFO, logger="goldfive"):
         out = await call_llm("system", "user", "stub")
 
     assert out == '{"on_task": true}'

--- a/tests/test_cooperative_cancellation.py
+++ b/tests/test_cooperative_cancellation.py
@@ -890,7 +890,7 @@ async def test_observe_reasoning_skipped_after_cancel(caplog: Any) -> None:
 
     import logging
 
-    with caplog.at_level(logging.DEBUG, logger="goldfive.adapters.adk"):
+    with caplog.at_level(logging.DEBUG, logger="goldfive"):
         await plugin.after_model_callback(
             callback_context=cb_ctx,
             llm_response=response,

--- a/tests/test_delegation_pin.py
+++ b/tests/test_delegation_pin.py
@@ -245,7 +245,7 @@ def test_no_eligible_task_leaves_session_unpinned(
     session = _session_with(plan)
     ctx = _ctx(session)
 
-    with caplog.at_level(logging.DEBUG, logger="goldfive.adapters.adk"):
+    with caplog.at_level(logging.DEBUG, logger="goldfive"):
         plugin._maybe_pin_delegation_task(
             ctx=ctx,
             invoked_agent_name="Z",

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -21,24 +21,26 @@ from goldfive.drift import _embed
 
 
 @pytest.fixture(autouse=True)
-def _reset_embed_state(monkeypatch: pytest.MonkeyPatch) -> Any:
+def _reset_embed_state(goldfive_embedding_env: Any) -> Any:
     """Ensure each test starts from a clean slate.
 
     ``set_model(None)`` both clears any installed encoder and resets
-    ``_MODEL_UNAVAILABLE`` so the lazy-load path can run again. We
-    also scrub the env vars so one test leaking a ``setenv`` can't
-    influence another. Under goldfive#225 ``configure(None)`` also
-    clears any :class:`~goldfive.config.EmbeddingConfig` a prior
-    ``goldfive.wrap()`` call may have installed; without this, the
-    env-var behaviour these tests exercise would be short-circuited
-    by a leaked config from another test module.
+    ``_MODEL_UNAVAILABLE`` so the lazy-load path can run again. The
+    ``goldfive_embedding_env`` fixture handles env scrubbing — its
+    ``clear()`` runs in its setup body so the ``GOLDFIVE_EMBEDDING_*``
+    surface is uniformly empty when this fixture yields. Under
+    goldfive#225 ``configure(None)`` also clears any
+    :class:`~goldfive.config.EmbeddingConfig` a prior ``goldfive.wrap()``
+    call may have installed; without this, the env-var behaviour these
+    tests exercise would be short-circuited by a leaked config from
+    another test module.
     """
     _embed.set_model(None)
     _embed.configure(None)
-    monkeypatch.delenv("GOLDFIVE_EMBEDDING_BASE_URL", raising=False)
-    monkeypatch.delenv("GOLDFIVE_EMBEDDING_MODEL", raising=False)
-    monkeypatch.delenv("GOLDFIVE_EMBEDDING_API_KEY", raising=False)
-    monkeypatch.delenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", raising=False)
+    # ``goldfive_embedding_env`` already pre-cleared the env vars in
+    # its own setup; the parameter here ensures pytest wires it before
+    # this autouse fixture runs.
+    _ = goldfive_embedding_env
     yield
     _embed.set_model(None)
     _embed.configure(None)
@@ -74,10 +76,13 @@ class _FakeBackend:
 # ---------------------------------------------------------------------------
 
 
-def test_openai_backend_env_driven(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_openai_backend_env_driven(
+    monkeypatch: pytest.MonkeyPatch,
+    goldfive_embedding_env: Any,
+) -> None:
     """Setting the env var lights up the HTTP backend, and the encode
     path returns a cosine in ``[-1, 1]``."""
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://fake:9999")
+    goldfive_embedding_env.set(base_url="http://fake:9999")
 
     def fake_build(base_url: str) -> Any:
         assert base_url == "http://fake:9999"
@@ -213,9 +218,10 @@ def test_cached_encode_lru_eviction(request: pytest.FixtureRequest) -> None:
 def test_set_model_overrides_env(
     monkeypatch: pytest.MonkeyPatch,
     request: pytest.FixtureRequest,
+    goldfive_embedding_env: Any,
 ) -> None:
     """``set_model(fake)`` wins over ``GOLDFIVE_EMBEDDING_BASE_URL``."""
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://should-not-be-used")
+    goldfive_embedding_env.set(base_url="http://should-not-be-used")
     # If ``_get_model`` ever reaches this, it would hit the real loader
     # and raise; we never want to see it happen when set_model is in
     # effect, so the loader is punitive.
@@ -236,11 +242,12 @@ def test_set_model_overrides_env(
 def test_openai_backend_env_failure_does_not_fall_back_to_st(
     monkeypatch: pytest.MonkeyPatch,
     request: pytest.FixtureRequest,
+    goldfive_embedding_env: Any,
 ) -> None:
     """If the user configured an HTTP endpoint but the backend cannot
     build, we prefer "no signal" over silently loading a local
     sentence-transformers model the user did not ask for."""
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://fake:9999")
+    goldfive_embedding_env.set(base_url="http://fake:9999")
     _embed.set_backend_loader(lambda _url: None)
     request.addfinalizer(lambda: _embed.set_backend_loader(None))
 
@@ -250,11 +257,14 @@ def test_openai_backend_env_failure_does_not_fall_back_to_st(
 def test_openai_backend_builder_honours_model_and_timeout(
     monkeypatch: pytest.MonkeyPatch,
     request: pytest.FixtureRequest,
+    goldfive_embedding_env: Any,
 ) -> None:
     """``_try_load_openai_backend`` reads every optional env var."""
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_MODEL", "qwen3-embed")
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_API_KEY", "secret")
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "2500")
+    goldfive_embedding_env.set(
+        model="qwen3-embed",
+        api_key="secret",
+        timeout_ms=2500,
+    )
 
     captured: dict[str, Any] = {}
 
@@ -449,17 +459,14 @@ def test_circuit_breaker_warns_once_on_trip(
     _embed.reset_circuit_breaker()
     backend = _make_always_failing_backend()
 
-    with caplog.at_level(
-        logging.WARNING, logger="goldfive.drift.reasoning.embed"
-    ):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         for _ in range(5):
             backend.encode(["x"])
 
     warnings = [
         r
         for r in caplog.records
-        if r.name == "goldfive.drift.reasoning.embed"
-        and "has failed" in r.getMessage()
+        if "has failed" in r.getMessage()
         and "in a row" in r.getMessage()
     ]
     assert len(warnings) == 1, (

--- a/tests/test_executor_supersede_cancel_nonfatal.py
+++ b/tests/test_executor_supersede_cancel_nonfatal.py
@@ -41,8 +41,6 @@ import os
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-import pytest
-
 from goldfive.control import (
     ControlChannel,
     ControlKind,
@@ -445,9 +443,9 @@ async def test_overlay_supersede_cancel_aborts_when_fail_fast_kwarg_set() -> Non
 
 
 async def test_overlay_env_var_enables_fail_fast(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_fail_fast_env: Any,
 ) -> None:
-    monkeypatch.setenv("GOLDFIVE_FAIL_FAST_ON_INVOKE_CANCEL", "1")
+    goldfive_fail_fast_env.set(invoke_cancel="1")
 
     plan = _two_task_plan()
     session = Session(run_id="r1")
@@ -495,9 +493,9 @@ async def test_overlay_env_var_enables_fail_fast(
 
 
 async def test_overlay_kwarg_false_overrides_env_var(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_fail_fast_env: Any,
 ) -> None:
-    monkeypatch.setenv("GOLDFIVE_FAIL_FAST_ON_INVOKE_CANCEL", "1")
+    goldfive_fail_fast_env.set(invoke_cancel="1")
     executor = SequentialExecutor(
         overlay_mode=True, fail_fast_on_invoke_cancel=False
     )
@@ -510,9 +508,10 @@ async def test_overlay_kwarg_false_overrides_env_var(
 
 
 def test_overlay_default_fail_fast_is_false(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_fail_fast_env: Any,
 ) -> None:
-    monkeypatch.delenv("GOLDFIVE_FAIL_FAST_ON_INVOKE_CANCEL", raising=False)
+    # Fixture pre-clears every fail-fast env var in its setup.
+    _ = goldfive_fail_fast_env
     executor = SequentialExecutor(overlay_mode=True)
     assert executor._fail_fast_on_invoke_cancel is False
 
@@ -713,9 +712,9 @@ async def test_steerer_cancel_inflight_stamps_supersede_flag() -> None:
 
 
 def test_overlay_env_var_zero_is_false(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_fail_fast_env: Any,
 ) -> None:
-    monkeypatch.setenv("GOLDFIVE_FAIL_FAST_ON_INVOKE_CANCEL", "0")
+    goldfive_fail_fast_env.set(invoke_cancel="0")
     executor = SequentialExecutor(overlay_mode=True)
     assert executor._fail_fast_on_invoke_cancel is False
 
@@ -726,13 +725,13 @@ def test_overlay_env_var_zero_is_false(
 
 
 def test_overlay_env_var_strict_match(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_fail_fast_env: Any,
 ) -> None:
     """The env-var contract is strict: only the literal "1" enables
     fail-fast (mirrors PR #332's ``GOLDFIVE_FAIL_FAST_REVISION_REJECTION``
     parsing). "true" / "yes" / "on" do NOT enable.
     """
-    monkeypatch.setenv("GOLDFIVE_FAIL_FAST_ON_INVOKE_CANCEL", "true")
+    goldfive_fail_fast_env.set(invoke_cancel="true")
     executor = SequentialExecutor(overlay_mode=True)
     assert executor._fail_fast_on_invoke_cancel is False
 

--- a/tests/test_goal_drift_classifier.py
+++ b/tests/test_goal_drift_classifier.py
@@ -701,7 +701,7 @@ async def test_task_boundary_noop_when_goal_drift_not_wired() -> None:
 async def test_classifier_logs_on_track_at_debug(caplog: pytest.LogCaptureFixture) -> None:
     """progressing=true → DEBUG log with 'on-track' so operators can diagnose."""
     call_llm = _stub_call_llm([{"progressing": True, "reason": "writing in progress"}])
-    with caplog.at_level("DEBUG", logger="goldfive.drift.goals"):
+    with caplog.at_level("DEBUG", logger="goldfive"):
         drift = await classify_goal_drift(
             goals=[Goal(id="g1", summary="ship memo")],
             plan=None,
@@ -721,7 +721,7 @@ async def test_classifier_logs_drift_detected_at_info(caplog: pytest.LogCaptureF
     without having to crank logging to DEBUG."""
     reason = "researching raccoons instead of solar panels"
     call_llm = _stub_call_llm([{"progressing": False, "reason": reason}])
-    with caplog.at_level("INFO", logger="goldfive.drift.goals"):
+    with caplog.at_level("INFO", logger="goldfive"):
         drift = await classify_goal_drift(
             goals=[Goal(id="g1", summary="ship memo")],
             plan=None,
@@ -739,7 +739,7 @@ async def test_classifier_logs_malformed_json_at_debug(
 ) -> None:
     """Malformed response → DEBUG log including the raw text snippet."""
     call_llm = _stub_call_llm(["this is not JSON at all -- raccoons everywhere"])
-    with caplog.at_level("DEBUG", logger="goldfive.drift.goals"):
+    with caplog.at_level("DEBUG", logger="goldfive"):
         drift = await classify_goal_drift(
             goals=[Goal(id="g1", summary="ship memo")],
             plan=None,
@@ -759,7 +759,7 @@ async def test_classifier_logs_missing_progressing_key_at_debug(
 ) -> None:
     """Dict without 'progressing' key → DEBUG log with 'lacks boolean'."""
     call_llm = _stub_call_llm([{"reason": "no key"}])
-    with caplog.at_level("DEBUG", logger="goldfive.drift.goals"):
+    with caplog.at_level("DEBUG", logger="goldfive"):
         drift = await classify_goal_drift(
             goals=[Goal(id="g1", summary="ship memo")],
             plan=None,

--- a/tests/test_immutable_plan.py
+++ b/tests/test_immutable_plan.py
@@ -270,7 +270,7 @@ def test_set_session_plan_inside_contextvar_no_warning(
     """The blessed path: swap inside the contextvar is silent."""
     plan = _plan("t1")
     session = Session(run_id="r1")
-    with caplog.at_level(logging.WARNING, logger="goldfive.types"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         with channel_processor_active():
             set_session_plan(session, plan)
     assert session.plan is plan
@@ -295,7 +295,7 @@ def test_set_session_plan_outside_contextvar_warns_in_non_strict_mode(
     # Force non-strict mode regardless of the test runner's pytest
     # auto-on default.
     with mock.patch.dict(os.environ, {"GOLDFIVE_STRICT_STATE_OWNERSHIP": "0"}):
-        with caplog.at_level(logging.WARNING, logger="goldfive.types"):
+        with caplog.at_level(logging.WARNING, logger="goldfive"):
             set_session_plan(session, plan)
     # Plan still installed — defensive, not blocking.
     assert session.plan is plan

--- a/tests/test_judge_task_lifetime.py
+++ b/tests/test_judge_task_lifetime.py
@@ -234,7 +234,7 @@ async def test_late_judge_verdict_records_drift_but_skips_refine(
     # No invocations registered on the StateStore for this
     # session — the agent has moved on. The fire-and-forget judge
     # treats this as a stale verdict.
-    with caplog.at_level(logging.INFO, logger="goldfive.steerer"):
+    with caplog.at_level(logging.INFO, logger="goldfive"):
         await steerer.observe_reasoning(
             "raccoons are nocturnal", session=session
         )
@@ -259,12 +259,13 @@ async def test_late_judge_verdict_records_drift_but_skips_refine(
     )
 
     # The structural log line was emitted at INFO so operators can see
-    # late verdicts in the run log.
+    # late verdicts in the run log. Assert on message content rather
+    # than logger name so the test survives the bucket-3b sibling-
+    # logger drop (the line now lands on ``goldfive.drift_observer``).
     info_records = [
         r
         for r in caplog.records
-        if r.name == "goldfive.steerer"
-        and r.levelno == logging.INFO
+        if r.levelno == logging.INFO
         and "stale judge verdict" in r.getMessage()
     ]
     assert len(info_records) == 1, (

--- a/tests/test_observation_only.py
+++ b/tests/test_observation_only.py
@@ -280,7 +280,7 @@ async def test_warning_drift_observation_only_suppresses_all_three_injections(
         prior_plan = session.plan
 
         drift = _drift_warning(kind=DriftKind.OFF_TOPIC)
-        with caplog.at_level(logging.INFO, logger="goldfive.steerer"):
+        with caplog.at_level(logging.INFO, logger="goldfive"):
             await steerer._handle_drift(drift, session)
 
         # 1. The planner produced a revision exactly once (detection +
@@ -447,7 +447,7 @@ def test_wrap_threads_observation_only_into_steerer() -> None:
 
 
 def test_steering_config_from_env_observation_only(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_steer_env: Any,
 ) -> None:
     """``GOLDFIVE_STEER_OBSERVATION_ONLY`` flips the field via ``from_env``.
 
@@ -460,31 +460,22 @@ def test_steering_config_from_env_observation_only(
       default); a test that suppresses the fixture would see the
       production ``True`` default.
     """
-    monkeypatch.setenv("GOLDFIVE_STEER_OBSERVATION_ONLY", "0")
-    assert SteeringConfig.from_env().observation_only is False
-    monkeypatch.setenv("GOLDFIVE_STEER_OBSERVATION_ONLY", "false")
-    assert SteeringConfig.from_env().observation_only is False
-    monkeypatch.setenv("GOLDFIVE_STEER_OBSERVATION_ONLY", "no")
-    assert SteeringConfig.from_env().observation_only is False
-    monkeypatch.setenv("GOLDFIVE_STEER_OBSERVATION_ONLY", "off")
-    assert SteeringConfig.from_env().observation_only is False
+    for falsey in ("0", "false", "no", "off"):
+        goldfive_steer_env.set(observation_only=falsey)
+        assert SteeringConfig.from_env().observation_only is False
 
-    monkeypatch.setenv("GOLDFIVE_STEER_OBSERVATION_ONLY", "1")
-    assert SteeringConfig.from_env().observation_only is True
-    monkeypatch.setenv("GOLDFIVE_STEER_OBSERVATION_ONLY", "true")
-    assert SteeringConfig.from_env().observation_only is True
-    monkeypatch.setenv("GOLDFIVE_STEER_OBSERVATION_ONLY", "yes")
-    assert SteeringConfig.from_env().observation_only is True
-    monkeypatch.setenv("GOLDFIVE_STEER_OBSERVATION_ONLY", "on")
-    assert SteeringConfig.from_env().observation_only is True
+    for truthy in ("1", "true", "yes", "on"):
+        goldfive_steer_env.set(observation_only=truthy)
+        assert SteeringConfig.from_env().observation_only is True
 
     # Unset: in the suite, the autouse fixture overrides to False.
-    monkeypatch.delenv("GOLDFIVE_STEER_OBSERVATION_ONLY", raising=False)
+    goldfive_steer_env.unset("observation_only")
     assert SteeringConfig.from_env().observation_only is False
 
 
 def test_steering_config_from_env_production_default(
     monkeypatch: pytest.MonkeyPatch,
+    goldfive_steer_env: Any,
 ) -> None:
     """Outside the suite override, the production default is ``True``.
 
@@ -494,7 +485,7 @@ def test_steering_config_from_env_production_default(
     """
     from goldfive import config as _gf_config
 
-    monkeypatch.delenv("GOLDFIVE_STEER_OBSERVATION_ONLY", raising=False)
+    goldfive_steer_env.unset("observation_only")
     prior = _gf_config._OBSERVATION_ONLY_DEFAULT
     _gf_config._OBSERVATION_ONLY_DEFAULT = None
     try:

--- a/tests/test_observation_only_pause_escalate_carveout.py
+++ b/tests/test_observation_only_pause_escalate_carveout.py
@@ -362,7 +362,7 @@ async def test_dispatch_pause_control_observation_only_skips_channel_send(
     steerer.bind_control_channel(channel)
 
     drift = _drift(kind=DriftKind.OFF_TOPIC)
-    with caplog.at_level(logging.INFO, logger="goldfive.steerer"):
+    with caplog.at_level(logging.INFO, logger="goldfive"):
         landed = await steerer._dispatch_goldfive_pause_control(
             drift, session, reason="test exhaustion"
         )
@@ -680,7 +680,7 @@ async def test_overlay_observation_only_drops_leaked_pause_escalate(
     adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
     executor = SequentialExecutor(overlay_mode=True, fail_fast=True)
 
-    with caplog.at_level(logging.INFO, logger="goldfive.executors.sequential"):
+    with caplog.at_level(logging.INFO, logger="goldfive"):
         outcome = await executor.run(
             plan=plan,
             session=session,

--- a/tests/test_pin_resolution_ladder.py
+++ b/tests/test_pin_resolution_ladder.py
@@ -468,7 +468,7 @@ async def test_signal4_dag_relaxed_pins_with_warning(
     )
     state, ctx = _ctx_for(session, "coord", sinks=sinks)
 
-    with caplog.at_level(logging.WARNING, logger="goldfive.adapters.adk"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         await plugin.before_agent_callback(
             agent=_Agent("researcher"),
             callback_context=ctx,

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1606,7 +1606,7 @@ def test_plan_from_json_drops_compound_assignees(
             },
         ],
     }
-    with caplog.at_level("WARNING", logger="goldfive.planner"):
+    with caplog.at_level("WARNING", logger="goldfive"):
         plan = _plan_from_json(payload, run_id="r", goal_ids=[])
     assert plan is not None
     assert [t.assignee_agent_id for t in plan.tasks] == ["", ""]
@@ -1625,7 +1625,7 @@ def test_plan_from_json_drops_bare_assignees(
             {"id": "t2", "title": "draft", "assignee_agent_id": "writer"},
         ],
     }
-    with caplog.at_level("WARNING", logger="goldfive.planner"):
+    with caplog.at_level("WARNING", logger="goldfive"):
         plan = _plan_from_json(payload, run_id="r", goal_ids=[])
     assert plan is not None
     assert [t.assignee_agent_id for t in plan.tasks] == ["", ""]
@@ -1647,7 +1647,7 @@ def test_plan_from_json_drops_mixed_assignees(
             {"id": "t3", "title": "review", "assignee_agent_id": "reviewer"},
         ],
     }
-    with caplog.at_level("WARNING", logger="goldfive.planner"):
+    with caplog.at_level("WARNING", logger="goldfive"):
         plan = _plan_from_json(payload, run_id="r", goal_ids=[])
     assert plan is not None
     assert [t.assignee_agent_id for t in plan.tasks] == ["", "", ""]
@@ -1971,7 +1971,7 @@ async def test_refine_emits_orphan_event_on_legitimate_drop(
         current_task_id="draft_body",
     )
 
-    with caplog.at_level("WARNING", logger="goldfive.planner"):
+    with caplog.at_level("WARNING", logger="goldfive"):
         revised = await planner.refine(plan=prior, drift=drift, goals=_goals())
 
     # Refine applied (validator does not reject — observability only).

--- a/tests/test_reasoning_content_fallback.py
+++ b/tests/test_reasoning_content_fallback.py
@@ -371,7 +371,7 @@ async def test_after_model_callback_flag_on_empty_reasoning_feeds_content(
 
     import logging
 
-    with caplog.at_level(logging.DEBUG, logger="goldfive.adapters.adk"):
+    with caplog.at_level(logging.DEBUG, logger="goldfive"):
         await plugin.after_model_callback(
             callback_context=cb_ctx, llm_response=response
         )
@@ -433,20 +433,22 @@ def test_reasoning_drift_config_default_is_false() -> None:
     assert cfg.fallback_to_content_when_no_reasoning is False
 
 
-def test_reasoning_drift_config_env_flip_to_true(monkeypatch: Any) -> None:
+def test_reasoning_drift_config_env_flip_to_true(goldfive_reasoning_drift_env: Any) -> None:
     """``GOLDFIVE_DRIFT_FALLBACK_TO_CONTENT=1`` flips the field to
     ``True`` via :meth:`ReasoningDriftConfig.from_env`.
     """
-    monkeypatch.setenv("GOLDFIVE_DRIFT_FALLBACK_TO_CONTENT", "1")
+    goldfive_reasoning_drift_env.set(fallback_to_content="1")
     cfg = ReasoningDriftConfig.from_env()
     assert cfg.fallback_to_content_when_no_reasoning is True
 
 
-def test_reasoning_drift_config_env_other_truthy_literals(monkeypatch: Any) -> None:
+def test_reasoning_drift_config_env_other_truthy_literals(
+    goldfive_reasoning_drift_env: Any,
+) -> None:
     """``_read_bool_env`` accepts ``true`` / ``yes`` / ``on`` /
     ``y`` / ``t`` too; pick one to anchor the link.
     """
-    monkeypatch.setenv("GOLDFIVE_DRIFT_FALLBACK_TO_CONTENT", "true")
+    goldfive_reasoning_drift_env.set(fallback_to_content="true")
     cfg = ReasoningDriftConfig.from_env()
     assert cfg.fallback_to_content_when_no_reasoning is True
 

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -229,7 +229,7 @@ async def test_malformed_json_returns_none_with_debug_log(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     call_llm = _stub_call_llm(["not json at all"])
-    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning_judge"):
+    with caplog.at_level(logging.DEBUG, logger="goldfive"):
         drift = await rjudge.classify_reasoning_drift(
             reasoning="thought",
             task=_task(),
@@ -240,7 +240,6 @@ async def test_malformed_json_returns_none_with_debug_log(
     assert drift is None
     assert any(
         "response was not JSON" in r.getMessage()
-        and r.name == "goldfive.drift.reasoning_judge"
         for r in caplog.records
     ), [r.getMessage() for r in caplog.records]
 
@@ -249,7 +248,7 @@ async def test_missing_on_task_key_returns_none_with_debug_log(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     call_llm = _stub_call_llm([{"verdict": "drift"}])
-    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning_judge"):
+    with caplog.at_level(logging.DEBUG, logger="goldfive"):
         drift = await rjudge.classify_reasoning_drift(
             reasoning="thought",
             task=_task(),
@@ -263,7 +262,6 @@ async def test_missing_on_task_key_returns_none_with_debug_log(
     # bool, since the parser tries both before quiet-failing.
     assert any(
         "lacks both 'classification' and boolean 'on_task'" in r.getMessage()
-        and r.name == "goldfive.drift.reasoning_judge"
         for r in caplog.records
     )
 
@@ -284,7 +282,7 @@ async def test_call_llm_raises_returns_none_with_warning_log(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     call_llm = _raising_call_llm(RuntimeError("boom"))
-    with caplog.at_level(logging.WARNING, logger="goldfive.drift.reasoning_judge"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         drift = await rjudge.classify_reasoning_drift(
             reasoning="thought",
             task=_task(),
@@ -295,8 +293,7 @@ async def test_call_llm_raises_returns_none_with_warning_log(
     assert drift is None
     matching = [
         r for r in caplog.records
-        if r.name == "goldfive.drift.reasoning_judge"
-        and "call_llm raised" in r.getMessage()
+        if "call_llm raised" in r.getMessage()
     ]
     assert len(matching) == 1
     assert matching[0].levelno == logging.WARNING
@@ -306,7 +303,7 @@ async def test_drift_emission_logs_info(caplog: pytest.LogCaptureFixture) -> Non
     call_llm = _stub_call_llm(
         [{"on_task": False, "severity": "critical", "reason": "off"}]
     )
-    with caplog.at_level(logging.INFO, logger="goldfive.drift.reasoning_judge"):
+    with caplog.at_level(logging.INFO, logger="goldfive"):
         drift = await rjudge.classify_reasoning_drift(
             reasoning="thought",
             task=_task(),
@@ -677,7 +674,7 @@ async def test_observe_reasoning_judge_exception_does_not_crash(
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
-    with caplog.at_level(logging.WARNING, logger="goldfive.steerer"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         await steerer.observe_reasoning("some thought", session=session)
         await _wait_for_judges(steerer)
 
@@ -687,12 +684,13 @@ async def test_observe_reasoning_judge_exception_does_not_crash(
     ] == []
     # The set drains cleanly (the raising task resolved).
     assert steerer._background_judges == set()
-    # The raise was swallowed and surfaced as a WARNING on the steerer
-    # logger.
+    # The raise was swallowed and surfaced as a WARNING. Assert on
+    # message content rather than logger name so the test survives the
+    # bucket-3b sibling-logger drop (line now lands on
+    # ``goldfive.drift_observer``).
     steerer_warnings = [
         r for r in caplog.records
-        if r.name == "goldfive.steerer"
-        and r.levelno == logging.WARNING
+        if r.levelno == logging.WARNING
         and "background reasoning-judge raised" in r.getMessage()
     ]
     assert len(steerer_warnings) == 1
@@ -772,7 +770,7 @@ async def test_shutdown_quiet_when_zero_tasks_actually_cancelled(
 
     await steerer.observe_reasoning("a thought", session=session)
 
-    with caplog.at_level(logging.WARNING, logger="goldfive.steerer"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         # timeout=0.0 → wait_for raises TimeoutError immediately even
         # if the gather wins the race in the same instant.
         await steerer.shutdown(timeout=0.0)
@@ -1161,7 +1159,7 @@ async def test_parser_demotes_justified_deviation_with_none_provenance(
             }
         ]
     )
-    with caplog.at_level(logging.INFO, logger="goldfive.drift.reasoning_judge"):
+    with caplog.at_level(logging.INFO, logger="goldfive"):
         verdict = await rjudge.classify_reasoning_drift_with_focus(
             reasoning="thought",
             task=_task(),
@@ -1177,7 +1175,6 @@ async def test_parser_demotes_justified_deviation_with_none_provenance(
     # Demotion is audited at INFO so operators can grep the rate.
     assert any(
         "demoted to erroneous_deviation" in r.getMessage()
-        and r.name == "goldfive.drift.reasoning_judge"
         for r in caplog.records
     )
 

--- a/tests/test_reasoning_logging.py
+++ b/tests/test_reasoning_logging.py
@@ -103,14 +103,13 @@ def test_intent_divergence_logs_cosine(
         description=task_description,
     )
 
-    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning"):
+    with caplog.at_level(logging.DEBUG, logger="goldfive"):
         dreason.detect_intent_divergence(reasoning_text, session)
 
     matching = [
         r
         for r in caplog.records
-        if r.name == "goldfive.drift.reasoning"
-        and "intent_divergence:" in r.getMessage()
+        if "intent_divergence:" in r.getMessage()
     ]
     assert len(matching) == 1, [r.getMessage() for r in caplog.records]
     msg = matching[0].getMessage()
@@ -139,14 +138,13 @@ def test_off_topic_logs_distance(caplog: pytest.LogCaptureFixture) -> None:
 
     session = _session_basic(title=task_title, description=task_description)
 
-    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning"):
+    with caplog.at_level(logging.DEBUG, logger="goldfive"):
         dreason.detect_off_topic(reasoning_text, session)
 
     matching = [
         r
         for r in caplog.records
-        if r.name == "goldfive.drift.reasoning"
-        and "off_topic:" in r.getMessage()
+        if "off_topic:" in r.getMessage()
     ]
     assert len(matching) == 1, [r.getMessage() for r in caplog.records]
     msg = matching[0].getMessage()
@@ -173,14 +171,13 @@ def test_looping_reasoning_logs_cosine(caplog: pytest.LogCaptureFixture) -> None
     # Steerer contract: current lives at -1, priors before it.
     session.reasoning_history = [past, current]
 
-    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning"):
+    with caplog.at_level(logging.DEBUG, logger="goldfive"):
         dreason.detect_looping_reasoning(current, session)
 
     matching = [
         r
         for r in caplog.records
-        if r.name == "goldfive.drift.reasoning"
-        and "looping_reasoning:" in r.getMessage()
+        if "looping_reasoning:" in r.getMessage()
     ]
     assert len(matching) == 1, [r.getMessage() for r in caplog.records]
     msg = matching[0].getMessage()
@@ -210,14 +207,13 @@ def test_cluster_tightening_logs_cosine(
     session = _session_basic()
     session.reasoning_history = [past, current]
 
-    with caplog.at_level(logging.DEBUG, logger="goldfive.drift.reasoning"):
+    with caplog.at_level(logging.DEBUG, logger="goldfive"):
         dreason.detect_reasoning_cluster_tightening(current, session)
 
     matching = [
         r
         for r in caplog.records
-        if r.name == "goldfive.drift.reasoning"
-        and "reasoning_cluster_tightening:" in r.getMessage()
+        if "reasoning_cluster_tightening:" in r.getMessage()
     ]
     assert len(matching) == 1, [r.getMessage() for r in caplog.records]
     msg = matching[0].getMessage()

--- a/tests/test_runner_build_identity_log.py
+++ b/tests/test_runner_build_identity_log.py
@@ -71,7 +71,7 @@ def test_runner_logs_build_identity_on_construction(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """``Runner(...)`` emits one ``goldfive runner starting`` INFO line."""
-    with caplog.at_level(logging.INFO, logger="goldfive.runner"):
+    with caplog.at_level(logging.INFO, logger="goldfive"):
         _make_runner()
 
     matches = [
@@ -109,7 +109,7 @@ def test_runner_build_identity_falls_through_to_unknown(
             clear=False,
         ),
     ):
-        with caplog.at_level(logging.INFO, logger="goldfive.runner"):
+        with caplog.at_level(logging.INFO, logger="goldfive"):
             _make_runner()
 
     matches = [
@@ -127,7 +127,7 @@ async def test_runner_build_identity_logged_once_not_per_run(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Two ``runner.run(...)`` calls must NOT re-emit the startup line."""
-    with caplog.at_level(logging.INFO, logger="goldfive.runner"):
+    with caplog.at_level(logging.INFO, logger="goldfive"):
         runner = _make_runner()
         await runner.run("go")
         await runner.run("go again")

--- a/tests/test_runner_extension.py
+++ b/tests/test_runner_extension.py
@@ -133,7 +133,7 @@ async def test_close_hook_exception_is_logged_and_does_not_block_others(
     runner.add_close_hook(hook_b)
     runner.add_close_hook(hook_c)
 
-    with caplog.at_level(logging.WARNING, logger="goldfive.runner"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         await runner.close()
 
     assert calls == ["a", "b", "c"]

--- a/tests/test_runner_revision_rejection_policy.py
+++ b/tests/test_runner_revision_rejection_policy.py
@@ -289,12 +289,12 @@ async def test_strict_kwarg_aborts_on_revision_rejection() -> None:
 
 
 async def test_strict_env_var_fallback(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_fail_fast_env: Any,
 ) -> None:
     """When the constructor kwarg is omitted (``None``), the env var
     ``GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1`` opts in to strict mode.
     """
-    monkeypatch.setenv("GOLDFIVE_FAIL_FAST_REVISION_REJECTION", "1")
+    goldfive_fail_fast_env.set(revision_rejection="1")
     sink = InMemorySink()
     plans: list[Plan | None] = []
     planner = _ProgrammablePlanner(plans)
@@ -318,13 +318,13 @@ async def test_strict_env_var_fallback(
 
 
 async def test_explicit_kwarg_overrides_env_var(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_fail_fast_env: Any,
 ) -> None:
     """Explicit ``fail_fast_on_revision_rejection=False`` wins over
     ``GOLDFIVE_FAIL_FAST_REVISION_REJECTION=1`` so tests can pin
     behaviour without unsetting the env first.
     """
-    monkeypatch.setenv("GOLDFIVE_FAIL_FAST_REVISION_REJECTION", "1")
+    goldfive_fail_fast_env.set(revision_rejection="1")
     sink = InMemorySink()
     plans: list[Plan | None] = []
     planner = _ProgrammablePlanner(plans)
@@ -416,13 +416,13 @@ async def test_user_steer_install_never_aborts_default_flag() -> None:
 
 
 async def test_user_steer_install_never_aborts_strict_flag(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_fail_fast_env: Any,
 ) -> None:
     """Same contract as the default-flag test, but with the strict env
     var on. The flag governs goldfive-authored installs only; user-
     authored installs go through the L2 type-safe path that has no
     failure mode."""
-    monkeypatch.setenv("GOLDFIVE_FAIL_FAST_REVISION_REJECTION", "1")
+    goldfive_fail_fast_env.set(revision_rejection="1")
     # Same setup as the default test — the steerer call doesn't
     # consult the env var.
     sink = InMemorySink()

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -16,6 +16,7 @@ Regression suite for goldfive#225. Covers:
 from __future__ import annotations
 
 import dataclasses
+from typing import Any
 
 import pytest
 
@@ -43,13 +44,15 @@ def test_embedding_config_defaults() -> None:
 
 
 def test_embedding_config_from_env_all_vars(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_embedding_env: Any,
 ) -> None:
     """All four env vars map to the matching fields."""
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://llm.local:8080")
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_MODEL", "qwen3-embed")
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_API_KEY", "secret-token")
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "2500")
+    goldfive_embedding_env.set(
+        base_url="http://llm.local:8080",
+        model="qwen3-embed",
+        api_key="secret-token",
+        timeout_ms=2500,
+    )
     cfg = EmbeddingConfig.from_env()
     assert cfg.base_url == "http://llm.local:8080"
     assert cfg.model == "qwen3-embed"
@@ -58,17 +61,13 @@ def test_embedding_config_from_env_all_vars(
 
 
 def test_embedding_config_from_env_subset(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_embedding_env: Any,
 ) -> None:
     """A partial env landscape fills in remaining fields with defaults."""
-    for name in (
-        "GOLDFIVE_EMBEDDING_BASE_URL",
-        "GOLDFIVE_EMBEDDING_MODEL",
-        "GOLDFIVE_EMBEDDING_API_KEY",
-        "GOLDFIVE_EMBEDDING_TIMEOUT_MS",
-    ):
-        monkeypatch.delenv(name, raising=False)
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://partial:1234")
+    # ``goldfive_embedding_env`` pre-clears every variable in its setup,
+    # so an explicit ``unset`` round is redundant; setting only the
+    # field we care about leaves the rest at their dataclass defaults.
+    goldfive_embedding_env.set(base_url="http://partial:1234")
     cfg = EmbeddingConfig.from_env()
     assert cfg.base_url == "http://partial:1234"
     # Remaining fields keep the built-in defaults.
@@ -78,21 +77,21 @@ def test_embedding_config_from_env_subset(
 
 
 def test_embedding_config_empty_base_url_is_none(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_embedding_env: Any,
 ) -> None:
     """An explicit empty string is treated as "not set" (maps to ``None``)."""
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "   ")
+    goldfive_embedding_env.set(base_url="   ")
     cfg = EmbeddingConfig.from_env()
     assert cfg.base_url is None
 
 
 def test_embedding_config_invalid_timeout_falls_back(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_embedding_env: Any,
 ) -> None:
     """Non-integer / non-positive timeouts fall back to the default."""
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "abc")
+    goldfive_embedding_env.set(timeout_ms="abc")
     assert EmbeddingConfig.from_env().timeout_ms == 10_000
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_TIMEOUT_MS", "0")
+    goldfive_embedding_env.set(timeout_ms="0")
     assert EmbeddingConfig.from_env().timeout_ms == 10_000
 
 
@@ -111,13 +110,15 @@ def test_tool_loop_config_defaults() -> None:
 
 
 def test_tool_loop_config_from_env_all_vars(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_tool_loop_env: Any,
 ) -> None:
     """All four env vars map to the matching fields."""
-    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_WINDOW", "12")
-    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD", "4")
-    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD", "7")
-    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD", "6")
+    goldfive_tool_loop_env.set(
+        window=12,
+        exact_threshold=4,
+        name_threshold=7,
+        alternating_threshold=6,
+    )
     cfg = ToolLoopConfig.from_env()
     assert cfg.window == 12
     assert cfg.exact_threshold == 4
@@ -126,17 +127,11 @@ def test_tool_loop_config_from_env_all_vars(
 
 
 def test_tool_loop_config_from_env_subset(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_tool_loop_env: Any,
 ) -> None:
     """Missing vars fall back to the built-in defaults."""
-    for name in (
-        "GOLDFIVE_TOOL_LOOP_WINDOW",
-        "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD",
-        "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD",
-        "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD",
-    ):
-        monkeypatch.delenv(name, raising=False)
-    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_WINDOW", "15")
+    # Fixture pre-clears every tool-loop env var in its setup.
+    goldfive_tool_loop_env.set(window=15)
     cfg = ToolLoopConfig.from_env()
     assert cfg.window == 15
     assert cfg.exact_threshold == 3
@@ -166,30 +161,30 @@ def test_reasoning_drift_config_defaults() -> None:
 
 @pytest.mark.parametrize("mode", ["judge", "embedding", "both", "off"])
 def test_reasoning_drift_config_from_env_mode(
-    monkeypatch: pytest.MonkeyPatch, mode: str
+    goldfive_reasoning_drift_env: Any, mode: str
 ) -> None:
     """`GOLDFIVE_DRIFT_REASONING_MODE` selects the pipeline mode."""
-    monkeypatch.setenv("GOLDFIVE_DRIFT_REASONING_MODE", mode)
+    goldfive_reasoning_drift_env.set(mode=mode)
     cfg = ReasoningDriftConfig.from_env()
     assert cfg.mode == mode
 
 
 def test_reasoning_drift_config_from_env_mode_is_case_insensitive(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_reasoning_drift_env: Any,
 ) -> None:
     """Mode parsing tolerates case variations + surrounding whitespace."""
-    monkeypatch.setenv("GOLDFIVE_DRIFT_REASONING_MODE", "  Embedding  ")
+    goldfive_reasoning_drift_env.set(mode="  Embedding  ")
     cfg = ReasoningDriftConfig.from_env()
     assert cfg.mode == "embedding"
 
 
 def test_reasoning_drift_config_from_env_mode_invalid_warns_and_defaults(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_reasoning_drift_env: Any,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Unknown mode logs a WARNING and falls back to the default."""
-    monkeypatch.setenv("GOLDFIVE_DRIFT_REASONING_MODE", "bogus")
-    with caplog.at_level("WARNING", logger="goldfive.config"):
+    goldfive_reasoning_drift_env.set(mode="bogus")
+    with caplog.at_level("WARNING", logger="goldfive"):
         cfg = ReasoningDriftConfig.from_env()
     assert cfg.mode == "judge"
     warnings = [
@@ -199,16 +194,18 @@ def test_reasoning_drift_config_from_env_mode_invalid_warns_and_defaults(
 
 
 def test_reasoning_drift_config_from_env_all_vars(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_reasoning_drift_env: Any,
 ) -> None:
     """The new ``GOLDFIVE_DRIFT_*`` env vars map to the matching fields."""
-    monkeypatch.setenv("GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE", "0.55")
-    monkeypatch.setenv("GOLDFIVE_DRIFT_INTENT_HEALTHY_SIMILARITY", "0.7")
-    monkeypatch.setenv("GOLDFIVE_DRIFT_INTENT_MINOR_SIMILARITY", "0.5")
-    monkeypatch.setenv("GOLDFIVE_DRIFT_INTENT_WARNING_SIMILARITY", "0.3")
-    monkeypatch.setenv("GOLDFIVE_DRIFT_LOOPING_SIMILARITY", "0.85")
-    monkeypatch.setenv("GOLDFIVE_DRIFT_CLUSTER_SIMILARITY", "0.7")
-    monkeypatch.setenv("GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW", "8")
+    goldfive_reasoning_drift_env.set(
+        off_topic_distance="0.55",
+        intent_healthy_similarity="0.7",
+        intent_minor_similarity="0.5",
+        intent_warning_similarity="0.3",
+        looping_similarity="0.85",
+        cluster_similarity="0.7",
+        looping_hash_window="8",
+    )
     cfg = ReasoningDriftConfig.from_env()
     assert cfg.off_topic_distance_threshold == 0.55
     assert cfg.intent_divergence_healthy_similarity == 0.7
@@ -220,28 +217,20 @@ def test_reasoning_drift_config_from_env_all_vars(
 
 
 def test_reasoning_drift_config_from_env_missing_falls_back(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_reasoning_drift_env: Any,
 ) -> None:
     """Missing env vars revert to defaults."""
-    for name in (
-        "GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE",
-        "GOLDFIVE_DRIFT_INTENT_HEALTHY_SIMILARITY",
-        "GOLDFIVE_DRIFT_INTENT_MINOR_SIMILARITY",
-        "GOLDFIVE_DRIFT_INTENT_WARNING_SIMILARITY",
-        "GOLDFIVE_DRIFT_LOOPING_SIMILARITY",
-        "GOLDFIVE_DRIFT_CLUSTER_SIMILARITY",
-        "GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW",
-    ):
-        monkeypatch.delenv(name, raising=False)
+    # ``goldfive_reasoning_drift_env`` pre-clears every reasoning-drift
+    # env var in its setup so we don't need an explicit unset round.
     cfg = ReasoningDriftConfig.from_env()
     assert cfg == ReasoningDriftConfig()
 
 
 def test_reasoning_drift_config_from_env_bad_float_falls_back(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_reasoning_drift_env: Any,
 ) -> None:
     """A non-float env var falls back to the default, not a crash."""
-    monkeypatch.setenv("GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE", "not-a-float")
+    goldfive_reasoning_drift_env.set(off_topic_distance="not-a-float")
     cfg = ReasoningDriftConfig.from_env()
     assert cfg.off_topic_distance_threshold == 0.7
 
@@ -258,21 +247,19 @@ def test_goal_drift_config_defaults() -> None:
 
 
 def test_goal_drift_config_from_env_all_vars(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_goal_drift_env: Any,
 ) -> None:
-    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL", "8")
-    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_ACTIVITY_WINDOW", "25")
+    goldfive_goal_drift_env.set(check_interval=8, activity_window=25)
     cfg = GoalDriftConfig.from_env()
     assert cfg.check_interval == 8
     assert cfg.activity_window == 25
 
 
 def test_goal_drift_config_from_env_subset(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_goal_drift_env: Any,
 ) -> None:
-    monkeypatch.delenv("GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL", raising=False)
-    monkeypatch.delenv("GOLDFIVE_GOAL_DRIFT_ACTIVITY_WINDOW", raising=False)
-    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL", "3")
+    # Fixture pre-clears the goal-drift env surface in its setup.
+    goldfive_goal_drift_env.set(check_interval=3)
     cfg = GoalDriftConfig.from_env()
     assert cfg.check_interval == 3
     assert cfg.activity_window == 10
@@ -292,12 +279,14 @@ def test_judge_config_defaults() -> None:
     assert cfg.timeout_ms == 10_000
 
 
-def test_judge_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_judge_config_from_env(goldfive_judge_env: Any) -> None:
     """All four ``GOLDFIVE_JUDGE_*`` env vars map to fields."""
-    monkeypatch.setenv("GOLDFIVE_JUDGE_BASE_URL", "http://judge.local:9000")
-    monkeypatch.setenv("GOLDFIVE_JUDGE_MODEL", "qwen3-judge")
-    monkeypatch.setenv("GOLDFIVE_JUDGE_API_KEY", "judge-token")
-    monkeypatch.setenv("GOLDFIVE_JUDGE_TIMEOUT_MS", "3500")
+    goldfive_judge_env.set(
+        base_url="http://judge.local:9000",
+        model="qwen3-judge",
+        api_key="judge-token",
+        timeout_ms=3500,
+    )
     cfg = JudgeConfig.from_env()
     assert cfg.base_url == "http://judge.local:9000"
     assert cfg.model == "qwen3-judge"
@@ -305,16 +294,10 @@ def test_judge_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg.timeout_ms == 3500
 
 
-def test_judge_config_from_env_subset(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_judge_config_from_env_subset(goldfive_judge_env: Any) -> None:
     """Missing env vars fall back to the built-in defaults."""
-    for name in (
-        "GOLDFIVE_JUDGE_BASE_URL",
-        "GOLDFIVE_JUDGE_MODEL",
-        "GOLDFIVE_JUDGE_API_KEY",
-        "GOLDFIVE_JUDGE_TIMEOUT_MS",
-    ):
-        monkeypatch.delenv(name, raising=False)
-    monkeypatch.setenv("GOLDFIVE_JUDGE_BASE_URL", "http://partial-judge:1234")
+    # Fixture pre-clears the judge env surface in its setup.
+    goldfive_judge_env.set(base_url="http://partial-judge:1234")
     cfg = JudgeConfig.from_env()
     assert cfg.base_url == "http://partial-judge:1234"
     assert cfg.model == ""
@@ -323,10 +306,10 @@ def test_judge_config_from_env_subset(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_judge_config_empty_base_url_is_none(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_judge_env: Any,
 ) -> None:
     """Whitespace-only ``GOLDFIVE_JUDGE_BASE_URL`` is treated as unset."""
-    monkeypatch.setenv("GOLDFIVE_JUDGE_BASE_URL", "   ")
+    goldfive_judge_env.set(base_url="   ")
     cfg = JudgeConfig.from_env()
     assert cfg.base_url is None
 
@@ -358,14 +341,14 @@ def test_runtime_config_includes_judge() -> None:
 
 
 def test_runtime_config_from_env_aggregates_all_four(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_runtime_env: dict,
 ) -> None:
     """Each sub-``from_env`` is called and the results are aggregated."""
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://agg:7000")
-    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_WINDOW", "14")
-    monkeypatch.setenv("GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW", "9")
-    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL", "7")
-    monkeypatch.setenv("GOLDFIVE_JUDGE_BASE_URL", "http://judge-agg:9001")
+    goldfive_runtime_env["embedding"].set(base_url="http://agg:7000")
+    goldfive_runtime_env["tool_loop"].set(window=14)
+    goldfive_runtime_env["reasoning_drift"].set(looping_hash_window=9)
+    goldfive_runtime_env["goal_drift"].set(check_interval=7)
+    goldfive_runtime_env["judge"].set(base_url="http://judge-agg:9001")
     cfg = RuntimeConfig.from_env()
     assert cfg.embedding.base_url == "http://agg:7000"
     assert cfg.tool_loops.window == 14

--- a/tests/test_steer_unification.py
+++ b/tests/test_steer_unification.py
@@ -586,34 +586,33 @@ def test_runtime_config_threads_steering_threshold() -> None:
     assert steerer._goldfive_steer_suppression_window_turns == 7
 
 
-def test_steering_config_from_env_accepts_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_steering_config_from_env_accepts_defaults(goldfive_steer_env: Any) -> None:
     from goldfive.config import SteeringConfig
 
-    monkeypatch.delenv("GOLDFIVE_STEER_THRESHOLD", raising=False)
-    monkeypatch.delenv("GOLDFIVE_STEER_SUPPRESSION_WINDOW_TURNS", raising=False)
+    # Fixture pre-clears the steering env vars in setup.
+    _ = goldfive_steer_env
     cfg = SteeringConfig.from_env()
     assert cfg.threshold == "warning"
     assert cfg.suppression_window_turns == 3
 
 
 def test_steering_config_from_env_reads_threshold(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_steer_env: Any,
 ) -> None:
     from goldfive.config import SteeringConfig
 
-    monkeypatch.setenv("GOLDFIVE_STEER_THRESHOLD", "critical")
-    monkeypatch.setenv("GOLDFIVE_STEER_SUPPRESSION_WINDOW_TURNS", "9")
+    goldfive_steer_env.set(threshold="critical", suppression_window_turns=9)
     cfg = SteeringConfig.from_env()
     assert cfg.threshold == "critical"
     assert cfg.suppression_window_turns == 9
 
 
 def test_steering_config_from_env_rejects_unknown_threshold(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_steer_env: Any,
 ) -> None:
     from goldfive.config import SteeringConfig
 
-    monkeypatch.setenv("GOLDFIVE_STEER_THRESHOLD", "nonsense")
+    goldfive_steer_env.set(threshold="nonsense")
     cfg = SteeringConfig.from_env()
     # Falls back to default
     assert cfg.threshold == "warning"

--- a/tests/test_wrap_goal_drift_wiring.py
+++ b/tests/test_wrap_goal_drift_wiring.py
@@ -250,13 +250,12 @@ def test_wrap_warns_when_judge_mode_without_call_llm(
     common mis-configuration. Emit a single WARNING so the gap is
     diagnosable from logs.
     """
-    with caplog.at_level(logging.WARNING, logger="goldfive.wrap"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         goldfive.wrap(_noop_agent, sinks=[])
     matching = [
         r
         for r in caplog.records
-        if r.name == "goldfive.wrap"
-        and "LLM-as-a-judge drift detection is disabled" in r.getMessage()
+        if "LLM-as-a-judge drift detection is disabled" in r.getMessage()
     ]
     assert len(matching) == 1, (
         f"expected exactly one WARNING, got {len(matching)}: "
@@ -270,7 +269,7 @@ def test_wrap_does_not_warn_when_mode_off(
     """No warning when the operator has explicitly disabled judge-mode."""
     from goldfive.config import ReasoningDriftConfig, RuntimeConfig
 
-    with caplog.at_level(logging.WARNING, logger="goldfive.wrap"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         goldfive.wrap(
             _noop_agent,
             runtime=RuntimeConfig(
@@ -281,8 +280,7 @@ def test_wrap_does_not_warn_when_mode_off(
     matching = [
         r
         for r in caplog.records
-        if r.name == "goldfive.wrap"
-        and "LLM-as-a-judge drift detection is disabled" in r.getMessage()
+        if "LLM-as-a-judge drift detection is disabled" in r.getMessage()
     ]
     assert matching == []
 
@@ -343,14 +341,13 @@ def test_wrap_warns_named_model_on_detection(
     """Auto-detected judge LLM fires the named-model WARNING with model + agent type."""
     _, detector = _make_detect_llm("gpt-4o-mini")
 
-    with caplog.at_level(logging.WARNING, logger="goldfive.wrap"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         goldfive.wrap(_MyAgent(), sinks=[], llm_detector=detector)
 
     matching = [
         r
         for r in caplog.records
-        if r.name == "goldfive.wrap"
-        and "judge LLM not explicitly configured" in r.getMessage()
+        if "judge LLM not explicitly configured" in r.getMessage()
     ]
     assert len(matching) == 1, (
         f"expected exactly one named-model WARNING, got {len(matching)}: "
@@ -375,14 +372,13 @@ def test_wrap_warns_named_model_prefers_agent_name_over_class_name(
     """
     _, detector = _make_detect_llm("gpt-4o-mini")
 
-    with caplog.at_level(logging.WARNING, logger="goldfive.wrap"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         goldfive.wrap(_NamedAgent(), sinks=[], llm_detector=detector)
 
     matching = [
         r
         for r in caplog.records
-        if r.name == "goldfive.wrap"
-        and "judge LLM not explicitly configured" in r.getMessage()
+        if "judge LLM not explicitly configured" in r.getMessage()
     ]
     assert len(matching) == 1
     msg = matching[0].getMessage()
@@ -397,7 +393,7 @@ def test_wrap_suppresses_named_model_warning_when_call_llm_explicit(
     _, detector = _make_detect_llm("should-not-appear")
     call_llm = _stub_call_llm([])
 
-    with caplog.at_level(logging.WARNING, logger="goldfive.wrap"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         goldfive.wrap(
             _noop_agent, call_llm=call_llm, sinks=[], llm_detector=detector
         )
@@ -405,8 +401,7 @@ def test_wrap_suppresses_named_model_warning_when_call_llm_explicit(
     matching = [
         r
         for r in caplog.records
-        if r.name == "goldfive.wrap"
-        and "judge LLM not explicitly configured" in r.getMessage()
+        if "judge LLM not explicitly configured" in r.getMessage()
     ]
     assert matching == []
 
@@ -428,7 +423,7 @@ def test_wrap_suppresses_named_model_warning_when_judge_config_explicit(
         judge=JudgeConfig(base_url="http://judge:9000", model="judge-model"),
     )
 
-    with caplog.at_level(logging.WARNING, logger="goldfive.wrap"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         goldfive.wrap(
             _noop_agent,
             runtime=runtime,
@@ -440,8 +435,7 @@ def test_wrap_suppresses_named_model_warning_when_judge_config_explicit(
     matching = [
         r
         for r in caplog.records
-        if r.name == "goldfive.wrap"
-        and "judge LLM not explicitly configured" in r.getMessage()
+        if "judge LLM not explicitly configured" in r.getMessage()
     ]
     assert matching == []
 
@@ -467,7 +461,7 @@ def test_runner_warns_when_goal_drift_enabled_without_call_llm(
             raise AssertionError("not invoked")
 
     steerer = DefaultSteerer()  # no judge callable
-    with caplog.at_level(logging.WARNING, logger="goldfive.runner"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         Runner(
             agent=_NoopAdapter(),
             planner=StubPlanner(),
@@ -477,8 +471,7 @@ def test_runner_warns_when_goal_drift_enabled_without_call_llm(
         )
     matching = [
         r for r in caplog.records
-        if r.name == "goldfive.runner"
-        and "goal-drift judge disabled" in r.getMessage()
+        if "goal-drift judge disabled" in r.getMessage()
     ]
     assert len(matching) == 1, (
         f"expected exactly one warning, got {len(matching)}: "
@@ -503,7 +496,7 @@ def test_runner_does_not_warn_when_call_llm_is_wired(
 
     call_llm = _stub_call_llm([{"progressing": True}])
     steerer = DefaultSteerer(goal_drift_call_llm=call_llm)
-    with caplog.at_level(logging.WARNING, logger="goldfive.runner"):
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
         Runner(
             agent=_NoopAdapter(),
             planner=StubPlanner(),

--- a/tests/test_wrap_runtime_config.py
+++ b/tests/test_wrap_runtime_config.py
@@ -44,32 +44,22 @@ from goldfive.steerer import DefaultSteerer  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def _scrub_module_state(monkeypatch: pytest.MonkeyPatch) -> Any:
+def _scrub_module_state(goldfive_runtime_env: dict) -> Any:
     """Clear every module-level config slot and env var before each test.
 
     Tests that install a config via ``wrap()`` must leave the process
     in a clean state for downstream tests — otherwise the reasoning-
     drift detectors run against last-test thresholds.
+
+    The ``goldfive_runtime_env`` fixture handles env-var scrubbing by
+    pre-clearing every ``RuntimeConfig`` sub-domain in its setup; we
+    only need to handle the module-level config slots here.
     """
     _embed.set_model(None)
     _embed.configure(None)
     _reasoning.configure(None)
     _tool_loops.configure(None)
-    for name in (
-        "GOLDFIVE_EMBEDDING_BASE_URL",
-        "GOLDFIVE_EMBEDDING_MODEL",
-        "GOLDFIVE_EMBEDDING_API_KEY",
-        "GOLDFIVE_EMBEDDING_TIMEOUT_MS",
-        "GOLDFIVE_TOOL_LOOP_WINDOW",
-        "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD",
-        "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD",
-        "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD",
-        "GOLDFIVE_DRIFT_OFF_TOPIC_DISTANCE",
-        "GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW",
-        "GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL",
-        "GOLDFIVE_GOAL_DRIFT_ACTIVITY_WINDOW",
-    ):
-        monkeypatch.delenv(name, raising=False)
+    _ = goldfive_runtime_env  # parameter forces fixture ordering.
     yield
     _embed.set_model(None)
     _embed.configure(None)
@@ -147,10 +137,10 @@ def test_wrap_threads_reasoning_drift_mode_from_config() -> None:
 
 
 def test_wrap_threads_reasoning_drift_mode_from_env(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_reasoning_drift_env: Any,
 ) -> None:
     """`GOLDFIVE_DRIFT_REASONING_MODE=both make demo` end-to-end."""
-    monkeypatch.setenv("GOLDFIVE_DRIFT_REASONING_MODE", "both")
+    goldfive_reasoning_drift_env.set(mode="both")
     runner = goldfive.wrap(_noop_agent, sinks=[])
     steerer = runner.steerer
     assert isinstance(steerer, DefaultSteerer)
@@ -158,14 +148,13 @@ def test_wrap_threads_reasoning_drift_mode_from_env(
 
 
 def test_wrap_falls_back_to_from_env_when_runtime_none(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_runtime_env: dict,
 ) -> None:
     """With ``runtime=None`` (the default) env vars drive the effective config."""
-    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_CHECK_INTERVAL", "11")
-    monkeypatch.setenv("GOLDFIVE_GOAL_DRIFT_ACTIVITY_WINDOW", "30")
-    monkeypatch.setenv("GOLDFIVE_TOOL_LOOP_WINDOW", "13")
-    monkeypatch.setenv("GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW", "11")
-    monkeypatch.setenv("GOLDFIVE_EMBEDDING_BASE_URL", "http://envfall:1234")
+    goldfive_runtime_env["goal_drift"].set(check_interval=11, activity_window=30)
+    goldfive_runtime_env["tool_loop"].set(window=13)
+    goldfive_runtime_env["reasoning_drift"].set(looping_hash_window=11)
+    goldfive_runtime_env["embedding"].set(base_url="http://envfall:1234")
 
     runner = goldfive.wrap(_noop_agent, sinks=[])
 
@@ -244,11 +233,10 @@ def test_wrap_threads_steering_config() -> None:
 
 
 def test_wrap_threads_steering_config_from_env(
-    monkeypatch: pytest.MonkeyPatch,
+    goldfive_steer_env: Any,
 ) -> None:
     """GOLDFIVE_STEER_THRESHOLD env var threads through wrap()."""
-    monkeypatch.setenv("GOLDFIVE_STEER_THRESHOLD", "off")
-    monkeypatch.setenv("GOLDFIVE_STEER_SUPPRESSION_WINDOW_TURNS", "11")
+    goldfive_steer_env.set(threshold="off", suppression_window_turns=11)
     runner = goldfive.wrap(_noop_agent, sinks=[])
     steerer = runner.steerer
     assert isinstance(steerer, DefaultSteerer)


### PR DESCRIPTION
## Summary

Two-part test-side cleanup that touches one production line (sibling logger drop).

### Part A — env-var fixture consolidation

- Add 10 domain-scoped env-var fixtures in ``tests/conftest.py``:
  ``goldfive_agent_env``, ``goldfive_embedding_env``, ``goldfive_steer_env``, ``goldfive_tool_loop_env``, ``goldfive_reasoning_drift_env``, ``goldfive_goal_drift_env``, ``goldfive_judge_env``, ``goldfive_fail_fast_env``, ``goldfive_examples_env``, and the aggregate ``goldfive_runtime_env``.
- Each fixture yields an ``_EnvController`` that wraps ``monkeypatch.setenv`` / ``delenv`` over an explicit allow-list. Callers use short kwarg keys (``set(base_url="...")``) instead of typing the underlying ``GOLDFIVE_*`` string.
- Fixtures pre-clear their variables in setup so tests start from a clean slate; teardown is automatic via the underlying ``monkeypatch`` fixture.
- Migrated ~99 inline ``monkeypatch.setenv``/``delenv`` calls across 11 test files (incl. ``tests/examples/*``). No production-code change here.

### Part B — logger-name widening + sibling-logger drop

- Wave C bucket 3b/3c left a sibling ``_steerer_log = logging.getLogger("goldfive.steerer")`` in ``goldfive/drift_observer.py`` because 6 caplog test files asserted on ``record.name == "goldfive.steerer"``.
- Widen 18 ``r.name == "goldfive.X"`` predicates to pure message-content matching; widen 44 ``caplog.at_level(..., logger="goldfive.X")`` calls to ``logger="goldfive"`` (parent logger).
- Drop the sibling: every line previously routed via ``_steerer_log.X(...)`` now lands on the natural ``goldfive.drift_observer`` logger (``log.X(...)``). 28 call sites updated.
- One narrow ``logger="goldfive.plan_reviser"`` in ``tests/test_steerer.py:1133`` is intentionally preserved — its inline comment explicitly flags the narrow scope as load-bearing.

### Per-file changes

- ``goldfive/drift_observer.py`` — drop ``_steerer_log``, rewire 28 call sites to ``log``.
- ``tests/conftest.py`` — add ``_EnvController`` + 10 fixtures.
- 11 test files migrated to env fixtures.
- 19 test files updated for widened logger assertions (overlap with env migration).

### Verified

- Full ``pytest tests/`` green both before and after the sibling-logger drop: **2543 passed, 59 skipped, 0 failed**, no ``StateOwnershipViolation`` warnings.
- ``ruff check tests/ goldfive/`` clean.

## Test plan

- [x] Run ``pytest tests/test_judge_task_lifetime.py tests/test_reasoning_judge.py tests/test_reasoning_logging.py tests/test_wrap_goal_drift_wiring.py tests/test_embedding_backend.py`` with sibling logger still in place to validate widening is sufficient (111 passed).
- [x] Drop the sibling and re-run the same set (111 passed).
- [x] Run the full ``pytest tests/`` suite (2543 passed).
- [x] ``ruff check tests/ goldfive/`` clean.