### PR TITLE
feat(eval): capture the agent's complete actual output as the gradeable artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
 
 ## Unreleased — 2026-05-11
 
+### Evaluation / output capture
+
+- **The agent's complete actual output is now the canonical gradeable
+  artifact, captured independent of the self-report
+  ([zicato#12](https://github.com/pedapudi/zicato/issues/12)).**
+  Evaluation previously keyed off either the agent-authored
+  `report_task_completed(summary=…)` status line (`session.completed_results`)
+  or `InvocationResult.text` — the LAST assistant turn only. Both are
+  lossy: graders ended up scoring *how the agent narrated what it did*
+  rather than *what it did*, injecting verdict noise that is especially
+  damaging in optimization loops. This change is **purely additive and
+  backward-compatible**:
+  - `InvocationResult` gains `text_turns` (every non-empty assistant
+    text turn, in order) and `full_text` (the turns joined by
+    `goldfive.results.TURN_SEPARATOR`). `text` is unchanged — still the
+    final turn — so existing consumers see no behavioural change.
+    `full_text` falls back to `text` when an adapter does not track
+    per-turn text. The ADK adapter now accumulates all turns.
+  - `Session` gains `completed_outputs: dict[str, str]`, the full actual
+    output per task, recorded by the sequential and parallel executors
+    **regardless of whether the agent self-reported**.
+    `completed_results` (the summary) is retained unchanged as separate
+    metadata and never shadows the real output. The map carries across
+    conversation turns alongside `completed_results` (later-turns-win)
+    and is cleared in lockstep when a task is reset to PENDING.
+  - Existing consumers of `completed_results` / `InvocationResult.text`
+    (`adk_wrap`, the Claude adapter, persistence reconstruction, planner
+    context) are untouched — they keep their current semantics.
+  - New evaluator-author contract doc: `docs/guides/evaluation.md`
+    (read `completed_outputs` / `full_text`, not the summary / last
+    turn; previews are previews; `report_task_completed(artifacts=…)` is
+    the exact-match-friendly structured channel). `api.md` updated.
+
 ### Judges
 
 - **`JudgeVerdict.drift_kind` / `severity` are now enum-typed.** The two

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -1,0 +1,107 @@
+# Grading agents: what to read, what not to read
+
+If you score agents with goldfive — expectation predicates, rubric
+judges, an exact-match check on returned ids, or a fitness function in
+an optimization loop — **grade the agent's actual output, not its
+self-report.** This guide names the gradeable artifact and the two
+traps that historically made grades imprecise and non-deterministic.
+
+Related: [Multi-turn conversations](multi-turn.md),
+[Writing an agent adapter](writing-an-agent-adapter.md),
+[api.md](../reference/api.md).
+
+## TL;DR
+
+| You want… | Read | Not |
+|---|---|---|
+| The agent's complete output for a task | `session.completed_outputs[task_id]` | `session.completed_results[task_id]` |
+| The complete output of one invocation | `InvocationResult.full_text` (or `.text_turns`) | `InvocationResult.text` |
+| Structured returned values (ids, citations, files) | `report_task_completed(..., artifacts={...})` event payload | substring-matching prose |
+
+`completed_results` and `InvocationResult.text` are still populated and
+still mean what they always did — they are kept for backward
+compatibility. They are **summaries / the last turn**, not the full
+output. Don't grade them.
+
+## The two traps
+
+### 1. The self-report is not the output
+
+When an agent ends a task with `report_task_completed(summary=…)`, that
+`summary` is an agent-authored **status line** ("Found the KEYWORD
+table."), written to signal completion — not to faithfully reproduce
+the answer. It lands in `session.completed_results[task_id]`.
+
+Grading that summary means grading *how the agent narrated what it did*.
+Two runs with byte-identical behavior can get opposite verdicts purely
+on the phrasing of the summary: run A's summary happens to repeat the
+exact id `KEYWORD_____ID_x_y_V2` → your token check passes; run B says
+"the KEYWORD table" → it fails. The grade becomes a function of summary
+verbosity, uncorrelated with correctness.
+
+**Fix:** read `session.completed_outputs[task_id]`. goldfive records the
+agent's *complete actual output* there for every task, **independent of
+whether the agent self-reported**. The self-reported summary stays in
+`completed_results` as separate metadata; it never shadows the real
+output.
+
+### 2. Only the last turn is the answer
+
+An agent often emits its substantive answer (a list, a table of ids, a
+JSON blob) in one turn and a terse wrap-up ("Done — let me know if you
+need anything else.") in the next. `InvocationResult.text` keeps only
+the **last** non-empty turn, so the substantive turn is silently
+dropped.
+
+**Fix:** read `InvocationResult.full_text` (every assistant text turn,
+joined by `goldfive.results.TURN_SEPARATOR`) or `InvocationResult.text_turns`
+(the ordered list). The executor records `full_text` into
+`session.completed_outputs`, so a session-level grader already gets the
+full-fidelity artifact.
+
+## Previews are previews, not gradeable artifacts
+
+Process judges that read `recent_events` tool-observation
+`result_preview` strings are reading **truncated** previews (≈480
+chars), bounded for observability. They are fine for "is the agent on
+task?" reasoning but are **not** a faithful grading target — do not run
+exact-match grading against a preview. For exact matching, use the
+full-fidelity channel (`completed_outputs` / `full_text`).
+
+## Structured output (exact-match-friendly)
+
+When a task's success is defined by a set of returned artifacts (ids,
+citations, file paths, numeric values), have the agent declare them
+structurally via the existing reporting tool:
+
+```python
+report_task_completed(
+    task_id="...",
+    summary="Looked up the three matching rows.",
+    artifacts={"row_ids": "KEYWORD_____ID_x_y_V2,KEYWORD_____ID_a_b_V1"},
+)
+```
+
+`artifacts` is a typed `dict[str, str]` carried on the `TaskCompleted`
+event. Grade it as exact-match on structured data instead of substring
+matching on prose — that removes the entire "did the prose happen to
+contain the token" class of fragility. `summary` remains free-form
+metadata.
+
+## Multi-turn
+
+Both maps carry across conversation turns on the owning
+`Conversation` (`completed_results` and `completed_outputs`), with
+later-turns-win merge semantics. A turn-N grader and the planner both
+see prior turns' full output, not only their summaries. See
+[Multi-turn conversations](multi-turn.md).
+
+## Backward compatibility
+
+This is purely additive. If you already grade `completed_results` /
+`InvocationResult.text`, nothing changed for you — but you are grading a
+lossy channel, and migrating to `completed_outputs` / `full_text` will
+raise your eval's signal-to-noise ratio. Adapters that cannot
+distinguish turns leave `text_turns` empty; `full_text` then falls back
+to `text`, and `completed_outputs` falls back to whatever the adapter
+recorded, so a grader can always read the new fields safely.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -473,7 +473,12 @@ class Session:
     goals: list[Goal] = field(default_factory=list)
     plan: Plan | None = None
     current_task_id: str = ""
+    # Agent-authored SUMMARY per task (lossy status-line metadata).
     completed_results: dict[str, str] = field(default_factory=dict)
+    # Agent's COMPLETE ACTUAL OUTPUT per task — the canonical, gradeable
+    # artifact. Recorded independent of self-reporting. Prefer this over
+    # ``completed_results`` for grading. See ../guides/evaluation.md.
+    completed_outputs: dict[str, str] = field(default_factory=dict)
     task_progress: dict[str, float] = field(default_factory=dict)
     agent_notes: dict[str, str] = field(default_factory=dict)
     divergence_flag: bool = False
@@ -531,11 +536,19 @@ Returned by `AgentAdapter.invoke()`.
 @dataclass
 class InvocationResult:
     task_id: str
-    text: str = ""
+    text: str = ""              # the LAST assistant text turn (legacy)
     stop_reason: str = ""
     error: Optional[Exception] = None
     raw: Any = None
+    text_turns: list[str] = field(default_factory=list)  # every text turn, in order
+    full_text: str = ""         # text_turns joined by TURN_SEPARATOR; falls back to text
 ```
+
+`text` is the **final** assistant turn only — kept for backward
+compatibility. For grading, read `full_text` (or `text_turns`): an
+agent often emits its substantive answer in one turn and a terse
+wrap-up in a later turn, and `text` keeps only the latter. See
+[../guides/evaluation.md](../guides/evaluation.md).
 
 ### `ExecutionOutcome`
 

--- a/goldfive/adapters/adk.py
+++ b/goldfive/adapters/adk.py
@@ -2024,6 +2024,11 @@ class ADKAdapter:
             log.debug("ADKAdapter.invoke: could not stash session context")
 
         final_text = ""
+        # zicato#12 mechanism 2: keep EVERY non-empty assistant text turn,
+        # not just the last. ``final_text`` stays the last turn (backward
+        # compatibility for InvocationResult.text); ``text_turns`` is the
+        # lossless record fed into InvocationResult.full_text for graders.
+        text_turns: list[str] = []
         stop_reason = "completed"
         err: Exception | None = None
         last_event: Any = None
@@ -2086,6 +2091,7 @@ class ADKAdapter:
                 text = _extract_text_from_event(event)
                 if text:
                     final_text = text
+                    text_turns.append(text)
                 if _is_final_event(event):
                     stop_reason = "final_response"
                 # Early termination when the agent has reported this
@@ -2232,6 +2238,7 @@ class ADKAdapter:
             stop_reason=stop_reason,
             error=err,
             raw=last_event,
+            text_turns=text_turns,
         )
 
     # ------------------------------------------------------------------

--- a/goldfive/conversation.py
+++ b/goldfive/conversation.py
@@ -101,6 +101,12 @@ class Conversation:
     started_at_ms: int
     goals: list[Goal] = dataclasses.field(default_factory=list)
     completed_results: dict[str, str] = dataclasses.field(default_factory=dict)
+    # zicato#12: merged ``task_id -> full actual output`` map across turns,
+    # the cross-turn mirror of :attr:`goldfive.types.Session.completed_outputs`.
+    # Carried alongside ``completed_results`` (the self-reported summary) so a
+    # later turn / planner / grader sees prior turns' real output, not only the
+    # summary.
+    completed_outputs: dict[str, str] = dataclasses.field(default_factory=dict)
     turns: list[TurnRecord] = dataclasses.field(default_factory=list)
     # Conversation-level wire sequence cursor (goldfive#271 Gap 2).
     # Each turn's :class:`Session` seeds its private ``_next_sequence``
@@ -173,6 +179,7 @@ class Conversation:
             started_at_ms=_now_ms(),
             goals=list(self.goals),
             completed_results=dict(self.completed_results),
+            completed_outputs=dict(self.completed_outputs),
             _next_sequence=self._next_sequence,
         )
 
@@ -290,6 +297,9 @@ class Conversation:
         # that a revised result on a follow-up turn is visible to the
         # turn after it.
         self.completed_results.update(session.completed_results)
+        # zicato#12: carry the full actual output forward with the same
+        # later-turns-win merge semantics as ``completed_results``.
+        self.completed_outputs.update(session.completed_outputs)
 
         # goldfive#271 Gap 2: lift the turn's high-water sequence back to
         # the Conversation cursor so the next ``next_turn_session()``

--- a/goldfive/executors/_control.py
+++ b/goldfive/executors/_control.py
@@ -581,6 +581,7 @@ def _rewind_plan(
         prev = prev_task.status
         if prev is TaskStatus.PENDING:
             session.completed_results.pop(tid, None)
+            session.completed_outputs.pop(tid, None)  # zicato#12
             session.task_progress.pop(tid, None)
             continue
         new_plan = with_task_status(new_plan, tid, TaskStatus.PENDING)
@@ -590,6 +591,7 @@ def _rewind_plan(
         new_task = next((t for t in new_plan.tasks if t.id == tid), prev_task)
         transitions.append((new_task, prev))
         session.completed_results.pop(tid, None)
+        session.completed_outputs.pop(tid, None)  # zicato#12
         session.task_progress.pop(tid, None)
     if new_plan is not plan:
         with channel_processor_active():

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -345,6 +345,13 @@ class ParallelDAGExecutor:
                             )
                         if inv is not None:
                             session.completed_results[task.id] = inv.text
+                            # zicato#12 mechanism 1: full-fidelity actual
+                            # output (every turn), recorded as the canonical
+                            # gradeable artifact alongside the legacy
+                            # last-turn ``completed_results`` write.
+                            full_output = inv.full_text or inv.text or ""
+                            if full_output:
+                                session.completed_outputs[task.id] = full_output
                     completed_stage_ids.add(task.id)
 
                 # If a STEER arrived mid-stage, apply it now (stage was

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -650,6 +650,21 @@ class SequentialExecutor(Executor):
                         reason=f"drift_pipeline_failed: {observe_exc}",
                     )
 
+            # zicato#12 mechanism 1: record the agent's COMPLETE actual output
+            # as the canonical gradeable artifact, INDEPENDENT of whether the
+            # agent self-reported via ``report_task_completed``. When the agent
+            # self-reports, the task is already terminal by the time the
+            # auto-transition below runs, so the ``detail=summary`` write path
+            # is skipped and ``completed_results`` would keep only the
+            # self-authored summary. ``completed_outputs`` always carries the
+            # full assistant text so a grader can match the real output. The
+            # self-reported summary remains in ``completed_results`` as
+            # separate metadata — it never shadows the real output here.
+            if result is not None and getattr(result, "error", None) is None:
+                full_output = getattr(result, "full_text", "") or getattr(result, "text", "") or ""
+                if full_output:
+                    session.completed_outputs[task.id] = full_output
+
             # Re-read the task's tracked status after the invocation.
             tracked = _find_task(session.plan or current_plan, task.id)
             tracked_status = tracked.status if tracked is not None else TaskStatus.PENDING

--- a/goldfive/results.py
+++ b/goldfive/results.py
@@ -10,13 +10,38 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+#: Separator placed between successive assistant text turns when an adapter
+#: joins them into :attr:`InvocationResult.full_text`. A blank line keeps the
+#: turns visually distinct without inventing markup a grader might trip over.
+TURN_SEPARATOR = "\n\n"
+
+
 @dataclasses.dataclass
 class InvocationResult:
     """Result returned by ``AgentAdapter.invoke`` for a single task.
 
-    ``text`` is the final assistant text, ``stop_reason`` is adapter-specific,
-    ``error`` is populated if the invocation raised, and ``raw`` carries the
-    adapter's native result object for debugging or downstream inspection.
+    ``text`` is the **final** assistant text turn, ``stop_reason`` is
+    adapter-specific, ``error`` is populated if the invocation raised, and
+    ``raw`` carries the adapter's native result object for debugging or
+    downstream inspection.
+
+    Full-fidelity output (goldfive#... / zicato#12)
+    ----------------------------------------------
+    Agents routinely emit their substantive answer (a list, a table of ids,
+    a detailed value) in one turn and a terse wrap-up ("Done — let me know if
+    you need anything else") in a later turn. ``text`` keeps only the last
+    non-empty turn, which silently drops the substantive turn. Graders that
+    need to match against the agent's *actual* output must read:
+
+    * ``text_turns`` — every non-empty assistant text turn, in order. The
+      lossless record of what the agent produced.
+    * ``full_text`` — the same turns joined by :data:`TURN_SEPARATOR`; the
+      canonical, full-fidelity gradeable artifact.
+
+    ``text`` is retained unchanged for backward compatibility (existing
+    consumers that only ever wanted the final turn keep their semantics).
+    Adapters that cannot distinguish turns may leave ``text_turns`` empty;
+    :attr:`full_text` then falls back to ``text`` (see ``__post_init__``).
     """
 
     task_id: str
@@ -24,6 +49,24 @@ class InvocationResult:
     stop_reason: str = ""
     error: Exception | None = None
     raw: Any = None
+    #: Every non-empty assistant text turn of this invocation, in emission
+    #: order. Empty for adapters that do not track per-turn text; in that
+    #: case ``full_text`` falls back to ``text``.
+    text_turns: list[str] = dataclasses.field(default_factory=list)
+    #: All assistant text turns joined by :data:`TURN_SEPARATOR`. The
+    #: full-fidelity gradeable artifact. Defaults to the joined ``text_turns``
+    #: when set; otherwise falls back to ``text``.
+    full_text: str = ""
+
+    def __post_init__(self) -> None:
+        # full_text is derived, not separately authored: prefer the joined
+        # turns, fall back to the single ``text`` so callers that construct an
+        # InvocationResult with only ``text=`` still get a sensible full_text.
+        if not self.full_text:
+            if self.text_turns:
+                self.full_text = TURN_SEPARATOR.join(self.text_turns)
+            else:
+                self.full_text = self.text
 
 
 @dataclasses.dataclass

--- a/goldfive/results.py
+++ b/goldfive/results.py
@@ -25,8 +25,8 @@ class InvocationResult:
     ``raw`` carries the adapter's native result object for debugging or
     downstream inspection.
 
-    Full-fidelity output (goldfive#... / zicato#12)
-    ----------------------------------------------
+    Full-fidelity output (zicato#12)
+    --------------------------------
     Agents routinely emit their substantive answer (a list, a table of ids,
     a detailed value) in one turn and a terse wrap-up ("Done — let me know if
     you need anything else") in a later turn. ``text`` keeps only the last

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1715,6 +1715,15 @@ class Session:
     plan: Plan | None = None
     current_task_id: str = ""
     completed_results: dict[str, str] = dataclasses.field(default_factory=dict)
+    # zicato#12: the agent's COMPLETE actual output per task, recorded
+    # independently of whether the agent self-reported via
+    # ``report_task_completed``. ``completed_results`` holds the agent-authored
+    # *summary* (a status line, lossy metadata); ``completed_outputs`` holds
+    # the full-fidelity assistant text (every turn, joined) — the canonical,
+    # gradeable artifact. Evaluators and exact-match graders should read
+    # ``completed_outputs`` (falling back to ``completed_results`` only when an
+    # entry is absent, e.g. legacy adapters). See docs/reference/EVALUATION.md.
+    completed_outputs: dict[str, str] = dataclasses.field(default_factory=dict)
     # task_id -> progress fraction 0-1
     task_progress: dict[str, float] = dataclasses.field(default_factory=dict)
     # task_id -> last agent note

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1722,7 +1722,7 @@ class Session:
     # the full-fidelity assistant text (every turn, joined) — the canonical,
     # gradeable artifact. Evaluators and exact-match graders should read
     # ``completed_outputs`` (falling back to ``completed_results`` only when an
-    # entry is absent, e.g. legacy adapters). See docs/reference/EVALUATION.md.
+    # entry is absent, e.g. legacy adapters). See docs/guides/evaluation.md.
     completed_outputs: dict[str, str] = dataclasses.field(default_factory=dict)
     # task_id -> progress fraction 0-1
     task_progress: dict[str, float] = dataclasses.field(default_factory=dict)

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -1326,6 +1326,49 @@ async def test_heal_is_noop_when_no_pending_calls() -> None:
     assert runner_empty.session_service.appended == []
 
 
+async def test_invoke_captures_all_text_turns_full_text() -> None:
+    """zicato#12 mechanism 2: every non-empty assistant text turn is captured.
+
+    The substantive turn (with the exact id a grader needs) lands in
+    ``full_text`` / ``text_turns``, while ``text`` keeps only the LAST turn for
+    backward compatibility.
+    """
+    from google.adk.events.event import Event  # type: ignore
+    from google.genai import types  # type: ignore
+
+    from goldfive.adapters.adk import ADKAdapter
+    from goldfive.results import TURN_SEPARATOR
+    from goldfive.types import Session, Task
+
+    agent = _make_agent()
+    substantive = "Result rows: KEYWORD_____ID_x_y_V2, KEYWORD_____ID_a_b_V1"
+    wrapup = "Done — let me know if you need anything else."
+
+    def _text_event(text: str):
+        return Event(
+            invocation_id="inv-mt",
+            author="test_agent",
+            content=types.Content(role="model", parts=[types.Part(text=text)]),
+        )
+
+    async def _run():
+        yield _text_event(substantive)
+        yield _text_event(wrapup)
+
+    runner = _FakeRunner(_run, agent)
+    adapter = ADKAdapter(runner, session_id="sess-mt")
+    result = await adapter.invoke(Task(id="t1", title="x"), Session(run_id="r"))
+
+    # Legacy field: last turn only.
+    assert result.text == wrapup
+    # Full-fidelity channel: both turns, in order.
+    assert result.text_turns == [substantive, wrapup]
+    assert result.full_text == TURN_SEPARATOR.join([substantive, wrapup])
+    # The id the grader needs survives in full_text but NOT in text.
+    assert "KEYWORD_____ID_x_y_V2" in result.full_text
+    assert "KEYWORD_____ID_x_y_V2" not in result.text
+
+
 # ---------------------------------------------------------------------------
 # goldfive#139 — reason-differentiated synthetic response content +
 # USER_STEER user-role primer event. The prior generic content shape

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -153,6 +153,34 @@ def test_conversation_absorb_turn_merges_goals_and_results() -> None:
     assert len(conv.turns) == 1
 
 
+def test_conversation_carries_completed_outputs_across_turns() -> None:
+    """zicato#12: the full actual output is carried across turns alongside the
+    self-reported summary, with later-turns-win merge semantics."""
+    from goldfive.results import ExecutionOutcome
+
+    conv = Conversation.new()
+    conv.completed_results = {"t_prior": "summary line"}
+    conv.completed_outputs = {"t_prior": "the full prior output with ID_99"}
+
+    # A fresh turn session inherits BOTH maps as copies.
+    s = conv.next_turn_session()
+    assert s.completed_results == {"t_prior": "summary line"}
+    assert s.completed_outputs == {"t_prior": "the full prior output with ID_99"}
+    assert s.completed_outputs is not conv.completed_outputs
+
+    # This turn produces its own (summary, full-output) pair.
+    s.completed_results["t1"] = "Found the table."
+    s.completed_outputs["t1"] = "row ID_x_y_V2 = 42 full dump"
+
+    outcome = ExecutionOutcome(success=True, session=s)
+    conv.absorb_turn(outcome, user_input_summary="q")
+
+    assert conv.completed_outputs["t_prior"] == "the full prior output with ID_99"
+    assert "ID_x_y_V2" in conv.completed_outputs["t1"]
+    # Summary map remains the lossy metadata, unchanged in shape.
+    assert conv.completed_results["t1"] == "Found the table."
+
+
 def test_conversation_absorb_turn_deduplicates_goal_ids() -> None:
     from goldfive.results import ExecutionOutcome
 

--- a/tests/test_invocation_result_full_text.py
+++ b/tests/test_invocation_result_full_text.py
@@ -1,0 +1,58 @@
+"""Tests for full-fidelity output capture on :class:`InvocationResult`.
+
+Background (zicato#12): evaluators that grade an agent's output must see the
+agent's *actual* produced text, not a lossy single-turn slice. ``text`` keeps
+its legacy meaning (the final assistant turn) for backward compatibility;
+``text_turns`` / ``full_text`` are the new additive, full-fidelity channel.
+"""
+
+from __future__ import annotations
+
+from goldfive.results import TURN_SEPARATOR, InvocationResult
+
+
+def test_text_only_construction_back_compat() -> None:
+    """A legacy caller passing only ``text=`` is unchanged, and ``full_text``
+    falls back to ``text`` so a grader reading the new field still works."""
+    r = InvocationResult(task_id="t1", text="the answer is 42")
+    assert r.text == "the answer is 42"
+    # No per-turn record supplied — full_text mirrors text.
+    assert r.text_turns == []
+    assert r.full_text == "the answer is 42"
+
+
+def test_text_turns_populate_full_text() -> None:
+    """When the adapter records every turn, ``full_text`` is the joined turns
+    and ``text`` stays the LAST turn (legacy semantics)."""
+    turns = [
+        "Found the KEYWORD_____ID_x_y_V2 table with 3 matching rows.",
+        "Done — let me know if you need anything else.",
+    ]
+    r = InvocationResult(task_id="t1", text=turns[-1], text_turns=turns)
+    # Legacy field: last turn only.
+    assert r.text == "Done — let me know if you need anything else."
+    # Full-fidelity field: every turn, in order — the substantive answer is
+    # NOT dropped.
+    assert r.full_text == TURN_SEPARATOR.join(turns)
+    assert "KEYWORD_____ID_x_y_V2" in r.full_text
+    # And the substantive id is absent from the lossy last-turn field, which is
+    # precisely the precision bug graders hit when keying off ``text``.
+    assert "KEYWORD_____ID_x_y_V2" not in r.text
+
+
+def test_explicit_full_text_is_respected() -> None:
+    """An adapter may author ``full_text`` directly; it is not overwritten."""
+    r = InvocationResult(
+        task_id="t1",
+        text="last",
+        text_turns=["a", "b"],
+        full_text="explicit override",
+    )
+    assert r.full_text == "explicit override"
+
+
+def test_empty_invocation() -> None:
+    r = InvocationResult(task_id="t1")
+    assert r.text == ""
+    assert r.text_turns == []
+    assert r.full_text == ""

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -1329,6 +1329,123 @@ async def test_observer_exception_emits_pipeline_failure_drift() -> None:
     assert "classifier exploded" in pipeline_failures[0].drift_detected.detail
 
 
+async def test_completed_outputs_records_full_output_on_self_report() -> None:
+    """zicato#12 mechanism 1: when the agent self-reports completion (task is
+    already terminal by the time the executor's auto-transition runs), the
+    full actual output must still land in ``completed_outputs`` — independent
+    of the lossy self-authored ``completed_results`` summary.
+    """
+    plan = _linear_plan(1)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    real_answer = "row id KEYWORD_____ID_x_y_V2 = 17 (full table dump follows)…"
+
+    async def _self_report(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        # Emulate report_task_completed: the task is ALREADY terminal and
+        # completed_results holds only the agent-authored summary line.
+        await steerer.transition(task.id, TaskStatus.COMPLETED, session=session)
+        session.completed_results[task.id] = "Found the KEYWORD table."
+        # The invocation envelope carries the agent's REAL output across turns.
+        return InvocationResult(
+            task_id=task.id,
+            text="Done — anything else?",
+            text_turns=[real_answer, "Done — anything else?"],
+        )
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_self_report)
+    executor = SequentialExecutor(max_task_invocations=1)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is True
+    # Self-report summary is preserved as metadata (unchanged behavior).
+    assert session.completed_results["t0"] == "Found the KEYWORD table."
+    # Full actual output is the canonical gradeable artifact and carries the
+    # exact id a grader needs.
+    assert "KEYWORD_____ID_x_y_V2" in session.completed_outputs["t0"]
+    assert real_answer in session.completed_outputs["t0"]
+
+
+async def test_completed_outputs_on_clean_return_without_self_report() -> None:
+    """When the agent returns cleanly WITHOUT self-reporting, the executor
+    auto-transitions to COMPLETED and ``completed_outputs`` still captures the
+    full output (here, multi-turn)."""
+    plan = _linear_plan(1)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _clean_return(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        # No transition, no completed_results write — clean return only.
+        return InvocationResult(
+            task_id=task.id,
+            text="wrap up",
+            text_turns=["substantive answer with TOKEN_42", "wrap up"],
+        )
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_clean_return)
+    executor = SequentialExecutor(max_task_invocations=1)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+
+    assert outcome.success is True
+    # The full output is captured for graders even on a clean auto-transition
+    # (the executor records completed_outputs directly off the invocation
+    # envelope, independent of whether the task self-reported).
+    assert "TOKEN_42" in session.completed_outputs["t0"]
+    assert session.completed_outputs["t0"].endswith("wrap up")
+
+
+async def test_completed_outputs_not_recorded_on_error() -> None:
+    """An invocation that carried an error records no gradeable output."""
+    plan = _linear_plan(1)
+    session = _fresh_session()
+    steerer = StubSteerer()
+    planner = StubPlanner()
+    sink = RecordingSink()
+
+    async def _errored(
+        task: Task, session: Session, steerer: StubSteerer, planner: StubPlanner
+    ) -> InvocationResult:
+        return InvocationResult(
+            task_id=task.id,
+            text="partial",
+            error=RuntimeError("boom"),
+        )
+
+    adapter = StubAdapter(steerer=steerer, planner=planner, on_invoke=_errored)
+    executor = SequentialExecutor(max_task_invocations=1, fail_fast=False)
+    await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=planner,
+        sinks=[sink],
+    )
+    assert "t0" not in session.completed_outputs
+
+
 def test_deprecation_warning_fires_for_old_kwarg() -> None:
     """Passing ``max_plan_reinvocations=`` emits a :class:`DeprecationWarning`
     and maps to the new attribute name.


### PR DESCRIPTION
## The bug

goldfive surfaces an agent's "result" — what expectation graders, process judges, and transcript reconstruction consume — as, in practice, a **self-authored summary** plus **only the last assistant turn**, not the agent's **actual produced output**. Any eval or judge that grades this artifact is really grading *how the agent narrated what it did*, not *what it did*. Two runs with byte-identical behavior can get opposite verdicts on the phrasing of a secondary self-report. In an optimization loop the noise can dominate the fitness signal.

Two independent mechanisms collapse real output into a lossy summary:

1. **Overlay completion records the self-report, not the answer.** When an agent ends a task via `report_task_completed(summary=…)`, the task is already terminal by the time `SequentialExecutor`'s auto-transition runs, so the "record the agent's actual answer" path is skipped and `session.completed_results[task_id]` retains only the agent-authored status line.
2. **Only the last assistant turn is kept.** `InvocationResult.text` is assigned the **last** non-empty text event. Agents routinely emit the substantive answer (a list, a table of ids) in one turn and a terse wrap-up ("Done — anything else?") in a later turn; the substantive turn is silently dropped.

## The fix — additive and backward-compatible

Nothing existing consumers receive changes in a breaking way. `completed_results` and `InvocationResult.text` keep their exact current semantics (summary / last turn). New full-fidelity channels are added **alongside** them:

- **`InvocationResult.text_turns`** — every non-empty assistant text turn, in order.
- **`InvocationResult.full_text`** — the turns joined by `goldfive.results.TURN_SEPARATOR`. Falls back to `text` (via `__post_init__`) when an adapter does not track per-turn text, so a grader can always read the new field safely. The ADK adapter now accumulates all turns.
- **`Session.completed_outputs: dict[str, str]`** — the agent's complete actual output per task, recorded by the sequential **and** parallel executors **independent of whether the agent self-reported**. `completed_results` (the summary) stays as separate metadata and never shadows the real output. The map carries across conversation turns alongside `completed_results` (later-turns-win) and is cleared in lockstep when a task is reset to PENDING.
- **Structured channel:** `report_task_completed(artifacts={...})` already carries a typed `dict[str,str]` on the `TaskCompleted` event — documented as the exact-match-friendly structured-output channel. No new tool needed.

### Why this doesn't break non-goldfive-optimizer users

The change is strictly opt-in: I **added** fields rather than changing any default. Every existing consumer of `completed_results` / `InvocationResult.text` — `adk_wrap`, the Claude adapter, `reconstruct_session`, the ADK-state planner-context bridge — is untouched and sees identical values. zicato-style exact-match grading is now *possible* (read `completed_outputs` / `full_text`) without forcing anything on others; callers who never opt in keep today's behavior byte-for-byte.

## Docs

- New evaluator-author contract: `docs/guides/evaluation.md` — read `completed_outputs` / `full_text` (not the summary / last turn); previews are previews; `report_task_completed(artifacts=…)` is the structured channel.
- `docs/reference/api.md` `Session` + `InvocationResult` updated; `CHANGELOG.md` entry added.

## Tests

- `tests/test_invocation_result_full_text.py` — `full_text`/`text_turns` population, `text` back-compat (last turn only), explicit-`full_text` respected, fallback for text-only construction, empty case.
- `tests/test_sequential_executor.py` — `completed_outputs` captured (a) on self-report while `completed_results` keeps the lossy summary, (b) on a clean auto-transition with no self-report, (c) not recorded on error.
- `tests/test_adk_adapter.py` — multi-turn invocation captures all turns; the exact id survives in `full_text` but not in `text`.
- `tests/test_conversation.py` — `completed_outputs` carries across turns with later-turns-win merge.

## Gate

```
$ uv run ruff check .
All checks passed!

$ uv run pytest -q
2788 passed, 59 skipped, 49 warnings in 40.25s
```

mypy: no new errors introduced over the pre-existing baseline (the touched executor files already had dynamic-attribute `[attr-defined]` errors; the new full-output access uses the same `getattr` pattern the surrounding code uses).

Refs: pedapudi/zicato#12 (https://github.com/pedapudi/zicato/issues/12)