### PR TITLE
refactor(drift_observer): merge recent_agent_activity + recent_tool_observations into recent_events

### DIFF
--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -537,10 +537,11 @@ class GoalDriftConfig:
     """Scheduling for the trajectory-level GOAL_DRIFT judge (#143).
 
     ``check_interval`` is the number of agent-invocation turns between
-    judge calls; ``activity_window`` bounds
-    ``session.recent_agent_activity`` and hence the prompt size. Both
-    were previously ``DefaultSteerer`` kwargs with no env or
-    ``wrap()``-level override; this config surfaces them.
+    judge calls; ``activity_window`` bounds the agent-activity subset of
+    ``session.recent_events`` (goldfive#239 — the unified buffer that
+    replaced the historical ``recent_agent_activity``) and hence the
+    prompt size. Both were previously ``DefaultSteerer`` kwargs with no
+    env or ``wrap()``-level override; this config surfaces them.
     """
 
     check_interval: int = 5

--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -53,7 +53,13 @@ from goldfive.drift.reasoning_judge import (
     classify_reasoning_drift,  # noqa: F401 — re-export consumed by tests
     classify_reasoning_drift_with_focus,
 )
-from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+from goldfive.types import (
+    RECENT_EVENT_KIND_TOOL_OBSERVED,
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    filter_recent_events_by_kind,
+)
 
 if TYPE_CHECKING:
     from goldfive.config import ReasoningDriftConfig
