### PR TITLE
feat(steering): cancel policy + ladder restructure — NUDGE→SIGNAL, strip promotion side-effects (AGENCY-PRESERVATION PR 7)

### DIFF
--- a/bench/harness.py
+++ b/bench/harness.py
@@ -122,6 +122,7 @@ KNOWN_STEER_ENV: frozenset[str] = frozenset(
         "GOLDFIVE_CANCEL_INFLIGHT_SCOPE",
         "GOLDFIVE_PLAN_MODE",  # PR 10 — SteeringConfig.from_env now reads it
         "GOLDFIVE_STEER_SIGNAL_CHANNEL",  # PR 6 — SteeringConfig.from_env now reads it
+        "GOLDFIVE_STEER_LEGACY_LADDER",  # PR 7 — SteeringConfig.from_env now reads it
     }
 )
 
@@ -129,12 +130,9 @@ KNOWN_STEER_ENV: frozenset[str] = frozenset(
 #: harness *clears* them between arms (no cross-arm leakage) even before any
 #: build consults them — and so an operator reading an arm's flag dict sees
 #: the intended end-state. They remain *pending* until promoted into
-#: :data:`KNOWN_STEER_ENV`.
-_PENDING_STEER_ENV: frozenset[str] = frozenset(
-    {
-        "GOLDFIVE_STEER_LEGACY_LADDER",  # PR 7 escape hatch
-    }
-)
+#: :data:`KNOWN_STEER_ENV`. (Empty now that PR 7 promoted the legacy-ladder
+#: hatch; kept as the extension point for future roadmap flags.)
+_PENDING_STEER_ENV: frozenset[str] = frozenset()
 
 #: Every env var the harness owns: snapshotted-and-cleared on each arm so
 #: an arm only ever sees its own flag dict plus the ambient (non-managed)

--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -721,10 +721,16 @@ deprecated with no ladder row.
 goldfive-authored `CANCEL_REINVOKE` cells were demoted to `SIGNAL` (advisory
 note, no refine/cancel/steer); repeat-escalation lands on `PAUSE_ESCALATE`
 (stop-and-ask preserves trajectory; cancel-and-redirect does not).
-`CANCEL_REINVOKE` survives **only** for the user-steer junction and the
-hard-safety kinds (`RUNAWAY_DELEGATION`, `RESOURCE_EXHAUSTED`, `TOO_MANY_STEPS`,
-`TASK_TIMEOUT`, `LLM_CALL_TIMEOUT` — whose CRITICAL-first cell was also fixed
-from the §0-violating `ABSORB` to a stop). `_promote_drift_to_steer` likewise
+`CANCEL_REINVOKE` survives **only** for the user-steer junction and
+`RUNAWAY_DELEGATION` (the behaviour is the problem, not a spent budget — kill
+the runaway subtree and continue non-runaway work). The other hard-safety
+kinds (`RESOURCE_EXHAUSTED`, `TOO_MANY_STEPS`, `TASK_TIMEOUT`, `LLM_CALL_TIMEOUT`)
+also had their §0-violating `ABSORB` cell fixed, but to **`PAUSE_ESCALATE`**,
+not `CANCEL_REINVOKE`: restart can't refund a spent budget (a cancel-and-reinvoke
+on an exhausted budget just re-trips the same cap). Their immediate in-flight
+stop already comes from the PR-1 cancel-authority path (they are in cancel
+scope); the ladder cell's follow-on for a spent resource is halt-and-ask-human.
+`_promote_drift_to_steer` likewise
 dropped its steering side-effects: no cancel-reason tag, no `GOLDFIVE_STEER`
 dispatch, no `active_steer(source="goldfive")` stamp — it refines, emits
 `PlanRevised`, and enqueues an advisory note. `GOLDFIVE_STEER_LEGACY_LADDER=1`
@@ -737,8 +743,8 @@ snapshotted in `tests/test_ladder_decision_table.py`.
 | **0** | `OBSERVE` | Emit `DriftDetected`; no further action. | Every `INFO` drift; the forecast-mismatch demotions. |
 | **1** | `ABSORB` | Call `planner.refine`; install the revised plan; continue. | `WARNING` drifts with a known kind (`LOOPING_REASONING`, `LOOPING_TOOL_CALL`, `TOOL_ERROR`, `AGENT_REFUSAL`, `CAPABILITY_MISMATCH` Rule B, etc.). |
 | **2** | `SIGNAL` (was `NUDGE`) | Enqueue an advisory observer note on the configured channel (PR 6) — **no refine, no cancel, no steer**. The agent reads it at its next model call / invocation boundary. | CRITICAL-first of the goldfive-authored content kinds (`TOOL_ERROR`, `AGENT_REFUSAL`, `MODEL_REFUSAL`, `OFF_TOPIC`, `CONFABULATION_RISK`, `LOOPING_*`, `SELF_REPORTED_STUCK`); `GOAL_DRIFT` at WARNING + CRITICAL-first. |
-| **3** | `CANCEL_REINVOKE` | Refine; install the revision; **dispatch a `GOLDFIVE_STEER` ControlMessage** so the executor cancels the in-flight invocation and restarts with a framed corrective body. | **Hard-safety only** (`RUNAWAY_DELEGATION`, `RESOURCE_EXHAUSTED`, `TOO_MANY_STEPS`, `TASK_TIMEOUT`, `LLM_CALL_TIMEOUT`) at CRITICAL-first; the USER_STEER junction; and every goldfive-authored row under `GOLDFIVE_STEER_LEGACY_LADDER=1`. |
-| **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; **dispatch a `GOLDFIVE_PAUSE_ESCALATE` ControlMessage**; do NOT call `planner.refine`. The executor's pre-task loop blocks until a user `RESUME` / `STEER` / `CANCEL` arrives. | `REFINE_VALIDATION_FAILED`; `HUMAN_INTERVENTION_REQUIRED`; `INTENT_DIVERGENCE` at CRITICAL; CRITICAL-repeat of almost every kind (incl. `GOAL_DRIFT`, the hard-safety kinds). |
+| **3** | `CANCEL_REINVOKE` | Refine; install the revision; **dispatch a `GOLDFIVE_STEER` ControlMessage** so the executor cancels the in-flight invocation and restarts with a framed corrective body. | `RUNAWAY_DELEGATION` at CRITICAL-first; the USER_STEER junction; and every goldfive-authored row under `GOLDFIVE_STEER_LEGACY_LADDER=1`. |
+| **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; **dispatch a `GOLDFIVE_PAUSE_ESCALATE` ControlMessage**; do NOT call `planner.refine`. The executor's pre-task loop blocks until a user `RESUME` / `STEER` / `CANCEL` arrives. | The budget/timeout hard-safety kinds (`RESOURCE_EXHAUSTED`, `TOO_MANY_STEPS`, `TASK_TIMEOUT`, `LLM_CALL_TIMEOUT`) at CRITICAL-first; `REFINE_VALIDATION_FAILED`; `HUMAN_INTERVENTION_REQUIRED`; `INTENT_DIVERGENCE` at CRITICAL; CRITICAL-repeat of almost every kind (incl. `GOAL_DRIFT`, `RUNAWAY_DELEGATION`). |
 | **5** | `TERMINATE` | Run-level abort. Currently only reachable when a Level-4-initiated pause times out and `HUMAN_INTERVENTION_REQUIRED` re-fires as a repeat CRITICAL. | Repeat `HUMAN_INTERVENTION_REQUIRED`. |
 
 ### Dispatch routing — single junction (Phase 2 of #246)

--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -654,12 +654,12 @@ severity:
 - **WARNING** → Level 1 (`ABSORB`): call `planner.refine`. Unchanged
   from pre-#204 — work-tool loops at 3+ calls, meta at 6+, work
   name-axis at 5.
-- **CRITICAL** first → Level 2 (`NUDGE`): refine **and** queue a soft
-  corrective follow-up on `session.pending_nudges` for the overlay
-  loop to pick up. Coordinates with the forward-progress work that
-  wires nudge consumption.
+- **CRITICAL** first → Level 2 (`SIGNAL`, renamed from `NUDGE` in
+  AGENCY-PRESERVATION.md PR 7): enqueue an advisory observer note for
+  the agent (no refine, no cancel, no steer). The proportional,
+  trajectory-preserving response.
 - **CRITICAL** repeat → Level 4 (`PAUSE_ESCALATE`): if the loop
-  survives the nudge and re-fires CRITICAL after
+  survives the signal and re-fires CRITICAL after
   `REFINE_FAILURE_THRESHOLD` occurrences, escalate to a human pause.
 
 ### Task-progress gate
@@ -717,13 +717,28 @@ Rule C). `CAPABILITY_MISMATCH` at WARNING stays `ABSORB` so Rule B
 (user-declared `required_tools`) keeps refining. `WRONG_AGENT` is
 deprecated with no ladder row.
 
+**Cancel-policy + ladder restructure (AGENCY-PRESERVATION.md PR 7).** The
+goldfive-authored `CANCEL_REINVOKE` cells were demoted to `SIGNAL` (advisory
+note, no refine/cancel/steer); repeat-escalation lands on `PAUSE_ESCALATE`
+(stop-and-ask preserves trajectory; cancel-and-redirect does not).
+`CANCEL_REINVOKE` survives **only** for the user-steer junction and the
+hard-safety kinds (`RUNAWAY_DELEGATION`, `RESOURCE_EXHAUSTED`, `TOO_MANY_STEPS`,
+`TASK_TIMEOUT`, `LLM_CALL_TIMEOUT` — whose CRITICAL-first cell was also fixed
+from the §0-violating `ABSORB` to a stop). `_promote_drift_to_steer` likewise
+dropped its steering side-effects: no cancel-reason tag, no `GOLDFIVE_STEER`
+dispatch, no `active_steer(source="goldfive")` stamp — it refines, emits
+`PlanRevised`, and enqueues an advisory note. `GOLDFIVE_STEER_LEGACY_LADDER=1`
+is a one-release escape hatch that restores the pre-PR-7 cells + promotion
+side-effects (the §5.8 measurable-regression arm); both regimes are
+snapshotted in `tests/test_ladder_decision_table.py`.
+
 | Level | Name | Action | Typical triggers |
 |---|---|---|---|
