### PR TITLE
fix(steerer): key user-steer suppression window on a logical-turn counter (closes #441)

### DIFF
--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -717,7 +717,7 @@ Keys:
 | `goldfive.current_plan_id` | `Runner` on plan submit, `DefaultSteerer._apply_revision` on revision | Set when a plan is installed; persists across the run |
 | `goldfive.current_task_id`, `goldfive.current_task_title` | `PlanReconciler` on before/after_agent; `DefaultSteerer.mark_task_*` on legacy transitions | Set on RUNNING; cleared on terminal transition of the same task and at run end |
 | `goldfive.goals_summary` | `Runner` after goal derivation; `DefaultSteerer._apply_user_steer_state` after USER_STEER | Formatted `"- [id] summary\n..."` block; refreshed whenever `session.goals` changes |
-| `goldfive.active_steer.body`, `goldfive.active_steer.at_turn` | `DefaultSteerer._apply_user_steer_state` on USER_STEER drift | `body` is the raw steer text; `at_turn` is the session sequence value at fire time. Cleared at run end |
+| `goldfive.active_steer.body`, `goldfive.active_steer.at_turn` | `DefaultSteerer._apply_user_steer_state` on USER_STEER drift | `body` is the raw steer text; `at_turn` is the logical-turn counter (`Session._reasoning_turn`) value at fire time — see goldfive#441. Cleared at run end |
 | `goldfive.cancelled_function_call_ids` | `ADKAdapter._heal_pending_tool_calls` | Append-only list of function_call ids that were healed mid-invocation. De-duplicated within the run |
 
 Ownership rules:

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -585,13 +585,17 @@ class SteeringConfig:
       promoted. Useful for high-noise trees where the WARNING judge
       fires too aggressively.
 
-    ``suppression_window_turns`` is the number of session-sequence
-    "turns" (monotonic ``_next_sequence`` increments) within which a
-    fresh user-authored steer suppresses any goldfive-authored steer
-    promotion. The goldfive drift still surfaces as a ``DriftDetected``
-    event with ``suppressed_by_user_steer=true``; no cancel or refine
-    fires. Default ``3`` keeps a live operator override dominant
-    across a few detector ticks.
+    ``suppression_window_turns`` is the number of *logical turns*
+    within which a fresh user-authored steer suppresses any
+    goldfive-authored steer promotion. A logical turn is one reasoning
+    observation (``Session._reasoning_turn`` — one tick per model
+    response fed through the drift pipeline), NOT a raw event-sequence
+    increment: keying on the per-event ``_next_sequence`` let
+    observability-event volume shrink the effective window
+    (goldfive#441). The goldfive drift still surfaces as a
+    ``DriftDetected`` event with ``suppressed_by_user_steer=true``; no
+    cancel or refine fires. Default ``3`` keeps a live operator
+    override dominant across a few agent turns.
 
     ``observation_only`` (goldfive#254) gates the three actual steering
     injection points on :class:`~goldfive.steerer.DefaultSteerer`:

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -1635,6 +1635,12 @@ class DriftObserver:
         """
         if not text:
             return
+        # goldfive#441 — advance the logical-turn counter once per
+        # reasoning observation. The user-steer suppression window
+        # (:meth:`_should_promote_to_steer`) measures freshness against
+        # this counter, NOT ``_next_sequence`` (which counts every
+        # emitted event and is inflated by decision-telemetry volume).
+        session.mark_reasoning_turn()
         history = session.reasoning_history
         history.append(text)
         cap = getattr(session, "reasoning_history_max", 20) or 20
@@ -4812,8 +4818,9 @@ class DriftObserver:
            their legacy ladder mapping.
         3. The severity must clear the configured ``threshold``.
         4. If a user-authored steer is within the freshness window
-           (``suppression_window_turns`` turns), stamp the suppression
-           flag and return ``False``. Otherwise return ``True``.
+           (``suppression_window_turns`` *logical turns* — see
+           ``Session._reasoning_turn``), stamp the suppression flag and
+           return ``False``. Otherwise return ``True``.
         """
         if drift.kind in self._USER_AUTHORED_DRIFT_KINDS:
             return False
@@ -4835,7 +4842,11 @@ class DriftObserver:
 
             active = StateStore.for_session(session).get_active_steer()
             if active is not None and active.source.lower() == "user":
-                current_turn = int(getattr(session, "_next_sequence", 0) or 0)
+                # goldfive#441 — freshness is measured in *logical
+                # turns* (``_reasoning_turn``: one tick per reasoning
+                # observation), NOT ``_next_sequence`` (per-event, and
+                # inflated by decision-telemetry volume from #436/#440).
+                current_turn = int(getattr(session, "_reasoning_turn", 0) or 0)
                 age = current_turn - active.at_turn
                 if 0 <= age < window:
                     drift.suppressed_by_user_steer = True
@@ -4925,7 +4936,9 @@ class DriftObserver:
         # only, or catch ``CancelledError`` at the goldfive-steer
         # boundary and continue.
         # 2. Stamp active-steer state + compose the restart body.
-        at_turn = int(getattr(session, "_next_sequence", 0) or 0)
+        # ``at_turn`` is the logical-turn counter (goldfive#441), the
+        # same surface the user-steer freshness window reads.
+        at_turn = int(getattr(session, "_reasoning_turn", 0) or 0)
         body = self._compose_goldfive_steer_body(drift)
         try:
             _ostate.set_active_steer(
@@ -5288,11 +5301,12 @@ class DriftObserver:
         raw_body, author, steer_id = self._unpack_steer_context(drift)
         body = raw_body.strip()
         # Stamp the active_steer keys regardless so readers see "a
-        # steer is active as of turn N". ``at_turn`` uses the
-        # session's monotonic sequence counter which increments on
-        # every emitted event — a cheap, always-available "turn"
-        # proxy.
-        at_turn = getattr(session, "_next_sequence", 0) or 0
+        # steer is active as of turn N". ``at_turn`` is the logical-turn
+        # counter (``_reasoning_turn``: one tick per reasoning
+        # observation) so the freshness window in
+        # :meth:`_should_promote_to_steer` measures real agent turns,
+        # not raw event volume (goldfive#441).
+        at_turn = getattr(session, "_reasoning_turn", 0) or 0
         try:
             _ostate.set_active_steer(
                 session.state,

--- a/goldfive/state_store.py
+++ b/goldfive/state_store.py
@@ -77,7 +77,8 @@ Active steer (set by DefaultSteerer on USER_STEER drift):
 * ``goldfive.active_steer.body`` — the steer body as authored by the
   operator (post-``_compose_steer_restart_message`` UNWRAPPING; i.e.
   the raw steer text, not the framed restart message).
-* ``goldfive.active_steer.at_turn`` — monotonic sequence value
+* ``goldfive.active_steer.at_turn`` — logical-turn counter value
+  (``Session._reasoning_turn``: one tick per reasoning observation)
   captured at steer-fire time. Lets downstream refines know "was this
   steer before or after the observation I'm looking at?".
 * ``goldfive.active_steer.author`` — operator identity from the
@@ -117,7 +118,8 @@ Design notes
   active — so ``goldfive.active_steer.*`` is just a durable read-back
   of the most recent USER_STEER, not a cooldown window. Consumers
   that want "has the steer expired?" compare the recorded ``at_turn``
-  against the current session sequence themselves.
+  against the current logical-turn counter (``Session._reasoning_turn``)
+  themselves.
 * **Tree-agnostic.** No presentation-specific or domain keys. The
   namespace is pure orchestration state.
 * **Writers only under the prefix.** :func:`write` refuses non-goldfive

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1945,11 +1945,33 @@ class Session:
     # remain at 0 so single-Session callers (tests, programmatic use)
     # see no behaviour change.
     _next_sequence: int = 0
+    # Monotonic *logical-turn* counter — one increment per reasoning
+    # observation (:meth:`DriftObserver.observe_reasoning`, i.e. one
+    # model response fed through the drift pipeline). Deliberately
+    # distinct from ``_next_sequence``, which counts every emitted
+    # event: the user-steer suppression window in
+    # :meth:`DriftObserver._should_promote_to_steer` measures steer
+    # freshness in *logical turns* and must not be inflated by
+    # observability-event volume (goldfive#441 — the decision-telemetry
+    # events added in #436/#440 emit several events per turn). Per-
+    # Session, starts at 0; a steer stamped against a prior Session's
+    # counter reads as stale once a fresh Session resets to 0, which is
+    # the desired cross-turn behaviour.
+    _reasoning_turn: int = 0
 
     def next_sequence(self) -> int:
         s = self._next_sequence
         self._next_sequence = s + 1
         return s
+
+    def mark_reasoning_turn(self) -> int:
+        """Advance the logical-turn counter and return the new value.
+
+        Called once per reasoning observation by
+        :meth:`DriftObserver.observe_reasoning`. See ``_reasoning_turn``.
+        """
+        self._reasoning_turn += 1
+        return self._reasoning_turn
 
     def next_sequence_and_event_id(self) -> tuple[int, str]:
         """Atomic pair: increment sequence, mint matching event_id.

--- a/tests/test_steer_unification.py
+++ b/tests/test_steer_unification.py
@@ -236,21 +236,14 @@ async def test_goldfive_steer_does_not_promote_at_info_severity() -> None:
 async def test_goldfive_steer_suppressed_when_user_steer_active() -> None:
     """Fresh user steer within the freshness window blocks a goldfive steer.
 
-    goldfive a4: each refine now emits two extra dict-envelope sidecars
-    (``refine_attempted`` + correlation ``plan_revised``) which advance
-    ``session._next_sequence`` alongside the canonical proto events.
-    ``_should_promote_to_steer`` reads ``_next_sequence`` as the "current
-    turn" surrogate, so the user-steer's promotion path now consumes
-    more sequence positions than before. The window is widened from 3
-    to 6 to keep the suppression invariant honoured under the new
-    emit count. (See the PR's "ordering invariant weakened" note.)
-    manifest-and-decision-telemetry: the new decision-telemetry events
-    (DetectorDispatchOrdered once per session, LadderTransitionDecided
-    + RetryBudgetSpent per drift handling) advance ``_next_sequence``
-    further; window widened to 20 so the suppression invariant
-    survives the extra emission overhead.
+    goldfive#441: freshness is measured in *logical turns*
+    (``Session._reasoning_turn``), not raw event sequence. No reasoning
+    observation elapses between the user steer and the goldfive drift
+    here, so the steer is age-0 and suppresses the drift at the default
+    window (3) — no test-only widening needed regardless of how many
+    decision-telemetry events the promotion path emits.
     """
-    steerer, session, sink, planner, adapter = _bind(window=20)
+    steerer, session, sink, planner, adapter = _bind()
 
     # Apply a user steer first.
     user_msg = ControlMessage(
@@ -300,16 +293,16 @@ async def test_goldfive_steer_fires_when_user_steer_stale() -> None:
     """User steer outside the freshness window no longer blocks promotion."""
     steerer, session, _sink, planner, _adapter = _bind(window=1)
 
-    # Apply a user steer then synthetically advance the session sequence
-    # beyond the window.
+    # Apply a user steer then advance the logical-turn counter
+    # (goldfive#441) beyond the window.
     user_msg = ControlMessage(
         kind=ControlKind.STEER,
         id="ctl-stale",
         payload={"note": "initial", "annotation_id": "ann_stale"},
     )
     await steerer.drift.observe(user_msg, session)
-    # Advance sequence beyond the window.
-    session._next_sequence += 10
+    # Advance the reasoning-turn counter beyond the window.
+    session._reasoning_turn += 10
 
     drift = DriftEvent(
         kind=DriftKind.OFF_TOPIC,
@@ -324,6 +317,111 @@ async def test_goldfive_steer_fires_when_user_steer_stale() -> None:
     # active_steer now carries the goldfive body.
     assert session.state[_ostate.KEY_ACTIVE_STEER_SOURCE] == "goldfive"
     assert session.state[_ostate.KEY_ACTIVE_STEER_BODY] == "fresh detector fire"
+
+
+async def test_suppression_window_unaffected_by_event_volume() -> None:
+    """goldfive#441 regression: telemetry-event volume cannot shrink the window.
+
+    The freshness window is keyed on the logical-turn counter
+    (``Session._reasoning_turn``), not the per-event ``_next_sequence``.
+    Emitting a large volume of observability events between the user
+    steer and the competing goldfive drift advances ``_next_sequence``
+    but NOT ``_reasoning_turn`` — so the steer stays age-0 and the
+    drift is still suppressed at the default window.
+    """
+    steerer, session, sink, planner, _adapter = _bind()  # default window=3
+
+    await steerer.drift.observe(
+        ControlMessage(
+            kind=ControlKind.STEER,
+            id="ctl-vol",
+            payload={"note": "stay on task", "annotation_id": "ann_vol"},
+        ),
+        session,
+    )
+    refine_steer_before = len(planner.refine_steer_calls)
+    # Simulate a heavy decision-telemetry stream (#436/#440 emit several
+    # events per turn): bump the per-event counter far past the window
+    # WITHOUT advancing the logical-turn counter.
+    session._next_sequence += 500
+
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="goldfive-signal-vol",
+        current_task_id="t2",
+    )
+    await steerer.drift.handle_drift(drift, session)
+
+    # Still suppressed — event volume did not consume the window.
+    assert len(planner.refine_steer_calls) == refine_steer_before
+    assert session.state[_ostate.KEY_ACTIVE_STEER_SOURCE] == "user"
+    matching = [
+        e
+        for e in _drift_detected_events(sink)
+        if e.drift_detected.detail == "goldfive-signal-vol"
+    ]
+    assert matching
+    assert matching[-1].drift_detected.suppressed_by_user_steer is True
+
+
+async def test_suppression_window_counts_logical_turns() -> None:
+    """goldfive#441: the window counts down once per reasoning turn.
+
+    A user steer is suppressing at age 0; after ``window`` logical
+    turns elapse (``_reasoning_turn`` advanced) it is stale and the
+    competing goldfive drift promotes.
+    """
+    steerer, session, _sink, planner, _adapter = _bind()  # default window=3
+
+    await steerer.drift.observe(
+        ControlMessage(
+            kind=ControlKind.STEER,
+            id="ctl-turns",
+            payload={"note": "initial", "annotation_id": "ann_turns"},
+        ),
+        session,
+    )
+    # Two logical turns elapse — still inside the window of 3.
+    session.mark_reasoning_turn()
+    session.mark_reasoning_turn()
+    drift_inside = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="inside-window",
+        current_task_id="t2",
+    )
+    await steerer.drift.handle_drift(drift_inside, session)
+    assert planner.refine_steer_calls == []  # suppressed
+    assert session.state[_ostate.KEY_ACTIVE_STEER_SOURCE] == "user"
+
+    # A third logical turn pushes the steer to age 3 == window -> stale.
+    session.mark_reasoning_turn()
+    drift_outside = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="outside-window",
+        current_task_id="t2",
+    )
+    await steerer.drift.handle_drift(drift_outside, session)
+    assert len(planner.refine_steer_calls) == 1  # promoted
+    assert session.state[_ostate.KEY_ACTIVE_STEER_SOURCE] == "goldfive"
+
+
+async def test_observe_reasoning_advances_logical_turn_counter() -> None:
+    """``observe_reasoning`` ticks ``Session._reasoning_turn`` once per call."""
+    steerer = DefaultSteerer(reasoning_drift_mode="off")
+    steerer.bind(sinks=[ListSink()], planner=_StubPlanner(revised=_make_plan()))
+    session = _make_session()
+
+    assert session._reasoning_turn == 0
+    await steerer.drift.observe_reasoning("a reasoning block", session=session)
+    assert session._reasoning_turn == 1
+    await steerer.drift.observe_reasoning("another reasoning block", session=session)
+    assert session._reasoning_turn == 2
+    # Empty reasoning is a no-op and does not advance the counter.
+    await steerer.drift.observe_reasoning("", session=session)
+    assert session._reasoning_turn == 2
 
 
 # ---------------------------------------------------------------------------
@@ -517,15 +615,13 @@ async def test_goldfive_drift_event_authored_by_goldfive_when_unset() -> None:
 async def test_suppressed_drift_event_wire_flag() -> None:
     """DriftDetected carries suppressed_by_user_steer=True on suppression.
 
-    ``window`` is measured against the session's monotonic event-
-    sequence counter, which now includes the paired
-    ``SteeringDecisionMade`` observability events introduced by
-    zicato-optimization-surface (one per ``DriftDetected``). The
-    suppression intent here is "fire-immediately-after-steer is
-    suppressed" — a generous window keeps the test honest while the
-    counter-vs-logical-turn semantic mismatch is in flight.
+    goldfive#441: the window is measured in logical turns
+    (``Session._reasoning_turn``). The goldfive drift fires immediately
+    after the steer with no reasoning observation in between, so it is
+    age-0 and suppressed at the default window — observability-event
+    volume no longer affects the outcome.
     """
-    steerer, session, sink, planner, _adapter = _bind(window=50)
+    steerer, session, sink, planner, _adapter = _bind()
     # User steer first.
     await steerer.drift.observe(
         ControlMessage(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -148,6 +148,22 @@ class TestSessionSequence:
         # b starts fresh regardless of a's state.
         assert b.next_sequence() == 0
 
+    def test_mark_reasoning_turn_is_monotonic_and_independent(self) -> None:
+        """goldfive#441: the logical-turn counter is separate from _next_sequence."""
+        s = Session(run_id="r1")
+        assert s._reasoning_turn == 0
+        assert s.mark_reasoning_turn() == 1
+        assert s.mark_reasoning_turn() == 2
+        # Advancing the per-event counter must NOT move the turn counter.
+        s.next_sequence()
+        s.next_sequence()
+        assert s._reasoning_turn == 2
+        # ...and vice versa.
+        before = s._next_sequence
+        s.mark_reasoning_turn()
+        assert s._next_sequence == before
+        assert s._reasoning_turn == 3
+
 
 # ---------------------------------------------------------------------------
 # Goal predicate is a live callable


### PR DESCRIPTION
Closes #441.

## Problem

The user-steer freshness window in `DriftObserver._should_promote_to_steer` measured "turns" against `Session._next_sequence` — a **per-event** counter. The decision-telemetry events added in #436/#440 emit several events per logical turn, inflating `_next_sequence` and shrinking the effective window: a fresh operator steer suppressed competing goldfive auto-steers for fewer real agent turns than configured. Evidence: #436/#440 had to widen test window overrides (5→50, 6→20) to stay green against the inflated stream.

## Fix

Add `Session._reasoning_turn` — a monotonic **logical-turn** counter ticked once per reasoning observation (`DriftObserver.observe_reasoning`, i.e. one model response fed through the drift pipeline), via `Session.mark_reasoning_turn()`. The suppression window's three sites now key on it:

- reader: `_should_promote_to_steer`
- writers of `active_steer.at_turn`: `_promote_drift_to_steer`, `_apply_user_steer_state`

`_next_sequence` is untouched (it stays the per-event sink counter). Observability-event volume can no longer consume the window. `suppression_window_turns` now genuinely means logical turns.

The counter is per-Session and starts at 0 — a steer stamped against a prior Session's counter reads as stale (negative age) once a fresh Session resets, which the existing `0 <= age` guard already handles correctly.

## Tests

- `test_mark_reasoning_turn_is_monotonic_and_independent` — the new counter is independent of `_next_sequence` in both directions.
- `test_suppression_window_unaffected_by_event_volume` — the #441 regression guard: bumping `_next_sequence` by 500 does NOT shrink the window.
- `test_suppression_window_counts_logical_turns` — the window counts down once per logical turn; stale after `window` turns.
- `test_observe_reasoning_advances_logical_turn_counter` — `observe_reasoning` ticks the counter (empty text is a no-op).
- Reverts the test-only window inflations from #436/#440.

Full suite: 2297 passed, 127 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)