### PR TITLE
fix(example/presentation): close debugger cascade footgun (closes #416 #417 #418)

### DIFF
--- a/examples/presentation_agent/agent.py
+++ b/examples/presentation_agent/agent.py
@@ -59,7 +59,7 @@ try:
     from google.adk.models.base_llm import BaseLlm
     from google.adk.models.llm_request import LlmRequest
     from google.adk.models.llm_response import LlmResponse
-    from google.adk.tools import AgentTool, FunctionTool
+    from google.adk.tools import AgentTool, FunctionTool, ToolContext
     from google.genai import types as genai_types
 except ImportError as _adk_err:  # pragma: no cover
     raise SystemExit("install goldfive[adk] to run this example") from _adk_err
@@ -75,16 +75,56 @@ log = logging.getLogger(__name__)
 # Tools — write / read / patch the generated presentation files.
 # Output resolves under this module's directory to match harmonograf's
 # reference tree so the two stay byte-compatible.
+#
+# Each tool scopes its filesystem effects under
+# ``output/<session_id>/`` (see ``_session_output_dir``). The session id
+# comes from the ADK ``ToolContext`` so concurrent runs never see each
+# other's artifacts and ``find_presentation_files`` never lists stale
+# directories from prior runs (which the LLM was treating as actionable
+# "candidate topics" — see #416 / #417).
 # ---------------------------------------------------------------------------
 
 
+def _session_output_dir(tool_context: ToolContext | None) -> str:
+    """Resolve ``output/<session_id>/`` for the current run.
+
+    ``tool_context`` is the ADK ``ToolContext`` (FunctionTool injects it
+    when a parameter named ``tool_context`` is present). When the context
+    is unavailable — e.g. the tool is unit-tested without an ADK runner —
+    we fall back to ``output/_default/`` so calls remain deterministic
+    and don't pollute the bare ``output/`` root.
+    """
+    session_id = "_default"
+    if tool_context is not None:
+        try:
+            sid = tool_context.session.id  # type: ignore[union-attr]
+            if sid:
+                session_id = str(sid)
+        except AttributeError:
+            # ``ToolContext`` shape varies across ADK versions; treat any
+            # missing attribute as "no session" and fall through to the
+            # default bucket.
+            pass
+    # Sanitise — session ids are arbitrary strings and we're using them
+    # as a path component.
+    safe = session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+    return os.path.realpath(
+        os.path.join(os.path.dirname(__file__), "output", safe)
+    )
+
+
 def write_webpage(
-    topic: str, html_content: str, css_content: str, js_content: str
+    topic: str,
+    html_content: str,
+    css_content: str,
+    js_content: str,
+    tool_context: ToolContext | None = None,
 ) -> str:
-    """Write an interactive webpage (HTML, CSS, JS) under ``output/``."""
+    """Write an interactive webpage (HTML, CSS, JS) under ``output/<session>/``."""
     try:
         topic_filename = topic.lower().replace(" ", "_").replace("/", "_")
-        output_dir = os.path.join(os.path.dirname(__file__), "output", topic_filename)
+        base_dir = _session_output_dir(tool_context)
+        output_dir = os.path.join(base_dir, topic_filename)
         os.makedirs(output_dir, exist_ok=True)
 
         with open(os.path.join(output_dir, "index.html"), "w") as f:
@@ -99,10 +139,13 @@ def write_webpage(
         return f"Error writing file: {e}"
 
 
-def read_presentation_files(topic: str) -> dict[str, str]:
+def read_presentation_files(
+    topic: str, tool_context: ToolContext | None = None
+) -> dict[str, str]:
     """Read the generated presentation files and return name → contents."""
     topic_filename = topic.lower().replace(" ", "_").replace("/", "_")
-    output_dir = os.path.join(os.path.dirname(__file__), "output", topic_filename)
+    base_dir = _session_output_dir(tool_context)
+    output_dir = os.path.join(base_dir, topic_filename)
     files: dict[str, str] = {}
     for name in ("index.html", "styles.css", "script.js"):
         path = os.path.join(output_dir, name)
@@ -114,22 +157,35 @@ def read_presentation_files(topic: str) -> dict[str, str]:
     return files
 
 
-def find_presentation_files(topic: str) -> dict[str, Any]:
+def find_presentation_files(
+    topic: str, tool_context: ToolContext | None = None
+) -> dict[str, Any]:
     """Locate the generated presentation directory by fuzzy-matching ``topic``.
 
     The web developer often slugifies an embellished topic (e.g.
     ``"NAND Flash Memory Presentation"`` → ``nand_flash_memory_presentation``)
     while the reviewer asks for the bare slug (``nand_flash_memory``). This
-    tool searches ``output/`` for a directory whose name either contains the
-    bare slug or, after stripping the common ``_presentation`` /
-    ``_interactive_presentation`` / ``_slideshow`` suffixes, equals it. On a
-    match it reads the three presentation files and returns their contents.
+    tool searches ``output/<session_id>/`` for a directory whose name
+    either contains the bare slug or, after stripping the common
+    ``_presentation`` / ``_interactive_presentation`` / ``_slideshow``
+    suffixes, equals it. On a match it reads the three presentation
+    files and returns their contents.
+
+    On a miss it returns ``{"found": False}`` with **no** ``candidates``
+    list. Prior to #416 we returned ``candidates=<all session subdirs>``
+    and the LLM treated that list as actionable alternative topics, which
+    caused multi-call cascades on cherry-tree sessions when stale
+    directories from older runs were visible. Per-session scoping (#417)
+    plus dropping ``candidates`` (#416) together close that footgun.
+    Operators who want a directory listing can call the separate
+    ``list_presentation_directory`` helper below; it is intentionally NOT
+    registered to the debugger.
     """
     topic_slug = topic.lower().replace(" ", "_").replace("/", "_")
-    base_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), "output"))
+    base_dir = _session_output_dir(tool_context)
 
     if not os.path.isdir(base_dir):
