### PR TITLE
fix(drift): tool_loops bucket scoping + freshness gate atomicity + double-cancel dedup (closes #420, partial #405)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -5983,6 +5983,18 @@ def make_adk_plugin(
                     if _gf_plan is not None
                     else 0
                 )
+                # goldfive#420: thread ``session.run_id`` so the tracker
+                # buckets accumulate across re-invocations of the same
+                # agent in one run. Pre-#420 the bucket keyed on
+                # ``invocation_id`` only, so a coordinator re-delegating
+                # to (e.g.) ``debugger_agent`` 11 times saw 11 fresh
+                # 2-entry windows and never tripped the 7-call CRITICAL
+                # name-tier on a same-tool/varying-args loop. Empty /
+                # missing ``run_id`` falls back to ``invocation_id`` for
+                # compatibility (test stubs, third-party adapters).
+                _session_run_id = str(
+                    _safe_attr(_gf_session, "run_id", "") or ""
+                )
                 drifts = self._tool_loop_tracker.observe_tool_call(
                     invocation_id=inv_id,
                     agent_name=agent_name,
@@ -5990,6 +6002,7 @@ def make_adk_plugin(
                     args=dict(args_payload),
                     task_id=task_id,
                     observed_revision_index=_observed_rev,
+                    session_run_id=_session_run_id,
                 )
             except Exception as exc:  # noqa: BLE001
                 log.debug(
@@ -6049,9 +6062,13 @@ def make_adk_plugin(
             if tool_name in self._progress_reporting_tools:
                 if _is_progress_report_success(result):
                     try:
+                        # goldfive#420: mirror the run-scoped key the
+                        # observe_tool_call call used so the reset
+                        # targets the same accumulating bucket.
                         self._tool_loop_tracker.on_task_progress(
                             invocation_id=inv_id,
                             agent_name=agent_name,
+                            session_run_id=_session_run_id,
                         )
                     except Exception as exc:  # noqa: BLE001
                         log.debug(

--- a/goldfive/drift/tool_loops.py
+++ b/goldfive/drift/tool_loops.py
@@ -103,12 +103,23 @@ flagged when each call completes its step.
    window unconditionally when called directly (tests and any
    future direct callers).
 
-Isolation: trackers are keyed on ``(invocation_id, agent_name)`` so
-each ADK invocation gets its own window, and parallel sub-agents
-within the same invocation (via AgentTool) are also isolated. State
-is intentionally held in a single :class:`ToolLoopTracker` instance
-on the plugin -- we don't need per-session persistence, the whole
-window is ephemeral to one run.
+Isolation: trackers are keyed on ``(scope_key, agent_name)`` where
+``scope_key`` is the ``session_run_id`` when the caller supplies one
+(the ADK plugin does, threading ``session.run_id`` through), and the
+ADK ``invocation_id`` otherwise (legacy callers / tests). Scoping on
+``session.run_id`` is the goldfive#420 fix: when a coordinator
+re-invokes the same sub-agent multiple times within a session (the
+debugger_agent / re-delegation pattern empirically observed on the
+cherry-tree e2e), each re-invocation got a fresh ``invocation_id`` —
+so 20 tool calls spread across 11 invocations only saw ~2 calls per
+bucket, never tripping the configured CRITICAL threshold (7 same-name
+calls). Re-keying on ``(session.run_id, agent_name)`` lets the
+detector see the cumulative window across re-invocations of the same
+agent within the same run. Parallel sub-agents within the same run
+remain isolated via ``agent_name``. State is intentionally held in a
+single :class:`ToolLoopTracker` instance on the plugin -- we don't
+need per-session persistence, the whole window is ephemeral to one
+run.
 
 Configuration
 -------------
@@ -511,6 +522,7 @@ class ToolLoopTracker:
         args: Any,
         task_id: str = "",
         observed_revision_index: int = 0,
+        session_run_id: str = "",
     ) -> list[DriftEvent]:
         """Record one tool call; return any drift observations it triggers.
 
@@ -526,12 +538,33 @@ class ToolLoopTracker:
         observed revision is older than the live plan's. Defaults to
         ``0`` (the "unset / pre-#245" sentinel) for legacy callers and
         unit tests that don't thread the session's plan revision.
+
+        ``session_run_id`` (goldfive#420) is the scope key used to
+        accumulate tool calls across re-invocations of the same agent
+        within one run. When supplied (the ADK plugin threads
+        ``session.run_id`` here), the bucket key is
+        ``(session_run_id, agent_name)`` — so 11 re-invocations of
+        ``debugger_agent`` calling ``find_presentation_files`` 2x each
+        accumulate into one 22-entry window instead of 11 isolated
+        2-entry windows. When empty (legacy callers, unit tests that
+        haven't been updated, third-party adapters), the bucket key
+        falls back to ``(invocation_id, agent_name)`` — preserving the
+        pre-#420 isolation semantics. ``invocation_id`` is still
+        recorded on the produced :class:`DriftEvent` so the dispatch-
+        time helpers (active-invocation lookup, cancel) get the right
+        target.
         """
-        key = (invocation_id or "", agent_name or "")
+        # goldfive#420: prefer the run-scoped key when the caller
+        # supplied one. Falls back to invocation-scoped for legacy
+        # callers (tests, third-party adapters) so the pre-#420
+        # contract is preserved when no session id is plumbed.
+        scope_key = session_run_id or invocation_id or ""
+        key = (scope_key, agent_name or "")
         signature = (tool_name or "", args_hash(args))
         self._buffers[key].append(signature)
         return self._classify(
             key,
+            invocation_id=invocation_id or "",
             current_task_id=task_id,
             observed_revision_index=observed_revision_index,
         )
@@ -541,8 +574,9 @@ class ToolLoopTracker:
         *,
         invocation_id: str,
         agent_name: str,
+        session_run_id: str = "",
     ) -> None:
-        """Reset the per-(invocation, agent) buffer after task progress.
+        """Reset the per-(scope, agent) buffer after task progress.
 
         Called whenever a task transitions to a progress state so
         mode 2's "no task progress in window" gate starts from a clean
@@ -550,6 +584,11 @@ class ToolLoopTracker:
         ``read_file read_file read_file`` that COMPLETES the task is
         not flagged because the next observation starts from an empty
         window.
+
+        ``session_run_id`` (goldfive#420) must match the value the
+        caller threads through :meth:`observe_tool_call` so the reset
+        targets the same bucket. Empty / unset falls back to
+        ``invocation_id`` for pre-#420 callers.
 
         .. note::
 
@@ -564,7 +603,8 @@ class ToolLoopTracker:
            whenever they have out-of-band knowledge that genuine
            task progress occurred.
         """
-        key = (invocation_id or "", agent_name or "")
+        scope_key = session_run_id or invocation_id or ""
+        key = (scope_key, agent_name or "")
         buf = self._buffers.get(key)
         if buf is not None:
             buf.clear()
@@ -578,9 +618,20 @@ class ToolLoopTracker:
         """
         self._buffers.clear()
 
-    def buffer_size(self, *, invocation_id: str, agent_name: str) -> int:
-        """Current entry count for the given key (test introspection helper)."""
-        key = (invocation_id or "", agent_name or "")
+    def buffer_size(
+        self,
+        *,
+        invocation_id: str,
+        agent_name: str,
+        session_run_id: str = "",
+    ) -> int:
+        """Current entry count for the given key (test introspection helper).
+
+        ``session_run_id`` (goldfive#420) selects the run-scoped key
+        when present; falls back to ``invocation_id`` otherwise.
+        """
+        scope_key = session_run_id or invocation_id or ""
+        key = (scope_key, agent_name or "")
         buf = self._buffers.get(key)
         return 0 if buf is None else len(buf)
 
@@ -598,6 +649,7 @@ class ToolLoopTracker:
         *,
         current_task_id: str,
         observed_revision_index: int = 0,
+        invocation_id: str = "",
     ) -> list[DriftEvent]:
         """Return zero or more drift observations for the current window.
 
@@ -607,10 +659,20 @@ class ToolLoopTracker:
         Alternating is suppressed when an exact/name drift already
         fired -- same rationale as pre-#204 (the weaker signal would
         be noise on top of the stronger).
+
+        ``invocation_id`` (goldfive#420) is stamped onto the emitted
+        :class:`DriftEvent`'s ``raw.invocation_id`` so the dispatch-
+        time cancel helper can target the actual in-flight invocation
+        even when the bucket key scoped on ``session_run_id``. Falls
+        back to the bucket scope when not supplied (legacy callers).
         """
         buf = list(self._buffers[key])
         observations: list[DriftEvent] = []
-        invocation_id, agent_name = key
+        scope_key, agent_name = key
+        # Prefer the explicitly-provided invocation id (goldfive#420);
+        # fall back to the bucket scope when callers didn't thread one
+        # through (legacy in-tree callers, third-party adapters).
+        emit_invocation_id = invocation_id or scope_key
 
         # Pre-compute per-signature and per-name counts in the window.
         exact_counts: dict[tuple[str, str], int] = {}
@@ -672,7 +734,7 @@ class ToolLoopTracker:
                         "args_hash": sig[1],
                         "count": exact_for_name,
                         "window_len": len(buf),
-                        "invocation_id": invocation_id,
+                        "invocation_id": emit_invocation_id,
                         "category": _classify_tool_category(name),
                         "tier": tier_key,
                     }
@@ -686,7 +748,7 @@ class ToolLoopTracker:
                         "tool_name": name,
                         "count": name_total,
                         "window_len": len(buf),
-                        "invocation_id": invocation_id,
+                        "invocation_id": emit_invocation_id,
                         "category": _classify_tool_category(name),
                         "tier": tier_key,
                     }
