### PR TITLE
judges: enum-type JudgeVerdict.drift_kind / severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
 
 ## Unreleased — 2026-05-11
 
+### Judges
+
+- **`JudgeVerdict.drift_kind` / `severity` are now enum-typed.** The two
+  drift-flavoured fields were bare lowercase `str`s documented as
+  "matching `DriftKind` / `DriftSeverity`" — every caller building or
+  consuming a verdict had to hand-write the magic string. They now
+  accept the real `DriftKind` / `DriftSeverity` enums (the preferred,
+  typed form). The legacy lowercase-string form is still accepted for
+  back-compat: a string matching a known enum value is normalised to
+  the enum at construction (`JudgeVerdict.__post_init__`), so a verdict
+  built either way exposes a real enum on `verdict.drift_kind` /
+  `verdict.severity`. Because both enums are `StrEnum`, the normalised
+  value still compares equal to its lowercase string — existing
+  string-equality consumers see no behavioural change. An empty string
+  (no drift) or an unrecognised custom string is left untouched. The
+  built-in judge wrappers (`goldfive.builtin_judges`) now pass the
+  `DriftEvent` enums straight through with no string round-trip, and
+  the steerer's verdict-consuming path (`_drift_from_judge_verdict`,
+  `_emit_judgement`) handles both shapes.
+
 ### Delegation pin
 
 - **[#265](https://github.com/pedapudi/goldfive/issues/265) — agent-name

--- a/goldfive/judges/base.py
+++ b/goldfive/judges/base.py
@@ -24,8 +24,47 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from goldfive.types import DriftKind, DriftSeverity
+
 if TYPE_CHECKING:
     from goldfive.types import Plan, Session
+
+
+def _normalize_drift_kind(value: DriftKind | str) -> DriftKind | str:
+    """Coerce a verdict ``drift_kind`` to :class:`DriftKind` when possible.
+
+    Accepts either a :class:`DriftKind` enum member (the preferred,
+    typed form) or the legacy lowercase string. A string that matches a
+    known :class:`DriftKind` value is upgraded to the enum so consumers
+    get a real enum off ``JudgeVerdict.drift_kind``; an empty string or
+    an unrecognised custom string is returned unchanged so a forward-
+    compatible / domain-specific judge is not broken. :class:`DriftKind`
+    is a :class:`~enum.StrEnum`, so the upgraded value still compares
+    equal to the original lowercase string — back-compat is preserved.
+    """
+    if isinstance(value, DriftKind) or not value:
+        return value
+    try:
+        return DriftKind(str(value))
+    except ValueError:
+        return value
+
+
+def _normalize_drift_severity(value: DriftSeverity | str) -> DriftSeverity | str:
+    """Coerce a verdict ``severity`` to :class:`DriftSeverity` when possible.
+
+    Mirrors :func:`_normalize_drift_kind`: a :class:`DriftSeverity` enum
+    member passes through, a recognised legacy lowercase string is
+    upgraded to the enum, and an empty / unrecognised string is returned
+    unchanged. :class:`DriftSeverity` is a :class:`~enum.StrEnum`, so the
+    upgrade is transparent to existing string-equality consumers.
+    """
+    if isinstance(value, DriftSeverity) or not value:
+        return value
+    try:
+        return DriftSeverity(str(value))
+    except ValueError:
+        return value
 
 
 @dataclasses.dataclass(frozen=True)
@@ -83,10 +122,20 @@ class JudgeVerdict:
     flavour in the order: drift, rubric, boolean, numeric):
 
     * **drift** — set ``drift_emitted = True`` and populate
-      ``drift_kind`` + ``severity`` (lowercase strings matching
+      ``drift_kind`` + ``severity``. Both fields accept the typed
       :class:`~goldfive.types.DriftKind` /
-      :class:`~goldfive.types.DriftSeverity`). The steerer fires both
-      :class:`DriftDetected` (back-compat) and :class:`JudgementEmitted`.
+      :class:`~goldfive.types.DriftSeverity` enums (the preferred
+      form). The legacy lowercase-string form (``"tool_error"``,
+      ``"critical"``, ...) is still accepted for back-compat: a string
+      matching a known enum value is normalised to the enum at
+      construction, so a verdict built either way exposes a real enum
+      on ``verdict.drift_kind`` / ``verdict.severity``. Because both
+      enums are :class:`~enum.StrEnum`, the normalised value still
+      compares equal to its lowercase string — existing
+      string-equality consumers see no change. An empty string (no
+      drift) or an unrecognised custom string is left untouched. The
+      steerer fires both :class:`DriftDetected` (back-compat) and
+      :class:`JudgementEmitted`.
     * **rubric** — set ``rubric_score`` (an aggregate in [0, 1] or any
       domain-defined range) and optionally ``rubric_dimensions`` with
       per-dimension sub-scores.