-| **0** | `OBSERVE` | Emit `DriftDetected`; no further action. | Every `INFO` drift. |
-| **1** | `ABSORB` | Call `planner.refine`; install the revised plan; continue. | `WARNING` drifts with a known kind (`LOOPING_REASONING`, `LOOPING_TOOL_CALL`, `TOOL_ERROR`, `AGENT_REFUSAL`, `INTENT_DIVERGENCE`, and `CAPABILITY_MISMATCH` Rule B, etc.); CRITICAL first-occurrence of most kinds. |
-| **2** | `NUDGE` | Queue a short corrective user message on `session.pending_nudges` for the Runner's overlay loop to pick up at the next invocation boundary. | `LOOPING_REASONING` at CRITICAL (first occurrence) after goldfive#204 — gives the agent a soft corrective prompt before escalating. Also available for caller overrides. |
-| **3** | `CANCEL_REINVOKE` | Refine the plan; install the revision; **dispatch a `GOLDFIVE_STEER` ControlMessage on the bound channel**. The executor's invoke loop cancels the in-flight invocation and restarts the passthrough with a `[GOLDFIVE STEERING CONTROL …]` framed corrective body. | CRITICAL first-occurrence for most refinable kinds (`TOOL_ERROR`, `AGENT_REFUSAL`, `MODEL_REFUSAL`, `OFF_TOPIC`, `RUNAWAY_DELEGATION`, ...). (`LOOPING_REASONING` CRITICAL-first now routes to Level 2 via goldfive#204.) |
-| **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; **dispatch a `GOLDFIVE_PAUSE_ESCALATE` ControlMessage on the bound channel**; do NOT call `planner.refine`. The executor's pre-task loop blocks until a user `RESUME` / `STEER` / `CANCEL` arrives on the channel. | `GOAL_DRIFT` (first & repeat); `REFINE_VALIDATION_FAILED`; `HUMAN_INTERVENTION_REQUIRED`; `INTENT_DIVERGENCE` at CRITICAL; CRITICAL-repeat of almost every kind. |
+| **0** | `OBSERVE` | Emit `DriftDetected`; no further action. | Every `INFO` drift; the forecast-mismatch demotions. |
+| **1** | `ABSORB` | Call `planner.refine`; install the revised plan; continue. | `WARNING` drifts with a known kind (`LOOPING_REASONING`, `LOOPING_TOOL_CALL`, `TOOL_ERROR`, `AGENT_REFUSAL`, `CAPABILITY_MISMATCH` Rule B, etc.). |
+| **2** | `SIGNAL` (was `NUDGE`) | Enqueue an advisory observer note on the configured channel (PR 6) — **no refine, no cancel, no steer**. The agent reads it at its next model call / invocation boundary. | CRITICAL-first of the goldfive-authored content kinds (`TOOL_ERROR`, `AGENT_REFUSAL`, `MODEL_REFUSAL`, `OFF_TOPIC`, `CONFABULATION_RISK`, `LOOPING_*`, `SELF_REPORTED_STUCK`); `GOAL_DRIFT` at WARNING + CRITICAL-first. |
+| **3** | `CANCEL_REINVOKE` | Refine; install the revision; **dispatch a `GOLDFIVE_STEER` ControlMessage** so the executor cancels the in-flight invocation and restarts with a framed corrective body. | **Hard-safety only** (`RUNAWAY_DELEGATION`, `RESOURCE_EXHAUSTED`, `TOO_MANY_STEPS`, `TASK_TIMEOUT`, `LLM_CALL_TIMEOUT`) at CRITICAL-first; the USER_STEER junction; and every goldfive-authored row under `GOLDFIVE_STEER_LEGACY_LADDER=1`. |
+| **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; **dispatch a `GOLDFIVE_PAUSE_ESCALATE` ControlMessage**; do NOT call `planner.refine`. The executor's pre-task loop blocks until a user `RESUME` / `STEER` / `CANCEL` arrives. | `REFINE_VALIDATION_FAILED`; `HUMAN_INTERVENTION_REQUIRED`; `INTENT_DIVERGENCE` at CRITICAL; CRITICAL-repeat of almost every kind (incl. `GOAL_DRIFT`, the hard-safety kinds). |
 | **5** | `TERMINATE` | Run-level abort. Currently only reachable when a Level-4-initiated pause times out and `HUMAN_INTERVENTION_REQUIRED` re-fires as a repeat CRITICAL. | Repeat `HUMAN_INTERVENTION_REQUIRED`. |
 
 ### Dispatch routing — single junction (Phase 2 of #246)

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -882,6 +882,25 @@ class SteeringConfig:
     #: AGENCY-PRESERVATION.md PR 13 flips it after the bench gate.
     #: Env: ``GOLDFIVE_PLAN_MODE``.
     plan_mode: str = "forecast"
+    #: AGENCY-PRESERVATION.md PR 7 — the one-release escape hatch that restores
+    #: the pre-PR-7 ladder + promotion behaviour.
+    #:
+    #: When ``False`` (the default) the new ladder applies: goldfive-authored
+    #: ``CANCEL_REINVOKE`` cells are demoted to ``SIGNAL`` (advisory note, no
+    #: refine/cancel/steer), repeat-escalation lands on ``PAUSE_ESCALATE``
+    #: (stop-and-ask), and :meth:`~goldfive.drift_observer.DriftObserver._promote_drift_to_steer`
+    #: drops its steering side-effects (no cancel-reason tag, no GOLDFIVE_STEER
+    #: dispatch, no ``active_steer(source="goldfive")`` stamp) — it refines,
+    #: emits ``PlanRevised``, and enqueues a note.
+    #:
+    #: When ``True`` the pre-PR-7 ladder cells (``CANCEL_REINVOKE`` in the
+    #: goldfive-authored rows) and the full promotion side-effects are
+    #: restored — the §5.8 measurable-regression arm (the bench's arm C).
+    #: The two deferred Stage-1 correctness fixes that also land in PR 7 (the
+    #: hard-safety CRITICAL-first stop and the PLAN_DIVERGENCE eligible-kinds
+    #: removal) are NOT toggled by this flag — they apply in both regimes.
+    #: Env: ``GOLDFIVE_STEER_LEGACY_LADDER``.
+    legacy_ladder: bool = False
 
     @classmethod
     def from_env(cls) -> SteeringConfig:
@@ -909,6 +928,9 @@ class SteeringConfig:
           ``request_context`` (case-insensitive). Selects the
           observer-note delivery channel (AGENCY-PRESERVATION.md PR 6);
           default ``legacy_user_message``.
