### PR TITLE
feat(drift): demote forecast-mismatch kinds to observability + ladder decision-table snapshot (AGENCY-PRESERVATION PR 3)

### DIFF
--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -85,7 +85,7 @@ kinds group naturally into six categories.
 
 | Kind | Trigger | Default severity | Recoverable |
 |---|---|---|---|
-| `PLAN_DIVERGENCE` | `report_plan_divergence(note, suggested_action)` | `warning` | yes |
+| `PLAN_DIVERGENCE` | `report_plan_divergence(note, suggested_action)` | `warning` | **observability-only** (AGENCY-PRESERVATION.md PR 3: ladder OBSERVE at all severities; also dropped at the top of `handle_drift` per #252. DriftDetected still emits via the executor reachability-audit emitter; no refine/steer/cancel.) |
 | `STOPPED_EARLY` | Agent stopped emitting before marking the task terminal. | `warning` | yes |
 | `TOO_MANY_STEPS` | Adapter observed an unreasonable step count in a single invocation. | `warning` | yes |
 | `UNEXPECTED_OUTPUT` | Output did not match a caller-supplied schema / heuristic. | `warning` | yes |
@@ -96,36 +96,63 @@ kinds group naturally into six categories.
 
 | Kind | Trigger | Default severity | Recoverable |
 |---|---|---|---|
-| `WRONG_AGENT` | Reporting tool call came from an agent that is not `task.assignee_agent_id`. | `warning` | yes |
+| `WRONG_AGENT` | **DEPRECATED (AGENCY-PRESERVATION.md PR 3) — no production emitter.** Was "reporting tool call came from an agent that is not `task.assignee_agent_id`". Subsumed by `CAPABILITY_MISMATCH` (#253) and the #252 move off assignee-grading. Enum value stays reserved (proto/wire compat); carries no intervention-ladder row. | n/a | n/a |
 | `AGENT_TRANSFER` | Adapter observed a transfer / delegation to an unplanned agent. | `info` | yes |
 | `CONTEXT_PRESSURE` | Adapter observed a `finish_reason` indicating the context window was hit. | `warning` | yes |
 | `RESOURCE_EXHAUSTED` | Adapter observed rate-limit or quota exhaustion. | `warning` | yes |
 | `BLOCKED` | `report_task_blocked(task_id, blocker)` with a structural blocker. | `warning` | sometimes |
-| `CAPABILITY_MISMATCH` | Structural capability gap at `delegation_observed` time: Rule A (coordinator-style leaf-assignment, #253), Rule B (required-tools cover, #253), Rule C (out-of-DAG-order delegation, #268). See `goldfive/drift/capability_check.py`. | `critical` | yes (refine) |
+| `CAPABILITY_MISMATCH` | Structural capability gap at `delegation_observed` time: Rule A (coordinator-style leaf-assignment, #253; **soft-retired, default OFF**), Rule B (required-tools cover, #253), Rule C (out-of-DAG-order delegation, #268; soft-retired). See `goldfive/drift/capability_check.py`. | Rule B `warning`; Rule A/C `critical` (gated off) | Rule B → refine (WARNING→ABSORB); Rule A/C → OBSERVE |
 
-**Rule C status under plan-descriptive growth (goldfive#423 /
-AGENCY-PRESERVATION.md PR 2).** Rule A and Rule B still fire normally
-for non-discovered bound tasks; both are skipped when the bound task
-is `discovered=True` (PLAN-DESCRIPTIVE-GROWTH.md §11.4(a)). **Rule C
-is soft-retired**: it no longer runs unless the operator explicitly
-sets `GOLDFIVE_CAPABILITY_RULE_C=1`. With
-`SteeringConfig.descriptive_growth_enabled=True` (the default; env
-`GOLDFIVE_STEER_DESCRIPTIVE_GROWTH`), the delegation pin grows a
-`discovered=True` task via `PlanReviser.install_descriptive_growth`
-whenever tier 1/2 matching misses — the plan grows to match reality
-BEFORE any capability rule runs, so the mispin shape Rule C detected
-no longer occurs. Hard deletion of Rule C follows in
-AGENCY-PRESERVATION.md PR 13. The data-model carriers
-(`Task.discovered`, `DelegationObserved.tool_args_json`) ship
-regardless of the flag. See
-[PLAN-DESCRIPTIVE-GROWTH.md](PLAN-DESCRIPTIVE-GROWTH.md) §7 for the
-full Rule A/B/C table under the new model.
+**Rule status under plan-descriptive growth + the PR 3 demotion
+(goldfive#423 / AGENCY-PRESERVATION.md PR 2 & PR 3).**
+
+* **Rule A is soft-retired (PR 3): default OFF**, re-enabled only via
+  `GOLDFIVE_CAPABILITY_RULE_A=1`. Its leaf-task read is stem/keyword
+  NL classification — the #166/#167 anti-pattern — and was the source
+  of the e2e 2d27ff4a refine storm. Even when re-enabled it only
+  OBSERVEs: the `CAPABILITY_MISMATCH` ladder row demotes the CRITICAL
+  cells to OBSERVE.
+* **Rule B is kept** as the one capability steering trigger
+  (user-declared `required_tools` is genuine prescriptive intent, not
+  a forecast), but now fires **WARNING, not CRITICAL** ("WARNING-max"):
+  the ladder refines (WARNING→ABSORB) but cannot escalate to
+  cancel/pause.
+* **Rule C is soft-retired** (PR 2): silent unless
+  `GOLDFIVE_CAPABILITY_RULE_C=1`; like Rule A it routes to OBSERVE when
+  re-enabled.
+* Both A and B are still skipped when the bound task is
+  `discovered=True` (PLAN-DESCRIPTIVE-GROWTH.md §11.4(a)). With
+  `SteeringConfig.descriptive_growth_enabled=True` (the default; env
+  `GOLDFIVE_STEER_DESCRIPTIVE_GROWTH`), the delegation pin grows a
+  `discovered=True` task via `PlanReviser.install_descriptive_growth`
+  whenever tier 1/2 matching misses — the plan grows to match reality
+  BEFORE any capability rule runs.
+
+Hard deletion of Rules A/C follows in AGENCY-PRESERVATION.md PR 13. The
+data-model carriers (`Task.discovered`,
+`DelegationObserved.tool_args_json`) ship regardless of the flags. See
+[PLAN-DESCRIPTIVE-GROWTH.md](PLAN-DESCRIPTIVE-GROWTH.md) §7 for the full
+Rule A/B/C table under the new model.
 
 ### Discovery category — new work that was not in the plan
 
 | Kind | Trigger | Default severity | Recoverable |
 |---|---|---|---|
-| `NEW_WORK_DISCOVERED` | `report_new_work_discovered(parent_task_id, title, description, assignee)` | `warning` | yes |
+| `NEW_WORK_DISCOVERED` | `report_new_work_discovered(parent_task_id, title, description, assignee)` | `info` (was `warning`) | **absorb-as-growth** (AGENCY-PRESERVATION.md PR 3) |
+
+**Reroute (AGENCY-PRESERVATION.md PR 3).** The agent-authored
+`report_new_work_discovered` reporting tool no longer fires a WARNING
+drift through `planner.refine` (the "Plan is a forecast the agent is
+graded against" defect, §1.2 / PLAN-DESCRIPTIVE-GROWTH.md §13). It now
+absorbs the report as a `discovered=True` ledger task via
+`PlanReviser.install_descriptive_growth` — the agent's verbatim
+title/description are preserved, the task lands as a sub-DAG root, and
+observability is kept (the growth path still emits `PlanRevised` +
+`DriftDetected`, now at INFO — "observational, not corrective"). The
+framework-synthesised discovery path (pin-time / reconciler growth) was
+already INFO and non-steering; the explicit `NEW_WORK_DISCOVERED`
+ladder row (OBSERVE at all severities) makes that the documented
+mapping.
 
 ### User category — external control signal
 
@@ -671,16 +698,31 @@ Drift handling routes through an explicit six-level ladder
 (goldfive#142) so "when does goldfive interrupt the tree" is a single
 table, not a tangle of conditionals. The live mapping from
 `(drift_kind, severity, occurrence_count)` to level is
-`DefaultSteerer._LADDER` plus the fallback in
-`DefaultSteerer._ladder_level_for`. See `goldfive/steerer.py` for
-the authoritative table.
+`DriftObserver._LADDER` plus the fallback in
+`DriftObserver._ladder_level_for` (in `goldfive/drift_observer.py` —
+the ladder moved off the router in the steerer split; a `steerer.py`
+reference in older docs is stale). The full `(kind × severity ×
+occurrence-bucket)` surface is snapshotted as a checked-in golden in
+`tests/test_ladder_decision_table.py` (AGENCY-PRESERVATION.md §5.3), so
+every cell change lands as an explicit, reviewable table diff.
+
+**Forecast-mismatch demotions (AGENCY-PRESERVATION.md PR 3).** Three
+kinds that signalled divergence from goldfive's *forecast* (not from
+the user's goal) are now observability-only — `DriftDetected` still
+emits, but the ladder takes no refine/steer/cancel action:
+`PLAN_DIVERGENCE` (OBSERVE at all severities), `NEW_WORK_DISCOVERED`
+(OBSERVE; the agent-authored reporting tool reroutes to descriptive
+growth), and `CAPABILITY_MISMATCH` at CRITICAL (Rule A / soft-retired
+Rule C). `CAPABILITY_MISMATCH` at WARNING stays `ABSORB` so Rule B
+(user-declared `required_tools`) keeps refining. `WRONG_AGENT` is
+deprecated with no ladder row.
 
 | Level | Name | Action | Typical triggers |
 |---|---|---|---|
 | **0** | `OBSERVE` | Emit `DriftDetected`; no further action. | Every `INFO` drift. |
-| **1** | `ABSORB` | Call `planner.refine`; install the revised plan; continue. | `WARNING` drifts with a known kind (`LOOPING_REASONING`, `LOOPING_TOOL_CALL`, `PLAN_DIVERGENCE`, `TOOL_ERROR`, `AGENT_REFUSAL`, `INTENT_DIVERGENCE`, etc.); CRITICAL first-occurrence of most kinds. |
+| **1** | `ABSORB` | Call `planner.refine`; install the revised plan; continue. | `WARNING` drifts with a known kind (`LOOPING_REASONING`, `LOOPING_TOOL_CALL`, `TOOL_ERROR`, `AGENT_REFUSAL`, `INTENT_DIVERGENCE`, and `CAPABILITY_MISMATCH` Rule B, etc.); CRITICAL first-occurrence of most kinds. |
 | **2** | `NUDGE` | Queue a short corrective user message on `session.pending_nudges` for the Runner's overlay loop to pick up at the next invocation boundary. | `LOOPING_REASONING` at CRITICAL (first occurrence) after goldfive#204 — gives the agent a soft corrective prompt before escalating. Also available for caller overrides. |
-| **3** | `CANCEL_REINVOKE` | Refine the plan; install the revision; **dispatch a `GOLDFIVE_STEER` ControlMessage on the bound channel**. The executor's invoke loop cancels the in-flight invocation and restarts the passthrough with a `[GOLDFIVE STEERING CONTROL …]` framed corrective body. | CRITICAL first-occurrence for most refinable kinds (`PLAN_DIVERGENCE`, `TOOL_ERROR`, `RUNAWAY_DELEGATION`, ...). (`LOOPING_REASONING` CRITICAL-first now routes to Level 2 via goldfive#204.) |
+| **3** | `CANCEL_REINVOKE` | Refine the plan; install the revision; **dispatch a `GOLDFIVE_STEER` ControlMessage on the bound channel**. The executor's invoke loop cancels the in-flight invocation and restarts the passthrough with a `[GOLDFIVE STEERING CONTROL …]` framed corrective body. | CRITICAL first-occurrence for most refinable kinds (`TOOL_ERROR`, `AGENT_REFUSAL`, `MODEL_REFUSAL`, `OFF_TOPIC`, `RUNAWAY_DELEGATION`, ...). (`LOOPING_REASONING` CRITICAL-first now routes to Level 2 via goldfive#204.) |
 | **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; **dispatch a `GOLDFIVE_PAUSE_ESCALATE` ControlMessage on the bound channel**; do NOT call `planner.refine`. The executor's pre-task loop blocks until a user `RESUME` / `STEER` / `CANCEL` arrives on the channel. | `GOAL_DRIFT` (first & repeat); `REFINE_VALIDATION_FAILED`; `HUMAN_INTERVENTION_REQUIRED`; `INTENT_DIVERGENCE` at CRITICAL; CRITICAL-repeat of almost every kind. |
 | **5** | `TERMINATE` | Run-level abort. Currently only reachable when a Level-4-initiated pause times out and `HUMAN_INTERVENTION_REQUIRED` re-fires as a repeat CRITICAL. | Repeat `HUMAN_INTERVENTION_REQUIRED`. |
 

--- a/goldfive/drift/capability_check.py
+++ b/goldfive/drift/capability_check.py
@@ -14,18 +14,29 @@ planner LLM hallucinated the assignee), we ground the comparison in
 
 Detection rules (intentionally surgical):
 
-* **Rule A — coordinator-style leaf-assignment.** If every tool on the
+* **Rule A — coordinator-style leaf-assignment. SOFT-RETIRED
+  (AGENCY-PRESERVATION.md PR 3): OFF by default.** If every tool on the
   invoked agent is an ``AgentTool`` instance (i.e. its only capability
   is to delegate further) AND the bound task reads as a leaf authoring
   task ("draft", "write", "review", "research", "patch", "locate" …
   rather than "coordinate", "delegate", "orchestrate"), the agent
-  cannot actually do the work. Fires CRITICAL.
+  cannot actually do the work. The leaf-task read is stem/keyword NL
+  classification — the #166/#167 anti-pattern — and was the source of
+  the e2e 2d27ff4a refine storm, so Rule A no longer runs unless the
+  operator sets ``GOLDFIVE_CAPABILITY_RULE_A=1``. Even when re-enabled
+  it only OBSERVEs: the CAPABILITY_MISMATCH ladder demotes the CRITICAL
+  cells (PR 3). Fires CRITICAL (for the observability signal). Hard
+  deletion follows in PR 13.
 
 * **Rule B — required-tools advisory.** If
   :attr:`~goldfive.types.Task.required_tools` is non-empty and the
   invoked agent's tool names do not cover every required name, fire
-  CRITICAL. Skipped entirely when the advisory is empty (legacy plans
-  and planners that don't populate it are a no-op).
+  WARNING. Skipped entirely when the advisory is empty (legacy plans
+  and planners that don't populate it are a no-op). Rule B is the one
+  capability rule kept as a steering trigger (user-declared
+  ``required_tools`` is genuine intent, not a forecast); it fires
+  WARNING rather than CRITICAL ("WARNING-max", PR 3) so the ladder
+  refines but never escalates to cancel/pause.
 
 * **Rule C — out-of-DAG-order delegation (goldfive#268). SOFT-RETIRED
   (goldfive#423 / AGENCY-PRESERVATION.md PR 2): OFF by default.** When
@@ -75,11 +86,27 @@ log = logging.getLogger(__name__)
 #: import) so tests and operators can flip it without re-importing.
 _RULE_C_ENV_VAR = "GOLDFIVE_CAPABILITY_RULE_C"
 
-#: Truthy spellings accepted for :data:`_RULE_C_ENV_VAR` — same
-#: vocabulary as :func:`goldfive.config._read_bool_env` so the env
-#: surface stays consistent across the project. (No falsy/typo
-#: handling needed: anything that is not an explicit truthy spelling
-#: leaves the rule retired, which is the safe default.)
+#: Env flag that re-enables the soft-retired Rule A (goldfive#253 /
+#: AGENCY-PRESERVATION.md PR 3). Rule A is default OFF for the same
+#: reason Rule C is: it is stem/keyword NL classification of whether a
+#: task "reads as a leaf authoring task" (the ``_looks_like_delegation_
+#: task`` marker scan + the leaf-title heuristic) — the exact
+#: #166/#167 anti-pattern the project retired twice. Its real-world
+#: failure mode is the cherry-tree refine storm (a coordinator
+#: delegating to a worker 20+ times, each delegation firing
+#: CAPABILITY_MISMATCH → refine; e2e session 2d27ff4a). Read per call
+#: so tests/operators can flip it without re-importing. When re-enabled
+#: it still only OBSERVEs (the CAPABILITY_MISMATCH ladder CRITICAL cells
+#: are OBSERVE per PR 3) — the flag restores the observability *signal*
+#: for debugging, not steering. Hard deletion follows in PR 13.
+_RULE_A_ENV_VAR = "GOLDFIVE_CAPABILITY_RULE_A"
+
+#: Truthy spellings accepted for :data:`_RULE_C_ENV_VAR` /
+#: :data:`_RULE_A_ENV_VAR` — same vocabulary as
+#: :func:`goldfive.config._read_bool_env` so the env surface stays
+#: consistent across the project. (No falsy/typo handling needed:
+#: anything that is not an explicit truthy spelling leaves the rule
+#: retired, which is the safe default.)
 _RULE_C_TRUTHY = frozenset({"1", "true", "yes", "on", "y", "t"})
 
 
@@ -91,6 +118,19 @@ def _rule_c_enabled() -> bool:
     module docstring and ``docs/design/PLAN-DESCRIPTIVE-GROWTH.md`` §7.
     """
     raw = os.environ.get(_RULE_C_ENV_VAR, "").strip().lower()
+    return raw in _RULE_C_TRUTHY
+
+
+def _rule_a_enabled() -> bool:
+    """Return True iff the operator explicitly re-enabled Rule A.
+
+    Rule A is soft-retired (default OFF) per AGENCY-PRESERVATION.md
+    PR 3: its leaf-task heuristic is NL classification (#166/#167), and
+    even when re-enabled it routes to OBSERVE (the CAPABILITY_MISMATCH
+    ladder demotes the CRITICAL cells). Same env vocabulary and
+    read-per-call discipline as :func:`_rule_c_enabled`.
+    """
+    raw = os.environ.get(_RULE_A_ENV_VAR, "").strip().lower()
     return raw in _RULE_C_TRUTHY
 
 
@@ -327,11 +367,15 @@ def detect_capability_mismatch(
     -------
     DriftEvent | None
         ``None`` when no rule trips OR when ``invoked_agent_tools`` is
-        empty AND ``required_tools`` is empty AND Rule C has no signal.
-        A ``DriftEvent`` with ``severity=CRITICAL`` otherwise. Rules
-        evaluate in order B → A → C; the first to fire wins so the
-        higher-confidence signal (B, then A, then C) takes precedence
-        and the steerer's refine only sees one verdict per delegation.
+        empty AND ``required_tools`` is empty AND Rules A/C are disabled
+        or have no signal. Otherwise a ``DriftEvent`` whose severity is
+        ``WARNING`` for Rule B (the "WARNING-max" survivor) and
+        ``CRITICAL`` for Rule A / Rule C (both soft-retired, default
+        OFF; CRITICAL is the observability signal — the ladder demotes
+        their cells to OBSERVE). Rules evaluate in order B → A → C; the
+        first to fire wins so the higher-confidence signal (B, then A,
+        then C) takes precedence and the steerer sees one verdict per
+        delegation. By default only Rule B can fire (A/C gated off).
     """
     if task is None:
         return None
@@ -343,6 +387,17 @@ def detect_capability_mismatch(
     # Rule B first — it consults explicit planner output, so it is the
     # higher-confidence signal. Fires only when populated; an empty
     # advisory is not a no-op miss, it's "no opinion".
+    #
+    # AGENCY-PRESERVATION.md PR 3 ("WARNING-max"): Rule B is the ONE
+    # capability rule that survives as a steering trigger, because a
+    # user-declared ``required_tools`` advisory is genuine prescriptive
+    # intent (not goldfive's forecast). It now fires WARNING, not
+    # CRITICAL: the CAPABILITY_MISMATCH ladder maps WARNING→ABSORB
+    # (refine + continue) but CRITICAL→OBSERVE, so emitting WARNING
+    # keeps Rule B's refine while capping it below the cancel/pause
+    # escalation tier. (CAPABILITY_MISMATCH is not in
+    # ``_GOLDFIVE_STEER_ELIGIBLE_KINDS``, so WARNING cannot auto-promote
+    # to a steer either.)
     if required_tools:
         agent_tool_names = {n for n in (_tool_name(t) for t in tools) if n}
         missing = tuple(name for name in required_tools if name not in agent_tool_names)
@@ -355,17 +410,24 @@ def detect_capability_mismatch(
             )
             return DriftEvent(
                 kind=DriftKind.CAPABILITY_MISMATCH,
-                severity=DriftSeverity.CRITICAL,
+                severity=DriftSeverity.WARNING,
                 detail=detail,
                 current_task_id=task_id,
                 current_agent_id=invoked_agent_name,
             )
 
-    # Rule A — coordinator-style leaf-assignment. Empty tool list does
-    # not trip Rule A: we cannot distinguish "agent has no tools" from
-    # "test stub / introspection failure", and the cost of a false
-    # positive (cancelling + refine) is high.
-    if tools and all(is_agent_tool(t) for t in tools):
+    # Rule A — coordinator-style leaf-assignment. SOFT-RETIRED
+    # (AGENCY-PRESERVATION.md PR 3): default OFF, re-enabled only via
+    # ``GOLDFIVE_CAPABILITY_RULE_A=1``. Its leaf-task heuristic
+    # (``_looks_like_delegation_task`` keyword scan + the AgentTool-only
+    # leaf-title read) is stem/keyword NL classification — the
+    # #166/#167 anti-pattern — and was the source of the 2d27ff4a
+    # refine storm. Even when re-enabled it OBSERVEs (the ladder demotes
+    # the CRITICAL cells); the flag restores the signal for debugging,
+    # not steering. Hard deletion follows in PR 13. Empty tool list does
+    # not trip Rule A regardless: we cannot distinguish "agent has no
+    # tools" from "test stub / introspection failure".
+    if _rule_a_enabled() and tools and all(is_agent_tool(t) for t in tools):
         if not _looks_like_delegation_task(task):
             detail = (
                 f"agent {invoked_agent_name!r} has only AgentTool "

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -1478,18 +1478,90 @@ class DriftObserver:
         description: str,
         assignee: str = "",
     ) -> None:
-        """Fire a ``NEW_WORK_DISCOVERED`` drift event → triggers refine."""
+        """Absorb agent-reported new work as descriptive growth (no refine).
+
+        AGENCY-PRESERVATION.md PR 3: the agent-authored
+        ``report_new_work_discovered`` reporting tool used to fire a
+        WARNING ``NEW_WORK_DISCOVERED`` drift through
+        :meth:`handle_drift`, which routed to ``planner.refine`` — i.e.
+        goldfive re-forecast the plan because the agent found work its
+        upfront forecast missed. That is exactly the "Plan is a forecast
+        the agent is graded against" defect (§1.2) and violates
+        PLAN-DESCRIPTIVE-GROWTH.md §13 ("adaptive, not predictive").
+
+        The reroute absorbs the report as a ``discovered=True`` ledger
+        task via
+        :meth:`~goldfive.plan_reviser.PlanReviser.install_descriptive_growth`
+        instead — the same absorb-as-growth machinery the pin-time and
+        reconciler paths use (goldfive#423 / PR 2). Observability is
+        preserved: ``install_descriptive_growth`` emits the
+        ``PlanRevised`` + ``DriftDetected`` pair (the drift is INFO —
+        "observational, not corrective", design doc §4.6 — a deliberate
+        severity drop from the old WARNING, since absorbed new work is
+        not a steering signal).
+
+        The agent's verbatim ``title`` / ``description`` are passed
+        through as overrides so the ledger task keeps the reported text.
+        ``tool_args_json`` encodes ``(parent_task_id, title,
+        description)`` purely to seed the dedup identity hash: a repeated
+        identical report is idempotent (dedup hit, no second task) while
+        two genuinely different reports under the same assignee stay
+        distinct.
+
+        The discovered task lands as an independent sub-DAG root (no edge
+        back to ``parent_task_id``); the forecast-DAG parent link the old
+        refine path could draw is intentionally not reconstructed — the
+        ledger records *what happened*, not a predicted decomposition.
+
+        Defensive fallback: when the bound steerer is a stub without
+        ``plans.install_descriptive_growth`` (some unit-test doubles),
+        emit a ``DriftDetected`` directly so the observability signal is
+        never silently dropped. Never routes back through
+        ``planner.refine``.
+        """
         detail = f"new work under {parent_task_id}: {title}: {description}" + (
             f" (assignee={assignee})" if assignee else ""
         )
+        plans = getattr(self._steerer, "plans", None)
+        install = getattr(plans, "install_descriptive_growth", None)
+        if callable(install):
+            # Seed the dedup identity from the full report so distinct
+            # reports don't collide and identical re-reports dedup.
+            tool_args_json = json.dumps(
+                {
+                    "parent_task_id": parent_task_id,
+                    "title": title,
+                    "description": description,
+                },
+                sort_keys=True,
+            )
+            try:
+                await install(
+                    session,
+                    agent_name=assignee or "",
+                    tool_args_json=tool_args_json,
+                    title=title,
+                    description=description,
+                )
+                return
+            except Exception as exc:  # noqa: BLE001 — growth is best-effort
+                log.debug(
+                    "DefaultSteerer.report_new_work_discovered: "
+                    "install_descriptive_growth raised: %s; falling back "
+                    "to direct DriftDetected emit",
+                    exc,
+                )
+        # Fallback (stub steerer / growth unavailable): preserve the
+        # observability signal without any refine/steer side effect.
         drift = DriftEvent(
             kind=DriftKind.NEW_WORK_DISCOVERED,
-            severity=DriftSeverity.WARNING,
+            severity=DriftSeverity.INFO,
             detail=detail,
             current_task_id=parent_task_id,
             current_agent_id=assignee,
+            authored_by="goldfive",
         )
-        await self.handle_drift(drift, session)
+        await self._emit_drift_detected(session, drift)
 
     async def report_plan_divergence(
         self,
@@ -3434,11 +3506,70 @@ class DriftObserver:
                 None,
                 (_IL.OBSERVE, _IL.OBSERVE),
             ),
+            # AGENCY-PRESERVATION.md PR 3 — forecast-mismatch demotions.
+            # These kinds are divergence from goldfive's *forecast* of how
+            # the agent would decompose the work, not divergence from the
+            # user's goal (§0/§1.2). They become observability-only:
+            # DriftDetected still emits, but the ladder takes no
+            # refine/steer/cancel action at any severity. Because OBSERVE
+            # short-circuits the dispatch before the refine path
+            # (:meth:`_handle_drift_dispatch`), a demoted kind also stops
+            # writing ``refine_outcomes`` — verified by the §5.3
+            # side-effect check (no other gate depended on those writes).
+            #
+            # PLAN_DIVERGENCE: belt-and-braces. The kind is ALSO dropped at
+            # the top of :meth:`handle_drift` (#252, reconciler emitter
+            # dead), so this row is normally unreachable; pinning it OBSERVE
+            # keeps the table honest and demotes any future / external
+            # producer that bypasses the #252 guard. The live observability
+            # signal comes from the executor reachability-audit emitter
+            # (``sequential._plan_divergence_drift_event``), which emits
+            # DriftDetected directly and is unchanged.
             DriftKind.PLAN_DIVERGENCE: (
                 _IL.OBSERVE,
-                _IL.ABSORB,
-                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+                _IL.OBSERVE,
+                (_IL.OBSERVE, _IL.OBSERVE),
             ),
+            # CAPABILITY_MISMATCH: Rule A (coordinator-style leaf-assignment)
+            # is stem/keyword NL classification — the #166/#167 anti-pattern
+            # — and is additionally gated OFF by default behind
+            # ``GOLDFIVE_CAPABILITY_RULE_A`` (see
+            # :mod:`goldfive.drift.capability_check`). The CRITICAL cells
+            # (where Rule A / the soft-retired Rule C fire) are demoted to
+            # OBSERVE so even a re-enabled rule only observes. WARNING stays
+            # ABSORB so Rule B — user-declared ``required_tools``, genuine
+            # prescriptive intent — keeps steering via refine, capped at the
+            # WARNING rung ("WARNING-max": Rule B now emits WARNING, never
+            # CRITICAL, so it cannot escalate to cancel/pause). PR 13 hard-
+            # deletes Rule A/C and revisits this row.
+            DriftKind.CAPABILITY_MISMATCH: (
+                _IL.OBSERVE,
+                _IL.ABSORB,
+                (_IL.OBSERVE, _IL.OBSERVE),
+            ),
+            # NEW_WORK_DISCOVERED: explicit observability-only row. The
+            # agent-authored reporting-tool path
+            # (:meth:`report_new_work_discovered`) no longer reaches the
+            # ladder at all — it reroutes to descriptive growth
+            # (``install_descriptive_growth``, absorb-as-growth) instead of
+            # ``planner.refine`` (§1.2 / PLAN-DESCRIPTIVE-GROWTH.md §13:
+            # adaptive, not predictive). Framework-synthesised discoveries
+            # are INFO and were already non-steering via the default
+            # fallthrough; this row makes "non-steering at every severity"
+            # explicit so the table self-documents the demotion.
+            DriftKind.NEW_WORK_DISCOVERED: (
+                _IL.OBSERVE,
+                _IL.OBSERVE,
+                (_IL.OBSERVE, _IL.OBSERVE),
+            ),
+            # WRONG_AGENT is deliberately absent (deprecated; no production
+            # emitter — grep ``DriftKind.WRONG_AGENT`` finds only the enum
+            # def, proto/pb stubs, and docs, never a ``DriftEvent(kind=…)``
+            # construction). Its enum value stays reserved (see the
+            # deprecation note in :mod:`goldfive.types`), but it gets no
+            # ladder row: there is no live dispatch to map. Mirrors the
+            # JUSTIFIED_DEVIATION "lack of a _LADDER row is intentional"
+            # precedent. AGENCY-PRESERVATION.md PR 3.
             DriftKind.OFF_TOPIC: (
                 _IL.OBSERVE,
                 _IL.ABSORB,

--- a/goldfive/plan_reviser.py
+++ b/goldfive/plan_reviser.py
@@ -713,6 +713,8 @@ class PlanReviser:
         agent_name: str,
         tool_args_json: str,
         delegation_event_id: str = "",
+        title: str | None = None,
+        description: str | None = None,
     ) -> Task:
         """Grow ``session.plan`` with a ``discovered=True`` task and return it.
 
@@ -758,6 +760,14 @@ class PlanReviser:
         triggered the growth. Empty when the caller has no event id on
         hand; the helper still works.
 
+        ``title`` / ``description`` are optional verbatim overrides
+        (AGENCY-PRESERVATION.md PR 3). ``None`` (the default) derives
+        both from ``tool_args_json`` exactly as before — pin-time and
+        reconciler growth are unaffected. The agent-authored
+        ``report_new_work_discovered`` reroute passes the agent's own
+        title/description so absorb-as-growth keeps the reported text
+        instead of an auto-derived ``agent: request`` label.
+
         Pipeline (under lock):
 
         1. Compute ``identity_hash`` from ``(agent_name, tool_args_json)``.
@@ -800,8 +810,25 @@ class PlanReviser:
         from goldfive.events import build_plan_revision_diff
 
         identity_hash = discovery_identity_hash(agent_name, tool_args_json or None)
-        title = self._derive_discovered_task_title(agent_name, tool_args_json)
-        description = self._derive_discovered_task_description(tool_args_json)
+        # Explicit ``title`` / ``description`` overrides (None → derive
+        # from the observed ``tool_args_json`` as before) let the
+        # agent-authored ``report_new_work_discovered`` reroute
+        # (AGENCY-PRESERVATION.md PR 3) preserve the agent's own verbatim
+        # title/description while still landing as a discovered ledger
+        # task. The identity hash still keys on ``(agent_name,
+        # tool_args_json)``, so callers wanting per-report dedup encode
+        # the distinguishing fields into ``tool_args_json``. Pin-time and
+        # reconciler callers pass neither and keep the derived titles.
+        title = (
+            title
+            if title is not None
+            else self._derive_discovered_task_title(agent_name, tool_args_json)
+        )
+        description = (
+            description
+            if description is not None
+            else self._derive_discovered_task_description(tool_args_json)
+        )
         # Mint a fresh id so two concurrent growths on the same
         # (agent, args-token-set) cannot collide on plan-task id even
         # if both miss the dedup check (the lock makes them sequential

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -120,6 +120,19 @@ class DriftKind(StrEnum):
     TASK_FAILED_FATAL = "task_failed_fatal"
     CONTEXT_PRESSURE = "context_pressure"
     BLOCKED = "blocked"
+    # WRONG_AGENT is DEPRECATED (AGENCY-PRESERVATION.md PR 3). No
+    # production code path ever constructs it — grep
+    # ``DriftKind.WRONG_AGENT`` finds only this enum def, the proto/pb
+    # stubs, and docs, never a ``DriftEvent(kind=DriftKind.WRONG_AGENT)``
+    # emission. The "reporting tool call arrived from an agent that is
+    # not ``task.assignee_agent_id``" signal it was meant to carry is
+    # subsumed by the structural CAPABILITY_MISMATCH detector (#253) and
+    # the goldfive#252 move off assignee-grading. The enum value stays
+    # reserved (wire/proto compat, same as the retired CONFUSION value
+    # below) and carries NO intervention-ladder row — there is no live
+    # dispatch to map. Do NOT add an emitter or a ladder row back; if a
+    # wrong-assignee signal is wanted, extend CAPABILITY_MISMATCH. Hard
+    # removal of any remaining references tracked for a later PR.
     WRONG_AGENT = "wrong_agent"
     AGENT_TRANSFER = "agent_transfer"
     MODEL_REFUSAL = "model_refusal"

--- a/tests/test_capability_mismatch.py
+++ b/tests/test_capability_mismatch.py
@@ -3,15 +3,22 @@
 Covers :func:`goldfive.drift.capability_check.detect_capability_mismatch`
 plus the integration wiring through the ADK adapter's
 ``before_tool_callback`` so a delegation to an under-qualified agent
-fires a CRITICAL ``CAPABILITY_MISMATCH`` drift through the steerer's
+fires a ``CAPABILITY_MISMATCH`` drift through the steerer's
 ``_handle_drift`` hook.
 
 Detection rules under test:
 
 * Rule A — coordinator-style leaf-assignment: agent has only AgentTool
   wrappers; bound task uses leaf-task verbs ("draft", "write", ...).
+  SOFT-RETIRED (AGENCY-PRESERVATION.md PR 3) — default OFF, fires
+  CRITICAL only under ``GOLDFIVE_CAPABILITY_RULE_A=1`` (the
+  rule-mechanics tests opt in via the ``_rule_a_escape_hatch``
+  fixture; ``test_rule_a_soft_retired_silent_by_default`` pins the new
+  default). The ladder additionally demotes its CRITICAL cells to
+  OBSERVE.
 * Rule B — task ``required_tools`` is non-empty and the invoked agent
-  doesn't cover the required names.
+  doesn't cover the required names. Kept as a steering trigger but
+  fires WARNING ("WARNING-max", PR 3), not CRITICAL.
 * Rule C (goldfive#268) — out-of-DAG-order delegation: agent role
   stem is absent from the bound task's title+description AND present
   in another PENDING task. Mirrors the live evidence from session
@@ -86,9 +93,39 @@ class _FakeFunctionTool:
 # ---------------------------------------------------------------------------
 
 
+def test_rule_a_soft_retired_silent_by_default() -> None:
+    """AGENCY-PRESERVATION.md PR 3: the canonical Rule A positive shape
+    (all-AgentTool agent bound to a leaf authoring task) returns
+    ``None`` unless ``GOLDFIVE_CAPABILITY_RULE_A=1`` is explicitly set —
+    Rule A is soft-retired (stem/keyword NL classification, #166/#167).
+    """
+    agent_tools: list[Any] = [_FakeAgentTool("writer"), _FakeAgentTool("reviewer")]
+    task = Task(
+        id="t-draft",
+        title="Draft a presentation about LLM observability",
+        description="Produce slides covering the goldfive design.",
+        assignee_agent_id="coordinator",
+    )
+
+    drift = detect_capability_mismatch(
+        invoked_agent_name="coordinator",
+        invoked_agent_tools=agent_tools,
+        task=task,
+    )
+
+    assert drift is None, (
+        "Rule A is soft-retired (AGENCY-PRESERVATION.md PR 3) and must "
+        "be silent without GOLDFIVE_CAPABILITY_RULE_A=1"
+    )
+
+
+@pytest.mark.usefixtures("_rule_a_escape_hatch")
 def test_rule_a_positive_only_agent_tools_on_leaf_task() -> None:
     """An agent whose tools are ALL AgentTool wrappers, bound to a leaf
     authoring task ("Draft a presentation"), must fire CAPABILITY_MISMATCH.
+
+    Gated behind ``_rule_a_escape_hatch`` (Rule A is default OFF, PR 3):
+    this pins the retired-but-re-enableable detection mechanics.
     """
     agent_tools: list[Any] = [_FakeAgentTool("writer"), _FakeAgentTool("reviewer")]
     task = Task(
@@ -165,9 +202,12 @@ def test_rule_a_suppressed_for_each_delegation_marker(verb: str) -> None:
     assert drift is None, f"Rule A must be suppressed by marker {verb!r}"
 
 
+@pytest.mark.usefixtures("_rule_a_escape_hatch")
 def test_rule_a_negative_review_research_are_leaf_verbs() -> None:
     """"Review" and "research" are LEAF-task verbs — a coordinator
     structurally cannot do them. Self-review guard from the brief.
+
+    Gated behind ``_rule_a_escape_hatch`` (Rule A is default OFF, PR 3).
     """
     agent_tools: list[Any] = [_FakeAgentTool("writer"), _FakeAgentTool("reader")]
 
@@ -197,7 +237,14 @@ def test_rule_a_negative_review_research_are_leaf_verbs() -> None:
 
 def test_rule_b_positive_required_tool_missing() -> None:
     """``Task.required_tools`` is non-empty and the agent's tool names
-    do not cover the required names — fire CRITICAL.
+    do not cover the required names — fire WARNING.
+
+    AGENCY-PRESERVATION.md PR 3 ("WARNING-max"): Rule B is the surviving
+    steering trigger but now fires WARNING, not CRITICAL, so the ladder
+    refines (WARNING→ABSORB) without escalating to cancel/pause
+    (CRITICAL→OBSERVE for CAPABILITY_MISMATCH). Rule B is NOT behind an
+    escape hatch — user-declared ``required_tools`` is genuine intent
+    and stays armed by default.
     """
     agent_tools: list[Any] = [_FakeFunctionTool("read_presentation_files")]
     task = Task(
@@ -214,7 +261,7 @@ def test_rule_b_positive_required_tool_missing() -> None:
 
     assert drift is not None
     assert drift.kind is DriftKind.CAPABILITY_MISMATCH
-    assert drift.severity is DriftSeverity.CRITICAL
+    assert drift.severity is DriftSeverity.WARNING
     assert "write_webpage" in drift.detail
 
 
@@ -310,6 +357,18 @@ def test_is_agent_tool_duck_type() -> None:
 def _rule_c_escape_hatch(monkeypatch: pytest.MonkeyPatch) -> None:
     """Re-enable the soft-retired Rule C for rule-mechanics tests."""
     monkeypatch.setenv("GOLDFIVE_CAPABILITY_RULE_C", "1")
+
+
+@pytest.fixture
+def _rule_a_escape_hatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-enable the soft-retired Rule A for rule-mechanics tests.
+
+    Rule A is default OFF (AGENCY-PRESERVATION.md PR 3; see
+    ``test_rule_a_soft_retired_silent_by_default`` for the new default).
+    The mechanics tests below opt in so the retired-but-re-enableable
+    detector stays pinned until its hard deletion in PR 13.
+    """
+    monkeypatch.setenv("GOLDFIVE_CAPABILITY_RULE_A", "1")
 
 
 def test_rule_c_soft_retired_silent_by_default() -> None:
@@ -503,12 +562,15 @@ def test_rule_c_negative_no_all_pending_tasks_passed() -> None:
     assert drift is None, "Rule C silent when caller doesn't pass pending set"
 
 
-@pytest.mark.usefixtures("_rule_c_escape_hatch")
+@pytest.mark.usefixtures("_rule_a_escape_hatch", "_rule_c_escape_hatch")
 def test_rule_c_precedence_rule_a_still_wins() -> None:
     """When Rule A also fires (all AgentTool wrappers + leaf task) AND
     Rule C would also fire (stem mismatch), Rule A's verdict wins. The
     detector returns one drift; the detail string identifies Rule A
     by mentioning "AgentTool".
+
+    Both rules are soft-retired (default OFF), so this precedence test
+    opts BOTH in via the escape-hatch fixtures (PR 3 / PR 2).
     """
     bound = Task(
         id="draft_slides",
@@ -692,11 +754,16 @@ def _make_quiet_llm() -> Any:
     return _Quiet
 
 
+@pytest.mark.usefixtures("_rule_a_escape_hatch")
 async def test_integration_capability_mismatch_flows_through_handle_drift() -> None:
     """End-to-end: a coordinator delegates to a sub-agent whose only
     tools are AgentTool wrappers (so it cannot perform a leaf task).
     The plan task is assigned to that sub-agent. The capability detector
     fires and the drift lands on the steerer's ``_handle_drift``.
+
+    Exercises Rule A's wiring, so it opts in via ``_rule_a_escape_hatch``
+    (Rule A is default OFF, PR 3). The drift is still CRITICAL when
+    Rule A fires — the ladder, not the detector, demotes it to OBSERVE.
     """
     from google.adk.agents import Agent
     from google.adk.tools.agent_tool import AgentTool

--- a/tests/test_delegation_pin.py
+++ b/tests/test_delegation_pin.py
@@ -1043,7 +1043,9 @@ async def test_delegation_observed_task_id_empty_when_no_eligible_task() -> None
     )
 
 
-async def test_capability_check_still_resolves_after_reorder() -> None:
+async def test_capability_check_still_resolves_after_reorder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """After the pin → emit → capability-check reorder, the capability
     detector still resolves the task via Strategy 1 (assignee, freshly
     stamped by the pin) — i.e. the reorder didn't break the goldfive#253
@@ -1051,8 +1053,12 @@ async def test_capability_check_still_resolves_after_reorder() -> None:
 
     Rule A scenario: the invoked sub-agent has only AgentTool wrappers
     (no leaf tools) and the bound plan task is a leaf authoring task.
-    The capability detector must fire CAPABILITY_MISMATCH.
+    The capability detector must fire CAPABILITY_MISMATCH. Rule A is
+    soft-retired (default OFF, AGENCY-PRESERVATION.md PR 3), so this
+    wiring test opts in via ``GOLDFIVE_CAPABILITY_RULE_A=1`` — it
+    exercises the pin→detector plumbing, which is unchanged.
     """
+    monkeypatch.setenv("GOLDFIVE_CAPABILITY_RULE_A", "1")
     from goldfive.types import DriftKind
 
     class _RecordingDrift:

--- a/tests/test_descriptive_growth_capability_mismatch_fallback.py
+++ b/tests/test_descriptive_growth_capability_mismatch_fallback.py
@@ -340,15 +340,17 @@ async def test_verdict_path_no_longer_grows() -> None:
     assert session.current_task_id == "draft_slides"
 
 
-async def test_flag_on_rule_a_still_fires() -> None:
-    """Rule A (leaf-task with AgentTool-only agent) is unaffected by the flag.
+async def test_flag_on_rule_a_still_fires(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rule A (leaf-task with AgentTool-only agent) still dispatches when re-enabled.
 
-    Rule A — coordinator-style leaf-assignment — still dispatches
-    normally for NON-discovered bound tasks (Rule A is
-    AGENCY-PRESERVATION.md PR 3's business, untouched by PR 2). Kept
-    from the original suite; only the removed growth-threading kwargs
-    changed.
+    Rule A — coordinator-style leaf-assignment — is now soft-retired and
+    default OFF (AGENCY-PRESERVATION.md PR 3), so this test opts in via
+    ``GOLDFIVE_CAPABILITY_RULE_A=1``. With the flag on it dispatches
+    normally for NON-discovered bound tasks (the discovered-task skip is
+    tested separately). The verdict is still CRITICAL at the detector;
+    the ladder, not the detector, demotes the CRITICAL cells to OBSERVE.
     """
+    monkeypatch.setenv("GOLDFIVE_CAPABILITY_RULE_A", "1")
 
     class _AgentToolWrapper:
         """An AgentTool wrapper as detected by ``is_agent_tool``."""

--- a/tests/test_intervention_ladder.py
+++ b/tests/test_intervention_ladder.py
@@ -91,19 +91,22 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         0,
         InterventionLevel.OBSERVE,
     ),
-    # PLAN_DIVERGENCE.
-    (DriftKind.PLAN_DIVERGENCE, DriftSeverity.WARNING, 0, InterventionLevel.ABSORB),
+    # PLAN_DIVERGENCE — DEMOTED to OBSERVE at all severities
+    # (AGENCY-PRESERVATION.md PR 3: forecast-mismatch, not goal drift;
+    # also already dropped at the top of handle_drift per #252). Was
+    # WARNING→ABSORB, CRITICAL→CANCEL_REINVOKE/PAUSE_ESCALATE.
+    (DriftKind.PLAN_DIVERGENCE, DriftSeverity.WARNING, 0, InterventionLevel.OBSERVE),
     (
         DriftKind.PLAN_DIVERGENCE,
         DriftSeverity.CRITICAL,
         0,
-        InterventionLevel.CANCEL_REINVOKE,
+        InterventionLevel.OBSERVE,
     ),
     (
         DriftKind.PLAN_DIVERGENCE,
         DriftSeverity.CRITICAL,
         2,
-        InterventionLevel.PAUSE_ESCALATE,
+        InterventionLevel.OBSERVE,
     ),
     # OFF_TOPIC: plan-context drift from the reasoning judge. Ladder
     # mirrors PLAN_DIVERGENCE so the ABSORB path can route to the
@@ -246,22 +249,29 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         0,
         InterventionLevel.ABSORB,
     ),
-    # Default fallback: a drift kind with no table entry. NEW_WORK_DISCOVERED
-    # is WARNING severity by default -> ABSORB.
+    # NEW_WORK_DISCOVERED — DEMOTED to OBSERVE at all severities
+    # (AGENCY-PRESERVATION.md PR 3). The agent-authored reporting tool
+    # reroutes to descriptive growth instead of refine, and the explicit
+    # _LADDER row makes "non-steering at every severity" the documented
+    # mapping. Was the default-fallback ABSORB / PAUSE_ESCALATE below.
     (
         DriftKind.NEW_WORK_DISCOVERED,
         DriftSeverity.WARNING,
         0,
-        InterventionLevel.ABSORB,
+        InterventionLevel.OBSERVE,
     ),
-    # Default fallback, CRITICAL repeat -> PAUSE_ESCALATE.
     (
         DriftKind.NEW_WORK_DISCOVERED,
         DriftSeverity.CRITICAL,
         2,
-        InterventionLevel.PAUSE_ESCALATE,
+        InterventionLevel.OBSERVE,
     ),
-    # INFO on a kind without a table entry -> OBSERVE.
+    # Default fallback: a drift kind with NO _LADDER entry. CUSTOM is the
+    # representative (NEW_WORK_DISCOVERED gained an explicit row in PR 3,
+    # so it no longer exercises this path). WARNING -> ABSORB; CRITICAL
+    # repeat -> PAUSE_ESCALATE; INFO -> OBSERVE.
+    (DriftKind.CUSTOM, DriftSeverity.WARNING, 0, InterventionLevel.ABSORB),
+    (DriftKind.CUSTOM, DriftSeverity.CRITICAL, 2, InterventionLevel.PAUSE_ESCALATE),
     (DriftKind.CUSTOM, DriftSeverity.INFO, 0, InterventionLevel.OBSERVE),
 ]
 

--- a/tests/test_ladder_decision_table.py
+++ b/tests/test_ladder_decision_table.py
@@ -1,0 +1,225 @@
+"""Golden decision-table snapshot for the intervention ladder.
+
+AGENCY-PRESERVATION.md §5.3 ("Decision-table snapshot tests") makes
+:meth:`goldfive.drift_observer.DriftObserver._ladder_level_for` — the
+pure function ``(kind, severity, occurrence) -> InterventionLevel`` that
+is the ONLY live ladder (goldfive#142; the ``steerer.py`` table
+reference in older docs is stale) — into a checked-in golden surface so
+every cell change shows up as an explicit, reviewable diff in this file.
+
+Why a whole-surface snapshot and not more per-case asserts? The
+roadmap's risk analysis (§5, "PR 3/7 — ladder cell changes silently
+altering what other gates read") is that a demotion of one kind quietly
+moves an unrelated row. ``test_intervention_ladder.py`` pins one
+representative case per branch; this test pins **every** cell of the
+``(kind × severity × occurrence-bucket)`` grid at once, so a stray edit
+to a row PR 3 never meant to touch fails here with a one-line diff.
+
+Buckets (§5.3, "occurrence"): ``first`` is ``occurrence_count == 0`` and
+``repeat`` is ``occurrence_count >= REFINE_FAILURE_THRESHOLD`` — the only
+boundary ``_ladder_level_for`` keys on (``is_repeat`` flips the
+``critical_pair``). INFO and WARNING cannot differ by bucket (the
+function returns ``info_level`` / ``warning_level`` without reading
+``occurrence_count``), so the snapshot renders them once and bucket-
+splits only the CRITICAL column. That rendering choice is itself pinned
+by :func:`test_info_and_warning_columns_are_bucket_invariant` — if a
+future edit makes INFO/WARNING occurrence-sensitive, that guard fails and
+tells us to widen the snapshot format rather than silently lose coverage.
+
+Commit-pairing contract (AGENCY-PRESERVATION.md PR 3): this file lands in
+its OWN commit BEFORE any ladder cell changes, pinning today's table.
+The demotions commit updates :data:`EXPECTED_LADDER_SURFACE` in the same
+commit as the ``_LADDER`` edits, so the snapshot diff IS the review
+artifact for which cells moved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.drift_observer import DriftObserver  # noqa: E402
+from goldfive.steerer import DefaultSteerer, InterventionLevel  # noqa: E402
+from goldfive.types import DriftKind, DriftSeverity  # noqa: E402
+
+
+def render_ladder_surface(steerer: DefaultSteerer) -> str:
+    """Render the full ``_ladder_level_for`` surface as deterministic text.
+
+    One line per :class:`~goldfive.types.DriftKind` (sorted by enum
+    value for a stable diff). INFO and WARNING carry their single level
+    (bucket-invariant — see the module docstring); CRITICAL carries the
+    ``[first|repeat]`` pair where ``first`` is occurrence 0 and
+    ``repeat`` is occurrence ``REFINE_FAILURE_THRESHOLD``.
+    """
+    threshold = steerer.REFINE_FAILURE_THRESHOLD
+    lines: list[str] = []
+    for kind in sorted(DriftKind, key=lambda k: k.value):
+        info = steerer.drift._ladder_level_for(kind, DriftSeverity.INFO, 0).name
+        warning = steerer.drift._ladder_level_for(kind, DriftSeverity.WARNING, 0).name
+        crit_first = steerer.drift._ladder_level_for(kind, DriftSeverity.CRITICAL, 0).name
+        crit_repeat = steerer.drift._ladder_level_for(
+            kind, DriftSeverity.CRITICAL, threshold
+        ).name
+        lines.append(
+            f"{kind.value:28s} INFO={info:7s} WARNING={warning:7s} "
+            f"CRITICAL=[{crit_first}|{crit_repeat}]"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Golden snapshot — regenerate via ``render_ladder_surface`` and hand-review
+# every changed line. NEVER overwrite blindly: a diff here is either an
+# intended ladder demotion (update + justify in the PR body) or a
+# regression (fix the code, not the golden).
+# ---------------------------------------------------------------------------
+EXPECTED_LADDER_SURFACE = """\
+agent_refusal                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+agent_transfer               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+ambiguous_intent             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+blocked                      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+capability_mismatch          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+confabulation_risk           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+context_pressure             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+custom                       INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+goal_drift                   INFO=OBSERVE WARNING=NUDGE   CRITICAL=[NUDGE|CANCEL_REINVOKE]
+goal_unreachable             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+hallucination_suspected      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+human_intervention_required  INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|TERMINATE]
+intent_divergence            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
+justified_deviation          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|ABSORB]
+llm_call_timeout             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+looping_reasoning            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[NUDGE|PAUSE_ESCALATE]
+looping_tool_call            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+model_refusal                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+new_work_discovered          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+off_topic                    INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+plan_divergence              INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+reasoning_cluster_tightening INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
+refine_validation_failed     INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
+repeated_failure             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+resource_exhausted           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+runaway_delegation           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+safety_concern               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+schema_violation             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+self_reported_stuck          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+stopped_early                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+task_failed_fatal            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+task_failed_recoverable      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+task_timeout                 INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+too_many_steps               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+tool_error                   INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+uncertain_progress           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+unexpected_output            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+user_cancel                  INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+user_pause                   INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+user_steer                   INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+wrong_agent                  INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]"""
+
+
+def test_ladder_decision_table_snapshot() -> None:
+    """The full ladder surface matches the checked-in golden.
+
+    A failure here is a ladder cell change. If intended (a demotion),
+    regenerate :data:`EXPECTED_LADDER_SURFACE` and justify the diff in
+    the PR body (§5.3); if not, the code regressed.
+    """
+    surface = render_ladder_surface(DefaultSteerer())
+    assert surface == EXPECTED_LADDER_SURFACE, (
+        "Ladder decision surface changed. Diff each line against the "
+        "golden; an intended demotion updates the golden in the SAME "
+        "commit and documents the cells in the PR body (§5.3)."
+    )
+
+
+def test_every_drift_kind_is_in_the_surface() -> None:
+    """No kind is silently dropped from the snapshot.
+
+    The snapshot iterates ``DriftKind`` directly, so a newly added kind
+    appears automatically — this guards the inverse: that the golden was
+    not hand-trimmed to hide a kind.
+    """
+    rendered_kinds = {line.split()[0] for line in EXPECTED_LADDER_SURFACE.splitlines()}
+    assert rendered_kinds == {k.value for k in DriftKind}
+
+
+def test_info_and_warning_columns_are_bucket_invariant() -> None:
+    """INFO/WARNING levels do not depend on the occurrence bucket.
+
+    The snapshot renders these columns once (not ``[first|repeat]``).
+    This guards that simplification: ``_ladder_level_for`` returns the
+    INFO/WARNING level without consulting ``occurrence_count`` today, so
+    first and repeat must agree. If they ever diverge, widen the
+    snapshot to bucket-split these columns too.
+    """
+    steerer = DefaultSteerer()
+    threshold = steerer.REFINE_FAILURE_THRESHOLD
+    for kind in DriftKind:
+        for severity in (DriftSeverity.INFO, DriftSeverity.WARNING):
+            first = steerer.drift._ladder_level_for(kind, severity, 0)
+            repeat = steerer.drift._ladder_level_for(kind, severity, threshold)
+            assert first is repeat, (kind, severity, first, repeat)
+
+
+def test_user_authored_rows_are_untouched_default_fallthrough() -> None:
+    """USER_* kinds keep the default fallthrough mapping (§2 authority split).
+
+    USER_STEER / USER_CANCEL / USER_PAUSE are never demoted by the
+    agency-preservation ladder work: user authority is absolute. They
+    are not in ``_LADDER`` and so resolve via the default fallthrough
+    (INFO→OBSERVE, WARNING→ABSORB, CRITICAL first→ABSORB / repeat→
+    PAUSE_ESCALATE). Pinning that here means a demotion commit that
+    accidentally adds a USER_* row trips this test, not just the
+    snapshot.
+    """
+    steerer = DefaultSteerer()
+    threshold = steerer.REFINE_FAILURE_THRESHOLD
+    for kind in (DriftKind.USER_STEER, DriftKind.USER_CANCEL, DriftKind.USER_PAUSE):
+        assert (
+            steerer.drift._ladder_level_for(kind, DriftSeverity.INFO, 0)
+            is InterventionLevel.OBSERVE
+        )
+        assert (
+            steerer.drift._ladder_level_for(kind, DriftSeverity.WARNING, 0)
+            is InterventionLevel.ABSORB
+        )
+        assert (
+            steerer.drift._ladder_level_for(kind, DriftSeverity.CRITICAL, 0)
+            is InterventionLevel.ABSORB
+        )
+        assert (
+            steerer.drift._ladder_level_for(kind, DriftSeverity.CRITICAL, threshold)
+            is InterventionLevel.PAUSE_ESCALATE
+        )
+
+
+def test_hard_safety_kinds_stay_armed_at_critical() -> None:
+    """Hard-safety (guardrail) kinds never drop to OBSERVE at CRITICAL.
+
+    The §0/§2 authority split keeps the budget/safety guardrails always
+    armed: a CRITICAL guardrail trip must still take a stop-or-steer
+    action, never silently observe. This anchors the snapshot against
+    :attr:`DriftObserver._HARD_SAFETY_DRIFT_KINDS` (#453) so a future
+    ladder edit cannot demote a guardrail row by accident.
+
+    Note (consistency, not a fix): RESOURCE_EXHAUSTED / TOO_MANY_STEPS /
+    TASK_TIMEOUT / LLM_CALL_TIMEOUT are hard-safety (cancel-authorised)
+    yet map CRITICAL-first to ABSORB (refine), i.e. "redirect" rather
+    than the §0 "stop". That latent mismatch predates PR 3 and is the
+    ladder restructure's concern (PR 7); this test only asserts they are
+    not OBSERVE.
+    """
+    steerer = DefaultSteerer()
+    threshold = steerer.REFINE_FAILURE_THRESHOLD
+    for kind in DriftObserver._HARD_SAFETY_DRIFT_KINDS:
+        first = steerer.drift._ladder_level_for(kind, DriftSeverity.CRITICAL, 0)
+        repeat = steerer.drift._ladder_level_for(kind, DriftSeverity.CRITICAL, threshold)
+        assert first is not InterventionLevel.OBSERVE, kind
+        assert repeat is not InterventionLevel.OBSERVE, kind

--- a/tests/test_ladder_decision_table.py
+++ b/tests/test_ladder_decision_table.py
@@ -79,13 +79,26 @@ def render_ladder_surface(steerer: DefaultSteerer) -> str:
 # every changed line. NEVER overwrite blindly: a diff here is either an
 # intended ladder demotion (update + justify in the PR body) or a
 # regression (fix the code, not the golden).
+#
+# AGENCY-PRESERVATION.md PR 3 demoted exactly three rows from this table
+# (the forecast-mismatch family); every other row is byte-for-byte the
+# Commit-1 baseline:
+#   * plan_divergence     WARNING ABSORB→OBSERVE, CRITICAL
+#                         [CANCEL_REINVOKE|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
+#   * capability_mismatch CRITICAL [ABSORB|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
+#                         (WARNING stays ABSORB: Rule B / "WARNING-max")
+#   * new_work_discovered WARNING ABSORB→OBSERVE, CRITICAL
+#                         [ABSORB|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
+# wrong_agent is unchanged here: it is deprecated with no _LADDER row and
+# no emitter, so its dead default-fallthrough line is moot (see the
+# types.py deprecation note + the _load_ladder_tables comment).
 # ---------------------------------------------------------------------------
 EXPECTED_LADDER_SURFACE = """\
 agent_refusal                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 agent_transfer               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 ambiguous_intent             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 blocked                      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
-capability_mismatch          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+capability_mismatch          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[OBSERVE|OBSERVE]
 confabulation_risk           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 context_pressure             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 custom                       INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
@@ -99,9 +112,9 @@ llm_call_timeout             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE
 looping_reasoning            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[NUDGE|PAUSE_ESCALATE]
 looping_tool_call            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 model_refusal                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
-new_work_discovered          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+new_work_discovered          INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
 off_topic                    INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
-plan_divergence              INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+plan_divergence              INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
 reasoning_cluster_tightening INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
 refine_validation_failed     INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 repeated_failure             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]

--- a/tests/test_ladder_demotion_observability.py
+++ b/tests/test_ladder_demotion_observability.py
@@ -1,0 +1,167 @@
+"""Observability + side-effect contract for the PR-3 ladder demotions.
+
+AGENCY-PRESERVATION.md PR 3 binding correctness requirements:
+
+* **Observability preserved** — DriftDetected still emits for the
+  demoted forecast-mismatch kinds; only the ladder *action* is removed.
+  Sinks (harmonograf / zicato) are unaffected.
+* **§5.3 side-effect check** — a demoted kind that no longer refines
+  must also stop writing ``session.refine_outcomes`` (the dict other
+  gates read for occurrence counts / the refine-skip gate). OBSERVE
+  short-circuits ``_handle_drift_dispatch`` before the refine path, so
+  the write never happens.
+
+Per demoted kind, the observability path differs:
+
+* ``CAPABILITY_MISMATCH`` (CRITICAL → OBSERVE) and the framework INFO
+  ``NEW_WORK_DISCOVERED`` flow through ``handle_drift``, which emits
+  ``DriftDetected`` and then OBSERVEs.
+* ``PLAN_DIVERGENCE`` is dropped at the TOP of ``handle_drift`` (#252),
+  so its observability comes from the executor reachability-audit
+  emitter (``_plan_divergence_drift_event``), which builds a
+  ``DriftDetected`` envelope directly. PR 3 leaves that emitter
+  untouched; this test pins that it still carries the real
+  ``PLAN_DIVERGENCE`` enum value.
+* Agent-authored ``NEW_WORK_DISCOVERED`` reroutes to descriptive
+  growth — its ``DriftDetected`` (INFO) is asserted in
+  ``test_steerer`` / ``test_reporting``; here we pin the no-refine
+  side-effect.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+)
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+
+class _RecordingPlanner:
+    """Planner stub that records every ``refine`` call so the test can
+    assert a demoted kind never reaches the refine path.
+    """
+
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def refine(self, **kwargs: Any) -> None:
+        self.refine_calls.append(kwargs)
+        return None
+
+
+def _fresh() -> tuple[DefaultSteerer, Session, _ListSink, _RecordingPlanner]:
+    steerer = DefaultSteerer()
+    sink = _ListSink()
+    planner = _RecordingPlanner()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="ship it")],
+        plan=Plan(
+            id="p1",
+            run_id="r1",
+            goal_ids=["g1"],
+            tasks=[Task(id="t1", title="A")],
+            edges=[],
+        ),
+    )
+    return steerer, session, sink, planner
+
+
+def _drift_detected(sink: _ListSink) -> list[Any]:
+    return [
+        e
+        for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "drift_detected"
+    ]
+
+
+@pytest.mark.parametrize("kind", [DriftKind.CAPABILITY_MISMATCH])
+async def test_demoted_critical_kind_observes_without_refine_or_outcome(
+    kind: DriftKind,
+) -> None:
+    """A CRITICAL drift of a demoted kind routed through ``handle_drift``
+    emits DriftDetected (observability preserved) but takes NO ladder
+    action: no ``planner.refine`` call and no ``refine_outcomes`` write
+    (§5.3 side-effect check).
+    """
+    steerer, session, sink, planner = _fresh()
+    drift = DriftEvent(
+        kind=kind,
+        severity=DriftSeverity.CRITICAL,
+        detail="demoted",
+        current_task_id="t1",
+    )
+    await steerer.drift.handle_drift(drift, session)
+    await steerer.drift._wait_background_drifts_idle()
+
+    # Observability preserved.
+    assert len(_drift_detected(sink)) == 1
+    # No ladder action (the demotion).
+    assert planner.refine_calls == []
+    # §5.3: no refine_outcomes side effect for the demoted kind.
+    assert dict(session.refine_outcomes) == {}
+
+
+async def test_plan_divergence_dropped_in_handle_drift_no_outcome() -> None:
+    """PLAN_DIVERGENCE is dropped at the top of ``handle_drift`` (#252):
+    no DriftDetected via this path, no refine, no ``refine_outcomes``
+    write. Its observability comes from the executor audit emitter
+    (asserted separately below).
+    """
+    steerer, session, sink, planner = _fresh()
+    drift = DriftEvent(
+        kind=DriftKind.PLAN_DIVERGENCE,
+        severity=DriftSeverity.CRITICAL,
+        detail="diverged",
+        current_task_id="t1",
+    )
+    await steerer.drift.handle_drift(drift, session)
+    await steerer.drift._wait_background_drifts_idle()
+
+    assert _drift_detected(sink) == []
+    assert planner.refine_calls == []
+    assert dict(session.refine_outcomes) == {}
+
+
+def test_plan_divergence_executor_audit_emitter_preserves_observability() -> None:
+    """The executor reachability-audit emitter
+    (``_plan_divergence_drift_event``) — PLAN_DIVERGENCE's live
+    observability path — still builds a DriftDetected carrying the real
+    PLAN_DIVERGENCE enum value. PR 3 leaves this emitter untouched.
+    """
+    from goldfive.executors.sequential import _plan_divergence_drift_event
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    session = Session(run_id="r1", goals=[], plan=None)
+    session.current_task_id = "t1"
+    evt = _plan_divergence_drift_event(session, "two PENDING tasks unreachable")
+
+    assert evt.WhichOneof("payload") == "drift_detected"
+    assert evt.drift_detected.kind == types_pb2.DRIFT_KIND_PLAN_DIVERGENCE
+    assert evt.drift_detected.current_task_id == "t1"

--- a/tests/test_pause_escalate.py
+++ b/tests/test_pause_escalate.py
@@ -210,18 +210,20 @@ async def test_refine_validation_failed_pauses_without_refining() -> None:
 async def test_ladder_level_for_pause_escalate_on_repeat() -> None:
     """Threshold-crossing occurrence drives CRITICAL to Level 4.
 
-    Uses PLAN_DIVERGENCE: first CRITICAL = CANCEL_REINVOKE, repeat =
-    PAUSE_ESCALATE.
+    Uses TOOL_ERROR: first CRITICAL = CANCEL_REINVOKE, repeat =
+    PAUSE_ESCALATE. (Was PLAN_DIVERGENCE, demoted to OBSERVE at all
+    severities in AGENCY-PRESERVATION.md PR 3 — re-pointed to a kind
+    that still exhibits the first→repeat escalation this test pins.)
     """
     steerer = DefaultSteerer()
     assert (
-        steerer.drift._ladder_level_for(DriftKind.PLAN_DIVERGENCE, DriftSeverity.CRITICAL, 0)
+        steerer.drift._ladder_level_for(DriftKind.TOOL_ERROR, DriftSeverity.CRITICAL, 0)
         is InterventionLevel.CANCEL_REINVOKE
     )
     # Threshold is 2 in DefaultSteerer.REFINE_FAILURE_THRESHOLD.
     assert (
         steerer.drift._ladder_level_for(
-            DriftKind.PLAN_DIVERGENCE,
+            DriftKind.TOOL_ERROR,
             DriftSeverity.CRITICAL,
             DefaultSteerer.REFINE_FAILURE_THRESHOLD,
         )

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -218,8 +218,20 @@ async def test_report_task_blocked_transitions_and_refines() -> None:
     assert planner.refine_calls[0]["drift"].kind is DriftKind.BLOCKED
 
 
-async def test_report_new_work_discovered_fires_refine() -> None:
-    steerer, session, _sink, planner = _fresh()
+async def test_report_new_work_discovered_grows_plan_not_refine() -> None:
+    """AGENCY-PRESERVATION.md PR 3: the agent-authored
+    ``report_new_work_discovered`` reporting tool now absorbs the report
+    as descriptive growth (a ``discovered=True`` ledger task) instead of
+    firing ``planner.refine``. Was ``test_report_new_work_discovered_
+    fires_refine`` (asserted one refine call).
+
+    Asserts: (1) NO refine call; (2) the plan grew by one discovered
+    task carrying the agent's verbatim title; (3) observability is
+    preserved — a NEW_WORK_DISCOVERED ``DriftDetected`` (INFO, from the
+    growth path) still reaches the sink.
+    """
+    steerer, session, sink, planner = _fresh()
+    before = len(session.plan.tasks)
     await _tool("report_new_work_discovered").handler(
         {
             "parent_task_id": "t1",
@@ -230,8 +242,19 @@ async def test_report_new_work_discovered_fires_refine() -> None:
         session,
         steerer,
     )
-    assert len(planner.refine_calls) == 1
-    assert planner.refine_calls[0]["drift"].kind is DriftKind.NEW_WORK_DISCOVERED
+    # (1) Absorbed as growth, never re-forecast.
+    assert planner.refine_calls == []
+    # (2) Plan grew by exactly one discovered task with the verbatim title.
+    assert len(session.plan.tasks) == before + 1
+    discovered = [t for t in session.plan.tasks if getattr(t, "discovered", False)]
+    assert len(discovered) == 1
+    assert discovered[0].title == "dig deeper"
+    assert discovered[0].assignee_agent_id == "analyst"
+    # (3) Observability preserved: DriftDetected still emits for the
+    # demoted kind (here via the growth path's INFO drift).
+    kinds = [e.WhichOneof("payload") for e in sink.proto_events]
+    assert "drift_detected" in kinds
+    assert "plan_revised" in kinds
 
 
 async def test_report_plan_divergence_sets_flag_only() -> None:

--- a/tests/test_reporting_tool_required_validation.py
+++ b/tests/test_reporting_tool_required_validation.py
@@ -198,8 +198,14 @@ async def test_new_work_discovered_rejects_null_description() -> None:
 
 
 async def test_new_work_discovered_accepts_valid_payload() -> None:
-    """Sanity: the happy path still drives the steerer."""
+    """Sanity: the happy path still drives the steerer.
+
+    AGENCY-PRESERVATION.md PR 3: the valid payload now drives
+    descriptive growth (a discovered ledger task) rather than
+    ``planner.refine`` (absorb-as-growth). Was ``len(refine_calls) == 1``.
+    """
     steerer, session, _sink, planner = _fresh()
+    before = len(session.plan.tasks)
     out = await _tool("report_new_work_discovered").handler(
         {
             "parent_task_id": "t1",
@@ -212,7 +218,9 @@ async def test_new_work_discovered_accepts_valid_payload() -> None:
     )
     # F1: directive ack on a real transition / accepted call.
     assert out["acknowledged"] is True
-    assert len(planner.refine_calls) == 1
+    # Absorbed as growth: no refine, plan grew by one discovered task.
+    assert planner.refine_calls == []
+    assert len(session.plan.tasks) == before + 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -904,8 +904,19 @@ def test_every_drift_kind_has_a_known_origin() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_report_new_work_discovered_fires_drift() -> None:
+async def test_report_new_work_discovered_grows_plan_not_refine() -> None:
+    """AGENCY-PRESERVATION.md PR 3: agent-authored
+    ``report_new_work_discovered`` absorbs the report as descriptive
+    growth (a ``discovered=True`` ledger task) instead of firing
+    ``planner.refine``. Was ``test_report_new_work_discovered_fires_drift``
+    (asserted a refine call + the original WARNING drift).
+
+    Observability is preserved: the growth path still emits a
+    NEW_WORK_DISCOVERED ``DriftDetected`` (now INFO — "observational,
+    not corrective"), plus a ``PlanRevised``. No refine.
+    """
     steerer, session, sink, planner = _fresh()
+    before = len(session.plan.tasks)
     await steerer.drift.report_new_work_discovered(
         session=session,
         parent_task_id="t1",
@@ -913,15 +924,25 @@ async def test_report_new_work_discovered_fires_drift() -> None:
         description="double-check the numbers",
         assignee="analyst",
     )
-    # Original drift + refine-failure drift (stub planner returns None).
-    # goldfive a4: also a refine_attempted + refine_failed dict envelope
-    # — filter to proto events for the count assertion.
-    assert len(sink.proto_events) == 2
-    assert sink.proto_events[0].WhichOneof("payload") == "drift_detected"
+    # Absorbed as growth, never re-forecast.
+    assert planner.refine_calls == []
+    # Plan grew by exactly one discovered task with the verbatim title.
+    assert len(session.plan.tasks) == before + 1
+    discovered = [t for t in session.plan.tasks if getattr(t, "discovered", False)]
+    assert len(discovered) == 1
+    assert discovered[0].title == "follow-up"
+    assert discovered[0].assignee_agent_id == "analyst"
+    # Observability preserved: DriftDetected (NEW_WORK_DISCOVERED) still
+    # emits for the demoted kind, via the growth path.
     from goldfive.pb.goldfive.v1 import types_pb2
 
-    assert sink.proto_events[0].drift_detected.kind == types_pb2.DRIFT_KIND_NEW_WORK_DISCOVERED
-    assert planner.refine_calls[0]["drift"].kind is DriftKind.NEW_WORK_DISCOVERED
+    drift_events = [
+        e for e in sink.proto_events if e.WhichOneof("payload") == "drift_detected"
+    ]
+    assert len(drift_events) == 1
+    assert (
+        drift_events[0].drift_detected.kind == types_pb2.DRIFT_KIND_NEW_WORK_DISCOVERED
+    )
 
 
 async def test_report_plan_divergence_sets_flag_only() -> None:


### PR DESCRIPTION
Implements **AGENCY-PRESERVATION.md PR 3** — demote the forecast-mismatch drift family from steering triggers to observability-only, gated by a checked-in ladder decision-table snapshot. §5.3 is binding, so this lands as **two commits in order**.

## Commit 1 — decision-table snapshot (before any cell changes)
`tests/test_ladder_decision_table.py` renders the full `(kind × severity × occurrence-bucket)` → action surface of `DriftObserver._ladder_level_for` (the ONLY live ladder) into a checked-in golden string. Pins **today's** table so every future cell change is an explicit, reviewable diff. Plus invariant guards: USER_* rows untouched (default fallthrough), `_HARD_SAFETY_DRIFT_KINDS` (#453) stay armed at CRITICAL, INFO/WARNING bucket-invariance, no kind silently dropped.

## Commit 2 — the demotions (golden updated in the same commit)
DriftDetected still emits for every demoted kind (observability preserved; sinks/zicato unaffected) — only the ladder *action* is removed.

| Kind | Change |
|---|---|
| `PLAN_DIVERGENCE` | OBSERVE at all severities (belt-and-braces — also dropped at top of `handle_drift` per #252; live observability via the executor reachability-audit emitter, untouched) |
| `CAPABILITY_MISMATCH` Rule A | soft-retired behind `GOLDFIVE_CAPABILITY_RULE_A` (default OFF, mirrors #454's Rule C flag); ladder CRITICAL cells → OBSERVE. Stem/keyword NL classification = the #166/#167 anti-pattern; source of the 2d27ff4a refine storm |
| `CAPABILITY_MISMATCH` Rule B | **kept** (user-declared `required_tools` = genuine intent), now fires **WARNING not CRITICAL** ("WARNING-max"): ladder WARNING→ABSORB refines but never escalates to cancel/pause |
| `NEW_WORK_DISCOVERED` (agent-authored) | reroute from `planner.refine` to `install_descriptive_growth` (absorb-as-growth); framework INFO already non-steering, now an explicit OBSERVE row |
| `WRONG_AGENT` | deprecated (no production emitter); enum value reserved, no ladder row |

### Snapshot diff (the review artifact) — exactly 3 rows changed
```
plan_divergence      WARNING ABSORB→OBSERVE  CRITICAL [CANCEL_REINVOKE|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
capability_mismatch  CRITICAL [ABSORB|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]  (WARNING stays ABSORB = Rule B)
new_work_discovered  WARNING ABSORB→OBSERVE  CRITICAL [ABSORB|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
```
Every other row is byte-for-byte the Commit-1 baseline. `wrong_agent` unchanged (no row; deprecation is a types.py doc-comment + a `_load_ladder_tables` comment).

## §5.3 side-effect check (refine_outcomes)
Demoted kinds no longer write `session.refine_outcomes`: OBSERVE short-circuits `_handle_drift_dispatch` before the refine path; PLAN_DIVERGENCE is dropped at the top of `handle_drift`; agent-authored NEW_WORK_DISCOVERED bypasses `handle_drift` entirely (growth). Proven empirically and in `tests/test_ladder_demotion_observability.py`. Readers of `refine_outcomes` (`_occurrence_count_for_ladder`, the refine-skip gate, the promote path, `_drift_already_refined`, the parallel executor's own counter) only consult counts on kinds that reach the refine path — none depended on a demoted kind's write (occurrence count is moot for an always-OBSERVE row). Rule B (WARNING→ABSORB) still writes, intentionally — it is not demoted.

## WRONG_AGENT grep evidence
`grep -rn DriftKind.WRONG_AGENT goldfive/` finds **only** the enum def, the new deprecation comments, the proto/pb stubs, and docs — **never** a `DriftEvent(kind=DriftKind.WRONG_AGENT)` construction. No production emitter exists.

## Budget/safety vs `_HARD_SAFETY_DRIFT_KINDS` — inconsistency flagged (not fixed)
Untouched by this PR, but surfaced per the brief: `RESOURCE_EXHAUSTED` / `TOO_MANY_STEPS` / `TASK_TIMEOUT` / `LLM_CALL_TIMEOUT` are in `_HARD_SAFETY_DRIFT_KINDS` (cancel-authorised = "stop") yet their ladder rows map CRITICAL-**first** → ABSORB (refine = "redirect"), contradicting §0's "guardrails stop, not redirect". This predates PR 3; it belongs to the PR 7 ladder restructure. The snapshot test documents and pins it; `test_hard_safety_kinds_stay_armed_at_critical` only asserts they are not OBSERVE.

## Existing tests re-pointed (documented, none deleted silently)
- `test_intervention_ladder.py` — plan_divergence/new_work_discovered cases → OBSERVE; default-fallback coverage re-pointed to CUSTOM.
- `test_capability_mismatch.py` — added `_rule_a_escape_hatch` fixture + `test_rule_a_soft_retired_silent_by_default`; Rule A mechanics tests opt in via the flag; Rule B severity assertion CRITICAL→WARNING.
- `test_descriptive_growth_capability_mismatch_fallback.py::test_flag_on_rule_a_still_fires` — sets `GOLDFIVE_CAPABILITY_RULE_A=1`.
- `test_delegation_pin.py::test_capability_check_still_resolves_after_reorder` — sets the Rule A flag.
- `test_pause_escalate.py::test_ladder_level_for_pause_escalate_on_repeat` — re-pointed PLAN_DIVERGENCE → TOOL_ERROR (still exhibits first→repeat escalation).
- `test_reporting.py` / `test_reporting_tool_required_validation.py` / `test_steerer.py` — NEW_WORK_DISCOVERED now asserts growth (no refine, plan grew, DriftDetected still emits) instead of refine.

## Known dead entry (deferred to PR 7)
`PLAN_DIVERGENCE` remains in `_GOLDFIVE_STEER_ELIGIBLE_KINDS`, but is unreachable (dropped at the top of `handle_drift` before the promotion check). Left as-is to avoid promotion-test churn; the promotion restructure is PR 7.

## Verification
`uv run pytest` (dev+adk+proto, CI parity): **2950 passed, 59 skipped**. `ruff check .`: clean. Rebased onto current `agency-preservation` (includes PR 5 #456) — diff is only the 15 files of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)