### PR TITLE
refactor(steerer): drop router shims, namespace components as properties (closes #410)

### DIFF
--- a/docs/design/PROTOCOLS.md
+++ b/docs/design/PROTOCOLS.md
@@ -210,16 +210,13 @@ response, see `goldfive/planner.py` or
 # ``goldfive/protocols.py``.
 @runtime_checkable
 class Steerer(Protocol):
-    async def observe(self, event: Any, session: Session) -> None: ...
-
-    async def observe_reasoning(
-        self,
-        text: str,
-        *,
-        task: Task | None = None,
-        session: Session,
-        provider: str = "",
-    ) -> None: ...
+    # Three component sub-objects expose the bulk of the surface.
+    # See ``TaskStateMachine`` / ``PlanReviser`` / ``DriftObserver``
+    # for the per-component contracts.
+    tasks: Any   # TaskStateMachine — mark_task_*, cascade_cancel_downstream
+    plans: Any   # PlanReviser     — install_*, _apply_revision, _emit_plan_revised
+    drift: Any   # DriftObserver   — observe, observe_reasoning, detect_drift,
+                 #                   handle_drift, request_invocation_cancel
 
     async def transition(
         self,
@@ -228,15 +225,8 @@ class Steerer(Protocol):
         *,
         detail: str = "",
         session: Session,
+        cancel_reason: str = "",
     ) -> None: ...
-
-    async def cascade_cancel_downstream(
-        self,
-        session: Session,
-        cancelled_id: str,
-    ) -> None: ...
-
-    def detect_drift(self, event: Any, session: Session) -> Optional[DriftEvent]: ...
 
     def bind(
         self,
@@ -248,32 +238,37 @@ class Steerer(Protocol):
 
 ### Contract
 
-- `observe(event, session)` — the adapter streams raw framework
-  events (LLM text, tool calls, stream chunks) here. The steerer may
-  classify drift, update per-task progress, or no-op. Must not mutate
-  `event`.
-- `observe_reasoning(text, *, task=, session, provider="")` — called
-  once per LLM response that carries chain-of-thought (OpenAI
+After goldfive#410 (post-Wave-C facade cleanup), the Steerer is a
+**thin coordinator** with three component sub-objects. Callers reach
+the right component directly rather than through router shims:
+
+- `steerer.tasks.mark_task_*` / `steerer.tasks.cascade_cancel_downstream`
+  — the canonical task-state-machine surface. Every transition
+  emits exactly one event; terminal states absorb.
+- `steerer.plans.install_*` / `steerer.plans._apply_revision` /
+  `steerer.plans._emit_plan_revised` — the plan-install + revision +
+  refine-attempt observability surface.
+- `steerer.drift.observe(event, session)` — adapter streams raw
+  framework events here. The DriftObserver may classify drift, update
+  per-task progress, or no-op. Must not mutate `event`.
+- `steerer.drift.observe_reasoning(text, *, task=, session, ...)` —
+  called once per LLM response that carries chain-of-thought (OpenAI
   `reasoning_content`, Anthropic `thinking`, Google thought parts).
   Feeds `Session.reasoning_history` and the reasoning-drift pipeline
-  (`LOOPING_REASONING`, `OFF_TOPIC`, `INTENT_DIVERGENCE`).
-  Adapters that cannot surface reasoning simply never call this.
-- `transition(task_id, to, session)` — the single source-of-truth
-  state-mutating method. Enforces monotonicity (see
+  (`LOOPING_REASONING`, `OFF_TOPIC`, `INTENT_DIVERGENCE`). Adapters
+  that cannot surface reasoning simply never call this.
+- `steerer.drift.detect_drift(event, session)` — pure classifier.
+  Returns a `DriftEvent` or `None`. No state mutation, no event
+  emission.
+- `steerer.drift.handle_drift(drift, session)` — the central drift
+  router that walks the intervention ladder (see DRIFT.md §
+  "Intervention ladder").
+- `steerer.transition(task_id, to, session, ...)` — the
+  router-level dispatch helper that fans out to the matching
+  `tasks.mark_task_*`. Enforces monotonicity (see
   [STATE-MACHINE.md](STATE-MACHINE.md)) and emits one event per
-  successful transition.
-- `cascade_cancel_downstream(session, cancelled_id)` — shared
-  cancellation-fanout primitive. BFS-walks `session.plan.edges`
-  forward from `cancelled_id`, transitions every reachable
-  non-terminal task to CANCELLED, and emits exactly one
-  `TaskCancelled` per transitioned task. De-duplicates diamond-DAG
-  reachability and skips already-terminal downstream tasks. Used by
-  both the unrecoverable-failure cascade
-  (`mark_task_failed(recoverable=False)`) and the
-  cancellation-cascade path. The initiator itself is *not*
-  transitioned by this method; callers own that.
-- `detect_drift(event, session)` — pure classifier. Returns a
-  `DriftEvent` or `None`. No state mutation, no event emission.
+  successful transition. Kept on the router so callers that don't
+  want to bind to a specific status helper have a uniform entry point.
 - `bind(sinks, planner)` — called once by the executor before the
   first `observe`. Wires the steerer to its downstream dependencies.
 
@@ -299,20 +294,56 @@ from goldfive.protocols import EventSink, Planner
 _TERMINAL = {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED}
 
 
-class MinimalSteerer:
-    """Minimal but compliant Steerer. No drift detection."""
+class _MinimalTasks:
+    """Component owner of mark_task_* transitions."""
 
-    def __init__(self) -> None:
-        self._sinks: list[EventSink] = []
-        self._planner: Optional[Planner] = None
+    async def mark_task_running(self, task_id: str, *, session: Session, **_: Any) -> None:
+        _transition(session, task_id, TaskStatus.RUNNING)
 
-    def bind(self, *, sinks: list[EventSink], planner: Planner) -> None:
-        self._sinks = sinks
-        self._planner = planner
+    async def mark_task_completed(self, task_id: str, *, session: Session, **_: Any) -> None:
+        _transition(session, task_id, TaskStatus.COMPLETED)
+
+    # (other mark_task_* + cascade_cancel_downstream + _emit_task_* elided
+    # for brevity — see TaskStateMachine for the full surface)
+
+
+class _MinimalDrift:
+    """Component owner of observe / detect_drift."""
 
     async def observe(self, event: Any, session: Session) -> None:
         # no-op
         return
+
+    def detect_drift(self, event: Any, session: Session) -> Optional[DriftEvent]:
+        return None
+
+
+def _transition(session: Session, task_id: str, to: TaskStatus) -> None:
+    assert session.plan is not None
+    task = next(t for t in session.plan.tasks if t.id == task_id)
+    if task.status in _TERMINAL:
+        return
+    task.status = to
+    # (skip event emission for brevity — see DefaultSteerer)
+
+
+class MinimalSteerer:
+    """Minimal but compliant Steerer. No drift detection.
+
+    Component-namespaced per goldfive#410: the surface lives on
+    ``tasks`` / ``plans`` / ``drift`` sub-objects.
+    """
+
+    def __init__(self) -> None:
+        self._sinks: list[EventSink] = []
+        self._planner: Optional[Planner] = None
+        self.tasks = _MinimalTasks()
+        self.plans = object()  # plan-install surface omitted in this minimal example
+        self.drift = _MinimalDrift()
+
+    def bind(self, *, sinks: list[EventSink], planner: Planner) -> None:
+        self._sinks = sinks
+        self._planner = planner
 
     async def transition(
         self,
@@ -321,16 +352,13 @@ class MinimalSteerer:
         *,
         detail: str = "",
         session: Session,
+        cancel_reason: str = "",
     ) -> None:
-        assert session.plan is not None
-        task = next(t for t in session.plan.tasks if t.id == task_id)
-        if task.status in _TERMINAL:
-            return
-        task.status = to
-        # (skip event emission for brevity — see DefaultSteerer)
-
-    def detect_drift(self, event: Any, session: Session) -> Optional[DriftEvent]:
-        return None
+        if to is TaskStatus.RUNNING:
+            await self.tasks.mark_task_running(task_id, session=session)
+        elif to is TaskStatus.COMPLETED:
+            await self.tasks.mark_task_completed(task_id, session=session)
+        # ... fan out to the remaining mark_task_* helpers.
 ```
 
 The production `DefaultSteerer` in `goldfive/steerer.py` adds the full

--- a/docs/design/STATE-MACHINE.md
+++ b/docs/design/STATE-MACHINE.md
@@ -3,8 +3,23 @@
 Every task in a goldfive plan moves through a strict state machine. The
 machine is **monotonic**: once a task reaches a terminal state, it
 cannot leave. It is **owned by the Steerer**: every transition runs
-through `Steerer.transition(task_id, to, *, session)` and emits an
-event to every sink.
+through `Steerer.transition(task_id, to, *, session)` (which dispatches
+to the matching `Steerer.tasks.mark_task_*` helper) and emits an event
+to every sink.
+
+The post-#410 facade exposes three components as public properties on
+`DefaultSteerer`:
+
+* `steerer.tasks` — :class:`~goldfive.task_state_machine.TaskStateMachine`,
+  owner of every `mark_task_*` transition + `cascade_cancel_downstream`
+  + per-status `_emit_task_*` emission.
+* `steerer.plans` — :class:`~goldfive.plan_reviser.PlanReviser`, owner
+  of every `install_*` plan-install entry point + `_apply_revision` +
+  `_emit_plan_revised` + the refine-attempt observability helpers.
+* `steerer.drift` — :class:`~goldfive.drift_observer.DriftObserver`,
+  owner of `observe` / `observe_reasoning` / `detect_drift` /
+  `handle_drift` / `request_invocation_cancel` + the reflective and
+  goal-drift judge orchestration.
 
 Related: [DRIFT.md](DRIFT.md), [PROTOCOLS.md](PROTOCOLS.md#steerer),
 [EVENT-MODEL.md](EVENT-MODEL.md),
@@ -215,9 +230,10 @@ downstream task without re-checking its history.
 
 The same cascade rule applies when **any single task** is
 transitioned to `CANCELLED` — not only as part of the unrecoverable
-FAILED cascade above. `DefaultSteerer.mark_task_cancelled` BFS-walks
-forward from the cancelled task through `Plan.edges` and transitions
-every reachable non-terminal task (PENDING / RUNNING / BLOCKED) to
+FAILED cascade above. `TaskStateMachine.mark_task_cancelled`
+(reachable as `steerer.tasks.mark_task_cancelled`) BFS-walks forward
+from the cancelled task through `Plan.edges` and transitions every
+reachable non-terminal task (PENDING / RUNNING / BLOCKED) to
 `CANCELLED` with reason `"cascade from <task_id>"`. This closes the
 soundness gap where a `USER_STEER` whose refine produces no new plan
 would cancel the current task but leave downstream PENDING tasks
@@ -229,10 +245,11 @@ predecessors COMPLETED" check). See
 
 Both cascades (the unrecoverable case above and the cancel-cascade
 below) fan out to downstream tasks through **one shared primitive**:
-`Steerer.cascade_cancel_downstream(session, cancelled_id)` on
-`goldfive/protocols.py` (reference impl on
-`DefaultSteerer.cascade_cancel_downstream` in
-`goldfive/steerer.py`). The primitive:
+`Steerer.cascade_cancel_downstream(session, cancelled_id)` declared
+on `goldfive/protocols.py` and implemented on
+`TaskStateMachine.cascade_cancel_downstream` in
+`goldfive/task_state_machine.py` (callers reach it as
+`steerer.tasks.cascade_cancel_downstream`). The primitive:
 
 - walks `session.plan.edges` forward from the initiator,
 - transitions every reachable non-terminal task to `CANCELLED`,
@@ -252,8 +269,19 @@ invalidated.
 ## Implementation notes
 
 The reference implementation is `DefaultSteerer` in
-`goldfive/steerer.py`. It ports harmonograf's `_AdkState` to a
-framework-agnostic form.
+`goldfive/steerer.py`, a thin router that exposes three components as
+public properties:
+
+* `goldfive/task_state_machine.py::TaskStateMachine` — task transitions
+  + cascade + per-status event emission (`steerer.tasks`).
+* `goldfive/plan_reviser.py::PlanReviser` — plan-install, refine
+  attempt observability, and revision application (`steerer.plans`).
+* `goldfive/drift_observer.py::DriftObserver` — drift detection,
+  intervention ladder, judge orchestration, and refine-outcome
+  bookkeeping (`steerer.drift`).
+
+Together they port harmonograf's `_AdkState` to a framework-agnostic
+form.
 
 - **State storage.** The canonical state lives on `Task.status` in the
   plan, not in a separate dict. `Session.plan` is the single source of

--- a/docs/design/STATE-OWNERSHIP-CONTRACT.md
+++ b/docs/design/STATE-OWNERSHIP-CONTRACT.md
@@ -161,7 +161,7 @@ The following writes touch `goldfive.types.Session.state` (the goldfive-owned di
 | `goldfive/orchestration_state.py:185` | `state.pop(key, None)` | Same as above. |
 | `goldfive/_correction_injection.py:217` | `state[key] = dict(correction)` | Caller is `write_correction`, takes a `goldfive.Session`; key is `goldfive.pending_corrections.*`. The bridge V2 mirrors to ADK. |
 | `goldfive/_correction_injection.py:352, :394` | `state.pop(key, None)` | Same. |
-| `goldfive/steerer.py:4602` | `state[_ostate.KEY_CURRENT_TASK_ID] = resolved` | Inside `_emit_plan_revised`'s supersession-rewrite path; `state` is the goldfive `Session.state`. |
+| `goldfive/plan_reviser.py:1322` | `state[_ostate.KEY_CURRENT_TASK_ID] = resolved` | Inside `PlanReviser._emit_plan_revised`'s supersession-rewrite path; `state` is the goldfive `Session.state`. (Moved from `goldfive/steerer.py` in #410 facade-cleanup.) |
 | `goldfive/adapters/_adk_state_protocol.py:159` etc. | `state[key] = value` inside the protocol module's `_set` and the `set_*_on_adk_state` helpers. | These are the *helpers* that target the ADK side. The violations are at the **call sites** (V1-V5), not in the helper itself. The tripwire flags the call sites (which run inside callbacks) and lets the helpers themselves run uninstrumented. |
 
 ## 6. Edge cases the contract explicitly addresses

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -23,7 +23,7 @@ goldfive's :class:`~goldfive.protocols.Steerer`. It does four jobs:
 4. **Drift observation** — ``after_model_callback``,
    ``on_event_callback`` (transfer/escalation), and
    ``on_tool_error_callback`` feed raw signals into
-   ``steerer.observe(...)`` so the steerer can classify drift.
+   ``steerer.drift.observe(...)`` so the steerer can classify drift.
 
 The plugin never imports ``google.adk`` at module load. It imports the
 ADK ``BasePlugin`` base class lazily inside :func:`make_adk_plugin`,
@@ -1356,7 +1356,7 @@ def _as_observation(
     task: Any = None,
     agent_id: str = "",
 ) -> dict[str, Any]:
-    """Build the lightweight observation dict handed to ``steerer.observe``.
+    """Build the lightweight observation dict handed to ``steerer.drift.observe``.
 
     The steerer is responsible for classifying this into a
     :class:`~goldfive.types.DriftEvent` via ``detect_drift``. This
@@ -2425,7 +2425,9 @@ def make_adk_plugin(
             # steerers without ``note_agent_activity`` fall through to
             # a no-op. Always safe — the recorder does not itself
             # trigger an LLM call.
-            note_activity = getattr(ctx.steerer, "note_agent_activity", None)
+            note_activity = getattr(
+                getattr(ctx.steerer, "drift", None), "note_agent_activity", None
+            )
             if note_activity is not None:
                 try:
                     note_activity(
@@ -3710,7 +3712,9 @@ def make_adk_plugin(
             # these hooks fall through cleanly. The counter is
             # trajectory-level and persists across task transitions.
             if ctx.steerer is not None:
-                note_activity = getattr(ctx.steerer, "note_agent_activity", None)
+                note_activity = getattr(
+                    getattr(ctx.steerer, "drift", None), "note_agent_activity", None
+                )
                 if note_activity is not None:
                     try:
                         note_activity(
@@ -3724,7 +3728,9 @@ def make_adk_plugin(
                             "after_run_callback: note_agent_activity raised: %s",
                             exc,
                         )
-                note_agent_turn = getattr(ctx.steerer, "note_agent_turn", None)
+                note_agent_turn = getattr(
+                    getattr(ctx.steerer, "drift", None), "note_agent_turn", None
+                )
                 if note_agent_turn is not None:
                     try:
                         await note_agent_turn(ctx.session)
@@ -3795,13 +3801,13 @@ def make_adk_plugin(
                 task=task,
                 agent_id=finishing_agent_name or self._host_agent_name,
             )
-            # Route through steerer.observe so the drift hits the same
+            # Route through steerer.drift.observe so the drift hits the same
             # pipeline AGENT_REFUSAL uses (DriftDetected sink event,
             # severity-based refine decision). We pre-classified above
             # so the steerer's classify_* cascade will no-op on the
             # observation dict — we still fire it explicitly by calling
             # _handle_drift directly when the steerer exposes it.
-            handle = getattr(ctx.steerer, "_handle_drift", None)
+            handle = getattr(getattr(ctx.steerer, "drift", None), "handle_drift", None)
             if handle is not None:
                 try:
                     await handle(drift, ctx.session)
@@ -3815,10 +3821,10 @@ def make_adk_plugin(
             # observation through observe() so custom steerers still
             # see the signal.
             try:
-                await ctx.steerer.observe(observation, ctx.session)
+                await ctx.steerer.drift.observe(observation, ctx.session)
             except Exception as exc:  # noqa: BLE001
                 log.debug(
-                    "_maybe_emit_confabulation_risk: steerer.observe raised: %s",
+                    "_maybe_emit_confabulation_risk: steerer.drift.observe raised: %s",
                     exc,
                 )
 
@@ -4045,7 +4051,7 @@ def make_adk_plugin(
             list off the ADK ``invoked_agent`` to
             :func:`goldfive.drift.capability_check.detect_capability_mismatch`.
             When the detector returns a drift, route it through
-            ``steerer._handle_drift`` so the standard intervention
+            ``steerer.drift.handle_drift`` so the standard intervention
             ladder fires (cancel + refine), with a direct sink-emission
             fallback when the steerer stub does not expose the helper.
 
@@ -4196,7 +4202,7 @@ def make_adk_plugin(
             except Exception:  # noqa: BLE001
                 pass
 
-            handle = getattr(steerer, "_handle_drift", None)
+            handle = getattr(getattr(steerer, "drift", None), "handle_drift", None)
             if callable(handle):
                 try:
                     await handle(drift, ctx.session)
@@ -4243,9 +4249,9 @@ def make_adk_plugin(
             """Emit a ``RUNAWAY_DELEGATION`` drift at CRITICAL severity.
 
             Built and dispatched directly (not through
-            ``steerer.observe`` → ``detect_drift``) because the cap is
+            ``steerer.drift.observe`` → ``detect_drift``) because the cap is
             an observed invariant violation, not a heuristic. Routes
-            through ``steerer._handle_drift`` when available so the
+            through ``steerer.drift.handle_drift`` when available so the
             planner gets a refine hook; falls back to a direct
             ``_emit_drift_detected`` if the steerer doesn't expose
             ``_handle_drift``. Failures swallowed — observability
@@ -4294,7 +4300,7 @@ def make_adk_plugin(
                 observed_revision_index=_observed_rev,
             )
             # Prefer _handle_drift so the full refine/emit path fires.
-            handle = getattr(steerer, "_handle_drift", None)
+            handle = getattr(getattr(steerer, "drift", None), "handle_drift", None)
             if callable(handle):
                 try:
                     await handle(drift, ctx.session)
@@ -4791,11 +4797,17 @@ def make_adk_plugin(
                         task=getattr(ctx, "task", None),
                         agent_id=self._host_agent_name,
                     )
-                    await steerer.observe(observation, session)
+                    await steerer.drift.observe(observation, session)
                     # Also surface as a structured DriftDetected so
                     # sinks see the drift even if the steerer's
-                    # observe() routes elsewhere.
-                    emit_drift = getattr(steerer, "_emit_drift_detected", None)
+                    # observe() routes elsewhere. After goldfive#410
+                    # the helper lives on the drift sub-component.
+                    drift_obs = getattr(steerer, "drift", None)
+                    emit_drift = (
+                        getattr(drift_obs, "_emit_drift_detected", None)
+                        if drift_obs is not None
+                        else None
+                    )
                     if emit_drift is not None:
                         try:
                             await emit_drift(session, drift)
@@ -5688,9 +5700,9 @@ def make_adk_plugin(
                 agent_id=self._host_agent_name,
             )
             try:
-                await ctx.steerer.observe(observation, ctx.session)
+                await ctx.steerer.drift.observe(observation, ctx.session)
             except Exception as exc:  # noqa: BLE001
-                log.debug("after_model_callback: steerer.observe raised: %s", exc)
+                log.debug("after_model_callback: steerer.drift.observe raised: %s", exc)
             if reasoning:
                 # Cooperative-cancel gate (iter-11D, goldfive#251 follow-up).
                 # Skip reasoning observation for cancelled invocations:
@@ -5710,7 +5722,9 @@ def make_adk_plugin(
                         inv_id,
                     )
                 else:
-                    observe_reasoning = getattr(ctx.steerer, "observe_reasoning", None)
+                    observe_reasoning = getattr(
+                        getattr(ctx.steerer, "drift", None), "observe_reasoning", None
+                    )
                     if observe_reasoning is not None:
                         # Tag synthesised-reasoning calls in the log so
                         # operators can tell content-fallback turns from
@@ -5791,7 +5805,7 @@ def make_adk_plugin(
                     inv_id,
                 )
             else:
-                note_llm_call = getattr(ctx.steerer, "note_llm_call", None)
+                note_llm_call = getattr(getattr(ctx.steerer, "drift", None), "note_llm_call", None)
                 if note_llm_call is not None:
                     try:
                         await note_llm_call(ctx.session)
@@ -5819,9 +5833,9 @@ def make_adk_plugin(
                 agent_id=self._host_agent_name,
             )
             try:
-                await ctx.steerer.observe(observation, ctx.session)
+                await ctx.steerer.drift.observe(observation, ctx.session)
             except Exception as exc:  # noqa: BLE001
-                log.debug("on_event_callback: steerer.observe raised: %s", exc)
+                log.debug("on_event_callback: steerer.drift.observe raised: %s", exc)
             return None
 
         async def on_tool_error_callback(
@@ -5844,9 +5858,9 @@ def make_adk_plugin(
                 agent_id=self._host_agent_name,
             )
             try:
-                await ctx.steerer.observe(observation, ctx.session)
+                await ctx.steerer.drift.observe(observation, ctx.session)
             except Exception as exc:  # noqa: BLE001
-                log.debug("on_tool_error_callback: steerer.observe raised: %s", exc)
+                log.debug("on_tool_error_callback: steerer.drift.observe raised: %s", exc)
             # Iter-10 PR 2: also record the raised-error path on
             # ``session.recent_tool_observations`` so the three-state
             # reasoning judge (PR 3) can recognise a provoked
@@ -5855,7 +5869,9 @@ def make_adk_plugin(
             # (e.g. ``classify_tool_error``) but never persisted on
             # the session.
             try:
-                note_obs = getattr(ctx.steerer, "note_tool_observation", None)
+                note_obs = getattr(
+                    getattr(ctx.steerer, "drift", None), "note_tool_observation", None
+                )
                 if note_obs is not None:
                     gf_session = ctx.session
                     pinned_agent = (
@@ -5915,9 +5931,9 @@ def make_adk_plugin(
             The detector is deterministic and O(1) per call modulo the
             tracker's ``window`` length; any failure is swallowed so a
             buggy classifier never breaks tool dispatch. Drifts are
-            routed through ``steerer._handle_drift`` when available so
+            routed through ``steerer.drift.handle_drift`` when available so
             the intervention ladder sees them; falls back to
-            ``steerer.observe`` for stubs that don't expose
+            ``steerer.drift.observe`` for stubs that don't expose
             ``_handle_drift``.
             """
             ctx = self._resolve_ctx(tool_context)
@@ -5995,7 +6011,9 @@ def make_adk_plugin(
             # the authoritative source — fall back to the ADK-resolved
             # agent_name and the ctx-task id when those are empty.
             try:
-                note_obs = getattr(ctx.steerer, "note_tool_observation", None)
+                note_obs = getattr(
+                    getattr(ctx.steerer, "drift", None), "note_tool_observation", None
+                )
                 if note_obs is not None:
                     gf_session = ctx.session
                     pinned_agent = (
@@ -6046,7 +6064,7 @@ def make_adk_plugin(
 
             # Prefer ``_handle_drift`` so the intervention ladder
             # sees the signal. Fall back to ``observe`` for stubs.
-            handle = getattr(ctx.steerer, "_handle_drift", None)
+            handle = getattr(getattr(ctx.steerer, "drift", None), "handle_drift", None)
             for drift in drifts:
                 if handle is not None:
                     try:
@@ -6067,10 +6085,10 @@ def make_adk_plugin(
                     agent_id=agent_name or self._host_agent_name,
                 )
                 try:
-                    await ctx.steerer.observe(observation, ctx.session)
+                    await ctx.steerer.drift.observe(observation, ctx.session)
                 except Exception as exc:  # noqa: BLE001
                     log.debug(
-                        "after_tool_callback: steerer.observe raised: %s",
+                        "after_tool_callback: steerer.drift.observe raised: %s",
                         exc,
                     )
             return None

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -1826,7 +1826,7 @@ class ADKAdapter:
         steerer = self._steerer
         if steerer is None or not text:
             return
-        observe = getattr(steerer, "observe_reasoning", None)
+        observe = getattr(getattr(steerer, "drift", None), "observe_reasoning", None)
         if observe is None:
             return
         try:

--- a/goldfive/adapters/callable.py
+++ b/goldfive/adapters/callable.py
@@ -86,7 +86,7 @@ class CallableAdapter:
         steerer = getattr(self, "_steerer", None)
         if steerer is None:
             return
-        observe = getattr(steerer, "observe_reasoning", None)
+        observe = getattr(getattr(steerer, "drift", None), "observe_reasoning", None)
         if observe is None:
             return
         try:

--- a/goldfive/adapters/claude.py
+++ b/goldfive/adapters/claude.py
@@ -203,7 +203,7 @@ class ClaudeAgentSDKAdapter:
         steerer = getattr(self, "_steerer", None)
         if steerer is None or not text:
             return
-        observe = getattr(steerer, "observe_reasoning", None)
+        observe = getattr(getattr(steerer, "drift", None), "observe_reasoning", None)
         if observe is None:
             return
         try:
@@ -451,7 +451,7 @@ class ClaudeAgentSDKAdapter:
 
 
 class _ToolCallObservation:
-    """Lightweight record passed to ``steerer.observe`` for tool_use.
+    """Lightweight record passed to ``steerer.drift.observe`` for tool_use.
 
     Using a plain object (instead of an SDK type) keeps the steerer
     framework-agnostic — it only needs ``name`` and ``arguments``.
@@ -544,11 +544,12 @@ def _strip_mcp_prefix(name: str) -> str:
 
 
 async def _safe_observe(steerer: SteererLike | None, event: Any, session: Session) -> None:
-    """Call ``steerer.observe`` without letting exceptions escape."""
+    """Call ``steerer.drift.observe`` without letting exceptions escape."""
 
     if steerer is None:
         return
-    observe = getattr(steerer, "observe", None)
+    drift_obs = getattr(steerer, "drift", None)
+    observe = getattr(drift_obs, "observe", None) if drift_obs is not None else None
     if observe is None:
         return
     try:

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -183,21 +183,22 @@ log = logging.getLogger(__name__)
 class DriftObserver:
     """Drift event observability + classification + dispatch helpers.
 
-    Constructed by :class:`DefaultSteerer` and held on
-    ``DefaultSteerer._drift_observer``. The router delegates the
-    drift-emit / detection / attribution / dispatch surface to the
-    matching method on this class via thin shims that forward
-    arguments verbatim. Tests that historically poked the
-    bare-attribute names on the steerer
-    (``steerer._emit_drift_detected``, ``steerer._handle_drift``,
-    ``steerer._promote_drift_to_steer``,
-    ``steerer.request_invocation_cancel``, etc.) keep working through
-    those shims; nothing on the public surface changes.
+    Constructed by :class:`DefaultSteerer` and exposed publicly as
+    ``DefaultSteerer.drift`` (goldfive#410). Callers — executors,
+    adapters, the runner, planners, tests — reach the drift-emit /
+    detection / attribution / dispatch surface directly as
+    ``steerer.drift.X``.
 
-    This is the post-**bucket 3c** state of the steerer split: bucket
-    3a (observability primitives), 3b (observation entry points +
-    judge orchestration), and 3c (dispatch + ladder + promotion +
-    refine-outcome bookkeeping) all live here.
+    Buckets retained from the original steerer-split:
+
+    * bucket 3a — observability primitives (``_emit_drift_detected``,
+      lifecycle stamping, ``_close_open_boundaries_for_terminal_drift``,
+      attribution helpers);
+    * bucket 3b — observation entry points + judge orchestration
+      (``observe`` / ``observe_reasoning`` / ``maybe_run_*_check``);
+    * bucket 3c — dispatch + ladder + promotion + refine-outcome
+      bookkeeping (``handle_drift`` / ``_ladder_level_for`` /
+      ``_promote_drift_to_steer`` / ``_record_refine_outcome``).
     """
 
     # ------------------------------------------------------------------
@@ -1080,12 +1081,11 @@ class DriftObserver:
             return
         drift = self._drift_from_control(event, session)
         if drift is None:
-            # Route through the router so subclasses overriding
-            # :meth:`DefaultSteerer.detect_drift` are still consulted
-            # (legacy extension surface; the router's shim forwards
-            # back into :meth:`DriftObserver.detect_drift` when the
-            # subclass does not override).
-            drift = self._steerer.detect_drift(event, session)
+            # Subclasses that need custom detection can subclass
+            # :class:`DriftObserver` and override
+            # :meth:`detect_drift`. The router-level shim that used
+            # to dispatch back here was retired in goldfive#410.
+            drift = self.detect_drift(event, session)
         if drift is None:
             return
         await self.handle_drift(drift, session)
@@ -2816,8 +2816,8 @@ class DriftObserver:
         _active_session_token = self._steerer._active_session_var.set(session)
         # goldfive a4: mint a refine-attempt id for correlation across
         # ``refine_attempted`` and the paired success/failure event.
-        attempt_id = self._steerer._new_attempt_id()
-        await self._steerer._emit_refine_attempted(session, drift, attempt_id=attempt_id)
+        attempt_id = self._steerer.plans._new_attempt_id()
+        await self._steerer.plans._emit_refine_attempted(session, drift, attempt_id=attempt_id)
         try:
             # Thread the adapter's available_agents_tree (goldfive#151)
             # through refine so the LLM is constrained to pick real
@@ -2873,7 +2873,7 @@ class DriftObserver:
                         drift.current_task_id,
                         exc,
                     )
-                    await self._steerer._emit_refine_failed(
+                    await self._steerer.plans._emit_refine_failed(
                         session,
                         drift,
                         attempt_id=attempt_id,
@@ -2896,7 +2896,7 @@ class DriftObserver:
                         drift.kind.value,
                         exc,
                     )
-                    await self._steerer._emit_refine_failed(
+                    await self._steerer.plans._emit_refine_failed(
                         session,
                         drift,
                         attempt_id=attempt_id,
@@ -2919,7 +2919,7 @@ class DriftObserver:
                     # ``_active_session_var``; we only own the paired-event
                     # stash here. Re-raise so cancellation continues to
                     # propagate per the asyncio contract.
-                    await self._steerer._emit_refine_failed(
+                    await self._steerer.plans._emit_refine_failed(
                         session,
                         drift,
                         attempt_id=attempt_id,
@@ -2946,7 +2946,7 @@ class DriftObserver:
                 "plan unchanged — escalating to HUMAN_INTERVENTION_REQUIRED",
                 drift.kind.value,
             )
-            await self._steerer._emit_refine_failed(
+            await self._steerer.plans._emit_refine_failed(
                 session,
                 drift,
                 attempt_id=attempt_id,
@@ -2965,7 +2965,7 @@ class DriftObserver:
         # carry that status into the persisted snapshot, even when the
         # LLM's view of the prior plan was stale.
         # goldfive#247: fold returns a NEW Plan (Plan is frozen).
-        revised = self._steerer._fold_runtime_terminal_statuses(revised, session.plan)
+        revised = self._steerer.plans._fold_runtime_terminal_statuses(revised, session.plan)
         try:
             revised.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
@@ -2986,7 +2986,7 @@ class DriftObserver:
             # PLAN-LIFECYCLE.md §3.1 (terminal task preservation) and
             # §3.2 (terminal->terminal edge preservation) on top of the
             # usual structural checks.
-            await self._steerer._emit_refine_failed(
+            await self._steerer.plans._emit_refine_failed(
                 session,
                 drift,
                 attempt_id=attempt_id,
@@ -3014,14 +3014,14 @@ class DriftObserver:
         # HUMAN_INTERVENTION_REQUIRED rather than bumping the revision
         # index for a no-op, which would otherwise loop forever on a
         # judge that keeps re-firing on a corrected task.
-        if self._steerer._plans_structurally_identical(session.plan, revised):
+        if self._steerer.plans._plans_structurally_identical(session.plan, revised):
             log.info(
                 "no-op revision skipped (kind=%s task=%r); escalating to "
                 "HUMAN_INTERVENTION_REQUIRED",
                 drift.kind.value,
                 drift.current_task_id,
             )
-            await self._steerer._emit_refine_failed(
+            await self._steerer.plans._emit_refine_failed(
                 session,
                 drift,
                 attempt_id=attempt_id,
@@ -3043,7 +3043,7 @@ class DriftObserver:
         # goldfive#255: _apply_revision returns ``(revised, was_installed)``
         # so the caller can thread the install outcome into PlanRevised's
         # ``dry_run`` marker.
-        revised, was_installed = self._steerer._apply_revision(session, revised, drift)
+        revised, was_installed = self._steerer.plans._apply_revision(session, revised, drift)
         # Cancel the in-flight coordinator invocation now that the plan
         # it was reasoning against has been superseded (goldfive#271
         # follow-up — v15 concurrent-invocation bug). Order: cancel
@@ -3052,7 +3052,7 @@ class DriftObserver:
         # and operators can correlate the two. Best-effort, never
         # raises — a no-op cancel still leaves the new plan installed.
         await self._cancel_inflight_for_revision(drift, session)
-        await self._steerer._emit_plan_revised(
+        await self._steerer.plans._emit_plan_revised(
             session,
             revised,
             drift,
@@ -4155,8 +4155,8 @@ class DriftObserver:
         _active_session_token = self._steerer._active_session_var.set(session)
         # goldfive a4: same attempt-id correlation contract as
         # ``_handle_drift``.
-        attempt_id = self._steerer._new_attempt_id()
-        await self._steerer._emit_refine_attempted(session, drift, attempt_id=attempt_id)
+        attempt_id = self._steerer.plans._new_attempt_id()
+        await self._steerer.plans._emit_refine_attempted(session, drift, attempt_id=attempt_id)
         # Resolve the registry constraint (goldfive#151) the same way
         # ``_handle_drift`` does so the goldfive steer refine honours it.
         planner = self._steerer._planner
@@ -4211,7 +4211,7 @@ class DriftObserver:
                     drift.current_task_id,
                     exc,
                 )
-                await self._steerer._emit_refine_failed(
+                await self._steerer.plans._emit_refine_failed(
                     session,
                     drift,
                     attempt_id=attempt_id,
@@ -4226,7 +4226,7 @@ class DriftObserver:
                     "DefaultSteerer._promote_drift_to_steer: refine raised %s; plan unchanged",
                     exc,
                 )
-                await self._steerer._emit_refine_failed(
+                await self._steerer.plans._emit_refine_failed(
                     session,
                     drift,
                     attempt_id=attempt_id,
@@ -4245,7 +4245,7 @@ class DriftObserver:
                 # paired ``refine_failed`` so cancelled goldfive-steer refines
                 # do not leave sinks with an unmatched ``refine_attempted``.
                 # Re-raise to preserve asyncio cancellation propagation.
-                await self._steerer._emit_refine_failed(
+                await self._steerer.plans._emit_refine_failed(
                     session,
                     drift,
                     attempt_id=attempt_id,
@@ -4269,7 +4269,7 @@ class DriftObserver:
                 "DefaultSteerer._promote_drift_to_steer: refine returned None; "
                 "plan unchanged — escalating to HUMAN_INTERVENTION_REQUIRED"
             )
-            await self._steerer._emit_refine_failed(
+            await self._steerer.plans._emit_refine_failed(
                 session,
                 drift,
                 attempt_id=attempt_id,
@@ -4283,7 +4283,7 @@ class DriftObserver:
         # I4 fix: fold runtime terminal statuses from the prior plan
         # onto the revised plan BEFORE validation (see _handle_drift
         # for the full rationale). goldfive#247: returns a NEW Plan.
-        revised = self._steerer._fold_runtime_terminal_statuses(revised, session.plan)
+        revised = self._steerer.plans._fold_runtime_terminal_statuses(revised, session.plan)
         try:
             revised.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
@@ -4294,7 +4294,7 @@ class DriftObserver:
             # HUMAN_INTERVENTION_REQUIRED. The actionable signal is
             # the paired ``refine_failed(validator_rejected)`` envelope
             # plus the escalation drift.
-            await self._steerer._emit_refine_failed(
+            await self._steerer.plans._emit_refine_failed(
                 session,
                 drift,
                 attempt_id=attempt_id,
@@ -4319,14 +4319,14 @@ class DriftObserver:
         # exhaustion semantics as ``_handle_drift`` — a structurally
         # identical plan means the planner cannot make progress on this
         # drift; escalate to HUMAN_INTERVENTION_REQUIRED.
-        if self._steerer._plans_structurally_identical(session.plan, revised):
+        if self._steerer.plans._plans_structurally_identical(session.plan, revised):
             log.info(
                 "no-op refine_steer revision skipped (kind=%s task=%r); "
                 "escalating to HUMAN_INTERVENTION_REQUIRED",
                 drift.kind.value,
                 drift.current_task_id,
             )
-            await self._steerer._emit_refine_failed(
+            await self._steerer.plans._emit_refine_failed(
                 session,
                 drift,
                 attempt_id=attempt_id,
@@ -4340,7 +4340,7 @@ class DriftObserver:
         prev_plan = session.plan
         # goldfive#247: rebind to the stamped instance.
         # goldfive#255: thread ``was_installed`` into PlanRevised.dry_run.
-        revised, was_installed = self._steerer._apply_revision(session, revised, drift)
+        revised, was_installed = self._steerer.plans._apply_revision(session, revised, drift)
         # Cancel the in-flight coordinator invocation now that
         # ``refine_steer`` produced a superseding plan (goldfive#271
         # follow-up — v15 concurrent-invocation bug). This is the
@@ -4357,7 +4357,7 @@ class DriftObserver:
         # revision and operators can correlate the two on the
         # gantt timeline.
         await self._cancel_inflight_for_revision(drift, session)
-        await self._steerer._emit_plan_revised(
+        await self._steerer.plans._emit_plan_revised(
             session,
             revised,
             drift,
@@ -4522,7 +4522,7 @@ class DriftObserver:
         task_id = drift.current_task_id
         reason = f"refine repeatedly failed for {drift.kind.value}"
         if task_id:
-            await self._steerer.mark_task_failed(
+            await self._steerer.tasks.mark_task_failed(
                 task_id,
                 reason=reason,
                 recoverable=False,

--- a/goldfive/executors/_control.py
+++ b/goldfive/executors/_control.py
@@ -25,7 +25,7 @@ members and their raw string equivalents — ``ControlKind`` is a
 
 * ``PAUSE`` / ``RESUME`` — pause / unpause the run loop between tasks.
 * ``CANCEL`` — abort the run; executor emits ``RunAborted``.
-* ``STEER`` — feed the message to ``steerer.observe`` so the planner
+* ``STEER`` — feed the message to ``steerer.drift.observe`` so the planner
   can produce a fresh plan on the ``USER_STEER`` drift.
 * ``REWIND_TO`` — mark a task and every downstream task ``PENDING``
   so the executor re-walks them.
@@ -263,7 +263,7 @@ async def dispatch_control(
 
     if kind == "STEER":
         # The steer message is queued for the executor to feed through
-        # ``steerer.observe`` so the planner can produce a USER_STEER-
+        # ``steerer.drift.observe`` so the planner can produce a USER_STEER-
         # driven plan revision. Phase 2 of the path-duality fix: a
         # STEER also acts as a RESUME for any goldfive-initiated pause
         # — the executor honours that by treating ``steer_message`` as
@@ -333,7 +333,7 @@ async def dispatch_control(
         # (custom Steerers may not implement it); failures are
         # swallowed at debug — observability MUST NOT break the
         # control path.
-        emit_transition = getattr(steerer, "_emit_task_transitioned", None)
+        emit_transition = getattr(getattr(steerer, "tasks", None), "_emit_task_transitioned", None)
         if callable(emit_transition):
             for task, prev_status in transitions:
                 try:

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -426,7 +426,7 @@ class ParallelDAGExecutor:
                                 except Exception as exc:  # noqa: BLE001
                                     log.debug(
                                         "ParallelDAGExecutor: "
-                                        "steerer._emit_plan_revised_correlation raised: %s",
+                                        "steerer.plans._emit_plan_revised_correlation raised: %s",
                                         exc,
                                     )
                         # Falls through to loop top: stages recomputed.
@@ -588,7 +588,9 @@ class ParallelDAGExecutor:
                                 session,
                                 with_task_status(session.plan, task.id, TaskStatus.RUNNING),
                             )
-                    emit_transition = getattr(steerer, "_emit_task_transitioned", None)
+                    emit_transition = getattr(
+                        getattr(steerer, "tasks", None), "_emit_task_transitioned", None
+                    )
                     if callable(emit_transition):
                         # Refresh the task reference so the emit reads
                         # the new status from the swapped plan.
@@ -624,8 +626,8 @@ class ParallelDAGExecutor:
                 try:
                     # Hand the result to the steerer for observation
                     # (sinks + any book-keeping) and drift detection.
-                    await steerer.observe(inv, session)
-                    drift = steerer.detect_drift(inv, session)
+                    await steerer.drift.observe(inv, session)
+                    drift = steerer.drift.detect_drift(inv, session)
                 except asyncio.CancelledError:
                     raise
                 except Exception as detect_exc:  # noqa: BLE001
@@ -638,7 +640,8 @@ class ParallelDAGExecutor:
                     # continues but operators can see the failure in
                     # the event stream. See goldfive#134.
                     log.warning(
-                        "ParallelDAGExecutor: steerer.observe/detect_drift raised for task=%s: %s",
+                        "ParallelDAGExecutor: steerer.drift.observe/detect_drift "
+                        "raised for task=%s: %s",
                         task.id,
                         detect_exc,
                     )
@@ -857,7 +860,11 @@ class ParallelDAGExecutor:
         # If a steerer with observe_refine is bound, route refine
         # attempt+failure emission through it. Otherwise fall back to
         # the legacy direct call (test stubs / custom steerers).
-        observe_refine = getattr(steerer, "observe_refine", None) if steerer is not None else None
+        observe_refine = (
+            getattr(getattr(steerer, "plans", None), "observe_refine", None)
+            if steerer is not None
+            else None
+        )
         attempt_id: str = ""
         if observe_refine is not None and callable(observe_refine):
             cm = observe_refine(session, drift)
@@ -1022,7 +1029,7 @@ class ParallelDAGExecutor:
         # goldfive#199: stamp the trigger_event_id on the plan for every
         # refine so harmonograf can strict-id-merge plan-revision rows
         # regardless of whether the executor refined via the steerer or
-        # inline here. Resolution mirrors steerer._apply_revision: source
+        # inline here. Resolution mirrors steerer.plans._apply_revision: source
         # annotation_id (user-control) → drift.id (autonomous). Preserves
         # any pre-existing stamp from the planner path.
         # goldfive#247: Plan is frozen — derive a new instance via
@@ -1078,7 +1085,7 @@ class ParallelDAGExecutor:
             )
         except Exception as exc:  # noqa: BLE001 — observability must never break the run
             log.debug(
-                "ParallelDAGExecutor: steerer._emit_refine_failed raised: %s",
+                "ParallelDAGExecutor: steerer.plans._emit_refine_failed raised: %s",
                 exc,
             )
 
@@ -1255,9 +1262,9 @@ class ParallelDAGExecutor:
     ) -> None:
         """Feed a STEER :class:`ControlMessage` to the steerer."""
         try:
-            await steerer.observe(message, session)
+            await steerer.drift.observe(message, session)
         except Exception as exc:  # noqa: BLE001
-            log.warning("ParallelDAGExecutor: steerer.observe(STEER) raised: %s", exc)
+            log.warning("ParallelDAGExecutor: steerer.drift.observe(STEER) raised: %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -1278,7 +1285,7 @@ async def _emit_pipeline_failure_drift(
 ) -> None:
     """Emit an INFO ``CUSTOM`` drift when the drift pipeline itself raised.
 
-    Surfaces plumbing failures in ``steerer.observe`` / ``detect_drift``
+    Surfaces plumbing failures in ``steerer.drift.observe`` / ``detect_drift``
     that would otherwise be swallowed. INFO severity so this is
     record-only and does not trigger another refine. Sinks that care
     can filter on the ``drift_pipeline_failed:`` detail prefix. See

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -159,14 +159,14 @@ async def _drain_steerer_at_run_boundary(
     it; bounded wait + cancel-stragglers semantics match the existing
     :meth:`shutdown` drain.
     """
-    drain = getattr(steerer, "drain_session_background_tasks", None)
+    drain = getattr(getattr(steerer, "drift", None), "drain_session_background_tasks", None)
     if not callable(drain):
         return
     try:
         await drain(session_id=session.id)
     except Exception as exc:  # noqa: BLE001 — never block run termination
         log.warning(
-            "SequentialExecutor: steerer.drain_session_background_tasks "
+            "SequentialExecutor: steerer.drift.drain_session_background_tasks "
             "raised at run boundary (swallowed): %s",
             exc,
         )
@@ -615,7 +615,7 @@ class SequentialExecutor(Executor):
 
             # If the adapter reported an error on the invocation envelope
             # (but didn't raise), record it; the auto-transition block
-            # below routes that through steerer.mark_task_failed unless
+            # below routes that through steerer.tasks.mark_task_failed unless
             # the agent already transitioned the task itself.
             invocation_error = result is not None and getattr(result, "error", None) is not None
             if invocation_error:
@@ -631,7 +631,7 @@ class SequentialExecutor(Executor):
             # invocation envelope (not only via reporting-tool handlers).
             if result is not None:
                 try:
-                    await steerer.observe(result, session)
+                    await steerer.drift.observe(result, session)
                 except Exception as observe_exc:  # noqa: BLE001
                     # Plumbing failure inside the drift pipeline: surface
                     # it so sinks see a signal, rather than silently
@@ -639,7 +639,7 @@ class SequentialExecutor(Executor):
                     # so the run continues but the failure is durably
                     # recorded. See goldfive#134.
                     log.warning(
-                        "SequentialExecutor: steerer.observe raised for task=%s: %s",
+                        "SequentialExecutor: steerer.drift.observe raised for task=%s: %s",
                         task.id,
                         observe_exc,
                     )
@@ -1014,7 +1014,7 @@ class SequentialExecutor(Executor):
             # branch (e.g. STEER, which calls ``_cancel_invoke_task``
             # directly and routes through the "steer" return) can
             # still trigger the flag-set as a side effect of
-            # ``steerer.observe`` → ``install_user_steer`` →
+            # ``steerer.drift.observe`` → ``install_user_steer`` →
             # ``_cancel_inflight_for_revision``; clearing here
             # prevents that stale flag from misclassifying a genuine
             # external cancel on the NEXT iteration as a supersede.
@@ -1144,7 +1144,7 @@ class SequentialExecutor(Executor):
                 # regression, preserved here post-#163).
                 log.info(
                     "SequentialExecutor._run_overlay: STEER received; "
-                    "feeding steerer.observe for USER_STEER drift + refine",
+                    "feeding steerer.drift.observe for USER_STEER drift + refine",
                 )
                 await self._apply_steer(payload, steerer=steerer, session=session)
                 # goldfive#152: wrap the steer body in a goldfive-authored
@@ -1178,7 +1178,7 @@ class SequentialExecutor(Executor):
                 # job is to compose the framed restart message and
                 # re-invoke. Mirrors the user-STEER branch above but
                 # with ``source="goldfive"`` framing and no
-                # ``steerer.observe`` call (the steerer originated the
+                # ``steerer.drift.observe`` call (the steerer originated the
                 # message; observing again would loop).
                 control_msg = payload
                 payload_dict = (
@@ -1684,7 +1684,7 @@ class SequentialExecutor(Executor):
             # steerer has already swapped ``session.plan`` and queued the
             # corrective body — propagating the message into the resume
             # path lets ``_apply_steer`` feed it back through
-            # ``steerer.observe`` so any downstream observers see the
+            # ``steerer.drift.observe`` so any downstream observers see the
             # message, and the outer loop picks up the swapped plan on
             # the next iteration.
             if outcome.goldfive_steer_message is not None:
@@ -1869,9 +1869,9 @@ class SequentialExecutor(Executor):
     ) -> None:
         """Feed a STEER :class:`ControlMessage` to the steerer."""
         try:
-            await steerer.observe(message, session)
+            await steerer.drift.observe(message, session)
         except Exception as exc:  # noqa: BLE001
-            log.warning("SequentialExecutor: steerer.observe(STEER) raised: %s", exc)
+            log.warning("SequentialExecutor: steerer.drift.observe(STEER) raised: %s", exc)
 
     @staticmethod
     def _compose_nudge_replay_message(nudges: list[str]) -> str:

--- a/goldfive/plan_reviser.py
+++ b/goldfive/plan_reviser.py
@@ -125,26 +125,22 @@ log = logging.getLogger(__name__)
 class PlanReviser:
     """Plan-install + refine-attempt observability owner.
 
-    Constructed by :class:`DefaultSteerer` and held on
-    ``DefaultSteerer._plan_reviser``. The router delegates every
-    install-* protocol method (and the internal helpers it composes
-    over) to the matching method on this class via thin shims that
-    forward arguments verbatim. Tests that historically poked the
-    bare-attribute names on the steerer (``steerer._apply_revision``,
-    ``steerer._emit_plan_revised``, etc.) keep working through those
-    shims; nothing on the public surface changes.
+    Constructed by :class:`DefaultSteerer` and exposed publicly as
+    ``DefaultSteerer.plans`` (goldfive#410). Callers — the Runner,
+    executors, planners, tests — reach the ``install_*`` family
+    directly as ``steerer.plans.install_X``.
     """
 
     def __init__(self, steerer: DefaultSteerer) -> None:
         # Back-reference to the router. Used to reach the shared
         # event-emission primitives (``_new_envelope`` / ``_emit`` /
         # ``_drift_*_pb_value``) and the cross-component cooperators:
-        # :class:`DriftObserver` for ``_emit_drift_detected`` /
+        # ``steerer.drift`` for ``_emit_drift_detected`` /
         # ``_cancel_inflight_for_revision`` / ``_apply_user_steer_state``
         # / ``_unpack_steer_context`` / ``_resolve_authored_by`` /
-        # ``_drift_annotation_id``, and
-        # :class:`TaskStateMachine` for ``mark_task_failed`` when a
-        # refine-failure cascade fires (REPEATED_FAILURE).
+        # ``_drift_annotation_id``, and ``steerer.tasks`` for
+        # ``_emit_plan_revision_transitions`` when a revision changes
+        # task statuses out-of-band.
         self._steerer = steerer
 
     # ------------------------------------------------------------------
@@ -207,7 +203,7 @@ class PlanReviser:
                 plan = self._fold_runtime_terminal_statuses(plan, session.plan)
                 plan.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
-            await self._steerer._emit_drift_detected(
+            await self._steerer.drift._emit_drift_detected(
                 session,
                 DriftEvent(
                     kind=DriftKind.SCHEMA_VIOLATION,
@@ -290,7 +286,7 @@ class PlanReviser:
                 "operator-pushed STEER ControlMessages."
             )
         if not drift.authored_by:
-            drift.authored_by = self._steerer._resolve_authored_by(drift)
+            drift.authored_by = self._steerer.drift._resolve_authored_by(drift)
         return await self._install_with_drift(
             session=session,
             drift=drift,
@@ -327,7 +323,7 @@ class PlanReviser:
         Returns ``True`` on success, ``False`` on validation failure.
         Never raises.
         """
-        body, author, _dedupe = self._steerer._unpack_steer_context(
+        body, author, _dedupe = self._steerer.drift._unpack_steer_context(
             DriftEvent(
                 kind=DriftKind.USER_STEER,
                 severity=DriftSeverity.WARNING,
@@ -429,8 +425,8 @@ class PlanReviser:
             chosen = self._build_minimal_steer_evolution(prior, drift)
         # Always run the user-steer state bookkeeping — every call to
         # this method represents a genuine operator action.
-        await self._steerer._apply_user_steer_state(drift, session)
-        await self._steerer._emit_drift_detected(session, drift)
+        await self._steerer.drift._apply_user_steer_state(drift, session)
+        await self._steerer.drift._emit_drift_detected(session, drift)
         # No-op short-circuit: the deterministic minimum on a prior with
         # no PENDING/RUNNING/BLOCKED tasks degenerates to a structurally
         # identical plan. Skip the install (avoids a misleading
@@ -451,7 +447,7 @@ class PlanReviser:
         # inside ``_apply_revision`` honours ``drift.authored_by == "user"``)
         # so ``was_installed`` is True even under observation_only.
         chosen, was_installed = self._apply_revision(session, chosen, drift)
-        await self._steerer._cancel_inflight_for_revision(drift, session)
+        await self._steerer.drift._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
             session,
             chosen,
@@ -561,8 +557,8 @@ class PlanReviser:
         installs do not.
         """
         if apply_user_steer_state:
-            await self._steerer._apply_user_steer_state(drift, session)
-        await self._steerer._emit_drift_detected(session, drift)
+            await self._steerer.drift._apply_user_steer_state(drift, session)
+        await self._steerer.drift._emit_drift_detected(session, drift)
         # I4 fix: fold runtime terminal statuses from the prior plan
         # onto the revised plan BEFORE validation. This is the path
         # that NEW_WORK_DISCOVERED installs (Runner._install_revision)
@@ -574,7 +570,7 @@ class PlanReviser:
         try:
             revised_plan.validate(for_revision=True, prior=session.plan)
         except ValueError as exc:
-            await self._steerer._emit_drift_detected(
+            await self._steerer.drift._emit_drift_detected(
                 session,
                 DriftEvent(
                     kind=DriftKind.SCHEMA_VIOLATION,
@@ -615,7 +611,7 @@ class PlanReviser:
         revised_plan, was_installed = self._apply_revision(
             session, revised_plan, drift
         )
-        await self._steerer._cancel_inflight_for_revision(drift, session)
+        await self._steerer.drift._cancel_inflight_for_revision(drift, session)
         await self._emit_plan_revised(
             session,
             revised_plan,
@@ -1479,7 +1475,7 @@ class PlanReviser:
         # attempt's trigger id).
         new_trigger_id = revised.revision_trigger_event_id
         if not new_trigger_id:
-            new_trigger_id = self._steerer._drift_annotation_id(drift) or str(
+            new_trigger_id = self._steerer.drift._drift_annotation_id(drift) or str(
                 getattr(drift, "id", "") or ""
             )
         revised = bump_revision(
@@ -1799,7 +1795,8 @@ class PlanReviser:
             # the revised plan (from ``_apply_revision`` or validator-retry
             # chain) → source annotation_id from the drift → drift.id.
             trig_id = revised.revision_trigger_event_id or (
-                self._steerer._drift_annotation_id(drift) or str(getattr(drift, "id", "") or "")
+                self._steerer.drift._drift_annotation_id(drift)
+                or str(getattr(drift, "id", "") or "")
             )
             if trig_id:
                 evt.plan_revised.trigger_event_id = trig_id
@@ -1887,7 +1884,7 @@ class PlanReviser:
             # consumer that processes events strictly in order sees the
             # plan flip first, then the per-task status changes that flow
             # from it.
-            await self._steerer._emit_plan_revision_transitions(session, prev_plan, revised)
+            await self._steerer.tasks._emit_plan_revision_transitions(session, prev_plan, revised)
             # goldfive a4: paired correlation envelope. The proto
             # ``PlanRevised`` carries no ``attempt_id`` field today; emit
             # a sidecar dict event so consumers can pair this success
@@ -1919,7 +1916,7 @@ class PlanReviser:
         what did the planner see?" at a glance. Truncated via the same
         convention used by ``trigger_input`` to keep event sinks bounded.
         """
-        from goldfive.steerer import DefaultSteerer
+        from goldfive.drift_observer import DriftObserver
 
         parts: list[str] = []
         parts.append(f"drift={drift.kind.value}/{drift.severity.value}")
@@ -1941,12 +1938,12 @@ class PlanReviser:
         else:
             parts.append("prior_plan=none")
         text = " | ".join(parts)
-        return DefaultSteerer._truncate_trigger_input(text)
+        return DriftObserver._truncate_trigger_input(text)
 
     @staticmethod
     def _build_refine_output_summary(revised: Plan) -> str:
         """Render a short summary of the plan the planner returned."""
-        from goldfive.steerer import DefaultSteerer
+        from goldfive.drift_observer import DriftObserver
 
         tasks = getattr(revised, "tasks", None) or []
         parts: list[str] = [
@@ -1960,4 +1957,4 @@ class PlanReviser:
         if titles:
             parts.append("titles=[" + ", ".join(titles) + "]")
         text = " | ".join(parts)
-        return DefaultSteerer._truncate_trigger_input(text)
+        return DriftObserver._truncate_trigger_input(text)

--- a/goldfive/planners/goldfive_planner.py
+++ b/goldfive/planners/goldfive_planner.py
@@ -274,7 +274,7 @@ class GoldfivePlanner(BasePlanner):
         via log.debug).
     session:
         Optional :class:`~goldfive.types.Session` passed to
-        ``steerer._handle_drift``. Same binding contract as
+        ``steerer.drift.handle_drift``. Same binding contract as
         ``steerer`` — set by the adapter when it auto-attaches.
     """
 
@@ -614,7 +614,7 @@ class GoldfivePlanner(BasePlanner):
         return None
 
     # ------------------------------------------------------------------
-    # Drift emission — plumbed through steerer._handle_drift to hit
+    # Drift emission — plumbed through steerer.drift.handle_drift to hit
     # the same pipeline PlanReconciler / RUNAWAY_DELEGATION use.
     # ------------------------------------------------------------------
 
@@ -626,7 +626,7 @@ class GoldfivePlanner(BasePlanner):
         kind_name: str,
         detail: str,
     ) -> None:
-        """Emit a structural tool-call drift via ``steerer._handle_drift``.
+        """Emit a structural tool-call drift via ``steerer.drift.handle_drift``.
 
         ``kind_name`` selects which :class:`DriftKind` member to fire
         — one of ``"PLAN_DIVERGENCE"`` (cross-layer delegation) or
@@ -639,7 +639,7 @@ class GoldfivePlanner(BasePlanner):
         whether to escalate via the intervention ladder (#142) or let
         it ride.
 
-        Routed through ``steerer._handle_drift`` (pre-built
+        Routed through ``steerer.drift.handle_drift`` (pre-built
         :class:`DriftEvent` path) matching the reconciler's
         convention — :meth:`observe` would round-trip the event back
         through classification and drop it.
@@ -693,10 +693,10 @@ class GoldfivePlanner(BasePlanner):
             current_agent_id=function_call_name,
             observed_revision_index=_observed_rev,
         )
-        handle = getattr(steerer, "_handle_drift", None)
+        handle = getattr(getattr(steerer, "drift", None), "handle_drift", None)
         if not callable(handle):
             log.debug(
-                "GoldfivePlanner: steerer has no _handle_drift; %s signal dropped",
+                "GoldfivePlanner: steerer.drift has no handle_drift; %s signal dropped",
                 kind_name,
             )
             return

--- a/goldfive/protocols.py
+++ b/goldfive/protocols.py
@@ -86,19 +86,39 @@ class Planner(Protocol):
 
 @runtime_checkable
 class Steerer(Protocol):
-    """Observes execution events, drives task transitions, and detects drift."""
+    """Observes execution events, drives task transitions, and detects drift.
 
-    async def observe(self, event: Any, session: Session) -> None: ...
+    After goldfive#410 (facade cleanup), the Steerer is a thin
+    coordinator with three component sub-objects:
 
-    async def observe_reasoning(
-        self,
-        text: str,
-        *,
-        task: Task | None = None,
-        session: Session,
-        provider: str = "",
-        agent_name: str = "",
-    ) -> None: ...
+    * ``tasks`` — :class:`~goldfive.task_state_machine.TaskStateMachine`,
+      holding ``mark_task_*`` / ``cascade_cancel_downstream`` /
+      ``_emit_task_*``.
+    * ``plans`` — :class:`~goldfive.plan_reviser.PlanReviser`, holding
+      ``install_*`` / ``_apply_revision`` / ``_emit_plan_revised`` /
+      ``_wait_plan_stable``.
+    * ``drift`` — :class:`~goldfive.drift_observer.DriftObserver`,
+      holding ``observe`` / ``observe_reasoning`` / ``detect_drift`` /
+      ``handle_drift`` / ``request_invocation_cancel`` / the reflective
+      and goal-drift checks.
+
+    Callers (Runner, executors, reporting handlers, adapters, planners,
+    tests) reach for ``steerer.tasks.X`` / ``steerer.plans.X`` /
+    ``steerer.drift.X`` directly rather than through router shims. The
+    Steerer itself retains only the cross-component ``transition``
+    helper and the shared ``bind`` / ``bind_adapter`` /
+    ``bind_control_channel`` wiring.
+    """
+
+    # Component sub-objects.  Protocol-level types are kept ``Any`` to
+    # avoid a hard dependency cycle (TaskStateMachine, PlanReviser, and
+    # DriftObserver all hold a back-pointer to a Steerer).  Conforming
+    # implementations should expose attributes of the corresponding
+    # concrete classes; the duck-typed contract is "has the methods the
+    # caller reaches for".
+    tasks: Any
+    plans: Any
+    drift: Any
 
     async def transition(
         self,
@@ -108,39 +128,14 @@ class Steerer(Protocol):
         detail: str = "",
         session: Session,
         cancel_reason: str = "",
-    ) -> None: ...
-
-    async def cascade_cancel_downstream(
-        self,
-        session: Session,
-        cancelled_id: str,
     ) -> None:
-        """BFS-cancel every downstream non-terminal task of ``cancelled_id``.
+        """Generic forward transition.
 
-        Shared cancellation-fanout primitive for both PLAN-LIFECYCLE.md
-        §6.2 (unrecoverable cascade) and §6.3 (cancel cascade). A
-        conforming Steerer MUST:
-
-        - Walk the current plan's forward edges from ``cancelled_id``.
-        - Transition every reachable non-terminal task to CANCELLED.
-        - Emit exactly one ``TaskCancelled`` event per transitioned
-          task, with a reason that identifies ``cancelled_id`` as the
-          cascade source.
-        - Skip tasks already in a terminal status (no re-cancellation,
-          no event re-emission).
-        - De-duplicate diamond-DAG reachability (emit at most one event
-          per downstream task per call).
-
-        The initiator (``cancelled_id``) itself is *not* transitioned
-        or emitted here — callers own that transition before invoking
-        this primitive.
+        Dispatches to the appropriate ``tasks.mark_task_*`` method.
+        Kept as a router-level convenience so callers that don't want
+        to bind to a specific status helper have a uniform entry
+        point.
         """
-
-    def detect_drift(
-        self,
-        event: Any,
-        session: Session,
-    ) -> DriftEvent | None: ...
 
     # Called by executors to wire sinks/planner into the steerer.
     def bind(

--- a/goldfive/reporting/_internal.py
+++ b/goldfive/reporting/_internal.py
@@ -523,16 +523,17 @@ def _rotate_after_terminal(
 async def _await_plan_stable(session: Session, steerer: Steerer) -> None:
     """Block briefly until the steerer's plan mutation region is idle.
 
-    Duck-types ``steerer._wait_plan_stable``: any Steerer implementation
-    that exposes an async ``_wait_plan_stable(session)`` method gets a
-    consistent plan-state read; implementations that don't (custom
-    Steerers, test stubs) silently fall through and observe whatever
-    plan state happens to be installed at call time — the pre-a4
-    behaviour. Atomicity is best-effort (the helper times out after a
-    short interval and proceeds anyway), so this is a soft barrier,
-    not a hard mutex.
+    Duck-types ``steerer.plans._wait_plan_stable``: any Steerer
+    implementation that exposes a ``plans`` component with an async
+    ``_wait_plan_stable(session)`` method gets a consistent plan-state
+    read; implementations that don't (custom Steerers, test stubs)
+    silently fall through and observe whatever plan state happens to
+    be installed at call time — the pre-a4 behaviour. Atomicity is
+    best-effort (the helper times out after a short interval and
+    proceeds anyway), so this is a soft barrier, not a hard mutex.
     """
-    waiter = getattr(steerer, "_wait_plan_stable", None)
+    plans = getattr(steerer, "plans", None)
+    waiter = getattr(plans, "_wait_plan_stable", None) if plans is not None else None
     if not callable(waiter):
         return
     try:

--- a/goldfive/reporting/handlers.py
+++ b/goldfive/reporting/handlers.py
@@ -377,7 +377,7 @@ async def _handle_task_started(
         "reporting._handle_task_started.mark_task_running"
     ):
         try:
-            await steerer.mark_task_running(
+            await steerer.tasks.mark_task_running(
                 task_id, session=session, detail=detail, source=source
             )
         finally:
@@ -459,7 +459,9 @@ async def _handle_task_progress(
                 attempted=TaskStatus.RUNNING,
                 task_id=task_id,
             )
-    await steerer.mark_task_progress(task_id, session=session, fraction=fraction, detail=detail)
+    await steerer.tasks.mark_task_progress(
+        task_id, session=session, fraction=fraction, detail=detail
+    )
     return _directive_ack(session=session, task_id=task_id, new_status=TaskStatus.RUNNING)
 
 
@@ -505,7 +507,7 @@ async def _handle_task_completed(
                 attempted=TaskStatus.COMPLETED,
                 task_id=task_id,
             )
-    await steerer.mark_task_completed(
+    await steerer.tasks.mark_task_completed(
         task_id, session=session, summary=summary, artifacts=artifacts, source=source
     )
     # Rotate the current-task pin now that this one has landed terminal.
@@ -549,7 +551,7 @@ async def _handle_task_failed(
                 attempted=TaskStatus.FAILED,
                 task_id=task_id,
             )
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         task_id,
         session=session,
         reason=reason,
@@ -596,7 +598,7 @@ async def _handle_task_blocked(
                 attempted=TaskStatus.BLOCKED,
                 task_id=task_id,
             )
-    await steerer.mark_task_blocked(
+    await steerer.tasks.mark_task_blocked(
         task_id, session=session, blocker=blocker, needed=needed, source=source
     )
     return _directive_ack(session=session, task_id=task_id, new_status=TaskStatus.BLOCKED)
@@ -612,7 +614,7 @@ async def _handle_new_work_discovered(
     title = _str(args, "title")
     description = _str(args, "description")
     assignee = _str(args, "assignee")
-    await steerer.report_new_work_discovered(
+    await steerer.drift.report_new_work_discovered(
         session=session,
         parent_task_id=parent_task_id,
         title=title,
@@ -630,7 +632,7 @@ async def _handle_plan_divergence(
         return err
     note = _str(args, "note")
     suggested_action = _str(args, "suggested_action")
-    await steerer.report_plan_divergence(
+    await steerer.drift.report_plan_divergence(
         session=session,
         note=note,
         suggested_action=suggested_action,
@@ -795,7 +797,7 @@ async def _handle_awaiting_approval(
     # ``decision`` and ``detail`` so this is safe.
     meta["prompt"] = prompt
 
-    await steerer.mark_task_blocked(
+    await steerer.tasks.mark_task_blocked(
         task_id,
         session=session,
         blocker="awaiting_approval",

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -890,7 +890,9 @@ class Runner:
                     authored_by="goldfive",
                 )
                 emit_helper = getattr(
-                    self.steerer, "_emit_drift_detected", None
+                    getattr(self.steerer, "drift", None),
+                    "_emit_drift_detected",
+                    None,
                 )
                 if callable(emit_helper):
                     try:
@@ -1477,7 +1479,7 @@ class Runner:
             try:
                 await steerer_shutdown()
             except Exception as exc:  # noqa: BLE001
-                log.warning("steerer.shutdown() raised: %s", exc)
+                log.warning("steerer.drift.shutdown() raised: %s", exc)
         for sink in self.sinks:
             try:
                 await sink.close()
@@ -1681,7 +1683,7 @@ class Runner:
                         if session.plan is not None
                         else "<none>",
                     )
-                installed = await self.steerer.install_initial_plan(
+                installed = await self.steerer.plans.install_initial_plan(
                     session=session, plan=revised_plan, is_pivot=is_pivot
                 )
             else:
@@ -1703,7 +1705,7 @@ class Runner:
                     detail=user_text,
                     authored_by="goldfive",
                 )
-                installed = await self.steerer.install_revision_for_drift(
+                installed = await self.steerer.plans.install_revision_for_drift(
                     session=session,
                     drift=drift,
                     revised_plan=revised_plan,

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -47,12 +47,10 @@ levels. See goldfive#142 for the full table.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import contextvars
 import enum
 import inspect
 import logging
-import re
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -670,13 +668,19 @@ class DefaultSteerer:
         # cannot reference one constructed later inside its own
         # ``__init__`` — none of them do today; every cross-call lands
         # at runtime.
+        #
+        # Components are exposed as public properties (``steerer.tasks``,
+        # ``steerer.plans``, ``steerer.drift``) so callers — executors,
+        # the runner, reporting handlers, planners, tests — can address
+        # the right component directly rather than going through a
+        # router shim. See goldfive#410.
         from goldfive.drift_observer import DriftObserver
         from goldfive.plan_reviser import PlanReviser
         from goldfive.task_state_machine import TaskStateMachine
 
-        self._task_state_machine: TaskStateMachine = TaskStateMachine(self)
-        self._plan_reviser: PlanReviser = PlanReviser(self)
-        self._drift_observer: DriftObserver = DriftObserver(self)
+        self.tasks: TaskStateMachine = TaskStateMachine(self)
+        self.plans: PlanReviser = PlanReviser(self)
+        self.drift: DriftObserver = DriftObserver(self)
 
     # ------------------------------------------------------------------
     # Protocol-required: wiring
@@ -828,7 +832,7 @@ class DefaultSteerer:
                 drift.kind.value,
             )
             return
-        await self._emit_drift_detected(session, drift)
+        await self.drift._emit_drift_detected(session, drift)
 
     # ------------------------------------------------------------------
     # Protocol-required: transition (generic)
@@ -873,683 +877,53 @@ class DefaultSteerer:
         FAILED.
         """
         if to is TaskStatus.RUNNING:
-            await self.mark_task_running(task_id, session=session, detail=detail, source=source)
+            await self.tasks.mark_task_running(
+                task_id, session=session, detail=detail, source=source
+            )
         elif to is TaskStatus.COMPLETED:
-            await self.mark_task_completed(task_id, summary=detail, session=session, source=source)
+            await self.tasks.mark_task_completed(
+                task_id, summary=detail, session=session, source=source
+            )
         elif to is TaskStatus.FAILED:
             reason = cancel_reason or detail
-            await self.mark_task_failed(task_id, reason=reason, session=session, source=source)
+            await self.tasks.mark_task_failed(
+                task_id, reason=reason, session=session, source=source
+            )
         elif to is TaskStatus.BLOCKED:
-            await self.mark_task_blocked(task_id, blocker=detail, session=session, source=source)
+            await self.tasks.mark_task_blocked(
+                task_id, blocker=detail, session=session, source=source
+            )
         elif to is TaskStatus.CANCELLED:
             reason = cancel_reason or detail
-            await self.mark_task_cancelled(task_id, reason=reason, session=session, source=source)
+            await self.tasks.mark_task_cancelled(
+                task_id, reason=reason, session=session, source=source
+            )
         elif to is TaskStatus.NOT_NEEDED:
-            await self.mark_task_not_needed(task_id, reason=detail, session=session, source=source)
+            await self.tasks.mark_task_not_needed(
+                task_id, reason=detail, session=session, source=source
+            )
         # PENDING and UNSPECIFIED are intentionally not reachable from
         # here; transitions are always forward in the lifecycle.
 
-    # ------------------------------------------------------------------
-    # Task state machine — delegated to :class:`TaskStateMachine`.
-    #
-    # See :mod:`goldfive.task_state_machine` for the implementation.
-    # These thin shims preserve the historical public surface
-    # (``DefaultSteerer.mark_task_*``) so executors / reporting handlers
-    # / tests that bind to the router don't have to change.
-    # ------------------------------------------------------------------
-
-    async def mark_task_running(
-        self,
-        task_id: str,
-        *,
-        session: Session,
-        detail: str = "",
-        source: str = "other",
-    ) -> None:
-        await self._task_state_machine.mark_task_running(
-            task_id, session=session, detail=detail, source=source
-        )
-
-    async def mark_task_progress(
-        self,
-        task_id: str,
-        *,
-        session: Session,
-        fraction: float = 0.0,
-        detail: str = "",
-    ) -> None:
-        await self._task_state_machine.mark_task_progress(
-            task_id, session=session, fraction=fraction, detail=detail
-        )
-
-    async def mark_task_completed(
-        self,
-        task_id: str,
-        *,
-        session: Session,
-        summary: str = "",
-        artifacts: dict[str, str] | None = None,
-        source: str = "other",
-    ) -> None:
-        await self._task_state_machine.mark_task_completed(
-            task_id,
-            session=session,
-            summary=summary,
-            artifacts=artifacts,
-            source=source,
-        )
-
-    async def mark_task_failed(
-        self,
-        task_id: str,
-        *,
-        session: Session,
-        reason: str = "",
-        recoverable: bool = True,
-        source: str = "other",
-    ) -> None:
-        await self._task_state_machine.mark_task_failed(
-            task_id,
-            session=session,
-            reason=reason,
-            recoverable=recoverable,
-            source=source,
-        )
-
-    async def mark_task_blocked(
-        self,
-        task_id: str,
-        *,
-        session: Session,
-        blocker: str = "",
-        needed: str = "",
-        source: str = "other",
-    ) -> None:
-        await self._task_state_machine.mark_task_blocked(
-            task_id,
-            session=session,
-            blocker=blocker,
-            needed=needed,
-            source=source,
-        )
-
-    async def mark_task_cancelled(
-        self,
-        task_id: str,
-        *,
-        session: Session,
-        reason: str = "",
-        source: str = "other",
-    ) -> None:
-        await self._task_state_machine.mark_task_cancelled(
-            task_id, session=session, reason=reason, source=source
-        )
-
-    async def mark_task_not_needed(
-        self,
-        task_id: str,
-        *,
-        session: Session,
-        reason: str = "",
-        source: str = "other",
-    ) -> None:
-        await self._task_state_machine.mark_task_not_needed(
-            task_id, session=session, reason=reason, source=source
-        )
-
-    async def cascade_cancel_downstream(
-        self,
-        session: Session,
-        cancelled_id: str,
-        *,
-        source: str = "cancellation",
-    ) -> None:
-        await self._task_state_machine.cascade_cancel_downstream(
-            session, cancelled_id, source=source
-        )
-
-    # ------------------------------------------------------------------
-    # Observer: drift detection + refine
-    # ------------------------------------------------------------------
-
-    async def observe(self, event: Any, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver.observe`."""
-        await self._drift_observer.observe(event, session)
-
-    async def observe_reasoning(
-        self,
-        text: str,
-        *,
-        task: Task | None = None,
-        session: Session,
-        provider: str = "",
-        agent_name: str = "",
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver.observe_reasoning`."""
-        await self._drift_observer.observe_reasoning(
-            text,
-            task=task,
-            session=session,
-            provider=provider,
-            agent_name=agent_name,
-        )
-
-    async def _run_judge_background(
-        self,
-        *,
-        text: str,
-        session: Session,
-        call_llm: ReflectiveCallLLM | None,
-        judge_sink: Any,
-        history_length: int,
-        agent_name: str = "",
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._run_judge_background`."""
-        await self._drift_observer._run_judge_background(
-            text=text,
-            session=session,
-            call_llm=call_llm,
-            judge_sink=judge_sink,
-            history_length=history_length,
-            agent_name=agent_name,
-        )
-
-    def _maybe_record_reasoning_binding(
-        self,
-        *,
-        session: Session,
-        verdict: Any,
-        agent_name: str,
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._maybe_record_reasoning_binding`."""
-        self._drift_observer._maybe_record_reasoning_binding(
-            session=session, verdict=verdict, agent_name=agent_name
-        )
-
-    async def shutdown(self, *, timeout: float = 5.0) -> None:
-        """Shim — delegate to :meth:`DriftObserver.shutdown`."""
-        await self._drift_observer.shutdown(timeout=timeout)
-
-    async def drain_session_background_tasks(
-        self, *, session_id: str, timeout: float = 2.0
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver.drain_session_background_tasks`."""
-        await self._drift_observer.drain_session_background_tasks(
-            session_id=session_id, timeout=timeout
-        )
-
-    async def _drain_background_set(
-        self,
-        bg_set: set[asyncio.Task[Any]],
-        *,
-        label: str,
-        timeout: float,
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._drain_background_set`."""
-        await self._drift_observer._drain_background_set(
-            bg_set, label=label, timeout=timeout
-        )
-
-    @staticmethod
-    def _truncate_trigger_input(text: str, limit: int = 2048) -> str:
-        """Shim — delegate to :meth:`DriftObserver._truncate_trigger_input`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._truncate_trigger_input(text, limit=limit)
-
-    def _resolve_available_agents(self) -> list[str] | list[dict[str, Any]] | None:
-        """Shim — delegate to :meth:`DriftObserver._resolve_available_agents`."""
-        return self._drift_observer._resolve_available_agents()
-
-    def _maybe_take_reasoning_judge_slot(
-        self,
-        session: Session,
-        *,
-        agent_name: str = "",
-    ) -> ReflectiveCallLLM | None:
-        """Shim — delegate to :meth:`DriftObserver._maybe_take_reasoning_judge_slot`."""
-        return self._drift_observer._maybe_take_reasoning_judge_slot(
-            session, agent_name=agent_name
-        )
-
-    # ------------------------------------------------------------------
-    # Reflective check — prompt + budget constants re-exported
-    # ------------------------------------------------------------------
-    #
-    # Re-exported as class attributes so callers / subclasses / tests
-    # that read ``DefaultSteerer.REFLECTIVE_*`` directly keep working.
-    # The canonical definitions live on :class:`DriftObserver`.
-
-    REFLECTIVE_SYSTEM_PROMPT: str = (
-        "You are assessing your own progress on a task. Answer truthfully. "
-        "Reply with a single JSON object and nothing else."
-    )
-
-    REFLECTIVE_USER_PROMPT_TEMPLATE: str = (
-        "You are assessing your own progress on a task.\n\n"
-        "CURRENT TASK:\n"
-        "id: {task_id}\n"
-        "title: {task_title}\n"
-        "description: {task_description}\n\n"
-        "WHAT YOU HAVE DONE IN THE LAST {window} LLM TURNS (summarized):\n"
-        "- recent tool calls: {tool_call_summary}\n"
-        "- recent reasoning (last 3 blocks): {reasoning_summary}\n\n"
-        "Q: Are you making forward progress on the task? Reply with a "
-        "single JSON object:\n"
-        '{{"making_progress": true|false, "confidence": 0.0-1.0, '
-        '"reason": "one-sentence explanation"}}'
-    )
-
-    REFLECTIVE_MAX_OUTPUT_TOKENS: int = 16384
-
-    async def note_llm_call(self, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver.note_llm_call`."""
-        await self._drift_observer.note_llm_call(session)
-
-    async def maybe_run_reflective_check(self, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver.maybe_run_reflective_check`."""
-        await self._drift_observer.maybe_run_reflective_check(session)
-
-    def note_agent_activity(
-        self,
-        session: Session,
-        *,
-        kind: str,
-        agent_name: str = "",
-        task_id: str = "",
-        detail: str = "",
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver.note_agent_activity`."""
-        self._drift_observer.note_agent_activity(
-            session,
-            kind=kind,
-            agent_name=agent_name,
-            task_id=task_id,
-            detail=detail,
-        )
-
-    def note_tool_observation(
-        self,
-        session: Session,
-        *,
-        agent_name: str,
-        task_id: str,
-        tool_name: str,
-        args: Any,
-        result: Any,
-        error: Exception | str | None = None,
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver.note_tool_observation`."""
-        self._drift_observer.note_tool_observation(
-            session,
-            agent_name=agent_name,
-            task_id=task_id,
-            tool_name=tool_name,
-            args=args,
-            result=result,
-            error=error,
-        )
-
-    async def note_agent_turn(self, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver.note_agent_turn`."""
-        await self._drift_observer.note_agent_turn(session)
-
-    # Minimum spacing between two task-boundary-triggered GOAL_DRIFT
-    # judge calls (seconds). Re-exported here as a class attribute so
-    # tests / subclasses that read ``DefaultSteerer._GOAL_DRIFT_TASK_BOUNDARY_MIN_INTERVAL_S``
-    # keep working. The canonical definition lives on :class:`DriftObserver`.
-    _GOAL_DRIFT_TASK_BOUNDARY_MIN_INTERVAL_S: float = 10.0
-
-    async def _maybe_run_goal_drift_on_task_boundary(self, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver._maybe_run_goal_drift_on_task_boundary`."""
-        await self._drift_observer._maybe_run_goal_drift_on_task_boundary(session)
-
-    async def maybe_run_goal_drift_check(self, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver.maybe_run_goal_drift_check`."""
-        await self._drift_observer.maybe_run_goal_drift_check(session)
-
-    def _spawn_goal_drift_judge_background(self, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver._spawn_goal_drift_judge_background`."""
-        self._drift_observer._spawn_goal_drift_judge_background(session)
-
-    async def _run_goal_drift_judge_background(self, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver._run_goal_drift_judge_background`."""
-        await self._drift_observer._run_goal_drift_judge_background(session)
-
-    def _spawn_drift_handler_background(
-        self, drift: DriftEvent, session: Session
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._spawn_drift_handler_background`."""
-        self._drift_observer._spawn_drift_handler_background(drift, session)
-
-    async def _run_drift_handler_background(
-        self, drift: DriftEvent, session: Session
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._run_drift_handler_background`."""
-        await self._drift_observer._run_drift_handler_background(drift, session)
-
-    async def _wait_background_drifts_idle(self) -> None:
-        """Shim — delegate to :meth:`DriftObserver._wait_background_drifts_idle`."""
-        await self._drift_observer._wait_background_drifts_idle()
-
-    async def _emit_reflective_failure(
-        self, session: Session, *, task_id: str, reason: str
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._emit_reflective_failure`."""
-        await self._drift_observer._emit_reflective_failure(
-            session, task_id=task_id, reason=reason
-        )
-
-    # --- Reflective prompt helpers -----------------------------------
-
-    # Liberal JSON extractor: tolerates markdown code fences and leading /
-    # trailing prose around the object. Re-exported here for any
-    # subclass / test that pokes the bare-attribute name; the canonical
-    # definition lives on :class:`DriftObserver`.
-    _JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
-
-    @classmethod
-    def _parse_reflective_response(cls, raw: Any) -> dict[str, Any] | None:
-        """Shim — delegate to :meth:`DriftObserver._parse_reflective_response`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._parse_reflective_response(raw)
-
-    @staticmethod
-    def _summarize_recent_tool_calls(session: Session, *, limit: int = 10) -> str:
-        """Shim — delegate to :meth:`DriftObserver._summarize_recent_tool_calls`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._summarize_recent_tool_calls(session, limit=limit)
-
-    @staticmethod
-    def _summarize_recent_reasoning(session: Session, *, limit: int = 3) -> str:
-        """Shim — delegate to :meth:`DriftObserver._summarize_recent_reasoning`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._summarize_recent_reasoning(session, limit=limit)
-
-    @staticmethod
-    def _steer_dedupe_id(event: Any) -> str:
-        """Shim — delegate to :meth:`DriftObserver._steer_dedupe_id`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._steer_dedupe_id(event)
-
-    @staticmethod
-    def _unpack_steer_context(drift: DriftEvent) -> tuple[str, str, str]:
-        """Shim — delegate to :meth:`DriftObserver._unpack_steer_context`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._unpack_steer_context(drift)
-
-    @classmethod
-    def _is_duplicate_steer(cls, event: Any, session: Session) -> bool:
-        """Shim — delegate to :meth:`DriftObserver._is_duplicate_steer`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._is_duplicate_steer(event, session)
-
-    @staticmethod
-    def _drift_from_control(event: Any, session: Session) -> DriftEvent | None:
-        """Shim — delegate to :meth:`DriftObserver._drift_from_control`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._drift_from_control(event, session)
-
-    def detect_drift(
-        self,
-        event: Any,
-        session: Session,
-    ) -> DriftEvent | None:
-        """Shim — delegate to :meth:`DriftObserver.detect_drift`."""
-        return self._drift_observer.detect_drift(event, session)
-
-    # ------------------------------------------------------------------
-    # Plan-mutation drift hooks (invoked by reporting-tool handlers)
-    # ------------------------------------------------------------------
-
-    async def report_new_work_discovered(
-        self,
-        *,
-        session: Session,
-        parent_task_id: str,
-        title: str,
-        description: str,
-        assignee: str = "",
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver.report_new_work_discovered`."""
-        await self._drift_observer.report_new_work_discovered(
-            session=session,
-            parent_task_id=parent_task_id,
-            title=title,
-            description=description,
-            assignee=assignee,
-        )
-
-    async def report_plan_divergence(
-        self,
-        *,
-        session: Session,
-        note: str,
-        suggested_action: str = "",
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver.report_plan_divergence`."""
-        await self._drift_observer.report_plan_divergence(
-            session=session,
-            note=note,
-            suggested_action=suggested_action,
-        )
-
     # ==================================================================
-    # Internals
+    # Internals (router-level, not delegated to a component)
     # ==================================================================
 
     # --- Plan lookup --------------------------------------------------
 
     @staticmethod
     def _find_task(session: Session, task_id: str) -> Task | None:
-        # Identity helper — kept as a router-level staticmethod so the
-        # historical call surface (``DefaultSteerer._find_task``) keeps
-        # working unchanged. Mirrors
-        # :meth:`goldfive.task_state_machine.TaskStateMachine._find_task`.
+        # Identity helper. Mirrors
+        # :meth:`goldfive.task_state_machine.TaskStateMachine._find_task`
+        # and remains here as a router-level staticmethod for callers
+        # (the reflective-check path on :class:`DriftObserver`, tests)
+        # that look up tasks without holding a component reference.
         if not task_id or session.plan is None:
             return None
         for t in session.plan.tasks:
             if t.id == task_id:
                 return t
         return None
-
-    # ------------------------------------------------------------------
-    # Drift dispatch + intervention ladder + promotion — thin shims to
-    # :class:`DriftObserver`. The real implementations live on
-    # ``self._drift_observer`` (bucket 3c of the steerer split). The
-    # router keeps these shims so the wide collection of tests, the
-    # planner's structural-drift hook, and any third-party subclasses
-    # that historically poked the bare-attribute names on
-    # :class:`DefaultSteerer` keep working byte-equivalently.
-    # ------------------------------------------------------------------
-
-    async def _handle_drift(self, drift: DriftEvent, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver.handle_drift`.
-
-        The central drift-routing entry point. See
-        :meth:`DriftObserver.handle_drift` for the contract.
-        """
-        await self._drift_observer.handle_drift(drift, session)
-
-    def _ladder_level_for(
-        self,
-        kind: DriftKind,
-        severity: DriftSeverity,
-        occurrence_count: int,
-    ) -> InterventionLevel:
-        """Shim — delegate to :meth:`DriftObserver._ladder_level_for`."""
-        return self._drift_observer._ladder_level_for(kind, severity, occurrence_count)
-
-    async def _dispatch_nudge(self, drift: DriftEvent, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver._dispatch_nudge`."""
-        await self._drift_observer._dispatch_nudge(drift, session)
-
-    async def _dispatch_goldfive_steer_control(
-        self,
-        drift: DriftEvent,
-        session: Session,
-        *,
-        body_override: str = "",
-    ) -> bool:
-        """Shim — delegate to :meth:`DriftObserver._dispatch_goldfive_steer_control`."""
-        return await self._drift_observer._dispatch_goldfive_steer_control(
-            drift, session, body_override=body_override
-        )
-
-    async def _dispatch_goldfive_pause_control(
-        self,
-        drift: DriftEvent,
-        session: Session,
-        *,
-        reason: str,
-    ) -> bool:
-        """Shim — delegate to :meth:`DriftObserver._dispatch_goldfive_pause_control`."""
-        return await self._drift_observer._dispatch_goldfive_pause_control(
-            drift, session, reason=reason
-        )
-
-    async def _dispatch_pause_escalate(
-        self,
-        drift: DriftEvent,
-        session: Session,
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._dispatch_pause_escalate`."""
-        await self._drift_observer._dispatch_pause_escalate(drift, session)
-
-    def _tag_adapter_cancel_reason(
-        self, drift: DriftEvent, *, session: Session | None = None
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._tag_adapter_cancel_reason`."""
-        self._drift_observer._tag_adapter_cancel_reason(drift, session=session)
-
-    def _tag_adapter_cancel_reason_for_promotion(
-        self, drift: DriftEvent, *, session: Session | None = None
-    ) -> str:
-        """Shim — delegate to :meth:`DriftObserver._tag_adapter_cancel_reason_for_promotion`."""
-        return self._drift_observer._tag_adapter_cancel_reason_for_promotion(
-            drift, session=session
-        )
-
-    async def _request_adapter_cancel(self, reason: str) -> None:
-        """Shim — delegate to :meth:`DriftObserver._request_adapter_cancel`."""
-        await self._drift_observer._request_adapter_cancel(reason)
-
-    def _is_late_drift_for_terminated_invocation(
-        self, drift: DriftEvent, session: Session
-    ) -> bool:
-        """Shim — delegate to :meth:`DriftObserver._is_late_drift_for_terminated_invocation`."""
-        return self._drift_observer._is_late_drift_for_terminated_invocation(drift, session)
-
-    def _resolve_active_invocation_ids(
-        self, drift: DriftEvent, session: Session
-    ) -> list[str]:
-        """Shim — delegate to :meth:`DriftObserver._resolve_active_invocation_ids`."""
-        return self._drift_observer._resolve_active_invocation_ids(drift, session)
-
-    async def request_invocation_cancel(
-        self,
-        *,
-        drift: DriftEvent,
-        session: Session,
-        cancel_inflight_task: bool = False,
-    ) -> list[str]:
-        """Shim — delegate to :meth:`DriftObserver.request_invocation_cancel`."""
-        return await self._drift_observer.request_invocation_cancel(
-            drift=drift,
-            session=session,
-            cancel_inflight_task=cancel_inflight_task,
-        )
-
-    @staticmethod
-    def _should_request_cancel_for_drift(drift: DriftEvent) -> bool:
-        """Shim — delegate to :meth:`DriftObserver._should_request_cancel_for_drift`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._should_request_cancel_for_drift(drift)
-
-    @staticmethod
-    def _cancel_reason_for_drift(drift: DriftEvent) -> str:
-        """Shim — delegate to :meth:`DriftObserver._cancel_reason_for_drift`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._cancel_reason_for_drift(drift)
-
-    async def _cancel_inflight_for_revision(
-        self, drift: DriftEvent, session: Session
-    ) -> list[str]:
-        """Shim — delegate to :meth:`DriftObserver._cancel_inflight_for_revision`."""
-        return await self._drift_observer._cancel_inflight_for_revision(drift, session)
-
-    def _severity_meets_promotion_threshold(self, severity: DriftSeverity) -> bool:
-        """Shim — delegate to :meth:`DriftObserver._severity_meets_promotion_threshold`."""
-        return self._drift_observer._severity_meets_promotion_threshold(severity)
-
-    def _should_promote_to_steer(self, drift: DriftEvent, session: Session) -> bool:
-        """Shim — delegate to :meth:`DriftObserver._should_promote_to_steer`."""
-        return self._drift_observer._should_promote_to_steer(drift, session)
-
-    async def _promote_drift_to_steer(self, drift: DriftEvent, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver._promote_drift_to_steer`.
-
-        Audit issue #402 (dispatch-before-plan-swap) is preserved on
-        the DriftObserver side; the shim simply forwards.
-        """
-        await self._drift_observer._promote_drift_to_steer(drift, session)
-
-    @staticmethod
-    def _compose_goldfive_steer_body(drift: DriftEvent) -> str:
-        """Shim — delegate to :meth:`DriftObserver._compose_goldfive_steer_body`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._compose_goldfive_steer_body(drift)
-
-    async def _apply_user_steer_state(
-        self,
-        drift: DriftEvent,
-        session: Session,
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._apply_user_steer_state`."""
-        await self._drift_observer._apply_user_steer_state(drift, session)
-
-    async def _record_refine_outcome(
-        self,
-        session: Session,
-        drift: DriftEvent,
-        *,
-        succeeded: bool,
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._record_refine_outcome`."""
-        await self._drift_observer._record_refine_outcome(
-            session, drift, succeeded=succeeded
-        )
-
-    def reset_for_turn(self, session: Session) -> None:
-        """Shim — delegate to :meth:`DriftObserver.reset_for_turn`.
-
-        Wired from :meth:`Runner.run` immediately after the
-        ``run_started`` event so each turn starts with an empty
-        outcome table.
-        """
-        self._drift_observer.reset_for_turn(session)
-
-    def _occurrence_count_for_ladder(self, session: Session, drift: DriftEvent) -> int:
-        """Shim — delegate to :meth:`DriftObserver._occurrence_count_for_ladder`."""
-        return self._drift_observer._occurrence_count_for_ladder(session, drift)
-
-    async def _escalate_refine_failure_as_critical_drift(
-        self, session: Session, source: DriftEvent, *, reason: str
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._escalate_refine_failure_as_critical_drift`."""
-        await self._drift_observer._escalate_refine_failure_as_critical_drift(
-            session, source, reason=reason
-        )
 
     # ------------------------------------------------------------------
     # ``observation_only`` gate — stays on the router because it reads
@@ -1563,12 +937,12 @@ class DefaultSteerer:
         Single named gate for the three steering injection points
         (goldfive#254):
 
-        * plan mutation in :meth:`_apply_revision`
+        * plan mutation in :meth:`PlanReviser._apply_revision`
           (``set_session_plan`` + ``last_addressed_revision_by_drift_key``);
         * ``GOLDFIVE_STEER`` ControlMessage enqueue in
-          :meth:`_dispatch_goldfive_steer_control`;
+          :meth:`DriftObserver._dispatch_goldfive_steer_control`;
         * the plugin ``request_invocation_cancel`` flag in
-          :meth:`request_invocation_cancel`.
+          :meth:`DriftObserver.request_invocation_cancel`.
 
         ``False`` when :class:`~goldfive.config.SteeringConfig.observation_only`
         is in effect — detection still runs, ``planner.refine_steer``
@@ -1580,99 +954,11 @@ class DefaultSteerer:
         """
         return not self._observation_only
 
-    # ------------------------------------------------------------------
-    # Plan install entry points — thin shims to :class:`PlanReviser`
-    # ------------------------------------------------------------------
-
-    async def install_initial_plan(
-        self,
-        *,
-        session: Session,
-        plan: Plan,
-        is_pivot: bool = False,
-    ) -> bool:
-        """Shim — delegate to :meth:`PlanReviser.install_initial_plan`."""
-        return await self._plan_reviser.install_initial_plan(
-            session=session, plan=plan, is_pivot=is_pivot
-        )
-
-    async def install_revision_for_drift(
-        self,
-        *,
-        session: Session,
-        drift: DriftEvent,
-        revised_plan: Plan,
-    ) -> bool:
-        """Shim — delegate to :meth:`PlanReviser.install_revision_for_drift`."""
-        return await self._plan_reviser.install_revision_for_drift(
-            session=session, drift=drift, revised_plan=revised_plan
-        )
-
-    async def install_revision_for_user_steer(
-        self,
-        *,
-        session: Session,
-        raw: Any,
-        revised_plan: Plan,
-    ) -> bool:
-        """Shim — delegate to :meth:`PlanReviser.install_revision_for_user_steer`."""
-        return await self._plan_reviser.install_revision_for_user_steer(
-            session=session, raw=raw, revised_plan=revised_plan
-        )
-
-    async def install_user_steer(
-        self,
-        *,
-        drift: DriftEvent,
-        prior: Plan,
-        llm_revision: Plan | None,
-        session: Session,
-    ) -> Plan:
-        """Shim — delegate to :meth:`PlanReviser.install_user_steer`."""
-        return await self._plan_reviser.install_user_steer(
-            drift=drift,
-            prior=prior,
-            llm_revision=llm_revision,
-            session=session,
-        )
-
-    def _build_minimal_steer_evolution(
-        self, prior: Plan, drift: DriftEvent
-    ) -> Plan:
-        """Shim — delegate to :meth:`PlanReviser._build_minimal_steer_evolution`."""
-        return self._plan_reviser._build_minimal_steer_evolution(prior, drift)
-
-    async def _install_with_drift(
-        self,
-        *,
-        session: Session,
-        drift: DriftEvent,
-        revised_plan: Plan,
-        apply_user_steer_state: bool,
-    ) -> bool:
-        """Shim — delegate to :meth:`PlanReviser._install_with_drift`."""
-        return await self._plan_reviser._install_with_drift(
-            session=session,
-            drift=drift,
-            revised_plan=revised_plan,
-            apply_user_steer_state=apply_user_steer_state,
-        )
-
-    async def apply_user_steer_with_plan(
-        self,
-        *,
-        drift: DriftEvent,
-        session: Session,
-        revised_plan: Plan,
-    ) -> bool:
-        """Shim — delegate to :meth:`PlanReviser.apply_user_steer_with_plan`."""
-        return await self._plan_reviser.apply_user_steer_with_plan(
-            drift=drift, session=session, revised_plan=revised_plan
-        )
-
     # Consecutive refine failures tolerated per (drift_kind, task_id)
     # before we give up and mark the task FAILED. Class attribute so
     # subclasses / tests can tune it without poking at instance state.
+    # Canonical definition; :class:`DriftObserver` and :class:`PlanReviser`
+    # both read it as ``self._steerer.REFINE_FAILURE_THRESHOLD``.
     REFINE_FAILURE_THRESHOLD: int = 2
 
     # Wall-clock seconds of task silence before a drift escalates to
@@ -1687,103 +973,9 @@ class DefaultSteerer:
     # work (model reasoning, multi-step research) is not interrupted,
     # tight enough that a Qwen judge re-firing on a wedged task does
     # not loop forever. ``0`` disables the gate (useful for tests).
+    # Canonical definition; :class:`DriftObserver` reads it as
+    # ``self._steerer.PROGRESS_STALL_THRESHOLD_SECONDS``.
     PROGRESS_STALL_THRESHOLD_SECONDS: float = 600.0
-
-
-    # --- Refine atomicity + observability (goldfive a4) --------------
-
-    def _get_plan_lock(self, session: Session) -> asyncio.Lock:
-        """Shim — delegate to :meth:`PlanReviser._get_plan_lock`."""
-        return self._plan_reviser._get_plan_lock(session)
-
-    async def _wait_plan_stable(
-        self,
-        session: Session,
-        *,
-        timeout: float | None = 1.0,
-    ) -> bool:
-        """Shim — delegate to :meth:`PlanReviser._wait_plan_stable`."""
-        return await self._plan_reviser._wait_plan_stable(session, timeout=timeout)
-
-    @staticmethod
-    def _new_attempt_id() -> str:
-        """Shim — delegate to :meth:`PlanReviser._new_attempt_id`."""
-        from goldfive.plan_reviser import PlanReviser
-
-        return PlanReviser._new_attempt_id()
-
-    async def _emit_refine_attempted(
-        self,
-        session: Session,
-        drift: DriftEvent,
-        *,
-        attempt_id: str,
-    ) -> None:
-        """Shim — delegate to :meth:`PlanReviser._emit_refine_attempted`."""
-        await self._plan_reviser._emit_refine_attempted(
-            session, drift, attempt_id=attempt_id
-        )
-
-    async def _emit_refine_failed(
-        self,
-        session: Session,
-        drift: DriftEvent,
-        *,
-        attempt_id: str,
-        failure_kind: str,
-        reason: str,
-        detail: str = "",
-    ) -> None:
-        """Shim — delegate to :meth:`PlanReviser._emit_refine_failed`."""
-        await self._plan_reviser._emit_refine_failed(
-            session,
-            drift,
-            attempt_id=attempt_id,
-            failure_kind=failure_kind,
-            reason=reason,
-            detail=detail,
-        )
-
-    def observe_refine(
-        self,
-        session: Session,
-        drift: DriftEvent,
-    ) -> contextlib.AbstractAsyncContextManager[str]:
-        """Shim — delegate to :meth:`PlanReviser.observe_refine`.
-
-        Note: this returns the underlying async context manager directly
-        rather than wrapping it in another ``@asynccontextmanager`` so
-        ``async with steerer.observe_refine(...)`` resolves to the same
-        ``_AsyncGeneratorContextManager`` instance that ``async with
-        steerer._plan_reviser.observe_refine(...)`` would resolve to.
-        """
-        return self._plan_reviser.observe_refine(session, drift)
-
-    async def _emit_plan_revised_correlation(
-        self,
-        session: Session,
-        revised: Plan,
-        drift: DriftEvent,
-        *,
-        attempt_id: str,
-    ) -> None:
-        """Shim — delegate to :meth:`PlanReviser._emit_plan_revised_correlation`."""
-        await self._plan_reviser._emit_plan_revised_correlation(
-            session, revised, drift, attempt_id=attempt_id
-        )
-
-    @staticmethod
-    def _fold_runtime_terminal_statuses(revised: Plan, prior: Plan | None) -> Plan:
-        """Shim — delegate to :meth:`PlanReviser._fold_runtime_terminal_statuses`."""
-        from goldfive.plan_reviser import PlanReviser
-
-        return PlanReviser._fold_runtime_terminal_statuses(revised, prior)
-
-    def _apply_revision(
-        self, session: Session, revised: Plan, drift: DriftEvent
-    ) -> tuple[Plan, bool]:
-        """Shim — delegate to :meth:`PlanReviser._apply_revision`."""
-        return self._plan_reviser._apply_revision(session, revised, drift)
 
     # --- Event construction ------------------------------------------
 
@@ -1812,234 +1004,3 @@ class DefaultSteerer:
         name = f"DRIFT_SEVERITY_{severity.name}"
         return getattr(types_pb2, name, getattr(types_pb2, "DRIFT_SEVERITY_UNSPECIFIED", 0))
 
-    # --- Concrete emitters -------------------------------------------
-    #
-    # Per-status proto emit helpers — delegated to
-    # :class:`~goldfive.task_state_machine.TaskStateMachine`. Thin shims
-    # so test fixtures that mock ``DefaultSteerer._emit_task_*`` keep
-    # intercepting at the router level and so other components inside
-    # this module can keep calling ``self._emit_task_*`` unchanged.
-
-    async def _emit_task_started(self, session: Session, task_id: str, detail: str) -> None:
-        await self._task_state_machine._emit_task_started(session, task_id, detail)
-
-    async def _emit_task_progress(
-        self, session: Session, task_id: str, fraction: float, detail: str
-    ) -> None:
-        await self._task_state_machine._emit_task_progress(session, task_id, fraction, detail)
-
-    async def _emit_task_completed(
-        self,
-        session: Session,
-        task_id: str,
-        summary: str,
-        artifacts: dict[str, str],
-    ) -> None:
-        await self._task_state_machine._emit_task_completed(
-            session, task_id, summary, artifacts
-        )
-
-    async def _emit_task_failed(
-        self, session: Session, task_id: str, reason: str, recoverable: bool
-    ) -> None:
-        await self._task_state_machine._emit_task_failed(
-            session, task_id, reason, recoverable
-        )
-
-    async def _emit_task_blocked(
-        self, session: Session, task_id: str, blocker: str, needed: str
-    ) -> None:
-        await self._task_state_machine._emit_task_blocked(
-            session, task_id, blocker, needed
-        )
-
-    async def _emit_task_cancelled(self, session: Session, task_id: str, reason: str) -> None:
-        await self._task_state_machine._emit_task_cancelled(session, task_id, reason)
-
-    async def _emit_task_transitioned(
-        self,
-        session: Session,
-        task: Task,
-        *,
-        from_status: TaskStatus,
-        to_status: TaskStatus,
-        source: str,
-    ) -> None:
-        await self._task_state_machine._emit_task_transitioned(
-            session,
-            task,
-            from_status=from_status,
-            to_status=to_status,
-            source=source,
-        )
-
-    async def _emit_plan_revision_transitions(
-        self,
-        session: Session,
-        prev_plan: Plan | None,
-        revised: Plan,
-    ) -> None:
-        await self._task_state_machine._emit_plan_revision_transitions(
-            session, prev_plan, revised
-        )
-
-    def _resolve_invocation_id_for_agent(self, agent_name: str) -> str:
-        return self._task_state_machine._resolve_invocation_id_for_agent(agent_name)
-
-    # ------------------------------------------------------------------
-    # DriftObserver shims — drift-event emission + lifecycle stamping +
-    # source attribution + structural escalation primitives. The real
-    # implementations live on :class:`goldfive.drift_observer.DriftObserver`
-    # held on ``self._drift_observer``; these are byte-equivalent shims
-    # for callers that historically poked the bare-attribute names on
-    # :class:`DefaultSteerer`.
-    # ------------------------------------------------------------------
-
-    # Class-level constants re-exported for callers (and methods still
-    # on this router) that read ``self._TERMINAL_DRIFT_KINDS`` /
-    # ``self._USER_AUTHORED_DRIFT_KINDS`` /
-    # ``self._USER_OR_TRAJECTORY_DRIFT_KINDS``. The canonical
-    # definitions live on :class:`DriftObserver`; aliasing them here
-    # keeps subclasses + tests that re-read these sets working.
-    _TERMINAL_DRIFT_KINDS: frozenset[DriftKind] = frozenset(
-        {
-            DriftKind.HUMAN_INTERVENTION_REQUIRED,
-            DriftKind.REPEATED_FAILURE,
-        }
-    )
-
-    _USER_AUTHORED_DRIFT_KINDS: frozenset[DriftKind] = frozenset(
-        {
-            DriftKind.USER_STEER,
-            DriftKind.USER_CANCEL,
-            DriftKind.USER_PAUSE,
-        }
-    )
-
-    _USER_OR_TRAJECTORY_DRIFT_KINDS: frozenset[DriftKind] = frozenset(
-        {
-            DriftKind.USER_STEER,
-            DriftKind.USER_CANCEL,
-            DriftKind.GOAL_DRIFT,
-        }
-    )
-
-    async def _emit_drift_detected(self, session: Session, drift: DriftEvent) -> None:
-        """Shim — delegate to :meth:`DriftObserver._emit_drift_detected`."""
-        await self._drift_observer._emit_drift_detected(session, drift)
-
-    @classmethod
-    def _is_terminal_drift(cls, drift: DriftEvent) -> bool:
-        """Shim — delegate to :meth:`DriftObserver._is_terminal_drift`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._is_terminal_drift(drift)
-
-    async def _close_open_boundaries_for_terminal_drift(self, drift: DriftEvent) -> None:
-        """Shim — delegate to :meth:`DriftObserver._close_open_boundaries_for_terminal_drift`."""
-        await self._drift_observer._close_open_boundaries_for_terminal_drift(drift)
-
-    def _stamp_drift_lifecycle(
-        self,
-        session: Session,
-        drift: DriftEvent,
-        evt: Any,
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._stamp_drift_lifecycle`."""
-        self._drift_observer._stamp_drift_lifecycle(session, drift, evt)
-
-    @staticmethod
-    def _drift_lifecycle_pb_value(lifecycle: str, types_pb2: Any) -> int:
-        """Shim — delegate to :meth:`DriftObserver._drift_lifecycle_pb_value`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._drift_lifecycle_pb_value(lifecycle, types_pb2)
-
-    @classmethod
-    def _resolve_authored_by(cls, drift: DriftEvent) -> str:
-        """Shim — delegate to :meth:`DriftObserver._resolve_authored_by`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._resolve_authored_by(drift)
-
-    @staticmethod
-    def _drift_annotation_id(drift: DriftEvent) -> str:
-        """Shim — delegate to :meth:`DriftObserver._drift_annotation_id`."""
-        from goldfive.drift_observer import DriftObserver
-
-        return DriftObserver._drift_annotation_id(drift)
-
-    def _is_task_progress_stalled(self, drift: DriftEvent, session: Session) -> bool:
-        """Shim — delegate to :meth:`DriftObserver._is_task_progress_stalled`."""
-        return self._drift_observer._is_task_progress_stalled(drift, session)
-
-    async def _emit_progress_stalled_escalation(
-        self, drift: DriftEvent, session: Session
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._emit_progress_stalled_escalation`."""
-        await self._drift_observer._emit_progress_stalled_escalation(drift, session)
-
-    async def _emit_handler_exhausted_escalation(
-        self, drift: DriftEvent, session: Session
-    ) -> None:
-        """Shim — delegate to :meth:`DriftObserver._emit_handler_exhausted_escalation`."""
-        await self._drift_observer._emit_handler_exhausted_escalation(drift, session)
-
-    @staticmethod
-    def _plans_structurally_identical(prior: Plan | None, revised: Plan) -> bool:
-        """Shim — delegate to :meth:`PlanReviser._plans_structurally_identical`."""
-        from goldfive.plan_reviser import PlanReviser
-
-        return PlanReviser._plans_structurally_identical(prior, revised)
-
-    @staticmethod
-    def _integrate_correction_supersedes(revised: Plan) -> Plan:
-        """Shim — delegate to :meth:`PlanReviser._integrate_correction_supersedes`."""
-        from goldfive.plan_reviser import PlanReviser
-
-        return PlanReviser._integrate_correction_supersedes(revised)
-
-    def _repin_current_task_on_supersedes(
-        self,
-        session: Session,
-        revised: Plan,
-    ) -> None:
-        """Shim — delegate to :meth:`PlanReviser._repin_current_task_on_supersedes`."""
-        self._plan_reviser._repin_current_task_on_supersedes(session, revised)
-
-    async def _emit_plan_revised(
-        self,
-        session: Session,
-        revised: Plan,
-        drift: DriftEvent,
-        *,
-        prev_plan: Plan | None = None,
-        attempt_id: str | None = None,
-        dry_run: bool | None = None,
-    ) -> None:
-        """Shim — delegate to :meth:`PlanReviser._emit_plan_revised`."""
-        await self._plan_reviser._emit_plan_revised(
-            session,
-            revised,
-            drift,
-            prev_plan=prev_plan,
-            attempt_id=attempt_id,
-            dry_run=dry_run,
-        )
-
-    @staticmethod
-    def _build_refine_input_summary(
-        drift: DriftEvent,
-        prev_plan: Plan | None,
-    ) -> str:
-        """Shim — delegate to :meth:`PlanReviser._build_refine_input_summary`."""
-        from goldfive.plan_reviser import PlanReviser
-
-        return PlanReviser._build_refine_input_summary(drift, prev_plan)
-
-    @staticmethod
-    def _build_refine_output_summary(revised: Plan) -> str:
-        """Shim — delegate to :meth:`PlanReviser._build_refine_output_summary`."""
-        from goldfive.plan_reviser import PlanReviser
-
-        return PlanReviser._build_refine_output_summary(revised)

--- a/goldfive/task_state_machine.py
+++ b/goldfive/task_state_machine.py
@@ -88,18 +88,16 @@ _TERMINAL_TASK_STATUSES = TERMINAL_TASK_STATUSES
 class TaskStateMachine:
     """Per-task status transitions + cascade + transition-event emission.
 
-    Constructed by :class:`DefaultSteerer` and held on
-    ``DefaultSteerer._task_state_machine``. The router delegates every
-    ``mark_task_*`` protocol method to the matching method on this
-    class. Tests that historically poked the bare-attribute names
-    (``steerer.mark_task_running``, ``steerer._emit_task_started``,
-    etc.) still find them via the router's ``__getattr__`` forwarder.
+    Constructed by :class:`DefaultSteerer` and exposed publicly as
+    ``DefaultSteerer.tasks`` (goldfive#410). Callers — the Runner,
+    executors, reporting handlers, planners, tests — reach the
+    ``mark_task_*`` family directly as ``steerer.tasks.mark_task_X``.
     """
 
     def __init__(self, steerer: DefaultSteerer) -> None:
         # Back-reference to the router. Used to reach the shared event-
         # emission primitives (``_new_envelope``, ``_emit``) and the
-        # other two components (``_drift_observer``, ``_plan_reviser``)
+        # other two components (``steerer.drift``, ``steerer.plans``)
         # when a transition path needs to cross a boundary
         # (e.g. mark_task_failed spawns a drift cascade owned by the
         # observer; cascade emits a TaskTransitioned which needs the
@@ -254,7 +252,7 @@ class TaskStateMachine:
         # actually returns; duplicate completed entries are harmless
         # (each is benign and the ring buffer trims naturally).
         if task.assignee_agent_id:
-            self._steerer.note_agent_activity(
+            self._steerer.drift.note_agent_activity(
                 session,
                 kind="agent_invocation_completed",
                 agent_name=task.assignee_agent_id,
@@ -269,7 +267,7 @@ class TaskStateMachine:
             source=source,
         )
         # goldfive#219: task boundary is a natural goal-drift checkpoint.
-        await self._steerer._maybe_run_goal_drift_on_task_boundary(session)
+        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(session)
 
     async def mark_task_failed(
         self,
@@ -319,7 +317,7 @@ class TaskStateMachine:
         # task-FAILED shape and false-positive on "looping".  See the
         # matching write in :meth:`mark_task_completed` for rationale.
         if task.assignee_agent_id:
-            self._steerer.note_agent_activity(
+            self._steerer.drift.note_agent_activity(
                 session,
                 kind="agent_invocation_completed",
                 agent_name=task.assignee_agent_id,
@@ -334,7 +332,7 @@ class TaskStateMachine:
             source=source,
         )
         # goldfive#219: task boundary is a natural goal-drift checkpoint.
-        await self._steerer._maybe_run_goal_drift_on_task_boundary(session)
+        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(session)
         # Fatal failures cascade downstream via the same primitive used
         # by mark_task_cancelled, so both §6.2 and §6.3 produce the
         # same TaskCancelled event stream and share rejection guards.
@@ -358,7 +356,7 @@ class TaskStateMachine:
         # (refine → supersedes → cancellation) lands asynchronously;
         # tests that need the post-cascade plan state await
         # :meth:`_wait_background_drifts_idle`.
-        self._steerer._spawn_drift_handler_background(drift, session)
+        self._steerer.drift._spawn_drift_handler_background(drift, session)
 
     async def mark_task_blocked(
         self,
@@ -410,7 +408,7 @@ class TaskStateMachine:
         # reporting tool that triggered us (``report_task_blocked``)
         # can return immediately. See :meth:`mark_task_failed` for
         # the matching call-site comment.
-        self._steerer._spawn_drift_handler_background(drift, session)
+        self._steerer.drift._spawn_drift_handler_background(drift, session)
 
     async def mark_task_cancelled(
         self,
@@ -462,7 +460,7 @@ class TaskStateMachine:
         # cascade-cancel downstream tasks share the same rate-limit bucket
         # and will no-op as subsequent boundary fires fall within the
         # 10s guard.
-        await self._steerer._maybe_run_goal_drift_on_task_boundary(session)
+        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(session)
         await self.cascade_cancel_downstream(session, task_id, source="cancellation")
 
     async def mark_task_not_needed(
@@ -521,7 +519,7 @@ class TaskStateMachine:
             source=source,
         )
         # goldfive#219: task boundary is a natural goal-drift checkpoint.
-        await self._steerer._maybe_run_goal_drift_on_task_boundary(session)
+        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(session)
 
     async def cascade_cancel_downstream(
         self,

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -67,20 +67,32 @@ def state_ctx_cls():
     return _Ctx
 
 
-class _RecordingSteerer:
-    """Minimal async-capable steerer stub for plugin observation tests."""
-
+class _RecordingDrift:
     def __init__(self) -> None:
         self.events: list[Any] = []
 
     async def observe(self, event: Any, session: Any) -> None:
         self.events.append(event)
 
-    async def transition(self, *a: Any, **kw: Any) -> None:
-        pass
-
     def detect_drift(self, event: Any, session: Any) -> None:
         return None
+
+
+class _RecordingSteerer:
+    """Minimal async-capable steerer stub for plugin observation tests.
+
+    Component-namespaced per goldfive#410.
+    """
+
+    def __init__(self) -> None:
+        self.drift = _RecordingDrift()
+
+    @property
+    def events(self) -> list[Any]:
+        return self.drift.events
+
+    async def transition(self, *a: Any, **kw: Any) -> None:
+        pass
 
     def bind(self, **kw: Any) -> None:
         pass
@@ -260,15 +272,26 @@ async def test_after_run_emits_confabulation_risk_on_zero_tools(state_ctx_cls) -
 
     plugin = make_adk_plugin(host_agent_name="research_agent")
 
-    class _ConfabulationAwareSteerer(_RecordingSteerer):
-        """Steerer stub that records drift emitted via _handle_drift."""
+    class _ConfabulationDrift(_RecordingDrift):
+        """DriftObserver stub that also records drift via handle_drift."""
 
         def __init__(self) -> None:
             super().__init__()
             self.drifts: list[DriftEvent] = []
 
-        async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+        async def handle_drift(self, drift: DriftEvent, session: Any) -> None:
             self.drifts.append(drift)
+
+    class _ConfabulationAwareSteerer(_RecordingSteerer):
+        """Steerer stub that records drift emitted via drift.handle_drift."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.drift = _ConfabulationDrift()
+
+        @property
+        def drifts(self) -> list[DriftEvent]:
+            return self.drift.drifts
 
     steerer = _ConfabulationAwareSteerer()
     session = Session(run_id="run-confab")
@@ -1809,7 +1832,7 @@ async def test_reporting_tool_duplicate_returns_idempotent_ack(state_ctx_cls) ->
     from goldfive.reporting import BUILTIN_REPORTING_TOOLS
     from goldfive.types import Plan, TaskEdge, TaskStatus
 
-    class _Steerer:
+    class _Tasks:
         def __init__(self) -> None:
             self.running_calls: int = 0
 
@@ -1817,7 +1840,7 @@ async def test_reporting_tool_duplicate_returns_idempotent_ack(state_ctx_cls) ->
             self.running_calls += 1
             # goldfive#247: Plan + Task are frozen — derive a new plan
             # via with_task_status. This stub mimics what the real
-            # DefaultSteerer.mark_task_running does.
+            # DefaultSteerer.tasks.mark_task_running does.
             from goldfive.types import (
                 channel_processor_active,
                 set_session_plan,
@@ -1832,6 +1855,14 @@ async def test_reporting_tool_duplicate_returns_idempotent_ack(state_ctx_cls) ->
                     session,
                     with_task_status(session.plan, task_id, TaskStatus.RUNNING),
                 )
+
+    class _Steerer:
+        def __init__(self) -> None:
+            self.tasks = _Tasks()
+
+        @property
+        def running_calls(self) -> int:
+            return self.tasks.running_calls
 
     spec = next(t for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_started")
 
@@ -2183,7 +2214,7 @@ async def test_reporting_tool_guards_fire_across_back_to_back_invocations() -> N
 
     # Simulate the STEER-driven plan revision: swap the plan on the
     # session to rev 1 with a new task, which is exactly what
-    # ``steerer._apply_revision`` does mid-run.
+    # ``steerer.plans._apply_revision`` does mid-run.
     t_raccoon = Task(id="raccoon_research", title="raccoons")
     plan_rev1 = Plan(
         id="p1",

--- a/tests/test_adk_plugin_tool_observations.py
+++ b/tests/test_adk_plugin_tool_observations.py
@@ -44,10 +44,10 @@ from goldfive.types import DriftEvent, Session, Task  # noqa: E402
 # ---------------------------------------------------------------------------
 
 
-class _RecordingSteerer:
-    """Async-capable steerer stub that captures every drift + every observation entry.
+class _RecordingDrift:
+    """Drift sub-component capturing every observation + drift (post #410).
 
-    Holds a real ``DefaultSteerer.note_tool_observation`` so the
+    Holds a real ``DriftObserver.note_tool_observation`` so the
     integration test exercises the steerer's writer end-to-end. Tests
     that want to override the writer (e.g. to assert dispatch survives
     a writer failure) can monkeypatch ``note_tool_observation`` after
@@ -66,12 +66,27 @@ class _RecordingSteerer:
     async def observe(self, event: Any, session: Any) -> None:
         self.observations.append(event)
 
-    async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+    async def handle_drift(self, drift: DriftEvent, session: Any) -> None:
         self.drifts.append(drift)
 
     def note_tool_observation(self, *args: Any, **kwargs: Any) -> None:
         # Delegate to the real implementation under test.
-        self._real_steerer.note_tool_observation(*args, **kwargs)
+        self._real_steerer.drift.note_tool_observation(*args, **kwargs)
+
+
+class _RecordingSteerer:
+    """Async-capable steerer stub that captures every drift + every observation entry."""
+
+    def __init__(self) -> None:
+        self.drift = _RecordingDrift()
+
+    @property
+    def observations(self) -> list[Any]:
+        return self.drift.observations
+
+    @property
+    def drifts(self) -> list[DriftEvent]:
+        return self.drift.drifts
 
 
 def _plugin_with_ctx(task: Task, session: Session, steerer: Any):
@@ -231,7 +246,7 @@ async def test_on_tool_error_callback_records_observation() -> None:
     assert entry["tool_name"] == "web_search"
     # ``on_tool_error`` doesn't get a result -- writer marks it as none.
     assert entry["result_preview"] == "(none)"
-    # The existing one-shot ``Observation`` for steerer.observe still
+    # The existing one-shot ``Observation`` for steerer.drift.observe still
     # fires alongside the new buffer write.
     assert len(steerer.observations) == 1
 
@@ -267,7 +282,7 @@ async def test_observation_does_not_break_on_buffer_failure_after_tool() -> None
     def _raise(*_a: Any, **_kw: Any) -> None:
         raise RuntimeError("buffer broken")
 
-    steerer.note_tool_observation = _raise  # type: ignore[assignment]
+    steerer.drift.note_tool_observation = _raise  # type: ignore[assignment]
 
     session = Session(run_id="run-iter10-pr2-broken")
     task = Task(id="t1", title="Task", assignee_agent_id="worker")
@@ -293,7 +308,7 @@ async def test_observation_does_not_break_on_buffer_failure_on_error() -> None:
     def _raise(*_a: Any, **_kw: Any) -> None:
         raise RuntimeError("buffer broken")
 
-    steerer.note_tool_observation = _raise  # type: ignore[assignment]
+    steerer.drift.note_tool_observation = _raise  # type: ignore[assignment]
 
     session = Session(run_id="run-iter10-pr2-broken-on-err")
     task = Task(id="t1", title="Task", assignee_agent_id="worker")

--- a/tests/test_agent_budget.py
+++ b/tests/test_agent_budget.py
@@ -202,25 +202,37 @@ def test_cap_skips_when_request_has_no_config() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _CapturingSteerer:
-    """Capture every observation + drift the watcher emits.
-
-    Shape mirrors the live :class:`DefaultSteerer` interface enough for
-    the watcher's emission path: ``observe(obs, session)`` and
-    ``_emit_drift_detected(session, drift)``. The watcher writes to both;
-    we expose both for assertions.
-    """
-
+class _CapturingDrift:
     def __init__(self) -> None:
         self.observations: list[Any] = []
         self.emitted_drifts: list[Any] = []
-        self._sinks: list[Any] = []
 
     async def observe(self, observation: Any, session: Any) -> None:
         self.observations.append(observation)
 
     async def _emit_drift_detected(self, session: Any, drift: Any) -> None:
         self.emitted_drifts.append(drift)
+
+
+class _CapturingSteerer:
+    """Capture every observation + drift the watcher emits.
+
+    Shape mirrors the live :class:`DefaultSteerer` interface for the
+    watcher's emission path after goldfive#410: the watcher reaches
+    for ``steerer.drift.observe`` and ``steerer.drift._emit_drift_detected``.
+    """
+
+    def __init__(self) -> None:
+        self.drift = _CapturingDrift()
+        self._sinks: list[Any] = []
+
+    @property
+    def observations(self) -> list[Any]:
+        return self.drift.observations
+
+    @property
+    def emitted_drifts(self) -> list[Any]:
+        return self.drift.emitted_drifts
 
 
 def _make_session_context(steerer: Any) -> Any:

--- a/tests/test_cancel_inflight_on_refine.py
+++ b/tests/test_cancel_inflight_on_refine.py
@@ -409,7 +409,7 @@ async def test_install_initial_plan_does_not_cancel_inflight() -> None:
         edges=[],
         summary="initial",
     )
-    installed = await steerer.install_initial_plan(session=session, plan=plan)
+    installed = await steerer.plans.install_initial_plan(session=session, plan=plan)
     assert installed
     # The plugin's cancel must NOT have been called: there is no
     # in-flight invocation on a fresh-session install.
@@ -446,7 +446,7 @@ async def test_cancel_inflight_for_revision_fires_for_real_drift() -> None:
         current_task_id="t1",
         current_agent_id="coordinator",
     )
-    flagged = await steerer._cancel_inflight_for_revision(drift, _make_session())
+    flagged = await steerer.drift._cancel_inflight_for_revision(drift, _make_session())
     assert flagged == ["inv-X"]
     assert len(adapter._plugin.calls) == 1
     assert adapter._plugin.calls[0]["cancel_inflight_task"] is True
@@ -560,7 +560,7 @@ async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> Non
         current_task_id="t1",
         current_agent_id="coordinator",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     try:
         await asyncio.wait_for(coord_task, timeout=1.0)

--- a/tests/test_cancel_reason.py
+++ b/tests/test_cancel_reason.py
@@ -100,7 +100,7 @@ async def test_upstream_failure_stamps_reason() -> None:
     sink = _ListSink()
     steerer.bind(sinks=[sink], planner=_StubPlanner())
 
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         "t1", session=session, reason="boom", recoverable=False
     )
 
@@ -120,7 +120,7 @@ async def test_cancel_cascade_stamps_upstream_failed() -> None:
     sink = _ListSink()
     steerer.bind(sinks=[sink], planner=_StubPlanner())
 
-    await steerer.mark_task_cancelled(
+    await steerer.tasks.mark_task_cancelled(
         "t1", session=session, reason="user cancelled"
     )
 

--- a/tests/test_cancellation_stash_audit.py
+++ b/tests/test_cancellation_stash_audit.py
@@ -150,7 +150,7 @@ async def test_c4_observe_refine_emits_refine_failed_on_cancellederror_and_rerai
 
     captured_attempt_id: str = ""
     with pytest.raises(asyncio.CancelledError):
-        async with steerer.observe_refine(session, drift) as attempt_id:
+        async with steerer.plans.observe_refine(session, drift) as attempt_id:
             captured_attempt_id = attempt_id
             raise asyncio.CancelledError()
 
@@ -182,7 +182,7 @@ async def test_c4_observe_refine_aclose_mid_refine_emits_failed() -> None:
     captured: dict[str, str] = {}
 
     async def _refine_user() -> None:
-        async with steerer.observe_refine(session, drift) as attempt_id:
+        async with steerer.plans.observe_refine(session, drift) as attempt_id:
             captured["id"] = attempt_id
             started.set()
             # Simulate a long-running refine the canceller will interrupt.
@@ -235,7 +235,7 @@ async def test_c4_handle_drift_emits_refine_failed_when_refine_cancelled() -> No
     drift = _drift()
 
     with pytest.raises(asyncio.CancelledError):
-        await steerer._handle_drift(drift, session)
+        await steerer.drift.handle_drift(drift, session)
 
     failed = sink.by_kind("refine_failed")
     assert len(failed) >= 1, (
@@ -356,15 +356,12 @@ async def test_c2_parallel_refine_cancelled_emits_critical_mirror_legacy_path() 
 
 # ---------------------------------------------------------------------------
 # C5 — _handle_task_started: correction GC must run even if
-# ``await steerer.mark_task_running`` is cancelled mid-flight.
+# ``await steerer.tasks.mark_task_running`` is cancelled mid-flight.
 # ---------------------------------------------------------------------------
 
 
-class _CancellingSteererForTaskStarted:
-    """Steerer stub whose ``mark_task_running`` raises CancelledError."""
-
+class _CancellingTasks:
     def __init__(self) -> None:
-        self._sinks: list[Any] = []
         self.calls: list[str] = []
 
     async def mark_task_running(
@@ -378,17 +375,32 @@ class _CancellingSteererForTaskStarted:
         self.calls.append(task_id)
         raise asyncio.CancelledError()
 
-    # Optional protocol surface used by the reporting handler:
-    async def transition(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
-        pass
 
+class _NoopPlans:
     async def _wait_plan_stable(self, _session: Session) -> None:
         return None
 
 
+class _CancellingSteererForTaskStarted:
+    """Steerer stub whose ``tasks.mark_task_running`` raises CancelledError."""
+
+    def __init__(self) -> None:
+        self._sinks: list[Any] = []
+        self.tasks = _CancellingTasks()
+        self.plans = _NoopPlans()
+
+    @property
+    def calls(self) -> list[str]:
+        return self.tasks.calls
+
+    # Optional protocol surface used by the reporting handler:
+    async def transition(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+        pass
+
+
 async def test_c5_clear_correction_runs_when_mark_running_cancelled() -> None:
     """Phase 3.5 §C5: ``_handle_task_started`` calls
-    ``await steerer.mark_task_running`` and then synchronously
+    ``await steerer.tasks.mark_task_running`` and then synchronously
     ``_clear_correction_on_started``. Pre-fix the post-await clear was
     skipped on CancelledError, leaving the pending correction wedged
     on session state for a task the agent had just acknowledged.

--- a/tests/test_capability_mismatch.py
+++ b/tests/test_capability_mismatch.py
@@ -536,31 +536,40 @@ def test_rule_c_excludes_bound_task_by_id() -> None:
 pytest.importorskip("google.adk")
 
 
-class _RecordingSteerer:
-    """Test stub matching ``test_runaway_delegation_cap``: records every
-    drift routed through ``_handle_drift`` so the test can assert on
-    CAPABILITY_MISMATCH emission without spinning up a full
-    DefaultSteerer.
-    """
-
+class _RecordingDrift:
     def __init__(self) -> None:
-        self._sinks: list[Any] = []
         self.drifts: list[Any] = []
 
     async def observe(self, *a: Any, **kw: Any) -> None:
         pass
 
-    async def transition(self, *a: Any, **kw: Any) -> None:
-        pass
-
     def detect_drift(self, *a: Any, **kw: Any) -> None:
         return None
 
-    def bind(self, **kw: Any) -> None:
+    async def handle_drift(self, drift: Any, session: Any) -> None:  # noqa: ARG002
+        self.drifts.append(drift)
+
+
+class _RecordingSteerer:
+    """Test stub matching ``test_runaway_delegation_cap``: records every
+    drift routed through ``drift.handle_drift`` so the test can assert
+    on CAPABILITY_MISMATCH emission without spinning up a full
+    DefaultSteerer.  Component-namespaced per goldfive#410.
+    """
+
+    def __init__(self) -> None:
+        self._sinks: list[Any] = []
+        self.drift = _RecordingDrift()
+
+    @property
+    def drifts(self) -> list[Any]:
+        return self.drift.drifts
+
+    async def transition(self, *a: Any, **kw: Any) -> None:
         pass
 
-    async def _handle_drift(self, drift: Any, session: Any) -> None:  # noqa: ARG002
-        self.drifts.append(drift)
+    def bind(self, **kw: Any) -> None:
+        pass
 
 
 def _make_one_shot_delegating_llm(tool_name: str) -> Any:

--- a/tests/test_cooperative_cancellation.py
+++ b/tests/test_cooperative_cancellation.py
@@ -549,7 +549,7 @@ async def test_info_drift_does_not_request_cancel() -> None:
         current_task_id="t1",
         current_agent_id="sub_agent",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     # No cancel was flagged for any invocation.
     assert plugin.peek_cancel_for_invocation("inv-A") is None
 
@@ -573,7 +573,7 @@ async def test_critical_drift_requests_cancel() -> None:
         current_task_id="t1",
         current_agent_id="sub_agent",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     # Cancel was flagged for the resolved invocation id.
     req = plugin.peek_cancel_for_invocation("inv-A")
     assert req is not None
@@ -600,7 +600,7 @@ async def test_cancel_noop_when_no_active_invocation() -> None:
         # No current_agent_id / current_task_id either.
     )
     # Does not raise.
-    flagged = await steerer.request_invocation_cancel(drift=drift, session=session)
+    flagged = await steerer.drift.request_invocation_cancel(drift=drift, session=session)
     assert flagged == []
 
 
@@ -718,7 +718,7 @@ async def test_user_steer_drift_bypasses_severity_gate() -> None:
     # The user-authored drift goes through _handle_drift's promotion
     # path before cancel is considered; ensure the directly-reachable
     # cancel API honours the bypass.
-    flagged = await steerer.request_invocation_cancel(drift=drift, session=session)
+    flagged = await steerer.drift.request_invocation_cancel(drift=drift, session=session)
     assert "inv-A" in flagged
 
 
@@ -784,7 +784,7 @@ class _ReasoningLlmResponse:
     """LlmResponse-shaped stub carrying both a regular text part and a
     thought part. ``_extract_reasoning`` picks up the thought; the
     after_model_callback path also runs ``_extract_text_parts`` which
-    reads the non-thought text for the regular ``steerer.observe``
+    reads the non-thought text for the regular ``steerer.drift.observe``
     fan-out.
     """
 
@@ -798,11 +798,8 @@ class _ReasoningLlmResponse:
         self.finish_reason = None
 
 
-class _SteererSpy:
-    """Wraps a real :class:`DefaultSteerer` so a test can assert which
-    of ``observe`` / ``observe_reasoning`` / ``note_llm_call`` ran on
-    a given ``after_model_callback`` invocation.
-    """
+class _DriftSpy:
+    """Spying drift sub-component (post #410)."""
 
     def __init__(self, inner: Any) -> None:
         self._inner = inner
@@ -820,13 +817,40 @@ class _SteererSpy:
 
     async def note_llm_call(self, session: Any) -> None:
         self.note_llm_calls += 1
-        # Forward to inner so the counter on the real steerer advances
-        # only when we actually delegate (no-op anyway when the inner
-        # steerer wasn't given a reflective_call_llm).
         await self._inner.note_llm_call(session)
 
-    # Plugin reads other attrs (e.g. ``request_invocation_cancel``,
-    # ``_background_judges``) directly off the steerer; forward those.
+    # Plugin reads other attrs (e.g. ``request_invocation_cancel``)
+    # directly off the drift component; forward them.
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+class _SteererSpy:
+    """Wraps a real :class:`DefaultSteerer` so a test can assert which
+    of ``observe`` / ``observe_reasoning`` / ``note_llm_call`` ran on
+    a given ``after_model_callback`` invocation.  Component-namespaced
+    per goldfive#410.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        # Wrap the inner steerer's drift sub-component with a spy.
+        self.drift = _DriftSpy(inner.drift)
+
+    @property
+    def observe_calls(self) -> int:
+        return self.drift.observe_calls
+
+    @property
+    def observe_reasoning_calls(self) -> int:
+        return self.drift.observe_reasoning_calls
+
+    @property
+    def note_llm_calls(self) -> int:
+        return self.drift.note_llm_calls
+
+    # Plugin reads other attrs (e.g. ``_background_judges``) directly
+    # off the steerer; forward those.
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
@@ -861,14 +885,14 @@ async def test_observe_reasoning_skipped_after_cancel(caplog: Any) -> None:
     """When the invocation is flagged cancelled, the
     after_model_callback path:
 
-    * Does NOT call ``steerer.observe_reasoning`` (the reasoning judge
+    * Does NOT call ``steerer.drift.observe_reasoning`` (the reasoning judge
       / pattern detectors don't run on zombie reasoning).
     * Does NOT spawn a background judge task — ``_background_judges``
       is unchanged.
     * Does NOT bump the reflective-check counter via ``note_llm_call``.
     * Logs the "skipping observe_reasoning for cancelled invocation"
       debug line.
-    * Still runs the regular ``steerer.observe`` LLM-response fan-out
+    * Still runs the regular ``steerer.drift.observe`` LLM-response fan-out
       (operators need the cancelled turn's text observable; the gate
       is local to reasoning).
     """
@@ -949,7 +973,7 @@ async def test_observe_reasoning_runs_when_not_cancelled() -> None:
 
 async def test_observe_reasoning_skip_does_not_break_other_observation() -> None:
     """The cancel gate must be local to the reasoning + reflective
-    paths. The plain ``steerer.observe`` LLM-response fan-out (kind=
+    paths. The plain ``steerer.drift.observe`` LLM-response fan-out (kind=
     'llm_response') should fire even on cancelled invocations so
     operators retain visibility into the cancelled turn's text.
     """
@@ -967,14 +991,15 @@ async def test_observe_reasoning_skip_does_not_break_other_observation() -> None
 
     # Capture observations the steerer received via the regular
     # observation path so we can confirm it was the llm_response fan-out.
+    # goldfive#410: ``observe`` now lives on the drift sub-component.
     observed: list[Any] = []
-    real_observe = spy._inner.observe  # noqa: SLF001
+    real_observe = spy._inner.drift.observe  # noqa: SLF001
 
     async def _capturing_observe(observation: Any, session: Any) -> None:
         observed.append(observation)
         await real_observe(observation, session)
 
-    spy._inner.observe = _capturing_observe  # type: ignore[method-assign] # noqa: SLF001
+    spy._inner.drift.observe = _capturing_observe  # type: ignore[method-assign] # noqa: SLF001
 
     await plugin.after_model_callback(
         callback_context=cb_ctx,

--- a/tests/test_correction_injection.py
+++ b/tests/test_correction_injection.py
@@ -175,8 +175,8 @@ async def _emit(
     prev = session.plan
     # goldfive#247: rebind to the stamped instance.
     # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
-    revised, _was_installed = steerer._apply_revision(session, revised, drift)
-    await steerer._emit_plan_revised(session, revised, drift, prev_plan=prev)
+    revised, _was_installed = steerer.plans._apply_revision(session, revised, drift)
+    await steerer.plans._emit_plan_revised(session, revised, drift, prev_plan=prev)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_delegation_pin.py
+++ b/tests/test_delegation_pin.py
@@ -875,25 +875,33 @@ async def test_capability_check_still_resolves_after_reorder() -> None:
     """
     from goldfive.types import DriftKind
 
-    class _RecordingSteerer:
+    class _RecordingDrift:
         def __init__(self) -> None:
-            self._sinks: list[Any] = []
             self.drifts: list[Any] = []
 
         async def observe(self, *a: Any, **kw: Any) -> None:
             pass
 
-        async def transition(self, *a: Any, **kw: Any) -> None:
-            pass
-
         def detect_drift(self, *a: Any, **kw: Any) -> None:
             return None
 
-        def bind(self, **kw: Any) -> None:
+        async def handle_drift(self, drift: Any, session: Any) -> None:  # noqa: ARG002
+            self.drifts.append(drift)
+
+    class _RecordingSteerer:
+        def __init__(self) -> None:
+            self._sinks: list[Any] = []
+            self.drift = _RecordingDrift()
+
+        @property
+        def drifts(self) -> list[Any]:
+            return self.drift.drifts
+
+        async def transition(self, *a: Any, **kw: Any) -> None:
             pass
 
-        async def _handle_drift(self, drift: Any, session: Any) -> None:  # noqa: ARG002
-            self.drifts.append(drift)
+        def bind(self, **kw: Any) -> None:
+            pass
 
     plugin = make_adk_plugin(host_agent_name="coord")
     # Single leaf authoring task (PENDING, no assignee) — the pin will

--- a/tests/test_drift_async_dispatch.py
+++ b/tests/test_drift_async_dispatch.py
@@ -147,7 +147,7 @@ async def test_mark_task_completed_appends_synthetic_invocation_completed() -> N
     """
     steerer, session, _sink, _planner = _bind(_NullPlanner())
     # Adapter would normally write this from ``before_run_callback``.
-    steerer.note_agent_activity(
+    steerer.drift.note_agent_activity(
         session,
         kind="agent_invocation_started",
         agent_name="worker",
@@ -155,7 +155,7 @@ async def test_mark_task_completed_appends_synthetic_invocation_completed() -> N
     )
     assert len(session.recent_agent_activity) == 1
 
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
 
     # Paired entry appended.
     completed_entries = [
@@ -173,15 +173,15 @@ async def test_mark_task_failed_appends_synthetic_invocation_completed() -> None
     look like "looping" to the goal-drift judge.
     """
     steerer, session, _sink, _planner = _bind(_NullPlanner())
-    steerer.note_agent_activity(
+    steerer.drift.note_agent_activity(
         session,
         kind="agent_invocation_started",
         agent_name="worker",
         task_id="t1",
     )
 
-    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
-    await steerer._wait_background_drifts_idle()
+    await steerer.tasks.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    await steerer.drift._wait_background_drifts_idle()
 
     completed_entries = [
         e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
@@ -208,14 +208,14 @@ async def test_mark_task_completed_skips_pairing_when_no_assignee() -> None:
     for t in list(session.plan.tasks):
         force_task_replace(session, t.id, assignee_agent_id="")
     # Pre-existing started entry from a prior agent's run.
-    steerer.note_agent_activity(
+    steerer.drift.note_agent_activity(
         session,
         kind="agent_invocation_started",
         agent_name="worker",
         task_id="t1",
     )
 
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
 
     completed_entries = [
         e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
@@ -233,8 +233,8 @@ async def test_mark_task_failed_skips_pairing_when_no_assignee() -> None:
     for t in list(session.plan.tasks):
         force_task_replace(session, t.id, assignee_agent_id="")
 
-    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
-    await steerer._wait_background_drifts_idle()
+    await steerer.tasks.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    await steerer.drift._wait_background_drifts_idle()
 
     completed_entries = [
         e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
@@ -251,16 +251,16 @@ async def test_duplicate_completed_entries_are_harmless() -> None:
     trims naturally on overflow.
     """
     steerer, session, _sink, _planner = _bind(_NullPlanner())
-    steerer.note_agent_activity(
+    steerer.drift.note_agent_activity(
         session,
         kind="agent_invocation_started",
         agent_name="worker",
         task_id="t1",
     )
 
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
     # Simulate the real after_run_callback firing slightly later.
-    steerer.note_agent_activity(
+    steerer.drift.note_agent_activity(
         session,
         kind="agent_invocation_completed",
         agent_name="worker",
@@ -297,7 +297,7 @@ async def test_mark_task_failed_does_not_block_on_refine() -> None:
     steerer, session, _sink, _planner = _bind(slow_planner)
 
     t0 = time.monotonic()
-    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    await steerer.tasks.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
     elapsed = time.monotonic() - t0
 
     # 100ms is generous — the synchronous portion is two event emits +
@@ -325,10 +325,10 @@ async def test_mark_task_failed_refine_runs_eventually() -> None:
     planner = _NullPlanner()
     steerer, session, _sink, _ = _bind(planner)
 
-    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    await steerer.tasks.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
     # No refine call yet — handler is still queued.
     assert planner.refine_calls == []
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     # After the drain refine WAS called.
     assert len(planner.refine_calls) == 1
     assert planner.refine_calls[0]["drift"].kind is DriftKind.TASK_FAILED_RECOVERABLE
@@ -345,7 +345,7 @@ async def test_mark_task_blocked_does_not_block_on_refine() -> None:
     steerer, session, _sink, _planner = _bind(slow_planner)
 
     t0 = time.monotonic()
-    await steerer.mark_task_blocked("t1", session=session, blocker="missing input")
+    await steerer.tasks.mark_task_blocked("t1", session=session, blocker="missing input")
     elapsed = time.monotonic() - t0
 
     assert elapsed < 0.1, (
@@ -368,13 +368,13 @@ async def test_shutdown_drains_background_drifts() -> None:
     slow_planner = _SlowPlanner(delay=30.0)
     steerer, session, _sink, _ = _bind(slow_planner)
 
-    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    await steerer.tasks.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
     # One pending drift task should be tracked.
     assert len(steerer._background_drifts) == 1
 
     t0 = time.monotonic()
     # Bounded timeout — slow_planner.delay (30s) >> shutdown timeout.
-    await steerer.shutdown(timeout=0.2)
+    await steerer.drift.shutdown(timeout=0.2)
     elapsed = time.monotonic() - t0
 
     # Shutdown should land within the timeout window plus the 0.5s
@@ -390,9 +390,9 @@ async def test_shutdown_idempotent_with_no_background_drifts() -> None:
     """``shutdown`` on an empty drift set is a no-op (matches judge drain)."""
     steerer = DefaultSteerer()
     steerer.bind(sinks=[_ListSink()], planner=_NullPlanner())
-    await steerer.shutdown(timeout=5.0)
+    await steerer.drift.shutdown(timeout=5.0)
     # Second call still safe.
-    await steerer.shutdown(timeout=5.0)
+    await steerer.drift.shutdown(timeout=5.0)
 
 
 def test_mark_task_failed_returns_immediately_when_no_loop() -> None:
@@ -418,16 +418,16 @@ def test_mark_task_failed_returns_immediately_when_no_loop() -> None:
     )
     # Direct test: call the spawner WITHOUT a running loop. It should
     # log+return rather than raise.
-    steerer._spawn_drift_handler_background(drift, session)
+    steerer.drift._spawn_drift_handler_background(drift, session)
     assert steerer._background_drifts == set()
     # Sanity: the same call WITH a loop does spawn a task.
     loop = asyncio.new_event_loop()
     try:
 
         async def _spawn() -> None:
-            steerer._spawn_drift_handler_background(drift, session)
+            steerer.drift._spawn_drift_handler_background(drift, session)
             assert len(steerer._background_drifts) == 1
-            await steerer._wait_background_drifts_idle()
+            await steerer.drift._wait_background_drifts_idle()
             assert steerer._background_drifts == set()
 
         loop.run_until_complete(_spawn())
@@ -455,8 +455,8 @@ async def test_background_drift_swallows_handler_exception() -> None:
         raise RuntimeError("simulated handler failure")
 
     # Patch _handle_drift on the instance for this one test.
-    steerer._handle_drift = _raise  # type: ignore[assignment]
-    steerer._spawn_drift_handler_background(drift, session)
+    steerer.drift.handle_drift = _raise  # type: ignore[assignment]
+    steerer.drift._spawn_drift_handler_background(drift, session)
     assert len(steerer._background_drifts) == 1
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     assert steerer._background_drifts == set()

--- a/tests/test_drift_classifiers.py
+++ b/tests/test_drift_classifiers.py
@@ -298,12 +298,12 @@ def test_drift_event_explicit_authored_by_preserved() -> None:
 def test_user_control_drifts_are_authored_by_user() -> None:
     """``_drift_from_control`` stamps user-sourced drifts as 'user'."""
     from goldfive.control import ControlKind, ControlMessage
-    from goldfive.steerer import DefaultSteerer
+    from goldfive.drift_observer import DriftObserver
     from goldfive.types import Session
 
     session = Session(run_id="r", current_task_id="t1")
 
-    steer_drift = DefaultSteerer._drift_from_control(
+    steer_drift = DriftObserver._drift_from_control(
         ControlMessage(
             kind=ControlKind.STEER,
             id="ctl-1",
@@ -314,7 +314,7 @@ def test_user_control_drifts_are_authored_by_user() -> None:
     assert steer_drift is not None
     assert steer_drift.authored_by == "user"
 
-    cancel_drift = DefaultSteerer._drift_from_control(
+    cancel_drift = DriftObserver._drift_from_control(
         ControlMessage(
             kind=ControlKind.CANCEL,
             id="ctl-2",
@@ -325,7 +325,7 @@ def test_user_control_drifts_are_authored_by_user() -> None:
     assert cancel_drift is not None
     assert cancel_drift.authored_by == "user"
 
-    pause_drift = DefaultSteerer._drift_from_control(
+    pause_drift = DriftObserver._drift_from_control(
         ControlMessage(kind=ControlKind.PAUSE, id="ctl-3", payload={}),
         session,
     )
@@ -335,7 +335,7 @@ def test_user_control_drifts_are_authored_by_user() -> None:
 
 def test_goldfive_detector_drifts_resolve_to_goldfive() -> None:
     """``_resolve_authored_by`` infers 'goldfive' for detector-sourced drifts."""
-    from goldfive.steerer import DefaultSteerer
+    from goldfive.drift_observer import DriftObserver
 
     # Built without an explicit authored_by (e.g. a detector that
     # predates the unification).
@@ -344,7 +344,7 @@ def test_goldfive_detector_drifts_resolve_to_goldfive() -> None:
         severity=DriftSeverity.WARNING,
         detail="loop",
     )
-    assert DefaultSteerer._resolve_authored_by(drift) == "goldfive"
+    assert DriftObserver._resolve_authored_by(drift) == "goldfive"
 
 
 # ---------------------------------------------------------------------------
@@ -352,19 +352,32 @@ def test_goldfive_detector_drifts_resolve_to_goldfive() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _RecordingToolLoopSteerer:
-    """Steerer stub that captures every drift routed via ``_handle_drift``."""
-
+class _ToolLoopDrift:
     def __init__(self) -> None:
         self.drifts: list[DriftEvent] = []
         self.observations: list[Any] = []
-        self._sinks: list[Any] = []
 
     async def observe(self, event: Any, session: Any) -> None:
         self.observations.append(event)
 
-    async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+    async def handle_drift(self, drift: DriftEvent, session: Any) -> None:
         self.drifts.append(drift)
+
+
+class _RecordingToolLoopSteerer:
+    """Steerer stub that captures every drift routed via ``drift.handle_drift``."""
+
+    def __init__(self) -> None:
+        self.drift = _ToolLoopDrift()
+        self._sinks: list[Any] = []
+
+    @property
+    def drifts(self) -> list[DriftEvent]:
+        return self.drift.drifts
+
+    @property
+    def observations(self) -> list[Any]:
+        return self.drift.observations
 
 
 def _plugin_with_tool_loop_ctx(task: Task, session: Session, steerer: Any):

--- a/tests/test_drift_drain_at_run_boundary.py
+++ b/tests/test_drift_drain_at_run_boundary.py
@@ -182,7 +182,7 @@ async def test_drain_cancels_in_flight_drift_at_run_boundary() -> None:
 
     # Mid-run: a reporting tool fires mark_task_failed which dispatches
     # the cascade fire-and-forget on _background_drifts.
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         "t1", session=session, reason="boom", recoverable=True
     )
     assert len(steerer._background_drifts) == 1
@@ -191,7 +191,7 @@ async def test_drain_cancels_in_flight_drift_at_run_boundary() -> None:
     await asyncio.wait_for(slow_planner.refine_started.wait(), timeout=2.0)
 
     t0 = time.monotonic()
-    await steerer.drain_session_background_tasks(
+    await steerer.drift.drain_session_background_tasks(
         session_id="s-leak", timeout=0.5
     )
     elapsed = time.monotonic() - t0
@@ -217,17 +217,17 @@ async def test_drain_is_idempotent() -> None:
     steerer.bind(sinks=[_ListSink()], planner=slow_planner)
     session = _make_session(session_id="s-idem")
 
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         "t1", session=session, reason="boom", recoverable=True
     )
     await asyncio.wait_for(slow_planner.refine_started.wait(), timeout=2.0)
 
-    await steerer.drain_session_background_tasks(
+    await steerer.drift.drain_session_background_tasks(
         session_id="s-idem", timeout=0.5
     )
     assert steerer._background_drifts == set()
     # Second call: empty set, must be a no-op (and must NOT raise).
-    await steerer.drain_session_background_tasks(
+    await steerer.drift.drain_session_background_tasks(
         session_id="s-idem", timeout=0.5
     )
     assert steerer._background_drifts == set()
@@ -248,16 +248,16 @@ async def test_drain_is_session_scoped() -> None:
     session_a = _make_session(session_id="s-A")
     session_b = _make_session(session_id="s-B")
 
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         "t1", session=session_a, reason="boom", recoverable=True
     )
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         "t1", session=session_b, reason="boom", recoverable=True
     )
     assert len(steerer._background_drifts) == 2
 
     # Drain only session A. Session B's task must survive.
-    await steerer.drain_session_background_tasks(
+    await steerer.drift.drain_session_background_tasks(
         session_id="s-A", timeout=0.5
     )
     surviving = list(steerer._background_drifts)
@@ -304,7 +304,7 @@ async def test_drain_post_abort_no_drift_detected_emitted() -> None:
     steerer.bind(sinks=[sink], planner=slow_planner)
     session = _make_session(session_id="s-post-abort")
 
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         "t1", session=session, reason="boom", recoverable=True
     )
     await asyncio.wait_for(slow_planner.refine_started.wait(), timeout=2.0)
@@ -313,7 +313,7 @@ async def test_drain_post_abort_no_drift_detected_emitted() -> None:
         1 for e in sink.events if _payload_kind(e) == "drift_detected"
     )
 
-    await steerer.drain_session_background_tasks(
+    await steerer.drift.drain_session_background_tasks(
         session_id="s-post-abort", timeout=0.5
     )
     # The drain returned. Give the loop a couple of yields to let any
@@ -369,14 +369,14 @@ async def test_drain_does_not_touch_user_steer_drifts() -> None:
     # Direct path: _handle_drift is the route observe() takes for
     # user-authored drifts. The fact that it does NOT spawn anything
     # onto _background_drifts is the structural guarantee we want.
-    await steerer._handle_drift(user_drift, session)
+    await steerer.drift.handle_drift(user_drift, session)
 
     # No background tasks were created — the USER_STEER cascade ran
     # synchronously inline.
     assert steerer._background_drifts == set()
     # Therefore the drain has nothing to do for this session — it
     # cannot accidentally cancel operator-authored intent.
-    await steerer.drain_session_background_tasks(
+    await steerer.drift.drain_session_background_tasks(
         session_id="s-user", timeout=0.5
     )
 
@@ -397,12 +397,12 @@ async def test_drain_runs_at_every_run_boundary_not_just_last() -> None:
 
     # Turn 1 — fresh session.
     session_turn_1 = _make_session(session_id="s-turn-1")
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         "t1", session=session_turn_1, reason="boom", recoverable=True
     )
     assert len(steerer._background_drifts) == 1
     await asyncio.wait_for(slow_planner.refine_started.wait(), timeout=2.0)
-    await steerer.drain_session_background_tasks(
+    await steerer.drift.drain_session_background_tasks(
         session_id="s-turn-1", timeout=0.5
     )
     assert steerer._background_drifts == set()
@@ -415,12 +415,12 @@ async def test_drain_runs_at_every_run_boundary_not_just_last() -> None:
     # steerer's spawn path: a new drift dispatched here lands on the
     # set and is cancellable by turn 2's drain.
     session_turn_2 = _make_session(session_id="s-turn-2")
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         "t1", session=session_turn_2, reason="boom again", recoverable=True
     )
     assert len(steerer._background_drifts) == 1
     await asyncio.wait_for(slow_planner.refine_started.wait(), timeout=2.0)
-    await steerer.drain_session_background_tasks(
+    await steerer.drift.drain_session_background_tasks(
         session_id="s-turn-2", timeout=0.5
     )
     assert steerer._background_drifts == set()
@@ -438,13 +438,13 @@ async def test_drain_empty_session_id_warns_and_no_ops() -> None:
     steerer.bind(sinks=[_ListSink()], planner=slow_planner)
     session = _make_session(session_id="s-empty-guard")
 
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         "t1", session=session, reason="boom", recoverable=True
     )
     assert len(steerer._background_drifts) == 1
 
     # Empty session_id: must NOT cancel the in-flight task.
-    await steerer.drain_session_background_tasks(session_id="", timeout=0.5)
+    await steerer.drift.drain_session_background_tasks(session_id="", timeout=0.5)
     assert len(steerer._background_drifts) == 1
 
     # Cleanup.
@@ -548,7 +548,7 @@ async def test_executor_run_aborted_drains_in_flight_drift_end_to_end() -> None:
         # Mid-invocation: a reporting tool would call mark_task_failed,
         # which spawns the fire-and-forget refine cascade on the slow
         # planner. fail_fast=True will then abort the run.
-        await steerer.mark_task_failed(
+        await steerer.tasks.mark_task_failed(
             task.id, session=session, reason="boom", recoverable=False
         )
         # Give the spawned task a yield to actually start the refine.

--- a/tests/test_drift_lifecycle.py
+++ b/tests/test_drift_lifecycle.py
@@ -430,7 +430,7 @@ async def test_emit_drift_detected_stamps_lifecycle_opened() -> None:
         current_task_id="t1",
         current_agent_id="a1",
     )
-    await steerer._emit_drift_detected(session, drift)
+    await steerer.drift._emit_drift_detected(session, drift)
 
     assert len(sink.events) == 1
     evt = sink.events[0]
@@ -470,8 +470,8 @@ async def test_emit_drift_detected_escalates_within_turn() -> None:
         current_task_id="t1",
         current_agent_id="a1",
     )
-    await steerer._emit_drift_detected(session, drift_a)
-    await steerer._emit_drift_detected(session, drift_b)
+    await steerer.drift._emit_drift_detected(session, drift_a)
+    await steerer.drift._emit_drift_detected(session, drift_b)
 
     first, second = sink.events
     # Same condition_id across both emits.
@@ -496,8 +496,8 @@ async def test_emit_drift_detected_distinct_turns_are_distinct_conditions() -> N
         current_task_id="t1",
         current_agent_id="a1",
     )
-    await steerer._emit_drift_detected(s1, drift)
-    await steerer._emit_drift_detected(s2, drift)
+    await steerer.drift._emit_drift_detected(s1, drift)
+    await steerer.drift._emit_drift_detected(s2, drift)
     assert len(sink.events) == 2
     cid1 = sink.events[0].drift_detected.condition_id
     cid2 = sink.events[1].drift_detected.condition_id
@@ -519,7 +519,7 @@ async def test_emit_drift_detected_preserves_legacy_fields() -> None:
         current_task_id="t1",
         current_agent_id="a1",
     )
-    await steerer._emit_drift_detected(session, drift)
+    await steerer.drift._emit_drift_detected(session, drift)
     payload = sink.events[0].drift_detected
     # Existing fields branch on these — none should be perturbed.
     assert payload.detail == "overlay diverged"

--- a/tests/test_drift_outcomes.py
+++ b/tests/test_drift_outcomes.py
@@ -191,7 +191,7 @@ async def test_first_drift_attempts_refine() -> None:
     key = (DriftKind.TOOL_ERROR.value, "t1")
     assert session.refine_outcomes.get(key) is None
 
-    await steerer._handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
 
     assert len(planner.refine_calls) == 1
     outcome = session.refine_outcomes[key]
@@ -219,7 +219,7 @@ async def test_second_drift_after_success_skipped() -> None:
     key = (DriftKind.TOOL_ERROR.value, "t1")
     session.refine_outcomes[key] = RefineOutcome(state="succeeded", fail_count=0)
 
-    await steerer._handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
 
     # Refine NOT called: the gate short-circuited at the top.
     assert planner.refine_calls == []
@@ -245,7 +245,7 @@ async def test_failure_increments_count() -> None:
     key = (DriftKind.TOOL_ERROR.value, "t1")
 
     # First emit -> refine raises -> outcome=(failed, 1).
-    await steerer._handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
     assert session.refine_outcomes[key].state == "failed"
     assert session.refine_outcomes[key].fail_count == 1
 
@@ -253,7 +253,7 @@ async def test_failure_increments_count() -> None:
     # threshold so the gate lets refine run again -> raises -> outcome
     # transitions to (failed, 2). The dict has ONE entry (same key
     # overwritten), not two.
-    await steerer._handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
     assert session.refine_outcomes[key].state == "failed"
     assert session.refine_outcomes[key].fail_count == 2
     # The ONLY non-cascade entries on the outcome table are
@@ -285,8 +285,8 @@ async def test_threshold_reached_marks_task_failed_and_emits_repeated_failure() 
     session = _make_session()
 
     # Two consecutive same-key failures cross the threshold.
-    await steerer._handle_drift(_drift(), session)
-    await steerer._handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
 
     from goldfive.pb.goldfive.v1 import types_pb2
 
@@ -353,7 +353,7 @@ async def test_user_steer_bypasses_outcome_check() -> None:
         detail="please pivot",
         current_task_id="t1",
     )
-    await steerer._handle_drift(user_drift, session)
+    await steerer.drift.handle_drift(user_drift, session)
 
     # Refine ran (USER_STEER bypassed the gate).
     assert len(planner.refine_calls) == 1
@@ -382,7 +382,7 @@ def test_run_started_resets_outcomes() -> None:
     )
     assert len(session.refine_outcomes) == 2
 
-    steerer.reset_for_turn(session)
+    steerer.drift.reset_for_turn(session)
 
     assert session.refine_outcomes == {}
 
@@ -413,10 +413,10 @@ async def test_v30_repro() -> None:
 
     key = (DriftKind.TOOL_ERROR.value, "t1")
 
-    await steerer._handle_drift(_drift(agent_id="agent-a"), session)
+    await steerer.drift.handle_drift(_drift(agent_id="agent-a"), session)
     assert session.refine_outcomes[key].fail_count == 1
 
-    await steerer._handle_drift(_drift(agent_id="agent-b"), session)
+    await steerer.drift.handle_drift(_drift(agent_id="agent-b"), session)
     # Threshold tripped on the SECOND emit despite distinct agent_ids.
     assert session.refine_outcomes[key].fail_count == 2
     assert _task_status(session, "t1") is TaskStatus.FAILED
@@ -456,8 +456,8 @@ async def test_repeated_failure_does_not_recurse_into_handle_drift() -> None:
     session = _make_session()
 
     # Drive two failures to cross the threshold.
-    await steerer._handle_drift(_drift(), session)
-    await steerer._handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
 
     # The threshold-crossed REPEATED_FAILURE is in the event stream.
     from goldfive.pb.goldfive.v1 import types_pb2  # noqa: PLC0415
@@ -521,7 +521,7 @@ async def test_goal_drift_bypasses_outcome_gate() -> None:
     session.refine_outcomes[key] = RefineOutcome(state="failed", fail_count=99)
 
     drift = _drift(kind=DriftKind.GOAL_DRIFT, severity=DriftSeverity.CRITICAL)
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # GOAL_DRIFT bypassed the gate and reached refine.
     assert len(planner.refine_calls) == 1, (
@@ -555,7 +555,7 @@ async def test_promote_to_steer_writes_outcome_on_failure() -> None:
     drift = _drift(severity=DriftSeverity.CRITICAL)
     # Direct invocation of the promote path's refine driver — the
     # public surface that _handle_drift's CRITICAL fall-through uses.
-    await steerer._promote_drift_to_steer(drift, session)
+    await steerer.drift._promote_drift_to_steer(drift, session)
 
     key = (DriftKind.TOOL_ERROR.value, "t1")
     outcome = session.refine_outcomes.get(key)

--- a/tests/test_drift_reasoning.py
+++ b/tests/test_drift_reasoning.py
@@ -572,7 +572,7 @@ async def test_reasoning_cluster_tightening_is_one_shot_per_task() -> None:
         current = (
             _pad_tokens("shared", 8) + f" uniqueturn{turn:02d}00 uniqueturn{turn:02d}01"
         )
-        await steerer.observe_reasoning(current, session=session)
+        await steerer.drift.observe_reasoning(current, session=session)
     # The embedding pipeline is now fire-and-forget (goldfive#251);
     # drain before inspecting the sink.
     await _wait_for_judges(steerer)
@@ -690,7 +690,7 @@ async def test_observe_reasoning_appends_to_history_and_caps() -> None:
     steerer.bind(sinks=[sink], planner=planner)
 
     for i in range(5):
-        await steerer.observe_reasoning(f"thought {i}", session=session)
+        await steerer.drift.observe_reasoning(f"thought {i}", session=session)
 
     assert session.reasoning_history == ["thought 2", "thought 3", "thought 4"]
 
@@ -705,7 +705,7 @@ async def test_observe_reasoning_emits_looping_drift_and_refines() -> None:
     repeated = "I should re-check the slides for typos"
     # Prime the history so the next observation repeats.
     session.reasoning_history = [repeated, repeated, repeated]
-    await steerer.observe_reasoning(repeated, session=session)
+    await steerer.drift.observe_reasoning(repeated, session=session)
 
     assert len(planner.refine_calls) == 1
     drift = planner.refine_calls[0]["drift"]
@@ -719,7 +719,7 @@ async def test_observe_reasoning_noops_on_empty_text() -> None:
     planner = NullPlanner()
     steerer.bind(sinks=[sink], planner=planner)
 
-    await steerer.observe_reasoning("", session=session)
+    await steerer.drift.observe_reasoning("", session=session)
     assert session.reasoning_history == []
     assert sink.events == []
 
@@ -841,7 +841,7 @@ async def test_observe_reasoning_populates_drift_trigger_input() -> None:
     # Prime the history so the next observation repeats and the loop
     # detector fires.
     session.reasoning_history = [text, text, text]
-    await steerer.observe_reasoning(text, session=session)
+    await steerer.drift.observe_reasoning(text, session=session)
 
     # LOOPING_REASONING is WARNING, so the steerer attempts refine. With
     # NullPlanner the refine returns None and the steerer escalates,
@@ -868,7 +868,7 @@ async def test_observe_reasoning_truncates_long_trigger_input() -> None:
     ) * 60
     # Prime the history so the loop detector fires on the same text.
     session.reasoning_history = [huge, huge, huge]
-    await steerer.observe_reasoning(huge, session=session)
+    await steerer.drift.observe_reasoning(huge, session=session)
 
     # See note in test_observe_reasoning_populates_drift_trigger_input:
     # WARNING-severity drift + NullPlanner refine triggers an

--- a/tests/test_drift_taxonomy.py
+++ b/tests/test_drift_taxonomy.py
@@ -108,7 +108,7 @@ def test_classifier_fires_for_every_drift_kind(kind_value: str) -> None:
     steerer = Steerer()
     session = types.Session(run_id="drift-classifier", current_task_id="t1")
     raw = _raw_event_for(kind_value)
-    drift = steerer.detect_drift(raw, session)
+    drift = steerer.drift.detect_drift(raw, session)
 
     if drift is None:
         pytest.skip(
@@ -132,5 +132,5 @@ def test_unknown_event_does_not_fire_drift() -> None:
     steerer = Steerer()
     session = types.Session(run_id="no-drift")
     # A benign progress event should not fire drift.
-    drift = steerer.detect_drift({"kind": "progress", "task_id": "t1"}, session)
+    drift = steerer.drift.detect_drift({"kind": "progress", "task_id": "t1"}, session)
     assert drift is None

--- a/tests/test_drift_version_pin.py
+++ b/tests/test_drift_version_pin.py
@@ -182,7 +182,7 @@ async def test_drift_stamped_with_current_revision_is_dispatched() -> None:
     session = _session(revision_index=3)
     drift = _drift(observed_revision_index=3)
 
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # DriftDetected should be on the wire (the first one is OUR drift;
     # the steerer may emit follow-up escalation drifts because the
@@ -222,7 +222,7 @@ async def test_redundant_same_kind_same_target_drift_is_rejected() -> None:
     ] = 4
     drift = _drift(observed_revision_index=3, severity=DriftSeverity.WARNING)
 
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # DriftDetected fires for observability.
     assert _emitted_drift_kinds(sink), "redundant drift must still emit DriftDetected"
@@ -273,7 +273,7 @@ async def test_orthogonal_kind_drift_dispatches_after_unrelated_revision() -> No
         task="t-other",
     )
 
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # DriftDetected fires AND the dispatch runs (planner.refine called).
     assert _emitted_drift_kinds(sink), "orthogonal drift must emit DriftDetected"
@@ -306,7 +306,7 @@ async def test_same_kind_different_target_drift_dispatches() -> None:
         task="t-other",
     )
 
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     assert planner.refine_calls, (
         "same-kind-different-target drift must dispatch; got 0 refine calls"
@@ -334,7 +334,7 @@ async def test_unstamped_drift_bypasses_the_gate() -> None:
     drift = _drift(observed_revision_index=0)
     assert drift.observed_revision_index == 0
 
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # DriftDetected fires (back-compat).
     payloads = _drift_detected_payloads(sink)
@@ -370,7 +370,7 @@ async def test_user_authored_drift_bypasses_the_gate() -> None:
             authored_by="user",
             observed_revision_index=2,  # very stale
         )
-        await steerer._handle_drift(drift, session)
+        await steerer.drift.handle_drift(drift, session)
         # User drift made it past the gate — at minimum DriftDetected
         # was emitted. (The cancel + refine machinery is the steerer's
         # downstream business; we only assert the gate did not skip
@@ -588,7 +588,7 @@ async def test_end_to_end_redundant_drift_emits_but_does_not_refine() -> None:
         (DriftKind.OFF_TOPIC.value, "t-draft")
     ] = 3
 
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # Drift on the wire (observability preserved) ...
     assert _emitted_drift_kinds(sink), "DriftDetected must still be emitted"
@@ -634,8 +634,8 @@ async def test_apply_revision_stamps_per_key_watermark() -> None:
     # session-mutation triad (set_session_plan + watermark stamp +
     # orchestration-state pointer) atomically under the lock.
     steerer = DefaultSteerer()
-    revised, _ = steerer._apply_revision(session, revised, drift)
-    await steerer._emit_plan_revised(session, revised, drift, prev_plan=session.plan)
+    revised, _ = steerer.plans._apply_revision(session, revised, drift)
+    await steerer.plans._emit_plan_revised(session, revised, drift, prev_plan=session.plan)
 
     key = (DriftKind.OFF_TOPIC.value, "t-draft")
     assert key in session.last_addressed_revision_by_drift_key, (
@@ -675,8 +675,8 @@ async def test_apply_revision_does_not_stamp_for_user_authored_drifts() -> None:
     # the post-install state — the watermark stamp moved into
     # _emit_plan_revised.
     steerer = DefaultSteerer()
-    revised, _ = steerer._apply_revision(session, revised, drift)
-    await steerer._emit_plan_revised(session, revised, drift, prev_plan=session.plan)
+    revised, _ = steerer.plans._apply_revision(session, revised, drift)
+    await steerer.plans._emit_plan_revised(session, revised, drift, prev_plan=session.plan)
 
     key = (DriftKind.USER_STEER.value, "t-draft")
     assert key not in session.last_addressed_revision_by_drift_key, (

--- a/tests/test_e2e_plan_causal_correction.py
+++ b/tests/test_e2e_plan_causal_correction.py
@@ -347,8 +347,8 @@ async def _drive_refine_cycle(
     prev = session.plan
     # goldfive#247: rebind to the stamped instance.
     # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
-    revised, _was_installed = steerer._apply_revision(session, revised, drift)
-    await steerer._emit_plan_revised(session, revised, drift, prev_plan=prev)
+    revised, _was_installed = steerer.plans._apply_revision(session, revised, drift)
+    await steerer.plans._emit_plan_revised(session, revised, drift, prev_plan=prev)
     return steerer, planner, sink
 
 
@@ -646,7 +646,7 @@ async def test_critical_drift_composes_cancel_with_correction() -> None:
     # _handle_drift takes on CRITICAL severity). Stream C's own unit
     # test covers the _handle_drift dispatch; here we just pin that
     # the API writes a request through the adapter's plugin.
-    flagged = await steerer.request_invocation_cancel(drift=drift, session=session)
+    flagged = await steerer.drift.request_invocation_cancel(drift=drift, session=session)
     assert "inv-research-1" in flagged, (
         "[Stream C regression] CRITICAL severity did not flag the active "
         "invocation for cancel. The in-flight turn would proceed and "
@@ -668,8 +668,8 @@ async def test_critical_drift_composes_cancel_with_correction() -> None:
     revised = _revised_with_correct_supersedes()
     # goldfive#247: rebind to the stamped instance.
     # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
-    revised, _was_installed = steerer._apply_revision(session, revised, drift)
-    await steerer._emit_plan_revised(
+    revised, _was_installed = steerer.plans._apply_revision(session, revised, drift)
+    await steerer.plans._emit_plan_revised(
         session, revised, drift, prev_plan=_presentation_style_plan()
     )
     corr_key = pending_correction_key("research_agent", "research_solar_corrected")

--- a/tests/test_executor_control.py
+++ b/tests/test_executor_control.py
@@ -69,33 +69,20 @@ class RecordingSink:
         return out
 
 
-class StubSteerer:
-    """Steerer stub that applies transitions directly and records observations.
+class _StubDrift:
+    """Drift sub-component (goldfive#410).
 
-    When ``refine_result`` is set, ``observe(msg)`` calls it on
-    ``ControlMessage`` and swaps session.plan with the result. This
-    emulates the real DefaultSteerer's USER_STEER behavior.
+    Emulates DefaultSteerer steering: when observing a STEER
+    ControlMessage, swap the plan on the session via the configured
+    ``refine_result``.
     """
 
     def __init__(self, *, refine_result: Plan | None = None) -> None:
-        self._sinks: list[EventSink] = []
-        self._planner: Any = None
         self.observed: list[Any] = []
         self.refine_result = refine_result
-        self.last_cancel_reason: str = ""
-        # goldfive#247: per-transition record for tests that need to
-        # verify cancellation happened even when the refine swap
-        # produces a plan that doesn't include the cancelled task id.
-        self.transitions: list[tuple[str, TaskStatus, str]] = []
-
-    def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
-        self._sinks = sinks
-        self._planner = planner
 
     async def observe(self, event: Any, session: Session) -> None:
         self.observed.append(event)
-        # Emulate DefaultSteerer steering: when observing a STEER
-        # ControlMessage, swap the plan on the session.
         kind = getattr(event, "kind", None)
         if (
             self.refine_result is not None
@@ -109,6 +96,42 @@ class StubSteerer:
             )
             with channel_processor_active():
                 set_session_plan(session, self.refine_result)
+
+    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
+        return None
+
+
+class StubSteerer:
+    """Steerer stub that applies transitions directly and records observations.
+
+    Component-namespaced per goldfive#410.
+    """
+
+    def __init__(self, *, refine_result: Plan | None = None) -> None:
+        self._sinks: list[EventSink] = []
+        self._planner: Any = None
+        self.drift = _StubDrift(refine_result=refine_result)
+        self.last_cancel_reason: str = ""
+        # goldfive#247: per-transition record for tests that need to
+        # verify cancellation happened even when the refine swap
+        # produces a plan that doesn't include the cancelled task id.
+        self.transitions: list[tuple[str, TaskStatus, str]] = []
+
+    @property
+    def observed(self) -> list[Any]:
+        return self.drift.observed
+
+    @property
+    def refine_result(self) -> Plan | None:
+        return self.drift.refine_result
+
+    @refine_result.setter
+    def refine_result(self, value: Plan | None) -> None:
+        self.drift.refine_result = value
+
+    def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
+        self._sinks = sinks
+        self._planner = planner
 
     async def transition(
         self,
@@ -140,9 +163,6 @@ class StubSteerer:
             session.completed_results[task_id] = detail
         if to == TaskStatus.CANCELLED:
             self.last_cancel_reason = cancel_reason or detail
-
-    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
-        return None
 
 
 class StubPlanner:
@@ -548,7 +568,7 @@ async def test_sequential_pause_loop_unwinds_on_goldfive_steer() -> None:
             with channel_processor_active():
                 set_session_plan(sess, refined)
 
-    steerer.observe = _observe_goldfive_steer  # type: ignore[method-assign]
+    steerer.drift.observe = _observe_goldfive_steer  # type: ignore[method-assign]
 
     await channel.send(
         ControlMessage(

--- a/tests/test_executor_supersede_cancel_nonfatal.py
+++ b/tests/test_executor_supersede_cancel_nonfatal.py
@@ -698,7 +698,7 @@ async def test_steerer_cancel_inflight_stamps_supersede_flag() -> None:
 
     # No adapter bound → request_invocation_cancel returns []. The
     # supersede stamp must STILL fire (it's set before the delegation).
-    flagged = await steerer._cancel_inflight_for_revision(drift, session)
+    flagged = await steerer.drift._cancel_inflight_for_revision(drift, session)
     assert flagged == []
     assert getattr(session, "_supersede_pending", False) is True, (
         "DefaultSteerer._cancel_inflight_for_revision must stamp "

--- a/tests/test_goal_drift_classifier.py
+++ b/tests/test_goal_drift_classifier.py
@@ -358,18 +358,18 @@ async def test_steerer_counter_fires_at_interval() -> None:
     steerer.bind(sinks=[ListSink()], planner=StubPlanner())
     session = _make_session()
     for _ in range(4):
-        await steerer.note_agent_turn(session)
+        await steerer.drift.note_agent_turn(session)
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 0, "should not fire before the 5th turn"  # type: ignore[attr-defined]
-    await steerer.note_agent_turn(session)
+    await steerer.drift.note_agent_turn(session)
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1, "should fire on the 5th turn"  # type: ignore[attr-defined]
     # Counter resets after check; next 4 should not re-fire.
     for _ in range(4):
-        await steerer.note_agent_turn(session)
+        await steerer.drift.note_agent_turn(session)
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
-    await steerer.note_agent_turn(session)
+    await steerer.drift.note_agent_turn(session)
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
 
@@ -396,7 +396,7 @@ async def test_steerer_off_track_emits_critical_drift_and_nudges() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
     for _ in range(2):
-        await steerer.note_agent_turn(session)
+        await steerer.drift.note_agent_turn(session)
     await _drain_background_judges(steerer)
 
     drifts = [e for e in sink.events if e.WhichOneof("payload") == "drift_detected"]
@@ -429,7 +429,7 @@ async def test_steerer_disabled_by_default_no_check_ever_fires() -> None:
     steerer.bind(sinks=[ListSink()], planner=StubPlanner())
     session = _make_session()
     for _ in range(100):
-        await steerer.note_agent_turn(session)
+        await steerer.drift.note_agent_turn(session)
     # Disabled steerer never spawns; nothing to drain. The counter
     # check below is the same end-state assertion the inline path
     # carried.
@@ -447,7 +447,7 @@ async def test_steerer_malformed_response_does_not_crash_run() -> None:
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
-    await steerer.note_agent_turn(session)
+    await steerer.drift.note_agent_turn(session)
     await _drain_background_judges(steerer)
     drifts = [e for e in sink.events if e.WhichOneof("payload") == "drift_detected"]
     assert drifts == []
@@ -459,7 +459,7 @@ async def test_steerer_activity_window_bounded() -> None:
     steerer = DefaultSteerer(goal_drift_activity_window=3)
     session = _make_session()
     for i in range(10):
-        steerer.note_agent_activity(
+        steerer.drift.note_agent_activity(
             session,
             kind="agent_invocation_started",
             agent_name=f"a{i}",
@@ -480,11 +480,11 @@ async def test_steerer_counter_is_not_task_scoped() -> None:
     steerer.bind(sinks=[ListSink()], planner=StubPlanner())
     session = _make_session()
     session.current_task_id = "t1"
-    await steerer.note_agent_turn(session)
+    await steerer.drift.note_agent_turn(session)
     # Task transition.
     session.current_task_id = "t2"
-    await steerer.note_agent_turn(session)
-    await steerer.note_agent_turn(session)
+    await steerer.drift.note_agent_turn(session)
+    await steerer.drift.note_agent_turn(session)
     await _drain_background_judges(steerer)
     # Third call should fire the check, not be held back by transition.
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
@@ -501,7 +501,7 @@ async def test_steerer_maybe_run_goal_drift_check_is_public() -> None:
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
-    await steerer.maybe_run_goal_drift_check(session)
+    await steerer.drift.maybe_run_goal_drift_check(session)
     # Counter NOT advanced by direct call.
     assert session._agent_turns_since_goal_check == 0
     # But drift was emitted.
@@ -547,7 +547,7 @@ async def test_runner_goal_drift_enabled_false_detaches_callable() -> None:
     # Steerer's callable is detached — no LLM call can fire now.
     assert steerer._goal_drift_call_llm is None
     session = _make_session()
-    await steerer.note_agent_turn(session)
+    await steerer.drift.note_agent_turn(session)
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 0  # type: ignore[attr-defined]
 
@@ -603,7 +603,7 @@ async def test_task_boundary_fires_goal_drift_check_on_mark_task_completed() -> 
     steerer.bind(sinks=[sink], planner=StubPlanner())
     session = _make_session()
 
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     # Turn counter is reset on task-boundary fire so we don't double-pay.
@@ -625,13 +625,13 @@ async def test_task_boundary_fires_on_mark_task_failed_and_cancelled() -> None:
     steerer.bind(sinks=[ListSink()], planner=StubPlanner())
     session = _make_session()
 
-    await steerer.mark_task_failed("t1", session=session, reason="boom")
+    await steerer.tasks.mark_task_failed("t1", session=session, reason="boom")
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
 
     # Rewind the rate-limit clock so the next boundary fires.
     session._last_goal_drift_check_ts = 0.0
-    await steerer.mark_task_cancelled("t2", session=session, reason="no longer needed")
+    await steerer.tasks.mark_task_cancelled("t2", session=session, reason="no longer needed")
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
 
@@ -647,7 +647,7 @@ async def test_task_boundary_fires_independent_of_turn_counter() -> None:
     session = _make_session()
     assert session._agent_turns_since_goal_check == 0
 
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
 
@@ -663,7 +663,7 @@ async def test_task_boundary_rate_limited_within_ten_seconds() -> None:
     session = _make_session()
 
     # First transition primes the timestamp.
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     first_ts = session._last_goal_drift_check_ts
@@ -673,7 +673,7 @@ async def test_task_boundary_rate_limited_within_ten_seconds() -> None:
     # The rate-limit gate fires synchronously before any spawn so no
     # drain is needed to observe the no-fire state, but call it anyway
     # to be defensive (no-op when the set is empty).
-    await steerer.mark_task_completed("t2", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t2", session=session, summary="done")
     await _drain_background_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     # Timestamp must NOT advance on a suppressed call.
@@ -689,7 +689,7 @@ async def test_task_boundary_noop_when_goal_drift_not_wired() -> None:
     steerer = DefaultSteerer(goal_drift_call_llm=None)
     steerer.bind(sinks=[ListSink()], planner=StubPlanner())
     session = _make_session()
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
     assert session._last_goal_drift_check_ts == 0.0
 
 

--- a/tests/test_goldfive_drift_routing.py
+++ b/tests/test_goldfive_drift_routing.py
@@ -180,7 +180,7 @@ async def test_goldfive_off_topic_drift_dispatches_goldfive_steer_control() -> N
         authored_by="goldfive",
     )
     session = _make_session()
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # Refine ran (the promotion path called planner.refine_steer).
     assert planner.refine_steer_calls, "refine_steer should have fired"
@@ -224,7 +224,7 @@ async def test_goldfive_intent_divergence_critical_dispatches_pause_escalate() -
         authored_by="goldfive",
     )
     session = _make_session()
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # Level 4 does NOT call refine.
     assert planner.refine_calls == []
@@ -350,7 +350,7 @@ async def test_multiple_goldfive_drifts_queue_in_order_on_channel() -> None:
         for i in (1, 2)
     ]
     for d in drifts:
-        await steerer._handle_drift(d, session)
+        await steerer.drift.handle_drift(d, session)
 
     msgs = [m for m in _drain_channel(channel) if m.kind is ControlKind.GOLDFIVE_STEER]
     assert len(msgs) == 2, f"expected 2 GOLDFIVE_STEER, got {len(msgs)}"
@@ -549,7 +549,7 @@ async def test_no_channel_bound_dispatch_is_noop_not_raise() -> None:
     )
     session = _make_session()
     # Must not raise.
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     # Refine still ran — the dispatch failure does not block the
     # promotion path.
     assert planner.refine_steer_calls, (

--- a/tests/test_goldfive_planner.py
+++ b/tests/test_goldfive_planner.py
@@ -104,18 +104,29 @@ class _FakePart:
         self.text = text
 
 
-class _RecordingSteerer:
-    """Async-capable steerer stub that records _handle_drift calls."""
+class _RecordingDrift:
+    """Records ``handle_drift`` / ``observe`` calls (post #410)."""
 
     def __init__(self) -> None:
         self.drifts: list[DriftEvent] = []
-        self._sinks: list = []
 
-    async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+    async def handle_drift(self, drift: DriftEvent, session: Any) -> None:
         self.drifts.append(drift)
 
     async def observe(self, event: Any, session: Any) -> None:
         pass
+
+
+class _RecordingSteerer:
+    """Async-capable steerer stub that records ``drift.handle_drift`` calls."""
+
+    def __init__(self) -> None:
+        self.drift = _RecordingDrift()
+        self._sinks: list = []
+
+    @property
+    def drifts(self) -> list[DriftEvent]:
+        return self.drift.drifts
 
 
 class _RecordingUserPlanner:

--- a/tests/test_goldfive_steer_request_cancel.py
+++ b/tests/test_goldfive_steer_request_cancel.py
@@ -201,7 +201,7 @@ async def test_goldfive_steer_request_cancel_fires() -> None:
         detail="agent wandered",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     assert adapter.request_cancel_calls == []  # reverted: deferred-cancel only
     # The same reason is on the cancel-tag so the adapter's healing
     # path picks it up when CancelledError flows.
@@ -218,7 +218,7 @@ async def test_goldfive_steer_request_cancel_supports_sync_hook() -> None:
         detail="agent abandoned the goal",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     assert adapter.request_cancel_calls == []  # reverted: deferred-cancel only
 
 
@@ -233,7 +233,7 @@ async def test_goldfive_steer_tolerates_adapter_without_request_cancel() -> None
         detail="minor wander",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     # Cancel-tag still stamped.
     assert adapter._next_cancel_reason == "goldfive_off_topic"
     # Refine still ran — the promotion path is intact.
@@ -251,7 +251,7 @@ async def test_goldfive_steer_swallows_request_cancel_raise() -> None:
         current_task_id="t2",
     )
     # Must not raise out.
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     assert adapter.request_cancel_calls == []  # reverted: deferred-cancel only
     assert planner.refine_steer_calls, "refine should still have fired"
 
@@ -270,7 +270,7 @@ async def test_user_steer_does_not_call_request_cancel() -> None:
         detail="operator note",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     assert adapter.request_cancel_calls == []
 
 

--- a/tests/test_intervention_ladder.py
+++ b/tests/test_intervention_ladder.py
@@ -278,7 +278,7 @@ def test_ladder_mapping(
     expected: InterventionLevel,
 ) -> None:
     steerer = DefaultSteerer()
-    level = steerer._ladder_level_for(kind, severity, occurrence)
+    level = steerer.drift._ladder_level_for(kind, severity, occurrence)
     assert level is expected, (
         f"ladder({kind.value}, {severity.value}, occ={occurrence}) "
         f"= {level.name}, expected {expected.name}"
@@ -311,18 +311,18 @@ def test_ladder_covers_goal_drift() -> None:
     steerer = DefaultSteerer()
     # WARNING -> NUDGE (corrective message; no plan change needed).
     assert (
-        steerer._ladder_level_for(DriftKind.GOAL_DRIFT, DriftSeverity.WARNING, 0)
+        steerer.drift._ladder_level_for(DriftKind.GOAL_DRIFT, DriftSeverity.WARNING, 0)
         is InterventionLevel.NUDGE
     )
     # CRITICAL first occurrence -> NUDGE.
     assert (
-        steerer._ladder_level_for(DriftKind.GOAL_DRIFT, DriftSeverity.CRITICAL, 0)
+        steerer.drift._ladder_level_for(DriftKind.GOAL_DRIFT, DriftSeverity.CRITICAL, 0)
         is InterventionLevel.NUDGE
     )
     # CRITICAL repeat -> CANCEL_REINVOKE (cancel + restart with the
     # corrective body as the new user input).
     assert (
-        steerer._ladder_level_for(
+        steerer.drift._ladder_level_for(
             DriftKind.GOAL_DRIFT,
             DriftSeverity.CRITICAL,
             DefaultSteerer.REFINE_FAILURE_THRESHOLD,
@@ -342,27 +342,27 @@ def test_justified_deviation_routes_to_absorb_at_all_severities() -> None:
     """
     steerer = DefaultSteerer()
     assert (
-        steerer._ladder_level_for(
+        steerer.drift._ladder_level_for(
             DriftKind.JUSTIFIED_DEVIATION, DriftSeverity.INFO, 0
         )
         is InterventionLevel.OBSERVE
     )
     assert (
-        steerer._ladder_level_for(
+        steerer.drift._ladder_level_for(
             DriftKind.JUSTIFIED_DEVIATION, DriftSeverity.WARNING, 0
         )
         is InterventionLevel.ABSORB
     )
     # CRITICAL first occurrence — ABSORB, NOT cancel-reinvoke.
     assert (
-        steerer._ladder_level_for(
+        steerer.drift._ladder_level_for(
             DriftKind.JUSTIFIED_DEVIATION, DriftSeverity.CRITICAL, 0
         )
         is InterventionLevel.ABSORB
     )
     # CRITICAL repeat — STILL ABSORB. Specifically NOT pause_escalate.
     assert (
-        steerer._ladder_level_for(
+        steerer.drift._ladder_level_for(
             DriftKind.JUSTIFIED_DEVIATION,
             DriftSeverity.CRITICAL,
             DefaultSteerer.REFINE_FAILURE_THRESHOLD,
@@ -371,7 +371,7 @@ def test_justified_deviation_routes_to_absorb_at_all_severities() -> None:
     )
     # And way past the repeat threshold for paranoia.
     assert (
-        steerer._ladder_level_for(
+        steerer.drift._ladder_level_for(
             DriftKind.JUSTIFIED_DEVIATION, DriftSeverity.CRITICAL, 99
         )
         is InterventionLevel.ABSORB
@@ -386,21 +386,21 @@ def test_off_topic_unchanged_by_justified_deviation_addition() -> None:
     """
     steerer = DefaultSteerer()
     assert (
-        steerer._ladder_level_for(DriftKind.OFF_TOPIC, DriftSeverity.INFO, 0)
+        steerer.drift._ladder_level_for(DriftKind.OFF_TOPIC, DriftSeverity.INFO, 0)
         is InterventionLevel.OBSERVE
     )
     assert (
-        steerer._ladder_level_for(DriftKind.OFF_TOPIC, DriftSeverity.WARNING, 0)
+        steerer.drift._ladder_level_for(DriftKind.OFF_TOPIC, DriftSeverity.WARNING, 0)
         is InterventionLevel.ABSORB
     )
     assert (
-        steerer._ladder_level_for(
+        steerer.drift._ladder_level_for(
             DriftKind.OFF_TOPIC, DriftSeverity.CRITICAL, 0
         )
         is InterventionLevel.CANCEL_REINVOKE
     )
     assert (
-        steerer._ladder_level_for(
+        steerer.drift._ladder_level_for(
             DriftKind.OFF_TOPIC,
             DriftSeverity.CRITICAL,
             DefaultSteerer.REFINE_FAILURE_THRESHOLD,

--- a/tests/test_iter11d_cancel_race.py
+++ b/tests/test_iter11d_cancel_race.py
@@ -220,7 +220,7 @@ async def test_gate_skips_drift_when_cancel_pending_with_active_invocations() ->
     try:
         # Sanity: pre-cancel, gate does NOT classify the drift as late.
         drift = _drift()
-        assert steerer._is_late_drift_for_terminated_invocation(drift, session) is False
+        assert steerer.drift._is_late_drift_for_terminated_invocation(drift, session) is False
 
         # Synchronous cancel-pending stamp (the part
         # request_invocation_cancel does at its top).
@@ -230,7 +230,7 @@ async def test_gate_skips_drift_when_cancel_pending_with_active_invocations() ->
         # this is the 4-8s window the bug lived in. The gate must
         # nonetheless treat the drift as late.
         assert store.active_invocation_ids() == ["inv-live"]
-        assert steerer._is_late_drift_for_terminated_invocation(drift, session) is True
+        assert steerer.drift._is_late_drift_for_terminated_invocation(drift, session) is True
     finally:
         store.deregister_invocation_task("inv-live")
         store.clear_active_invocations()
@@ -247,7 +247,7 @@ async def test_gate_still_classifies_empty_active_list_as_late() -> None:
         assert store.active_invocation_ids() == []
         assert store.cancel_requested_invocation_ids() == []
         drift = _drift()
-        assert steerer._is_late_drift_for_terminated_invocation(drift, session) is True
+        assert steerer.drift._is_late_drift_for_terminated_invocation(drift, session) is True
     finally:
         store.clear_active_invocations()
 
@@ -266,7 +266,7 @@ async def test_gate_lets_user_authored_drift_through_even_with_cancel_pending() 
         ):
             drift = _drift(kind=kind, authored_by="user")
             assert (
-                steerer._is_late_drift_for_terminated_invocation(drift, session)
+                steerer.drift._is_late_drift_for_terminated_invocation(drift, session)
                 is False
             ), (
                 f"user-authored drift kind={kind!r} must bypass the late-drift "
@@ -311,7 +311,7 @@ async def test_request_invocation_cancel_stamps_cancel_pending_synchronously() -
             kind=DriftKind.GOAL_DRIFT,
             severity=DriftSeverity.CRITICAL,
         )
-        flagged = await steerer.request_invocation_cancel(
+        flagged = await steerer.drift.request_invocation_cancel(
             drift=cancel_drift, session=session
         )
         assert flagged == ["inv-A"]
@@ -329,7 +329,7 @@ async def test_request_invocation_cancel_stamps_cancel_pending_synchronously() -
         # A goldfive-authored drift firing immediately after is gated.
         late_drift = _drift(kind=DriftKind.JUSTIFIED_DEVIATION)
         assert (
-            steerer._is_late_drift_for_terminated_invocation(late_drift, session)
+            steerer.drift._is_late_drift_for_terminated_invocation(late_drift, session)
             is True
         )
     finally:

--- a/tests/test_judge_lifetime_v22_regression.py
+++ b/tests/test_judge_lifetime_v22_regression.py
@@ -34,7 +34,7 @@ scenario:
   ``request_invocation_cancel`` path or from upstream cancel propagation
   (adk-web stream close, generator ``aclose()``).
 * The fix preserves PR #320's contract: the judge is still drainable
-  by ``steerer.shutdown()``.
+  by ``steerer.drift.shutdown()``.
 * Both spawn sites — task-boundary (``mark_task_*``) and turn-counter
   (``note_agent_turn``) — are covered.
 """
@@ -149,7 +149,7 @@ async def test_judge_survives_cancel_of_spawning_task_at_task_boundary() -> None
         # spawns the goal-drift judge as a background task; we then
         # cancel ourselves to simulate a sibling cancel landing on
         # this task.
-        await steerer.mark_task_completed(
+        await steerer.tasks.mark_task_completed(
             "t1", session=session, summary="research_panels done"
         )
         # Wait for the judge to have started before we yield to the
@@ -219,7 +219,7 @@ async def test_judge_survives_cancel_of_spawning_task_via_note_agent_turn() -> N
     session = _make_session()
 
     async def host_after_run() -> None:
-        await steerer.note_agent_turn(session)
+        await steerer.drift.note_agent_turn(session)
         await judge_started.wait()
         await asyncio.sleep(1.0)
 
@@ -266,7 +266,7 @@ async def test_two_back_to_back_task_transitions_do_not_clobber_running_judge() 
 
     # First transition spawns the judge, primes the rate-limit
     # timestamp. Second transition rate-limits to no-op (timestamp guard).
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
     # Sanity: spawn happened.
     assert len(steerer._background_judges) == 1
     # Second transition immediately after — within rate-limit window —
@@ -284,7 +284,7 @@ async def test_two_back_to_back_task_transitions_do_not_clobber_running_judge() 
             session,
             add_tasks(plan, [Task(id="t2", title="t2", description="")]),
         )
-    await steerer.mark_task_completed("t2", session=session, summary="also done")
+    await steerer.tasks.mark_task_completed("t2", session=session, summary="also done")
     # First judge still pending.
     assert len(steerer._background_judges) == 1
 
@@ -306,7 +306,7 @@ async def test_two_back_to_back_task_transitions_do_not_clobber_running_judge() 
 
 
 async def test_goal_drift_judge_drainable_at_steerer_shutdown() -> None:
-    """``steerer.shutdown()`` drains a still-running goal-drift judge.
+    """``steerer.drift.shutdown()`` drains a still-running goal-drift judge.
 
     PR #320's contract — judges live for the lifetime of the Runner,
     drained at ``Runner.close()`` — must hold for goal-drift judges
@@ -326,12 +326,12 @@ async def test_goal_drift_judge_drainable_at_steerer_shutdown() -> None:
     steerer.bind(sinks=[ListSink()], planner=StubPlanner())
     session = _make_session()
 
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
     assert len(steerer._background_judges) == 1
 
     # shutdown with a tight timeout — the judge is sleeping 2s, so it
     # will be cancelled by the shutdown path.
-    await steerer.shutdown(timeout=0.1)
+    await steerer.drift.shutdown(timeout=0.1)
     # Yield once so done-callbacks fire.
     await asyncio.sleep(0)
     assert steerer._background_judges == set(), (
@@ -359,7 +359,7 @@ async def test_goal_drift_judge_completes_naturally_when_left_alone() -> None:
     steerer.bind(sinks=[sink], planner=StubPlanner())
     session = _make_session()
 
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
     # Drain.
     pending = list(steerer._background_judges)
     await asyncio.gather(*pending, return_exceptions=True)
@@ -395,7 +395,7 @@ async def test_spawn_helper_is_noop_when_no_judge_is_wired() -> None:
     steerer = DefaultSteerer()  # no goal_drift_call_llm
     steerer.bind(sinks=[ListSink()], planner=StubPlanner())
     session = _make_session()
-    steerer._spawn_goal_drift_judge_background(session)
+    steerer.drift._spawn_goal_drift_judge_background(session)
     assert steerer._background_judges == set(), (
         "spawn helper must not register a task when no judge is wired"
     )
@@ -420,5 +420,5 @@ def test_spawn_helper_is_noop_outside_event_loop() -> None:
     session = _make_session()
 
     # No running loop — helper must return cleanly without scheduling.
-    steerer._spawn_goal_drift_judge_background(session)
+    steerer.drift._spawn_goal_drift_judge_background(session)
     assert steerer._background_judges == set()

--- a/tests/test_judge_task_lifetime.py
+++ b/tests/test_judge_task_lifetime.py
@@ -4,7 +4,7 @@ must not be cancelled at the per-turn boundary.
 The fire-and-forget reasoning judge (goldfive#251) runs off the critical
 path so the adapter's model-response callback can return before the
 slow LLM judge completes. Pre-fix, ``GoldfiveADKAgent._run_async_impl``
-called ``steerer.shutdown(timeout=0.5)`` in its per-turn ``finally``
+called ``steerer.drift.shutdown(timeout=0.5)`` in its per-turn ``finally``
 block, which fired ``task.cancel()`` on every still-running judge — the
 verdict was dropped on the floor whenever the LLM was slower than 0.5s,
 even when the same Runner had many more turns ahead of it.
@@ -137,7 +137,7 @@ async def test_slow_judge_completes_when_per_turn_drain_is_removed() -> None:
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
-    await steerer.observe_reasoning(
+    await steerer.drift.observe_reasoning(
         "raccoons are nocturnal", session=session
     )
     assert len(steerer._background_judges) == 1, (
@@ -176,7 +176,7 @@ async def test_done_callback_removes_from_background_judges() -> None:
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
-    await steerer.observe_reasoning("clean reasoning", session=session)
+    await steerer.drift.observe_reasoning("clean reasoning", session=session)
     assert len(steerer._background_judges) == 1
 
     # Drain the task; the done_callback fires synchronously when the
@@ -235,7 +235,7 @@ async def test_late_judge_verdict_records_drift_but_skips_refine(
     # session — the agent has moved on. The fire-and-forget judge
     # treats this as a stale verdict.
     with caplog.at_level(logging.INFO, logger="goldfive"):
-        await steerer.observe_reasoning(
+        await steerer.drift.observe_reasoning(
             "raccoons are nocturnal", session=session
         )
         pending = list(steerer._background_judges)
@@ -312,7 +312,7 @@ async def test_judge_verdict_with_live_invocation_proceeds_normally() -> None:
     fake_task = asyncio.create_task(_placeholder())
     store.register_invocation_task("inv-live", fake_task)
     try:
-        await steerer.observe_reasoning(
+        await steerer.drift.observe_reasoning(
             "raccoons are nocturnal", session=session
         )
         pending = list(steerer._background_judges)
@@ -349,7 +349,7 @@ async def test_synchronous_tool_flow_unaffected_by_late_drift_guard() -> None:
     # Drive a tool-flow drift (mark_task_failed -> TASK_FAILED_RECOVERABLE
     # -> Level 1 ABSORB) without any registered invocation. The guard
     # must not fire because this isn't the background-judge path.
-    await steerer.mark_task_failed(
+    await steerer.tasks.mark_task_failed(
         "t1", session=session, reason="boom", recoverable=True
     )
 
@@ -358,7 +358,7 @@ async def test_synchronous_tool_flow_unaffected_by_late_drift_guard() -> None:
     # asserting on planner.refine. The late-drift guard rationale
     # below still applies — what changed is the dispatch mechanism,
     # not the guard scope.
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     # planner.refine WAS called: synchronous tool-flow drifts route
     # through ``_handle_drift`` directly and are not gated.
     assert len(planner.refine_calls) >= 1, (

--- a/tests/test_judge_token_caps.py
+++ b/tests/test_judge_token_caps.py
@@ -50,9 +50,9 @@ def test_llm_planner_cap_is_16k():
 
 
 def test_reflective_check_cap_is_16k():
-    from goldfive.steerer import DefaultSteerer
+    from goldfive.drift_observer import DriftObserver
 
-    assert DefaultSteerer.REFLECTIVE_MAX_OUTPUT_TOKENS == 16384
+    assert DriftObserver.REFLECTIVE_MAX_OUTPUT_TOKENS == 16384
 
 
 def test_goal_deriver_cap_is_8k():

--- a/tests/test_judge_uses_real_agent_id.py
+++ b/tests/test_judge_uses_real_agent_id.py
@@ -123,7 +123,7 @@ async def test_reflective_drift_uses_session_current_agent_id_when_set() -> None
         current_agent_id="research_agent",
     )
 
-    await steerer.maybe_run_reflective_check(session)
+    await steerer.drift.maybe_run_reflective_check(session)
 
     drifts = await _capture_drifts(steerer, sink)
     # ``_handle_drift`` may emit a lifecycle follow-up (ESCALATING) on top
@@ -157,7 +157,7 @@ async def test_reflective_drift_falls_back_to_assignee_when_pin_empty() -> None:
         current_agent_id="",  # empty pin
     )
 
-    await steerer.maybe_run_reflective_check(session)
+    await steerer.drift.maybe_run_reflective_check(session)
 
     drifts = await _capture_drifts(steerer, sink)
     assert drifts, "reflective check should have emitted at least one drift"
@@ -186,7 +186,7 @@ async def test_uncertain_progress_drift_also_uses_session_pin() -> None:
         current_agent_id="research_agent",
     )
 
-    await steerer.maybe_run_reflective_check(session)
+    await steerer.drift.maybe_run_reflective_check(session)
 
     drifts = await _capture_drifts(steerer, sink)
     assert drifts, "reflective check should have emitted at least one drift"

--- a/tests/test_llm_call_budget.py
+++ b/tests/test_llm_call_budget.py
@@ -116,9 +116,9 @@ def test_reasoning_judge_cap_is_16384():
 
 
 def test_reflective_check_cap_is_16384():
-    from goldfive.steerer import DefaultSteerer
+    from goldfive.drift_observer import DriftObserver
 
-    assert DefaultSteerer.REFLECTIVE_MAX_OUTPUT_TOKENS == 16384
+    assert DriftObserver.REFLECTIVE_MAX_OUTPUT_TOKENS == 16384
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_call_timeout_watcher.py
+++ b/tests/test_llm_call_timeout_watcher.py
@@ -26,20 +26,36 @@ adk_plugin = pytest.importorskip("goldfive.adapters._adk_plugin")
 pytest.importorskip("google.adk")
 
 
-class _CapturingSteerer:
-    """Minimal steerer stub — captures every observation seen + every
-    drift emitted via the conventional ``_emit_drift_detected`` path."""
+class _CapturingDrift:
+    """Captures every observation seen + drift emitted (post #410)."""
 
     def __init__(self) -> None:
         self.observations: list[Any] = []
         self.emitted_drifts: list[Any] = []
-        self._sinks: list[Any] = []
 
     async def observe(self, observation: Any, session: Any) -> None:
         self.observations.append(observation)
 
     async def _emit_drift_detected(self, session: Any, drift: Any) -> None:
         self.emitted_drifts.append(drift)
+
+
+class _CapturingSteerer:
+    """Minimal steerer stub — exposes a ``drift`` sub-component that
+    captures every observation seen + every drift emitted via the
+    conventional ``_emit_drift_detected`` path."""
+
+    def __init__(self) -> None:
+        self.drift = _CapturingDrift()
+        self._sinks: list[Any] = []
+
+    @property
+    def observations(self) -> list[Any]:
+        return self.drift.observations
+
+    @property
+    def emitted_drifts(self) -> list[Any]:
+        return self.drift.emitted_drifts
 
 
 def _make_session_context(steerer: Any) -> Any:

--- a/tests/test_llm_span_decision_context.py
+++ b/tests/test_llm_span_decision_context.py
@@ -680,7 +680,7 @@ async def test_reflective_check_stamps_decision_context() -> None:
     )
     # Call the reflective check directly (bypasses the interval gate
     # so we don't have to reason about LLM-call accounting state).
-    await steerer.maybe_run_reflective_check(session)
+    await steerer.drift.maybe_run_reflective_check(session)
     events = _span_events(sink)
     assert events, "expected at least one span pair"
     start = _start(events[0])

--- a/tests/test_observation_only.py
+++ b/tests/test_observation_only.py
@@ -281,7 +281,7 @@ async def test_warning_drift_observation_only_suppresses_all_three_injections(
 
         drift = _drift_warning(kind=DriftKind.OFF_TOPIC)
         with caplog.at_level(logging.INFO, logger="goldfive"):
-            await steerer._handle_drift(drift, session)
+            await steerer.drift.handle_drift(drift, session)
 
         # 1. The planner produced a revision exactly once (detection +
         # planner LLM unaffected by the gate). OFF_TOPIC + WARNING is on
@@ -379,7 +379,7 @@ async def test_warning_drift_active_steering_drives_all_three_injections() -> No
     try:
         prior_plan = session.plan
         drift = _drift_warning(kind=DriftKind.OFF_TOPIC)
-        await steerer._handle_drift(drift, session)
+        await steerer.drift.handle_drift(drift, session)
 
         refine_total = len(planner.refine_calls) + len(
             planner.refine_steer_calls
@@ -508,7 +508,7 @@ async def test_capability_mismatch_under_observation_only_suppresses_injections(
     same gated ``_handle_drift`` path: no cancel, no plan mutation.
 
     The ADK adapter's ``_maybe_emit_capability_mismatch`` builds a
-    DriftEvent and calls ``steerer._handle_drift(drift, session)``
+    DriftEvent and calls ``steerer.drift.handle_drift(drift, session)``
     directly (see ``goldfive/adapters/_adk_plugin.py``). We exercise the
     steerer side of that contract with a hand-built drift so the test
     is independent of the ADK adapter and runs without the ``google.adk``
@@ -530,7 +530,7 @@ async def test_capability_mismatch_under_observation_only_suppresses_injections(
         kind=DriftKind.CAPABILITY_MISMATCH,
         severity=DriftSeverity.CRITICAL,
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # Plan was NOT mutated.
     assert session.plan is prior_plan
@@ -577,7 +577,7 @@ async def test_info_drift_below_promotion_threshold_unchanged_by_flag() -> None:
             kind=DriftKind.CONFABULATION_RISK,
             severity=DriftSeverity.INFO,
         )
-        await steerer._handle_drift(drift, session)
+        await steerer.drift.handle_drift(drift, session)
 
         # OBSERVE: no refine, no plan revision, no cancel, no steer.
         assert planner.refine_calls == [], (
@@ -645,7 +645,7 @@ async def test_observe_reasoning_warning_verdict_under_observation_only() -> Non
     store.register_invocation_task("inv-live", fake_task)
     try:
         prior_plan = session.plan
-        await steerer.observe_reasoning("raccoons are nocturnal", session=session)
+        await steerer.drift.observe_reasoning("raccoons are nocturnal", session=session)
         pending = list(steerer._background_judges)
         await asyncio.gather(*pending, return_exceptions=True)
 
@@ -738,7 +738,7 @@ async def test_bootstrap_install_lands_under_observation_only() -> None:
     steerer.bind(sinks=[sink], planner=planner)
 
     initial = _initial_plan()
-    installed = await steerer.install_initial_plan(session=session, plan=initial)
+    installed = await steerer.plans.install_initial_plan(session=session, plan=initial)
     assert installed is True, "bootstrap must succeed"
 
     # session.plan was set (non-None) post-install.
@@ -798,7 +798,7 @@ async def test_user_authored_revision_lands_under_observation_only() -> None:
     # Drive the canonical user-authored install path. ``raw=None`` is
     # accepted: ``_unpack_steer_context`` falls back to drift.detail
     # when raw is absent.
-    installed = await steerer.install_revision_for_user_steer(
+    installed = await steerer.plans.install_revision_for_user_steer(
         session=session,
         raw=None,
         revised_plan=revised,
@@ -849,7 +849,7 @@ async def test_goldfive_corrective_drift_is_gated_under_observation_only() -> No
         kind=DriftKind.OFF_TOPIC,
         authored_by="goldfive",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # session.plan unchanged — gate held.
     assert session.plan is prior_plan, (
@@ -896,7 +896,7 @@ async def test_goldfive_corrective_drift_lands_with_observation_only_false() -> 
         kind=DriftKind.OFF_TOPIC,
         authored_by="goldfive",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # session.plan mutated to the revised plan.
     assert session.plan is not prior_plan, (
@@ -955,7 +955,7 @@ async def test_discovery_revision_lands_under_observation_only() -> None:
         authored_by="goldfive",
     )
 
-    installed = await steerer.install_revision_for_drift(
+    installed = await steerer.plans.install_revision_for_drift(
         session=session,
         drift=drift,
         revised_plan=revised,
@@ -1038,7 +1038,7 @@ async def test_discovery_revision_lands_under_observation_only_initial_plan_seed
         tasks=[Task(id="t1", title="Research solar panels")],
         edges=[],
     )
-    installed = await steerer.install_initial_plan(session=session, plan=initial)
+    installed = await steerer.plans.install_initial_plan(session=session, plan=initial)
     assert installed is True, "initial plan install must succeed"
 
     # session.plan was swapped from the empty seed onto the real plan.
@@ -1090,7 +1090,7 @@ async def test_discovery_via_install_revision_for_drift_under_observation_only()
         detail="the user asked a follow-up that surfaced new work",
         authored_by="goldfive",
     )
-    installed = await steerer.install_revision_for_drift(
+    installed = await steerer.plans.install_revision_for_drift(
         session=session,
         drift=drift,
         revised_plan=revised,

--- a/tests/test_observation_only_emit_supersedes_carveout.py
+++ b/tests/test_observation_only_emit_supersedes_carveout.py
@@ -273,8 +273,8 @@ async def _drive_emit(
     drift = _drift_looping()
 
     # goldfive#247: _apply_revision returns ``(revised, was_installed)``.
-    chosen, was_installed = steerer._apply_revision(session, revised_plan, drift)
-    await steerer._emit_plan_revised(
+    chosen, was_installed = steerer.plans._apply_revision(session, revised_plan, drift)
+    await steerer.plans._emit_plan_revised(
         session,
         chosen,
         drift,

--- a/tests/test_observation_only_pause_escalate_carveout.py
+++ b/tests/test_observation_only_pause_escalate_carveout.py
@@ -363,7 +363,7 @@ async def test_dispatch_pause_control_observation_only_skips_channel_send(
 
     drift = _drift(kind=DriftKind.OFF_TOPIC)
     with caplog.at_level(logging.INFO, logger="goldfive"):
-        landed = await steerer._dispatch_goldfive_pause_control(
+        landed = await steerer.drift._dispatch_goldfive_pause_control(
             drift, session, reason="test exhaustion"
         )
 
@@ -402,7 +402,7 @@ async def test_dispatch_pause_control_active_steering_sends_channel_message() ->
     steerer.bind_control_channel(channel)
 
     drift = _drift(kind=DriftKind.OFF_TOPIC)
-    landed = await steerer._dispatch_goldfive_pause_control(
+    landed = await steerer.drift._dispatch_goldfive_pause_control(
         drift, session, reason="test exhaustion"
     )
 
@@ -451,7 +451,7 @@ async def test_observation_only_no_op_refine_does_not_dispatch_pause_but_emits_d
     steerer.bind_control_channel(channel)
 
     drift = _drift(kind=DriftKind.OFF_TOPIC)
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # Refine ran (detection + planner unaffected by the gate). OFF_TOPIC
     # + WARNING is on the goldfive-steer promotion path so it lands on
@@ -496,7 +496,7 @@ async def test_observation_only_refine_returns_none_does_not_dispatch_pause() ->
     steerer.bind_control_channel(channel)
 
     drift = _drift(kind=DriftKind.OFF_TOPIC)
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     pause_msgs = _pause_escalate_messages(channel)
     assert pause_msgs == [], (
@@ -525,7 +525,7 @@ async def test_active_steering_no_op_refine_dispatches_pause_escalate() -> None:
     steerer.bind_control_channel(channel)
 
     drift = _drift(kind=DriftKind.OFF_TOPIC)
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     pause_msgs = _pause_escalate_messages(channel)
     assert len(pause_msgs) == 1, (

--- a/tests/test_orchestration_state.py
+++ b/tests/test_orchestration_state.py
@@ -174,7 +174,7 @@ async def test_user_steer_writes_active_steer_state() -> None:
         kind=ControlKind.STEER,
         payload={"note": "focus on the writing instead"},
     )
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     body = _ostate.read(session.state, _ostate.KEY_ACTIVE_STEER_BODY, "")
     assert body == "focus on the writing instead"
@@ -341,11 +341,11 @@ async def test_mark_task_running_stamps_orchestration_state() -> None:
     steerer = DefaultSteerer()
     steerer.bind(sinks=[_ListSink()], planner=_StubPlanner())
 
-    await steerer.mark_task_running("t1", session=session, detail="starting")
+    await steerer.tasks.mark_task_running("t1", session=session, detail="starting")
     assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_ID) == "t1"
     assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_TITLE) == "First"
 
-    await steerer.mark_task_completed("t1", session=session, summary="done")
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
     assert _ostate.read(session.state, _ostate.KEY_CURRENT_TASK_ID, "") == ""
 
 

--- a/tests/test_overlay_forward_progress.py
+++ b/tests/test_overlay_forward_progress.py
@@ -687,7 +687,7 @@ async def test_absorb_on_looping_reasoning_queues_nudge() -> None:
         detail="tool-loop detector fired",
         current_task_id="define_structure",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # Refine applied (plan swapped in). goldfive#247: _apply_revision
     # builds a NEW Plan via bump_revision; identity is no longer the

--- a/tests/test_overlay_steer.py
+++ b/tests/test_overlay_steer.py
@@ -12,7 +12,7 @@ cascade-cancel + refine.
 These tests exercise the control-channel-driven STEER path end-to-end
 through the overlay loop, asserting:
 
-* ``steerer.observe`` is called with the STEER ``ControlMessage``.
+* ``steerer.drift.observe`` is called with the STEER ``ControlMessage``.
 * The reconciler's task-claim state is reset for the revised plan.
 * ``invoke_passthrough`` is re-invoked with the steer body as user
   input.
@@ -76,8 +76,8 @@ class RecordingSink:
         return kinds
 
 
-class SteerAwareStubSteerer:
-    """Steerer stub that reacts to STEER ControlMessage observations.
+class _SteerAwareDrift:
+    """STEER-aware drift sub-component (goldfive#410).
 
     Captures the full observe stream, and when a STEER arrives: records
     the fact, cascade-cancels every non-terminal task in the current
@@ -89,18 +89,12 @@ class SteerAwareStubSteerer:
     """
 
     def __init__(self, *, refined_plans: list[Plan] | None = None) -> None:
-        self._sinks: list[EventSink] = []
-        self._planner: Any = None
         self.observed: list[Any] = []
         self.drift_events: list[DriftEvent] = []
         self.cascade_cancelled: list[str] = []
         self.planner_refine_calls: list[tuple[Plan, DriftEvent]] = []
         # One refined plan per STEER received, consumed in order.
         self._refined_plans: list[Plan] = list(refined_plans or [])
-
-    def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
-        self._sinks = sinks
-        self._planner = planner
 
     async def observe(self, event: Any, session: Session) -> None:
         self.observed.append(event)
@@ -141,8 +135,40 @@ class SteerAwareStubSteerer:
             with channel_processor_active():
                 set_session_plan(session, self._refined_plans.pop(0))
 
-    async def _handle_drift(self, drift: DriftEvent, session: Session) -> None:  # noqa: ARG002
+    async def handle_drift(self, drift: DriftEvent, session: Session) -> None:  # noqa: ARG002
         self.drift_events.append(drift)
+
+    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:  # noqa: ARG002
+        return None
+
+
+class SteerAwareStubSteerer:
+    """Component-namespaced steerer stub (goldfive#410)."""
+
+    def __init__(self, *, refined_plans: list[Plan] | None = None) -> None:
+        self._sinks: list[EventSink] = []
+        self._planner: Any = None
+        self.drift = _SteerAwareDrift(refined_plans=refined_plans)
+
+    @property
+    def observed(self) -> list[Any]:
+        return self.drift.observed
+
+    @property
+    def drift_events(self) -> list[DriftEvent]:
+        return self.drift.drift_events
+
+    @property
+    def cascade_cancelled(self) -> list[str]:
+        return self.drift.cascade_cancelled
+
+    @property
+    def planner_refine_calls(self) -> list[tuple[Plan, DriftEvent]]:
+        return self.drift.planner_refine_calls
+
+    def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
+        self._sinks = sinks
+        self._planner = planner
 
     async def transition(
         self,
@@ -165,9 +191,6 @@ class SteerAwareStubSteerer:
         )
         with channel_processor_active():
             set_session_plan(session, with_task_status(session.plan, task_id, to))
-
-    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:  # noqa: ARG002
-        return None
 
 
 class StubPlanner:

--- a/tests/test_parallel_executor.py
+++ b/tests/test_parallel_executor.py
@@ -95,21 +95,45 @@ class NoopSink:
         return None
 
 
-class RecordingSteerer:
-    """Steerer fake that surfaces any drift the adapter attached to
-    ``InvocationResult.raw['_drift_to_surface']`` and records observed
-    events.
+class _RecordingDrift:
+    """Drift sub-component for :class:`RecordingSteerer`.
+
+    Implements only the surface the parallel executor reaches for:
+    ``observe`` and ``detect_drift``. Surfaces an attached drift from
+    ``InvocationResult.raw['_drift_to_surface']`` so tests can stage
+    arbitrary drift shapes without driving real detection.
     """
 
     def __init__(self) -> None:
         self.observed: list[Any] = []
-        self.bound_sinks: list | None = None
-
-    def bind(self, *, sinks: list, planner: Any) -> None:
-        self.bound_sinks = sinks
 
     async def observe(self, event: Any, session: Session) -> None:
         self.observed.append(event)
+
+    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
+        if isinstance(event, InvocationResult):
+            raw = event.raw or {}
+            if isinstance(raw, dict):
+                return raw.get("_drift_to_surface")
+        return None
+
+
+class RecordingSteerer:
+    """Steerer fake that surfaces any drift the adapter attached to
+    ``InvocationResult.raw['_drift_to_surface']`` and records observed
+    events.  Component-namespaced shape per goldfive#410.
+    """
+
+    def __init__(self) -> None:
+        self.drift = _RecordingDrift()
+        self.bound_sinks: list | None = None
+
+    @property
+    def observed(self) -> list[Any]:
+        return self.drift.observed
+
+    def bind(self, *, sinks: list, planner: Any) -> None:
+        self.bound_sinks = sinks
 
     async def transition(  # pragma: no cover - not exercised here
         self,
@@ -120,13 +144,6 @@ class RecordingSteerer:
         session: Session,
         cancel_reason: str = "",
     ) -> None:
-        return None
-
-    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
-        if isinstance(event, InvocationResult):
-            raw = event.raw or {}
-            if isinstance(raw, dict):
-                return raw.get("_drift_to_surface")
         return None
 
 
@@ -898,7 +915,7 @@ async def test_repeated_refine_failure_aborts_run() -> None:
 
 @pytest.mark.asyncio
 async def test_observer_exception_emits_pipeline_failure_drift() -> None:
-    """``steerer.observe`` raising must emit an INFO ``CUSTOM`` drift.
+    """``steerer.drift.observe`` raising must emit an INFO ``CUSTOM`` drift.
 
     Previously the executor would ``log.debug`` and set ``drift = None``,
     leaving sinks unaware the drift pipeline had silently failed for
@@ -907,12 +924,17 @@ async def test_observer_exception_emits_pipeline_failure_drift() -> None:
     plumbing failure is durably visible.
     """
 
-    class RaisingSteerer(RecordingSteerer):
+    class _RaisingDrift(_RecordingDrift):
         async def observe(self, event: Any, session: Session) -> None:
             raise RuntimeError("classifier exploded")
 
         def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
             return None  # pragma: no cover - never reached; observe raises
+
+    class RaisingSteerer(RecordingSteerer):
+        def __init__(self) -> None:
+            super().__init__()
+            self.drift = _RaisingDrift()
 
     adapter = TracingAdapter(delay=0.005)
     sink = NoopSink()
@@ -937,7 +959,7 @@ async def test_observer_exception_emits_pipeline_failure_drift() -> None:
     ]
     assert pipeline_failures, (
         "expected at least one INFO CUSTOM drift with "
-        "'drift_pipeline_failed:' prefix after steerer.observe raised"
+        "'drift_pipeline_failed:' prefix after steerer.drift.observe raised"
     )
     assert (
         pipeline_failures[0].drift_detected.severity

--- a/tests/test_pause_escalate.py
+++ b/tests/test_pause_escalate.py
@@ -147,7 +147,7 @@ async def test_pause_escalate_dispatches_control_and_emits_drift() -> None:
         detail="critical intent drift",
         current_task_id="t1",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     pause_msgs = _drain_goldfive_pause(channel)
     assert len(pause_msgs) == 1
@@ -176,7 +176,7 @@ async def test_pause_escalate_does_not_double_emit_human_intervention() -> None:
         detail="stuck",
         current_task_id="t1",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     assert _drain_goldfive_pause(channel)  # at least one dispatched
     human_intervention_events = [
@@ -196,7 +196,7 @@ async def test_refine_validation_failed_pauses_without_refining() -> None:
         detail="planner retry budget spent",
         current_task_id="t1",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     assert _drain_goldfive_pause(channel)
     assert planner.refine_calls == []
     # HUMAN_INTERVENTION_REQUIRED escalation is on the sink.
@@ -215,12 +215,12 @@ async def test_ladder_level_for_pause_escalate_on_repeat() -> None:
     """
     steerer = DefaultSteerer()
     assert (
-        steerer._ladder_level_for(DriftKind.PLAN_DIVERGENCE, DriftSeverity.CRITICAL, 0)
+        steerer.drift._ladder_level_for(DriftKind.PLAN_DIVERGENCE, DriftSeverity.CRITICAL, 0)
         is InterventionLevel.CANCEL_REINVOKE
     )
     # Threshold is 2 in DefaultSteerer.REFINE_FAILURE_THRESHOLD.
     assert (
-        steerer._ladder_level_for(
+        steerer.drift._ladder_level_for(
             DriftKind.PLAN_DIVERGENCE,
             DriftSeverity.CRITICAL,
             DefaultSteerer.REFINE_FAILURE_THRESHOLD,
@@ -365,7 +365,7 @@ async def test_nudge_queues_message_on_session() -> None:
         detail="agent reported no progress",
         current_task_id="t1",
     )
-    await steerer._dispatch_nudge(drift, session)
+    await steerer.drift._dispatch_nudge(drift, session)
     assert len(session.pending_nudges) == 1
     assert "t1" in session.pending_nudges[0]
 
@@ -417,7 +417,7 @@ async def test_cancel_reinvoke_dispatches_goldfive_steer_control() -> None:
         detail="tool error",
         current_task_id="t1",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     steer_msgs = _drain_goldfive_steer(channel)
     assert len(steer_msgs) == 1
     payload = steer_msgs[0].payload

--- a/tests/test_pin_versioning.py
+++ b/tests/test_pin_versioning.py
@@ -112,6 +112,58 @@ class _CapturingSink:
         pass
 
 
+class _StubTasks:
+    """No-op transitions so the report handlers can drive through.
+
+    Mirrors the surface of :class:`TaskStateMachine` that reporting
+    handlers reach for via ``steerer.tasks``.
+    """
+
+    async def mark_task_running(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    async def mark_task_progress(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    async def mark_task_completed(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    async def mark_task_failed(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    async def mark_task_blocked(self, *a: Any, **kw: Any) -> None:
+        pass
+
+
+class _StubDriftObs:
+    async def observe(self, *a: Any, **kw: Any) -> None:  # pragma: no cover
+        pass
+
+
+class _StubPlans:
+    """No-op plan reviser; the ``_wait_plan_stable`` spy lives here
+    so reporting-handler tests can assert the call.
+    """
+
+    def __init__(
+        self,
+        *,
+        wait_plan_stable_delay: float = 0.0,
+        on_wait: Any = None,
+    ) -> None:
+        self._wait_calls = 0
+        self._wait_delay = wait_plan_stable_delay
+        self._on_wait = on_wait
+
+    async def _wait_plan_stable(self, session: Any, *, timeout: float = 1.0) -> bool:
+        self._wait_calls += 1
+        if self._on_wait is not None:
+            await self._on_wait(session)
+        if self._wait_delay > 0:
+            await asyncio.sleep(self._wait_delay)
+        return True
+
+
 class _SinkingSteerer:
     """Steerer stub that exposes ``_sinks`` so the plugin emits events.
 
@@ -128,36 +180,16 @@ class _SinkingSteerer:
         on_wait: Any = None,
     ) -> None:
         self._sinks = list(sinks)
-        self._wait_calls = 0
-        self._wait_delay = wait_plan_stable_delay
-        self._on_wait = on_wait
+        self.tasks = _StubTasks()
+        self.drift = _StubDriftObs()
+        self.plans = _StubPlans(
+            wait_plan_stable_delay=wait_plan_stable_delay,
+            on_wait=on_wait,
+        )
 
-    async def observe(self, *a: Any, **kw: Any) -> None:  # pragma: no cover
-        pass
-
-    async def _wait_plan_stable(self, session: Any, *, timeout: float = 1.0) -> bool:
-        self._wait_calls += 1
-        if self._on_wait is not None:
-            await self._on_wait(session)
-        if self._wait_delay > 0:
-            await asyncio.sleep(self._wait_delay)
-        return True
-
-    # No-op transitions so the report handlers can drive through.
-    async def mark_task_running(self, *a: Any, **kw: Any) -> None:
-        pass
-
-    async def mark_task_progress(self, *a: Any, **kw: Any) -> None:
-        pass
-
-    async def mark_task_completed(self, *a: Any, **kw: Any) -> None:
-        pass
-
-    async def mark_task_failed(self, *a: Any, **kw: Any) -> None:
-        pass
-
-    async def mark_task_blocked(self, *a: Any, **kw: Any) -> None:
-        pass
+    @property
+    def _wait_calls(self) -> int:
+        return self.plans._wait_calls
 
 
 def _plan_with(
@@ -368,7 +400,7 @@ async def test_handler_stale_replace_routes_to_successor() -> None:
     async def _capture(task_id: str, **kw: Any) -> None:
         seen["task_id"] = task_id
 
-    steerer.mark_task_running = _capture  # type: ignore[assignment]
+    steerer.tasks.mark_task_running = _capture  # type: ignore[assignment]
 
     result = await _tool("report_task_started").handler(
         {"task_id": "research_solar"},
@@ -426,7 +458,7 @@ async def test_handler_stale_correct_refuses_and_emits_event() -> None:
     async def _capture(task_id: str, **kw: Any) -> None:
         seen_steerer_task_ids.append(task_id)
 
-    steerer.mark_task_completed = _capture  # type: ignore[assignment]
+    steerer.tasks.mark_task_completed = _capture  # type: ignore[assignment]
 
     result = await _tool("report_task_completed").handler(
         {"task_id": "research_solar", "summary": "done"},
@@ -479,7 +511,7 @@ async def test_handler_stale_no_supersedes_refuses() -> None:
     async def _capture(task_id: str, **kw: Any) -> None:
         seen_steerer_task_ids.append(task_id)
 
-    steerer.mark_task_progress = _capture  # type: ignore[assignment]
+    steerer.tasks.mark_task_progress = _capture  # type: ignore[assignment]
 
     result = await _tool("report_task_progress").handler(
         {"task_id": "orphan", "fraction": 0.5},
@@ -558,7 +590,7 @@ def test_pending_delegations_back_compat_string_shape() -> None:
 
 
 async def test_handler_waits_for_plan_stable_during_concurrent_refine() -> None:
-    """The handler invokes ``steerer._wait_plan_stable`` before classifying.
+    """The handler invokes ``steerer.plans._wait_plan_stable`` before classifying.
 
     Simulates a refine in flight: the steerer's barrier delays the
     handler until the refine has bumped ``revision_index``. Without
@@ -648,7 +680,7 @@ async def test_handler_fresh_pin_routes_through_replace_chain() -> None:
     async def _capture(task_id: str, **kw: Any) -> None:
         seen["task_id"] = task_id
 
-    steerer.mark_task_running = _capture  # type: ignore[assignment]
+    steerer.tasks.mark_task_running = _capture  # type: ignore[assignment]
 
     result = await _tool("report_task_started").handler(
         {"task_id": "t_old"},

--- a/tests/test_plan_reviser.py
+++ b/tests/test_plan_reviser.py
@@ -283,13 +283,13 @@ async def test_apply_revision_no_partial_state_visible_during_cancel_inflight_yi
     # completes (it can still snapshot ``session.plan`` raw, which is
     # either the prior pointer or the fully-integrated revised
     # pointer).
-    original_cancel = steerer._cancel_inflight_for_revision
+    original_cancel = steerer.drift._cancel_inflight_for_revision
 
     async def slow_cancel(d: DriftEvent, s: Session) -> list[str]:
         await asyncio.sleep(0.05)
         return await original_cancel(d, s)
 
-    steerer._cancel_inflight_for_revision = slow_cancel  # type: ignore[method-assign]
+    steerer.drift._cancel_inflight_for_revision = slow_cancel  # type: ignore[method-assign]
 
     partial_snapshots: list[dict[str, Any]] = []
 
@@ -325,7 +325,7 @@ async def test_apply_revision_no_partial_state_visible_during_cancel_inflight_yi
             await asyncio.sleep(0)  # yield to the refine task
 
     async def refine_driver() -> None:
-        await steerer._handle_drift(drift, session)
+        await steerer.drift.handle_drift(drift, session)
 
     await asyncio.gather(refine_driver(), partial_state_poller())
 
@@ -386,7 +386,7 @@ async def test_apply_revision_does_not_mutate_session_before_emit() -> None:
     drift = _drift(kind=DriftKind.OFF_TOPIC, task_id="t1")
 
     steerer = DefaultSteerer()
-    returned, was_installed = steerer._apply_revision(session, revised, drift)
+    returned, was_installed = steerer.plans._apply_revision(session, revised, drift)
 
     # The decision is "install" (no observation-only carve-out fires).
     assert was_installed is True, (

--- a/tests/test_promote_drift_to_steer.py
+++ b/tests/test_promote_drift_to_steer.py
@@ -208,7 +208,7 @@ async def test_promote_drift_dispatches_after_plan_swap_audit_402() -> None:
         f"t_old_pending, got {prior_pendings}"
     )
 
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # refine_steer ran — promotion path was exercised.
     assert planner.refine_steer_calls, (

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -73,19 +73,17 @@ class _PlannerStub:
 
 
 class _SteererStub:
-    async def observe(self, event: Any, session: Any) -> None:
-        return None
+    """Conforming stub for the post-#410 Steerer protocol.
 
-    async def observe_reasoning(
-        self,
-        text: str,
-        *,
-        task: Any = None,
-        session: Any,
-        provider: str = "",
-        agent_name: str = "",
-    ) -> None:
-        return None
+    The component-namespaced shape: ``tasks`` / ``plans`` / ``drift``
+    sub-objects are accepted as ``Any``-typed attributes by the
+    protocol's structural check, so a bare ``object()`` satisfies them.
+    """
+
+    def __init__(self) -> None:
+        self.tasks: Any = object()
+        self.plans: Any = object()
+        self.drift: Any = object()
 
     async def transition(
         self,
@@ -94,13 +92,8 @@ class _SteererStub:
         *,
         detail: str = "",
         session: Any,
+        cancel_reason: str = "",
     ) -> None:
-        return None
-
-    async def cascade_cancel_downstream(self, session: Any, cancelled_id: str) -> None:
-        return None
-
-    def detect_drift(self, event: Any, session: Any) -> Any | None:
         return None
 
     def bind(self, *, sinks: list[Any], planner: Any) -> None:

--- a/tests/test_reasoning_content_fallback.py
+++ b/tests/test_reasoning_content_fallback.py
@@ -4,7 +4,7 @@ Background — reproduced live 2026-05-11 on Gemma-4 (session
 ``4a721a07``). Gemma's responses carry ``reasoning: null`` end-to-end,
 so :func:`goldfive.adapters._adk_plugin._extract_reasoning` returns an
 empty string and the plugin's ``after_model_callback`` never invokes
-``steerer.observe_reasoning``. Result: zero ``reasoning_judge``
+``steerer.drift.observe_reasoning``. Result: zero ``reasoning_judge``
 invocations across the entire run, zero OFF_TOPIC / GOAL_DRIFT
 detection from the reasoning surface, even on agent flows that would
 have tripped on a thinking-capable model (Qwen3.5, Claude with
@@ -30,7 +30,7 @@ These tests pin five invariants:
 3. **Flag on, empty reasoning + content body** — the synthesised path
    fires and ``observe_reasoning`` gets the CONTENT text. The
    ``raw["reasoning_source"]`` annotation on the
-   ``steerer.observe(llm_response)`` payload reads
+   ``steerer.drift.observe(llm_response)`` payload reads
    ``"content_fallback"`` so downstream consumers can tell synthesised
    from real reasoning.
 4. **Flag on, both empty** — defensive: ``observe_reasoning`` is NOT
@@ -161,11 +161,8 @@ class _FakeCallbackContext:
         self.state = invocation_context.session.state
 
 
-class _SteererSpy:
-    """Records every call into ``observe`` / ``observe_reasoning`` /
-    ``note_llm_call`` so a test can assert which path the plugin took
-    and inspect the text it forwarded.
-    """
+class _DriftSpy:
+    """Records every call into the drift sub-component (post #410)."""
 
     def __init__(self, inner: Any) -> None:
         self._inner = inner
@@ -184,6 +181,34 @@ class _SteererSpy:
     async def note_llm_call(self, session: Any) -> None:
         self.note_llm_calls += 1
         await self._inner.note_llm_call(session)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+class _SteererSpy:
+    """Wraps a real steerer with a spying drift sub-component so a test
+    can assert which observe/observe_reasoning/note_llm_call path the
+    plugin took.  Component-namespaced per goldfive#410.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        # Replace the inner steerer's drift with a spying wrapper so
+        # the plugin's ``steerer.drift.X`` calls land on the spy.
+        self.drift = _DriftSpy(inner.drift)
+
+    @property
+    def observe_calls(self) -> list[Any]:
+        return self.drift.observe_calls
+
+    @property
+    def observe_reasoning_calls(self) -> list[tuple[str, dict[str, Any]]]:
+        return self.drift.observe_reasoning_calls
+
+    @property
+    def note_llm_calls(self) -> int:
+        return self.drift.note_llm_calls
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -369,25 +369,25 @@ async def test_rate_limit_fires_first_call_then_every_N(
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
     # 1st turn -> judge fires (count=0 starts the task).
-    await steerer.observe_reasoning("turn 1", session=session)
+    await steerer.drift.observe_reasoning("turn 1", session=session)
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     # 2nd / 3rd turn -> skip (count=1,2).
-    await steerer.observe_reasoning("turn 2", session=session)
-    await steerer.observe_reasoning("turn 3", session=session)
+    await steerer.drift.observe_reasoning("turn 2", session=session)
+    await steerer.drift.observe_reasoning("turn 3", session=session)
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
     # 4th turn -> fire again (count=3 = 3 % 3 == 0).
-    await steerer.observe_reasoning("turn 4", session=session)
+    await steerer.drift.observe_reasoning("turn 4", session=session)
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
     # 5th-6th -> skip.
-    await steerer.observe_reasoning("turn 5", session=session)
-    await steerer.observe_reasoning("turn 6", session=session)
+    await steerer.drift.observe_reasoning("turn 5", session=session)
+    await steerer.drift.observe_reasoning("turn 6", session=session)
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
     # 7th -> fire.
-    await steerer.observe_reasoning("turn 7", session=session)
+    await steerer.drift.observe_reasoning("turn 7", session=session)
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 3  # type: ignore[attr-defined]
 
@@ -411,10 +411,10 @@ async def test_rate_limit_resets_on_task_transition() -> None:
     # them as a near-duplicate cluster (which would short-circuit
     # ``observe_reasoning`` before the judge dispatches and break this
     # test under any venv that has sentence-transformers installed).
-    await steerer.observe_reasoning(
+    await steerer.drift.observe_reasoning(
         "investigating solar panel efficiency curves", session=session
     )
-    await steerer.observe_reasoning(
+    await steerer.drift.observe_reasoning(
         "comparing inverter topologies for residential rooftops",
         session=session,
     )
@@ -437,7 +437,7 @@ async def test_rate_limit_resets_on_task_transition() -> None:
     # First reasoning on t2 -> fresh judge call (the counter for t2 is 0).
     # Use a topic that's semantically far from the two t1 strings above
     # so the looping detector does not flag this as a continuation.
-    await steerer.observe_reasoning(
+    await steerer.drift.observe_reasoning(
         "examining hydroponic tomato yield variance under LED grow lights",
         session=session,
     )
@@ -455,7 +455,7 @@ async def test_judge_disabled_when_call_llm_is_none() -> None:
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
-    await steerer.observe_reasoning("any thought", session=session)
+    await steerer.drift.observe_reasoning("any thought", session=session)
     await _wait_for_judges(steerer)
     # Only the looping always-on detector ran, and it does not fire
     # on a single clean-text thinking message with no history.
@@ -506,10 +506,10 @@ async def test_judge_rate_limit_buckets_per_agent_not_globally() -> None:
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
     # Round 1: both agents fire on their first unpinned block.
-    await steerer.observe_reasoning("A turn 1", session=session, agent_name="agent_a")
+    await steerer.drift.observe_reasoning("A turn 1", session=session, agent_name="agent_a")
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
-    await steerer.observe_reasoning("B turn 1", session=session, agent_name="agent_b")
+    await steerer.drift.observe_reasoning("B turn 1", session=session, agent_name="agent_b")
     await _wait_for_judges(steerer)
     # The bug reproduces here: pre-fix this would stay at 1 because
     # agent A's turn had already incremented the shared ``""`` bucket.
@@ -520,23 +520,23 @@ async def test_judge_rate_limit_buckets_per_agent_not_globally() -> None:
     )
 
     # Round 2: both skip (count=1 for each agent's bucket).
-    await steerer.observe_reasoning("A turn 2", session=session, agent_name="agent_a")
-    await steerer.observe_reasoning("B turn 2", session=session, agent_name="agent_b")
+    await steerer.drift.observe_reasoning("A turn 2", session=session, agent_name="agent_a")
+    await steerer.drift.observe_reasoning("B turn 2", session=session, agent_name="agent_b")
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
 
     # Round 3: both skip again (count=2).
-    await steerer.observe_reasoning("A turn 3", session=session, agent_name="agent_a")
-    await steerer.observe_reasoning("B turn 3", session=session, agent_name="agent_b")
+    await steerer.drift.observe_reasoning("A turn 3", session=session, agent_name="agent_a")
+    await steerer.drift.observe_reasoning("B turn 3", session=session, agent_name="agent_b")
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 2  # type: ignore[attr-defined]
 
     # Round 4: both fire (count=3 % 3 == 0). Confirms the per-agent
     # counters advance independently and are NOT a shared global bucket.
-    await steerer.observe_reasoning("A turn 4", session=session, agent_name="agent_a")
+    await steerer.drift.observe_reasoning("A turn 4", session=session, agent_name="agent_a")
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 3  # type: ignore[attr-defined]
-    await steerer.observe_reasoning("B turn 4", session=session, agent_name="agent_b")
+    await steerer.drift.observe_reasoning("B turn 4", session=session, agent_name="agent_b")
     await _wait_for_judges(steerer)
     assert len(call_llm.calls) == 4  # type: ignore[attr-defined]
 
@@ -578,7 +578,7 @@ async def test_observe_reasoning_returns_fast_when_judge_is_slow() -> None:
 
     loop = asyncio.get_event_loop()
     t0 = loop.time()
-    await steerer.observe_reasoning("clean on-task reasoning", session=session)
+    await steerer.drift.observe_reasoning("clean on-task reasoning", session=session)
     elapsed = loop.time() - t0
     try:
         assert elapsed < 0.1, (
@@ -618,7 +618,7 @@ async def test_observe_reasoning_judge_still_fires_in_background() -> None:
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
-    await steerer.observe_reasoning("raccoons are nocturnal", session=session)
+    await steerer.drift.observe_reasoning("raccoons are nocturnal", session=session)
     # Judge hasn't run yet -> no drift emitted.
     drift_events_pre = [
         e for e in sink.events if e.WhichOneof("payload") == "drift_detected"
@@ -675,7 +675,7 @@ async def test_observe_reasoning_judge_exception_does_not_crash(
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
     with caplog.at_level(logging.WARNING, logger="goldfive"):
-        await steerer.observe_reasoning("some thought", session=session)
+        await steerer.drift.observe_reasoning("some thought", session=session)
         await _wait_for_judges(steerer)
 
     # No drift was emitted (analyze_reasoning never returned a verdict).
@@ -717,12 +717,12 @@ async def test_shutdown_bounded_timeout_does_not_wait_for_slow_judge() -> None:
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
     # Schedule a judge that will be running when shutdown fires.
-    await steerer.observe_reasoning("slow-path thought", session=session)
+    await steerer.drift.observe_reasoning("slow-path thought", session=session)
     assert len(steerer._background_judges) == 1
 
     loop = asyncio.get_event_loop()
     t0 = loop.time()
-    await steerer.shutdown(timeout=0.5)
+    await steerer.drift.shutdown(timeout=0.5)
     elapsed = loop.time() - t0
     # 0.5 timeout + 0.5 cancel-drain budget = ~1.0s ceiling; we want
     # well under the judge's 10s. Allow a little jitter for slow CI.
@@ -737,7 +737,7 @@ async def test_shutdown_is_noop_when_no_background_judges() -> None:
     steerer.bind(sinks=[ListSink()], planner=NullPlanner())
     # No observe_reasoning call -> empty set.
     assert steerer._background_judges == set()
-    await steerer.shutdown(timeout=5.0)
+    await steerer.drift.shutdown(timeout=5.0)
 
 
 async def test_shutdown_quiet_when_zero_tasks_actually_cancelled(
@@ -768,12 +768,12 @@ async def test_shutdown_quiet_when_zero_tasks_actually_cancelled(
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=NullPlanner())
 
-    await steerer.observe_reasoning("a thought", session=session)
+    await steerer.drift.observe_reasoning("a thought", session=session)
 
     with caplog.at_level(logging.WARNING, logger="goldfive"):
         # timeout=0.0 → wait_for raises TimeoutError immediately even
         # if the gather wins the race in the same instant.
-        await steerer.shutdown(timeout=0.0)
+        await steerer.drift.shutdown(timeout=0.0)
 
     warnings = [
         r for r in caplog.records

--- a/tests/test_reasoning_judge_agent_tree.py
+++ b/tests/test_reasoning_judge_agent_tree.py
@@ -568,7 +568,7 @@ async def test_steerer_observe_reasoning_threads_available_agents() -> None:
     steerer.bind(sinks=[sink], planner=NullPlanner())
     steerer.bind_adapter(_StubAdapterWithTree())
     session = _brussels_sprouts_session()
-    await steerer.observe_reasoning(
+    await steerer.drift.observe_reasoning(
         (
             "draft_slides is assigned to me. I'll delegate to "
             "web_developer_agent to build the actual slide content."
@@ -618,7 +618,7 @@ async def test_steerer_observe_reasoning_no_adapter_keeps_default_prompt() -> No
     # return None and the judge prompt should look pre-#244.
     steerer.bind(sinks=[sink], planner=NullPlanner())
     session = _brussels_sprouts_session()
-    await steerer.observe_reasoning(
+    await steerer.drift.observe_reasoning(
         "Drafting slides for the deck.",
         session=session,
         agent_name="coordinator_agent",

--- a/tests/test_reasoning_judge_covers_delegated_agents.py
+++ b/tests/test_reasoning_judge_covers_delegated_agents.py
@@ -271,7 +271,7 @@ async def test_delegated_subagent_reasoning_dispatched_to_judge() -> None:
         "write a detailed section about raccoons — their masks, "
         "nocturnal behaviour, and dexterous paws."
     )
-    await steerer.observe_reasoning(
+    await steerer.drift.observe_reasoning(
         raccoon_reasoning,
         session=session,
         agent_name="research_agent",
@@ -368,14 +368,14 @@ async def test_coordinator_and_subagent_reasoning_both_judged_and_attributed() -
     session = _coordinator_session()
 
     # Coordinator turn first.
-    await steerer.observe_reasoning(
+    await steerer.drift.observe_reasoning(
         "I'll delegate research to research_agent then build slides.",
         session=session,
         agent_name="coordinator",
     )
     await _drain_judges(steerer)
     # Research_agent turn second — same session, same current_task_id.
-    await steerer.observe_reasoning(
+    await steerer.drift.observe_reasoning(
         "Let me write about raccoons in addition to solar panels.",
         session=session,
         agent_name="research_agent",

--- a/tests/test_refine_atomicity_events.py
+++ b/tests/test_refine_atomicity_events.py
@@ -222,7 +222,7 @@ async def test_successful_refine_emits_attempted_and_correlation_with_same_attem
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
 
-    await steerer._handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
 
     attempted = sink.by_kind("refine_attempted")
     failed = sink.by_kind("refine_failed")
@@ -263,7 +263,7 @@ async def test_planner_exception_emits_attempted_and_failed_no_plan_revised() ->
     session = _make_session()
     initial_revision = session.plan.revision_index
 
-    await steerer._handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
 
     attempted = sink.by_kind("refine_attempted")
     failed = sink.by_kind("refine_failed")
@@ -292,7 +292,7 @@ async def test_planner_returns_none_emits_failed_with_parse_error_kind() -> None
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
 
-    await steerer._handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
 
     failed = sink.by_kind("refine_failed")
     assert len(failed) == 1
@@ -321,7 +321,7 @@ async def test_validator_rejection_emits_failed_with_validator_kind() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
 
-    await steerer._handle_drift(_drift(), session)
+    await steerer.drift.handle_drift(_drift(), session)
 
     failed = sink.by_kind("refine_failed")
     assert len(failed) == 1
@@ -339,11 +339,11 @@ async def test_attempt_id_is_unique_per_attempt() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
 
-    await steerer._handle_drift(_drift(kind=DriftKind.TOOL_ERROR), session)
+    await steerer.drift.handle_drift(_drift(kind=DriftKind.TOOL_ERROR), session)
     # Use a different drift kind so the outcome gate (goldfive#215 P2,
     # keyed on (kind, task)) doesn't fold the second attempt onto the
     # first's "succeeded" outcome and short-circuit it.
-    await steerer._handle_drift(_drift(kind=DriftKind.LOOPING_REASONING), session)
+    await steerer.drift.handle_drift(_drift(kind=DriftKind.LOOPING_REASONING), session)
 
     attempted = sink.by_kind("refine_attempted")
     assert len(attempted) == 2
@@ -368,7 +368,7 @@ async def test_refine_attempted_carries_drift_kind_and_severity() -> None:
         kind=DriftKind.LOOPING_REASONING,
         severity=DriftSeverity.WARNING,
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     attempted = sink.by_kind("refine_attempted")
     assert len(attempted) == 1
@@ -391,7 +391,7 @@ async def test_wait_plan_stable_returns_immediately_when_unlocked() -> None:
     session = _make_session()
 
     # Fast-path: lock not even instantiated yet.
-    ok = await steerer._wait_plan_stable(session, timeout=0.5)
+    ok = await steerer.plans._wait_plan_stable(session, timeout=0.5)
     assert ok is True
 
 
@@ -410,13 +410,13 @@ async def test_wait_plan_stable_blocks_until_emit_plan_revised_completes() -> No
     session = _make_session()
 
     # Hold the per-session lock manually to simulate an in-flight mutation.
-    lock = steerer._get_plan_lock(session)
+    lock = steerer.plans._get_plan_lock(session)
     initial_revision = session.plan.revision_index
     barrier_observed: list[int] = []
 
     async def reader() -> None:
         # Wait for stability, then snapshot what the read sees.
-        await steerer._wait_plan_stable(session, timeout=2.0)
+        await steerer.plans._wait_plan_stable(session, timeout=2.0)
         assert session.plan is not None
         barrier_observed.append(session.plan.revision_index)
 
@@ -489,7 +489,7 @@ async def test_concurrent_emit_plan_revised_and_report_observe_consistent_state(
     async def reporter() -> None:
         # Slight delay so the refine path enters the lock first.
         await asyncio.sleep(0.001)
-        await steerer._wait_plan_stable(session, timeout=2.0)
+        await steerer.plans._wait_plan_stable(session, timeout=2.0)
         # Snapshot plan revision_index + current_task_id together. By
         # contract these must agree: pre-revision (0, "t1") or
         # post-revision (1, "t1_corr").
@@ -497,7 +497,7 @@ async def test_concurrent_emit_plan_revised_and_report_observe_consistent_state(
         snapshots.append((session.plan.revision_index, session.current_task_id))
 
     async def refiner() -> None:
-        await steerer._handle_drift(drift, session)
+        await steerer.drift.handle_drift(drift, session)
 
     await asyncio.gather(refiner(), reporter())
 
@@ -525,10 +525,10 @@ async def test_wait_plan_stable_times_out_gracefully_when_lock_held() -> None:
     steerer.bind(sinks=[sink], planner=StubPlanner())
     session = _make_session()
 
-    lock = steerer._get_plan_lock(session)
+    lock = steerer.plans._get_plan_lock(session)
     async with lock:
         # The waiter has a tight timeout; we never release before it.
-        ok = await steerer._wait_plan_stable(session, timeout=0.05)
+        ok = await steerer.plans._wait_plan_stable(session, timeout=0.05)
     assert ok is False
 
 
@@ -561,13 +561,13 @@ async def test_report_handler_invokes_wait_plan_stable() -> None:
 
     # Spy on _wait_plan_stable.
     call_log: list[str] = []
-    original = steerer._wait_plan_stable
+    original = steerer.plans._wait_plan_stable
 
     async def _spy(session_arg: Any, *, timeout: Any = 1.0) -> bool:
         call_log.append("called")
         return await original(session_arg, timeout=timeout)
 
-    steerer._wait_plan_stable = _spy  # type: ignore[method-assign]
+    steerer.plans._wait_plan_stable = _spy  # type: ignore[method-assign]
 
     handler = next(
         t.handler for t in BUILTIN_REPORTING_TOOLS if t.name == "report_task_completed"
@@ -586,14 +586,24 @@ async def test_report_handler_tolerates_steerer_without_wait_plan_stable() -> No
     """
     from goldfive.reporting import BUILTIN_REPORTING_TOOLS
 
-    class MinimalSteerer:
-        """Bare-minimum Steerer stub without a4's helper."""
-
+    class _MinimalTasks:
         async def mark_task_completed(self, *args: Any, **kwargs: Any) -> None:
             pass
 
         async def mark_task_running(self, *args: Any, **kwargs: Any) -> None:
             pass
+
+    class MinimalSteerer:
+        """Bare-minimum Steerer stub without a4's helper.
+
+        Exposes ``tasks`` (goldfive#410) so the reporting-handler call
+        path resolves, but intentionally does NOT expose ``plans``
+        (which is what holds ``_wait_plan_stable`` after the facade
+        cleanup).  The handler must tolerate the missing helper.
+        """
+
+        def __init__(self) -> None:
+            self.tasks = _MinimalTasks()
 
     session = _make_session()
     # goldfive#247: Plan + Task are frozen — derive via helper.
@@ -630,7 +640,7 @@ async def test_proto_plan_revised_event_unchanged_on_success() -> None:
     session = _make_session()
 
     drift = _drift(kind=DriftKind.TOOL_ERROR)
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     proto_pr = [
         e for e in sink.proto_events if e.WhichOneof("payload") == "plan_revised"
@@ -674,7 +684,7 @@ async def test_plan_revised_event_populates_refine_summaries() -> None:
         current_task_id="t1",
         current_agent_id="researcher",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     events = _plan_revised_events(sink)
     assert len(events) == 1
@@ -710,7 +720,7 @@ async def test_plan_revised_event_stamps_target_agent_id() -> None:
         current_task_id="t1",
         current_agent_id="researcher",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     pr = _plan_revised_events(sink)[0].plan_revised
     assert pr.target_agent_id == "researcher"
@@ -732,7 +742,7 @@ async def test_plan_revised_event_target_agent_id_empty_for_trajectory_drift() -
         current_task_id="t1",
         current_agent_id="",  # no agent bound — trajectory-level
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     pr = _plan_revised_events(sink)[0].plan_revised
     assert pr.target_agent_id == ""
@@ -755,7 +765,7 @@ async def test_plan_revised_refine_input_summary_truncates_when_long() -> None:
         current_task_id="t1",
         current_agent_id="researcher",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     pr = _plan_revised_events(sink)[0].plan_revised
     assert pr.refine_input_summary.endswith(" … [truncated]")

--- a/tests/test_refine_emit_parity.py
+++ b/tests/test_refine_emit_parity.py
@@ -135,7 +135,7 @@ async def test_observe_refine_emits_attempted_on_enter() -> None:
         current_task_id="t1",
     )
 
-    async with steerer.observe_refine(session, drift) as attempt_id:
+    async with steerer.plans.observe_refine(session, drift) as attempt_id:
         # Inside the context the planner's span-ctx provider resolves
         # to a non-None tuple, so the planner-side _emit_refine_orphaned_tasks
         # would route to the bound sinks.
@@ -186,7 +186,7 @@ async def test_observe_refine_emits_failed_on_exception_and_reraises() -> None:
 
     captured_attempt_id: str = ""
     with pytest.raises(RuntimeError, match="boom"):
-        async with steerer.observe_refine(session, drift) as attempt_id:
+        async with steerer.plans.observe_refine(session, drift) as attempt_id:
             captured_attempt_id = attempt_id
             raise RuntimeError("boom")
 
@@ -282,7 +282,7 @@ async def test_planner_orphan_emit_fires_when_steerer_observes_refine() -> None:
         current_task_id="draft_body",
     )
 
-    async with steerer.observe_refine(session, drift) as _attempt_id:
+    async with steerer.plans.observe_refine(session, drift) as _attempt_id:
         revised = await planner.refine(plan=prior, drift=drift, goals=list(session.goals))
 
     assert revised is not None
@@ -355,7 +355,7 @@ async def test_planner_no_orphan_emit_when_coverage_complete() -> None:
         current_task_id="draft",
     )
 
-    async with steerer.observe_refine(session, drift) as _attempt_id:
+    async with steerer.plans.observe_refine(session, drift) as _attempt_id:
         revised = await planner.refine(plan=prior, drift=drift, goals=list(session.goals))
 
     assert revised is not None
@@ -451,16 +451,26 @@ class _FixedDriftSteerer(DefaultSteerer):
     the classifier heuristics. All other behaviour (the
     :meth:`observe_refine` plumbing under test) is inherited from the
     real DefaultSteerer.
+
+    goldfive#410: ``detect_drift`` now lives on the DriftObserver
+    component.  The override patches the bound DriftObserver in
+    place by wrapping its ``detect_drift`` method.
     """
 
-    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
-        if isinstance(event, InvocationResult):
-            raw = event.raw or {}
-            if isinstance(raw, dict):
-                drift = raw.get("_drift_to_surface")
-                if isinstance(drift, DriftEvent):
-                    return drift
-        return super().detect_drift(event, session)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        base_detect = self.drift.detect_drift
+
+        def _detect(event: Any, session: Session) -> DriftEvent | None:
+            if isinstance(event, InvocationResult):
+                raw = event.raw or {}
+                if isinstance(raw, dict):
+                    drift = raw.get("_drift_to_surface")
+                    if isinstance(drift, DriftEvent):
+                        return drift
+            return base_detect(event, session)
+
+        self.drift.detect_drift = _detect  # type: ignore[method-assign]
 
 
 class _ScriptedRefinePlanner:
@@ -710,7 +720,7 @@ async def test_refine_attempted_emitted_from_both_steerer_and_executor_paths() -
             edges=[TaskEdge("t1", "t2")],
         ),
     )
-    await steerer_st._handle_drift(_drift(task_id="t1"), session_st)
+    await steerer_st.drift.handle_drift(_drift(task_id="t1"), session_st)
     assert sink_st.by_kind("refine_attempted"), (
         "steerer-driven refine emits refine_attempted"
     )

--- a/tests/test_reflective_check.py
+++ b/tests/test_reflective_check.py
@@ -143,15 +143,15 @@ async def test_reflective_check_fires_at_interval() -> None:
 
     session = _make_session_with_task()
     for _ in range(14):
-        await steerer.note_llm_call(session)
+        await steerer.drift.note_llm_call(session)
     assert len(calls) == 0, "check should not fire before the 15th call"
-    await steerer.note_llm_call(session)
+    await steerer.drift.note_llm_call(session)
     assert len(calls) == 1, "check should fire on the 15th call"
     # Counter resets after a check; another 14 should not re-fire.
     for _ in range(14):
-        await steerer.note_llm_call(session)
+        await steerer.drift.note_llm_call(session)
     assert len(calls) == 1
-    await steerer.note_llm_call(session)
+    await steerer.drift.note_llm_call(session)
     assert len(calls) == 2
 
 
@@ -169,7 +169,7 @@ async def test_reflective_check_making_progress_emits_no_drift() -> None:
 
     session = _make_session_with_task()
     for _ in range(3):
-        await steerer.note_llm_call(session)
+        await steerer.drift.note_llm_call(session)
     # No drift_detected events emitted (high-confidence yes).
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     assert "drift_detected" not in kinds
@@ -191,7 +191,7 @@ async def test_reflective_check_low_confidence_emits_uncertain() -> None:
 
     session = _make_session_with_task()
     for _ in range(2):
-        await steerer.note_llm_call(session)
+        await steerer.drift.note_llm_call(session)
     drifts = [e for e in sink.proto_events if e.WhichOneof("payload") == "drift_detected"]
     assert len(drifts) == 1
     from goldfive.pb.goldfive.v1 import types_pb2
@@ -223,7 +223,7 @@ async def test_reflective_check_stuck_emits_warning() -> None:
 
     session = _make_session_with_task()
     for _ in range(2):
-        await steerer.note_llm_call(session)
+        await steerer.drift.note_llm_call(session)
     drifts = [e for e in sink.proto_events if e.WhichOneof("payload") == "drift_detected"]
     # The WARNING drift flows through _handle_drift, which also emits a
     # follow-up drift_detected when planner.refine returns None (refine
@@ -253,7 +253,7 @@ async def test_reflective_check_malformed_response_is_graceful() -> None:
     steerer.bind(sinks=[sink], planner=planner)
 
     session = _make_session_with_task()
-    await steerer.note_llm_call(session)
+    await steerer.drift.note_llm_call(session)
     drifts = [e for e in sink.proto_events if e.WhichOneof("payload") == "drift_detected"]
     assert len(drifts) == 1
     from goldfive.pb.goldfive.v1 import types_pb2
@@ -274,7 +274,7 @@ async def test_reflective_check_raised_exception_is_graceful() -> None:
     steerer.bind(sinks=[sink], planner=planner)
 
     session = _make_session_with_task()
-    await steerer.note_llm_call(session)  # should not raise
+    await steerer.drift.note_llm_call(session)  # should not raise
     drifts = [e for e in sink.proto_events if e.WhichOneof("payload") == "drift_detected"]
     assert len(drifts) == 1
     from goldfive.pb.goldfive.v1 import types_pb2
@@ -293,12 +293,12 @@ async def test_reflective_check_disabled_by_default() -> None:
 
     session = _make_session_with_task()
     for _ in range(100):
-        await steerer.note_llm_call(session)
+        await steerer.drift.note_llm_call(session)
     # Counter never incremented (feature is off), and no drift emitted.
     assert session._llm_calls_since_check == 0
     assert [e.WhichOneof("payload") for e in sink.proto_events] == []
     # Even calling maybe_run_reflective_check directly is a no-op.
-    await steerer.maybe_run_reflective_check(session)
+    await steerer.drift.maybe_run_reflective_check(session)
     assert [e.WhichOneof("payload") for e in sink.proto_events] == []
 
 
@@ -321,15 +321,15 @@ async def test_reflective_check_configurable_interval() -> None:
 
     session = _make_session_with_task()
     for _ in range(5):
-        await steerer.note_llm_call(session)
+        await steerer.drift.note_llm_call(session)
     assert call_count == 1
     for _ in range(5):
-        await steerer.note_llm_call(session)
+        await steerer.drift.note_llm_call(session)
     assert call_count == 2
     for _ in range(4):
-        await steerer.note_llm_call(session)
+        await steerer.drift.note_llm_call(session)
     assert call_count == 2  # 14 total → still 2 checks
-    await steerer.note_llm_call(session)
+    await steerer.drift.note_llm_call(session)
     assert call_count == 3  # 15 total → 3 checks
 
 
@@ -350,11 +350,11 @@ async def test_reflective_check_resets_counter_on_task_transition() -> None:
     session = _make_session_with_task()
     # First 3 calls on t1.
     for _ in range(3):
-        await steerer.note_llm_call(session)
+        await steerer.drift.note_llm_call(session)
     assert session._llm_calls_since_check == 3
     # Simulate task transition -- executor updates current_task_id.
     session.current_task_id = "t2"
-    await steerer.note_llm_call(session)
+    await steerer.drift.note_llm_call(session)
     # Counter resets to 1 (one new call on t2) -- we did not carry
     # over from t1.
     assert session._llm_calls_since_check == 1
@@ -377,7 +377,7 @@ async def test_reflective_check_tolerates_fenced_markdown() -> None:
     steerer.bind(sinks=[sink], planner=planner)
 
     session = _make_session_with_task()
-    await steerer.note_llm_call(session)
+    await steerer.drift.note_llm_call(session)
     drifts = [e for e in sink.proto_events if e.WhichOneof("payload") == "drift_detected"]
     from goldfive.pb.goldfive.v1 import types_pb2
 
@@ -402,7 +402,7 @@ async def test_reflective_check_no_current_task_is_noop() -> None:
 
     session = _make_session_with_task()
     session.current_task_id = ""  # no active task
-    await steerer.note_llm_call(session)
+    await steerer.drift.note_llm_call(session)
     # The counter incremented (feature enabled), but the check found no
     # task and bailed cleanly without calling call_llm.
     assert calls == []

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -191,7 +191,7 @@ async def test_report_task_failed_transitions_and_refines() -> None:
     # iter-11A: drift cascade is fire-and-forget so the reporting tool
     # ack is no longer gated on planner.refine; drain before asserting
     # on the refine side effects.
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     # Sequence: TaskFailed, DriftDetected. Planner.refine invoked once.
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     assert "task_failed" in kinds and "drift_detected" in kinds
@@ -213,7 +213,7 @@ async def test_report_task_blocked_transitions_and_refines() -> None:
     assert session.plan.tasks[0].status is TaskStatus.BLOCKED
     # iter-11A: drift cascade is fire-and-forget; drain before
     # asserting on planner.refine side effects.
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     assert len(planner.refine_calls) == 1
     assert planner.refine_calls[0]["drift"].kind is DriftKind.BLOCKED
 
@@ -285,7 +285,7 @@ async def test_handler_recoverable_accepts_string_bool() -> None:
     )
     # iter-11A: drift cascade is fire-and-forget; drain before
     # asserting on planner.refine side effects.
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     # "false" string → recoverable=False → TASK_FAILED_FATAL
     assert planner.refine_calls[0]["drift"].kind is DriftKind.TASK_FAILED_FATAL
 

--- a/tests/test_runaway_delegation_cap.py
+++ b/tests/test_runaway_delegation_cap.py
@@ -88,30 +88,40 @@ def _make_quiet_llm() -> Any:
     return _Quiet
 
 
-class _RecordingSteerer:
-    """Steerer stub that records drift events routed through
-    ``_handle_drift`` so tests can assert on the RUNAWAY_DELEGATION
-    emission without spinning up a full ``DefaultSteerer``.
-    """
-
+class _RecordingDrift:
     def __init__(self) -> None:
-        self._sinks: list[Any] = []
         self.drifts: list[Any] = []
 
     async def observe(self, *a: Any, **kw: Any) -> None:
         pass
 
-    async def transition(self, *a: Any, **kw: Any) -> None:
-        pass
-
     def detect_drift(self, *a: Any, **kw: Any) -> None:
         return None
 
-    def bind(self, **kw: Any) -> None:
+    async def handle_drift(self, drift: Any, session: Any) -> None:  # noqa: ARG002
+        self.drifts.append(drift)
+
+
+class _RecordingSteerer:
+    """Steerer stub that records drift events routed through
+    ``drift.handle_drift`` so tests can assert on the
+    RUNAWAY_DELEGATION emission without spinning up a full
+    ``DefaultSteerer``. Component-namespaced per goldfive#410.
+    """
+
+    def __init__(self) -> None:
+        self._sinks: list[Any] = []
+        self.drift = _RecordingDrift()
+
+    @property
+    def drifts(self) -> list[Any]:
+        return self.drift.drifts
+
+    async def transition(self, *a: Any, **kw: Any) -> None:
         pass
 
-    async def _handle_drift(self, drift: Any, session: Any) -> None:  # noqa: ARG002
-        self.drifts.append(drift)
+    def bind(self, **kw: Any) -> None:
+        pass
 
 
 async def test_below_cap_runs_cleanly_with_no_drift() -> None:

--- a/tests/test_runner_install_revision_stall.py
+++ b/tests/test_runner_install_revision_stall.py
@@ -464,7 +464,7 @@ async def test_install_revision_for_user_steer_emits_user_steer_with_raw() -> No
         summary="post-steer",
     )
     installed = await asyncio.wait_for(
-        steerer.install_revision_for_user_steer(
+        steerer.plans.install_revision_for_user_steer(
             session=session, raw=control, revised_plan=revised
         ),
         timeout=5.0,
@@ -523,7 +523,7 @@ async def test_install_revision_for_user_steer_writes_active_steer() -> None:
         summary="post-steer",
     )
     installed = await asyncio.wait_for(
-        steerer.install_revision_for_user_steer(
+        steerer.plans.install_revision_for_user_steer(
             session=session, raw=control, revised_plan=revised
         ),
         timeout=5.0,
@@ -557,7 +557,7 @@ async def test_install_initial_plan_emits_only_plan_revised() -> None:
         summary="initial",
     )
     installed = await asyncio.wait_for(
-        steerer.install_initial_plan(session=session, plan=plan),
+        steerer.plans.install_initial_plan(session=session, plan=plan),
         timeout=5.0,
     )
     assert installed

--- a/tests/test_runner_revision_rejection_policy.py
+++ b/tests/test_runner_revision_rejection_policy.py
@@ -399,7 +399,7 @@ async def test_user_steer_install_never_aborts_default_flag() -> None:
         detail="pivot",
         authored_by="user",
     )
-    returned = await steerer.install_user_steer(
+    returned = await steerer.plans.install_user_steer(
         drift=drift, prior=prior, llm_revision=invalid, session=session
     )
     # The fallback fired — pending was cancelled, done preserved.
@@ -455,7 +455,7 @@ async def test_user_steer_install_never_aborts_strict_flag(
         detail="pivot",
         authored_by="user",
     )
-    await steerer.install_user_steer(
+    await steerer.plans.install_user_steer(
         drift=drift, prior=prior, llm_revision=invalid, session=session
     )
     payload_kinds = _payload_kinds(sink)

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -61,23 +61,37 @@ class RecordingSink:
         return kinds
 
 
+class _StubDrift:
+    """Drift sub-component for :class:`StubSteerer` (goldfive#410)."""
+
+    def __init__(self) -> None:
+        self.observed: list[Any] = []
+
+    async def observe(self, event: Any, session: Session) -> None:
+        self.observed.append(event)
+
+    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
+        return None
+
+
 class StubSteerer:
     """Minimal Steerer stub that just forwards reporting-tool calls into
     plan.Task.status mutations. Acts as the central authority over task state
-    the way a real Steerer would.
+    the way a real Steerer would.  Component-namespaced per goldfive#410.
     """
 
     def __init__(self) -> None:
         self._sinks: list[EventSink] = []
         self._planner: Any = None
-        self.observed: list[Any] = []
+        self.drift = _StubDrift()
+
+    @property
+    def observed(self) -> list[Any]:
+        return self.drift.observed
 
     def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
         self._sinks = sinks
         self._planner = planner
-
-    async def observe(self, event: Any, session: Session) -> None:
-        self.observed.append(event)
 
     async def transition(
         self,
@@ -100,9 +114,6 @@ class StubSteerer:
         )
         with channel_processor_active():
             set_session_plan(session, with_task_status(session.plan, task_id, to))
-
-    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:
-        return None
 
 
 class StubPlanner:
@@ -1250,7 +1261,7 @@ async def test_max_task_invocations_explicit_cap_honored() -> None:
 
 
 async def test_observer_exception_emits_pipeline_failure_drift() -> None:
-    """``steerer.observe`` raising must emit an INFO ``CUSTOM`` drift.
+    """``steerer.drift.observe`` raising must emit an INFO ``CUSTOM`` drift.
 
     goldfive#134: a bug in the drift pipeline used to be swallowed at
     ``log.debug`` level. The run now surfaces an INFO ``CUSTOM`` drift
@@ -1263,9 +1274,14 @@ async def test_observer_exception_emits_pipeline_failure_drift() -> None:
     planner = StubPlanner()
     sink = RecordingSink()
 
-    class RaisingSteerer(StubSteerer):
+    class _RaisingDrift(_StubDrift):
         async def observe(self, event: Any, session: Session) -> None:
             raise RuntimeError("classifier exploded")
+
+    class RaisingSteerer(StubSteerer):
+        def __init__(self) -> None:
+            super().__init__()
+            self.drift = _RaisingDrift()
 
     steerer = RaisingSteerer()
 
@@ -1304,7 +1320,7 @@ async def test_observer_exception_emits_pipeline_failure_drift() -> None:
     ]
     assert pipeline_failures, (
         "expected an INFO CUSTOM 'drift_pipeline_failed' drift after "
-        "steerer.observe raised"
+        "steerer.drift.observe raised"
     )
     assert (
         pipeline_failures[0].drift_detected.severity

--- a/tests/test_sequential_executor_overlay.py
+++ b/tests/test_sequential_executor_overlay.py
@@ -62,25 +62,39 @@ class RecordingSink:
         return kinds
 
 
+class _OverlayDrift:
+    """Drift sub-component exposing ``observe`` / ``handle_drift``."""
+
+    def __init__(self) -> None:
+        self.observed: list[Any] = []
+
+    async def observe(self, event: Any, session: Session) -> None:  # noqa: ARG002
+        self.observed.append(event)
+
+    async def handle_drift(self, drift: DriftEvent, session: Session) -> None:  # noqa: ARG002
+        self.observed.append(drift)
+
+    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:  # noqa: ARG002
+        return None
+
+
 class StubSteerer:
     def __init__(self) -> None:
         self._sinks: list[EventSink] = []
         self._planner: Any = None
-        self.observed: list[Any] = []
+        self.drift = _OverlayDrift()
         self.transitions: list[tuple[str, TaskStatus]] = []
         # Full call record including detail/cancel_reason so tests can
         # assert on the structured reason strings the executor emits.
         self.transition_details: list[tuple[str, TaskStatus, str, str]] = []
 
+    @property
+    def observed(self) -> list[Any]:
+        return self.drift.observed
+
     def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
         self._sinks = sinks
         self._planner = planner
-
-    async def observe(self, event: Any, session: Session) -> None:  # noqa: ARG002
-        self.observed.append(event)
-
-    async def _handle_drift(self, drift: DriftEvent, session: Session) -> None:  # noqa: ARG002
-        self.observed.append(drift)
 
     async def transition(
         self,
@@ -105,9 +119,6 @@ class StubSteerer:
         )
         with channel_processor_active():
             set_session_plan(session, with_task_status(session.plan, task_id, to))
-
-    def detect_drift(self, event: Any, session: Session) -> DriftEvent | None:  # noqa: ARG002
-        return None
 
 
 class StubPlanner:
@@ -808,7 +819,7 @@ async def test_overlay_steer_restart_still_works() -> None:
     control-channel integration is covered in
     ``tests/test_overlay_steer.py``; this test is a belt-and-
     suspenders check that the restart loop in ``_run_overlay``
-    still routes STEERs to ``steerer.observe`` and re-invokes
+    still routes STEERs to ``steerer.drift.observe`` and re-invokes
     passthrough.
     """
     # We exercise the STEER branch through the real
@@ -881,7 +892,7 @@ async def test_overlay_steer_restart_still_works() -> None:
     assert any(
         str(getattr(getattr(o, "kind", None), "value", "")).upper() == "STEER"
         for o in steerer.observed
-    ), "steerer.observe was not called with the STEER message"
+    ), "steerer.drift.observe was not called with the STEER message"
     # No follow-up dispatch (even though we had a steer in the middle).
     assert adapter.follow_up_calls == []
 

--- a/tests/test_session_recent_tool_observations.py
+++ b/tests/test_session_recent_tool_observations.py
@@ -54,7 +54,7 @@ def test_note_tool_observation_appends() -> None:
     steerer = DefaultSteerer()
     session = _make_session()
 
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="planner",
         task_id="t1",
@@ -92,7 +92,7 @@ def test_note_tool_observation_records_none_result_as_marker() -> None:
     steerer = DefaultSteerer()
     session = _make_session()
 
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="planner",
         task_id="t1",
@@ -124,7 +124,7 @@ def test_note_tool_observation_trims_to_max() -> None:
     assert cap == 16  # default per §3.1
 
     for i in range(cap + 5):
-        steerer.note_tool_observation(
+        steerer.drift.note_tool_observation(
             session,
             agent_name=f"a{i}",
             task_id="t1",
@@ -146,7 +146,7 @@ def test_note_tool_observation_respects_session_local_max_override() -> None:
     session.recent_tool_observations_max = 3
 
     for i in range(8):
-        steerer.note_tool_observation(
+        steerer.drift.note_tool_observation(
             session,
             agent_name=f"a{i}",
             task_id="t1",
@@ -169,7 +169,7 @@ def test_note_tool_observation_records_error_path() -> None:
     steerer = DefaultSteerer()
     session = _make_session()
 
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="worker",
         task_id="t2",
@@ -189,7 +189,7 @@ def test_note_tool_observation_records_error_dict_result() -> None:
     steerer = DefaultSteerer()
     session = _make_session()
 
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="worker",
         task_id="t3",
@@ -208,7 +208,7 @@ def test_note_tool_observation_record_error_string() -> None:
     steerer = DefaultSteerer()
     session = _make_session()
 
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="worker",
         task_id="t",
@@ -229,7 +229,7 @@ def test_note_tool_observation_truncates_long_error_messages() -> None:
     session = _make_session()
     long = "x" * 1000
 
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="w",
         task_id="t",
@@ -253,7 +253,7 @@ def test_note_tool_observation_truncates_args_preview() -> None:
     steerer = DefaultSteerer()
     session = _make_session()
 
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="w",
         task_id="t",
@@ -271,7 +271,7 @@ def test_note_tool_observation_truncates_result_preview() -> None:
     steerer = DefaultSteerer()
     session = _make_session()
 
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="w",
         task_id="t",
@@ -295,7 +295,7 @@ def test_note_tool_observation_handles_unhashable_args() -> None:
     session = _make_session()
 
     # ``{"x": object()}`` is unhashable but ``repr`` works.
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="w",
         task_id="t",
@@ -320,7 +320,7 @@ def test_note_tool_observation_handles_repr_failure_in_args() -> None:
 
     steerer = DefaultSteerer()
     session = _make_session()
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="w",
         task_id="t",
@@ -355,7 +355,7 @@ def test_note_tool_observation_swallows_internal_errors() -> None:
         side_effect=RuntimeError("clock dead"),
     ):
         # Must not raise.
-        steerer.note_tool_observation(
+        steerer.drift.note_tool_observation(
             session,
             agent_name="w",
             task_id="t",
@@ -379,7 +379,7 @@ def test_note_tool_observation_zero_max_clamps_to_one() -> None:
     session.recent_tool_observations_max = 0
 
     for i in range(3):
-        steerer.note_tool_observation(
+        steerer.drift.note_tool_observation(
             session,
             agent_name=f"a{i}",
             task_id="t",
@@ -423,7 +423,7 @@ def test_note_tool_observation_per_task_filter_left_to_reader() -> None:
     steerer = DefaultSteerer()
     session = _make_session()
 
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="w",
         task_id="t1",
@@ -431,7 +431,7 @@ def test_note_tool_observation_per_task_filter_left_to_reader() -> None:
         args={},
         result={},
     )
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="w",
         task_id="t2",
@@ -455,7 +455,7 @@ def test_note_tool_observation_ts_ms_is_monotonic() -> None:
     session = _make_session()
 
     for i in range(5):
-        steerer.note_tool_observation(
+        steerer.drift.note_tool_observation(
             session,
             agent_name=f"a{i}",
             task_id="t",
@@ -477,7 +477,7 @@ def test_note_tool_observation_handles_none_args() -> None:
     """``args=None`` (some adapter edge cases) -> repr-shaped, no raise."""
     steerer = DefaultSteerer()
     session = _make_session()
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="w",
         task_id="t",
@@ -493,7 +493,7 @@ def test_note_tool_observation_with_string_result() -> None:
     """Bare string ``result`` is repr-encoded, not flagged as error."""
     steerer = DefaultSteerer()
     session = _make_session()
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="w",
         task_id="t",
@@ -517,7 +517,7 @@ def test_writer_accepts_arbitrary_any_types() -> None:
     arbitrary: Any = object()
     steerer = DefaultSteerer()
     session = _make_session()
-    steerer.note_tool_observation(
+    steerer.drift.note_tool_observation(
         session,
         agent_name="w",
         task_id="t",

--- a/tests/test_state_protocol_propagation.py
+++ b/tests/test_state_protocol_propagation.py
@@ -354,7 +354,7 @@ async def test_user_steer_to_planner_instruction_no_bridge() -> None:
 
     # USER_STEER via the steerer — same path a control-channel STEER
     # takes in production. Writes active_steer onto goldfive.Session.state.
-    await steerer.observe(
+    await steerer.drift.observe(
         ControlMessage(
             kind=ControlKind.STEER,
             payload={"note": "pivot toward reliability"},
@@ -505,7 +505,7 @@ async def test_user_steer_between_invocations_no_stale_session_valueerror() -> N
     # exercises. The control-channel STEER drives DefaultSteerer's
     # _apply_user_steer_state which writes the active_steer keys onto
     # goldfive Session.state.
-    await steerer.observe(
+    await steerer.drift.observe(
         ControlMessage(
             kind=ControlKind.STEER,
             payload={"note": "pivot to reliability"},
@@ -609,7 +609,7 @@ async def test_phase_0_tripwire_stays_green_through_user_steer_flow() -> None:
 
     # No ValueError, no StateOwnershipViolation:
     await adapter.invoke(task=task, session=session)
-    await steerer.observe(
+    await steerer.drift.observe(
         ControlMessage(
             kind=ControlKind.STEER,
             payload={"note": "stay reliable"},

--- a/tests/test_steer_unification.py
+++ b/tests/test_steer_unification.py
@@ -190,7 +190,7 @@ async def test_goldfive_steer_promotes_at_warning_severity() -> None:
         detail="agent wandered into raccoons",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # refine_steer was called (not the generic refine path).
     assert len(planner.refine_steer_calls) == 1
@@ -218,7 +218,7 @@ async def test_goldfive_steer_does_not_promote_at_info_severity() -> None:
         detail="minor wander",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # INFO drift -> ladder OBSERVE. No refine of either flavour runs.
     assert planner.refine_steer_calls == []
@@ -253,7 +253,7 @@ async def test_goldfive_steer_suppressed_when_user_steer_active() -> None:
         id="ctl-user",
         payload={"note": "focus on X", "annotation_id": "ann_user"},
     )
-    await steerer.observe(user_msg, session)
+    await steerer.drift.observe(user_msg, session)
     user_at_turn = session.state[_ostate.KEY_ACTIVE_STEER_AT_TURN]
     user_body = session.state[_ostate.KEY_ACTIVE_STEER_BODY]
     user_refine_steer_calls = len(planner.refine_steer_calls)
@@ -267,7 +267,7 @@ async def test_goldfive_steer_suppressed_when_user_steer_active() -> None:
         detail="agent drifting",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # No new refine_steer call (the user steer's refine already ran via
     # planner.refine, but the goldfive promotion must NOT have called
@@ -302,7 +302,7 @@ async def test_goldfive_steer_fires_when_user_steer_stale() -> None:
         id="ctl-stale",
         payload={"note": "initial", "annotation_id": "ann_stale"},
     )
-    await steerer.observe(user_msg, session)
+    await steerer.drift.observe(user_msg, session)
     # Advance sequence beyond the window.
     session._next_sequence += 10
 
@@ -312,7 +312,7 @@ async def test_goldfive_steer_fires_when_user_steer_stale() -> None:
         detail="fresh detector fire",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # refine_steer fired now (stale user steer shouldn't block).
     assert len(planner.refine_steer_calls) == 1
@@ -334,7 +334,7 @@ async def test_goldfive_steer_cancel_reason_off_topic() -> None:
         detail="wander",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     assert adapter._next_cancel_reason == "goldfive_off_topic"
 
 
@@ -346,7 +346,7 @@ async def test_goldfive_steer_cancel_reason_intent_divergence_critical() -> None
         detail="diverged",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     assert adapter._next_cancel_reason == "goldfive_intent_divergence"
 
 
@@ -364,7 +364,7 @@ async def test_goldfive_steer_body_from_drift_detail() -> None:
         detail="agent acknowledged discrepancy but chose to adopt expanded topic",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     assert (
         session.state[_ostate.KEY_ACTIVE_STEER_BODY]
         == "agent acknowledged discrepancy but chose to adopt expanded topic"
@@ -380,7 +380,7 @@ async def test_goldfive_steer_body_fallback_when_detail_empty() -> None:
         detail="",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     body = session.state[_ostate.KEY_ACTIVE_STEER_BODY]
     assert "Goldfive detected" in body
     assert "OFF_TOPIC" in body
@@ -402,7 +402,7 @@ async def test_goldfive_steer_threshold_off_disables_promotion() -> None:
         detail="even critical stays legacy",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # No refine_steer call (promotion disabled).
     assert planner.refine_steer_calls == []
@@ -430,7 +430,7 @@ async def test_goldfive_steer_threshold_critical_skips_warning() -> None:
         detail="warning-only",
         current_task_id="t2",
     )
-    await steerer._handle_drift(warn, session)
+    await steerer.drift.handle_drift(warn, session)
     assert planner.refine_steer_calls == []
 
     # CRITICAL -> promoted (distinct task so the outcome gate doesn't gate it).
@@ -440,7 +440,7 @@ async def test_goldfive_steer_threshold_critical_skips_warning() -> None:
         detail="critical-promoted",
         current_task_id="t1",
     )
-    await steerer._handle_drift(crit, session)
+    await steerer.drift.handle_drift(crit, session)
     assert len(planner.refine_steer_calls) == 1
 
 
@@ -459,7 +459,7 @@ async def test_processed_steer_ids_records_goldfive_drift_id() -> None:
         current_task_id="t2",
     )
     drift_id = drift.id
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     processed = session.state.get(_ostate.KEY_PROCESSED_STEER_IDS, [])
     assert drift_id in processed
 
@@ -477,7 +477,7 @@ async def test_user_steer_drift_event_authored_by_user() -> None:
         id="ctl-user",
         payload={"note": "focus", "annotation_id": "ann_1"},
     )
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
     steer_drifts = [
         e
         for e in _drift_detected_events(sink)
@@ -498,7 +498,7 @@ async def test_goldfive_drift_event_authored_by_goldfive_when_unset() -> None:
         detail="boom",
         current_task_id="t2",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
     evts = _drift_detected_events(sink)
     assert evts
     assert all(e.drift_detected.authored_by == "goldfive" for e in evts)
@@ -513,7 +513,7 @@ async def test_suppressed_drift_event_wire_flag() -> None:
     """DriftDetected carries suppressed_by_user_steer=True on suppression."""
     steerer, session, sink, planner, _adapter = _bind(window=5)
     # User steer first.
-    await steerer.observe(
+    await steerer.drift.observe(
         ControlMessage(
             kind=ControlKind.STEER,
             id="ctl-user-sup",
@@ -529,7 +529,7 @@ async def test_suppressed_drift_event_wire_flag() -> None:
         current_task_id="t2",
     )
     refine_steer_before = len(planner.refine_steer_calls)
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     assert len(planner.refine_steer_calls) == refine_steer_before
     matching = [

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -182,7 +182,7 @@ def _task(session: Session, task_id: str) -> Task:
 
 async def test_mark_task_running_transitions_and_emits() -> None:
     steerer, session, sink, _ = _fresh()
-    await steerer.mark_task_running("t1", session=session, detail="kicking off")
+    await steerer.tasks.mark_task_running("t1", session=session, detail="kicking off")
     assert _task(session, "t1").status is TaskStatus.RUNNING
     assert session.current_task_id == "t1"
     assert session.agent_notes["t1"] == "kicking off"
@@ -206,20 +206,20 @@ async def test_mark_task_running_no_op_on_terminal() -> None:
         set_session_plan(
             session, with_task_status(session.plan, "t1", TaskStatus.COMPLETED)
         )
-    await steerer.mark_task_running("t1", session=session)
+    await steerer.tasks.mark_task_running("t1", session=session)
     assert _task(session, "t1").status is TaskStatus.COMPLETED
     assert sink.events == []
 
 
 async def test_mark_task_running_unknown_task_is_noop() -> None:
     steerer, session, sink, _ = _fresh()
-    await steerer.mark_task_running("bogus", session=session)
+    await steerer.tasks.mark_task_running("bogus", session=session)
     assert sink.events == []
 
 
 async def test_mark_task_progress_records_and_emits() -> None:
     steerer, session, sink, _ = _fresh()
-    await steerer.mark_task_progress("t1", session=session, fraction=0.42, detail="halfway")
+    await steerer.tasks.mark_task_progress("t1", session=session, fraction=0.42, detail="halfway")
     assert session.task_progress["t1"] == pytest.approx(0.42)
     assert session.agent_notes["t1"] == "halfway"
     # Status is untouched by progress updates.
@@ -235,15 +235,15 @@ async def test_mark_task_progress_records_and_emits() -> None:
 
 async def test_mark_task_progress_clamps_fraction() -> None:
     steerer, session, _sink, _ = _fresh()
-    await steerer.mark_task_progress("t1", session=session, fraction=-1.0)
+    await steerer.tasks.mark_task_progress("t1", session=session, fraction=-1.0)
     assert session.task_progress["t1"] == 0.0
-    await steerer.mark_task_progress("t1", session=session, fraction=9.0)
+    await steerer.tasks.mark_task_progress("t1", session=session, fraction=9.0)
     assert session.task_progress["t1"] == 1.0
 
 
 async def test_mark_task_completed_transitions_and_emits() -> None:
     steerer, session, sink, _ = _fresh()
-    await steerer.mark_task_completed(
+    await steerer.tasks.mark_task_completed(
         "t1",
         session=session,
         summary="done-zo",
@@ -263,11 +263,11 @@ async def test_mark_task_completed_transitions_and_emits() -> None:
 
 async def test_mark_task_failed_recoverable_fires_drift() -> None:
     steerer, session, sink, planner = _fresh()
-    await steerer.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
+    await steerer.tasks.mark_task_failed("t1", session=session, reason="boom", recoverable=True)
     assert _task(session, "t1").status is TaskStatus.FAILED
     # iter-11A: drift cascade is fire-and-forget; drain before
     # asserting on its observable side effects.
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     # TaskFailed + DriftDetected + refine-failure DriftDetected (planner
     # returns None so no PlanRevised; the follow-up drift surfaces that).
@@ -286,10 +286,12 @@ async def test_mark_task_failed_recoverable_fires_drift() -> None:
 
 async def test_mark_task_failed_fatal_fires_critical_drift() -> None:
     steerer, session, sink, _planner = _fresh()
-    await steerer.mark_task_failed("t1", session=session, reason="unrecoverable", recoverable=False)
+    await steerer.tasks.mark_task_failed(
+        "t1", session=session, reason="unrecoverable", recoverable=False
+    )
     # iter-11A: drift cascade is fire-and-forget; drain before
     # asserting on its observable side effects.
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     # Event order: TaskFailed(t1) → TaskCancelled(t2, cascade) → DriftDetected(TASK_FAILED_FATAL) →
     # refine-failure DriftDetected (stub planner returns None). The
     # cascade fires before the fatal drift so planner.refine (if it ran)
@@ -312,13 +314,13 @@ async def test_mark_task_failed_fatal_fires_critical_drift() -> None:
 
 async def test_mark_task_blocked_transitions_and_emits_drift() -> None:
     steerer, session, sink, planner = _fresh()
-    await steerer.mark_task_blocked(
+    await steerer.tasks.mark_task_blocked(
         "t1", session=session, blocker="need API key", needed="credentials.json"
     )
     assert _task(session, "t1").status is TaskStatus.BLOCKED
     # iter-11A: drift cascade is fire-and-forget; drain before
     # asserting on its observable side effects.
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     # TaskBlocked + DriftDetected + refine-failure DriftDetected (stub
     # planner returns None; the follow-up drift surfaces that).
@@ -336,7 +338,7 @@ async def test_mark_task_cancelled_transitions() -> None:
     # TaskCancelled for t2 as well. Verify both the primary transition
     # and the cascaded one; detailed cascade behaviour is exercised in
     # the dedicated cascade tests below.
-    await steerer.mark_task_cancelled("t1", session=session, reason="user cancelled")
+    await steerer.tasks.mark_task_cancelled("t1", session=session, reason="user cancelled")
     assert _task(session, "t1").status is TaskStatus.CANCELLED
     assert _task(session, "t2").status is TaskStatus.CANCELLED
     cancelled = [
@@ -504,19 +506,22 @@ def test_detect_drift_prefers_tool_error_then_refusal_then_stop_reason() -> None
     sess = _make_session()
     # Tool-error dict wins even if it also contains refusal text.
     combo = {"error": "nope", "text": "I cannot"}
-    assert s.detect_drift(combo, sess).kind is DriftKind.TOOL_ERROR
+    assert s.drift.detect_drift(combo, sess).kind is DriftKind.TOOL_ERROR
     # Refusal wins over stop_reason alone.
     assert (
-        s.detect_drift(
+        s.drift.detect_drift(
             {"text": "I can't help with that", "stop_reason": "MAX_TOKENS"},
             sess,
         ).kind
         is DriftKind.AGENT_REFUSAL
     )
     # Pure stop_reason goes to CONTEXT_PRESSURE.
-    assert s.detect_drift({"stop_reason": "MAX_TOKENS"}, sess).kind is DriftKind.CONTEXT_PRESSURE
+    assert (
+        s.drift.detect_drift({"stop_reason": "MAX_TOKENS"}, sess).kind
+        is DriftKind.CONTEXT_PRESSURE
+    )
     # Nothing → None.
-    assert s.detect_drift({"text": "all good"}, sess) is None
+    assert s.drift.detect_drift({"text": "all good"}, sess) is None
 
 
 async def test_observe_emits_drift_and_refines() -> None:
@@ -533,7 +538,7 @@ async def test_observe_emits_drift_and_refines() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
 
-    await steerer.observe({"error": "oh no"}, session)
+    await steerer.drift.observe({"error": "oh no"}, session)
 
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     assert kinds == ["drift_detected", "plan_revised"]
@@ -552,28 +557,28 @@ async def test_observe_emits_drift_and_refines() -> None:
 
 async def test_observe_skips_refine_when_no_drift() -> None:
     steerer, session, sink, planner = _fresh()
-    await steerer.observe({"text": "nothing interesting"}, session)
+    await steerer.drift.observe({"text": "nothing interesting"}, session)
     assert sink.events == []
     assert planner.refine_calls == []
 
 
 async def test_observe_skips_refine_on_info_severity() -> None:
     # Craft a direct DriftEvent at INFO severity via a custom detector.
-    class InfoSteerer(DefaultSteerer):
-        def detect_drift(self, event, session):  # type: ignore[override]
-            return DriftEvent(
-                kind=DriftKind.CUSTOM,
-                severity=DriftSeverity.INFO,
-                detail="just a note",
-            )
-
+    # goldfive#410: the facade no longer dispatches subclass-overridden
+    # ``detect_drift`` through a router shim; custom detection now lives
+    # on the :class:`DriftObserver` component, which we patch in place.
     planner = StubPlanner()
     sink = ListSink()
-    steerer = InfoSteerer()
+    steerer = DefaultSteerer()
     steerer.bind(sinks=[sink], planner=planner)
+    steerer.drift.detect_drift = lambda event, session: DriftEvent(  # type: ignore[method-assign]
+        kind=DriftKind.CUSTOM,
+        severity=DriftSeverity.INFO,
+        detail="just a note",
+    )
     session = _make_session()
 
-    await steerer.observe({}, session)
+    await steerer.drift.observe({}, session)
     assert len(sink.events) == 1
     assert sink.events[0].WhichOneof("payload") == "drift_detected"
     # INFO is below the WARNING threshold — no refine.
@@ -588,7 +593,7 @@ async def test_observe_swallows_planner_exceptions() -> None:
     session = _make_session()
 
     # Must not raise even though refine() blows up.
-    await steerer.observe({"error": "x"}, session)
+    await steerer.drift.observe({"error": "x"}, session)
     # First failure: emit original drift + refine-failure visibility
     # drift. Counter bumps to 1 (below the threshold), so we stay in
     # visibility-only mode — no REPEATED_FAILURE, no mark_task_failed.
@@ -618,7 +623,7 @@ async def test_observe_surfaces_refine_none_return() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
 
-    await steerer.observe({"error": "x"}, session)
+    await steerer.drift.observe({"error": "x"}, session)
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     assert kinds == ["drift_detected", "drift_detected"]
     from goldfive.pb.goldfive.v1 import types_pb2
@@ -688,13 +693,13 @@ async def test_refine_failure_counter_increments_on_exception() -> None:
     # Outcome gate keys only on (kind, task) so back-to-back drifts
     # of the same TOOL_ERROR on t1 are now legitimately tracked on a
     # single counter — no agent_id dance required.
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer.drift.handle_drift(_tool_error_drift(), session)
     outcome_after_1 = session.refine_outcomes[key]
     assert outcome_after_1.state == "failed"
     assert outcome_after_1.fail_count == 1
     assert len(planner.refine_calls) == 1
 
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer.drift.handle_drift(_tool_error_drift(), session)
     # Second failure hits the threshold: _record_refine_outcome calls
     # mark_task_failed, which fires a TASK_FAILED_FATAL drift that routes
     # through _handle_drift and triggers one more refine attempt (keyed
@@ -703,7 +708,7 @@ async def test_refine_failure_counter_increments_on_exception() -> None:
     # iter-11A: the TASK_FAILED_FATAL refine attempt now lands
     # asynchronously via mark_task_failed's spawned cascade — drain
     # before asserting on the fatal-key outcome.
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     outcome_after_2 = session.refine_outcomes[key]
     assert outcome_after_2.state == "failed"
     assert outcome_after_2.fail_count == 2
@@ -725,19 +730,19 @@ async def test_refine_failure_counter_increments_on_none_return() -> None:
     key = (DriftKind.TOOL_ERROR.value, "t1")
     assert session.refine_outcomes.get(key) is None
 
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer.drift.handle_drift(_tool_error_drift(), session)
     outcome_after_1 = session.refine_outcomes[key]
     assert outcome_after_1.state == "failed"
     assert outcome_after_1.fail_count == 1
     assert len(planner.refine_calls) == 1
 
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer.drift.handle_drift(_tool_error_drift(), session)
     # Same cascade as the exception case: the TOOL_ERROR counter is
     # clamped at the threshold (2), the cascaded TASK_FAILED_FATAL drift
     # kicks off its own independent counter at 1.
     # iter-11A: drain the spawned mark_task_failed cascade before
     # asserting on the fatal-key outcome.
-    await steerer._wait_background_drifts_idle()
+    await steerer.drift._wait_background_drifts_idle()
     outcome_after_2 = session.refine_outcomes[key]
     assert outcome_after_2.state == "failed"
     assert outcome_after_2.fail_count == 2
@@ -755,12 +760,12 @@ async def test_two_consecutive_refine_failures_marks_task_failed() -> None:
     session = _make_session()
 
     # First failure: visibility-only, task stays PENDING.
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer.drift.handle_drift(_tool_error_drift(), session)
     assert _task(session, "t1").status is TaskStatus.PENDING
 
     # Second failure: backoff trips — task marked FAILED, REPEATED_FAILURE
     # drift emitted.
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer.drift.handle_drift(_tool_error_drift(), session)
     assert _task(session, "t1").status is TaskStatus.FAILED
 
     from goldfive.pb.goldfive.v1 import types_pb2
@@ -796,7 +801,7 @@ async def test_two_consecutive_refine_failures_marks_task_failed() -> None:
     # short-circuit without calling refine again — the outcome gate
     # prevents the loop that §7.3 targets.
     calls_before = len(planner.refine_calls)
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer.drift.handle_drift(_tool_error_drift(), session)
     assert len(planner.refine_calls) == calls_before
 
 
@@ -811,7 +816,7 @@ async def test_successful_refine_resets_failure_counter() -> None:
 
     key = (DriftKind.TOOL_ERROR.value, "t1")
 
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer.drift.handle_drift(_tool_error_drift(), session)
     assert session.refine_outcomes[key].state == "failed"
     assert session.refine_outcomes[key].fail_count == 1
 
@@ -822,7 +827,7 @@ async def test_successful_refine_resets_failure_counter() -> None:
     # outcome with state="succeeded", fail_count=0.
     planner.raise_exc = None
     planner.revised = revised
-    await steerer._handle_drift(_tool_error_drift(), session)
+    await steerer.drift.handle_drift(_tool_error_drift(), session)
     assert session.refine_outcomes[key].state == "succeeded"
     assert session.refine_outcomes[key].fail_count == 0
     # And the plan actually got revised on the success.
@@ -874,7 +879,7 @@ def test_every_drift_kind_has_a_known_origin() -> None:
 
 async def test_report_new_work_discovered_fires_drift() -> None:
     steerer, session, sink, planner = _fresh()
-    await steerer.report_new_work_discovered(
+    await steerer.drift.report_new_work_discovered(
         session=session,
         parent_task_id="t1",
         title="follow-up",
@@ -901,7 +906,7 @@ async def test_report_plan_divergence_sets_flag_only() -> None:
     CAPABILITY_MISMATCH in #253).
     """
     steerer, session, sink, planner = _fresh()
-    await steerer.report_plan_divergence(
+    await steerer.drift.report_plan_divergence(
         session=session,
         note="agent is doing something different",
         suggested_action="replan from here",
@@ -919,9 +924,9 @@ async def test_report_plan_divergence_sets_flag_only() -> None:
 
 async def test_event_sequence_is_monotonic_and_run_id_stamped() -> None:
     steerer, session, sink, _ = _fresh()
-    await steerer.mark_task_running("t1", session=session)
-    await steerer.mark_task_progress("t1", session=session, fraction=0.5)
-    await steerer.mark_task_completed("t1", session=session, summary="ok")
+    await steerer.tasks.mark_task_running("t1", session=session)
+    await steerer.tasks.mark_task_progress("t1", session=session, fraction=0.5)
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="ok")
     # mark_task_running and mark_task_completed each emit a per-status
     # envelope plus a goldfive#251 R4 task_transitioned envelope; progress
     # is a liveness tick (no transition). 5 envelopes total, monotonic.
@@ -965,7 +970,7 @@ async def test_observe_rejects_invalid_revised_plan() -> None:
     session = _make_session()
     original_plan = session.plan
 
-    await steerer.observe({"error": "trigger refine"}, session)
+    await steerer.drift.observe({"error": "trigger refine"}, session)
 
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     # Three drift_detected events:
@@ -1018,7 +1023,7 @@ async def test_observe_rejects_revised_plan_with_cycle() -> None:
     session = _make_session()
     original_plan = session.plan
 
-    await steerer.observe({"error": "trigger refine"}, session)
+    await steerer.drift.observe({"error": "trigger refine"}, session)
 
     assert session.plan is original_plan
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
@@ -1058,7 +1063,7 @@ async def test_observe_rejects_revised_plan_with_unknown_edge() -> None:
     session = _make_session()
     original_plan = session.plan
 
-    await steerer.observe({"error": "trigger refine"}, session)
+    await steerer.drift.observe({"error": "trigger refine"}, session)
 
     assert session.plan is original_plan
     second = sink.proto_events[1].drift_detected
@@ -1131,7 +1136,7 @@ async def test_apply_revision_silently_folds_terminal_regression(
     # the fold-emission site (no stray INFOs from other ``goldfive.*``
     # modules can satisfy the substring match by luck).
     with caplog.at_level(logging.INFO, logger="goldfive.plan_reviser"):
-        await steerer.observe({"error": "trigger refine"}, session)
+        await steerer.drift.observe({"error": "trigger refine"}, session)
 
     # Plan was installed (revision_index advanced) and t1 is still
     # COMPLETED — the fold corrected the regression. goldfive#247: the
@@ -1210,7 +1215,7 @@ async def test_apply_revision_emits_schema_violation_on_missing_terminal_edge() 
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session(plan=prior)
 
-    await steerer.observe({"error": "trigger refine"}, session)
+    await steerer.drift.observe({"error": "trigger refine"}, session)
 
     assert session.plan is prior
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
@@ -1270,7 +1275,7 @@ async def test_plan_revised_carries_diff() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session(old)
 
-    await steerer.observe({"error": "trigger refine"}, session)
+    await steerer.drift.observe({"error": "trigger refine"}, session)
 
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     assert kinds == ["drift_detected", "plan_revised"]
@@ -1313,7 +1318,7 @@ async def test_no_op_revision_is_rejected_and_escalates() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session(old)
 
-    await steerer.observe({"error": "trigger refine"}, session)
+    await steerer.drift.observe({"error": "trigger refine"}, session)
 
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
     # No plan_revised emitted — handler exhausted instead.
@@ -1367,7 +1372,7 @@ async def test_refine_returns_none_escalates_to_pause() -> None:
         detail="off-topic reasoning on t1",
         current_task_id="t1",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # Refine was called exactly once.
     assert len(planner.refine_calls) == 1
@@ -1448,7 +1453,7 @@ async def test_refine_validator_rejected_escalates_to_pause() -> None:
         detail="trigger refine",
         current_task_id="t1",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # Refine was called exactly once.
     assert len(planner.refine_calls) == 1
@@ -1510,7 +1515,7 @@ async def test_refine_returns_none_does_not_cascade_further_drifts() -> None:
         detail="reviewer reported BLOCKED",
         current_task_id="t1",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     # Refine called exactly once — no cascade-driven retry.
     assert len(planner.refine_calls) == 1
@@ -1569,7 +1574,7 @@ async def test_refine_exhausted_path_unchanged() -> None:
         detail="off-topic",
         current_task_id="t1",
     )
-    await steerer._handle_drift(drift, session)
+    await steerer.drift.handle_drift(drift, session)
 
     assert len(planner.refine_calls) == 1
     # Phase 2 (path-duality fix): pause is now signalled by a
@@ -1609,7 +1614,7 @@ async def test_no_op_revision_path_unchanged() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session(old)
 
-    await steerer.observe({"error": "trigger refine"}, session)
+    await steerer.drift.observe({"error": "trigger refine"}, session)
 
     # Phase 2 (path-duality fix): pause is now signalled by a
     # GOLDFIVE_PAUSE_ESCALATE ControlMessage on the bound channel,
@@ -1645,7 +1650,7 @@ async def test_promote_drift_to_steer_refine_none_escalates_to_pause() -> None:
         detail="trigger goldfive-steer",
         current_task_id="t1",
     )
-    await steerer._promote_drift_to_steer(drift, session)
+    await steerer.drift._promote_drift_to_steer(drift, session)
 
     assert len(planner.refine_calls) == 1
     # Phase 2 (path-duality fix): pause is now signalled by a
@@ -1701,7 +1706,7 @@ async def test_promote_drift_to_steer_validator_rejected_escalates_to_pause() ->
         detail="trigger goldfive-steer",
         current_task_id="t1",
     )
-    await steerer._promote_drift_to_steer(drift, session)
+    await steerer.drift._promote_drift_to_steer(drift, session)
 
     # Phase 2 (path-duality fix): pause is now signalled by a
     # GOLDFIVE_PAUSE_ESCALATE ControlMessage on the bound channel,
@@ -1733,7 +1738,7 @@ async def test_bind_replaces_sinks() -> None:
     steerer.bind(sinks=[sink_a], planner=planner)
     steerer.bind(sinks=[sink_b], planner=planner)
     session = _make_session()
-    await steerer.mark_task_running("t1", session=session)
+    await steerer.tasks.mark_task_running("t1", session=session)
     assert sink_a.events == []
     # task_started + R4 task_transitioned.
     assert len(sink_b.events) == 2
@@ -1760,7 +1765,7 @@ async def test_mark_task_cancelled_cascades_to_downstream_pending() -> None:
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=StubPlanner())
 
-    await steerer.mark_task_cancelled("t1", session=session, reason="user cancelled")
+    await steerer.tasks.mark_task_cancelled("t1", session=session, reason="user cancelled")
 
     # All three tasks end up CANCELLED.
     assert _task(session, "t1").status is TaskStatus.CANCELLED
@@ -1805,7 +1810,7 @@ async def test_mark_task_cancelled_does_not_cascade_to_completed() -> None:
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=StubPlanner())
 
-    await steerer.mark_task_cancelled("t1", session=session, reason="steer")
+    await steerer.tasks.mark_task_cancelled("t1", session=session, reason="steer")
 
     assert _task(session, "t1").status is TaskStatus.CANCELLED
     assert _task(session, "t2").status is TaskStatus.COMPLETED
@@ -1838,7 +1843,7 @@ async def test_mark_task_cancelled_multiple_downstream_paths() -> None:
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=StubPlanner())
 
-    await steerer.mark_task_cancelled("t1", session=session, reason="steer")
+    await steerer.tasks.mark_task_cancelled("t1", session=session, reason="steer")
 
     for tid in ("t1", "t2", "t3", "t4"):
         assert _task(session, tid).status is TaskStatus.CANCELLED, tid
@@ -1871,14 +1876,14 @@ async def test_mark_task_cancelled_does_not_re_cancel() -> None:
     sink = ListSink()
     steerer.bind(sinks=[sink], planner=StubPlanner())
 
-    await steerer.mark_task_cancelled("t1", session=session, reason="first")
+    await steerer.tasks.mark_task_cancelled("t1", session=session, reason="first")
     first_event_count = len(sink.events)
     # t1 task_cancelled + R4 task_transitioned + cascaded t2 task_cancelled
     # + R4 task_transitioned = 4 envelopes.
     assert first_event_count == 4
 
     # Second call on the same already-terminal task: no new events.
-    await steerer.mark_task_cancelled("t1", session=session, reason="again")
+    await steerer.tasks.mark_task_cancelled("t1", session=session, reason="again")
     assert len(sink.events) == first_event_count
     assert _task(session, "t1").status is TaskStatus.CANCELLED
     assert _task(session, "t2").status is TaskStatus.CANCELLED
@@ -1924,7 +1929,7 @@ async def test_cascade_primitive_shared_between_recoverable_and_unrecoverable_pa
 
     # --- Recoverable path: mark_task_cancelled("t1") -------------------
     rec_steerer, rec_session, rec_sink = _build()
-    await rec_steerer.mark_task_cancelled("t1", session=rec_session, reason="steer")
+    await rec_steerer.tasks.mark_task_cancelled("t1", session=rec_session, reason="steer")
     rec_cancelled = [
         e.task_cancelled
         for e in rec_sink.proto_events
@@ -1938,7 +1943,9 @@ async def test_cascade_primitive_shared_between_recoverable_and_unrecoverable_pa
 
     # --- Unrecoverable path: mark_task_failed("t1", recoverable=False) -
     fat_steerer, fat_session, fat_sink = _build()
-    await fat_steerer.mark_task_failed("t1", session=fat_session, reason="fatal", recoverable=False)
+    await fat_steerer.tasks.mark_task_failed(
+        "t1", session=fat_session, reason="fatal", recoverable=False
+    )
     fat_cancelled = [
         e.task_cancelled
         for e in fat_sink.proto_events

--- a/tests/test_steerer_concurrent_sessions.py
+++ b/tests/test_steerer_concurrent_sessions.py
@@ -170,7 +170,7 @@ async def test_span_ctx_provider_isolated_across_concurrent_observe_refine() -> 
     captured: dict[str, str] = {}
 
     async def _refine_for(label: str, session: Session) -> None:
-        async with steerer.observe_refine(session, drift):
+        async with steerer.plans.observe_refine(session, drift):
             # Yield so the other task can enter its own observe_refine
             # and (pre-fix) clobber _active_session.
             await asyncio.sleep(0)
@@ -244,7 +244,7 @@ async def test_planner_drift_emitter_routes_to_calling_task_session() -> None:
     assert sink.proto_drifts() == []
 
     async def _refine_for(session: Session, drift: DriftEvent) -> None:
-        async with steerer.observe_refine(session, _drift()):
+        async with steerer.plans.observe_refine(session, _drift()):
             # Yield to interleave with the other task's bracketed
             # window — pre-fix, this is where _active_session gets
             # overwritten.
@@ -323,7 +323,7 @@ async def test_active_session_resets_to_default_after_block() -> None:
 
     assert planner.provider() is None
 
-    async with steerer.observe_refine(session, drift):
+    async with steerer.plans.observe_refine(session, drift):
         ctx = planner.provider()
         assert ctx is not None
         _sinks_arg, run_id, _session_id, _task_id, _seq_fn = ctx

--- a/tests/test_steerer_fold_runtime_terminal.py
+++ b/tests/test_steerer_fold_runtime_terminal.py
@@ -39,6 +39,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.plan_reviser import PlanReviser  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
     DriftEvent,
@@ -62,7 +63,7 @@ def _fold_ids(revised: Plan, prior: Plan | None) -> tuple[list[str], Plan]:
     folded-id list by diffing input vs output so the existing test
     assertions ``folded == [...]`` keep working.
     """
-    folded_plan = DefaultSteerer._fold_runtime_terminal_statuses(revised, prior)
+    folded_plan = PlanReviser._fold_runtime_terminal_statuses(revised, prior)
     if folded_plan is revised:
         return [], folded_plan
     before = {t.id: t.status for t in revised.tasks}
@@ -395,7 +396,7 @@ async def test_install_with_drift_folds_runtime_not_needed_into_snapshot() -> No
         authored_by="goldfive",
     )
 
-    installed = await steerer.install_revision_for_drift(
+    installed = await steerer.plans.install_revision_for_drift(
         session=session,
         drift=drift,
         revised_plan=revised,
@@ -472,7 +473,7 @@ async def test_install_with_drift_genuine_terminal_regression_still_rejected() -
         authored_by="goldfive",
     )
 
-    installed = await steerer.install_revision_for_drift(
+    installed = await steerer.plans.install_revision_for_drift(
         session=session,
         drift=drift,
         revised_plan=revised,
@@ -545,7 +546,7 @@ async def test_install_user_steer_folds_before_validating_llm_revision() -> None
         authored_by="user",
     )
 
-    returned = await steerer.install_user_steer(
+    returned = await steerer.plans.install_user_steer(
         drift=drift,
         prior=prior,
         llm_revision=llm_revision,
@@ -605,7 +606,7 @@ async def test_handle_drift_refine_path_folds_before_validation() -> None:
 
     # Trigger an autonomous refine via observe (any error context fires
     # the drift -> refine -> apply pipeline).
-    await steerer.observe({"error": "trigger refine"}, session)
+    await steerer.drift.observe({"error": "trigger refine"}, session)
 
     # Plan was installed; t_reaped landed as NOT_NEEDED (folded), not
     # PENDING.
@@ -669,7 +670,7 @@ async def test_apply_revision_defensive_fold_idempotent_when_caller_already_fold
     # RETURNED plan to verify the defensive fold is idempotent — the
     # session.plan pointer is unchanged at this point, which is the
     # whole point of the fix.
-    revised, _was_installed = DefaultSteerer()._apply_revision(session, revised, drift)
+    revised, _was_installed = DefaultSteerer().plans._apply_revision(session, revised, drift)
 
     # goldfive#403: session.plan is still the PRIOR plan (install
     # deferred to _emit_plan_revised). The defensive-fold invariant

--- a/tests/test_steerer_usersteer.py
+++ b/tests/test_steerer_usersteer.py
@@ -155,7 +155,7 @@ async def test_observe_steer_triggers_user_steer_drift_and_refine() -> None:
         payload={"note": "focus on clarity"},
     )
 
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     # Planner.refine was called with a USER_STEER drift carrying the note.
     assert len(planner.refine_calls) == 1
@@ -186,7 +186,7 @@ async def test_observe_cancel_triggers_critical_user_cancel_drift() -> None:
         kind=ControlKind.CANCEL,
         payload={"reason": "operator abort"},
     )
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     assert len(planner.refine_calls) == 1
     drift: DriftEvent = planner.refine_calls[0]["drift"]
@@ -205,7 +205,7 @@ async def test_observe_pause_emits_drift_but_does_not_refine() -> None:
     steerer, session, sink, planner = _bind_fresh()
     msg = ControlMessage(kind=ControlKind.PAUSE, payload={"note": "coffee"})
 
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     # INFO severity → refine must NOT be called.
     assert planner.refine_calls == []
@@ -223,7 +223,7 @@ async def test_observe_non_control_event_still_uses_classifier() -> None:
     steerer, session, sink, planner = _bind_fresh()
 
     # A tool-error shape — detect_drift should still classify this.
-    await steerer.observe({"error": "boom"}, session)
+    await steerer.drift.observe({"error": "boom"}, session)
 
     # Should have produced a tool_error drift (classify_tool_error path).
     kinds = [e.WhichOneof("payload") for e in sink.proto_events]
@@ -254,8 +254,8 @@ async def test_observe_steer_dedupes_by_annotation_id() -> None:
         id="ctl-retry-2",
         payload={"note": "pivot", "annotation_id": "ann_abc"},
     )
-    await steerer.observe(first, session)
-    await steerer.observe(second, session)
+    await steerer.drift.observe(first, session)
+    await steerer.drift.observe(second, session)
 
     assert len(planner.refine_calls) == 1
     assert session.state.get("goldfive.processed_steer_ids") == ["ann_abc"]
@@ -270,9 +270,9 @@ async def test_observe_steer_dedupes_by_control_id_when_annotation_id_absent() -
         payload={"note": "pivot"},
     )
 
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
     # Same id, deliberately re-delivered.
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     assert len(planner.refine_calls) == 1
     assert session.state.get("goldfive.processed_steer_ids") == ["ctl-noid-1"]
@@ -292,8 +292,8 @@ async def test_observe_steer_distinct_ids_each_trigger_refine() -> None:
         payload={"note": "two", "annotation_id": "ann_2"},
     )
 
-    await steerer.observe(first, session)
-    await steerer.observe(second, session)
+    await steerer.drift.observe(first, session)
+    await steerer.drift.observe(second, session)
 
     assert len(planner.refine_calls) == 2
     assert session.state.get("goldfive.processed_steer_ids") == ["ann_1", "ann_2"]
@@ -325,12 +325,12 @@ async def test_observe_dedupe_does_not_affect_heuristic_drifts() -> None:
         id="ctl-s",
         payload={"note": "go", "annotation_id": "ann_s"},
     )
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
     # Two tool-error events on DIFFERENT pinned tasks — each is its own
     # drift condition (per-condition gate is keyed on kind+task+agent
     # within a turn) and therefore gets its own refine.
-    await steerer.observe({"error": "boom", "task_id": "t1"}, session)
-    await steerer.observe({"error": "boom", "task_id": "t2"}, session)
+    await steerer.drift.observe({"error": "boom", "task_id": "t1"}, session)
+    await steerer.drift.observe({"error": "boom", "task_id": "t2"}, session)
 
     # planner.refine: 1 steer + 2 tool_error observations across distinct tasks.
     assert len(planner.refine_calls) == 3
@@ -356,7 +356,7 @@ async def test_observe_steer_stamps_annotation_id_on_drift_detected(
         },
     )
 
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     drift_events = [
         e for e in sink.proto_events if e.WhichOneof("payload") == "drift_detected"
@@ -381,7 +381,7 @@ async def test_observe_steer_without_annotation_id_leaves_drift_annotation_id_em
         payload={"note": "focus"},
     )
 
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     drift_events = [
         e for e in sink.proto_events if e.WhichOneof("payload") == "drift_detected"
@@ -404,7 +404,7 @@ async def test_observe_cancel_stamps_annotation_id_on_drift_detected(
         payload={"reason": "operator abort", "annotation_id": "ann_cxl"},
     )
 
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     drift_events = [
         e for e in sink.proto_events if e.WhichOneof("payload") == "drift_detected"
@@ -428,7 +428,7 @@ async def test_autonomous_drift_has_empty_annotation_id() -> None:
     steerer, session, sink, _planner = _bind_fresh()
     # Use a tool-error event — classify_tool_error mints a drift directly
     # from an untyped event (no ControlMessage.raw).
-    await steerer.observe({"error": "boom"}, session)
+    await steerer.drift.observe({"error": "boom"}, session)
 
     drift_events = [
         e for e in sink.proto_events if e.WhichOneof("payload") == "drift_detected"
@@ -451,7 +451,7 @@ async def test_observe_steer_propagates_author_into_state_and_detail() -> None:
         },
     )
 
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     assert session.state.get("goldfive.active_steer.author") == "alice"
     # Raw body — not the "by alice: ..." rewrite — lands on body.
@@ -470,7 +470,7 @@ async def test_observe_steer_without_author_leaves_author_empty() -> None:
         payload={"note": "quiet nudge", "annotation_id": "ann_na"},
     )
 
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     assert session.state.get("goldfive.active_steer.author") == ""
     assert session.state.get("goldfive.active_steer.body") == "quiet nudge"
@@ -493,7 +493,7 @@ async def test_processed_steer_ids_list_evicts_oldest_when_capped() -> None:
             id=f"ctl-{i}",
             payload={"note": f"n{i}", "annotation_id": f"ann_{i}"},
         )
-        await steerer.observe(msg, session)
+        await steerer.drift.observe(msg, session)
 
     ids = session.state.get("goldfive.processed_steer_ids") or []
     assert len(ids) == cap
@@ -521,7 +521,7 @@ async def test_direct_user_steer_drift_event_without_raw_still_writes_state() ->
         current_task_id="t2",
     )
 
-    await steerer._apply_user_steer_state(drift, session)
+    await steerer.drift._apply_user_steer_state(drift, session)
 
     assert session.state.get("goldfive.active_steer.body") == "direct call"
     assert session.state.get("goldfive.active_steer.author") == "bob"
@@ -566,7 +566,7 @@ async def test_steerer_sets_adapter_next_cancel_reason_on_user_steer() -> None:
         kind=ControlKind.STEER,
         payload={"note": "pivot to security posture"},
     )
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     assert adapter._next_cancel_reason == "user_steer"
 
@@ -584,11 +584,11 @@ async def test_steerer_does_not_tag_adapter_on_non_user_steer_drift() -> None:
 
     # PAUSE → USER_PAUSE drift (INFO severity, no refine).
     pause_msg = ControlMessage(kind=ControlKind.PAUSE, payload={"note": "wait"})
-    await steerer.observe(pause_msg, session)
+    await steerer.drift.observe(pause_msg, session)
     assert adapter._next_cancel_reason == ""
 
     # A raw tool-error event also should not tag the adapter.
-    await steerer.observe({"error": "boom"}, session)
+    await steerer.drift.observe({"error": "boom"}, session)
     assert adapter._next_cancel_reason == ""
 
 
@@ -608,7 +608,7 @@ async def test_steerer_bind_adapter_tolerates_adapter_without_attr() -> None:
 
     msg = ControlMessage(kind=ControlKind.STEER, payload={"note": "x"})
     # Must not raise.
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
     # Refine still ran.
     assert len(planner.refine_calls) == 1
 
@@ -808,7 +808,7 @@ async def test_plan_revised_stamps_annotation_id_from_user_steer(
         },
     )
 
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     revised_events = [
         e for e in sink.proto_events if e.WhichOneof("payload") == "plan_revised"
@@ -836,7 +836,7 @@ async def test_plan_revised_without_annotation_id_falls_back_to_drift_id(
         payload={"note": "pivot"},
     )
 
-    await steerer.observe(msg, session)
+    await steerer.drift.observe(msg, session)
 
     revised_events = [
         e for e in sink.proto_events if e.WhichOneof("payload") == "plan_revised"
@@ -857,7 +857,7 @@ async def test_apply_revision_stamps_trigger_event_id_from_annotation(
     drifts via the raw ControlMessage payload. Rescope keeps that
     behaviour but the field is now the unified ``trigger_event_id``.
     """
-    from goldfive.steerer import DefaultSteerer
+    from goldfive.drift_observer import DriftObserver
 
     session = _make_session()
     msg = ControlMessage(
@@ -865,7 +865,7 @@ async def test_apply_revision_stamps_trigger_event_id_from_annotation(
         id="ctl-ar",
         payload={"note": "refocus", "annotation_id": "ann_ar_77"},
     )
-    drift = DefaultSteerer._drift_from_control(msg, session)
+    drift = DriftObserver._drift_from_control(msg, session)
     assert drift is not None
 
     revised = Plan(
@@ -884,7 +884,7 @@ async def test_apply_revision_stamps_trigger_event_id_from_annotation(
     # in observation-only mode); the test-suite fixture flips the
     # default to active-steering so the install lands.
     # goldfive#255: returns ``(revised, was_installed)``.
-    revised, _was_installed = DefaultSteerer()._apply_revision(session, revised, drift)
+    revised, _was_installed = DefaultSteerer().plans._apply_revision(session, revised, drift)
 
     assert session.plan is not None and session.plan.id == revised.id
     assert revised.revision_trigger_event_id == "ann_ar_77"
@@ -920,7 +920,7 @@ async def test_apply_revision_stamps_drift_id_on_autonomous_drift(
     # goldfive#247: _apply_revision returns the stamped Plan; the input
     # stays unchanged (frozen). goldfive#254: instance method now.
     # goldfive#255: returns ``(revised, was_installed)``.
-    revised, _was_installed = DefaultSteerer()._apply_revision(session, revised, drift)
+    revised, _was_installed = DefaultSteerer().plans._apply_revision(session, revised, drift)
     assert revised.revision_trigger_event_id == drift.id
 
 
@@ -931,7 +931,7 @@ async def test_apply_revision_preserves_prestamped_trigger_event_id() -> None:
     retry attempt's plan with the original trigger id, re-applying the
     revision must not clobber it.
     """
-    from goldfive.steerer import DefaultSteerer
+    from goldfive.drift_observer import DriftObserver
 
     session = _make_session()
     msg = ControlMessage(
@@ -939,7 +939,7 @@ async def test_apply_revision_preserves_prestamped_trigger_event_id() -> None:
         id="ctl-ar2",
         payload={"note": "refocus", "annotation_id": "ann_from_drift"},
     )
-    drift = DefaultSteerer._drift_from_control(msg, session)
+    drift = DriftObserver._drift_from_control(msg, session)
     assert drift is not None
 
     revised = Plan(
@@ -951,7 +951,7 @@ async def test_apply_revision_preserves_prestamped_trigger_event_id() -> None:
         revision_trigger_event_id="ann_prestamped",
     )
     # goldfive#254: instance method now.
-    DefaultSteerer()._apply_revision(session, revised, drift)
+    DefaultSteerer().plans._apply_revision(session, revised, drift)
     assert revised.revision_trigger_event_id == "ann_prestamped"
 
 
@@ -966,7 +966,7 @@ async def test_autonomous_refine_stamps_drift_id_on_plan_revised(
     """
     steerer, session, sink, _planner = _bind_fresh()
     # Feed an untyped event — classify_tool_error path, no ControlMessage.
-    await steerer.observe({"error": "boom"}, session)
+    await steerer.drift.observe({"error": "boom"}, session)
     revised_events = [
         e for e in sink.proto_events if e.WhichOneof("payload") == "plan_revised"
     ]

--- a/tests/test_structural_loop_prevention.py
+++ b/tests/test_structural_loop_prevention.py
@@ -193,7 +193,7 @@ async def test_no_op_revision_does_not_bump_revision_index() -> None:
 
     initial_revision = session.plan.revision_index
 
-    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
+    await steerer.drift.handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
 
     # Refine WAS called (the planner attempted to produce a revision).
     assert len(planner.refine_calls) == 1
@@ -216,7 +216,7 @@ async def test_no_op_revision_escalates_to_human_intervention_after_one_attempt(
     planner = _NoOpPlanner()
     steerer.bind(sinks=[sink], planner=planner)
 
-    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
+    await steerer.drift.handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
 
     # Exactly ONE refine call (no retry loop).
     assert len(planner.refine_calls) == 1
@@ -259,7 +259,7 @@ async def test_progress_stall_escalates_when_task_silent(
     # Advance past the threshold and fire a drift.
     clock[0] = 1100.0  # 100s elapsed > 60s threshold
 
-    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
+    await steerer.drift.handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
 
     # Refine was NOT called — the gate fired before refine.
     assert planner.refine_calls == []
@@ -293,7 +293,7 @@ async def test_progress_stall_does_not_fire_when_task_is_iterating(
     # Only 10s elapsed — well within threshold.
     clock[0] = 1010.0
 
-    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
+    await steerer.drift.handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
 
     # Refine WAS called (the gate did not fire).
     assert len(planner.refine_calls) == 1
@@ -327,7 +327,7 @@ async def test_progress_stall_skipped_when_task_has_no_progress_record(
     # No entry in ``task_last_progress_at`` for "t1".
     assert "t1" not in session.task_last_progress_at
 
-    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
+    await steerer.drift.handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
 
     # Refine WAS called (no record => no gate).
     assert len(planner.refine_calls) == 1
@@ -361,7 +361,7 @@ async def test_user_steer_bypasses_progress_stall_gate(
     session.task_last_progress_at["t1"] = 1000.0
     clock[0] = 1100.0  # past threshold
 
-    await steerer._handle_drift(
+    await steerer.drift.handle_drift(
         _drift(DriftKind.USER_STEER, task_id="t1", severity=DriftSeverity.WARNING),
         session,
     )
@@ -410,7 +410,7 @@ async def test_refine_exhausted_sentinel_escalates_immediately() -> None:
     planner = _ExhaustedPlanner()
     steerer.bind(sinks=[sink], planner=planner)
 
-    await steerer._handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
+    await steerer.drift.handle_drift(_drift(DriftKind.OFF_TOPIC, task_id="t1"), session)
 
     # Refine was called exactly once (no retry).
     assert len(planner.refine_calls) == 1
@@ -433,7 +433,7 @@ async def test_mark_task_running_stamps_progress(
     clock = [1234.5]
     monkeypatch.setattr("goldfive.drift_observer.time.monotonic", lambda: clock[0])
 
-    await steerer.mark_task_running("t1", session=session)
+    await steerer.tasks.mark_task_running("t1", session=session)
 
     assert session.task_last_progress_at["t1"] == pytest.approx(1234.5)
 
@@ -451,9 +451,9 @@ async def test_mark_task_progress_refreshes_progress(
     clock = [1000.0]
     monkeypatch.setattr("goldfive.drift_observer.time.monotonic", lambda: clock[0])
 
-    await steerer.mark_task_running("t1", session=session)
+    await steerer.tasks.mark_task_running("t1", session=session)
     assert session.task_last_progress_at["t1"] == pytest.approx(1000.0)
 
     clock[0] = 1500.0
-    await steerer.mark_task_progress("t1", session=session, fraction=0.5)
+    await steerer.tasks.mark_task_progress("t1", session=session, fraction=0.5)
     assert session.task_last_progress_at["t1"] == pytest.approx(1500.0)

--- a/tests/test_task_binding_follows_revision.py
+++ b/tests/test_task_binding_follows_revision.py
@@ -33,6 +33,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 from goldfive import state_store as _ostate  # noqa: E402
+from goldfive.plan_reviser import PlanReviser  # noqa: E402
 from goldfive.reporting import (  # noqa: E402
     BUILTIN_REPORTING_TOOLS,
     _resolve_effective_task_id,
@@ -170,8 +171,8 @@ async def test_current_task_id_repins_on_revision() -> None:
     steerer.bind(sinks=[ListSink()], planner=planner)
     # goldfive#247: rebind to the stamped instance.
     # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
-    revised, _was_installed = steerer._apply_revision(session, revised, _drift())
-    await steerer._emit_plan_revised(session, revised, _drift(), prev_plan=None)
+    revised, _was_installed = steerer.plans._apply_revision(session, revised, _drift())
+    await steerer.plans._emit_plan_revised(session, revised, _drift(), prev_plan=None)
 
     assert session.current_task_id == "research_solar_corrected"
 
@@ -286,7 +287,7 @@ async def test_multiple_supersessions_all_repin() -> None:
 
     steerer = DefaultSteerer()
     steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
-    steerer._repin_current_task_on_supersedes(session, plan)
+    steerer.plans._repin_current_task_on_supersedes(session, plan)
 
     assert session.current_task_id == "a2"
     assert session.state[_ostate.KEY_CURRENT_TASK_ID] == "b2"
@@ -315,7 +316,7 @@ async def test_no_supersedes_field_no_change() -> None:
 
     steerer = DefaultSteerer()
     steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
-    steerer._repin_current_task_on_supersedes(session, plan)
+    steerer.plans._repin_current_task_on_supersedes(session, plan)
 
     assert session.current_task_id == "t1"
     assert session.state[_ostate.KEY_CURRENT_TASK_ID] == "t1"
@@ -438,7 +439,7 @@ async def test_integrate_correction_supersedes_keeps_old_task() -> None:
         revision_index=1,
     )
 
-    revised = DefaultSteerer._integrate_correction_supersedes(revised)
+    revised = PlanReviser._integrate_correction_supersedes(revised)
 
     by_id = {t.id: t for t in revised.tasks}
     # Old task preserved with its COMPLETED status intact.
@@ -463,7 +464,7 @@ async def test_integrate_correction_supersedes_replace_kind_no_dag_rewrite() -> 
     """
     revised = _revised_with_replacement()
     original_edges = [(e.from_task_id, e.to_task_id) for e in revised.edges]
-    revised = DefaultSteerer._integrate_correction_supersedes(revised)
+    revised = PlanReviser._integrate_correction_supersedes(revised)
     # No edge mutations.
     assert [(e.from_task_id, e.to_task_id) for e in revised.edges] == original_edges
 
@@ -641,7 +642,7 @@ async def test_downstream_edge_rewrite_on_correct_chain() -> None:
         revision_index=1,
     )
 
-    revised = DefaultSteerer._integrate_correction_supersedes(revised)
+    revised = PlanReviser._integrate_correction_supersedes(revised)
 
     edges_set = {(e.from_task_id, e.to_task_id) for e in revised.edges}
     # Chain is now a -> a_prime -> b -> c.
@@ -823,8 +824,8 @@ async def test_correct_integration_via_emit_plan_revised_end_to_end() -> None:
     steerer.bind(sinks=[sink], planner=planner)
     # goldfive#247: rebind to the stamped instance.
     # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
-    revised, _was_installed = steerer._apply_revision(session, revised, _drift())
-    await steerer._emit_plan_revised(session, revised, _drift(), prev_plan=None)
+    revised, _was_installed = steerer.plans._apply_revision(session, revised, _drift())
+    await steerer.plans._emit_plan_revised(session, revised, _drift(), prev_plan=None)
 
     # Session plan now has the corrected topology.
     edges_set = {(e.from_task_id, e.to_task_id) for e in session.plan.edges}

--- a/tests/test_task_id_wiring.py
+++ b/tests/test_task_id_wiring.py
@@ -67,12 +67,11 @@ class _Agent:
         self.name = name
 
 
-class _RecordingSteerer:
-    """Steerer stub that records transitions + drifts for assertions."""
+class _RecordingTasks:
+    """Tasks sub-component: records every transition the handler routes."""
 
     def __init__(self) -> None:
         self.transitions: list[tuple[str, Any, str]] = []
-        self.drifts: list[Any] = []
 
     async def mark_task_running(
         self, task_id: str, *, session: Any, detail: str = "", **_: Any
@@ -123,20 +122,43 @@ class _RecordingSteerer:
     ) -> None:
         self.transitions.append((task_id, "BLOCKED", blocker))
 
+
+class _RecordingDrift:
+    """Drift sub-component: records observed events + plan-mutation hooks."""
+
+    def __init__(self) -> None:
+        self.drifts: list[Any] = []
+
+    async def observe(self, event: Any, session: Any) -> None:
+        self.drifts.append(event)
+
     async def report_new_work_discovered(self, **kwargs: Any) -> None:
         pass
 
     async def report_plan_divergence(self, **kwargs: Any) -> None:
         pass
 
-    async def observe(self, event: Any, session: Any) -> None:
-        self.drifts.append(event)
+    def detect_drift(self, event: Any, session: Any) -> Any:
+        return None
+
+
+class _RecordingSteerer:
+    """Steerer stub that records transitions + drifts for assertions."""
+
+    def __init__(self) -> None:
+        self.tasks = _RecordingTasks()
+        self.drift = _RecordingDrift()
+
+    @property
+    def transitions(self) -> list[tuple[str, Any, str]]:
+        return self.tasks.transitions
+
+    @property
+    def drifts(self) -> list[Any]:
+        return self.drift.drifts
 
     async def transition(self, *a: Any, **kw: Any) -> None:
         pass
-
-    def detect_drift(self, event: Any, session: Any) -> Any:
-        return None
 
     def bind(self, **kw: Any) -> None:
         pass

--- a/tests/test_task_lineage.py
+++ b/tests/test_task_lineage.py
@@ -93,7 +93,7 @@ async def test_lineage_initialises_on_task_running() -> None:
     steerer, session, task = _build_session_with_running_task(assignee="coordinator")
     assert task.id not in session.task_lineage  # pre-condition
 
-    await steerer.mark_task_running(task.id, session=session)
+    await steerer.tasks.mark_task_running(task.id, session=session)
 
     assert session.task_lineage[task.id] == {"coordinator"}
 
@@ -107,7 +107,7 @@ async def test_lineage_initialises_empty_set_when_no_assignee() -> None:
     have we observed".
     """
     steerer, session, task = _build_session_with_running_task(assignee="")
-    await steerer.mark_task_running(task.id, session=session)
+    await steerer.tasks.mark_task_running(task.id, session=session)
     assert session.task_lineage[task.id] == set()
 
 
@@ -120,7 +120,7 @@ async def test_delegation_observed_extends_lineage_on_pinned_task() -> None:
     framework-neutral.
     """
     steerer, session, task = _build_session_with_running_task(assignee="coordinator")
-    await steerer.mark_task_running(task.id, session=session)
+    await steerer.tasks.mark_task_running(task.id, session=session)
     assert session.current_task_id == task.id
 
     # Simulate the plugin's idempotent set.add on a delegated child.
@@ -131,7 +131,7 @@ async def test_delegation_observed_extends_lineage_on_pinned_task() -> None:
 async def test_lineage_accumulates_multiple_delegations() -> None:
     """Two delegations under the same task end up in one set."""
     steerer, session, task = _build_session_with_running_task(assignee="coordinator")
-    await steerer.mark_task_running(task.id, session=session)
+    await steerer.tasks.mark_task_running(task.id, session=session)
 
     session.task_lineage[task.id].add("research_agent")
     session.task_lineage[task.id].add("writer_agent")
@@ -147,34 +147,34 @@ async def test_lineage_accumulates_multiple_delegations() -> None:
 
 async def test_lineage_clears_on_completed() -> None:
     steerer, session, task = _build_session_with_running_task()
-    await steerer.mark_task_running(task.id, session=session)
+    await steerer.tasks.mark_task_running(task.id, session=session)
     assert task.id in session.task_lineage
 
-    await steerer.mark_task_completed(task.id, session=session)
+    await steerer.tasks.mark_task_completed(task.id, session=session)
     assert task.id not in session.task_lineage
 
 
 async def test_lineage_clears_on_failed_recoverable() -> None:
     steerer, session, task = _build_session_with_running_task()
-    await steerer.mark_task_running(task.id, session=session)
+    await steerer.tasks.mark_task_running(task.id, session=session)
 
-    await steerer.mark_task_failed(task.id, session=session, recoverable=True)
+    await steerer.tasks.mark_task_failed(task.id, session=session, recoverable=True)
     assert task.id not in session.task_lineage
 
 
 async def test_lineage_clears_on_failed_fatal() -> None:
     steerer, session, task = _build_session_with_running_task()
-    await steerer.mark_task_running(task.id, session=session)
+    await steerer.tasks.mark_task_running(task.id, session=session)
 
-    await steerer.mark_task_failed(task.id, session=session, recoverable=False)
+    await steerer.tasks.mark_task_failed(task.id, session=session, recoverable=False)
     assert task.id not in session.task_lineage
 
 
 async def test_lineage_clears_on_cancelled() -> None:
     steerer, session, task = _build_session_with_running_task()
-    await steerer.mark_task_running(task.id, session=session)
+    await steerer.tasks.mark_task_running(task.id, session=session)
 
-    await steerer.mark_task_cancelled(task.id, session=session)
+    await steerer.tasks.mark_task_cancelled(task.id, session=session)
     assert task.id not in session.task_lineage
 
 
@@ -186,9 +186,9 @@ async def test_lineage_clears_on_not_needed() -> None:
     other terminal transition.
     """
     steerer, session, task = _build_session_with_running_task()
-    await steerer.mark_task_running(task.id, session=session)
+    await steerer.tasks.mark_task_running(task.id, session=session)
 
-    await steerer.mark_task_not_needed(task.id, session=session)
+    await steerer.tasks.mark_task_not_needed(task.id, session=session)
     assert task.id not in session.task_lineage
 
 
@@ -221,14 +221,14 @@ async def test_lineage_clears_on_cascade_cancel_downstream() -> None:
     steerer = DefaultSteerer()
     steerer.bind(sinks=[_ListSink()], planner=_NullPlanner())
 
-    await steerer.mark_task_running("u", session=session)
-    await steerer.mark_task_running("d", session=session)
+    await steerer.tasks.mark_task_running("u", session=session)
+    await steerer.tasks.mark_task_running("d", session=session)
     assert "u" in session.task_lineage
     assert "d" in session.task_lineage
 
     # Fatal failure on upstream cascades cancellation to downstream;
     # both lineage entries should be cleared.
-    await steerer.mark_task_failed("u", session=session, recoverable=False)
+    await steerer.tasks.mark_task_failed("u", session=session, recoverable=False)
     assert "u" not in session.task_lineage
     assert "d" not in session.task_lineage
     # goldfive#247: read live status from session.plan; the local

--- a/tests/test_task_state_machine.py
+++ b/tests/test_task_state_machine.py
@@ -62,32 +62,15 @@ class _ListSink:
         self.events.append(event_pb)
 
 
-class _StubRouter:
-    """Minimal mock router that satisfies :class:`TaskStateMachine`.
-
-    Records every cross-component call so tests can assert the TSM
-    routes them through the router back-reference (rather than
-    importing the sibling components directly).
+class _StubDrift:
+    """Tiny stub of :class:`DriftObserver` exposing only the methods
+    :class:`TaskStateMachine` reaches for via ``self._steerer.drift``.
     """
 
     def __init__(self) -> None:
-        self._sink = _ListSink()
-        self._sinks = [self._sink]
-        self._adapter: Any = None
-        # Spy state for cross-component routing.
         self.note_agent_activity_calls: list[dict[str, Any]] = []
         self.spawn_drift_calls: list[tuple[DriftEvent, Session]] = []
         self.goal_drift_boundary_calls: int = 0
-
-    def _new_envelope(self, session: Session) -> Any:
-        from goldfive.events import new_event
-
-        return new_event(session.run_id, session.next_sequence(), session_id=session.id)
-
-    async def _emit(self, event_pb: Any) -> None:
-        from goldfive.events import emit
-
-        await emit(self._sinks, event_pb)
 
     def note_agent_activity(
         self,
@@ -114,6 +97,46 @@ class _StubRouter:
 
     async def _maybe_run_goal_drift_on_task_boundary(self, session: Session) -> None:
         self.goal_drift_boundary_calls += 1
+
+
+class _StubRouter:
+    """Minimal mock router that satisfies :class:`TaskStateMachine`.
+
+    Records every cross-component call so tests can assert the TSM
+    routes them through the router back-reference (rather than
+    importing the sibling components directly).
+    """
+
+    def __init__(self) -> None:
+        self._sink = _ListSink()
+        self._sinks = [self._sink]
+        self._adapter: Any = None
+        # Cross-component routing now goes through ``self.drift``;
+        # forward the spy attributes via properties so existing tests
+        # that read ``router.note_agent_activity_calls`` stay readable.
+        self.drift = _StubDrift()
+
+    @property
+    def note_agent_activity_calls(self) -> list[dict[str, Any]]:
+        return self.drift.note_agent_activity_calls
+
+    @property
+    def spawn_drift_calls(self) -> list[tuple[DriftEvent, Session]]:
+        return self.drift.spawn_drift_calls
+
+    @property
+    def goal_drift_boundary_calls(self) -> int:
+        return self.drift.goal_drift_boundary_calls
+
+    def _new_envelope(self, session: Session) -> Any:
+        from goldfive.events import new_event
+
+        return new_event(session.run_id, session.next_sequence(), session_id=session.id)
+
+    async def _emit(self, event_pb: Any) -> None:
+        from goldfive.events import emit
+
+        await emit(self._sinks, event_pb)
 
 
 def _seed_session_with_plan() -> Session:

--- a/tests/test_task_transitioned_events.py
+++ b/tests/test_task_transitioned_events.py
@@ -334,8 +334,8 @@ async def test_refine_replace_supersedes_emits_plan_revision_transition() -> Non
     # emits the proto + per-transition envelopes.
     # goldfive#247: rebind to the stamped instance.
     # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
-    revised, _was_installed = steerer._apply_revision(session, revised, drift)
-    await steerer._emit_plan_revised(session, revised, drift, prev_plan=prev_plan)
+    revised, _was_installed = steerer.plans._apply_revision(session, revised, drift)
+    await steerer.plans._emit_plan_revised(session, revised, drift, prev_plan=prev_plan)
 
     transitions = _transition_events(sink)
     # Exactly one transition: t1 RUNNING -> CANCELLED. The brand-new
@@ -382,7 +382,7 @@ async def test_cooperative_cancellation_emits_cancellation_source() -> None:
     sink = ListSink()
     steerer = _bound_steerer(sink)
 
-    await steerer.mark_task_cancelled(
+    await steerer.tasks.mark_task_cancelled(
         "t1",
         session=session,
         reason="adk_cancellation:invoc-1",

--- a/tests/test_terminal_drift_closes_spans.py
+++ b/tests/test_terminal_drift_closes_spans.py
@@ -210,7 +210,7 @@ async def test_human_intervention_required_closes_open_boundaries() -> None:
         current_task_id="t1",
         current_agent_id="coordinator",
     )
-    await steerer._emit_drift_detected(session, drift)
+    await steerer.drift._emit_drift_detected(session, drift)
 
     exited = _events_of_kind(sink, "invocation_boundary_exited")
     assert len(exited) == 2, (
@@ -250,7 +250,7 @@ async def test_looping_reasoning_escalation_closes_open_boundaries() -> None:
     # Step 1: LOOPING_REASONING fires -- by itself it does NOT close
     # boundaries because the run might still recover through the
     # nudge / refine ladder.
-    await steerer._emit_drift_detected(session, looping)
+    await steerer.drift._emit_drift_detected(session, looping)
     assert _events_of_kind(sink, "invocation_boundary_exited") == [], (
         "LOOPING_REASONING alone must not close boundaries — CRITICAL-first is recoverable"
     )
@@ -264,7 +264,7 @@ async def test_looping_reasoning_escalation_closes_open_boundaries() -> None:
         current_task_id="t1",
         current_agent_id="coordinator",
     )
-    await steerer._emit_drift_detected(session, escalation)
+    await steerer.drift._emit_drift_detected(session, escalation)
 
     exited = _events_of_kind(sink, "invocation_boundary_exited")
     assert len(exited) == 2, (
@@ -295,7 +295,7 @@ async def test_repeated_failure_closes_open_boundaries() -> None:
         current_task_id="t1",
         current_agent_id="coordinator",
     )
-    await steerer._emit_drift_detected(session, drift)
+    await steerer.drift._emit_drift_detected(session, drift)
 
     exited = _events_of_kind(sink, "invocation_boundary_exited")
     assert len(exited) == 1
@@ -327,7 +327,7 @@ async def test_looping_reasoning_alone_does_not_close_boundaries() -> None:
             current_task_id="t1",
             current_agent_id="coordinator",
         )
-        await steerer._emit_drift_detected(session, drift)
+        await steerer.drift._emit_drift_detected(session, drift)
 
         exited = _events_of_kind(sink, "invocation_boundary_exited")
         assert exited == [], (
@@ -356,7 +356,7 @@ async def test_non_terminal_drift_does_not_close_boundaries() -> None:
         current_task_id="t1",
         current_agent_id="coordinator",
     )
-    await steerer._emit_drift_detected(session, drift)
+    await steerer.drift._emit_drift_detected(session, drift)
 
     exited = _events_of_kind(sink, "invocation_boundary_exited")
     assert exited == []
@@ -392,7 +392,7 @@ async def test_terminal_drift_with_no_open_boundaries_is_noop() -> None:
         current_task_id="t1",
         current_agent_id="coordinator",
     )
-    await steerer._emit_drift_detected(session, drift)
+    await steerer.drift._emit_drift_detected(session, drift)
 
     exited = _events_of_kind(sink, "invocation_boundary_exited")
     # No additional Exited event — cleanup walks an empty registry.
@@ -421,7 +421,7 @@ async def test_terminal_drift_without_adapter_does_not_raise() -> None:
         current_agent_id="coordinator",
     )
     # Must not raise.
-    await steerer._emit_drift_detected(session, drift)
+    await steerer.drift._emit_drift_detected(session, drift)
     # DriftDetected still landed on the wire.
     assert _events_of_kind(sink, "drift_detected"), (
         "the drift itself must still be emitted even without an adapter"
@@ -456,5 +456,5 @@ async def test_terminal_drift_with_legacy_plugin_does_not_raise() -> None:
         current_agent_id="coordinator",
     )
     # Must not raise.
-    await steerer._emit_drift_detected(session, drift)
+    await steerer.drift._emit_drift_detected(session, drift)
     assert _events_of_kind(sink, "drift_detected")

--- a/tests/test_tier1_loop_prevention.py
+++ b/tests/test_tier1_loop_prevention.py
@@ -370,7 +370,7 @@ def test_f3_allows_dispatch_when_next_pending_is_same_agent() -> None:
 def test_f4_goal_drift_warning_routes_to_nudge() -> None:
     """F4: WARNING-severity GOAL_DRIFT -> NUDGE (queue corrective msg)."""
     steerer = DefaultSteerer()
-    level = steerer._ladder_level_for(
+    level = steerer.drift._ladder_level_for(
         DriftKind.GOAL_DRIFT, DriftSeverity.WARNING, occurrence_count=0
     )
     assert level is InterventionLevel.NUDGE
@@ -383,7 +383,7 @@ def test_f4_goal_drift_critical_first_routes_to_nudge() -> None:
     NUDGE first so the corrective user message re-anchors the LLM
     without refining a plan that's already correct."""
     steerer = DefaultSteerer()
-    level = steerer._ladder_level_for(
+    level = steerer.drift._ladder_level_for(
         DriftKind.GOAL_DRIFT, DriftSeverity.CRITICAL, occurrence_count=0
     )
     assert level is InterventionLevel.NUDGE
@@ -395,7 +395,7 @@ def test_f4_goal_drift_critical_repeat_routes_to_cancel_reinvoke() -> None:
     PAUSE_ESCALATE is the last-resort fallback the default ladder
     surfaces only after CANCEL_REINVOKE also fails to break the loop."""
     steerer = DefaultSteerer()
-    level = steerer._ladder_level_for(
+    level = steerer.drift._ladder_level_for(
         DriftKind.GOAL_DRIFT,
         DriftSeverity.CRITICAL,
         occurrence_count=DefaultSteerer.REFINE_FAILURE_THRESHOLD,

--- a/tests/test_tier2_steer_pipeline.py
+++ b/tests/test_tier2_steer_pipeline.py
@@ -200,50 +200,14 @@ async def test_f5_replaces_prior_false_preserves_plan_id() -> None:
     assert getattr(plan, "_goldfive_pivot", False) is False
 
 
-async def test_f5_pivot_routes_through_install_initial_plan() -> None:
+async def test_f5_pivot_routes_through_install_initial_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """End-to-end: drive turn 1 (initial plan) then turn 2 with a pivot
     input. Assert turn 2 lands a NEW plan_id (Rule 6 NOT applied) by
     checking that ``install_initial_plan`` was called for both turns
     and ``install_revision_for_drift`` was never called.
     """
-    from goldfive.steerer import DefaultSteerer
-
-    initial_calls: list[tuple[str, bool]] = []
-    drift_calls: list[str] = []
-
-    class _SpyingSteerer(DefaultSteerer):
-        """Public-method subclass that records install_* call shapes.
-
-        Replaces the previous instance-level ``monkeypatch.setattr`` spy
-        with a subclass spy: the test owns the steerer class it injects
-        into the runner, so production code never has to learn the
-        pattern.
-        """
-
-        async def install_initial_plan(
-            self,
-            *,
-            session: Session,
-            plan: Plan,
-            is_pivot: bool = False,
-        ) -> bool:
-            initial_calls.append((plan.id, is_pivot))
-            return await super().install_initial_plan(
-                session=session, plan=plan, is_pivot=is_pivot
-            )
-
-        async def install_revision_for_drift(
-            self,
-            *,
-            session: Session,
-            drift: Any,
-            revised_plan: Plan,
-        ) -> bool:
-            drift_calls.append(revised_plan.id)
-            return await super().install_revision_for_drift(
-                session=session, drift=drift, revised_plan=revised_plan
-            )
-
     plan_t1 = _plan_dict(
         plan_id="ignored-by-runner",
         summary="2-slide presentation about solar panels",
@@ -313,8 +277,33 @@ async def test_f5_pivot_routes_through_install_initial_plan() -> None:
         planner=planner,
         executor=SequentialExecutor(),
         goal_deriver=PassthroughGoalDeriver("demo"),
-        steerer=_SpyingSteerer(),
         sinks=[sink],
+    )
+
+    # Spy on the steerer's install paths via ``steerer.plans`` (now
+    # public surface per #410 facade cleanup; previous DefaultSteerer
+    # subclass override is no longer available since the router shims
+    # were removed).
+    initial_calls: list[tuple[str, bool]] = []
+    drift_calls: list[str] = []
+    real_initial = runner.steerer.plans.install_initial_plan
+    real_drift = runner.steerer.plans.install_revision_for_drift
+
+    async def _spy_initial(
+        *, session: Session, plan: Plan, is_pivot: bool = False
+    ) -> bool:
+        initial_calls.append((plan.id, is_pivot))
+        return await real_initial(session=session, plan=plan, is_pivot=is_pivot)
+
+    async def _spy_drift(*, session: Session, drift: Any, revised_plan: Plan) -> bool:
+        drift_calls.append(revised_plan.id)
+        return await real_drift(
+            session=session, drift=drift, revised_plan=revised_plan
+        )
+
+    monkeypatch.setattr(runner.steerer.plans, "install_initial_plan", _spy_initial)
+    monkeypatch.setattr(
+        runner.steerer.plans, "install_revision_for_drift", _spy_drift
     )
 
     out1 = await runner.run("make a 2-slide presentation about solar panels")

--- a/tests/test_tool_loop_exemption_tightening.py
+++ b/tests/test_tool_loop_exemption_tightening.py
@@ -53,19 +53,34 @@ from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Session, Task
 # ---------------------------------------------------------------------------
 
 
-class _RecordingToolLoopSteerer:
-    """Steerer stub that captures every drift routed via ``_handle_drift``."""
+class _ToolLoopDrift:
+    """Drift sub-component capturing observations + ``handle_drift`` calls."""
 
     def __init__(self) -> None:
         self.drifts: list[DriftEvent] = []
         self.observations: list[Any] = []
-        self._sinks: list[Any] = []
 
     async def observe(self, event: Any, session: Any) -> None:
         self.observations.append(event)
 
-    async def _handle_drift(self, drift: DriftEvent, session: Any) -> None:
+    async def handle_drift(self, drift: DriftEvent, session: Any) -> None:
         self.drifts.append(drift)
+
+
+class _RecordingToolLoopSteerer:
+    """Steerer stub that captures every drift routed via ``drift.handle_drift``."""
+
+    def __init__(self) -> None:
+        self.drift = _ToolLoopDrift()
+        self._sinks: list[Any] = []
+
+    @property
+    def drifts(self) -> list[DriftEvent]:
+        return self.drift.drifts
+
+    @property
+    def observations(self) -> list[Any]:
+        return self.drift.observations
 
 
 def _plugin_with_tool_loop_ctx(task: Task, session: Session, steerer: Any):

--- a/tests/test_user_steer_invariant.py
+++ b/tests/test_user_steer_invariant.py
@@ -338,7 +338,7 @@ async def test_install_user_steer_always_returns_valid_plan(
     drift = _drift()
     prior_index = prior.revision_index
 
-    returned = await steerer.install_user_steer(
+    returned = await steerer.plans.install_user_steer(
         drift=drift,
         prior=prior,
         llm_revision=llm_revision,
@@ -452,7 +452,7 @@ async def test_deterministic_minimum_cancels_pending_running_blocked() -> None:
     session = _new_session(prior)
     drift = _drift()
 
-    returned = await steerer.install_user_steer(
+    returned = await steerer.plans.install_user_steer(
         drift=drift,
         prior=prior,
         llm_revision=None,
@@ -484,7 +484,7 @@ async def test_install_user_steer_prefers_valid_llm_revision() -> None:
     session = _new_session(prior)
     drift = _drift()
 
-    returned = await steerer.install_user_steer(
+    returned = await steerer.plans.install_user_steer(
         drift=drift,
         prior=prior,
         llm_revision=llm_revision,
@@ -516,7 +516,7 @@ async def test_install_user_steer_falls_back_on_invalid_llm_revision(
     drift = _drift()
 
     caplog.set_level(logging.WARNING, logger="goldfive.steerer")
-    returned = await steerer.install_user_steer(
+    returned = await steerer.plans.install_user_steer(
         drift=drift,
         prior=prior,
         llm_revision=invalid,
@@ -558,7 +558,7 @@ async def test_install_user_steer_does_not_touch_refine_outcomes() -> None:
     )
 
     drift = _drift()
-    await steerer.install_user_steer(
+    await steerer.plans.install_user_steer(
         drift=drift,
         prior=prior,
         llm_revision=invalid,
@@ -579,7 +579,7 @@ async def test_install_user_steer_swaps_session_plan() -> None:
     session = _new_session(prior)
     drift = _drift()
 
-    returned = await steerer.install_user_steer(
+    returned = await steerer.plans.install_user_steer(
         drift=drift,
         prior=prior,
         llm_revision=None,

--- a/tests/test_wrap_adk.py
+++ b/tests/test_wrap_adk.py
@@ -427,7 +427,7 @@ async def test_per_turn_boundary_does_not_call_steerer_shutdown(
     stub_call_llm: Any,
 ) -> None:
     """``_run_async_impl``'s ``finally`` MUST NOT invoke
-    ``steerer.shutdown`` (goldfive#319).
+    ``steerer.drift.shutdown`` (goldfive#319).
 
     The previous Phase 2.X drain called ``shutdown(timeout=0.5)`` at
     every adk-web outer-turn boundary, which fired ``task.cancel()`` on
@@ -472,7 +472,7 @@ async def test_per_turn_boundary_does_not_call_steerer_shutdown(
     [evt async for evt in wrapped._run_async_impl(ctx)]
 
     assert shutdown_call_count == 0, (
-        "per-turn ``_run_async_impl`` must not call ``steerer.shutdown`` "
+        "per-turn ``_run_async_impl`` must not call ``steerer.drift.shutdown`` "
         "(goldfive#319 regression: that cancels in-flight background "
         f"judges). Got {shutdown_call_count} call(s)."
     )

--- a/tests/test_wrap_goal_drift_wiring.py
+++ b/tests/test_wrap_goal_drift_wiring.py
@@ -537,7 +537,7 @@ async def test_goal_drift_judge_fires_when_wired() -> None:
 
     # Below interval -- no judge call yet.
     for _ in range(2):
-        await steerer.note_agent_turn(session)
+        await steerer.drift.note_agent_turn(session)
     # Drain any spawned judges (none expected below interval) so the
     # call-llm count assertion is post-judge.
     pending = list(steerer._background_judges)
@@ -546,7 +546,7 @@ async def test_goal_drift_judge_fires_when_wired() -> None:
     assert len(call_llm.calls) == 0  # type: ignore[attr-defined]
 
     # Third turn crosses the interval -> judge fires, drift is emitted.
-    await steerer.note_agent_turn(session)
+    await steerer.drift.note_agent_turn(session)
     pending = list(steerer._background_judges)
     if pending:
         await asyncio.gather(*pending, return_exceptions=True)


### PR DESCRIPTION
## Summary

Post-Wave-C facade cleanup. ``DefaultSteerer`` had ~80+ router shims
that were one-line delegations to the underlying components
(``TaskStateMachine`` / ``PlanReviser`` / ``DriftObserver``). This PR
collapses them and exposes the three components as public properties:

* ``steerer.tasks`` — ``TaskStateMachine`` (mark_task_*, cascade_cancel_downstream)
* ``steerer.plans`` — ``PlanReviser`` (install_*, _apply_revision, _emit_plan_revised)
* ``steerer.drift`` — ``DriftObserver`` (observe, observe_reasoning, detect_drift, handle_drift, request_invocation_cancel)

### Before

```python
await steerer.mark_task_failed(task_id, reason="x", session=s)
await steerer.observe(event, session)
await steerer._emit_plan_revised(session, revised, drift)
await steerer.install_initial_plan(session=s, plan=p)
```

### After

```python
await steerer.tasks.mark_task_failed(task_id, reason="x", session=s)
await steerer.drift.observe(event, session)
await steerer.plans._emit_plan_revised(session, revised, drift)
await steerer.plans.install_initial_plan(session=s, plan=p)
```

### Numbers

* **Callsite migrations**: ~561 across 74 files (executors, Runner,
  adapters, reporting handlers, planners, tests).
* **Code reduction**: ``goldfive/steerer.py`` from 2046 → 994 lines
  (-1052 lines net; 1080 deletions, 28 additions).
* **Total diff**: 98 files changed, 1551 insertions, 2161 deletions.

### Re-exports dropped

* ``REFLECTIVE_SYSTEM_PROMPT`` / ``REFLECTIVE_USER_PROMPT_TEMPLATE`` /
  ``REFLECTIVE_MAX_OUTPUT_TOKENS`` (canonical lives on
  ``DriftObserver``).
* ``_TERMINAL_DRIFT_KINDS`` / ``_USER_AUTHORED_DRIFT_KINDS`` /
  ``_USER_OR_TRAJECTORY_DRIFT_KINDS`` / ``_JSON_OBJECT_RE`` /
  ``_GOAL_DRIFT_TASK_BOUNDARY_MIN_INTERVAL_S`` (canonical on
  ``DriftObserver``).
* Two test files updated to reference ``DriftObserver.REFLECTIVE_MAX_OUTPUT_TOKENS``
  directly.

### Retained on ``DefaultSteerer``

* ``REFINE_FAILURE_THRESHOLD`` / ``PROGRESS_STALL_THRESHOLD_SECONDS`` —
  canonical knobs that both components and external test fixtures
  read.
* ``transition`` — router-level fan-out helper to
  ``self.tasks.mark_task_*``.
* ``_should_inject``, ``_find_task``, ``_new_envelope``, ``_emit``,
  ``_drift_kind_pb_value``, ``_drift_severity_pb_value`` — router-
  level helpers that aren't owned by a single component.
* ``bind`` / ``bind_adapter`` / ``bind_control_channel`` /
  ``get_tool_loop_config`` / ``_dispatch_goldfive_control`` /
  ``_span_context_for_planner`` /
  ``_emit_planner_refine_validation_failed`` — wiring + cross-cutting
  hooks that aren't pure pass-throughs.

### Protocol change (BREAKING)

``Steerer`` protocol updated to expose ``tasks`` / ``plans`` /
``drift`` slots; ``observe`` / ``detect_drift`` /
``cascade_cancel_downstream`` removed from the protocol surface
(callers reach them via the components).

**Custom Steerer implementations must now expose** ``tasks`` / ``plans`` /
``drift`` attributes (typed ``Any`` in the protocol). Subclass-override
of ``detect_drift``/``observe``/``cascade_cancel_downstream`` on
``DefaultSteerer`` no longer takes effect — the router shims that
dispatched into the override are gone; custom detection logic lives on
``DriftObserver``. Tests that previously subclassed ``DefaultSteerer``
to override these methods migrate to either (a) wrapping
``self.drift.detect_drift`` in ``__init__``, or (b) assigning onto
``steerer.drift.X`` directly (``.drift`` is public surface now).

### Docs updated

* ``docs/design/STATE-MACHINE.md`` — component layout + cascade
  ownership refs.
* ``docs/design/STATE-OWNERSHIP-CONTRACT.md`` — line-pointer moved for
  the ``KEY_CURRENT_TASK_ID`` write that travelled from
  ``steerer.py`` → ``plan_reviser.py``.
* ``docs/design/PROTOCOLS.md`` — Steerer protocol pseudo-code +
  MinimalSteerer example regenerated for the new shape.

## Test plan

- [x] Full pytest suite: **2543 passed, 59 skipped, 0 failed** in 30s.
- [x] Verified ``DefaultSteerer().tasks`` / ``.plans`` / ``.drift``
      resolve to the three component classes.
- [x] Verified the ``Steerer`` protocol structural check accepts
      ``DefaultSteerer`` (and a minimal stub with ``tasks`` /
      ``plans`` / ``drift`` attributes).
- [x] Confirmed no stray ``steerer._task_state_machine`` /
      ``steerer._plan_reviser`` / ``steerer._drift_observer`` private
      attr references remain.
- [x] Confirmed ``_state_audit.py`` catalog has no entries pointing
      at the old steerer.py method lines.

Behavior unchanged — pure structural rename.
