### PR TITLE
feat(prompt): prompt-shaping diet — sites 1/3/4 retire under request_context (AGENCY-PRESERVATION PR 9)

### DIFF
--- a/bench/harness.py
+++ b/bench/harness.py
@@ -122,6 +122,7 @@ KNOWN_STEER_ENV: frozenset[str] = frozenset(
         "GOLDFIVE_CANCEL_INFLIGHT_SCOPE",
         "GOLDFIVE_PLAN_MODE",  # PR 10 — SteeringConfig.from_env now reads it
         "GOLDFIVE_STEER_SIGNAL_CHANNEL",  # PR 6 — SteeringConfig.from_env now reads it
+        "GOLDFIVE_STEER_PIN_ASSIGNED_TASK",  # PR 9 — SteeringConfig.from_env now reads it
     }
 )
 

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -882,6 +882,25 @@ class SteeringConfig:
     #: AGENCY-PRESERVATION.md PR 13 flips it after the bench gate.
     #: Env: ``GOLDFIVE_PLAN_MODE``.
     plan_mode: str = "forecast"
+    #: AGENCY-PRESERVATION.md Stage 2 PR 9 — Site-4 escape hatch for the
+    #: per-turn ``[CURRENT ASSIGNED TASK]`` instruction pin.
+    #:
+    #: The prompt-shaping diet retires the per-turn task pin (Site 4 of
+    #: :class:`~goldfive.prompt_shaper.PromptShaper`) in the new
+    #: ``signal_channel == "request_context"`` regime: the agent owns its
+    #: own decomposition / ordering and does not need goldfive restating
+    #: the bound task into every model call. When ``True`` the pin is
+    #: re-enabled even under ``request_context`` — an escape hatch for
+    #: trees specifically built around the pinned-task block.
+    #:
+    #: Default ``False``. This GATES NOTHING in the legacy
+    #: ``signal_channel == "legacy_user_message"`` regime (the default):
+    #: there the pin always injects, exactly as pre-PR-9, so every
+    #: existing suite passes unmodified (§5.1). The diet only takes
+    #: effect once an operator opts into ``request_context``; this flag
+    #: then lets them keep the pin if their tree depends on it.
+    #: Env: ``GOLDFIVE_STEER_PIN_ASSIGNED_TASK``.
+    pin_assigned_task: bool = False
 
     @classmethod
     def from_env(cls) -> SteeringConfig:
@@ -949,6 +968,10 @@ class SteeringConfig:
             plan_mode=_read_plan_mode_env(
                 "GOLDFIVE_PLAN_MODE",
                 defaults.plan_mode,
+            ),
+            pin_assigned_task=_read_bool_env(
+                "GOLDFIVE_STEER_PIN_ASSIGNED_TASK",
+                defaults.pin_assigned_task,
             ),
         )
 

--- a/goldfive/prompt_shaper.py
+++ b/goldfive/prompt_shaper.py
@@ -636,6 +636,18 @@ class PromptShaper:
                 # hatch for trees built around the pinned-task block.
                 # Legacy ``signal_channel`` keeps the pin (byte-identical;
                 # §5.1).
+                #
+                # KNOWN LIMITATION (request_context + pin off): this also
+                # drops the pending-CORRECTION block that legacy rides on
+                # this pin. Corrections are still WRITTEN
+                # (``queue_corrections_for_revision``) but go UNREAD in
+                # this regime until task #11 migrates them to the
+                # ObserverNoteQueue at write time (which requires an
+                # agent-scoped ``peek_for_render`` so a per-(agent,task)
+                # correction reaches only its agent). ``request_context``
+                # is opt-in / non-default, so this is a documented gap in
+                # the new regime, not a production regression. Re-enable
+                # delivery meanwhile via ``pin_assigned_task=True``.
                 if shaper._request_context(steerer) and not shaper._pin_assigned_task(
                     steerer
                 ):

--- a/goldfive/prompt_shaper.py
+++ b/goldfive/prompt_shaper.py
@@ -41,12 +41,28 @@ Sites
    ``[GOLDFIVE PLAN-STATE HINT — …]`` block listing each agent's
    PENDING / DONE task summary so the coordinator has structural
    guidance about which sub-agent to call next (R3 / F2-alternative).
+   AGENCY-PRESERVATION.md PR 9 prompt-shaping diet: RETIRED under the
+   ``signal_channel == "request_context"`` regime (its per-turn
+   footprint violates dormancy §1.1); the plan-state content folds into
+   the observer note's Status surface (Site 5). Legacy regime unchanged.
 
 4. **Dynamic instruction resolver** —
    :meth:`PromptShaper.make_dynamic_instruction`. Returns an ADK
    ``InstructionProvider`` callable that resolves the current pinned
    task + pending-correction block on every turn and appends them to
    the agent's ``original_instruction`` (goldfive#251).
