### PR TITLE
feat(bench): three-arm counterfactual harness + §5.4 shadow-diff tooling (AGENCY-PRESERVATION PR 13a)

### DIFF
--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -1,0 +1,7 @@
+"""goldfive bench harness package.
+
+Importable home for the three-arm counterfactual bench
+(:mod:`bench.harness`) and the §5.4 shadow / differential-validation tool
+(:mod:`bench.shadow_diff`). The perf baseline entrypoint stays in
+``bench/run_100_tasks.py`` and is runnable as a script.
+"""

--- a/bench/harness.py
+++ b/bench/harness.py
@@ -1,0 +1,706 @@
+"""Three-arm counterfactual bench harness (AGENCY-PRESERVATION.md PR 13a).
+
+This is the scaffold the Stage-3 measurement gate (§3 PR 13, §4
+"Counterfactual gate", §5.8) is built on. It runs the **same workload**
+under three steering regimes and records per-arm metrics from the
+*captured artifacts* (goldfive#447 ``Session.completed_outputs`` + goal
+predicates) and the *sink event stream* (``SignalDelivered`` /
+``SignalOutcome`` / ``DriftDetected`` / ``RunAborted`` — the PR-5
+telemetry), never from parsing agent prose:
+
+* **arm A — ``baseline``**: ``wrap(judge_only=True)``. The judge-only
+  counterfactual (goldfive#446): the wrapped agent runs natively, drift
+  judges stay armed, and ZERO planning / steering authority is exercised.
+  This is the bar arm B must be *non-inferior to* before any default
+  flip (§3 PR 13).
+* **arm B — ``signal``**: the new SIGNAL regime —
+  ``observation_only=False`` plus the new-regime flags
+  (``signal_channel=request_context`` once PR 6 lands, ``plan_mode=ledger``
+  once PR 10 lands, …). Arms are defined as **flag dicts of environment
+  variables** so the harness does NOT hard-depend on unmerged PRs: a flag
+  whose env var this build's :meth:`RuntimeConfig.from_env` does not yet
+  consult is applied to the environment, reported as *pending*, and simply
+  no-ops until the PR that reads it lands (graceful degradation — §5.1
+  "no-op by default").
+* **arm C — ``legacy``**: the legacy ladder regime —
+  ``GOLDFIVE_STEER_LEGACY_LADDER=1`` (PR 7's escape hatch) +
+  ``observation_only=False`` + ``GOLDFIVE_CANCEL_INFLIGHT_SCOPE=all`` (the
+  PR-1 kill-switch that restores cancel-on-every-install). Arm C exists so
+  regressions are *measurable rather than argued about* (§5.8).
+
+Why env-var flag dicts (not :class:`SteeringConfig` kwargs)
+----------------------------------------------------------
+``signal_channel`` / ``GOLDFIVE_STEER_LEGACY_LADDER`` / ``plan_mode`` do
+not exist in this build (PRs 6/7/10 are unmerged on the integration
+branch). Passing them as :class:`SteeringConfig` constructor kwargs would
+raise ``TypeError`` the day they are defined-but-renamed; passing them as
+**env vars** that :meth:`RuntimeConfig.from_env` reads means an unknown
+flag is silently ignored today and *automatically* picked up the moment
+the consuming PR teaches ``from_env`` about it — zero harness change. The
+harness reports which arm flags this build actually consults
+(:func:`arm_flag_status`) so a *pending* flag is never silently mistaken
+for an *applied* one.
+
+Determinism for the smoke test
+------------------------------
+``13b`` (running the real bench against a live model) is a separate,
+gated task. For ``13a``'s self-test the workload is driven by a stub
+``call_llm`` and an optional :func:`inject_demo_signals` deterministic
+drift sequence that exercises the **real** ``DefaultSteerer`` dispatch
+path (the same methods production calls) so the telemetry pipeline —
+dispatch → :class:`SignalLedger` → wire event → sink → metrics / shadow
+diff — is validated end-to-end. ``signal_telemetry`` ships DEFAULT OFF
+(goldfive#456): every arm here enables it explicitly, and the tooling
+treats *zero parsed signal events* as a loud error, never an empty report
+(§5.6 integration-not-unit).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import json
+import os
+from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from goldfive import (
+    CallableAdapter,
+    Goal,
+    InvocationResult,
+    LiteralGoalDeriver,
+    Plan,
+    Session,
+    StaticPlanner,
+    Task,
+    wrap,
+)
+from goldfive.config import RuntimeConfig
+from goldfive.results import ExecutionOutcome, evaluate_goal_predicates
+from goldfive.sinks import InMemorySink, JSONLPersistenceSink
+from goldfive.steerer import DefaultSteerer
+from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+
+__all__ = [
+    "Arm",
+    "ArmMetrics",
+    "MANAGED_STEER_ENV",
+    "KNOWN_STEER_ENV",
+    "Scenario",
+    "apply_arm_env",
+    "arm_flag_status",
+    "default_arms",
+    "inject_demo_signals",
+    "make_linear_run_driver",
+    "metrics_from_events",
+    "run_arm",
+    "run_arms",
+]
+
+
+# ---------------------------------------------------------------------------
+# Flag-dict configurability + graceful degradation
+# ---------------------------------------------------------------------------
+
+#: Steering env vars this build's :meth:`SteeringConfig.from_env` actually
+#: consults (see ``goldfive/config.py``). An arm flag whose env var is in
+#: this set is *applied* (it changes the resolved config); a flag NOT in it
+#: is *pending* (applied to the environment, but inert until the PR that
+#: teaches ``from_env`` about it lands). Reviewers extend this set in the
+#: same PR that adds the env read — e.g. PR 6 adds
+#: ``GOLDFIVE_STEER_SIGNAL_CHANNEL``, PR 7 ``GOLDFIVE_STEER_LEGACY_LADDER``,
+#: PR 10 ``GOLDFIVE_PLAN_MODE``.
+KNOWN_STEER_ENV: frozenset[str] = frozenset(
+    {
+        "GOLDFIVE_STEER_THRESHOLD",
+        "GOLDFIVE_STEER_SUPPRESSION_WINDOW_TURNS",
+        "GOLDFIVE_STEER_OBSERVATION_ONLY",
+        "GOLDFIVE_STEER_CONTEXT_EDITOR_RULES",
+        "GOLDFIVE_STEER_DESCRIPTIVE_GROWTH",
+        "GOLDFIVE_STEER_SIGNAL_TELEMETRY",
+        "GOLDFIVE_CANCEL_INFLIGHT_SCOPE",
+    }
+)
+
+#: Forward-declared env vars the roadmap will introduce. Listed here so the
+#: harness *clears* them between arms (no cross-arm leakage) even before any
+#: build consults them — and so an operator reading an arm's flag dict sees
+#: the intended end-state. They remain *pending* until promoted into
+#: :data:`KNOWN_STEER_ENV`.
+_PENDING_STEER_ENV: frozenset[str] = frozenset(
+    {
+        "GOLDFIVE_STEER_LEGACY_LADDER",  # PR 7 escape hatch
+        "GOLDFIVE_STEER_SIGNAL_CHANNEL",  # PR 6 (request_context | legacy_user_message)
+        "GOLDFIVE_PLAN_MODE",  # PR 10 (forecast | ledger)
+    }
+)
+
+#: Every env var the harness owns: snapshotted-and-cleared on each arm so
+#: an arm only ever sees its own flag dict plus the ambient (non-managed)
+#: environment.
+MANAGED_STEER_ENV: frozenset[str] = KNOWN_STEER_ENV | _PENDING_STEER_ENV
+
+
+@dataclasses.dataclass(frozen=True)
+class Arm:
+    """One steering regime under test, defined as an env-var flag dict.
+
+    ``env`` maps environment-variable names to string values; the harness
+    applies them (clearing every other :data:`MANAGED_STEER_ENV` key first)
+    around the arm's run, then builds :meth:`RuntimeConfig.from_env`. This
+    is the indirection that keeps the harness independent of unmerged PRs.
+    """
+
+    name: str
+    kind: str  # "baseline" | "signal" | "legacy" — the §3 PR-13 arm labels
+    env: Mapping[str, str] = dataclasses.field(default_factory=dict)
+    judge_only: bool = False
+    description: str = ""
+
+
+def default_arms() -> list[Arm]:
+    """The three §3 PR-13 arms as configurable flag dicts.
+
+    Every arm enables ``signal_telemetry`` explicitly (it is DEFAULT OFF —
+    goldfive#456) so the captured-event metrics and the shadow diff have
+    data to read. Callers building a *shadow* campaign (§5.4) override
+    ``GOLDFIVE_STEER_OBSERVATION_ONLY=1`` on arms B/C so the new decision
+    logic runs dry (``SignalDelivered(dry_run=true)``); see
+    :func:`shadow_arms`.
+    """
+    return [
+        Arm(
+            name="A-baseline-judge-only",
+            kind="baseline",
+            judge_only=True,
+            env={
+                "GOLDFIVE_STEER_SIGNAL_TELEMETRY": "1",
+                # judge_only exercises no steering authority; observation_only
+                # is moot but pinned for a clean, explicit flag dict.
+                "GOLDFIVE_STEER_OBSERVATION_ONLY": "1",
+            },
+            description="judge-only counterfactual baseline (goldfive#446)",
+        ),
+        Arm(
+            name="B-signal-regime",
+            kind="signal",
+            judge_only=False,
+            env={
+                "GOLDFIVE_STEER_SIGNAL_TELEMETRY": "1",
+                "GOLDFIVE_STEER_OBSERVATION_ONLY": "0",
+                "GOLDFIVE_CANCEL_INFLIGHT_SCOPE": "user_and_safety",
+                # Pending (no-op until the consuming PR lands):
+                "GOLDFIVE_STEER_SIGNAL_CHANNEL": "request_context",  # PR 6
+                "GOLDFIVE_PLAN_MODE": "ledger",  # PR 10
+            },
+            description="new SIGNAL regime (observation_only=False + new-regime flags)",
+        ),
+        Arm(
+            name="C-legacy-ladder",
+            kind="legacy",
+            judge_only=False,
+            env={
+                "GOLDFIVE_STEER_SIGNAL_TELEMETRY": "1",
+                "GOLDFIVE_STEER_OBSERVATION_ONLY": "0",
+                "GOLDFIVE_CANCEL_INFLIGHT_SCOPE": "all",  # PR-1 kill-switch
+                "GOLDFIVE_STEER_LEGACY_LADDER": "1",  # PR 7 escape hatch (pending)
+            },
+            description="legacy ladder regime (GOLDFIVE_STEER_LEGACY_LADDER=1)",
+        ),
+    ]
+
+
+def shadow_arms() -> list[Arm]:
+    """Arms for the §5.4 shadow campaign: behavior arms forced dry-run.
+
+    Identical to :func:`default_arms` except arms B/C run under
+    ``observation_only=1`` so every dispatch records
+    ``SignalDelivered(dry_run=true)`` — the new decision logic accrues
+    production mileage with zero production authority, and the
+    :mod:`bench.shadow_diff` tool diffs legacy-would-do vs. new-would-do on
+    the resulting logs.
+    """
+    arms: list[Arm] = []
+    for arm in default_arms():
+        env = dict(arm.env)
+        if arm.kind in ("signal", "legacy"):
+            env["GOLDFIVE_STEER_OBSERVATION_ONLY"] = "1"
+        arms.append(dataclasses.replace(arm, env=env))
+    return arms
+
+
+def arm_flag_status(arm: Arm) -> tuple[list[str], list[str]]:
+    """Split ``arm.env`` into ``(applied, pending)`` env-var name lists.
+
+    ``applied`` flags are consulted by this build; ``pending`` flags are
+    set in the environment but inert until the PR that reads them lands.
+    This is the operator-facing transparency that keeps a *pending* flag
+    from being silently mistaken for an *applied* one (§5.1).
+    """
+    applied = sorted(k for k in arm.env if k in KNOWN_STEER_ENV)
+    pending = sorted(k for k in arm.env if k not in KNOWN_STEER_ENV)
+    return applied, pending
+
+
+@contextlib.contextmanager
+def apply_arm_env(arm: Arm) -> Iterator[None]:
+    """Apply ``arm.env`` with every other managed flag cleared; restore on exit.
+
+    The clear step is what prevents cross-arm leakage: an ambient
+    ``GOLDFIVE_STEER_OBSERVATION_ONLY`` (or a flag set by a previous arm)
+    cannot bleed into an arm that does not declare it. Only
+    :data:`MANAGED_STEER_ENV` keys are touched; unrelated environment is
+    left untouched and fully restored.
+    """
+    managed = MANAGED_STEER_ENV | set(arm.env)
+    saved = {k: os.environ.get(k) for k in managed}
+    try:
+        for k in managed:
+            os.environ.pop(k, None)
+        for k, v in arm.env.items():
+            os.environ[k] = str(v)
+        yield
+    finally:
+        for k, prior in saved.items():
+            if prior is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prior
+
+
+# ---------------------------------------------------------------------------
+# Per-arm metrics from captured artifacts + sink events
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class ArmMetrics:
+    """The §3 PR-13 metric vector for one arm, from artifacts + events.
+
+    Every field is sourced from a captured artifact (``completed_outputs``,
+    goal predicates, the :class:`SignalLedger` on ``session.state``) or the
+    sink event stream — never from parsing agent prose (§5.6 / project
+    scar tissue).
+    """
+
+    arm_name: str
+    arm_kind: str
+    # --- captured-artifact outcome (goldfive#447) ---------------------
+    goal_success: bool
+    goal_reason: str
+    completed_outputs: int
+    turns: int
+    tokens: int | None  # best-effort; None when the adapter reports no usage
+    aborted: bool
+    abort_reason: str
+    # --- sink-event telemetry (PR 5) ----------------------------------
+    drift_detected: int
+    signals_total: int
+    signals_real: int  # non-dry_run deliveries == actual interventions
+    signals_dry_run: int
+    intervention_count: int  # alias for signals_real, named per the brief
+    by_channel: dict[str, int]
+    outcomes: dict[str, int]
+    self_correction_base_rate: float | None  # unaided / (unaided + after_signal)
+    post_signal_refire_rate: float | None  # ledger: re-fires / delivered keys
+    # --- provenance / degradation ------------------------------------
+    applied_flags: list[str]
+    pending_flags: list[str]
+    jsonl_path: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def _drift_kind_name(value: int) -> str:
+    """Map a ``DriftDetected.kind`` enum int back to a ``DriftKind`` value.
+
+    The proto stores the UPPER enum name (e.g. ``OFF_TOPIC``); the
+    ``SignalDelivered.kind`` string is the ``DriftKind`` *value*
+    (lowercase, e.g. ``off_topic``). Normalise to the value form so a
+    re-fire correlation on the event stream lines up with deliveries.
+    """
+    try:
+        from goldfive.pb.goldfive.v1 import events_pb2 as pb
+
+        return str(pb.DriftKind.Name(value)).lower()
+    except Exception:  # noqa: BLE001 - defensive; metrics are best-effort
+        return str(value)
+
+
+def _ledger_refire_rate(session: Session | None) -> float | None:
+    """Post-signal drift re-fire rate from the :class:`SignalLedger`.
+
+    The ledger (``session.state``) is the authoritative, designed home for
+    re-fire bookkeeping (PR 5 docstring; PR 8 *gates* on it). Rate =
+    (sum of re-fires across delivered keys) / (delivered keys). ``None``
+    when no session is available (pure-JSONL callers) or no key carried a
+    delivery.
+    """
+    if session is None:
+        return None
+    try:
+        from goldfive.signal_ledger import SignalLedger
+
+        entries = SignalLedger.for_session(session).entries()
+    except Exception:  # noqa: BLE001 - telemetry best-effort
+        return None
+    delivered = [e for e in entries if e.has_delivery]
+    if not delivered:
+        return None
+    refires = sum(int(getattr(e, "refire_count", 0) or 0) for e in delivered)
+    return refires / len(delivered)
+
+
+def metrics_from_events(
+    events: Sequence[Any],
+    *,
+    arm: Arm,
+    session: Session | None = None,
+    tokens: int | None = None,
+    jsonl_path: str = "",
+) -> ArmMetrics:
+    """Reduce a captured event stream (+ optional session) to an :class:`ArmMetrics`.
+
+    Pure over proto ``Event`` messages: it never reaches into goldfive
+    internals beyond the documented ``session.completed_outputs`` /
+    ``_reasoning_turn`` artifacts and the :class:`SignalLedger`. Works on
+    an in-memory sink's ``.events`` or a list parsed back from JSONL.
+    """
+    drift_detected = 0
+    signals_total = 0
+    signals_real = 0
+    signals_dry_run = 0
+    by_channel: dict[str, int] = {}
+    outcomes: dict[str, int] = {}
+    aborted = False
+    abort_reason = ""
+    task_terminal = 0
+
+    for evt in events:
+        which = evt.WhichOneof("payload") if hasattr(evt, "WhichOneof") else None
+        if which == "drift_detected":
+            drift_detected += 1
+        elif which == "signal_delivered":
+            sd = evt.signal_delivered
+            signals_total += 1
+            if sd.dry_run:
+                signals_dry_run += 1
+            else:
+                signals_real += 1
+            by_channel[sd.channel] = by_channel.get(sd.channel, 0) + 1
+        elif which == "signal_outcome":
+            oc = evt.signal_outcome.outcome
+            outcomes[oc] = outcomes.get(oc, 0) + 1
+        elif which == "run_aborted":
+            aborted = True
+            abort_reason = evt.run_aborted.reason
+        elif which in ("task_completed", "task_failed", "task_cancelled"):
+            task_terminal += 1
+
+    unaided = outcomes.get("self_corrected_unaided", 0)
+    after = outcomes.get("self_corrected_after_signal", 0)
+    base_rate = unaided / (unaided + after) if (unaided + after) else None
+
+    completed_outputs = len(getattr(session, "completed_outputs", {}) or {}) if session else 0
+    # Turns: prefer the goldfive#441 logical-turn clock; fall back to the
+    # count of task-terminal transitions when the adapter never advances it.
+    turns = 0
+    if session is not None:
+        turns = int(getattr(session, "_reasoning_turn", 0) or 0)
+    turns = max(turns, task_terminal)
+
+    goal_reason = ""
+    goal_success = not aborted
+    if session is not None:
+        reason = evaluate_goal_predicates(session)
+        if reason is not None:
+            goal_success = False
+            goal_reason = reason
+
+    applied, pending = arm_flag_status(arm)
+    return ArmMetrics(
+        arm_name=arm.name,
+        arm_kind=arm.kind,
+        goal_success=goal_success,
+        goal_reason=goal_reason,
+        completed_outputs=completed_outputs,
+        turns=turns,
+        tokens=tokens,
+        aborted=aborted,
+        abort_reason=abort_reason,
+        drift_detected=drift_detected,
+        signals_total=signals_total,
+        signals_real=signals_real,
+        signals_dry_run=signals_dry_run,
+        intervention_count=signals_real,
+        by_channel=by_channel,
+        outcomes=outcomes,
+        self_correction_base_rate=base_rate,
+        post_signal_refire_rate=_ledger_refire_rate(session),
+        applied_flags=applied,
+        pending_flags=pending,
+        jsonl_path=str(jsonl_path),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario / workload + arm runner
+# ---------------------------------------------------------------------------
+
+#: A driver runs one arm's workload against the supplied sinks under the
+#: supplied resolved config and returns the run outcome. Keeping the driver
+#: pluggable is what lets 13b swap in a real coordinator+AgentTool tree and
+#: a live model while reusing this harness's flag-dict + metrics machinery.
+Driver = Callable[..., Awaitable[ExecutionOutcome]]
+
+
+@dataclasses.dataclass
+class Scenario:
+    """A named workload plus the driver that runs it under an arm."""
+
+    name: str
+    driver: Driver
+    #: Optional best-effort token accounting; 13b wires the adapter's usage.
+    extract_tokens: Callable[[Session], int | None] | None = None
+
+
+async def run_arm(
+    arm: Arm,
+    scenario: Scenario,
+    *,
+    jsonl_dir: str | Path,
+) -> ArmMetrics:
+    """Run one arm of ``scenario`` and return its :class:`ArmMetrics`.
+
+    Applies the arm's flag dict, builds the resolved runtime, runs the
+    driver against a JSONL artifact sink (durable, the 13b/§5.4 input) and
+    an in-memory sink (fast metric reduction), then reduces to metrics from
+    the captured artifacts + events.
+    """
+    jsonl_dir = Path(jsonl_dir)
+    jsonl_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path = jsonl_dir / f"{arm.name}.jsonl"
+
+    with apply_arm_env(arm):
+        runtime = RuntimeConfig.from_env()
+        jsonl_sink = JSONLPersistenceSink(jsonl_path, mode="write")
+        mem_sink = InMemorySink()
+        outcome = await scenario.driver(
+            sinks=[jsonl_sink, mem_sink], runtime=runtime, arm=arm
+        )
+        await jsonl_sink.close()
+
+    tokens = None
+    if scenario.extract_tokens is not None and outcome.session is not None:
+        with contextlib.suppress(Exception):
+            tokens = scenario.extract_tokens(outcome.session)
+
+    return metrics_from_events(
+        mem_sink.events,
+        arm=arm,
+        session=outcome.session,
+        tokens=tokens,
+        jsonl_path=str(jsonl_path),
+    )
+
+
+async def run_arms(
+    arms: Sequence[Arm],
+    scenario: Scenario,
+    *,
+    jsonl_dir: str | Path,
+) -> list[ArmMetrics]:
+    """Run every arm of ``scenario`` sequentially (isolated env per arm)."""
+    results: list[ArmMetrics] = []
+    for arm in arms:
+        results.append(await run_arm(arm, scenario, jsonl_dir=jsonl_dir))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# A concrete, deterministic scenario for the smoke test (stub model)
+# ---------------------------------------------------------------------------
+
+
+def _linear_plan(n: int, *, goal_id: str, run_id: str = "") -> Plan:
+    tasks = [
+        Task(
+            id=f"t{i:03d}",
+            title=f"Task {i}",
+            description=f"Bench task #{i}",
+            assignee_agent_id="bench-agent",
+        )
+        for i in range(n)
+    ]
+    edges: list[Any] = []
+    from goldfive import TaskEdge
+
+    for i in range(n - 1):
+        edges.append(TaskEdge(from_task_id=f"t{i:03d}", to_task_id=f"t{i + 1:03d}"))
+    return Plan(
+        id="bench-arm-plan",
+        run_id=run_id,
+        goal_ids=[goal_id],
+        tasks=tasks,
+        edges=edges,
+        summary=f"Linear {n}-task bench plan",
+    )
+
+
+async def _noop_agent(
+    task: Task, session: Session, tools: Any
+) -> InvocationResult:
+    _ = (session, tools)
+    return InvocationResult(task_id=task.id, text=f"native ran: {task.title}")
+
+
+async def _always_progressing_call_llm(system: str, user: str, model: str) -> str:
+    """Stub ``call_llm`` that keeps any armed judge from drifting/exhausting.
+
+    Returns a permissive ``progressing`` verdict for every judge call so a
+    healthy run stays healthy regardless of how many times a judge fires —
+    drift in the smoke test is injected deterministically by
+    :func:`inject_demo_signals`, not produced by this stub.
+    """
+    _ = (system, user, model)
+    return json.dumps({"progressing": True})
+
+
+async def inject_demo_signals(
+    *,
+    runtime: RuntimeConfig,
+    session: Session,
+    sinks: Sequence[Any],
+) -> None:
+    """Drive a deterministic drift lifecycle through the REAL dispatch path.
+
+    Builds a fresh :class:`DefaultSteerer` from the arm's resolved steering
+    config plus a throwaway one-task *drift session* (an OPEN task, so the
+    task-terminal chokepoint actually resolves the ledger keys instead of
+    no-opping on the already-completed run plan), and exercises the
+    production ``_dispatch_nudge`` / ``_emit_drift_detected`` / task-terminal
+    / finalize chokepoints so the telemetry pipeline emits genuine
+    ``SignalDelivered`` / ``SignalOutcome`` events (not hand-built
+    envelopes). The resulting :class:`SignalLedger` is then merged onto the
+    run's ``session.state`` so :func:`metrics_from_events` reads
+    completed-output and signal metrics off one consistent session.
+
+    The drift kinds/severities are chosen so the recorded
+    ``decision.would_cancel_inflight`` *diverges by arm*: a CRITICAL
+    goldfive-authored ``OFF_TOPIC`` drift cancels in-flight work under
+    ``cancel_inflight_scope="all"`` (legacy arm C) but not under
+    ``"user_and_safety"`` (signal arm B) — the PR-1 authority split, which
+    is merged and therefore a *real* divergence the shadow diff surfaces
+    today, before PR 7's ladder restructure lands. The OFF_TOPIC key also
+    re-fires once after delivery so ``post_signal_refire_rate`` is exercised.
+
+    This stands in for organically-produced drift so 13a's tooling is
+    validated end-to-end; 13b drops it and lets a live model drift.
+    """
+    from goldfive import TaskStatus
+    from goldfive.signal_ledger import KEY_SIGNAL_LEDGER
+
+    dtask = Task(
+        id="dt0",
+        title="Demo drift task",
+        description="Open task carrying the injected drift lifecycle",
+        assignee_agent_id="bench-agent",
+        status=TaskStatus.RUNNING,
+    )
+    drift_session = Session(
+        run_id=session.run_id,
+        goals=list(session.goals),
+        plan=Plan(
+            id="demo-drift-plan",
+            run_id=session.run_id,
+            goal_ids=[g.id for g in session.goals],
+            tasks=[dtask],
+            edges=[],
+        ),
+        current_task_id="dt0",
+    )
+
+    steerer = DefaultSteerer(steering_config=runtime.steering)
+    steerer.bind(sinks=list(sinks), planner=StaticPlanner(drift_session.plan))
+
+    def _off_topic() -> DriftEvent:
+        return DriftEvent(
+            kind=DriftKind.OFF_TOPIC,
+            severity=DriftSeverity.CRITICAL,
+            detail="trajectory wandered off the user goal",
+            current_task_id="dt0",
+            current_agent_id="bench-agent",
+            authored_by="goldfive",
+        )
+
+    # First delivery on the OFF_TOPIC/dt0 key (would_cancel_inflight diverges
+    # by cancel-scope regime).
+    await steerer.drift._dispatch_nudge(_off_topic(), drift_session)
+    # A distinct OFF_TOPIC fire AFTER the delivery → a post-signal re-fire.
+    await steerer.drift._emit_drift_detected(drift_session, _off_topic())
+    # A second, distinct loop-shaped key so the stream carries >1 drift.
+    looping = DriftEvent(
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        severity=DriftSeverity.WARNING,
+        detail="search_web called 5x with identical args",
+        current_task_id="dt0",
+        current_agent_id="bench-agent",
+        authored_by="goldfive",
+    )
+    await steerer.drift._dispatch_nudge(looping, drift_session)
+    # Resolve the bound task → SignalOutcome for both delivered keys
+    # (self_corrected_unaided under observation_only, after_signal otherwise).
+    await steerer.tasks.mark_task_completed("dt0", session=drift_session, summary="done")
+    # Finalize any still-open delivered keys at the run boundary (idempotent).
+    await steerer.drift.finalize_signal_ledger(drift_session)
+
+    # Merge the drift session's signal ledger onto the run session so the
+    # metric reducer reads one consistent session.
+    from goldfive import state_store as _ostate
+
+    ledger = _ostate.read(drift_session.state, KEY_SIGNAL_LEDGER, {})
+    if ledger:
+        _ostate.write(session.state, KEY_SIGNAL_LEDGER, dict(ledger))
+
+
+def make_linear_run_driver(
+    *,
+    num_tasks: int = 3,
+    inject_signals: bool = True,
+    user_goal: str = "Summarise the quarterly report",
+) -> Driver:
+    """Build a deterministic linear-plan driver for the smoke test / demo.
+
+    All arms share this workload so the comparison is apples-to-apples:
+    a one-goal :class:`LiteralGoalDeriver` (no goal-derive LLM call), an
+    explicit :class:`StaticPlanner` (so judge-only arm A runs the SAME
+    tasks, not its 1-task native-run framing plan), a no-op agent, and a
+    permissive stub ``call_llm`` for any armed judge. With
+    ``inject_signals`` the driver appends :func:`inject_demo_signals` so the
+    telemetry path is exercised.
+    """
+    goal = Goal(id="bench-goal", summary=user_goal)
+    plan = _linear_plan(num_tasks, goal_id=goal.id)
+
+    async def driver(*, sinks: Sequence[Any], runtime: RuntimeConfig, arm: Arm) -> ExecutionOutcome:
+        runner = wrap(
+            CallableAdapter(_noop_agent, available_agents=["bench-agent"]),
+            judge_only=arm.judge_only,
+            planner=StaticPlanner(plan),
+            goal_deriver=LiteralGoalDeriver(),
+            call_llm=_always_progressing_call_llm,
+            model="bench-stub-model",
+            runtime=runtime,
+            sinks=list(sinks),
+        )
+        outcome = await runner.run([goal])
+        if inject_signals:
+            await inject_demo_signals(
+                runtime=runtime, session=outcome.session, sinks=sinks
+            )
+        await runner.close()
+        return outcome
+
+    return driver

--- a/bench/run_100_tasks.py
+++ b/bench/run_100_tasks.py
@@ -1,23 +1,43 @@
-"""100-task performance baseline for goldfive.
+"""goldfive bench entrypoints: perf baseline + AGENCY-PRESERVATION three-arm.
 
-Runs a synthetic 100-task linear plan through ``SequentialExecutor``
-plus ``JSONLPersistenceSink`` with a no-op ``CallableAdapter``. The
-goal is to measure goldfive's orchestration overhead in isolation —
-no LLM call, no network, no real agent work — so future regressions
-in the runner / executor / sink path are visible against a pinned
-baseline.
+Three subcommands (``perf`` is the default, so the original invocation is
+unchanged):
 
-Run with::
+``perf`` (default)
+    The 100-task performance baseline. Runs a synthetic 100-task linear
+    plan through ``SequentialExecutor`` + ``JSONLPersistenceSink`` with a
+    no-op ``CallableAdapter`` — no LLM, no network — so runner / executor /
+    sink regressions are visible against a pinned baseline. Prints one
+    block of measurements and exits 0.
 
-    uv run python bench/run_100_tasks.py
+        uv run python bench/run_100_tasks.py
+        uv run python bench/run_100_tasks.py perf
 
-The script prints a single block of measurements to stdout and exits
-with status 0. The temporary JSONL file is unlinked before exit.
+``three-arm``
+    The AGENCY-PRESERVATION.md PR 13 counterfactual harness: runs the same
+    workload under arm A (judge-only baseline), arm B (new SIGNAL regime)
+    and arm C (legacy ladder), printing the per-arm metric table sourced
+    from captured artifacts + sink events. With a stub model this exercises
+    the harness + telemetry plumbing; 13b plugs in a live model.
+
+        uv run python bench/run_100_tasks.py three-arm --out-dir /tmp/bench
+
+``shadow``
+    Runs the three arms in §5.4 shadow mode (behavior arms forced
+    ``observation_only`` so signals are dry-run) and diffs the legacy vs.
+    new logs into the divergence report — the exit-criterion artifact for
+    enabling a behavior PR.
+
+        uv run python bench/run_100_tasks.py shadow --out-dir /tmp/bench
+
+See :mod:`bench.harness` and :mod:`bench.shadow_diff` for the library API.
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
+import json
 import os
 import sys
 import tempfile
@@ -41,6 +61,13 @@ from goldfive import (
     TaskEdge,
 )
 from goldfive.sinks import JSONLPersistenceSink
+
+# Ensure the repo root is importable so ``from bench.harness import ...`` works
+# both when this file is run as a script (``python bench/run_100_tasks.py``)
+# and when imported as ``bench.run_100_tasks``.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 NUM_TASKS = 100
 
@@ -107,7 +134,8 @@ async def run_benchmark(jsonl_path: Path) -> tuple[float, int, bool]:
     return elapsed, peak, outcome.success
 
 
-def main() -> int:
+def perf_main() -> int:
+    """The original 100-task perf baseline (the default subcommand)."""
     tmp = tempfile.NamedTemporaryFile(
         prefix="goldfive-bench-", suffix=".jsonl", delete=False
     )
@@ -142,6 +170,104 @@ def main() -> int:
     print(f"Python:           {py.major}.{py.minor}.{py.micro}")
     print(f"goldfive:         {goldfive.__version__}")
     return 0
+
+
+def _print_arm_metrics_table(results: list) -> None:
+    print("goldfive three-arm bench (AGENCY-PRESERVATION.md PR 13)")
+    print("=" * 72)
+    for m in results:
+        reason = f"({m.goal_reason})" if m.goal_reason else ""
+        tokens = m.tokens if m.tokens is not None else "n/a"
+        signals = f"{m.signals_total} / {m.signals_real} / {m.signals_dry_run}"
+        print(f"\narm {m.arm_name}  [{m.arm_kind}]")
+        print("-" * 72)
+        print(f"  goal_success:            {m.goal_success}  {reason}")
+        print(f"  completed_outputs:       {m.completed_outputs}")
+        print(f"  turns / tokens:          {m.turns} / {tokens}")
+        print(f"  run aborted:             {m.aborted}  {m.abort_reason}")
+        print(f"  drift_detected:          {m.drift_detected}")
+        print(f"  signals (total/real/dry):{signals}")
+        print(f"  intervention_count:      {m.intervention_count}")
+        print(f"  by_channel:              {m.by_channel}")
+        print(f"  outcomes:                {m.outcomes}")
+        print(f"  self_correction_base:    {m.self_correction_base_rate}")
+        print(f"  post_signal_refire_rate: {m.post_signal_refire_rate}")
+        print(f"  applied flags:           {m.applied_flags}")
+        if m.pending_flags:
+            print(f"  PENDING flags (no-op):   {m.pending_flags}  (not consulted by this build)")
+        print(f"  jsonl artifact:          {m.jsonl_path}")
+
+
+def three_arm_main(args: argparse.Namespace) -> int:
+    """Run the three arms over the deterministic stub-model workload."""
+    from bench.harness import Scenario, default_arms, make_linear_run_driver, run_arms
+
+    out_dir = Path(args.out_dir)
+    scenario = Scenario(
+        name="linear-stub",
+        driver=make_linear_run_driver(num_tasks=args.tasks, inject_signals=True),
+    )
+    results = asyncio.run(run_arms(default_arms(), scenario, jsonl_dir=out_dir))
+    if args.json:
+        print(json.dumps([m.to_dict() for m in results], indent=2, sort_keys=True, default=str))
+    else:
+        _print_arm_metrics_table(results)
+    # A run is "ok" if every arm completed and emitted telemetry (loud signal
+    # the plumbing is wired); the comparative judgement is 13b's job.
+    if any(m.signals_total == 0 for m in results if m.arm_kind != "baseline"):
+        print("\nWARNING: a behavior arm emitted 0 signals — telemetry may be off", file=sys.stderr)
+        return 1
+    return 0
+
+
+def shadow_main(args: argparse.Namespace) -> int:
+    """Run the arms in shadow mode and emit the legacy-vs-new divergence report."""
+    from bench.harness import Scenario, make_linear_run_driver, run_arms, shadow_arms
+    from bench.shadow_diff import diff_two_logs, load_signals, render_two_log_text
+
+    out_dir = Path(args.out_dir)
+    arms = shadow_arms()
+    scenario = Scenario(
+        name="linear-stub-shadow",
+        driver=make_linear_run_driver(num_tasks=args.tasks, inject_signals=True),
+    )
+    results = asyncio.run(run_arms(arms, scenario, jsonl_dir=out_dir))
+    by_kind = {m.arm_kind: m for m in results}
+    legacy_log = by_kind["legacy"].jsonl_path
+    new_log = by_kind["signal"].jsonl_path
+
+    legacy = load_signals(legacy_log)
+    new = load_signals(new_log)
+    report = diff_two_logs(legacy, new, legacy_path=legacy_log, new_path=new_log)
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True, default=str))
+    else:
+        print(render_two_log_text(report))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="run_100_tasks", description=__doc__)
+    sub = parser.add_subparsers(dest="cmd")
+    sub.add_parser("perf", help="100-task perf baseline (default)")
+    ta = sub.add_parser("three-arm", help="three-arm counterfactual bench")
+    ta.add_argument("--out-dir", default="/tmp/g5-bench-artifacts", help="JSONL artifact dir")
+    ta.add_argument("--tasks", type=int, default=3, help="tasks per arm (stub workload)")
+    ta.add_argument("--json", action="store_true")
+    sh = sub.add_parser("shadow", help="shadow-mode run + legacy-vs-new divergence report")
+    sh.add_argument("--out-dir", default="/tmp/g5-bench-artifacts", help="JSONL artifact dir")
+    sh.add_argument("--tasks", type=int, default=3, help="tasks per arm (stub workload)")
+    sh.add_argument("--json", action="store_true")
+
+    args = parser.parse_args(argv)
+    if args.cmd in (None, "perf"):
+        return perf_main()
+    if args.cmd == "three-arm":
+        return three_arm_main(args)
+    if args.cmd == "shadow":
+        return shadow_main(args)
+    parser.error(f"unknown command {args.cmd!r}")
+    return 2  # unreachable
 
 
 if __name__ == "__main__":

--- a/bench/shadow_diff.py
+++ b/bench/shadow_diff.py
@@ -1,0 +1,546 @@
+"""§5.4 shadow / differential-validation tool (AGENCY-PRESERVATION.md PR 13a).
+
+The roadmap makes a *reviewed divergence report over real traffic* the
+**exit criterion** for enabling any behavior PR (§5.4, §5.8): before a
+default flip, the new steering decision logic must run dry
+(``observation_only`` → ``SignalDelivered(dry_run=true)``) and its
+would-be decisions must be diffed against the legacy regime's would-be
+decisions *on the same runs*, with the divergences reviewed.
+
+This tool consumes the ``SignalDelivered`` telemetry (PR 5) out of one or
+two JSONL sink logs and renders that divergence report. It reads events
+through goldfive's own :func:`replay_from_jsonl` (proto-canonical, so it
+is immune to the camelCase JSON field naming), never by string-matching
+the log.
+
+Two modes
+---------
+* **two-log (primary)** — ``--legacy LEG.jsonl --new NEW.jsonl``: the same
+  workload run once under the legacy regime and once under the new regime
+  (both ``observation_only`` so signals are dry-run). The tool aligns
+  deliveries across the logs by a stable cross-run key
+  ``(kind, task_id, occurrence#)`` — drift ids are per-run minted, so they
+  are NOT used as the join key (the project's stable-keys discipline) —
+  and reports, per drift, exactly how the two regimes' decisions differ,
+  plus drifts that fired in only one regime.
+* **single-log (census)** — one positional ``LOG.jsonl``: a per-event
+  legacy-would-do vs. new-would-do derivation from each delivery's own
+  ``decision`` payload, plus a census of channels / ladder levels /
+  dry-run. Useful for a quick read of one shadow run.
+
+Loud on zero (§5.6 integration-not-unit)
+----------------------------------------
+``signal_telemetry`` is DEFAULT OFF (goldfive#456). A log produced with it
+off contains **no** ``SignalDelivered`` events — and a tool that silently
+renders an empty report from such a log is the exact "dead middleware /
+flag was off" trap the roadmap calls out. So :func:`load_signals` raises
+:class:`ShadowDiffError` when a log carries zero deliveries, unless
+``allow_empty=True`` (``--allow-empty``) is passed for a run known to be
+genuinely drift-free.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "ShadowDiffError",
+    "SignalRecord",
+    "KeyDivergence",
+    "DivergenceReport",
+    "load_signals",
+    "diff_two_logs",
+    "single_log_report",
+    "render_two_log_text",
+    "render_single_log_text",
+    "main",
+]
+
+
+class ShadowDiffError(RuntimeError):
+    """Raised on an unusable input — most importantly, zero deliveries.
+
+    A zero-delivery log almost always means ``signal_telemetry`` was off
+    (its default). Surfacing that as a hard error rather than an empty
+    report is the point (§5.6).
+    """
+
+
+# --- comparable decision fields -------------------------------------------
+# The subset of the ``SignalDelivered.decision`` payload (+ envelope) that
+# defines *what a regime would do* to the agent. Prose (``note_text``) is
+# deliberately excluded from the divergence set — §5.4 diffs decisions, not
+# wording — but is retained on the record for the human-readable detail.
+_DECISION_FIELDS: tuple[str, ...] = (
+    "channel",
+    "ladder_level",
+    "would_cancel_inflight",
+    "channel_action",
+    "promotion",
+    "superseded_task_ids",
+    "replacement_task_ids",
+    "dry_run",
+)
+
+
+@dataclasses.dataclass
+class SignalRecord:
+    """One parsed ``SignalDelivered`` event."""
+
+    sequence: int
+    drift_id: str
+    kind: str
+    task_id: str
+    channel: str
+    severity: str
+    turn: int
+    dry_run: bool
+    ladder_level: str
+    note_text: str
+    decision: dict[str, Any]
+
+    def decision_view(self) -> dict[str, Any]:
+        """The comparable (kind-agnostic) projection used for diffing."""
+        view: dict[str, Any] = {}
+        for field in _DECISION_FIELDS:
+            if field == "channel":
+                view[field] = self.channel
+            elif field == "dry_run":
+                view[field] = self.dry_run
+            elif field == "ladder_level":
+                view[field] = self.ladder_level or self.decision.get("ladder_level", "")
+            else:
+                view[field] = self.decision.get(field)
+        return view
+
+
+@dataclasses.dataclass
+class KeyDivergence:
+    """The legacy-vs-new comparison for one aligned drift key."""
+
+    kind: str
+    task_id: str
+    occurrence: int
+    present_in: str  # "both" | "legacy_only" | "new_only"
+    legacy: dict[str, Any] | None
+    new: dict[str, Any] | None
+    diverged_fields: list[str]
+
+    @property
+    def diverged(self) -> bool:
+        return self.present_in != "both" or bool(self.diverged_fields)
+
+
+@dataclasses.dataclass
+class DivergenceReport:
+    """Aligned two-log divergence report (the §5.4 exit-criterion artifact)."""
+
+    legacy_path: str
+    new_path: str
+    legacy_count: int
+    new_count: int
+    keys: list[KeyDivergence]
+
+    @property
+    def diverged_keys(self) -> list[KeyDivergence]:
+        return [k for k in self.keys if k.diverged]
+
+    @property
+    def legacy_only(self) -> list[KeyDivergence]:
+        return [k for k in self.keys if k.present_in == "legacy_only"]
+
+    @property
+    def new_only(self) -> list[KeyDivergence]:
+        return [k for k in self.keys if k.present_in == "new_only"]
+
+    @property
+    def field_divergences(self) -> list[KeyDivergence]:
+        return [k for k in self.keys if k.present_in == "both" and k.diverged_fields]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "legacy_path": self.legacy_path,
+            "new_path": self.new_path,
+            "legacy_delivery_count": self.legacy_count,
+            "new_delivery_count": self.new_count,
+            "aligned_keys": len(self.keys),
+            "diverged_keys": len(self.diverged_keys),
+            "legacy_only": len(self.legacy_only),
+            "new_only": len(self.new_only),
+            "field_divergences": len(self.field_divergences),
+            "keys": [dataclasses.asdict(k) for k in self.keys],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def load_signals(path: str | Path, *, allow_empty: bool = False) -> list[SignalRecord]:
+    """Parse the ``SignalDelivered`` events out of one JSONL sink log.
+
+    Reads via goldfive's proto-canonical :func:`replay_from_jsonl`. Raises
+    :class:`ShadowDiffError` if the log has events but **no** deliveries
+    (the ``signal_telemetry``-was-off trap) unless ``allow_empty``.
+    """
+    try:
+        from goldfive.sinks import replay_from_jsonl
+    except ImportError as exc:  # pragma: no cover - proto extra missing
+        raise ShadowDiffError(
+            "goldfive proto stubs unavailable; install the `proto`/`dev` extra "
+            "to parse JSONL sink logs"
+        ) from exc
+    if replay_from_jsonl is None:  # pragma: no cover - proto extra missing
+        raise ShadowDiffError(
+            "goldfive proto stubs unavailable; install the `proto`/`dev` extra"
+        )
+
+    p = Path(path)
+    if not p.exists():
+        raise ShadowDiffError(f"log not found: {p}")
+
+    events = replay_from_jsonl(p)
+    records: list[SignalRecord] = []
+    for evt in events:
+        if not hasattr(evt, "WhichOneof") or evt.WhichOneof("payload") != "signal_delivered":
+            continue
+        sd = evt.signal_delivered
+        try:
+            decision = json.loads(sd.decision_json) if sd.decision_json else {}
+        except (TypeError, ValueError):
+            decision = {}
+        if not isinstance(decision, dict):
+            decision = {}
+        records.append(
+            SignalRecord(
+                sequence=int(getattr(evt, "sequence", 0) or 0),
+                drift_id=sd.drift_id,
+                kind=sd.kind,
+                task_id=sd.task_id,
+                channel=sd.channel,
+                severity=sd.severity,
+                turn=int(sd.turn),
+                dry_run=bool(sd.dry_run),
+                ladder_level=str(decision.get("ladder_level", "") or ""),
+                note_text=sd.note_text,
+                decision=decision,
+            )
+        )
+
+    if not records and not allow_empty:
+        raise ShadowDiffError(
+            f"{p}: parsed {len(events)} event(s) but 0 SignalDelivered — is "
+            "signal_telemetry enabled? It is DEFAULT OFF (goldfive#456); a "
+            "shadow run must set GOLDFIVE_STEER_SIGNAL_TELEMETRY=1. Pass "
+            "allow_empty/--allow-empty only if this run was genuinely "
+            "drift-free."
+        )
+    return records
+
+
+def _assign_occurrences(
+    records: list[SignalRecord],
+) -> list[tuple[tuple[str, str, int], SignalRecord]]:
+    """Key each record by ``(kind, task_id, occurrence#)`` in sequence order.
+
+    drift ids are per-run minted and so cannot join across two logs; the
+    stable cross-run key is the running occurrence index of the
+    ``(kind, task_id)`` pair (deterministic workloads line up exactly;
+    real-traffic mismatches surface as legacy_only / new_only).
+    """
+    counters: dict[tuple[str, str], int] = defaultdict(int)
+    keyed: list[tuple[tuple[str, str, int], SignalRecord]] = []
+    for rec in sorted(records, key=lambda r: r.sequence):
+        base = (rec.kind, rec.task_id)
+        occ = counters[base]
+        counters[base] += 1
+        keyed.append(((rec.kind, rec.task_id, occ), rec))
+    return keyed
+
+
+# ---------------------------------------------------------------------------
+# Two-log divergence (primary)
+# ---------------------------------------------------------------------------
+
+
+def diff_two_logs(
+    legacy: list[SignalRecord],
+    new: list[SignalRecord],
+    *,
+    legacy_path: str = "legacy",
+    new_path: str = "new",
+) -> DivergenceReport:
+    """Align two logs per drift key and report decision divergences."""
+    legacy_keyed = dict(_assign_occurrences(legacy))
+    new_keyed = dict(_assign_occurrences(new))
+    all_keys = sorted(set(legacy_keyed) | set(new_keyed))
+
+    keys: list[KeyDivergence] = []
+    for key in all_keys:
+        kind, task_id, occ = key
+        lrec = legacy_keyed.get(key)
+        nrec = new_keyed.get(key)
+        if lrec is not None and nrec is not None:
+            lview = lrec.decision_view()
+            nview = nrec.decision_view()
+            diverged = [f for f in _DECISION_FIELDS if lview.get(f) != nview.get(f)]
+            keys.append(
+                KeyDivergence(
+                    kind=kind,
+                    task_id=task_id,
+                    occurrence=occ,
+                    present_in="both",
+                    legacy=lview,
+                    new=nview,
+                    diverged_fields=diverged,
+                )
+            )
+        elif lrec is not None:
+            keys.append(
+                KeyDivergence(
+                    kind=kind,
+                    task_id=task_id,
+                    occurrence=occ,
+                    present_in="legacy_only",
+                    legacy=lrec.decision_view(),
+                    new=None,
+                    diverged_fields=[],
+                )
+            )
+        else:
+            assert nrec is not None
+            keys.append(
+                KeyDivergence(
+                    kind=kind,
+                    task_id=task_id,
+                    occurrence=occ,
+                    present_in="new_only",
+                    legacy=None,
+                    new=nrec.decision_view(),
+                    diverged_fields=[],
+                )
+            )
+
+    return DivergenceReport(
+        legacy_path=str(legacy_path),
+        new_path=str(new_path),
+        legacy_count=len(legacy),
+        new_count=len(new),
+        keys=keys,
+    )
+
+
+def render_two_log_text(report: DivergenceReport) -> str:
+    """Human-readable two-log divergence report."""
+    lines: list[str] = []
+    lines.append("goldfive shadow-diff — legacy vs. new regime (§5.4)")
+    lines.append("=" * 64)
+    lines.append(f"legacy log:  {report.legacy_path}  ({report.legacy_count} deliveries)")
+    lines.append(f"new log:     {report.new_path}  ({report.new_count} deliveries)")
+    lines.append("-" * 64)
+    lines.append(f"aligned drift keys:        {len(report.keys)}")
+    lines.append(f"  diverged:                {len(report.diverged_keys)}")
+    lines.append(f"  decision-field diffs:    {len(report.field_divergences)}")
+    lines.append(f"  legacy-only (new silent):{len(report.legacy_only)}")
+    lines.append(f"  new-only (legacy silent):{len(report.new_only)}")
+    lines.append("-" * 64)
+
+    if not report.diverged_keys:
+        lines.append("VERDICT: no divergence — the two regimes' decisions are identical")
+        lines.append("on this traffic. (Expected before the behavior PRs land; once")
+        lines.append("PR 7's ladder restructure merges, ladder_level diffs appear here.)")
+        return "\n".join(lines)
+
+    lines.append(f"VERDICT: {len(report.diverged_keys)} drift key(s) diverge — review below.")
+    lines.append("")
+    for kd in report.diverged_keys:
+        head = f"[{kd.kind} / {kd.task_id} #{kd.occurrence}] {kd.present_in}"
+        lines.append(head)
+        if kd.present_in == "both":
+            for field in kd.diverged_fields:
+                lines.append(
+                    f"    {field}: legacy={kd.legacy.get(field)!r}  ->  new={kd.new.get(field)!r}"
+                )
+        elif kd.present_in == "legacy_only":
+            lines.append(
+                f"    legacy signalled ({kd.legacy.get('ladder_level')!r} on "
+                f"{kd.legacy.get('channel')!r}); new regime stayed silent."
+            )
+        else:
+            lines.append(
+                f"    new regime signalled ({kd.new.get('ladder_level')!r} on "
+                f"{kd.new.get('channel')!r}); legacy stayed silent."
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+# ---------------------------------------------------------------------------
+# Single-log census + per-event legacy-vs-new derivation
+# ---------------------------------------------------------------------------
+
+
+def _legacy_vs_new_within_event(rec: SignalRecord) -> dict[str, Any]:
+    """Derive legacy-would-do vs. new-would-do from one delivery's payload.
+
+    The ``decision`` payload carries the legacy cancel intent
+    (``would_cancel_inflight``) and the chosen channel/ladder. The new
+    regime's contract is "signal without preempting in-flight work", so the
+    divergence within a single event is: does the legacy regime cancel /
+    swap the plan where the new regime would only signal?
+    """
+    cancels = bool(rec.decision.get("would_cancel_inflight")) or rec.channel in (
+        "steer_control",
+        "promotion",
+    )
+    ladder = rec.ladder_level or rec.decision.get("ladder_level", "") or "signal"
+    if cancels:
+        # The legacy regime preempts in-flight work / swaps the plan here; the
+        # new regime only signals. A genuine decision divergence.
+        return {
+            "legacy_action": "cancel_reinvoke+plan_swap",
+            "new_action": f"signal({ladder}) [no in-flight cancel]",
+            "diverges": True,
+        }
+    # Both regimes only signal — same action, no divergence (the trailing
+    # "[no in-flight cancel]" qualifier is cosmetic, not a decision change).
+    return {
+        "legacy_action": f"signal({ladder})",
+        "new_action": f"signal({ladder})",
+        "diverges": False,
+    }
+
+
+def single_log_report(records: list[SignalRecord]) -> dict[str, Any]:
+    """Census + per-event legacy-vs-new derivation for one shadow log."""
+    by_channel: dict[str, int] = defaultdict(int)
+    by_ladder: dict[str, int] = defaultdict(int)
+    by_kind: dict[str, int] = defaultdict(int)
+    dry = 0
+    diverging: list[dict[str, Any]] = []
+    for rec in records:
+        by_channel[rec.channel] += 1
+        by_ladder[rec.ladder_level or rec.decision.get("ladder_level", "") or "?"] += 1
+        by_kind[rec.kind] += 1
+        if rec.dry_run:
+            dry += 1
+        derived = _legacy_vs_new_within_event(rec)
+        if derived["diverges"]:
+            diverging.append(
+                {
+                    "kind": rec.kind,
+                    "task_id": rec.task_id,
+                    "drift_id": rec.drift_id,
+                    "legacy_action": derived["legacy_action"],
+                    "new_action": derived["new_action"],
+                }
+            )
+    return {
+        "deliveries": len(records),
+        "dry_run": dry,
+        "real": len(records) - dry,
+        "by_channel": dict(by_channel),
+        "by_ladder_level": dict(by_ladder),
+        "by_kind": dict(by_kind),
+        "diverging_events": diverging,
+    }
+
+
+def render_single_log_text(report: dict[str, Any], *, path: str) -> str:
+    lines: list[str] = []
+    lines.append("goldfive shadow-diff — single-log census (§5.4)")
+    lines.append("=" * 64)
+    lines.append(f"log:           {path}")
+    lines.append(
+        f"deliveries:    {report['deliveries']}  "
+        f"(dry_run={report['dry_run']}, real={report['real']})"
+    )
+    lines.append(f"by channel:    {report['by_channel']}")
+    lines.append(f"by ladder:     {report['by_ladder_level']}")
+    lines.append(f"by kind:       {report['by_kind']}")
+    lines.append("-" * 64)
+    diverging = report["diverging_events"]
+    if not diverging:
+        lines.append("no per-event legacy/new divergence derivable from the payloads.")
+        return "\n".join(lines)
+    lines.append(f"{len(diverging)} delivery(ies) where legacy != new:")
+    for d in diverging:
+        lines.append(
+            f"  [{d['kind']} / {d['task_id']}] "
+            f"legacy={d['legacy_action']}  ->  new={d['new_action']}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="shadow_diff",
+        description=(
+            "§5.4 shadow / differential-validation: diff legacy-would-do vs. "
+            "new-would-do from goldfive SignalDelivered JSONL logs."
+        ),
+    )
+    p.add_argument(
+        "log",
+        nargs="?",
+        help="single JSONL sink log (single-log census mode)",
+    )
+    p.add_argument("--legacy", help="legacy-regime JSONL log (two-log mode)")
+    p.add_argument("--new", help="new-regime JSONL log (two-log mode)")
+    p.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    p.add_argument("--out", help="write the report to this path instead of stdout")
+    p.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="do not error on a log with zero SignalDelivered events",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    two_log = bool(args.legacy or args.new)
+
+    try:
+        if two_log:
+            if not (args.legacy and args.new):
+                raise ShadowDiffError("two-log mode needs both --legacy and --new")
+            legacy = load_signals(args.legacy, allow_empty=args.allow_empty)
+            new = load_signals(args.new, allow_empty=args.allow_empty)
+            report = diff_two_logs(
+                legacy, new, legacy_path=args.legacy, new_path=args.new
+            )
+            text = render_two_log_text(report)
+            payload = report.to_dict()
+        else:
+            if not args.log:
+                raise ShadowDiffError("provide a LOG (single-log) or --legacy/--new (two-log)")
+            records = load_signals(args.log, allow_empty=args.allow_empty)
+            payload = single_log_report(records)
+            text = render_single_log_text(payload, path=args.log)
+    except ShadowDiffError as exc:
+        print(f"shadow_diff: error: {exc}", file=sys.stderr)
+        return 2
+
+    out = json.dumps(payload, indent=2, sort_keys=True, default=str) if args.json else text
+    if args.out:
+        Path(args.out).write_text(out + "\n", encoding="utf-8")
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -105,3 +105,88 @@ raise your eval's signal-to-noise ratio. Adapters that cannot
 distinguish turns leave `text_turns` empty; `full_text` then falls back
 to `text`, and `completed_outputs` falls back to whatever the adapter
 recorded, so a grader can always read the new fields safely.
+
+## The three-arm counterfactual bench (`bench/`)
+
+The AGENCY-PRESERVATION rollout (`docs/design/AGENCY-PRESERVATION.md`)
+flips `observation_only=False` (and `plan_mode=ledger`) back to the
+default **only** when the new steering regime is measurably non-inferior
+to a *disabled* goldfive. That decision is gated on one artifact: the
+three-arm bench in `bench/`, plus the §5.4 shadow-diff that must show a
+*reviewed* legacy-vs-new divergence report before any behavior PR is
+enabled.
+
+The library lives in `bench/harness.py` (the harness) and
+`bench/shadow_diff.py` (the divergence tool); `bench/run_100_tasks.py` is
+the CLI. Running the real bench against a live model is the *next* task —
+this is the tooling.
+
+### The three arms
+
+The harness runs the **same workload** under three steering regimes and
+records per-arm metrics from *captured artifacts* (`completed_outputs`,
+goal predicates, the `SignalLedger`) and the *sink event stream*
+(`SignalDelivered` / `SignalOutcome` / `DriftDetected`) — never from
+parsing agent prose:
+
+| Arm | Kind | What it is |
+|---|---|---|
+| A | `baseline` | `wrap(judge_only=True)` — the judge-only counterfactual (goldfive#446). The agent runs natively, judges stay armed, zero steering authority. This is the bar arm B must be non-inferior to. |
+| B | `signal` | the new SIGNAL regime — `observation_only=False` + the new-regime flags (`signal_channel=request_context`, `plan_mode=ledger`). |
+| C | `legacy` | the legacy ladder — `GOLDFIVE_STEER_LEGACY_LADDER=1` + `cancel_inflight_scope=all`, kept alive so regressions are measurable rather than argued about (§5.8). |
+
+Arms are defined as **flag dicts of environment variables**, not
+`SteeringConfig` kwargs, so the harness does not hard-depend on unmerged
+PRs. A flag whose env var this build's `RuntimeConfig.from_env` does not
+yet consult (e.g. `GOLDFIVE_STEER_SIGNAL_CHANNEL` before PR 6) is applied
+to the environment, reported as **pending**, and simply no-ops until the
+PR that reads it lands — graceful degradation by construction.
+`arm_flag_status(arm)` returns `(applied, pending)` so a pending flag is
+never silently mistaken for an applied one.
+
+```bash
+uv run python bench/run_100_tasks.py three-arm --out-dir /tmp/bench
+```
+
+Per-arm metrics (`ArmMetrics`): goal-predicate success, turns/tokens to
+completion, `intervention_count` (real, non-dry-run deliveries),
+`post_signal_refire_rate` (from the `SignalLedger`), run-abort, and the
+PR-5 **self-correction base rate** (`self_corrected_unaided` vs.
+`self_corrected_after_signal` from `SignalOutcome`).
+
+### `signal_telemetry` is DEFAULT OFF
+
+`SteeringConfig.signal_telemetry` ships off (goldfive#456): a run that
+does not set it emits **no** `SignalDelivered` events. Every arm here
+enables it explicitly, and the tooling treats *zero parsed signal events*
+as a **loud error**, never an empty report — `load_signals()` raises
+`ShadowDiffError` on a zero-delivery log so "the flag was off" can never
+masquerade as "no divergence". Pass `--allow-empty` only for a run known
+to be genuinely drift-free.
+
+### The §5.4 shadow diff
+
+Shadow mode runs arms B/C with `observation_only=1` so the new decision
+logic runs *dry* — `SignalDelivered(dry_run=true)` with a full decision
+payload — and accrues production mileage with zero production authority.
+The tool then diffs legacy-would-do vs. new-would-do **on the same
+runs**, aligning deliveries by a stable cross-run key
+`(kind, task_id, occurrence#)` (drift ids are per-run minted, so they are
+never the join key — the project's stable-keys discipline):
+
+```bash
+uv run python bench/run_100_tasks.py shadow --out-dir /tmp/bench
+# or diff two existing logs directly:
+uv run python bench/shadow_diff.py --legacy C.jsonl --new B.jsonl
+# single-log census of one shadow run:
+uv run python bench/shadow_diff.py B.jsonl
+```
+
+Even before PR 7's ladder restructure lands, the diff surfaces a real,
+merged divergence: a CRITICAL goldfive-authored `OFF_TOPIC` drift cancels
+in-flight work under `cancel_inflight_scope=all` (legacy) but not under
+`user_and_safety` (new) — the PR-1 authority split — so the report reads
+`would_cancel_inflight: legacy=True -> new=False`. Once the behavior PRs
+merge, `ladder_level` and channel divergences appear in the same report.
+The reviewed two-log report is the **exit criterion** for enabling any
+behavior PR (§5.4, §5.8).

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -1,0 +1,251 @@
+"""Smoke test for the PR 13a three-arm bench harness + shadow-diff tool.
+
+Integration-not-unit (AGENCY-PRESERVATION.md §5.6): these assert the
+telemetry actually flows *end to end* through the harness — a tool that
+parses zero events because ``signal_telemetry`` was off (its default,
+goldfive#456) must be a LOUD error, not an empty report — and that the
+§5.4 shadow diff surfaces the *real* PR-1 cancel-authority divergence
+between the legacy and new arms on the same workload.
+
+The workload is deterministic (stub ``call_llm`` + an injected drift
+lifecycle through the real ``DefaultSteerer`` dispatch path); running the
+bench against a live model is task 13b, deliberately out of scope here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev`/`proto` extra)",
+)
+
+# The bench harness lives in the (non-installed) ``bench`` package at the repo
+# root; make it importable regardless of pytest's import mode.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from bench.harness import (  # noqa: E402
+    KNOWN_STEER_ENV,
+    Arm,
+    Scenario,
+    apply_arm_env,
+    arm_flag_status,
+    default_arms,
+    make_linear_run_driver,
+    run_arm,
+    run_arms,
+    shadow_arms,
+)
+from bench.shadow_diff import (  # noqa: E402
+    ShadowDiffError,
+    diff_two_logs,
+    load_signals,
+    render_two_log_text,
+    single_log_report,
+)
+
+
+def _scenario(tasks: int = 3, inject: bool = True) -> Scenario:
+    return Scenario(
+        name="smoke",
+        driver=make_linear_run_driver(num_tasks=tasks, inject_signals=inject),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Three-arm harness runs and telemetry flows end to end
+# ---------------------------------------------------------------------------
+
+
+async def test_three_arm_harness_runs_and_emits_telemetry(tmp_path: Path) -> None:
+    results = await run_arms(default_arms(), _scenario(), jsonl_dir=tmp_path)
+    assert [m.arm_kind for m in results] == ["baseline", "signal", "legacy"]
+
+    for m in results:
+        # The workload completed: captured-artifact outcome is healthy.
+        assert m.goal_success, m.goal_reason
+        assert m.completed_outputs == 3
+        assert m.turns >= 1
+        # Telemetry flowed: the JSONL artifact exists and carries signals.
+        assert Path(m.jsonl_path).exists()
+        assert m.signals_total > 0, f"{m.arm_name}: 0 signals — telemetry not wired"
+
+    by_kind = {m.arm_kind: m for m in results}
+    # The baseline runs observation-only: every signal is dry-run, so the
+    # self-correction *base rate* is fully unaided (the §2 counterfactual).
+    base = by_kind["baseline"]
+    assert base.signals_real == 0
+    assert base.signals_dry_run == base.signals_total
+    assert base.intervention_count == 0
+    assert base.outcomes.get("self_corrected_unaided", 0) > 0
+    assert base.self_correction_base_rate == 1.0
+
+    # The behavior arms intervene for real (active steering).
+    for kind in ("signal", "legacy"):
+        m = by_kind[kind]
+        assert m.signals_real > 0
+        assert m.intervention_count == m.signals_real
+        assert m.outcomes.get("self_corrected_after_signal", 0) > 0
+        assert m.self_correction_base_rate == 0.0
+
+    # post-signal re-fire rate is read from the SignalLedger (a captured
+    # artifact), exercised by the injected re-fire.
+    assert all(m.post_signal_refire_rate == 0.5 for m in results)
+
+
+# ---------------------------------------------------------------------------
+# 2. signal_telemetry OFF (the default) → a LOUD error, not an empty report
+# ---------------------------------------------------------------------------
+
+
+async def test_telemetry_off_is_a_loud_error(tmp_path: Path) -> None:
+    off = Arm(
+        name="telemetry-off",
+        kind="signal",
+        env={
+            "GOLDFIVE_STEER_SIGNAL_TELEMETRY": "0",  # explicit OFF
+            "GOLDFIVE_STEER_OBSERVATION_ONLY": "0",
+        },
+    )
+    metrics = await run_arm(off, _scenario(), jsonl_dir=tmp_path)
+    # With telemetry off, the dispatch path emits no SignalDelivered events.
+    assert metrics.signals_total == 0
+
+    # The shadow-diff loader refuses to render an empty report from a
+    # zero-signal log — it raises so "the flag was off" can never masquerade
+    # as "no divergence".
+    with pytest.raises(ShadowDiffError) as exc:
+        load_signals(metrics.jsonl_path)
+    assert "signal_telemetry" in str(exc.value)
+
+    # ...unless the caller explicitly opts into the empty case.
+    assert load_signals(metrics.jsonl_path, allow_empty=True) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. The shadow diff surfaces the real PR-1 cancel-authority divergence
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_diff_surfaces_cancel_authority_divergence(tmp_path: Path) -> None:
+    results = await run_arms(shadow_arms(), _scenario(), jsonl_dir=tmp_path)
+    by_kind = {m.arm_kind: m for m in results}
+
+    # Shadow mode forces the behavior arms observation-only → dry-run signals.
+    assert by_kind["signal"].signals_dry_run == by_kind["signal"].signals_total
+    assert by_kind["legacy"].signals_dry_run == by_kind["legacy"].signals_total
+
+    legacy = load_signals(by_kind["legacy"].jsonl_path)
+    new = load_signals(by_kind["signal"].jsonl_path)
+    report = diff_two_logs(legacy, new, legacy_path="legacy", new_path="new")
+
+    # The same OFF_TOPIC/CRITICAL drift diverges on would_cancel_inflight:
+    # legacy (cancel scope=all) would cancel in-flight work; new
+    # (user_and_safety) would not — the merged PR-1 authority split.
+    diverged = report.diverged_keys
+    assert diverged, "expected the cancel-authority divergence to surface"
+    off_topic = [k for k in diverged if k.kind == "off_topic"]
+    assert off_topic, "off_topic key should diverge"
+    kd = off_topic[0]
+    assert kd.present_in == "both"
+    assert "would_cancel_inflight" in kd.diverged_fields
+    assert kd.legacy["would_cancel_inflight"] is True
+    assert kd.new["would_cancel_inflight"] is False
+
+    # The looping WARNING key never cancels under either regime → no divergence.
+    looping = [k for k in report.keys if k.kind == "looping_tool_call"]
+    assert looping and not looping[0].diverged
+
+    # The rendered report names the divergence (the reviewed §5.4 artifact).
+    text = render_two_log_text(report)
+    assert "would_cancel_inflight" in text
+    assert "VERDICT" in text
+
+
+# ---------------------------------------------------------------------------
+# 4. Single-log census mode
+# ---------------------------------------------------------------------------
+
+
+async def test_single_log_census(tmp_path: Path) -> None:
+    results = await run_arms(shadow_arms(), _scenario(), jsonl_dir=tmp_path)
+    legacy = {m.arm_kind: m for m in results}["legacy"]
+    records = load_signals(legacy.jsonl_path)
+    census = single_log_report(records)
+    assert census["deliveries"] == len(records) > 0
+    assert census["dry_run"] == census["deliveries"]  # shadow mode
+    assert set(census["by_kind"]) == {"off_topic", "looping_tool_call"}
+    # In the legacy log the OFF_TOPIC delivery would cancel in-flight work,
+    # so its single-event legacy-vs-new derivation diverges.
+    assert any(d["kind"] == "off_topic" for d in census["diverging_events"])
+
+
+# ---------------------------------------------------------------------------
+# 5. Graceful degradation: pending vs. applied flags
+# ---------------------------------------------------------------------------
+
+
+def test_arm_flag_status_reports_pending_flags() -> None:
+    arms = {a.kind: a for a in default_arms()}
+    # The new SIGNAL arm carries flags this build does not yet consult
+    # (PR 6 / PR 10); they must be reported as PENDING, not silently applied.
+    _, pending = arm_flag_status(arms["signal"])
+    assert "GOLDFIVE_STEER_SIGNAL_CHANNEL" in pending
+    assert "GOLDFIVE_PLAN_MODE" in pending
+    # The legacy arm's escape hatch is likewise pending until PR 7.
+    _, legacy_pending = arm_flag_status(arms["legacy"])
+    assert "GOLDFIVE_STEER_LEGACY_LADDER" in legacy_pending
+    # The flags this build DOES consult are reported as applied.
+    applied, _ = arm_flag_status(arms["signal"])
+    assert "GOLDFIVE_STEER_SIGNAL_TELEMETRY" in applied
+    assert set(applied) <= KNOWN_STEER_ENV
+
+
+async def test_unknown_flag_degrades_gracefully(tmp_path: Path) -> None:
+    """An arm carrying a flag no build will ever read still runs (it no-ops)."""
+    arm = Arm(
+        name="unknown-flag",
+        kind="signal",
+        env={
+            "GOLDFIVE_STEER_SIGNAL_TELEMETRY": "1",
+            "GOLDFIVE_STEER_OBSERVATION_ONLY": "0",
+            "GOLDFIVE_TOTALLY_MADE_UP_FLAG": "1",
+        },
+    )
+    metrics = await run_arm(arm, _scenario(), jsonl_dir=tmp_path)
+    assert metrics.goal_success
+    assert metrics.signals_total > 0
+    _, pending = arm_flag_status(arm)
+    assert "GOLDFIVE_TOTALLY_MADE_UP_FLAG" in pending
+
+
+# ---------------------------------------------------------------------------
+# 6. apply_arm_env isolates managed flags (no cross-arm leakage)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_arm_env_clears_and_restores(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An ambient managed flag must NOT leak into an arm that does not set it.
+    monkeypatch.setenv("GOLDFIVE_STEER_OBSERVATION_ONLY", "1")
+    arm = Arm(name="x", kind="signal", env={"GOLDFIVE_STEER_SIGNAL_TELEMETRY": "1"})
+    import os
+
+    with apply_arm_env(arm):
+        assert os.environ["GOLDFIVE_STEER_SIGNAL_TELEMETRY"] == "1"
+        # cleared inside the block (declared on neither side managed-cleared):
+        assert "GOLDFIVE_STEER_OBSERVATION_ONLY" not in os.environ
+    # restored afterwards:
+    assert os.environ["GOLDFIVE_STEER_OBSERVATION_ONLY"] == "1"
+    assert "GOLDFIVE_STEER_SIGNAL_TELEMETRY" not in os.environ
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-q"])


### PR DESCRIPTION
## What

The measurement scaffold the Stage-3 default-flip gate is built on (roadmap §3 PR 13, §4 counterfactual gate, §5.4 / §5.8). This is the **tooling**, not the run — running the bench against a live model and deciding the default flips is PR 13b (deliberately out of scope here, blocked on this + everything else + user sign-off).

Extends `bench/run_100_tasks.py` (perf baseline preserved as the default subcommand) rather than rewriting it.

### (a) Three-arm harness — `bench/harness.py`
Runs the **same workload** under three regimes and records per-arm metrics from *captured artifacts* + *sink events* (never agent prose):
- **arm A `baseline`** — `wrap(judge_only=True)`, the judge-only counterfactual (goldfive#446);
- **arm B `signal`** — new SIGNAL regime (`observation_only=False` + new-regime flags);
- **arm C `legacy`** — legacy ladder (`GOLDFIVE_STEER_LEGACY_LADDER=1` + `cancel_inflight_scope=all`).

Arms are **env-var flag dicts**, not `SteeringConfig` kwargs, so the harness does **not** hard-depend on unmerged PRs. A flag this build's `RuntimeConfig.from_env` does not yet consult (`signal_channel` → PR 6, `plan_mode` → PR 10, `legacy_ladder` → PR 7) is applied to the environment, reported **PENDING** via `arm_flag_status`, and simply no-ops until its PR lands — graceful degradation by construction; it auto-activates when `from_env` learns to read it. `arm_flag_status` keeps a pending flag from ever being silently mistaken for an applied one.

Per-arm `ArmMetrics`: goal-predicate success (`evaluate_goal_predicates`), turns/tokens to completion, `intervention_count` (real non-dry-run deliveries), `post_signal_refire_rate` (from the `SignalLedger` — its designed home), run-abort, and the PR-5 **self-correction base rate** (`self_corrected_unaided` vs `self_corrected_after_signal`). Sourced from `#447` `completed_outputs` + the `SignalDelivered`/`SignalOutcome`/`DriftDetected` event stream.

### (b) §5.4 shadow-diff — `bench/shadow_diff.py`
Consumes `SignalDelivered(dry_run=true)` from JSONL sink logs (via goldfive's proto-canonical `replay_from_jsonl`, immune to the camelCase JSON naming) and reports **legacy-would-do vs new-would-do per drift**:
- **two-log mode** (primary, the exit-criterion artifact): aligns deliveries across the legacy/new logs by a stable `(kind, task_id, occurrence#)` key — never the per-run-minted `drift_id` (project stable-keys discipline) — and reports decision-field divergences plus legacy-only / new-only drifts;
- **single-log mode**: census + per-event legacy-vs-new derivation.

### signal_telemetry is DEFAULT OFF (#456) — loud on zero (§5.6)
Every bench/shadow arm enables `GOLDFIVE_STEER_SIGNAL_TELEMETRY=1` explicitly, and `load_signals()` **raises** `ShadowDiffError` on a zero-delivery log — "the flag was off" can never masquerade as "no divergence" / an empty report. `--allow-empty` is the explicit opt-out for a genuinely drift-free run.

## §5 requirements satisfied
- **§5.4 shadow / differential validation** — the two-log divergence report, the reviewed exit-criterion artifact for enabling a behavior PR; the dry-run decision payload is diffed legacy-vs-new on the same runs.
- **§5.1 no-op by default / graceful degradation** — env-var flag dicts; unmerged-PR flags applied-but-pending and inert; perf baseline + existing suites unchanged.
- **§5.6 integration-not-unit** — telemetry verified to flow end-to-end; zero parsed signal events is a loud error, not an empty report; stable `(kind, task)` keys, never LLM-minted ids.
- **§5.8 bench-gated flips** — arm C keeps the legacy regime measurable; the harness produces the comparative metric vector 13b's flips are gated on.

## Demonstrated divergence (merged today)
Even before PR 7's ladder restructure lands, the shadow diff surfaces a **real** divergence grounded in the merged PR-1 authority split: a CRITICAL goldfive-authored `OFF_TOPIC` drift cancels in-flight work under `cancel_inflight_scope=all` (legacy) but not under `user_and_safety` (new), so the report reads `would_cancel_inflight: legacy=True -> new=False`. A WARNING loop key never cancels under either regime → no divergence. Once the behavior PRs merge, `ladder_level`/channel divergences appear in the same report.

## Tests
- `tests/test_bench_harness.py` (7 tests): end-to-end on a 3-task stub workload — three-arm telemetry flow, telemetry-off loud error, shadow-diff cancel-authority divergence, single-log census, pending/applied flag reporting, unknown-flag degradation, env isolation.
- **Full suite: 2958 passed, 59 skipped** (`uv run pytest`); **ruff clean** (`uv run ruff check .`). Existing suites pass UNMODIFIED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)