@@ -1017,10 +1023,21 @@ async def _run_judge_with_focus(
     task = _current_task(session)
     # iter-10 PR 3: surface lineage + recent tool observations to the
     # judge as additional context. ``task_lineage`` was added in iter-9
-    # (#344); ``recent_tool_observations`` was added in iter-10 PR 2
+    # (#344); recent tool observations were added in iter-10 PR 2
     # (#347). Both are passed by attribute lookup so older Session
     # snapshots without the fields still parse cleanly (the helpers
     # treat None as "no data").
+    # Goldfive#239: the dedicated ``recent_tool_observations`` buffer
+    # was merged into :attr:`Session.recent_events`; filter to the
+    # ``tool_observed`` kind here so the judge prompt sees the same
+    # subset it saw pre-merge (the kwarg name is preserved for the
+    # public ``classify_reasoning_drift*`` API).
+    recent_events_attr = getattr(session, "recent_events", None)
+    tool_obs = (
+        filter_recent_events_by_kind(recent_events_attr, RECENT_EVENT_KIND_TOOL_OBSERVED)
+        if recent_events_attr
+        else None
+    )
     return await classify_reasoning_drift_with_focus(
         reasoning=text,
         task=task,
@@ -1035,7 +1052,7 @@ async def _run_judge_with_focus(
         session_id=session.id,
         sequence_fn=session.next_sequence,
         task_lineage=getattr(session, "task_lineage", None),
-        recent_tool_observations=getattr(session, "recent_tool_observations", None),
+        recent_tool_observations=tool_obs,
         available_agents=available_agents,
     )
 

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -149,6 +149,8 @@ from goldfive.drift import (
     classify_tool_error,
 )
 from goldfive.types import (
+    RECENT_EVENT_AGENT_ACTIVITY_KINDS,
+    RECENT_EVENT_KIND_TOOL_OBSERVED,
     CancellationRequest,
     DriftEvent,
     DriftKind,
@@ -157,6 +159,7 @@ from goldfive.types import (
     Session,
     Task,
     TaskStatus,
+    filter_recent_events_by_kind,
 )
 
 if TYPE_CHECKING:
@@ -783,7 +786,8 @@ class DriftObserver:
     def _summarize_recent_tool_calls(session: Session, *, limit: int = 10) -> str:
         """Build a short human-readable summary of the last N tool calls.
 
-        Reads from ``session.recent_tool_observations`` (populated by
+        Reads from ``session.recent_events`` filtered to
+        ``tool_observed`` kinds (populated by
         :meth:`note_tool_observation` from the adapter's
         ``after_tool_callback`` / ``on_tool_error_callback`` hooks).
         Falls back to "(no recent tool calls)" when the buffer is empty.
@@ -797,7 +801,8 @@ class DriftObserver:
 
         Adapters that want richer summaries can subclass and override.
         """
-        hist = getattr(session, "recent_tool_observations", None) or []
+        events = getattr(session, "recent_events", None) or []
+        hist = filter_recent_events_by_kind(events, RECENT_EVENT_KIND_TOOL_OBSERVED)
         if not hist:
             return "(no recent tool calls)"
         # Take the tail (most recent ``limit`` entries) oldest-first.
@@ -1935,9 +1940,15 @@ class DriftObserver:
 
         Push-only: adapters (or executors) call this once per
         ``AgentInvocationStarted`` / ``AgentInvocationCompleted`` so the
-        GOAL_DRIFT judge has a rolling view of the trajectory. The ring
-        buffer is trimmed to ``goal_drift_activity_window`` so the
-        prompt stays bounded regardless of run length.
+        GOAL_DRIFT judge has a rolling view of the trajectory.
+
+        Goldfive#239: writes into the unified
+        :attr:`Session.recent_events` buffer with the supplied ``kind``
+        (one of :data:`RECENT_EVENT_AGENT_ACTIVITY_KINDS`). Trimming is
+        per-kind-class: the agent-activity subset is trimmed to
+        ``goal_drift_activity_window`` so a flood of ``tool_observed``
+        entries cannot evict legitimate agent activity (and vice
+        versa) — preserves the pre-merge semantics exactly.
 
         Always safe to call (feature-gate is enforced at check time, not
         at record time) -- unlike :meth:`note_agent_turn`, this method
@@ -1956,11 +1967,13 @@ class DriftObserver:
             # Keep individual entries bounded so a pathological detail
             # cannot blow up the prompt even before trimming.
             entry["detail"] = detail[:500]
-        hist = session.recent_agent_activity
-        hist.append(entry)
-        overflow = len(hist) - self._steerer._goal_drift_activity_window
-        if overflow > 0:
-            del hist[:overflow]
+        events = session.recent_events
+        events.append(entry)
+        self._trim_recent_events_kind_class(
+            events,
+            RECENT_EVENT_AGENT_ACTIVITY_KINDS,
+            max(1, int(self._steerer._goal_drift_activity_window)),
+        )
 
     def note_tool_observation(
         self,
@@ -1973,7 +1986,7 @@ class DriftObserver:
         result: Any,
         error: Exception | str | None = None,
     ) -> None:
-        """Append a bounded tool-observation entry to ``session.recent_tool_observations``.
+        """Append a bounded tool-observation entry to ``session.recent_events``.
 
         Iter-10 PR 2. Population path for the three-state reasoning
         judge (PR 3 reads this buffer to distinguish a provoked
@@ -1982,10 +1995,13 @@ class DriftObserver:
         and ``on_tool_error_callback`` hooks.
 
         Push-only and trim-on-write — mirrors
-        :meth:`note_agent_activity`. The buffer is bounded by
-        ``session.recent_tool_observations_max`` (default 16) so the
-        prompt the judge eventually reads stays small regardless of
-        run length. Per-task filtering happens at READ time in the
+        :meth:`note_agent_activity`. Goldfive#239 merged the
+        previously-separate ``recent_tool_observations`` buffer into
+        :attr:`Session.recent_events`; entries are stamped with
+        ``kind="tool_observed"`` and the ``tool_observed`` subset is
+        trimmed to ``session.recent_tool_observations_max`` (default 16)
+        so the prompt the judge eventually reads stays small regardless
+        of run length. Per-task filtering happens at READ time in the
         judge's prompt renderer; this writer captures every call.
 
         Always swallow internal errors. Observability must never break
@@ -2026,6 +2042,7 @@ class DriftObserver:
                 except Exception:  # noqa: BLE001
                     error_message = "(unrepresentable error)"
             entry: dict[str, Any] = {
+                "kind": RECENT_EVENT_KIND_TOOL_OBSERVED,
                 "ts_ms": ts_ms,
                 "agent_name": agent_name,
                 "task_id": task_id,
@@ -2035,8 +2052,8 @@ class DriftObserver:
                 "is_error": is_error,
                 "error_message": error_message,
             }
-            hist = session.recent_tool_observations
-            hist.append(entry)
+            events = session.recent_events
+            events.append(entry)
             # Cap defaults to 16 (§3.1) but honour any session-local
             # override; clamp to >=1 so a pathological 0 / negative
             # value doesn't disable the buffer entirely (we always
@@ -2046,15 +2063,46 @@ class DriftObserver:
             except (TypeError, ValueError):
                 cap_raw = 16
             cap = max(1, cap_raw)
-            overflow = len(hist) - cap
-            if overflow > 0:
-                # Slice-delete is amortized O(1) on average for the
-                # bounded ``overflow == 1`` case (the steady state once
-                # the buffer is full), and is the same pattern
-                # ``note_agent_activity`` uses.
-                del hist[:overflow]
+            self._trim_recent_events_kind_class(
+                events, frozenset({RECENT_EVENT_KIND_TOOL_OBSERVED}), cap
+            )
         except Exception as exc:  # noqa: BLE001
             log.debug("note_tool_observation: swallowed: %s", exc)
+
+    @staticmethod
+    def _trim_recent_events_kind_class(
+        events: list[dict[str, Any]],
+        kinds: frozenset[str],
+        cap: int,
+    ) -> None:
+        """In-place trim entries of the given kind-class to ``cap``.
+
+        Goldfive#239: the unified :attr:`Session.recent_events` buffer
+        holds multiple event kinds (agent activity + tool observations).
+        Each kind-class is bounded by its own cap so a flood of one
+        kind cannot evict another. This helper finds the
+        oldest-first indices of entries whose ``kind`` is in ``kinds``
+        and drops the leading overflow.
+
+        ``cap`` must be ``>= 1`` — callers floor user-supplied values
+        before calling.
+
+        O(n) in the buffer length; both kind-classes have bounded caps
+        (10 / 16) so the buffer length is always small and the walk
+        is cheap.
+        """
+        if cap <= 0:
+            return
+        # Indices in order of insertion. Need only the leading overflow.
+        indices = [i for i, e in enumerate(events) if isinstance(e, dict) and e.get("kind") in kinds]
+        overflow = len(indices) - cap
+        if overflow <= 0:
+            return
+        # Drop the ``overflow`` oldest entries of this kind-class. We
+        # iterate from the highest index down so popping doesn't shift
+        # the indices we still need to drop.
+        for idx in sorted(indices[:overflow], reverse=True):
+            del events[idx]
 
     async def note_agent_turn(self, session: Session) -> None:
         """Record one agent invocation against ``session``.
@@ -2174,8 +2222,15 @@ class DriftObserver:
         from goldfive.drift.goals import classify_goal_drift
 
         # Snapshot activity so subsequent appends during the await do
-        # not perturb the prompt the judge saw.
-        activity = list(session.recent_agent_activity)
+        # not perturb the prompt the judge saw. Goldfive#239: read from
+        # the unified ``recent_events`` buffer, filtered to the
+        # agent-activity kinds the goal-drift judge expects (the
+        # legacy ``recent_agent_activity`` buffer carried exactly
+        # these kinds, so the snapshot is byte-identical to the
+        # pre-merge path).
+        activity = filter_recent_events_by_kind(
+            session.recent_events, RECENT_EVENT_AGENT_ACTIVITY_KINDS
+        )
         drift = await classify_goal_drift(
             goals=session.goals,
             plan=session.plan,

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -2094,7 +2094,11 @@ class DriftObserver:
         if cap <= 0:
             return
         # Indices in order of insertion. Need only the leading overflow.
-        indices = [i for i, e in enumerate(events) if isinstance(e, dict) and e.get("kind") in kinds]
+        indices = [
+            i
+            for i, e in enumerate(events)
+            if isinstance(e, dict) and e.get("kind") in kinds
+        ]
         overflow = len(indices) - cap
         if overflow <= 0:
             return

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -409,10 +409,13 @@ class DefaultSteerer:
         goal_drift_model:
             Model name forwarded to ``goal_drift_call_llm``.
         goal_drift_activity_window:
-            Number of recent-activity entries retained on
-            ``session.recent_agent_activity`` and passed to the
+            Number of agent-activity entries retained in the
+            ``recent_events`` buffer (goldfive#239) and passed to the
             judge. Bounds the prompt size; defaults to ``10`` when
-            ``goal_drift_config`` is also ``None``.
+            ``goal_drift_config`` is also ``None``. The ``tool_observed``
+            subset of the same buffer is bounded independently by
+            ``session.recent_tool_observations_max`` so a flood of one
+            kind cannot evict the other.
         goal_drift_config:
             Optional :class:`~goldfive.config.GoalDriftConfig` (see
             goldfive#225). When provided, its fields supply fallback

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1362,6 +1362,62 @@ class RefineOutcome:
     fail_count: int = 0
 
 
+# ---------------------------------------------------------------------------
+# Recent-events buffer (goldfive#239)
+# ---------------------------------------------------------------------------
+#
+# Constants + filtering helper for :attr:`Session.recent_events`. The buffer
+# unifies the historical ``recent_agent_activity`` (fed to the GOAL_DRIFT
+# judge) and ``recent_tool_observations`` (fed to the reasoning judge); each
+# entry is discriminated by its ``kind`` field.
+
+#: Recent-events kind: agent invocation started (was ``recent_agent_activity``).
+RECENT_EVENT_KIND_AGENT_STARTED: str = "agent_invocation_started"
+
+#: Recent-events kind: agent invocation completed (was ``recent_agent_activity``).
+RECENT_EVENT_KIND_AGENT_COMPLETED: str = "agent_invocation_completed"
+
+#: Recent-events kind: tool observation (was ``recent_tool_observations``).
+RECENT_EVENT_KIND_TOOL_OBSERVED: str = "tool_observed"
+
+#: Subset of kinds that the legacy ``recent_agent_activity`` buffer carried.
+#: Used by the goal-drift judge snapshot path (writers trim this group as a
+#: unit so the legacy ``goal_drift_activity_window`` semantics are preserved).
+RECENT_EVENT_AGENT_ACTIVITY_KINDS: frozenset[str] = frozenset(
+    {RECENT_EVENT_KIND_AGENT_STARTED, RECENT_EVENT_KIND_AGENT_COMPLETED}
+)
+
+
+def filter_recent_events_by_kind(
+    events: list[dict[str, Any]] | None,
+    kinds: str | frozenset[str] | set[str] | tuple[str, ...] | list[str],
+) -> list[dict[str, Any]]:
+    """Return the subset of ``events`` whose ``kind`` is in ``kinds``.
+
+    Preserves insertion order so callers get a stable snapshot. Tolerates
+    ``None`` / non-dict entries (returns an empty list / skips them) so
+    readers operating on a partially-initialised :class:`Session` cannot
+    raise. The returned list is a fresh copy — mutating it does NOT affect
+    the underlying buffer.
+
+    The accepted ``kinds`` shape mirrors common filter idioms: a single
+    string ``"tool_observed"`` for one-kind filters, or a collection of
+    strings (e.g. :data:`RECENT_EVENT_AGENT_ACTIVITY_KINDS`) for the
+    multi-kind case.
+    """
+    if not events:
+        return []
+    if isinstance(kinds, str):
+        accepted: frozenset[str] = frozenset({kinds})
+    else:
+        accepted = frozenset(kinds)
+    return [
+        e
+        for e in events
+        if isinstance(e, dict) and e.get("kind") in accepted
+    ]
+
+
 @dataclasses.dataclass
 class Session:
     """Live state for one Runner.run() invocation.
@@ -1492,14 +1548,22 @@ class Session:
     # No task-id scoping: GOAL_DRIFT is a trajectory-level signal, so the
     # counter persists across task transitions.
     _agent_turns_since_goal_check: int = 0
-    # Ring buffer of recent agent activity summaries fed to the
-    # :func:`goldfive.drift.classify_goal_drift` judge. Adapters push
-    # entries via ``DefaultSteerer.note_agent_activity``; the steerer
-    # trims to ``goal_drift_activity_window`` entries to bound the
-    # prompt. Each entry is a small dict (``kind``, ``agent_name``,
-    # ``task_id``, ``detail``) rather than a full event proto to keep
-    # this framework-neutral.
-    recent_agent_activity: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+    # Unified ring buffer of recent session events (goldfive#239). Holds
+    # entries previously split across ``recent_agent_activity`` (fed to
+    # the :func:`goldfive.drift.classify_goal_drift` judge) and
+    # ``recent_tool_observations`` (fed to the three-state reasoning
+    # judge). Each entry is a small framework-neutral ``dict`` with a
+    # ``kind`` discriminator — current kinds are
+    # ``agent_invocation_started`` / ``agent_invocation_completed``
+    # (the old agent-activity entries) and ``tool_observed`` (the old
+    # tool-observation entries). Adapters push entries via
+    # :meth:`DriftObserver.note_agent_activity` and
+    # :meth:`DriftObserver.note_tool_observation`; the writers trim
+    # **per kind-class** so a flood of tool observations cannot evict
+    # agent-activity entries (and vice versa). Readers filter by
+    # ``kind`` to recover the equivalent of the old buffers — see
+    # :func:`goldfive.types.filter_recent_events_by_kind`.
+    recent_events: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     # Monotonic-ish timestamp (``time.time()``, seconds since epoch) of the
     # last GOAL_DRIFT judge call fired via the task-boundary trigger
     # (goldfive#219). Prevents two task transitions <10s apart from paying
@@ -1573,27 +1637,15 @@ class Session:
     # the reasoning judge) can use this to distinguish "child of a
     # delegation chain rooted at the assignee" from "off-plan agent".
     task_lineage: dict[str, set[str]] = dataclasses.field(default_factory=dict)
-    # Ring buffer of recent tool-call observations consumed by the
-    # iter-10 three-state reasoning judge so it can distinguish a
-    # provoked deviation (the agent saw a tool error / surprising
-    # result and pivoted) from an unprovoked one. Adapters push
-    # entries via ``DefaultSteerer.note_tool_observation`` from their
-    # ``after_tool_callback`` / ``on_tool_error_callback`` hooks; the
-    # steerer trims to ``recent_tool_observations_max`` so the prompt
-    # stays bounded regardless of run length. Each entry is a small
-    # dict (``ts_ms``, ``agent_name``, ``task_id``, ``tool_name``,
-    # ``args_preview``, ``result_preview``, ``is_error``,
-    # ``error_message``) — framework-neutral, no protos, so sinks /
-    # tests can introspect cheaply. Per-task scoping is applied at
-    # READ time by the judge's prompt renderer (PR 3): writers store
-    # everything so a deviation rooted in an earlier task's artefact
-    # remains visible.
-    recent_tool_observations: list[dict[str, Any]] = dataclasses.field(default_factory=list)
-    # Cap for ``recent_tool_observations``. Default 16 covers a couple
-    # of agent invocations on typical traces while keeping the prompt
-    # block under ~1.5KB even before the per-entry truncation. Tunable
-    # via the ``Steerer`` config so operators on tight context budgets
-    # can drop it.
+    # Per-kind cap for ``tool_observed`` entries in ``recent_events``
+    # (goldfive#239 — merged from the legacy ``recent_tool_observations_max``).
+    # Default 16 covers a couple of agent invocations on typical
+    # traces while keeping the prompt block under ~1.5KB even before
+    # the per-entry truncation. Tunable via the ``Steerer`` config so
+    # operators on tight context budgets can drop it. The legacy name
+    # was preserved for env/config compatibility — see
+    # :class:`goldfive.config.ReasoningJudgeConfig` (TODO when
+    # surfacing operator knob).
     recent_tool_observations_max: int = 16
     # Monotonic event sequence counter for sinks. When this Session was
     # built by :meth:`Conversation.next_turn_session`, the seed value is

--- a/tests/test_adk_plugin_tool_observations.py
+++ b/tests/test_adk_plugin_tool_observations.py
@@ -3,8 +3,9 @@
 iter-10 PR 2. Pins the contract that
 :func:`goldfive.adapters._adk_plugin._GoldfiveADKPlugin.after_tool_callback`
 and :meth:`_GoldfiveADKPlugin.on_tool_error_callback` write into
-``session.recent_tool_observations`` via the steerer's
-``note_tool_observation`` method.
+the ``tool_observed`` subset of ``session.recent_events`` (goldfive#239 —
+the unified buffer that replaced ``recent_tool_observations``) via the
+steerer's ``note_tool_observation`` method.
 
 Three integration cases:
 
@@ -37,7 +38,24 @@ pytestmark = pytest.mark.skipif(
 
 pytest.importorskip("google.adk")
 
-from goldfive.types import DriftEvent, Session, Task  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    RECENT_EVENT_KIND_TOOL_OBSERVED,
+    DriftEvent,
+    Session,
+    Task,
+    filter_recent_events_by_kind,
+)
+
+
+def _tool_obs(session: Session) -> list[dict[str, Any]]:
+    """Pre-merge ``session.recent_tool_observations`` accessor.
+
+    Goldfive#239: the dedicated buffer was merged into ``recent_events``;
+    test assertions filter back to the ``tool_observed`` kind.
+    """
+    return filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_KIND_TOOL_OBSERVED
+    )
 
 # ---------------------------------------------------------------------------
 # Stubs — minimal surface that mirrors what the live ADK runtime gives us.
@@ -150,8 +168,8 @@ async def test_after_tool_callback_records_observation() -> None:
         tool=tool, tool_args=args, tool_context=tool_ctx, result=result
     )
 
-    assert len(session.recent_tool_observations) == 1
-    entry = session.recent_tool_observations[0]
+    assert len(_tool_obs(session)) == 1
+    entry = _tool_obs(session)[0]
     assert entry["tool_name"] == "web_search"
     assert entry["is_error"] is False
     assert entry["error_message"] == ""
@@ -179,8 +197,8 @@ async def test_after_tool_callback_uses_pinned_agent_id_when_set() -> None:
         result={"ok": True},
     )
 
-    assert len(session.recent_tool_observations) == 1
-    entry = session.recent_tool_observations[0]
+    assert len(_tool_obs(session)) == 1
+    entry = _tool_obs(session)[0]
     # Pin wins over the ADK-resolved ``parent`` name.
     assert entry["agent_name"] == "delegated_child"
     # And the task pin from iter-9 wins over ctx.task.id.
@@ -213,8 +231,8 @@ async def test_after_tool_callback_records_error_result() -> None:
         result=err_result,
     )
 