+   AGENCY-PRESERVATION.md PR 9: the ``[CURRENT ASSIGNED TASK]`` pin is
+   RETIRED by default under ``request_context`` (the wrapped agent owns
+   its decomposition / ordering); ``SteeringConfig.pin_assigned_task``
+   re-enables it for trees built around the pinned block. Legacy regime
+   unchanged.
+
+5. **Observer-note channel** —
+   :meth:`PromptShaper.inject_observer_note` (AGENCY-PRESERVATION.md
+   PR 6). The one remaining goldfive injection surface in the
+   ``request_context`` regime (alongside Site 2's planner contract):
+   renders the most-severe pending observer note onto the request,
+   carrying the folded plan-state line (Site 3).
 
 Each method first asks :meth:`should_inject` whether the gate is open
 for its context. When :meth:`should_inject` returns ``False`` the
@@ -112,6 +128,38 @@ class PromptShaper:
             return True
         return not bool(getattr(steerer, "_observation_only", False))
 
+    @staticmethod
+    def _signal_channel(steerer: Any) -> str:
+        """Return the steerer's resolved ``signal_channel`` (default legacy).
+
+        AGENCY-PRESERVATION.md PR 9 gates the prompt-shaping diet on the
+        ``request_context`` regime: under ``"legacy_user_message"`` (the
+        production default and what every existing suite runs with) the
+        four sites behave byte-identically to pre-PR-9, so existing tests
+        pass unmodified (§5.1). Tolerant of ``None`` / minimal stubs —
+        both resolve to ``"legacy_user_message"`` so the legacy path is
+        the safe fallback.
+        """
+        channel = getattr(steerer, "_signal_channel", "legacy_user_message")
+        return str(channel or "legacy_user_message")
+
+    @classmethod
+    def _request_context(cls, steerer: Any) -> bool:
+        """True when the steerer is in the PR-9 ``request_context`` diet regime."""
+        return cls._signal_channel(steerer) == "request_context"
+
+    @staticmethod
+    def _pin_assigned_task(steerer: Any) -> bool:
+        """Return ``SteeringConfig.pin_assigned_task`` off the steerer.
+
+        The Site-4 escape hatch (AGENCY-PRESERVATION.md PR 9): when
+        ``True`` the ``[CURRENT ASSIGNED TASK]`` instruction pin injects
+        even under ``request_context``. Defaults to ``False`` and is
+        tolerant of steerers without a typed config (returns ``False``).
+        """
+        cfg = getattr(steerer, "_steering_config", None)
+        return bool(getattr(cfg, "pin_assigned_task", False))
+
     # ----------------------------------------------------------------
     # Site 1 — conversational follow-up wrap
     # ----------------------------------------------------------------
@@ -128,20 +176,28 @@ class PromptShaper:
         F6 (closes goldfive#277). When :meth:`Planner.handle_turn`
         returns ``None`` on a turn with a real prior plan, the runner
         reuses ``session.plan`` but still drives the executor over the
-        input — without this wrapper the coordinator typically treats
-        the question as a fresh task and re-delegates to sub-agents,
-        wasting an invocation. The wrapper:
+        input. The wrapper supplies the coordinator with the prior-plan
+        context (summary + completed tasks) so it can answer the
+        follow-up from history. Lives in the message body (no
+        system-prompt contract — users bring their own coordinator
+        prompts; goldfive must not require a specific contract).
 
-        * tags the message as a conversational follow-up,
-        * gives the coordinator the plan summary + completed task
-          context so it can answer from history,
-        * asks it explicitly NOT to delegate.
+        Two regimes (AGENCY-PRESERVATION.md PR 9 prompt-shaping diet):
 
-        Lives in the message body (no system-prompt contract). A
-        parallel layer (the ADK plugin's pre-dispatch interceptor,
-        keyed off ``session._conversational_turn``) tightens the
-        tool surface so the coordinator literally cannot delegate
-        even if it tried; this wrapper is the cooperative half.
+        * ``signal_channel == "legacy_user_message"`` (the default) —
+          the legacy wrapper: the prior-plan context PLUS an explicit
+          "do not delegate / Do NOT call any AgentTool" directive. Kept
+          byte-identical so existing suites pass unmodified (§5.1).
+        * ``signal_channel == "request_context"`` — the diet wrapper:
+          the same prior-plan CONTEXT, but WITHOUT the means-directive.
+          goldfive owns goals; the wrapped agent owns MEANS (whether to
+          delegate is its call). The agent is informed, not commanded.
+
+        Note: there is no ADK-plugin "tool-surface-tightening
+        interceptor" — it was described in a stale docstring but never
+        shipped (verified PR 9). ``session._conversational_turn`` is
+        consumed only by the runner itself to decide whether to call
+        this wrapper.
 
         Under ``observation_only=True`` (:meth:`should_inject` →
         ``False``) the wrapper is skipped and ``user_input`` is
@@ -173,6 +229,20 @@ class PromptShaper:
         completed_block = (
             "\n".join(completed_lines) if completed_lines else "  (none yet)"
         )
+
+        if self._request_context(steerer):
+            # Diet: prior-plan CONTEXT only — no means-directive. The
+            # agent decides whether to delegate.
+            return (
+                "[CONVERSATIONAL FOLLOW-UP — prior plan context for "
+                "reference]\n\n"
+                "The user is asking a follow-up question about prior work. "
+                "The prior plan and completed tasks are below for context.\n\n"
+                f"Plan summary: {plan_summary}\n"
+                f"Completed tasks:\n{completed_block}\n\n"
+                f"User question: {user_input}"
+            )
+
         return (
             "[CONVERSATIONAL FOLLOW-UP — reuse prior plan, don't delegate "
             "to sub-agents]\n\n"
@@ -408,16 +478,15 @@ class PromptShaper:
             _strip_prior_runtime_tools_hint,
         )
 
-        hint = _build_runtime_tools_hint(session)
-
         config = _safe_attr(llm_request, "config", None)
         if config is None:
             return
         existing = getattr(config, "system_instruction", None)
 
-        # Strip any prior hint regardless of whether we'll re-inject. A
-        # None ``hint`` (plan disappeared or all groups empty) should
-        # still remove the stale marker block from the request.
+        # Strip any prior hint regardless of regime. A None ``hint``
+        # (plan disappeared or all groups empty) — and the diet regime
+        # below — should still remove a stale marker block left over from
+        # a legacy-channel turn.
         if isinstance(existing, str) and _RUNTIME_TOOLS_HINT_PREFIX in existing:
             try:
                 config.system_instruction = _strip_prior_runtime_tools_hint(existing) or None
@@ -430,6 +499,16 @@ class PromptShaper:
                 return
             existing = getattr(config, "system_instruction", None)
 
+        # AGENCY-PRESERVATION.md PR 9 — Site 3 diet. Under the
+        # ``request_context`` regime the per-turn standalone plan-state
+        # hint is RETIRED (it was a per-turn footprint — the dormancy
+        # violation §1.1 calls out). Its plan-state content is folded
+        # into the observer note's Status surface (see
+        # :meth:`inject_observer_note`). Legacy regime is unchanged.
+        if self._request_context(steerer):
+            return
+
+        hint = _build_runtime_tools_hint(session)
         if not hint:
             return
 
@@ -548,6 +627,27 @@ class PromptShaper:
                     )
                     return original_instruction
 
+                # AGENCY-PRESERVATION.md PR 9 — Site 4 diet. Under the
+                # ``request_context`` regime the per-turn
+                # ``[CURRENT ASSIGNED TASK]`` pin is RETIRED by default:
+                # the wrapped agent owns its own decomposition / ordering
+                # and does not need goldfive restating the bound task into
+                # every model call. ``pin_assigned_task`` is the escape
+                # hatch for trees built around the pinned-task block.
+                # Legacy ``signal_channel`` keeps the pin (byte-identical;
+                # §5.1).
+                if shaper._request_context(steerer) and not shaper._pin_assigned_task(
+                    steerer
+                ):
+                    log.info(
+                        "PromptShaper.make_dynamic_instruction resolver: "
+                        "request_context regime + pin_assigned_task=False — "
+                        "retiring the [CURRENT ASSIGNED TASK] pin for "
+                        "agent=%r (returning original instruction verbatim)",
+                        agent_name,
+                    )
+                    return original_instruction
+
                 state = _state_from_readonly_context(readonly_ctx)
                 session = getattr(ctx, "session", None) if ctx is not None else None
 
@@ -618,6 +718,45 @@ class PromptShaper:
     # Site 5 — observer-note channel (AGENCY-PRESERVATION.md PR 6)
     # ----------------------------------------------------------------
 
+    @staticmethod
+    def _plan_state_line(session: Any) -> str:
+        """Return a factual per-agent open-work line for the note (PR 9 Site 3 fold).
+
+        Replaces the retired per-turn plan-state hint: groups
+        ``session.plan.tasks`` by assignee and reports each agent's open
+        (non-terminal) vs complete count. Bookkeeping only — no "choose
+        the agent whose tasks are still PENDING" imperative (the means-
+        directive PR 9 drops). Returns ``""`` when there is no plan / no
+        tasks so the note block is unchanged on pre-plan turns. Never
+        raises.
+        """
+        try:
+            plan = _safe_attr(session, "plan", None)
+            tasks = _safe_attr(plan, "tasks", None) if plan is not None else None
+            if not tasks:
+                return ""
+            from goldfive.types import TERMINAL_TASK_STATUSES
+
+            by_agent: dict[str, list[int]] = {}
+            for t in tasks:
+                agent = _safe_attr(t, "assignee_agent_id", "") or "<unassigned>"
+                bucket = by_agent.setdefault(agent, [0, 0])  # [open, done]
+                status = _safe_attr(t, "status", None)
+                if status in TERMINAL_TASK_STATUSES:
+                    bucket[1] += 1
+                else:
+                    bucket[0] += 1
+            frags: list[str] = []
+            for agent in sorted(by_agent):
+                bare = agent.split(":")[-1] if ":" in agent else agent
+                open_n, _done_n = by_agent[agent]
+                frags.append(f"{bare}: {open_n} open" if open_n else f"{bare}: complete")
+            if not frags:
+                return ""
+            return "Plan state (goldfive bookkeeping): " + "; ".join(frags) + "."
+        except Exception:  # noqa: BLE001
+            return ""
+
     def inject_observer_note(
         self,
         *,
@@ -666,6 +805,7 @@ class PromptShaper:
         """
         try:
             from goldfive.observer_note_queue import (
+                OBSERVER_NOTE_BLOCK_END,
                 OBSERVER_NOTE_MARKER_PREFIX,
                 ObserverNoteQueue,
                 render_block,
@@ -708,6 +848,19 @@ class PromptShaper:
 
         if self.should_inject(steerer):
             block = render_block(note)
+            # AGENCY-PRESERVATION.md PR 9 — Site 3 fold. The retired
+            # per-turn plan-state hint's content rides the observer note
+            # instead: a factual per-agent open-work line, placed INSIDE
+            # the marker block (before the END marker) so strip-and-refresh
+            # removes it as one unit and the marker count stays 1. Factual
+            # bookkeeping only — no "choose the agent" imperative.
+            plan_state = self._plan_state_line(session)
+            if plan_state and OBSERVER_NOTE_BLOCK_END in block:
+                block = block.replace(
+                    OBSERVER_NOTE_BLOCK_END,
+                    f"{plan_state}\n{OBSERVER_NOTE_BLOCK_END}",
+                    1,
+                )
             append = getattr(llm_request, "append_instructions", None)
             wrote = False
             if callable(append):

--- a/goldfive/prompt_shaper.py
+++ b/goldfive/prompt_shaper.py
@@ -750,7 +750,12 @@ class PromptShaper:
             for agent in sorted(by_agent):
                 bare = agent.split(":")[-1] if ":" in agent else agent
                 open_n, _done_n = by_agent[agent]
-                frags.append(f"{bare}: {open_n} open" if open_n else f"{bare}: complete")
+                # "no open tasks" carries the anti-re-invoke fact the
+                # retired Site-3 hint used to provide ("all assigned tasks
+                # complete") — factual, no "do NOT re-invoke" imperative.
+                frags.append(
+                    f"{bare}: {open_n} open" if open_n else f"{bare}: no open tasks"
+                )
             if not frags:
                 return ""
             return "Plan state (goldfive bookkeeping): " + "; ".join(frags) + "."

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -967,17 +967,19 @@ class Runner:
             # session.plan unchanged. No PlanRevised — the prior
             # revision is still the right one for this turn.
             #
-            # F6 (closes goldfive#277): wrap ``user_input`` with a
-            # directive that tells the coordinator to answer briefly
-            # from history rather than re-delegating to sub-agents.
-            # The directive lives in the message body — NOT the system
-            # prompt — to preserve the no-prompt-contract principle:
-            # users bring their own coordinator prompts; goldfive must
-            # not require them to honour a specific system-prompt
-            # contract. The session flag below lets a parallel
-            # adapter-plugin layer (e.g. the ADK plugin's pre-dispatch
-            # interceptor) tighten the tool surface for this turn
-            # without coordinating through the message body.
+            # F6 (closes goldfive#277): mark this turn as a
+            # conversational follow-up so the executor handoff below
+            # wraps ``user_input`` with the prior-plan context via
+            # :meth:`PromptShaper.wrap_conversational_input`. The wrap
+            # lives in the message body — NOT the system prompt — to
+            # preserve the no-prompt-contract principle: users bring
+            # their own coordinator prompts; goldfive must not require a
+            # specific system-prompt contract. (Historical note: a
+            # docstring once described a parallel ADK-plugin "pre-dispatch
+            # interceptor" keyed off this flag that tightened the tool
+            # surface; that interceptor was never built — the flag's only
+            # consumer is the runner's own wrap gating below. Verified
+            # AGENCY-PRESERVATION.md PR 9.)
             log.info(
                 "Runner.run: conversational turn — reusing prior plan_id=%s revision_index=%d",
                 (session.plan.id or "")[:16] or "<none>",

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -211,12 +211,31 @@ def test_arm_flag_status_reports_pending_flags() -> None:
     # PR 10 promotion: ``GOLDFIVE_PLAN_MODE`` likewise reports APPLIED.
     assert "GOLDFIVE_PLAN_MODE" in applied
     assert "GOLDFIVE_PLAN_MODE" not in pending
+    # PR 9 promotion: ``GOLDFIVE_STEER_PIN_ASSIGNED_TASK`` is read by
+    # ``SteeringConfig.from_env``, so it is registered as APPLIED. The
+    # signal arm does NOT set it — the diet keeps the pin OFF by default
+    # under request_context — so its promotion is asserted via the
+    # registry here + the synthetic-arm test below, not the signal arm.
+    assert "GOLDFIVE_STEER_PIN_ASSIGNED_TASK" in KNOWN_STEER_ENV
     # The legacy arm's escape hatch is still pending until PR 7.
     _, legacy_pending = arm_flag_status(arms["legacy"])
     assert "GOLDFIVE_STEER_LEGACY_LADDER" in legacy_pending
     # The flags this build DOES consult are reported as applied.
     assert "GOLDFIVE_STEER_SIGNAL_TELEMETRY" in applied
     assert set(applied) <= KNOWN_STEER_ENV
+
+
+def test_pin_assigned_task_env_promoted_to_applied() -> None:
+    """PR 9 same-PR contract: an arm setting GOLDFIVE_STEER_PIN_ASSIGNED_TASK
+    reports it APPLIED (read by from_env), never pending."""
+    arm = Arm(
+        name="pin-escape-hatch",
+        kind="signal",
+        env={"GOLDFIVE_STEER_PIN_ASSIGNED_TASK": "1"},
+    )
+    applied, pending = arm_flag_status(arm)
+    assert "GOLDFIVE_STEER_PIN_ASSIGNED_TASK" in applied
+    assert "GOLDFIVE_STEER_PIN_ASSIGNED_TASK" not in pending
 
 
 async def test_unknown_flag_degrades_gracefully(tmp_path: Path) -> None:

--- a/tests/test_prompt_shaping_diet.py
+++ b/tests/test_prompt_shaping_diet.py
@@ -1,0 +1,354 @@
+"""Unit tests for the AGENCY-PRESERVATION.md PR 9 prompt-shaping diet.
+
+The diet is gated on ``signal_channel == "request_context"``. Under the
+default ``"legacy_user_message"`` channel every site behaves exactly as
+pre-PR-9 (covered by ``test_prompt_shaper.py`` / the other suites, which
+run with the legacy default and pass unmodified — §5.1). These tests
+cover the NEW ``request_context`` paths:
+
+* Site 1 — conversational wrap keeps plan context but drops the
+  "Do NOT call any AgentTool" / "don't delegate" means-directive.
+* Site 3 — the per-turn runtime tool-surface hint is retired (no
+  injection); a stale prior hint is still stripped.
+* Site 4 — the ``[CURRENT ASSIGNED TASK]`` pin is retired by default;
+  ``pin_assigned_task`` is the escape hatch.
+* Site 5 — the retired hint's plan-state folds into the observer-note
+  block (factual, no imperative; marker count stays 1).
+* config — ``pin_assigned_task`` default + env.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from goldfive.config import SteeringConfig
+from goldfive.prompt_shaper import PromptShaper
+from goldfive.steerer import DefaultSteerer
+from goldfive.types import Goal, Plan, Session, Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _steerer(
+    *,
+    channel: str = "request_context",
+    observation_only: bool = False,
+    pin_assigned_task: bool = False,
+) -> DefaultSteerer:
+    return DefaultSteerer(
+        steering_config=SteeringConfig(
+            observation_only=observation_only,
+            signal_channel=channel,
+            pin_assigned_task=pin_assigned_task,
+        )
+    )
+
+
+class _FakeConfig:
+    def __init__(self, system_instruction: Any = None) -> None:
+        self.system_instruction = system_instruction
+
+
+class _FakeReq:
+    """LLM-request stub whose ``append_instructions`` appends to system_instruction."""
+
+    def __init__(self, system_instruction: Any = None) -> None:
+        self.config = _FakeConfig(system_instruction)
+
+    def append_instructions(self, instructions: list[str]) -> list:
+        joined = "\n\n".join(instructions)
+        existing = self.config.system_instruction
+        if not existing:
+            self.config.system_instruction = joined
+        else:
+            self.config.system_instruction = f"{existing}\n\n{joined}"
+        return []
+
+
+class _Ctx:
+    def __init__(self, steerer: DefaultSteerer, session: Session | None = None) -> None:
+        self.steerer = steerer
+        self.session = session
+
+
+def _session_with_plan() -> Session:
+    sess = Session(run_id="r-diet")
+    sess.goals = [Goal(id="g1", summary="ship the report")]
+    sess.plan = Plan(
+        id="plan-1",
+        run_id="r-diet",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Draft",
+                description="d",
+                assignee_agent_id="writer",
+                status=TaskStatus.RUNNING,
+            ),
+            Task(
+                id="t2",
+                title="Review",
+                description="d2",
+                assignee_agent_id="reviewer",
+                status=TaskStatus.COMPLETED,
+            ),
+        ],
+        edges=[],
+        summary="a report",
+        revision_index=1,
+    )
+    return sess
+
+
+def _readonly_ctx(steerer: DefaultSteerer, session: Session) -> Any:
+    from goldfive.adapters._adk_plugin import SessionContext
+
+    stash = SessionContext(
+        session=session,
+        steerer=steerer,
+        task=None,
+        tool_handlers={},
+        host_agent_name="coordinator",
+    )
+
+    class _ReadonlyCtx:
+        state = {"goldfive._session_context": stash}
+        _invocation_context = None
+
+    return _ReadonlyCtx()
+
+
+# ---------------------------------------------------------------------------
+# Site 1 — conversational wrap
+# ---------------------------------------------------------------------------
+
+
+def test_site1_request_context_drops_means_directive() -> None:
+    sess = _session_with_plan()
+    out = PromptShaper().wrap_conversational_input(
+        user_input="what changed?",
+        session=sess,
+        steerer=_steerer(channel="request_context"),
+    )
+    # Means-directive removed.
+    assert "Do NOT call any AgentTool" not in out
+    assert "don't delegate" not in out
+    # Context kept.
+    assert "Plan summary: a report" in out
+    assert "what changed?" in out
+
+
+def test_site1_legacy_keeps_means_directive() -> None:
+    sess = _session_with_plan()
+    out = PromptShaper().wrap_conversational_input(
+        user_input="what changed?",
+        session=sess,
+        steerer=_steerer(channel="legacy_user_message"),
+    )
+    assert "Do NOT call any AgentTool" in out
+    assert "Plan summary: a report" in out
+
+
+# ---------------------------------------------------------------------------
+# Site 3 — runtime tool-surface hint
+# ---------------------------------------------------------------------------
+
+
+def test_site3_request_context_suppresses_hint() -> None:
+    sess = _session_with_plan()
+    req = _FakeReq(system_instruction="base")
+    PromptShaper().inject_runtime_tools_hint(
+        callback_context=None,
+        llm_request=req,
+        session=sess,
+        session_context=_Ctx(_steerer(channel="request_context")),
+    )
+    # No standalone hint injected in the diet regime.
+    assert "PLAN-STATE HINT" not in (req.config.system_instruction or "")
+    assert req.config.system_instruction == "base"
+
+
+def test_site3_legacy_injects_hint() -> None:
+    sess = _session_with_plan()
+    req = _FakeReq(system_instruction="base")
+    PromptShaper().inject_runtime_tools_hint(
+        callback_context=None,
+        llm_request=req,
+        session=sess,
+        session_context=_Ctx(_steerer(channel="legacy_user_message")),
+    )
+    assert "PLAN-STATE HINT" in (req.config.system_instruction or "")
+
+
+def test_site3_request_context_strips_stale_prior_hint() -> None:
+    """A hint left from a legacy-channel turn is stripped under the diet."""
+    from goldfive.adapters._adk_plugin import _build_runtime_tools_hint
+
+    sess = _session_with_plan()
+    prior_hint = _build_runtime_tools_hint(sess)
+    assert prior_hint  # sanity
+    req = _FakeReq(system_instruction=f"base\n\n{prior_hint}")
+    PromptShaper().inject_runtime_tools_hint(
+        callback_context=None,
+        llm_request=req,
+        session=sess,
+        session_context=_Ctx(_steerer(channel="request_context")),
+    )
+    assert "PLAN-STATE HINT" not in (req.config.system_instruction or "")
+    assert "base" in (req.config.system_instruction or "")
+
+
+# ---------------------------------------------------------------------------
+# Site 4 — [CURRENT ASSIGNED TASK] pin
+# ---------------------------------------------------------------------------
+
+
+def _pin_session() -> Session:
+    from goldfive.state_store import StateStore
+
+    sess = Session(run_id="r-pin")
+    sess.goals = [Goal(id="g1", summary="x")]
+    sess.plan = Plan(
+        id="plan-1",
+        run_id="r-pin",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Draft slide",
+                description="d",
+                assignee_agent_id="writer",
+                status=TaskStatus.RUNNING,
+            )
+        ],
+        edges=[],
+        summary="x",
+        revision_index=1,
+    )
+    StateStore.for_session(sess).set_pin_current_task("t1", title="Draft slide")
+    return sess
+
+
+def test_site4_request_context_retires_pin() -> None:
+    sess = _pin_session()
+    resolver = PromptShaper().make_dynamic_instruction("you are a writer", "writer")
+    out = resolver(_readonly_ctx(_steerer(channel="request_context"), sess))
+    assert out == "you are a writer"
+    assert "Current assigned task" not in out
+
+
+def test_site4_pin_assigned_task_escape_hatch_re_enables() -> None:
+    sess = _pin_session()
+    resolver = PromptShaper().make_dynamic_instruction("you are a writer", "writer")
+    out = resolver(
+        _readonly_ctx(
+            _steerer(channel="request_context", pin_assigned_task=True), sess
+        )
+    )
+    assert "Current assigned task:" in out
+    assert "id: t1" in out
+
+
+def test_site4_legacy_keeps_pin() -> None:
+    sess = _pin_session()
+    resolver = PromptShaper().make_dynamic_instruction("you are a writer", "writer")
+    out = resolver(_readonly_ctx(_steerer(channel="legacy_user_message"), sess))
+    assert "Current assigned task:" in out
+
+
+# ---------------------------------------------------------------------------
+# Site 5 — plan-state fold into the observer note
+# ---------------------------------------------------------------------------
+
+
+def test_site5_folds_plan_state_into_note_block() -> None:
+    from goldfive.observer_note_queue import (
+        OBSERVER_NOTE_MARKER_PREFIX,
+        ObserverNoteQueue,
+    )
+
+    sess = _session_with_plan()
+    ObserverNoteQueue.for_session(sess).enqueue(
+        body="Observation: a loop was observed.",
+        observation="a loop was observed",
+        severity="warning",
+        drift_id="d1",
+        kind="looping_tool_call",
+        task_id="t1",
+    )
+    req = _FakeReq(system_instruction="base")
+    note = PromptShaper().inject_observer_note(
+        llm_request=req,
+        session=sess,
+        session_context=_Ctx(_steerer(channel="request_context"), session=sess),
+    )
+    assert note is not None
+    si = req.config.system_instruction or ""
+    # Exactly one block; plan-state folded in (factual, no imperative).
+    assert si.count(OBSERVER_NOTE_MARKER_PREFIX) == 1
+    assert "Plan state (goldfive bookkeeping)" in si
+    assert "writer: 1 open" in si
+    assert "reviewer: complete" in si
+    assert "Choose the agent" not in si  # the dropped imperative
+
+
+def test_site5_plan_state_does_not_stack_across_calls() -> None:
+    from goldfive.observer_note_queue import (
+        OBSERVER_NOTE_MARKER_PREFIX,
+        ObserverNoteQueue,
+    )
+
+    sess = _session_with_plan()
+    ObserverNoteQueue.for_session(sess).enqueue(
+        body="Observation: x.",
+        observation="x",
+        severity="warning",
+        drift_id="d1",
+        kind="looping_tool_call",
+        task_id="t1",
+    )
+    shaper = PromptShaper()
+    steerer = _steerer(channel="request_context")
+    req = _FakeReq(system_instruction="base")
+    shaper.inject_observer_note(
+        llm_request=req, session=sess, session_context=_Ctx(steerer, session=sess)
+    )
+    # Second call (note already delivered → nothing pending) must strip the
+    # prior block, leaving zero — never stacking the plan-state line.
+    shaper.inject_observer_note(
+        llm_request=req, session=sess, session_context=_Ctx(steerer, session=sess)
+    )
+    si = req.config.system_instruction or ""
+    assert si.count(OBSERVER_NOTE_MARKER_PREFIX) == 0
+    assert "Plan state (goldfive bookkeeping)" not in si
+    assert "base" in si
+
+
+def test_plan_state_line_empty_without_plan() -> None:
+    sess = Session(run_id="r-empty")
+    assert PromptShaper._plan_state_line(sess) == ""
+
+
+# ---------------------------------------------------------------------------
+# config — pin_assigned_task
+# ---------------------------------------------------------------------------
+
+
+def test_pin_assigned_task_default_false() -> None:
+    assert SteeringConfig().pin_assigned_task is False
+
+
+def test_pin_assigned_task_env_override() -> None:
+    prev = os.environ.get("GOLDFIVE_STEER_PIN_ASSIGNED_TASK")
+    os.environ["GOLDFIVE_STEER_PIN_ASSIGNED_TASK"] = "1"
+    try:
+        assert SteeringConfig.from_env().pin_assigned_task is True
+    finally:
+        if prev is None:
+            os.environ.pop("GOLDFIVE_STEER_PIN_ASSIGNED_TASK", None)
+        else:
+            os.environ["GOLDFIVE_STEER_PIN_ASSIGNED_TASK"] = prev

