### PR TITLE
feat(plan): descriptive growth at pin time — finish #423 (AGENCY-PRESERVATION PR 2)

### DIFF
--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -103,18 +103,23 @@ kinds group naturally into six categories.
 | `BLOCKED` | `report_task_blocked(task_id, blocker)` with a structural blocker. | `warning` | sometimes |
 | `CAPABILITY_MISMATCH` | Structural capability gap at `delegation_observed` time: Rule A (coordinator-style leaf-assignment, #253), Rule B (required-tools cover, #253), Rule C (out-of-DAG-order delegation, #268). See `goldfive/drift/capability_check.py`. | `critical` | yes (refine) |
 
-**Rule C status under plan-descriptive growth (goldfive#423).** Rule A
-and Rule B still fire normally. **Rule C** is active until PR 4 of
-#423 lands. When `SteeringConfig.descriptive_growth_enabled=True`
-(env `GOLDFIVE_STEER_DESCRIPTIVE_GROWTH=1`), the steerer bypasses
-Rule C in favour of synthesising a `discovered=True` task via
-`PlanReviser.install_descriptive_growth` — the plan grows to match
-reality rather than firing a structural drift. When the flag is
-False (the default until PR 4), Rule C fires as before. The data-
-model carriers (`Task.discovered`,
-`DelegationObserved.tool_args_json`) ship regardless of the flag.
-See [PLAN-DESCRIPTIVE-GROWTH.md](PLAN-DESCRIPTIVE-GROWTH.md) §7 for
-the full Rule A/B/C table under the new model.
+**Rule C status under plan-descriptive growth (goldfive#423 /
+AGENCY-PRESERVATION.md PR 2).** Rule A and Rule B still fire normally
+for non-discovered bound tasks; both are skipped when the bound task
+is `discovered=True` (PLAN-DESCRIPTIVE-GROWTH.md §11.4(a)). **Rule C
+is soft-retired**: it no longer runs unless the operator explicitly
+sets `GOLDFIVE_CAPABILITY_RULE_C=1`. With
+`SteeringConfig.descriptive_growth_enabled=True` (the default; env
+`GOLDFIVE_STEER_DESCRIPTIVE_GROWTH`), the delegation pin grows a
+`discovered=True` task via `PlanReviser.install_descriptive_growth`
+whenever tier 1/2 matching misses — the plan grows to match reality
+BEFORE any capability rule runs, so the mispin shape Rule C detected
+no longer occurs. Hard deletion of Rule C follows in
+AGENCY-PRESERVATION.md PR 13. The data-model carriers
+(`Task.discovered`, `DelegationObserved.tool_args_json`) ship
+regardless of the flag. See
+[PLAN-DESCRIPTIVE-GROWTH.md](PLAN-DESCRIPTIVE-GROWTH.md) §7 for the
+full Rule A/B/C table under the new model.
 
 ### Discovery category — new work that was not in the plan
 

--- a/docs/design/PLAN-DESCRIPTIVE-GROWTH.md
+++ b/docs/design/PLAN-DESCRIPTIVE-GROWTH.md
@@ -2,16 +2,39 @@
 
 ## 1. Status
 
-**Phase 1 shipped (PRs 1-3 of 5).** `Task.discovered` data model +
+**COMPLETE (all 5 PRs shipped).** `Task.discovered` data model +
 `DelegationObserved.tool_args_json` proto extension landed in #431
-(merged at `498320e`). Descriptive growth fallback in
-`_maybe_pin_delegation_task` landed in #433 (merged at `1abee69`)
-behind `SteeringConfig.descriptive_growth_enabled` (default OFF, env
-`GOLDFIVE_STEER_DESCRIPTIVE_GROWTH`). Harmonograf rendering landed
-in `pedapudi/harmonograf#291` (merged at `d2b3921`). **PR 4 (flag
-flip + Rule C retirement) and PR 5 (this docs sync) close out the
-phase.** PR 4 is deferred until live validation is possible
-(kossel.lan offline at the time of writing).
+(merged at `498320e`). The Phase-1 growth fallback landed in #433
+(merged at `1abee69`) wired to the CAPABILITY_MISMATCH Rule-C verdict
+path behind `SteeringConfig.descriptive_growth_enabled` (then default
+OFF). Harmonograf rendering landed in `pedapudi/harmonograf#291`
+(merged at `d2b3921`).
+
+**PR 4 (flag flip + Rule C soft retirement) shipped as
+AGENCY-PRESERVATION.md Stage 1 PR 2**, which also corrected the
+Phase-1 trigger placement: #433 had wired growth to the Rule-C
+*verdict* path only, leaving the tier-3 scorer's misattribution and
+the Rule-A-bypass gap (the 2d27ff4a cherry-tree storm) in place. The
+completing PR moved the trigger to the §4.3 tier-3 *fallback* position
+in `_maybe_pin_delegation_task` (tier-1/2 miss → dedup-hash lookup →
+`install_descriptive_growth` → pin; growth now happens BEFORE any
+capability rule runs), flipped `descriptive_growth_enabled` to default
+ON, soft-retired Rule C behind `GOLDFIVE_CAPABILITY_RULE_C` (§7.1 step
+1; default OFF), skipped the capability rules on discovered bound
+tasks (§11.4 resolution (a)), enforced the §11.1 dedup TTL
+(terminal discovered tasks no longer absorb fresh same-hash
+delegations), and added the same dedup-hash → grow → claim flow to
+`PlanReconciler.on_before_agent`'s unmatched-agent branch so
+`transfer_to_agent`-style trees grow the ledger via the degraded
+per-`(agent_name, "")` hash (§9 forward compat — `before_agent`
+observations carry no tool args).
+
+Still legacy-reachable, scheduled for hard deletion in
+AGENCY-PRESERVATION.md PR 13: the tier-3 topic-args scorer inside
+`_maybe_pin_delegation_task` (only under
+`descriptive_growth_enabled=False`) and `_rule_c_dag_order` + the
+`all_pending_tasks` parameter (only under
+`GOLDFIVE_CAPABILITY_RULE_C=1`; §7.1 step 2).
 
 Related: [PLAN-LIFECYCLE.md](PLAN-LIFECYCLE.md) (the contract this proposal
 extends), [DRIFT.md](DRIFT.md) (the `CAPABILITY_MISMATCH` Rule C retirement
@@ -782,8 +805,8 @@ refines do not happen.
 | 1 | `Task.discovered: bool` + `Task.discovery_identity_hash: str` fields + `Plan.validate` update (no rule change; just opaque metadata) + **`DelegationObserved.tool_args_json` proto extension** (canonical args representation on `goldfive.v1`, so PR 2's dedup hash is computed from observed-fact data, not a pin-time intercept — see §13) + state-store migration (proto regen + harmonograf-side ingestion of the new field + schema bump). Forward-compat: old events without `tool_args_json` default-empty; PR 2's dedup must tolerate `tool_args=None` and fall back to per-`(agent, task_id)` granularity as a coarser-but-still-useful dedup. | n/a — additive | **Shipped** (#431, `498320e`) |
 | 2 | `_maybe_pin_delegation_task` fallback to discovery + `PlanReviser.install_descriptive_growth` helper (§5 Option D, lock-acquiring) + §5.2 test plan + **§11.6 regression race test** (mandatory acceptance criterion) + tracking issue cross-link to #413 for the test template | `SteeringConfig.descriptive_growth_enabled` (env `GOLDFIVE_STEER_DESCRIPTIVE_GROWTH`), default OFF | **Shipped** (#433, `1abee69`) |
 | 3 | Harmonograf-side rendering of discovered tasks (badge, separate visualisation lane, drift filter) | flag-gated | **Shipped** (`pedapudi/harmonograf#291`, `d2b3921`) |
-| 4 | Retire `CAPABILITY_MISMATCH` Rule C (4a soft, 4b hard) — flip `descriptive_growth_enabled` default to True; bypass Rule C when flag is on | flag → default-on | **Deferred** — requires live validation (kossel.lan offline at time of writing) |
-| 5 | Docs: update PLAN-LIFECYCLE.md (Phase 1 discovery section), DRIFT.md (Rule C status under flag), this design doc (mark Phase 1 shipped) | n/a | **This PR** |
+| 4 | Retire `CAPABILITY_MISMATCH` Rule C (4a soft, 4b hard) — flip `descriptive_growth_enabled` default to True; move the growth trigger from the Rule-C verdict path to the §4.3 tier-3 fallback position (also closes the Rule-A-bypass gap); reconciler-side growth for transfer-style trees | flag → default-on; Rule C behind `GOLDFIVE_CAPABILITY_RULE_C` (default OFF) | **Shipped** (4a soft — AGENCY-PRESERVATION.md Stage 1 PR 2; 4b hard deletion deferred to AGENCY-PRESERVATION.md PR 13) |
+| 5 | Docs: update PLAN-LIFECYCLE.md (Phase 1 discovery section), DRIFT.md (Rule C status under flag), this design doc (mark Phase 1 shipped; status sync'd again by the PR-4 completion) | n/a | **Shipped** |
 
 Each PR is independently merge-able. PR 2 ships behind the flag so
 production traffic stays on the old path until PR 4 flips the

--- a/docs/design/PLAN-LIFECYCLE.md
+++ b/docs/design/PLAN-LIFECYCLE.md
@@ -790,19 +790,28 @@ extends the plan-lifecycle contract to cover one new write path:
 delegates to an agent the planner did not forecast.
 
 When `_maybe_pin_delegation_task` cannot match an observed delegation
-to an existing PENDING task via the tier-1 / tier-2 / tier-3 disambiguation
-ladder, the steerer synthesises a `Task(discovered=True, ...)`, installs
-it onto `session.plan` via `PlanReviser.install_descriptive_growth`, and
-re-pins `session.current_task_id` onto the new task. The revision is
-emitted as a `NEW_WORK_DISCOVERED` drift (INFO severity, framework-
-authored) and lands in both steering and observation modes (the
-`_apply_revision` discovery carve-out from goldfive#258).
+to an existing forecast PENDING task via tier 1 (required-tools cover)
+or tier 2 (agent-name stem) — the tier-3 topic-args scorer is bypassed
+in the growth flow (goldfive#423 / AGENCY-PRESERVATION.md PR 2) — the
+steerer synthesises a `Task(discovered=True, ...)`, installs it onto
+`session.plan` via `PlanReviser.install_descriptive_growth`, and pins
+`session.current_task_id` onto the new task BEFORE the
+`DelegationObserved` emit and before any capability rule runs. The
+revision is emitted as a `NEW_WORK_DISCOVERED` drift (INFO severity,
+framework-authored) and lands in both steering and observation modes
+(the `_apply_revision` discovery carve-out from goldfive#258).
+`PlanReconciler.on_before_agent` applies the same dedup-hash → grow →
+claim flow to unmatched agents in `transfer_to_agent`-style trees,
+using the degraded per-`(agent_name, "")` hash (no tool args at that
+hook).
 
 **Feature flag.** Gated on `SteeringConfig.descriptive_growth_enabled`
-(env `GOLDFIVE_STEER_DESCRIPTIVE_GROWTH`, default OFF). When the flag
-is off, `_maybe_pin_delegation_task` retains the pre-#423 fallback
-behaviour and `CAPABILITY_MISMATCH` Rule C fires as today. PR 4 of
-#423 (deferred pending live validation) flips the default.
+(env `GOLDFIVE_STEER_DESCRIPTIVE_GROWTH`, **default ON** since
+goldfive#423 / AGENCY-PRESERVATION.md PR 2). When the flag is off,
+`_maybe_pin_delegation_task` retains the pre-#423 tier-1/2/3 fallback
+behaviour (scheduled for deletion in AGENCY-PRESERVATION.md PR 13) and
+`CAPABILITY_MISMATCH` Rule C can fire — though Rule C is itself
+soft-retired behind `GOLDFIVE_CAPABILITY_RULE_C=1`.
 
 **Dedup.** Repeated delegations to the same `(agent_name,
 args-token-set)` re-pin to the existing discovered task rather than

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1579,36 +1579,16 @@ def _safe_jsonify_tool_args(tool_args: Any) -> str:
         return ""
 
 
-# Rule C detail-string marker emitted by
-# ``goldfive.drift.capability_check._rule_c_dag_order``. Used to
-# distinguish Rule C verdicts from Rule A / Rule B without refactoring
-# the detector's return signature. If the marker drifts, the
-# descriptive-growth fallback simply doesn't fire — Rule C dispatch
-# continues as today — and tests catch the regression.
-_RULE_C_DETAIL_MARKER: str = "delegated out of DAG order"
-
-
-def _is_rule_c_verdict(drift: Any) -> bool:
-    """Return True iff ``drift`` is the CAPABILITY_MISMATCH Rule C verdict.
-
-    Identified by substring match on the detail string emitted by
-    :func:`goldfive.drift.capability_check._rule_c_dag_order`. Rule A
-    and Rule B use distinct detail prefixes ("has only AgentTool" and
-    "is missing required tool", respectively) so this check is
-    unambiguous. See design doc §4.3.2 + §7.
-    """
-    detail = str(getattr(drift, "detail", "") or "")
-    return _RULE_C_DETAIL_MARKER in detail
-
-
 def _descriptive_growth_enabled(steerer: Any) -> bool:
     """Return True iff ``SteeringConfig.descriptive_growth_enabled`` is on.
 
     Reads through ``steerer._steering_config.descriptive_growth_enabled``
-    (the post-#225 typed config). Falls back to ``False`` (the
-    documented default) on any read failure so the new path stays
-    opt-in. Honours the goldfive#423 PR 2 feature-flag contract: PR 2
-    lands behind the flag; PR 4 flips the default after validation.
+    (the post-#225 typed config). Falls back to ``False`` on any read
+    failure — a steerer that doesn't carry a typed steering config
+    (custom Steerer implementations, lightweight test stubs) keeps the
+    legacy pin behaviour, since it cannot expose the growth machinery
+    the new flow needs. The field default is ``True`` as of
+    goldfive#423 / AGENCY-PRESERVATION.md Stage 1 PR 2.
     """
     if steerer is None:
         return False
@@ -1617,6 +1597,28 @@ def _descriptive_growth_enabled(steerer: Any) -> bool:
         if cfg is None:
             return False
         return bool(getattr(cfg, "descriptive_growth_enabled", False))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _growth_at_pin_enabled(steerer: Any) -> bool:
+    """Return True iff the pin-time descriptive-growth flow can run.
+
+    Two conditions (goldfive#423 / AGENCY-PRESERVATION.md PR 2):
+
+    1. The feature flag is on (:func:`_descriptive_growth_enabled`).
+    2. The steerer actually exposes
+       ``plans.install_descriptive_growth`` — without the helper the
+       "tier 1/2 miss → grow" signal would strand the delegation
+       unpinned, which is strictly worse than the legacy tier-3
+       fallback. Custom steerers without the helper keep legacy
+       behaviour even with the flag on.
+    """
+    if not _descriptive_growth_enabled(steerer):
+        return False
+    try:
+        plans = getattr(steerer, "plans", None)
+        return callable(getattr(plans, "install_descriptive_growth", None))
     except Exception:  # noqa: BLE001
         return False
 
@@ -1633,7 +1635,8 @@ async def _attempt_descriptive_growth(
 
     Returns the discovered :class:`~goldfive.types.Task` on success,
     ``None`` on any failure (helper missing, install raised, etc.) so
-    the caller can fall through to the legacy Rule C drift dispatch.
+    the caller degrades to a no-pin delegation — the same silent
+    failure contract every other branch of the pin honours.
 
     Per design doc §4.3 + §5 Option D: the helper acquires the
     per-session plan lock for the swap window and dedups by
@@ -1656,8 +1659,8 @@ async def _attempt_descriptive_growth(
         )
     except Exception as exc:  # noqa: BLE001
         log.debug(
-            "_attempt_descriptive_growth: install raised: %s; falling "
-            "back to Rule C dispatch",
+            "_attempt_descriptive_growth: install raised: %s; leaving "
+            "the delegation unpinned",
             exc,
         )
         return None
@@ -4051,9 +4054,11 @@ def make_adk_plugin(
             invoked_agent_name: str,
             tool_args: Any,
             invoked_agent: Any = None,
-        ) -> None:
+            tool_args_json: str = "",
+        ) -> bool:
             """Observationally bind a plan task to ``invoked_agent_name`` at
-            delegation_observed time (goldfive#259, refined by #265).
+            delegation_observed time (goldfive#259, refined by #265; growth
+            flow by goldfive#423 / AGENCY-PRESERVATION.md Stage 1 PR 2).
 
             #252 zeroed ``Task.assignee_agent_id`` at plan-parse time so the
             LLM cannot pre-declare which sub-agent will pick up a task; the
@@ -4066,10 +4071,40 @@ def make_adk_plugin(
             :func:`_resolve_pinned_task_id` finds the task without needing a
             pre-declared assignee.
 
-            Selection algorithm (multi-eligible disambiguation tiers):
+            Selection algorithm with descriptive growth ON (the default —
+            :attr:`SteeringConfig.descriptive_growth_enabled`; design doc
+            ``PLAN-DESCRIPTIVE-GROWTH.md`` §4.3):
 
+            0. **Dedup-hash re-pin.** If any non-terminal plan task carries
+               the §4.3.0 ``discovery_identity_hash`` of
+               ``(invoked_agent_name, tool_args_json)``, pin to it — a
+               prior delegation in this run already discovered this
+               logical unit of work (§11.1 per-(agent, args-token-set)
+               granularity; the §11.1 TTL excludes terminal tasks).
             1. Eligible set = PENDING tasks whose every upstream-edge
                predecessor is COMPLETED (DAG-ready).
+            2. **Tier 1 — required-tools cover** and **Tier 2 —
+               agent-name stem match** run over the *forecast*
+               (non-discovered) candidates, even when only one candidate
+               is eligible — the single-eligible shortcut is what
+               mispinned the cherry-tree run (e2e ``2d27ff4a``, §8): the
+               only eligible task is not necessarily the work this
+               delegation enacts.
+            3. Tier 1/2 miss -> return ``True`` so the (async) caller
+               grows the plan via
+               :meth:`PlanReviser.install_descriptive_growth` and pins
+               the discovered task. The tier-3 topic-args scorer is
+               deliberately NOT run — it is the misattribution path this
+               flow retires.
+
+            Selection algorithm with descriptive growth OFF (legacy,
+            pre-#423 — kept verbatim for the
+            ``descriptive_growth_enabled=False`` escape hatch and for
+            steerers that don't expose the growth helper; the tier-3
+            scorer below is scheduled for deletion in
+            AGENCY-PRESERVATION.md PR 13 once the legacy path goes):
+
+            1. Eligible set as above.
             2. If exactly one eligible -> bind it.
             3. Multi-eligible disambiguation, short-circuiting on first
                unique pick (goldfive#265):
@@ -4093,32 +4128,53 @@ def make_adk_plugin(
                  wins; tie or zero overlap -> first eligible by plan
                  order.
 
-            4. If zero eligible -> log DEBUG and return.
+            4. If zero eligible -> log DEBUG and return (growth mode
+               instead returns ``True``: the delegation is observed work
+               and the §4.3 contract is that observed work lands in the
+               ledger).
 
             Tier 1 wins on conflict with Tier 2 by construction: it runs
             first and short-circuits. ``invoked_agent`` is optional so
             legacy callers (and tests that don't carry an ADK agent
             object) still get the tier-2 + tier-3 path.
 
+            ``tool_args_json`` is the canonical serialisation of
+            ``tool_args`` — the exact string stamped onto the
+            ``DelegationObserved`` proto by the caller — so the dedup
+            hash is computed from the agent-authored observed-fact data,
+            not a divergent goldfive-side re-serialisation (design doc
+            §13 "adaptive, not predictive").
+
             The stamp is a real mutation, not a dry run. Assignee
             repopulation is observational in the same sense that
             ``NEW_WORK_DISCOVERED`` is — describing observed reality, not a
             revision — so it does NOT emit ``PlanRevised``.
 
+            Returns ``True`` iff the caller must run the descriptive-growth
+            fallback (tier 1/2 missed under growth mode); ``False`` in
+            every other case (pinned, or silently gave up). The growth
+            install is async (it acquires the per-session plan lock) and
+            this method runs synchronously inside ADK's
+            ``before_tool_callback`` machinery, hence the signal-the-caller
+            split rather than growing inline.
+
             Silent on every failure mode.
             """
             if not invoked_agent_name:
-                return
+                return False
             plan = _safe_attr(ctx.session, "plan", None)
             if plan is None:
-                return
+                return False
             tasks = tuple(_safe_attr(plan, "tasks", None) or ())
-            if not tasks:
-                return
+            growth_mode = _growth_at_pin_enabled(ctx.steerer)
+            if not tasks and not growth_mode:
+                return False
             try:
                 from goldfive.types import (  # noqa: PLC0415 — lazy
+                    TERMINAL_TASK_STATUSES,
                     TaskStatus,
                     channel_processor_active,
+                    discovery_identity_hash,
                     replace_task,
                     set_session_plan,
                 )
@@ -4127,7 +4183,32 @@ def make_adk_plugin(
                     "_maybe_pin_delegation_task: cannot import deps: %s",
                     exc,
                 )
-                return
+                return False
+
+            chosen: Any = None
+            if growth_mode:
+                # Step 0 — dedup-hash re-pin (§4.3.0 / §11.1). Scans ALL
+                # non-terminal tasks (not just the DAG-ready eligible
+                # set) because the previously-discovered task is
+                # typically RUNNING by the time the coordinator
+                # re-delegates. The hash survives refines (§4.3.0
+                # "cross-refine survival") so we match on the hash
+                # field alone, not on ``discovered``.
+                identity_hash = discovery_identity_hash(
+                    invoked_agent_name, tool_args_json or None
+                )
+                for task in tasks:
+                    if (
+                        str(
+                            _safe_attr(task, "discovery_identity_hash", "")
+                            or ""
+                        )
+                        == identity_hash
+                        and _safe_attr(task, "status", None)
+                        not in TERMINAL_TASK_STATUSES
+                    ):
+                        chosen = task
+                        break
 
             edges = tuple(_safe_attr(plan, "edges", None) or ())
             completed_ids: set[str] = set()
@@ -4156,41 +4237,88 @@ def make_adk_plugin(
                     continue
                 eligible.append(task)
 
-            if not eligible:
-                log.debug(
-                    "_maybe_pin_delegation_task: no eligible PENDING task "
-                    "to bind for delegation to %s; leaving unpinned",
-                    invoked_agent_name,
-                )
-                return
-
-            chosen: Any
-            if len(eligible) == 1:
-                chosen = eligible[0]
-            else:
-                # goldfive#265 — structural disambiguation tiers run
-                # BEFORE the topic-args scorer + plan-order fallback.
-                # Order: tier 1 (required-tools cover) -> tier 2
-                # (agent-name semantic match) -> tier 3 (existing
-                # scorer + topo-order). Each tier short-circuits on a
-                # unique pick; ambiguous tiers fall through.
-                chosen = None
+            if chosen is None and growth_mode:
+                # goldfive#423 / AGENCY-PRESERVATION.md PR 2 — growth
+                # flow (design doc §4.3). Tiers 1/2 run over the
+                # FORECAST (non-discovered) candidates only, and they
+                # run even when a single candidate is eligible: the
+                # pre-#423 single-eligible shortcut is exactly what
+                # mispinned the cherry-tree run (e2e 2d27ff4a — sole
+                # eligible ``find_presentation_files``, delegation to
+                # ``debugger_agent``). Discovered tasks are matched by
+                # identity hash in step 0; a stem match against an old
+                # discovered task here would wrongly block growth for a
+                # NEW (agent, args-token-set) pair (§11.1 granularity).
+                forecast = [
+                    t
+                    for t in eligible
+                    if not bool(_safe_attr(t, "discovered", False))
+                ]
                 tier1_agent_tool_names = _agent_tool_names(invoked_agent)
-                if tier1_agent_tool_names:
+                if forecast and tier1_agent_tool_names:
                     chosen = _select_by_required_tools(
-                        eligible, tier1_agent_tool_names
+                        forecast, tier1_agent_tool_names
                     )
-                if chosen is None:
+                if chosen is None and forecast:
                     chosen = _select_by_agent_name_stems(
-                        eligible, invoked_agent_name, invoked_agent
+                        forecast, invoked_agent_name, invoked_agent
                     )
                 if chosen is None:
-                    scored = _score_candidates_by_args(eligible, tool_args)
-                    chosen = scored if scored is not None else eligible[0]
+                    # Tier 1/2 missed (or nothing was eligible) →
+                    # descriptive growth. The tier-3 topic-args scorer
+                    # (:func:`_score_candidates_by_args`) is deliberately
+                    # NOT consulted — it is the misattribution path this
+                    # flow retires (it survives below only for the
+                    # descriptive_growth_enabled=False escape hatch and
+                    # gets deleted in AGENCY-PRESERVATION.md PR 13).
+                    # Growth happens at pin time, BEFORE any
+                    # CAPABILITY_MISMATCH rule runs, which is what closes
+                    # the Rule-A-bypass gap.
+                    log.info(
+                        "_maybe_pin_delegation_task: tier 1/2 miss for "
+                        "delegation to %s (eligible=%d) — requesting "
+                        "descriptive growth",
+                        invoked_agent_name,
+                        len(eligible),
+                    )
+                    return True
+            elif chosen is None:
+                # Legacy (descriptive_growth_enabled=False) selection —
+                # pre-#423 behaviour, kept verbatim. Scheduled for
+                # deletion together with the tier-3 scorer
+                # (AGENCY-PRESERVATION.md PR 13).
+                if not eligible:
+                    log.debug(
+                        "_maybe_pin_delegation_task: no eligible PENDING task "
+                        "to bind for delegation to %s; leaving unpinned",
+                        invoked_agent_name,
+                    )
+                    return False
+                if len(eligible) == 1:
+                    chosen = eligible[0]
+                else:
+                    # goldfive#265 — structural disambiguation tiers run
+                    # BEFORE the topic-args scorer + plan-order fallback.
+                    # Order: tier 1 (required-tools cover) -> tier 2
+                    # (agent-name semantic match) -> tier 3 (existing
+                    # scorer + topo-order). Each tier short-circuits on a
+                    # unique pick; ambiguous tiers fall through.
+                    tier1_agent_tool_names = _agent_tool_names(invoked_agent)
+                    if tier1_agent_tool_names:
+                        chosen = _select_by_required_tools(
+                            eligible, tier1_agent_tool_names
+                        )
+                    if chosen is None:
+                        chosen = _select_by_agent_name_stems(
+                            eligible, invoked_agent_name, invoked_agent
+                        )
+                    if chosen is None:
+                        scored = _score_candidates_by_args(eligible, tool_args)
+                        chosen = scored if scored is not None else eligible[0]
 
             chosen_id = str(_safe_attr(chosen, "id", "") or "")
             if not chosen_id:
-                return
+                return False
 
             # Stamp assignee onto the chosen task by deriving a new Plan
             # under the channel-processor envelope. Skip when the assignee
@@ -4212,7 +4340,7 @@ def make_adk_plugin(
                     "_maybe_pin_delegation_task: assignee stamp raised: %s",
                     exc,
                 )
-                return
+                return False
 
             # Pin the chosen task as session.current_task_id via the
             # StateStore so the reporting-tool pin lookup
@@ -4242,7 +4370,7 @@ def make_adk_plugin(
                     "_maybe_pin_delegation_task: current_task pin raised: %s",
                     exc,
                 )
-                return
+                return False
 
             log.info(
                 "goldfive.delegation.assignee_observed: task_id=%s "
@@ -4251,6 +4379,7 @@ def make_adk_plugin(
                 invoked_agent_name,
                 len(eligible),
             )
+            return False
 
         async def _maybe_emit_capability_mismatch(
             self,
@@ -4259,8 +4388,6 @@ def make_adk_plugin(
             invoked_agent: Any,
             invoked_agent_name: str,
             invocation_id: str,
-            tool_args_json: str = "",
-            delegation_event_id: str = "",
         ) -> None:
             """Run the structural capability-mismatch detector at delegation time (goldfive#253).
 
@@ -4273,18 +4400,22 @@ def make_adk_plugin(
             ladder fires (cancel + refine), with a direct sink-emission
             fallback when the steerer stub does not expose the helper.
 
-            goldfive#423 PR 2 — descriptive-growth fallback. When the
-            detector returns a Rule C (out-of-DAG-order) verdict AND
-            :class:`~goldfive.config.SteeringConfig.descriptive_growth_enabled`
-            is ``True``, the steerer synthesises a ``discovered=True``
-            task via
-            :meth:`~goldfive.plan_reviser.PlanReviser.install_descriptive_growth`
-            and re-pins the delegation to it INSTEAD of dispatching the
-            Rule C drift. Rule A and Rule B unaffected. ``tool_args_json``
-            (the agent-authored args off the
-            :class:`~goldfive.types.DelegationObserved` proto field) and
-            ``delegation_event_id`` thread the observed-fact data needed
-            by the growth helper. See design doc §4.3 + §13.
+            goldfive#423 / AGENCY-PRESERVATION.md PR 2 — descriptive
+            growth no longer lives here. The original #423 Phase 1
+            wired a Rule C → growth fallback into this verdict path;
+            that trigger moved to pin time
+            (:meth:`_maybe_pin_delegation_task` tier-1/2 miss →
+            :meth:`~goldfive.plan_reviser.PlanReviser.install_descriptive_growth`),
+            which runs BEFORE this detector — so by the time we get
+            here the bound task already reflects observed reality.
+            Discovered tasks are skipped outright per design doc §11.4
+            resolution (a): the auto-derived ``agent_name: request``
+            title reads leaf-shaped to Rule A's heuristic and would
+            re-fire on every delegation to a delegation-only agent
+            (the cherry-tree Rule-A storm, e2e 2d27ff4a); Rule B is
+            vacuous on discovered tasks (empty ``required_tools``);
+            Rule C is soft-retired behind ``GOLDFIVE_CAPABILITY_RULE_C``.
+            AGENCY-PRESERVATION.md PR 3 revisits Rule A wholesale.
 
             Silent on every failure mode — observability cannot block
             the in-flight invocation.
@@ -4386,6 +4517,22 @@ def make_adk_plugin(
                 # Pin missing or pinned task not live in the plan. The
                 # detector cannot decide capability without a task.
                 return
+            if bool(_safe_attr(chosen_task, "discovered", False)):
+                # goldfive#423 / AGENCY-PRESERVATION.md PR 2 — design
+                # doc §11.4 resolution (a): skip the capability rules
+                # entirely on discovered tasks. The task IS the observed
+                # delegation (synthesised from it at pin time), so
+                # "can this agent perform this task" is true by
+                # construction; Rule A's leaf-title heuristic would
+                # misread the auto-derived title and re-fire the
+                # 2d27ff4a refine storm the growth flow exists to stop.
+                log.debug(
+                    "_maybe_emit_capability_mismatch: bound task %s is "
+                    "discovered=True — capability rules skipped "
+                    "(design doc §11.4(a))",
+                    str(_safe_attr(chosen_task, "id", "") or ""),
+                )
+                return
 
             tool_list = list(_safe_attr(invoked_agent, "tools", None) or [])
             # goldfive#268 — gather the full PENDING set (DAG-ready and
@@ -4433,45 +4580,13 @@ def make_adk_plugin(
             except Exception:  # noqa: BLE001
                 pass
 
-            # goldfive#423 PR 2 — descriptive-growth fallback. When the
-            # feature flag is on AND the drift is specifically Rule C
-            # (out-of-DAG-order: the pin landed on a task whose role-stem
-            # mismatches the invoked agent, but another PENDING task
-            # carries that stem), bypass the Rule C drift dispatch and
-            # synthesise a discovered=True task instead. The new task
-            # carries the agent's role naturally so the structural
-            # mismatch dissolves at the source rather than being papered
-            # over with a refine that has no clean answer (design doc
-            # §2 + §7). Rule A and Rule B verdicts still dispatch normally
-            # — those are skill-gap signals, not pin-mismatch signals.
-            if _is_rule_c_verdict(drift) and _descriptive_growth_enabled(steerer):
-                grew = await _attempt_descriptive_growth(
-                    steerer=steerer,
-                    session=ctx.session,
-                    agent_name=invoked_agent_name,
-                    tool_args_json=tool_args_json,
-                    delegation_event_id=delegation_event_id,
-                )
-                if grew is not None:
-                    # Successful growth (or dedup hit). Re-pin the
-                    # delegation onto the discovered task and suppress
-                    # the Rule C drift. The pin write must be inside
-                    # ``channel_processor_active()`` per the
-                    # single-writer envelope (#247).
-                    await _repin_delegation_to_discovered(
-                        ctx=ctx,
-                        discovered_task=grew,
-                        invoked_agent_name=invoked_agent_name,
-                    )
-                    log.info(
-                        "_maybe_emit_capability_mismatch: descriptive "
-                        "growth absorbed Rule C verdict — discovered "
-                        "task id=%s agent=%r (Rule C drift SUPPRESSED)",
-                        grew.id,
-                        invoked_agent_name,
-                    )
-                    return
-
+            # NOTE (goldfive#423 / AGENCY-PRESERVATION.md PR 2): the
+            # Rule C → descriptive-growth fallback that used to live
+            # here moved to pin time (_maybe_pin_delegation_task / the
+            # before_tool_callback growth branch). Any verdict reaching
+            # this point — including a Rule C verdict under the
+            # GOLDFIVE_CAPABILITY_RULE_C=1 escape hatch — dispatches
+            # through the standard drift path below.
             handle = getattr(getattr(steerer, "drift", None), "handle_drift", None)
             if callable(handle):
                 try:
@@ -5655,8 +5770,22 @@ def make_adk_plugin(
                 # MUST run before the emit so ``task_id`` below is
                 # non-empty for the typical orchestration-only
                 # coordinator turn (``ctx.task is None``).
+                #
+                # goldfive#423 PR 1 proto extension: the canonical
+                # tool_args JSON is stamped onto DelegationObserved (the
+                # emit below) so the descriptive-growth dedup hash (and
+                # any future adaptive consumer) reads the agent-authored
+                # args off the observed event, not a goldfive-side
+                # intercept. See design doc §13 "adaptive, not
+                # predictive". Computed BEFORE the pin so the pin's
+                # step-0 hash lookup and the growth install hash the
+                # exact same string the event will carry. Empty
+                # tool_args degrade to "" — the hash falls back to a
+                # coarser per-(agent, "") key per §9 forward-compat.
+                tool_args_json_text = _safe_jsonify_tool_args(tool_args)
+                needs_growth = False
                 try:
-                    self._maybe_pin_delegation_task(
+                    needs_growth = self._maybe_pin_delegation_task(
                         ctx=ctx,
                         invoked_agent_name=to_agent,
                         tool_args=tool_args,
@@ -5665,12 +5794,49 @@ def make_adk_plugin(
                         # ``agent.tools``. Optional; falls through to the
                         # tier-2/3 paths when absent (legacy callers).
                         invoked_agent=nested_agent,
+                        tool_args_json=tool_args_json_text,
                     )
                 except Exception as exc:  # noqa: BLE001
                     log.debug(
                         "before_tool_callback: delegation_pin hook raised: %s",
                         exc,
                     )
+                if needs_growth:
+                    # goldfive#423 / AGENCY-PRESERVATION.md PR 2 —
+                    # descriptive growth at PIN time (design doc §4.3).
+                    # Tier 1/2 missed: no forecast task structurally
+                    # matches this delegation, so the plan grows a
+                    # discovered=True task and the pin lands on it.
+                    # Runs BEFORE the DelegationObserved emit (so the
+                    # event carries the discovered task id) and BEFORE
+                    # _maybe_emit_capability_mismatch (so no capability
+                    # rule ever grades the delegation against a
+                    # mispinned forecast task — the Rule-A-bypass gap
+                    # from e2e 2d27ff4a). install_descriptive_growth
+                    # acquires the per-session plan lock and dedups by
+                    # identity hash (§5 Option D / §11.6); it lands in
+                    # observation mode too via the goldfive#258
+                    # NEW_WORK_DISCOVERED carve-out.
+                    try:
+                        grew = await _attempt_descriptive_growth(
+                            steerer=ctx.steerer,
+                            session=ctx.session,
+                            agent_name=to_agent,
+                            tool_args_json=tool_args_json_text,
+                            delegation_event_id="",
+                        )
+                        if grew is not None:
+                            await _repin_delegation_to_discovered(
+                                ctx=ctx,
+                                discovered_task=grew,
+                                invoked_agent_name=to_agent,
+                            )
+                    except Exception as exc:  # noqa: BLE001
+                        log.debug(
+                            "before_tool_callback: descriptive growth "
+                            "raised: %s",
+                            exc,
+                        )
 
                 # Resolve task_id for the emit AFTER the pin has run.
                 # Prefer the freshly-pinned ``session.current_task_id``
@@ -5689,15 +5855,6 @@ def make_adk_plugin(
                 if not bound_task_id:
                     bound_task_id = str(_safe_attr(ctx.task, "id", "") or "")
                 task_id = bound_task_id
-                # goldfive#423 PR 1 proto extension: stamp the canonical
-                # tool_args JSON onto DelegationObserved so PR 2's
-                # descriptive-growth dedup hash (and any future
-                # adaptive-consumer) reads the agent-authored args off
-                # the observed event, not a goldfive-side intercept. See
-                # design doc §13 "adaptive, not predictive". Empty
-                # tool_args degrade to "" — PR 2's hash falls back to a
-                # coarser per-(agent, "") key per §9 forward-compat.
-                tool_args_json_text = _safe_jsonify_tool_args(tool_args)
                 await self._emit_observability(
                     "delegation_observed",
                     from_agent=from_agent,
@@ -5748,22 +5905,17 @@ def make_adk_plugin(
                 # truth check on the invoked agent's tool surface. Fires
                 # CAPABILITY_MISMATCH when the agent has only AgentTool
                 # wrappers but was bound to a leaf authoring task, or
-                # when ``Task.required_tools`` are not covered.
-                #
-                # goldfive#423 PR 2 — thread the observed-fact data
-                # (tool_args_json + delegation_event_id) so when the
-                # detector returns a Rule C verdict, the descriptive-
-                # growth fallback can synthesise a discovered task from
-                # the OBSERVED args (not a pin-time intercept of agent
-                # state). See design doc §13 "adaptive, not predictive".
+                # when ``Task.required_tools`` are not covered. Runs
+                # AFTER the pin/growth above, so under descriptive
+                # growth (the default) the bound task already reflects
+                # observed reality and discovered tasks are skipped
+                # inside the helper (design doc §11.4(a)).
                 try:
                     await self._maybe_emit_capability_mismatch(
                         ctx=ctx,
                         invoked_agent=nested_agent,
                         invoked_agent_name=to_agent,
                         invocation_id=inv_id,
-                        tool_args_json=tool_args_json_text,
-                        delegation_event_id="",
                     )
                 except Exception as exc:  # noqa: BLE001
                     log.debug(

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -687,24 +687,36 @@ class SteeringConfig:
     #: capability. See ``docs/design/CONTEXT-EDITING.md`` for the rule
     #: catalog and the rationale behind drop-only edits.
     context_editor_rules: list[str] | None = None
-    #: Plan-descriptive growth fallback for unmatched delegations
-    #: (goldfive#423 PR 2). When ``True`` and the structural capability
-    #: detector returns a Rule C (out-of-DAG-order) verdict, the steerer
-    #: synthesises a ``discovered=True`` task via
+    #: Plan-descriptive growth for unmatched delegations (goldfive#423,
+    #: completed by AGENCY-PRESERVATION.md Stage 1 PR 2). When ``True``
+    #: (the default) the growth trigger lives at PIN time: when the
+    #: delegation pin's tier 1 (required-tools cover) and tier 2
+    #: (agent-name stem) both miss in
+    #: ``_maybe_pin_delegation_task``, the plugin synthesises a
+    #: ``discovered=True`` task via
     #: :meth:`~goldfive.plan_reviser.PlanReviser.install_descriptive_growth`
-    #: and re-pins the delegation to it instead of firing the
-    #: CAPABILITY_MISMATCH drift. Rule A and Rule B are unaffected. When
-    #: ``False`` (the default) the existing CAPABILITY_MISMATCH Rule C
-    #: path fires as today, so PR 2 lands behind the flag without
-    #: behaviour change for existing tests/runs. PR 4 flips the default
-    #: after sufficient validation. Env: ``GOLDFIVE_STEER_DESCRIPTIVE_GROWTH``.
+    #: and pins the delegation to it — the tier-3 topic-args scorer is
+    #: bypassed and no CAPABILITY_MISMATCH rule ever sees a mispinned
+    #: task (this closes the Rule-A-bypass gap from the cherry-tree
+    #: failure, e2e session ``2d27ff4a``). The
+    #: :class:`~goldfive.reconciler.PlanReconciler` applies the same
+    #: dedup-hash → grow → claim flow to unmatched ``before_agent``
+    #: observations so ``transfer_to_agent``-style trees grow the
+    #: ledger too.
+    #:
+    #: When ``False`` the legacy pre-#423 pin behaviour is restored
+    #: (tier-3 topic-args scorer + topo-order fallback; mispins are
+    #: caught downstream by the CAPABILITY_MISMATCH rules). The tier-3
+    #: scorer survives only for this legacy path and is scheduled for
+    #: deletion (AGENCY-PRESERVATION.md PR 13).
+    #: Env: ``GOLDFIVE_STEER_DESCRIPTIVE_GROWTH``.
     #:
     #: Design ref: ``docs/design/PLAN-DESCRIPTIVE-GROWTH.md`` §4.3 + §9
-    #: (PR table). The flag gates ONLY the §4.3 fallback; the data-model
-    #: fields shipped in PR 1 (``Task.discovered``,
+    #: (PR table). The flag gates ONLY the §4.3 growth flow; the
+    #: data-model fields shipped in PR 1 (``Task.discovered``,
     #: ``Task.discovery_identity_hash``, ``DelegationObserved.tool_args_json``)
     #: are always available regardless of this flag.
-    descriptive_growth_enabled: bool = False
+    descriptive_growth_enabled: bool = True
     #: Authority scope for cancelling the wrapped agent's IN-FLIGHT
     #: invocation on a drift-driven plan install (AGENCY-PRESERVATION.md
     #: PR 1; goldfive#449/#452).

--- a/goldfive/drift/capability_check.py
+++ b/goldfive/drift/capability_check.py
@@ -27,16 +27,27 @@ Detection rules (intentionally surgical):
   CRITICAL. Skipped entirely when the advisory is empty (legacy plans
   and planners that don't populate it are a no-op).
 
-* **Rule C — out-of-DAG-order delegation (goldfive#268).** When the
-  invoked agent's *role stem* (the head of its name, with role-suffix
-  tokens like ``agent``/``worker`` trimmed) is absent from the bound
-  task's title+description AND present in some OTHER pending task,
-  the pin has bound the delegation to a structurally-wrong task —
+* **Rule C — out-of-DAG-order delegation (goldfive#268). SOFT-RETIRED
+  (goldfive#423 / AGENCY-PRESERVATION.md PR 2): OFF by default.** When
+  the invoked agent's *role stem* (the head of its name, with
+  role-suffix tokens like ``agent``/``worker`` trimmed) is absent from
+  the bound task's title+description AND present in some OTHER pending
+  task, the pin has bound the delegation to a structurally-wrong task —
   typically because the coordinator dispatched a downstream agent
   before its DAG predecessors completed and the pin had only one
   eligible candidate to choose from. Fires CRITICAL. Requires the
   caller to pass ``all_pending_tasks`` so the cross-task lookup can
   see non-DAG-ready tasks too; otherwise the rule is silent.
+
+  With descriptive growth at pin time
+  (``SteeringConfig.descriptive_growth_enabled``, default ON) the
+  "no right task existed" cause Rule C papered over is fixed at the
+  source — the plan grows a ``discovered=True`` task carrying the
+  agent's role stem, so Rule C's trigger shape no longer occurs
+  (design doc §7). The rule is therefore disabled unless the operator
+  explicitly re-enables it via ``GOLDFIVE_CAPABILITY_RULE_C=1``
+  (per design doc §7.1 soft retirement; hard deletion follows in
+  AGENCY-PRESERVATION.md PR 13).
 
 All three rules return :class:`~goldfive.types.DriftEvent` carrying the
 agent name + bound task id + the structural gap, suitable for the
@@ -48,12 +59,39 @@ for AgentTool detection, ``.name`` for the required-tools cover).
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Sequence
 from typing import Any
 
 from goldfive.types import DriftEvent, DriftKind, DriftSeverity, Task
 
 log = logging.getLogger(__name__)
+
+
+#: Env flag that re-enables the soft-retired Rule C (goldfive#423 /
+#: AGENCY-PRESERVATION.md PR 2; retirement plan in design doc §7.1).
+#: Named so re-enabling is an explicit operator act:
+#: ``GOLDFIVE_CAPABILITY_RULE_C=1``. Read per call (not cached at
+#: import) so tests and operators can flip it without re-importing.
+_RULE_C_ENV_VAR = "GOLDFIVE_CAPABILITY_RULE_C"
+
+#: Truthy spellings accepted for :data:`_RULE_C_ENV_VAR` — same
+#: vocabulary as :func:`goldfive.config._read_bool_env` so the env
+#: surface stays consistent across the project. (No falsy/typo
+#: handling needed: anything that is not an explicit truthy spelling
+#: leaves the rule retired, which is the safe default.)
+_RULE_C_TRUTHY = frozenset({"1", "true", "yes", "on", "y", "t"})
+
+
+def _rule_c_enabled() -> bool:
+    """Return True iff the operator explicitly re-enabled Rule C.
+
+    Rule C is soft-retired (default OFF) because descriptive growth at
+    pin time removes the trigger shape it existed to catch — see the
+    module docstring and ``docs/design/PLAN-DESCRIPTIVE-GROWTH.md`` §7.
+    """
+    raw = os.environ.get(_RULE_C_ENV_VAR, "").strip().lower()
+    return raw in _RULE_C_TRUTHY
 
 
 __all__ = [
@@ -280,7 +318,10 @@ def detect_capability_mismatch(
         Every ``PENDING`` task in the plan (DAG-ready and not). Powers
         the goldfive#268 Rule C cross-task lookup. ``None`` /empty
         disables Rule C — legacy callers and tests that don't pass it
-        keep their pre-#268 behaviour exactly.
+        keep their pre-#268 behaviour exactly. Note Rule C is
+        soft-retired and additionally requires
+        ``GOLDFIVE_CAPABILITY_RULE_C=1`` to run at all (goldfive#423 /
+        AGENCY-PRESERVATION.md PR 2).
 
     Returns
     -------
@@ -350,19 +391,29 @@ def detect_capability_mismatch(
     # pin's tier-2 stem disambiguator couldn't help because only one
     # task was eligible. Rule C fires on that exact shape.
     #
+    # SOFT-RETIRED (goldfive#423 / AGENCY-PRESERVATION.md PR 2): the
+    # rule no longer runs unless the operator explicitly re-enables it
+    # via ``GOLDFIVE_CAPABILITY_RULE_C=1``. Descriptive growth at pin
+    # time grows the plan when no structurally-right task exists, so
+    # the mispin shape Rule C detected no longer occurs (design doc
+    # §7). Hard deletion of ``_rule_c_dag_order`` + the
+    # ``all_pending_tasks`` parameter follows in AGENCY-PRESERVATION.md
+    # PR 13 (§7.1 step 2).
+    #
     # Cross-task signal — needs the full PENDING set (DAG-ready and
     # not). Silent when the caller didn't pass it, when the agent
     # name produces no usable stem (generic ``coordinator_agent`` style
     # names degrade gracefully), or when no other PENDING task
     # mentions the stem (in which case Rule C has nothing to say — the
     # pin is just doing its best with a generic agent).
-    drift_c = _rule_c_dag_order(
-        invoked_agent_name=invoked_agent_name,
-        bound_task=task,
-        all_pending_tasks=all_pending_tasks,
-    )
-    if drift_c is not None:
-        return drift_c
+    if _rule_c_enabled():
+        drift_c = _rule_c_dag_order(
+            invoked_agent_name=invoked_agent_name,
+            bound_task=task,
+            all_pending_tasks=all_pending_tasks,
+        )
+        if drift_c is not None:
+            return drift_c
 
     return None
 

--- a/goldfive/plan_reviser.py
+++ b/goldfive/plan_reviser.py
@@ -728,11 +728,14 @@ class PlanReviser:
         method re-reads ``session.plan`` (the lock acquisition is the
         linearisation point — any concurrent refine has either completed
         before the read or is queued behind it) and checks for an
-        existing task with the same hash. If found, the existing task
-        is returned and the plan is NOT grown. Two delegations of the
-        same ``(agent, args-token-set)`` arriving simultaneously thus
-        produce ONE discovered task, not two (§11.6 dedup
-        linearisability).
+        existing NON-TERMINAL task with the same hash. If found, the
+        existing task is returned and the plan is NOT grown. Two
+        delegations of the same ``(agent, args-token-set)`` arriving
+        simultaneously thus produce ONE discovered task, not two
+        (§11.6 dedup linearisability). The dedup window follows the
+        §11.1 TTL: once the discovered task reaches a terminal status,
+        a fresh delegation with the same hash is a genuinely new unit
+        of work and grows the plan again.
 
         The new task lands as an independent sub-DAG root: no predecessor
         edges, no supersedes link. Rule 7 of :meth:`Plan.validate` allows
@@ -759,9 +762,9 @@ class PlanReviser:
 
         1. Compute ``identity_hash`` from ``(agent_name, tool_args_json)``.
         2. Acquire ``_get_plan_lock(session)``.
-        3. Re-read ``session.plan``. If any task already carries
-           ``discovery_identity_hash == identity_hash``, return it
-           (dedup; no growth).
+        3. Re-read ``session.plan``. If any NON-TERMINAL task already
+           carries ``discovery_identity_hash == identity_hash``,
+           return it (dedup; no growth — §11.1 TTL).
         4. Build the new :class:`Task` with ``discovered=True``,
            ``discovery_identity_hash=identity_hash``,
            ``status=PENDING``, ``assignee_agent_id=agent_name``, and a
@@ -847,6 +850,16 @@ class PlanReviser:
                     ) == identity_hash and bool(
                         getattr(existing, "discovered", False)
                     ):
+                        # Dedup TTL (design doc §11.1): the window is
+                        # "until the discovered task reaches a terminal
+                        # status". A fresh delegation matching a TERMINAL
+                        # discovered task is a genuinely new unit of work
+                        # and grows the plan again.
+                        if (
+                            getattr(existing, "status", None)
+                            in TERMINAL_TASK_STATUSES
+                        ):
+                            continue
                         # Dedup hit — a prior delegation already grew the
                         # plan for this (agent, args-token-set). Re-pin
                         # to the existing task; no growth.

--- a/goldfive/reconciler.py
+++ b/goldfive/reconciler.py
@@ -65,8 +65,14 @@ Tolerance
   double-count: a sub-Runner whose agent name matches a plan task
   still produces one RUNNING→COMPLETED pair per plan task.
 - **Off-plan agents.** An agent whose name matches no plan
-  assignee emits a ``PLAN_DIVERGENCE`` drift at INFO severity.
-  Escalation is the steerer's job (see #142's intervention ladder).
+  assignee grows the plan with a ``discovered=True`` task and
+  claims it (goldfive#423 / AGENCY-PRESERVATION.md PR 2 — the
+  ``transfer_to_agent``-style counterpart of the AgentTool
+  delegation-pin growth; see :meth:`_maybe_grow_discovered_task`).
+  When descriptive growth is disabled or unavailable, the legacy
+  behaviour remains: a divergence record on
+  ``divergence_events`` (the PLAN_DIVERGENCE drift itself was
+  disabled by goldfive#252).
 
 The reconciler is deliberately small (~150 LOC) and framework-
 agnostic. It calls back into the :class:`~goldfive.protocols.Steerer`
@@ -251,6 +257,41 @@ class PlanReconciler:
             # divergence.
             chain = self._parent_chain(invocation_id)
             if any(self._agent_has_any_plan_task(name) for name in chain):
+                return
+            # goldfive#423 / AGENCY-PRESERVATION.md PR 2 — descriptive
+            # growth for transfer_to_agent-style trees. The AgentTool
+            # delegation path grows the plan at pin time
+            # (``_maybe_pin_delegation_task``), but trees that move via
+            # ADK ``transfer_to_agent`` never cross that hook — their
+            # only goldfive-visible signal is this before_agent
+            # observation. Apply the same dedup-hash → grow → claim
+            # flow here so the ledger reflects observed work for every
+            # tree shape. On growth, claim the discovered task exactly
+            # like the direct-match path above (RUNNING transition +
+            # bookkeeping) so ``on_after_agent`` closes it out.
+            grown = await self._maybe_grow_discovered_task(agent_name)
+            if grown is not None:
+                self._running_by_agent[agent_name] = grown.id
+                self._observed_task_ids.add(grown.id)
+                try:
+                    await self._steerer.transition(
+                        grown.id,
+                        TaskStatus.RUNNING,
+                        detail=(
+                            f"observed: {agent_name} started "
+                            f"(discovered via descriptive growth)"
+                        ),
+                        session=self._session,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "PlanReconciler.on_before_agent: discovered-task "
+                        "transition(RUNNING) raised: %s",
+                        exc,
+                    )
+                _ostate.sync_current_task_from_transition(
+                    self._session.state, grown, TaskStatus.RUNNING
+                )
                 return
             self._off_plan_seen.add(agent_name)
             await self._emit_divergence(
@@ -554,6 +595,61 @@ class PlanReconciler:
         if plan is None:
             return False
         return any(t.assignee_agent_id == agent_name for t in plan.tasks)
+
+    async def _maybe_grow_discovered_task(self, agent_name: str) -> Task | None:
+        """Grow the plan with a ``discovered=True`` task for an off-plan agent.
+
+        goldfive#423 / AGENCY-PRESERVATION.md PR 2 — the reconciler-side
+        descriptive-growth trigger for ``transfer_to_agent``-style trees
+        (the AgentTool path grows at delegation-pin time instead; see
+        ``_maybe_pin_delegation_task`` in the ADK plugin).
+
+        Gated on ``SteeringConfig.descriptive_growth_enabled`` (read off
+        the bound steerer's typed config, mirroring the ADK plugin's
+        ``_descriptive_growth_enabled``) and on the steerer exposing
+        :meth:`~goldfive.plan_reviser.PlanReviser.install_descriptive_growth`
+        — custom :class:`~goldfive.protocols.Steerer` implementations
+        without either keep the pre-#423 divergence-record-only
+        behaviour.
+
+        Identity hash: ``before_agent`` observations carry NO tool
+        args (ADK's callback surfaces only the agent + invocation ids;
+        there is no ``DelegationObserved.tool_args_json`` equivalent
+        for a transfer), so we pass ``tool_args_json=""`` and the hash
+        degrades to the documented per-``(agent_name, "")`` key — the
+        §9 forward-compat fallback of
+        ``docs/design/PLAN-DESCRIPTIVE-GROWTH.md``. Coarser than the
+        AgentTool path's per-(agent, args-token-set) granularity, but
+        still dedups repeat transfers to the same agent onto one
+        discovered task while it is live (§11.1 TTL).
+
+        Returns the discovered (or dedup-matched) task, or ``None``
+        when growth is unavailable / disabled / failed — the caller
+        then falls through to the legacy divergence record.
+        """
+        try:
+            cfg = getattr(self._steerer, "_steering_config", None)
+            if cfg is None or not bool(
+                getattr(cfg, "descriptive_growth_enabled", False)
+            ):
+                return None
+            plans = getattr(self._steerer, "plans", None)
+            install = getattr(plans, "install_descriptive_growth", None)
+            if not callable(install):
+                return None
+            return await install(
+                self._session,
+                agent_name=agent_name,
+                tool_args_json="",
+                delegation_event_id="",
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "PlanReconciler._maybe_grow_discovered_task: growth "
+                "raised: %s; falling back to divergence record",
+                exc,
+            )
+            return None
 
     def _find_task(self, task_id: str) -> Task | None:
         plan = self._session.plan

--- a/tests/test_capability_mismatch.py
+++ b/tests/test_capability_mismatch.py
@@ -17,7 +17,10 @@ Detection rules under test:
   in another PENDING task. Mirrors the live evidence from session
   ``f0630532-…`` where ``reviewer_agent`` got pinned to ``draft_slides``
   because ``review_presentation`` wasn't DAG-ready yet and only one
-  task was eligible.
+  task was eligible. SOFT-RETIRED by goldfive#423 /
+  AGENCY-PRESERVATION.md PR 2 — silent unless
+  ``GOLDFIVE_CAPABILITY_RULE_C=1`` (the rule-mechanics tests opt in
+  via the ``_rule_c_escape_hatch`` fixture).
 
 Negative cases mirror each positive: the same shapes WITHOUT the
 trigger condition must return ``None``.
@@ -291,9 +294,58 @@ def test_is_agent_tool_duck_type() -> None:
 
 # ---------------------------------------------------------------------------
 # Rule C (goldfive#268) — out-of-DAG-order delegation
+#
+# SOFT-RETIRED by goldfive#423 / AGENCY-PRESERVATION.md PR 2: Rule C no
+# longer runs unless the operator explicitly sets
+# ``GOLDFIVE_CAPABILITY_RULE_C=1`` (descriptive growth at pin time fixes
+# the mispin shape Rule C detected — design doc §7/§7.1). The
+# rule-mechanics tests below opt in via the ``_rule_c_escape_hatch``
+# fixture so the retired-but-re-enableable implementation stays pinned
+# until its hard deletion (AGENCY-PRESERVATION.md PR 13);
+# ``test_rule_c_soft_retired_silent_by_default`` pins the new default.
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def _rule_c_escape_hatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-enable the soft-retired Rule C for rule-mechanics tests."""
+    monkeypatch.setenv("GOLDFIVE_CAPABILITY_RULE_C", "1")
+
+
+def test_rule_c_soft_retired_silent_by_default() -> None:
+    """goldfive#423 / AGENCY-PRESERVATION.md PR 2: the canonical Rule C
+    positive shape (stem absent from bound task, present in another
+    PENDING task) returns ``None`` unless ``GOLDFIVE_CAPABILITY_RULE_C``
+    is explicitly set — Rule C is soft-retired.
+    """
+    bound = Task(
+        id="draft_slides",
+        title="Draft the presentation slides",
+        description="Author the slide content based on the outline.",
+    )
+    pending = [
+        bound,
+        Task(
+            id="review_presentation",
+            title="Review the presentation",
+            description="Read the slides and flag issues.",
+        ),
+    ]
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="reviewer_agent",
+        invoked_agent_tools=[_FakeFunctionTool("read_presentation_files")],
+        task=bound,
+        all_pending_tasks=pending,
+    )
+
+    assert drift is None, (
+        "Rule C is soft-retired (goldfive#423 PR 2) and must be silent "
+        "without GOLDFIVE_CAPABILITY_RULE_C=1"
+    )
+
+
+@pytest.mark.usefixtures("_rule_c_escape_hatch")
 def test_rule_c_positive_reviewer_pinned_to_draft() -> None:
     """Live evidence from session ``f0630532-…``: ``reviewer_agent``
     pinned to ``draft_slides`` while ``review_presentation`` sits
@@ -339,6 +391,7 @@ def test_rule_c_positive_reviewer_pinned_to_draft() -> None:
     assert "review_presentation" in drift.detail
 
 
+@pytest.mark.usefixtures("_rule_c_escape_hatch")
 def test_rule_c_negative_stem_found_in_bound_task() -> None:
     """Stem ``reviewer`` is present in the bound task itself
     ("Review the presentation") — no conflict. Rule C must NOT fire.
@@ -362,6 +415,7 @@ def test_rule_c_negative_stem_found_in_bound_task() -> None:
     assert drift is None, "Rule C must not fire when stem is in the bound task"
 
 
+@pytest.mark.usefixtures("_rule_c_escape_hatch")
 def test_rule_c_negative_stem_found_nowhere() -> None:
     """Agent ``helper_agent`` (stem ``helper``) bound to ``draft_slides``
     with no other ``helper``-shaped task — Rule C has no signal of
@@ -384,6 +438,7 @@ def test_rule_c_negative_stem_found_nowhere() -> None:
     assert drift is None, "Rule C must not fire when stem isn't anywhere"
 
 
+@pytest.mark.usefixtures("_rule_c_escape_hatch")
 def test_rule_c_negative_generic_coordinator_agent_name() -> None:
     """``coordinator_agent`` has the stem ``coordinator`` — which would
     typically not appear anywhere in a normal pending plan. Rule C
@@ -409,6 +464,7 @@ def test_rule_c_negative_generic_coordinator_agent_name() -> None:
     )
 
 
+@pytest.mark.usefixtures("_rule_c_escape_hatch")
 def test_rule_c_negative_short_stem_skipped() -> None:
     """Agent named ``qa_agent`` has stem ``qa`` (length 2) which is
     below the ≥4 length filter; ``agent_name_stems`` returns an empty
@@ -430,6 +486,7 @@ def test_rule_c_negative_short_stem_skipped() -> None:
     assert drift is None, "Short stems must skip Rule C cleanly"
 
 
+@pytest.mark.usefixtures("_rule_c_escape_hatch")
 def test_rule_c_negative_no_all_pending_tasks_passed() -> None:
     """Legacy callers that don't pass ``all_pending_tasks`` get the
     pre-#268 behaviour: Rules A/B still run, Rule C is silent.
@@ -446,6 +503,7 @@ def test_rule_c_negative_no_all_pending_tasks_passed() -> None:
     assert drift is None, "Rule C silent when caller doesn't pass pending set"
 
 
+@pytest.mark.usefixtures("_rule_c_escape_hatch")
 def test_rule_c_precedence_rule_a_still_wins() -> None:
     """When Rule A also fires (all AgentTool wrappers + leaf task) AND
     Rule C would also fire (stem mismatch), Rule A's verdict wins. The
@@ -476,6 +534,7 @@ def test_rule_c_precedence_rule_a_still_wins() -> None:
     assert "role-stem" not in drift.detail
 
 
+@pytest.mark.usefixtures("_rule_c_escape_hatch")
 def test_rule_c_precedence_rule_b_still_wins() -> None:
     """Rule B (required_tools advisory) takes priority over Rule C.
     Same agent/task confusion shape as the positive case, but the
@@ -505,6 +564,7 @@ def test_rule_c_precedence_rule_b_still_wins() -> None:
     assert "role-stem" not in drift.detail
 
 
+@pytest.mark.usefixtures("_rule_c_escape_hatch")
 def test_rule_c_excludes_bound_task_by_id() -> None:
     """Even when the bound task itself appears in ``all_pending_tasks``
     (the natural shape — every pending task in the plan, including the
@@ -709,6 +769,7 @@ async def test_integration_capability_mismatch_flows_through_handle_drift() -> N
     assert drift.current_agent_id == "underqualified"
 
 
+@pytest.mark.usefixtures("_rule_c_escape_hatch")
 async def test_integration_rule_c_dag_order_mismatch_through_pin() -> None:
     """End-to-end Rule C (goldfive#268): mirror the live evidence
     where ``reviewer_agent`` got delegated while only ``draft_slides``

--- a/tests/test_descriptive_growth_capability_mismatch_fallback.py
+++ b/tests/test_descriptive_growth_capability_mismatch_fallback.py
@@ -1,20 +1,42 @@
-"""Integration tests for the CAPABILITY_MISMATCH → descriptive-growth fallback.
+"""CAPABILITY_MISMATCH verdict path after the descriptive-growth move.
 
-Per goldfive#423 PR 2: when ``SteeringConfig.descriptive_growth_enabled``
-is ``True`` and the structural capability detector returns a Rule C
-verdict (out-of-DAG-order delegation — invoked agent's role stem
-absent from the bound task but present in another PENDING task), the
-ADK plugin's ``_maybe_emit_capability_mismatch`` synthesises a
-``discovered=True`` task via
-:meth:`~goldfive.plan_reviser.PlanReviser.install_descriptive_growth`
-and re-pins the delegation to it INSTEAD of dispatching the Rule C
-drift. With the flag off (the default) the legacy Rule C dispatch
-fires as today.
+History: goldfive#423 Phase 1 wired a Rule C → descriptive-growth
+fallback INTO ``_maybe_emit_capability_mismatch`` (this file originally
+pinned that behaviour). goldfive#423 / AGENCY-PRESERVATION.md Stage 1
+PR 2 moved the growth trigger to PIN time
+(``_maybe_pin_delegation_task`` tier-1/2 miss →
+:meth:`~goldfive.plan_reviser.PlanReviser.install_descriptive_growth`),
+which runs BEFORE any capability rule, and soft-retired Rule C behind
+``GOLDFIVE_CAPABILITY_RULE_C``.
 
-Rule A and Rule B verdicts dispatch normally regardless of the flag —
-those are skill-gap signals, not pin-mismatch signals.
+This file now pins the VERDICT-path side of that contract:
 
-Design ref: ``docs/design/PLAN-DESCRIPTIVE-GROWTH.md`` §4.3, §7.
+* the verdict path never grows the plan (growth lives at pin time —
+  see ``tests/test_descriptive_growth_pin_time.py``);
+* Rule C is silent by default and dispatches as a plain drift under
+  the explicit escape hatch (no growth absorption);
+* Rule A still dispatches normally for non-discovered bound tasks;
+* discovered bound tasks skip the capability rules entirely
+  (design doc §11.4 resolution (a)).
+
+Test migration map (every original assertion re-pointed, none deleted
+silently — see the PR body for the one-line justifications):
+
+* ``test_flag_off_dispatches_rule_c_drift_as_today`` →
+  ``test_rule_c_dispatches_under_escape_hatch_without_growth``.
+* ``test_flag_on_grows_discovered_task_and_suppresses_rule_c`` →
+  ``test_verdict_path_no_longer_grows`` (inverted: the growth the old
+  test asserted here now happens at pin time; the pin-time positive
+  lives in ``test_descriptive_growth_pin_time.py``).
+* ``test_flag_on_rule_a_still_fires`` → kept (signature updated: the
+  growth-threading kwargs were removed from
+  ``_maybe_emit_capability_mismatch``).
+* ``test_flag_on_dedups_repeated_unmatched_delegations`` → migrated to
+  ``test_descriptive_growth_pin_time.py::test_2d27ff4a_repeated_delegations_one_task_no_drift``
+  (the dedup now exercises the pin-time path, which is where the 20×
+  cherry-tree delegations actually arrive).
+
+Design ref: ``docs/design/PLAN-DESCRIPTIVE-GROWTH.md`` §4.3, §7, §11.4.
 """
 
 from __future__ import annotations
@@ -98,16 +120,10 @@ class _NullPlanner:
 def _rule_c_plan() -> Plan:
     """Build the canonical Rule C shape from design doc §2.1.
 
-    Coordinator delegates to ``debugger_agent`` but pin lands on
-    ``find_presentation_files`` (the first eligible). The agent's role
-    stem ``debugger`` is absent from the bound task and not present
-    in any other PENDING task — actually that means Rule C WON'T
-    fire on a generic find-files plan. We need a shape where the
-    invoked agent's stem matches a different PENDING task.
-
-    Better fixture: bind ``reviewer_agent`` to a ``draft`` task while
-    a separate ``review`` task is also PENDING. The stem ``reviewer``
-    → ``review`` is absent from ``draft`` and present in ``review``.
+    Bind ``reviewer_agent`` to a ``draft`` task while a separate
+    ``review`` task is also PENDING. The stem ``reviewer`` → ``review``
+    is absent from ``draft`` and present in ``review`` — the Rule C
+    trigger shape.
     """
     return Plan(
         id="p-rulec",
@@ -136,7 +152,7 @@ def _rule_c_plan() -> Plan:
 def _make_session(plan: Plan | None = None) -> Session:
     return Session(
         run_id="r-rulec",
-        goals=[Goal(id="g-rulec", summary="exercise rule c fallback")],
+        goals=[Goal(id="g-rulec", summary="exercise rule c retirement")],
         plan=plan if plan is not None else _rule_c_plan(),
     )
 
@@ -171,7 +187,7 @@ def _build_ctx_and_plugin(session: Session, steerer: Any):
 
 
 class _AgentToolStub:
-    """Minimal AgentTool surface (a leaf-only tool list)."""
+    """Minimal leaf-tool surface (just a ``.name``)."""
 
     def __init__(self, name: str) -> None:
         self.name = name
@@ -183,17 +199,27 @@ class _InvokedAgentStub:
     def __init__(self, name: str) -> None:
         self.name = name
         # Some leaf tools so Rule A doesn't fire (we want to exercise
-        # specifically Rule C).
+        # specifically the Rule C shape).
         self.tools = [_AgentToolStub("search_web"), _AgentToolStub("read_file")]
 
 
-async def test_flag_off_dispatches_rule_c_drift_as_today() -> None:
-    """With the feature flag OFF, the Rule C CAPABILITY_MISMATCH dispatches as today."""
+async def test_rule_c_dispatches_under_escape_hatch_without_growth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With growth OFF and ``GOLDFIVE_CAPABILITY_RULE_C=1``, the Rule C
+    CAPABILITY_MISMATCH dispatches as a plain drift — the verdict-path
+    growth absorption was removed (growth lives at pin time now).
+
+    Migrated from ``test_flag_off_dispatches_rule_c_drift_as_today``:
+    Rule C is soft-retired by default, so reaching the legacy dispatch
+    now additionally requires the explicit env escape hatch.
+    """
+    monkeypatch.setenv("GOLDFIVE_CAPABILITY_RULE_C", "1")
     sink = _ListSink()
     steerer = DefaultSteerer(
         steering_config=SteeringConfig(
             observation_only=False,
-            descriptive_growth_enabled=False,  # FLAG OFF
+            descriptive_growth_enabled=False,  # legacy escape hatch
         )
     )
     steerer.bind(sinks=[sink], planner=_NullPlanner())
@@ -211,8 +237,6 @@ async def test_flag_off_dispatches_rule_c_drift_as_today() -> None:
         invoked_agent=_InvokedAgentStub("reviewer_agent"),
         invoked_agent_name="reviewer_agent",
         invocation_id="inv-test-1",
-        tool_args_json='{"request": "review the draft"}',
-        delegation_event_id="evt-1",
     )
 
     # Rule C drift was dispatched.
@@ -223,21 +247,67 @@ async def test_flag_off_dispatches_rule_c_drift_as_today() -> None:
     ]
     assert (
         len(rule_c) == 1
-    ), f"with flag OFF, expected 1 Rule C drift; got {len(rule_c)}"
-    # No discovered task synthesised.
+    ), f"under the escape hatch, expected 1 Rule C drift; got {len(rule_c)}"
+    # No discovered task synthesised — the verdict-path fallback is gone.
     discovered = [t for t in session.plan.tasks if getattr(t, "discovered", False)]
     assert (
         discovered == []
-    ), f"flag OFF must not grow discovered tasks; got {[t.id for t in discovered]}"
+    ), f"verdict path must not grow discovered tasks; got {[t.id for t in discovered]}"
 
 
-async def test_flag_on_grows_discovered_task_and_suppresses_rule_c() -> None:
-    """With the feature flag ON, Rule C is replaced by descriptive growth."""
+async def test_rule_c_silent_by_default_on_verdict_path() -> None:
+    """Same Rule C shape, no env flag: nothing fires and nothing grows.
+
+    New default pinned by goldfive#423 / AGENCY-PRESERVATION.md PR 2
+    (correctness requirement (c)): Rule C is soft-retired, and the
+    verdict path no longer owns any growth, so the canonical Rule C
+    fixture produces zero drift dispatches and zero plan mutations.
+    """
     sink = _ListSink()
     steerer = DefaultSteerer(
         steering_config=SteeringConfig(
             observation_only=False,
-            descriptive_growth_enabled=True,  # FLAG ON
+            descriptive_growth_enabled=False,
+        )
+    )
+    steerer.bind(sinks=[sink], planner=_NullPlanner())
+    recorder = _RecordingDriftSteerer(steerer)
+
+    session = _make_session()
+    session.current_task_id = "draft_slides"
+    plugin, _state = _build_ctx_and_plugin(session, steerer)
+
+    ctx = plugin._active_ctx
+    await plugin._maybe_emit_capability_mismatch(
+        ctx=ctx,
+        invoked_agent=_InvokedAgentStub("reviewer_agent"),
+        invoked_agent_name="reviewer_agent",
+        invocation_id="inv-test-default",
+    )
+
+    assert recorder.handled_drifts == [], (
+        f"Rule C must be silent by default; got "
+        f"{[d.detail for d in recorder.handled_drifts]}"
+    )
+    discovered = [t for t in session.plan.tasks if getattr(t, "discovered", False)]
+    assert discovered == []
+
+
+async def test_verdict_path_no_longer_grows() -> None:
+    """With growth ON, the verdict path neither grows nor dispatches Rule C.
+
+    Migrated from ``test_flag_on_grows_discovered_task_and_suppresses_rule_c``
+    with the polarity inverted: the growth that test asserted HERE now
+    happens at pin time (positive coverage in
+    ``test_descriptive_growth_pin_time.py``); the verdict path is a
+    pure detector again, and Rule C's retirement means the old fixture
+    produces no verdict at all.
+    """
+    sink = _ListSink()
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(
+            observation_only=False,
+            descriptive_growth_enabled=True,
         )
     )
     steerer.bind(sinks=[sink], planner=_NullPlanner())
@@ -249,49 +319,35 @@ async def test_flag_on_grows_discovered_task_and_suppresses_rule_c() -> None:
 
     ctx = plugin._active_ctx
     prior_task_count = len(session.plan.tasks)
+    prior_revision = session.plan.revision_index
 
     await plugin._maybe_emit_capability_mismatch(
         ctx=ctx,
         invoked_agent=_InvokedAgentStub("reviewer_agent"),
         invoked_agent_name="reviewer_agent",
         invocation_id="inv-test-2",
-        tool_args_json='{"request": "review the draft"}',
-        delegation_event_id="evt-2",
     )
 
-    # Rule C drift was SUPPRESSED.
-    rule_c = [
-        d
-        for d in recorder.handled_drifts
-        if d.kind is DriftKind.CAPABILITY_MISMATCH
-    ]
-    assert (
-        rule_c == []
-    ), f"flag ON must suppress Rule C drift; got {[d.detail for d in rule_c]}"
-
-    # Discovered task was synthesised.
+    # No drift dispatched (Rule C retired; Rules A/B don't apply here).
+    assert recorder.handled_drifts == []
+    # No growth from the verdict path — the plan is untouched.
     assert session.plan is not None
-    assert len(session.plan.tasks) == prior_task_count + 1
-    discovered = [
-        t for t in session.plan.tasks if getattr(t, "discovered", False)
-    ]
-    assert len(discovered) == 1, (
-        f"flag ON must synthesise 1 discovered task; got {len(discovered)}"
-    )
-    new_task = discovered[0]
-    assert new_task.assignee_agent_id == "reviewer_agent"
-    assert new_task.discovery_identity_hash != ""
-
-    # Pin moved to the new discovered task.
-    assert session.current_task_id == new_task.id
+    assert len(session.plan.tasks) == prior_task_count
+    assert session.plan.revision_index == prior_revision
+    discovered = [t for t in session.plan.tasks if getattr(t, "discovered", False)]
+    assert discovered == []
+    # The pin was not moved.
+    assert session.current_task_id == "draft_slides"
 
 
 async def test_flag_on_rule_a_still_fires() -> None:
     """Rule A (leaf-task with AgentTool-only agent) is unaffected by the flag.
 
-    The descriptive-growth fallback gates ONLY on Rule C detail
-    substring. Rule A — coordinator-style leaf-assignment — has a
-    different detail prefix and still dispatches normally.
+    Rule A — coordinator-style leaf-assignment — still dispatches
+    normally for NON-discovered bound tasks (Rule A is
+    AGENCY-PRESERVATION.md PR 3's business, untouched by PR 2). Kept
+    from the original suite; only the removed growth-threading kwargs
+    changed.
     """
 
     class _AgentToolWrapper:
@@ -368,12 +424,9 @@ async def test_flag_on_rule_a_still_fires() -> None:
         invoked_agent=_OnlyAgentToolsAgent(),
         invoked_agent_name="coordinator_b",
         invocation_id="inv-test-rulea",
-        tool_args_json='{"request": "go write the report"}',
-        delegation_event_id="evt-rulea",
     )
 
-    # Rule A drift was dispatched normally (NOT suppressed by the
-    # descriptive-growth gate).
+    # Rule A drift was dispatched normally.
     cap_drifts = [
         d
         for d in recorder.handled_drifts
@@ -393,12 +446,51 @@ async def test_flag_on_rule_a_still_fires() -> None:
     )
 
 
-async def test_flag_on_dedups_repeated_unmatched_delegations() -> None:
-    """Repeated same-args delegations grow the plan once, then re-pin.
+async def test_discovered_bound_task_skips_capability_rules() -> None:
+    """A ``discovered=True`` bound task short-circuits the detector.
 
-    Cherry-tree run from design doc §2.1 motivating evidence: 20+
-    debugger_agent delegations dedup to a single discovered task.
+    Design doc §11.4 resolution (a): the auto-derived
+    ``agent_name: request`` title reads leaf-shaped, so without the
+    skip an AgentTool-only agent pinned to its own discovered task
+    would re-fire Rule A on every delegation — the exact 2d27ff4a
+    storm descriptive growth exists to stop.
     """
+
+    class _AgentToolWrapper:
+        def __init__(self, name: str, agent_name: str) -> None:
+            self.name = name
+            self.agent = type("_A", (), {"name": agent_name})()
+
+    class _OnlyAgentToolsAgent:
+        def __init__(self) -> None:
+            self.name = "debugger_agent"
+            self.tools = [_AgentToolWrapper("delegate_x", "agent_x")]
+
+    plan = Plan(
+        id="p-disc",
+        run_id="r-disc",
+        goal_ids=["g-disc"],
+        tasks=[
+            Task(
+                id="discovered-abc123",
+                title="debugger_agent: locate cherry tree files",
+                description='{"request": "locate cherry tree files"}',
+                assignee_agent_id="debugger_agent",
+                status=TaskStatus.PENDING,
+                discovered=True,
+                discovery_identity_hash="hash1234abcd5678",
+            ),
+        ],
+        edges=[],
+        revision_index=2,
+    )
+    session = Session(
+        run_id="r-disc",
+        goals=[Goal(id="g-disc", summary="discovered tasks skip rules")],
+        plan=plan,
+    )
+    session.current_task_id = "discovered-abc123"
+
     sink = _ListSink()
     steerer = DefaultSteerer(
         steering_config=SteeringConfig(
@@ -406,31 +498,34 @@ async def test_flag_on_dedups_repeated_unmatched_delegations() -> None:
         )
     )
     steerer.bind(sinks=[sink], planner=_NullPlanner())
-    _RecordingDriftSteerer(steerer)  # silence drift dispatch
+    recorder = _RecordingDriftSteerer(steerer)
 
-    session = _make_session()
-    session.current_task_id = "draft_slides"
-    plugin, _state = _build_ctx_and_plugin(session, steerer)
+    from goldfive.adapters._adk_plugin import (
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="coordinator")
+    plugin.set_active_context(
+        SessionContext(
+            session=session,
+            steerer=steerer,
+            task=plan.tasks[0],
+            tool_handlers={},
+            host_agent_name="coordinator",
+        )
+    )
 
     ctx = plugin._active_ctx
-
-    # Fire 10 delegations to the same (agent, tool_args).
-    for i in range(10):
-        await plugin._maybe_emit_capability_mismatch(
-            ctx=ctx,
-            invoked_agent=_InvokedAgentStub("reviewer_agent"),
-            invoked_agent_name="reviewer_agent",
-            invocation_id=f"inv-{i}",
-            tool_args_json='{"request": "review the draft"}',
-            delegation_event_id=f"evt-{i}",
-        )
-
-    # Only one discovered task.
-    assert session.plan is not None
-    discovered = [t for t in session.plan.tasks if getattr(t, "discovered", False)]
-    assert len(discovered) == 1, (
-        f"10 same-args delegations must dedup to 1 discovered task; "
-        f"got {len(discovered)}"
+    await plugin._maybe_emit_capability_mismatch(
+        ctx=ctx,
+        invoked_agent=_OnlyAgentToolsAgent(),
+        invoked_agent_name="debugger_agent",
+        invocation_id="inv-test-disc",
     )
-    # current_task_id pinned to that one discovered task.
-    assert session.current_task_id == discovered[0].id
+
+    assert recorder.handled_drifts == [], (
+        f"capability rules must be skipped on discovered tasks "
+        f"(design doc §11.4(a)); got "
+        f"{[d.detail for d in recorder.handled_drifts]}"
+    )

--- a/tests/test_descriptive_growth_pin_time.py
+++ b/tests/test_descriptive_growth_pin_time.py
@@ -1,0 +1,820 @@
+"""Descriptive growth at PIN time (goldfive#423 / AGENCY-PRESERVATION.md PR 2).
+
+Pins the completed #423 contract per
+``docs/design/PLAN-DESCRIPTIVE-GROWTH.md`` §4.3: the growth trigger
+lives in the delegation pin, not the CAPABILITY_MISMATCH verdict path.
+When ``SteeringConfig.descriptive_growth_enabled`` is ON (the default):
+
+* a tier-1 (required-tools cover) or tier-2 (agent-name stem) hit pins
+  the forecast task exactly as before — NO growth;
+* a tier-1/2 miss grows a ``discovered=True`` task via
+  :meth:`~goldfive.plan_reviser.PlanReviser.install_descriptive_growth`
+  and pins it — the tier-3 topic-args scorer is NOT invoked and no
+  CAPABILITY_MISMATCH rule ever sees a mispinned forecast task (the
+  Rule-A-bypass gap from e2e session ``2d27ff4a``);
+* repeated delegations to the same (agent, args-token-set) dedup onto
+  ONE discovered task (§11.1); different args grow distinct tasks;
+* the flow works identically in observation mode (the goldfive#258
+  ``NEW_WORK_DISCOVERED`` carve-out) — growth is descriptive, not
+  corrective;
+* with the flag OFF (or a steerer that lacks the growth machinery),
+  the legacy pre-#423 pin — including the tier-3 scorer — is
+  preserved verbatim until its deletion (AGENCY-PRESERVATION.md PR 13).
+
+The ``2d27ff4a`` regression test reproduces the cherry-tree failure
+shape end-to-end at the plugin level: N repeated delegations to the
+same unmatched agent with identical args must produce exactly one
+discovered task, zero CAPABILITY_MISMATCH drifts, and zero planner
+refines.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+# Plugin-level tests require the google.adk extra.
+pytest.importorskip("google.adk")
+
+from goldfive.adapters._adk_plugin import (  # noqa: E402
+    SESSION_CONTEXT_STATE_KEY,
+    SessionContext,
+    make_adk_plugin,
+)
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / stubs
+# ---------------------------------------------------------------------------
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class _RecordingPlanner:
+    """Planner that records refine calls (the 2d27ff4a storm metric)."""
+
+    def __init__(self) -> None:
+        self.refine_calls: list[Any] = []
+
+    async def generate(
+        self,
+        *,
+        goals: list[Goal],
+        available_agents: list[str],
+        context: Any | None = None,
+    ) -> Plan | None:
+        return None
+
+    async def refine(
+        self,
+        *,
+        plan: Plan,
+        drift: DriftEvent,
+        goals: list[Goal],
+    ) -> Plan | None:
+        self.refine_calls.append(drift)
+        return None
+
+
+def _capture_drifts(steerer: DefaultSteerer) -> list[DriftEvent]:
+    """Wrap ``steerer.drift.handle_drift`` to record dispatched drifts."""
+    handled: list[DriftEvent] = []
+    real_handle = steerer.drift.handle_drift
+
+    async def capture(drift: DriftEvent, session: Session) -> None:
+        handled.append(drift)
+        await real_handle(drift, session)
+
+    steerer.drift.handle_drift = capture  # type: ignore[method-assign]
+    return handled
+
+
+def _make_steerer(
+    *,
+    descriptive_growth_enabled: bool = True,
+    observation_only: bool = False,
+) -> tuple[DefaultSteerer, _RecordingPlanner, _ListSink]:
+    planner = _RecordingPlanner()
+    sink = _ListSink()
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(
+            observation_only=observation_only,
+            descriptive_growth_enabled=descriptive_growth_enabled,
+        )
+    )
+    steerer.bind(sinks=[sink], planner=planner)
+    return steerer, planner, sink
+
+
+def _cherry_tree_plan() -> Plan:
+    """The 2d27ff4a forecast shape (design doc §2.1 / §8).
+
+    Three forecast tasks; only ``find_presentation_files`` is
+    DAG-ready. None of the titles carries the stem ``debugger``, so a
+    delegation to ``debugger_agent`` misses tier 1 and tier 2.
+    """
+    return Plan(
+        id="p-cherry",
+        run_id="r-cherry",
+        goal_ids=["g-cherry"],
+        tasks=[
+            Task(id="find_presentation_files", title="Find the presentation files"),
+            Task(id="read_presentation", title="Read the presentation"),
+            Task(id="summarise_presentation", title="Summarise the presentation"),
+        ],
+        edges=[
+            TaskEdge(
+                from_task_id="find_presentation_files",
+                to_task_id="read_presentation",
+            ),
+            TaskEdge(
+                from_task_id="read_presentation",
+                to_task_id="summarise_presentation",
+            ),
+        ],
+        revision_index=1,
+    )
+
+
+def _make_session(plan: Plan) -> Session:
+    return Session(
+        run_id=plan.run_id,
+        goals=[Goal(id=g, summary="summarise the pothos presentation") for g in plan.goal_ids],
+        plan=plan,
+    )
+
+
+class _FakeAgent:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeLeafTool:
+    """FunctionTool stand-in: ``.name`` but no ``.agent``."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeSubAgent:
+    """The nested ADK agent an AgentTool wraps (``.name`` + ``.tools``)."""
+
+    def __init__(self, name: str, tools: list[Any] | None = None) -> None:
+        self.name = name
+        self.tools = list(tools or [_FakeLeafTool("find_files")])
+
+
+class _FakeAgentTool:
+    """ADK AgentTool stand-in: has both ``.agent`` and ``.name``."""
+
+    def __init__(self, sub_agent: _FakeSubAgent) -> None:
+        self.agent = sub_agent
+        self.name = sub_agent.name
+
+
+class _FakeInvocationContext:
+    def __init__(self, session_state: dict, agent_name: str, inv_id: str = "inv-1") -> None:
+        class _ADKSession:
+            def __init__(self, state: dict) -> None:
+                self.state = state
+
+        self.session = _ADKSession(session_state)
+        self.invocation_id = inv_id
+        self.agent = _FakeAgent(agent_name)
+
+
+class _FakeToolContext:
+    def __init__(self, inv_ctx: Any, function_call_id: str = "fc-1") -> None:
+        self._invocation_context = inv_ctx
+        self.function_call_id = function_call_id
+
+
+def _wire_plugin(session: Session, steerer: Any):
+    """Build plugin + SessionContext + ADK-state plumbing for callbacks."""
+    plugin = make_adk_plugin(host_agent_name="coordinator")
+    ctx_obj = SessionContext(
+        session=session,
+        steerer=steerer,
+        task=None,
+        tool_handlers={},
+        host_agent_name="coordinator",
+    )
+    plugin.set_active_context(ctx_obj)
+    adk_state: dict[str, Any] = {SESSION_CONTEXT_STATE_KEY: ctx_obj}
+    return plugin, adk_state
+
+
+async def _dispatch_delegation(
+    plugin: Any,
+    adk_state: dict,
+    *,
+    agent: _FakeSubAgent,
+    tool_args: dict[str, Any],
+    fc_id: str = "fc-1",
+    inv_id: str = "inv-1",
+) -> Any:
+    """Drive ``before_tool_callback`` for one AgentTool dispatch."""
+    inv_ctx = _FakeInvocationContext(adk_state, "coordinator", inv_id)
+    tool_context = _FakeToolContext(inv_ctx, function_call_id=fc_id)
+    return await plugin.before_tool_callback(
+        tool=_FakeAgentTool(agent),
+        tool_args=tool_args,
+        tool_context=tool_context,
+    )
+
+
+def _discovered(plan: Plan | None) -> list[Task]:
+    return [t for t in (plan.tasks if plan else ()) if getattr(t, "discovered", False)]
+
+
+# ---------------------------------------------------------------------------
+# (a) Tier-1 / tier-2 hits do NOT grow — pin as before.
+# ---------------------------------------------------------------------------
+
+
+async def test_tier1_required_tools_hit_pins_without_growth() -> None:
+    """Required-tools cover (tier 1) still wins under growth mode."""
+    steerer, planner, _sink = _make_steerer()
+    plan = Plan(
+        id="p-t1",
+        run_id="r-t1",
+        goal_ids=["g-t1"],
+        tasks=[
+            Task(id="B", title="general work"),
+            Task(id="A", title="apply patch", required_tools=("patch_file",)),
+        ],
+        edges=[],
+        revision_index=1,
+    )
+    session = _make_session(plan)
+    plugin, adk_state = _wire_plugin(session, steerer)
+
+    await _dispatch_delegation(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("patcher", tools=[_FakeLeafTool("patch_file")]),
+        tool_args={"x": "go"},
+    )
+
+    assert session.current_task_id == "A", "tier-1 cover must pin task A"
+    assert _discovered(session.plan) == [], "a tier-1 hit must not grow"
+    assert session.plan.revision_index == 1
+    assert planner.refine_calls == []
+
+
+async def test_tier2_stem_hit_pins_without_growth() -> None:
+    """Agent-name stem match (tier 2) still wins under growth mode."""
+    steerer, planner, _sink = _make_steerer()
+    plan = Plan(
+        id="p-t2",
+        run_id="r-t2",
+        goal_ids=["g-t2"],
+        tasks=[
+            Task(id="outline_presentation", title="Outline the presentation"),
+            Task(id="review_presentation", title="Review the presentation"),
+        ],
+        edges=[],
+        revision_index=1,
+    )
+    session = _make_session(plan)
+    plugin, adk_state = _wire_plugin(session, steerer)
+
+    await _dispatch_delegation(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("reviewer_agent"),
+        tool_args={"request": "please proceed"},
+    )
+
+    assert session.current_task_id == "review_presentation"
+    assert _discovered(session.plan) == [], "a tier-2 hit must not grow"
+    assert session.plan.revision_index == 1
+    assert planner.refine_calls == []
+
+
+# ---------------------------------------------------------------------------
+# (b) Tier-1/2 miss → growth + pin; no tier-3 scorer; no CAPABILITY_MISMATCH.
+# ---------------------------------------------------------------------------
+
+
+async def test_tier12_miss_grows_and_pins_without_tier3_or_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The §4.3 flow: miss → grow discovered task → pin it.
+
+    Asserts the three PR-2 binding negatives in one shot: the tier-3
+    topic-args scorer is never consulted, no CAPABILITY_MISMATCH is
+    dispatched, and the planner is never asked to refine.
+    """
+    import goldfive.adapters._adk_plugin as plugin_mod
+
+    scorer_calls: list[Any] = []
+    real_scorer = plugin_mod._score_candidates_by_args
+
+    def recording_scorer(candidates: list[Any], tool_args: Any) -> Any:
+        scorer_calls.append((candidates, tool_args))
+        return real_scorer(candidates, tool_args)
+
+    monkeypatch.setattr(
+        plugin_mod, "_score_candidates_by_args", recording_scorer
+    )
+
+    steerer, planner, sink = _make_steerer()
+    handled = _capture_drifts(steerer)
+    session = _make_session(_cherry_tree_plan())
+    plugin, adk_state = _wire_plugin(session, steerer)
+
+    await _dispatch_delegation(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("debugger_agent"),
+        tool_args={"request": "locate cherry tree files"},
+    )
+
+    discovered = _discovered(session.plan)
+    assert len(discovered) == 1, (
+        f"tier-1/2 miss must grow exactly one discovered task; got "
+        f"{[t.id for t in session.plan.tasks]}"
+    )
+    new_task = discovered[0]
+    assert new_task.assignee_agent_id == "debugger_agent"
+    assert new_task.discovery_identity_hash != ""
+    assert new_task.title.startswith("debugger_agent:")
+    # The pin landed on the discovered task.
+    assert session.current_task_id == new_task.id
+    # The DelegationObserved emit carries the discovered task id (it
+    # runs after the growth, by construction).
+    delegations = [
+        e.delegation_observed
+        for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "delegation_observed"
+    ]
+    assert len(delegations) == 1
+    assert delegations[0].task_id == new_task.id
+    # The forecast tasks were not touched.
+    assert {t.id for t in session.plan.tasks if not t.discovered} == {
+        "find_presentation_files",
+        "read_presentation",
+        "summarise_presentation",
+    }
+    # Binding negatives.
+    assert scorer_calls == [], (
+        "the tier-3 topic-args scorer must not run in the default "
+        f"(growth) path; called with {scorer_calls}"
+    )
+    mismatches = [d for d in handled if d.kind is DriftKind.CAPABILITY_MISMATCH]
+    assert mismatches == [], (
+        f"growth at pin time must pre-empt CAPABILITY_MISMATCH; got "
+        f"{[d.detail for d in mismatches]}"
+    )
+    assert planner.refine_calls == [], "no refine may fire on a tier-1/2 miss"
+
+
+async def test_growth_lands_in_observation_mode_too() -> None:
+    """The goldfive#258 discovery carve-out: growth is descriptive, so
+    it lands a REAL plan revision under ``observation_only=True`` as
+    well — the plan view must reflect what actually happened in both
+    modes (design doc §6.2).
+    """
+    steerer, planner, _sink = _make_steerer(observation_only=True)
+    session = _make_session(_cherry_tree_plan())
+    plugin, adk_state = _wire_plugin(session, steerer)
+
+    await _dispatch_delegation(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("debugger_agent"),
+        tool_args={"request": "locate cherry tree files"},
+    )
+
+    discovered = _discovered(session.plan)
+    assert len(discovered) == 1, "observation mode must still grow the ledger"
+    assert session.current_task_id == discovered[0].id
+    assert session.plan.revision_index == 2
+    assert planner.refine_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Dedup granularity (§11.1): same args re-pin; different args grow anew.
+# ---------------------------------------------------------------------------
+
+
+async def test_different_args_grow_distinct_discovered_tasks() -> None:
+    """Per-(agent, args-token-set) granularity: a second delegation to
+    the same agent with DIFFERENT args is a new unit of work and grows
+    a second discovered task (the §11.1 ``web_developer=2`` case).
+    """
+    steerer, _planner, _sink = _make_steerer()
+    session = _make_session(_cherry_tree_plan())
+    plugin, adk_state = _wire_plugin(session, steerer)
+
+    await _dispatch_delegation(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("debugger_agent"),
+        tool_args={"request": "locate cherry tree files"},
+        fc_id="fc-1",
+    )
+    await _dispatch_delegation(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("debugger_agent"),
+        tool_args={"request": "inspect webserver logs"},
+        fc_id="fc-2",
+    )
+
+    discovered = _discovered(session.plan)
+    assert len(discovered) == 2, (
+        f"different args must grow distinct tasks; got "
+        f"{[t.title for t in discovered]}"
+    )
+    hashes = {t.discovery_identity_hash for t in discovered}
+    assert len(hashes) == 2
+
+
+async def test_same_args_re_pin_while_discovered_task_running() -> None:
+    """The step-0 hash lookup re-pins onto a RUNNING discovered task —
+    the dedup window spans the task's whole non-terminal lifetime, not
+    just while it is PENDING (§11.1 TTL).
+    """
+    from goldfive.types import (
+        channel_processor_active,
+        set_session_plan,
+        with_task_status,
+    )
+
+    steerer, _planner, _sink = _make_steerer()
+    session = _make_session(_cherry_tree_plan())
+    plugin, adk_state = _wire_plugin(session, steerer)
+
+    await _dispatch_delegation(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("debugger_agent"),
+        tool_args={"request": "locate cherry tree files"},
+        fc_id="fc-1",
+    )
+    first = _discovered(session.plan)[0]
+    # Simulate the sub-invocation starting: discovered task → RUNNING.
+    with channel_processor_active():
+        set_session_plan(
+            session, with_task_status(session.plan, first.id, TaskStatus.RUNNING)
+        )
+
+    await _dispatch_delegation(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("debugger_agent"),
+        tool_args={"request": "locate cherry tree files"},
+        fc_id="fc-2",
+    )
+
+    discovered = _discovered(session.plan)
+    assert len(discovered) == 1, "same-args delegation must re-pin, not re-grow"
+    assert session.current_task_id == first.id
+
+
+# ---------------------------------------------------------------------------
+# (e) The 2d27ff4a regression shape.
+# ---------------------------------------------------------------------------
+
+
+async def test_2d27ff4a_repeated_delegations_one_task_no_drift() -> None:
+    """Cherry-tree regression (e2e session 2d27ff4a, 2026-05-13).
+
+    A coordinator delegates to ``debugger_agent`` 20 times with the
+    same args before touching the planned agents. Pre-#423: every
+    delegation mispinned ``find_presentation_files`` and fired
+    CAPABILITY_MISMATCH → refine (~20 spurious refines). Post-PR-2:
+
+    * exactly ONE discovered task (per-(agent, args-token-set) dedup);
+    * ZERO CAPABILITY_MISMATCH drifts (growth runs before the rules
+      and the discovered bound task skips them — §11.4(a));
+    * ZERO planner refines.
+    """
+    steerer, planner, sink = _make_steerer()
+    handled = _capture_drifts(steerer)
+    session = _make_session(_cherry_tree_plan())
+    plugin, adk_state = _wire_plugin(session, steerer)
+
+    for i in range(20):
+        # One delegation per coordinator invocation, matching the real
+        # session (each pre-fix refine restarted the invocation). The
+        # plugin's before_run normally resets this counter per
+        # invocation; reset it here so the goldfive#130
+        # RUNAWAY_DELEGATION per-invocation backstop — which design
+        # doc §11.5 deliberately keeps orthogonal to descriptive
+        # growth — doesn't fold a second signal into this regression.
+        plugin._agent_tool_spawn_count = 0
+        await _dispatch_delegation(
+            plugin,
+            adk_state,
+            agent=_FakeSubAgent("debugger_agent"),
+            tool_args={"request": "locate cherry tree files"},
+            fc_id=f"fc-{i}",
+            inv_id=f"inv-{i}",
+        )
+
+    discovered = _discovered(session.plan)
+    assert len(discovered) == 1, (
+        f"20 same-args delegations must dedup to exactly 1 discovered "
+        f"task; got {len(discovered)}: {[t.id for t in discovered]}"
+    )
+    assert session.current_task_id == discovered[0].id
+    mismatches = [d for d in handled if d.kind is DriftKind.CAPABILITY_MISMATCH]
+    assert mismatches == [], (
+        f"2d27ff4a regression: {len(mismatches)} CAPABILITY_MISMATCH "
+        f"drift(s) fired; first: {mismatches[0].detail if mismatches else ''}"
+    )
+    assert planner.refine_calls == [], (
+        f"2d27ff4a regression: {len(planner.refine_calls)} refine(s) fired"
+    )
+    # Exactly one NEW_WORK_DISCOVERED revision landed (rev 1 → 2).
+    assert session.plan.revision_index == 2
+
+
+# ---------------------------------------------------------------------------
+# Legacy escape hatches.
+# ---------------------------------------------------------------------------
+
+
+async def test_flag_off_keeps_legacy_tier3_pin() -> None:
+    """``descriptive_growth_enabled=False`` restores the pre-#423 pin:
+    the tier-3 topo-order fallback binds the first eligible forecast
+    task and nothing grows. (The tier-3 scorer stays reachable ONLY on
+    this path; it is deleted in AGENCY-PRESERVATION.md PR 13.)
+    """
+    steerer, _planner, _sink = _make_steerer(descriptive_growth_enabled=False)
+    session = _make_session(_cherry_tree_plan())
+    plugin, adk_state = _wire_plugin(session, steerer)
+
+    await _dispatch_delegation(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("debugger_agent"),
+        tool_args={"request": "locate cherry tree files"},
+    )
+
+    assert _discovered(session.plan) == [], "flag off must not grow"
+    # Legacy behaviour: single eligible task bound by the shortcut.
+    assert session.current_task_id == "find_presentation_files"
+
+
+async def test_steerer_without_growth_helper_keeps_legacy_pin() -> None:
+    """A steerer whose ``plans`` lacks ``install_descriptive_growth``
+    keeps the legacy pin even with the flag on — signalling growth
+    with nobody to perform it would strand the delegation unpinned.
+    """
+
+    class _BarePlans:
+        pass
+
+    steerer, _planner, _sink = _make_steerer()
+    steerer.plans = _BarePlans()  # type: ignore[assignment]
+    session = _make_session(_cherry_tree_plan())
+    plugin, adk_state = _wire_plugin(session, steerer)
+
+    await _dispatch_delegation(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("debugger_agent"),
+        tool_args={"request": "locate cherry tree files"},
+    )
+
+    assert _discovered(session.plan) == []
+    assert session.current_task_id == "find_presentation_files"
+
+
+# ---------------------------------------------------------------------------
+# Reconciler growth (transfer_to_agent-style trees) — correctness req (d).
+# ---------------------------------------------------------------------------
+
+
+async def test_reconciler_unmatched_agent_grows_and_claims() -> None:
+    """``PlanReconciler.on_before_agent`` for an off-plan agent grows a
+    discovered task (degraded per-(agent, "") hash — before_agent
+    observations carry no tool args; §9 forward-compat) and claims it
+    RUNNING; ``on_after_agent`` then closes it COMPLETED.
+    """
+    from goldfive.reconciler import PlanReconciler
+    from goldfive.types import discovery_identity_hash
+
+    steerer, _planner, _sink = _make_steerer()
+    session = _make_session(_cherry_tree_plan())
+    rec = PlanReconciler(
+        session=session, steerer=steerer, host_agent_name="coordinator"
+    )
+
+    await rec.on_before_agent(agent_name="scout_agent", invocation_id="inv-s1")
+
+    discovered = _discovered(session.plan)
+    assert len(discovered) == 1, "unmatched agent must grow the ledger"
+    grown = discovered[0]
+    assert grown.assignee_agent_id == "scout_agent"
+    # Degraded hash: per-(agent_name, "") — no tool args at this hook.
+    assert grown.discovery_identity_hash == discovery_identity_hash(
+        "scout_agent", None
+    )
+    # Claimed RUNNING, and no divergence was recorded for the agent.
+    live = next(t for t in session.plan.tasks if t.id == grown.id)
+    assert live.status is TaskStatus.RUNNING
+    assert rec.divergence_events == []
+
+    await rec.on_after_agent(agent_name="scout_agent", invocation_id="inv-s1")
+    closed = next(t for t in session.plan.tasks if t.id == grown.id)
+    assert closed.status is TaskStatus.COMPLETED
+
+
+async def test_reconciler_degraded_hash_dedups_concurrent_observations() -> None:
+    """Two reconcilers (parallel invocations) observing the same
+    off-plan agent produce ONE discovered task — the degraded
+    per-(agent, "") hash dedups inside the plan lock (§11.6
+    linearisability applies to the reconciler trigger too).
+    """
+    import asyncio
+
+    from goldfive.reconciler import PlanReconciler
+
+    steerer, _planner, _sink = _make_steerer()
+    session = _make_session(_cherry_tree_plan())
+    rec_a = PlanReconciler(
+        session=session, steerer=steerer, host_agent_name="coordinator"
+    )
+    rec_b = PlanReconciler(
+        session=session, steerer=steerer, host_agent_name="coordinator"
+    )
+
+    await asyncio.gather(
+        rec_a.on_before_agent(agent_name="scout_agent", invocation_id="inv-a"),
+        rec_b.on_before_agent(agent_name="scout_agent", invocation_id="inv-b"),
+    )
+
+    discovered = _discovered(session.plan)
+    assert len(discovered) == 1, (
+        f"concurrent unmatched observations must dedup to 1 task; got "
+        f"{[t.id for t in discovered]}"
+    )
+
+
+async def test_reconciler_flag_off_keeps_divergence_record() -> None:
+    """With growth disabled the reconciler keeps the legacy behaviour:
+    a divergence record on ``divergence_events``, no plan mutation.
+    """
+    from goldfive.reconciler import PlanReconciler
+
+    steerer, _planner, _sink = _make_steerer(descriptive_growth_enabled=False)
+    session = _make_session(_cherry_tree_plan())
+    rec = PlanReconciler(
+        session=session, steerer=steerer, host_agent_name="coordinator"
+    )
+
+    await rec.on_before_agent(agent_name="scout_agent", invocation_id="inv-s1")
+
+    assert _discovered(session.plan) == []
+    assert len(rec.divergence_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Real dispatch path: full ADKAdapter.invoke with real ADK agents.
+# ---------------------------------------------------------------------------
+
+
+async def test_growth_fires_through_real_adk_adapter_invoke() -> None:
+    """End-to-end through the REAL dispatch path (no direct callback
+    calls): a genuine ADK coordinator + AgentTool tree driven by
+    ``ADKAdapter.invoke`` with a ``DefaultSteerer``. The coordinator
+    delegates once to an agent no forecast task matches — the plan
+    must grow a discovered task and pin it, proving the growth call
+    site is live middleware on the production callback path.
+    """
+    from google.adk.agents import Agent
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_response import LlmResponse
+    from google.adk.tools import FunctionTool
+    from google.adk.tools.agent_tool import AgentTool
+    from google.genai import types as genai_types
+
+    class _OneShotDelegator(BaseLlm):
+        model: str = "fake-model"
+        _step: int = 0
+
+        async def generate_content_async(self, llm_request: Any, stream: bool = False):  # noqa: ARG002
+            self._step += 1
+            if self._step == 1:
+                yield LlmResponse(
+                    content=genai_types.Content(
+                        role="model",
+                        parts=[
+                            genai_types.Part(
+                                function_call=genai_types.FunctionCall(
+                                    id="c1",
+                                    name="debugger_agent",
+                                    args={"request": "locate cherry tree files"},
+                                )
+                            ),
+                        ],
+                    ),
+                )
+            else:
+                yield LlmResponse(
+                    content=genai_types.Content(
+                        role="model",
+                        parts=[genai_types.Part(text="done")],
+                    ),
+                    turn_complete=True,
+                )
+
+    class _Quiet(BaseLlm):
+        model: str = "fake-model"
+
+        async def generate_content_async(self, llm_request: Any, stream: bool = False):  # noqa: ARG002
+            yield LlmResponse(
+                content=genai_types.Content(
+                    role="model",
+                    parts=[genai_types.Part(text="ok")],
+                ),
+                turn_complete=True,
+            )
+
+    def find_files(path: str) -> dict[str, Any]:  # noqa: ARG001
+        return {"ok": True}
+
+    debugger = Agent(
+        name="debugger_agent",
+        model=_Quiet(),
+        instruction="",
+        tools=[FunctionTool(find_files)],
+    )
+    coord = Agent(
+        name="coord",
+        model=_OneShotDelegator(),
+        instruction="",
+        tools=[AgentTool(debugger)],
+    )
+
+    from goldfive.adapters.adk import ADKAdapter
+
+    adapter = ADKAdapter(coord)
+    steerer, planner, _sink = _make_steerer()
+    handled = _capture_drifts(steerer)
+    adapter.bind_steerer(steerer)
+
+    plan = _cherry_tree_plan()
+    coord_task = Task(
+        id="t-coord",
+        title="Coordinate the work",
+        assignee_agent_id="coord",
+        status=TaskStatus.RUNNING,
+    )
+    plan = Plan(
+        id=plan.id,
+        run_id=plan.run_id,
+        goal_ids=list(plan.goal_ids),
+        tasks=[coord_task, *plan.tasks],
+        edges=list(plan.edges),
+        revision_index=plan.revision_index,
+    )
+    session = _make_session(plan)
+
+    await adapter.invoke(task=coord_task, session=session)
+
+    discovered = _discovered(session.plan)
+    assert len(discovered) == 1, (
+        f"real ADK dispatch must grow exactly one discovered task; "
+        f"plan tasks: {[t.id for t in session.plan.tasks]}"
+    )
+    assert discovered[0].assignee_agent_id == "debugger_agent"
+    mismatches = [d for d in handled if d.kind is DriftKind.CAPABILITY_MISMATCH]
+    assert mismatches == [], (
+        f"no CAPABILITY_MISMATCH may fire on the grown delegation; got "
+        f"{[d.detail for d in mismatches]}"
+    )
+    assert planner.refine_calls == []

--- a/tests/test_install_descriptive_growth.py
+++ b/tests/test_install_descriptive_growth.py
@@ -402,3 +402,42 @@ async def test_dedup_preserves_first_task_id_across_concurrent_calls() -> None:
         "concurrent same-args calls must dedup to a single discovered "
         f"task; got ids: {unique_ids}"
     )
+
+
+async def test_dedup_ttl_terminal_discovered_task_regrows() -> None:
+    """§11.1 TTL: dedup window ends when the discovered task goes terminal.
+
+    A fresh delegation whose identity hash matches a COMPLETED (or
+    otherwise terminal) discovered task is a genuinely new unit of
+    work — the helper must grow a NEW task instead of re-pinning the
+    finished one. (goldfive#423 / AGENCY-PRESERVATION.md PR 2.)
+    """
+    from goldfive.types import (
+        channel_processor_active,
+        set_session_plan,
+        with_task_status,
+    )
+
+    session = _make_session()
+    steerer = _make_steerer()
+
+    t1 = await steerer.plans.install_descriptive_growth(
+        session, agent_name="debugger_agent", tool_args_json='{"request": "locate"}'
+    )
+    # The discovered work finishes.
+    with channel_processor_active():
+        set_session_plan(
+            session, with_task_status(session.plan, t1.id, TaskStatus.COMPLETED)
+        )
+
+    t2 = await steerer.plans.install_descriptive_growth(
+        session, agent_name="debugger_agent", tool_args_json='{"request": "locate"}'
+    )
+
+    assert t2.id != t1.id, (
+        "a terminal discovered task must NOT absorb a fresh same-hash "
+        "delegation (§11.1 TTL)"
+    )
+    assert t2.discovery_identity_hash == t1.discovery_identity_hash
+    live = [t for t in session.plan.tasks if t.discovered]
+    assert {t.id for t in live} == {t1.id, t2.id}

--- a/tests/test_plan_descriptive_growth_race.py
+++ b/tests/test_plan_descriptive_growth_race.py
@@ -526,3 +526,100 @@ async def test_wait_plan_stable_observes_no_partial_growth() -> None:
             "post-stable snapshot must reflect the grown plan; "
             f"discovered={discovered} ids={ids}"
         )
+
+
+async def test_concurrent_identical_delegations_through_pin_path_grow_once() -> None:
+    """Tier-3-path variant (goldfive#423 / AGENCY-PRESERVATION.md PR 2).
+
+    The growth trigger moved from the Rule-C verdict path to the
+    delegation pin (``before_tool_callback`` → tier-1/2 miss →
+    ``install_descriptive_growth``). Two IDENTICAL delegations racing
+    through the full plugin pin path must still produce exactly ONE
+    discovered task: both sync pins miss the step-0 hash lookup (no
+    task installed yet), both signal growth, and the per-session plan
+    lock inside ``install_descriptive_growth`` linearises the two
+    installs — the loser dedups against the winner's task (§11.6).
+    """
+    pytest.importorskip("google.adk")
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+    from goldfive.config import SteeringConfig
+
+    session = _make_session()
+    planner = _StubPlanner(revised_factory=_refine_revised)
+    sink = _ListSink()
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(
+            observation_only=False, descriptive_growth_enabled=True
+        )
+    )
+    steerer.bind(sinks=[sink], planner=planner)
+
+    plugin = make_adk_plugin(host_agent_name="coordinator")
+    ctx_obj = SessionContext(
+        session=session,
+        steerer=steerer,
+        task=None,
+        tool_handlers={},
+        host_agent_name="coordinator",
+    )
+    plugin.set_active_context(ctx_obj)
+    adk_state: dict[str, Any] = {SESSION_CONTEXT_STATE_KEY: ctx_obj}
+
+    class _FakeAgent:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class _FakeLeafTool:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class _FakeSubAgent:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.tools = [_FakeLeafTool("find_files")]
+
+    class _FakeAgentTool:
+        def __init__(self, sub: Any) -> None:
+            self.agent = sub
+            self.name = sub.name
+
+    class _FakeInvocationContext:
+        def __init__(self, state: dict, inv_id: str) -> None:
+            class _ADKSession:
+                def __init__(self, s: dict) -> None:
+                    self.state = s
+
+            self.session = _ADKSession(state)
+            self.invocation_id = inv_id
+            self.agent = _FakeAgent("coordinator")
+
+    class _FakeToolContext:
+        def __init__(self, inv_ctx: Any, fc_id: str) -> None:
+            self._invocation_context = inv_ctx
+            self.function_call_id = fc_id
+
+    async def dispatch(i: int) -> None:
+        inv_ctx = _FakeInvocationContext(adk_state, f"inv-race-{i}")
+        await plugin.before_tool_callback(
+            tool=_FakeAgentTool(_FakeSubAgent("debugger_agent")),
+            tool_args={"request": "locate cherry tree files"},
+            tool_context=_FakeToolContext(inv_ctx, f"fc-race-{i}"),
+        )
+
+    await asyncio.gather(*(dispatch(i) for i in range(5)))
+
+    assert session.plan is not None
+    discovered = [
+        t for t in session.plan.tasks if getattr(t, "discovered", False)
+    ]
+    assert len(discovered) == 1, (
+        f"5 concurrent identical delegations through the pin path must "
+        f"dedup to 1 discovered task; got {len(discovered)}: "
+        f"{[t.id for t in discovered]}"
+    )
+    # Every dispatch converged on the same pin.
+    assert session.current_task_id == discovered[0].id


### PR DESCRIPTION
Completes goldfive#423 per `docs/design/PLAN-DESCRIPTIVE-GROWTH.md` §4.3 — this is **AGENCY-PRESERVATION.md Stage 1 PR 2**.

## The gap being fixed

#423 Phase 1 (#433) shipped descriptive growth but wired its trigger to the **CAPABILITY_MISMATCH Rule-C verdict path only**. Verified consequences:

- **Tier-3 misattribution survived**: `_score_candidates_by_args` (and the single-eligible shortcut before it) still pinned unmatched delegations onto arbitrary forecast tasks.
- **Rule-A misfires bypassed growth entirely**: the cherry-tree failure (e2e session `2d27ff4a`, 2026-05-13) — a coordinator delegated to `debugger_agent` 20+ times; each delegation mispinned `find_presentation_files` (the sole eligible task), fired CAPABILITY_MISMATCH **Rule A** (not Rule C), and triggered a refine. The Rule-C-only fallback never saw it.

## What this PR does

1. **`descriptive_growth_enabled` default → `True`** (`config.py`; env `GOLDFIVE_STEER_DESCRIPTIVE_GROWTH` unchanged).
2. **Growth trigger moved to pin time** (`_maybe_pin_delegation_task` + the `before_tool_callback` AgentTool branch), per §4.3:
   - step 0: dedup-hash re-pin against any non-terminal task carrying the §4.3.0 identity hash (§11.1 granularity + TTL);
   - tiers 1/2 run over **forecast** candidates, **even when only one is eligible** (the 2d27ff4a mispin shape);
   - tier-1/2 miss → `install_descriptive_growth` (lock-acquiring, §5 Option D) → pin the discovered task — **before** the `DelegationObserved` emit and **before any capability rule runs** (closes the Rule-A-bypass gap). The tier-3 scorer is never consulted on this path; it stays reachable only under `descriptive_growth_enabled=False` and is deleted in AGENCY-PRESERVATION PR 13 (comments in code say so).
3. **Rule C soft-retired**: `_rule_c_dag_order` runs only under explicit `GOLDFIVE_CAPABILITY_RULE_C=1` (design doc §7.1 step 1). The now-redundant Rule-C → growth fallback was removed from the verdict path (`_is_rule_c_verdict` + `_RULE_C_DETAIL_MARKER` deleted — grep confirms no other consumer existed). Rules A/B logic untouched (Rule A is PR 3's business); discovered bound tasks skip the detector per §11.4 resolution (a) so the auto-derived `agent: request` title can't re-fire Rule A.
4. **Reconciler growth trigger**: `PlanReconciler.on_before_agent`'s unmatched-agent branch applies the same dedup-hash → grow → claim flow for `transfer_to_agent`-style trees, using the documented **degraded per-`(agent_name, "")` hash** (§9 — `before_agent` observations carry no tool args; commented in code).
5. **§11.1 TTL enforced** in `install_descriptive_growth`'s dedup: terminal discovered tasks no longer absorb fresh same-hash delegations.
6. **Docs ship with code**: PLAN-DESCRIPTIVE-GROWTH.md §1 status + §9 PR table (PR 4 → shipped-soft / hard-deletion deferred to PR 13; PR 5 → shipped); DRIFT.md Rule C paragraph.

## Correctness requirements (AGENCY-PRESERVATION §5)

- **Dedup linearisability**: existing `test_plan_descriptive_growth_race.py` passes unmodified; new pin-path variant `test_concurrent_identical_delegations_through_pin_path_grow_once` (5 concurrent identical delegations through the full `before_tool_callback` → 1 discovered task).
- **New suite `tests/test_descriptive_growth_pin_time.py`** (13 tests): tier-1/tier-2 hits do NOT grow; tier-1/2 miss → growth + pin with the tier-3 scorer provably uninvoked, zero CAPABILITY_MISMATCH, zero refines; observation-mode growth (goldfive#258 carve-out); §11.1 granularity (different args → distinct tasks) + RUNNING re-pin; the **2d27ff4a regression** (20 same-args delegations → exactly 1 discovered task, 0 CAPABILITY_MISMATCH, 0 refines); flag-off + helper-missing legacy escape hatches; reconciler growth + degraded-hash concurrent dedup + flag-off divergence record; and a **real-dispatch-path e2e** (`ADKAdapter.invoke` over genuine ADK `Agent`/`AgentTool` objects with a `DefaultSteerer`).
- **Live-middleware check**: `install_descriptive_growth` call sites are on the production dispatch path — `_adk_plugin.py` `before_tool_callback` (via `_attempt_descriptive_growth`) and `reconciler.py:on_before_agent` (via `_maybe_grow_discovered_task`); both are exercised by integration tests that drive the real callbacks, not the helpers.
- Full suite: **2814 passed, 59 skipped**; `ruff check` clean.

## Test-migration table

Every change to an existing test, with justification (nothing deleted silently):

| Suite | Test | Change | Why |
|---|---|---|---|
| test_descriptive_growth_capability_mismatch_fallback.py | `test_flag_off_dispatches_rule_c_drift_as_today` | → `test_rule_c_dispatches_under_escape_hatch_without_growth` | Rule C is soft-retired; reaching the legacy dispatch now requires `GOLDFIVE_CAPABILITY_RULE_C=1`. Same assertions (1 Rule C drift, no growth) under the explicit hatch. |
| 〃 | `test_flag_on_grows_discovered_task_and_suppresses_rule_c` | → `test_verdict_path_no_longer_grows` (polarity inverted) | The growth this test asserted on the verdict path moved to pin time; the verdict path must now grow NOTHING. The positive (growth + pin + suppression) is re-pointed to `test_descriptive_growth_pin_time.py::test_tier12_miss_grows_and_pins_without_tier3_or_mismatch`. |
| 〃 | `test_flag_on_rule_a_still_fires` | kept; dropped `tool_args_json`/`delegation_event_id` kwargs | Those params only threaded growth data; growth left this method, so the params were removed (no dead parameters). Assertions unchanged. |
| 〃 | `test_flag_on_dedups_repeated_unmatched_delegations` | migrated to `test_descriptive_growth_pin_time.py::test_2d27ff4a_repeated_delegations_one_task_no_drift` | Dedup now exercises the pin path — where the repeated delegations actually arrive — with strictly stronger assertions (exactly 1 task, 0 drifts, 0 refines, 1 revision). |
| 〃 | (new) `test_rule_c_silent_by_default_on_verdict_path`, `test_discovered_bound_task_skips_capability_rules` | added | Pin the two new verdict-path behaviours: Rule C default-silent (req (c)) and the §11.4(a) discovered-task skip. |
| test_capability_mismatch.py | 9 Rule-C mechanics tests (positive, 5 negatives, 2 precedence, excludes-bound) + `test_integration_rule_c_dag_order_mismatch_through_pin` | added `_rule_c_escape_hatch` fixture (`GOLDFIVE_CAPABILITY_RULE_C=1`) | The rule's implementation survives until PR 13's hard deletion; these tests keep its mechanics pinned under the hatch instead of going silently vacuous. No assertion changed. |
| 〃 | (new) `test_rule_c_soft_retired_silent_by_default` | added | Pins the new default: the canonical Rule C positive shape returns `None` without the env flag (req (c)). |
| test_install_descriptive_growth.py | (new) `test_dedup_ttl_terminal_discovered_task_regrows` | added | Pins the §11.1 TTL fix in `install_descriptive_growth`. |
| test_plan_descriptive_growth_race.py | (new) `test_concurrent_identical_delegations_through_pin_path_grow_once` | added | The required tier-3-path race variant. Existing race tests unmodified. |
| test_delegation_pin.py | **unmodified, green** | — | Its fixtures use `steerer=None` / config-less stubs, which keep the legacy tier-2/3 path by design (`_growth_at_pin_enabled` requires a typed config + the growth helper). |

## For PR 3 (ladder demotions, Rule A → OBSERVE)

- The §11.4(a) discovered-task skip lives in `_maybe_emit_capability_mismatch` (caller-side), not in `capability_check.py` — Rule A's code is untouched and ready for the OBSERVE demotion.
- Rule C's hard deletion (PR 13) removes `_rule_c_dag_order`, `_task_text_contains_stem`, the `all_pending_tasks` parameter, the `GOLDFIVE_CAPABILITY_RULE_C` env read, and the `_rule_c_escape_hatch`-marked tests.
- The tier-3 scorer (`_score_candidates_by_args`) is still live in OTHER resolution paths (`_pin_delegation_task_id`, the pin-resolution ladder, executor task resolution) — PR 13's "delete the tier-3 scorer" applies to the `_maybe_pin_delegation_task` legacy branch; the other call sites need their own disposition.

Design refs: PLAN-DESCRIPTIVE-GROWTH.md §4.3/§4.3.0/§7/§9/§11/§13; AGENCY-PRESERVATION.md §1.2, Stage 1 PR 2, §5.
