### PR TITLE
docs: plan-descriptive growth Phase 1 status sync (PR 5 of 5 for #423)

### DIFF
--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -101,6 +101,20 @@ kinds group naturally into six categories.
 | `CONTEXT_PRESSURE` | Adapter observed a `finish_reason` indicating the context window was hit. | `warning` | yes |
 | `RESOURCE_EXHAUSTED` | Adapter observed rate-limit or quota exhaustion. | `warning` | yes |
 | `BLOCKED` | `report_task_blocked(task_id, blocker)` with a structural blocker. | `warning` | sometimes |
+| `CAPABILITY_MISMATCH` | Structural capability gap at `delegation_observed` time: Rule A (coordinator-style leaf-assignment, #253), Rule B (required-tools cover, #253), Rule C (out-of-DAG-order delegation, #268). See `goldfive/drift/capability_check.py`. | `critical` | yes (refine) |
+
+**Rule C status under plan-descriptive growth (goldfive#423).** Rule A
+and Rule B still fire normally. **Rule C** is active until PR 4 of
+#423 lands. When `SteeringConfig.descriptive_growth_enabled=True`
+(env `GOLDFIVE_STEER_DESCRIPTIVE_GROWTH=1`), the steerer bypasses
+Rule C in favour of synthesising a `discovered=True` task via
+`PlanReviser.install_descriptive_growth` — the plan grows to match
+reality rather than firing a structural drift. When the flag is
+False (the default until PR 4), Rule C fires as before. The data-
+model carriers (`Task.discovered`,
+`DelegationObserved.tool_args_json`) ship regardless of the flag.
+See [PLAN-DESCRIPTIVE-GROWTH.md](PLAN-DESCRIPTIVE-GROWTH.md) §7 for
+the full Rule A/B/C table under the new model.
 
 ### Discovery category — new work that was not in the plan
 

--- a/docs/design/PLAN-DESCRIPTIVE-GROWTH.md
+++ b/docs/design/PLAN-DESCRIPTIVE-GROWTH.md
@@ -2,10 +2,16 @@
 
 ## 1. Status
 
-**Proposal — not yet implemented.** Filed for tracking; ships behind a feature
-flag (`GOLDFIVE_PLAN_DESCRIPTIVE_GROWTH=1`) if accepted. No production code
-in this PR. A separate implementation PR (with the 5-PR sequence in §9)
-follows after design review.
+**Phase 1 shipped (PRs 1-3 of 5).** `Task.discovered` data model +
+`DelegationObserved.tool_args_json` proto extension landed in #431
+(merged at `498320e`). Descriptive growth fallback in
+`_maybe_pin_delegation_task` landed in #433 (merged at `1abee69`)
+behind `SteeringConfig.descriptive_growth_enabled` (default OFF, env
+`GOLDFIVE_STEER_DESCRIPTIVE_GROWTH`). Harmonograf rendering landed
+in `pedapudi/harmonograf#291` (merged at `d2b3921`). **PR 4 (flag
+flip + Rule C retirement) and PR 5 (this docs sync) close out the
+phase.** PR 4 is deferred until live validation is possible
+(kossel.lan offline at the time of writing).
 
 Related: [PLAN-LIFECYCLE.md](PLAN-LIFECYCLE.md) (the contract this proposal
 extends), [DRIFT.md](DRIFT.md) (the `CAPABILITY_MISMATCH` Rule C retirement
@@ -771,17 +777,17 @@ refines do not happen.
 
 ## 9. Implementation plan
 
-| PR | Scope | Behind flag |
-|---|---|---|
-| 1 | `Task.discovered: bool` + `Task.discovery_identity_hash: str` fields + `Plan.validate` update (no rule change; just opaque metadata) + **`DelegationObserved.tool_args` proto extension** (canonical args representation on `goldfive.v1`, so PR 2's dedup hash is computed from observed-fact data, not a pin-time intercept — see §13) + state-store migration (proto regen + harmonograf-side ingestion of the new field + schema bump). Forward-compat: old events without `tool_args` default-empty; PR 2's dedup must tolerate `tool_args=None` and fall back to per-`(agent, task_id)` granularity as a coarser-but-still-useful dedup. | n/a — additive |
-| 2 | `_maybe_pin_delegation_task` fallback to discovery + `PlanReviser.install_descriptive_growth` helper (§5 Option D, lock-acquiring) + §5.2 test plan + **§11.6 regression race test** (mandatory acceptance criterion) + tracking issue cross-link to #413 for the test template | `GOLDFIVE_PLAN_DESCRIPTIVE_GROWTH=1` |
-| 3 | Harmonograf-side rendering of discovered tasks (badge, separate visualisation lane, drift filter) | flag-gated |
-| 4 | Retire `CAPABILITY_MISMATCH` Rule C (4a soft, 4b hard) | flag → default-on |
-| 5 | Docs: update PLAN-LIFECYCLE.md (revision-cascade §4.5 covers discovery), DRIFT.md (Rule C retirement), this design doc (mark Implemented) | n/a |
+| PR | Scope | Behind flag | Status |
+|---|---|---|---|
+| 1 | `Task.discovered: bool` + `Task.discovery_identity_hash: str` fields + `Plan.validate` update (no rule change; just opaque metadata) + **`DelegationObserved.tool_args_json` proto extension** (canonical args representation on `goldfive.v1`, so PR 2's dedup hash is computed from observed-fact data, not a pin-time intercept — see §13) + state-store migration (proto regen + harmonograf-side ingestion of the new field + schema bump). Forward-compat: old events without `tool_args_json` default-empty; PR 2's dedup must tolerate `tool_args=None` and fall back to per-`(agent, task_id)` granularity as a coarser-but-still-useful dedup. | n/a — additive | **Shipped** (#431, `498320e`) |
+| 2 | `_maybe_pin_delegation_task` fallback to discovery + `PlanReviser.install_descriptive_growth` helper (§5 Option D, lock-acquiring) + §5.2 test plan + **§11.6 regression race test** (mandatory acceptance criterion) + tracking issue cross-link to #413 for the test template | `SteeringConfig.descriptive_growth_enabled` (env `GOLDFIVE_STEER_DESCRIPTIVE_GROWTH`), default OFF | **Shipped** (#433, `1abee69`) |
+| 3 | Harmonograf-side rendering of discovered tasks (badge, separate visualisation lane, drift filter) | flag-gated | **Shipped** (`pedapudi/harmonograf#291`, `d2b3921`) |
+| 4 | Retire `CAPABILITY_MISMATCH` Rule C (4a soft, 4b hard) — flip `descriptive_growth_enabled` default to True; bypass Rule C when flag is on | flag → default-on | **Deferred** — requires live validation (kossel.lan offline at time of writing) |
+| 5 | Docs: update PLAN-LIFECYCLE.md (Phase 1 discovery section), DRIFT.md (Rule C status under flag), this design doc (mark Phase 1 shipped) | n/a | **This PR** |
 
 Each PR is independently merge-able. PR 2 ships behind the flag so
-production traffic stays on the old path until PR 3 lands the UI
-support.
+production traffic stays on the old path until PR 4 flips the
+default.
 
 ## 10. Alternatives considered
 

--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -779,3 +779,56 @@ is non-trivial, and the model's self-assessment can itself be wrong
 their workload justifies it, not as a default. See
 [DRIFT.md §"Reflective self-progress category"](DRIFT.md#reflective-self-progress-category--the-agent-assessing-itself)
 for the full taxonomy and failure-mode handling.
+
+---
+
+## 9. Plan-descriptive growth (Phase 1)
+
+Phase 1 of [goldfive#423](https://github.com/pedapudi/goldfive/issues/423)
+extends the plan-lifecycle contract to cover one new write path:
+**reactive growth at delegation-observation time** when a coordinator
+delegates to an agent the planner did not forecast.
+
+When `_maybe_pin_delegation_task` cannot match an observed delegation
+to an existing PENDING task via the tier-1 / tier-2 / tier-3 disambiguation
+ladder, the steerer synthesises a `Task(discovered=True, ...)`, installs
+it onto `session.plan` via `PlanReviser.install_descriptive_growth`, and
+re-pins `session.current_task_id` onto the new task. The revision is
+emitted as a `NEW_WORK_DISCOVERED` drift (INFO severity, framework-
+authored) and lands in both steering and observation modes (the
+`_apply_revision` discovery carve-out from goldfive#258).
+
+**Feature flag.** Gated on `SteeringConfig.descriptive_growth_enabled`
+(env `GOLDFIVE_STEER_DESCRIPTIVE_GROWTH`, default OFF). When the flag
+is off, `_maybe_pin_delegation_task` retains the pre-#423 fallback
+behaviour and `CAPABILITY_MISMATCH` Rule C fires as today. PR 4 of
+#423 (deferred pending live validation) flips the default.
+
+**Dedup.** Repeated delegations to the same `(agent_name,
+args-token-set)` re-pin to the existing discovered task rather than
+growing the plan. The key is `Task.discovery_identity_hash`, a
+stable SHA-256 prefix computed from the observed
+`DelegationObserved.tool_args_json` payload (NOT a goldfive-side
+intercept of args at pin time — see PLAN-DESCRIPTIVE-GROWTH.md §13
+"adaptive, not predictive").
+
+**Write path.** `install_descriptive_growth` acquires the per-session
+plan lock (`_get_plan_lock(session)`) for the swap window, re-reads
+`session.plan` inside the lock as the linearisation point against
+concurrent refines and concurrent discoveries, runs the dedup check,
+and only then builds the revised plan via `add_tasks` + `bump_revision`
+and swaps via `set_session_plan`. This is the lock-acquiring synchronous
+growth path (Option D from the design doc) — single writer, inside the
+lock, full stop. The race contract is identical to goldfive#403's
+partial-apply window fix.
+
+**Topology.** Discovered tasks land as independent sub-DAG roots: no
+predecessor edges, no supersedes link. Rule 7 of `Plan.validate`
+allows this because the predecessor set is empty. A subsequent
+planner-authored refine may supersede a discovered task with a
+`SupersessionKind.REPLACE` / `CORRECT` link if the planner decides to
+consolidate the discovered work into its forecast.
+
+See [PLAN-DESCRIPTIVE-GROWTH.md](PLAN-DESCRIPTIVE-GROWTH.md) for the
+full design rationale, the dedup hash function, the refine-cascade
+semantics, and the §11.6 race-test contract.

--- a/goldfive/plan_reviser.py
+++ b/goldfive/plan_reviser.py
@@ -18,6 +18,10 @@ Responsibilities
     :class:`~goldfive.control.ControlMessage` STEER deliveries.
   - :meth:`install_user_steer` — the always-lands user-steer path with
     a deterministic minimum-evolution fallback (PLAN-LIFECYCLE.md §4.2.1).
+  - :meth:`install_descriptive_growth` — reactive plan growth at
+    delegation-observation time for unmatched delegations (goldfive#423
+    PR 2). See ``docs/design/PLAN-DESCRIPTIVE-GROWTH.md`` §4.3 + §5
+    Option D for the lock-acquiring synchronous growth contract.
   - :meth:`apply_user_steer_with_plan` — deprecated back-compat shim.
 
 * The shared install pipeline :meth:`_install_with_drift`:


### PR DESCRIPTION
## Summary

PR 5 of 5 for the plan-descriptive growth feature (#423) — docs-only
sync to reflect what is currently in main. PR 4 (flag flip + Rule C
retirement) is deferred until live validation is possible.

- `docs/design/PLAN-DESCRIPTIVE-GROWTH.md` — status flipped from
  "Proposal" to "Phase 1 shipped (PRs 1-3 of 5)" with merge commits
  (#431/498320e, #433/1abee69, harmonograf#291/d2b3921). §9
  implementation-plan table gains a Status column; PR 4 marked
  Deferred (live validation), PR 5 as this PR.
- `docs/design/PLAN-LIFECYCLE.md` — new section 9 covering reactive
  plan growth at delegation-observation time: `discovered=true`
  tasks, the `descriptive_growth_enabled` flag (default OFF), dedup
  via `discovery_identity_hash`, and the lock-acquiring synchronous
  growth path (Option D). References the design doc for detail.
- `docs/design/DRIFT.md` — `CAPABILITY_MISMATCH` row added to the
  Structural category table with a status note: Rule A/B unchanged,
  Rule C active until PR 4 (bypassed when flag is on).
- `goldfive/plan_reviser.py` — module docstring lists
  `install_descriptive_growth` among public install entry points
  with a pointer to the design doc.

No code logic changes. Tests still pass (2640 passed, 59 skipped).

## Test plan

- [x] `pytest tests/ -x --tb=short` — 2640 passed, 59 skipped, no
  failures.
- [x] Design-doc cross-references verified: PLAN-LIFECYCLE.md §9 and
  DRIFT.md both link back to PLAN-DESCRIPTIVE-GROWTH.md for full
  detail.
- [x] Status fields precise: PR 1 (#431, 498320e), PR 2 (#433,
  1abee69), PR 3 (harmonograf#291, d2b3921), PR 4 Deferred, PR 5
  This PR.
- [x] `Co-Authored-By: Claude` trailer absent.

**DO NOT merge** — team lead reviews.