### PR TITLE
refactor(bench): exclude delivery transport from shadow-diff divergence set (PR 13a follow-up)

### DIFF
--- a/bench/shadow_diff.py
+++ b/bench/shadow_diff.py
@@ -21,8 +21,13 @@ Two modes
   deliveries across the logs by a stable cross-run key
   ``(kind, task_id, occurrence#)`` — drift ids are per-run minted, so they
   are NOT used as the join key (the project's stable-keys discipline) —
-  and reports, per drift, exactly how the two regimes' decisions differ,
-  plus drifts that fired in only one regime.
+  and reports, per drift, exactly how the two regimes' *decisions* differ,
+  plus drifts that fired in only one regime. The delivery ``channel`` /
+  ``channel_action`` are per-regime *transport identity* (since PR 6 the new
+  regime always rides ``request_context`` and the legacy regime
+  ``nudge_replay``), so they are reported informationally but excluded from
+  the divergence-driving comparison — otherwise every aligned key would
+  trivially "diverge" on transport and drown the real decision divergences.
 * **single-log (census)** — one positional ``LOG.jsonl``: a per-event
   legacy-would-do vs. new-would-do derivation from each delivery's own
   ``decision`` payload, plus a census of channels / ladder levels /
@@ -77,16 +82,33 @@ class ShadowDiffError(RuntimeError):
 # defines *what a regime would do* to the agent. Prose (``note_text``) is
 # deliberately excluded from the divergence set — §5.4 diffs decisions, not
 # wording — but is retained on the record for the human-readable detail.
+#
+# ``channel`` / ``channel_action`` are deliberately NOT here: they are
+# per-regime *transport identity*, not a steering decision. Since PR 6 the new
+# regime always rides ``request_context`` and the legacy regime always rides
+# ``nudge_replay`` (``channel_action`` enqueued vs. queued), so EVERY aligned
+# key would trivially differ on them — that noise would swamp the real decision
+# divergences (``would_cancel_inflight``, ``ladder_level``, plan-swap targets)
+# the §5.4 review exists to surface. They live in :data:`_TRANSPORT_FIELDS`
+# instead, shown informationally per key but never counted as a divergence.
 _DECISION_FIELDS: tuple[str, ...] = (
-    "channel",
     "ladder_level",
     "would_cancel_inflight",
-    "channel_action",
     "promotion",
     "superseded_task_ids",
     "replacement_task_ids",
     "dry_run",
 )
+
+#: Per-regime transport identity — which delivery channel carried the signal.
+#: Reported informationally (a transport line on each key) but excluded from
+#: the divergence-driving comparison; a key that differs ONLY here is NOT a
+#: decision divergence (AGENCY-PRESERVATION.md §5.4 diffs decisions).
+_TRANSPORT_FIELDS: tuple[str, ...] = ("channel", "channel_action")
+
+#: All fields surfaced in a record's comparable projection (decision +
+#: transport), so the rendered report can still show channel/channel_action.
+_VIEW_FIELDS: tuple[str, ...] = _DECISION_FIELDS + _TRANSPORT_FIELDS
 
 
 @dataclasses.dataclass
@@ -106,9 +128,9 @@ class SignalRecord:
     decision: dict[str, Any]
 
     def decision_view(self) -> dict[str, Any]:
-        """The comparable (kind-agnostic) projection used for diffing."""
+        """The comparable projection (decision + transport fields) for diffing."""
         view: dict[str, Any] = {}
-        for field in _DECISION_FIELDS:
+        for field in _VIEW_FIELDS:
             if field == "channel":
                 view[field] = self.channel
             elif field == "dry_run":
@@ -131,10 +153,20 @@ class KeyDivergence:
     legacy: dict[str, Any] | None
     new: dict[str, Any] | None
     diverged_fields: list[str]
+    #: Per-regime transport fields (channel / channel_action) that differ.
+    #: Informational only — a key that differs ONLY here is NOT ``diverged``.
+    transport_fields: list[str] = dataclasses.field(default_factory=list)
 
     @property
     def diverged(self) -> bool:
         return self.present_in != "both" or bool(self.diverged_fields)
+
+    @property
+    def transport_only(self) -> bool:
+        """True iff the key differs ONLY in transport (not a decision divergence)."""
+        return self.present_in == "both" and not self.diverged_fields and bool(
+            self.transport_fields
+        )
 
 
 @dataclasses.dataclass
@@ -163,6 +195,11 @@ class DivergenceReport:
     def field_divergences(self) -> list[KeyDivergence]:
         return [k for k in self.keys if k.present_in == "both" and k.diverged_fields]
 
+    @property
+    def transport_only_keys(self) -> list[KeyDivergence]:
+        """Keys that differ ONLY in transport (channel) — informational, not divergences."""
+        return [k for k in self.keys if k.transport_only]
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "legacy_path": self.legacy_path,
@@ -174,6 +211,7 @@ class DivergenceReport:
             "legacy_only": len(self.legacy_only),
             "new_only": len(self.new_only),
             "field_divergences": len(self.field_divergences),
+            "transport_only_keys": len(self.transport_only_keys),
             "keys": [dataclasses.asdict(k) for k in self.keys],
         }
 
@@ -291,6 +329,7 @@ def diff_two_logs(
             lview = lrec.decision_view()
             nview = nrec.decision_view()
             diverged = [f for f in _DECISION_FIELDS if lview.get(f) != nview.get(f)]
+            transport = [f for f in _TRANSPORT_FIELDS if lview.get(f) != nview.get(f)]
             keys.append(
                 KeyDivergence(
                     kind=kind,
@@ -300,6 +339,7 @@ def diff_two_logs(
                     legacy=lview,
                     new=nview,
                     diverged_fields=diverged,
+                    transport_fields=transport,
                 )
             )
         elif lrec is not None:
@@ -350,12 +390,17 @@ def render_two_log_text(report: DivergenceReport) -> str:
     lines.append(f"  decision-field diffs:    {len(report.field_divergences)}")
     lines.append(f"  legacy-only (new silent):{len(report.legacy_only)}")
     lines.append(f"  new-only (legacy silent):{len(report.new_only)}")
+    lines.append(
+        f"  transport-only (channel): {len(report.transport_only_keys)}  "
+        "(per-regime transport, not a divergence)"
+    )
     lines.append("-" * 64)
 
     if not report.diverged_keys:
-        lines.append("VERDICT: no divergence — the two regimes' decisions are identical")
-        lines.append("on this traffic. (Expected before the behavior PRs land; once")
-        lines.append("PR 7's ladder restructure merges, ladder_level diffs appear here.)")
+        lines.append("VERDICT: no decision divergence — the two regimes' steering")
+        lines.append("decisions are identical on this traffic (transport channel aside).")
+        lines.append("(Expected before the behavior PRs land; once PR 7's ladder")
+        lines.append("restructure merges, ladder_level diffs appear here.)")
         return "\n".join(lines)
 
     lines.append(f"VERDICT: {len(report.diverged_keys)} drift key(s) diverge — review below.")
@@ -367,6 +412,11 @@ def render_two_log_text(report: DivergenceReport) -> str:
             for field in kd.diverged_fields:
                 lines.append(
                     f"    {field}: legacy={kd.legacy.get(field)!r}  ->  new={kd.new.get(field)!r}"
+                )
+            for field in kd.transport_fields:
+                lines.append(
+                    f"    [transport] {field}: legacy={kd.legacy.get(field)!r}  ->  "
+                    f"new={kd.new.get(field)!r}  (informational)"
                 )
         elif kd.present_in == "legacy_only":
             lines.append(

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -187,6 +187,13 @@ merged divergence: a CRITICAL goldfive-authored `OFF_TOPIC` drift cancels
 in-flight work under `cancel_inflight_scope=all` (legacy) but not under
 `user_and_safety` (new) — the PR-1 authority split — so the report reads
 `would_cancel_inflight: legacy=True -> new=False`. Once the behavior PRs
-merge, `ladder_level` and channel divergences appear in the same report.
-The reviewed two-log report is the **exit criterion** for enabling any
-behavior PR (§5.4, §5.8).
+merge, `ladder_level` divergences appear in the same report.
+
+The delivery **transport** — `channel` (`nudge_replay` vs.
+`request_context` since PR 6) and `channel_action` — is per-regime
+identity, not a steering decision, so it is reported *informationally*
+(a `[transport]` line plus a `transport-only` count) but **excluded** from
+the divergence-driving comparison; otherwise every aligned key would
+trivially "diverge" on transport and drown the real decision divergences
+the review exists to surface. The reviewed two-log report is the **exit
+criterion** for enabling any behavior PR (§5.4, §5.8).

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -4462,9 +4462,11 @@ class DriftObserver:
         # cancel write-paths are gated), so ``channel_action="queued"`` records
         # that mechanical truth while ``dry_run`` tracks shadow-mode for the
         # §5.4 divergence report. PR 6's request_context channel routes through
-        # the gated observer-note queue and the asymmetry goes away (the note
-        # is delivered — and SignalDelivered emitted — only when a surface
-        # actually renders it, under ``_should_inject``).
+        # the gated observer-note queue: SignalDelivered is emitted once HERE at
+        # the dispatch decision point (the PR-5 model the §5.4 diff is built on),
+        # and a delivery surface later RENDERS the note exactly-once under
+        # ``_should_inject`` — rendering at a surface does NOT emit a second
+        # event; ``dry_run`` records whether the note actually reaches the agent.
         await self._route_corrective_note(session, drift, msg, ladder_level="nudge")
 
     async def _dispatch_goldfive_steer_control(

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -46,6 +46,7 @@ from bench.harness import (  # noqa: E402
 )
 from bench.shadow_diff import (  # noqa: E402
     ShadowDiffError,
+    SignalRecord,
     diff_two_logs,
     load_signals,
     render_two_log_text,
@@ -160,15 +161,18 @@ async def test_shadow_diff_surfaces_cancel_authority_divergence(tmp_path: Path) 
     assert kd.legacy["would_cancel_inflight"] is True
     assert kd.new["would_cancel_inflight"] is False
 
-    # The looping WARNING key never cancels under either regime, so it does
-    # NOT diverge on the cancel-authority dimension this test pins. (Since
-    # AGENCY-PRESERVATION.md PR 6 it DOES diverge on ``channel`` — the signal
-    # arm rides the new ``request_context`` observer-note channel while the
-    # legacy arm rides ``nudge_replay`` — which is the expected per-regime
-    # transport difference, not a cancel-authority divergence.)
+    # The looping WARNING key never cancels under either regime, so it is NOT
+    # a decision divergence. Since PR 6 it DOES ride a different transport (the
+    # signal arm rides ``request_context``, the legacy arm ``nudge_replay``) —
+    # but channel/channel_action are per-regime transport identity, excluded
+    # from the divergence-driving set, so the key reports as transport-only,
+    # not diverged.
     looping = [k for k in report.keys if k.kind == "looping_tool_call"]
     assert looping
     assert "would_cancel_inflight" not in looping[0].diverged_fields
+    assert not looping[0].diverged
+    assert looping[0].transport_only
+    assert "channel" in looping[0].transport_fields
 
     # The rendered report names the divergence (the reviewed §5.4 artifact).
     text = render_two_log_text(report)
@@ -192,6 +196,67 @@ async def test_single_log_census(tmp_path: Path) -> None:
     # In the legacy log the OFF_TOPIC delivery would cancel in-flight work,
     # so its single-event legacy-vs-new derivation diverges.
     assert any(d["kind"] == "off_topic" for d in census["diverging_events"])
+
+
+# ---------------------------------------------------------------------------
+# 4b. Transport (channel/channel_action) is excluded from decision divergence
+# ---------------------------------------------------------------------------
+
+
+def _rec(seq: int, *, channel: str, channel_action: str, **decision: object) -> SignalRecord:
+    dec = {"channel_action": channel_action, **decision}
+    return SignalRecord(
+        sequence=seq,
+        drift_id=f"d{seq}",
+        kind="off_topic",
+        task_id="t0",
+        channel=channel,
+        severity="warning",
+        turn=1,
+        dry_run=True,
+        ladder_level=str(decision.get("ladder_level", "nudge")),
+        note_text="",
+        decision=dec,
+    )
+
+
+def test_channel_difference_alone_is_transport_not_divergence() -> None:
+    """A key differing ONLY in channel/channel_action is transport-only."""
+    legacy = [
+        _rec(1, channel="nudge_replay", channel_action="queued", would_cancel_inflight=False)
+    ]
+    new = [
+        _rec(1, channel="request_context", channel_action="enqueued", would_cancel_inflight=False)
+    ]
+    report = diff_two_logs(legacy, new)
+    kd = report.keys[0]
+    assert not kd.diverged
+    assert kd.transport_only
+    assert set(kd.transport_fields) == {"channel", "channel_action"}
+    assert report.diverged_keys == []
+    assert len(report.transport_only_keys) == 1
+    # The verdict reflects "no decision divergence" despite the transport swap.
+    text = render_two_log_text(report)
+    assert "no decision divergence" in text
+    assert "transport-only (channel): 1" in text
+
+
+def test_real_decision_divergence_survives_transport_difference() -> None:
+    """A genuine decision diff (would_cancel_inflight) still diverges even when
+    the channel also differs — transport never masks a real divergence."""
+    legacy = [
+        _rec(1, channel="nudge_replay", channel_action="queued", would_cancel_inflight=True)
+    ]
+    new = [
+        _rec(1, channel="request_context", channel_action="enqueued", would_cancel_inflight=False)
+    ]
+    report = diff_two_logs(legacy, new)
+    kd = report.keys[0]
+    assert kd.diverged
+    assert "would_cancel_inflight" in kd.diverged_fields
+    # channel still differs, recorded as informational transport (not masking).
+    assert "channel" in kd.transport_fields
+    assert not kd.transport_only  # it IS a real divergence, not transport-only
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

A small, standalone follow-up to the §5.4 shadow-diff tool (PR 13a, #461), arising from the PR 6 (#462) review. Two parts:

1. **Exclude per-regime delivery transport from the divergence-driving comparison** (the main change).
2. **Cross-file doc correction** (`drift_observer.py`) — a stale `SignalDelivered` emission-timing comment I found in the #462 review, carried here so it doesn't survive into PR 8.

### Part 1 — transport exclusion

The shadow-diff diffs the steering *decisions* the legacy and new regimes make on the same runs. Since PR 6, the new regime always rides the `request_context` observer-note channel while the legacy regime rides `nudge_replay` (`channel_action` enqueued vs. queued). So **every** aligned drift key trivially differs on `channel`/`channel_action` — per-regime *transport identity*, not a steering decision. Left in the divergence set, it swamps the real decision divergences (`would_cancel_inflight`, `ladder_level`, plan-swap targets) the §5.4 review exists to surface.

- Split `channel`/`channel_action` out of `_DECISION_FIELDS` into a new `_TRANSPORT_FIELDS`. They're still shown (`decision_view` keeps them via `_VIEW_FIELDS`) but no longer drive `diverged_fields`.
- `KeyDivergence` gains `transport_fields` + a `transport_only` property; `DivergenceReport` gains `transport_only_keys`. `diverged` is unchanged, so a key differing **only** in transport is no longer counted as a divergence.
- `render_two_log_text` adds a `transport-only (channel)` summary count + a per-key `[transport] … (informational)` line; the no-divergence verdict now reads "no decision divergence … (transport channel aside)".
- A genuine decision divergence still surfaces even when the channel also differs — transport never masks a real divergence.

**§5.4 proof-of-life preserved** (per #461): `would_cancel_inflight` stays in the divergence set, so the merged PR-1 cancel-authority divergence still surfaces — `test_shadow_diff_surfaces_cancel_authority_divergence` still asserts `legacy=True -> new=False` on the off_topic key (the `"would_cancel_inflight" in diverged_fields` assertion is itself the guard against accidentally excluding it):
```
aligned drift keys:        2
  diverged:                1
  transport-only (channel): 1  (per-regime transport, not a divergence)
VERDICT: 1 drift key(s) diverge — review below.
[off_topic / dt0 #0] both
    would_cancel_inflight: legacy=True  ->  new=False
    [transport] channel: legacy='nudge_replay'  ->  new='request_context'  (informational)
    [transport] channel_action: legacy='queued'  ->  new='enqueued'  (informational)
```

### Part 2 — cross-file doc correction (from the #462 review)

The comment in `DriftObserver._dispatch_nudge` claimed the `request_context` note's `SignalDelivered` is "emitted — only when a surface actually renders it, under `_should_inject`". That's wrong: `SignalDelivered` fires once at the **dispatch** decision point (the PR-5 model the §5.4 diff is built on); a delivery surface later *renders* the note (the separate visibility leg, exactly-once across surfaces, gated on `_should_inject`) without emitting a second event. Comment-only, no behavior change — corrected here so PR 8 (which keys its grace window on the rendering/visibility turn against this exact code) isn't misled.

## Tests
- Strengthened the looping-key negative control: now asserted `transport_only` (channel differs) and **not** `diverged`.
- Two focused synthetic tests: `test_channel_difference_alone_is_transport_not_divergence` and `test_real_decision_divergence_survives_transport_difference`.
- `docs/guides/evaluation.md` documents the transport exclusion.
- **Full suite: 3033 passed, 59 skipped**; **ruff clean**. Only my own bench files + the eval guide + the one-line `drift_observer.py` comment touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)