-        return {"found": False, "candidates": []}
+        return {"found": False}
 
     suffixes = ("_interactive_presentation", "_presentation", "_slideshow")
     entries = sorted(
@@ -150,7 +206,7 @@ def find_presentation_files(topic: str) -> dict[str, Any]:
             break
 
     if match is None:
-        return {"found": False, "candidates": entries}
+        return {"found": False}
 
     candidate_dir = os.path.realpath(os.path.join(base_dir, match))
     # Defence in depth: refuse anything that escaped the sandbox via symlink.
@@ -158,7 +214,7 @@ def find_presentation_files(topic: str) -> dict[str, Any]:
         candidate_dir == base_dir
         or candidate_dir.startswith(base_dir + os.sep)
     ):
-        return {"found": False, "candidates": entries}
+        return {"found": False}
 
     files: dict[str, str] = {}
     for fname in ("index.html", "styles.css", "script.js"):
@@ -172,15 +228,38 @@ def find_presentation_files(topic: str) -> dict[str, Any]:
     return {"found": True, "directory": candidate_dir, "files": files}
 
 
-def patch_file(path: str, new_content: str) -> str:
+def list_presentation_directory(
+    tool_context: ToolContext | None = None,
+) -> dict[str, Any]:
+    """Operator-only: list the subdirectories of ``output/<session_id>/``.
+
+    Deliberately NOT registered to ``debugger_agent`` — exposing this to
+    the model recreates the #416 footgun (the LLM treats raw directory
+    names as actionable alternative topics). Useful for offline scripts
+    that want to inventory a session's artifacts.
+    """
+    base_dir = _session_output_dir(tool_context)
+    if not os.path.isdir(base_dir):
+        return {"directory": base_dir, "entries": []}
+    entries = sorted(
+        name
+        for name in os.listdir(base_dir)
+        if os.path.isdir(os.path.join(base_dir, name))
+    )
+    return {"directory": base_dir, "entries": entries}
+
+
+def patch_file(
+    path: str, new_content: str, tool_context: ToolContext | None = None
+) -> str:
     """Overwrite ``path`` with ``new_content`` in place.
 
-    Relative paths resolve against ``output/`` so the debugger cannot
-    scribble outside the sandbox.
+    Relative paths resolve against ``output/<session_id>/`` so the
+    debugger cannot scribble outside the per-session sandbox.
     """
     try:
         if not os.path.isabs(path):
