### PR TITLE
test(drift): pin SignalLedger fire-recording survives PR-3 demotion + comment refinements

### DIFF
--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -3540,8 +3540,22 @@ class DriftObserver:
             # ABSORB so Rule B — user-declared ``required_tools``, genuine
             # prescriptive intent — keeps steering via refine, capped at the
             # WARNING rung ("WARNING-max": Rule B now emits WARNING, never
-            # CRITICAL, so it cannot escalate to cancel/pause). PR 13 hard-
-            # deletes Rule A/C and revisits this row.
+            # CRITICAL, so it cannot escalate to cancel/pause).
+            #
+            # Trajectory-safety synergy with #453: an ABSORB-driven refine
+            # is goldfive-authored, and post-#453 goldfive-authored drift
+            # never cancels the in-flight invocation (CAPABILITY_MISMATCH
+            # is not in ``_HARD_SAFETY_DRIFT_KINDS``). So Rule B's retained
+            # steering refines the ledger plan WITHOUT preempting the
+            # running agent — the demotion and the cancel-authority gate
+            # compose into "advise, don't grab the wheel".
+            #
+            # In the DEFAULT config the CRITICAL cells are unreachable
+            # belt-and-suspenders: Rule A and Rule C are both gated off,
+            # and the only live emitter (Rule B) emits WARNING. The
+            # CRITICAL→OBSERVE mapping bites only if an operator re-enables
+            # Rule A/C via the escape-hatch env flags. PR 13 hard-deletes
+            # Rule A/C and revisits this row.
             DriftKind.CAPABILITY_MISMATCH: (
                 _IL.OBSERVE,
                 _IL.ABSORB,

--- a/tests/test_ladder_decision_table.py
+++ b/tests/test_ladder_decision_table.py
@@ -86,7 +86,12 @@ def render_ladder_surface(steerer: DefaultSteerer) -> str:
 #   * plan_divergence     WARNING ABSORB→OBSERVE, CRITICAL
 #                         [CANCEL_REINVOKE|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
 #   * capability_mismatch CRITICAL [ABSORB|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
-#                         (WARNING stays ABSORB: Rule B / "WARNING-max")
+#                         (WARNING stays ABSORB: Rule B / "WARNING-max").
+#                         The CRITICAL→OBSERVE cells are unreachable in the
+#                         DEFAULT config — Rule A and Rule C are both env-
+#                         gated OFF and the only live emitter (Rule B) emits
+#                         WARNING; the cells bite only under the Rule A/C
+#                         escape hatches (belt-and-suspenders).
 #   * new_work_discovered WARNING ABSORB→OBSERVE, CRITICAL
 #                         [ABSORB|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
 # wrong_agent is unchanged here: it is deprecated with no _LADDER row and

--- a/tests/test_ladder_demotion_observability.py
+++ b/tests/test_ladder_demotion_observability.py
@@ -128,6 +128,62 @@ async def test_demoted_critical_kind_observes_without_refine_or_outcome(
     assert dict(session.refine_outcomes) == {}
 
 
+async def test_demoted_kind_still_records_signal_ledger_fire_at_observe() -> None:
+    """PR #456's SignalLedger fire-recording survives the PR-3 demotion.
+
+    The fire-recording hook (``_note_signal_drift_fire``) lives at the
+    END of ``_emit_drift_detected`` — the single DriftDetected
+    chokepoint, which runs in the dispatch BEFORE the ladder routing.
+    So a CAPABILITY_MISMATCH routed to OBSERVE still records a fire on
+    the ledger: the demotion removes the ladder *action* (no signal
+    delivered), not the observability telemetry. This guards the lead's
+    binding concern that demotions "must not silently stop telemetry for
+    demoted kinds (DriftDetected + fire-recording still happen at
+    OBSERVE)".
+    """
+    from goldfive.config import SteeringConfig
+    from goldfive.signal_ledger import SignalLedger
+
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(observation_only=False, signal_telemetry=True)
+    )
+    sink = _ListSink()
+    planner = _RecordingPlanner()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="ship it")],
+        plan=Plan(
+            id="p1",
+            run_id="r1",
+            goal_ids=["g1"],
+            tasks=[Task(id="t1", title="A")],
+            edges=[],
+        ),
+    )
+    session.current_task_id = "t1"
+    drift = DriftEvent(
+        kind=DriftKind.CAPABILITY_MISMATCH,
+        severity=DriftSeverity.CRITICAL,
+        detail="demoted",
+        current_task_id="t1",
+    )
+    await steerer.drift.handle_drift(drift, session)
+    await steerer.drift._wait_background_drifts_idle()
+
+    # OBSERVE: no signal delivered, no refine.
+    assert planner.refine_calls == []
+    assert len(_drift_detected(sink)) == 1
+    # PR #456 fire-recording preserved: the ledger saw the fire, but no
+    # delivery (OBSERVE delivers no signal).
+    entry = SignalLedger.for_session(session).entry(
+        DriftKind.CAPABILITY_MISMATCH.value, "t1"
+    )
+    assert entry is not None
+    assert entry.fire_count >= 1
+    assert not entry.has_delivery
+
+
 async def test_plan_divergence_dropped_in_handle_drift_no_outcome() -> None:
     """PLAN_DIVERGENCE is dropped at the top of ``handle_drift`` (#252):
     no DriftDetected via this path, no refine, no ``refine_outcomes``


### PR DESCRIPTION
Follow-up to **PR #457** (AGENCY-PRESERVATION PR 3), addressing the lead's post-merge review notes. **Comment/test-only — no behavior change.**

## Why a follow-up
PR #457 was merged before the lead's review notes arrived. These three items are the requested refinements, applied on top of the merged base.

## Changes
1. **Telemetry-preservation test** (`test_demoted_kind_still_records_signal_ledger_fire_at_observe`) — proves PR #456's `SignalLedger` fire-recording survives the demotion to OBSERVE. `_note_signal_drift_fire` is at the end of `_emit_drift_detected` (the DriftDetected chokepoint), which runs in the dispatch **before** ladder routing — so a `CAPABILITY_MISMATCH` routed to OBSERVE still records a fire (`fire_count >= 1`, `has_delivery == False`). The demotion removes the ladder *action* (no signal delivered), not the observability telemetry.
2. **CAPABILITY_MISMATCH ladder comment** — documents the trajectory-safety synergy with #453: an ABSORB-driven refine is goldfive-authored, and post-#453 goldfive-authored drift never cancels the in-flight invocation (CAPABILITY_MISMATCH ∉ `_HARD_SAFETY_DRIFT_KINDS`), so Rule B's retained WARNING→ABSORB steering refines the ledger **without preempting the running agent**. Also notes the CRITICAL→OBSERVE cells are unreachable in the default config (Rule A and Rule C both env-gated off; the only live emitter, Rule B, emits WARNING).
3. **Snapshot golden comment** — same default-config unreachability note.

## §5.3 side-effect evidence (per lead request #3)
`CAPABILITY_MISMATCH` is **not** in `DriftObserver._GOLDFIVE_STEER_ELIGIBLE_KINDS`, so changing Rule B's emission to WARNING cannot accidentally auto-promote it to a full steer — it is purely ladder-routed. (Verified by grep; the eligible set is `{OFF_TOPIC, INTENT_DIVERGENCE, UNEXPECTED_OUTPUT, CONFABULATION_RISK, LOOPING_REASONING, LOOPING_TOOL_CALL, PLAN_DIVERGENCE}`.)

## Verification
`uv run pytest` (dev+adk+proto) = **2951 passed, 59 skipped**; `ruff check .` clean. Diff is 3 files, +78/-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)