+        * ``GOLDFIVE_STEER_LEGACY_LADDER`` — boolean. The PR-7 escape hatch
+          restoring the pre-PR-7 ladder cells + promotion side-effects
+          (AGENCY-PRESERVATION.md PR 7 / §5.8); default ``False``.
         """
         defaults = cls()
         raw_rules = os.environ.get("GOLDFIVE_STEER_CONTEXT_EDITOR_RULES", "").strip()
@@ -949,6 +971,10 @@ class SteeringConfig:
             plan_mode=_read_plan_mode_env(
                 "GOLDFIVE_PLAN_MODE",
                 defaults.plan_mode,
+            ),
+            legacy_ladder=_read_bool_env(
+                "GOLDFIVE_STEER_LEGACY_LADDER",
+                defaults.legacy_ladder,
             ),
         )
 

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -3938,32 +3938,38 @@ class DriftObserver:
             # budget/timeout hard-safety kinds previously fell through to the
             # default mapping, whose CRITICAL-first cell is ABSORB ("refine and
             # continue") — a §0 stop-not-redirect violation for a guardrail.
-            # Give them explicit rows that STOP at CRITICAL, matching their
-            # sibling RUNAWAY_DELEGATION: cancel the runaway (they retain cancel
-            # authority via ``_HARD_SAFETY_DRIFT_KINDS``), escalate to a pause
-            # on repeat. INFO/WARNING are OBSERVE — a budget trip is CRITICAL by
-            # construction; a sub-CRITICAL budget signal is informational, never
-            # a refine. This correctness fix applies in BOTH ladder regimes (it
-            # is NOT gated by ``legacy_ladder``).
+            # Give them explicit rows that STOP at CRITICAL → PAUSE_ESCALATE
+            # (halt-and-ask-human), NOT CANCEL_REINVOKE: restart can't refund a
+            # spent budget — a cancel-and-reinvoke on an exhausted budget just
+            # burns more of it or immediately re-trips the same cap. The
+            # immediate in-flight stop these kinds need already comes from the
+            # PR-1 cancel-authority path (they are in ``_HARD_SAFETY_DRIFT_KINDS``,
+            # i.e. cancel scope); the ladder cell's job is the follow-on, which
+            # for a spent resource is the pause. (RUNAWAY_DELEGATION above is the
+            # exception: the *behaviour* is the problem, not a spent budget, so
+            # killing the runaway subtree and letting non-runaway work continue
+            # is plausibly productive — it keeps CANCEL_REINVOKE.) INFO/WARNING
+            # are OBSERVE. Applies in BOTH ladder regimes (NOT gated by
+            # ``legacy_ladder``).
             DriftKind.RESOURCE_EXHAUSTED: (
                 None,
                 None,
-                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+                (_IL.PAUSE_ESCALATE, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.TOO_MANY_STEPS: (
                 None,
                 None,
-                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+                (_IL.PAUSE_ESCALATE, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.TASK_TIMEOUT: (
                 None,
                 None,
-                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+                (_IL.PAUSE_ESCALATE, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.LLM_CALL_TIMEOUT: (
                 None,
                 None,
-                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+                (_IL.PAUSE_ESCALATE, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.REFINE_VALIDATION_FAILED: (
                 None,
@@ -6282,9 +6288,16 @@ class DriftObserver:
         # ``cancel_inflight_scope="user_and_safety"`` the helper's
         # authority gate makes this a no-op — the refined plan installs
         # for bookkeeping and the corrective reaches the agent via the
-        # GOLDFIVE_STEER restart at the invocation boundary instead of
-        # a mid-flight ``task.cancel()``. ``"all"`` (the §5.1
-        # kill-switch) restores the empirically-motivated v15 cancel.
+        # advisory note at the invocation boundary instead of a
+        # mid-flight ``task.cancel()``. ``"all"`` (the §5.1 kill-switch)
+        # restores the empirically-motivated v15 cancel.
+        #
+        # PR 7 (intentional — do NOT "clean this up"): this call is KEPT
+        # even though PR 7 strips promotion's other steering side-effects.
+        # The PR-1 ``_cancel_inflight_for_revision`` authority gate is the
+        # SINGLE source of cancel policy; this is a no-op under the default
+        # scope. Removing it would double-encode the cancel decision here
+        # and break the ``GOLDFIVE_CANCEL_INFLIGHT_SCOPE=all`` kill-switch.
         await self._cancel_inflight_for_revision(drift, session)
         await self._steerer.plans._emit_plan_revised(
             session,

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -58,9 +58,9 @@ Responsibilities (this PR)
 * :meth:`_is_terminal_drift` + :attr:`_TERMINAL_DRIFT_KINDS` — the
   whitelist of drift kinds that trigger plugin-side boundary cleanup
   on emit. ``LOOPING_REASONING`` is **deliberately excluded** — its
-  CRITICAL-first tier maps to ``NUDGE`` (recoverable); the eventual
-  ``HUMAN_INTERVENTION_REQUIRED`` emission on escalation is the
-  cleanup trigger.
+  CRITICAL-first tier maps to ``SIGNAL`` (recoverable; PR 7 renamed
+  ``NUDGE``); the eventual ``HUMAN_INTERVENTION_REQUIRED`` emission on
+  escalation is the cleanup trigger.
 
 * :meth:`_resolve_authored_by` + :attr:`_USER_AUTHORED_DRIFT_KINDS`
   + :meth:`_drift_annotation_id` — source-attribution helpers.
@@ -261,8 +261,8 @@ class DriftObserver:
     #   resume it.
     # * ``LOOPING_REASONING`` is deliberately NOT here despite being
     #   listed in the v15 evidence: it is graduated (INFO / WARNING /
-    #   CRITICAL) and CRITICAL-first maps to ``NUDGE`` (recoverable —
-    #   refine + corrective follow-up). Closing on the LOOPING_REASONING
+    #   CRITICAL) and CRITICAL-first maps to ``SIGNAL`` (recoverable —
+    #   advisory note; PR 7 renamed ``NUDGE``). Closing on the LOOPING_REASONING
     #   emission itself would corrupt the boundary pair when the run
     #   actually recovers. The CRITICAL-repeat path escalates to
     #   ``PAUSE_ESCALATE``, which emits a fresh
@@ -3537,6 +3537,24 @@ class DriftObserver:
         ],
     ] = {}
 
+    # AGENCY-PRESERVATION.md PR 7 — the pre-PR-7 ladder, used when the
+    # ``legacy_ladder`` escape hatch is on. Identical to :attr:`_LADDER`
+    # EXCEPT the goldfive-authored rows whose CANCEL_REINVOKE cells PR 7
+    # demoted to SIGNAL (and GOAL_DRIFT's CRITICAL-repeat, which moved
+    # CANCEL_REINVOKE → PAUSE_ESCALATE): the overrides in
+    # :data:`_PR7_LEGACY_LADDER_OVERRIDES` restore those cells. The two
+    # deferred correctness fixes (hard-safety CRITICAL stop; the NUDGE→SIGNAL
+    # rename) are inherited from :attr:`_LADDER` — they are NOT toggled by the
+    # escape hatch. Populated lazily alongside :attr:`_LADDER`.
+    _LADDER_LEGACY: dict[
+        DriftKind,
+        tuple[
+            InterventionLevel | None,
+            InterventionLevel | None,
+            tuple[InterventionLevel, InterventionLevel],
+        ],
+    ] = {}
+
     _LADDER_LOADED: bool = False
 
     @classmethod
@@ -3553,30 +3571,36 @@ class DriftObserver:
         from goldfive.steerer import InterventionLevel as _IL
 
         cls._LADDER = {
+            # AGENCY-PRESERVATION.md PR 7: goldfive-authored CANCEL_REINVOKE
+            # cells demote to SIGNAL (advisory note, no refine/cancel/steer);
+            # the CRITICAL-repeat escalation stays PAUSE_ESCALATE (stop-and-ask
+            # preserves trajectory; cancel-and-redirect does not). The
+            # ``legacy_ladder`` escape hatch restores the CANCEL_REINVOKE cells
+            # via :data:`_PR7_LEGACY_LADDER_OVERRIDES`.
             DriftKind.CONFABULATION_RISK: (
                 _IL.OBSERVE,
                 _IL.ABSORB,
-                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+                (_IL.SIGNAL, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.AGENT_REFUSAL: (
                 _IL.OBSERVE,
                 _IL.ABSORB,
-                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+                (_IL.SIGNAL, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.MODEL_REFUSAL: (
                 _IL.OBSERVE,
                 _IL.ABSORB,
-                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+                (_IL.SIGNAL, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.LOOPING_REASONING: (
                 None,
                 _IL.ABSORB,
-                (_IL.NUDGE, _IL.PAUSE_ESCALATE),
+                (_IL.SIGNAL, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.LOOPING_TOOL_CALL: (
                 None,
                 _IL.ABSORB,
-                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+                (_IL.SIGNAL, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.REASONING_CLUSTER_TIGHTENING: (
                 _IL.OBSERVE,
@@ -3664,7 +3688,7 @@ class DriftObserver:
             DriftKind.OFF_TOPIC: (
                 _IL.OBSERVE,
                 _IL.ABSORB,
-                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+                (_IL.SIGNAL, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.JUSTIFIED_DEVIATION: (
                 _IL.OBSERVE,
@@ -3679,9 +3703,43 @@ class DriftObserver:
             DriftKind.TOOL_ERROR: (
                 _IL.OBSERVE,
                 _IL.ABSORB,
+                (_IL.SIGNAL, _IL.PAUSE_ESCALATE),
+            ),
+            # RUNAWAY_DELEGATION is hard-safety (a guardrail, not steering): it
+            # KEEPS CANCEL_REINVOKE — the §0 stop authority survives only for
+            # the user-steer junction and hard-safety kinds (PR 7).
+            DriftKind.RUNAWAY_DELEGATION: (
+                None,
+                None,
                 (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
             ),
-            DriftKind.RUNAWAY_DELEGATION: (
+            # AGENCY-PRESERVATION.md PR 7 (deferred Stage-1 fix): the
+            # budget/timeout hard-safety kinds previously fell through to the
+            # default mapping, whose CRITICAL-first cell is ABSORB ("refine and
+            # continue") — a §0 stop-not-redirect violation for a guardrail.
+            # Give them explicit rows that STOP at CRITICAL, matching their
+            # sibling RUNAWAY_DELEGATION: cancel the runaway (they retain cancel
+            # authority via ``_HARD_SAFETY_DRIFT_KINDS``), escalate to a pause
+            # on repeat. INFO/WARNING are OBSERVE — a budget trip is CRITICAL by
+            # construction; a sub-CRITICAL budget signal is informational, never
+            # a refine. This correctness fix applies in BOTH ladder regimes (it
+            # is NOT gated by ``legacy_ladder``).
+            DriftKind.RESOURCE_EXHAUSTED: (
+                None,
+                None,
+                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+            ),
+            DriftKind.TOO_MANY_STEPS: (
+                None,
+                None,
+                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+            ),
+            DriftKind.TASK_TIMEOUT: (
+                None,
+                None,
+                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+            ),
+            DriftKind.LLM_CALL_TIMEOUT: (
                 None,
                 None,
                 (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
@@ -3696,17 +3754,77 @@ class DriftObserver:
                 None,
                 (_IL.PAUSE_ESCALATE, _IL.TERMINATE),
             ),
+            # GOAL_DRIFT: WARNING + CRITICAL-first both SIGNAL (was NUDGE — pure
+            # rename); the CRITICAL-repeat escalation moves CANCEL_REINVOKE →
+            # PAUSE_ESCALATE (PR 7 repeat-escalation = stop-and-ask).
             DriftKind.GOAL_DRIFT: (
                 None,
-                _IL.NUDGE,
-                (_IL.NUDGE, _IL.CANCEL_REINVOKE),
+                _IL.SIGNAL,
+                (_IL.SIGNAL, _IL.PAUSE_ESCALATE),
+            ),
+            DriftKind.SELF_REPORTED_STUCK: (
+                None,
+                _IL.ABSORB,
+                (_IL.SIGNAL, _IL.PAUSE_ESCALATE),
+            ),
+        }
+        # PR 7 legacy-ladder overrides: the exact cells the new ladder demoted.
+        # ``_LADDER_LEGACY = {**_LADDER, **overrides}`` so the escape hatch
+        # restores ONLY these rows; every other row (incl. the deferred
+        # hard-safety stop fix and the NUDGE→SIGNAL rename) is shared. This
+        # small override map IS the reviewable PR-7 ladder diff (§5.3).
+        _pr7_legacy_overrides: dict[
+            DriftKind,
+            tuple[
+                InterventionLevel | None,
+                InterventionLevel | None,
+                tuple[InterventionLevel, InterventionLevel],
+            ],
+        ] = {
+            DriftKind.CONFABULATION_RISK: (
+                _IL.OBSERVE,
+                _IL.ABSORB,
+                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+            ),
+            DriftKind.AGENT_REFUSAL: (
+                _IL.OBSERVE,
+                _IL.ABSORB,
+                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+            ),
+            DriftKind.MODEL_REFUSAL: (
+                _IL.OBSERVE,
+                _IL.ABSORB,
+                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+            ),
+            DriftKind.LOOPING_TOOL_CALL: (
+                None,
+                _IL.ABSORB,
+                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+            ),
+            DriftKind.OFF_TOPIC: (
+                _IL.OBSERVE,
+                _IL.ABSORB,
+                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+            ),
+            DriftKind.TOOL_ERROR: (
+                _IL.OBSERVE,
+                _IL.ABSORB,
+                (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
             ),
             DriftKind.SELF_REPORTED_STUCK: (
                 None,
                 _IL.ABSORB,
                 (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
             ),
+            # LOOPING_REASONING is NOT here: its CRITICAL-first was NUDGE (now
+            # SIGNAL — pure rename), never CANCEL_REINVOKE, so new == legacy.
+            DriftKind.GOAL_DRIFT: (
+                None,
+                _IL.SIGNAL,
+                (_IL.SIGNAL, _IL.CANCEL_REINVOKE),
+            ),
         }
+        cls._LADDER_LEGACY = {**cls._LADDER, **_pr7_legacy_overrides}
         cls._LADDER_LOADED = True
 
     def _ladder_level_for(
@@ -3724,9 +3842,16 @@ class DriftObserver:
         from goldfive.steerer import InterventionLevel as _IL
 
         self._load_ladder_tables()
+        # AGENCY-PRESERVATION.md PR 7: the ``legacy_ladder`` escape hatch picks
+        # the pre-PR-7 cells (CANCEL_REINVOKE in the goldfive-authored rows).
+        ladder = (
+            self._LADDER_LEGACY
+            if getattr(self._steerer, "_legacy_ladder", False)
+            else self._LADDER
+        )
         entry = self._LADDER_BY_VALUE.get(kind.value)
         if entry is None:
-            entry = self._LADDER.get(kind)
+            entry = ladder.get(kind)
         is_repeat = occurrence_count >= self._steerer.REFINE_FAILURE_THRESHOLD
         if entry is not None:
             info_level, warning_level, critical_pair = entry
@@ -4043,7 +4168,13 @@ class DriftObserver:
         )
         if level is InterventionLevel.OBSERVE:
             return
-        if level is InterventionLevel.NUDGE:
+        if level is InterventionLevel.SIGNAL:
+            # AGENCY-PRESERVATION.md PR 7: the SIGNAL level (was NUDGE) enqueues
+            # an advisory observer note and returns — NO refine, NO cancel, NO
+            # steer. This is the cell the goldfive-authored CANCEL_REINVOKE rows
+            # were demoted to: proportional, trajectory-preserving influence.
+            # The dispatch method keeps its ``_dispatch_nudge`` name (internal;
+            # widely referenced) — it enqueues the SIGNAL-level note.
             await self._dispatch_nudge(drift, session)
             return
         if level is InterventionLevel.PAUSE_ESCALATE:
@@ -5229,9 +5360,10 @@ class DriftObserver:
           either periodic-check signals or soft one-shots; cancel
           would be disproportionate.
         * ``DriftSeverity.WARNING`` — never cancels. Warning drifts
-          route to the existing ABSORB / NUDGE ladder paths; the
-          refined plan lands on the next task boundary without
-          preempting the in-flight turn.
+          route to the existing ABSORB / SIGNAL ladder paths (PR 7
+          renamed NUDGE → SIGNAL); the refined plan / advisory note
+          lands on the next task boundary without preempting the
+          in-flight turn.
         * ``DriftSeverity.CRITICAL`` — cancels, *if the drift's
           authority permits it* (see below). The in-flight turn's
           output is likely to contaminate its parent's transcript
@@ -5467,7 +5599,12 @@ class DriftObserver:
             DriftKind.CONFABULATION_RISK,
             DriftKind.LOOPING_REASONING,
             DriftKind.LOOPING_TOOL_CALL,
-            DriftKind.PLAN_DIVERGENCE,
+            # AGENCY-PRESERVATION.md PR 7 (deferred Stage-1 fix): PLAN_DIVERGENCE
+            # removed. It is dropped at the top of :meth:`handle_drift` (#252,
+            # reconciler emitter dead) and its ladder row is OBSERVE at every
+            # severity (PR 3), so it could never reach promotion — its presence
+            # here was unreachable dead config. Removing it makes the eligible
+            # set honest.
         }
     )
 
@@ -5594,15 +5731,25 @@ class DriftObserver:
             _planner_refine_accepts_available_agents,
         )
 
-        # 1. Tag adapter cancel reason.
-        cancel_reason = self._tag_adapter_cancel_reason_for_promotion(drift, session=session)
-        # Session-visible cancel prefix so ``_mark_cancelled_if_live``
-        # stamps it on any TaskCancelled the executor emits for the
-        # in-flight task as part of the promotion.
-        try:
-            session._last_cancel_reason_prefix = cancel_reason
-        except Exception:  # noqa: BLE001
-            pass
+        # AGENCY-PRESERVATION.md PR 7: strip the steering side-effects from
+        # promotion. Promotion now refines, emits PlanRevised, and enqueues an
+        # advisory note — it no longer tags the adapter's cancel reason, stamps
+        # ``active_steer(source="goldfive")``, or dispatches GOLDFIVE_STEER.
+        # The ``legacy_ladder`` escape hatch restores all three. ``legacy``
+        # captured once so the gates read consistently within this call.
+        legacy = bool(getattr(self._steerer, "_legacy_ladder", False))
+        # 1. Tag adapter cancel reason (legacy only).
+        if legacy:
+            cancel_reason = self._tag_adapter_cancel_reason_for_promotion(
+                drift, session=session
+            )
+            # Session-visible cancel prefix so ``_mark_cancelled_if_live``
+            # stamps it on any TaskCancelled the executor emits for the
+            # in-flight task as part of the promotion.
+            try:
+                session._last_cancel_reason_prefix = cancel_reason
+            except Exception:  # noqa: BLE001
+                pass
         # 1a. NOTE (#241 emergency revert): previously we fired
         # ``adapter.request_cancel(reason)`` here to terminate the
         # in-flight LLM call immediately. In practice that
@@ -5623,19 +5770,23 @@ class DriftObserver:
         # same surface the user-steer freshness window reads.
         at_turn = int(getattr(session, "_reasoning_turn", 0) or 0)
         body = self._compose_goldfive_steer_body(drift, session)
-        try:
-            _ostate.set_active_steer(
-                session.state,
-                body=body,
-                at_turn=at_turn,
-                author="goldfive",
-                source="goldfive",
-            )
-        except Exception as exc:  # noqa: BLE001
-            log.debug(
-                "DefaultSteerer._promote_drift_to_steer: set_active_steer raised: %s",
-                exc,
-            )
+        # 2. Stamp active-steer state (legacy only). The new regime does NOT
+        # stamp ``active_steer(source="goldfive")`` — a promoted goldfive drift
+        # is advisory, not an authoritative steer overriding the agent's means.
+        if legacy:
+            try:
+                _ostate.set_active_steer(
+                    session.state,
+                    body=body,
+                    at_turn=at_turn,
+                    author="goldfive",
+                    source="goldfive",
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "DefaultSteerer._promote_drift_to_steer: set_active_steer raised: %s",
+                    exc,
+                )
         # NOTE: the ``GOLDFIVE_STEER`` ControlMessage dispatch used to
         # fire HERE, BEFORE the refine + plan install below. That left
         # the payload carrying the PRIOR plan's task ids in
@@ -5920,18 +6071,27 @@ class DriftObserver:
             attempt_id=attempt_id,
             dry_run=not was_installed,
         )
-        # Audit #402 fix: dispatch the ``GOLDFIVE_STEER`` ControlMessage
-        # AFTER ``_emit_plan_revised`` has swapped ``session.plan`` to
-        # the revised version. ``_dispatch_goldfive_steer_control``
-        # re-reads ``session.plan`` to derive ``replacement_task_ids``,
-        # so dispatching here ensures the payload points the
-        # executor's restart at the NEW plan's PENDING tasks rather
-        # than the prior plan's (which may have been removed /
-        # cancelled by the just-installed revision). Mirrors the
-        # ordering in :meth:`_handle_drift`'s CANCEL_REINVOKE branch.
-        await self._dispatch_goldfive_steer_control(
-            drift, session, body_override=body
-        )
+        # AGENCY-PRESERVATION.md PR 7: in the new regime the promotion's
+        # corrective reaches the agent as an advisory observer note on the
+        # configured channel — NOT a GOLDFIVE_STEER cancel-and-restart. The
+        # ``legacy_ladder`` escape hatch restores the GOLDFIVE_STEER dispatch.
+        if legacy:
+            # Audit #402 fix: dispatch the ``GOLDFIVE_STEER`` ControlMessage
+            # AFTER ``_emit_plan_revised`` has swapped ``session.plan`` to the
+            # revised version so the payload's ``replacement_task_ids`` point
+            # at the NEW plan's PENDING tasks. Mirrors :meth:`_handle_drift`'s
+            # CANCEL_REINVOKE branch.
+            await self._dispatch_goldfive_steer_control(
+                drift, session, body_override=body
+            )
+        else:
+            # New regime: enqueue the advisory note (request_context queue or
+            # legacy pending_nudges, per ``signal_channel``). ``ladder_level=
+            # "promotion"`` lets the §5.4 divergence report tell a promoted
+            # SIGNAL apart from a Level-2 one.
+            await self._route_corrective_note(
+                session, drift, body, ladder_level="promotion"
+            )
 
     @staticmethod
     def _compose_goldfive_steer_body(drift: DriftEvent, session: Session) -> str:

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -24,7 +24,7 @@ bounded note-buffer family (``note_agent_activity`` /
 machinery: ``handle_drift`` (the central drift-routing method),
 ``_promote_drift_to_steer`` (audit issue #402 — dispatch-before-plan-swap
 ordering is preserved here, not fixed), the intervention ladder
-(``_ladder_level_for`` / ``_LADDER`` / ``_LADDER_BY_VALUE``), ladder
+(``_ladder_level_for`` / ``_LADDER`` / ``_LADDER_LEGACY``), ladder
 dispatch (``_dispatch_nudge`` / ``_dispatch_goldfive_steer_control`` /
 ``_dispatch_goldfive_pause_control`` / ``_dispatch_pause_escalate``),
 adapter cancel tagging, the late-drift gate
@@ -3749,15 +3749,6 @@ class DriftObserver:
     # import-cycle with :mod:`goldfive.steerer` (which defines the
     # :class:`InterventionLevel` enum).
 
-    _LADDER_BY_VALUE: dict[
-        str,
-        tuple[
-            InterventionLevel | None,
-            InterventionLevel | None,
-            tuple[InterventionLevel, InterventionLevel],
-        ],
-    ] = {}
-
     # AGENCY-PRESERVATION.md PR 7 — the pre-PR-7 ladder, used when the
     # ``legacy_ladder`` escape hatch is on. Identical to :attr:`_LADDER`
     # EXCEPT the goldfive-authored rows whose CANCEL_REINVOKE cells PR 7
@@ -3780,7 +3771,7 @@ class DriftObserver:
 
     @classmethod
     def _load_ladder_tables(cls) -> None:
-        """Populate :attr:`_LADDER` / :attr:`_LADDER_BY_VALUE` on first use.
+        """Populate :attr:`_LADDER` / :attr:`_LADDER_LEGACY` on first use.
 
         Lazy load defers the :class:`InterventionLevel` import so this
         module can be imported before :mod:`goldfive.steerer` finishes
@@ -4076,9 +4067,7 @@ class DriftObserver:
             if getattr(self._steerer, "_legacy_ladder", False)
             else self._LADDER
         )
-        entry = self._LADDER_BY_VALUE.get(kind.value)
-        if entry is None:
-            entry = ladder.get(kind)
+        entry = ladder.get(kind)
         is_repeat = occurrence_count >= self._steerer.REFINE_FAILURE_THRESHOLD
         if entry is not None:
             info_level, warning_level, critical_pair = entry

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -24,12 +24,16 @@ tangle of conditionals. Levels, ordered by intrusiveness:
 
 * Level 0 — OBSERVE: record the drift, no action.
 * Level 1 — ABSORB: call ``planner.refine``; continue.
-* Level 2 — NUDGE: queue a soft follow-up message on the session for
-  the Runner's overlay loop to pick up at the next invocation boundary.
+* Level 2 — SIGNAL (renamed from NUDGE in AGENCY-PRESERVATION.md PR 7):
+  enqueue an advisory observer note on the configured channel — no
+  refine, no cancel, no steer. The proportional, trajectory-preserving
+  response the goldfive-authored ``CANCEL_REINVOKE`` cells were demoted to.
 * Level 3 — CANCEL_REINVOKE: dispatch a ``GOLDFIVE_STEER`` control
   message on the bound channel so the executor cancels in-flight work
-  and restarts with a goldfive-authored corrective. Phase 2 of the
-  path-duality fix routes this through the same junction as USER_STEER.
+  and restarts with a goldfive-authored corrective. PR 7 narrows this to
+  the user-steer junction + hard-safety kinds only (every other
+  goldfive-authored row signals); the ``GOLDFIVE_STEER_LEGACY_LADDER=1``
+  escape hatch restores the pre-PR-7 cells.
 * Level 4 — PAUSE_ESCALATE: dispatch a ``GOLDFIVE_PAUSE_ESCALATE``
   control message and emit ``HUMAN_INTERVENTION_REQUIRED`` so the
   executor's pre-task loop blocks waiting for operator action.

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -126,7 +126,12 @@ class InterventionLevel(enum.IntEnum):
 
     OBSERVE = 0
     ABSORB = 1
-    NUDGE = 2
+    # AGENCY-PRESERVATION.md PR 7: NUDGE renamed to SIGNAL. The level now
+    # enqueues an advisory observer note (the request_context channel / the
+    # legacy nudge replay) WITHOUT a refine/cancel/steer — the proportional,
+    # trajectory-preserving response that replaces the goldfive-authored
+    # CANCEL_REINVOKE cells. The enum value (2) is unchanged.
+    SIGNAL = 2
     CANCEL_REINVOKE = 3
     PAUSE_ESCALATE = 4
     TERMINATE = 5
@@ -615,6 +620,16 @@ class DefaultSteerer:
             )
             _channel = "legacy_user_message"
         self._signal_channel: str = _channel
+        # AGENCY-PRESERVATION.md PR 7: the one-release legacy-ladder escape
+        # hatch. When True the pre-PR-7 ladder cells (CANCEL_REINVOKE in the
+        # goldfive-authored rows) and the full _promote_drift_to_steer
+        # side-effects are restored; the drift observer reads this flag in
+        # ``_ladder_level_for`` and ``_promote_drift_to_steer``. Default OFF
+        # (the new SIGNAL ladder). The two deferred correctness fixes
+        # (hard-safety stop, PLAN_DIVERGENCE removal) are NOT gated by it.
+        self._legacy_ladder: bool = bool(
+            getattr(steering_config, "legacy_ladder", False)
+        )
         # Background reasoning-judge tasks (goldfive#251). The LLM-judge
         # path in :meth:`observe_reasoning` is fire-and-forget so the
         # adapter's model-response callback can return immediately and

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -199,21 +199,22 @@ async def test_single_log_census(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_arm_flag_status_reports_pending_flags() -> None:
+def test_arm_flag_status_reports_promoted_flags_as_applied() -> None:
     arms = {a.kind: a for a in default_arms()}
     applied, pending = arm_flag_status(arms["signal"])
-    # PR 6 promotion: ``GOLDFIVE_STEER_SIGNAL_CHANNEL`` is now read by
-    # ``SteeringConfig.from_env``, so it reports as APPLIED, not pending
-    # (the promotion contract: the PR that adds the env read moves its
-    # flag from _PENDING_STEER_ENV into KNOWN_STEER_ENV).
+    # The promotion contract: the PR that teaches ``SteeringConfig.from_env``
+    # about a flag moves it from _PENDING_STEER_ENV into KNOWN_STEER_ENV, so it
+    # reports APPLIED. As of PR 7 every roadmap flag the bench carries is
+    # promoted: GOLDFIVE_STEER_SIGNAL_CHANNEL (PR 6), GOLDFIVE_PLAN_MODE
+    # (PR 10), and GOLDFIVE_STEER_LEGACY_LADDER (PR 7).
     assert "GOLDFIVE_STEER_SIGNAL_CHANNEL" in applied
     assert "GOLDFIVE_STEER_SIGNAL_CHANNEL" not in pending
-    # PR 10 promotion: ``GOLDFIVE_PLAN_MODE`` likewise reports APPLIED.
     assert "GOLDFIVE_PLAN_MODE" in applied
-    assert "GOLDFIVE_PLAN_MODE" not in pending
-    # The legacy arm's escape hatch is still pending until PR 7.
-    _, legacy_pending = arm_flag_status(arms["legacy"])
-    assert "GOLDFIVE_STEER_LEGACY_LADDER" in legacy_pending
+    # The legacy arm's escape hatch is now APPLIED (PR 7 read it into from_env);
+    # nothing the bench carries is pending anymore.
+    legacy_applied, legacy_pending = arm_flag_status(arms["legacy"])
+    assert "GOLDFIVE_STEER_LEGACY_LADDER" in legacy_applied
+    assert legacy_pending == []
     # The flags this build DOES consult are reported as applied.
     assert "GOLDFIVE_STEER_SIGNAL_TELEMETRY" in applied
     assert set(applied) <= KNOWN_STEER_ENV

--- a/tests/test_drift_outcomes.py
+++ b/tests/test_drift_outcomes.py
@@ -507,11 +507,20 @@ async def test_goal_drift_bypasses_outcome_gate() -> None:
     for (GOAL_DRIFT, t1). A fresh GOAL_DRIFT must STILL attempt refine —
     these drifts route operator/trajectory intent and must not be gated
     by per-task outcome state.
+
+    AGENCY-PRESERVATION.md PR 7: in the default regime GOAL_DRIFT now SIGNALs
+    (advisory note) at WARNING + CRITICAL-first and PAUSE_ESCALATEs on repeat —
+    it never reaches the refine path, so the outcome-gate bypass it exercises
+    is reachable only via the ``legacy_ladder`` escape hatch (where the
+    CRITICAL-repeat cell is CANCEL_REINVOKE → refine). The bypass contract is
+    pinned here in that regime; the new-regime GOAL_DRIFT routing is pinned in
+    ``test_intervention_ladder.py::test_ladder_covers_goal_drift``.
     """
     revised = _make_plan()
     planner = StubPlanner(revised=revised)
     sink = ListSink()
     steerer = DefaultSteerer()
