### PR TITLE
feat(steering): gate in-flight cancellation on user-authored/hard-safety drift (AGENCY-PRESERVATION PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,38 @@ All notable changes to goldfive are documented in this file. Dates are ISO-8601.
 ### Steering
 
 - **BREAKING:
+  [#449](https://github.com/pedapudi/goldfive/issues/449)/[#452](https://github.com/pedapudi/goldfive/issues/452)
+  (AGENCY-PRESERVATION.md PR 1) — in-flight cancellation is gated on
+  drift authority.** `DriftObserver._cancel_inflight_for_revision`
+  used to fire on EVERY drift-driven plan install — including Level-1
+  ABSORB refines and `NEW_WORK_DISCOVERED` installs — killing the
+  wrapped agent's in-flight invocation within ~one event-loop tick
+  (design doc §1.1). Under the new default
+  (`SteeringConfig.cancel_inflight_scope="user_and_safety"`) only
+  user-authored drifts (`USER_STEER` / `USER_CANCEL` / `USER_PAUSE`)
+  or hard-safety kinds (`RESOURCE_EXHAUSTED`, `RUNAWAY_DELEGATION`,
+  `TOO_MANY_STEPS`, `TASK_TIMEOUT`, `LLM_CALL_TIMEOUT`,
+  `HUMAN_INTERVENTION_REQUIRED`) may preempt in-flight work; the same
+  authority gate applies to the pre-refine cooperative-cancel path
+  (`_should_request_cancel_for_drift`), so a CRITICAL
+  goldfive-authored steering drift no longer flags a cancel either.
+  Goldfive-authored revisions still install for bookkeeping (the
+  `PlanRevised` stream is unchanged) and corrections reach the agent
+  at the natural invocation boundary (nudge replay / `GOLDFIVE_STEER`
+  restart). Skipped cancels stamp NOTHING — no
+  `session._supersede_pending`, no per-invocation supersede-registry
+  entry — so the executor's cancelled branch cannot misread a
+  stranded flag. The v15 concurrent-invocation loop the unconditional
+  cancel guarded against stays bounded by the
+  [#245](https://github.com/pedapudi/goldfive/issues/245)
+  verdict-freshness gate, the
+  [#405](https://github.com/pedapudi/goldfive/issues/405) in-flight
+  refine registry, and no-op-revision rejection (pinned in
+  `tests/test_cancel_authority_gate.py`). Kill-switch:
+  `cancel_inflight_scope="all"` (env
+  `GOLDFIVE_CANCEL_INFLIGHT_SCOPE=all`) restores the legacy
+  cancel-on-every-install behaviour exactly.
+- **BREAKING:
   [#254](https://github.com/pedapudi/goldfive/issues/254) —
   observation-only is the new default on `goldfive.wrap()`.**
   `SteeringConfig.observation_only` (default `True`) gates the three

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -80,6 +80,8 @@ __all__ = [
 
 _VALID_STEER_THRESHOLDS: frozenset[str] = frozenset({"off", "warning", "critical"})
 
+_VALID_CANCEL_INFLIGHT_SCOPES: frozenset[str] = frozenset({"user_and_safety", "all"})
+
 
 # Test-only override hook for :class:`SteeringConfig.observation_only`'s
 # default (goldfive#254). Production code path: this stays ``None`` and
@@ -223,6 +225,30 @@ def _read_float_env(name: str, default: float) -> float:
 _VALID_REASONING_DRIFT_MODES: frozenset[str] = frozenset(
     {"judge", "embedding", "both", "off"}
 )
+
+
+def _read_cancel_inflight_scope_env(name: str, default: str) -> str:
+    """Return ``os.environ[name]`` as a cancel-inflight scope literal, or ``default``.
+
+    Accepts ``"user_and_safety"`` / ``"all"`` (case-insensitive).
+    Anything else logs a WARNING and falls back so a typo never
+    silently re-enables (or disables) the in-flight cancel authority
+    gate (AGENCY-PRESERVATION.md PR 1, goldfive#449/#452).
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if value in _VALID_CANCEL_INFLIGHT_SCOPES:
+        return value
+    log.warning(
+        "ignoring unknown %s=%r (expected one of %s); using default %r",
+        name,
+        raw,
+        sorted(_VALID_CANCEL_INFLIGHT_SCOPES),
+        default,
+    )
+    return default
 
 
 def _read_reasoning_drift_mode_env(
@@ -679,6 +705,32 @@ class SteeringConfig:
     #: ``Task.discovery_identity_hash``, ``DelegationObserved.tool_args_json``)
     #: are always available regardless of this flag.
     descriptive_growth_enabled: bool = False
+    #: Authority scope for cancelling the wrapped agent's IN-FLIGHT
+    #: invocation on a drift-driven plan install (AGENCY-PRESERVATION.md
+    #: PR 1; goldfive#449/#452).
+    #:
+    #: * ``"user_and_safety"`` (the default) — in-flight cancellation is
+    #:   permitted ONLY when the triggering drift is user-authored
+    #:   (USER_STEER / USER_CANCEL / USER_PAUSE) or a hard-safety kind
+    #:   (budget/resource protection and termination — see
+    #:   :attr:`goldfive.drift_observer.DriftObserver._HARD_SAFETY_DRIFT_KINDS`).
+    #:   Goldfive-authored revisions (Level-1 ABSORB refines,
+    #:   NEW_WORK_DISCOVERED installs, drift→steer promotions) still
+    #:   install for bookkeeping, but the in-flight invocation runs to
+    #:   completion; corrections reach the agent at the natural
+    #:   invocation boundary (nudge replay / GOLDFIVE_STEER restart).
+    #: * ``"all"`` — the legacy behaviour: EVERY drift-driven plan
+    #:   install fires :meth:`DriftObserver._cancel_inflight_for_revision`
+    #:   (the goldfive#271-follow-up v15 concurrent-invocation fix in
+    #:   its original, unconditional form). This is the §5.1 one-line
+    #:   kill-switch for PR 1: setting
+    #:   ``GOLDFIVE_CANCEL_INFLIGHT_SCOPE=all`` restores today's
+    #:   behaviour exactly.
+    #:
+    #: Orthogonal to ``observation_only``: observation-only suppresses
+    #: the plugin cancel call itself; this knob decides which drift
+    #: AUTHORITIES may request it in the first place.
+    cancel_inflight_scope: str = "user_and_safety"
 
     @classmethod
     def from_env(cls) -> SteeringConfig:
@@ -698,6 +750,10 @@ class SteeringConfig:
         * ``GOLDFIVE_STEER_CONTEXT_EDITOR_RULES`` — comma-separated rule
           names (goldfive#397). Empty / unset → ``None`` (editor unwired).
           Example: ``GOLDFIVE_STEER_CONTEXT_EDITOR_RULES=prune_cancelled_reasoning``.
+        * ``GOLDFIVE_CANCEL_INFLIGHT_SCOPE`` — ``user_and_safety`` /
+          ``all`` (case-insensitive). ``all`` is the PR-1 kill-switch
+          that restores the legacy cancel-on-every-install behaviour
+          (AGENCY-PRESERVATION.md §5.1).
         """
         defaults = cls()
         raw_rules = os.environ.get("GOLDFIVE_STEER_CONTEXT_EDITOR_RULES", "").strip()
@@ -722,6 +778,10 @@ class SteeringConfig:
             descriptive_growth_enabled=_read_bool_env(
                 "GOLDFIVE_STEER_DESCRIPTIVE_GROWTH",
                 defaults.descriptive_growth_enabled,
+            ),
+            cancel_inflight_scope=_read_cancel_inflight_scope_env(
+                "GOLDFIVE_CANCEL_INFLIGHT_SCOPE",
+                defaults.cancel_inflight_scope,
             ),
         )
 

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -287,6 +287,65 @@ class DriftObserver:
         }
     )
 
+    # AGENCY-PRESERVATION.md PR 1 (goldfive#449/#452): hard-safety drift
+    # kinds — the GUARDRAIL half of the §0 authority split. Together
+    # with :attr:`_USER_AUTHORED_DRIFT_KINDS` these are the ONLY drift
+    # authorities permitted to cancel the wrapped agent's in-flight
+    # invocation under the default ``cancel_inflight_scope=
+    # "user_and_safety"`` policy (see
+    # :meth:`_drift_authorizes_inflight_cancel`).
+    #
+    # Inclusion rationale — a kind belongs here iff it represents
+    # budget/resource protection or run termination, i.e. its job is to
+    # *stop* runaway behaviour (observed fact, no judgment call), not to
+    # redirect a trajectory:
+    #
+    # * ``RESOURCE_EXHAUSTED`` — budget exhaustion. Named explicitly in
+    #   the roadmap's PR-1 entry ("budget exhaustion"). No goldfive-core
+    #   emitter today, but external producers / adapters use the kind;
+    #   a budget trip must retain stop authority wherever it comes from.
+    # * ``RUNAWAY_DELEGATION`` — the AgentTool-per-invoke cap
+    #   (goldfive#130). The backstop for coordinator prompts that
+    #   delegate forever; CRITICAL by construction and named explicitly
+    #   in the roadmap ("runaway delegation").
+    # * ``TOO_MANY_STEPS`` — step-budget trip. Same observed-fact budget
+    #   family as RESOURCE_EXHAUSTED.
+    # * ``TASK_TIMEOUT`` — per-task wall-clock budget. Budget family.
+    # * ``LLM_CALL_TIMEOUT`` — per-LLM-call wall-clock budget
+    #   (goldfive#256 / #271 follow-up). Its plugin-side emitter already
+    #   pairs the drift with a cooperative cancel on the invocation;
+    #   excluding it here would leave the dispatch path's cancel policy
+    #   inconsistent with the emitter's own contract.
+    # * ``HUMAN_INTERVENTION_REQUIRED`` — the ONLY kind the ladder's
+    #   TERMINATE cell maps from (the CRITICAL-repeat pair of its
+    #   ``_LADDER`` row is ``(PAUSE_ESCALATE, TERMINATE)``; verified
+    #   against :meth:`_load_ladder_tables`). The run is stopping for an
+    #   operator; preempting in-flight work is stop authority, not
+    #   steering.
+    #
+    # Deliberately EXCLUDED:
+    #
+    # * ``REPEATED_FAILURE`` — terminal for the *task*, but it is
+    #   goldfive's own refine-failure escalation (a steering artifact,
+    #   not an external budget); its emitter already marked the task
+    #   FAILED and the executor will not resume it.
+    # * The loop/judge/forecast kinds (``LOOPING_*``, ``OFF_TOPIC``,
+    #   ``GOAL_DRIFT``, ``CAPABILITY_MISMATCH``, ``NEW_WORK_DISCOVERED``,
+    #   …) — goldfive-authored steering signals. Under the
+    #   dormant-supervisor identity their corrections arrive at the next
+    #   invocation boundary (nudge replay / GOLDFIVE_STEER restart);
+    #   they never preempt in-flight work.
+    _HARD_SAFETY_DRIFT_KINDS: frozenset[DriftKind] = frozenset(
+        {
+            DriftKind.RESOURCE_EXHAUSTED,
+            DriftKind.RUNAWAY_DELEGATION,
+            DriftKind.TOO_MANY_STEPS,
+            DriftKind.TASK_TIMEOUT,
+            DriftKind.LLM_CALL_TIMEOUT,
+            DriftKind.HUMAN_INTERVENTION_REQUIRED,
+        }
+    )
+
     # Drift kinds whose origin is a user intervention (USER_STEER /
     # USER_CANCEL) or a trajectory-level signal that has its own rate
     # limit (GOAL_DRIFT — task-boundary throttle via
@@ -3454,6 +3513,15 @@ class DriftObserver:
         # the severity gate because an operator directive must be
         # honoured even when emitted at a lower severity tier.
         #
+        # AGENCY-PRESERVATION.md PR 1 (goldfive#449/#452): the CRITICAL
+        # arm is additionally authority-gated inside
+        # :meth:`_should_request_cancel_for_drift` — goldfive-authored
+        # steering drift never cancels in-flight work; only
+        # user-authored and hard-safety kinds
+        # (:attr:`_HARD_SAFETY_DRIFT_KINDS`) reach the cancel.
+        # ``cancel_inflight_scope="all"`` restores the legacy
+        # any-CRITICAL-cancels behaviour.
+        #
         # The actual short-circuit happens in the ADK plugin's next
         # ``before_agent_callback`` / ``before_model_callback`` /
         # ``before_tool_callback``; this call just writes the flag.
@@ -3847,6 +3915,10 @@ class DriftObserver:
         # sink event lands adjacent to the revision in the wire log
         # and operators can correlate the two. Best-effort, never
         # raises — a no-op cancel still leaves the new plan installed.
+        # AGENCY-PRESERVATION.md PR 1: the helper itself gates on drift
+        # authority — only user-authored / hard-safety drifts actually
+        # cancel; goldfive-authored steering installs land for
+        # bookkeeping while the invocation runs to completion.
         await self._cancel_inflight_for_revision(drift, session)
         await self._steerer.plans._emit_plan_revised(
             session,
@@ -4588,8 +4660,48 @@ class DriftObserver:
             )
         return flagged
 
-    @staticmethod
-    def _should_request_cancel_for_drift(drift: DriftEvent) -> bool:
+    def _drift_authorizes_inflight_cancel(self, drift: DriftEvent) -> bool:
+        """Authority predicate for cancelling in-flight work (AGENCY-PRESERVATION.md PR 1).
+
+        The single place the goldfive#449/#452 authority split is
+        encoded for the cancel surface: in-flight cancellation is
+        permitted ONLY when the triggering drift is
+
+        * **user-authored** — :attr:`_USER_AUTHORED_DRIFT_KINDS`
+          (USER_STEER / USER_CANCEL / USER_PAUSE). User authority is
+          absolute (§2 of the design doc); behaviour for these kinds is
+          byte-identical to the pre-PR-1 implementation.
+        * **hard safety** — :attr:`_HARD_SAFETY_DRIFT_KINDS` (budget /
+          resource protection and termination; see the constant's
+          rationale comment). Guardrails stop runaway behaviour; that
+          is stop authority, legitimately always armed.
+
+        Everything else — Level-1 ABSORB refines, NEW_WORK_DISCOVERED
+        installs, drift→steer promotions, every judge/forecast kind —
+        is goldfive-authored *steering* and never preempts the wrapped
+        agent's in-flight invocation. Corrections reach the agent at
+        the natural invocation boundary instead (the overlay loop's
+        nudge-replay path, the GOLDFIVE_STEER restart).
+
+        Kill-switch (§5.1): ``cancel_inflight_scope="all"`` (env
+        ``GOLDFIVE_CANCEL_INFLIGHT_SCOPE=all``) short-circuits to
+        ``True`` for every drift, restoring the legacy
+        cancel-on-every-install behaviour exactly. The scope is read
+        off the router (:class:`DefaultSteerer`) the same way the
+        ``observation_only`` flag is, with a defensive default for
+        duck-typed steerers that predate the knob.
+        """
+        scope = str(
+            getattr(self._steerer, "_cancel_inflight_scope", "user_and_safety")
+            or "user_and_safety"
+        )
+        if scope == "all":
+            return True
+        if drift.kind in self._USER_AUTHORED_DRIFT_KINDS:
+            return True
+        return drift.kind in self._HARD_SAFETY_DRIFT_KINDS
+
+    def _should_request_cancel_for_drift(self, drift: DriftEvent) -> bool:
         """Decide whether a drift warrants a cooperative cancel.
 
         Severity ladder (goldfive#251 design decision):
@@ -4601,7 +4713,8 @@ class DriftObserver:
           route to the existing ABSORB / NUDGE ladder paths; the
           refined plan lands on the next task boundary without
           preempting the in-flight turn.
-        * ``DriftSeverity.CRITICAL`` — cancels. The in-flight turn's
+        * ``DriftSeverity.CRITICAL`` — cancels, *if the drift's
+          authority permits it* (see below). The in-flight turn's
           output is likely to contaminate its parent's transcript
           (stale prompt, wrong scope, broken tool); short-circuit
           cleanly and let the parent see ``{"status": "cancelled"}``.
@@ -4609,14 +4722,26 @@ class DriftObserver:
         User-authored drifts (``USER_STEER`` / ``USER_CANCEL`` /
         ``USER_PAUSE``) bypass the severity gate — an operator
         directive must be honoured even when the ControlMessage-to-
-        DriftEvent coercion landed on a lower severity tier.
+        DriftEvent coercion landed on a lower severity tier. This arm
+        is byte-identical to the pre-PR-1 implementation.
+
+        AGENCY-PRESERVATION.md PR 1 (goldfive#449/#452): the CRITICAL
+        arm is additionally gated on
+        :meth:`_drift_authorizes_inflight_cancel`. Pre-PR-1 ANY
+        CRITICAL goldfive-authored drift (OFF_TOPIC, LOOPING_*, …)
+        could flag the in-flight invocation for cooperative cancel
+        here; under the new policy goldfive-authored *steering* drift
+        never cancels in-flight work — only hard-safety kinds
+        (:attr:`_HARD_SAFETY_DRIFT_KINDS`) keep the CRITICAL cancel.
+        ``cancel_inflight_scope="all"`` restores the legacy behaviour
+        (the predicate returns ``True`` unconditionally, so this
+        method degenerates to the pre-PR-1 ``severity is CRITICAL``
+        check).
         """
-        if drift.kind in (
-            DriftKind.USER_STEER,
-            DriftKind.USER_CANCEL,
-            DriftKind.USER_PAUSE,
-        ):
+        if drift.kind in self._USER_AUTHORED_DRIFT_KINDS:
             return True
+        if not self._drift_authorizes_inflight_cancel(drift):
+            return False
         return drift.severity is DriftSeverity.CRITICAL
 
     @staticmethod
@@ -4691,7 +4816,46 @@ class DriftObserver:
         supersede flag is still stamped in the no-op case — it costs
         nothing and a downstream overlay that DOES observe a cancel
         from a separate path stays correctly classified.
+
+        Authority gate (AGENCY-PRESERVATION.md PR 1; goldfive#449/#452):
+        the unconditional cancel described above fired on EVERY
+        drift-driven install — including Level-1 ABSORB refines and
+        NEW_WORK_DISCOVERED installs — which made it the single
+        largest trajectory destroyer in the system (design doc §1.1).
+        This method now early-returns for drifts that fail
+        :meth:`_drift_authorizes_inflight_cancel` (not user-authored,
+        not hard-safety), BEFORE any side effect: no
+        ``session._supersede_pending`` stamp, no per-invocation
+        supersede-registry entry, no plugin call. Stamping the flag
+        for a cancel that never fires would hand the executor's
+        cancelled branch a supersede signal with no matching cancel —
+        exactly the stranded-flag bug class the v22 Bug-A fix exists
+        to prevent (the executor only consumes the flag inside its
+        ``kind == "cancelled"`` branch, so a flag without a cancel
+        either goes stale or misclassifies a later EXTERNAL cancel as
+        an internal supersede). The revised plan still installs and
+        ``PlanRevised`` still emits; the in-flight invocation runs to
+        completion and picks up the correction at the next invocation
+        boundary. ``cancel_inflight_scope="all"`` restores the
+        unconditional behaviour exactly (§5.1 kill-switch).
         """
+        # AGENCY-PRESERVATION.md PR 1 authority gate — must run BEFORE
+        # the supersede stamp below (see the authority-gate paragraph
+        # in the docstring: a stamped-but-never-consumed supersede flag
+        # is the bug class to avoid).
+        if not self._drift_authorizes_inflight_cancel(drift):
+            log.info(
+                "DefaultSteerer._cancel_inflight_for_revision: drift "
+                "kind=%s severity=%s authored_by=%s is neither "
+                "user-authored nor hard-safety — leaving the in-flight "
+                "invocation running (AGENCY-PRESERVATION PR 1; set "
+                "cancel_inflight_scope='all' to restore the legacy "
+                "cancel-on-every-install behaviour)",
+                drift.kind.value,
+                drift.severity.value,
+                drift.authored_by or "-",
+            )
+            return []
         # Stamp the supersede marker so the overlay loop can
         # distinguish this internal cancel from an external one. See
         # the supersede-contract paragraph in the docstring above.
@@ -5218,6 +5382,16 @@ class DriftObserver:
         # InvocationCancelled sink event lands adjacent to the
         # revision and operators can correlate the two on the
         # gantt timeline.
+        #
+        # AGENCY-PRESERVATION.md PR 1: promotion is goldfive-authored
+        # by construction (``_should_promote_to_steer`` returns False
+        # for user drifts), so under the default
+        # ``cancel_inflight_scope="user_and_safety"`` the helper's
+        # authority gate makes this a no-op — the refined plan installs
+        # for bookkeeping and the corrective reaches the agent via the
+        # GOLDFIVE_STEER restart at the invocation boundary instead of
+        # a mid-flight ``task.cancel()``. ``"all"`` (the §5.1
+        # kill-switch) restores the empirically-motivated v15 cancel.
         await self._cancel_inflight_for_revision(drift, session)
         await self._steerer.plans._emit_plan_revised(
             session,

--- a/goldfive/plan_reviser.py
+++ b/goldfive/plan_reviser.py
@@ -273,7 +273,11 @@ class PlanReviser:
         * :meth:`_apply_revision` — bump ``revision_index`` + stamp
           metadata
         * :meth:`_cancel_inflight_for_revision` — preempt any
-          in-flight invocation per the drift's severity
+          in-flight invocation, IF the drift's authority permits it
+          (AGENCY-PRESERVATION.md PR 1: user-authored / hard-safety
+          only under the default ``cancel_inflight_scope``; a
+          goldfive-authored install lands for bookkeeping while the
+          invocation runs to completion)
         * :meth:`_emit_plan_revised` — ``PlanRevised`` + the paired
           refine-attempted / -success sidecar envelopes
 
@@ -391,7 +395,9 @@ class PlanReviser:
         * :meth:`_emit_drift_detected` emits the ``USER_STEER`` drift.
         * :meth:`_apply_revision` swaps ``session.plan`` and bumps
           ``revision_index``.
-        * :meth:`_cancel_inflight_for_revision` preempts in-flight work.
+        * :meth:`_cancel_inflight_for_revision` preempts in-flight work
+          (USER_STEER is user-authored, so the AGENCY-PRESERVATION PR-1
+          authority gate always permits this cancel).
         * :meth:`_emit_plan_revised` fires ``PlanRevised``.
 
         The deterministic-fallback branch deliberately does NOT touch

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -383,6 +383,7 @@ class DefaultSteerer:
         steering_config: SteeringConfig | None = None,
         goldfive_steer_threshold: str | None = None,
         goldfive_steer_suppression_window_turns: int | None = None,
+        cancel_inflight_scope: str | None = None,
         judges: list[Any] | None = None,
     ) -> None:
         """Build a steerer.
@@ -625,6 +626,30 @@ class DefaultSteerer:
         else:
             _window = 3
         self._goldfive_steer_suppression_window_turns = max(0, _window)
+        # AGENCY-PRESERVATION.md PR 1 (goldfive#449/#452): authority
+        # scope for cancelling the wrapped agent's in-flight invocation
+        # on a drift-driven plan install. Precedence mirrors the other
+        # goldfive#225 knobs: explicit kwarg > ``SteeringConfig`` >
+        # built-in default (``"user_and_safety"``). Consumed by
+        # :meth:`DriftObserver._drift_authorizes_inflight_cancel`;
+        # ``"all"`` is the §5.1 kill-switch restoring the legacy
+        # cancel-on-every-install behaviour (env:
+        # ``GOLDFIVE_CANCEL_INFLIGHT_SCOPE=all`` via
+        # :meth:`SteeringConfig.from_env`).
+        if cancel_inflight_scope is not None:
+            _cancel_scope = str(cancel_inflight_scope).strip().lower()
+        elif steering_config is not None:
+            _cancel_scope = str(steering_config.cancel_inflight_scope).strip().lower()
+        else:
+            _cancel_scope = "user_and_safety"
+        if _cancel_scope not in {"user_and_safety", "all"}:
+            log.warning(
+                "DefaultSteerer: unknown cancel_inflight_scope=%r; "
+                "falling back to 'user_and_safety'",
+                _cancel_scope,
+            )
+            _cancel_scope = "user_and_safety"
+        self._cancel_inflight_scope: str = _cancel_scope
         self._steering_config: SteeringConfig | None = steering_config
         # goldfive#254: observation-only mode. Detection still runs in
         # full and ``planner.refine_steer`` still runs (operators see the

--- a/tests/test_cancel_authority_gate.py
+++ b/tests/test_cancel_authority_gate.py
@@ -1,0 +1,827 @@
+"""Authority gate for in-flight cancellation (AGENCY-PRESERVATION.md PR 1).
+
+goldfive#449/#452: pre-PR-1, ``DriftObserver._cancel_inflight_for_revision``
+fired on EVERY drift-driven plan install — including Level-1 ABSORB
+refines and NEW_WORK_DISCOVERED installs — killing the wrapped agent's
+in-flight invocation within ~one event-loop tick (design doc §1.1, "the
+single largest trajectory destroyer"). PR 1 gates the cancel on drift
+*authority*: only user-authored (USER_STEER / USER_CANCEL / USER_PAUSE)
+or hard-safety (budget / resource protection and termination —
+``DriftObserver._HARD_SAFETY_DRIFT_KINDS``) drifts may preempt in-flight
+work. ``SteeringConfig.cancel_inflight_scope="all"`` (env
+``GOLDFIVE_CANCEL_INFLIGHT_SCOPE=all``) is the §5.1 kill-switch that
+restores the legacy behaviour exactly.
+
+Cancel-guarantee inventory (§5.2) — what the unconditional cancel used
+to provide and what proves its replacement here:
+
+(a) **Loop-break for the v15 concurrent-invocation bug** — a slow
+    refine overlapping a still-generating coordinator used to be bounded
+    by killing the coordinator. Now bounded by the goldfive#405 in-flight
+    refine registry (same-key concurrent verdicts short-circuit), the
+    goldfive#245 verdict-freshness watermark (stale verdicts drop), and
+    the goldfive#271 no-op-revision rejection.
+    → ``test_v15_pin_slow_refine_with_concurrent_drift_does_not_loop``
+    (THE pinned v15 regression test).
+
+(b) **Plan coherence for reporting** — the revision still installs and
+    ``PlanRevised`` still emits; only the cancel is withheld.
+    → ``test_gated_install_still_installs_plan_and_emits_plan_revised``.
+
+(c) **Restart boundary for nudge delivery** — nudges used to ride the
+    cancel-forced restart. They now deliver at the *natural* invocation
+    boundary via the overlay loop's scoped nudge-replay path
+    (``sequential.py`` ``_run_overlay``).
+    → ``test_nudge_delivers_at_natural_boundary_without_cancel``.
+
+(d) **Supersede-flag consumption** — the executor's cancelled branch
+    consumes ``session._supersede_pending``. Skipped cancels stamp
+    NOTHING (flag, registry, plugin), so no stranded flag can
+    misclassify a later external cancel.
+    → ``test_skipped_cancel_stamps_no_supersede_flag_or_registry``;
+    the stamp-then-consume contract for cancels that DO fire is pinned
+    in ``tests/test_executor_supersede_cancel_nonfatal.py`` (re-pointed
+    at hard-safety kinds).
+
+Legacy-mode equivalence under ``"all"`` is parametrized at the bottom of
+this file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.executors.sequential import SequentialExecutor  # noqa: E402
+from goldfive.results import InvocationResult  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs (no ADK / no LLM / no network).
+# ---------------------------------------------------------------------------
+
+
+class _CountingPlugin:
+    """Records every ``request_invocation_cancel`` forwarded by the steerer."""
+
+    def __init__(self, top_invocation_id: str = "inv-X") -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._top_invocation_id = top_invocation_id
+        self._invocation_parents: dict[str, str] = {}
+        self._reconciler = None
+
+    def request_invocation_cancel(self, **kwargs: Any) -> list[str]:
+        self.calls.append(kwargs)
+        return [str(kwargs.get("invocation_id", ""))]
+
+
+class _CountingAdapter:
+    def __init__(self, top_invocation_id: str = "inv-X") -> None:
+        self._next_cancel_reason = ""
+        self._plugin = _CountingPlugin(top_invocation_id)
+        self.available_agents = ["coordinator"]
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        return None
+
+    def payload_kinds(self) -> list[str]:
+        return [e.WhichOneof("payload") for e in self.events if hasattr(e, "WhichOneof")]
+
+
+def _make_plan(revision_index: int = 0) -> Plan:
+    return Plan(
+        id="p1",
+        run_id="run-gate",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="T1", status=TaskStatus.RUNNING, assignee_agent_id="coordinator"),
+            Task(id="t2", title="T2", status=TaskStatus.PENDING, assignee_agent_id="worker"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+        revision_index=revision_index,
+    )
+
+
+def _make_session(revision_index: int = 0) -> Session:
+    return Session(
+        run_id="run-gate",
+        goals=[Goal(id="g1", summary="ship the gate")],
+        plan=_make_plan(revision_index),
+        current_task_id="t1",
+    )
+
+
+def _drift(
+    kind: DriftKind,
+    severity: DriftSeverity = DriftSeverity.WARNING,
+    **kwargs: Any,
+) -> DriftEvent:
+    return DriftEvent(
+        kind=kind,
+        severity=severity,
+        detail=kwargs.pop("detail", "gate test"),
+        current_task_id=kwargs.pop("current_task_id", "t1"),
+        current_agent_id=kwargs.pop("current_agent_id", "coordinator"),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. The authority predicate, in one place.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [DriftKind.USER_STEER, DriftKind.USER_CANCEL, DriftKind.USER_PAUSE],
+)
+@pytest.mark.parametrize(
+    "severity",
+    [DriftSeverity.INFO, DriftSeverity.WARNING, DriftSeverity.CRITICAL],
+)
+def test_predicate_user_authored_always_authorized(
+    kind: DriftKind, severity: DriftSeverity
+) -> None:
+    """User authority is absolute (§2): any severity, always authorized."""
+    steerer = DefaultSteerer()
+    assert steerer.drift._drift_authorizes_inflight_cancel(_drift(kind, severity)) is True
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        DriftKind.RESOURCE_EXHAUSTED,
+        DriftKind.RUNAWAY_DELEGATION,
+        DriftKind.TOO_MANY_STEPS,
+        DriftKind.TASK_TIMEOUT,
+        DriftKind.LLM_CALL_TIMEOUT,
+        DriftKind.HUMAN_INTERVENTION_REQUIRED,
+    ],
+)
+def test_predicate_hard_safety_authorized(kind: DriftKind) -> None:
+    """The hard-safety set keeps stop authority (budget/termination)."""
+    steerer = DefaultSteerer()
+    assert (
+        steerer.drift._drift_authorizes_inflight_cancel(_drift(kind, DriftSeverity.CRITICAL))
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        DriftKind.OFF_TOPIC,
+        DriftKind.LOOPING_REASONING,
+        DriftKind.LOOPING_TOOL_CALL,
+        DriftKind.GOAL_DRIFT,
+        DriftKind.NEW_WORK_DISCOVERED,
+        DriftKind.CAPABILITY_MISMATCH,
+        DriftKind.PLAN_DIVERGENCE,
+        DriftKind.INTENT_DIVERGENCE,
+        DriftKind.SELF_REPORTED_STUCK,
+        DriftKind.REPEATED_FAILURE,
+    ],
+)
+@pytest.mark.parametrize(
+    "severity",
+    [DriftSeverity.WARNING, DriftSeverity.CRITICAL],
+)
+def test_predicate_goldfive_steering_kinds_not_authorized(
+    kind: DriftKind, severity: DriftSeverity
+) -> None:
+    """Goldfive-authored steering drift never cancels in-flight work —
+    even at CRITICAL severity."""
+    steerer = DefaultSteerer()
+    assert steerer.drift._drift_authorizes_inflight_cancel(_drift(kind, severity)) is False
+
+
+def test_predicate_scope_all_authorizes_everything() -> None:
+    """The §5.1 kill-switch: ``"all"`` restores unconditional authority."""
+    steerer = DefaultSteerer(cancel_inflight_scope="all")
+    for kind in (DriftKind.OFF_TOPIC, DriftKind.NEW_WORK_DISCOVERED, DriftKind.USER_STEER):
+        assert (
+            steerer.drift._drift_authorizes_inflight_cancel(_drift(kind, DriftSeverity.WARNING))
+            is True
+        )
+
+
+def test_predicate_defensive_default_for_ducktyped_steerer() -> None:
+    """A router without the knob (duck-typed / pre-PR-1 subclass) gets
+    the safe default scope, not a crash and not legacy ``"all"``."""
+    steerer = DefaultSteerer()
+    observer = steerer.drift
+    # Simulate a router that predates the knob.
+    del steerer._cancel_inflight_scope
+    assert (
+        observer._drift_authorizes_inflight_cancel(
+            _drift(DriftKind.OFF_TOPIC, DriftSeverity.CRITICAL)
+        )
+        is False
+    )
+    assert (
+        observer._drift_authorizes_inflight_cancel(
+            _drift(DriftKind.USER_STEER, DriftSeverity.WARNING)
+        )
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. The pre-refine cooperative-cancel path (_should_request_cancel_for_drift).
+# ---------------------------------------------------------------------------
+
+
+def test_pre_refine_cancel_user_authored_byte_identical() -> None:
+    """User-authored drifts bypass the severity gate — exactly the
+    pre-PR-1 contract."""
+    steerer = DefaultSteerer()
+    for kind in (DriftKind.USER_STEER, DriftKind.USER_CANCEL, DriftKind.USER_PAUSE):
+        for severity in (DriftSeverity.INFO, DriftSeverity.WARNING, DriftSeverity.CRITICAL):
+            assert steerer.drift._should_request_cancel_for_drift(_drift(kind, severity)) is True
+
+
+def test_pre_refine_cancel_hard_safety_critical_only() -> None:
+    """Hard-safety kinds keep the goldfive#251 severity ladder: CRITICAL
+    cancels, WARNING/INFO do not (the gate never EXPANDS cancellation)."""
+    steerer = DefaultSteerer()
+    assert (
+        steerer.drift._should_request_cancel_for_drift(
+            _drift(DriftKind.RUNAWAY_DELEGATION, DriftSeverity.CRITICAL)
+        )
+        is True
+    )
+    assert (
+        steerer.drift._should_request_cancel_for_drift(
+            _drift(DriftKind.RUNAWAY_DELEGATION, DriftSeverity.WARNING)
+        )
+        is False
+    )
+
+
+def test_pre_refine_cancel_goldfive_critical_no_longer_cancels() -> None:
+    """The PR-1 behaviour change on this path: a CRITICAL goldfive-
+    authored steering drift used to cancel; now it never does."""
+    steerer = DefaultSteerer()
+    assert (
+        steerer.drift._should_request_cancel_for_drift(
+            _drift(DriftKind.OFF_TOPIC, DriftSeverity.CRITICAL)
+        )
+        is False
+    )
+    # Kill-switch restores it.
+    legacy = DefaultSteerer(cancel_inflight_scope="all")
+    assert (
+        legacy.drift._should_request_cancel_for_drift(
+            _drift(DriftKind.OFF_TOPIC, DriftSeverity.CRITICAL)
+        )
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Guarantee (d): a skipped cancel stamps NOTHING.
+# ---------------------------------------------------------------------------
+
+
+async def test_skipped_cancel_stamps_no_supersede_flag_or_registry() -> None:
+    """A gated (goldfive-authored) drift through
+    ``_cancel_inflight_for_revision`` must leave zero traces: no
+    ``session._supersede_pending``, no per-invocation supersede-registry
+    entry, no plugin call. A stamped-but-never-consumed flag would make
+    the executor's cancelled branch misclassify a later EXTERNAL cancel
+    (USER_CANCEL, upstream CancelledError) as an internal supersede —
+    exactly the v22 Bug-A class.
+    """
+    from goldfive.state_store import StateStore
+
+    steerer = DefaultSteerer()
+    adapter = _CountingAdapter()
+    steerer.bind_adapter(adapter)
+    session = _make_session()
+    store = StateStore.for_session(session)
+
+    for kind, severity in (
+        (DriftKind.OFF_TOPIC, DriftSeverity.WARNING),
+        (DriftKind.OFF_TOPIC, DriftSeverity.CRITICAL),
+        (DriftKind.NEW_WORK_DISCOVERED, DriftSeverity.INFO),
+        (DriftKind.LOOPING_REASONING, DriftSeverity.CRITICAL),
+    ):
+        flagged = await steerer.drift._cancel_inflight_for_revision(_drift(kind, severity), session)
+        assert flagged == []
+    assert adapter._plugin.calls == [], "gated cancels must never reach the plugin"
+    assert getattr(session, "_supersede_pending", False) is False, (
+        "no stranded supersede flag for skipped cancels (guarantee d)"
+    )
+    assert store.has_any_supersede_pending() is False, (
+        "no stranded per-invocation supersede-registry entries either"
+    )
+
+
+async def test_user_steer_cancel_still_stamps_and_fires() -> None:
+    """The user-authored arm is byte-identical: supersede flag stamped,
+    plugin reached with ``cancel_inflight_task=True``."""
+    steerer = DefaultSteerer()
+    adapter = _CountingAdapter()
+    steerer.bind_adapter(adapter)
+    session = _make_session()
+
+    flagged = await steerer.drift._cancel_inflight_for_revision(
+        _drift(DriftKind.USER_STEER, DriftSeverity.WARNING, authored_by="user"),
+        session,
+    )
+    assert flagged == ["inv-X"]
+    assert len(adapter._plugin.calls) == 1
+    assert adapter._plugin.calls[0]["cancel_inflight_task"] is True
+    assert getattr(session, "_supersede_pending", False) is True
+
+
+async def test_hard_safety_cancel_still_stamps_and_fires() -> None:
+    """Hard-safety drifts keep stop authority through the install path."""
+    steerer = DefaultSteerer()
+    adapter = _CountingAdapter()
+    steerer.bind_adapter(adapter)
+    session = _make_session()
+
+    flagged = await steerer.drift._cancel_inflight_for_revision(
+        _drift(DriftKind.RESOURCE_EXHAUSTED, DriftSeverity.CRITICAL), session
+    )
+    assert flagged == ["inv-X"]
+    assert getattr(session, "_supersede_pending", False) is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Guarantee (b): plan coherence — the install + PlanRevised survive
+#    the withheld cancel.
+# ---------------------------------------------------------------------------
+
+
+async def test_gated_install_still_installs_plan_and_emits_plan_revised() -> None:
+    """A goldfive-authored NEW_WORK_DISCOVERED install through
+    ``install_revision_for_drift`` (the ``plan_reviser._install_with_drift``
+    call site of ``_cancel_inflight_for_revision``) lands the revision
+    and emits ``PlanRevised`` — reporting stays coherent — while the
+    in-flight invocation is left untouched.
+    """
+    steerer = DefaultSteerer()
+    adapter = _CountingAdapter()
+    sink = _ListSink()
+    steerer.bind(sinks=[sink], planner=None)
+    steerer.bind_adapter(adapter)
+    session = _make_session()
+    prior = session.plan
+    assert prior is not None
+
+    revised = dataclasses.replace(
+        prior,
+        tasks=(*prior.tasks, Task(id="t3", title="discovered work", assignee_agent_id="worker")),
+    )
+    installed = await steerer.plans.install_revision_for_drift(
+        session=session,
+        drift=_drift(
+            DriftKind.NEW_WORK_DISCOVERED,
+            DriftSeverity.INFO,
+            authored_by="goldfive",
+        ),
+        revised_plan=revised,
+    )
+    assert installed is True
+    assert session.plan is not None and any(t.id == "t3" for t in session.plan.tasks)
+    assert "plan_revised" in sink.payload_kinds(), (
+        "PlanRevised must still emit when the cancel is withheld (guarantee b)"
+    )
+    assert adapter._plugin.calls == [], (
+        "the NEW_WORK_DISCOVERED install must not cancel in-flight work"
+    )
+    assert getattr(session, "_supersede_pending", False) is False
+
+
+async def test_user_steer_install_path_still_cancels() -> None:
+    """``install_user_steer`` (the plan_reviser user-steer install path)
+    keeps its cancel: a genuine operator pivot preempts in-flight work
+    exactly as before PR 1."""
+    steerer = DefaultSteerer()
+    adapter = _CountingAdapter()
+    sink = _ListSink()
+    steerer.bind(sinks=[sink], planner=None)
+    steerer.bind_adapter(adapter)
+    session = _make_session()
+    prior = session.plan
+    assert prior is not None
+
+    drift = _drift(
+        DriftKind.USER_STEER,
+        DriftSeverity.WARNING,
+        detail="by operator: pivot to the new topic",
+        authored_by="user",
+    )
+    chosen = await steerer.plans.install_user_steer(
+        drift=drift, prior=prior, llm_revision=None, session=session
+    )
+    # The deterministic minimum cancelled the mutable tasks — a real install.
+    assert chosen is not prior
+    assert len(adapter._plugin.calls) == 1, (
+        "USER_STEER installs must keep preempting in-flight work"
+    )
+    assert adapter._plugin.calls[0]["cancel_inflight_task"] is True
+    assert getattr(session, "_supersede_pending", False) is True
+
+
+# ---------------------------------------------------------------------------
+# 5. Promotion-driven installs (goldfive-authored) no longer cancel.
+# ---------------------------------------------------------------------------
+
+
+async def test_promotion_install_does_not_cancel_inflight() -> None:
+    """New-default counterpart of
+    ``tests/test_cancel_inflight_on_refine.py::
+    test_plan_divergence_refine_cancels_inflight_coordinator_task``
+    (now pinned to the legacy ``"all"`` scope): an OFF_TOPIC WARNING
+    drift promotes to a goldfive steer, ``refine_steer`` installs the
+    revised plan — and the in-flight coordinator invocation is NOT
+    cancelled. The corrective reaches the agent via the GOLDFIVE_STEER
+    restart at the invocation boundary instead.
+    """
+    session = _make_session()
+    prior = session.plan
+    assert prior is not None
+    revised = dataclasses.replace(
+        prior,
+        tasks=(*prior.tasks, Task(id="t2b", title="Replanned T2", assignee_agent_id="worker")),
+    )
+
+    class _StubPlanner:
+        def __init__(self) -> None:
+            self.refine_steer_calls = 0
+
+        async def refine_steer(self, **_kwargs: Any) -> Plan:
+            self.refine_steer_calls += 1
+            return revised
+
+        async def refine(self, **_kwargs: Any) -> Plan:
+            return revised
+
+    planner = _StubPlanner()
+    steerer = DefaultSteerer(goldfive_steer_threshold="warning")
+    adapter = _CountingAdapter(top_invocation_id="inv-coord-1")
+    sink = _ListSink()
+    steerer.bind(sinks=[sink], planner=planner)
+    steerer.bind_adapter(adapter)
+
+    await steerer.drift.handle_drift(_drift(DriftKind.OFF_TOPIC, DriftSeverity.WARNING), session)
+
+    assert planner.refine_steer_calls == 1
+    # The revision installed (bookkeeping kept) ...
+    assert session.plan is not None and any(t.id == "t2b" for t in session.plan.tasks)
+    assert "plan_revised" in sink.payload_kinds()
+    # ... but the steerer never asked the plugin to cancel anything.
+    assert adapter._plugin.calls == [], (
+        "promotion-driven (goldfive-authored) installs must not cancel "
+        "in-flight work under the default cancel_inflight_scope"
+    )
+    assert getattr(session, "_supersede_pending", False) is False
+
+
+# ---------------------------------------------------------------------------
+# 6. THE PINNED v15 REGRESSION TEST (guarantee a).
+# ---------------------------------------------------------------------------
+
+
+async def test_v15_pin_slow_refine_with_concurrent_drift_does_not_loop() -> None:
+    """**v15 pin** (goldfive#271 follow-up; AGENCY-PRESERVATION PR 1
+    §5.2 correctness requirement).
+
+    The v15 concurrent-invocation bug: a slow ``refine_steer`` (10+
+    minutes on a slow planner) overlapped the coordinator's invocation,
+    whose continuing output kept triggering the SAME drift — looping the
+    refine. The original fix killed the coordinator
+    (``_cancel_inflight_for_revision``). PR 1 withholds that cancel for
+    goldfive-authored drift, so THIS test pins what bounds the loop in
+    the new regime:
+
+    * while the refine is in flight, same-``(kind, task)`` verdicts are
+      short-circuited by the goldfive#405 in-flight refine registry;
+    * after the refine installs, verdicts observed against the OLD
+      revision are dropped by the goldfive#245 verdict-freshness
+      watermark;
+    * (and, not exercised here: a planner that can only return a
+      structurally identical plan trips the goldfive#271
+      no-op-revision rejection → HUMAN_INTERVENTION_REQUIRED, never a
+      loop).
+
+    Net: the coordinator keeps generating for the full refine duration
+    and the planner refines exactly ONCE.
+    """
+    session = _make_session(revision_index=1)
+    prior = session.plan
+    assert prior is not None
+    revised = dataclasses.replace(
+        prior,
+        tasks=(*prior.tasks, Task(id="t2b", title="Replanned T2", assignee_agent_id="worker")),
+    )
+
+    refine_started = asyncio.Event()
+    release_refine = asyncio.Event()
+
+    class _SlowPlanner:
+        def __init__(self) -> None:
+            self.refine_calls = 0
+
+        async def refine_steer(self, **_kwargs: Any) -> Plan:
+            self.refine_calls += 1
+            refine_started.set()
+            # Simulate the multi-minute LLM round-trip: block until the
+            # test releases us, i.e. until the "coordinator" has had
+            # time to produce more drift-triggering output.
+            await release_refine.wait()
+            return revised
+
+        async def refine(self, **_kwargs: Any) -> Plan:
+            return await self.refine_steer()
+
+    planner = _SlowPlanner()
+    steerer = DefaultSteerer(goldfive_steer_threshold="warning")
+    adapter = _CountingAdapter(top_invocation_id="inv-coord-1")
+    sink = _ListSink()
+    steerer.bind(sinks=[sink], planner=planner)
+    steerer.bind_adapter(adapter)
+
+    def _stamped_drift() -> DriftEvent:
+        d = _drift(DriftKind.OFF_TOPIC, DriftSeverity.WARNING)
+        # Judges stamp the observation-time revision BEFORE their LLM
+        # await (goldfive#245); both gates key off this.
+        d.observed_revision_index = 1
+        return d
+
+    # t0: the first verdict dispatches; its refine blocks (slow planner).
+    dispatch = asyncio.create_task(steerer.drift.handle_drift(_stamped_drift(), session))
+    await asyncio.wait_for(refine_started.wait(), timeout=2.0)
+
+    # t1: the still-generating coordinator triggers the SAME (kind, task)
+    # verdict twice more while the refine is in flight. The #405
+    # in-flight refine registry must short-circuit both — no second
+    # refine, no queueing.
+    await steerer.drift.handle_drift(_stamped_drift(), session)
+    await steerer.drift.handle_drift(_stamped_drift(), session)
+    assert planner.refine_calls == 1, (
+        "v15 REGRESSION: concurrent same-key drift during a slow refine "
+        "must not dispatch a second refine"
+    )
+
+    # t2: the refine completes and installs revision 2.
+    release_refine.set()
+    await asyncio.wait_for(dispatch, timeout=2.0)
+    assert session.plan is not None and session.plan.revision_index == 2
+
+    # t3: a late verdict from the coordinator's PRE-refine output (still
+    # observed against revision 1) arrives after the install. The #245
+    # freshness watermark must drop it.
+    await steerer.drift.handle_drift(_stamped_drift(), session)
+    assert planner.refine_calls == 1, (
+        "v15 REGRESSION: a stale verdict against the superseded revision "
+        "must not re-fire the refine"
+    )
+
+    # And throughout: the coordinator was never cancelled — the steerer
+    # never reached the plugin.
+    assert adapter._plugin.calls == []
+
+
+# ---------------------------------------------------------------------------
+# 7. Guarantee (c): nudge delivery at the natural invocation boundary.
+# ---------------------------------------------------------------------------
+
+
+async def test_nudge_delivers_at_natural_boundary_without_cancel() -> None:
+    """With cancels gated off, a Level-2 nudge queued mid-invocation by a
+    real ``DefaultSteerer`` ABSORB dispatch (LOOPING_REASONING → refine →
+    nudge) must still reach the coordinator: the invocation runs to its
+    natural end and the overlay loop's scoped nudge-replay path re-invokes
+    the passthrough with the framed nudge as the next user message.
+    """
+    plan = Plan(
+        id="p0",
+        run_id="run-nudge",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="define", assignee_agent_id="coordinator"),
+            Task(id="t2", title="draft", assignee_agent_id="worker"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    session = Session(run_id="run-nudge", goals=[Goal(id="g1", summary="ship")], plan=plan)
+
+    revised = dataclasses.replace(
+        plan,
+        tasks=(*plan.tasks, Task(id="t1_v2", title="define (v2)", assignee_agent_id="coordinator")),
+    )
+
+    class _StubPlanner:
+        async def generate(self, **_kwargs: Any) -> Plan | None:
+            return None
+
+        async def refine(self, **_kwargs: Any) -> Plan:
+            return revised
+
+    # threshold="critical" keeps the WARNING LOOPING_REASONING on the
+    # ladder's ABSORB row (the promotion path is exercised separately
+    # above) so the post-ABSORB nudge queueing fires.
+    steerer = DefaultSteerer(goldfive_steer_threshold="critical")
+    sink = _ListSink()
+
+    class _OverlayAdapter:
+        """Overlay adapter whose first passthrough simulates the
+        coordinator triggering a LOOPING_REASONING drift mid-invocation
+        and then finishing normally."""
+
+        def __init__(self) -> None:
+            self._plugin = _CountingPlugin(top_invocation_id="inv-coord-1")
+            self._next_cancel_reason = ""
+            self.passthrough_calls: list[str] = []
+
+        @property
+        def available_agents(self) -> list[str]:
+            return ["coordinator", "worker"]
+
+        async def register_reporting_tools(self, tools: list[Any]) -> None:  # noqa: ARG002
+            return None
+
+        async def invoke(self, task: Task, session: Session) -> InvocationResult:  # noqa: ARG002
+            return InvocationResult(task_id=task.id, text="")
+
+        async def invoke_passthrough(
+            self,
+            user_message: str,
+            *,
+            session: Session,
+            reconciler: Any = None,  # noqa: ARG002
+            ctx: Any = None,  # noqa: ARG002
+        ) -> InvocationResult:
+            self.passthrough_calls.append(user_message)
+            if len(self.passthrough_calls) == 1:
+                # Mid-invocation: the drift pipeline fires. ABSORB →
+                # refine installs t1_v2 → nudge queued. No cancel may
+                # reach this (still running) invocation.
+                await steerer.drift.handle_drift(
+                    _drift(DriftKind.LOOPING_REASONING, DriftSeverity.WARNING),
+                    session,
+                )
+                # The invocation then COMPLETES NATURALLY — this return
+                # is the natural boundary the replay relies on.
+            return InvocationResult(task_id="", text="ok")
+
+    adapter = _OverlayAdapter()
+    steerer.bind_adapter(adapter)
+    executor = SequentialExecutor(overlay_mode=True)
+    outcome = await executor.run(
+        plan=plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=_StubPlanner(),
+        sinks=[sink],
+        user_input="make the deck",
+    )
+
+    # The cancel was withheld for the goldfive-authored drift...
+    assert adapter._plugin.calls == [], (
+        "LOOPING_REASONING (goldfive-authored) must not cancel the in-flight invocation"
+    )
+    # ...the plan still revised...
+    assert session.plan is not None and any(t.id == "t1_v2" for t in session.plan.tasks)
+    # ...and the nudge delivered at the natural invocation boundary.
+    assert len(adapter.passthrough_calls) == 2, (
+        f"expected the overlay nudge-replay to re-invoke once; calls={adapter.passthrough_calls!r}"
+    )
+    assert adapter.passthrough_calls[0] == "make the deck"
+    assert adapter.passthrough_calls[1].startswith("[GOLDFIVE PLAN REVISION"), (
+        adapter.passthrough_calls[1]
+    )
+    assert session.pending_nudges == []
+    assert outcome.success is True, outcome.reason
+
+
+# ---------------------------------------------------------------------------
+# 8. Legacy mode (`"all"`): behaviour identical to pre-PR-1.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("kind", "severity"),
+    [
+        (DriftKind.OFF_TOPIC, DriftSeverity.WARNING),
+        (DriftKind.NEW_WORK_DISCOVERED, DriftSeverity.INFO),
+        (DriftKind.LOOPING_TOOL_CALL, DriftSeverity.CRITICAL),
+        (DriftKind.USER_STEER, DriftSeverity.WARNING),
+    ],
+)
+async def test_legacy_scope_all_cancel_inflight_fires_for_every_install(
+    kind: DriftKind, severity: DriftSeverity
+) -> None:
+    """Under the ``"all"`` kill-switch, ``_cancel_inflight_for_revision``
+    behaves exactly as pre-PR-1: every drift-driven install stamps the
+    supersede flag and forwards ``cancel_inflight_task=True`` to the
+    plugin — including the goldfive-authored kinds the default scope
+    now withholds."""
+    steerer = DefaultSteerer(cancel_inflight_scope="all")
+    adapter = _CountingAdapter()
+    steerer.bind_adapter(adapter)
+    session = _make_session()
+
+    flagged = await steerer.drift._cancel_inflight_for_revision(_drift(kind, severity), session)
+    assert flagged == ["inv-X"]
+    assert len(adapter._plugin.calls) == 1
+    assert adapter._plugin.calls[0]["cancel_inflight_task"] is True
+    assert getattr(session, "_supersede_pending", False) is True
+
+
+@pytest.mark.parametrize(
+    ("kind", "severity", "expected"),
+    [
+        # Pre-PR-1 contract: any CRITICAL cancels; WARNING/INFO do not;
+        # user kinds bypass the severity gate.
+        (DriftKind.OFF_TOPIC, DriftSeverity.CRITICAL, True),
+        (DriftKind.OFF_TOPIC, DriftSeverity.WARNING, False),
+        (DriftKind.GOAL_DRIFT, DriftSeverity.CRITICAL, True),
+        (DriftKind.REASONING_CLUSTER_TIGHTENING, DriftSeverity.INFO, False),
+        (DriftKind.USER_STEER, DriftSeverity.WARNING, True),
+        (DriftKind.USER_CANCEL, DriftSeverity.INFO, True),
+    ],
+)
+def test_legacy_scope_all_pre_refine_predicate_identical(
+    kind: DriftKind, severity: DriftSeverity, expected: bool
+) -> None:
+    steerer = DefaultSteerer(cancel_inflight_scope="all")
+    assert steerer.drift._should_request_cancel_for_drift(_drift(kind, severity)) is expected
+
+
+# ---------------------------------------------------------------------------
+# 9. Config plumbing.
+# ---------------------------------------------------------------------------
+
+
+def test_steering_config_default_scope() -> None:
+    assert SteeringConfig().cancel_inflight_scope == "user_and_safety"
+
+
+def test_steering_config_from_env_reads_kill_switch(monkeypatch: Any) -> None:
+    monkeypatch.setenv("GOLDFIVE_CANCEL_INFLIGHT_SCOPE", "ALL")
+    assert SteeringConfig.from_env().cancel_inflight_scope == "all"
+
+
+def test_steering_config_from_env_rejects_typo(monkeypatch: Any) -> None:
+    """A typo must never silently flip the cancel policy — fall back to
+    the safe default (mirrors the threshold/bool env helpers)."""
+    monkeypatch.setenv("GOLDFIVE_CANCEL_INFLIGHT_SCOPE", "everything")
+    assert SteeringConfig.from_env().cancel_inflight_scope == "user_and_safety"
+
+
+def test_steerer_threads_scope_from_steering_config() -> None:
+    """``goldfive.wrap`` passes ``steering_config=RuntimeConfig().steering``
+    to ``DefaultSteerer`` — the same threading ``observation_only`` uses —
+    so the config field is what production runs read."""
+    cfg = SteeringConfig(cancel_inflight_scope="all")
+    assert DefaultSteerer(steering_config=cfg)._cancel_inflight_scope == "all"
+    assert DefaultSteerer()._cancel_inflight_scope == "user_and_safety"
+
+
+def test_steerer_explicit_kwarg_wins_over_config() -> None:
+    cfg = SteeringConfig(cancel_inflight_scope="all")
+    steerer = DefaultSteerer(steering_config=cfg, cancel_inflight_scope="user_and_safety")
+    assert steerer._cancel_inflight_scope == "user_and_safety"
+
+
+def test_steerer_rejects_unknown_scope() -> None:
+    """An invalid literal falls back to the safe default with a warning
+    (never crashes, never silently goes legacy)."""
+    steerer = DefaultSteerer(cancel_inflight_scope="bogus")
+    assert steerer._cancel_inflight_scope == "user_and_safety"

--- a/tests/test_cancel_inflight_on_refine.py
+++ b/tests/test_cancel_inflight_on_refine.py
@@ -417,8 +417,17 @@ async def test_install_initial_plan_does_not_cancel_inflight() -> None:
 
 
 async def test_cancel_inflight_for_revision_fires_for_real_drift() -> None:
-    """A non-synthetic drift (PLAN_DIVERGENCE, real USER_STEER, OFF_TOPIC,
-    …) MUST forward to the plugin with ``cancel_inflight_task=True``."""
+    """A cancel-authorized drift (user-authored or hard-safety) MUST
+    forward to the plugin with ``cancel_inflight_task=True``.
+
+    AGENCY-PRESERVATION.md PR 1: originally exercised with
+    PLAN_DIVERGENCE (goldfive-authored), which no longer cancels under
+    the default ``cancel_inflight_scope="user_and_safety"``. The
+    plugin-forwarding contract under test is authority-agnostic, so
+    the drift is re-pointed to USER_STEER (user-authored — always
+    authorized). The goldfive-authored case under the legacy ``"all"``
+    scope is pinned in ``tests/test_cancel_authority_gate.py``.
+    """
 
     class _CountingAdapter:
         def __init__(self) -> None:
@@ -440,11 +449,12 @@ async def test_cancel_inflight_for_revision_fires_for_real_drift() -> None:
     adapter = _CountingAdapter()
     steerer.bind_adapter(adapter)
     drift = DriftEvent(
-        kind=DriftKind.PLAN_DIVERGENCE,
+        kind=DriftKind.USER_STEER,
         severity=DriftSeverity.WARNING,
-        detail="off-plan agent",
+        detail="operator pivot",
         current_task_id="t1",
         current_agent_id="coordinator",
+        authored_by="user",
     )
     flagged = await steerer.drift._cancel_inflight_for_revision(drift, _make_session())
     assert flagged == ["inv-X"]
@@ -481,6 +491,17 @@ async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> Non
     CAPABILITY_MISMATCH in #253). The cancel-inflight contract is
     independent of which drift kind triggers it, so we exercise the
     same code path with ``OFF_TOPIC`` (also WARNING → ABSORB → refine).
+
+    AGENCY-PRESERVATION.md PR 1: OFF_TOPIC is goldfive-authored
+    steering drift, which under the default
+    ``cancel_inflight_scope="user_and_safety"`` no longer cancels
+    in-flight work — the very behaviour this test pinned is now the
+    *legacy* regime. The steerer is constructed with the ``"all"``
+    kill-switch so the empirically-motivated v15 cancel contract stays
+    pinned for the escape hatch; the new-default counterpart (promotion
+    installs the plan but leaves the coordinator running, with refine
+    looping bounded by the #245/#405 gates) lives in
+    ``tests/test_cancel_authority_gate.py``.
     """
 
     revised = Plan(
@@ -515,6 +536,8 @@ async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> Non
     steerer = DefaultSteerer(
         goldfive_steer_threshold="warning",
         goldfive_steer_suppression_window_turns=3,
+        # AGENCY-PRESERVATION.md PR 1 legacy pin — see docstring.
+        cancel_inflight_scope="all",
     )
     steerer.bind(sinks=[], planner=_StubPlanner())
 

--- a/tests/test_cooperative_cancellation.py
+++ b/tests/test_cooperative_cancellation.py
@@ -560,9 +560,16 @@ async def test_info_drift_does_not_request_cancel() -> None:
 
 
 async def test_critical_drift_requests_cancel() -> None:
+    # AGENCY-PRESERVATION.md PR 1: OFF_TOPIC is goldfive-authored
+    # steering drift, which no longer cancels under the default
+    # ``cancel_inflight_scope="user_and_safety"``. This test pins the
+    # legacy any-CRITICAL-cancels contract, so it runs under the
+    # ``"all"`` kill-switch; the new-default policy (hard-safety
+    # cancels, goldfive steering does not) is covered in
+    # ``tests/test_cancel_authority_gate.py``.
     plugin, _sink, session = _make_plugin()
     adapter = _StubAdapter(plugin)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(cancel_inflight_scope="all")
     steerer.bind(sinks=[], planner=None)
     steerer.bind_adapter(adapter)
     plugin._top_invocation_id = "inv-A"
@@ -605,6 +612,11 @@ async def test_cancel_inflight_for_revision_skips_when_precancel_already_fired()
     ``_cancel_inflight_for_revision`` and assert the underlying
     plugin's ``request_invocation_cancel`` was NOT invoked.
     """
+    # AGENCY-PRESERVATION.md PR 1: the dedup machinery under test is
+    # downstream of the new authority gate, so the drift must be one
+    # that still cancels under the default scope. RUNAWAY_DELEGATION
+    # (hard-safety, CRITICAL by construction) replaces the original
+    # OFF_TOPIC — the dedup logic itself is kind-agnostic.
     plugin, _sink, session = _make_plugin()
     adapter = _StubAdapter(plugin)
     steerer = DefaultSteerer()
@@ -613,7 +625,7 @@ async def test_cancel_inflight_for_revision_skips_when_precancel_already_fired()
     plugin._top_invocation_id = "inv-A"
 
     drift = DriftEvent(
-        kind=DriftKind.OFF_TOPIC,
+        kind=DriftKind.RUNAWAY_DELEGATION,
         severity=DriftSeverity.CRITICAL,
         current_task_id="t1",
         current_agent_id="sub_agent",
@@ -638,6 +650,12 @@ async def test_cancel_inflight_for_revision_still_fires_without_precancel() -> N
     """When NO pre-cancel ran for the drift (e.g. WARNING severity
     promote-eligible kind), :meth:`_cancel_inflight_for_revision`
     must still fire — the dedup only kicks in for same-drift repeats.
+
+    AGENCY-PRESERVATION.md PR 1: drift kind re-pointed from OFF_TOPIC
+    to RUNAWAY_DELEGATION (hard-safety) so the post-refine cancel under
+    test still passes the new authority gate at the default scope.
+    WARNING severity is preserved — it is what guarantees the
+    pre-refine cancel (CRITICAL-only) did NOT stamp the dedup set.
     """
     plugin, _sink, session = _make_plugin()
     adapter = _StubAdapter(plugin)
@@ -647,7 +665,7 @@ async def test_cancel_inflight_for_revision_still_fires_without_precancel() -> N
     plugin._top_invocation_id = "inv-A"
 
     drift = DriftEvent(
-        kind=DriftKind.OFF_TOPIC,
+        kind=DriftKind.RUNAWAY_DELEGATION,
         severity=DriftSeverity.WARNING,
         current_task_id="t1",
         current_agent_id="sub_agent",
@@ -670,6 +688,12 @@ async def test_handle_drift_dispatch_records_drift_id_in_cancelled_set() -> None
     in :meth:`_cancel_inflight_for_revision` engages.
 
     Asserts the bookkeeping primitive that bug #6's fix relies on.
+
+    AGENCY-PRESERVATION.md PR 1: drift kind re-pointed from OFF_TOPIC
+    to RUNAWAY_DELEGATION (hard-safety, CRITICAL by construction) so
+    the pre-refine cancel under test still fires at the default
+    ``cancel_inflight_scope`` — the dedup-stamp bookkeeping is
+    kind-agnostic.
     """
     plugin, _sink, session = _make_plugin()
     adapter = _StubAdapter(plugin)
@@ -679,7 +703,7 @@ async def test_handle_drift_dispatch_records_drift_id_in_cancelled_set() -> None
     plugin._top_invocation_id = "inv-A"
 
     drift = DriftEvent(
-        kind=DriftKind.OFF_TOPIC,
+        kind=DriftKind.RUNAWAY_DELEGATION,
         severity=DriftSeverity.CRITICAL,
         current_task_id="t1",
         current_agent_id="sub_agent",

--- a/tests/test_executor_supersede_cancel_nonfatal.py
+++ b/tests/test_executor_supersede_cancel_nonfatal.py
@@ -686,14 +686,20 @@ async def test_steerer_cancel_inflight_stamps_supersede_flag() -> None:
     ``session._supersede_pending = True`` before delegating to
     ``request_invocation_cancel``. Without this stamp, the executor's
     cancelled branch can't disambiguate the supersede.
+
+    AGENCY-PRESERVATION.md PR 1: drift kind re-pointed from OFF_TOPIC
+    to RUNAWAY_DELEGATION (hard-safety) so the cancel path under test
+    still passes the new authority gate at the default scope. The
+    inverse — a goldfive-authored steering drift must stamp NOTHING —
+    is pinned in ``tests/test_cancel_authority_gate.py``.
     """
     steerer = DefaultSteerer()
     session = Session(run_id="r1")
 
     drift = DriftEvent(
-        kind=DriftKind.OFF_TOPIC,
+        kind=DriftKind.RUNAWAY_DELEGATION,
         severity=DriftSeverity.WARNING,
-        detail="off topic",
+        detail="delegation cap exceeded",
     )
 
     # No adapter bound → request_invocation_cancel returns []. The
@@ -858,6 +864,10 @@ async def test_405_low7_steerer_stamps_per_invocation_registry() -> None:
     via the registry. Patches the resolver to return a known
     invocation id so the test does not depend on the reconciler /
     plugin internals the resolver reads.
+
+    AGENCY-PRESERVATION.md PR 1: drift kind re-pointed from OFF_TOPIC
+    to RUNAWAY_DELEGATION (hard-safety) so the registry stamp under
+    test still passes the new authority gate at the default scope.
     """
     from goldfive.state_store import StateStore as _SS
 
@@ -867,9 +877,9 @@ async def test_405_low7_steerer_stamps_per_invocation_registry() -> None:
     store = _SS.for_session(session)
 
     drift = DriftEvent(
-        kind=DriftKind.OFF_TOPIC,
+        kind=DriftKind.RUNAWAY_DELEGATION,
         severity=DriftSeverity.WARNING,
-        detail="off topic",
+        detail="delegation cap exceeded",
     )
 
     # Patch the resolver to return our known invocation id. The

--- a/tests/test_observation_only.py
+++ b/tests/test_observation_only.py
@@ -352,8 +352,16 @@ async def test_warning_drift_active_steering_drives_all_three_injections() -> No
     four side effects fire and ``dry_run`` is ``False`` on the emitted
     ``PlanRevised``. Confirms the gate is the only difference — no
     second drift mechanism was disturbed by the refactor.
+
+    AGENCY-PRESERVATION.md PR 1: this positive control pins the
+    *historical* behaviour, which included the in-flight cancel for a
+    goldfive-authored OFF_TOPIC drift. The new orthogonal
+    ``cancel_inflight_scope`` authority gate is pinned to ``"all"``
+    (legacy) here so the observation_only gate remains the ONLY
+    variable under test; the new-default cancel policy has its own
+    coverage in ``tests/test_cancel_authority_gate.py``.
     """
-    cfg = SteeringConfig(observation_only=False)
+    cfg = SteeringConfig(observation_only=False, cancel_inflight_scope="all")
     steerer = DefaultSteerer(steering_config=cfg)
     session = _make_session()
     sink = ListSink()


### PR DESCRIPTION
Implements **AGENCY-PRESERVATION.md PR 1** (goldfive#449/#452, Stage 1 — "stop the bleeding").

## What changed

`DriftObserver._cancel_inflight_for_revision` fired on **every** drift-driven plan install — Level-1 ABSORB refines, `NEW_WORK_DISCOVERED` installs, drift→steer promotions — killing the wrapped agent's in-flight invocation within ~one event-loop tick (design doc §1.1: "the single largest trajectory destroyer"). In-flight cancellation is now permitted **only** when the triggering drift is **user-authored** or **hard-safety**.

- **Authority predicate in one place**: `DriftObserver._drift_authorizes_inflight_cancel`, backed by the new documented `_HARD_SAFETY_DRIFT_KINDS` constant.
  - *User-authored* = the existing `_USER_AUTHORED_DRIFT_KINDS` (`USER_STEER`, `USER_CANCEL`, `USER_PAUSE`) — behaviour byte-identical.
  - *Hard-safety* = `RESOURCE_EXHAUSTED`, `RUNAWAY_DELEGATION`, `TOO_MANY_STEPS`, `TASK_TIMEOUT`, `LLM_CALL_TIMEOUT`, `HUMAN_INTERVENTION_REQUIRED`. Rationale: budget/resource protection (the first five are the observed-fact budget family; `LLM_CALL_TIMEOUT`'s plugin emitter already pairs its drift with a cooperative cancel, so excluding it would make dispatch policy inconsistent with the emitter's own contract) plus termination (`HUMAN_INTERVENTION_REQUIRED` is the **only** kind the ladder's TERMINATE cell maps from — verified against `_load_ladder_tables`). `REPEATED_FAILURE` is deliberately excluded: it is goldfive's own refine-failure escalation (a steering artifact), and its emitter already marked the task FAILED.
- **`_cancel_inflight_for_revision` gated**: early-return for non-qualifying drifts **before any side effect** — no `session._supersede_pending` stamp, no per-invocation supersede-registry entry, no plugin call. A stamped-but-never-consumed flag is exactly the v22 Bug-A class (the executor consumes the flag only inside its `kind == "cancelled"` branch; a flag without a cancel goes stale or misclassifies a later *external* cancel as an internal supersede).
- **Pre-refine cooperative-cancel path gated the same way**: `_should_request_cancel_for_drift` previously allowed any CRITICAL goldfive-authored drift to flag a cancel; now goldfive-authored steering drift never cancels in-flight work. The severity ladder is preserved for qualifying kinds (hard-safety still cancels only at CRITICAL — the gate never *expands* cancellation); user-authored drifts still bypass severity.
- **Config / kill-switch (§5.1)**: `SteeringConfig.cancel_inflight_scope: str = "user_and_safety"`, env `GOLDFIVE_CANCEL_INFLIGHT_SCOPE`. `"all"` restores today's behaviour exactly (the predicate short-circuits to `True`). Threaded `wrap() → RuntimeConfig.steering → DefaultSteerer.__init__ → DriftObserver` the same way `observation_only` is, with the standard kwarg > config > default precedence and typo-safe env parsing.
- **`_promote_drift_to_steer`** flows through the same gated helper: promotion-driven (goldfive-authored by construction) installs no longer cancel; USER_STEER's install paths (`install_user_steer`, `install_revision_for_user_steer`) still do — both proven by tests.

## Cancel-guarantee inventory (§5.2 — binding)

Every guarantee the unconditional cancel provided, what supplies it now, and the test that proves it:

| # | Guarantee | What supplies it in the new regime | Proving test |
|---|---|---|---|
| (a) | **Loop-break for the v15 concurrent-invocation bug** (slow refine overlapping a still-generating coordinator used to be bounded by killing the coordinator) | goldfive#405 in-flight refine registry (concurrent same-`(kind, task)` verdicts short-circuit), goldfive#245 verdict-freshness watermark (stale verdicts observed against the superseded revision drop), goldfive#271 no-op-revision rejection (a planner that cannot make progress escalates to HUMAN_INTERVENTION_REQUIRED instead of looping) | `test_cancel_authority_gate.py::test_v15_pin_slow_refine_with_concurrent_drift_does_not_loop` — **the pinned v15 regression test**: refine blocks while the same drift fires twice concurrently and once stale-after-install; planner refines exactly once, zero cancels. Legacy arm kept alive: `test_cancel_inflight_on_refine.py::test_plan_divergence_refine_cancels_inflight_coordinator_task` under `"all"` |
| (b) | **Plan coherence for reporting** (the revision the drift produced is the one reporting sees) | The install machinery is untouched — `_apply_revision` / `_emit_plan_revised` still run on every install; only the cancel is withheld | `test_cancel_authority_gate.py::test_gated_install_still_installs_plan_and_emits_plan_revised` (NEW_WORK_DISCOVERED install lands + `PlanRevised` emits + zero cancels); `test_promotion_install_does_not_cancel_inflight` (same for the promotion path) |
| (c) | **Restart boundary nudge delivery relied on** (nudges used to ride the cancel-forced restart) | The overlay loop's scoped nudge-replay path (`sequential.py` `_run_overlay`, `kind == "result"` branch) consumes `session.pending_nudges` at the **natural** invocation boundary | `test_cancel_authority_gate.py::test_nudge_delivers_at_natural_boundary_without_cancel` — real `DefaultSteerer` ABSORB on LOOPING_REASONING mid-invocation, zero cancels, second passthrough call is the framed `[GOLDFIVE PLAN REVISION…]` replay |
| (d) | **Supersede-flag consumption in the executor's cancelled branch** | Cancels that DO fire (user/hard-safety) stamp flag + registry exactly as before; skipped cancels stamp **nothing**, so the executor's union-of-signals read can never see a supersede without a matching cancel | `test_cancel_authority_gate.py::test_skipped_cancel_stamps_no_supersede_flag_or_registry` (no stranded flag/registry); `test_executor_supersede_cancel_nonfatal.py::test_steerer_cancel_inflight_stamps_supersede_flag` + `test_405_low7_steerer_stamps_per_invocation_registry` (stamp contract for firing cancels, re-pointed to hard-safety kinds); the executor-side consumption tests in that file are unchanged |

**Legacy-mode equivalence**: `test_cancel_authority_gate.py::test_legacy_scope_all_cancel_inflight_fires_for_every_install` and `test_legacy_scope_all_pre_refine_predicate_identical` parametrize a representative subset (OFF_TOPIC WARNING/CRITICAL, NEW_WORK_DISCOVERED INFO, LOOPING_TOOL_CALL CRITICAL, GOAL_DRIFT CRITICAL, REASONING_CLUSTER_TIGHTENING INFO, USER_*) under `"all"` and assert behaviour identical to pre-PR-1.

## Existing-test changes (every one, with justification)

| Test | Change | Why |
|---|---|---|
| `test_cancel_inflight_on_refine.py::test_cancel_inflight_for_revision_fires_for_real_drift` | drift kind PLAN_DIVERGENCE → USER_STEER | The plugin-forwarding contract under test (`cancel_inflight_task=True`) is authority-agnostic; USER_STEER is always authorized. Goldfive-kind coverage moved to the legacy parametrized test. |
| `test_cancel_inflight_on_refine.py::test_plan_divergence_refine_cancels_inflight_coordinator_task` | steerer constructed with `cancel_inflight_scope="all"` | This IS the original empirical v15 cancel pin; the behaviour it pins is now the legacy regime, kept alive for the kill-switch. New-default counterpart: `test_promotion_install_does_not_cancel_inflight` + the new v15 pin. |
| `test_cooperative_cancellation.py::test_critical_drift_requests_cancel` | steerer constructed with `cancel_inflight_scope="all"` | Pins the legacy any-CRITICAL-flags-cancel contract; new-default split (hard-safety cancels / steering does not) covered in the new file. |
| `test_cooperative_cancellation.py::test_cancel_inflight_for_revision_skips_when_precancel_already_fired` | drift kind OFF_TOPIC → RUNAWAY_DELEGATION | #405 #6 dedup machinery is downstream of the gate and kind-agnostic; using a hard-safety kind keeps the pin on the **default** scope. |
| `test_cooperative_cancellation.py::test_cancel_inflight_for_revision_still_fires_without_precancel` | drift kind OFF_TOPIC → RUNAWAY_DELEGATION (WARNING preserved) | Same as above; WARNING is what guarantees no pre-cancel stamped the dedup set. |
| `test_cooperative_cancellation.py::test_handle_drift_dispatch_records_drift_id_in_cancelled_set` | drift kind OFF_TOPIC → RUNAWAY_DELEGATION | Same dedup-stamp bookkeeping pin, kept on the default scope. |
| `test_executor_supersede_cancel_nonfatal.py::test_steerer_cancel_inflight_stamps_supersede_flag` | drift kind OFF_TOPIC → RUNAWAY_DELEGATION | Guarantee (d) stamp contract must be pinned on a drift that still cancels; the inverse (steering drift stamps nothing) is pinned in the new file. |
| `test_executor_supersede_cancel_nonfatal.py::test_405_low7_steerer_stamps_per_invocation_registry` | drift kind OFF_TOPIC → RUNAWAY_DELEGATION | Same — #405 LOW #7 registry stamp for firing cancels. |
| `test_observation_only.py::test_warning_drift_active_steering_drives_all_three_injections` | `SteeringConfig(observation_only=False, cancel_inflight_scope="all")` | Positive control whose purpose is "observation_only is the ONLY variable"; pinning the new orthogonal knob to legacy preserves that isolation. |

No assertion was deleted; every re-point is documented in-test with an AGENCY-PRESERVATION PR 1 comment.

## Verification

- Full suite: **2861 passed, 59 skipped** (baseline at `7f965cf` with the same `dev`+`adk` extras: 2797 passed, 59 skipped; +64 new tests in `tests/test_cancel_authority_gate.py`).
- `make lint` (`ruff check .`): clean. (`ruff format --check` is not clean on main — 180 pre-existing files — and is not a CI gate; the new test file is format-clean.)
- Call-site grep for every new helper/flag (no dead middleware): `_drift_authorizes_inflight_cancel` → consumed by both `_should_request_cancel_for_drift` (pre-refine dispatch path) and `_cancel_inflight_for_revision` (all four install call sites: `_handle_drift_dispatch`, `_promote_drift_to_steer`, `plan_reviser.install_user_steer`, `plan_reviser._install_with_drift`); `_cancel_inflight_scope` → written in `DefaultSteerer.__init__`, read in the predicate; `SteeringConfig.cancel_inflight_scope` → threaded by `goldfive.wrap` via `steering_config=resolved_runtime.steering`.

## Notes for reviewers

- `install_descriptive_growth` (goldfive#423 ledger write) never called `_cancel_inflight_for_revision` on main — it installs inline under the plan lock. The design doc §1.1 sentence implying the #423 ledger write fires `task.cancel()` is slightly stale on that one path; `NEW_WORK_DISCOVERED` installs via `install_revision_for_drift` (Runner turn-N+1 replans) **did** cancel and are now gated.
- The CANCEL_REINVOKE ladder level still dispatches `GOLDFIVE_STEER` ControlMessages (executor-side restart at the control checkpoint). That surface is PR 7's scope (cancel policy + ladder restructure), not this PR's.

Design ref: `docs/design/AGENCY-PRESERVATION.md` §0–§2, Stage 1 PR 1, §5.1–§5.2. Closes nothing; first implementation PR of goldfive#449.
