### PR TITLE
feat: first-class judge-only mode (native run + judges, no planning/steering overlay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,26 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
     turn; previews are previews; `report_task_completed(artifacts=…)` is
     the exact-match-friendly structured channel). `api.md` updated.
 
+### Convenience
+
+- **First-class judge-only mode: `goldfive.wrap(agent, judge_only=True)`
+  (and `goldfive.run`, via `**wrap_kwargs`) — closes #445.** Runs the
+  wrapped agent NATIVELY while keeping the drift judges armed, issuing
+  ZERO planning / steering LLM calls (no goal-derivation, no
+  plan / refine, no drift-reactive steering). Default `judge_only=False`
+  is byte-identical to today — the full `LLMPlanner` / `LLMGoalDeriver`
+  overlay still runs. It is a convenience that supplies the defaults for
+  `planner` (a one-task `StaticPlanner` that drives a single native
+  overlay run — a real transcript, unlike `PassthroughPlanner`, which
+  returns `None` and aborts empty) and `goal_deriver`
+  (`LiteralGoalDeriver`, no goal-derive call); an explicit `planner=` /
+  `goal_deriver=` / `steerer=` still wins. The judges are untouched —
+  still wired off `call_llm` / the detected tree LLM / `JudgeConfig`
+  exactly as in full mode. Note `SteeringConfig.observation_only` does
+  NOT achieve this: it gates only the three drift-reactive injection
+  points while the planner's goal-derivation / per-turn planning /
+  refine still run and burn LLM calls.
+
 ### Judges
 
 - **`JudgeVerdict.drift_kind` / `severity` are now enum-typed.** The two

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -31,7 +31,7 @@ from goldfive.adapters.auto import auto_adapter, is_adk_agent
 from goldfive.config import JudgeConfig, RuntimeConfig
 from goldfive.executors.sequential import SequentialExecutor
 from goldfive.goal_deriver import LiteralGoalDeriver, LLMGoalDeriver