@@ -749,7 +811,7 @@ class ToolLoopTracker:
                                 "mode": "alternating",
                                 "tools": [a_name, b_name],
                                 "window_len": len(tail),
-                                "invocation_id": invocation_id,
+                                "invocation_id": emit_invocation_id,
                             },
                             trigger_input=(
                                 f"tool_loop alternating ({len(tail)} calls): "

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -285,6 +285,48 @@ class DriftObserver:
         # ``REFINE_FAILURE_THRESHOLD`` / ``PROGRESS_STALL_THRESHOLD_SECONDS``
         # class constants).
         self._steerer = steerer
+        # goldfive#405 MEDIUM #4: in-flight refine registry. Closes the
+        # race where two concurrent judges observing the SAME
+        # ``(kind, current_task_id)`` at the same
+        # ``observed_revision_index`` both read
+        # ``session.last_addressed_revision_by_drift_key.get(key, 0) == 0``
+        # before either ``_apply_revision`` has stamped a new
+        # watermark — so both pass the freshness gate and both
+        # dispatch a redundant refine. The watermark write is gated by
+        # the per-session plan lock inside :meth:`PlanReviser._emit_plan_revised`,
+        # but that lock isn't acquired until well AFTER refine completes
+        # (the lock spans only the install + emit, not the multi-second
+        # LLM round trip). Holding the plan lock around refine would
+        # serialise unrelated drift refines on the same session, so we
+        # take the lighter-weight approach: stamp ``(session_id, kind,
+        # current_task_id)`` synchronously at the freshness-gate check
+        # site; a subsequent same-key judge sees the in-flight entry,
+        # emits ``DriftDetected`` for observability, and short-circuits
+        # the dispatch. The entry is cleared in a ``finally`` at the
+        # end of dispatch (success, exception, or cancel) so a single
+        # crash can never wedge a key permanently.
+        #
+        # Keyed by ``(session.id, kind.value, current_task_id)`` because
+        # the freshness watermark itself is keyed by
+        # ``(kind, current_task_id)`` and the steerer is shared across
+        # sessions (multi-runner processes). Per-session dict scope.
+        self._inflight_refine_keys: set[tuple[str, str, str]] = set()
+        # goldfive#405 MEDIUM #6 — double-cancel dedup. Stamped by
+        # :meth:`_handle_drift_dispatch` when its top-level
+        # ``request_invocation_cancel`` (flag-only) fires for a
+        # CRITICAL drift; consulted by
+        # :meth:`_cancel_inflight_for_revision` so a second
+        # post-refine hard cancel for the SAME drift short-circuits.
+        # Without this dedup, a CRITICAL promote-eligible drift fires
+        # two cancels: the flag-only one writes the cancel-state flag
+        # the executor consumes (driving the channel-message restart),
+        # then ``_cancel_inflight_for_revision`` hard-cancels after
+        # refine — by which point the executor may already have
+        # restarted, so the hard cancel lands on a fresh invocation.
+        # Keyed by ``drift.id`` (unique per dispatch) so repeat-drift
+        # firings (separate dispatch instances at higher occurrence
+        # counts) each get their own slot.
+        self._cancelled_drift_ids: set[str] = set()
 
     # ------------------------------------------------------------------
     # Drift event emission + lifecycle stamping
@@ -2571,14 +2613,15 @@ class DriftObserver:
         :meth:`_emit_plan_revised`). See the original docstring in
         :class:`DefaultSteerer` for the long-form contract; the body
         and behaviour are unchanged here.