@@ -100,10 +149,13 @@ class JudgeVerdict:
     :class:`JudgementEmitted.detail` for the UI.
     """
 
-    # drift-flavored (back-compat with existing detectors)
+    # drift-flavored (back-compat with existing detectors). ``drift_kind``
+    # / ``severity`` accept either the typed enum (preferred) or the
+    # legacy lowercase string; ``__post_init__`` normalises a recognised
+    # string to its enum so consumers always get a real enum value back.
     drift_emitted: bool = False
-    drift_kind: str = ""
-    severity: str = ""
+    drift_kind: DriftKind | str = ""
+    severity: DriftSeverity | str = ""
     # rubric-flavored
     rubric_score: float | None = None
     rubric_dimensions: dict[str, float] = dataclasses.field(default_factory=dict)
@@ -113,6 +165,19 @@ class JudgeVerdict:
     numeric_value: float | None = None
     metric_name: str = ""
     detail: str = ""
+
+    def __post_init__(self) -> None:
+        # The dataclass is ``frozen``; ``object.__setattr__`` is the
+        # sanctioned way to write a derived/normalised value during
+        # construction. Normalising here (rather than at every read
+        # site) means every consumer — the steerer, sinks, external
+        # callers — sees the typed enum without each having to coerce.
+        normalized_kind = _normalize_drift_kind(self.drift_kind)
+        if normalized_kind is not self.drift_kind:
+            object.__setattr__(self, "drift_kind", normalized_kind)
+        normalized_severity = _normalize_drift_severity(self.severity)
+        if normalized_severity is not self.severity:
+            object.__setattr__(self, "severity", normalized_severity)
 
 
 @runtime_checkable

--- a/goldfive/judges/base.py
+++ b/goldfive/judges/base.py
@@ -22,7 +22,7 @@ steerer between emission and dispatch.
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
 
 from goldfive.types import DriftKind, DriftSeverity
 
@@ -30,39 +30,29 @@ if TYPE_CHECKING:
     from goldfive.types import Plan, Session
 
 
-def _normalize_drift_kind(value: DriftKind | str) -> DriftKind | str:
-    """Coerce a verdict ``drift_kind`` to :class:`DriftKind` when possible.
+_DriftEnum = TypeVar("_DriftEnum", DriftKind, DriftSeverity)
 
-    Accepts either a :class:`DriftKind` enum member (the preferred,
-    typed form) or the legacy lowercase string. A string that matches a
-    known :class:`DriftKind` value is upgraded to the enum so consumers
-    get a real enum off ``JudgeVerdict.drift_kind``; an empty string or
-    an unrecognised custom string is returned unchanged so a forward-
-    compatible / domain-specific judge is not broken. :class:`DriftKind`
-    is a :class:`~enum.StrEnum`, so the upgraded value still compares
-    equal to the original lowercase string — back-compat is preserved.
+
+def _normalize_drift_field(
+    value: _DriftEnum | str, enum_cls: type[_DriftEnum]
+) -> _DriftEnum | str:
+    """Coerce a verdict drift field to its enum when the value matches a member.
+
+    Used by :meth:`JudgeVerdict.__post_init__` to normalise the
+    ``drift_kind`` / ``severity`` fields. Accepts either an ``enum_cls``
+    member — :class:`DriftKind` or :class:`DriftSeverity`, the preferred
+    typed form — or the legacy lowercase string. A string matching a
+    known ``enum_cls`` value is upgraded to the enum so consumers get a
+    real enum off ``JudgeVerdict``; an empty string (no drift) or an
+    unrecognised custom string is returned unchanged so a forward-
+    compatible / domain-specific judge is not broken. Both enums are
+    :class:`~enum.StrEnum`, so the upgraded value still compares equal to
+    the original lowercase string — back-compat is preserved.
     """