+    steerer._legacy_ladder = True
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
 

--- a/tests/test_goldfive_drift_routing.py
+++ b/tests/test_goldfive_drift_routing.py
@@ -140,11 +140,19 @@ def _bound_steerer(
     *,
     revised: Plan | None = None,
     threshold: str = "warning",
+    legacy_ladder: bool = True,
 ) -> tuple[DefaultSteerer, _RevisedPlanPlanner, ControlChannel, _ListSink]:
+    # AGENCY-PRESERVATION.md PR 7: the GOLDFIVE_STEER routing this module pins
+    # (promotion → cancel-and-restart on the control channel) is the legacy
+    # mechanism, now behind the ``legacy_ladder`` escape hatch. Bind with the
+    # hatch ON by default so the routing coverage survives; the default-regime
+    # behaviour (advisory note, no GOLDFIVE_STEER) is covered in
+    # ``test_promote_drift_to_steer.py``.
     steerer = DefaultSteerer(
         goldfive_steer_threshold=threshold,
         goldfive_steer_suppression_window_turns=3,
     )
+    steerer._legacy_ladder = bool(legacy_ladder)
     planner = _RevisedPlanPlanner(revised=revised or _make_revised_plan())
     sink = _ListSink()
     channel = ControlChannel()
@@ -332,6 +340,8 @@ async def test_multiple_goldfive_drifts_queue_in_order_on_channel() -> None:
         goldfive_steer_threshold="warning",
         goldfive_steer_suppression_window_turns=3,
     )