+
+        goldfive#405 MEDIUM #4 refactor: the dispatch body now lives in
+        :meth:`_handle_drift_dispatch` so this method can wrap it in a
+        try/finally that clears an in-flight-refine entry. The entry
+        guards (PLAN_DIVERGENCE drop, authored_by normalisation,
+        verdict-freshness watermark check) and the in-flight stamp
+        remain inline; everything from "tag the bound adapter's next
+        cancel reason" onward moved.
         """
-        from goldfive.steerer import (
-            _ABSORB_NUDGE_KINDS,
-            InterventionLevel,
-            RefineExhausted,
-            _planner_refine_accepts_available_agents,
-            compose_corrective_user_message,
-        )
 
         # goldfive#252: PLAN_DIVERGENCE replaced by CAPABILITY_MISMATCH
         # (#253) — disabled here. Guard at the very top so any external
@@ -2617,6 +2660,13 @@ class DriftObserver:
         #     operator directive must be honoured regardless of the
         #     framework's plan-state cursor (preserves the iter-11D /
         #     #242 contract).
+        # goldfive#405 MEDIUM #4 — in-flight-refine registry key. Stamped
+        # synchronously below (alongside the freshness-gate watermark
+        # check) and cleared in this method's ``finally`` so a second
+        # concurrent judge observing the SAME ``(kind, current_task_id)``
+        # short-circuits before duplicating the refine. ``None`` outside
+        # the goldfive-authored / observation-stamped guard.
+        inflight_key: tuple[str, str, str] | None = None
         if drift.observed_revision_index and (drift.authored_by or "").lower() != "user":
             # Per-(kind, target) addressed-watermark check — narrower
             # than naive ``observed < live_revision`` gating so parallel
@@ -2650,6 +2700,75 @@ class DriftObserver:
                 # ran; do NOT cancel / refine on a redundant view.
                 await self._emit_drift_detected(session, drift)
                 return
+            # goldfive#405 MEDIUM #4 — concurrent-refine race close. The
+            # watermark above stamps AT THE END of a successful refine
+            # (inside :meth:`PlanReviser._emit_plan_revised`'s lock), so
+            # two concurrent judges that observed the same
+            # ``(kind, current_task_id)`` at the same revision both read
+            # ``last_addressed == 0`` here, both pass the watermark
+            # check, and both proceed to dispatch — running two refines
+            # for one drift. The plan lock isn't held across
+            # ``planner.refine`` (multi-second LLM round-trip) by design,
+            # so widening it would serialise unrelated drift handling on
+            # the same session. Instead, stamp an in-flight key
+            # synchronously here. A second same-key judge sees the entry,
+            # emits ``DriftDetected`` for observability, and skips the
+            # cancel+refine machinery; cleared in the ``finally`` at the
+            # end of this method so a single dispatch crash can't wedge
+            # a key permanently.
+            inflight_key = (
+                str(session.id or session.run_id or ""),
+                drift.kind.value,
+                drift.current_task_id or "",
+            )
+            if inflight_key in self._inflight_refine_keys:
+                log.info(
+                    "DefaultSteerer._handle_drift: concurrent refine — "
+                    "drift kind=%s target=%r already in-flight at "
+                    "observed revision %d; skipping dispatch",
+                    drift.kind.value,
+                    drift.current_task_id or "<trajectory>",
+                    drift.observed_revision_index,
+                )
+                await self._emit_drift_detected(session, drift)
+                return
+            self._inflight_refine_keys.add(inflight_key)
+        try:
+            await self._handle_drift_dispatch(drift, session)
+        finally:
+            if inflight_key is not None:
+                self._inflight_refine_keys.discard(inflight_key)
+            # goldfive#405 MEDIUM #6 — release the cancelled-drift slot
+            # at the end of dispatch. Safe to discard unconditionally:
+            # if the drift never made it to the pre-cancel branch the
+            # set has no entry and discard is a no-op; if it did and
+            # ``_cancel_inflight_for_revision`` already consumed the
+            # entry, discard is still a no-op. Bounds the set to the
+            # active dispatch depth so it can't grow indefinitely
+            # across the steerer's lifetime.
+            drift_id = str(getattr(drift, "id", "") or "")
+            if drift_id:
+                self._cancelled_drift_ids.discard(drift_id)
+
+    async def _handle_drift_dispatch(self, drift: DriftEvent, session: Session) -> None:
+        """Dispatch the drift through cancel + ladder (goldfive#405 MEDIUM #4).
+
+        Extracted from :meth:`handle_drift` so the freshness gate can
+        wrap dispatch in a try/finally that clears the in-flight refine
+        entry. The body is unchanged from the pre-#405 inline version —
+        every comment / log line / control-flow contract preserved.
+        Callers must ensure :meth:`handle_drift`'s entry guards
+        (USER_STEER side effects, freshness-watermark check) have
+        already run; this method jumps straight into cancel + refine.
+        """
+        from goldfive.steerer import (
+            _ABSORB_NUDGE_KINDS,
+            InterventionLevel,
+            RefineExhausted,
+            _planner_refine_accepts_available_agents,
+            compose_corrective_user_message,
+        )
+
         # Tag the bound adapter's next cancel with a symbolic reason so
         # the synthetic function_response the adapter appends on cancel
         # carries LLM-actionable content. Done BEFORE the drift event
@@ -2715,7 +2834,20 @@ class DriftObserver:
         # Whether to re-dispatch after the cancel is the parent
         # agent's decision, informed by plan-causal prompting from
         # Stream B — the framework itself does NOT auto-reinvoke.
+        #
         if self._should_request_cancel_for_drift(drift):
+            # goldfive#405 MEDIUM #6 — record the drift id BEFORE the
+            # cancel fires so the post-refine
+            # :meth:`_cancel_inflight_for_revision` short-circuits the
+            # second cancel for the SAME drift. Stamping before rather
+            # than after the await ensures the dedup engages even if
+            # the cancel call yields the event loop and a same-task
+            # background tries to fire its own ``_cancel_inflight_for_revision``
+            # before this branch returns. See the docstring on
+            # :attr:`_cancelled_drift_ids` for the full rationale.
+            drift_id = str(getattr(drift, "id", "") or "")
+            if drift_id:
+                self._cancelled_drift_ids.add(drift_id)
             try:
                 await self.request_invocation_cancel(drift=drift, session=session)
             except Exception as exc:  # noqa: BLE001 — cancel is best-effort
@@ -3895,6 +4027,31 @@ class DriftObserver:
                 "could not stamp supersede flag on session: %s",
                 exc,
             )
+        # goldfive#405 MEDIUM #6 — short-circuit when the same drift
+        # already had a flag-only cancel fired at the top of
+        # :meth:`_handle_drift_dispatch`. The flag write the executor
+        # consumes is idempotent; firing a SECOND cancel here would
+        # add no value but could land on a different invocation than
+        # the first cancel targeted — between the two cancels the
+        # executor may have restarted the invocation in response to
+        # the first flag's channel-message restart. The supersede
+        # marker above is still stamped (cheap, idempotent) so an
+        # overlay reading it sees the same internal-cancel signal.
+        drift_id = str(getattr(drift, "id", "") or "")
+        if drift_id and drift_id in self._cancelled_drift_ids:
+            log.debug(
+                "DefaultSteerer._cancel_inflight_for_revision: "
+                "drift id=%s already had a pre-refine cancel — "
+                "skipping post-refine cancel to avoid double-cancel "
+                "against a freshly-restarted invocation",
+                drift_id,
+            )
+            # Drop the entry so the slot is GC'd once the dispatch
+            # completes. Subsequent ``_cancel_inflight_for_revision``
+            # invocations for OTHER drifts won't see this id and the
+            # set stays bounded by in-flight handler depth.
+            self._cancelled_drift_ids.discard(drift_id)
+            return []
         try:
             return await self.request_invocation_cancel(
                 drift=drift,

--- a/tests/test_cooperative_cancellation.py
+++ b/tests/test_cooperative_cancellation.py
@@ -582,6 +582,136 @@ async def test_critical_drift_requests_cancel() -> None:
 
 
 # ---------------------------------------------------------------------------
+# goldfive#405 MEDIUM #6 — double-cancel dedup
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_inflight_for_revision_skips_when_precancel_already_fired() -> None:
+    """goldfive#405 MEDIUM #6 regression: a drift whose top-level
+    flag-only cancel already fired must not be hard-cancelled a second
+    time by :meth:`_cancel_inflight_for_revision`.
+
+    Without the dedup, a CRITICAL promote-eligible drift fires both
+    cancels: the flag-only one writes the cancel-state flag the
+    executor consumes (driving a channel-message restart), then the
+    post-refine ``_cancel_inflight_for_revision`` hard-cancels — by
+    which point the executor may have restarted, landing the second
+    cancel on a fresh invocation and producing two restarts for one
+    drift.
+
+    Direct test: pre-stamp the drift id on the observer's
+    ``_cancelled_drift_ids`` set (the synchronous bookkeeping the
+    top-level cancel does), then call
+    ``_cancel_inflight_for_revision`` and assert the underlying
+    plugin's ``request_invocation_cancel`` was NOT invoked.
+    """
+    plugin, _sink, session = _make_plugin()
+    adapter = _StubAdapter(plugin)
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[], planner=None)
+    steerer.bind_adapter(adapter)
+    plugin._top_invocation_id = "inv-A"
+
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.CRITICAL,
+        current_task_id="t1",
+        current_agent_id="sub_agent",
+    )
+    # Simulate the top-level pre-cancel having already fired by
+    # stamping the drift id on the dedup set directly.
+    steerer.drift._cancelled_drift_ids.add(drift.id)
+
+    flagged = await steerer.drift._cancel_inflight_for_revision(drift, session)
+    # Result is an empty list because the dedup short-circuit returned
+    # before calling the plugin.
+    assert flagged == []
+    # The supersede flag is still stamped (idempotent best-effort);
+    # the cancel itself did not fire.
+    assert getattr(session, "_supersede_pending", False) is True
+    # And the dedup set is cleared so a different drift on the same
+    # session isn't accidentally suppressed.
+    assert drift.id not in steerer.drift._cancelled_drift_ids
+
+
+async def test_cancel_inflight_for_revision_still_fires_without_precancel() -> None:
+    """When NO pre-cancel ran for the drift (e.g. WARNING severity
+    promote-eligible kind), :meth:`_cancel_inflight_for_revision`
+    must still fire — the dedup only kicks in for same-drift repeats.
+    """
+    plugin, _sink, session = _make_plugin()
+    adapter = _StubAdapter(plugin)
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[], planner=None)
+    steerer.bind_adapter(adapter)
+    plugin._top_invocation_id = "inv-A"
+
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        current_task_id="t1",
+        current_agent_id="sub_agent",
+    )
+    # No pre-cancel stamp — dedup must not engage.
+    assert drift.id not in steerer.drift._cancelled_drift_ids
+
+    flagged = await steerer.drift._cancel_inflight_for_revision(drift, session)
+    # Cancel fired against the resolved invocation.
+    assert flagged != [], (
+        "without a prior pre-cancel, _cancel_inflight_for_revision must "
+        "still drive the hard cancel"
+    )
+    req = plugin.peek_cancel_for_invocation("inv-A")
+    assert req is not None
+
+
+async def test_handle_drift_dispatch_records_drift_id_in_cancelled_set() -> None:
+    """The top-level flag-only cancel stamps the drift id so the dedup
+    in :meth:`_cancel_inflight_for_revision` engages.
+
+    Asserts the bookkeeping primitive that bug #6's fix relies on.
+    """
+    plugin, _sink, session = _make_plugin()
+    adapter = _StubAdapter(plugin)
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[], planner=None)
+    steerer.bind_adapter(adapter)
+    plugin._top_invocation_id = "inv-A"
+
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.CRITICAL,
+        current_task_id="t1",
+        current_agent_id="sub_agent",
+    )
+
+    # Use a probe to catch the moment between the pre-cancel and the
+    # finally-clear: peek at the cancelled set immediately after the
+    # cancel fires by monkey-patching ``request_invocation_cancel``.
+    original = steerer.drift.request_invocation_cancel
+    seen_after_precancel: list[bool] = []
+
+    async def _probing_cancel(*args: Any, **kwargs: Any) -> Any:
+        result = await original(*args, **kwargs)
+        # Look at the dedup set immediately after the pre-cancel fires.
+        seen_after_precancel.append(drift.id in steerer.drift._cancelled_drift_ids)
+        return result
+
+    steerer.drift.request_invocation_cancel = _probing_cancel  # type: ignore[method-assign]
+
+    await steerer.drift.handle_drift(drift, session)
+    # At least one cancel invocation; the pre-cancel slot was stamped
+    # before the planner ran (planner is None so dispatch returns
+    # early — the finally still ran and cleared it).
+    assert seen_after_precancel and seen_after_precancel[0] is True, (
+        f"goldfive#405 #6: pre-cancel must stamp drift.id on the "
+        f"dedup set; observations={seen_after_precancel}"
+    )
+    # After dispatch completes, the finally cleared the entry.
+    assert drift.id not in steerer.drift._cancelled_drift_ids
+
+
+# ---------------------------------------------------------------------------
 # 8. Empty invocation-id guard
 # ---------------------------------------------------------------------------
 

--- a/tests/test_drift_version_pin.py
+++ b/tests/test_drift_version_pin.py
@@ -646,6 +646,223 @@ async def test_apply_revision_stamps_per_key_watermark() -> None:
     )
 
 
+async def _verify_pre_fix_bug_reproduces() -> None:
+    """Companion verifier: without the in-flight registry, both refines
+    do fire — proving the bug reproduces without the fix.
+
+    Implemented as a fixture-style helper so the canonical regression
+    test below stays clean; this helper just confirms that monkey-
+    patching out the registry restores the buggy behaviour.
+    """
+    import asyncio
+
+    class _SlowPlanner:
+        def __init__(self) -> None:
+            self.refine_calls: list[dict[str, Any]] = []
+            self.gate = asyncio.Event()
+
+        async def generate(self, **kwargs: Any) -> Plan | None:
+            return None
+
+        async def refine(self, **kwargs: Any) -> Plan | None:
+            self.refine_calls.append(kwargs)
+            await self.gate.wait()
+            return None
+
+    sink = _ListSink()
+    planner = _SlowPlanner()
+    steerer = _build_steerer(sinks=[sink], planner=planner)
+    session = _session(revision_index=3)
+
+    # Disable the registry by giving it a no-op set so the bug
+    # reproduces.
+    class _NoOpSet(set):
+        def __contains__(self, item: Any) -> bool:
+            return False
+
+        def add(self, item: Any) -> None:
+            return None
+
+    steerer.drift._inflight_refine_keys = _NoOpSet()
+
+    drift_a = _drift(observed_revision_index=3, severity=DriftSeverity.WARNING)
+    drift_b = _drift(observed_revision_index=3, severity=DriftSeverity.WARNING)
+    task_a = asyncio.create_task(steerer.drift.handle_drift(drift_a, session))
+    for _ in range(100):
+        await asyncio.sleep(0)
+        if planner.refine_calls:
+            break
+    # Without the registry, drift_b's handle_drift will also block in
+    # the planner. Dispatch as a task so we can release the gate.
+    task_b = asyncio.create_task(steerer.drift.handle_drift(drift_b, session))
+    # Yield until B has also entered the planner.
+    for _ in range(200):
+        await asyncio.sleep(0)
+        if len(planner.refine_calls) >= 2:
+            break
+    planner.gate.set()
+    await asyncio.gather(task_a, task_b)
+    # Both judges fire refine; a follow-up escalation drift (raised by
+    # the handler-exhaustion path) MAY also drive a refine, so we
+    # assert at-least-two — the post-fix path is at-most-one.
+    assert len(planner.refine_calls) >= 2, (
+        f"pre-fix demonstrator: both concurrent judges should drive refine "
+        f"when the registry is disabled; got {len(planner.refine_calls)}"
+    )
+
+
+async def test_pre_fix_bug_reproducible_when_registry_disabled() -> None:
+    """Companion sanity test: the bug reproduces when the registry is bypassed.
+
+    Belt-and-braces for the regression below — confirms the test
+    methodology is sound (we're not testing a no-op).
+    """
+    await _verify_pre_fix_bug_reproduces()
+
+
+async def test_concurrent_judges_same_key_only_one_refine_fires() -> None:
+    """goldfive#405 MEDIUM #4: parallel judges observing the SAME
+    ``(kind, current_task_id)`` at the same revision must only dispatch
+    ONE refine.
+
+    Pre-fix: both judges read
+    ``session.last_addressed_revision_by_drift_key.get(key, 0) == 0``
+    before either's ``_apply_revision`` stamped the watermark — so
+    both passed the freshness gate and both ran refine.
+
+    Post-fix: an in-flight-refine registry stamped synchronously at
+    the gate site short-circuits the second arrival. Both judges still
+    emit ``DriftDetected`` for observability, but only one drives
+    ``planner.refine``.
+
+    Race construction: spin a slow planner (asyncio.sleep before
+    returning) so the first refine sits in-flight while we start the
+    second handle_drift in parallel. With the registry in place the
+    second observes the in-flight entry and short-circuits; without it,
+    both would land on the planner.
+    """
+    import asyncio
+
+    class _SlowPlanner:
+        def __init__(self) -> None:
+            self.refine_calls: list[dict[str, Any]] = []
+            self.gate = asyncio.Event()
+
+        async def generate(self, **kwargs: Any) -> Plan | None:
+            return None
+
+        async def refine(self, **kwargs: Any) -> Plan | None:
+            self.refine_calls.append(kwargs)
+            # Block until released so the second handle_drift starts
+            # while the first refine is still in-flight.
+            await self.gate.wait()
+            return None  # _NullPlanner-equivalent: forces handler-exhaustion path
+
+    sink = _ListSink()
+    planner = _SlowPlanner()
+    steerer = _build_steerer(sinks=[sink], planner=planner)
+    session = _session(revision_index=3)
+    drift_a = _drift(observed_revision_index=3, severity=DriftSeverity.WARNING)
+    drift_b = _drift(observed_revision_index=3, severity=DriftSeverity.WARNING)
+
+    # Start the first dispatch; it'll await the planner gate.
+    task_a = asyncio.create_task(steerer.drift.handle_drift(drift_a, session))
+    # Yield until A is sitting inside refine — at most a handful of
+    # event-loop iterations after the in-flight key has been stamped.
+    for _ in range(100):
+        await asyncio.sleep(0)
+        if planner.refine_calls:
+            break
+    assert planner.refine_calls, "drift A should have reached planner.refine"
+
+    # Now dispatch B. A is still in-flight; B must short-circuit on
+    # the in-flight key check.
+    await steerer.drift.handle_drift(drift_b, session)
+
+    # Release A.
+    planner.gate.set()
+    await task_a
+
+    assert len(planner.refine_calls) == 1, (
+        f"goldfive#405 MEDIUM #4: only one refine must fire for two "
+        f"concurrent same-(kind, target) judges; got "
+        f"{len(planner.refine_calls)}"
+    )
+    # Both judges emit DriftDetected (observability preserved).
+    detected = _drift_detected_payloads(sink)
+    of_topic_emits = [p for p in detected if int(p.kind) == int(detected[0].kind)]
+    assert len(of_topic_emits) >= 2, (
+        "both judges must emit DriftDetected even when the second "
+        "short-circuits on the in-flight registry"
+    )
+
+
+async def test_inflight_key_cleared_after_dispatch_completes() -> None:
+    """The in-flight key is cleared in a finally so subsequent same-key
+    drifts (after the first completes) can dispatch normally.
+
+    Closes the failure mode where a crash / cancel mid-dispatch would
+    permanently wedge the key, silently suppressing every future
+    same-(kind, target) drift on the session.
+    """
+    sink = _ListSink()
+    planner = _NullPlanner()
+    steerer = _build_steerer(sinks=[sink], planner=planner)
+    session = _session(revision_index=3)
+    drift_first = _drift(observed_revision_index=3, severity=DriftSeverity.WARNING)
+    await steerer.drift.handle_drift(drift_first, session)
+
+    # First call recorded a refine attempt (planner is the null one;
+    # the path runs through to None-return and the entry is freed).
+    assert planner.refine_calls, "first drift must have dispatched"
+    # Inflight set should be empty post-dispatch.
+    assert steerer.drift._inflight_refine_keys == set(), (
+        "inflight key must be cleared after dispatch completes"
+    )
+
+    # A second same-(kind, target) drift dispatches normally (its
+    # observed revision is still 3 -- _NullPlanner doesn't install a
+    # new plan so the watermark isn't bumped). Confirms the entry
+    # didn't permanently suppress this key.
+    drift_second = _drift(observed_revision_index=3, severity=DriftSeverity.WARNING)
+    await steerer.drift.handle_drift(drift_second, session)
+    assert len(planner.refine_calls) == 2, (
+        "second drift must dispatch -- the registry entry was cleared"
+    )
+
+
+async def test_inflight_key_cleared_on_dispatch_exception() -> None:
+    """The in-flight key is cleared even if dispatch raises.
+
+    The ``finally`` clause guarantees no permanent wedge — a planner
+    that raises during refine still releases the key so the next
+    same-(kind, target) verdict can land.
+    """
+    class _RaisingPlanner:
+        def __init__(self) -> None:
+            self.refine_calls: list[dict[str, Any]] = []
+
+        async def generate(self, **kwargs: Any) -> Plan | None:
+            return None
+
+        async def refine(self, **kwargs: Any) -> Plan | None:
+            self.refine_calls.append(kwargs)
+            raise RuntimeError("simulated refine failure")
+
+    sink = _ListSink()
+    planner = _RaisingPlanner()
+    steerer = _build_steerer(sinks=[sink], planner=planner)
+    session = _session(revision_index=3)
+    drift = _drift(observed_revision_index=3, severity=DriftSeverity.WARNING)
+
+    # handle_drift catches refine exceptions internally; should not raise.
+    await steerer.drift.handle_drift(drift, session)
+    # Key released even though refine raised.
+    assert steerer.drift._inflight_refine_keys == set(), (
+        "inflight key must be cleared in finally even when dispatch raises"
+    )
+
+
 async def test_apply_revision_does_not_stamp_for_user_authored_drifts() -> None:
     """User-authored drifts bypass the gate AND don't stamp the watermark.
 

--- a/tests/test_tool_loops.py
+++ b/tests/test_tool_loops.py
@@ -333,6 +333,180 @@ def test_cross_invocation_isolation() -> None:
 
 
 # ---------------------------------------------------------------------------
+# goldfive#420 — run-scoped buckets accumulate across re-invocations
+# ---------------------------------------------------------------------------
+
+
+def test_run_scoped_bucket_accumulates_across_reinvocations() -> None:
+    """goldfive#420 regression: re-invocations of the same agent within
+    one run share a bucket when ``session_run_id`` is threaded.
+
+    Reproduces the cherry-tree e2e (session ``2d27ff4a``, 2026-05-13)
+    failure mode where ``debugger_agent`` was re-invoked 11+ times,
+    each time calling ``find_presentation_files`` with varying args.
+    Pre-#420 the per-(invocation_id, agent_name) bucket gave every
+    re-invocation a fresh 2-entry window — never tripping the 7-call
+    CRITICAL name-tier. With ``session_run_id`` threaded, the calls
+    accumulate into one bucket and CRITICAL fires once the cumulative
+    name-tier threshold is met.
+    """
+    tracker = ToolLoopTracker()
+    # 11 re-invocations of the same agent, each emitting one
+    # find_presentation_files call with varying args. After 7 cumulative
+    # calls on the (run-id, agent) bucket the WORK name-tier CRITICAL
+    # (count >= 7) fires.
+    drifts_per_call: list[list[Any]] = []
+    for i in range(11):
+        result = tracker.observe_tool_call(
+            invocation_id=f"adk-inv-{i}",  # ADK mints a fresh id each re-invocation
+            agent_name="debugger_agent",
+            tool_name="find_presentation_files",
+            args={"topic": f"q{i}"},  # varying args -> name-tier path
+            task_id="t-debug",
+            session_run_id="run-cherry-tree",
+        )
+        drifts_per_call.append(result)
+    # By call 5: name count = 5 -> WARNING (work name warning=5).
+    assert drifts_per_call[4], "expected WARNING at cumulative call 5"
+    assert drifts_per_call[4][0].severity is DriftSeverity.WARNING
+    # By call 7: name count = 7 -> CRITICAL.
+    seventh = drifts_per_call[6]
+    assert len(seventh) == 1, (
+        f"goldfive#420: cumulative same-name calls across re-invocations "
+        f"should trip CRITICAL at 7, got {seventh}"
+    )
+    drift = seventh[0]
+    assert drift.severity is DriftSeverity.CRITICAL
+    assert drift.kind is DriftKind.LOOPING_REASONING
+    assert drift.raw is not None
+    assert drift.raw.get("category") == "work"
+    assert drift.raw.get("tier") == "critical"
+    assert drift.raw.get("mode") == "name"
+    # The drift event records the actual ADK invocation id (so the
+    # cancel target is right), not the run-scoped bucket key.
+    assert drift.raw.get("invocation_id") == "adk-inv-6"
+
+
+def test_run_scoped_bucket_isolates_parallel_agents() -> None:
+    """Same run, different agent names -> independent buckets.
+
+    Even under run-scoping, parallel sub-agents within one run still
+    must be isolated by agent_name so a researcher's read_file loop
+    doesn't poison the writer's bucket. Mirrors the legacy cross-
+    agent-isolation contract under the new scope key.
+    """
+    tracker = ToolLoopTracker()
+    for agent in ("coord", "researcher", "writer"):
+        for _ in range(2):
+            tracker.observe_tool_call(
+                invocation_id="inv-1",
+                agent_name=agent,
+                tool_name="read_file",
+                args={"path": "x"},
+                task_id="t1",
+                session_run_id="run-1",
+            )
+    # 2 calls per agent, each in its own (run-id, agent) bucket.
+    assert (
+        tracker.buffer_size(
+            invocation_id="inv-1", agent_name="coord", session_run_id="run-1"
+        )
+        == 2
+    )
+    assert (
+        tracker.buffer_size(
+            invocation_id="inv-1",
+            agent_name="researcher",
+            session_run_id="run-1",
+        )
+        == 2
+    )
+    assert (
+        tracker.buffer_size(
+            invocation_id="inv-1", agent_name="writer", session_run_id="run-1"
+        )
+        == 2
+    )
+
+
+def test_run_scoped_isolation_across_distinct_runs() -> None:
+    """Calls in different runs do NOT share a bucket even at same agent name.
+
+    Run-scoped accumulation must not bleed across runs. Two separate
+    runs of the same agent calling the same tool stay isolated.
+    """
+    tracker = ToolLoopTracker()
+    for run_id in ("run-a", "run-b"):
+        for i in range(3):
+            tracker.observe_tool_call(
+                invocation_id=f"{run_id}-inv-{i}",
+                agent_name="debugger_agent",
+                tool_name="find_presentation_files",
+                args={"topic": f"q{i}"},
+                task_id="t1",
+                session_run_id=run_id,
+            )
+    # Three calls in each run, isolated buckets.
+    assert (
+        tracker.buffer_size(
+            invocation_id="run-a-inv-0",
+            agent_name="debugger_agent",
+            session_run_id="run-a",
+        )
+        == 3
+    )
+    assert (
+        tracker.buffer_size(
+            invocation_id="run-b-inv-0",
+            agent_name="debugger_agent",
+            session_run_id="run-b",
+        )
+        == 3
+    )
+
+
+def test_run_scoped_progress_reset_clears_accumulated_bucket() -> None:
+    """on_task_progress with a session_run_id clears the run-scoped bucket.
+
+    The progress-reset gate must clear the SAME bucket that
+    observe_tool_call populates, otherwise a successful
+    report_task_completed would leave the run-scoped window unflushed
+    and a benign next call would still trip the loop detector.
+    """
+    tracker = ToolLoopTracker()
+    for i in range(3):
+        tracker.observe_tool_call(
+            invocation_id=f"inv-{i}",
+            agent_name="debugger_agent",
+            tool_name="find_presentation_files",
+            args={"topic": f"q{i}"},
+            task_id="t1",
+            session_run_id="run-1",
+        )
+    assert (
+        tracker.buffer_size(
+            invocation_id="inv-0",
+            agent_name="debugger_agent",
+            session_run_id="run-1",
+        )
+        == 3
+    )
+    tracker.on_task_progress(
+        invocation_id="inv-final",
+        agent_name="debugger_agent",
+        session_run_id="run-1",
+    )
+    assert (
+        tracker.buffer_size(
+            invocation_id="inv-0",
+            agent_name="debugger_agent",
+            session_run_id="run-1",
+        )
+        == 0
+    )
+
+
+# ---------------------------------------------------------------------------
 # Cross-agent isolation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Three coupled drift-detector bugs from the audit cluster, each with a regression test.

### #420 — tool_loops bucket fragments across re-invocations (HIGH)

`ToolLoopTracker` keyed buckets on `(invocation_id, agent_name)`. When a coordinator re-invokes the same sub-agent across one run (cherry-tree e2e, session `2d27ff4a`, 2026-05-13), each re-invocation got a fresh `invocation_id` and a fresh 2-entry window — 20 calls across 11 invocations never tripped the 7-call CRITICAL name-tier threshold. **Fix**: re-key on `(session.run_id, agent_name)` when the caller supplies a run id (the ADK plugin now does). Legacy callers (tests, third-party adapters) keep the per-invocation isolation as a fallback.

### #405 MEDIUM #4 — freshness-gate race between concurrent judges

Two parallel background judges observing the same `(kind, current_task_id)` at the same `observed_revision_index` both read `last_addressed = 0` before either's `_apply_revision` stamped the watermark (the stamp lives inside `_emit_plan_revised`'s lock, acquired after refine completes). Both passed the gate and dispatched. **Fix**: in-flight-refine registry stamped synchronously at the gate site; a second same-key judge emits `DriftDetected` for observability and short-circuits cancel+refine. Cleared in a `finally`. Required extracting `handle_drift`'s dispatch body into `_handle_drift_dispatch` so the try/finally wraps cleanly.

### #405 MEDIUM #6 — double-cancel for one drift

A CRITICAL promote-eligible drift fired two cancels: (1) the flag-only `request_invocation_cancel` at the top of dispatch wrote the cancel-state flag the executor consumes, then (2) `_cancel_inflight_for_revision` hard-cancelled after refine — by which point the executor may have restarted the invocation, so the second cancel landed on a fresh target and produced two unnecessary restarts. **Fix**: stamp `drift.id` in a per-observer set before the pre-cancel fires; `_cancel_inflight_for_revision` checks the set and short-circuits. Cleared in `handle_drift`'s `finally`.

## Tests (11 new)

- `tests/test_tool_loops.py` (+4): #420 regression simulating the cherry-tree re-invocation pattern; run-scoped accumulation; cross-run isolation; progress-reset clears the run-scoped bucket.
- `tests/test_drift_version_pin.py` (+4): #405 #4 regression (concurrent judges, only one refine fires); inflight key cleared after dispatch; inflight key cleared on exception; companion sanity test that the bug reproduces when the registry is bypassed.
- `tests/test_cooperative_cancellation.py` (+3): #405 #6 regression (`_cancel_inflight_for_revision` short-circuits when pre-cancel already fired); invariant (it still fires without a pre-cancel); bookkeeping primitive (pre-cancel stamps `drift.id` synchronously).

Full suite: **2556 passed, 59 skipped** (no regressions).

## Test plan

- [x] `pytest tests/test_tool_loops.py` — 37 passed (4 new for #420)
- [x] `pytest tests/test_drift_version_pin.py` — 17 passed (4 new for #405 #4)
- [x] `pytest tests/test_cooperative_cancellation.py` — 21 passed (3 new for #405 #6)
- [x] Full suite — 2556 passed, 59 skipped, 0 failed
- [x] Each new test verified to fail pre-fix when the corresponding registry is bypassed (companion sanity test `test_pre_fix_bug_reproducible_when_registry_disabled` confirms #405 #4 reproduces)

## Contracts preserved

- Existing `tool_loops` exact-repetition detection unchanged (test_exact_repeat_fires_warning et al. still pass).
- All thresholds unchanged.
- `observation_only` behaviour unchanged.
- Audit #402 / #403 / #404 fixes intact (their tests still pass).
- State-ownership audit clean.