-    assert len(session.recent_tool_observations) == 1
-    entry = session.recent_tool_observations[0]
+    assert len(_tool_obs(session)) == 1
+    entry = _tool_obs(session)[0]
     assert entry["is_error"] is True
     assert entry["error_message"] == "missing_task_id"
     assert entry["tool_name"] == "report_task_started"
@@ -239,8 +257,8 @@ async def test_on_tool_error_callback_records_observation() -> None:
         error=RuntimeError("upstream 500"),
     )
 
-    assert len(session.recent_tool_observations) == 1
-    entry = session.recent_tool_observations[0]
+    assert len(_tool_obs(session)) == 1
+    entry = _tool_obs(session)[0]
     assert entry["is_error"] is True
     assert "upstream 500" in entry["error_message"]
     assert entry["tool_name"] == "web_search"
@@ -266,7 +284,7 @@ async def test_on_tool_error_callback_uses_pinned_agent_id_when_set() -> None:
         error=RuntimeError("boom"),
     )
 
-    entry = session.recent_tool_observations[0]
+    entry = _tool_obs(session)[0]
     assert entry["agent_name"] == "child"
 
 
@@ -298,7 +316,7 @@ async def test_observation_does_not_break_on_buffer_failure_after_tool() -> None
 
     # Buffer is empty (the writer raised before appending) but no
     # exception escaped the callback.
