### PR TITLE
feat(drift): goal-grounded judging — graduated goal-drift + re-grounded reasoning judge + outcome-progress (AGENCY-PRESERVATION PR 11)

### DIFF
--- a/goldfive/drift/goals.py
+++ b/goldfive/drift/goals.py
@@ -57,6 +57,7 @@ __all__ = [
     "classify_goal_drift",
     "GOAL_DRIFT_SYSTEM_PROMPT",
     "GOAL_DRIFT_USER_PROMPT_TEMPLATE",
+    "GOAL_DRIFT_GRADUATED_USER_PROMPT_TEMPLATE",
     "GOAL_DRIFT_CHECK_INTERVAL",
     "GOAL_DRIFT_IDLE_SECONDS",
     "GOAL_DRIFT_MAX_OUTPUT_TOKENS",
@@ -119,6 +120,59 @@ GOAL_DRIFT_USER_PROMPT_TEMPLATE: str = (
 )
 
 
+# AGENCY-PRESERVATION.md Stage 3 PR 11(a) — the GRADUATED goal-drift
+# prompt. Used only in ledger plan mode (``graduated=True``). It asks for
+# a three-state verdict so WARNING can fire BEFORE CRITICAL: an
+# ``uncertain`` band lets goldfive surface "this may be drifting" as a
+# proportional advisory note, reserving CRITICAL for clearly off-track
+# trajectories. The plan rendered here is the LEDGER (goal-anchored
+# OUTCOME deliverables + the descriptively-grown DISCOVERED trajectory),
+# which is the agent's own observed intent — a self-consistent,
+# adaptive reference rather than a forecast the agent is graded against.
+GOAL_DRIFT_GRADUATED_USER_PROMPT_TEMPLATE: str = (
+    "You are assessing whether an autonomous agent tree is making "
+    "progress toward a stated goal.\n\n"
+    "GOALS (what the user wants — the primary reference):\n{goals_block}\n\n"
+    "LEDGER (OUTCOME = deliverables that define success; DISCOVERED = "
+    "what the agent has actually done so far):\n{tasks_block}\n\n"
+    "RECENT AGENT ACTIVITY (most recent {activity_count} invocations, "
+    "newest last):\n{activity_block}\n\n"
+    "Decide how the recent activity relates to the GOALS, given the "
+    "agent's own observed trajectory in the LEDGER. Answer STRICTLY in "
+    "one of these three JSON shapes:\n"
+    '{{"progressing": true}}\n'
+    "OR\n"
+    '{{"progressing": false, "band": "uncertain", "reason": '
+    '"one-sentence explanation", "note_to_agent": "..."}}\n'
+    "OR\n"
+    '{{"progressing": false, "band": "off_track", "reason": '
+    '"one-sentence explanation", "note_to_agent": "..."}}\n\n'
+    "progressing=true — activity plausibly advances the goals; no concern.\n"
+    'band="uncertain" — the connection to the goals is unclear or the '
+    "trajectory may be starting to drift, but it is not yet clearly "
+    "wrong. This is an EARLY, proportional signal.\n"
+    'band="off_track" — activity is clearly not advancing the goals '
+    "(looping, refusing, pursuing a different objective).\n\n"
+    "``note_to_agent`` is one or two sentences addressed to the agent "
+    "itself: state only what you observed and how it relates to the "
+    "goals. Neutral and factual — no commands, no instructions about "
+    "which task, tool, or agent to use next, and no fault language. For "
+    'the "uncertain" band especially, prefer a QUESTION (e.g. "Does the '
+    'current approach still serve the goal of X?") over a statement.'
+)
+
+
+# Graduated-mode band → severity map. ``uncertain`` fires WARNING (the
+# early, proportional signal); ``off_track`` — and any unrecognised /
+# missing band on a non-progressing verdict — fires CRITICAL, matching
+# the binary judge's pre-PR-11 behaviour so a graduated judge that omits
+# the band degrades safely to the legacy severity.
+_GRADUATED_BAND_SEVERITY: dict[str, DriftSeverity] = {
+    "uncertain": DriftSeverity.WARNING,
+    "off_track": DriftSeverity.CRITICAL,
+}
+
+
 # Liberal JSON extraction + goals rendering live in
 # :mod:`goldfive.drift.registry` so the goal-drift judge and the
 # per-reasoning judge share one implementation. The aliased imports at
@@ -127,7 +181,15 @@ GOAL_DRIFT_USER_PROMPT_TEMPLATE: str = (
 # work) without re-declaring the function bodies here.
 
 
-def _format_tasks(plan: Plan | Any | None) -> str:
+def _format_tasks(plan: Plan | Any | None, *, annotate_kind: bool = False) -> str:
+    """Render the plan's tasks for the judge prompt.
+
+    When ``annotate_kind`` (ledger / graduated mode), each task is
+    tagged with its ``kind`` (OUTCOME / DISCOVERED / FORECAST) so the
+    judge reads the plan as a LEDGER — deliverables vs the agent's
+    observed trajectory — rather than a flat task list. Forecast mode
+    (``annotate_kind=False``, the default) renders exactly as before.
+    """
     if plan is None:
         return "(no plan yet)"
     tasks = getattr(plan, "tasks", None) or []
@@ -139,10 +201,16 @@ def _format_tasks(plan: Plan | Any | None) -> str:
         title = str(getattr(t, "title", "") or "")
         status = getattr(t, "status", "")
         status_str = str(getattr(status, "value", status) or "").upper() or "UNSPECIFIED"
+        kind_tag = ""
+        if annotate_kind:
+            kind = getattr(t, "kind", "")
+            kind_str = str(getattr(kind, "value", kind) or "").upper()
+            if kind_str:
+                kind_tag = f"{kind_str} "
         if tid:
-            lines.append(f"{i}. [{tid}] {title} ({status_str})")
+            lines.append(f"{i}. {kind_tag}[{tid}] {title} ({status_str})")
         else:
-            lines.append(f"{i}. {title} ({status_str})")
+            lines.append(f"{i}. {kind_tag}{title} ({status_str})")
     return "\n".join(lines)
 
 
@@ -201,6 +269,7 @@ async def classify_goal_drift(
     current_agent_id: str = "",
     system_prompt: str | None = None,
     user_prompt_template: str | None = None,
+    graduated: bool = False,
     sinks: list[Any] | None = None,
     run_id: str = "",
     session_id: str = "",
@@ -255,7 +324,16 @@ async def classify_goal_drift(
         pinned in :data:`GOAL_DRIFT_USER_PROMPT_TEMPLATE`.
     """
     system = system_prompt or GOAL_DRIFT_SYSTEM_PROMPT
-    template = user_prompt_template or GOAL_DRIFT_USER_PROMPT_TEMPLATE
+    # AGENCY-PRESERVATION.md PR 11(a) — in ledger mode (``graduated``) ask
+    # for the three-band verdict so WARNING can fire before CRITICAL. An
+    # explicit ``user_prompt_template`` override always wins; otherwise
+    # the band selection is forecast (binary) vs ledger (graduated).
+    if user_prompt_template is not None:
+        template = user_prompt_template
+    elif graduated:
+        template = GOAL_DRIFT_GRADUATED_USER_PROMPT_TEMPLATE
+    else:
+        template = GOAL_DRIFT_USER_PROMPT_TEMPLATE
     # goldfive#245 — capture the plan-revision the judge is observing
     # BEFORE we render the prompt or await the LLM. The post-LLM
     # re-read below uses this snapshot to detect when the plan moved
@@ -276,7 +354,7 @@ async def classify_goal_drift(
             status = getattr(t, "status", "")
             pre_call_task_status[tid] = str(getattr(status, "value", status) or "")
     goals_block = _format_goals(goals)
-    tasks_block = _format_tasks(plan)
+    tasks_block = _format_tasks(plan, annotate_kind=graduated)
     activity_block, activity_count = _format_activity(observed_actions)
     user = template.format(
         goals_block=goals_block,
@@ -486,9 +564,20 @@ async def classify_goal_drift(
     # observer-note composer falls back to ``detail``.
     note_raw = parsed.get("note_to_agent", "")
     note_to_agent = note_raw.strip() if isinstance(note_raw, str) else ""
+    # AGENCY-PRESERVATION.md PR 11(a) — graduated severity. In ledger mode
+    # the judge may band a non-progressing verdict as ``uncertain`` (early,
+    # proportional → WARNING) vs ``off_track`` (clear drift → CRITICAL).
+    # Forecast mode (``graduated=False``) keeps the pre-PR-11 behaviour
+    # exactly: every non-progressing verdict is CRITICAL. A graduated
+    # verdict missing / with an unrecognised band degrades to CRITICAL so
+    # the severity never silently softens below the legacy default.
+    severity = DriftSeverity.CRITICAL
+    if graduated:
+        band = str(parsed.get("band", "") or "").strip().lower()
+        severity = _GRADUATED_BAND_SEVERITY.get(band, DriftSeverity.CRITICAL)
     return DriftEvent(
         kind=DriftKind.GOAL_DRIFT,
-        severity=DriftSeverity.CRITICAL,
+        severity=severity,
         detail=detail,
         current_task_id=current_task_id,
         current_agent_id=current_agent_id,

--- a/goldfive/drift/outcome_progress.py
+++ b/goldfive/drift/outcome_progress.py
@@ -1,0 +1,383 @@
+"""Outcome-progress judge for ledger plan mode (AGENCY-PRESERVATION.md PR 11c).
+
+In ledger plan mode the Plan is a ledger: goal-anchored OUTCOME tasks
+(deliverables that define success) plus a descriptively-grown record of
+DISCOVERED tasks (what the agent actually did). The wrapped agent never
+reports on the OUTCOME tasks — it owns the means, not goldfive's
+bookkeeping — so OUTCOME tasks reach a terminal status only when
+goldfive's own judge decides they are met. That is what makes "run
+completion = all outcomes terminal" decidable *without agent
+cooperation* (design doc §2, §3 PR 11(c)).
+
+This module is the judge. Like :mod:`goldfive.drift.goals` and
+:mod:`goldfive.drift.reasoning_judge` it is framework-neutral: it takes
+the data it needs by keyword and returns plain verdicts. It does NOT
+mutate the plan, emit events, or import the steerer — the caller (the
+drift observer's task-boundary / run-end hooks) applies the transitions.
+
+Two pieces:
+
+* :func:`evaluate_outcome_progress` — one cost-bounded LLM call that
+  grades every non-terminal OUTCOME task against the GOALS, using the
+  goldfive#447 full-output capture (``session.completed_outputs``) and
+  the DISCOVERED trajectory as evidence. Quiet on every failure
+  (malformed JSON, ``call_llm`` raised) — a flaky judge must never
+  spuriously complete or fail a deliverable.
+* :func:`plan_outcome_transitions` — a PURE function that turns verdicts
+  into the set of task-status transitions and ``contributes_to`` stamps
+  the caller should apply. ``met`` → COMPLETED at any cadence;
+  ``unmet`` → FAILED only at run end (``run_ending=True``), because a
+  deliverable that is not yet met mid-run is simply not done yet.
+  ``contributes_to`` is stamped onto the DISCOVERED tasks the judge
+  named as advancing each met OUTCOME, linking the trajectory lane to
+  the deliverable it produced.
+
+User-supplied goal predicates remain authoritative: the caller passes
+``goal_predicates_met`` and this module refuses to COMPLETE any outcome
+when a user predicate is explicitly unmet — the deterministic predicate
+overrides the LLM's opinion (the existing
+:func:`goldfive.results.evaluate_goal_predicates` run-success gate is
+unchanged and still has the final say on ``Outcome.success``).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from collections.abc import Awaitable, Callable, Iterable, Sequence
+from typing import Any
+
+from goldfive.drift.registry import (
+    format_goals_block as _format_goals,
+)
+from goldfive.drift.registry import (
+    parse_json_response as _parse_response,
+)
+from goldfive.types import Goal, Plan, Task, TaskKind, TaskStatus
+
+log = logging.getLogger(__name__)
+
+
+__all__ = [
+    "CallLLM",
+    "OutcomeVerdict",
+    "OutcomeTransition",
+    "evaluate_outcome_progress",
+    "plan_outcome_transitions",
+    "OUTCOME_PROGRESS_SYSTEM_PROMPT",
+    "OUTCOME_PROGRESS_USER_PROMPT_TEMPLATE",
+    "OUTCOME_PROGRESS_MAX_OUTPUT_TOKENS",
+    "OUTCOME_PROGRESS_EVIDENCE_MAX_CHARS",
+]
+
+
+CallLLM = Callable[[str, str, str], Awaitable[str]]
+
+# Mirrors GOAL_DRIFT_MAX_OUTPUT_TOKENS — the verdict is a small JSON
+# array, but the ceiling has to clear thinking-model preludes.
+OUTCOME_PROGRESS_MAX_OUTPUT_TOKENS: int = 16384
+
+# Per-task evidence cap so a chatty agent's full output cannot blow the
+# prompt budget. The capture is the canonical gradeable artifact; the
+# tail is the part the judge most needs (the final deliverable).
+OUTCOME_PROGRESS_EVIDENCE_MAX_CHARS: int = 4000
+
+
+OUTCOME_PROGRESS_SYSTEM_PROMPT: str = (
+    "You are deciding whether each of a small set of DELIVERABLES has "
+    "been produced, based on evidence of what an autonomous agent "
+    "actually did. Reply with a single JSON object and nothing else."
+)
+
+OUTCOME_PROGRESS_USER_PROMPT_TEMPLATE: str = (
+    "You are deciding which DELIVERABLES are DONE.\n\n"
+    "GOALS (what the user wants):\n{goals_block}\n\n"
+    "DELIVERABLES TO JUDGE (each is an outcome the run must produce; "
+    "decide DONE or NOT DONE for each):\n{outcomes_block}\n\n"
+    "WHAT THE AGENT ACTUALLY DID (its observed trajectory — use the ids "
+    "to attribute which steps produced which deliverable):\n"
+    "{trajectory_block}\n\n"
+    "EVIDENCE (the agent's captured outputs, keyed by trajectory id):\n"
+    "{evidence_block}\n\n"
+    "For each deliverable in DELIVERABLES TO JUDGE, decide whether the "
+    "EVIDENCE shows it has been produced. Be strict: mark met=true only "
+    "when the evidence actually contains or demonstrates the "
+    "deliverable, not merely that the agent attempted it.\n\n"
+    "Reply with a single JSON object and nothing else:\n"
+    "{{\n"
+    '  "outcomes": [\n'
+    '    {{"task_id": "<deliverable id>", "met": true|false, '
+    '"reason": "one-sentence justification grounded in the evidence", '
+    '"contributing_task_ids": ["<trajectory id that produced it>", ...]}}\n'
+    "  ]\n"
+    "}}\n\n"
+    "Include exactly one entry per deliverable id listed above. "
+    "``contributing_task_ids`` lists the trajectory ids whose evidence "
+    "supports a met=true verdict (empty list when met=false or unknown)."
+)
+
+
+def _is_outcome(task: Any) -> bool:
+    return getattr(task, "kind", None) is TaskKind.OUTCOME
+
+
+def _is_terminal(task: Any) -> bool:
+    from goldfive.types import TERMINAL_TASK_STATUSES
+
+    return getattr(task, "status", None) in TERMINAL_TASK_STATUSES
+
+
+def _format_outcomes(outcome_tasks: Sequence[Task]) -> str:
+    if not outcome_tasks:
+        return "(no outcome deliverables)"
+    lines = []
+    for t in outcome_tasks:
+        desc = (getattr(t, "description", "") or "").strip()
+        suffix = f" — {desc}" if desc else ""
+        lines.append(f"- [{t.id}] {t.title}{suffix}")
+    return "\n".join(lines)
+
+
+def _format_trajectory(discovered_tasks: Sequence[Task]) -> str:
+    if not discovered_tasks:
+        return "(no observed trajectory yet)"
+    lines = []
+    for t in discovered_tasks:
+        status = getattr(t, "status", "")
+        status_str = str(getattr(status, "value", status) or "").upper()
+        agent = (getattr(t, "assignee_agent_id", "") or "").strip()
+        agent_str = f" by {agent}" if agent else ""
+        lines.append(f"- [{t.id}] {t.title}{agent_str} ({status_str})")
+    return "\n".join(lines)
+
+
+def _format_evidence(
+    completed_outputs: dict[str, str] | None,
+    discovered_tasks: Sequence[Task],
+    *,
+    per_task_cap: int,
+) -> str:
+    """Render the captured outputs (#447) for the trajectory tasks.
+
+    Keyed by task id so the judge can attribute ``contributing_task_ids``.
+    Each entry is capped to ``per_task_cap`` chars (tail-truncated keeps
+    the final deliverable, which is what the judge most needs).
+    """
+    outputs = completed_outputs or {}
+    if not outputs:
+        return "(no captured outputs)"
+    ids = {t.id for t in discovered_tasks}
+    blocks = []
+    for tid, text in outputs.items():
+        # Restrict to trajectory ids when we have them; otherwise show
+        # all captures (defensive — a capture keyed to a non-ledger id
+        # is still evidence).
+        if ids and tid not in ids:
+            continue
+        body = (text or "").strip()
+        if len(body) > per_task_cap:
+            body = "…(truncated)\n" + body[-per_task_cap:]
+        blocks.append(f"[{tid}]\n{body}")
+    if not blocks:
+        return "(no captured outputs for the observed trajectory)"
+    return "\n\n".join(blocks)
+
+
+@dataclasses.dataclass(frozen=True)
+class OutcomeVerdict:
+    """One outcome-progress verdict (no plan mutation; advisory data)."""
+
+    task_id: str
+    met: bool
+    reason: str = ""
+    contributing_task_ids: tuple[str, ...] = ()
+
+
+@dataclasses.dataclass(frozen=True)
+class OutcomeTransition:
+    """A planned status transition for an OUTCOME task + contributes_to stamps.
+
+    ``contributes_stamps`` maps a DISCOVERED task id → the OUTCOME id it
+    advanced (the value the caller writes onto that task's
+    ``contributes_to``). Only populated for ``COMPLETED`` transitions.
+    """
+
+    task_id: str
+    new_status: TaskStatus
+    reason: str
+    contributes_stamps: tuple[tuple[str, str], ...] = ()
+
+
+async def evaluate_outcome_progress(
+    *,
+    goals: Sequence[Goal] | Iterable[Any] | None,
+    plan: Plan | Any | None,
+    completed_outputs: dict[str, str] | None,
+    model: str,
+    call_llm: CallLLM,
+    system_prompt: str | None = None,
+    user_prompt_template: str | None = None,
+    sinks: list[Any] | None = None,
+    run_id: str = "",
+    session_id: str = "",
+    sequence_fn: Callable[[], int] | None = None,
+) -> list[OutcomeVerdict]:
+    """Grade every non-terminal OUTCOME task against the goals + evidence.
+
+    One LLM call. Returns a verdict per non-terminal OUTCOME task; an
+    empty list when there are no OUTCOME tasks to judge or on any
+    quiet-failure path (malformed JSON, ``call_llm`` raised, no plan).
+    The "quiet on failure" contract matches :func:`classify_goal_drift`:
+    a flaky judge must never spuriously complete or fail a deliverable.
+    """
+    tasks = list(getattr(plan, "tasks", None) or [])
+    outcome_tasks = [t for t in tasks if _is_outcome(t) and not _is_terminal(t)]
+    if not outcome_tasks:
+        return []
+    discovered_tasks = [
+        t
+        for t in tasks
+        if getattr(t, "discovered", False)
+        or getattr(t, "kind", None) is TaskKind.DISCOVERED
+    ]
+    system = system_prompt or OUTCOME_PROGRESS_SYSTEM_PROMPT
+    template = user_prompt_template or OUTCOME_PROGRESS_USER_PROMPT_TEMPLATE
+    user = template.format(
+        goals_block=_format_goals(goals),
+        outcomes_block=_format_outcomes(outcome_tasks),
+        trajectory_block=_format_trajectory(discovered_tasks),
+        evidence_block=_format_evidence(
+            completed_outputs, discovered_tasks, per_task_cap=OUTCOME_PROGRESS_EVIDENCE_MAX_CHARS
+        ),
+    )
+    valid_outcome_ids = {t.id for t in outcome_tasks}
+    valid_discovered_ids = {t.id for t in discovered_tasks}
+    parsed: dict[str, Any] | None = None
+    try:
+        from goldfive._llm import call_llm_budget, call_llm_thinking_disabled
+        from goldfive._llm_span import goldfive_llm_span
+
+        async with goldfive_llm_span(
+            sinks=list(sinks or []),
+            name="judge_outcome_progress",
+            model=model,
+            session_id=session_id,
+            run_id=run_id,
+            task_id="",
+            sequence_fn=sequence_fn,
+            input_preview=_format_outcomes(outcome_tasks),
+        ) as span:
+            with call_llm_budget(OUTCOME_PROGRESS_MAX_OUTPUT_TOKENS), call_llm_thinking_disabled():
+                raw = await call_llm(system, user, model)
+            parsed = _parse_response(raw)
+            if parsed is None:
+                span.output_preview = "(unparseable verdict)"
+                span.decision_summary = "outcome-progress: unparseable verdict (no transitions)"
+            else:
+                n = len(parsed.get("outcomes", []) or []) if isinstance(parsed, dict) else 0
+                span.output_preview = raw[:2048] if isinstance(raw, str) else "(non-str)"
+                span.decision_summary = f"outcome-progress: graded {n} deliverable(s)"
+    except Exception as exc:  # noqa: BLE001 — never break the run
+        log.warning("evaluate_outcome_progress: call_llm raised %s; no transitions", exc)
+        return []
+    if not isinstance(parsed, dict):
+        return []
+    raw_outcomes = parsed.get("outcomes")
+    if not isinstance(raw_outcomes, list):
+        log.debug("evaluate_outcome_progress: verdict missing 'outcomes' list; ignored")
+        return []
+    verdicts: list[OutcomeVerdict] = []
+    seen: set[str] = set()
+    for entry in raw_outcomes:
+        if not isinstance(entry, dict):
+            continue
+        tid = str(entry.get("task_id", "") or "").strip()
+        # Only accept verdicts for OUTCOME tasks we actually asked about.
+        if tid not in valid_outcome_ids or tid in seen:
+            continue
+        seen.add(tid)
+        met = bool(entry.get("met", False))
+        reason = str(entry.get("reason", "") or "").strip()
+        contributing = entry.get("contributing_task_ids") or []
+        contrib_ids = tuple(
+            str(c).strip()
+            for c in contributing
+            if isinstance(c, (str, int)) and str(c).strip() in valid_discovered_ids
+        )
+        verdicts.append(
+            OutcomeVerdict(
+                task_id=tid,
+                met=met,
+                reason=reason,
+                contributing_task_ids=contrib_ids,
+            )
+        )
+    return verdicts
+
+
+def plan_outcome_transitions(
+    plan: Plan | Any | None,
+    verdicts: Sequence[OutcomeVerdict],
+    *,
+    run_ending: bool = False,
+    goal_predicates_met: bool = True,
+) -> list[OutcomeTransition]:
+    """Turn outcome verdicts into the transitions the caller should apply.
+
+    PURE — no plan mutation, no I/O. Rules:
+
+    * ``met`` OUTCOME (non-terminal) → COMPLETED at any cadence, BUT only
+      when ``goal_predicates_met`` (a user-supplied predicate that is
+      explicitly unmet overrides the LLM and blocks completion).
+    * ``unmet`` OUTCOME → FAILED only when ``run_ending`` (a deliverable
+      that is not yet met mid-run is simply not done yet, not failed).
+    * A met → COMPLETED transition carries ``contributes_stamps`` for the
+      named DISCOVERED tasks (``discovered_id -> outcome_id``), but only
+      for tasks that exist in the plan and are not already stamped with a
+      different outcome (stable, idempotent).
+
+    OUTCOME tasks already terminal, and verdicts whose ``task_id`` is not
+    a non-terminal OUTCOME in ``plan``, are skipped.
+    """
+    tasks_by_id: dict[str, Task] = {
+        t.id: t for t in (getattr(plan, "tasks", None) or []) if getattr(t, "id", "")
+    }
+    transitions: list[OutcomeTransition] = []
+    for v in verdicts:
+        task = tasks_by_id.get(v.task_id)
+        if task is None or not _is_outcome(task) or _is_terminal(task):
+            continue
+        if v.met:
+            if not goal_predicates_met:
+                # A user predicate is authoritative and currently unmet —
+                # do not complete the deliverable on the LLM's say-so.
+                continue
+            stamps: list[tuple[str, str]] = []
+            for cid in v.contributing_task_ids:
+                ctask = tasks_by_id.get(cid)
+                if ctask is None:
+                    continue
+                existing = (getattr(ctask, "contributes_to", "") or "").strip()
+                if existing and existing != v.task_id:
+                    # Already attributed to a different outcome — leave it.
+                    continue
+                if existing == v.task_id:
+                    continue  # idempotent — no-op stamp
+                stamps.append((cid, v.task_id))
+            transitions.append(
+                OutcomeTransition(
+                    task_id=v.task_id,
+                    new_status=TaskStatus.COMPLETED,
+                    reason=v.reason or "outcome met",
+                    contributes_stamps=tuple(stamps),
+                )
+            )
+        elif run_ending:
+            transitions.append(
+                OutcomeTransition(
+                    task_id=v.task_id,
+                    new_status=TaskStatus.FAILED,
+                    reason=v.reason or "outcome unmet at run end",
+                )
+            )
+    return transitions

--- a/goldfive/drift/outcome_progress.py
+++ b/goldfive/drift/outcome_progress.py
@@ -62,6 +62,9 @@ __all__ = [
     "CallLLM",
     "OutcomeVerdict",
     "OutcomeTransition",
+    "OUTCOME_ASSESSMENT_MET",
+    "OUTCOME_ASSESSMENT_FAILED",
+    "OUTCOME_ASSESSMENT_PENDING",
     "evaluate_outcome_progress",
     "plan_outcome_transitions",
     "OUTCOME_PROGRESS_SYSTEM_PROMPT",
@@ -99,21 +102,30 @@ OUTCOME_PROGRESS_USER_PROMPT_TEMPLATE: str = (
     "{trajectory_block}\n\n"
     "EVIDENCE (the agent's captured outputs, keyed by trajectory id):\n"
     "{evidence_block}\n\n"
-    "For each deliverable in DELIVERABLES TO JUDGE, decide whether the "
-    "EVIDENCE shows it has been produced. Be strict: mark met=true only "
-    "when the evidence actually contains or demonstrates the "
-    "deliverable, not merely that the agent attempted it.\n\n"
+    "For each deliverable in DELIVERABLES TO JUDGE, classify it into "
+    "EXACTLY ONE of three states, grounded in the EVIDENCE:\n"
+    '  - "met": the evidence actually contains or demonstrates the '
+    "deliverable. Be strict — an attempt is not a deliverable.\n"
+    '  - "failed": the goal this deliverable serves is contradicted or '
+    "the deliverable provably CANNOT be produced (e.g. the user "
+    "cancelled it, or a hard prerequisite is impossible). Use this ONLY "
+    "when you are CONFIDENT the deliverable will never be met — not for "
+    "work that simply is not done yet.\n"
+    '  - "pending": not done yet, in progress, or you cannot tell from '
+    "the evidence. This is the default — a run boundary is often just a "
+    "pause, and pending work legitimately continues later.\n\n"
     "Reply with a single JSON object and nothing else:\n"
     "{{\n"
     '  "outcomes": [\n'
-    '    {{"task_id": "<deliverable id>", "met": true|false, '
+    '    {{"task_id": "<deliverable id>", '
+    '"assessment": "met" | "failed" | "pending", '
     '"reason": "one-sentence justification grounded in the evidence", '
     '"contributing_task_ids": ["<trajectory id that produced it>", ...]}}\n'
     "  ]\n"
     "}}\n\n"
     "Include exactly one entry per deliverable id listed above. "
     "``contributing_task_ids`` lists the trajectory ids whose evidence "
-    "supports a met=true verdict (empty list when met=false or unknown)."
+    'supports a "met" verdict (empty list for "failed" / "pending").'
 )
 
 
@@ -183,14 +195,40 @@ def _format_evidence(
     return "\n\n".join(blocks)
 
 
+#: The three outcome assessments. ``met`` → the deliverable exists;
+#: ``failed`` → CONFIDENTLY unmet (goal contradicted / cannot be met);
+#: ``pending`` → not done yet / uncertain (the default — carries forward
+#: across a turn boundary like a goldfive#208 reachable-PENDING task). An
+#: unrecognised assessment degrades to ``pending`` (never to a transition).
+OUTCOME_ASSESSMENT_MET = "met"
+OUTCOME_ASSESSMENT_FAILED = "failed"
+OUTCOME_ASSESSMENT_PENDING = "pending"
+_VALID_ASSESSMENTS = frozenset(
+    {OUTCOME_ASSESSMENT_MET, OUTCOME_ASSESSMENT_FAILED, OUTCOME_ASSESSMENT_PENDING}
+)
+
+
 @dataclasses.dataclass(frozen=True)
 class OutcomeVerdict:
-    """One outcome-progress verdict (no plan mutation; advisory data)."""
+    """One outcome-progress verdict (no plan mutation; advisory data).
+
+    ``assessment`` is one of :data:`OUTCOME_ASSESSMENT_MET` /
+    ``_FAILED`` / ``_PENDING``. The three-state shape (vs a ``met`` bool)
+    is the goldfive#208-forced narrowing of "unmet at exit → FAILED": a
+    run end is usually just a turn boundary, so only a CONFIDENTLY-unmet
+    deliverable is failed; merely not-yet-met work stays PENDING and
+    carries to the next turn (the dormancy-respecting choice — goldfive
+    does not manufacture failure verdicts at every turn boundary).
+    """
 
     task_id: str
-    met: bool
+    assessment: str
     reason: str = ""
     contributing_task_ids: tuple[str, ...] = ()
+
+    @property
+    def met(self) -> bool:
+        return self.assessment == OUTCOME_ASSESSMENT_MET
 
 
 @dataclasses.dataclass(frozen=True)
@@ -296,7 +334,11 @@ async def evaluate_outcome_progress(
         if tid not in valid_outcome_ids or tid in seen:
             continue
         seen.add(tid)
-        met = bool(entry.get("met", False))
+        assessment = str(entry.get("assessment", "") or "").strip().lower()
+        # Unrecognised / missing assessment degrades to PENDING — never to
+        # a transition (a flaky judge must not manufacture a terminal).
+        if assessment not in _VALID_ASSESSMENTS:
+            assessment = OUTCOME_ASSESSMENT_PENDING
         reason = str(entry.get("reason", "") or "").strip()
         contributing = entry.get("contributing_task_ids") or []
         contrib_ids = tuple(
@@ -307,7 +349,7 @@ async def evaluate_outcome_progress(
         verdicts.append(
             OutcomeVerdict(
                 task_id=tid,
-                met=met,
+                assessment=assessment,
                 reason=reason,
                 contributing_task_ids=contrib_ids,
             )
@@ -329,8 +371,12 @@ def plan_outcome_transitions(
     * ``met`` OUTCOME (non-terminal) → COMPLETED at any cadence, BUT only
       when ``goal_predicates_met`` (a user-supplied predicate that is
       explicitly unmet overrides the LLM and blocks completion).
-    * ``unmet`` OUTCOME → FAILED only when ``run_ending`` (a deliverable
-      that is not yet met mid-run is simply not done yet, not failed).
+    * ``failed`` (CONFIDENTLY unmet) OUTCOME → FAILED only when
+      ``run_ending``. A deliverable the judge merely cannot confirm yet is
+      ``pending``, not ``failed``; a run end is usually just a turn
+      boundary (goldfive#208), so uncertain work carries forward as
+      reachable-PENDING and the next boundary judge re-evaluates.
+    * ``pending`` OUTCOME → no transition (left PENDING to carry forward).
     * A met → COMPLETED transition carries ``contributes_stamps`` for the
       named DISCOVERED tasks (``discovered_id -> outcome_id``), but only
       for tasks that exist in the plan and are not already stamped with a
@@ -347,7 +393,7 @@ def plan_outcome_transitions(
         task = tasks_by_id.get(v.task_id)
         if task is None or not _is_outcome(task) or _is_terminal(task):
             continue
-        if v.met:
+        if v.assessment == OUTCOME_ASSESSMENT_MET:
             if not goal_predicates_met:
                 # A user predicate is authoritative and currently unmet —
                 # do not complete the deliverable on the LLM's say-so.
@@ -372,12 +418,13 @@ def plan_outcome_transitions(
                     contributes_stamps=tuple(stamps),
                 )
             )
-        elif run_ending:
+        elif v.assessment == OUTCOME_ASSESSMENT_FAILED and run_ending:
             transitions.append(
                 OutcomeTransition(
                     task_id=v.task_id,
                     new_status=TaskStatus.FAILED,
-                    reason=v.reason or "outcome unmet at run end",
+                    reason=v.reason or "outcome cannot be met",
                 )
             )
+        # OUTCOME_ASSESSMENT_PENDING (and "failed" mid-run) → no transition.
     return transitions

--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -1002,6 +1002,7 @@ async def _run_judge_with_focus(
     sink: Any = None,
     agent_name: str = "",
     available_agents: list[str] | list[dict[str, Any]] | None = None,
+    ledger: bool = False,
 ) -> ReasoningJudgeVerdict:
     """Dispatch :func:`classify_reasoning_drift_with_focus` against the current task.
 
@@ -1054,6 +1055,8 @@ async def _run_judge_with_focus(
         task_lineage=getattr(session, "task_lineage", None),
         recent_tool_observations=tool_obs,
         available_agents=available_agents,
+        # AGENCY-PRESERVATION.md PR 11(b) — ledger re-grounding flag.
+        ledger=ledger,
     )
 
 
@@ -1069,6 +1072,7 @@ async def analyze_reasoning_with_focus(
     available_agents: list[str] | list[dict[str, Any]] | None = None,
     embedding_pipeline: Any = None,
     judge_runner: Any = None,
+    ledger: bool = False,
 ) -> ReasoningJudgeVerdict:
     """Phase-1 sibling of :func:`analyze_reasoning` returning a focused verdict.
 
@@ -1123,6 +1127,7 @@ async def analyze_reasoning_with_focus(
             sink=sink,
             agent_name=agent_name,
             available_agents=available_agents,
+            ledger=ledger,
         )
     if mode == "both":
         embedding_drift = embed(text, session)
@@ -1136,6 +1141,7 @@ async def analyze_reasoning_with_focus(
                 sink=sink,
                 agent_name=agent_name,
                 available_agents=available_agents,
+                ledger=ledger,
             )
         if judge_verdict is None:
             return ReasoningJudgeVerdict(drift=embedding_drift)

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -77,6 +77,7 @@ __all__ = [
     "REASONING_DRIFT_TOOL_OBS_MAX_CHARS",
     "REASONING_DRIFT_TOOL_OBS_MAX_ENTRIES",
     "REASONING_DRIFT_USER_PROMPT_TEMPLATE",
+    "REASONING_DRIFT_LEDGER_USER_PROMPT_TEMPLATE",
     "ReasoningJudgeVerdict",
     "classify_reasoning_drift",
     "classify_reasoning_drift_with_focus",
@@ -238,6 +239,88 @@ REASONING_DRIFT_USER_PROMPT_TEMPLATE: str = (
     "any plan task. focus_confidence is your subjective certainty in "
     "the attribution: 1.0 when the reasoning explicitly names the "
     "task, 0.0 when you are guessing."
+)
+
+
+# AGENCY-PRESERVATION.md Stage 3 PR 11(b) — the LEDGER-regrounded
+# reasoning-judge prompt. Used only in ledger plan mode. The verdict
+# JSON shape and classification labels are IDENTICAL to the forecast
+# template (so the parser is unchanged), but the GROUNDING is inverted:
+#
+#   * GOALS lead — they are the PRIMARY reference for whether the
+#     reasoning is on task. The user's goal is what goldfive owns.
+#   * The bound task is presented as CONTEXT — in ledger mode it is the
+#     agent's OWN observed intent (an OUTCOME deliverable, or a
+#     DISCOVERED record of what it chose to do), not a forecast the agent
+#     is graded against. Divergence from the bound task is therefore NOT
+#     drift by itself; only divergence from the GOALS is. This is the
+#     self-consistent, adaptive reference §2 calls for.
+REASONING_DRIFT_LEDGER_USER_PROMPT_TEMPLATE: str = (
+    "You are assessing whether an autonomous agent's chain-of-thought "
+    "still serves the user's GOALS.\n\n"
+    "GOALS (what the user wants — the PRIMARY reference for this "
+    "judgement):\n{goals_block}\n\n"
+    "LEDGER — OUTCOME deliverables that define success + DISCOVERED "
+    "records of what the agent has actually done (id -> title):\n"
+    "{plan_tasks_summary}\n\n"
+    "CURRENTLY BOUND TASK (CONTEXT ONLY — in ledger mode this is the "
+    "agent's OWN observed intent, NOT a prescription to grade against; "
+    "the agent owns HOW it pursues the goals):\n{task_block}\n\n"
+    "Currently reasoning agent: {current_agent_id}\n"
+    "Task lineage: {task_lineage_block}\n\n"
+    "RECENT TOOL OBSERVATIONS (last {tool_obs_count}, oldest first):\n"
+    "{tool_obs_block}\n\n"
+    "REASONING (the agent's most recent chain-of-thought block):\n"
+    "{reasoning_block}\n\n"
+    "Decide FOUR things, grounding PRIMARILY on the GOALS:\n"
+    "1. CLASSIFICATION. Which best describes the reasoning?\n"
+    "   - on_task: it plausibly advances the GOALS. Choosing a different\n"
+    "     decomposition, sub-agent, tool, or order than the bound task\n"
+    "     suggests is the agent exercising its own judgement — that is\n"
+    "     on_task as long as it still serves the GOALS.\n"
+    "   - justified_deviation: it departs from the GOALS, but a recent\n"
+    "     tool observation, surprising result, discovered dependency, or\n"
+    "     new information visible above plausibly provoked it. The\n"
+    "     provoking signal MUST be visible in the GOALS or RECENT TOOL\n"
+    "     OBSERVATIONS — the agent's CLAIM is not itself evidence.\n"
+    "   - erroneous_deviation: it pursues an objective the GOALS do not\n"
+    "     support, with no provoking signal in the context above.\n"
+    "2. ATTRIBUTION. Which LEDGER task is the reasoning advancing right\n"
+    "   now? Use the literal id, or '' when it maps to no ledger task.\n"
+    "3. PROVENANCE. ONLY when classification is justified_deviation, name\n"
+    "   the signal: tool_error | surprising_result | "
+    "discovered_dependency | new_information. Otherwise \"none\".\n"
+    "4. NOTE. ONLY when classification is NOT on_task, write "
+    "note_to_agent:\n"
+    "   one or two sentences addressed to the agent itself, stating only\n"
+    "   what you observed and how it relates to the GOALS. Neutral and\n"
+    "   factual — no commands, no means-level instructions, no fault\n"
+    "   language. If your confidence is low, phrase it as a question\n"
+    '   (e.g. "Does the current approach still serve the goal of X?").\n'
+    '   When classification is on_task, set note_to_agent to "".\n\n'
+    "Reply with a single JSON object and nothing else, in this shape:\n"
+    "{{\n"
+    '  "classification": "on_task" | "justified_deviation" | "erroneous_deviation",\n'
+    '  "severity": "info" | "warning" | "critical",\n'
+    '  "reason": "one-sentence explanation",\n'
+    '  "provenance": "tool_error" | "surprising_result" | '
+    '"discovered_dependency" | "new_information" | "none",\n'
+    '  "focused_task_id": "<id from LEDGER, or \'\' if unmapped>",\n'
+    '  "focus_confidence": 0.0-1.0,\n'
+    '  "stated_intent": "one-sentence summary of what the agent says it '
+    'is doing",\n'
+    '  "note_to_agent": "one-or-two-sentence neutral observation for the '
+    "agent, or '' when on_task\"\n"
+    "}}\n\n"
+    "Severity guidance when classification is non-on_task:\n"
+    "  info     = mild deviation from the goals that may self-correct.\n"
+    "  warning  = clear deviation from the goals that deserves a note.\n"
+    "  critical = proposing to abandon the goals entirely.\n\n"
+    "focused_task_id MUST be the literal id of one of the listed ledger "
+    "tasks, or an empty string when the reasoning maps to no ledger "
+    "task. focus_confidence is your subjective certainty in the "
+    "attribution: 1.0 when the reasoning explicitly names the task, 0.0 "
+    "when you are guessing."
 )
 
 
@@ -776,6 +859,7 @@ async def classify_reasoning_drift_with_focus(
     current_agent_id: str = "",
     system_prompt: str | None = None,
     user_prompt_template: str | None = None,
+    ledger: bool = False,
     sink: Any = None,
     run_id: str = "",
     session_id: str = "",
@@ -872,7 +956,16 @@ async def classify_reasoning_drift_with_focus(
     if not reasoning or not reasoning.strip():
         return ReasoningJudgeVerdict(drift=None)
     system = system_prompt or REASONING_DRIFT_SYSTEM_PROMPT
-    template = user_prompt_template or REASONING_DRIFT_USER_PROMPT_TEMPLATE
+    # AGENCY-PRESERVATION.md PR 11(b) — in ledger mode re-ground the judge
+    # on the GOALS (primary) with the bound task as context (the agent's
+    # own observed intent). An explicit ``user_prompt_template`` override
+    # always wins; otherwise the grounding is forecast vs ledger.
+    if user_prompt_template is not None:
+        template = user_prompt_template
+    elif ledger:
+        template = REASONING_DRIFT_LEDGER_USER_PROMPT_TEMPLATE
+    else:
+        template = REASONING_DRIFT_USER_PROMPT_TEMPLATE
     # goldfive#245 — capture the plan revision the judge is observing
     # BEFORE we render the prompt or await the LLM. Stamped onto the
     # drift below; the dispatch-time gate in

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -3239,6 +3239,22 @@ class DriftObserver:
         session._agent_turns_since_goal_check = 0
         self._spawn_goal_drift_judge_background(session)
 
+    def _ledger_mode(self) -> bool:
+        """Return True iff ``SteeringConfig.plan_mode == "ledger"``.
+
+        AGENCY-PRESERVATION.md Stage 3 PR 11. Read off the steerer's
+        typed config exactly as the pin path / reviser read it. Defensive:
+        any read failure resolves to forecast mode, so the goal-drift
+        judge stays on its pre-PR-11 binary/CRITICAL path by default.
+        """
+        try:
+            cfg = getattr(self._steerer, "_steering_config", None)
+            if cfg is None:
+                return False
+            return str(getattr(cfg, "plan_mode", "forecast")).strip().lower() == "ledger"
+        except Exception:  # noqa: BLE001
+            return False
+
     async def maybe_run_goal_drift_check(self, session: Session) -> None:
         """Run the trajectory-level GOAL_DRIFT judge once, cost-bounded.
 
@@ -3282,6 +3298,10 @@ class DriftObserver:
             model=self._steerer._goal_drift_model,
             call_llm=call_llm,
             current_task_id=session.current_task_id,
+            # AGENCY-PRESERVATION.md PR 11(a) — in ledger mode the judge
+            # uses the graduated (uncertain → WARNING / off_track →
+            # CRITICAL) verdict and reads the plan as the ledger.
+            graduated=self._ledger_mode(),
             sinks=self._steerer._sinks,
             run_id=session.run_id,
             session_id=session.id,

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -151,6 +151,7 @@ from goldfive.drift import (
 from goldfive.types import (
     RECENT_EVENT_AGENT_ACTIVITY_KINDS,
     RECENT_EVENT_KIND_TOOL_OBSERVED,
+    TERMINAL_TASK_STATUSES,
     CancellationRequest,
     DriftEvent,
     DriftKind,
@@ -158,8 +159,12 @@ from goldfive.types import (
     RefineOutcome,
     Session,
     Task,
+    TaskKind,
     TaskStatus,
+    channel_processor_active,
     filter_recent_events_by_kind,
+    replace_task,
+    set_session_plan,
 )
 
 if TYPE_CHECKING:
@@ -3189,7 +3194,9 @@ class DriftObserver:
         session._agent_turns_since_goal_check = 0
         self._spawn_goal_drift_judge_background(session)
 
-    async def _maybe_run_goal_drift_on_task_boundary(self, session: Session) -> None:
+    async def _maybe_run_goal_drift_on_task_boundary(
+        self, session: Session, transitioned_task: Task | None = None
+    ) -> None:
         """Fire :meth:`maybe_run_goal_drift_check` on a task transition.
 
         Task completions / failures / cancellations are natural
@@ -3231,6 +3238,19 @@ class DriftObserver:
         :meth:`_run_judge_background` — keeps it alive across cancel
         propagation and drainable at :meth:`shutdown`.
         """
+        # AGENCY-PRESERVATION.md PR 11(c) re-entrancy guard: an OUTCOME
+        # task only transitions via goldfive's own outcome-progress judge
+        # (the agent never reports on deliverables). Those transitions are
+        # judge-authored bookkeeping, not agent progress, so re-firing the
+        # task-boundary cadence on them adds no information and would loop
+        # (outcome judge marks an OUTCOME COMPLETED → mark_task_completed
+        # → this hook → re-judge → …). Skip the whole cadence on OUTCOME
+        # transitions. A no-op in forecast mode (no OUTCOME-kind tasks).
+        if (
+            transitioned_task is not None
+            and getattr(transitioned_task, "kind", None) is TaskKind.OUTCOME
+        ):
+            return
         if self._steerer._goal_drift_call_llm is None:
             return
         now = time.time()
@@ -3242,6 +3262,10 @@ class DriftObserver:
         # fresh rather than firing one more judge call on the next turn.
         session._agent_turns_since_goal_check = 0
         self._spawn_goal_drift_judge_background(session)
+        # AGENCY-PRESERVATION.md PR 11(c): in ledger mode the task boundary
+        # is also where met OUTCOME deliverables transition to COMPLETED.
+        # Fire-and-forget + single-in-flight (see the spawn helper).
+        self._spawn_outcome_progress_background(session)
 
     def _ledger_mode(self) -> bool:
         """Return True iff ``SteeringConfig.plan_mode == "ledger"``.
@@ -3415,6 +3439,179 @@ class DriftObserver:
                 "(swallowed): %s",
                 exc,
             )
+
+    # ------------------------------------------------------------------
+    # AGENCY-PRESERVATION.md PR 11(c): outcome-progress judge.
+    #
+    # In ledger plan mode the Plan is a ledger of OUTCOME deliverables +
+    # a DISCOVERED trajectory. The wrapped agent never reports on OUTCOME
+    # tasks, so they reach a terminal status only via goldfive's own
+    # judge here. Run completion ("all outcomes terminal") is therefore
+    # decided WITHOUT agent cooperation. Two cadences:
+    #   * task boundary — fire-and-forget, completes MET deliverables as
+    #     they are achieved (``_spawn_outcome_progress_background``);
+    #   * run end — awaited finalize, completes MET + fails CONFIDENTLY-
+    #     unmet, leaving uncertain deliverables PENDING to carry forward
+    #     (``finalize_outcomes``).
+    # All ledger-gated; a no-op in forecast mode.
+    # ------------------------------------------------------------------
+
+    async def finalize_outcomes(self, session: Session) -> None:
+        """Judge + finalize OUTCOME deliverables at the run boundary.
+
+        Awaited (not fire-and-forget) so the transitions land BEFORE the
+        executor's end-of-overlay PENDING disposition (goldfive#208) and
+        the fatal-failure gate read it. Ledger-gated; no-op otherwise.
+        """
+        await self._run_outcome_progress(session, run_ending=True)
+
+    def _spawn_outcome_progress_background(self, session: Session) -> None:
+        """Fire-and-forget the task-boundary outcome-progress judge.
+
+        Single-in-flight per session (``session._outcome_progress_inflight``):
+        a second task boundary that lands while one judge is mid-flight
+        does not stack a second judge — the in-flight one already sees the
+        latest plan. Tracked on ``_background_judges`` so :meth:`shutdown`
+        drains it, matching the goal-drift background pattern. No-op when
+        not in ledger mode, when no judge ``call_llm`` is configured, or
+        when no event loop is running.
+        """
+        if not self._ledger_mode() or self._steerer._goal_drift_call_llm is None:
+            return
+        if getattr(session, "_outcome_progress_inflight", False):
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        session._outcome_progress_inflight = True
+        bg_task = asyncio.create_task(
+            self._run_outcome_progress_background(session),
+            name=f"goldfive-outcome-progress:{session.id}",
+        )
+        self._steerer._background_judges.add(bg_task)
+        bg_task.add_done_callback(self._steerer._background_judges.discard)
+
+    async def _run_outcome_progress_background(self, session: Session) -> None:
+        """Body of the fire-and-forget task-boundary outcome-progress judge."""
+        try:
+            await self._run_outcome_progress(session, run_ending=False)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — background task
+            log.warning(
+                "DefaultSteerer: background outcome-progress judge raised "
+                "(swallowed): %s",
+                exc,
+            )
+        finally:
+            session._outcome_progress_inflight = False
+
+    async def _run_outcome_progress(self, session: Session, *, run_ending: bool) -> None:
+        """Judge non-terminal OUTCOME tasks and apply the transitions.
+
+        Ledger-gated shared body for both cadences. Quiet on every failure
+        (the judge module never raises into the run). User goal predicates
+        remain authoritative: a predicate that is explicitly unmet blocks
+        LLM-driven completion.
+        """
+        if not self._ledger_mode():
+            return
+        call_llm = self._steerer._goal_drift_call_llm
+        if call_llm is None:
+            return
+        plan = session.plan
+        outcome_tasks = [
+            t
+            for t in (getattr(plan, "tasks", None) or ())
+            if getattr(t, "kind", None) is TaskKind.OUTCOME
+            and getattr(t, "status", None) not in TERMINAL_TASK_STATUSES
+        ]
+        if not outcome_tasks:
+            return
+        from goldfive.drift.outcome_progress import (
+            evaluate_outcome_progress,
+            plan_outcome_transitions,
+        )
+
+        verdicts = await evaluate_outcome_progress(
+            goals=session.goals,
+            plan=plan,
+            completed_outputs=getattr(session, "completed_outputs", None),
+            model=self._steerer._goal_drift_model,
+            call_llm=call_llm,
+            sinks=self._steerer._sinks,
+            run_id=session.run_id,
+            session_id=session.id,
+            sequence_fn=session.next_sequence,
+        )
+        if not verdicts:
+            return
+        from goldfive.results import evaluate_goal_predicates
+
+        predicates_met = evaluate_goal_predicates(session) is None
+        transitions = plan_outcome_transitions(
+            plan,
+            verdicts,
+            run_ending=run_ending,
+            goal_predicates_met=predicates_met,
+        )
+        await self._apply_outcome_transitions(session, transitions)
+
+    async def _apply_outcome_transitions(
+        self, session: Session, transitions: list[Any]
+    ) -> None:
+        """Apply outcome transitions: stamp contributes_to, then transition.
+
+        ``contributes_to`` stamps land first in a single
+        channel-processor envelope (one plan rebuild for all stamps);
+        then each OUTCOME task is transitioned via the task state machine
+        so the normal TaskCompleted / TaskFailed events + cascade fire.
+        Marking an OUTCOME terminal re-enters ``mark_task_*`` → the
+        task-boundary hook, which the PR 11(c) OUTCOME-skip guard
+        short-circuits, so this does not recurse.
+        """
+        if not transitions:
+            return
+        stamps: list[tuple[str, str]] = [
+            pair for tr in transitions for pair in getattr(tr, "contributes_stamps", ())
+        ]
+        if stamps:
+            try:
+                with channel_processor_active():
+                    plan = session.plan
+                    for discovered_id, outcome_id in stamps:
+                        plan = replace_task(plan, discovered_id, contributes_to=outcome_id)
+                    set_session_plan(session, plan)
+            except Exception as exc:  # noqa: BLE001 — observability stamp
+                log.warning(
+                    "DefaultSteerer: contributes_to stamp raised (swallowed): %s",
+                    exc,
+                )
+        for tr in transitions:
+            try:
+                if tr.new_status is TaskStatus.COMPLETED:
+                    await self._steerer.tasks.mark_task_completed(
+                        tr.task_id,
+                        session=session,
+                        summary=tr.reason,
+                        source="goldfive_outcome_judge",
+                    )
+                elif tr.new_status is TaskStatus.FAILED:
+                    await self._steerer.tasks.mark_task_failed(
+                        tr.task_id,
+                        session=session,
+                        reason=tr.reason,
+                        recoverable=True,
+                        source="goldfive_outcome_judge",
+                    )
+            except Exception as exc:  # noqa: BLE001 — never break the run
+                log.warning(
+                    "DefaultSteerer: outcome transition for %r raised "
+                    "(swallowed): %s",
+                    tr.task_id,
+                    exc,
+                )
 
     # ------------------------------------------------------------------
     # iter-11A: fire-and-forget drift-cascade dispatch.

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -2309,6 +2309,10 @@ class DriftObserver:
                     sink=judge_sink,
                     agent_name=agent_name,
                     available_agents=judge_available_agents,
+                    # AGENCY-PRESERVATION.md PR 11(b) — ledger mode
+                    # re-grounds the judge on goals (primary) with the
+                    # bound task as context.
+                    ledger=self._ledger_mode(),
                 )
             finally:
                 # Restore the live history. Any entries appended by

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -61,6 +61,7 @@ from goldfive.types import (
     Plan,
     Session,
     Task,
+    TaskKind,
     TaskStatus,
     channel_processor_active,
     set_session_plan,
@@ -186,6 +187,54 @@ async def _drain_steerer_at_run_boundary(
             "raised at run boundary (swallowed): %s",
             exc,
         )
+
+
+async def _finalize_outcomes_at_run_boundary(steerer: Any, session: Session) -> None:
+    """Judge + finalize ledger OUTCOME deliverables at the overlay boundary.
+
+    AGENCY-PRESERVATION.md Stage 3 PR 11(c). In ledger plan mode OUTCOME
+    deliverables are never reported by the agent, so goldfive's
+    outcome-progress judge is what makes "run completion = all outcomes
+    terminal" decidable. Called from :meth:`SequentialExecutor._run_overlay`
+    immediately after the passthrough loop breaks and BEFORE the
+    goldfive#208 end-of-overlay PENDING disposition + the fatal-failure
+    gate, so met deliverables land COMPLETED and CONFIDENTLY-unmet ones
+    flow through the existing fatal-failure path (whose ``observation_only``
+    carve-out is already correct). Uncertain deliverables stay PENDING and
+    carry forward like any #208 reachable-PENDING task.
+
+    Duck-typed + ledger-gated inside the steerer: custom steerers without
+    ``finalize_outcomes`` (or forecast mode) fall through cleanly. Awaited
+    so the transitions are visible to the disposition that follows; never
+    blocks run termination.
+    """
+    finalize = getattr(steerer, "finalize_outcomes", None)
+    if not callable(finalize):
+        return
+    try:
+        await finalize(session)
+    except Exception as exc:  # noqa: BLE001 — never block run termination
+        log.warning(
+            "SequentialExecutor: steerer.finalize_outcomes raised at run "
+            "boundary (swallowed): %s",
+            exc,
+        )
+
+
+def _executor_plan_mode(steerer: Any) -> str:
+    """Read ``SteeringConfig.plan_mode`` off the steerer ("forecast"/"ledger").
+
+    AGENCY-PRESERVATION.md PR 11(c). Defensive: any read failure resolves
+    to ``"forecast"`` so the misconfiguration guard never fires
+    spuriously on a custom steerer without a typed config.
+    """
+    try:
+        cfg = getattr(steerer, "_steering_config", None)
+        if cfg is None:
+            return "forecast"
+        return str(getattr(cfg, "plan_mode", "forecast")).strip().lower()
+    except Exception:  # noqa: BLE001
+        return "forecast"
 
 
 _DEFAULT_MAX_NUDGE_REPLAYS: int = 3
@@ -387,7 +436,28 @@ class SequentialExecutor(Executor):
         # duck-typed so third-party AgentAdapter implementations that
         # predate the overlay refactor still work under ``overlay_mode=False``
         # (the caller's choice).
-        if self.overlay_mode and callable(getattr(adapter, "invoke_passthrough", None)):
+        _uses_overlay = self.overlay_mode and callable(
+            getattr(adapter, "invoke_passthrough", None)
+        )
+        if not _uses_overlay and _executor_plan_mode(steerer) == "ledger":
+            # AGENCY-PRESERVATION.md PR 11(c) misconfiguration guard.
+            # Ledger plan mode expects OVERLAY execution: the coordinator
+            # drives and OUTCOME deliverables are never per-task
+            # dispatched. The legacy per-task loop WOULD try to invoke an
+            # assignee-less OUTCOME root. We deliberately do NOT change the
+            # legacy scheduler (forecast risk for zero benefit); instead we
+            # warn loudly so the misconfiguration is visible.
+            log.warning(
+                "SequentialExecutor.run: plan_mode=ledger but the legacy "
+                "per-task loop was selected (overlay_mode=%s, "
+                "invoke_passthrough=%s). Ledger plan mode expects overlay "
+                "execution; OUTCOME deliverables are not per-task "
+                "dispatchable. Use SequentialExecutor(overlay_mode=True) "
+                "with an adapter exposing invoke_passthrough.",
+                self.overlay_mode,
+                callable(getattr(adapter, "invoke_passthrough", None)),
+            )
+        if _uses_overlay:
             return await self._run_overlay(
                 plan=plan,
                 session=session,
@@ -1430,6 +1500,17 @@ class SequentialExecutor(Executor):
                 continue
             break
 
+        # --- Outcome-progress finalize (AGENCY-PRESERVATION.md PR 11c).
+        #     The passthrough loop has ended; in ledger plan mode, judge
+        #     the OUTCOME deliverables now — BEFORE the #208 PENDING
+        #     disposition and the fatal-failure gate below — so met
+        #     deliverables land COMPLETED, CONFIDENTLY-unmet ones become
+        #     FAILED (flowing through the existing fatal-failure path),
+        #     and uncertain ones stay PENDING to carry forward exactly
+        #     like a #208 reachable-PENDING task. Ledger-gated inside the
+        #     steerer; a no-op in forecast mode.
+        await _finalize_outcomes_at_run_boundary(steerer, session)
+
         # --- End-of-overlay PENDING disposition (goldfive#163, revised
         #     by goldfive#208). The tree finished its natural flow; we
         #     now have to decide what to do with PENDING tasks the tree
@@ -2232,14 +2313,26 @@ def _any_failed(plan: Plan) -> bool:
 
 
 def _has_live_pending_or_running(plan: Plan) -> bool:
-    """Return True if the plan has any PENDING or RUNNING task left.
+    """Return True if the plan has any non-OUTCOME PENDING/RUNNING task.
 
     Used by the overlay's nudge-replay gate (goldfive#202): a queued
     nudge should only trigger a re-invoke when there is actually
     outstanding work for the coordinator to do. Guards against replaying
     against a terminated plan.
+
+    AGENCY-PRESERVATION.md PR 11(c): OUTCOME-kind tasks (ledger
+    deliverables) are EXCLUDED. They stay PENDING for the whole run — the
+    agent never works on them directly — so counting them would make this
+    gate perpetually true and strip its discriminating power (it would
+    replay even when no real agent work remains). Only DISCOVERED /
+    forecast tasks count as "live work justifying a replay". A no-op in
+    forecast mode, where no OUTCOME-kind tasks exist.
     """
-    return any(t.status in (TaskStatus.PENDING, TaskStatus.RUNNING) for t in plan.tasks)
+    return any(
+        t.status in (TaskStatus.PENDING, TaskStatus.RUNNING)
+        and getattr(t, "kind", None) is not TaskKind.OUTCOME
+        for t in plan.tasks
+    )
 
 
 def _steerer_should_inject(steerer: Any) -> bool:

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -1147,6 +1147,18 @@ class DefaultSteerer:
     # Protocol-required: transition (generic)
     # ------------------------------------------------------------------
 
+    async def finalize_outcomes(self, session: Session) -> None:
+        """Judge + finalize ledger OUTCOME deliverables at the run boundary.
+
+        AGENCY-PRESERVATION.md Stage 3 PR 11(c). Delegates to
+        :meth:`DriftObserver.finalize_outcomes` (the judge + transition
+        logic lives drift-side); the executor calls this single method at
+        the overlay run boundary, mirroring the
+        ``_drain_steerer_at_run_boundary`` contract. Ledger-gated and
+        quiet on failure — a no-op in forecast mode.
+        """
+        await self.drift.finalize_outcomes(session)
+
     async def transition(
         self,
         task_id: str,

--- a/goldfive/task_state_machine.py
+++ b/goldfive/task_state_machine.py
@@ -267,7 +267,9 @@ class TaskStateMachine:
             source=source,
         )
         # goldfive#219: task boundary is a natural goal-drift checkpoint.
-        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(session)
+        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(
+            session, transitioned_task=task
+        )
 
     async def mark_task_failed(
         self,
@@ -332,7 +334,9 @@ class TaskStateMachine:
             source=source,
         )
         # goldfive#219: task boundary is a natural goal-drift checkpoint.
-        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(session)
+        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(
+            session, transitioned_task=task
+        )
         # Fatal failures cascade downstream via the same primitive used
         # by mark_task_cancelled, so both §6.2 and §6.3 produce the
         # same TaskCancelled event stream and share rejection guards.
@@ -460,7 +464,9 @@ class TaskStateMachine:
         # cascade-cancel downstream tasks share the same rate-limit bucket
         # and will no-op as subsequent boundary fires fall within the
         # 10s guard.
-        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(session)
+        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(
+            session, transitioned_task=task
+        )
         await self.cascade_cancel_downstream(session, task_id, source="cancellation")
 
     async def mark_task_not_needed(
@@ -519,7 +525,9 @@ class TaskStateMachine:
             source=source,
         )
         # goldfive#219: task boundary is a natural goal-drift checkpoint.
-        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(session)
+        await self._steerer.drift._maybe_run_goal_drift_on_task_boundary(
+            session, transitioned_task=task
+        )
 
     async def cascade_cancel_downstream(
         self,

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -75,6 +75,25 @@ def test_task_default_status_round_trip() -> None:
     assert from_pb_task(to_pb_task(t)) == t
 
 
+def test_forecast_task_omits_kind_and_contributes_to_in_json() -> None:
+    """A FORECAST task emits no ``kind`` / ``contributesTo`` JSON keys.
+
+    AGENCY-PRESERVATION.md Stage 3 PR 10/11 carry-over — pins the zicato
+    JSON-emission contract directly (rather than relying on sink-snapshot
+    suites indirectly): in the default forecast plan mode the ledger
+    taxonomy fields are at their proto3 value-0 / empty defaults, so
+    ``MessageToJson`` omits them and forecast-mode JSON output is
+    byte-identical to pre-PR-10. This is the property the cardinal
+    "forecast bit-identical" rule protects.
+    """
+    from google.protobuf.json_format import MessageToJson
+
+    forecast_task = Task(id="t1", title="forecast task")
+    js = MessageToJson(to_pb_task(forecast_task))
+    assert "kind" not in js
+    assert "contributesTo" not in js
+
+
 def test_task_supersedes_string_round_trip_no_char_split() -> None:
     """``Task.supersedes`` survives proto round-trip as a single string.
 

--- a/tests/test_ledger_goal_grounded_judging.py
+++ b/tests/test_ledger_goal_grounded_judging.py
@@ -27,6 +27,10 @@ from goldfive.drift.goals import (  # noqa: E402
     GOAL_DRIFT_GRADUATED_USER_PROMPT_TEMPLATE,
     classify_goal_drift,
 )
+from goldfive.drift.outcome_progress import (  # noqa: E402
+    evaluate_outcome_progress,
+    plan_outcome_transitions,
+)
 from goldfive.drift.reasoning_judge import (  # noqa: E402
     classify_reasoning_drift_with_focus,
 )
@@ -37,6 +41,7 @@ from goldfive.types import (  # noqa: E402
     Plan,
     Task,
     TaskKind,
+    TaskStatus,
 )
 
 
@@ -239,3 +244,175 @@ def test_reasoning_ledger_verdict_shape_unchanged() -> None:
     )
     assert verdict.drift is None
     assert verdict.focused_task_id == "o1"
+
+
+# ---------------------------------------------------------------------------
+# (c) Outcome-progress judge + pure transition planning
+# ---------------------------------------------------------------------------
+
+
+def _outcome_ledger() -> Plan:
+    return Plan(
+        id="p",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=(
+            Task(
+                id="o1",
+                title="Summary delivered",
+                kind=TaskKind.OUTCOME,
+                description="has summary",
+            ),
+            Task(id="o2", title="Translation delivered", kind=TaskKind.OUTCOME),
+            Task(
+                id="d1",
+                title="writer: drafted summary",
+                discovered=True,
+                kind=TaskKind.DISCOVERED,
+                status=TaskStatus.COMPLETED,
+            ),
+        ),
+        edges=(),
+    )
+
+
+def _outcome_llm(payload: str):
+    async def llm(system: str, user: str, model: str) -> str:
+        return payload
+
+    return llm
+
+
+def test_outcome_judge_grades_deliverables_against_evidence() -> None:
+    captured: dict[str, str] = {}
+
+    async def llm(system: str, user: str, model: str) -> str:
+        captured["user"] = user
+        return (
+            '{"outcomes": ['
+            '{"task_id": "o1", "met": true, "reason": "summary present", '
+            '"contributing_task_ids": ["d1"]},'
+            '{"task_id": "o2", "met": false, "reason": "no translation", '
+            '"contributing_task_ids": []}]}'
+        )
+
+    verdicts = asyncio.run(
+        evaluate_outcome_progress(
+            goals=_goals(),
+            plan=_outcome_ledger(),
+            completed_outputs={"d1": "Full summary of the deck: ...."},
+            model="m",
+            call_llm=llm,
+        )
+    )
+    by_id = {v.task_id: v for v in verdicts}
+    assert by_id["o1"].met is True
+    assert by_id["o1"].contributing_task_ids == ("d1",)
+    assert by_id["o2"].met is False
+    # The prompt carried the goals, deliverables, trajectory, and evidence.
+    assert "DELIVERABLES TO JUDGE" in captured["user"]
+    assert "EVIDENCE" in captured["user"]
+    assert "[d1]" in captured["user"]
+
+
+def test_outcome_judge_no_outcome_tasks_skips_llm() -> None:
+    async def boom(system: str, user: str, model: str) -> str:
+        raise AssertionError("must not call the LLM when there are no OUTCOME tasks")
+
+    plan = Plan(
+        id="p", run_id="r", goal_ids=["g"], tasks=(Task(id="f1", title="forecast"),), edges=()
+    )
+    assert (
+        asyncio.run(
+            evaluate_outcome_progress(
+                goals=_goals(), plan=plan, completed_outputs={}, model="m", call_llm=boom
+            )
+        )
+        == []
+    )
+
+
+def test_outcome_judge_quiet_on_malformed_json() -> None:
+    verdicts = asyncio.run(
+        evaluate_outcome_progress(
+            goals=_goals(),
+            plan=_outcome_ledger(),
+            completed_outputs={},
+            model="m",
+            call_llm=_outcome_llm("not json at all"),
+        )
+    )
+    assert verdicts == []
+
+
+def test_outcome_judge_ignores_unknown_outcome_ids() -> None:
+    # A verdict for an id that is not a non-terminal OUTCOME is dropped.
+    verdicts = asyncio.run(
+        evaluate_outcome_progress(
+            goals=_goals(),
+            plan=_outcome_ledger(),
+            completed_outputs={},
+            model="m",
+            call_llm=_outcome_llm(
+                '{"outcomes": [{"task_id": "bogus", "met": true}, '
+                '{"task_id": "o1", "met": true, "contributing_task_ids": ["nope"]}]}'
+            ),
+        )
+    )
+    by_id = {v.task_id: v for v in verdicts}
+    assert set(by_id) == {"o1"}
+    # contributing id "nope" is not a DISCOVERED task → filtered out.
+    assert by_id["o1"].contributing_task_ids == ()
+
+
+def test_plan_transitions_met_completes_and_stamps_contributes_to() -> None:
+    from goldfive.drift.outcome_progress import OutcomeVerdict
+
+    verdicts = [
+        OutcomeVerdict(task_id="o1", met=True, reason="done", contributing_task_ids=("d1",)),
+        OutcomeVerdict(task_id="o2", met=False, reason="not yet"),
+    ]
+    tr = plan_outcome_transitions(_outcome_ledger(), verdicts, run_ending=False)
+    assert len(tr) == 1
+    assert tr[0].task_id == "o1"
+    assert tr[0].new_status is TaskStatus.COMPLETED
+    assert tr[0].contributes_stamps == (("d1", "o1"),)
+
+
+def test_plan_transitions_unmet_fails_only_at_run_end() -> None:
+    from goldfive.drift.outcome_progress import OutcomeVerdict
+
+    verdicts = [OutcomeVerdict(task_id="o2", met=False, reason="no translation")]
+    assert plan_outcome_transitions(_outcome_ledger(), verdicts, run_ending=False) == []
+    tr = plan_outcome_transitions(_outcome_ledger(), verdicts, run_ending=True)
+    assert len(tr) == 1
+    assert tr[0].task_id == "o2"
+    assert tr[0].new_status is TaskStatus.FAILED
+
+
+def test_plan_transitions_predicate_authoritative_blocks_completion() -> None:
+    from goldfive.drift.outcome_progress import OutcomeVerdict
+
+    verdicts = [OutcomeVerdict(task_id="o1", met=True, reason="llm says done")]
+    # User predicate is explicitly unmet → the deterministic predicate
+    # overrides the LLM and the outcome is NOT completed.
+    assert (
+        plan_outcome_transitions(
+            _outcome_ledger(), verdicts, run_ending=False, goal_predicates_met=False
+        )
+        == []
+    )
+
+
+def test_plan_transitions_skips_terminal_outcomes() -> None:
+    from goldfive.drift.outcome_progress import OutcomeVerdict
+
+    plan = Plan(
+        id="p",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=(Task(id="o1", title="done", kind=TaskKind.OUTCOME, status=TaskStatus.COMPLETED),),
+        edges=(),
+    )
+    verdicts = [OutcomeVerdict(task_id="o1", met=False)]
+    assert plan_outcome_transitions(plan, verdicts, run_ending=True) == []

--- a/tests/test_ledger_goal_grounded_judging.py
+++ b/tests/test_ledger_goal_grounded_judging.py
@@ -27,6 +27,9 @@ from goldfive.drift.goals import (  # noqa: E402
     GOAL_DRIFT_GRADUATED_USER_PROMPT_TEMPLATE,
     classify_goal_drift,
 )
+from goldfive.drift.reasoning_judge import (  # noqa: E402
+    classify_reasoning_drift_with_focus,
+)
 from goldfive.types import (  # noqa: E402
     DriftKind,
     DriftSeverity,
@@ -147,3 +150,92 @@ def test_graduated_template_has_three_bands() -> None:
     assert '"progressing": true' in tmpl
     assert '"band": "uncertain"' in tmpl
     assert '"band": "off_track"' in tmpl
+
+
+# ---------------------------------------------------------------------------
+# (b) Reasoning judge re-grounding (goals primary, bound task as context)
+# ---------------------------------------------------------------------------
+
+
+def _reasoning_task() -> Task:
+    return Task(id="o1", title="Summary delivered", kind=TaskKind.OUTCOME)
+
+
+def _on_task_verdict() -> str:
+    return (
+        '{"classification": "on_task", "severity": "info", "reason": "ok", '
+        '"provenance": "none", "focused_task_id": "o1", '
+        '"focus_confidence": 1.0, "stated_intent": "summarising", '
+        '"note_to_agent": ""}'
+    )
+
+
+def test_reasoning_ledger_grounds_goals_primary_task_as_context() -> None:
+    captured: dict[str, str] = {}
+
+    async def llm(system: str, user: str, model: str) -> str:
+        captured["user"] = user
+        return _on_task_verdict()
+
+    asyncio.run(
+        classify_reasoning_drift_with_focus(
+            reasoning="let me summarise the deck",
+            task=_reasoning_task(),
+            goals=_goals(),
+            plan=_ledger_plan(),
+            model="m",
+            call_llm=llm,
+            ledger=True,
+        )
+    )
+    user = captured["user"]
+    # GOALS lead; the bound task is explicitly framed as context only.
+    assert user.index("GOALS") < user.index("CURRENTLY BOUND TASK")
+    assert "PRIMARY reference" in user
+    assert "CONTEXT ONLY" in user
+    assert "LEDGER" in user
+
+
+def test_reasoning_forecast_mode_unchanged_task_first() -> None:
+    captured: dict[str, str] = {}
+
+    async def llm(system: str, user: str, model: str) -> str:
+        captured["user"] = user
+        return _on_task_verdict()
+
+    asyncio.run(
+        classify_reasoning_drift_with_focus(
+            reasoning="let me summarise the deck",
+            task=_reasoning_task(),
+            goals=_goals(),
+            plan=_ledger_plan(),
+            model="m",
+            call_llm=llm,
+            ledger=False,
+        )
+    )
+    user = captured["user"]
+    # Forecast template (pre-PR-11): bound task precedes goals.
+    assert user.index("CURRENTLY BOUND TASK") < user.index("GOALS")
+    assert "PRIMARY reference" not in user
+
+
+def test_reasoning_ledger_verdict_shape_unchanged() -> None:
+    # The ledger template keeps the IDENTICAL verdict JSON shape, so the
+    # parser still produces an on-task (no drift) verdict.
+    async def llm(system: str, user: str, model: str) -> str:
+        return _on_task_verdict()
+
+    verdict = asyncio.run(
+        classify_reasoning_drift_with_focus(
+            reasoning="summarising",
+            task=_reasoning_task(),
+            goals=_goals(),
+            plan=_ledger_plan(),
+            model="m",
+            call_llm=llm,
+            ledger=True,
+        )
+    )
+    assert verdict.drift is None
+    assert verdict.focused_task_id == "o1"

--- a/tests/test_ledger_goal_grounded_judging.py
+++ b/tests/test_ledger_goal_grounded_judging.py
@@ -290,9 +290,9 @@ def test_outcome_judge_grades_deliverables_against_evidence() -> None:
         captured["user"] = user
         return (
             '{"outcomes": ['
-            '{"task_id": "o1", "met": true, "reason": "summary present", '
+            '{"task_id": "o1", "assessment": "met", "reason": "summary present", '
             '"contributing_task_ids": ["d1"]},'
-            '{"task_id": "o2", "met": false, "reason": "no translation", '
+            '{"task_id": "o2", "assessment": "pending", "reason": "not yet", '
             '"contributing_task_ids": []}]}'
         )
 
@@ -307,8 +307,10 @@ def test_outcome_judge_grades_deliverables_against_evidence() -> None:
     )
     by_id = {v.task_id: v for v in verdicts}
     assert by_id["o1"].met is True
+    assert by_id["o1"].assessment == "met"
     assert by_id["o1"].contributing_task_ids == ("d1",)
     assert by_id["o2"].met is False
+    assert by_id["o2"].assessment == "pending"
     # The prompt carried the goals, deliverables, trajectory, and evidence.
     assert "DELIVERABLES TO JUDGE" in captured["user"]
     assert "EVIDENCE" in captured["user"]
@@ -354,8 +356,8 @@ def test_outcome_judge_ignores_unknown_outcome_ids() -> None:
             completed_outputs={},
             model="m",
             call_llm=_outcome_llm(
-                '{"outcomes": [{"task_id": "bogus", "met": true}, '
-                '{"task_id": "o1", "met": true, "contributing_task_ids": ["nope"]}]}'
+                '{"outcomes": [{"task_id": "bogus", "assessment": "met"}, '
+                '{"task_id": "o1", "assessment": "met", "contributing_task_ids": ["nope"]}]}'
             ),
         )
     )
@@ -369,8 +371,10 @@ def test_plan_transitions_met_completes_and_stamps_contributes_to() -> None:
     from goldfive.drift.outcome_progress import OutcomeVerdict
 
     verdicts = [
-        OutcomeVerdict(task_id="o1", met=True, reason="done", contributing_task_ids=("d1",)),
-        OutcomeVerdict(task_id="o2", met=False, reason="not yet"),
+        OutcomeVerdict(
+            task_id="o1", assessment="met", reason="done", contributing_task_ids=("d1",)
+        ),
+        OutcomeVerdict(task_id="o2", assessment="pending", reason="not yet"),
     ]
     tr = plan_outcome_transitions(_outcome_ledger(), verdicts, run_ending=False)
     assert len(tr) == 1
@@ -379,10 +383,11 @@ def test_plan_transitions_met_completes_and_stamps_contributes_to() -> None:
     assert tr[0].contributes_stamps == (("d1", "o1"),)
 
 
-def test_plan_transitions_unmet_fails_only_at_run_end() -> None:
+def test_plan_transitions_confident_fail_only_at_run_end() -> None:
     from goldfive.drift.outcome_progress import OutcomeVerdict
 
-    verdicts = [OutcomeVerdict(task_id="o2", met=False, reason="no translation")]
+    # CONFIDENTLY-unmet ("failed") → FAILED only at run end.
+    verdicts = [OutcomeVerdict(task_id="o2", assessment="failed", reason="user cancelled it")]
     assert plan_outcome_transitions(_outcome_ledger(), verdicts, run_ending=False) == []
     tr = plan_outcome_transitions(_outcome_ledger(), verdicts, run_ending=True)
     assert len(tr) == 1
@@ -390,10 +395,19 @@ def test_plan_transitions_unmet_fails_only_at_run_end() -> None:
     assert tr[0].new_status is TaskStatus.FAILED
 
 
+def test_plan_transitions_pending_never_fails_even_at_run_end() -> None:
+    from goldfive.drift.outcome_progress import OutcomeVerdict
+
+    # #208 carry-forward: not-yet-met ("pending") is NOT failed at run end
+    # — it stays PENDING for the next turn.
+    verdicts = [OutcomeVerdict(task_id="o2", assessment="pending", reason="still working")]
+    assert plan_outcome_transitions(_outcome_ledger(), verdicts, run_ending=True) == []
+
+
 def test_plan_transitions_predicate_authoritative_blocks_completion() -> None:
     from goldfive.drift.outcome_progress import OutcomeVerdict
 
-    verdicts = [OutcomeVerdict(task_id="o1", met=True, reason="llm says done")]
+    verdicts = [OutcomeVerdict(task_id="o1", assessment="met", reason="llm says done")]
     # User predicate is explicitly unmet → the deterministic predicate
     # overrides the LLM and the outcome is NOT completed.
     assert (
@@ -414,5 +428,5 @@ def test_plan_transitions_skips_terminal_outcomes() -> None:
         tasks=(Task(id="o1", title="done", kind=TaskKind.OUTCOME, status=TaskStatus.COMPLETED),),
         edges=(),
     )
-    verdicts = [OutcomeVerdict(task_id="o1", met=False)]
+    verdicts = [OutcomeVerdict(task_id="o1", assessment="failed")]
     assert plan_outcome_transitions(plan, verdicts, run_ending=True) == []

--- a/tests/test_ledger_goal_grounded_judging.py
+++ b/tests/test_ledger_goal_grounded_judging.py
@@ -1,0 +1,149 @@
+"""Goal-grounded judging in ledger mode (AGENCY-PRESERVATION.md Stage 3 PR 11).
+
+New, ledger-gated judging behaviour. Forecast mode is unchanged (the
+existing goal-drift / reasoning-judge suites pass unmodified); these
+tests exercise only the additive ledger surface:
+
+* (a) ``classify_goal_drift(graduated=True)`` — three-band verdict so
+  WARNING (``uncertain``) can fire before CRITICAL (``off_track``), with
+  the plan rendered as a kind-annotated LEDGER. Forecast mode
+  (``graduated=False``) keeps the binary / always-CRITICAL behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.drift.goals import (  # noqa: E402
+    GOAL_DRIFT_GRADUATED_USER_PROMPT_TEMPLATE,
+    classify_goal_drift,
+)
+from goldfive.types import (  # noqa: E402
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Task,
+    TaskKind,
+)
+
+
+def _ledger_plan() -> Plan:
+    return Plan(
+        id="p",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=(
+            Task(id="o1", title="Summary delivered", kind=TaskKind.OUTCOME),
+            Task(
+                id="d1",
+                title="reviewer: drafted notes",
+                discovered=True,
+                kind=TaskKind.DISCOVERED,
+            ),
+        ),
+        edges=(),
+    )
+
+
+def _goals() -> list[Goal]:
+    return [Goal(id="g", summary="summarise the deck")]
+
+
+def _run(call_llm, *, graduated: bool):
+    return asyncio.run(
+        classify_goal_drift(
+            goals=_goals(),
+            plan=_ledger_plan(),
+            observed_actions=[],
+            model="m",
+            call_llm=call_llm,
+            graduated=graduated,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) Graduated goal-drift
+# ---------------------------------------------------------------------------
+
+
+def test_graduated_uncertain_band_fires_warning() -> None:
+    captured: dict[str, str] = {}
+
+    async def llm(system: str, user: str, model: str) -> str:
+        captured["user"] = user
+        return (
+            '{"progressing": false, "band": "uncertain", '
+            '"reason": "connection to the goal is unclear", '
+            '"note_to_agent": "Does the current approach still serve goal X?"}'
+        )
+
+    drift = _run(llm, graduated=True)
+    assert drift is not None
+    assert drift.kind is DriftKind.GOAL_DRIFT
+    assert drift.severity is DriftSeverity.WARNING  # fires BEFORE critical
+    assert drift.note_to_agent  # judge authored the advisory note
+    # The graduated prompt renders the plan as a kind-annotated LEDGER.
+    assert "LEDGER" in captured["user"]
+    assert "OUTCOME" in captured["user"]
+    assert "DISCOVERED" in captured["user"]
+
+
+def test_graduated_off_track_band_fires_critical() -> None:
+    async def llm(system: str, user: str, model: str) -> str:
+        return '{"progressing": false, "band": "off_track", "reason": "looping"}'
+
+    drift = _run(llm, graduated=True)
+    assert drift is not None
+    assert drift.severity is DriftSeverity.CRITICAL
+
+
+def test_graduated_missing_band_degrades_to_critical() -> None:
+    # A graduated judge that omits the band must NOT silently soften below
+    # the legacy CRITICAL default.
+    async def llm(system: str, user: str, model: str) -> str:
+        return '{"progressing": false, "reason": "off"}'
+
+    drift = _run(llm, graduated=True)
+    assert drift is not None
+    assert drift.severity is DriftSeverity.CRITICAL
+
+
+def test_graduated_progressing_emits_no_drift() -> None:
+    async def llm(system: str, user: str, model: str) -> str:
+        return '{"progressing": true}'
+
+    assert _run(llm, graduated=True) is None
+
+
+def test_forecast_mode_unchanged_binary_critical() -> None:
+    captured: dict[str, str] = {}
+
+    async def llm(system: str, user: str, model: str) -> str:
+        captured["user"] = user
+        return '{"progressing": false, "reason": "off-topic"}'
+
+    drift = _run(llm, graduated=False)
+    assert drift is not None
+    assert drift.severity is DriftSeverity.CRITICAL  # always critical, pre-PR-11
+    # Forecast prompt is the binary template — no LEDGER framing.
+    assert "LEDGER" not in captured["user"]
+
+
+def test_graduated_template_has_three_bands() -> None:
+    # Belt-and-suspenders: the graduated template must offer all three
+    # verdict shapes so the judge can express the WARNING band.
+    tmpl = GOAL_DRIFT_GRADUATED_USER_PROMPT_TEMPLATE
+    assert '"progressing": true' in tmpl
+    assert '"band": "uncertain"' in tmpl
+    assert '"band": "off_track"' in tmpl

--- a/tests/test_ledger_outcome_wiring.py
+++ b/tests/test_ledger_outcome_wiring.py
@@ -1,0 +1,296 @@
+"""Outcome-progress WIRING in ledger mode (AGENCY-PRESERVATION.md PR 11c).
+
+Covers the observer/executor wiring of the outcome-progress judge:
+
+* ``DriftObserver.finalize_outcomes`` (run-end): met → COMPLETED,
+  CONFIDENTLY-unmet → FAILED, uncertain → stays PENDING (carry forward),
+  with ``contributes_to`` stamped onto the named DISCOVERED tasks;
+* forecast mode is a no-op (the judge LLM is never called);
+* re-entrancy guard: the task-boundary cadence does NOT fire on OUTCOME
+  transitions (the "outcome COMPLETED → boundary → no second judge"
+  shape);
+* single-in-flight guard on the fire-and-forget task-boundary judge;
+* the executor's ``_has_live_pending_or_running`` ignores OUTCOME tasks;
+* ``_executor_plan_mode`` reads the steerer config for the
+  ledger+overlay_mode=False misconfiguration warning.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskKind,
+    TaskStatus,
+)
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class _NullPlanner:
+    async def generate(self, *, goals: Any, available_agents: Any, context: Any = None) -> Any:
+        return None
+
+    async def refine(self, *, plan: Any, drift: Any, goals: Any) -> Any:
+        return None
+
+
+def _make_steerer(*, plan_mode: str, judge_llm: Any, calls: list[str] | None = None):
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(observation_only=False, plan_mode=plan_mode),
+        goal_drift_call_llm=judge_llm,
+        goal_drift_model="m",
+    )
+    steerer.bind(sinks=[_ListSink()], planner=_NullPlanner())
+    return steerer
+
+
+def _ledger_session() -> Session:
+    plan = Plan(
+        id="p",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=(
+            Task(id="o1", title="Summary delivered", kind=TaskKind.OUTCOME),
+            Task(id="o2", title="Translation delivered", kind=TaskKind.OUTCOME),
+            Task(
+                id="d1",
+                title="writer: drafted summary",
+                discovered=True,
+                kind=TaskKind.DISCOVERED,
+                status=TaskStatus.COMPLETED,
+            ),
+        ),
+        edges=(),
+        revision_index=1,
+    )
+    session = Session(
+        run_id="r",
+        goals=[Goal(id="g", summary="summarise + translate")],
+        plan=plan,
+    )
+    session.completed_outputs["d1"] = "Full summary of the deck: ...."
+    return session
+
+
+def _judge(payload: str, calls: list[str] | None = None):
+    async def llm(system: str, user: str, model: str) -> str:
+        if calls is not None:
+            calls.append(user)
+        return payload
+
+    return llm
+
+
+# ---------------------------------------------------------------------------
+# finalize_outcomes — run-end transitions
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_outcomes_completes_met_and_stamps_contributes_to() -> None:
+    payload = (
+        '{"outcomes": ['
+        '{"task_id": "o1", "assessment": "met", "reason": "summary present", '
+        '"contributing_task_ids": ["d1"]},'
+        '{"task_id": "o2", "assessment": "pending", "reason": "not yet"}]}'
+    )
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=_judge(payload))
+    session = _ledger_session()
+
+    asyncio.run(steerer.finalize_outcomes(session))
+
+    by_id = {t.id: t for t in session.plan.tasks}
+    assert by_id["o1"].status is TaskStatus.COMPLETED  # met → COMPLETED
+    assert by_id["o2"].status is TaskStatus.PENDING  # pending → carries forward
+    # contributes_to stamped onto the DISCOVERED task that produced o1.
+    assert by_id["d1"].contributes_to == "o1"
+
+
+def test_finalize_outcomes_fails_confidently_unmet() -> None:
+    payload = (
+        '{"outcomes": [{"task_id": "o2", "assessment": "failed", '
+        '"reason": "user cancelled the translation"}]}'
+    )
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=_judge(payload))
+    session = _ledger_session()
+
+    asyncio.run(steerer.finalize_outcomes(session))
+
+    by_id = {t.id: t for t in session.plan.tasks}
+    assert by_id["o2"].status is TaskStatus.FAILED  # confident-fail → FAILED at run end
+    assert by_id["o1"].status is TaskStatus.PENDING  # untouched (no verdict)
+
+
+def test_finalize_outcomes_forecast_mode_is_noop() -> None:
+    calls: list[str] = []
+
+    async def boom(system: str, user: str, model: str) -> str:
+        calls.append(user)
+        raise AssertionError("forecast mode must not invoke the outcome judge")
+
+    steerer = _make_steerer(plan_mode="forecast", judge_llm=boom)
+    session = _ledger_session()
+
+    asyncio.run(steerer.finalize_outcomes(session))
+
+    assert calls == []  # judge never called
+    # No transitions in forecast mode.
+    assert all(
+        t.status in (TaskStatus.PENDING, TaskStatus.COMPLETED)
+        for t in session.plan.tasks
+    )
+    assert {t.id: t.status for t in session.plan.tasks}["o1"] is TaskStatus.PENDING
+
+
+def test_finalize_outcomes_no_outcome_tasks_skips_judge() -> None:
+    calls: list[str] = []
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=_judge("{}", calls))
+    session = Session(
+        run_id="r",
+        goals=[Goal(id="g", summary="x")],
+        plan=Plan(
+            id="p",
+            run_id="r",
+            goal_ids=["g"],
+            tasks=(Task(id="f1", title="forecast"),),
+            edges=(),
+        ),
+    )
+    asyncio.run(steerer.finalize_outcomes(session))
+    assert calls == []  # no OUTCOME tasks → judge short-circuits before the LLM
+
+
+# ---------------------------------------------------------------------------
+# Re-entrancy + single-in-flight guards
+# ---------------------------------------------------------------------------
+
+
+def test_task_boundary_skips_outcome_transitions_no_judge() -> None:
+    # The exact loop shape: an OUTCOME task transition must NOT fire the
+    # task-boundary cadence (goal-drift OR outcome-progress) — otherwise
+    # marking an OUTCOME COMPLETED would re-judge → re-mark → loop.
+    calls: list[str] = []
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=_judge("{}", calls))
+    session = _ledger_session()
+    outcome_task = next(t for t in session.plan.tasks if t.id == "o1")
+
+    async def go() -> None:
+        await steerer.drift._maybe_run_goal_drift_on_task_boundary(
+            session, transitioned_task=outcome_task
+        )
+        # Nothing was spawned: no goal-drift judge, no outcome-progress.
+        assert len(steerer._background_judges) == 0
+        assert getattr(session, "_outcome_progress_inflight", False) is False
+
+    asyncio.run(go())
+    assert calls == []
+
+
+def test_task_boundary_on_discovered_transition_spawns() -> None:
+    # A non-OUTCOME (DISCOVERED) transition DOES fire the cadence.
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=_judge("{}"))
+    session = _ledger_session()
+    discovered = next(t for t in session.plan.tasks if t.id == "d1")
+
+    async def go() -> None:
+        await steerer.drift._maybe_run_goal_drift_on_task_boundary(
+            session, transitioned_task=discovered
+        )
+        # Background judges were spawned (goal-drift + outcome-progress).
+        assert len(steerer._background_judges) >= 1
+        # Drain so the test doesn't leak tasks.
+        await steerer.drift.drain_session_background_tasks(session_id=session.id)
+
+    asyncio.run(go())
+
+
+def test_single_in_flight_guard_blocks_second_outcome_judge() -> None:
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=_judge("{}"))
+    session = _ledger_session()
+
+    async def go() -> None:
+        # Mark a judge already in-flight; a second spawn must no-op.
+        session._outcome_progress_inflight = True
+        steerer.drift._spawn_outcome_progress_background(session)
+        assert len(steerer._background_judges) == 0
+
+    asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# Executor helpers
+# ---------------------------------------------------------------------------
+
+
+def test_has_live_pending_ignores_outcome_tasks() -> None:
+    from goldfive.executors.sequential import _has_live_pending_or_running
+
+    # ONLY a PENDING OUTCOME task → not "live work" (would loop the
+    # nudge-replay gate forever otherwise).
+    only_outcome = Plan(
+        id="p",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=(Task(id="o1", title="deliverable", kind=TaskKind.OUTCOME),),
+        edges=(),
+    )
+    assert _has_live_pending_or_running(only_outcome) is False
+
+    # A PENDING DISCOVERED task IS live work.
+    with_discovered = Plan(
+        id="p",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=(
+            Task(id="o1", title="deliverable", kind=TaskKind.OUTCOME),
+            Task(id="d1", title="agent work", discovered=True, kind=TaskKind.DISCOVERED),
+        ),
+        edges=(),
+    )
+    assert _has_live_pending_or_running(with_discovered) is True
+
+    # Forecast plan unaffected: a PENDING forecast task is live.
+    forecast = Plan(
+        id="p",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=(Task(id="f1", title="forecast task"),),
+        edges=(),
+    )
+    assert _has_live_pending_or_running(forecast) is True
+
+
+def test_executor_plan_mode_reads_steerer_config() -> None:
+    from goldfive.executors.sequential import _executor_plan_mode
+
+    ledger = _make_steerer(plan_mode="ledger", judge_llm=_judge("{}"))
+    forecast = _make_steerer(plan_mode="forecast", judge_llm=_judge("{}"))
+    assert _executor_plan_mode(ledger) == "ledger"
+    assert _executor_plan_mode(forecast) == "forecast"
+    # Defensive: a steerer without a typed config → forecast.
+    assert _executor_plan_mode(object()) == "forecast"

--- a/tests/test_task_state_machine.py
+++ b/tests/test_task_state_machine.py
@@ -95,7 +95,13 @@ class _StubDrift:
     ) -> None:
         self.spawn_drift_calls.append((drift, session))
 
-    async def _maybe_run_goal_drift_on_task_boundary(self, session: Session) -> None:
+    async def _maybe_run_goal_drift_on_task_boundary(
+        self, session: Session, transitioned_task: Any = None
+    ) -> None:
+        # AGENCY-PRESERVATION.md PR 11(c): mirror the production
+        # signature, which gained an optional ``transitioned_task`` so the
+        # boundary cadence can skip OUTCOME-kind transitions. Interface
+        # sync only — no behavioural assertion changes.
         self.goal_drift_boundary_calls += 1
 
 


### PR DESCRIPTION
Stage 3 PR 11 of the AGENCY-PRESERVATION roadmap — goal-grounded judging. All three parts complete and wired. Every new path is ledger-gated; forecast mode is byte-identical and existing suites pass unmodified. Rebased onto latest `agency-preservation` (includes PR 6). **Full suite 3061 passed, 59 skipped.**

## What landed

**(a) Graduated goal-drift** (`drift/goals.py`). `classify_goal_drift(graduated=False)`; in ledger mode the DriftObserver passes `graduated=True` → a three-band verdict (`progressing` → no drift; band `uncertain` → **WARNING**, the early proportional signal; band `off_track` → CRITICAL), plan rendered as a kind-annotated **LEDGER**, question-form notes preferred for `uncertain`. The ladder already maps `GOAL_DRIFT@WARNING`, so no ladder change. Forecast keeps the binary/always-CRITICAL prompt; a missing band degrades safely to CRITICAL.

**(b) Reasoning judge re-grounded** (`drift/reasoning_judge.py` via `drift/reasoning.py`). `classify_reasoning_drift_with_focus(ledger=False)`; in ledger mode GOALS are primary and the bound task is CONTEXT (the agent's own observed intent — a different decomposition/sub-agent/order stays `on_task` as long as the goals are served). Verdict JSON shape identical → parser unchanged. Forecast prompt byte-identical.

**(c) Outcome-progress judge** (`drift/outcome_progress.py`, new + wired). Lets "run completion = all outcomes terminal" be decided **without agent cooperation**.
- `evaluate_outcome_progress()` — one cost-bounded LLM call grading non-terminal OUTCOME tasks against the GOALS, evidence = `session.completed_outputs` (goldfive#447) + DISCOVERED trajectory; quiet on failure; validates ids against the live plan.
- `plan_outcome_transitions()` — PURE; **3-state** verdict.
- **Wiring**: task-boundary cadence (fire-and-forget, completes MET deliverables as achieved) + run-end `finalize_outcomes` (awaited, in `_run_overlay` before the #208 disposition + fatal-failure gate). `contributes_to` stamped on the named DISCOVERED tasks. User goal predicates remain authoritative.

## Per the team-lead's fork rulings

- **Run-end hook**: `_finalize_outcomes_at_run_boundary(steerer, session)` in `_run_overlay`, after the passthrough break and BEFORE the goldfive#208 PENDING disposition + `_fatally_failed_task_ids` (mirrors `_drain_steerer_at_run_boundary`). Met → COMPLETED lands; CONFIDENTLY-unmet → FAILED flows through the existing fatal-failure gate (whose `observation_only` carve-out is already correct).
- **Semantic deviation from the doc (cite goldfive#208)**: the doc's "unmet at exit → FAILED" is too aggressive — a run end is usually just a turn boundary, and OUTCOME roots are always reachable. So the verdict is narrowed to 3 states: `met` → COMPLETED; **CONFIDENTLY-unmet** (`failed`: goal contradicted / cannot be met) → FAILED at run end only; not-yet/uncertain (`pending`) → leave PENDING to carry forward like a #208 reachable-PENDING task. Dormancy-respecting — goldfive does not manufacture failure verdicts at every turn boundary.
- **Scheduling**: NO `_pick_next_task` change (overlay never dispatches per-task). `_has_live_pending_or_running` ignores OUTCOME-kind tasks (else the nudge-replay gate is perpetually true; no-op in forecast). `log.warning` at `run()` entry on `ledger + overlay_mode=False` misconfiguration (the legacy per-task loop would dispatch an assignee-less OUTCOME root — we warn, don't touch the scheduler).
- **Re-entrancy guard**: `_maybe_run_goal_drift_on_task_boundary` gains an optional `transitioned_task`; OUTCOME-kind transitions skip the whole cadence (outcome transitions are judge-authored bookkeeping — this breaks the mark-COMPLETED → boundary → re-judge loop in both cadences). Plus a session-keyed single-in-flight guard on the fire-and-forget judge. The 4 `mark_task_*` sites pass `transitioned_task=task`; the test's `_StubDrift` mirrors the optional kwarg (interface sync, no assertion change).
- **observation_only**: transitions land (observational status recording, #258-class carve-out); judges run; nothing dispatched.

## §5 correctness

- Every new path ledger-gated; forecast mode byte-identical. Existing goal-drift (113) + reasoning/judge (278) + task-state-machine suites pass unmodified. Full suite **3061 passed, 59 skipped**, ruff clean.
- All judges keep the "quiet on failure" contract.
- No regex NL classification; kind taxonomy is explicit fields; verdict ids validated against the live plan.

## Tests
- `tests/test_conv.py`: forecast-task JSON omission (carry-over).
- `tests/test_ledger_goal_grounded_judging.py`: graduated bands (a), reasoning re-grounding + forecast control (b), outcome judge + 3-state pure transitions + predicate-authority + run-end-only-FAIL (c).
- `tests/test_ledger_outcome_wiring.py`: finalize transitions, forecast no-op, re-entrancy (outcome COMPLETED → boundary → no second judge), single-in-flight, `_has_live_pending` ignores OUTCOME, plan-mode read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)