### PR TITLE
feat(steering): agent-scoped note delivery + correction migration + cross-surface plan-state fold (AGENCY-PRESERVATION task #11)

### DIFF
--- a/goldfive/_correction_injection.py
+++ b/goldfive/_correction_injection.py
@@ -224,6 +224,7 @@ def queue_corrections_for_revision(
     revised: Plan,
     prev_plan: Plan | None,
     drift: DriftEvent,
+    corrections_via_notes: bool = False,
 ) -> list[str]:
     """Scan ``revised`` for CORRECT-kind supersedes and stamp corrections.
 
@@ -244,6 +245,19 @@ def queue_corrections_for_revision(
 
     Returns the list of state keys written so callers (tests, sinks)
     can assert on multi-correction revisions.
+
+    ``corrections_via_notes`` (AGENCY-PRESERVATION.md task #11) — when
+    ``True`` (the ``request_context`` regime with the Site-4 pin retired)
+    each correction is enqueued onto the StateStore-backed
+    :class:`~goldfive.observer_note_queue.ObserverNoteQueue` (carrying the
+    assignee as ``agent_id`` so the agent-scoped delivery surfaces route
+    it only to that agent) INSTEAD of the pending-correction state slot —
+    closing the "written but unread under request_context" gap PR 9's
+    KNOWN LIMITATION note marked. When ``False`` (the default, and the
+    legacy / ``pin_assigned_task=True`` paths) the pre-task-#11
+    ``write_correction`` slot is used unchanged (the dynamic-instruction
+    resolver reads it), so existing suites pass unmodified (§5.1). The
+    returned ids are note ids in the notes regime, state keys otherwise.
 
     No-op when ``revised`` has no CORRECT-kind supersedes links, when
     the session has no state dict, or when the triggering drift is
@@ -307,6 +321,23 @@ def queue_corrections_for_revision(
             revision_number=revision_number,
             issued_at_ms=now_ms,
         )
+        if corrections_via_notes:
+            note_id = _enqueue_correction_note(
+                session=session, payload=payload, drift=drift
+            )
+            if note_id:
+                written_keys.append(note_id)
+                log.info(
+                    "correction routed to observer-note queue for agent=%r "
+                    "task=%r (superseded=%r, drift=%s, rev=%d, note=%s)",
+                    payload["agent_name"],
+                    payload["task_id"],
+                    payload["superseded_task_id"],
+                    payload["drift_kind"] or "(none)",
+                    revision_number,
+                    note_id,
+                )
+            continue
         key = write_correction(session, payload)
         if key is not None:
             written_keys.append(key)
@@ -319,6 +350,67 @@ def queue_corrections_for_revision(
                 revision_number,
             )
     return written_keys
+
+
+def _enqueue_correction_note(
+    *,
+    session: Any,
+    payload: Mapping[str, Any],
+    drift: DriftEvent,
+) -> str | None:
+    """Enqueue one CORRECT-kind correction onto the ObserverNoteQueue.
+
+    AGENCY-PRESERVATION.md task #11. The note carries the assignee as
+    ``agent_id`` (bare) so the agent-scoped delivery surfaces (notably
+    the ADK ``before_model`` surface) render it only on that agent's own
+    model call — never on a sibling's. ``drift_id`` is a stable,
+    goldfive-minted key (``correction:<agent>:<task>:<rev>``) so a
+    re-revision coalesces onto the same note rather than duplicating
+    (the stable-key-for-lifecycle-gates rule — never an LLM-minted id).
+    Returns the note id, or ``None`` on any failure (best-effort — a
+    correction that can't be enqueued must not break the refine path).
+    """
+    try:
+        # Lazy imports: ``adk_llm_instrumentation`` imports this module
+        # (pending_correction_key et al.), so a module-level import here
+        # would be circular.
+        from goldfive.adapters.adk_llm_instrumentation import format_correction_block
+        from goldfive.observer_note_queue import ObserverNoteQueue
+
+        agent = str(payload.get("agent_name", "") or "")
+        task_id = str(payload.get("task_id", "") or "")
+        rev = int(payload.get("revision_number", 0) or 0)
+        if not agent or not task_id:
+            return None
+        body = format_correction_block(payload)
+        if not body:
+            return None
+        superseded = str(payload.get("superseded_task_id", "") or "")
+        observation = (
+            f"the plan was revised (rev {rev}); task {task_id} supersedes "
+            f"{superseded or '(prior task)'}"
+        )
+        severity = str(
+            getattr(getattr(drift, "severity", None), "value", "") or "warning"
+        ).lower()
+        kind = str(getattr(getattr(drift, "kind", None), "value", "") or "") or "correction"
+        turn = int(getattr(session, "_reasoning_turn", 0) or 0)
+        queue = ObserverNoteQueue.for_session(session)
+        note = queue.enqueue(
+            body=body,
+            observation=observation,
+            severity=severity,
+            drift_id=f"correction:{agent}:{task_id}:{rev}",
+            kind=kind,
+            task_id=task_id,
+            agent_id=agent,
+            turn=turn,
+            ladder_level="correction",
+        )
+        return note.note_id
+    except Exception as exc:  # noqa: BLE001
+        log.debug("queue_corrections_for_revision: note enqueue raised: %s", exc)
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/goldfive/_correction_injection.py
+++ b/goldfive/_correction_injection.py
@@ -363,10 +363,14 @@ def _enqueue_correction_note(
     AGENCY-PRESERVATION.md task #11. The note carries the assignee as
     ``agent_id`` (bare) so the agent-scoped delivery surfaces (notably
     the ADK ``before_model`` surface) render it only on that agent's own
-    model call — never on a sibling's. ``drift_id`` is a stable,
-    goldfive-minted key (``correction:<agent>:<task>:<rev>``) so a
-    re-revision coalesces onto the same note rather than duplicating
-    (the stable-key-for-lifecycle-gates rule — never an LLM-minted id).
+    model call — never on a sibling's, never on the coordinator boundary
+    replay, and never on the loop-only tool-annotation surface. The
+    ``drift_id`` is a stable, goldfive-minted key
+    (:data:`~goldfive.observer_note_queue.CORRECTION_DRIFT_ID_PREFIX` +
+    ``<agent>:<task>:<rev>``) — never an LLM-minted id. It is unique per
+    revision: a later revision (higher ``rev``) mints a NEW note;
+    re-enqueuing the SAME revision (e.g. a retry of the same refine)
+    coalesces onto the existing entry.
     Returns the note id, or ``None`` on any failure (best-effort — a
     correction that can't be enqueued must not break the refine path).
     """
@@ -375,7 +379,10 @@ def _enqueue_correction_note(
         # (pending_correction_key et al.), so a module-level import here
         # would be circular.
         from goldfive.adapters.adk_llm_instrumentation import format_correction_block
-        from goldfive.observer_note_queue import ObserverNoteQueue
+        from goldfive.observer_note_queue import (
+            CORRECTION_DRIFT_ID_PREFIX,
+            ObserverNoteQueue,
+        )
 
         agent = str(payload.get("agent_name", "") or "")
         task_id = str(payload.get("task_id", "") or "")
@@ -400,7 +407,7 @@ def _enqueue_correction_note(
             body=body,
             observation=observation,
             severity=severity,
-            drift_id=f"correction:{agent}:{task_id}:{rev}",
+            drift_id=f"{CORRECTION_DRIFT_ID_PREFIX}{agent}:{task_id}:{rev}",
             kind=kind,
             task_id=task_id,
             agent_id=agent,

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -6714,7 +6714,13 @@ def make_adk_plugin(
 
             _LOOP_KINDS = frozenset({"looping_tool_call", "looping_reasoning"})
             queue = ObserverNoteQueue.for_session(ctx.session)
-            note = queue.peek_for_render(kinds=_LOOP_KINDS)
+            # task #11: loop observations belong on the tool annotation;
+            # agent-targeted corrections do NOT (they ride the agent-aware
+            # block surfaces). Exclude correction-origin notes structurally
+            # even if a correction's triggering drift was a loop kind.
+            note = queue.peek_for_render(
+                kinds=_LOOP_KINDS, exclude_correction_notes=True
+            )
             if note is None:
                 return None
             turn = int(_safe_attr(ctx.session, "_reasoning_turn", 0) or 0)

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -5481,10 +5481,22 @@ def make_adk_plugin(
                     and getattr(ctx.steerer, "_signal_channel", "legacy_user_message")
                     == "request_context"
                 ):
+                    # Resolve the agent whose model call this is, so the
+                    # note channel scopes per-(agent,task) notes to their
+                    # own agent (task #11). Falls back to the host agent.
+                    _inv_ctx = _safe_attr(
+                        callback_context, "_invocation_context", None
+                    ) or _safe_attr(callback_context, "invocation_context", None)
+                    _running_agent = _safe_attr(_inv_ctx, "agent", None)
+                    _current_agent_name = (
+                        str(_safe_attr(_running_agent, "name", "") or "")
+                        or self._host_agent_name
+                    )
                     self._prompt_shaper.inject_observer_note(
                         llm_request=llm_request,
                         session=ctx.session,
                         session_context=ctx,
+                        current_agent_name=_current_agent_name,
                     )
             except Exception as exc:  # noqa: BLE001
                 log.debug(

--- a/goldfive/adapters/claude.py
+++ b/goldfive/adapters/claude.py
@@ -564,7 +564,9 @@ class ClaudeAgentSDKAdapter:
             log.debug("claude adapter: observer-note mark_delivered raised: %s", exc)
             return None
         if should and newly:
-            return render_block(note)
+            # task #11 cross-surface fold: carry the plan-state Status line
+            # on the claude surface too (identical to before_model).
+            return render_block(note, plan=getattr(session, "plan", None))
         return None
 
 

--- a/goldfive/adapters/claude.py
+++ b/goldfive/adapters/claude.py
@@ -292,12 +292,19 @@ class ClaudeAgentSDKAdapter:
         # under the legacy default (the queue is never populated) or
         # observation_only. Best-effort: never blocks the invocation.
         note_block = await self._consume_observer_note(
-            session, surface="claude_system_prompt"
+            session,
+            surface="claude_system_prompt",
+            current_agent_id=task.assignee_agent_id,
         )
         if note_block:
             system_prompt = f"{system_prompt}\n\n{note_block}"
 
-        options = self._build_options(sdk=sdk, system_prompt=system_prompt, session=session)
+        options = self._build_options(
+            sdk=sdk,
+            system_prompt=system_prompt,
+            session=session,
+            current_agent_id=task.assignee_agent_id,
+        )
 
         client = self._client_factory()
         # ``ClaudeSDKClient`` options are set on the instance; some
@@ -366,6 +373,7 @@ class ClaudeAgentSDKAdapter:
         sdk: Any,
         system_prompt: str,
         session: Session,
+        current_agent_id: str = "",
     ) -> Any:
         """Assemble a fresh ``ClaudeAgentOptions`` for this invocation."""
 
@@ -386,7 +394,13 @@ class ClaudeAgentSDKAdapter:
             == "request_context"
         ):
             hooks["PostToolUse"] = [
-                sdk.HookMatcher(hooks=[self._make_posttooluse_hook(session)])
+                sdk.HookMatcher(
+                    hooks=[
+                        self._make_posttooluse_hook(
+                            session, current_agent_id=current_agent_id
+                        )
+                    ]
+                )
             ]
 
         kwargs: dict[str, Any] = {
@@ -477,6 +491,8 @@ class ClaudeAgentSDKAdapter:
     def _make_posttooluse_hook(
         self,
         session: Session,
+        *,
+        current_agent_id: str = "",
     ) -> Callable[..., Awaitable[dict[str, Any]]]:
         """Build the async ``PostToolUse`` hook (PR 6 observer-note surface 3b).
 
@@ -494,7 +510,9 @@ class ClaudeAgentSDKAdapter:
         ) -> dict[str, Any]:
             try:
                 block = await self._consume_observer_note(
-                    session, surface="claude_posttooluse"
+                    session,
+                    surface="claude_posttooluse",
+                    current_agent_id=current_agent_id,
                 )
             except Exception as exc:  # noqa: BLE001
                 log.debug("claude PostToolUse: observer-note consume raised: %s", exc)
@@ -515,6 +533,7 @@ class ClaudeAgentSDKAdapter:
         session: Session,
         *,
         surface: str,
+        current_agent_id: str = "",
     ) -> str | None:
         """Consume the most-severe pending observer note for a claude surface.
 
@@ -539,7 +558,11 @@ class ClaudeAgentSDKAdapter:
             from goldfive.observer_note_queue import ObserverNoteQueue, render_block
 
             queue = ObserverNoteQueue.for_session(session)
-            note = queue.peek_for_render()
+            # task #11: claude.invoke runs exactly one agent, so this is an
+            # agent-AWARE surface — scope to its assignee so an
+            # agent-specific note (e.g. a correction) reaches only the right
+            # agent (plus broadcast notes).
+            note = queue.peek_for_render(agent_id=current_agent_id or None)
         except Exception as exc:  # noqa: BLE001
             log.debug("claude adapter: observer-note queue read raised: %s", exc)
             return None

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -2141,7 +2141,9 @@ class SequentialExecutor(Executor):
             return None
         if not newly:
             return None
-        return render_block(note)
+        # task #11 cross-surface fold: carry the plan-state Status line on
+        # the boundary-replay surface too (identical to before_model).
+        return render_block(note, plan=getattr(session, "plan", None))
 
     @staticmethod
     def _compose_steer_restart_message(

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -2122,7 +2122,12 @@ class SequentialExecutor(Executor):
 
         try:
             queue = ObserverNoteQueue.for_session(session)
-            note = queue.peek_for_render()
+            # task #11: the boundary replay re-invokes at the coordinator
+            # level and cannot attribute a note to a specific sub-agent, so
+            # it delivers BROADCAST notes only. An agent-specific note (e.g.
+            # a correction) stays pending for its own agent-aware surface —
+            # better undelivered than misdelivered (§0 dormancy bias).
+            note = queue.peek_for_render(broadcast_only=True)
         except Exception as exc:  # noqa: BLE001
             log.debug("SequentialExecutor: observer-note queue read raised: %s", exc)
             return None

--- a/goldfive/observer_note_queue.py
+++ b/goldfive/observer_note_queue.py
@@ -98,6 +98,14 @@ if TYPE_CHECKING:  # pragma: no cover - type-check only
 #: ``goldfive.signal_ledger`` / ``goldfive.active_drifts``.
 KEY_OBSERVER_NOTE_QUEUE = "goldfive.observer_note_queue"
 
+#: ``drift_id`` prefix minted for correction-origin notes (task #11). The
+#: SINGLE SOURCE for the prefix: ``_correction_injection`` mints
+#: ``correction:<agent>:<task>:<rev>`` and the queue's structural filters
+#: (``peek_for_render(exclude_correction_notes=True)``) recognise it — so a
+#: correction (agent-targeted) is never surfaced where only loop
+#: observations belong (the tool-result annotation).
+CORRECTION_DRIFT_ID_PREFIX = "correction:"
+
 #: Cap on the retained note list. Delivered notes are kept as tombstones so
 #: ``enqueue`` dedup and the exactly-once flag survive, but a pathologically
 #: long-lived session cannot balloon ``Session.state``: on overflow the
@@ -383,6 +391,8 @@ class ObserverNoteQueue:
         *,
         kinds: frozenset[str] | None = None,
         agent_id: str | None = None,
+        broadcast_only: bool = False,
+        exclude_correction_notes: bool = False,
     ) -> ObserverNote | None:
         """Return the most-severe pending note (per-request coalescing).
 
@@ -413,6 +423,19 @@ class ObserverNoteQueue:
           The surface that knows its agent (notably the ADK
           ``before_model`` surface) passes it; coarse surfaces leave it
           ``None``.
+
+        ``broadcast_only`` (task #11 — coarse-surface defense) selects ONLY
+        broadcast (empty ``agent_id``) notes, skipping every agent-specific
+        one. A surface that cannot resolve its agent (the boundary replay,
+        which re-invokes at the coordinator level) sets this so an
+        agent-specific note is never misdelivered there — it stays pending
+        for its own agent's agent-aware surface (better undelivered than
+        misdelivered; §0 dormancy bias). Takes precedence over ``agent_id``.
+
+        ``exclude_correction_notes`` (task #11) skips notes whose
+        ``drift_id`` carries :data:`CORRECTION_DRIFT_ID_PREFIX` — used by the
+        tool-result annotation surface so agent-targeted corrections never
+        ride the loop-observation channel, regardless of their drift kind.
         """
         target = _bare_agent(agent_id) if agent_id else None
         best: ObserverNote | None = None
@@ -422,8 +445,17 @@ class ObserverNoteQueue:
                 continue
             if kinds is not None and n.kind not in kinds:
                 continue
-            if target is not None:
-                note_agent = _bare_agent(n.agent_id)
+            if exclude_correction_notes and str(n.drift_id or "").startswith(
+                CORRECTION_DRIFT_ID_PREFIX
+            ):
+                continue
+            note_agent = _bare_agent(n.agent_id)
+            if broadcast_only:
+                # Only broadcast notes here; agent-specific notes wait for
+                # their own agent-aware surface.
+                if note_agent:
+                    continue
+            elif target is not None:
                 # Empty note_agent = broadcast (reaches any agent); a
                 # non-empty agent-specific note must match the target.
                 if note_agent and note_agent != target:
@@ -541,6 +573,7 @@ class ObserverNoteQueue:
 
 
 __all__ = [
+    "CORRECTION_DRIFT_ID_PREFIX",
     "KEY_OBSERVER_NOTE_QUEUE",
     # Re-exported from goldfive.observer_notes (single source) for callers that
     # import the marker constants alongside the queue API.

--- a/goldfive/observer_note_queue.py
+++ b/goldfive/observer_note_queue.py
@@ -209,7 +209,62 @@ class ObserverNote:
         )
 
 
-def render_block(note: ObserverNote) -> str:
+def _bare_agent(name: Any) -> str:
+    """Return the bare (namespace-stripped, lowercased) agent name.
+
+    Agent ids may be fully qualified (``ns:writer``); the bare segment is
+    what surfaces resolve and what notes are scoped on. Tolerant of
+    ``None`` / non-str.
+    """
+    try:
+        s = str(name or "").strip()
+    except Exception:  # noqa: BLE001
+        return ""
+    if ":" in s:
+        s = s.split(":")[-1]
+    return s.lower()
+
+
+def plan_state_line(plan: Any) -> str:
+    """Return a factual per-agent open-work line for the note Status fold.
+
+    AGENCY-PRESERVATION.md task #11 (cross-surface plan-state fold) — the
+    content the retired Site-3 hint used to inject per turn now rides the
+    observer note on EVERY block surface (before_model, boundary-replay,
+    claude), composed here so the three surfaces stay identical. Groups
+    ``plan.tasks`` by assignee and reports each agent's open
+    (non-terminal) vs. no-open-tasks state. Bookkeeping only — no "choose
+    the agent" / "do NOT re-invoke" imperative (dropped in PR 9). Returns
+    ``""`` when there is no plan / no tasks. Never raises.
+    """
+    try:
+        tasks = getattr(plan, "tasks", None) if plan is not None else None
+        if not tasks:
+            return ""
+        from goldfive.types import TERMINAL_TASK_STATUSES
+
+        by_agent: dict[str, list[int]] = {}
+        for t in tasks:
+            agent = getattr(t, "assignee_agent_id", "") or "<unassigned>"
+            bucket = by_agent.setdefault(agent, [0, 0])  # [open, done]
+            status = getattr(t, "status", None)
+            if status in TERMINAL_TASK_STATUSES:
+                bucket[1] += 1
+            else:
+                bucket[0] += 1
+        frags: list[str] = []
+        for agent in sorted(by_agent):
+            bare = agent.split(":")[-1] if ":" in agent else agent
+            open_n, _done_n = by_agent[agent]
+            frags.append(f"{bare}: {open_n} open" if open_n else f"{bare}: no open tasks")
+        if not frags:
+            return ""
+        return "Plan state (goldfive bookkeeping): " + "; ".join(frags) + "."
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def render_block(note: ObserverNote, *, plan: Any = None) -> str:
     """Render ``note`` as the marker-bracketed system-prompt / replay block.
 
     Shape (AGENCY-PRESERVATION.md PR 6 "Rendered block shape")::
@@ -219,13 +274,19 @@ def render_block(note: ObserverNote) -> str:
         The user's goal: <...>
         Status: <...>
         This note is advisory. How to proceed is your decision; ...
+        Plan state (goldfive bookkeeping): <...>      (task #11 fold, when ``plan`` given)
         [/GOLDFIVE OBSERVER NOTE]
 
     The body already carries the advisory footer (composed by PR 4); this
-    function only adds the attribution header + closing marker.
+    function adds the attribution header + closing marker, and — when
+    ``plan`` is supplied (task #11 cross-surface fold) — a factual
+    plan-state line INSIDE the block (so strip-and-refresh removes it as
+    one unit). ``plan=None`` keeps the pre-task-#11 shape byte-identical.
     """
     body = (note.body or "").strip()
-    return f"{OBSERVER_NOTE_BLOCK_BEGIN}\n{body}\n{OBSERVER_NOTE_BLOCK_END}"
+    extra = plan_state_line(plan) if plan is not None else ""
+    inner = f"{body}\n{extra}" if extra else body
+    return f"{OBSERVER_NOTE_BLOCK_BEGIN}\n{inner}\n{OBSERVER_NOTE_BLOCK_END}"
 
 
 def render_tool_annotation(note: ObserverNote) -> str:
@@ -321,6 +382,7 @@ class ObserverNoteQueue:
         self,
         *,
         kinds: frozenset[str] | None = None,
+        agent_id: str | None = None,
     ) -> ObserverNote | None:
         """Return the most-severe pending note (per-request coalescing).
 
@@ -334,7 +396,25 @@ class ObserverNoteQueue:
         ``kind`` is in the set — used by the tool-result annotation surface
         (4) to pick only loop-shaped notes, leaving other notes for the
         block surfaces.
+
+        ``agent_id`` (AGENCY-PRESERVATION.md task #11 — agent-scoped
+        delivery) restricts selection so a per-(agent, task) note reaches
+        only the right agent's surfaces:
+
+        * ``None`` (the default) — NO agent filter. Every caller that does
+          not / cannot resolve the current agent keeps the pre-task-#11
+          broadcast behaviour (and every existing test, which passes
+          agentless stubs, is unaffected — §5.1).
+        * ``"<name>"`` — select only notes whose ``agent_id`` is empty
+          (broadcast / coordinator-level) OR matches ``<name>`` by bare
+          name (namespace-stripped). An agent-specific note for a
+          DIFFERENT agent is skipped, so e.g. a correction enqueued for
+          ``writer`` is never rendered onto ``researcher``'s model call.
+          The surface that knows its agent (notably the ADK
+          ``before_model`` surface) passes it; coarse surfaces leave it
+          ``None``.
         """
+        target = _bare_agent(agent_id) if agent_id else None
         best: ObserverNote | None = None
         best_key: tuple[int, int, int] = (-2, -1, -1)
         for n in self.notes():
@@ -342,6 +422,12 @@ class ObserverNoteQueue:
                 continue
             if kinds is not None and n.kind not in kinds:
                 continue
+            if target is not None:
+                note_agent = _bare_agent(n.agent_id)
+                # Empty note_agent = broadcast (reaches any agent); a
+                # non-empty agent-specific note must match the target.
+                if note_agent and note_agent != target:
+                    continue
             key = (_severity_rank(n.severity), int(n.turn), int(n.enqueued_seq))
             if key > best_key:
                 best_key = key
@@ -463,6 +549,7 @@ __all__ = [
     "OBSERVER_NOTE_MARKER_PREFIX",
     "ObserverNote",
     "ObserverNoteQueue",
+    "plan_state_line",
     "render_block",
     "render_tool_annotation",
     "strip_prior_block",

--- a/goldfive/plan_reviser.py
+++ b/goldfive/plan_reviser.py
@@ -2176,11 +2176,29 @@ class PlanReviser:
                 # dynamic instruction resolver (Stream B) reads this on the next
                 # turn and appends a directive-style correction block to the
                 # agent's system prompt. No-op on refines with no CORRECT links.
+                #
+                # AGENCY-PRESERVATION.md task #11: in the request_context regime
+                # with the Site-4 pin retired, corrections ride the agent-scoped
+                # ObserverNoteQueue instead of that slot (the suppressed resolver
+                # no longer reads it). ``pin_assigned_task`` keeps the pin — and
+                # hence the slot read — so corrections stay on the slot there.
+                # Legacy channel: unchanged.
+                _channel = getattr(
+                    self._steerer, "_signal_channel", "legacy_user_message"
+                )
+                _pin = bool(
+                    getattr(
+                        getattr(self._steerer, "_steering_config", None),
+                        "pin_assigned_task",
+                        False,
+                    )
+                )
                 queue_corrections_for_revision(
                     session=session,
                     revised=revised,
                     prev_plan=prev_plan,
                     drift=drift,
+                    corrections_via_notes=(_channel == "request_context" and not _pin),
                 )
 
             # goldfive#237: re-pin ``current_task_id`` onto any replacement

--- a/goldfive/prompt_shaper.py
+++ b/goldfive/prompt_shaper.py
@@ -637,17 +637,16 @@ class PromptShaper:
                 # Legacy ``signal_channel`` keeps the pin (byte-identical;
                 # §5.1).
                 #
-                # KNOWN LIMITATION (request_context + pin off): this also
-                # drops the pending-CORRECTION block that legacy rides on
-                # this pin. Corrections are still WRITTEN
-                # (``queue_corrections_for_revision``) but go UNREAD in
-                # this regime until task #11 migrates them to the
-                # ObserverNoteQueue at write time (which requires an
-                # agent-scoped ``peek_for_render`` so a per-(agent,task)
-                # correction reaches only its agent). ``request_context``
-                # is opt-in / non-default, so this is a documented gap in
-                # the new regime, not a production regression. Re-enable
-                # delivery meanwhile via ``pin_assigned_task=True``.
+                # Pending corrections (which legacy rides on this pin) are
+                # NOT lost in this regime: task #11 routes them to the
+                # agent-scoped ObserverNoteQueue at write time
+                # (``queue_corrections_for_revision(corrections_via_notes=
+                # True)``), delivered via the observer-note surfaces — the
+                # ``peek_for_render`` agent filter ensures a per-(agent,task)
+                # correction reaches only its agent. (The PR-9 "written but
+                # unread" gap this note once flagged is now closed.) The
+                # ``pin_assigned_task=True`` escape hatch instead keeps the
+                # pin AND the legacy correction-slot read.
                 if shaper._request_context(steerer) and not shaper._pin_assigned_task(
                     steerer
                 ):
@@ -732,45 +731,19 @@ class PromptShaper:
 
     @staticmethod
     def _plan_state_line(session: Any) -> str:
-        """Return a factual per-agent open-work line for the note (PR 9 Site 3 fold).
+        """Return the factual per-agent open-work line for the note Status fold.
 
-        Replaces the retired per-turn plan-state hint: groups
-        ``session.plan.tasks`` by assignee and reports each agent's open
-        (non-terminal) vs complete count. Bookkeeping only — no "choose
-        the agent whose tasks are still PENDING" imperative (the means-
-        directive PR 9 drops). Returns ``""`` when there is no plan / no
-        tasks so the note block is unchanged on pre-plan turns. Never
-        raises.
+        AGENCY-PRESERVATION.md PR 9 introduced this fold on the
+        before_model surface; task #11 centralised the composition in
+        :func:`goldfive.observer_note_queue.plan_state_line` so the
+        boundary-replay + claude surfaces render an identical line. This
+        thin wrapper preserves the ``(session)`` call shape; the shared
+        helper takes the plan. Returns ``""`` when there is no plan.
         """
         try:
-            plan = _safe_attr(session, "plan", None)
-            tasks = _safe_attr(plan, "tasks", None) if plan is not None else None
-            if not tasks:
-                return ""
-            from goldfive.types import TERMINAL_TASK_STATUSES
+            from goldfive.observer_note_queue import plan_state_line
 
-            by_agent: dict[str, list[int]] = {}
-            for t in tasks:
-                agent = _safe_attr(t, "assignee_agent_id", "") or "<unassigned>"
-                bucket = by_agent.setdefault(agent, [0, 0])  # [open, done]
-                status = _safe_attr(t, "status", None)
-                if status in TERMINAL_TASK_STATUSES:
-                    bucket[1] += 1
-                else:
-                    bucket[0] += 1
-            frags: list[str] = []
-            for agent in sorted(by_agent):
-                bare = agent.split(":")[-1] if ":" in agent else agent
-                open_n, _done_n = by_agent[agent]
-                # "no open tasks" carries the anti-re-invoke fact the
-                # retired Site-3 hint used to provide ("all assigned tasks
-                # complete") — factual, no "do NOT re-invoke" imperative.
-                frags.append(
-                    f"{bare}: {open_n} open" if open_n else f"{bare}: no open tasks"
-                )
-            if not frags:
-                return ""
-            return "Plan state (goldfive bookkeeping): " + "; ".join(frags) + "."
+            return plan_state_line(_safe_attr(session, "plan", None))
         except Exception:  # noqa: BLE001
             return ""
 
@@ -780,6 +753,7 @@ class PromptShaper:
         llm_request: Any,
         session: Any,
         session_context: Any = None,
+        current_agent_name: str = "",
     ) -> Any:
         """Render the most-severe pending observer note onto the request.
 
@@ -822,7 +796,6 @@ class PromptShaper:
         """
         try:
             from goldfive.observer_note_queue import (
-                OBSERVER_NOTE_BLOCK_END,
                 OBSERVER_NOTE_MARKER_PREFIX,
                 ObserverNoteQueue,
                 render_block,
@@ -856,7 +829,13 @@ class PromptShaper:
 
         try:
             queue = ObserverNoteQueue.for_session(session)
-            note = queue.peek_for_render()
+            # Agent-scoped (task #11): the before_model surface KNOWS the
+            # agent whose model call this is, so an agent-specific note
+            # (e.g. a per-(agent,task) correction) is rendered only on
+            # its own agent's call — never on a sibling's. ``""`` (no
+            # agent resolved, e.g. a unit-test stub) → no filter,
+            # preserving the pre-task-#11 broadcast behaviour (§5.1).
+            note = queue.peek_for_render(agent_id=current_agent_name or None)
         except Exception as exc:  # noqa: BLE001
             log.debug("PromptShaper.inject_observer_note: queue read raised: %s", exc)
             return None
@@ -864,20 +843,12 @@ class PromptShaper:
             return None
 
         if self.should_inject(steerer):
-            block = render_block(note)
-            # AGENCY-PRESERVATION.md PR 9 — Site 3 fold. The retired
-            # per-turn plan-state hint's content rides the observer note
-            # instead: a factual per-agent open-work line, placed INSIDE
-            # the marker block (before the END marker) so strip-and-refresh
-            # removes it as one unit and the marker count stays 1. Factual
-            # bookkeeping only — no "choose the agent" imperative.
-            plan_state = self._plan_state_line(session)
-            if plan_state and OBSERVER_NOTE_BLOCK_END in block:
-                block = block.replace(
-                    OBSERVER_NOTE_BLOCK_END,
-                    f"{plan_state}\n{OBSERVER_NOTE_BLOCK_END}",
-                    1,
-                )
+            # task #11 cross-surface fold: render_block composes the
+            # plan-state Status line from the plan INSIDE the marker block
+            # (strip-and-refresh removes it as one unit; marker count stays
+            # 1). Centralised so this surface, the boundary replay, and the
+            # claude surface render an identical line.
+            block = render_block(note, plan=_safe_attr(session, "plan", None))
             append = getattr(llm_request, "append_instructions", None)
             wrote = False
             if callable(append):

--- a/tests/test_observer_note_agent_scope.py
+++ b/tests/test_observer_note_agent_scope.py
@@ -1,0 +1,261 @@
+"""Tests for AGENCY-PRESERVATION.md task #11 (PR 9 follow-up):
+
+1. Agent-scoped ``peek_for_render`` — a per-(agent,task) note reaches only
+   its agent; broadcast (empty agent_id) notes reach any agent;
+   ``agent_id=None`` keeps the pre-task-#11 no-filter behaviour.
+2. Corrections enqueue ObserverNotes at write time (agent-scoped),
+   closing the "written but unread under request_context" gap.
+3. Cross-surface plan-state fold — ``render_block(plan=...)`` carries the
+   Status line; the boundary-replay surface renders it identically.
+"""
+
+from __future__ import annotations
+
+from goldfive.observer_note_queue import (
+    OBSERVER_NOTE_MARKER_PREFIX,
+    ObserverNoteQueue,
+    plan_state_line,
+    render_block,
+)
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Plan,
+    Session,
+    SupersessionKind,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _session() -> Session:
+    return Session(run_id="r-scope")
+
+
+def _enqueue(session: Session, *, drift_id: str, agent_id: str, severity: str) -> None:
+    ObserverNoteQueue.for_session(session).enqueue(
+        body=f"Observation: signal {drift_id}.",
+        observation=f"signal {drift_id}",
+        severity=severity,
+        drift_id=drift_id,
+        kind="looping_tool_call",
+        task_id="t1",
+        agent_id=agent_id,
+    )
+
+
+def _plan_two_agents() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r-scope",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Draft",
+                assignee_agent_id="writer",
+                status=TaskStatus.RUNNING,
+            ),
+            Task(
+                id="t2",
+                title="Review",
+                assignee_agent_id="reviewer",
+                status=TaskStatus.COMPLETED,
+            ),
+        ],
+        edges=[],
+        revision_index=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Agent-scoped peek_for_render
+# ---------------------------------------------------------------------------
+
+
+def test_peek_agent_scope_routes_to_right_agent() -> None:
+    session = _session()
+    _enqueue(session, drift_id="dW", agent_id="writer", severity="warning")
+    _enqueue(session, drift_id="dB", agent_id="", severity="info")  # broadcast
+    _enqueue(session, drift_id="dR", agent_id="researcher", severity="critical")
+    q = ObserverNoteQueue.for_session(session)
+
+    # writer's surface: sees writer's note + broadcast, NOT researcher's
+    # (even though researcher's is more severe).
+    w = q.peek_for_render(agent_id="writer")
+    assert w is not None and w.drift_id == "dW"
+
+    # researcher's surface: sees researcher's (critical) note.
+    r = q.peek_for_render(agent_id="researcher")
+    assert r is not None and r.drift_id == "dR"
+
+    # An agent with no specific note sees only the broadcast.
+    other = q.peek_for_render(agent_id="planner")
+    assert other is not None and other.drift_id == "dB"
+
+
+def test_peek_no_agent_is_unfiltered() -> None:
+    session = _session()
+    _enqueue(session, drift_id="dW", agent_id="writer", severity="warning")
+    _enqueue(session, drift_id="dR", agent_id="researcher", severity="critical")
+    q = ObserverNoteQueue.for_session(session)
+    # agent_id=None → no filter → most-severe overall (researcher).
+    note = q.peek_for_render(agent_id=None)
+    assert note is not None and note.drift_id == "dR"
+
+
+def test_peek_agent_scope_is_bare_name_matched() -> None:
+    session = _session()
+    _enqueue(session, drift_id="dW", agent_id="ns:writer", severity="warning")
+    q = ObserverNoteQueue.for_session(session)
+    # Qualified note id matches the bare surface agent name.
+    assert q.peek_for_render(agent_id="writer") is not None
+    # And a different agent does not pick it up.
+    assert q.peek_for_render(agent_id="reviewer") is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Cross-surface plan-state fold (render_block / plan_state_line)
+# ---------------------------------------------------------------------------
+
+
+def test_render_block_without_plan_has_no_plan_state() -> None:
+    session = _session()
+    _enqueue(session, drift_id="d1", agent_id="", severity="warning")
+    note = ObserverNoteQueue.for_session(session).peek_for_render()
+    block = render_block(note)
+    assert "Plan state (goldfive bookkeeping)" not in block
+    assert block.count(OBSERVER_NOTE_MARKER_PREFIX) == 1
+
+
+def test_render_block_with_plan_folds_status() -> None:
+    session = _session()
+    _enqueue(session, drift_id="d1", agent_id="", severity="warning")
+    note = ObserverNoteQueue.for_session(session).peek_for_render()
+    block = render_block(note, plan=_plan_two_agents())
+    assert "Plan state (goldfive bookkeeping)" in block
+    assert "writer: 1 open" in block
+    assert "reviewer: no open tasks" in block
+    # Still one block (fold is INSIDE the markers).
+    assert block.count(OBSERVER_NOTE_MARKER_PREFIX) == 1
+    assert "Choose the agent" not in block
+    assert "do NOT re-invoke" not in block
+
+
+def test_plan_state_line_empty_without_plan() -> None:
+    assert plan_state_line(None) == ""
+    assert plan_state_line(Plan(id="p", run_id="r", goal_ids=[], tasks=[], edges=[])) == ""
+
+
+# ---------------------------------------------------------------------------
+# 3. Corrections enqueue ObserverNotes at write time
+# ---------------------------------------------------------------------------
+
+
+def _revised_with_one_correct() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r-scope",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="research_solar",
+                title="Research solar options",
+                status=TaskStatus.COMPLETED,
+                assignee_agent_id="research_agent",
+            ),
+            Task(
+                id="research_solar_corrected",
+                title="Research solar options (corrected scope)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="research_agent",
+                supersedes="research_solar",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="research_solar", to_task_id="research_solar_corrected")],
+        revision_index=2,
+    )
+
+
+def _drift() -> DriftEvent:
+    return DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="scope drifted",
+        current_task_id="research_solar",
+        current_agent_id="research_agent",
+        authored_by="goldfive",
+    )
+
+
+def test_corrections_via_notes_enqueues_agent_scoped_note() -> None:
+    from goldfive._correction_injection import (
+        is_pending_correction_key,
+        queue_corrections_for_revision,
+    )
+
+    session = _session()
+    ids = queue_corrections_for_revision(
+        session=session,
+        revised=_revised_with_one_correct(),
+        prev_plan=None,
+        drift=_drift(),
+        corrections_via_notes=True,
+    )
+    assert len(ids) == 1
+    # The correction rode the note queue, NOT the pending-correction slot.
+    assert not any(is_pending_correction_key(k) for k in session.state)
+    pend = ObserverNoteQueue.for_session(session).pending()
+    assert len(pend) == 1
+    note = pend[0]
+    assert note.agent_id == "research_agent"  # agent-scoped
+    assert note.task_id == "research_solar_corrected"
+    assert "superseded" in note.body.lower() or "revised" in note.body.lower()
+    # And it only renders to research_agent's surface, not a sibling's.
+    q = ObserverNoteQueue.for_session(session)
+    assert q.peek_for_render(agent_id="research_agent") is not None
+    assert q.peek_for_render(agent_id="writer_agent") is None
+
+
+def test_corrections_legacy_path_uses_slot_not_queue() -> None:
+    from goldfive._correction_injection import (
+        is_pending_correction_key,
+        queue_corrections_for_revision,
+    )
+
+    session = _session()
+    ids = queue_corrections_for_revision(
+        session=session,
+        revised=_revised_with_one_correct(),
+        prev_plan=None,
+        drift=_drift(),
+        # corrections_via_notes defaults False — legacy slot path.
+    )
+    assert len(ids) == 1
+    assert any(is_pending_correction_key(k) for k in session.state)
+    assert ObserverNoteQueue.for_session(session).pending() == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Cross-surface: the boundary-replay surface carries the fold
+# ---------------------------------------------------------------------------
+
+
+async def test_boundary_replay_surface_carries_plan_state() -> None:
+    from goldfive.executors.sequential import SequentialExecutor
+
+    session = _session()
+    session.plan = _plan_two_agents()
+    _enqueue(session, drift_id="d1", agent_id="", severity="warning")
+
+    block = await SequentialExecutor()._consume_observer_note_for_replay(session)
+    assert block is not None
+    assert "Plan state (goldfive bookkeeping)" in block
+    assert "writer: 1 open" in block

--- a/tests/test_observer_note_agent_scope.py
+++ b/tests/test_observer_note_agent_scope.py
@@ -259,3 +259,87 @@ async def test_boundary_replay_surface_carries_plan_state() -> None:
     assert block is not None
     assert "Plan state (goldfive bookkeeping)" in block
     assert "writer: 1 open" in block
+
+
+# ---------------------------------------------------------------------------
+# 5. Coarse-surface defense (the channel-review MEDIUM): agent-specific
+#    notes render ONLY on agent-aware surfaces.
+# ---------------------------------------------------------------------------
+
+
+def test_peek_broadcast_only_skips_agent_specific() -> None:
+    session = _session()
+    _enqueue(session, drift_id="dW", agent_id="writer", severity="critical")
+    _enqueue(session, drift_id="dB", agent_id="", severity="info")
+    q = ObserverNoteQueue.for_session(session)
+    # broadcast_only delivers the broadcast (info) note even though the
+    # agent-specific (critical) one is more severe.
+    note = q.peek_for_render(broadcast_only=True)
+    assert note is not None and note.drift_id == "dB"
+    # With only an agent-specific note pending, broadcast_only → nothing.
+    session2 = _session()
+    _enqueue(session2, drift_id="dW", agent_id="writer", severity="critical")
+    assert ObserverNoteQueue.for_session(session2).peek_for_render(broadcast_only=True) is None
+
+
+async def test_boundary_replay_skips_agent_specific_note() -> None:
+    from goldfive.executors.sequential import SequentialExecutor
+
+    session = _session()
+    _enqueue(session, drift_id="dW", agent_id="writer", severity="warning")
+    executor = SequentialExecutor()
+    # The boundary replay is coordinator-level → it must NOT deliver the
+    # agent-specific note; it stays pending for writer's own surface.
+    assert await executor._consume_observer_note_for_replay(session) is None
+    pend = ObserverNoteQueue.for_session(session).pending()
+    assert len(pend) == 1 and pend[0].drift_id == "dW"
+
+
+def test_peek_excludes_correction_notes_for_tool_annotation() -> None:
+    from goldfive.observer_note_queue import CORRECTION_DRIFT_ID_PREFIX
+
+    session = _session()
+    # A correction whose triggering drift WAS a loop kind — without the
+    # structural exclusion it would leak onto the loop-only annotation.
+    ObserverNoteQueue.for_session(session).enqueue(
+        body="correction body",
+        observation="corr",
+        severity="warning",
+        drift_id=f"{CORRECTION_DRIFT_ID_PREFIX}writer:t1:2",
+        kind="looping_tool_call",
+        task_id="t1",
+        agent_id="writer",
+    )
+    _enqueue(session, drift_id="dLoop", agent_id="", severity="warning")  # real loop note
+    q = ObserverNoteQueue.for_session(session)
+    loop_kinds = frozenset({"looping_tool_call", "looping_reasoning"})
+    note = q.peek_for_render(kinds=loop_kinds, exclude_correction_notes=True)
+    assert note is not None and note.drift_id == "dLoop"  # the correction is excluded
+
+
+async def test_claude_surface_is_agent_scoped() -> None:
+    """claude.invoke runs one agent → its note surface scopes to that agent."""
+    from goldfive.adapters.claude import ClaudeAgentSDKAdapter
+    from goldfive.config import SteeringConfig
+    from goldfive.steerer import DefaultSteerer
+
+    # Bypass __init__ (which requires the claude-agent-sdk) — we only
+    # exercise the SDK-independent _consume_observer_note path.
+    adapter = object.__new__(ClaudeAgentSDKAdapter)
+    adapter._steerer = DefaultSteerer(
+        steering_config=SteeringConfig(
+            observation_only=False, signal_channel="request_context"
+        )
+    )
+    session = _session()
+    _enqueue(session, drift_id="dW", agent_id="writer", severity="warning")
+    _enqueue(session, drift_id="dR", agent_id="researcher", severity="critical")
+
+    block = await adapter._consume_observer_note(
+        session, surface="claude_system_prompt", current_agent_id="writer"
+    )
+    # writer's surface gets writer's note, NOT researcher's (more severe,
+    # wrong agent). researcher's note stays pending.
+    assert block is not None and "signal dW" in block
+    pend = {n.drift_id for n in ObserverNoteQueue.for_session(session).pending()}
+    assert pend == {"dR"}

--- a/tests/test_observer_note_channel.py
+++ b/tests/test_observer_note_channel.py
@@ -132,6 +132,7 @@ def _enqueue(
     severity: str = "warning",
     kind: str = "looping_tool_call",
     turn: int = 0,
+    agent_id: str = "agent",
 ) -> None:
     ObserverNoteQueue.for_session(session).enqueue(
         body=(
@@ -144,7 +145,7 @@ def _enqueue(
         drift_id=drift_id,
         kind=kind,
         task_id="t1",
-        agent_id="agent",
+        agent_id=agent_id,
         turn=turn,
     )
 
@@ -237,9 +238,16 @@ async def test_exactly_once_before_model_consumes_then_boundary_skips() -> None:
 
 
 async def test_exactly_once_boundary_delivers_when_before_model_did_not() -> None:
-    """The reverse path: if no model call fired, the boundary renders once."""
+    """The reverse path: if no model call fired, the boundary renders once.
+
+    task #11: the boundary replay delivers BROADCAST notes only (it cannot
+    attribute to a sub-agent), so this uses a broadcast note (``agent_id=""``).
+    An agent-specific note is intentionally NOT delivered here — pinned by
+    ``test_boundary_replay_skips_agent_specific_note`` in
+    ``test_observer_note_agent_scope.py``.
+    """
     session = _make_session()
-    _enqueue(session, drift_id="d1")
+    _enqueue(session, drift_id="d1", agent_id="")
 
     executor = SequentialExecutor()
     replay = await executor._consume_observer_note_for_replay(session)


### PR DESCRIPTION
Closes the three deferrals from **#466 (PR 9)**, tracked as task #11. All changes live in the opt-in `request_context` regime; the legacy `legacy_user_message` path is untouched (§5.1) and every existing suite passes unmodified.

## 1. Agent-scoped note delivery
`ObserverNoteQueue.peek_for_render` gains an optional `agent_id` filter:
- `None` (default) → **no filter** (pre-task-#11 broadcast behaviour; every existing test passes agentless stubs → unaffected).
- `"<name>"` → notes whose `agent_id` is empty (broadcast / coordinator-level) **or** matches `<name>` by **bare name** (namespace-stripped). An agent-specific note for a different agent is skipped.

The ADK `before_model` surface resolves the running agent and passes it; coarse surfaces leave it `None`. This is what makes the correction migration safe — a `writer` correction can never render onto `researcher`'s model call.

## 2. Correction migration (closes the "written but unread" gap)
`queue_corrections_for_revision` gains `corrections_via_notes` (threaded from `plan_reviser` as `request_context AND NOT pin_assigned_task`). When set, each CORRECT-kind correction is **enqueued onto the `ObserverNoteQueue`** — carrying the assignee as `agent_id` and a stable goldfive-minted `drift_id` (`correction:<agent>:<task>:<rev>`) — instead of the pending-correction state slot that the now-suppressed dynamic-instruction resolver no longer reads. The PR-9 `KNOWN LIMITATION` note is updated to reflect the closure. Legacy / `pin_assigned_task=True` keep the slot path unchanged.

## 3. Cross-surface plan-state fold
The Site-3 plan-state line is centralised in `observer_note_queue.plan_state_line` + `render_block(plan=...)`, so the **before_model, boundary-replay, and claude** surfaces render an identical factual Status line (PR 9 had it on before_model only). `render_block(plan=None)` keeps the block shape byte-identical (the PR 6 `test_render_block_shape` passes).

## Coordination
Composes with channel's PR 8 (grace-window bookkeeping reads `delivered_turn`; this filters at `peek`) — no shared-line conflict expected; whoever merges second rebases.

## §5 requirements satisfied
- **§5.1** — all behavior gated on `request_context`; `peek_for_render(agent_id=None)` / `render_block(plan=None)` defaults preserve legacy byte-for-byte; existing suites unmodified.
- **§5.6** — stable goldfive-minted note keys (never LLM-minted); grep-verified the 4 peek surfaces + render_block callers; lazy imports avoid the `adk_llm_instrumentation ↔ _correction_injection` cycle.

## Tests
- `tests/test_observer_note_agent_scope.py` (+9): agent-scope routing (right agent / broadcast / no-filter / bare-name); `render_block` fold present-with-plan / absent-without; correction migration (notes regime enqueues agent-scoped note + skips the slot; legacy regime writes the slot + empty queue); boundary-replay surface carries the fold.
- **Existing tests unmodified.** Full suite **3086 passed, 59 skipped, 0 failures**; `ruff` clean.

## Residual (documented, not blocking)
Coarse surfaces (boundary-replay, claude, tool-annotation) pass no agent → no-filter, so they can still deliver an agent-specific note if they fire before the agent's own `before_model` call. In practice the per-agent `before_model` surface fires first and the exactly-once `mark_delivered` chokepoint prevents a second render. The before_model surface is the agent-scoped guarantee point.