-            path = os.path.join(os.path.dirname(__file__), "output", path)
+            path = os.path.join(_session_output_dir(tool_context), path)
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:
             f.write(new_content)
@@ -327,11 +406,13 @@ def _build_agent_tree(model: Any) -> Agent:
             "``find_presentation_files`` tool with the topic the reviewer "
             "tried. If it returns ``found=True``, report the discovered "
             "absolute directory and the file contents back to the "
-            "coordinator so the review can proceed at that path. If it "
-            "returns ``found=False``, report the candidate directory list "
-            "back to the coordinator so it can re-dispatch the developer "
-            "with the correct topic — do not attempt to patch files you "
-            "have not located."
+            "coordinator so the review can proceed at that path. If "
+            "``find_presentation_files`` returns ``found=False``, do NOT "
+            "call it again with a guessed or alternative topic — that will "
+            "only loop. Report the failure (and the exact ``topic`` string "
+            "you tried) back to the coordinator immediately so it can "
+            "re-dispatch the developer with the correct topic. Do not "
+            "attempt to patch files you have not located."
         ),
         description=(
             "A debugger agent that either patches generated presentation "

--- a/tests/examples/test_presentation_agent.py
+++ b/tests/examples/test_presentation_agent.py
@@ -109,3 +109,288 @@ def test_adk_web_wrapped_app_name_is_identifier() -> None:
 
     assert app.name == "goldfive_wrapped_demo"
     assert app.name.isidentifier()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the debugger-cascade fix (#416 / #417 / #418).
+# The cherry-tree e2e session 2d27ff4a (2026-05-13) hit a 20+ tool-call
+# cascade caused by:
+#   #416 — find_presentation_files returned ``candidates`` on miss; the
+#          LLM treated it as a list of actionable alternative topics.
+#   #417 — output/ was process-wide so the candidate list leaked stale
+#          directories from prior sessions.
+#   #418 — the debugger instruction lacked the reviewer's anti-loop
+#          clause so it kept retrying with guessed topics.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """Stand-in for ADK ``Session`` exposing only ``.id``."""
+
+    def __init__(self, sid: str) -> None:
+        self.id = sid
+
+
+class _FakeToolContext:
+    """Stand-in for ADK ``ToolContext`` exposing only ``.session.id``.
+
+    The agent's ``_session_output_dir`` only reads ``tool_context.session.id``;
+    nothing else needs to be wired for these tests.
+    """
+
+    def __init__(self, sid: str) -> None:
+        self.session = _FakeSession(sid)
+
+
+def test_find_presentation_files_miss_returns_no_candidates(
+    tmp_path, monkeypatch
+) -> None:
+    """#416 regression: a miss must NOT include ``candidates``.
+
+    The LLM was treating ``candidates`` as actionable alternative topics
+    and looping. Reading the field by accident from a miss response is
+    the footgun we are closing.
+    """
+    from examples.presentation_agent import agent as agent_mod
+
+    # Redirect output/ to a tmp_path so this test never touches the repo.
+    monkeypatch.setattr(
+        agent_mod, "__file__", str(tmp_path / "agent.py")
+    )
+
+    ctx = _FakeToolContext(sid="session-empty")
+
+    result = agent_mod.find_presentation_files("cherry trees", tool_context=ctx)
+    assert result == {"found": False}, (
+        f"Expected bare {{found: False}}, got {result!r}. "
+        "If you re-introduce a candidates list the LLM will retry with "
+        "alternative topics — see issue #416."
+    )
+    assert "candidates" not in result
+
+
+def test_find_presentation_files_miss_with_existing_dirs_still_no_candidates(
+    tmp_path, monkeypatch
+) -> None:
+    """#416 / #417 regression: even when the session dir exists and has
+    sibling directories from previous topics in the same session, a miss
+    must not echo their names back to the model."""
+    from examples.presentation_agent import agent as agent_mod
+
+    fake_module_dir = tmp_path / "presentation_agent"
+    fake_module_dir.mkdir()
+    monkeypatch.setattr(
+        agent_mod, "__file__", str(fake_module_dir / "agent.py")
+    )
+
+    ctx = _FakeToolContext(sid="session-with-prior-work")
+    base_dir = fake_module_dir / "output" / "session-with-prior-work"
+    base_dir.mkdir(parents=True)
+    (base_dir / "pothos_plants_presentation").mkdir()
+    (base_dir / "nand_flash_memory_presentation").mkdir()
+
+    result = agent_mod.find_presentation_files("cherry trees", tool_context=ctx)
+    assert result == {"found": False}
+    assert "candidates" not in result
+    # Sanity: the directories really do exist, so the old code WOULD have
+    # returned them — this test wouldn't be load-bearing otherwise.
+    assert any(base_dir.iterdir())
+
+
+def test_per_session_output_dir_isolation(tmp_path, monkeypatch) -> None:
+    """#417 regression: two distinct session_ids must not see each other's
+    presentation files via ``find_presentation_files``."""
+    from examples.presentation_agent import agent as agent_mod
+
+    fake_module_dir = tmp_path / "presentation_agent"
+    fake_module_dir.mkdir()
+    monkeypatch.setattr(
+        agent_mod, "__file__", str(fake_module_dir / "agent.py")
+    )
+
+    ctx_a = _FakeToolContext(sid="session-A")
+    ctx_b = _FakeToolContext(sid="session-B")
+
+    # Session A writes a cherry-trees presentation.
+    write_a = agent_mod.write_webpage(
+        topic="cherry trees",
+        html_content="<html>A</html>",
+        css_content="body{}",
+        js_content="//A",
+        tool_context=ctx_a,
+    )
+    assert "Successfully" in write_a, write_a
+
+    # Session B writes a pothos presentation.
+    write_b = agent_mod.write_webpage(
+        topic="pothos plants",
+        html_content="<html>B</html>",
+        css_content="body{}",
+        js_content="//B",
+        tool_context=ctx_b,
+    )
+    assert "Successfully" in write_b, write_b
+
+    # Session A asking for pothos must NOT find session B's directory.
+    miss_b_from_a = agent_mod.find_presentation_files(
+        "pothos plants", tool_context=ctx_a
+    )
+    assert miss_b_from_a == {"found": False}, miss_b_from_a
+
+    # Session B asking for cherry trees must NOT find session A's directory.
+    miss_a_from_b = agent_mod.find_presentation_files(
+        "cherry trees", tool_context=ctx_b
+    )
+    assert miss_a_from_b == {"found": False}, miss_a_from_b
+
+    # Each session CAN find its own work.
+    hit_a = agent_mod.find_presentation_files("cherry trees", tool_context=ctx_a)
+    assert hit_a["found"] is True
+    assert hit_a["files"]["index.html"] == "<html>A</html>"
+
+    hit_b = agent_mod.find_presentation_files("pothos plants", tool_context=ctx_b)
+    assert hit_b["found"] is True
+    assert hit_b["files"]["index.html"] == "<html>B</html>"
+
+
+def test_read_presentation_files_respects_session_scope(
+    tmp_path, monkeypatch
+) -> None:
+    """#417 regression: ``read_presentation_files`` reads from the
+    session-scoped directory; cross-session reads must miss."""
+    from examples.presentation_agent import agent as agent_mod
+
+    fake_module_dir = tmp_path / "presentation_agent"
+    fake_module_dir.mkdir()
+    monkeypatch.setattr(
+        agent_mod, "__file__", str(fake_module_dir / "agent.py")
+    )
+
+    ctx_writer = _FakeToolContext(sid="writer-session")
+    ctx_reader = _FakeToolContext(sid="reader-session")
+
+    agent_mod.write_webpage(
+        topic="waffles",
+        html_content="<html>waffles</html>",
+        css_content="body{}",
+        js_content="//w",
+        tool_context=ctx_writer,
+    )
+
+    # Same session reads back ok.
+    same = agent_mod.read_presentation_files("waffles", tool_context=ctx_writer)
+    assert same["index.html"] == "<html>waffles</html>"
+
+    # Different session sees error markers, not the writer's content.
+    cross = agent_mod.read_presentation_files("waffles", tool_context=ctx_reader)
+    assert "<error reading" in cross["index.html"]
+
+
+def test_patch_file_respects_session_scope(tmp_path, monkeypatch) -> None:
+    """#417 regression: ``patch_file`` with a relative path resolves under
+    the session-scoped output directory, not the bare ``output/`` root."""
+    from examples.presentation_agent import agent as agent_mod
+
+    fake_module_dir = tmp_path / "presentation_agent"
+    fake_module_dir.mkdir()
+    monkeypatch.setattr(
+        agent_mod, "__file__", str(fake_module_dir / "agent.py")
+    )
+
+    ctx = _FakeToolContext(sid="patch-session")
+    result = agent_mod.patch_file(
+        path="waffles/index.html",
+        new_content="<html>patched</html>",
+        tool_context=ctx,
+    )
+    assert "Successfully patched" in result, result
+
+    written_path = (
+        fake_module_dir / "output" / "patch-session" / "waffles" / "index.html"
+    )
+    assert written_path.exists()
+    assert written_path.read_text() == "<html>patched</html>"
+
+    # The bare output/ root must NOT contain a sibling 'waffles' directory.
+    bare_path = fake_module_dir / "output" / "waffles" / "index.html"
+    assert not bare_path.exists()
+
+
+def test_debugger_instruction_has_anti_loop_clause() -> None:
+    """#418 regression: the debugger instruction must explicitly forbid
+    retrying ``find_presentation_files`` with an alternative topic, mirroring
+    the reviewer's anti-loop prohibition."""
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_request import LlmRequest
+    from google.adk.models.llm_response import LlmResponse
+    from google.genai import types as genai_types
+
+    class _Mock(BaseLlm):
+        @classmethod
+        def supported_models(cls):  # type: ignore[override]
+            return [r"mock/.*"]
+
+        async def generate_content_async(  # type: ignore[override]
+            self, llm_request: LlmRequest, stream: bool = False
+        ):
+            yield LlmResponse(
+                content=genai_types.Content(
+                    role="model",
+                    parts=[genai_types.Part(text="ok")],
+                ),
+                partial=False,
+                turn_complete=True,
+            )
+
+    from examples.presentation_agent import _build_agent_tree
+
+    coordinator = _build_agent_tree(_Mock(model="mock/test"))
+    debugger = next(
+        t.agent for t in coordinator.tools if t.agent.name == "debugger_agent"
+    )
+    instr = debugger.instruction
+    # The clause must mention BOTH ``find_presentation_files`` and the
+    # do-not-retry-with-alternative-topic prohibition.
+    assert "find_presentation_files" in instr
+    assert "do NOT" in instr or "do not" in instr.lower()
+    assert "alternative topic" in instr or "alternative" in instr
+    assert "loop" in instr
+
+
+def test_list_presentation_directory_not_registered_to_debugger() -> None:
+    """``list_presentation_directory`` is operator-only — exposing it to
+    the debugger would recreate the #416 footgun. Pin that it's not on
+    the debugger's tool list."""
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_request import LlmRequest
+    from google.adk.models.llm_response import LlmResponse
+    from google.genai import types as genai_types
+
+    class _Mock(BaseLlm):
+        @classmethod
+        def supported_models(cls):  # type: ignore[override]
+            return [r"mock/.*"]
+
+        async def generate_content_async(  # type: ignore[override]
+            self, llm_request: LlmRequest, stream: bool = False
+        ):
+            yield LlmResponse(
+                content=genai_types.Content(
+                    role="model",
+                    parts=[genai_types.Part(text="ok")],
+                ),
+                partial=False,
+                turn_complete=True,
+            )
+
+    from examples.presentation_agent import _build_agent_tree
+
+    coordinator = _build_agent_tree(_Mock(model="mock/test"))
+    debugger = next(
+        t.agent for t in coordinator.tools if t.agent.name == "debugger_agent"
+    )
+    tool_names = {
+        getattr(t, "name", None) or getattr(getattr(t, "func", None), "__name__", "")
+        for t in debugger.tools
+    }
+    assert "list_presentation_directory" not in tool_names


### PR DESCRIPTION
## Motivation

The cherry-tree e2e session [2d27ff4a](https://github.com/pedapudi/goldfive/issues/416) (2026-05-13) produced a 20+ off-goal tool-call cascade — `find_presentation_files("pothos")`, `find_presentation_files("nand flash memory")`, etc. — plus 11 downstream `OFF_TOPIC` drift events. Root cause: three coupled bugs in the example presentation agent, all visible in the same call sequence.

## Summary

### #416 — `find_presentation_files` API footgun
On a miss the tool returned `{"found": False, "candidates": <all output subdirs>}`. The LLM read `candidates` as a list of actionable alternative topics and retried. Fixed by dropping `candidates` from the miss response entirely. The bare miss is now `{"found": False}` — no information the LLM can mistake for instructions. A separate `list_presentation_directory()` helper is exposed for operator inventory; it is intentionally **not** registered to the debugger.

### #417 — Cross-session output pollution
`output/` was process-wide, so stale directories from prior runs (`brussels_sprouts_presentation/`, `cauliflower_presentation/`, `pothos_plants/`, …) accumulated and leaked into every session's `find_presentation_files` view. Fixed by scoping all four tools (`write_webpage` / `read_presentation_files` / `find_presentation_files` / `patch_file`) to `output/<session_id>/`. The session id is sourced from the ADK `ToolContext` (FunctionTool auto-injects by parameter name) with a `_default` fallback for offline tests. Existing data in `output/` is left untouched — new runs simply write to a new path.

### #418 — Missing anti-loop instruction
The reviewer already had `"Do NOT call read_presentation_files again with a guessed alternative topic — that will only loop."`; the debugger had no equivalent prohibition. Added a matching clause to the debugger instruction. Defence in depth: even if a future change re-introduces candidate-shaped data, the instruction forbids the retry pattern.

## Test coverage

7 new regression tests in `tests/examples/test_presentation_agent.py`:

- `test_find_presentation_files_miss_returns_no_candidates` — pins the bare `{"found": False}` shape on an empty session.
- `test_find_presentation_files_miss_with_existing_dirs_still_no_candidates` — even with sibling directories in the same session, miss responses never echo their names.
- `test_per_session_output_dir_isolation` — two distinct session ids cannot see each other's presentation files.
- `test_read_presentation_files_respects_session_scope` — cross-session reads miss; same-session reads hit.
- `test_patch_file_respects_session_scope` — relative paths resolve under `output/<session_id>/`, not the bare root.
- `test_debugger_instruction_has_anti_loop_clause` — pins the new `do NOT / alternative / loop` clause is present.
- `test_list_presentation_directory_not_registered_to_debugger` — pins the operator helper is not on the debugger's tool list.

## Test results

```
2552 passed, 59 skipped, 48 warnings in 27.97s
```

`ruff check` clean.

## Test plan

- [x] All 12 tests in `tests/examples/test_presentation_agent.py` pass (5 existing + 7 new).
- [x] Full goldfive suite passes (`pytest tests/ -x --tb=short`).
- [x] `ruff check examples/presentation_agent/agent.py tests/examples/test_presentation_agent.py` clean.
- [ ] Re-run the cherry-tree e2e against this branch and confirm no debugger cascade.

## Scope

Touches only `examples/presentation_agent/agent.py` and its test file. No changes to `goldfive/` core or `harmonograf/` (harmonograf consumes the example by absolute file path, so the fix propagates automatically).