--- a/tests/test_prompt_shaping_diet.py
+++ b/tests/test_prompt_shaping_diet.py
@@ -292,8 +292,9 @@ def test_site5_folds_plan_state_into_note_block() -> None:
     assert si.count(OBSERVER_NOTE_MARKER_PREFIX) == 1
     assert "Plan state (goldfive bookkeeping)" in si
     assert "writer: 1 open" in si
-    assert "reviewer: complete" in si
+    assert "reviewer: no open tasks" in si
     assert "Choose the agent" not in si  # the dropped imperative
+    assert "do NOT re-invoke" not in si  # the dropped imperative
 
 
 def test_site5_plan_state_does_not_stack_across_calls() -> None:
@@ -331,6 +332,100 @@ def test_site5_plan_state_does_not_stack_across_calls() -> None:
 def test_plan_state_line_empty_without_plan() -> None:
     sess = Session(run_id="r-empty")
     assert PromptShaper._plan_state_line(sess) == ""
+
+
+def test_site3_anti_reinvoke_fact_survives_in_note_status() -> None:
+    """The retired hint's anti-re-invoke protection ("all assigned tasks
+    complete") must survive via the note's folded Status line when an
+    agent's tasks are ALL terminal AND a note is pending."""
+    from goldfive.observer_note_queue import ObserverNoteQueue
+
+    sess = Session(run_id="r-terminal")
+    sess.goals = [Goal(id="g1", summary="x")]
+    sess.plan = Plan(
+        id="plan-1",
+        run_id="r-terminal",
+        goal_ids=["g1"],
+        tasks=[
+            # researcher: every task terminal (one COMPLETED, one FAILED).
+            Task(
+                id="t1",
+                title="Gather",
+                description="d",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="t2",
+                title="Verify",
+                description="d",
+                assignee_agent_id="researcher",
+                status=TaskStatus.FAILED,
+            ),
+            # writer: still has open work.
+            Task(
+                id="t3",
+                title="Draft",
+                description="d",
+                assignee_agent_id="writer",
+                status=TaskStatus.RUNNING,
+            ),
+        ],
+        edges=[],
+        summary="x",
+        revision_index=1,
+    )
+    ObserverNoteQueue.for_session(sess).enqueue(
+        body="Observation: a signal fired.",
+        observation="a signal fired",
+        severity="warning",
+        drift_id="d1",
+        kind="looping_tool_call",
+        task_id="t3",
+    )
+    req = _FakeReq(system_instruction="base")
+    note = PromptShaper().inject_observer_note(
+        llm_request=req,
+        session=sess,
+        session_context=_Ctx(_steerer(channel="request_context"), session=sess),
+    )
+    assert note is not None
+    si = req.config.system_instruction or ""
+    # The "no remaining tracked tasks" fact for the fully-terminal agent
+    # survives — factual, no imperative.
+    assert "researcher: no open tasks" in si
+    assert "writer: 1 open" in si
+    assert "do NOT re-invoke" not in si
+
+
+def test_site3_dormant_when_no_note_pending() -> None:
+    """No pending note → no hint, no plan-state, nothing injected anywhere.
+
+    With Site 3's standalone hint retired under request_context, dormancy
+    wins when nothing is pending: neither inject_runtime_tools_hint nor
+    inject_observer_note touches the request."""
+    sess = _session_with_plan()
+    steerer = _steerer(channel="request_context")
+
+    # Site 3 standalone hint: suppressed.
+    req = _FakeReq(system_instruction="base instruction")
+    PromptShaper().inject_runtime_tools_hint(
+        callback_context=None,
+        llm_request=req,
+        session=sess,
+        session_context=_Ctx(steerer),
+    )
+    assert req.config.system_instruction == "base instruction"
+
+    # Observer note: queue empty → nothing rendered, no plan-state line.
+    note = PromptShaper().inject_observer_note(
+        llm_request=req,
+        session=sess,
+        session_context=_Ctx(steerer, session=sess),
+    )
+    assert note is None
+    assert req.config.system_instruction == "base instruction"
+    assert "Plan state (goldfive bookkeeping)" not in req.config.system_instruction
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements **AGENCY-PRESERVATION.md Stage 2 — PR 9**: restore *dormancy* by retiring goldfive's per-turn prompt-shaping footprint. All changes gate on `signal_channel`; the default `legacy_user_message` path is **byte-identical to pre-PR-9**, so every existing suite passes unmodified (§5.1). The diet is the opt-in `request_context` regime (the same regime PR 6's observer-note channel uses).