-    assert session.recent_tool_observations == []
+    assert _tool_obs(session) == []
 
 
 async def test_observation_does_not_break_on_buffer_failure_on_error() -> None:
@@ -322,7 +340,7 @@ async def test_observation_does_not_break_on_buffer_failure_on_error() -> None:
         error=RuntimeError("upstream 500"),
     )
 
-    assert session.recent_tool_observations == []
+    assert _tool_obs(session) == []
     # The original ``observe(observation, session)`` path still fires.
     assert len(steerer.observations) == 1
 
@@ -354,7 +372,7 @@ async def test_after_tool_callback_no_observation_when_steerer_lacks_writer() ->
         result={"ok": True},
     )
     # Buffer untouched, no exception.
-    assert session.recent_tool_observations == []
+    assert _tool_obs(session) == []
 
 
 # ---------------------------------------------------------------------------
@@ -391,7 +409,7 @@ async def test_after_tool_callback_writes_across_task_boundaries() -> None:
         result={"ok": True},
     )
 
-    task_ids = [e["task_id"] for e in session.recent_tool_observations]
-    tool_names = [e["tool_name"] for e in session.recent_tool_observations]
+    task_ids = [e["task_id"] for e in _tool_obs(session)]
+    tool_names = [e["tool_name"] for e in _tool_obs(session)]
     assert task_ids == ["ta", "tb"]
     assert tool_names == ["tool_a", "tool_b"]

--- a/tests/test_drift_async_dispatch.py
+++ b/tests/test_drift_async_dispatch.py
@@ -17,7 +17,8 @@ cascade fire-and-forget on
 
 Iter-11B: ``mark_task_completed`` / ``mark_task_failed`` now write a
 synthetic ``agent_invocation_completed`` entry to
-:attr:`Session.recent_agent_activity` so the GOAL_DRIFT judge does not
+:attr:`Session.recent_events` (goldfive#239 — the unified buffer that
+replaced ``recent_agent_activity``) so the GOAL_DRIFT judge does not
 read an orphan-start + task-COMPLETED shape and false-positive on
 "looping". The real ``after_run_callback`` will append another
 ``agent_invocation_completed`` slightly later — duplicate completed
@@ -42,6 +43,7 @@ pytestmark = pytest.mark.skipif(
 
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
+    RECENT_EVENT_AGENT_ACTIVITY_KINDS,
     DriftEvent,
     DriftKind,
     DriftSeverity,
@@ -50,7 +52,19 @@ from goldfive.types import (  # noqa: E402
     Session,
     Task,
     TaskEdge,
+    filter_recent_events_by_kind,
 )
+
+
+def _agent_activity(session: Session) -> list[dict[str, Any]]:
+    """Pre-merge ``_agent_activity(session)`` accessor.
+
+    Goldfive#239 merged the dedicated buffer into ``recent_events``;
+    test assertions filter back to the agent-activity kinds.
+    """
+    return filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_AGENT_ACTIVITY_KINDS
+    )
 
 # ---------------------------------------------------------------------------
 # Stubs (intentionally local to this file — keep the spec self-contained).
@@ -153,13 +167,13 @@ async def test_mark_task_completed_appends_synthetic_invocation_completed() -> N
         agent_name="worker",
         task_id="t1",
     )
-    assert len(session.recent_agent_activity) == 1
+    assert len(_agent_activity(session)) == 1
 
     await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
 
     # Paired entry appended.
     completed_entries = [
-        e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
+        e for e in _agent_activity(session) if e["kind"] == "agent_invocation_completed"
     ]
     assert len(completed_entries) == 1
     assert completed_entries[0]["agent_name"] == "worker"
@@ -184,7 +198,7 @@ async def test_mark_task_failed_appends_synthetic_invocation_completed() -> None
     await steerer.drift._wait_background_drifts_idle()
 
     completed_entries = [
-        e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
+        e for e in _agent_activity(session) if e["kind"] == "agent_invocation_completed"
     ]
     assert len(completed_entries) == 1
     assert completed_entries[0]["agent_name"] == "worker"
@@ -218,7 +232,7 @@ async def test_mark_task_completed_skips_pairing_when_no_assignee() -> None:
     await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
 
     completed_entries = [
-        e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
+        e for e in _agent_activity(session) if e["kind"] == "agent_invocation_completed"
     ]
     assert completed_entries == []
 
@@ -237,7 +251,7 @@ async def test_mark_task_failed_skips_pairing_when_no_assignee() -> None:
     await steerer.drift._wait_background_drifts_idle()
 
     completed_entries = [
-        e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
+        e for e in _agent_activity(session) if e["kind"] == "agent_invocation_completed"
     ]
     assert completed_entries == []
 
@@ -268,7 +282,7 @@ async def test_duplicate_completed_entries_are_harmless() -> None:
     )
 
     completed_entries = [
-        e for e in session.recent_agent_activity if e["kind"] == "agent_invocation_completed"
+        e for e in _agent_activity(session) if e["kind"] == "agent_invocation_completed"
     ]
     assert len(completed_entries) == 2
     # Each entry carries the canonical keys; the goal-drift prompt

--- a/tests/test_goal_drift_classifier.py
+++ b/tests/test_goal_drift_classifier.py
@@ -41,6 +41,7 @@ pytestmark = pytest.mark.skipif(
 from goldfive.drift import classify_goal_drift  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
+    RECENT_EVENT_AGENT_ACTIVITY_KINDS,
     DriftEvent,
     DriftKind,
     DriftSeverity,
@@ -50,6 +51,7 @@ from goldfive.types import (  # noqa: E402
     Task,
     TaskEdge,
     TaskStatus,
+    filter_recent_events_by_kind,
 )
 
 # ---------------------------------------------------------------------------
@@ -455,7 +457,13 @@ async def test_steerer_malformed_response_does_not_crash_run() -> None:
 
 
 async def test_steerer_activity_window_bounded() -> None:
-    """note_agent_activity trims to goal_drift_activity_window."""
+    """note_agent_activity trims the agent-activity subset of recent_events.
+
+    Goldfive#239: the unified ``recent_events`` buffer is bounded
+    per-kind-class, so ``goal_drift_activity_window=3`` caps the
+    agent-activity subset at 3 regardless of what other kinds are
+    interleaved.
+    """
     steerer = DefaultSteerer(goal_drift_activity_window=3)
     session = _make_session()
     for i in range(10):
@@ -465,9 +473,12 @@ async def test_steerer_activity_window_bounded() -> None:
             agent_name=f"a{i}",
             task_id=f"t{i}",
         )
