### PR TITLE
judges: typed BuiltinJudge selector + wrap(disable_judges=...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
   `DriftEvent` enums straight through with no string round-trip, and
   the steerer's verdict-consuming path (`_drift_from_judge_verdict`,
   `_emit_judgement`) handles both shapes.
+- **Typed opt-out for the built-in judges: `goldfive.wrap(disable_judges=...)`.**
+  External callers could already supply a custom judge list via
+  `wrap(judges=[...])`, but the only way to keep the default detector
+  set *minus* a subset was to re-list every wanted built-in by hand —
+  and the built-ins were keyed by magic string. New `BuiltinJudge`
+  enum (`goldfive.builtin_judges.BuiltinJudge`) gives each built-in a
+  typed identifier (a `StrEnum`, so it interoperates with the existing
+  string-keyed surfaces). `default_judges(disable=[BuiltinJudge...])`
+  and `wrap(disable_judges=[BuiltinJudge...])` drop the named built-ins
+  from the default set; an unrecognised entry is ignored
+  (forward-compatible). Passing both `judges=` and `disable_judges=`
+  raises `TypeError`. `BUILTIN_JUDGE_NAMES` is now derived from
+  `BuiltinJudge` (still a `frozenset[str]` — back-compat preserved).
+  `docs/reference/api.md` gains a Judges section and a refreshed `wrap`
+  signature.
 
 ### Delegation pin
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -89,6 +89,11 @@ def wrap(
     model: str | None = None,
     max_task_invocations: int | None = None,
     plugins: list[Any] | None = None,
+    runtime: RuntimeConfig | None = None,
+    dynamic_instruction: bool = True,
+    drift_self_reporting: bool | list[str] = False,
+    judges: list[Judge] | None = None,
+    disable_judges: Iterable[BuiltinJudge | str] | None = None,
 ) -> Runner: ...
 
 