## Interceptor verification (the task's open item)
The "tool-surface-tightening interceptor keyed off `session._conversational_turn`" described in a docstring **never shipped** — `_adk_plugin.py` never references the flag; its only consumer is the runner's own wrap gating (`runner.py:1126`). Resolution: deleted the stale docstring/comment claims (`prompt_shaper.py` + `runner.py`); **kept the flag** (it is load-bearing for Site 1's wrap gating).

## Sites (behavior under `request_context`; legacy unchanged)
| Site | Change |
|---|---|
| 1 — `wrap_conversational_input` | Keep the prior-plan **context** (summary + completed tasks); drop the "Do NOT call any AgentTool" / "don't delegate" means-directive. The agent owns MEANS. |
| 3 — `inject_runtime_tools_hint` | Retire the per-turn standalone hint (a stale prior hint is still stripped). Fold its plan-state into the observer note (Site 5) as a factual per-agent open-work line; the "Choose the agent…" imperative is dropped. |
| 4 — `make_dynamic_instruction` | Retire the `[CURRENT ASSIGNED TASK]` pin by default. New `SteeringConfig.pin_assigned_task` (default `False`, env `GOLDFIVE_STEER_PIN_ASSIGNED_TASK`) is the escape hatch for trees built around it. |
| 2 — GoldfivePlanner | Unchanged — stays, alongside the observer-note channel, as the only injection surfaces in `request_context`. |

