### PR TITLE
feat(steering): observation+goal note composers replace corrective command templates (AGENCY-PRESERVATION PR 4)

### DIFF
--- a/goldfive/drift/goals.py
+++ b/goldfive/drift/goals.py
@@ -105,7 +105,13 @@ GOAL_DRIFT_USER_PROMPT_TEMPLATE: str = (
     "STRICTLY in one of these two JSON shapes:\n"
     '{{"progressing": true}}\n'
     "OR\n"
-    '{{"progressing": false, "reason": "one-sentence explanation"}}\n\n'
+    '{{"progressing": false, "reason": "one-sentence explanation", '
+    '"note_to_agent": "one or two sentences addressed to the agent '
+    "itself: state only what you observed and how it relates to the "
+    "goals. Neutral and factual — no commands, no instructions about "
+    "which task, tool, or agent to use next, and no fault language. "
+    "If your confidence is low, phrase the note as a question (e.g. "
+    "'Does the current approach still serve the goal of X?')\"}}\n\n"
     "Progressing = agents are doing work that plausibly contributes to "
     "the goal.\n"
     "Not progressing = agents are looping, refusing, off-topic, or "
@@ -474,6 +480,12 @@ async def classify_goal_drift(
     # goldfive decide this is off-goal?" on the timeline without
     # re-fetching the per-invocation activity log.
     trigger_input = _truncate_trigger_input(activity_block)
+    # AGENCY-PRESERVATION.md PR 4 — the judge authors the agent-facing
+    # observation in the same call that produced the verdict. Old-style
+    # responses (key absent / non-string) degrade to "" and the
+    # observer-note composer falls back to ``detail``.
+    note_raw = parsed.get("note_to_agent", "")
+    note_to_agent = note_raw.strip() if isinstance(note_raw, str) else ""
     return DriftEvent(
         kind=DriftKind.GOAL_DRIFT,
         severity=DriftSeverity.CRITICAL,
@@ -482,6 +494,7 @@ async def classify_goal_drift(
         current_agent_id=current_agent_id,
         trigger_input=trigger_input,
         observed_revision_index=observed_revision_index,
+        note_to_agent=note_to_agent,
     )
 
 

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -163,7 +163,7 @@ REASONING_DRIFT_USER_PROMPT_TEMPLATE: str = (
     "{tool_obs_block}\n\n"
     "REASONING (the agent's most recent chain-of-thought block):\n"
     "{reasoning_block}\n\n"
-    "Decide THREE things:\n"
+    "Decide FOUR things:\n"
     "1. CLASSIFICATION. Which best describes the reasoning?\n"
     "   - on_task: it advances the BOUND TASK or the GOALS.\n"
     "   - justified_deviation: it departs from the BOUND TASK, but a recent\n"
@@ -185,7 +185,15 @@ REASONING_DRIFT_USER_PROMPT_TEMPLATE: str = (
     "   signal that justifies the deviation. Pick exactly one of:\n"
     "     tool_error | surprising_result | discovered_dependency | new_information\n"
     "   When classification is on_task or erroneous_deviation, set\n"
-    '   provenance to "none".\n\n'
+    '   provenance to "none".\n'
+    "4. NOTE. ONLY when classification is NOT on_task, write note_to_agent:\n"
+    "   one or two sentences addressed to the agent itself, stating only what\n"
+    "   you observed and how it relates to the GOALS. Neutral and factual —\n"
+    "   no commands, no instructions about which task, tool, or agent to use\n"
+    "   next, and no fault language (avoid words like 'failed', 'wrong',\n"
+    "   'broken'). If your confidence in this verdict is low, phrase the note\n"
+    '   as a question (e.g. "Does the current approach still serve the goal\n'
+    '   of X?"). When classification is on_task, set note_to_agent to "".\n\n'
     "Reply with a single JSON object and nothing else, in this shape:\n"
     "{{\n"
     '  "classification": "on_task" | "justified_deviation" | "erroneous_deviation",\n'
@@ -196,7 +204,9 @@ REASONING_DRIFT_USER_PROMPT_TEMPLATE: str = (
     '  "focused_task_id": "<id from PLAN TASKS, or \'\' if off-plan>",\n'
     '  "focus_confidence": 0.0-1.0,\n'
     '  "stated_intent": "one-sentence summary of what the agent says it '
-    'is doing"\n'
+    'is doing",\n'
+    '  "note_to_agent": "one-or-two-sentence neutral observation for the '
+    "agent, or '' when on_task\"\n"
     "}}\n\n"
     "GUIDANCE:\n"
     "- on_task includes clarifying sub-steps, exploring tradeoffs, and\n"
@@ -656,6 +666,16 @@ class ReasoningJudgeVerdict:
     # change ships in PR 3 (parser) + PR 4 (routing).
     classification: str = ""
     provenance: str = ""
+    # AGENCY-PRESERVATION.md PR 4 — the judge's agent-facing
+    # observation, authored in the same call that produced the verdict
+    # (prompt decision 4). Neutral facts relative to the goals; question
+    # form when the judge is unsure. Mirrored onto
+    # ``DriftEvent.note_to_agent`` for non-on_task verdicts so the
+    # observer-note composers prefer it over ``detail``. Empty string
+    # for on_task verdicts, quiet-failure paths, and old-style
+    # responses that omit the field (graceful degradation: the
+    # composer falls back to ``detail``).
+    note_to_agent: str = ""
 
 
 # Map the judge's ``severity`` string to a :class:`DriftSeverity`. Missing
@@ -932,6 +952,10 @@ async def classify_reasoning_drift_with_focus(
     # below populates these post-call.
     classification_parsed: str = ""
     provenance_parsed: str = ""
+    # AGENCY-PRESERVATION.md PR 4 — judge-authored agent-facing
+    # observation. Empty for on_task verdicts, quiet-failures, and
+    # old-style responses missing the field.
+    note_to_agent_parsed: str = ""
     try:
         async with goldfive_llm_span(
             sinks=span_sinks,
@@ -1048,6 +1072,15 @@ async def classify_reasoning_drift_with_focus(
                 intent_raw = parsed.get("stated_intent", "")
                 if isinstance(intent_raw, str):
                     stated_intent_parsed = intent_raw.strip()
+                # AGENCY-PRESERVATION.md PR 4 — the agent-facing note.
+                # Only honoured on non-on_task verdicts (the prompt
+                # asks for "" on on_task; a chatty model that fills it
+                # anyway is ignored so healthy turns stay note-free).
+                # Old-style responses (key absent) degrade to "".
+                if classification_parsed and classification_parsed != "on_task":
+                    note_raw = parsed.get("note_to_agent", "")
+                    if isinstance(note_raw, str):
+                        note_to_agent_parsed = note_raw.strip()
             # Build the span's output / decision strings from the parsed
             # verdict so harmonograf can render "judged agent/task:
             # on-task" inline.
@@ -1179,6 +1212,7 @@ async def classify_reasoning_drift_with_focus(
                     reasoning, REASONING_JUDGE_MAX_REASONING_INPUT_CHARS
                 ),
                 observed_revision_index=observed_revision_index,
+                note_to_agent=note_to_agent_parsed,
             )
         else:
             # erroneous_deviation — same wire shape as the pre-iter-10
@@ -1236,6 +1270,7 @@ async def classify_reasoning_drift_with_focus(
                     reasoning, REASONING_JUDGE_MAX_REASONING_INPUT_CHARS
                 ),
                 observed_revision_index=observed_revision_index,
+                note_to_agent=note_to_agent_parsed,
             )
     # Emit ReasoningJudgeInvoked on every invocation, regardless of
     # verdict. Done after the drift decision so the event carries the
@@ -1276,6 +1311,7 @@ async def classify_reasoning_drift_with_focus(
         stated_intent=stated_intent_parsed,
         classification=classification_parsed,
         provenance=provenance_parsed,
+        note_to_agent=note_to_agent_parsed,
     )
 
 

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -3387,12 +3387,12 @@ class DriftObserver:
         (USER_STEER side effects, freshness-watermark check) have
         already run; this method jumps straight into cancel + refine.
         """
+        from goldfive.observer_notes import compose_note_for_drift
         from goldfive.steerer import (
             _ABSORB_NUDGE_KINDS,
             InterventionLevel,
             RefineExhausted,
             _planner_refine_accepts_available_agents,
-            compose_corrective_user_message,
         )
 
         # Tag the bound adapter's next cancel with a symbolic reason so
@@ -3885,10 +3885,11 @@ class DriftObserver:
         # rescue — their corrective path fires at the next task
         # boundary or via Level 3 CANCEL_REINVOKE.
         if level is InterventionLevel.ABSORB and drift.kind in _ABSORB_NUDGE_KINDS:
-            nudge_msg = compose_corrective_user_message(
-                drift=drift,
-                refined_plan=session.plan,
-            )
+            # AGENCY-PRESERVATION.md PR 4: the nudge body is an
+            # observation+goal advisory note, not a directive about
+            # which task / agent comes next. Same queue, same overlay
+            # replay path — content only.
+            nudge_msg = compose_note_for_drift(drift=drift, session=session)
             session.pending_nudges.append(nudge_msg)
             log.debug(
                 "DefaultSteerer._handle_drift: queued post-ABSORB nudge for kind=%s task=%s: %s",
@@ -3908,13 +3909,14 @@ class DriftObserver:
         nudge at the next invocation boundary and sends it as a gentle
         corrective user message. Until #141 lands, the queue is
         observable but inert; nothing consumes it.
-        """
-        from goldfive.steerer import compose_corrective_user_message
 
-        msg = compose_corrective_user_message(
-            drift=drift,
-            refined_plan=session.plan,
-        )
+        Body content (AGENCY-PRESERVATION.md PR 4): an observation+goal
+        advisory note from :mod:`goldfive.observer_notes` — no
+        next-task / next-agent directives.
+        """
+        from goldfive.observer_notes import compose_note_for_drift
+
+        msg = compose_note_for_drift(drift=drift, session=session)
         session.pending_nudges.append(msg)
         log.debug(
             "DefaultSteerer: queued nudge for kind=%s task=%s: %s",
@@ -3942,23 +3944,21 @@ class DriftObserver:
         body. The promotion path passes its already-composed
         :meth:`_compose_goldfive_steer_body` output; the Level 3
         CANCEL_REINVOKE path leaves it empty and falls back to
-        :func:`compose_corrective_user_message` against the freshly
-        revised plan.
+        :func:`goldfive.observer_notes.compose_note_for_drift` against
+        the freshly revised plan (AGENCY-PRESERVATION.md PR 4 —
+        observation+goal note, not a next-task directive).
 
         Returns ``True`` on successful dispatch, ``False`` on no
         bound channel / send failure (best-effort — see
         :meth:`DefaultSteerer._dispatch_goldfive_control`).
         """
         from goldfive.control import ControlKind, ControlMessage
-        from goldfive.steerer import compose_corrective_user_message
+        from goldfive.observer_notes import compose_note_for_drift
 
         if body_override:
             body = body_override
         else:
-            body = compose_corrective_user_message(
-                drift=drift,
-                refined_plan=session.plan,
-            )
+            body = compose_note_for_drift(drift=drift, session=session)
         superseded_ids = (
             [str(drift.current_task_id)] if drift.current_task_id else []
         )
@@ -4939,7 +4939,7 @@ class DriftObserver:
         # ``at_turn`` is the logical-turn counter (goldfive#441), the
         # same surface the user-steer freshness window reads.
         at_turn = int(getattr(session, "_reasoning_turn", 0) or 0)
-        body = self._compose_goldfive_steer_body(drift)
+        body = self._compose_goldfive_steer_body(drift, session)
         try:
             _ostate.set_active_steer(
                 session.state,
@@ -5241,26 +5241,31 @@ class DriftObserver:
         )
 
     @staticmethod
-    def _compose_goldfive_steer_body(drift: DriftEvent) -> str:
+    def _compose_goldfive_steer_body(drift: DriftEvent, session: Session) -> str:
         """Derive the steer body for a goldfive-promoted drift.
 
-        Prefers ``drift.detail`` verbatim — the reasoning judge and
-        other LLM-as-a-judge paths already emit human-readable reasons
-        like "agent acknowledged discrepancy but chose to adopt
-        expanded topic" that are directly usable as a corrective. When
-        ``detail`` is empty, synthesise a generic template from the
-        drift's kind / severity / task context.
+        AGENCY-PRESERVATION.md PR 4: renders the full observation+goal
+        advisory note via :mod:`goldfive.observer_notes`. The
+        observation-sourcing chain is formalised there
+        (:func:`~goldfive.observer_notes.observation_for_drift`):
+
+        1. ``drift.note_to_agent`` verbatim — the judge authored the
+           agent-facing observation in the same call that produced the
+           verdict;
+        2. structured detector facts (tool-loop counts / fingerprints
+           on ``drift.raw``);
+        3. ``drift.detail`` verbatim — the pre-PR-4 preference, kept as
+           the fallback for judges that don't author notes;
+        4. a per-kind neutral fallback template (replaces the retired
+           "Goldfive detected {KIND} drift … proceed with the
+           corrective plan" command text).
+
+        ``session`` supplies the goals line and the bookkeeping Status
+        snapshot.
         """
-        detail = str(getattr(drift, "detail", "") or "").strip()
-        if detail:
-            return detail
-        task_id = drift.current_task_id or "the current task"
-        return (
-            f"Goldfive detected {drift.kind.name} drift "
-            f"(severity={drift.severity.name}). The preceding agent "
-            f"output did not match the task: {task_id}. Discard prior "
-            "work on this task and proceed with the corrective plan."
-        )
+        from goldfive.observer_notes import compose_note_for_drift
+
+        return compose_note_for_drift(drift=drift, session=session)
 
     # ------------------------------------------------------------------
     # USER_STEER state handler (goldfive#152)

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -1943,37 +1943,36 @@ class SequentialExecutor(Executor):
         Mirrors :meth:`_compose_steer_restart_message` but for the
         autonomous-nudge path (goldfive#202). The LLM sees:
 
-        * A header distinguishing this from a fresh user turn: the
-          operator did not intervene; goldfive detected drift (e.g.
-          repeated ``report_task_completed`` calls), revised the plan,
-          and is directing the coordinator to the new next task.
-        * Each queued nudge verbatim (short, action-focused strings
-          composed by :func:`compose_corrective_user_message`).
-        * A brief instruction to continue with the revised plan.
+        * A header distinguishing this from a fresh user turn (the
+          ``[GOLDFIVE PLAN REVISION`` attribution marker is preserved
+          for plugins / sinks / prompt templates that match on it).
+        * Each queued nudge verbatim — full observation+goal advisory
+          notes composed by
+          :func:`goldfive.observer_notes.compose_note_for_drift`
+          (AGENCY-PRESERVATION.md PR 4: the pre-PR-4 body commanded
+          means — "Proceed with the replacement; do NOT retry the
+          prior task" — which overrode the agent's own judgment about
+          decomposition and retries; the note body now carries neutral
+          facts, the user's goal, and the advisory footer instead).
 
         The scoped replay path is the carefully-narrowed successor to
         the blanket follow-up loop that goldfive#163 removed. #163's
         removal was correct when every PENDING task triggered a
         follow-up; this path only fires when the STEERER explicitly
         queued a nudge in response to a tracked drift + plan
-        revision — not on every PENDING-at-invocation-end.
+        revision — not on every PENDING-at-invocation-end. Delivery
+        mechanics (queue, replay cap, reconciler reset, re-entry
+        kind) are unchanged by PR 4 — content only.
         """
-        body = "\n".join(f"- {n}" for n in nudges if n)
+        body = "\n\n".join(n for n in nudges if n)
         return (
-            "[GOLDFIVE PLAN REVISION — replace superseded task(s)]\n"
+            "[GOLDFIVE PLAN REVISION — observer note]\n"
             "\n"
-            "Goldfive detected drift during the prior turn and revised "
-            "the active plan. The task you were last working on has "
-            "been superseded by a replacement. Proceed with the "
-            "replacement; do NOT retry the prior task.\n"
+            "goldfive — an external monitoring layer, not the user — "
+            "revised its plan bookkeeping during the prior turn. The "
+            "note(s) below describe what it observed.\n"
             "\n"
-            f"{body}\n"
-            "\n"
-            "Notes:\n"
-            "- Continue the run with the revised plan. Resume with the "
-            "next unfinished task — the replacement mentioned above, "
-            "or any other PENDING task your tree still owns.\n"
-            "- Do not re-invoke reporting tools for the superseded task."
+            f"{body}"
         )
 
     @staticmethod
@@ -2001,14 +2000,21 @@ class SequentialExecutor(Executor):
 
         * ``"user"`` (default) — ``[USER STEERING CONTROL — supersedes
           prior task context]`` header: this is an operator override,
-          not a fresh user turn.
+          not a fresh user turn. **Byte-identical to the pre-PR-4
+          rendering** — AGENCY-PRESERVATION.md PR 4 changes only
+          goldfive-authored content; user-authority relay text is
+          untouched (and pinned by test).
         * ``"goldfive"`` — ``[GOLDFIVE STEERING CONTROL — supersedes
-          prior task context]`` header: goldfive's drift ladder
-          promoted a detector signal into a steer and is directing the
-          coordinator away from contaminated work. When the optional
+          prior task context]`` header (the attribution marker is
+          preserved so plugins / sinks can discriminate authors). The
+          body is the observation+goal advisory note the steerer
+          composed via :mod:`goldfive.observer_notes`. The optional
           ``superseded_task_ids`` / ``replacement_task_ids`` lists are
-          provided, a task-id block is appended so the LLM knows
-          precisely which ids are void and what replaced them.
+          rendered as a *bookkeeping* line — goldfive's ledger facts,
+          not instructions (the pre-PR-4 "do NOT resume these" /
+          "pick these up instead" command block is retired; the ids
+          also remain on the ControlMessage payload for
+          observability).
 
         Falls back to ``fallback`` when the extracted text is empty,
         then wraps that fallback in the same header so the re-invocation
@@ -2026,32 +2032,28 @@ class SequentialExecutor(Executor):
         source_norm = (source or "user").strip().lower()
         if source_norm == "goldfive":
             header = "[GOLDFIVE STEERING CONTROL — supersedes prior task context]"
-            extra_notes: list[str] = []
+            bookkeeping_bits: list[str] = []
             sup = [str(t) for t in (superseded_task_ids or []) if t]
             rep = [str(t) for t in (replacement_task_ids or []) if t]
             if sup:
-                extra_notes.append(
-                    "- Superseded task ids (do NOT resume these): "
+                bookkeeping_bits.append(
+                    "goldfive's plan tracking records task id(s) "
                     + ", ".join(sup)
+                    + " as superseded by this revision"
                 )
             if rep:
-                extra_notes.append(
-                    "- Replacement task ids (pick these up instead): "
-                    + ", ".join(rep)
+                bookkeeping_bits.append(
+                    "its ledger contains replacement entrie(s): " + ", ".join(rep)
                 )
-            extra_block = ("\n" + "\n".join(extra_notes)) if extra_notes else ""
+            extra_block = (
+                ("\n\ngoldfive bookkeeping (for reference): " + "; ".join(bookkeeping_bits) + ".")
+                if bookkeeping_bits
+                else ""
+            )
             return (
                 f"{header}\n"
                 "\n"
-                f"{effective}\n"
-                "\n"
-                "Notes:\n"
-                "- Goldfive detected drift in the prior turn's activity. "
-                "Prior research, partial work, or planned tasks from the "
-                "contaminated step are superseded unless this message "
-                "explicitly references them.\n"
-                "- Proceed with the corrective direction above. Do not "
-                "retry the superseded task."
+                f"{effective}"
                 f"{extra_block}"
             )
         return (

--- a/goldfive/judges/base.py
+++ b/goldfive/judges/base.py
@@ -137,6 +137,21 @@ class JudgeVerdict:
     ``detail`` is a free-form one-line human-readable explanation that
     every flavour can populate. Surfaced on
     :class:`JudgementEmitted.detail` for the UI.
+
+    ``note_to_agent`` (AGENCY-PRESERVATION.md PR 4) is an optional
+    observation addressed to the *wrapped agent*, authored by the judge
+    in the same evaluation that produced the verdict: one or two
+    neutral, factual sentences stating what was observed relative to
+    the user's goal — no commands, no fault language; question form
+    when the judge's confidence is low. Drift-flavoured verdicts thread
+    it onto :attr:`~goldfive.types.DriftEvent.note_to_agent` (see
+    ``DefaultSteerer._drift_from_judge_verdict``) where
+    :mod:`goldfive.observer_notes` prefers it verbatim over ``detail``
+    when composing agent-facing notes. Optional and additive: judges
+    that never populate it (including every pre-PR-4 judge) degrade
+    gracefully to the ``detail`` fallback. Not emitted on the
+    ``JudgementEmitted`` proto envelope in this PR (no proto regen;
+    the wire surface belongs to the PR 5 telemetry pass).
     """
 
     # drift-flavored (back-compat with existing detectors). ``drift_kind``
@@ -155,6 +170,11 @@ class JudgeVerdict:
     numeric_value: float | None = None
     metric_name: str = ""
     detail: str = ""
+    # AGENCY-PRESERVATION.md PR 4 — judge-authored agent-facing
+    # observation (see class docstring). Follows the additive-field
+    # pattern the enum-typed drift fields established: optional,
+    # default-empty, back-compat with every existing constructor call.
+    note_to_agent: str = ""
 
     def __post_init__(self) -> None:
         # The dataclass is ``frozen``; ``object.__setattr__`` is the

--- a/goldfive/observer_notes.py
+++ b/goldfive/observer_notes.py
@@ -1,0 +1,442 @@
+"""Observation + goal note composers (AGENCY-PRESERVATION.md PR 4).
+
+Every message goldfive composes *for the wrapped agent* renders through
+this module. The content contract replaces the retired
+``_CORRECTIVE_TEMPLATES`` / ``compose_corrective_user_message`` command
+templates ("proceed to '{next_task_title}' via {next_task_agent}",
+"do NOT retry") with the observation+goal shape from
+``docs/design/AGENCY-PRESERVATION.md`` §2 (surface 3 — *speak*: honestly
+attributed advisory notes) and the PR 4 entry:
+
+* **Observation** — factual and evidence-bearing ("``search_web`` was
+  called 5 times in the last 10 tool calls with identical arguments"),
+  never imperative, never problem-naming ("failed" / "broken" /
+  "wrong"). The neutral-framing lesson comes from
+  :mod:`goldfive._correction_injection` (goldfive#250 / #252 / #253):
+  problem-naming language provokes apologies / meta-commentary /
+  retries-of-the-wrong-thing — but where #251 chose *directive*
+  framing as the alternative, observer notes are *neither* commanding
+  nor apology-bait: neutral facts plus the goal.
+* **The user's goal** — verbatim from ``session.goals`` so the agent
+  re-anchors on the authoritative reference, not on goldfive's opinion
+  of what to do next.
+* **Status** (optional) — goldfive's bookkeeping presented AS
+  bookkeeping ("goldfive's tracking shows task t2 recorded as
+  completed"), never as instruction. Task ids may appear here as
+  ledger facts; they never appear as commands.
+* **Advisory footer** — the explicit authority statement. Control
+  (cancel / pause / terminate) stays on the control channel and never
+  depends on the agent honouring a note (the no-prompt-contract rule).
+
+Question form
+-------------
+When the triggering verdict is an LLM judge's *opinion* (rather than a
+counted, observed fact) and its severity sits below CRITICAL, the note
+is rendered in question form ("… does the current approach still serve
+the user's goal?"). A self-generated correction integrates into a
+trajectory better than an external one, and a question is the
+lowest-footprint speech act available. Statement form stays for hard
+observed facts (loop counters, budgets) and for CRITICAL judge
+verdicts. Neither :class:`~goldfive.types.DriftEvent` nor
+:class:`~goldfive.judges.JudgeVerdict` carries a per-verdict confidence
+scalar today (``focus_confidence`` on ``ReasoningJudgeVerdict`` scores
+*task attribution*, not the drift verdict itself), so severity is the
+confidence proxy; judges asked to author ``note_to_agent`` directly are
+additionally prompted to phrase the note as a question when unsure.
+
+Rendered shape (PR 6 compatibility)
+-----------------------------------
+The body lines produced here match the "Rendered block shape" the PR 6
+observer-note channel will wrap in ``[GOLDFIVE OBSERVER NOTE …]``
+markers::
+
+    Observation: <factual description of what was observed>
+    The user's goal: <from session.goals>
+    Status: <bookkeeping snapshot>            (optional)
+    This note is advisory. How to proceed is your decision; the user's
+    instructions remain authoritative.
+
+Until PR 6 lands, the legacy delivery paths (nudge replay, GOLDFIVE
+steer restart, active-steer body) consume this rendering as plain text;
+only their ``[GOLDFIVE …]`` attribution headers are added by the
+executor (delivery mechanics unchanged in this PR).
+
+Observation sourcing — the fallback chain
+-----------------------------------------
+:func:`observation_for_drift` resolves the observation text in strict
+preference order:
+
+1. ``drift.note_to_agent`` — authored by the LLM judge in the same call
+   that produced the verdict (PR 4 scope item 3; prompts in
+   :mod:`goldfive.drift.reasoning_judge` / :mod:`goldfive.drift.goals`).
+   Used verbatim; the judge already chose statement vs question form.
+2. Deterministic detector facts — for tool-loop drifts the structured
+   ``drift.raw`` payload (tool name, exact-match args fingerprint,
+   counts, window length) renders directly into the observation line.
+   No new LLM calls, no NL classification — counts and exact-match
+   hashes only (the #166/#167 rule).
+3. ``drift.detail`` — the human-readable reason every detector already
+   emits.
+4. A per-kind neutral fallback template (no detail available at all).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from goldfive.types import (
+    TERMINAL_TASK_STATUSES,
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Plan,
+    TaskStatus,
+)
+
+if TYPE_CHECKING:
+    from goldfive.types import Session
+
+__all__ = [
+    "ADVISORY_FOOTER",
+    "GOAL_QUESTION",
+    "compose_note_for_drift",
+    "compose_observer_note",
+    "compose_status_line",
+    "observation_for_drift",
+    "render_goals_text",
+]
+
+
+#: The advisory footer every note carries. Exact wording pinned by the
+#: AGENCY-PRESERVATION.md PR 6 "Rendered block shape" — PR 6's channel
+#: wraps these same lines, so the text must not fork between regimes.
+ADVISORY_FOOTER: str = (
+    "This note is advisory. How to proceed is your decision; the user's "
+    "instructions remain authoritative."
+)
+
+#: Question-form suffix appended to the observation when the verdict is
+#: a low-confidence judge opinion (see module docstring). Mirrors the
+#: design doc's example phrasing.
+GOAL_QUESTION: str = "Does the current approach still serve the user's goal?"
+
+
+# Drift kinds minted by LLM judges (subjective opinions) rather than by
+# deterministic counters. Below-CRITICAL verdicts of these kinds render
+# in question form when goldfive composes the observation itself (a
+# judge-authored ``note_to_agent`` already chose its own form).
+_JUDGE_OPINION_KINDS: frozenset[DriftKind] = frozenset(
+    {
+        DriftKind.OFF_TOPIC,
+        DriftKind.GOAL_DRIFT,
+        DriftKind.INTENT_DIVERGENCE,
+        DriftKind.JUSTIFIED_DEVIATION,
+        DriftKind.UNCERTAIN_PROGRESS,
+    }
+)
+
+
+# Per-kind neutral fallback observations, used only when the drift
+# carries neither a judge-authored note, structured detector facts, nor
+# a ``detail`` string. ``{task}`` interpolates the current task id (or
+# the readable placeholder). Wording rules: facts only; no imperative
+# means-verbs ("retry", "proceed to", "call", "do not", …); no
+# problem-naming ("failed" / "broken" / "wrong" — the
+# ``_correction_injection`` lesson); no goldfive postmortem jargon in
+# the prose ("drift", "steerer", "synthetic").
+_FALLBACK_OBSERVATIONS: dict[DriftKind, str] = {
+    DriftKind.LOOPING_REASONING: (
+        "Repeated, near-identical activity was observed on {task} "
+        "without recorded progress."
+    ),
+    DriftKind.LOOPING_TOOL_CALL: (
+        "The same tool invocation was observed several times on {task} "
+        "without recorded progress."
+    ),
+    DriftKind.PLAN_DIVERGENCE: (
+        "goldfive's plan tracking did not match the activity observed on {task}."
+    ),
+    DriftKind.AGENT_REFUSAL: (
+        "The most recent response on {task} declined to continue."
+    ),
+    DriftKind.MODEL_REFUSAL: (
+        "The model declined to produce a response on {task}."
+    ),
+    DriftKind.INTENT_DIVERGENCE: (
+        "Recent reasoning on {task} moved away from the stated goals."
+    ),
+    DriftKind.TOOL_ERROR: (
+        "A tool invocation on {task} returned an error result."
+    ),
+    DriftKind.RUNAWAY_DELEGATION: (
+        "A large number of delegations was observed while {task} remained open."
+    ),
+    DriftKind.SELF_REPORTED_STUCK: (
+        "In a recent self-check, the agent's own assessment reported no "
+        "progress on {task}."
+    ),
+    DriftKind.CONFABULATION_RISK: (
+        "Output on {task} referenced external data, but no tool "
+        "invocation was recorded for it."
+    ),
+    DriftKind.GOAL_DRIFT: (
+        "Recent activity did not appear to advance the user's goal "
+        "while {task} was active."
+    ),
+    DriftKind.OFF_TOPIC: (
+        "Recent reasoning on {task} appeared unrelated to the bound "
+        "task and goals."
+    ),
+    DriftKind.JUSTIFIED_DEVIATION: (
+        "Recent reasoning on {task} departed from the recorded task in "
+        "response to new information."
+    ),
+}
+
+#: Generic fallback for kinds without a dedicated template. Phrased as
+#: an open observation (the question-form decision still applies on
+#: top of it for judge-opinion kinds).
+_GENERIC_FALLBACK_OBSERVATION: str = (
+    "goldfive's monitoring raised a signal while {task} was active."
+)
+
+
+def render_goals_text(goals: Any) -> str:
+    """Project ``session.goals`` onto a one-line verbatim summary string.
+
+    Joins each goal's ``summary`` (or the goal itself when it is a
+    plain string) with ``"; "`` so a multi-goal session reads as one
+    compact line. Returns ``"(no goals recorded for this run)"`` when
+    no goals are available so the note shape stays invariant — the
+    PR 6 block always carries the goal line.
+    """
+    summaries: list[str] = []
+    for g in goals or ():
+        summary = str(getattr(g, "summary", "") or "")
+        if not summary and isinstance(g, str):
+            summary = g
+        summary = summary.strip()
+        if summary:
+            summaries.append(summary)
+    if not summaries:
+        return "(no goals recorded for this run)"
+    return "; ".join(summaries)
+
+
+def compose_observer_note(
+    *,
+    observation: str,
+    goals_text: str = "",
+    status: str = "",
+    question_form: bool = False,
+) -> str:
+    """Render one observer note in the PR 6 block-body shape.
+
+    Parameters
+    ----------
+    observation:
+        The factual observation line (already neutral; see the module
+        docstring for sourcing). Required — an empty observation
+        renders a generic "goldfive's monitoring raised a signal."
+        line rather than an empty slot.
+    goals_text:
+        The verbatim/derived goal summary (see
+        :func:`render_goals_text`). Empty string renders the
+        "(no goals recorded for this run)" placeholder so the line is
+        always present.
+    status:
+        Optional bookkeeping snapshot (see :func:`compose_status_line`).
+        Omitted from the rendering when empty.
+    question_form:
+        When ``True``, the observation is rendered as a question by
+        appending :data:`GOAL_QUESTION` — the lowest-footprint speech
+        act for a low-confidence judge opinion. Statement form is the
+        default and stays for hard observed facts.
+    """
+    obs = (observation or "").strip() or "goldfive's monitoring raised a signal."
+    if question_form and not obs.rstrip().endswith("?"):
+        obs = f"{obs} {GOAL_QUESTION}"
+    lines = [f"Observation: {obs}"]
+    lines.append(
+        f"The user's goal: {goals_text.strip() or '(no goals recorded for this run)'}"
+    )
+    status = (status or "").strip()
+    if status:
+        lines.append(f"Status: {status}")
+    lines.append(ADVISORY_FOOTER)
+    return "\n".join(lines)
+
+
+def _readable_task(task_id: str) -> str:
+    return task_id or "the current task"
+
+
+def _tool_loop_observation(drift: DriftEvent) -> str:
+    """Render a tool-loop drift's structured facts into one line.
+
+    The tool-loop tracker (:mod:`goldfive.drift.tool_loops`) stamps a
+    structured dict onto ``drift.raw`` carrying the mode, tool name,
+    exact-match args fingerprint, repeat count, and window length — the
+    facts the detector already holds. We render exactly those counts;
+    no inference, no NL classification (the #166/#167 rule: exact-match
+    arg hashes and counts are fine, regex over natural language is not).
+    Returns ``""`` when the raw payload is not the tracker's shape so
+    the caller falls through to ``drift.detail``.
+    """
+    raw = drift.raw
+    if not isinstance(raw, dict):
+        return ""
+    mode = str(raw.get("mode", "") or "")
+    window_len = int(raw.get("window_len", 0) or 0)
+    if mode == "exact":
+        tool = str(raw.get("tool_name", "") or "")
+        count = int(raw.get("count", 0) or 0)
+        fingerprint = str(raw.get("args_hash", "") or "")
+        if not tool or count <= 0:
+            return ""
+        suffix = f" (args fingerprint {fingerprint})" if fingerprint else ""
+        return (
+            f"`{tool}` was invoked {count} times in the last {window_len} "
+            f"tool invocations with identical arguments{suffix}; no task "
+            "progress was recorded in that window."
+        )
+    if mode == "name":
+        tool = str(raw.get("tool_name", "") or "")
+        count = int(raw.get("count", 0) or 0)
+        if not tool or count <= 0:
+            return ""
+        return (
+            f"`{tool}` was invoked {count} times in the last {window_len} "
+            "tool invocations with varying arguments; no task progress "
+            "was recorded in that window."
+        )
+    if mode == "alternating":
+        tools = [str(t) for t in (raw.get("tools") or []) if t]
+        if len(tools) != 2:
+            return ""
+        return (
+            f"`{tools[0]}` and `{tools[1]}` alternated across the last "
+            f"{window_len} tool invocations without recorded task progress."
+        )
+    return ""
+
+
+def observation_for_drift(drift: DriftEvent) -> tuple[str, bool]:
+    """Resolve ``(observation_text, question_form)`` for a drift.
+
+    Implements the fallback chain from the module docstring:
+    judge-authored ``note_to_agent`` (verbatim, judge chose its own
+    form) → deterministic detector facts (``drift.raw`` for tool
+    loops) → ``drift.detail`` → per-kind neutral fallback.
+
+    ``question_form`` is ``True`` only for goldfive-composed
+    observations of judge-opinion kinds below CRITICAL severity
+    (severity as the confidence proxy — see the module docstring).
+    """
+    note = str(getattr(drift, "note_to_agent", "") or "").strip()
+    if note:
+        # The judge authored this in the same call that produced the
+        # verdict; it already chose statement vs question form.
+        return note, False
+    question = (
+        drift.kind in _JUDGE_OPINION_KINDS
+        and drift.severity is not DriftSeverity.CRITICAL
+    )
+    if drift.kind in (DriftKind.LOOPING_REASONING, DriftKind.LOOPING_TOOL_CALL):
+        rendered = _tool_loop_observation(drift)
+        if rendered:
+            # Hard observed fact — statement form always.
+            return rendered, False
+    detail = str(getattr(drift, "detail", "") or "").strip()
+    if detail:
+        return detail, question
+    template = _FALLBACK_OBSERVATIONS.get(drift.kind, _GENERIC_FALLBACK_OBSERVATION)
+    return template.format(task=_readable_task(drift.current_task_id)), question
+
+
+def compose_status_line(plan: Plan | None, current_task_id: str) -> str:
+    """Render goldfive's bookkeeping snapshot for the Status line.
+
+    Bookkeeping, not instruction: the line reports what goldfive's
+    ledger currently records — the triggering task's recorded status
+    and the open-work count — and deliberately does NOT name a "next"
+    task or assignee (the retired templates' command surface). Task
+    ids appear here as ledger facts only.
+
+    Returns ``""`` when there is nothing to report (no plan and no
+    task id), so callers can omit the Status line entirely.
+    """
+    parts: list[str] = []
+    task_status = ""
+    terminal = False
+    if plan is not None and current_task_id:
+        for t in plan.tasks:
+            if t.id == current_task_id:
+                status = getattr(t, "status", None)
+                task_status = str(getattr(status, "value", status) or "")
+                terminal = status in TERMINAL_TASK_STATUSES
+                break
+    if current_task_id:
+        if task_status and terminal:
+            parts.append(
+                f"goldfive's tracking records task {current_task_id} as "
+                f"{task_status.lower()}"
+            )
+        elif task_status:
+            parts.append(
+                f"goldfive's tracking records task {current_task_id} as "
+                f"{task_status.lower()} (still open)"
+            )
+        else:
+            parts.append(
+                f"goldfive's tracking associates this note with task "
+                f"{current_task_id}"
+            )
+    if plan is not None:
+        completed = sum(
+            1 for t in plan.tasks if t.status is TaskStatus.COMPLETED
+        )
+        open_count = sum(
+            1 for t in plan.tasks if t.status not in TERMINAL_TASK_STATUSES
+        )
+        parts.append(
+            f"its ledger shows {completed} task(s) recorded complete and "
+            f"{open_count} still open"
+        )
+    if not parts:
+        return ""
+    return "; ".join(parts) + "."
+
+
+def compose_note_for_drift(
+    *,
+    drift: DriftEvent,
+    session: Session | None = None,
+    plan: Plan | None = None,
+    status: str | None = None,
+) -> str:
+    """Compose the full observer note for ``drift``.
+
+    The one entry point every legacy delivery path renders through:
+    the post-ABSORB nudge queue and Level 2 ``_dispatch_nudge``
+    (:mod:`goldfive.drift_observer`), the ``GOLDFIVE_STEER`` corrective
+    body (``_compose_goldfive_steer_body`` /
+    ``_dispatch_goldfive_steer_control``), and the deprecated
+    :func:`goldfive.steerer.compose_corrective_user_message` shim.
+
+    ``session`` supplies ``goals`` (the goal line) and, when ``plan``
+    is not given explicitly, the live plan for the Status snapshot.
+    ``status=None`` derives the bookkeeping line from the plan;
+    pass ``status=""`` to suppress the Status line entirely.
+    """
+    effective_plan = plan if plan is not None else getattr(session, "plan", None)
+    goals = getattr(session, "goals", None) if session is not None else None
+    observation, question_form = observation_for_drift(drift)
+    if status is None:
+        status = compose_status_line(effective_plan, drift.current_task_id)
+    return compose_observer_note(
+        observation=observation,
+        goals_text=render_goals_text(goals),
+        status=status,
+        question_form=question_form,
+    )

--- a/goldfive/optimization/prompts/goal_drift_user.md
+++ b/goldfive/optimization/prompts/goal_drift_user.md
@@ -27,7 +27,7 @@ RECENT AGENT ACTIVITY (most recent {activity_count} invocations, newest last):
 Decide: is the recent activity moving toward the goals? Answer STRICTLY in one of these two JSON shapes:
 {{"progressing": true}}
 OR
-{{"progressing": false, "reason": "one-sentence explanation"}}
+{{"progressing": false, "reason": "one-sentence explanation", "note_to_agent": "one or two sentences addressed to the agent itself: state only what you observed and how it relates to the goals. Neutral and factual — no commands, no instructions about which task, tool, or agent to use next, and no fault language. If your confidence is low, phrase the note as a question (e.g. 'Does the current approach still serve the goal of X?')"}}
 
 Progressing = agents are doing work that plausibly contributes to the goal.
 Not progressing = agents are looping, refusing, off-topic, or otherwise not advancing.

--- a/goldfive/optimization/prompts/reasoning_judge_user.md
+++ b/goldfive/optimization/prompts/reasoning_judge_user.md
@@ -37,7 +37,7 @@ RECENT TOOL OBSERVATIONS (last {tool_obs_count}, oldest first):
 REASONING (the agent's most recent chain-of-thought block):
 {reasoning_block}
 
-Decide THREE things:
+Decide FOUR things:
 1. CLASSIFICATION. Which best describes the reasoning?
    - on_task: it advances the BOUND TASK or the GOALS.
    - justified_deviation: it departs from the BOUND TASK, but a recent
@@ -60,6 +60,14 @@ Decide THREE things:
      tool_error | surprising_result | discovered_dependency | new_information
    When classification is on_task or erroneous_deviation, set
    provenance to "none".
+4. NOTE. ONLY when classification is NOT on_task, write note_to_agent:
+   one or two sentences addressed to the agent itself, stating only what
+   you observed and how it relates to the GOALS. Neutral and factual —
+   no commands, no instructions about which task, tool, or agent to use
+   next, and no fault language (avoid words like 'failed', 'wrong',
+   'broken'). If your confidence in this verdict is low, phrase the note
+   as a question (e.g. "Does the current approach still serve the goal
+   of X?"). When classification is on_task, set note_to_agent to "".
 
 Reply with a single JSON object and nothing else, in this shape:
 {{
@@ -69,7 +77,8 @@ Reply with a single JSON object and nothing else, in this shape:
   "provenance": "tool_error" | "surprising_result" | "discovered_dependency" | "new_information" | "none",
   "focused_task_id": "<id from PLAN TASKS, or '' if off-plan>",
   "focus_confidence": 0.0-1.0,
-  "stated_intent": "one-sentence summary of what the agent says it is doing"
+  "stated_intent": "one-sentence summary of what the agent says it is doing",
+  "note_to_agent": "one-or-two-sentence neutral observation for the agent, or '' when on_task"
 }}
 
 GUIDANCE:

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -158,128 +158,33 @@ _ABSORB_NUDGE_KINDS: frozenset[DriftKind] = frozenset(
 )
 
 
-# Default drift messages per kind, used by
-# :func:`compose_corrective_user_message` when the drift carries no
-# kind-specific override. Keep SHORT, action-focused; no goldfive jargon
-# ("synthetic", "healed", "orphan", "drift") in user-facing copy.
-_CORRECTIVE_TEMPLATES: dict[DriftKind, str] = {
-    DriftKind.LOOPING_REASONING: (
-        "The prior attempt looped on {current_task_id}. "
-        "Refined plan: {next_task_title}. Please try a different approach."
-    ),
-    DriftKind.LOOPING_TOOL_CALL: (
-        "The prior attempt kept retrying the same tool call on "
-        "{current_task_id} without progress. Refined plan: "
-        "{next_task_title}. Please try a different approach."
-    ),
-    DriftKind.PLAN_DIVERGENCE: (
-        "The tree's prior activity diverged from the plan. "
-        "Refined plan: proceed with {next_task_title}."
-    ),
-    DriftKind.AGENT_REFUSAL: (
-        "The prior attempt could not complete {current_task_id}. "
-        "Refined plan: try {next_task_title}."
-    ),
-    DriftKind.MODEL_REFUSAL: (
-        "The model declined to proceed on {current_task_id}. Refined plan: try {next_task_title}."
-    ),
-    DriftKind.INTENT_DIVERGENCE: (
-        "The prior attempt strayed from the stated intent for "
-        "{current_task_id}. Refined plan: proceed with "
-        "{next_task_title}."
-    ),
-    DriftKind.TOOL_ERROR: (
-        "The prior attempt hit a tool error on {current_task_id}. "
-        "Refined plan: proceed with {next_task_title}."
-    ),
-    DriftKind.RUNAWAY_DELEGATION: (
-        "The prior attempt kept delegating without finishing "
-        "{current_task_id}. Refined plan: proceed with "
-        "{next_task_title} directly."
-    ),
-    DriftKind.SELF_REPORTED_STUCK: (
-        "The prior attempt reported being stuck on {current_task_id}. "
-        "Refined plan: try {next_task_title}."
-    ),
-    DriftKind.CONFABULATION_RISK: (
-        "The prior attempt may have produced {current_task_id} "
-        "without consulting external data. Refined plan: "
-        "{next_task_title}."
-    ),
-    # Tier 1 / F4 — GOAL_DRIFT corrective. The judge's signal is "agent
-    # is grinding on completed work / not advancing the goal". The plan
-    # itself is fine; the agent just needs a pointer at the next hand-
-    # off. Includes ``{next_task_agent}`` so the coordinator can route
-    # to the assignee directly rather than re-invoking the stuck agent.
-    DriftKind.GOAL_DRIFT: (
-        "Task '{current_task_id}' is already complete. "
-        "Please proceed to '{next_task_title}' via {next_task_agent}."
-    ),
-}
-
-
 def compose_corrective_user_message(
     *,
     drift: DriftEvent,
     refined_plan: Plan | None,
 ) -> str:
-    """Build a short directive user message for Level 3 re-invoke.
+    """DEPRECATED shim — delegates to :mod:`goldfive.observer_notes`.
 
-    Shape varies by drift kind (see :data:`_CORRECTIVE_TEMPLATES`). The
-    message is deliberately short, action-focused, and avoids goldfive
-    jargon -- the consumer is the agent's LLM, which should read a
-    natural instruction rather than a framework postmortem.
+    AGENCY-PRESERVATION.md PR 4 retired the ``_CORRECTIVE_TEMPLATES``
+    command templates this function used to render ("proceed to
+    '{next_task_title}' via {next_task_agent}", "do NOT retry", …):
+    goldfive owns goals / budgets / observability, the wrapped agent
+    owns MEANS (decomposition, delegation, ordering, retries), so the
+    agent-facing message is now an observation+goal advisory note, not
+    a directive about which task or agent comes next.
+
+    Kept as a thin delegating shim because the name is in the public
+    ``__all__`` and external callers / tests import it. In-tree call
+    sites (``goldfive.drift_observer``) call
+    :func:`goldfive.observer_notes.compose_note_for_drift` directly —
+    it accepts the ``session`` so the note carries the user's goals;
+    this shim cannot (signature compatibility), so notes it renders
+    carry the "(no goals recorded for this run)" placeholder. New code
+    should not call this.
     """
-    current = drift.current_task_id or "the current task"
-    next_title = _next_pending_task_title(refined_plan) or "the next planned step"
-    next_agent = _next_pending_task_agent(refined_plan) or "the next assigned agent"
-    template = _CORRECTIVE_TEMPLATES.get(drift.kind)
-    if template is None:
-        # Generic fallback for drift kinds that didn't get a
-        # custom shape. Keep it tight and action-focused.
-        template = (
-            "The prior attempt on {current_task_id} did not complete "
-            "successfully. Refined plan: proceed with {next_task_title}."
-        )
-    return template.format(
-        current_task_id=current,
-        next_task_title=next_title,
-        next_task_agent=next_agent,
-    )
+    from goldfive.observer_notes import compose_note_for_drift
 
-
-def _next_pending_task_title(plan: Plan | None) -> str:
-    """Return the title of the next PENDING task in topological order.
-
-    Falls back to the task id if no title is set. Returns an empty
-    string when there is no eligible task.
-    """
-    if plan is None:
-        return ""
-    for t in plan.tasks:
-        if t.status is TaskStatus.PENDING:
-            return (t.title or t.id or "").strip()
-    return ""
-
-
-def _next_pending_task_agent(plan: Plan | None) -> str:
-    """Return the bare agent name assigned to the next PENDING task.
-
-    Tier 1 / F4 — used by the GOAL_DRIFT corrective template, which
-    redirects the LLM's next action to a different agent. Returns the
-    last dot-separated segment of ``assignee_agent_id`` so the LLM sees
-    a name it can pass back as the AgentTool target. Empty string when
-    no eligible task exists or the task has no assignee.
-    """
-    if plan is None:
-        return ""
-    for t in plan.tasks:
-        if t.status is TaskStatus.PENDING:
-            assignee = (getattr(t, "assignee_agent_id", "") or "").strip()
-            if "." in assignee:
-                return assignee.rsplit(".", 1)[-1]
-            return assignee
-    return ""
+    return compose_note_for_drift(drift=drift, plan=refined_plan)
 
 
 def _enum_or_str_value(value: Any) -> str:
@@ -968,6 +873,12 @@ class DefaultSteerer:
             kind=kind,
             severity=severity,
             detail=str(getattr(verdict, "detail", "") or ""),
+            # AGENCY-PRESERVATION.md PR 4 — thread the judge-authored
+            # agent-facing observation onto the drift so
+            # ``goldfive.observer_notes`` can prefer it over ``detail``
+            # when composing notes. ``getattr`` keeps pre-PR-4 verdict
+            # shapes (no field) degrading to the empty string.
+            note_to_agent=str(getattr(verdict, "note_to_agent", "") or ""),
         )
 
     async def _emit_judgement(

--- a/goldfive/testkit/adversarial.py
+++ b/goldfive/testkit/adversarial.py
@@ -40,6 +40,7 @@ from goldfive.results import InvocationResult
 from goldfive.types import DriftKind, Session, Task
 
 __all__ = [
+    "MEANS_COMMAND_PHRASES",
     "AdversarialAgentBase",
     "CleanAgent",
     "HallucinatingAgent",
@@ -48,7 +49,62 @@ __all__ = [
     "RunawayDelegationAgent",
     "SlowAgent",
     "WanderingAgent",
+    "find_means_commands",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Agent-facing content checker (AGENCY-PRESERVATION.md PR 4 / §5)
+# ---------------------------------------------------------------------------
+
+#: Imperative means-command phrases that must never appear in
+#: goldfive-composed agent-facing text (observer notes, nudge bodies,
+#: GOLDFIVE steer correctives). The wrapped agent owns MEANS —
+#: decomposition, delegation, ordering, retries (AGENCY-PRESERVATION.md
+#: §2) — so goldfive's notes may state observations and goals but never
+#: command the agent's next move. Single words match whole tokens
+#: ("call" flags "call X" but not "called" / "tool calls"); multi-word
+#: phrases match consecutive tokens.
+#:
+#: TEST-SIDE ONLY. This is an assertion wordlist for adversarial
+#: content tests, not an NL classifier — production code MUST NOT use
+#: it (or any keyword/regex heuristic) to classify natural language
+#: (the #166/#167 rule).
+MEANS_COMMAND_PHRASES: tuple[str, ...] = (
+    "retry",
+    "proceed to",
+    "call",
+    "use agent",
+    "do not",
+    "don t",  # tokenised form of "don't"
+    "you must",
+    "switch to",
+)
+
+
+def _tokenize_for_content_check(text: str) -> list[str]:
+    """Lowercase ``text`` and split on non-alphanumerics (no regex)."""
+    normalized = "".join(c if c.isalnum() else " " for c in text.lower())
+    return normalized.split()
+
+
+def find_means_commands(text: str) -> list[str]:
+    """Return every means-command phrase present in ``text``.
+
+    Token-based matching: a single-word entry must match a whole token
+    (so "called" / "recall" / "tool calls" do not false-positive on
+    "call"), and a multi-word entry must match consecutive tokens.
+    Tests assert the result is empty for every rendered goldfive note;
+    a non-empty return names the offending phrases for the failure
+    message.
+    """
+    tokens = _tokenize_for_content_check(text)
+    joined = " " + " ".join(tokens) + " "
+    found: list[str] = []
+    for phrase in MEANS_COMMAND_PHRASES:
+        if f" {phrase} " in joined:
+            found.append(phrase)
+    return found
 
 
 @dataclasses.dataclass

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1500,6 +1500,22 @@ class DriftEvent:
     # round-trip cannot move the cursor between observation and emit
     # without the gate noticing.
     observed_revision_index: int = 0
+    # AGENCY-PRESERVATION.md PR 4 — judge-authored observation addressed
+    # to the wrapped agent. Populated by the LLM judges
+    # (:mod:`goldfive.drift.reasoning_judge`, :mod:`goldfive.drift.goals`,
+    # and drift-flavoured :class:`~goldfive.judges.JudgeVerdict`s via
+    # ``DefaultSteerer._drift_from_judge_verdict``) in the SAME call
+    # that produced the verdict: one or two neutral, factual sentences —
+    # no commands, no fault language; question form when the judge is
+    # unsure. ``goldfive.observer_notes.observation_for_drift`` prefers
+    # this verbatim over ``detail`` when composing the agent-facing
+    # note; ``detail`` remains the operator/observability rendering.
+    # In-process only in this PR — NOT mirrored onto the ``DriftDetected``
+    # / ``JudgementEmitted`` proto envelopes (that would require a proto
+    # regen; the PR 5 telemetry pass owns the wire surface). Old-style
+    # judge responses that omit the field leave this empty and the
+    # composer falls through to ``detail`` (graceful degradation).
+    note_to_agent: str = ""
 
 
 @dataclasses.dataclass

--- a/tests/test_corrective_message.py
+++ b/tests/test_corrective_message.py
@@ -1,9 +1,30 @@
-"""Tests for :func:`goldfive.steerer.compose_corrective_user_message`.
+"""Tests for the deprecated :func:`compose_corrective_user_message` shim.
 
-Pins the shape of the directive user message the Steerer hands off to
-the Runner's overlay loop on Level 3 (CANCEL_REINVOKE) of the
-intervention ladder. Messages are short, action-focused, and avoid
-goldfive jargon (see goldfive#142).
+AGENCY-PRESERVATION.md PR 4 re-point: this file used to pin the
+``_CORRECTIVE_TEMPLATES`` command shapes ("Refined plan: proceed with
+{next_task_title}", "Please proceed to '{next_task_title}' via
+{next_task_agent}") per drift kind. Those templates are retired — the
+agent owns MEANS, so goldfive's notes carry observation + goal +
+advisory footer, never a next-task directive. The original assertions
+map onto the new contract as follows:
+
+* per-kind "message shape" tests (looping / plan-divergence / refusal /
+  tool-error / runaway-delegation) → the shim delegates to
+  :func:`goldfive.observer_notes.compose_note_for_drift`; one
+  delegation test plus the means-command sweep below replace them.
+* ``test_message_avoids_goldfive_jargon`` → kept (tightened: "drift" /
+  "synthetic" / "healed" / "orphan" / "steerer" still banned) and
+  extended with the §5 imperative means-verb wordlist.
+* ``test_message_is_short`` → dropped: the note is deliberately a
+  multi-line block (observation + goal + status + footer), not a
+  one-line directive; the length cap was an artifact of the command
+  format.
+* ``test_handles_missing_plan`` / ``test_handles_missing_task_id`` /
+  ``test_unknown_drift_kind_uses_generic_fallback`` → re-pointed at the
+  note's graceful-degradation behaviour.
+
+The full adversarial × golden coverage for the composers lives in
+``tests/test_observer_notes.py``; this file only pins the shim.
 """
 
 from __future__ import annotations
@@ -17,7 +38,12 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.observer_notes import (  # noqa: E402
+    ADVISORY_FOOTER,
+    compose_note_for_drift,
+)
 from goldfive.steerer import compose_corrective_user_message  # noqa: E402
+from goldfive.testkit.adversarial import find_means_commands  # noqa: E402
 from goldfive.types import (  # noqa: E402
     DriftEvent,
     DriftKind,
@@ -42,87 +68,95 @@ def _plan_with_next(next_title: str = "Summarize findings") -> Plan:
     )
 
 
-def _drift(kind: DriftKind, task_id: str = "t0") -> DriftEvent:
+def _drift(kind: DriftKind, task_id: str = "t0", detail: str = "") -> DriftEvent:
     return DriftEvent(
         kind=kind,
         severity=DriftSeverity.CRITICAL,
-        detail=f"synthetic {kind.value}",
+        detail=detail,
         current_task_id=task_id,
     )
 
 
-def test_looping_reasoning_message_shape() -> None:
-    msg = compose_corrective_user_message(
-        drift=_drift(DriftKind.LOOPING_REASONING, task_id="t0"),
-        refined_plan=_plan_with_next("Draft the final note"),
-    )
-    assert "looped on t0" in msg
-    assert "Draft the final note" in msg
-    assert "different approach" in msg
+# A representative sweep of drift kinds the retired template table
+# carried entries for, plus CUSTOM for the generic fallback.
+_SWEEP_KINDS = (
+    DriftKind.LOOPING_REASONING,
+    DriftKind.LOOPING_TOOL_CALL,
+    DriftKind.PLAN_DIVERGENCE,
+    DriftKind.AGENT_REFUSAL,
+    DriftKind.MODEL_REFUSAL,
+    DriftKind.INTENT_DIVERGENCE,
+    DriftKind.TOOL_ERROR,
+    DriftKind.RUNAWAY_DELEGATION,
+    DriftKind.SELF_REPORTED_STUCK,
+    DriftKind.CONFABULATION_RISK,
+    DriftKind.GOAL_DRIFT,
+    DriftKind.CUSTOM,
+)
 
 
-def test_plan_divergence_message_shape() -> None:
-    msg = compose_corrective_user_message(
-        drift=_drift(DriftKind.PLAN_DIVERGENCE),
-        refined_plan=_plan_with_next("Summarize findings"),
-    )
-    assert "diverged from the plan" in msg
-    assert "Summarize findings" in msg
+def test_shim_delegates_to_observer_notes() -> None:
+    """The deprecated shim renders exactly what the new composer renders."""
+    drift = _drift(DriftKind.LOOPING_REASONING)
+    plan = _plan_with_next()
+    assert compose_corrective_user_message(
+        drift=drift, refined_plan=plan
+    ) == compose_note_for_drift(drift=drift, plan=plan)
 
 
-def test_agent_refusal_message_shape() -> None:
-    msg = compose_corrective_user_message(
-        drift=_drift(DriftKind.AGENT_REFUSAL, task_id="t7"),
-        refined_plan=_plan_with_next("Alternative approach"),
-    )
-    assert "t7" in msg
-    assert "Alternative approach" in msg
-    assert "could not complete" in msg
+def test_every_kind_renders_advisory_note_shape() -> None:
+    """Every kind renders the observation+goal+footer block."""
+    for kind in _SWEEP_KINDS:
+        msg = compose_corrective_user_message(
+            drift=_drift(kind),
+            refined_plan=_plan_with_next(),
+        )
+        assert msg.startswith("Observation: "), msg
+        assert "The user's goal: " in msg, msg
+        assert ADVISORY_FOOTER in msg, msg
 
 
-def test_tool_error_message_shape() -> None:
-    msg = compose_corrective_user_message(
-        drift=_drift(DriftKind.TOOL_ERROR, task_id="t4"),
-        refined_plan=_plan_with_next("Second attempt"),
-    )
-    assert "tool error" in msg
-    assert "Second attempt" in msg
-    assert "t4" in msg
+def test_no_imperative_means_commands_any_kind() -> None:
+    """§5 adversarial gate: no means-verbs directed at the agent.
+
+    The retired templates commanded means ("proceed with …", "do NOT
+    retry", "try {next_task_title}"); the note must not, for any kind,
+    with or without a plan / detail.
+    """
+    for kind in _SWEEP_KINDS:
+        for plan in (_plan_with_next(), None):
+            msg = compose_corrective_user_message(
+                drift=_drift(kind), refined_plan=plan
+            )
+            offending = find_means_commands(msg)
+            assert not offending, (
+                f"{kind.value} note contains means-command(s) "
+                f"{offending!r}: {msg!r}"
+            )
 
 
-def test_runaway_delegation_message_shape() -> None:
-    msg = compose_corrective_user_message(
-        drift=_drift(DriftKind.RUNAWAY_DELEGATION, task_id="coord"),
-        refined_plan=_plan_with_next("Do the work directly"),
-    )
-    assert "kept delegating" in msg
-    assert "coord" in msg
-    assert "Do the work directly" in msg
+def test_no_next_task_routing_any_kind() -> None:
+    """The next PENDING task's title never appears in the note.
+
+    Replaces the per-kind "Refined plan: {next_task_title}" shape
+    assertions: pointing the agent at goldfive's choice of next task
+    is exactly the command surface PR 4 removes.
+    """
+    for kind in _SWEEP_KINDS:
+        msg = compose_corrective_user_message(
+            drift=_drift(kind),
+            refined_plan=_plan_with_next("A very distinctive next step"),
+        )
+        assert "A very distinctive next step" not in msg, (kind, msg)
 
 
 def test_message_avoids_goldfive_jargon() -> None:
-    """No 'synthetic', 'healed', 'orphan', 'drift' in user-facing copy.
-
-    Enumerated from goldfive#142's "keep messages SHORT, action-focused,
-    no goldfive jargon, no 'synthetic'/'healed'/'orphan' language."
-    """
-    # "Refined plan" is allowed (the issue's own example uses that
-    # phrasing); jargon-gate is specifically on the goldfive-internal
-    # vocabulary ("synthetic", "healed", "orphan", "steerer") plus the
-    # word "drift" which is a postmortem term for end-users.
+    """No 'synthetic', 'healed', 'orphan', 'drift', 'steerer' in
+    agent-facing copy (carried over from goldfive#142's content rule)."""
     forbidden = ("synthetic", "healed", "orphan", "drift", "steerer")
-    for kind in (
-        DriftKind.LOOPING_REASONING,
-        DriftKind.PLAN_DIVERGENCE,
-        DriftKind.AGENT_REFUSAL,
-        DriftKind.INTENT_DIVERGENCE,
-        DriftKind.TOOL_ERROR,
-        DriftKind.RUNAWAY_DELEGATION,
-        DriftKind.CONFABULATION_RISK,
-        DriftKind.SELF_REPORTED_STUCK,
-    ):
+    for kind in _SWEEP_KINDS:
         msg = compose_corrective_user_message(
-            drift=_drift(kind, task_id="t0"),
+            drift=_drift(kind),
             refined_plan=_plan_with_next(),
         )
         lower = msg.lower()
@@ -132,35 +166,16 @@ def test_message_avoids_goldfive_jargon() -> None:
             )
 
 
-def test_message_is_short() -> None:
-    """A corrective message should be at most ~250 chars -- a single
-    directive, not a postmortem. Pins the "short, action-focused" rule.
-    """
-    for kind in (
-        DriftKind.LOOPING_REASONING,
-        DriftKind.PLAN_DIVERGENCE,
-        DriftKind.AGENT_REFUSAL,
-        DriftKind.TOOL_ERROR,
-        DriftKind.RUNAWAY_DELEGATION,
-    ):
-        msg = compose_corrective_user_message(
-            drift=_drift(kind, task_id="task-with-long-identifier"),
-            refined_plan=_plan_with_next("A fairly descriptive next step title"),
-        )
-        assert len(msg) < 260, f"{kind.value} message too long ({len(msg)}): {msg!r}"
-
-
 def test_handles_missing_plan() -> None:
-    """A composer called with a missing refined plan falls back to a
-    generic 'next planned step' rather than interpolating an empty
-    title -- prevents malformed outputs like 'proceed with  .'."""
+    """No plan → goal placeholder + task bookkeeping, no Status crash."""
     msg = compose_corrective_user_message(
         drift=_drift(DriftKind.PLAN_DIVERGENCE),
         refined_plan=None,
     )
-    assert "next planned step" in msg
-    # No double-space artifacts from an empty title.
-    assert "  " not in msg or msg.count("  ") <= 0
+    assert "t0" in msg
+    assert ADVISORY_FOOTER in msg
+    # No double-space artifacts from empty interpolations.
+    assert "  " not in msg
 
 
 def test_handles_missing_task_id() -> None:
@@ -176,7 +191,7 @@ def test_handles_missing_task_id() -> None:
     )
     # Falls back to a readable placeholder, not an empty interpolation.
     assert "the current task" in msg
-    assert "Try option B" in msg
+    assert ADVISORY_FOOTER in msg
 
 
 def test_unknown_drift_kind_uses_generic_fallback() -> None:
@@ -185,6 +200,17 @@ def test_unknown_drift_kind_uses_generic_fallback() -> None:
         refined_plan=_plan_with_next("Move forward"),
     )
     assert "t3" in msg
-    assert "Move forward" in msg
-    # Still action-focused: ends with a directive.
-    assert msg.lower().endswith(".") or "proceed" in msg.lower()
+    assert msg.startswith("Observation: ")
+    assert ADVISORY_FOOTER in msg
+
+
+def test_detail_is_embedded_verbatim() -> None:
+    """A detector's human-readable detail rides the observation line."""
+    msg = compose_corrective_user_message(
+        drift=_drift(
+            DriftKind.SELF_REPORTED_STUCK,
+            detail="the agent's own self-check reported no recent progress",
+        ),
+        refined_plan=_plan_with_next(),
+    )
+    assert "the agent's own self-check reported no recent progress" in msg

--- a/tests/test_observer_notes.py
+++ b/tests/test_observer_notes.py
@@ -1,0 +1,664 @@
+"""AGENCY-PRESERVATION.md PR 4 — observer-note content contract tests.
+
+Four binding §5 requirements covered here:
+
+1. **Adversarial content tests** — every rendered note, across all
+   drift kinds × severities × composers (the note composer, the
+   executor nudge-replay wrapper, the goldfive steer-restart wrapper),
+   contains no imperative means-verbs directed at the agent. The
+   wordlist checker lives in :mod:`goldfive.testkit.adversarial`
+   (test-side only; never an NL classifier in production).
+2. **Golden-output tests** — exact rendered notes for representative
+   drift kinds, so future content changes are reviewable diffs.
+3. **USER_STEER byte-identity** — the user-authored steer-restart
+   rendering is pinned as a full-string equality; PR 4 changes only
+   goldfive-authored content.
+4. **Graceful degradation** — judges returning old-style responses
+   (no ``note_to_agent``) leave the field empty and the composer falls
+   back to ``detail``; the full fallback chain
+   (``note_to_agent`` → detector facts → ``detail`` → per-kind
+   template) is pinned.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.executors.sequential import SequentialExecutor  # noqa: E402
+from goldfive.observer_notes import (  # noqa: E402
+    ADVISORY_FOOTER,
+    GOAL_QUESTION,
+    compose_note_for_drift,
+    compose_observer_note,
+    compose_status_line,
+    observation_for_drift,
+    render_goals_text,
+)
+from goldfive.testkit.adversarial import find_means_commands  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Task,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[
+            Task(id="t0", title="Research", status=TaskStatus.COMPLETED),
+            Task(id="t1", title="Draft the summary", status=TaskStatus.RUNNING),
+            Task(id="t2", title="Review", status=TaskStatus.PENDING),
+        ],
+        edges=[],
+    )
+
+
+def _session(plan: Plan | None = None) -> SimpleNamespace:
+    """Duck-typed session: the composer reads only ``goals`` / ``plan``."""
+    return SimpleNamespace(
+        goals=[Goal(id="g1", summary="research raccoon habitats and draft a summary")],
+        plan=plan if plan is not None else _plan(),
+    )
+
+
+def _drift(
+    kind: DriftKind,
+    *,
+    severity: DriftSeverity = DriftSeverity.WARNING,
+    detail: str = "",
+    task_id: str = "t1",
+    raw: object = None,
+    note_to_agent: str = "",
+) -> DriftEvent:
+    return DriftEvent(
+        kind=kind,
+        severity=severity,
+        detail=detail,
+        current_task_id=task_id,
+        raw=raw,
+        note_to_agent=note_to_agent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Adversarial content sweep — kinds × severities × composers
+# ---------------------------------------------------------------------------
+
+
+def _all_rendered_messages() -> list[tuple[str, str]]:
+    """Render (label, message) across every kind, severity, composer."""
+    rendered: list[tuple[str, str]] = []
+    session = _session()
+    for kind in DriftKind:
+        for severity in DriftSeverity:
+            for detail in ("", "detector emitted a reason string"):
+                drift = _drift(kind, severity=severity, detail=detail)
+                label = f"{kind.value}/{severity.value}/detail={bool(detail)}"
+                note = compose_note_for_drift(drift=drift, session=session)
+                rendered.append((f"note:{label}", note))
+                # Executor wrappers (delivery framing) on top of the
+                # same note bodies.
+                rendered.append(
+                    (
+                        f"nudge_replay:{label}",
+                        SequentialExecutor._compose_nudge_replay_message([note]),
+                    )
+                )
+                rendered.append(
+                    (
+                        f"steer_restart:{label}",
+                        SequentialExecutor._compose_steer_restart_message(
+                            None,
+                            fallback=note,
+                            source="goldfive",
+                            superseded_task_ids=["t1"],
+                            replacement_task_ids=["t1b"],
+                        ),
+                    )
+                )
+    # Tool-loop deterministic renderings (all three modes).
+    for raw in (
+        {
+            "mode": "exact",
+            "tool_name": "search_web",
+            "args_hash": "a1b2c3d4",
+            "count": 5,
+            "window_len": 10,
+        },
+        {"mode": "name", "tool_name": "search_web", "count": 7, "window_len": 10},
+        {"mode": "alternating", "tools": ["lint", "build"], "window_len": 5},
+    ):
+        drift = _drift(DriftKind.LOOPING_REASONING, raw=raw)
+        rendered.append(
+            (
+                f"note:tool_loop/{raw['mode']}",
+                compose_note_for_drift(drift=drift, session=session),
+            )
+        )
+    return rendered
+
+
+def test_no_imperative_means_verbs_in_any_rendering() -> None:
+    """§5 adversarial gate over the full kind × severity × composer grid."""
+    for label, msg in _all_rendered_messages():
+        offending = find_means_commands(msg)
+        assert not offending, (
+            f"{label} contains means-command(s) {offending!r}:\n{msg}"
+        )
+
+
+def test_no_problem_naming_or_jargon_in_composed_observations() -> None:
+    """goldfive-composed text avoids apology-bait problem naming.
+
+    The ``_correction_injection`` lesson (#250/#252/#253): "failed" /
+    "broken" / "wrong" provoke meta-commentary instead of work. Checked
+    on goldfive-COMPOSED fallback observations (empty detail) — judge /
+    detector ``detail`` strings pass through verbatim and are governed
+    by the judge prompts instead. The Status line may carry the literal
+    ledger status word (bookkeeping is exempt), so the check runs on
+    the observation line only.
+    """
+    session = _session()
+    banned = ("failed", "broken", "wrong", "incorrect", "drift", "steerer")
+    for kind in DriftKind:
+        drift = _drift(kind, detail="")
+        observation, _question = observation_for_drift(drift)
+        lower = observation.lower()
+        for bad in banned:
+            assert bad not in lower, (kind, bad, observation)
+        # And the full note shape is always present.
+        note = compose_note_for_drift(drift=drift, session=session)
+        assert note.startswith("Observation: ")
+        assert "The user's goal: " in note
+        assert ADVISORY_FOOTER in note
+
+
+# ---------------------------------------------------------------------------
+# 2. Golden outputs — representative kinds (reviewable-diff contract)
+# ---------------------------------------------------------------------------
+
+
+def test_golden_tool_loop_exact_note() -> None:
+    """Deterministic detector facts render verbatim into the observation."""
+    drift = _drift(
+        DriftKind.LOOPING_REASONING,
+        severity=DriftSeverity.WARNING,
+        detail="tool_loop_exact: search_web x 5 in last 10 calls",
+        raw={
+            "mode": "exact",
+            "tool_name": "search_web",
+            "args_hash": "a1b2c3d4",
+            "count": 5,
+            "window_len": 10,
+            "invocation_id": "inv-1",
+            "category": "work",
+            "tier": "warning",
+        },
+    )
+    note = compose_note_for_drift(drift=drift, session=_session())
+    assert note == (
+        "Observation: `search_web` was invoked 5 times in the last 10 tool "
+        "invocations with identical arguments (args fingerprint a1b2c3d4); "
+        "no task progress was recorded in that window.\n"
+        "The user's goal: research raccoon habitats and draft a summary\n"
+        "Status: goldfive's tracking records task t1 as running (still "
+        "open); its ledger shows 1 task(s) recorded complete and 2 still "
+        "open.\n"
+        "This note is advisory. How to proceed is your decision; the "
+        "user's instructions remain authoritative."
+    )
+
+
+def test_golden_goal_drift_question_form_note() -> None:
+    """A below-CRITICAL judge opinion renders in question form."""
+    drift = _drift(
+        DriftKind.GOAL_DRIFT,
+        severity=DriftSeverity.WARNING,
+        detail="recent turns kept re-reading completed research",
+        task_id="t0",
+    )
+    note = compose_note_for_drift(drift=drift, session=_session())
+    assert note == (
+        "Observation: recent turns kept re-reading completed research "
+        "Does the current approach still serve the user's goal?\n"
+        "The user's goal: research raccoon habitats and draft a summary\n"
+        "Status: goldfive's tracking records task t0 as completed; its "
+        "ledger shows 1 task(s) recorded complete and 2 still open.\n"
+        "This note is advisory. How to proceed is your decision; the "
+        "user's instructions remain authoritative."
+    )
+
+
+def test_golden_judge_authored_note_used_verbatim() -> None:
+    """note_to_agent wins the chain and is rendered exactly as authored."""
+    drift = _drift(
+        DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="operator-facing reason",
+        note_to_agent=(
+            "The last three reasoning turns discussed raccoon migration, "
+            "which does not appear in the user's request. Does that line "
+            "of inquiry still serve the goal of drafting the summary?"
+        ),
+    )
+    note = compose_note_for_drift(drift=drift, session=_session())
+    assert note == (
+        "Observation: The last three reasoning turns discussed raccoon "
+        "migration, which does not appear in the user's request. Does "
+        "that line of inquiry still serve the goal of drafting the "
+        "summary?\n"
+        "The user's goal: research raccoon habitats and draft a summary\n"
+        "Status: goldfive's tracking records task t1 as running (still "
+        "open); its ledger shows 1 task(s) recorded complete and 2 still "
+        "open.\n"
+        "This note is advisory. How to proceed is your decision; the "
+        "user's instructions remain authoritative."
+    )
+
+
+def test_golden_per_kind_fallback_observations() -> None:
+    """Pin the composed fallback observation per representative kind."""
+    cases = {
+        DriftKind.LOOPING_TOOL_CALL: (
+            "The same tool invocation was observed several times on t1 "
+            "without recorded progress."
+        ),
+        DriftKind.AGENT_REFUSAL: (
+            "The most recent response on t1 declined to continue."
+        ),
+        DriftKind.SELF_REPORTED_STUCK: (
+            "In a recent self-check, the agent's own assessment reported "
+            "no progress on t1."
+        ),
+        DriftKind.CONFABULATION_RISK: (
+            "Output on t1 referenced external data, but no tool "
+            "invocation was recorded for it."
+        ),
+        DriftKind.CUSTOM: (
+            "goldfive's monitoring raised a signal while t1 was active."
+        ),
+    }
+    for kind, expected in cases.items():
+        observation, _q = observation_for_drift(_drift(kind, detail=""))
+        assert observation == expected, kind
+
+
+def test_golden_nudge_replay_wrapper() -> None:
+    """The executor's nudge framing: attribution header + note verbatim."""
+    msg = SequentialExecutor._compose_nudge_replay_message(["NOTE-BODY"])
+    assert msg == (
+        "[GOLDFIVE PLAN REVISION — observer note]\n"
+        "\n"
+        "goldfive — an external monitoring layer, not the user — revised "
+        "its plan bookkeeping during the prior turn. The note(s) below "
+        "describe what it observed.\n"
+        "\n"
+        "NOTE-BODY"
+    )
+
+
+def test_golden_goldfive_steer_restart_wrapper() -> None:
+    """The goldfive steer framing: header + body + bookkeeping line."""
+    msg = SequentialExecutor._compose_steer_restart_message(
+        None,
+        fallback="NOTE-BODY",
+        source="goldfive",
+        superseded_task_ids=["t2"],
+        replacement_task_ids=["t2b"],
+    )
+    assert msg == (
+        "[GOLDFIVE STEERING CONTROL — supersedes prior task context]\n"
+        "\n"
+        "NOTE-BODY\n"
+        "\n"
+        "goldfive bookkeeping (for reference): goldfive's plan tracking "
+        "records task id(s) t2 as superseded by this revision; its ledger "
+        "contains replacement entrie(s): t2b."
+    )
+
+
+def test_goldfive_steer_restart_wrapper_without_task_ids() -> None:
+    """No bookkeeping block when there is nothing to report."""
+    msg = SequentialExecutor._compose_steer_restart_message(
+        None, fallback="NOTE-BODY", source="goldfive"
+    )
+    assert msg == (
+        "[GOLDFIVE STEERING CONTROL — supersedes prior task context]\n"
+        "\n"
+        "NOTE-BODY"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. USER_STEER paths byte-identical (§5 pin)
+# ---------------------------------------------------------------------------
+
+
+def test_user_steer_restart_message_byte_identical() -> None:
+    """Full-string pin of the pre-PR-4 user-steer rendering.
+
+    PR 4 changes goldfive-authored content only; the USER-authority
+    relay text must not change by a single byte.
+    """
+    msg = SequentialExecutor._compose_steer_restart_message(
+        None, fallback="user body"
+    )
+    assert msg == (
+        "[USER STEERING CONTROL — supersedes prior task context]\n"
+        "\n"
+        "user body\n"
+        "\n"
+        "Notes:\n"
+        "- Prior research, partial work, or planned tasks from the "
+        "pre-steer conversation are superseded unless this message "
+        "explicitly references them.\n"
+        "- Proceed with the new direction. Do not continue prior work "
+        "unless doing so directly serves this steer."
+    )
+
+
+def test_user_steer_restart_message_payload_note_byte_identical() -> None:
+    """Same pin through the ControlMessage payload path."""
+    msg_obj = SimpleNamespace(payload={"note": "pivot to tomatoes"})
+    msg = SequentialExecutor._compose_steer_restart_message(
+        msg_obj, fallback="ignored"
+    )
+    assert msg == (
+        "[USER STEERING CONTROL — supersedes prior task context]\n"
+        "\n"
+        "pivot to tomatoes\n"
+        "\n"
+        "Notes:\n"
+        "- Prior research, partial work, or planned tasks from the "
+        "pre-steer conversation are superseded unless this message "
+        "explicitly references them.\n"
+        "- Proceed with the new direction. Do not continue prior work "
+        "unless doing so directly serves this steer."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Observation fallback chain + question form
+# ---------------------------------------------------------------------------
+
+
+def test_chain_note_to_agent_beats_detector_facts_and_detail() -> None:
+    drift = _drift(
+        DriftKind.LOOPING_REASONING,
+        detail="detector detail",
+        raw={"mode": "exact", "tool_name": "x", "count": 3, "window_len": 5},
+        note_to_agent="judge-authored note",
+    )
+    observation, question = observation_for_drift(drift)
+    assert observation == "judge-authored note"
+    assert question is False  # judge chose its own form
+
+
+def test_chain_detector_facts_beat_detail() -> None:
+    drift = _drift(
+        DriftKind.LOOPING_REASONING,
+        detail="tool_loop_exact: x x 3 in last 5 calls",
+        raw={"mode": "exact", "tool_name": "x", "count": 3, "window_len": 5},
+    )
+    observation, question = observation_for_drift(drift)
+    assert observation.startswith("`x` was invoked 3 times")
+    assert question is False
+
+
+def test_chain_detail_beats_fallback_template() -> None:
+    drift = _drift(DriftKind.TOOL_ERROR, detail="the search tool returned a 429")
+    observation, _q = observation_for_drift(drift)
+    assert observation == "the search tool returned a 429"
+
+
+def test_chain_malformed_raw_falls_back_to_detail() -> None:
+    """A raw payload that isn't the tracker shape degrades to detail."""
+    drift = _drift(
+        DriftKind.LOOPING_REASONING,
+        detail="loop detail",
+        raw={"mode": "exact"},  # missing tool_name / count
+    )
+    observation, _q = observation_for_drift(drift)
+    assert observation == "loop detail"
+
+
+def test_question_form_only_for_low_confidence_judge_opinions() -> None:
+    """Severity is the confidence proxy: judge kinds below CRITICAL ask;
+    CRITICAL verdicts and deterministic facts state."""
+    # Judge opinion, WARNING → question.
+    _obs, question = observation_for_drift(
+        _drift(DriftKind.OFF_TOPIC, severity=DriftSeverity.WARNING, detail="d")
+    )
+    assert question is True
+    # Judge opinion, CRITICAL → statement.
+    _obs, question = observation_for_drift(
+        _drift(DriftKind.OFF_TOPIC, severity=DriftSeverity.CRITICAL, detail="d")
+    )
+    assert question is False
+    # Deterministic kind, WARNING → statement.
+    _obs, question = observation_for_drift(
+        _drift(DriftKind.LOOPING_REASONING, severity=DriftSeverity.WARNING, detail="d")
+    )
+    assert question is False
+
+
+def test_question_form_not_doubled_when_already_a_question() -> None:
+    note = compose_observer_note(
+        observation="Is this still on track?",
+        goals_text="g",
+        question_form=True,
+    )
+    assert note.count("?") == 1
+    assert GOAL_QUESTION not in note
+
+
+# ---------------------------------------------------------------------------
+# Building blocks
+# ---------------------------------------------------------------------------
+
+
+def test_render_goals_text_joins_and_degrades() -> None:
+    assert render_goals_text(None) == "(no goals recorded for this run)"
+    assert render_goals_text([]) == "(no goals recorded for this run)"
+    assert render_goals_text(["plain string goal"]) == "plain string goal"
+    goals = [Goal(id="g1", summary="first"), Goal(id="g2", summary="second")]
+    assert render_goals_text(goals) == "first; second"
+
+
+def test_compose_status_line_handles_missing_everything() -> None:
+    assert compose_status_line(None, "") == ""
+    line = compose_status_line(None, "t9")
+    assert line == "goldfive's tracking associates this note with task t9."
+
+
+def test_status_line_suppressible_and_overridable() -> None:
+    drift = _drift(DriftKind.TOOL_ERROR, detail="d")
+    no_status = compose_note_for_drift(drift=drift, session=_session(), status="")
+    assert "Status:" not in no_status
+    custom = compose_note_for_drift(
+        drift=drift, session=_session(), status="custom bookkeeping line."
+    )
+    assert "Status: custom bookkeeping line." in custom
+
+
+# ---------------------------------------------------------------------------
+# 5. Judges: note_to_agent authored in the verdict call; old-style
+#    responses degrade gracefully
+# ---------------------------------------------------------------------------
+
+
+def _stub_call_llm(response: str):
+    async def _call(_system: str, _user: str, _model: str) -> str:
+        return response
+
+    return _call
+
+
+async def test_goal_drift_judge_stamps_note_to_agent() -> None:
+    from goldfive.drift.goals import classify_goal_drift
+
+    drift = await classify_goal_drift(
+        goals=[Goal(id="g1", summary="ship it")],
+        plan=None,
+        observed_actions=[],
+        model="m",
+        call_llm=_stub_call_llm(
+            '{"progressing": false, "reason": "looping", '
+            '"note_to_agent": "Recent activity repeated the same lookup; '
+            'does it still serve the goal of shipping?"}'
+        ),
+    )
+    assert drift is not None
+    assert drift.note_to_agent == (
+        "Recent activity repeated the same lookup; does it still serve "
+        "the goal of shipping?"
+    )
+    # The composed note prefers the judge's note over detail: the
+    # observation line is the note verbatim; the operator-facing
+    # detail string does not leak into it.
+    note = compose_note_for_drift(drift=drift)
+    observation_line = note.split("\n")[0]
+    assert observation_line == (
+        "Observation: Recent activity repeated the same lookup; does it "
+        "still serve the goal of shipping?"
+    )
+
+
+async def test_goal_drift_judge_old_style_response_degrades() -> None:
+    """Pre-PR-4 response shape (no note_to_agent) → empty field,
+    composer falls back to detail."""
+    from goldfive.drift.goals import classify_goal_drift
+
+    drift = await classify_goal_drift(
+        goals=[Goal(id="g1", summary="ship it")],
+        plan=None,
+        observed_actions=[],
+        model="m",
+        call_llm=_stub_call_llm('{"progressing": false, "reason": "stalled out"}'),
+    )
+    assert drift is not None
+    assert drift.note_to_agent == ""
+    note = compose_note_for_drift(drift=drift)
+    assert "goal drift detected: stalled out" in note
+
+
+async def test_reasoning_judge_stamps_note_to_agent() -> None:
+    from goldfive.drift import reasoning_judge as rjudge
+
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thinking about raccoons",
+        task=None,
+        goals=[Goal(id="g1", summary="ship it")],
+        model="m",
+        call_llm=_stub_call_llm(
+            '{"classification": "erroneous_deviation", "severity": "warning", '
+            '"reason": "off task", "provenance": "none", '
+            '"focused_task_id": "", "focus_confidence": 0.2, '
+            '"stated_intent": "exploring raccoons", '
+            '"note_to_agent": "The recent reasoning explored raccoons, '
+            'which is not part of the recorded goal."}'
+        ),
+        current_task_id="t1",
+    )
+    assert verdict.note_to_agent == (
+        "The recent reasoning explored raccoons, which is not part of "
+        "the recorded goal."
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.note_to_agent == verdict.note_to_agent
+
+
+async def test_reasoning_judge_old_style_response_degrades() -> None:
+    """Legacy {"on_task": false} shape (no note field) → empty note."""
+    from goldfive.drift import reasoning_judge as rjudge
+
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thinking",
+        task=None,
+        goals=None,
+        model="m",
+        call_llm=_stub_call_llm(
+            '{"on_task": false, "severity": "warning", "reason": "off"}'
+        ),
+        current_task_id="t1",
+    )
+    assert verdict.note_to_agent == ""
+    assert verdict.drift is not None
+    assert verdict.drift.note_to_agent == ""
+    # The composed note still renders (detail fallback).
+    note = compose_note_for_drift(drift=verdict.drift)
+    assert note.startswith("Observation: reasoning drift: off")
+
+
+async def test_reasoning_judge_ignores_note_on_on_task_verdicts() -> None:
+    """A chatty model filling note_to_agent on on_task is ignored —
+    healthy turns stay note-free (dormancy)."""
+    from goldfive.drift import reasoning_judge as rjudge
+
+    verdict = await rjudge.classify_reasoning_drift_with_focus(
+        reasoning="thinking",
+        task=None,
+        goals=None,
+        model="m",
+        call_llm=_stub_call_llm(
+            '{"classification": "on_task", "severity": "info", "reason": "fine", '
+            '"provenance": "none", "note_to_agent": "spurious chatter"}'
+        ),
+        current_task_id="t1",
+    )
+    assert verdict.note_to_agent == ""
+    assert verdict.drift is None
+
+
+def test_judge_verdict_note_threads_onto_drift_event() -> None:
+    """DefaultSteerer._drift_from_judge_verdict carries note_to_agent."""
+    from goldfive.judges import JudgeVerdict
+    from goldfive.steerer import DefaultSteerer
+
+    steerer = DefaultSteerer()
+    verdict = JudgeVerdict(
+        drift_emitted=True,
+        drift_kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="operator detail",
+        note_to_agent="agent-facing observation",
+    )
+    drift = steerer._drift_from_judge_verdict(verdict, judge_name="j")
+    assert drift is not None
+    assert drift.note_to_agent == "agent-facing observation"
+
+
+def test_judge_verdict_without_note_field_degrades() -> None:
+    """Duck-typed verdicts lacking the attribute degrade to ''."""
+    from goldfive.steerer import DefaultSteerer
+
+    steerer = DefaultSteerer()
+    verdict = SimpleNamespace(
+        drift_emitted=True,
+        drift_kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="d",
+    )
+    drift = steerer._drift_from_judge_verdict(verdict, judge_name="j")
+    assert drift is not None
+    assert drift.note_to_agent == ""

--- a/tests/test_pause_escalate.py
+++ b/tests/test_pause_escalate.py
@@ -423,4 +423,14 @@ async def test_cancel_reinvoke_dispatches_goldfive_steer_control() -> None:
     payload = steer_msgs[0].payload
     assert payload["drift_kind"] == DriftKind.TOOL_ERROR.value
     assert "t1" in payload["body"]
-    assert "Try a different approach" in payload["body"]
+    # Re-pointed by AGENCY-PRESERVATION.md PR 4: the body used to
+    # interpolate the next PENDING task's title ("Try a different
+    # approach") as a directive. The body is now an observation+goal
+    # advisory note — the next-task pointer is gone by design (the
+    # agent owns means); the task ids still ride the payload's
+    # superseded/replacement lists for observability.
+    from goldfive.observer_notes import ADVISORY_FOOTER
+
+    assert "Try a different approach" not in payload["body"]
+    assert ADVISORY_FOOTER in payload["body"]
+    assert payload["replacement_task_ids"] == ["t1"]

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -345,7 +345,12 @@ async def test_truncates_long_reasoning_in_prompt() -> None:
     # The user prompt carries the truncation marker, not the full text.
     _system, user, _model = call_llm.calls[0]  # type: ignore[attr-defined]
     assert "[truncated]" in user
-    assert len(user) < len(big) + 2000  # prompt framing but not full 3500 chars
+    # Framing margin re-pointed by AGENCY-PRESERVATION.md PR 4: the
+    # template grew the "4. NOTE" / note_to_agent instructions (~700
+    # chars of framing). The assertion's purpose is unchanged — the
+    # truncated reasoning, not the full 3500+ chars, lands in the
+    # prompt — so the margin covers framing only.
+    assert len(user) < len(big) + 3000  # prompt framing but not full 3500 chars
 
 
 # ---------------------------------------------------------------------------
@@ -1510,11 +1515,15 @@ def test_prompt_lineage_block_when_agent_not_in_set() -> None:
 
 
 def test_prompt_renders_three_state_decision_section() -> None:
-    """The user prompt template carries the iter-10 'Decide THREE things' block.
+    """The user prompt template carries the decision block.
 
     Snapshot-style contains-check: pins the literal markers so a
-    well-meaning prompt edit that drops one of the three decisions
-    fails this test.
+    well-meaning prompt edit that drops one of the decisions fails
+    this test. Re-pointed by AGENCY-PRESERVATION.md PR 4: the iter-10
+    'Decide THREE things' block grew a fourth decision — the
+    judge-authored ``note_to_agent`` observation — so the header now
+    reads FOUR and the NOTE marker is pinned alongside the original
+    three.
     """
     rendered = rjudge.REASONING_DRIFT_USER_PROMPT_TEMPLATE.format(
         plan_tasks_summary="(no plan tasks)",
@@ -1526,11 +1535,15 @@ def test_prompt_renders_three_state_decision_section() -> None:
         tool_obs_block="(no recent tool observations)",
         tool_obs_count=0,
     )
-    assert "Decide THREE things:" in rendered
-    # The three decisions are listed.
+    assert "Decide FOUR things:" in rendered
+    # The four decisions are listed.
     assert "1. CLASSIFICATION." in rendered
     assert "2. ATTRIBUTION." in rendered
     assert "3. PROVENANCE." in rendered
+    assert "4. NOTE." in rendered
+    # The note's JSON key + content rules appear verbatim.
+    assert "note_to_agent" in rendered
+    assert "no commands" in rendered
     # Provenance enum literals appear verbatim (the LLM's output must
     # match these strings; the parser strip+lowercases before
     # comparison but the prompt asks for the canonical names).

--- a/tests/test_steer_unification.py
+++ b/tests/test_steer_unification.py
@@ -198,8 +198,16 @@ async def test_goldfive_steer_promotes_at_warning_severity() -> None:
     # DriftDetected + PlanRevised emitted.
     assert len(_drift_detected_events(sink)) >= 1
     assert len(_plan_revised_events(sink)) == 1
-    # active_steer state stamped with source="goldfive".
-    assert session.state[_ostate.KEY_ACTIVE_STEER_BODY] == "agent wandered into raccoons"
+    # active_steer state stamped with source="goldfive". Re-pointed by
+    # AGENCY-PRESERVATION.md PR 4: the body is now the full
+    # observation+goal advisory note (judge detail embedded as the
+    # observation, advisory footer appended) instead of the bare
+    # drift.detail.
+    from goldfive.observer_notes import ADVISORY_FOOTER
+
+    body = session.state[_ostate.KEY_ACTIVE_STEER_BODY]
+    assert "agent wandered into raccoons" in body
+    assert ADVISORY_FOOTER in body
     assert session.state[_ostate.KEY_ACTIVE_STEER_AUTHOR] == "goldfive"
     assert session.state[_ostate.KEY_ACTIVE_STEER_SOURCE] == "goldfive"
     # Adapter cancel reason tagged.
@@ -314,9 +322,12 @@ async def test_goldfive_steer_fires_when_user_steer_stale() -> None:
 
     # refine_steer fired now (stale user steer shouldn't block).
     assert len(planner.refine_steer_calls) == 1
-    # active_steer now carries the goldfive body.
+    # active_steer now carries the goldfive body. Re-pointed by
+    # AGENCY-PRESERVATION.md PR 4: the body is the full
+    # observation+goal advisory note embedding the judge detail, not
+    # the bare drift.detail.
     assert session.state[_ostate.KEY_ACTIVE_STEER_SOURCE] == "goldfive"
-    assert session.state[_ostate.KEY_ACTIVE_STEER_BODY] == "fresh detector fire"
+    assert "fresh detector fire" in session.state[_ostate.KEY_ACTIVE_STEER_BODY]
 
 
 async def test_suppression_window_unaffected_by_event_volume() -> None:
@@ -459,7 +470,18 @@ async def test_goldfive_steer_cancel_reason_intent_divergence_critical() -> None
 
 
 async def test_goldfive_steer_body_from_drift_detail() -> None:
-    """Non-empty drift.detail is used verbatim as the steer body."""
+    """Non-empty drift.detail is embedded as the note's observation.
+
+    Re-pointed by AGENCY-PRESERVATION.md PR 4: the pre-PR-4 contract
+    was "detail verbatim as the whole body"; the body is now the full
+    observation+goal advisory note. The detail is still carried
+    verbatim inside it (observation line), the goal line renders from
+    ``session.goals``, and — because a WARNING judge opinion with no
+    judge-authored ``note_to_agent`` is low-confidence — the
+    observation renders in question form.
+    """
+    from goldfive.observer_notes import ADVISORY_FOOTER, GOAL_QUESTION
+
     steerer, session, _sink, _planner, _adapter = _bind()
     drift = DriftEvent(
         kind=DriftKind.OFF_TOPIC,
@@ -468,14 +490,48 @@ async def test_goldfive_steer_body_from_drift_detail() -> None:
         current_task_id="t2",
     )
     await steerer.drift.handle_drift(drift, session)
-    assert (
-        session.state[_ostate.KEY_ACTIVE_STEER_BODY]
-        == "agent acknowledged discrepancy but chose to adopt expanded topic"
+    body = session.state[_ostate.KEY_ACTIVE_STEER_BODY]
+    assert "agent acknowledged discrepancy but chose to adopt expanded topic" in body
+    assert GOAL_QUESTION in body
+    assert ADVISORY_FOOTER in body
+
+
+async def test_goldfive_steer_body_prefers_note_to_agent() -> None:
+    """A judge-authored note_to_agent wins over detail (PR 4 chain)."""
+    from goldfive.observer_notes import ADVISORY_FOOTER
+
+    steerer, session, _sink, _planner, _adapter = _bind()
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="operator-facing reason string",
+        current_task_id="t2",
+        note_to_agent=(
+            "Does the recent focus on raccoons still serve the goal of "
+            "shipping the thing?"
+        ),
     )
+    await steerer.drift.handle_drift(drift, session)
+    body = session.state[_ostate.KEY_ACTIVE_STEER_BODY]
+    assert "Does the recent focus on raccoons" in body
+    # detail remains the observability rendering, NOT the agent-facing
+    # observation, when the judge authored a note.
+    assert "operator-facing reason string" not in body
+    assert ADVISORY_FOOTER in body
 
 
 async def test_goldfive_steer_body_fallback_when_detail_empty() -> None:
-    """Empty detail falls through to the synthesised template."""
+    """Empty detail falls through to the neutral per-kind fallback.
+
+    Re-pointed by AGENCY-PRESERVATION.md PR 4: the retired synthesised
+    template said "Goldfive detected OFF_TOPIC drift … Discard prior
+    work … proceed with the corrective plan" — a command about means.
+    The fallback is now a neutral observation; the task id stays
+    present as bookkeeping (Status line), and the advisory footer
+    closes the note.
+    """
+    from goldfive.observer_notes import ADVISORY_FOOTER
+
     steerer, session, _sink, _planner, _adapter = _bind()
     drift = DriftEvent(
         kind=DriftKind.OFF_TOPIC,
@@ -485,10 +541,11 @@ async def test_goldfive_steer_body_fallback_when_detail_empty() -> None:
     )
     await steerer.drift.handle_drift(drift, session)
     body = session.state[_ostate.KEY_ACTIVE_STEER_BODY]
-    assert "Goldfive detected" in body
-    assert "OFF_TOPIC" in body
-    assert "WARNING" in body
     assert "t2" in body
+    assert ADVISORY_FOOTER in body
+    # The retired command template must not resurface.
+    assert "Goldfive detected" not in body
+    assert "Discard prior" not in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tier1_loop_prevention.py
+++ b/tests/test_tier1_loop_prevention.py
@@ -403,9 +403,25 @@ def test_f4_goal_drift_critical_repeat_routes_to_cancel_reinvoke() -> None:
     assert level is InterventionLevel.CANCEL_REINVOKE
 
 
-def test_f4_goal_drift_template_renders_with_next_agent() -> None:
-    """F4: the GOAL_DRIFT corrective template names the next pending task
-    AND the agent it's assigned to so the coordinator routes directly."""
+# The three pre-PR-4 tests here pinned the GOAL_DRIFT corrective
+# template's next-task routing ("Please proceed to '{next_task_title}'
+# via {next_task_agent}"): rendering the next pending task's title, the
+# missing-assignee placeholder, and bare-agent-name collapsing.
+# AGENCY-PRESERVATION.md PR 4 retired that command surface entirely —
+# the wrapped agent owns MEANS (which task / agent comes next), so the
+# composed note must NOT name a next task or assignee. The re-pointed
+# tests below pin the replacement contract: triggering-task bookkeeping
+# stays, next-task / next-agent directives are gone.
+
+
+def test_f4_goal_drift_note_keeps_bookkeeping_drops_routing() -> None:
+    """PR 4 re-point of ``test_f4_goal_drift_template_renders_with_next_agent``:
+    the GOAL_DRIFT note keeps the triggering task's ledger status
+    ("recorded as completed" — the bookkeeping form of the old
+    "already complete" signal) and the judge detail, but no longer
+    names the next pending task or its assignee."""
+    from goldfive.observer_notes import ADVISORY_FOOTER
+
     plan = Plan(
         id="p1",
         run_id="r1",
@@ -428,41 +444,22 @@ def test_f4_goal_drift_template_renders_with_next_agent() -> None:
         current_task_id="t0",
     )
     msg = compose_corrective_user_message(drift=drift, refined_plan=plan)
+    # Bookkeeping: the triggering task and its recorded status survive.
     assert "t0" in msg
-    assert "already complete" in msg
-    assert "Draft the brief" in msg
-    assert "writer" in msg
+    assert "completed" in msg.lower()
+    assert "agent grinding on completed research" in msg
+    assert ADVISORY_FOOTER in msg
+    # The command surface is gone: no next-task title, no assignee
+    # routing, no "proceed to ... via ...".
+    assert "Draft the brief" not in msg
+    assert "writer" not in msg
+    assert "proceed to" not in msg.lower()
 
 
-def test_f4_goal_drift_template_handles_missing_assignee() -> None:
-    """F4: when the next pending task has no assignee, the template
-    falls back to a readable placeholder rather than interpolating an
-    empty agent name."""
-    plan = Plan(
-        id="p1",
-        run_id="r1",
-        goal_ids=[],
-        tasks=[
-            Task(id="t0", title="Research", status=TaskStatus.COMPLETED),
-            Task(id="t1", title="Draft", status=TaskStatus.PENDING),
-        ],
-        edges=[],
-    )
-    drift = DriftEvent(
-        kind=DriftKind.GOAL_DRIFT,
-        severity=DriftSeverity.CRITICAL,
-        detail="x",
-        current_task_id="t0",
-    )
-    msg = compose_corrective_user_message(drift=drift, refined_plan=plan)
-    assert "Draft" in msg
-    # No double-space artifact from an empty interpolation.
-    assert "via  " not in msg
-
-
-def test_f4_goal_drift_uses_bare_agent_name() -> None:
-    """F4: fully-qualified ADK agent paths collapse to the bare name so
-    the LLM sees something it can pass back as the AgentTool target."""
+def test_f4_goal_drift_note_never_names_next_assignee() -> None:
+    """PR 4 re-point of ``test_f4_goal_drift_uses_bare_agent_name``:
+    assignee names (qualified or bare) never appear in the note at
+    all — the routing decision belongs to the agent."""
     plan = Plan(
         id="p1",
         run_id="r1",
@@ -485,8 +482,10 @@ def test_f4_goal_drift_uses_bare_agent_name() -> None:
         current_task_id="t0",
     )
     msg = compose_corrective_user_message(drift=drift, refined_plan=plan)
-    assert "via writer_agent" in msg
+    assert "writer_agent" not in msg
     assert "coordinator.writer_agent" not in msg
+    # And no interpolation artifacts from the retired template.
+    assert "via " not in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements **AGENCY-PRESERVATION.md PR 4 — Intervention content rewrite** (Stage 1). Content-only: every message goldfive composes *for the wrapped agent* moves from commands-about-means to observation + goal + advisory footer. No dispatch, queueing, ladder, or ControlMessage changes — the full suite passes with only text-assertion tests re-pointed (table below).

## What changed

- **New `goldfive/observer_notes.py`** — the single composer every legacy delivery path renders through. Body lines match the PR 6 "Rendered block shape" (`Observation:` / `The user's goal:` / `Status:` / advisory footer) so the future observer-note channel wraps these same bodies in `[GOLDFIVE OBSERVER NOTE …]` markers without forking content.
- **Observation sourcing chain** (formalised in `observation_for_drift`): judge-authored `note_to_agent` (verbatim) → deterministic detector facts (tool-loop counts + exact-match arg fingerprints from `drift.raw`; no new LLM calls, no NL classification) → `drift.detail` → per-kind neutral fallback template.
- **`_CORRECTIVE_TEMPLATES` retired**; `compose_corrective_user_message` is a deprecated delegating shim (public `__all__` name; external/test importers keep working). `_next_pending_task_title` / `_next_pending_task_agent` deleted — nothing points the agent at goldfive's choice of next task/agent anymore.
- **Judge-authored observations**: `note_to_agent: str = ""` added to `JudgeVerdict`, `ReasoningJudgeVerdict`, and `DriftEvent` (the in-process transport to the composer). Reasoning-judge prompt grows decision "4. NOTE"; goal-drift judge's `progressing: false` schema grows the field. The judge writes the note in the SAME call that produces the verdict, and is instructed to use question form when unsure. Field route: **plain dataclass fields, in-process only** — `DriftDetected`/`JudgementEmitted` protos untouched (no regen; the wire surface belongs to PR 5 telemetry).
- **Question form**: neither `JudgeVerdict` nor `DriftEvent` carries a per-verdict confidence scalar today (`focus_confidence` scores task *attribution*, not the verdict), so **severity is the confidence proxy**: goldfive-composed observations for judge-opinion kinds (OFF_TOPIC, GOAL_DRIFT, INTENT_DIVERGENCE, JUSTIFIED_DEVIATION, UNCERTAIN_PROGRESS) below CRITICAL render as questions; hard observed facts (loop counters) and CRITICAL verdicts stay statements. Judge-authored notes choose their own form via the prompt.
- **Executor composers**: `_compose_nudge_replay_message` and the goldfive branch of `_compose_steer_restart_message` keep their `[GOLDFIVE PLAN REVISION` / `[GOLDFIVE STEERING CONTROL` attribution markers (delivery mechanics unchanged); bodies drop "do NOT retry"/"do NOT resume"/next-task routing. Superseded/replacement ids render as a *bookkeeping* line and remain on the ControlMessage payload for observability. **USER steer branch is byte-identical** (full-string pinned in tests).
- `goldfive/testkit/adversarial.py` grows the test-side means-command wordlist checker (`find_means_commands`) — explicitly test-only, never a production NL classifier (#166/#167 rule).
- Optimization prompt markdown copies (`goal_drift_user.md`, `reasoning_judge_user.md`) regenerated from the live constants (manifest sync test `test_prompt_mutations_match_live_python_attrs`).

## Before / after examples

### 1. GOAL_DRIFT (judge opinion, agent grinding on completed work)

Before (template, commands means + names next agent):
```
Task 't0' is already complete. Please proceed to 'Draft the brief' via writer.
```
After:
```
Observation: recent turns kept re-reading completed research Does the current approach still serve the user's goal?
The user's goal: research raccoon habitats and draft a summary
Status: goldfive's tracking records task t0 as completed; its ledger shows 1 task(s) recorded complete and 2 still open.
This note is advisory. How to proceed is your decision; the user's instructions remain authoritative.
```

### 2. LOOPING_REASONING (deterministic tool-loop detector, exact mode)

Before:
```
The prior attempt looped on t1. Refined plan: Draft the summary. Please try a different approach.
```
After (statement form — hard observed fact, rendered from `drift.raw` counts/fingerprint the tracker already holds):
```
Observation: `search_web` was invoked 5 times in the last 10 tool invocations with identical arguments (args fingerprint a1b2c3d4); no task progress was recorded in that window.
The user's goal: research raccoon habitats and draft a summary
Status: goldfive's tracking records task t1 as running (still open); its ledger shows 1 task(s) recorded complete and 2 still open.
This note is advisory. How to proceed is your decision; the user's instructions remain authoritative.
```

### 3. OFF_TOPIC promoted to GOLDFIVE_STEER (judge-authored note + executor framing)

Before (steer body = bare `drift.detail`; executor appended):
```
[GOLDFIVE STEERING CONTROL — supersedes prior task context]

agent acknowledged discrepancy but chose to adopt expanded topic

Notes:
- Goldfive detected drift in the prior turn's activity. Prior research, partial work, or planned tasks from the contaminated step are superseded unless this message explicitly references them.
- Proceed with the corrective direction above. Do not retry the superseded task.
- Superseded task ids (do NOT resume these): t2
- Replacement task ids (pick these up instead): t2b
```
After (judge `note_to_agent` preferred; ids as bookkeeping):
```
[GOLDFIVE STEERING CONTROL — supersedes prior task context]

Observation: The last three reasoning turns discussed raccoon migration, which does not appear in the user's request. Does that line of inquiry still serve the goal of drafting the summary?
The user's goal: research raccoon habitats and draft a summary
Status: goldfive's tracking records task t1 as running (still open); its ledger shows 1 task(s) recorded complete and 2 still open.
This note is advisory. How to proceed is your decision; the user's instructions remain authoritative.

goldfive bookkeeping (for reference): goldfive's plan tracking records task id(s) t2 as superseded by this revision; its ledger contains replacement entrie(s): t2b.
```

The nudge-replay header changed `[GOLDFIVE PLAN REVISION — replace superseded task(s)]` → `[GOLDFIVE PLAN REVISION — observer note]`: the marker prefix plugins/tests match on (`[GOLDFIVE PLAN REVISION`) is preserved; the em-dash suffix was itself a means-command ("replace …") so it could not stay.

## Test migration table (every re-pointed text assertion)

| Test | Was | Now | Why |
|---|---|---|---|
| `test_corrective_message.py` (whole file) | pinned per-kind `_CORRECTIVE_TEMPLATES` shapes ("Refined plan: …", "proceed with …"), 250-char cap | pins shim delegation, note shape per kind, means-command sweep, no-next-task-routing, jargon ban kept | templates retired; the length cap was an artifact of the one-line command format |
| `test_tier1_loop_prevention.py::test_f4_goal_drift_template_renders_with_next_agent` | asserted next task title + assignee in message | `test_f4_goal_drift_note_keeps_bookkeeping_drops_routing`: task id + "completed" bookkeeping + detail + footer; next title/assignee asserted ABSENT | next-task routing is the command surface PR 4 removes |
| `test_tier1_loop_prevention.py::test_f4_goal_drift_template_handles_missing_assignee` | asserted no `"via  "` interpolation artifact | folded into `test_f4_goal_drift_note_never_names_next_assignee` (`"via "` never renders at all) | the `via {agent}` interpolation no longer exists |
| `test_tier1_loop_prevention.py::test_f4_goal_drift_uses_bare_agent_name` | asserted bare agent name rendered | re-pointed: NO assignee name (bare or qualified) renders | routing decision belongs to the agent |
| `test_steer_unification.py::test_goldfive_steer_promotes_at_warning_severity` | `active_steer body == drift.detail` | detail embedded in note + advisory footer present | body is now the full note |
| `test_steer_unification.py::test_goldfive_steer_fires_when_user_steer_stale` | `body == "fresh detector fire"` | `"fresh detector fire" in body` | same |
| `test_steer_unification.py::test_goldfive_steer_body_from_drift_detail` | detail verbatim as whole body | detail on observation line + question form + footer; new sibling test `test_goldfive_steer_body_prefers_note_to_agent` | fallback chain formalised |
| `test_steer_unification.py::test_goldfive_steer_body_fallback_when_detail_empty` | asserted "Goldfive detected" / "OFF_TOPIC" / "WARNING" | asserts t2 bookkeeping + footer + retired command text ABSENT | synthesised command template retired |
| `test_pause_escalate.py::test_cancel_reinvoke_dispatches_goldfive_steer_control` | asserted next PENDING task title in body | title asserted ABSENT; footer present; ids still on `replacement_task_ids` payload | next-task pointer removed by design; observability unchanged |
| `test_reasoning_judge.py::test_prompt_renders_three_state_decision_section` | "Decide THREE things:" | "Decide FOUR things:" + "4. NOTE." + `note_to_agent` markers | prompt grew the note decision |
| `test_reasoning_judge.py::test_truncates_long_reasoning_in_prompt` | framing margin `+2000` | `+3000` | template framing grew ~700 chars; assertion intent (truncated reasoning, not full text) unchanged |

No dispatch/behavior test was modified. Suite: **2354 passed, 127 skipped** (baseline at main: 2328 passed, 127 skipped; +26 net new tests), `ruff check` clean.

## §5 correctness requirements

- **Adversarial content tests**: `tests/test_observer_notes.py::test_no_imperative_means_verbs_in_any_rendering` sweeps every `DriftKind` × every `DriftSeverity` × {note composer, nudge-replay wrapper, goldfive steer-restart wrapper} × {with/without detail} plus all three tool-loop modes against the wordlist ("retry", "proceed to", "call", "use agent", "do not", "you must", "switch to"). Token-based matching (no regex), test-side only.
- **Golden outputs**: exact full-string pins for tool-loop-exact, GOAL_DRIFT question form, judge-authored note, per-kind fallbacks, and both executor wrappers — future content changes are reviewable diffs.
- **USER_STEER byte-identity**: two full-string pins (fallback path + payload-note path) of the pre-PR-4 user-steer rendering.
- **Graceful degradation**: old-style judge responses (no `note_to_agent`) tested for both judges → empty field → composer falls back to `detail`; duck-typed `JudgeVerdict`s without the attribute degrade via `getattr`; on_task verdicts ignore spurious notes (healthy turns stay note-free — dormancy).
- **No orphans**: grep-verified — no remaining callers of `_CORRECTIVE_TEMPLATES` / `_next_pending_task_*`; the shim's only callers are external-API tests.

## Notes / out-of-scope command language (for the record)

- `adapters/adk.py` synthetic cancelled-function_response content ("Do NOT retry. Await next instruction.") and the `_USER_STEER_PRIMER_TEXT` belong to the cancel surface (PR 1/7 family), and `GoldfivePlanner`'s orchestration block + `prompt_shaper`'s "Do NOT call any AgentTool" are the PR 9 prompt-shaping diet — all outside PR 4's enumerated composer set, left untouched.
- `note_to_agent` is not mirrored onto `DriftDetected`/`JudgementEmitted` protos (would need a regen); PR 5's telemetry pass should add it to the wire if dry-run diffing wants it.
- For PR 6: the composer bodies here are already the block-body shape — the channel only needs to add the `[GOLDFIVE OBSERVER NOTE …]` wrapper and consume `ObserverNoteQueue` instead of `pending_nudges`; `ADVISORY_FOOTER`/`GOAL_QUESTION` are importable constants so the two regimes cannot fork wording.