@@ -126,6 +131,56 @@ the one runner. ADK propagates the plugin manager into any
 `AgentTool`-spawned sub-Runner so delegation inherits the same plugin
 surface. Duplicate plugin instances (same `plugin.name`) are
 silently deduped (#166/#169).
+
+### Judges (`judges=` / `disable_judges=`)
+
+A `Judge` is the pluggable verdict-producing extension point (#437):
+an object with a stable `name: str` and an async
+`evaluate(JudgeContext) -> JudgeVerdict`. The steerer runs every
+installed judge at each observation point and emits a
+`JudgementEmitted` envelope per populated verdict. Judges produce one
+of four verdict flavours: **drift** (`drift_kind` + `severity`),
+**rubric** (`rubric_score` + per-dimension scores), **boolean**
+(pass/fail), **numeric** (a named metric). `JudgeVerdict.drift_kind` /
+`severity` accept the typed `DriftKind` / `DriftSeverity` enums.
+
+`wrap` installs `goldfive.builtin_judges.default_judges()` — the
+built-in detector set (`reasoning_drift`, `looping_reasoning`,
+`goal_drift`, `refusal`, `tool_error`, `stop_reason`, `looping_tool`) —
+unless the caller controls the set explicitly:
+
+- **`judges=[...]`** — the explicit list. Replaces the default set
+  entirely. Pass `judges=[]` to disable the `JudgementEmitted` surface.
+  Mix built-in factories with custom judges:
+
+  ```python
+  runner = goldfive.wrap(
+      agent,
+      judges=[
+          goldfive.builtin_judges.reasoning_drift(),
+          MyRubricJudge(rubric="..."),
+      ],
+  )
+  ```
+
+- **`disable_judges=[...]`** — keep the default set minus the named
+  built-ins. Members are `goldfive.builtin_judges.BuiltinJudge` enum
+  values (a `StrEnum`; legacy wire-name strings also accepted). The
+  typed, surgical opt-out — no need to re-list the rest:
+
+  ```python
+  from goldfive.builtin_judges import BuiltinJudge
+
+  # Full default set minus the tool-error judge.
+  runner = goldfive.wrap(agent, disable_judges=[BuiltinJudge.TOOL_ERROR])
+  ```
+
+  Passing both `judges=` and `disable_judges=` raises `TypeError` — an
+  explicit `judges=` list already specifies the exact set.
+
+Drift-flavoured verdicts (from built-in **or** custom judges) also fire
+the legacy `DriftDetected` envelope, so existing sinks see no
+behavioural change.
 
 When the wrap target is an ADK `BaseAgent`, the returned object is a
 `GoldfiveADKAgent` — a `BaseAgent` subclass that *also* exposes the

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -92,6 +92,8 @@ def wrap(
     runtime: RuntimeConfig | None = None,
     dynamic_instruction: bool = True,
     drift_self_reporting: bool | list[str] = False,
+    llm_detector: Any = None,
+    judge_call_llm_builder: Any = None,
     judges: list[Judge] | None = None,
     disable_judges: Iterable[BuiltinJudge | str] | None = None,
 ) -> Runner: ...

--- a/goldfive/builtin_judges.py
+++ b/goldfive/builtin_judges.py
@@ -10,6 +10,7 @@ matches the issue-time contract.
 from __future__ import annotations
 
 from goldfive.judges.builtins import (
+    BuiltinJudge,
     default_judges,
     goal_drift,
     looping_reasoning,
@@ -21,6 +22,7 @@ from goldfive.judges.builtins import (
 )
 
 __all__ = [
+    "BuiltinJudge",
     "default_judges",
     "goal_drift",
     "looping_reasoning",

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 import warnings
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from goldfive._llm_detect import CallLLM, detect_llm
@@ -47,6 +47,7 @@ from goldfive.types import Goal
 
 if TYPE_CHECKING:
     from goldfive.control import ControlChannel
+    from goldfive.judges.builtins import BuiltinJudge
 
 log = logging.getLogger("goldfive.wrap")
 
@@ -227,6 +228,7 @@ def wrap(
     llm_detector: Any = None,
     judge_call_llm_builder: Any = None,
     judges: list[Any] | None = None,
+    disable_judges: Iterable[BuiltinJudge | str] | None = None,
     **legacy_kwargs: Any,
 ) -> Runner:
     """Build a :class:`Runner` that drives ``agent`` with goldfive.
@@ -334,6 +336,27 @@ def wrap(
                     MyRubricJudge(rubric="..."),
                 ],
             )
+
+    disable_judges:
+        Optional iterable of
+        :class:`~goldfive.builtin_judges.BuiltinJudge` members (or their
+        wire-name strings) to drop from the **default** judge set. The
+        typed, surgical opt-out: keep every built-in detector except the
+        ones named here, without having to re-list the rest via
+        ``judges=``. Mutually exclusive with an explicit ``judges=``
+        list — when ``judges=`` is supplied the caller is already
+        specifying the exact set, so ``disable_judges`` is rejected with
+        a :class:`TypeError` rather than silently ignored::
+
+            # Keep the full default set minus the tool-error judge —
+            # e.g. an agent that legitimately makes no tool calls.
+            runner = goldfive.wrap(
+                agent,
+                disable_judges=[goldfive.builtin_judges.BuiltinJudge.TOOL_ERROR],
+            )
+
+        An unrecognised entry is ignored (forward-compatible). ``None``
+        (the default) keeps the full default set.
 
     drift_self_reporting:
         Forwarded to :class:`Runner`. Default ``False`` (goldfive#196):
@@ -645,13 +668,24 @@ def wrap(
     # Passing an explicit empty list (``judges=[]``) is the opt-out
     # token — the steerer's hardcoded detector path still runs but no
     # ``JudgementEmitted`` envelopes ride the sink stream.
+    #
+    # ``disable_judges=`` drops named built-ins from the *default* set.
+    # It is meaningless alongside an explicit ``judges=`` (which already
+    # spells out the exact set), so the combination is rejected loudly
+    # rather than silently ignoring one of the two.
+    if judges is not None and disable_judges is not None:
+        raise TypeError(
+            "goldfive.wrap: pass either judges= (the explicit judge list) "
+            "or disable_judges= (drop built-ins from the default set), not "
+            "both — an explicit judges= list already specifies the exact set."
+        )
     resolved_judges: list[Any]
     if judges is not None:
         resolved_judges = list(judges)
     else:
         from goldfive.builtin_judges import default_judges as _default_judges
 
-        resolved_judges = _default_judges()
+        resolved_judges = _default_judges(disable=disable_judges)
     set_judges = getattr(resolved_steerer, "set_judges", None)
     if callable(set_judges):
         set_judges(resolved_judges)

--- a/goldfive/judges/builtins.py
+++ b/goldfive/judges/builtins.py
@@ -32,6 +32,8 @@ multiple runners without state-bleed.
 
 from __future__ import annotations
 
+import enum
+from collections.abc import Iterable
 from typing import Any
 
 from goldfive.drift import (
@@ -196,6 +198,37 @@ class LoopingToolJudge:
 
 
 # ---------------------------------------------------------------------------
+# Typed selector for the built-in judges
+# ---------------------------------------------------------------------------
+
+
+class BuiltinJudge(enum.StrEnum):
+    """Typed identifier for each judge in the goldfive default set.
+
+    Each member's value is the judge's wire ``name`` — the same token
+    used as the :class:`~goldfive.judges.JudgementEmitted.judge_name`
+    key and the historical opt-in / opt-out string. ``BuiltinJudge``
+    exists so external callers select / disable built-ins **by enum**
+    rather than by hand-written magic string:
+
+        goldfive.wrap(agent, disable_judges=[BuiltinJudge.TOOL_ERROR])
+
+    Because :class:`BuiltinJudge` is a :class:`~enum.StrEnum`, a member
+    compares equal to its wire name, so it interoperates with the
+    string-keyed APIs (``judge.name``, :data:`BUILTIN_JUDGE_NAMES`)
+    without any coercion at the call site.
+    """
+
+    REASONING_DRIFT = "reasoning_drift"
+    LOOPING_REASONING = "looping_reasoning"
+    GOAL_DRIFT = "goal_drift"
+    REFUSAL = "refusal"
+    TOOL_ERROR = "tool_error"
+    STOP_REASON = "stop_reason"
+    LOOPING_TOOL = "looping_tool"
+
+
+# ---------------------------------------------------------------------------
 # Factory functions (the public opt-in surface)
 # ---------------------------------------------------------------------------
 #
@@ -241,21 +274,48 @@ def looping_tool() -> Judge:
     return LoopingToolJudge()
 
 
-def default_judges() -> list[Judge]:
+#: Maps every :class:`BuiltinJudge` to its factory. Single source of
+#: truth for the default set, :data:`BUILTIN_JUDGE_NAMES`, and the
+#: :func:`default_judges` ``disable=`` filter — adding a built-in judge
+#: means adding one row here and one :class:`BuiltinJudge` member.
+_BUILTIN_JUDGE_FACTORIES: dict[BuiltinJudge, Any] = {
+    BuiltinJudge.REASONING_DRIFT: reasoning_drift,
+    BuiltinJudge.LOOPING_REASONING: looping_reasoning,
+    BuiltinJudge.GOAL_DRIFT: goal_drift,
+    BuiltinJudge.REFUSAL: refusal,
+    BuiltinJudge.TOOL_ERROR: tool_error,
+    BuiltinJudge.STOP_REASON: stop_reason,
+    BuiltinJudge.LOOPING_TOOL: looping_tool,
+}
+
+
+def default_judges(
+    disable: Iterable[BuiltinJudge | str] | None = None,
+) -> list[Judge]:
     """Return the goldfive default judge set.
 
     Mirrors the detectors the pre-judges code path armed by default.
     :func:`goldfive.wrap` installs this set when the caller does not
     supply an explicit ``judges=`` list.
+
+    Parameters
+    ----------
+    disable:
+        Optional iterable of :class:`BuiltinJudge` members (preferred)
+        or their wire-name strings. Built-ins named here are omitted
+        from the returned list — the typed way to keep the default set
+        but drop a subset (e.g. an agent that legitimately makes no
+        tool calls disabling :attr:`BuiltinJudge.TOOL_ERROR`). An
+        unrecognised entry is ignored (forward-compatible). ``None`` /
+        empty returns the full set.
     """
+    disabled: frozenset[str] = (
+        frozenset(str(d) for d in disable) if disable is not None else frozenset()
+    )
     return [
-        reasoning_drift(),
-        looping_reasoning(),
-        goal_drift(),
-        refusal(),
-        tool_error(),
-        stop_reason(),
-        looping_tool(),
+        factory()
+        for judge, factory in _BUILTIN_JUDGE_FACTORIES.items()
+        if str(judge) not in disabled
     ]
 
 
@@ -268,21 +328,17 @@ def default_judges() -> list[Judge]:
 #: ``DriftDetected`` for the same logical signal. Operator-supplied
 #: custom judges (any name not in this set) run on every reasoning
 #: observation. See goldfive#437.
-BUILTIN_JUDGE_NAMES: frozenset[str] = frozenset(
-    {
-        "reasoning_drift",
-        "looping_reasoning",
-        "goal_drift",
-        "refusal",
-        "tool_error",
-        "stop_reason",
-        "looping_tool",
-    }
-)
+#:
+#: Derived from :class:`BuiltinJudge` so the enum stays the single
+#: source of truth; remains a ``frozenset[str]`` for back-compat with
+#: existing ``name in BUILTIN_JUDGE_NAMES`` callers (a ``BuiltinJudge``
+#: member is a ``str``, so membership tests work with either form).
+BUILTIN_JUDGE_NAMES: frozenset[str] = frozenset(str(j) for j in BuiltinJudge)
 
 
 __all__ = [
     "BUILTIN_JUDGE_NAMES",
+    "BuiltinJudge",
     "GoalDriftJudge",
     "LoopingReasoningJudge",
     "LoopingToolJudge",

--- a/goldfive/judges/builtins.py
+++ b/goldfive/judges/builtins.py
@@ -32,8 +32,8 @@ multiple runners without state-bleed.
 
 from __future__ import annotations
 
-import enum
 from collections.abc import Iterable
+from enum import StrEnum
 from typing import Any
 
 from goldfive.drift import (
@@ -202,7 +202,7 @@ class LoopingToolJudge:
 # ---------------------------------------------------------------------------
 
 
-class BuiltinJudge(enum.StrEnum):
+class BuiltinJudge(StrEnum):
     """Typed identifier for each judge in the goldfive default set.
 
     Each member's value is the judge's wire ``name`` — the same token

--- a/tests/test_pluggable_judges.py
+++ b/tests/test_pluggable_judges.py
@@ -229,6 +229,67 @@ def test_factories_return_fresh_instances() -> None:
     assert a is not b
 
 
+def test_builtin_judge_enum_values_match_judge_names() -> None:
+    """Every :class:`BuiltinJudge` member's value equals the wire ``name``
+    of the judge its factory builds — the enum is a typed alias for the
+    historical magic-string judge names."""
+    from goldfive.builtin_judges import BuiltinJudge
+
+    enum_values = {str(j) for j in BuiltinJudge}
+    factory_names = {j.name for j in builtin_judges.default_judges()}
+    assert enum_values == factory_names
+    # StrEnum: a member compares equal to its wire name.
+    assert BuiltinJudge.TOOL_ERROR == "tool_error"
+
+
+def test_builtin_judge_names_derives_from_enum() -> None:
+    """``BUILTIN_JUDGE_NAMES`` stays a ``frozenset[str]`` (back-compat)
+    and is exactly the set of :class:`BuiltinJudge` values."""
+    from goldfive.builtin_judges import BuiltinJudge
+    from goldfive.judges.builtins import BUILTIN_JUDGE_NAMES
+
+    assert BUILTIN_JUDGE_NAMES == {str(j) for j in BuiltinJudge}
+    # Membership works with either a plain string or a BuiltinJudge.
+    assert "reasoning_drift" in BUILTIN_JUDGE_NAMES
+    assert BuiltinJudge.REFUSAL in BUILTIN_JUDGE_NAMES
+
+
+def test_default_judges_disable_by_enum() -> None:
+    """``default_judges(disable=[BuiltinJudge...])`` drops exactly the
+    named built-ins and keeps the rest."""
+    from goldfive.builtin_judges import BuiltinJudge
+
+    full = builtin_judges.default_judges()
+    filtered = builtin_judges.default_judges(
+        disable=[BuiltinJudge.TOOL_ERROR, BuiltinJudge.GOAL_DRIFT]
+    )
+    names = {j.name for j in filtered}
+    assert "tool_error" not in names
+    assert "goal_drift" not in names
+    assert "reasoning_drift" in names
+    assert len(filtered) == len(full) - 2
+
+
+def test_default_judges_disable_accepts_legacy_strings() -> None:
+    """``disable=`` also accepts the legacy wire-name strings."""
+    filtered = builtin_judges.default_judges(disable=["refusal"])
+    assert "refusal" not in {j.name for j in filtered}
+
+
+def test_default_judges_disable_ignores_unknown_entries() -> None:
+    """An unrecognised ``disable=`` entry is ignored (forward-compatible)."""
+    full = builtin_judges.default_judges()
+    filtered = builtin_judges.default_judges(disable=["not_a_real_judge"])
+    assert len(filtered) == len(full)
+
+
+def test_default_judges_no_disable_returns_full_set() -> None:
+    """``default_judges()`` / ``default_judges(disable=None)`` return the
+    full set unchanged — back-compat with the no-arg call."""
+    assert len(builtin_judges.default_judges()) == 7
+    assert len(builtin_judges.default_judges(disable=None)) == 7
+
+
 async def test_refusal_judge_emits_drift_verdict_on_match() -> None:
     judge = builtin_judges.refusal()
     ctx = JudgeContext(reasoning_text="I cannot help with that request")
@@ -633,6 +694,46 @@ async def test_wrap_judges_empty_list_disables_judges() -> None:
     steerer = runner.steerer  # type: ignore[attr-defined]
     assert steerer.get_judges() == []
     await runner.close()
+
+
+async def test_wrap_disable_judges_drops_named_builtins() -> None:
+    """``goldfive.wrap(disable_judges=[BuiltinJudge...])`` installs the
+    default set minus the named built-ins."""
+    from goldfive.builtin_judges import BuiltinJudge
+
+    async def _agent(task: Any, session: Any, tools: Any) -> Any:  # noqa: ARG001
+        from goldfive.results import InvocationResult
+
+        return InvocationResult(output="ok")
+
+    runner = goldfive.wrap(
+        _agent, sinks=[], disable_judges=[BuiltinJudge.TOOL_ERROR]
+    )
+    steerer = runner.steerer  # type: ignore[attr-defined]
+    names = {j.name for j in steerer.get_judges()}
+    assert "tool_error" not in names
+    assert "reasoning_drift" in names
+    assert len(names) == 6
+    await runner.close()
+
+
+async def test_wrap_disable_judges_rejects_combination_with_judges() -> None:
+    """Passing both ``judges=`` and ``disable_judges=`` is a ``TypeError``
+    — an explicit ``judges=`` list already names the exact set."""
+    from goldfive.builtin_judges import BuiltinJudge
+
+    async def _agent(task: Any, session: Any, tools: Any) -> Any:  # noqa: ARG001
+        from goldfive.results import InvocationResult
+
+        return InvocationResult(output="ok")
+
+    with pytest.raises(TypeError, match="disable_judges"):
+        goldfive.wrap(
+            _agent,
+            sinks=[],
+            judges=[],
+            disable_judges=[BuiltinJudge.REFUSAL],
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

`goldfive.wrap` already lets an external caller register custom judges via `judges=[...]`. But two gaps remained for callers configuring the judge surface:

1. **No typed way to disable a subset of built-ins.** To keep the default detector set *minus* one judge (e.g. an agent that legitimately makes no tool calls, where the `tool_error` judge is noise), the caller had to re-list every *other* built-in by hand into `judges=`. The built-ins were also keyed only by hand-written magic string (`"reasoning_drift"`, `"tool_error"`, ...) — no enum, no type-checker support, no autocomplete.
2. **The judge surface was undocumented.** `docs/reference/api.md`'s `wrap` signature was stale (no `judges=`, `runtime=`, etc.) and had no mention of the `Judge` extension point at all.

## Change

A typed, enum-keyed opt-out:

- **`BuiltinJudge`** (`goldfive.builtin_judges.BuiltinJudge`) — a `StrEnum` with one member per built-in judge. Each member's value is the judge's wire `name`, so it interoperates with the existing string-keyed surfaces (`judge.name`, `BUILTIN_JUDGE_NAMES`) with zero coercion at the call site.

- **`default_judges(disable=[BuiltinJudge...])`** — drops the named built-ins from the default set. Accepts `BuiltinJudge` members (preferred) or legacy wire-name strings; an unrecognised entry is ignored (forward-compatible).

- **`wrap(disable_judges=[BuiltinJudge...])`** — threads the same filter, so a caller keeps the full default set minus a subset without re-listing the rest:

  ```python
  from goldfive.builtin_judges import BuiltinJudge

  # Full default set minus the tool-error judge.
  runner = goldfive.wrap(agent, disable_judges=[BuiltinJudge.TOOL_ERROR])
  ```

  Passing both `judges=` and `disable_judges=` raises `TypeError` — an explicit `judges=` list already names the exact set, so the combination is rejected loudly rather than silently honouring one.

- A new `_BUILTIN_JUDGE_FACTORIES` registry is the single source of truth for the default set, the `disable=` filter, and `BUILTIN_JUDGE_NAMES` — which is now *derived* from `BuiltinJudge` (still a `frozenset[str]`, so existing `name in BUILTIN_JUDGE_NAMES` callers are unaffected).

- `docs/reference/api.md` gains a **Judges** section and a refreshed `wrap` signature.

### Back-compat

No behavioural change for callers that do not pass `disable_judges`: `default_judges()` with no args returns the same judge set in the same order. `judges=[...]` and `judges=[]` are unchanged.

## Verification

- Full suite green: `2305 passed, 127 skipped` (8 new tests; 127 skipped are pre-existing optional-extra gates).
- `ruff check` clean across `goldfive/` and the test file.
- `mypy` clean on `judges/builtins.py`, `builtin_judges.py`, `convenience.py`.

## Note for reviewers

The disable surface is keyed on a `BuiltinJudge` enum (one member per built-in *judge*) rather than on `DriftKind`. The built-in judges do not map 1:1 to `DriftKind` — `reasoning_drift` alone can emit `OFF_TOPIC`, `INTENT_DIVERGENCE`, `JUSTIFIED_DEVIATION`, and more — so a `DriftKind`-keyed disable would be a leaky abstraction for that judge. `BuiltinJudge` is precise: it disables exactly the judge the caller names.