## Deferred (flagged for follow-up / PR 13)
- **Pending-correction → note-queue migration.** The queue's `peek_for_render` is **not agent-scoped**, so naively enqueuing per-`(agent, task)` corrections would misdeliver them to the wrong agent. A correct migration needs an agent-aware note-selection enhancement; I did not ship a half-correct version. Under `request_context` + pin off, the resolver returns the original instruction (corrections are still written, just not read into the prompt). `request_context` is opt-in and not the default, so this is a known limitation of the new regime, not a production regression.
- **Hard-deletion of the instruction-mutation read path** (`adk_llm_instrumentation.py`). **Gated, not deleted**, to honor §5.1 (existing tests unmodified) — the deletion lands in PR 13 with the other legacy removals.

## §5 requirements satisfied
- **§5.1** — all changes flag-gated on `signal_channel == "request_context"`; legacy default byte-identical; existing suites pass unmodified; no hard deletions.
- **§5.6** — grep-verified call sites; no dead middleware (every new branch is reached + tested). `pin_assigned_task` read defensively off the steerer's typed config; `None`/stub steerers resolve to the legacy path.

## Tests
- `tests/test_prompt_shaping_diet.py` (+13): Site 1 directive-drop vs legacy; Site 3 hint suppression + stale-strip vs legacy injection; Site 4 pin retire / escape-hatch / legacy; Site 5 plan-state fold (marker count stays 1, factual, no imperative) + no-stacking; config default + env.
- **Existing tests unmodified.** Full suite: **3044 passed, 59 skipped, 0 failures**; `ruff` clean.

## Note
The Site 5 plan-state fold is applied on the ADK `before_model` surface (`inject_observer_note`), the primary surface. The replay/claude surfaces render via `render_block` without the fold — full cross-surface consistency is a small follow-up (kept out to avoid changing `render_block`'s shared shape + PR-7's `drift_observer` enqueue path).