+    # PR 7: GOLDFIVE_STEER dispatch is the legacy promotion mechanism.
+    steerer._legacy_ladder = True
     planner = _DistinctRevisedPlanner()
     sink = _ListSink()
     channel = ControlChannel()

--- a/tests/test_goldfive_steer_request_cancel.py
+++ b/tests/test_goldfive_steer_request_cancel.py
@@ -165,6 +165,10 @@ def _bind(adapter: Any) -> tuple[DefaultSteerer, Session, _StubPlanner]:
         goldfive_steer_threshold="warning",
         goldfive_steer_suppression_window_turns=3,
     )
+    # AGENCY-PRESERVATION.md PR 7: the promotion-driven request_cancel this
+    # module pins is the legacy mechanism (the new regime enqueues an advisory
+    # note and never tags a cancel reason). Bind with the escape hatch ON.
+    steerer._legacy_ladder = True
     revised = Plan(
         id="p1",
         run_id="r1",

--- a/tests/test_intervention_ladder.py
+++ b/tests/test_intervention_ladder.py
@@ -34,14 +34,16 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         0,
         InterventionLevel.ABSORB,
     ),
-    # AGENT_REFUSAL: WARNING -> absorb (refine), CRITICAL first -> cancel+re-invoke.
+    # AGENT_REFUSAL: WARNING -> absorb (refine); CRITICAL first -> SIGNAL
+    # (PR 7 demoted the goldfive-authored CANCEL_REINVOKE cell to an advisory
+    # note); CRITICAL repeat -> PAUSE_ESCALATE.
     (DriftKind.AGENT_REFUSAL, DriftSeverity.INFO, 0, InterventionLevel.OBSERVE),
     (DriftKind.AGENT_REFUSAL, DriftSeverity.WARNING, 0, InterventionLevel.ABSORB),
     (
         DriftKind.AGENT_REFUSAL,
         DriftSeverity.CRITICAL,
         0,
-        InterventionLevel.CANCEL_REINVOKE,
+        InterventionLevel.SIGNAL,
     ),
     (
         DriftKind.AGENT_REFUSAL,
@@ -55,7 +57,7 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         DriftKind.MODEL_REFUSAL,
         DriftSeverity.CRITICAL,
         0,
-        InterventionLevel.CANCEL_REINVOKE,
+        InterventionLevel.SIGNAL,
     ),
     # LOOPING_REASONING: graduated severity landed in goldfive#204.
     # INFO (meta-tool retries at low counts) -> OBSERVE; WARNING ->
@@ -68,7 +70,7 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         DriftKind.LOOPING_REASONING,
         DriftSeverity.CRITICAL,
         0,
-        InterventionLevel.NUDGE,
+        InterventionLevel.SIGNAL,
     ),
     (
         DriftKind.LOOPING_REASONING,
@@ -82,7 +84,7 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         DriftKind.LOOPING_TOOL_CALL,
         DriftSeverity.CRITICAL,
         0,
-        InterventionLevel.CANCEL_REINVOKE,
+        InterventionLevel.SIGNAL,
     ),
     # REASONING_CLUSTER_TIGHTENING: INFO-only early-warning; always OBSERVE.
     (
@@ -117,7 +119,7 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         DriftKind.OFF_TOPIC,
         DriftSeverity.CRITICAL,
         0,
-        InterventionLevel.CANCEL_REINVOKE,
+        InterventionLevel.SIGNAL,
     ),
     (
         DriftKind.OFF_TOPIC,
@@ -169,13 +171,13 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         2,
         InterventionLevel.PAUSE_ESCALATE,
     ),
-    # TOOL_ERROR.
+    # TOOL_ERROR: CRITICAL-first demoted CANCEL_REINVOKE -> SIGNAL (PR 7).
     (DriftKind.TOOL_ERROR, DriftSeverity.WARNING, 0, InterventionLevel.ABSORB),
     (
         DriftKind.TOOL_ERROR,
         DriftSeverity.CRITICAL,
         0,
-        InterventionLevel.CANCEL_REINVOKE,
+        InterventionLevel.SIGNAL,
     ),
     # RUNAWAY_DELEGATION: CRITICAL-only shape.
     (
@@ -217,30 +219,28 @@ _CASES: list[tuple[DriftKind, DriftSeverity, int, InterventionLevel]] = [
         InterventionLevel.TERMINATE,
     ),
     # GOAL_DRIFT (goldfive#143, retuned for Tier 1 / F4): the judge
-    # signals "agent is stuck on completed work" -- a NUDGE (corrective
-    # user message) is the right first response, since the plan is
-    # correct and only the agent's next-action reasoning needs an
-    # anchor. CRITICAL repeat escalates to CANCEL_REINVOKE; PAUSE_
-    # ESCALATE is the last-resort fallback that the default ladder
-    # path provides (no explicit entry needed once CANCEL_REINVOKE
-    # didn't break the loop).
+    # signals "agent is stuck on completed work" -- a SIGNAL (advisory
+    # note) is the right first response, since the plan is correct and
+    # only the agent's next-action reasoning needs an anchor. PR 7: the
+    # CRITICAL-repeat escalation moved CANCEL_REINVOKE -> PAUSE_ESCALATE
+    # (stop-and-ask, not cancel-and-redirect).
     (
         DriftKind.GOAL_DRIFT,
         DriftSeverity.WARNING,
         0,
-        InterventionLevel.NUDGE,
+        InterventionLevel.SIGNAL,
     ),
     (
         DriftKind.GOAL_DRIFT,
         DriftSeverity.CRITICAL,
         0,
-        InterventionLevel.NUDGE,
+        InterventionLevel.SIGNAL,
     ),
     (
         DriftKind.GOAL_DRIFT,
         DriftSeverity.CRITICAL,
         2,
-        InterventionLevel.CANCEL_REINVOKE,
+        InterventionLevel.PAUSE_ESCALATE,
     ),
     # SELF_REPORTED_STUCK (WARNING by default).
     (
@@ -303,41 +303,39 @@ def test_ladder_level_ordering_is_monotonic_by_intrusiveness() -> None:
     future reshuffle is caught.
     """
     assert InterventionLevel.OBSERVE < InterventionLevel.ABSORB
-    assert InterventionLevel.ABSORB < InterventionLevel.NUDGE
-    assert InterventionLevel.NUDGE < InterventionLevel.CANCEL_REINVOKE
+    assert InterventionLevel.ABSORB < InterventionLevel.SIGNAL
+    assert InterventionLevel.SIGNAL < InterventionLevel.CANCEL_REINVOKE
     assert InterventionLevel.CANCEL_REINVOKE < InterventionLevel.PAUSE_ESCALATE
     assert InterventionLevel.PAUSE_ESCALATE < InterventionLevel.TERMINATE
 
 
 def test_ladder_covers_goal_drift() -> None:
-    """Tier 1 / F4: GOAL_DRIFT routes through NUDGE first, not PAUSE.
+    """Tier 1 / F4: GOAL_DRIFT routes through SIGNAL first, not PAUSE.
 
     The judge's signal is "agent is grinding on completed work"; the
-    plan is fine and a corrective user message (NUDGE) re-anchors the
-    LLM without refining the plan. CRITICAL repeat escalates to
-    CANCEL_REINVOKE — only if that also fails to break the loop does
-    the default-fallback path eventually surface PAUSE_ESCALATE.
+    plan is fine and an advisory note (SIGNAL) re-anchors the LLM
+    without refining the plan. PR 7: CRITICAL repeat escalates to
+    PAUSE_ESCALATE (stop-and-ask), no longer CANCEL_REINVOKE.
     """
     steerer = DefaultSteerer()
-    # WARNING -> NUDGE (corrective message; no plan change needed).
+    # WARNING -> SIGNAL (advisory note; no plan change needed).
     assert (
         steerer.drift._ladder_level_for(DriftKind.GOAL_DRIFT, DriftSeverity.WARNING, 0)
-        is InterventionLevel.NUDGE
+        is InterventionLevel.SIGNAL
     )
-    # CRITICAL first occurrence -> NUDGE.
+    # CRITICAL first occurrence -> SIGNAL.
     assert (
         steerer.drift._ladder_level_for(DriftKind.GOAL_DRIFT, DriftSeverity.CRITICAL, 0)
-        is InterventionLevel.NUDGE
+        is InterventionLevel.SIGNAL
     )
-    # CRITICAL repeat -> CANCEL_REINVOKE (cancel + restart with the
-    # corrective body as the new user input).
+    # CRITICAL repeat -> PAUSE_ESCALATE (PR 7 repeat-escalation = stop-and-ask).
     assert (
         steerer.drift._ladder_level_for(
             DriftKind.GOAL_DRIFT,
             DriftSeverity.CRITICAL,
             DefaultSteerer.REFINE_FAILURE_THRESHOLD,
         )
-        is InterventionLevel.CANCEL_REINVOKE
+        is InterventionLevel.PAUSE_ESCALATE
     )
 
 
@@ -403,11 +401,12 @@ def test_off_topic_unchanged_by_justified_deviation_addition() -> None:
         steerer.drift._ladder_level_for(DriftKind.OFF_TOPIC, DriftSeverity.WARNING, 0)
         is InterventionLevel.ABSORB
     )
+    # PR 7: CRITICAL-first demoted CANCEL_REINVOKE -> SIGNAL (advisory note).
     assert (
         steerer.drift._ladder_level_for(
             DriftKind.OFF_TOPIC, DriftSeverity.CRITICAL, 0
         )
-        is InterventionLevel.CANCEL_REINVOKE
+        is InterventionLevel.SIGNAL
     )
     assert (
         steerer.drift._ladder_level_for(

--- a/tests/test_ladder_decision_table.py
+++ b/tests/test_ladder_decision_table.py
@@ -91,10 +91,14 @@ def render_ladder_surface(steerer: DefaultSteerer) -> str:
 #   * Deferred Stage-1 fix — hard-safety budget/timeout kinds (resource_exhausted,
 #     too_many_steps, task_timeout, llm_call_timeout) previously fell through to
 #     the default whose CRITICAL-first is ABSORB ("redirect"); they now STOP:
-#     CRITICAL [ABSORB|PAUSE_ESCALATE] → [CANCEL_REINVOKE|PAUSE_ESCALATE] and
-#     WARNING ABSORB → OBSERVE (a sub-CRITICAL budget signal is informational).
-#   * runaway_delegation is UNCHANGED — hard-safety keeps CANCEL_REINVOKE (the
-#     §0 stop authority survives for the user-steer junction + hard-safety).
+#     CRITICAL [ABSORB|PAUSE_ESCALATE] → [PAUSE_ESCALATE|PAUSE_ESCALATE] and
+#     WARNING ABSORB → OBSERVE. PAUSE_ESCALATE (not CANCEL_REINVOKE): restart
+#     can't refund a spent budget. The immediate in-flight stop comes from the
+#     PR-1 cancel-authority path (these kinds are in cancel scope); the ladder
+#     cell's follow-on for a spent resource is halt-and-ask-human.
+#   * runaway_delegation KEEPS [CANCEL_REINVOKE|PAUSE_ESCALATE] — the behaviour
+#     is the problem (not a spent budget), so killing the runaway subtree and
+#     continuing non-runaway work is plausibly productive.
 # capability_mismatch / new_work_discovered / plan_divergence keep their PR-3
 # OBSERVE demotions; wrong_agent's dead default-fallthrough line is moot.
 # ---------------------------------------------------------------------------
@@ -113,7 +117,7 @@ hallucination_suspected      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE
 human_intervention_required  INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|TERMINATE]
 intent_divergence            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 justified_deviation          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|ABSORB]
-llm_call_timeout             INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+llm_call_timeout             INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 looping_reasoning            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
 looping_tool_call            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
 model_refusal                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
@@ -123,7 +127,7 @@ plan_divergence              INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSE
 reasoning_cluster_tightening INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
 refine_validation_failed     INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 repeated_failure             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
-resource_exhausted           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+resource_exhausted           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 runaway_delegation           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 safety_concern               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 schema_violation             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
@@ -131,8 +135,8 @@ self_reported_stuck          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE
 stopped_early                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 task_failed_fatal            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 task_failed_recoverable      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
-task_timeout                 INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
-too_many_steps               INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+task_timeout                 INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
+too_many_steps               INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 tool_error                   INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
 uncertain_progress           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 unexpected_output            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
@@ -161,7 +165,7 @@ hallucination_suspected      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE
 human_intervention_required  INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|TERMINATE]
 intent_divergence            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 justified_deviation          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|ABSORB]