-    if isinstance(value, DriftKind) or not value:
+    if isinstance(value, enum_cls) or not value:
         return value
     try:
-        return DriftKind(str(value))
-    except ValueError:
-        return value
-
-
-def _normalize_drift_severity(value: DriftSeverity | str) -> DriftSeverity | str:
-    """Coerce a verdict ``severity`` to :class:`DriftSeverity` when possible.
-
-    Mirrors :func:`_normalize_drift_kind`: a :class:`DriftSeverity` enum
-    member passes through, a recognised legacy lowercase string is
-    upgraded to the enum, and an empty / unrecognised string is returned
-    unchanged. :class:`DriftSeverity` is a :class:`~enum.StrEnum`, so the
-    upgrade is transparent to existing string-equality consumers.
-    """
-    if isinstance(value, DriftSeverity) or not value:
-        return value
-    try:
-        return DriftSeverity(str(value))
+        return enum_cls(str(value))
     except ValueError:
         return value
 
@@ -172,12 +162,12 @@ class JudgeVerdict:
         # construction. Normalising here (rather than at every read
         # site) means every consumer — the steerer, sinks, external
         # callers — sees the typed enum without each having to coerce.
-        normalized_kind = _normalize_drift_kind(self.drift_kind)
-        if normalized_kind is not self.drift_kind:
-            object.__setattr__(self, "drift_kind", normalized_kind)
-        normalized_severity = _normalize_drift_severity(self.severity)
-        if normalized_severity is not self.severity:
-            object.__setattr__(self, "severity", normalized_severity)
+        object.__setattr__(
+            self, "drift_kind", _normalize_drift_field(self.drift_kind, DriftKind)
+        )
+        object.__setattr__(
+            self, "severity", _normalize_drift_field(self.severity, DriftSeverity)
+        )
 
 
 @runtime_checkable

--- a/goldfive/judges/builtins.py
+++ b/goldfive/judges/builtins.py
@@ -49,13 +49,18 @@ def _verdict_from_drift(drift: DriftEvent | None) -> JudgeVerdict:
     Returns an empty-default :class:`JudgeVerdict` when ``drift`` is
     ``None`` — the steerer skips :class:`JudgementEmitted` emission
     for empty verdicts (no signal == no event).
+
+    ``DriftEvent.kind`` / ``severity`` are already the typed
+    :class:`~goldfive.types.DriftKind` / :class:`~goldfive.types.DriftSeverity`
+    enums; they are passed through to :class:`JudgeVerdict` directly
+    (the preferred, enum-typed form — no string round-trip).
     """
     if drift is None:
         return JudgeVerdict()
     return JudgeVerdict(
         drift_emitted=True,
-        drift_kind=str(drift.kind),
-        severity=str(drift.severity),
+        drift_kind=drift.kind,
+        severity=drift.severity,
         detail=drift.detail or "",
     )
 

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -282,6 +282,22 @@ def _next_pending_task_agent(plan: Plan | None) -> str:
     return ""
 
 
+def _enum_or_str_value(value: Any) -> str:
+    """Project a ``DriftKind``/``DriftSeverity``-or-string onto its string value.
+
+    :class:`~goldfive.judges.JudgeVerdict` accepts either the typed
+    :class:`DriftKind` / :class:`DriftSeverity` enum (preferred) or a
+    legacy lowercase string for its ``drift_kind`` / ``severity``
+    fields. Proto envelopes carry plain strings, so the emit path needs
+    one place that flattens either shape: an enum member yields its
+    ``.value``, anything else is ``str()``-coerced. ``None`` / empty
+    yields the empty string.
+    """
+    if isinstance(value, enum.Enum):
+        return str(value.value)
+    return str(value or "")
+
+
 # Task statuses that are terminal (no further transitions allowed).
 # Re-exported from :mod:`goldfive.types` — the canonical definition —
 # under the historical private name so existing imports in this module
@@ -927,9 +943,15 @@ class DefaultSteerer:
         :class:`DriftKind` so a malformed judge can't crash the
         handler — the :class:`JudgementEmitted` envelope is still
         emitted in that case.
+
+        ``JudgeVerdict.drift_kind`` / ``severity`` may be a typed
+        :class:`DriftKind` / :class:`DriftSeverity` enum (the preferred
+        form) or a legacy lowercase string; ``DriftKind(...)`` /
+        ``DriftSeverity(...)`` accept both an enum member and a string,
+        so this handles either shape.
         """
         try:
-            kind = DriftKind(str(verdict.drift_kind))
+            kind = DriftKind(verdict.drift_kind)
         except (ValueError, AttributeError):
             log.debug(
                 "DefaultSteerer._drift_from_judge_verdict: judge %r returned "
@@ -939,7 +961,7 @@ class DefaultSteerer:
             )
             return None
         try:
-            severity = DriftSeverity(str(verdict.severity))
+            severity = DriftSeverity(verdict.severity)
         except (ValueError, AttributeError):
             severity = DriftSeverity.INFO
         return DriftEvent(
@@ -1007,8 +1029,13 @@ class DefaultSteerer:
         payload = _pb.JudgementEmitted()
         payload.judge_name = judge_name
         payload.verdict_kind = verdict_kind
-        payload.drift_kind = str(getattr(verdict, "drift_kind", "") or "")
-        payload.severity = str(getattr(verdict, "severity", "") or "")
+        # ``drift_kind`` / ``severity`` on a :class:`JudgeVerdict` may be
+        # a typed :class:`DriftKind` / :class:`DriftSeverity` enum or a
+        # legacy lowercase string. The proto field is a plain string;
+        # ``_enum_or_str_value`` projects either shape onto its string
+        # value so the wire form is identical regardless.
+        payload.drift_kind = _enum_or_str_value(getattr(verdict, "drift_kind", ""))
+        payload.severity = _enum_or_str_value(getattr(verdict, "severity", ""))
         rubric_score = getattr(verdict, "rubric_score", None)
         if rubric_score is not None:
             payload.rubric_score = float(rubric_score)

--- a/tests/test_pluggable_judges.py
+++ b/tests/test_pluggable_judges.py
@@ -418,6 +418,47 @@ async def test_evaluate_judges_drift_flavour_accepts_enum_typed_verdict() -> Non
     assert captured_drifts[0].severity is DriftSeverity.WARNING
 
 
+async def test_evaluate_judges_drift_flavour_with_unrecognised_kind_emits_only_judgement() -> None:
+    """A drift verdict whose ``drift_kind`` is an unrecognised custom
+    string (not a :class:`DriftKind` member) still emits a
+    ``JudgementEmitted`` envelope but forwards NO ``DriftEvent``.
+
+    ``__post_init__`` leaves an unrecognised string untouched (a
+    forward-compatible / domain-specific judge is not broken), so the
+    steerer's ``_drift_from_judge_verdict`` cannot project it onto a
+    :class:`DriftKind`. It returns ``None`` — the legacy refine
+    machinery is skipped, but the typed judge signal still reaches the
+    wire via ``JudgementEmitted``.
+    """
+    sink = ListSink()
+    steerer = goldfive.DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=_NullPlanner())  # type: ignore[arg-type]
+    drift_verdict = JudgeVerdict(
+        drift_emitted=True,
+        drift_kind="domain_specific_signal",  # not a DriftKind member
+        severity="critical",
+        detail="custom judge with a bespoke drift kind",
+    )
+    # The unrecognised string is left as-is — not coerced to an enum.
+    assert drift_verdict.drift_kind == "domain_specific_signal"
+    assert not isinstance(drift_verdict.drift_kind, DriftKind)
+    captured_drifts: list[DriftEvent] = []
+
+    async def _capture(drift: DriftEvent, session: Session) -> None:  # noqa: ARG001
+        captured_drifts.append(drift)
+
+    steerer.drift.handle_drift = _capture  # type: ignore[method-assign]
+    steerer.set_judges([_StubJudge("bespoke_j", drift_verdict)])
+    await steerer.evaluate_judges(JudgeContext(), session=_make_session())
+    # JudgementEmitted still reaches the wire, carrying the raw string.
+    judgements = _judgement_events(sink)
+    assert len(judgements) == 1
+    assert judgements[0].verdict_kind == "drift"
+    assert judgements[0].drift_kind == "domain_specific_signal"
+    # ...but no DriftEvent is projected from the unrecognised kind.
+    assert captured_drifts == []
+
+
 async def test_custom_drift_judge_emits_exactly_one_judgement() -> None:
     """A custom drift-flavoured judge produces exactly ONE
     ``JudgementEmitted`` — keyed on the judge's real ``name``.

--- a/tests/test_pluggable_judges.py
+++ b/tests/test_pluggable_judges.py
@@ -138,6 +138,63 @@ def dataclasses_error() -> type[Exception]:
     return _dc.FrozenInstanceError
 
 
+def test_judge_verdict_accepts_drift_enums() -> None:
+    """``JudgeVerdict`` accepts the typed ``DriftKind`` / ``DriftSeverity``
+    enums (the preferred form) and stores them as enum members."""
+    v = JudgeVerdict(
+        drift_emitted=True,
+        drift_kind=DriftKind.TOOL_ERROR,
+        severity=DriftSeverity.CRITICAL,
+    )
+    assert v.drift_kind is DriftKind.TOOL_ERROR
+    assert v.severity is DriftSeverity.CRITICAL
+    assert isinstance(v.drift_kind, DriftKind)
+    assert isinstance(v.severity, DriftSeverity)
+
+
+def test_judge_verdict_normalizes_legacy_string_form() -> None:
+    """A legacy lowercase-string ``drift_kind`` / ``severity`` is
+    normalised to the matching enum at construction, so consumers always
+    read a real enum — yet string equality still holds (StrEnum)."""
+    v = JudgeVerdict(
+        drift_emitted=True,
+        drift_kind="tool_error",
+        severity="critical",
+    )
+    # Normalised to the enum.
+    assert v.drift_kind is DriftKind.TOOL_ERROR
+    assert v.severity is DriftSeverity.CRITICAL
+    # Back-compat: still compares equal to the legacy lowercase string.
+    assert v.drift_kind == "tool_error"
+    assert v.severity == "critical"
+    assert str(v.drift_kind) == "tool_error"
+    assert str(v.severity) == "critical"
+
+
+def test_judge_verdict_empty_default_leaves_drift_fields_blank() -> None:
+    """The empty-default verdict keeps ``drift_kind`` / ``severity`` as
+    empty strings — no spurious enum coercion of the no-drift sentinel."""
+    v = JudgeVerdict()
+    assert v.drift_kind == ""
+    assert v.severity == ""
+    assert not isinstance(v.drift_kind, DriftKind)
+    assert not isinstance(v.severity, DriftSeverity)
+
+
+def test_judge_verdict_unrecognised_string_passes_through() -> None:
+    """An unrecognised custom ``drift_kind`` / ``severity`` string is
+    left untouched so a forward-compatible / domain-specific judge is
+    not broken by normalisation."""
+    v = JudgeVerdict(
+        drift_emitted=True,
+        drift_kind="some_future_kind",
+        severity="unusual",
+    )
+    assert v.drift_kind == "some_future_kind"
+    assert v.severity == "unusual"
+    assert not isinstance(v.drift_kind, DriftKind)
+
+
 def test_judge_protocol_accepts_duck_typed_implementation() -> None:
     class _MyJudge:
         name = "my_judge"
@@ -316,6 +373,46 @@ async def test_evaluate_judges_drift_flavour_emits_judgement_with_kind() -> None
     assert judgements[0].drift_kind == str(DriftKind.AGENT_REFUSAL)
     # And the verdict was forwarded to the legacy handler for the
     # DriftDetected back-compat fan-out.
+    assert len(captured_drifts) == 1
+    assert captured_drifts[0].kind is DriftKind.AGENT_REFUSAL
+    assert captured_drifts[0].severity is DriftSeverity.WARNING
+
+
+async def test_evaluate_judges_drift_flavour_accepts_enum_typed_verdict() -> None:
+    """A drift-flavoured verdict built with the typed ``DriftKind`` /
+    ``DriftSeverity`` enums (rather than legacy strings) is consumed
+    correctly: the ``JudgementEmitted`` envelope carries the string
+    value and the forwarded ``DriftEvent`` carries the real enums.
+
+    Pins the steerer-side half of the enum-typed judge API — the
+    consumer that reads ``JudgeVerdict`` and fires ``DriftDetected``
+    handles both the enum form and the legacy-string form.
+    """
+    sink = ListSink()
+    steerer = goldfive.DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=_NullPlanner())  # type: ignore[arg-type]
+    # Built entirely from enums — no magic strings.
+    drift_verdict = JudgeVerdict(
+        drift_emitted=True,
+        drift_kind=DriftKind.AGENT_REFUSAL,
+        severity=DriftSeverity.WARNING,
+        detail="enum-typed refusal verdict",
+    )
+    captured_drifts: list[DriftEvent] = []
+
+    async def _capture(drift: DriftEvent, session: Session) -> None:  # noqa: ARG001
+        captured_drifts.append(drift)
+
+    steerer.drift.handle_drift = _capture  # type: ignore[method-assign]
+    steerer.set_judges([_StubJudge("enum_refusal_j", drift_verdict)])
+    await steerer.evaluate_judges(JudgeContext(), session=_make_session())
+    judgements = _judgement_events(sink)
+    assert len(judgements) == 1
+    assert judgements[0].verdict_kind == "drift"
+    # Proto carries the plain string value regardless of input shape.
+    assert judgements[0].drift_kind == str(DriftKind.AGENT_REFUSAL)
+    assert judgements[0].severity == str(DriftSeverity.WARNING)
+    # The forwarded DriftEvent carries the real enum members.
     assert len(captured_drifts) == 1
     assert captured_drifts[0].kind is DriftKind.AGENT_REFUSAL
     assert captured_drifts[0].severity is DriftSeverity.WARNING


### PR DESCRIPTION
## Motivation

`JudgeVerdict` is the public result type returned by every `Judge.evaluate(...)`. Its two drift-flavoured fields — `drift_kind` and `severity` — were declared as bare lowercase `str`, documented only as "lowercase strings matching `DriftKind` / `DriftSeverity`".

`DriftKind` and `DriftSeverity` are already public enums (`goldfive.DriftKind`, `goldfive.DriftSeverity`). Leaving the verdict fields as untyped strings means:

- every caller building a verdict hand-writes a magic string (`"tool_error"`, `"critical"`) with no type-checker support and no autocomplete;
- every caller consuming a verdict has to know the string is "really" an enum value and coerce it themselves;
- a typo in the string is silently a different (or invalid) drift kind.

This makes the judge API fully enum-typed so no integration has to round-trip through magic strings.

## Change

`JudgeVerdict.drift_kind` / `severity` now accept the real `DriftKind` / `DriftSeverity` enums — the preferred, typed form:

```python
JudgeVerdict(drift_emitted=True, drift_kind=DriftKind.TOOL_ERROR, severity=DriftSeverity.CRITICAL)
```

The legacy lowercase-string form is still accepted for back-compat. A frozen-safe `JudgeVerdict.__post_init__` normalises a string that matches a known enum value to the enum, so a verdict built **either** way exposes a real enum on `verdict.drift_kind` / `verdict.severity`. Because both enums are `StrEnum`, the normalised value still compares equal to its lowercase string — existing string-equality consumers (and the existing test corpus) see no behavioural change. An empty string (no drift) or an unrecognised custom string is left untouched, so forward-compatible / domain-specific judges are not broken.

- **`judges/base.py`** — field annotations widened to `DriftKind | str` / `DriftSeverity | str`; `_normalize_drift_kind` / `_normalize_drift_severity` helpers; `__post_init__` applies them via `object.__setattr__` (the dataclass is `frozen`); docstring updated.
- **`judges/builtins.py`** — the built-in judge wrappers pass the `DriftEvent` enums straight through with no `str()` round-trip.
- **`steerer.py`** — the verdict-consuming path handles either shape. `_drift_from_judge_verdict` feeds the value directly to `DriftKind(...)` / `DriftSeverity(...)` (both accept an enum member or a string); `_emit_judgement` flattens either shape to the plain-string proto field via a new `_enum_or_str_value` helper.
- **Tests** — extended `test_pluggable_judges.py` covering both directions: enum-form construction, legacy-string normalisation, the empty-default sentinel, unrecognised-string pass-through, and a steerer `evaluate_judges` round-trip on an enum-typed drift verdict.

## Verification

- Full suite green: `2297 passed, 127 skipped` (127 skipped are pre-existing optional-extra gates).
- `ruff check` clean on all changed files.
- `mypy` clean on `judges/base.py` + `judges/builtins.py`. (`steerer.py` has one pre-existing `getattr` typing nit unrelated to this change — confirmed present on `main`.)