-    assert len(session.recent_agent_activity) == 3
+    activity = filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_AGENT_ACTIVITY_KINDS
+    )
+    assert len(activity) == 3
     # Newest three retained (ring buffer drops oldest).
-    assert [e["agent_name"] for e in session.recent_agent_activity] == ["a7", "a8", "a9"]
+    assert [e["agent_name"] for e in activity] == ["a7", "a8", "a9"]
 
 
 async def test_steerer_counter_is_not_task_scoped() -> None:

--- a/tests/test_recent_events_buffer.py
+++ b/tests/test_recent_events_buffer.py
@@ -1,0 +1,434 @@
+"""Regression tests for the unified ``Session.recent_events`` buffer.
+
+Goldfive#239. Merges the historical ``recent_agent_activity`` (fed to
+the GOAL_DRIFT judge) and ``recent_tool_observations`` (fed to the
+three-state reasoning judge) into a single discriminator-tagged buffer.
+
+Pins:
+
+* Both writer paths land entries on ``session.recent_events`` with the
+  correct ``kind`` discriminator.
+* Insertion order is preserved across writes regardless of which
+  writer produced the entry (interleaved writes round-trip as one
+  monotonic stream).
+* The unified-buffer filter helper (:func:`filter_recent_events_by_kind`)
+  recovers the pre-merge sub-buffers byte-identical to what the old
+  ``recent_agent_activity`` / ``recent_tool_observations`` properties
+  returned.
+* Per-kind-class trim semantics: a flood of one kind cannot evict
+  entries of the other kind (the legacy buffers had independent caps;
+  the unified buffer preserves that with per-kind trimming at write
+  time).
+* The legacy cap knobs continue to bound their respective kind-classes.
+
+This module is the regression net for the refactor; if any reader/
+writer drifts off the unified contract, the asserts here fire.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    RECENT_EVENT_AGENT_ACTIVITY_KINDS,
+    RECENT_EVENT_KIND_AGENT_COMPLETED,
+    RECENT_EVENT_KIND_AGENT_STARTED,
+    RECENT_EVENT_KIND_TOOL_OBSERVED,
+    Session,
+    filter_recent_events_by_kind,
+)
+
+
+def _make_session() -> Session:
+    return Session(run_id="r-goldfive-239")
+
+
+# ---------------------------------------------------------------------------
+# Writers land on the unified buffer with the right discriminator
+# ---------------------------------------------------------------------------
+
+
+def test_note_agent_activity_writes_to_recent_events_with_kind() -> None:
+    """``note_agent_activity`` lands an entry on ``recent_events`` with
+    the supplied ``kind``."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.drift.note_agent_activity(
+        session,
+        kind=RECENT_EVENT_KIND_AGENT_STARTED,
+        agent_name="worker",
+        task_id="t1",
+    )
+
+    assert len(session.recent_events) == 1
+    entry = session.recent_events[0]
+    assert entry["kind"] == RECENT_EVENT_KIND_AGENT_STARTED
+    assert entry["agent_name"] == "worker"
+    assert entry["task_id"] == "t1"
+
+
+def test_note_tool_observation_writes_to_recent_events_with_kind() -> None:
+    """``note_tool_observation`` lands a ``tool_observed``-kind entry."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.drift.note_tool_observation(
+        session,
+        agent_name="worker",
+        task_id="t1",
+        tool_name="web_search",
+        args={"q": "foo"},
+        result={"ok": True},
+    )
+
+    assert len(session.recent_events) == 1
+    entry = session.recent_events[0]
+    assert entry["kind"] == RECENT_EVENT_KIND_TOOL_OBSERVED
+    assert entry["tool_name"] == "web_search"
+
+
+# ---------------------------------------------------------------------------
+# Ordering: interleaved writes preserve insertion order
+# ---------------------------------------------------------------------------
+
+
+def test_interleaved_writes_preserve_insertion_order() -> None:
+    """Mixed agent-activity + tool-observation writes share one ordered
+    stream — the canonical use case the merge enables."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.drift.note_agent_activity(
+        session,
+        kind=RECENT_EVENT_KIND_AGENT_STARTED,
+        agent_name="worker",
+        task_id="t1",
+    )
+    steerer.drift.note_tool_observation(
+        session,
+        agent_name="worker",
+        task_id="t1",
+        tool_name="web_search",
+        args={"q": "a"},
+        result={"ok": True},
+    )
+    steerer.drift.note_tool_observation(
+        session,
+        agent_name="worker",
+        task_id="t1",
+        tool_name="http_get",
+        args={"url": "u"},
+        result=None,
+    )
+    steerer.drift.note_agent_activity(
+        session,
+        kind=RECENT_EVENT_KIND_AGENT_COMPLETED,
+        agent_name="worker",
+        task_id="t1",
+    )
+
+    kinds_in_order = [e["kind"] for e in session.recent_events]
+    assert kinds_in_order == [
+        RECENT_EVENT_KIND_AGENT_STARTED,
+        RECENT_EVENT_KIND_TOOL_OBSERVED,
+        RECENT_EVENT_KIND_TOOL_OBSERVED,
+        RECENT_EVENT_KIND_AGENT_COMPLETED,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Filter helper recovers the pre-merge sub-buffers
+# ---------------------------------------------------------------------------
+
+
+def test_filter_recent_events_by_kind_recovers_tool_observations() -> None:
+    """The ``tool_observed`` filter view matches the pre-merge buffer."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.drift.note_agent_activity(
+        session,
+        kind=RECENT_EVENT_KIND_AGENT_STARTED,
+        agent_name="worker",
+        task_id="t1",
+    )
+    steerer.drift.note_tool_observation(
+        session,
+        agent_name="worker",
+        task_id="t1",
+        tool_name="web_search",
+        args={"q": "a"},
+        result={"ok": True},
+    )
+
+    tool_obs = filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_KIND_TOOL_OBSERVED
+    )
+    assert len(tool_obs) == 1
+    assert tool_obs[0]["tool_name"] == "web_search"
+
+
+def test_filter_recent_events_by_kind_recovers_agent_activity() -> None:
+    """The agent-activity filter view matches the pre-merge buffer."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.drift.note_agent_activity(
+        session,
+        kind=RECENT_EVENT_KIND_AGENT_STARTED,
+        agent_name="worker",
+        task_id="t1",
+    )
+    steerer.drift.note_tool_observation(
+        session,
+        agent_name="worker",
+        task_id="t1",
+        tool_name="web_search",
+        args={"q": "a"},
+        result={"ok": True},
+    )
+    steerer.drift.note_agent_activity(
+        session,
+        kind=RECENT_EVENT_KIND_AGENT_COMPLETED,
+        agent_name="worker",
+        task_id="t1",
+    )
+
+    activity = filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_AGENT_ACTIVITY_KINDS
+    )
+    assert len(activity) == 2
+    assert [e["kind"] for e in activity] == [
+        RECENT_EVENT_KIND_AGENT_STARTED,
+        RECENT_EVENT_KIND_AGENT_COMPLETED,
+    ]
+
+
+def test_filter_returns_fresh_copy() -> None:
+    """The filter helper returns a fresh list; mutations are isolated."""
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.drift.note_tool_observation(
+        session,
+        agent_name="w",
+        task_id="t",
+        tool_name="x",
+        args={},
+        result={},
+    )
+
+    view = filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_KIND_TOOL_OBSERVED
+    )
+    view.clear()
+    # Underlying buffer untouched.
+    assert len(session.recent_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-kind-class trim: floods of one kind do not evict the other
+# ---------------------------------------------------------------------------
+
+
+def test_tool_observation_flood_does_not_evict_agent_activity() -> None:
+    """Push 50 tool observations after one agent_invocation_started.
+
+    Without per-kind trimming the agent entry would be evicted; with
+    per-kind trimming the agent-activity subset is preserved while the
+    ``tool_observed`` subset is bounded by
+    ``recent_tool_observations_max`` (default 16).
+    """
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    steerer.drift.note_agent_activity(
+        session,
+        kind=RECENT_EVENT_KIND_AGENT_STARTED,
+        agent_name="worker",
+        task_id="t1",
+    )
+    for i in range(50):
+        steerer.drift.note_tool_observation(
+            session,
+            agent_name="worker",
+            task_id="t1",
+            tool_name="tool",
+            args={"i": i},
+            result={"i": i},
+        )
+
+    # Agent-activity entry SURVIVED.
+    activity = filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_AGENT_ACTIVITY_KINDS
+    )
+    assert len(activity) == 1
+    assert activity[0]["agent_name"] == "worker"
+
+    # Tool observations capped at the default 16.
+    tool_obs = filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_KIND_TOOL_OBSERVED
+    )
+    assert len(tool_obs) == session.recent_tool_observations_max == 16
+
+
+def test_agent_activity_flood_does_not_evict_tool_observations() -> None:
+    """Inverse: 50 agent_invocation_started writes after a tool obs.
+
+    The tool observation must survive; the agent-activity subset is
+    capped at ``goal_drift_activity_window`` (default 10).
+    """
+    steerer = DefaultSteerer()  # default goal_drift_activity_window=10
+    session = _make_session()
+
+    steerer.drift.note_tool_observation(
+        session,
+        agent_name="worker",
+        task_id="t1",
+        tool_name="web_search",
+        args={"q": "the one true tool obs"},
+        result={"ok": True},
+    )
+    for i in range(50):
+        steerer.drift.note_agent_activity(
+            session,
+            kind=RECENT_EVENT_KIND_AGENT_STARTED,
+            agent_name=f"a{i}",
+            task_id="t1",
+        )
+
+    # Tool observation SURVIVED.
+    tool_obs = filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_KIND_TOOL_OBSERVED
+    )
+    assert len(tool_obs) == 1
+    assert tool_obs[0]["tool_name"] == "web_search"
+
+    # Agent-activity capped at the default window=10.
+    activity = filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_AGENT_ACTIVITY_KINDS
+    )
+    assert len(activity) == 10
+    # Newest 10 retained (oldest dropped).
+    assert [e["agent_name"] for e in activity] == [f"a{i}" for i in range(40, 50)]
+
+
+def test_per_kind_caps_are_independent() -> None:
+    """Both kind-classes can simultaneously sit at their respective caps.
+
+    Pushes 25 entries of each kind. Expected: tool_observed capped at
+    ``recent_tool_observations_max`` (16); agent-activity capped at
+    ``goal_drift_activity_window`` (10 default). Total buffer size is
+    bounded by the sum (10+16=26).
+    """
+    steerer = DefaultSteerer()
+    session = _make_session()
+
+    for i in range(25):
+        steerer.drift.note_agent_activity(
+            session,
+            kind=RECENT_EVENT_KIND_AGENT_STARTED,
+            agent_name=f"a{i}",
+            task_id="t1",
+        )
+        steerer.drift.note_tool_observation(
+            session,
+            agent_name=f"a{i}",
+            task_id="t1",
+            tool_name="x",
+            args={},
+            result={},
+        )
+
+    activity = filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_AGENT_ACTIVITY_KINDS
+    )
+    tool_obs = filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_KIND_TOOL_OBSERVED
+    )
+    assert len(activity) == 10
+    assert len(tool_obs) == 16
+    # Buffer is bounded.
+    assert len(session.recent_events) == 10 + 16
+
+
+# ---------------------------------------------------------------------------
+# Filter helper edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_filter_handles_empty_buffer() -> None:
+    """An empty buffer filters to an empty list."""
+    assert filter_recent_events_by_kind([], RECENT_EVENT_KIND_TOOL_OBSERVED) == []
+    assert filter_recent_events_by_kind(None, RECENT_EVENT_KIND_TOOL_OBSERVED) == []
+
+
+def test_filter_handles_non_dict_entries() -> None:
+    """Pathological non-dict entries are skipped, not raised on."""
+    events = [
+        {"kind": RECENT_EVENT_KIND_TOOL_OBSERVED, "tool_name": "x"},
+        "not a dict",
+        None,
+        {"kind": "other"},
+        {"kind": RECENT_EVENT_KIND_TOOL_OBSERVED, "tool_name": "y"},
+    ]
+    filtered = filter_recent_events_by_kind(events, RECENT_EVENT_KIND_TOOL_OBSERVED)
+    assert [e["tool_name"] for e in filtered] == ["x", "y"]
+
+
+def test_filter_accepts_string_kind() -> None:
+    """One-kind filter accepts a bare string."""
+    events = [
+        {"kind": RECENT_EVENT_KIND_TOOL_OBSERVED, "tool_name": "x"},
+        {"kind": RECENT_EVENT_KIND_AGENT_STARTED},
+    ]
+    filtered = filter_recent_events_by_kind(events, "tool_observed")
+    assert len(filtered) == 1
+
+
+def test_filter_accepts_multiple_kinds() -> None:
+    """Multi-kind filter accepts a set/frozenset/tuple/list."""
+    events = [
+        {"kind": RECENT_EVENT_KIND_AGENT_STARTED},
+        {"kind": RECENT_EVENT_KIND_TOOL_OBSERVED},
+        {"kind": RECENT_EVENT_KIND_AGENT_COMPLETED},
+    ]
+    multi = filter_recent_events_by_kind(events, RECENT_EVENT_AGENT_ACTIVITY_KINDS)
+    assert len(multi) == 2
+
+    # Also accepts a plain list.
+    multi_list = filter_recent_events_by_kind(
+        events,
+        [RECENT_EVENT_KIND_AGENT_STARTED, RECENT_EVENT_KIND_AGENT_COMPLETED],
+    )
+    assert len(multi_list) == 2
+
+
+# ---------------------------------------------------------------------------
+# Bare ``Session`` shape — back-compat for callers wiring sessions directly
+# ---------------------------------------------------------------------------
+
+
+def test_bare_session_has_empty_recent_events() -> None:
+    """Bare ``Session(run_id=...)`` starts with an empty unified buffer."""
+    session = Session(run_id="r")
+    assert session.recent_events == []
+    # The legacy cap knob is still on the dataclass for env compatibility.
+    assert session.recent_tool_observations_max == 16
+
+
+def test_two_sessions_have_independent_recent_events() -> None:
+    """Mutable-default-list gotcha guard."""
+    s1 = Session(run_id="r1")
+    s2 = Session(run_id="r2")
+    s1.recent_events.append({"kind": RECENT_EVENT_KIND_AGENT_STARTED})
+    assert s2.recent_events == []