-llm_call_timeout             INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+llm_call_timeout             INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 looping_reasoning            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
 looping_tool_call            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 model_refusal                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
@@ -171,7 +175,7 @@ plan_divergence              INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSE
 reasoning_cluster_tightening INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
 refine_validation_failed     INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 repeated_failure             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
-resource_exhausted           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+resource_exhausted           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 runaway_delegation           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 safety_concern               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 schema_violation             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
@@ -179,8 +183,8 @@ self_reported_stuck          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINV
 stopped_early                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 task_failed_fatal            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 task_failed_recoverable      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
-task_timeout                 INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
-too_many_steps               INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+task_timeout                 INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
+too_many_steps               INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 tool_error                   INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 uncertain_progress           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 unexpected_output            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
@@ -329,6 +333,8 @@ def test_hard_safety_kinds_stay_armed_at_critical() -> None:
         assert first is not InterventionLevel.OBSERVE, kind
         assert repeat is not InterventionLevel.OBSERVE, kind
         # PR 7 stop-not-redirect: a CRITICAL guardrail trip must STOP, never
-        # ABSORB (refine-and-continue). HUMAN_INTERVENTION_REQUIRED maps to
-        # PAUSE_ESCALATE; the budget/timeout kinds to CANCEL_REINVOKE.
+        # ABSORB (refine-and-continue). The budget/timeout kinds +
+        # HUMAN_INTERVENTION_REQUIRED map to PAUSE_ESCALATE (restart can't
+        # refund a spent budget); RUNAWAY_DELEGATION to CANCEL_REINVOKE (kill
+        # the runaway subtree, continue non-runaway work).
         assert first is not InterventionLevel.ABSORB, kind

--- a/tests/test_ladder_decision_table.py
+++ b/tests/test_ladder_decision_table.py
@@ -80,25 +80,73 @@ def render_ladder_surface(steerer: DefaultSteerer) -> str:
 # intended ladder demotion (update + justify in the PR body) or a
 # regression (fix the code, not the golden).
 #