-from goldfive.planner import LLMPlanner, PassthroughPlanner
+from goldfive.planner import LLMPlanner, PassthroughPlanner, StaticPlanner
 from goldfive.protocols import (
     EventSink,
     Executor,
@@ -43,13 +43,67 @@ from goldfive.results import ExecutionOutcome
 from goldfive.runner import Runner
 from goldfive.sinks import LoggingSink
 from goldfive.steerer import DefaultSteerer
-from goldfive.types import Goal
+from goldfive.types import Goal, Plan, Task
 
 if TYPE_CHECKING:
     from goldfive.control import ControlChannel
     from goldfive.judges.builtins import BuiltinJudge
 
 log = logging.getLogger("goldfive.wrap")
+
+
+#: Stable task id for the synthetic single-task plan that judge-only mode
+#: installs. Kept distinct so operators can recognise it in transcripts /
+#: telemetry as the framing task the native run executed under.
+_JUDGE_ONLY_TASK_ID = "judge_only_native_run"
+
+
+def _build_judge_only_planner() -> StaticPlanner:
+    """Return the planner that drives a NATIVE, un-steered agent run.
+
+    Judge-only mode runs the wrapped agent natively while keeping the
+    drift judges armed, and issues ZERO planning / steering LLM calls.
+    The recipe (validated downstream): a :class:`StaticPlanner` carrying
+    a single task.
+
+    Why a one-task :class:`StaticPlanner` rather than
+    :class:`PassthroughPlanner`:
+
+    * :class:`PassthroughPlanner` returns ``None`` from ``generate`` /
+      ``handle_turn``, so the Runner has no plan to execute and the run
+      aborts with an EMPTY transcript — nothing for the judges to score.
+    * :class:`StaticPlanner` returns a baked single-task plan. Under the
+      overlay executor (``SequentialExecutor(overlay_mode=True)``, the
+      ``wrap()`` default) that drives ONE ``invoke_passthrough`` of the
+      native agent tree against the user's input — a real transcript is
+      produced — and ``refine`` returns ``None`` so no refine / steer
+      planning call ever fires.
+
+    The single task's ``assignee_agent_id`` is intentionally left empty:
+    overlay dispatch runs the native tree regardless of assignee, and
+    the framework populates assignment observationally (goldfive#252).
+    The task is pure framing so the Gantt / transcript has a node to
+    hang native activity under.
+    """
+    return StaticPlanner(
+        Plan(
+            id="",
+            run_id="",
+            goal_ids=(),
+            tasks=(
+                Task(
+                    id=_JUDGE_ONLY_TASK_ID,
+                    title="Native agent run (judge-only)",
+                    description=(
+                        "Run the wrapped agent natively with no planning or "
+                        "steering overlay; drift judges stay armed."
+                    ),
+                ),
+            ),
+            edges=(),
+            summary="Native agent run (judge-only mode)",
+        )
+    )
 
 
 def _build_judge_call_llm(config: JudgeConfig) -> tuple[CallLLM, str] | None:
@@ -225,6 +279,7 @@ def wrap(
     runtime: RuntimeConfig | None = None,
     dynamic_instruction: bool = True,
     drift_self_reporting: bool | list[str] = False,
+    judge_only: bool = False,
     llm_detector: Any = None,
     judge_call_llm_builder: Any = None,
     judges: list[Any] | None = None,
@@ -372,6 +427,42 @@ def wrap(
         steerer's refine machinery) remain the canonical detectors.
         Pass ``True`` to restore the full pre-#196 set, or a list of
         drift tool names to enable a subset.
+    judge_only:
+        First-class JUDGE-ONLY mode. Default ``False`` — behaviour is
+        byte-identical to today (the full planning overlay runs:
+        goal-derivation, per-turn planning, refine, and drift-reactive
+        steering).
+
+        When ``True`` the wrapped agent runs NATIVELY while the drift
+        judges stay armed, and NO planning / steering LLM call is ever
+        issued (no goal-derive, no plan / refine, no drift-reactive
+        steering). This is the mode an evaluation / benchmarking harness
+        wants: judge an agent's own NATIVE behaviour without goldfive
+        steering it.
+
+        It is a convenience that sets the defaults for ``planner`` and
+        ``goal_deriver``; it does NOT touch the judges (they remain wired
+        from ``call_llm`` / the detected tree LLM / ``JudgeConfig`` exactly
+        as in full mode). Concretely, when the caller did not supply them:
+
+        * ``planner`` defaults to a :class:`StaticPlanner` carrying a
+          single framing task. Under the overlay executor that drives ONE
+          native ``invoke_passthrough`` of the agent tree — a real
+          transcript is produced — and its ``refine`` returns ``None`` so
+          no refine / steer planning call fires. (A
+          :class:`PassthroughPlanner` would instead return ``None`` from
+          ``generate`` and ABORT the run with an empty transcript — the
+          trap this mode exists to avoid.)
+        * ``goal_deriver`` defaults to :class:`LiteralGoalDeriver`, which
+          wraps the user input as a single goal WITHOUT an LLM call (vs
+          the goal-derive LLM call :class:`LLMGoalDeriver` would make).
+
+        An explicit ``planner=`` / ``goal_deriver=`` / ``steerer=`` still
+        wins — ``judge_only`` only supplies the defaults. Note that
+        ``SteeringConfig.observation_only`` does NOT achieve this: it
+        gates only the three drift-reactive INJECTION points, while the
+        planner's goal-derivation / per-turn planning / refine still run
+        and burn LLM calls.
 
     Returns
     -------
@@ -510,9 +601,7 @@ def wrap(
     # :func:`_build_judge_call_llm` for this call. Same pattern as
     # ``llm_detector`` above — leave ``None`` in production.
     judge_builder = (
-        judge_call_llm_builder
-        if judge_call_llm_builder is not None
-        else _build_judge_call_llm
+        judge_call_llm_builder if judge_call_llm_builder is not None else _build_judge_call_llm
     )
     if call_llm is None and resolved_runtime.judge.base_url:
         built = judge_builder(resolved_runtime.judge)
@@ -557,6 +646,13 @@ def wrap(
     resolved_planner: Planner
     if planner is not None:
         resolved_planner = planner
+    elif judge_only:
+        # Judge-only mode: a one-task StaticPlanner drives a native
+        # overlay run (real transcript) while issuing zero planning
+        # LLM calls — no generate-time plan synthesis, and refine
+        # returns None so no refine / steer call fires. See the
+        # ``judge_only`` docstring and :func:`_build_judge_only_planner`.
+        resolved_planner = _build_judge_only_planner()
     elif resolved_call_llm is not None:
         resolved_planner = LLMPlanner(call_llm=resolved_call_llm, model=resolved_model)
     else:
@@ -570,6 +666,10 @@ def wrap(
     resolved_goal_deriver: GoalDeriver
     if goal_deriver is not None:
         resolved_goal_deriver = goal_deriver
+    elif judge_only:
+        # Judge-only mode: wrap the user input as a single goal without
+        # an LLM call (LLMGoalDeriver would issue a goal-derive call).
+        resolved_goal_deriver = LiteralGoalDeriver()
     elif resolved_call_llm is not None:
         resolved_goal_deriver = LLMGoalDeriver(
             call_llm=resolved_call_llm,

--- a/tests/test_wrap_judge_only.py
+++ b/tests/test_wrap_judge_only.py
@@ -1,0 +1,325 @@
+"""Tests for the first-class judge-only mode on :func:`goldfive.wrap`.
+
+Judge-only mode (``goldfive.wrap(agent, judge_only=True)``) runs the
+wrapped agent NATIVELY while keeping the drift judges armed, and issues
+ZERO planning / steering LLM calls (no goal-derive, no plan / refine, no
+drift-reactive steering). It encapsulates the validated recipe:
+
+* a one-task :class:`StaticPlanner` so the overlay / per-task executor
+  produces a real transcript (NOT :class:`PassthroughPlanner`, which
+  returns ``None`` and aborts with an empty transcript);
+* :class:`LiteralGoalDeriver` so the user input becomes a single goal
+  with no goal-derive LLM call;
+* the judges stay wired from ``call_llm`` / the detected tree LLM exactly
+  as in full mode.
+
+The suite pins:
+
+1. ``judge_only=True`` selects the StaticPlanner + LiteralGoalDeriver
+   defaults (so structurally NO planning / goal-derive LLM call can fire)
+   while the steerer's judges stay armed — contrasted with
+   ``judge_only=False``, which builds the LLMPlanner / LLMGoalDeriver.
+2. A ``judge_only=True`` run produces a NON-EMPTY transcript (the native
+   agent executed; the run did NOT abort empty like PassthroughPlanner).
+3. The drift judges still fire under the judge-only steerer.
+4. Explicit ``planner=`` / ``goal_deriver=`` override under
+   ``judge_only=True``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+import goldfive
+from goldfive import (
+    ExecutionOutcome,
+    InMemorySink,
+    InvocationResult,
+    LiteralGoalDeriver,
+    LLMGoalDeriver,
+    LLMPlanner,
+    PassthroughPlanner,
+    ReportingToolSpec,
+    Session,
+    StaticPlanner,
+    Task,
+)
+from goldfive.steerer import DefaultSteerer
+from goldfive.types import Goal, Plan
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _happy_agent(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    """Reference agent: returns a non-empty result so the executor completes."""
+    _ = (session, tools)
+    return InvocationResult(task_id=task.id, text=f"native ran: {task.title}")
+
+
+def _spy_call_llm(responses: list[Any]):
+    """Async ``CallLLM``-shaped stub that records every call.
+
+    ``.calls`` accumulates ``(system, user, model)`` triples so a test
+    can assert how many — and which — LLM calls fired.
+    """
+    queue = list(responses)
+    calls: list[tuple[str, str, str]] = []
+
+    async def _call_llm(system: str, user: str, model: str) -> str:
+        calls.append((system, user, model))
+        if not queue:
+            raise AssertionError("spy call_llm exhausted")
+        resp = queue.pop(0)
+        if isinstance(resp, (dict, list)):
+            return json.dumps(resp)
+        return str(resp)
+
+    _call_llm.calls = calls  # type: ignore[attr-defined]
+    return _call_llm
+
+
+def _make_drift_session() -> Session:
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="Research", description="Research topic X")],
+        edges=[],
+    )
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="Publish a memo on solar panels")],
+        plan=plan,
+        current_task_id="t1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. judge_only selects the native-run defaults (no planning callables)
+# ---------------------------------------------------------------------------
+
+
+def test_judge_only_wires_static_planner_and_literal_goal_deriver() -> None:
+    """``judge_only=True`` => StaticPlanner + LiteralGoalDeriver defaults.
+
+    Structurally this guarantees ZERO planning / goal-derive LLM calls:
+    neither :class:`LLMPlanner` nor :class:`LLMGoalDeriver` is even
+    constructed, so no ``call_llm`` planning surface exists. The judges,
+    however, stay armed off the supplied ``call_llm``.
+    """
+    call_llm = _spy_call_llm([])
+    runner = goldfive.wrap(
+        _happy_agent,
+        judge_only=True,
+        call_llm=call_llm,
+        model="fake-model",
+        sinks=[],
+    )
+
+    # NATIVE-run planner (one-task StaticPlanner), NOT PassthroughPlanner
+    # (which aborts empty) and NOT LLMPlanner (which would plan via LLM).
+    assert isinstance(runner.planner, StaticPlanner)
+    assert not isinstance(runner.planner, PassthroughPlanner)
+    # Goal derivation without an LLM call.
+    assert isinstance(runner.goal_deriver, LiteralGoalDeriver)
+
+    # Judges stay armed: the steerer carries the supplied call_llm for
+    # BOTH the trajectory-level goal-drift judge and the reasoning-drift
+    # judge — judge_only does not touch the judge wiring.
+    steerer = runner.steerer
+    assert isinstance(steerer, DefaultSteerer)
+    assert steerer._goal_drift_call_llm is call_llm
+    assert steerer._reasoning_drift_call_llm is call_llm
+
+    # No planning / judge call has fired merely from wiring.
+    assert call_llm.calls == []  # type: ignore[attr-defined]
+
+
+def test_judge_only_false_is_byte_identical_full_planning() -> None:
+    """``judge_only=False`` (default) builds the full LLM planning overlay.
+
+    Contrast partner to the test above: the default path still wires
+    :class:`LLMPlanner` + :class:`LLMGoalDeriver`, proving judge_only is
+    a strict opt-in and the default behaviour is unchanged.
+    """
+    call_llm = _spy_call_llm([])
+    runner = goldfive.wrap(
+        _happy_agent,
+        call_llm=call_llm,
+        model="fake-model",
+        sinks=[],
+    )
+    assert isinstance(runner.planner, LLMPlanner)
+    assert isinstance(runner.goal_deriver, LLMGoalDeriver)
+
+
+# ---------------------------------------------------------------------------
+# 2. A judge_only run produces a NON-EMPTY transcript (no empty-abort trap)
+# ---------------------------------------------------------------------------
+
+
+async def test_judge_only_run_produces_non_empty_transcript() -> None:
+    """A judge_only run executes the native agent and does NOT abort empty.
+
+    The PassthroughPlanner trap is "generate() -> None => empty
+    transcript, nothing to judge". The one-task StaticPlanner avoids it:
+    the native agent is invoked, the task completes, and the sink
+    captures real activity.
+    """
+    call_llm = _spy_call_llm([{"progressing": True}])
+    sink = InMemorySink()
+    outcome = await goldfive.run(
+        _happy_agent,
+        "summarise the quarterly report",
+        judge_only=True,
+        call_llm=call_llm,
+        model="fake-model",
+        sinks=[sink],
+    )
+
+    assert isinstance(outcome, ExecutionOutcome)
+    assert outcome.success, outcome.reason
+    # NON-EMPTY transcript: a real plan with the framing task executed.
+    assert outcome.session.plan is not None
+    assert len(outcome.session.plan.tasks) >= 1
+    # Sink captured native activity — the run did not abort with nothing.
+    assert len(sink.events) > 0
+
+
+async def test_judge_only_does_not_abort_unlike_passthrough() -> None:
+    """Direct contrast: PassthroughPlanner aborts empty; judge_only does not.
+
+    A bare ``PassthroughPlanner`` (the obvious "no planning" trap)
+    returns ``None`` from generate/handle_turn, so the run ends without
+    a plan. ``judge_only=True`` produces a real plan instead.
+    """
+    # Trap: explicit PassthroughPlanner => no usable plan lands, run
+    # aborts (``success=False``, "no plan generated") with no tasks.
+    trap = await goldfive.run(
+        _happy_agent,
+        "do the thing",
+        planner=PassthroughPlanner(),
+        sinks=[InMemorySink()],
+    )
+    assert trap.success is False
+    assert trap.session.plan is None or not trap.session.plan.tasks
+
+    # judge_only: a real plan lands and the agent runs natively.
+    jo = await goldfive.run(
+        _happy_agent,
+        "do the thing",
+        judge_only=True,
+        call_llm=_spy_call_llm([{"progressing": True}]),
+        model="fake-model",
+        sinks=[InMemorySink()],
+    )
+    assert jo.session.plan is not None
+    assert len(jo.session.plan.tasks) >= 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Drift judges still fire under the judge-only steerer
+# ---------------------------------------------------------------------------
+
+
+async def test_judge_only_steerer_still_fires_goal_drift_judge() -> None:
+    """The judge-only-built steerer emits a GOAL_DRIFT drift at the interval.
+
+    Proves the judges remain functional under judge_only — only the
+    planning overlay is suppressed, not the judging.
+    """
+    call_llm = _spy_call_llm(
+        [{"progressing": False, "reason": "researching raccoons not solar panels"}]
+    )
+    runner = goldfive.wrap(
+        _happy_agent,
+        judge_only=True,
+        call_llm=call_llm,
+        model="fake-model",
+        sinks=[],
+    )
+    steerer = runner.steerer
+    assert isinstance(steerer, DefaultSteerer)
+    # Drive the trajectory judge directly through the steerer (mirrors
+    # test_wrap_goal_drift_wiring). Use the steerer's own interval.
+    sink = InMemorySink()
+    steerer.bind(sinks=[sink], planner=runner.planner)
+    session = _make_drift_session()
+
+    # Cross the check interval so the goal-drift judge fires.
+    for _ in range(steerer._goal_drift_check_interval):
+        await steerer.drift.note_agent_turn(session)
+    pending = list(steerer._background_judges)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    # The judge fired (the spy recorded exactly the judge call).
+    assert len(call_llm.calls) == 1  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# 4. Explicit planner / goal_deriver override under judge_only
+# ---------------------------------------------------------------------------
+
+
+def test_judge_only_respects_explicit_planner() -> None:
+    """An explicit ``planner=`` wins even under ``judge_only=True``."""
+    explicit = StaticPlanner(
+        Plan(id="px", run_id="", goal_ids=[], tasks=[Task(id="tx", title="custom")], edges=[])
+    )
+    runner = goldfive.wrap(
+        _happy_agent,
+        judge_only=True,
+        planner=explicit,
+        call_llm=_spy_call_llm([]),
+        model="fake-model",
+        sinks=[],
+    )
+    assert runner.planner is explicit
+
+
+def test_judge_only_respects_explicit_goal_deriver() -> None:
+    """An explicit ``goal_deriver=`` wins even under ``judge_only=True``."""
+
+    class _ExplicitGoalDeriver:
+        async def derive(self, user_input: str, **_: Any) -> list[Goal]:
+            return [Goal(id="g-explicit", summary=user_input)]
+
+    explicit = _ExplicitGoalDeriver()
+    runner = goldfive.wrap(
+        _happy_agent,
+        judge_only=True,
+        goal_deriver=explicit,
+        call_llm=_spy_call_llm([]),
+        model="fake-model",
+        sinks=[],
+    )
+    assert runner.goal_deriver is explicit
+
+
+@pytest.mark.parametrize("judge_only", [True, False])
+def test_judge_only_flag_does_not_disturb_judge_arming(judge_only: bool) -> None:
+    """Judges are armed off ``call_llm`` regardless of the judge_only flag."""
+    call_llm = _spy_call_llm([])
+    runner = goldfive.wrap(
+        _happy_agent,
+        judge_only=judge_only,
+        call_llm=call_llm,
+        model="fake-model",
+        sinks=[],
+    )
+    steerer = runner.steerer
+    assert isinstance(steerer, DefaultSteerer)
+    assert steerer._goal_drift_call_llm is call_llm
+    assert steerer._reasoning_drift_call_llm is call_llm


### PR DESCRIPTION

Closes #445

## What changed

Adds a `judge_only: bool = False` keyword to `goldfive.wrap` (and, via
`**wrap_kwargs`, `goldfive.run`). When `judge_only=True`, the wrapped agent runs
NATIVELY while the drift judges stay armed, and NO planning / steering LLM call
is ever issued (no goal-derive, no plan / refine, no drift-reactive steering).

`judge_only=False` (the default) is byte-identical to today — the full planning
overlay (`LLMPlanner` / `LLMGoalDeriver` + drift-reactive steering) still runs.

## The recipe it encapsulates

`judge_only=True` is a convenience that sets the `planner` / `goal_deriver`
defaults to the validated "native run, no overlay" recipe (reusing existing
machinery — nothing reinvented):

- **`planner`** → a one-task `StaticPlanner` (`_build_judge_only_planner`).
  Under the overlay executor (`SequentialExecutor(overlay_mode=True)`, the
  `wrap()` default) this drives ONE native `invoke_passthrough` of the agent
  tree against the user's input — a real transcript is produced — and its
  `refine` returns `None`, so no refine / steer planning call fires. This avoids
  the `PassthroughPlanner` trap, which returns `None` from `generate` and aborts
  the run with an empty transcript (nothing to judge).
- **`goal_deriver`** → `LiteralGoalDeriver`, which wraps the user input as a
  single goal with NO goal-derive LLM call (vs the call `LLMGoalDeriver` makes).
- **judges** → untouched: still wired off `call_llm` / the detected tree LLM /
  `JudgeConfig` exactly as in full mode.

Explicit `planner=` / `goal_deriver=` / `steerer=` still win — `judge_only` only
supplies the defaults.

Note: `SteeringConfig.observation_only` does NOT achieve this — it gates only
the three drift-reactive INJECTION points, while the planner's goal-derivation /
per-turn planning / refine still run and burn LLM calls.

## Tests

New `tests/test_wrap_judge_only.py`:

- `judge_only=True` selects the `StaticPlanner` + `LiteralGoalDeriver` defaults
  (so structurally NO planning / goal-derive LLM call can fire) while the
  steerer's judges stay armed off `call_llm` — contrasted with `judge_only=False`,
  which builds `LLMPlanner` / `LLMGoalDeriver`.
- a `judge_only=True` run produces a NON-EMPTY transcript (the native agent
  executed; the run did not abort empty), with a direct contrast against the
  `PassthroughPlanner` empty-abort trap.
- the drift judges still fire under the judge-only-built steerer.
- explicit `planner=` / `goal_deriver=` override under `judge_only=True`.
- judge arming is unaffected by the flag (parametrized over both values).

Full suite: **2258 passed, 127 skipped**. `ruff check` / `ruff format` clean;
`mypy` clean on the changed file.

## Downstream validation

A downstream consumer validated this exact recipe end-to-end on live runs: the
steering LLM-call surface (`goal_derive` / `refine` / `refine_steer`) drops to
ZERO while the native agent executes and the drift judges still fire.