--- a/tests/test_session_recent_tool_observations.py
+++ b/tests/test_session_recent_tool_observations.py
@@ -1,15 +1,21 @@
-"""Unit tests for ``Session.recent_tool_observations`` + steerer writer.
+"""Unit tests for the ``tool_observed`` subset of ``Session.recent_events``
++ the steerer writer.
 
-iter-10 PR 2. The buffer feeds the three-state reasoning judge (PR 3)
-so it can distinguish a provoked deviation (the agent saw a tool error
-or surprising result and pivoted) from an unprovoked one.
+iter-10 PR 2 originally added a dedicated ``recent_tool_observations``
+buffer. Goldfive#239 merged it into the unified ``recent_events``
+buffer; this module pins the same writer contract against the new
+storage. The buffer feeds the three-state reasoning judge (PR 3) so it
+can distinguish a provoked deviation (the agent saw a tool error or
+surprising result and pivoted) from an unprovoked one.
 
 These tests pin the writer contract:
 
-* :meth:`DefaultSteerer.note_tool_observation` appends one entry per
-  call.
-* The buffer is bounded by ``session.recent_tool_observations_max``
-  with trim-on-write — newest wins, oldest dropped.
+* :meth:`DefaultSteerer.note_tool_observation` appends one
+  ``tool_observed`` entry per call to ``session.recent_events``.
+* The ``tool_observed`` subset is bounded by
+  ``session.recent_tool_observations_max`` with trim-on-write — newest
+  wins, oldest dropped. Other kinds in ``recent_events`` are NOT
+  evicted (goldfive#239 per-kind-class trim).
 * The error path is detected from either an explicit ``error=`` kwarg
   (the ``on_tool_error_callback`` shape) or from a ``{"error": ...}``
   dict ``result`` (the acknowledged-failure shape).
@@ -18,7 +24,7 @@ These tests pin the writer contract:
 * Unhashable / unrepresentable args + results are repr-shaped and do
   not raise out of the writer.
 
-PR 3 wires the judge prompt to read from this buffer; this PR ships
+PR 3 wires the judge prompt to read from this buffer; this module ships
 only the population path.
 """
 
@@ -37,11 +43,27 @@ pytestmark = pytest.mark.skipif(
 )
 
 from goldfive.steerer import DefaultSteerer  # noqa: E402
-from goldfive.types import Session  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    RECENT_EVENT_KIND_TOOL_OBSERVED,
+    Session,
+    filter_recent_events_by_kind,
+)
 
 
 def _make_session() -> Session:
     return Session(run_id="r-iter10-pr2")
+
+
+def _tool_obs(session: Session) -> list[dict[str, Any]]:
+    """Return the ``tool_observed`` subset of ``session.recent_events``.
+
+    Goldfive#239: convenience wrapper around the unified buffer's
+    by-kind filter so the assertion shape mirrors the pre-merge
+    ``session.recent_tool_observations`` access pattern.
+    """
+    return filter_recent_events_by_kind(
+        session.recent_events, RECENT_EVENT_KIND_TOOL_OBSERVED
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -63,10 +85,13 @@ def test_note_tool_observation_appends() -> None:
         result={"results": ["fact a", "fact b"]},
     )
 
-    assert len(session.recent_tool_observations) == 1
-    entry = session.recent_tool_observations[0]
-    # Spec-mandated keys.
+    tool_obs = _tool_obs(session)
+    assert len(tool_obs) == 1
+    entry = tool_obs[0]
+    # Spec-mandated keys (goldfive#239 added ``kind`` as the buffer
+    # discriminator).
     assert set(entry.keys()) == {
+        "kind",
         "ts_ms",
         "agent_name",
         "task_id",
@@ -76,6 +101,7 @@ def test_note_tool_observation_appends() -> None:
         "is_error",
         "error_message",
     }
+    assert entry["kind"] == RECENT_EVENT_KIND_TOOL_OBSERVED
     assert isinstance(entry["ts_ms"], int)
     assert entry["agent_name"] == "planner"
     assert entry["task_id"] == "t1"
@@ -101,7 +127,7 @@ def test_note_tool_observation_records_none_result_as_marker() -> None:
         result=None,
     )
 
-    entry = session.recent_tool_observations[0]
+    entry = _tool_obs(session)[0]
     assert entry["result_preview"] == "(none)"
     # No error signal in this path — None is just an absent result.
     assert entry["is_error"] is False
@@ -133,7 +159,7 @@ def test_note_tool_observation_trims_to_max() -> None:
             result={"i": i},
         )
 
-    hist = session.recent_tool_observations
+    hist = _tool_obs(session)
     assert len(hist) == cap
     # Oldest five (a0..a4) dropped; a5..a20 retained, oldest first.
     assert [e["agent_name"] for e in hist] == [f"a{i}" for i in range(5, cap + 5)]
@@ -155,8 +181,9 @@ def test_note_tool_observation_respects_session_local_max_override() -> None:
             result={},
         )
 
-    assert len(session.recent_tool_observations) == 3
-    assert [e["agent_name"] for e in session.recent_tool_observations] == ["a5", "a6", "a7"]
+    hist = _tool_obs(session)
+    assert len(hist) == 3
+    assert [e["agent_name"] for e in hist] == ["a5", "a6", "a7"]
 
 
 # ---------------------------------------------------------------------------
@@ -179,7 +206,7 @@ def test_note_tool_observation_records_error_path() -> None:
         error=Exception("boom"),
     )
 
-    entry = session.recent_tool_observations[0]
+    entry = _tool_obs(session)[0]
     assert entry["is_error"] is True
     assert entry["error_message"] == "boom"
 
@@ -198,7 +225,7 @@ def test_note_tool_observation_records_error_dict_result() -> None:
         result={"acknowledged": False, "error": "tool failed: 503"},
     )
 
-    entry = session.recent_tool_observations[0]
+    entry = _tool_obs(session)[0]
     assert entry["is_error"] is True
     assert entry["error_message"] == "tool failed: 503"
 
@@ -218,7 +245,7 @@ def test_note_tool_observation_record_error_string() -> None:
         error="upstream 500",
     )
 
-    entry = session.recent_tool_observations[0]
+    entry = _tool_obs(session)[0]
     assert entry["is_error"] is True
     assert entry["error_message"] == "upstream 500"
 
@@ -239,7 +266,7 @@ def test_note_tool_observation_truncates_long_error_messages() -> None:
         error=long,
     )
 
-    entry = session.recent_tool_observations[0]
+    entry = _tool_obs(session)[0]
     assert len(entry["error_message"]) == 240
 
 
@@ -262,7 +289,7 @@ def test_note_tool_observation_truncates_args_preview() -> None:
         result={"ok": True},
     )
 
-    entry = session.recent_tool_observations[0]
+    entry = _tool_obs(session)[0]
     assert len(entry["args_preview"]) <= 240
 
 
@@ -280,7 +307,7 @@ def test_note_tool_observation_truncates_result_preview() -> None:
         result={"data": "a" * 1000},
     )
 
-    entry = session.recent_tool_observations[0]
+    entry = _tool_obs(session)[0]
     assert len(entry["result_preview"]) <= 480
 
 
@@ -304,8 +331,9 @@ def test_note_tool_observation_handles_unhashable_args() -> None:
         result={"ok": True},
     )
 
-    assert len(session.recent_tool_observations) == 1
-    entry = session.recent_tool_observations[0]
+    tool_obs = _tool_obs(session)
+    assert len(tool_obs) == 1
+    entry = tool_obs[0]
     # repr of object() shape is "<object object at 0x...>" — sanity-check
     # that we ran repr at all.
     assert entry["args_preview"].startswith("{")
@@ -329,8 +357,9 @@ def test_note_tool_observation_handles_repr_failure_in_args() -> None:
         result={"ok": True},
     )
 
-    assert len(session.recent_tool_observations) == 1
-    entry = session.recent_tool_observations[0]
+    tool_obs = _tool_obs(session)
+    assert len(tool_obs) == 1
+    entry = tool_obs[0]
     assert entry["args_preview"] == "(unrepresentable args)"
 
 
@@ -365,7 +394,7 @@ def test_note_tool_observation_swallows_internal_errors() -> None:
         )
 
     # And: the buffer is left untouched (no half-written entry).
-    assert session.recent_tool_observations == []
+    assert _tool_obs(session) == []
 
 
 def test_note_tool_observation_zero_max_clamps_to_one() -> None:
@@ -388,8 +417,9 @@ def test_note_tool_observation_zero_max_clamps_to_one() -> None:
             result={},
         )
 
-    assert len(session.recent_tool_observations) == 1
-    assert session.recent_tool_observations[0]["agent_name"] == "a2"
+    tool_obs = _tool_obs(session)
+    assert len(tool_obs) == 1
+    assert tool_obs[0]["agent_name"] == "a2"
 
 
 # ---------------------------------------------------------------------------
@@ -397,10 +427,10 @@ def test_note_tool_observation_zero_max_clamps_to_one() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_session_default_recent_tool_observations_is_empty_list() -> None:
+def test_session_default_recent_events_is_empty_list() -> None:
     """Bare ``Session(run_id=...)`` constructions get an empty buffer."""
     session = Session(run_id="r")
-    assert session.recent_tool_observations == []
+    assert session.recent_events == []
     assert session.recent_tool_observations_max == 16
 
 
@@ -408,8 +438,8 @@ def test_two_sessions_have_independent_buffers() -> None:
     """The mutable-default-list classic gotcha must not bite us."""
     s1 = Session(run_id="r1")
     s2 = Session(run_id="r2")
-    s1.recent_tool_observations.append({"sentinel": True})
-    assert s2.recent_tool_observations == []
+    s1.recent_events.append({"sentinel": True})
+    assert s2.recent_events == []
 
 
 def test_note_tool_observation_per_task_filter_left_to_reader() -> None:
@@ -440,7 +470,7 @@ def test_note_tool_observation_per_task_filter_left_to_reader() -> None:
         result={},
     )
 
-    task_ids = [e["task_id"] for e in session.recent_tool_observations]
+    task_ids = [e["task_id"] for e in _tool_obs(session)]
     assert task_ids == ["t1", "t2"]
 
 
@@ -464,7 +494,7 @@ def test_note_tool_observation_ts_ms_is_monotonic() -> None:
             result={},
         )
 
-    ts_values: list[int] = [int(e["ts_ms"]) for e in session.recent_tool_observations]
+    ts_values: list[int] = [int(e["ts_ms"]) for e in _tool_obs(session)]
     assert ts_values == sorted(ts_values)
 
 
@@ -485,8 +515,9 @@ def test_note_tool_observation_handles_none_args() -> None:
         args=None,
         result={"ok": True},
     )
-    assert len(session.recent_tool_observations) == 1
-    assert session.recent_tool_observations[0]["args_preview"] == "None"
+    tool_obs = _tool_obs(session)
+    assert len(tool_obs) == 1
+    assert tool_obs[0]["args_preview"] == "None"
 
 
 def test_note_tool_observation_with_string_result() -> None:
@@ -501,7 +532,7 @@ def test_note_tool_observation_with_string_result() -> None:
         args={},
         result="hello world",
     )
-    entry = session.recent_tool_observations[0]
+    entry = _tool_obs(session)[0]
     assert "hello world" in entry["result_preview"]
     assert entry["is_error"] is False
 
@@ -525,4 +556,4 @@ def test_writer_accepts_arbitrary_any_types() -> None:
         args=arbitrary,
         result=arbitrary,
     )
-    assert len(session.recent_tool_observations) == 1
+    assert len(_tool_obs(session)) == 1


### PR DESCRIPTION
Closes #239.

## Summary

Iter-10 PR 2 added `recent_tool_observations` alongside the pre-existing `recent_agent_activity`; both buffers were session-scoped, read by drift detectors / judge prompts, and tracked related state. This change merges them into a single `Session.recent_events` buffer discriminated by a `kind` field — single source of truth, no double-tracking, cleaner reader API.

## Schema

| Aspect | Before | After |
|---|---|---|
| Storage | `Session.recent_agent_activity: list[dict]` + `Session.recent_tool_observations: list[dict]` | `Session.recent_events: list[dict]` (unified) |
| Discriminator | implicit (two separate buffers) | `kind` field on each entry |
| Kinds | n/a | `agent_invocation_started`, `agent_invocation_completed`, `tool_observed` (constants: `RECENT_EVENT_KIND_*`) |
| Caps | independent per buffer | per-kind-class trim at write time; both legacy caps respected |
| Cap knobs | `goal_drift_activity_window` (10) + `recent_tool_observations_max` (16) | unchanged — both still bound their respective kind-classes |
| Reader API | `session.recent_agent_activity` / `session.recent_tool_observations` | `filter_recent_events_by_kind(session.recent_events, kind_or_kinds)` |

## Reader / writer migration

| Path | Before | After |
|---|---|---|
| `DriftObserver.note_agent_activity` (writer) | append to `session.recent_agent_activity`, trim to `goal_drift_activity_window` | append to `session.recent_events` with supplied `kind`, trim agent-activity subset to `goal_drift_activity_window` |
| `DriftObserver.note_tool_observation` (writer) | append to `session.recent_tool_observations`, trim to `recent_tool_observations_max` | append to `session.recent_events` with `kind="tool_observed"`, trim tool-observed subset to `recent_tool_observations_max` |
| `DriftObserver._summarize_recent_tool_calls` (reader) | `getattr(session, "recent_tool_observations", None) or []` | `filter_recent_events_by_kind(session.recent_events, RECENT_EVENT_KIND_TOOL_OBSERVED)` |
| `DriftObserver.maybe_run_goal_drift_check` (reader) | `list(session.recent_agent_activity)` | `filter_recent_events_by_kind(session.recent_events, RECENT_EVENT_AGENT_ACTIVITY_KINDS)` |
| `drift.reasoning.analyze_reasoning*` (reader) | `getattr(session, "recent_tool_observations", None)` | filter `recent_events` by `tool_observed` kind, pass into the judge as the existing `recent_tool_observations` kwarg (public-API kwarg preserved) |

Writer call sites in `task_state_machine.py` and `adapters/_adk_plugin.py` are unchanged — they continue to call `note_agent_activity` / `note_tool_observation`, which now route to the unified buffer.

## Per-kind-class trim

A flood of `tool_observed` entries cannot evict legitimate agent-activity entries (and vice versa). `DriftObserver._trim_recent_events_kind_class` walks the unified buffer at write time, identifies entries of the just-written kind-class, and drops the leading overflow. This preserves the pre-merge cap semantics exactly: total buffer size is bounded by the sum of the two caps (default 10 + 16 = 26).

## Test plan

- [x] New regression module `tests/test_recent_events_buffer.py` (15 cases): writer landing + `kind` stamp, interleaved-write ordering, filter-helper edge cases (None / non-dict entries / string vs collection kinds), per-kind cap independence (flood of one kind does NOT evict the other).
- [x] Existing tests updated to filter `recent_events` by kind via the new helper (`test_session_recent_tool_observations`, `test_adk_plugin_tool_observations`, `test_drift_async_dispatch`, `test_goal_drift_classifier`); assertion shapes preserved byte-identical.
- [x] Full `pytest tests/ -x --tb=short`: **2560 passed, 59 skipped**.
- [x] State-ownership audit clean under strict mode (the audit covers ADK `Session.state` writes, not goldfive `Session` dataclass fields).
- [x] Reasoning-judge prompt rendering unchanged: `_format_tool_observations` still receives the same `tool_observed` list it saw pre-merge (verified by `test_trace_b_prompt_includes_tool_observation` / `test_trace_a_prompt_includes_empty_tool_obs_marker`).
- [x] GOAL_DRIFT judge prompt unchanged: `classify_goal_drift` receives the same `observed_actions` list (filtered to agent-activity kinds) it saw pre-merge.