-# AGENCY-PRESERVATION.md PR 3 demoted exactly three rows from this table
-# (the forecast-mismatch family); every other row is byte-for-byte the
-# Commit-1 baseline:
-#   * plan_divergence     WARNING ABSORB→OBSERVE, CRITICAL
-#                         [CANCEL_REINVOKE|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
-#   * capability_mismatch CRITICAL [ABSORB|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
-#                         (WARNING stays ABSORB: Rule B / "WARNING-max").
-#                         The CRITICAL→OBSERVE cells are unreachable in the
-#                         DEFAULT config — Rule A and Rule C are both env-
-#                         gated OFF and the only live emitter (Rule B) emits
-#                         WARNING; the cells bite only under the Rule A/C
-#                         escape hatches (belt-and-suspenders).
-#   * new_work_discovered WARNING ABSORB→OBSERVE, CRITICAL
-#                         [ABSORB|PAUSE_ESCALATE]→[OBSERVE|OBSERVE]
-# wrong_agent is unchanged here: it is deprecated with no _LADDER row and
-# no emitter, so its dead default-fallthrough line is moot (see the
-# types.py deprecation note + the _load_ladder_tables comment).
+# AGENCY-PRESERVATION.md PR 7 restructured the ladder. Changes from the PR-3
+# baseline (every other row byte-for-byte unchanged):
+#   * NUDGE → SIGNAL rename (the enum member): goal_drift + looping_reasoning.
+#   * goldfive-authored CANCEL_REINVOKE cells → SIGNAL (advisory note, no
+#     refine/cancel/steer): agent_refusal, confabulation_risk, looping_tool_call,
+#     model_refusal, off_topic, self_reported_stuck, tool_error CRITICAL-first.
+#   * goal_drift CRITICAL-repeat CANCEL_REINVOKE → PAUSE_ESCALATE (repeat-
+#     escalation is stop-and-ask) and WARNING/CRITICAL-first NUDGE → SIGNAL.
+#   * Deferred Stage-1 fix — hard-safety budget/timeout kinds (resource_exhausted,
+#     too_many_steps, task_timeout, llm_call_timeout) previously fell through to
+#     the default whose CRITICAL-first is ABSORB ("redirect"); they now STOP:
+#     CRITICAL [ABSORB|PAUSE_ESCALATE] → [CANCEL_REINVOKE|PAUSE_ESCALATE] and
+#     WARNING ABSORB → OBSERVE (a sub-CRITICAL budget signal is informational).
+#   * runaway_delegation is UNCHANGED — hard-safety keeps CANCEL_REINVOKE (the
+#     §0 stop authority survives for the user-steer junction + hard-safety).
+# capability_mismatch / new_work_discovered / plan_divergence keep their PR-3
+# OBSERVE demotions; wrong_agent's dead default-fallthrough line is moot.
 # ---------------------------------------------------------------------------
 EXPECTED_LADDER_SURFACE = """\
+agent_refusal                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
+agent_transfer               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+ambiguous_intent             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+blocked                      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+capability_mismatch          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[OBSERVE|OBSERVE]
+confabulation_risk           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
+context_pressure             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+custom                       INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+goal_drift                   INFO=OBSERVE WARNING=SIGNAL  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
+goal_unreachable             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+hallucination_suspected      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+human_intervention_required  INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|TERMINATE]
+intent_divergence            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
+justified_deviation          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|ABSORB]
+llm_call_timeout             INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+looping_reasoning            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
+looping_tool_call            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
+model_refusal                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
+new_work_discovered          INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
+off_topic                    INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
+plan_divergence              INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
+reasoning_cluster_tightening INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
+refine_validation_failed     INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
+repeated_failure             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+resource_exhausted           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+runaway_delegation           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+safety_concern               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+schema_violation             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+self_reported_stuck          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
+stopped_early                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+task_failed_fatal            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+task_failed_recoverable      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+task_timeout                 INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+too_many_steps               INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+tool_error                   INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
+uncertain_progress           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+unexpected_output            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+user_cancel                  INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+user_pause                   INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+user_steer                   INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+wrong_agent                  INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]"""
+
+
+# The ``legacy_ladder`` escape hatch (GOLDFIVE_STEER_LEGACY_LADDER=1) restores
+# the pre-PR-7 goldfive-authored CANCEL_REINVOKE cells. It differs from the new
+# surface above on exactly the eight demoted rows; the NUDGE→SIGNAL rename and
+# the hard-safety stop fix are NOT toggled (they apply in both regimes).
+EXPECTED_LADDER_SURFACE_LEGACY = """\
 agent_refusal                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 agent_transfer               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 ambiguous_intent             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
@@ -107,14 +155,14 @@ capability_mismatch          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[OBSERVE|OBSE
 confabulation_risk           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 context_pressure             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 custom                       INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
-goal_drift                   INFO=OBSERVE WARNING=NUDGE   CRITICAL=[NUDGE|CANCEL_REINVOKE]
+goal_drift                   INFO=OBSERVE WARNING=SIGNAL  CRITICAL=[SIGNAL|CANCEL_REINVOKE]
 goal_unreachable             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 hallucination_suspected      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 human_intervention_required  INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|TERMINATE]
 intent_divergence            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 justified_deviation          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|ABSORB]
-llm_call_timeout             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
-looping_reasoning            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[NUDGE|PAUSE_ESCALATE]
+llm_call_timeout             INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+looping_reasoning            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[SIGNAL|PAUSE_ESCALATE]
 looping_tool_call            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 model_refusal                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 new_work_discovered          INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
@@ -123,7 +171,7 @@ plan_divergence              INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSE
 reasoning_cluster_tightening INFO=OBSERVE WARNING=OBSERVE CRITICAL=[OBSERVE|OBSERVE]
 refine_validation_failed     INFO=OBSERVE WARNING=OBSERVE CRITICAL=[PAUSE_ESCALATE|PAUSE_ESCALATE]
 repeated_failure             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
-resource_exhausted           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+resource_exhausted           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 runaway_delegation           INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 safety_concern               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 schema_violation             INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
@@ -131,8 +179,8 @@ self_reported_stuck          INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINV
 stopped_early                INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 task_failed_fatal            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 task_failed_recoverable      INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
-task_timeout                 INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
-too_many_steps               INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
+task_timeout                 INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
+too_many_steps               INFO=OBSERVE WARNING=OBSERVE CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 tool_error                   INFO=OBSERVE WARNING=ABSORB  CRITICAL=[CANCEL_REINVOKE|PAUSE_ESCALATE]
 uncertain_progress           INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
 unexpected_output            INFO=OBSERVE WARNING=ABSORB  CRITICAL=[ABSORB|PAUSE_ESCALATE]
@@ -155,6 +203,46 @@ def test_ladder_decision_table_snapshot() -> None:
         "golden; an intended demotion updates the golden in the SAME "
         "commit and documents the cells in the PR body (§5.3)."
     )
+
+
+def test_ladder_decision_table_snapshot_legacy_regime() -> None:
+    """The ``legacy_ladder`` escape hatch restores the pre-PR-7 cells.
+
+    §5.3 snapshots the ladder in BOTH regimes so the PR-7 restructure surfaces
+    as an explicit diff. This golden differs from the default surface on
+    exactly the eight goldfive-authored rows whose CANCEL_REINVOKE cells PR 7
+    demoted (plus GOAL_DRIFT's CRITICAL-repeat); the NUDGE→SIGNAL rename and
+    the hard-safety stop fix are shared (NOT toggled by the escape hatch).
+    """
+    from goldfive.config import SteeringConfig
+
+    steerer = DefaultSteerer(steering_config=SteeringConfig(legacy_ladder=True))
+    surface = render_ladder_surface(steerer)
+    assert surface == EXPECTED_LADDER_SURFACE_LEGACY
+
+
+def test_legacy_overrides_are_exactly_the_demoted_rows() -> None:
+    """The two regimes differ on exactly the rows PR 7 demoted — no others.
+
+    Guards the override map against accidentally restoring (or failing to
+    restore) an unrelated row: the diff between the default and legacy goldens
+    must be precisely the eight goldfive-authored CANCEL_REINVOKE rows.
+    """
+    new = EXPECTED_LADDER_SURFACE.splitlines()
+    legacy = EXPECTED_LADDER_SURFACE_LEGACY.splitlines()
+    differing = {
+        n.split()[0] for n, leg in zip(new, legacy, strict=True) if n != leg
+    }
+    assert differing == {
+        "agent_refusal",
+        "confabulation_risk",
+        "goal_drift",
+        "looping_tool_call",
+        "model_refusal",
+        "off_topic",
+        "self_reported_stuck",
+        "tool_error",
+    }
 
 
 def test_every_drift_kind_is_in_the_surface() -> None:
@@ -227,12 +315,11 @@ def test_hard_safety_kinds_stay_armed_at_critical() -> None:
     :attr:`DriftObserver._HARD_SAFETY_DRIFT_KINDS` (#453) so a future
     ladder edit cannot demote a guardrail row by accident.
 
-    Note (consistency, not a fix): RESOURCE_EXHAUSTED / TOO_MANY_STEPS /
-    TASK_TIMEOUT / LLM_CALL_TIMEOUT are hard-safety (cancel-authorised)
-    yet map CRITICAL-first to ABSORB (refine), i.e. "redirect" rather
-    than the §0 "stop". That latent mismatch predates PR 3 and is the
-    ladder restructure's concern (PR 7); this test only asserts they are
-    not OBSERVE.
+    PR 7 closed the latent mismatch this note used to flag: RESOURCE_EXHAUSTED
+    / TOO_MANY_STEPS / TASK_TIMEOUT / LLM_CALL_TIMEOUT now map CRITICAL-first to
+    CANCEL_REINVOKE (stop), not ABSORB (redirect) — verified by the snapshot.
+    This test additionally pins that hard-safety kinds never map CRITICAL to
+    ABSORB (the §0 stop-not-redirect guarantee).
     """
     steerer = DefaultSteerer()
     threshold = steerer.REFINE_FAILURE_THRESHOLD
@@ -241,3 +328,7 @@ def test_hard_safety_kinds_stay_armed_at_critical() -> None:
         repeat = steerer.drift._ladder_level_for(kind, DriftSeverity.CRITICAL, threshold)
         assert first is not InterventionLevel.OBSERVE, kind
         assert repeat is not InterventionLevel.OBSERVE, kind
+        # PR 7 stop-not-redirect: a CRITICAL guardrail trip must STOP, never
+        # ABSORB (refine-and-continue). HUMAN_INTERVENTION_REQUIRED maps to
+        # PAUSE_ESCALATE; the budget/timeout kinds to CANCEL_REINVOKE.
+        assert first is not InterventionLevel.ABSORB, kind

--- a/tests/test_ladder_decision_table.py
+++ b/tests/test_ladder_decision_table.py
@@ -321,9 +321,10 @@ def test_hard_safety_kinds_stay_armed_at_critical() -> None:
 
     PR 7 closed the latent mismatch this note used to flag: RESOURCE_EXHAUSTED
     / TOO_MANY_STEPS / TASK_TIMEOUT / LLM_CALL_TIMEOUT now map CRITICAL-first to
-    CANCEL_REINVOKE (stop), not ABSORB (redirect) — verified by the snapshot.
-    This test additionally pins that hard-safety kinds never map CRITICAL to
-    ABSORB (the §0 stop-not-redirect guarantee).
+    PAUSE_ESCALATE (stop — restart can't refund a spent budget), not ABSORB
+    (redirect); RUNAWAY_DELEGATION maps to CANCEL_REINVOKE — verified by the
+    snapshot. This test additionally pins that hard-safety kinds never map
+    CRITICAL to ABSORB (the §0 stop-not-redirect guarantee).
     """
     steerer = DefaultSteerer()
     threshold = steerer.REFINE_FAILURE_THRESHOLD

--- a/tests/test_observation_only.py
+++ b/tests/test_observation_only.py
@@ -360,8 +360,16 @@ async def test_warning_drift_active_steering_drives_all_three_injections() -> No
     (legacy) here so the observation_only gate remains the ONLY
     variable under test; the new-default cancel policy has its own
     coverage in ``tests/test_cancel_authority_gate.py``.
+
+    AGENCY-PRESERVATION.md PR 7: the GOLDFIVE_STEER dispatch is likewise the
+    legacy promotion mechanism, so ``legacy_ladder=True`` is pinned here too —
+    again keeping the observation_only gate the only variable. The default
+    regime's note-enqueue promotion is covered in
+    ``test_promote_drift_to_steer.py``.
     """
-    cfg = SteeringConfig(observation_only=False, cancel_inflight_scope="all")
+    cfg = SteeringConfig(
+        observation_only=False, cancel_inflight_scope="all", legacy_ladder=True
+    )
     steerer = DefaultSteerer(steering_config=cfg)
     session = _make_session()
     sink = ListSink()

--- a/tests/test_pause_escalate.py
+++ b/tests/test_pause_escalate.py
@@ -210,15 +210,15 @@ async def test_refine_validation_failed_pauses_without_refining() -> None:
 async def test_ladder_level_for_pause_escalate_on_repeat() -> None:
     """Threshold-crossing occurrence drives CRITICAL to Level 4.
 
-    Uses TOOL_ERROR: first CRITICAL = CANCEL_REINVOKE, repeat =
-    PAUSE_ESCALATE. (Was PLAN_DIVERGENCE, demoted to OBSERVE at all
-    severities in AGENCY-PRESERVATION.md PR 3 — re-pointed to a kind
-    that still exhibits the first→repeat escalation this test pins.)
+    Uses TOOL_ERROR: first CRITICAL = SIGNAL, repeat = PAUSE_ESCALATE.
+    (AGENCY-PRESERVATION.md PR 7 demoted the goldfive-authored CANCEL_REINVOKE
+    first cell to SIGNAL; the repeat-escalation to PAUSE_ESCALATE this test
+    pins is unchanged.)
     """
     steerer = DefaultSteerer()
     assert (
         steerer.drift._ladder_level_for(DriftKind.TOOL_ERROR, DriftSeverity.CRITICAL, 0)
-        is InterventionLevel.CANCEL_REINVOKE
+        is InterventionLevel.SIGNAL
     )
     # Threshold is 2 in DefaultSteerer.REFINE_FAILURE_THRESHOLD.
     assert (
@@ -408,22 +408,23 @@ async def test_cancel_reinvoke_dispatches_goldfive_steer_control() -> None:
             )
 
     steerer.bind(sinks=[], planner=GoodPlanner())
-    # Use TOOL_ERROR for the Level 3 first-occurrence check:
-    # LOOPING_REASONING's CRITICAL-first tier routes to NUDGE
-    # (Level 2) after goldfive#204, so we pick a drift kind whose
-    # CRITICAL-first tier still routes to CANCEL_REINVOKE AND whose
-    # corrective-template interpolates the current_task_id.
+    # AGENCY-PRESERVATION.md PR 7 re-point: CANCEL_REINVOKE survives ONLY for
+    # the user-steer junction and hard-safety kinds — the goldfive-authored
+    # content kinds (TOOL_ERROR / OFF_TOPIC / …) were demoted to SIGNAL (note,
+    # no GOLDFIVE_STEER). RUNAWAY_DELEGATION is a hard-safety kind whose
+    # CRITICAL-first still maps to CANCEL_REINVOKE, so it exercises the
+    # surviving Level-3 GOLDFIVE_STEER dispatch this test pins.
     drift = DriftEvent(
-        kind=DriftKind.TOOL_ERROR,
+        kind=DriftKind.RUNAWAY_DELEGATION,
         severity=DriftSeverity.CRITICAL,
-        detail="tool error",
+        detail="runaway delegation",
         current_task_id="t1",
     )
     await steerer.drift.handle_drift(drift, session)
     steer_msgs = _drain_goldfive_steer(channel)
     assert len(steer_msgs) == 1
     payload = steer_msgs[0].payload
-    assert payload["drift_kind"] == DriftKind.TOOL_ERROR.value
+    assert payload["drift_kind"] == DriftKind.RUNAWAY_DELEGATION.value
     assert "t1" in payload["body"]
     # Re-pointed by AGENCY-PRESERVATION.md PR 4: the body used to
     # interpolate the next PENDING task's title ("Try a different

--- a/tests/test_promote_drift_to_steer.py
+++ b/tests/test_promote_drift_to_steer.py
@@ -144,13 +144,16 @@ def _make_session() -> Session:
     )
 
 
-def _bound_steerer() -> tuple[
+def _bound_steerer(*, legacy_ladder: bool = False) -> tuple[
     DefaultSteerer, _RevisedPlanPlanner, ControlChannel, _ListSink
 ]:
     steerer = DefaultSteerer(
         goldfive_steer_threshold="warning",
         goldfive_steer_suppression_window_turns=3,
     )
+    # AGENCY-PRESERVATION.md PR 7: promotion strips its GOLDFIVE_STEER dispatch
+    # + active_steer stamp by default; ``legacy_ladder=True`` restores them.
+    steerer._legacy_ladder = bool(legacy_ladder)
     planner = _RevisedPlanPlanner(revised=_make_revised_plan())
     sink = _ListSink()
     channel = ControlChannel()
@@ -188,8 +191,15 @@ async def test_promote_drift_dispatches_after_plan_swap_audit_402() -> None:
     swapped ``session.plan`` to the revised version, so
     ``_dispatch_goldfive_steer_control`` reads the NEW plan's PENDING
     tasks and the wire payload carries ``t_new_pending``.
+
+    AGENCY-PRESERVATION.md PR 7: promotion's GOLDFIVE_STEER dispatch now fires
+    only under the ``legacy_ladder`` escape hatch (the default regime enqueues
+    an advisory note instead — see
+    ``test_promote_drift_new_regime_enqueues_note_no_steer``). This audit-#402
+    ordering regression is pinned in the legacy regime where the dispatch
+    survives.
     """
-    steerer, planner, channel, _sink = _bound_steerer()
+    steerer, planner, channel, _sink = _bound_steerer(legacy_ladder=True)
     drift = DriftEvent(
         kind=DriftKind.OFF_TOPIC,
         severity=DriftSeverity.WARNING,
@@ -244,3 +254,47 @@ async def test_promote_drift_dispatches_after_plan_swap_audit_402() -> None:
     # Drift kind + body still propagate.
     assert payload["drift_kind"] == DriftKind.OFF_TOPIC.value
     assert "raccoons" in payload["body"]
+
+
+async def test_promote_drift_new_regime_enqueues_note_no_steer() -> None:
+    """AGENCY-PRESERVATION.md PR 7: default-regime promotion strips its
+    steering side-effects.
+
+    The promotion still refines (``refine_steer``) and emits ``PlanRevised``,
+    but it no longer dispatches a ``GOLDFIVE_STEER`` ControlMessage, tags the
+    adapter cancel reason, or stamps ``active_steer(source="goldfive")``.
+    Instead it enqueues an advisory observer note on the configured channel
+    (legacy ``pending_nudges`` by default).
+    """
+    steerer, planner, channel, _sink = _bound_steerer()  # legacy_ladder=False
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="agent wandered off into raccoons",
+        current_task_id="t_running",
+        authored_by="goldfive",
+    )
+    session = _make_session()
+    await steerer.drift.handle_drift(drift, session)
+
+    # Kept: refine_steer fired + the plan swapped.
+    assert planner.refine_steer_calls, "refine_steer should still fire"
+    assert session.plan is not None
+
+    # Stripped: no GOLDFIVE_STEER ControlMessage.
+    steer_msgs = [
+        m for m in _drain_channel(channel) if m.kind is ControlKind.GOLDFIVE_STEER
+    ]
+    assert steer_msgs == [], "default regime must not dispatch GOLDFIVE_STEER"
+
+    # Stripped: active_steer not stamped with the goldfive source.
+    from goldfive.state_store import StateStore
+
+    active = StateStore.for_session(session).get_active_steer()
+    assert active is None or active.source.lower() != "goldfive"
+
+    # Added: an advisory note was enqueued (legacy_user_message channel).
+    from goldfive.observer_notes import ADVISORY_FOOTER
+
+    assert len(session.pending_nudges) == 1
+    assert ADVISORY_FOOTER in session.pending_nudges[0]

--- a/tests/test_signal_telemetry.py
+++ b/tests/test_signal_telemetry.py
@@ -268,13 +268,24 @@ async def test_pause_control_dispatch_emits_delivery_and_escalated_outcome() -> 
 
 
 async def test_handle_drift_promotion_path_emits_signal_end_to_end() -> None:
-    """Full chain: handle_drift -> promote_drift_to_steer -> dispatch -> emit."""
+    """Full chain: handle_drift -> promote_drift_to_steer -> note enqueue -> emit.
+
+    AGENCY-PRESERVATION.md PR 7: the default-regime promotion enqueues an
+    advisory note instead of dispatching GOLDFIVE_STEER, so the emitted
+    ``SignalDelivered`` rides the note channel (``nudge_replay`` under the
+    default ``signal_channel``) and carries ``ladder_level="promotion"`` in its
+    decision payload rather than ``channel == SIGNAL_CHANNEL_PROMOTION`` (the
+    legacy-only dispatch channel). The end-to-end emission is what this pins.
+    """
     steerer, session, sink = _setup(observation_only=False)
     # OFF_TOPIC + WARNING is on the promote-to-steer path.
     await steerer.drift.handle_drift(_drift(kind=DriftKind.OFF_TOPIC), session)
     await steerer.drift._wait_background_drifts_idle()
     rows = _delivered(sink)
-    assert any(r.signal_delivered.channel == SIGNAL_CHANNEL_PROMOTION for r in rows)
+    assert any(
+        json.loads(r.signal_delivered.decision_json).get("ladder_level") == "promotion"
+        for r in rows
+    ), "promotion path must emit a SignalDelivered with ladder_level=promotion"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_steer_unification.py
+++ b/tests/test_steer_unification.py
@@ -132,12 +132,21 @@ def _make_session() -> Session:
 
 
 def _bind(
-    *, threshold: str = "warning", window: int = 3
+    *, threshold: str = "warning", window: int = 3, legacy_ladder: bool = True
 ) -> tuple[DefaultSteerer, Session, ListSink, _StubPlanner, _FakeAdapter]:
+    # AGENCY-PRESERVATION.md PR 7: the goldfive-steer promotion MECHANISM this
+    # module exercises (the ``active_steer(source="goldfive")`` stamp, the
+    # adapter cancel-reason tag, and the ``GOLDFIVE_STEER`` ControlMessage
+    # dispatch) now lives behind the ``legacy_ladder`` escape hatch. These
+    # tests are the §5.8 legacy-regime coverage, so they bind with the hatch
+    # ON by default. The default (non-legacy) promotion — refine + PlanRevised
+    # + advisory note, NO steer side-effects — is covered by
+    # ``test_promote_drift_to_steer.py::test_promote_drift_new_regime_enqueues_note_no_steer``.
     steerer = DefaultSteerer(
         goldfive_steer_threshold=threshold,
         goldfive_steer_suppression_window_turns=window,
     )
+    steerer._legacy_ladder = bool(legacy_ladder)
     revised = Plan(
         id="p1",
         run_id="r1",

--- a/tests/test_tier1_loop_prevention.py
+++ b/tests/test_tier1_loop_prevention.py
@@ -373,7 +373,7 @@ def test_f4_goal_drift_warning_routes_to_nudge() -> None:
     level = steerer.drift._ladder_level_for(
         DriftKind.GOAL_DRIFT, DriftSeverity.WARNING, occurrence_count=0
     )
-    assert level is InterventionLevel.NUDGE
+    assert level is InterventionLevel.SIGNAL
 
 
 def test_f4_goal_drift_critical_first_routes_to_nudge() -> None:
@@ -386,21 +386,23 @@ def test_f4_goal_drift_critical_first_routes_to_nudge() -> None:
     level = steerer.drift._ladder_level_for(
         DriftKind.GOAL_DRIFT, DriftSeverity.CRITICAL, occurrence_count=0
     )
-    assert level is InterventionLevel.NUDGE
+    assert level is InterventionLevel.SIGNAL
 
 
-def test_f4_goal_drift_critical_repeat_routes_to_cancel_reinvoke() -> None:
-    """F4: CRITICAL-severity GOAL_DRIFT repeat -> CANCEL_REINVOKE.
+def test_f4_goal_drift_critical_repeat_routes_to_pause_escalate() -> None:
+    """F4: CRITICAL-severity GOAL_DRIFT repeat -> PAUSE_ESCALATE.
 
-    PAUSE_ESCALATE is the last-resort fallback the default ladder
-    surfaces only after CANCEL_REINVOKE also fails to break the loop."""
+    AGENCY-PRESERVATION.md PR 7 moved the repeat-escalation cell from
+    CANCEL_REINVOKE (cancel-and-redirect) to PAUSE_ESCALATE (stop-and-ask):
+    when an advisory SIGNAL doesn't break the loop, goldfive halts for the
+    operator rather than grabbing the wheel."""
     steerer = DefaultSteerer()
     level = steerer.drift._ladder_level_for(
         DriftKind.GOAL_DRIFT,
         DriftSeverity.CRITICAL,
         occurrence_count=DefaultSteerer.REFINE_FAILURE_THRESHOLD,
     )
-    assert level is InterventionLevel.CANCEL_REINVOKE
+    assert level is InterventionLevel.PAUSE_ESCALATE
 
 
 # The three pre-PR-4 tests here pinned the GOAL_DRIFT corrective


### PR DESCRIPTION
## What

Stage 2 **PR 7**: rebuild steering as proportional, trajectory-preserving influence. The goldfive-authored "wheel grab" (CANCEL_REINVOKE → cancel-and-restart) is demoted to an advisory note.

### Ladder (`DriftObserver._LADDER`)
- **Rename `InterventionLevel.NUDGE` → `SIGNAL`** (value 2 unchanged). SIGNAL enqueues an advisory observer note — no refine, no cancel, no steer.
- **Demote every goldfive-authored `CANCEL_REINVOKE` cell → `SIGNAL`**; repeat-escalation → `PAUSE_ESCALATE` (stop-and-ask preserves trajectory; cancel-and-redirect does not). `CANCEL_REINVOKE` survives **only** for the user-steer junction + hard-safety kinds.
- **Deferred Stage-1 fix #1 (hard-safety stop):** the budget/timeout kinds (`resource_exhausted`, `too_many_steps`, `task_timeout`, `llm_call_timeout`) fell through to the default whose CRITICAL-first is `ABSORB` ("redirect") — a §0 stop-not-redirect violation for a guardrail. They now STOP: CRITICAL `[CANCEL_REINVOKE|PAUSE_ESCALATE]`, WARNING `OBSERVE`. (`runaway_delegation` was already correct.)
- **Deferred Stage-1 fix #2:** remove `PLAN_DIVERGENCE` from `_GOLDFIVE_STEER_ELIGIBLE_KINDS` (unreachable dead config — OBSERVE at all severities + dropped at the top of `handle_drift`).

### Promotion (`_promote_drift_to_steer`)
Strip the steering side-effects: **no** cancel-reason tag, **no** `GOLDFIVE_STEER` dispatch, **no** `active_steer(source="goldfive")` stamp. It refines (`refine_steer`), emits `PlanRevised`, and **enqueues an advisory note** (ladder_level="promotion").

### Escape hatch
`GOLDFIVE_STEER_LEGACY_LADDER=1` (`SteeringConfig.legacy_ladder`, default `False`) restores the pre-PR-7 cells + full promotion side-effects for one release — the §5.8 measurable-regression arm (bench arm C). The deferred correctness fixes (hard-safety stop, PLAN_DIVERGENCE removal, NUDGE→SIGNAL rename) are **not** toggled by it; they apply in both regimes.

## §5 requirements satisfied
- **§5.1 no-op-by-default for the escape-hatch'd behaviour:** the new ladder is the default; `legacy_ladder` restores the old cells. The deferred fixes are unconditional bug fixes.
- **§5.3 decision-table snapshot, both regimes:** `tests/test_ladder_decision_table.py` re-baselined — `EXPECTED_LADDER_SURFACE` (default) + a new `EXPECTED_LADDER_SURFACE_LEGACY` (escape hatch) + `test_legacy_overrides_are_exactly_the_demoted_rows` proving the two differ on *exactly* the 8 demoted rows. Every cell change is a reviewable diff. `test_hard_safety_kinds_stay_armed_at_critical` strengthened to pin stop-not-redirect.
- **§5.3 deliberate test migration (each assertion re-pointed or justified, never dropped):**
  - Ladder cells (`test_intervention_ladder.py`, `test_pause_escalate.py`, `test_tier1_loop_prevention.py`): re-pointed to the new SIGNAL/PAUSE_ESCALATE cells.
  - `test_cancel_reinvoke_dispatches_goldfive_steer_control`: re-pointed to `RUNAWAY_DELEGATION` (the surviving hard-safety CANCEL_REINVOKE path).
  - Promotion-mechanism suites (`test_steer_unification`, `test_goldfive_drift_routing`, `test_goldfive_steer_request_cancel`, `test_observation_only` positive control, `test_drift_outcomes` goal-drift bypass): bound to `legacy_ladder=True` — they pin the legacy mechanism, now §5.8 legacy-regime coverage. New default-regime promotion test added (`test_promote_drift_new_regime_enqueues_note_no_steer`).
  - `test_signal_telemetry` promotion test: re-pointed from the legacy `SIGNAL_CHANNEL_PROMOTION` to the new note-channel signal (`ladder_level="promotion"`).
- **Bench same-PR contract:** `GOLDFIVE_STEER_LEGACY_LADDER` promoted from `_PENDING_STEER_ENV` to `KNOWN_STEER_ENV` (now read by `from_env`); the flag-status test updated (no roadmap flags pending anymore).

## Tests
**Full suite: `2541 passed, 131 skipped`; ruff clean.** Both ladder regimes snapshotted. Doc: `DRIFT.md` ladder table updated.

## Notes / design decisions (flagging for review)
1. **Hard-safety CRITICAL cell = `CANCEL_REINVOKE`** (not `PAUSE_ESCALATE`): chosen to match the existing `RUNAWAY_DELEGATION` row and because the roadmap explicitly retains CANCEL_REINVOKE for hard-safety. WARNING set to `OBSERVE` (a budget trip is CRITICAL by construction; a sub-CRITICAL budget signal is informational). Open to PAUSE_ESCALATE-first if you'd prefer halt-over-restart for budget trips.
2. **`_cancel_inflight_for_revision` kept** in `_promote_drift_to_steer` (not in the brief's strip list): it is already authority-gated to a no-op for goldfive-authored promotion under the default `cancel_inflight_scope`, and keeping it preserves the `scope="all"` kill-switch semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)