### PR TITLE
feat(drift): refine retirement in ledger mode + [GOALS] block for DISCOVERED pins (AGENCY-PRESERVATION PR 12)

### DIFF
--- a/goldfive/adapters/adk_llm_instrumentation.py
+++ b/goldfive/adapters/adk_llm_instrumentation.py
@@ -526,10 +526,12 @@ def _compose_instruction(
     task_title: str,
     task_description: str,
     pending_correction: str,
+    task_kind: str = "",
+    goals_block: str = "",
 ) -> str:
     """Assemble the final prompt string the LLM sees this turn.
 
-    Shape:
+    Shape (FORECAST / OUTCOME pin — the legacy task block):
 
         {original}
 
@@ -541,7 +543,53 @@ def _compose_instruction(
           description: {task_description}
 
         {pending_correction}  # appended only when non-empty
+
+    AGENCY-PRESERVATION.md Stage 3 PR 12 — when the pinned task is
+    DISCOVERED-kind (``task_kind == TaskKind.DISCOVERED.value`` and a
+    non-empty ``goals_block`` is supplied), render a ``[GOALS]`` block
+    INSTEAD of the ``Current assigned task:`` block:
+
+        {original}
+
+        ---
+
+        [GOALS]
+        {goals_block}
+
+        {pending_correction}
+
+    Rationale: a DISCOVERED task is the agent's OWN observed means-work
+    (the trajectory lane of the ledger), not a forecast the agent is
+    graded against. Pinning it back as a prescription re-imposes exactly
+    the forecast framing PR 11/12 retire — so for a discovered pin we
+    ground the agent on the user's GOALS and let it own the means.
+    ``task_kind``/``goals_block`` default to ``""`` so every legacy /
+    forecast / OUTCOME caller renders the unchanged task block (the
+    DISCOVERED kind only exists in ledger plan mode — forecast-mode pins
+    are byte-identical, §5.1).
+
+    Interaction with the PR 9 prompt-shaping diet: under
+    ``signal_channel == "request_context"`` with ``pin_assigned_task``
+    off, the resolver returns the original instruction BEFORE reaching
+    this function (the pin is retired entirely), so the ``[GOALS]`` block
+    applies only where a pin WOULD render — legacy ``signal_channel`` or
+    ``pin_assigned_task=True``.
     """
+    from goldfive.types import TaskKind
+
+    if task_kind == TaskKind.DISCOVERED.value and goals_block:
+        block = (
+            f"{original}\n"
+            "\n"
+            "---\n"
+            "\n"
+            "[GOALS]\n"
+            f"{goals_block}\n"
+        )
+        if pending_correction:
+            block = f"{block}\n{pending_correction}\n"
+        return block
+
     title = task_title or _MISSING_TITLE_PLACEHOLDER
     description = task_description or _MISSING_DESCRIPTION_PLACEHOLDER
 
@@ -647,6 +695,49 @@ def _task_title_description_from_session(session: Any, task_id: str) -> tuple[st
             description = str(getattr(task, "description", "") or "")
             return title, description
     return "", ""
+
+
+def _task_kind_from_session(session: Any, task_id: str) -> str:
+    """Return the :attr:`Task.kind` VALUE for ``task_id`` in ``session.plan``.
+
+    AGENCY-PRESERVATION.md Stage 3 PR 12. Returns the kind's string value
+    (e.g. ``"DISCOVERED"`` / ``"OUTCOME"`` / ``"FORECAST"``) so the
+    resolver can choose the ``[GOALS]`` block for a discovered pin. Returns
+    ``""`` when the plan / task is missing or carries no kind — the caller
+    then renders the unchanged task block. Forecast-mode tasks are always
+    FORECAST-kind, so this never selects the discovered branch outside
+    ledger plan mode (§5.1 forecast bit-identity).
+    """
+    if session is None or not task_id:
+        return ""
+    plan = getattr(session, "plan", None)
+    if plan is None:
+        return ""
+    for task in getattr(plan, "tasks", None) or ():
+        if str(getattr(task, "id", "") or "") == task_id:
+            kind = getattr(task, "kind", None)
+            return str(getattr(kind, "value", kind) or "")
+    return ""
+
+
+def _goals_block_from_session(session: Any) -> str:
+    """Render ``session.goals`` as the body of the PR-12 ``[GOALS]`` block.
+
+    One bullet per goal summary; goals without a summary are skipped.
+    Returns ``""`` when there are no goals so the caller falls back to the
+    task block (a discovered pin with no goals has nothing to ground on).
+    Never raises.
+    """
+    try:
+        goals = getattr(session, "goals", None) or ()
+        lines: list[str] = []
+        for g in goals:
+            summary = str(getattr(g, "summary", "") or "").strip()
+            if summary:
+                lines.append(f"  - {summary}")
+        return "\n".join(lines)
+    except Exception:  # noqa: BLE001
+        return ""
 
 
 def is_dynamic_instruction(value: Any) -> bool:

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -3283,6 +3283,68 @@ class DriftObserver:
         except Exception:  # noqa: BLE001
             return False
 
+    #: AGENCY-PRESERVATION.md Stage 3 PR 12 — the looping kinds whose
+    #: ledger-mode rung is a deterministic force-FAIL of the bound task.
+    #: A loop on a DISCOVERED task means that unit of means-level work is
+    #: stuck and there is no forecast to route around, so the
+    #: deterministic looping fallback (planner ``_refine_looping_tool_call``
+    #: in forecast mode) reduces to "fail the looping ledger task".
+    _LEDGER_FORCE_FAIL_DRIFT_KINDS: frozenset[DriftKind] = frozenset(
+        {DriftKind.LOOPING_TOOL_CALL, DriftKind.LOOPING_REASONING}
+    )
+
+    async def _ledger_retire_refine(self, drift: DriftEvent, session: Session) -> None:
+        """Ledger-mode substitute for the drift-triggered forecast-repair refine.
+
+        AGENCY-PRESERVATION.md Stage 3 PR 12. In ledger plan mode there is
+        no forecast plan to repair, so a goldfive-authored drift that would
+        otherwise reach ``planner.refine`` (ladder ABSORB/CANCEL_REINVOKE)
+        or ``refine_steer`` (promotion) instead takes one of the ledger
+        rungs:
+
+        * **looping kinds** (:data:`_LEDGER_FORCE_FAIL_DRIFT_KINDS`) with a
+          bound task → **force-FAIL** the bound ledger task. ``recoverable``
+          is True — a sibling/replacement DISCOVERED task may still cover
+          the work, and the outcome-progress judge (PR 11) still grades the
+          OUTCOME deliverables independently.
+        * **everything else** → enqueue the advisory observer **note** (the
+          SIGNAL rung's trajectory-preserving influence), via
+          :meth:`_dispatch_nudge`.
+
+        The PAUSE_ESCALATE / SIGNAL / OBSERVE rungs never reach here — they
+        return earlier in :meth:`_handle_drift_dispatch` and are already
+        mode-agnostic. USER_STEER, ``handle_turn`` replans, and descriptive
+        absorption are SEPARATE dispatch paths and keep their refine. Never
+        raises into the dispatch.
+        """
+        task_id = drift.current_task_id or ""
+        if drift.kind in self._LEDGER_FORCE_FAIL_DRIFT_KINDS and task_id:
+            reason = (
+                f"ledger force-fail (loop): {drift.detail}"
+                if drift.detail
+                else f"ledger force-fail (loop): {drift.kind.value}"
+            )
+            try:
+                await self._steerer.tasks.mark_task_failed(
+                    task_id,
+                    session=session,
+                    reason=reason,
+                    recoverable=True,
+                    source="goldfive_ledger_refine_retire",
+                )
+                return
+            except Exception as exc:  # noqa: BLE001 — never break the run
+                log.warning(
+                    "DefaultSteerer._ledger_retire_refine: force-fail of %r "
+                    "raised (falling back to note): %s",
+                    task_id,
+                    exc,
+                )
+        # Default rung: the advisory note. Trajectory-preserving influence
+        # instead of repairing a forecast that does not exist in ledger
+        # mode.
+        await self._dispatch_nudge(drift, session)
+
     async def maybe_run_goal_drift_check(self, session: Session) -> None:
         """Run the trajectory-level GOAL_DRIFT judge once, cost-bounded.
 
@@ -4346,7 +4408,17 @@ class DriftObserver:
                     exc,
                 )
         if promote_to_steer:
-            await self._promote_drift_to_steer(drift, session)
+            # AGENCY-PRESERVATION.md Stage 3 PR 12 — refine retirement in
+            # ledger plan mode. Promotion produces a forecast-repair
+            # ``refine_steer`` (PR 7 kept it on the promotion path); in
+            # ledger mode there is no forecast to repair, so route to the
+            # ledger rung instead. Promotion never selects USER_STEER
+            # (``_should_promote_to_steer`` returns False for user-authored
+            # kinds), so this is always a goldfive-authored drift.
+            if self._ledger_mode():
+                await self._ledger_retire_refine(drift, session)
+            else:
+                await self._promote_drift_to_steer(drift, session)
             return
         # Route through the intervention ladder. The per-(kind, task)
         # occurrence count drives the "first vs repeat" distinction in
@@ -4408,6 +4480,22 @@ class DriftObserver:
         # (goldfive#141). The refine call itself is identical so we
         # share the implementation below and read the level at the end
         # to decide whether to emit the follow-up handoff.
+        #
+        # AGENCY-PRESERVATION.md Stage 3 PR 12 — refine retirement in
+        # ledger plan mode. The drift-triggered forecast-repair refine has
+        # no forecast to repair in ledger mode (the plan is a ledger of
+        # OUTCOME deliverables + a DISCOVERED trajectory record, not a
+        # forecast the agent is graded against). Refine survives for
+        # exactly three authors (§3 PR 12): USER_STEER (handled here —
+        # falls through to the refine below), turn-level ``handle_turn``
+        # replans, and descriptive absorption (both SEPARATE dispatch
+        # paths, untouched). Every other (goldfive-authored)
+        # ABSORB/CANCEL_REINVOKE drift takes the ledger rung instead. The
+        # OBSERVE / SIGNAL / PAUSE_ESCALATE rungs returned earlier and are
+        # already mode-agnostic.
+        if self._ledger_mode() and drift.kind is not DriftKind.USER_STEER:
+            await self._ledger_retire_refine(drift, session)
+            return
         if self._steerer._planner is None or session.plan is None:
             return
         if drift.kind is DriftKind.REFINE_VALIDATION_FAILED:

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -3302,6 +3302,21 @@ class DriftObserver:
         or ``refine_steer`` (promotion) instead takes one of the ledger
         rungs:
 
+        * **hard-safety kinds** (:attr:`_HARD_SAFETY_DRIFT_KINDS`, e.g.
+          ``RUNAWAY_DELEGATION`` — the only one that reaches here, the
+          others being PAUSE_ESCALATE-first and returning earlier) →
+          **PAUSE_ESCALATE** (stop-and-ask). Their forecast
+          CANCEL_REINVOKE follow-on depended on the refine's revised plan
+          to route around the offending subtree: the GOLDFIVE_STEER
+          restart carries ``replacement_task_ids`` picked from the
+          POST-refine ``session.plan`` (audit #402). In ledger mode there
+          is no refine to produce that plan, so a note-replay would just
+          re-invoke the same coordinator on the same plan and likely
+          re-trip the guardrail. The hard-safety CANCEL itself already
+          fired earlier in :meth:`_handle_drift_dispatch` (mode-agnostic);
+          this is purely the post-cancel disposition, and stop-and-ask is
+          the safe choice — consistent with PR 7's PAUSE_ESCALATE-first
+          treatment of the other hard-safety kinds.
         * **looping kinds** (:data:`_LEDGER_FORCE_FAIL_DRIFT_KINDS`) with a
           bound task → **force-FAIL** the bound ledger task. ``recoverable``
           is True — a sibling/replacement DISCOVERED task may still cover
@@ -3317,6 +3332,11 @@ class DriftObserver:
         absorption are SEPARATE dispatch paths and keep their refine. Never
         raises into the dispatch.
         """
+        if drift.kind in self._HARD_SAFETY_DRIFT_KINDS:
+            # Hard-safety guardrail whose productive continuation needed the
+            # refine (see docstring). No refine in ledger mode → stop-and-ask.
+            await self._dispatch_pause_escalate(drift, session)
+            return
         task_id = drift.current_task_id or ""
         if drift.kind in self._LEDGER_FORCE_FAIL_DRIFT_KINDS and task_id:
             reason = (

--- a/goldfive/prompt_shaper.py
+++ b/goldfive/prompt_shaper.py
@@ -608,9 +608,11 @@ class PromptShaper:
                 from goldfive.adapters import _adk_state_protocol as _sp
                 from goldfive.adapters.adk_llm_instrumentation import (
                     _compose_instruction,
+                    _goals_block_from_session,
                     _goldfive_session_context_from_readonly_context,
                     _read_pending_correction,
                     _state_from_readonly_context,
+                    _task_kind_from_session,
                     _task_title_description_from_session,
                 )
 
@@ -697,12 +699,33 @@ class PromptShaper:
                     current_task_id=current_task_id,
                 )
 
+                # AGENCY-PRESERVATION.md Stage 3 PR 12 — for a DISCOVERED
+                # pin (ledger plan mode), render a [GOALS] block instead of
+                # the task block (the agent owns its own means-work; ground
+                # it on goals, don't re-pin the discovered task as a
+                # prescription). ``_compose_instruction`` falls back to the
+                # task block when the kind is not DISCOVERED or there are no
+                # goals, so forecast / OUTCOME pins are byte-identical. This
+                # branch is reached only where the pin WOULD render — under
+                # the PR 9 request_context+pin-off diet the resolver already
+                # returned above.
+                task_kind = (
+                    _task_kind_from_session(session, current_task_id)
+                    if session is not None
+                    else ""
+                )
+                goals_block = (
+                    _goals_block_from_session(session) if session is not None else ""
+                )
+
                 return _compose_instruction(
                     original=original_instruction,
                     task_id=current_task_id,
                     task_title=current_task_title,
                     task_description=current_task_description,
                     pending_correction=pending_correction,
+                    task_kind=task_kind,
+                    goals_block=goals_block,
                 )
             except Exception as exc:  # noqa: BLE001
                 # Instrumentation path — any failure here degrades to

--- a/tests/test_ledger_refine_retirement.py
+++ b/tests/test_ledger_refine_retirement.py
@@ -1,0 +1,305 @@
+"""Refine retirement in ledger plan mode (AGENCY-PRESERVATION.md PR 12).
+
+In ledger mode the Plan is a ledger (OUTCOME deliverables + a DISCOVERED
+trajectory record), not a forecast the agent is graded against — so the
+drift-triggered forecast-repair refine has nothing to repair. Both
+forecast-repair paths (the ladder ABSORB/CANCEL_REINVOKE ``planner.refine``
+and the promotion ``refine_steer``) are gated on ``plan_mode``; in ledger
+mode a goldfive-authored drift takes the ledger rung instead:
+
+* looping kinds → force-FAIL the bound ledger task;
+* everything else → the advisory observer note.
+
+Refine survives for exactly three authors: USER_STEER (tested here),
+``handle_turn`` replans, and descriptive absorption (separate dispatch
+paths). ``_compose_instruction`` renders a ``[GOALS]`` block instead of
+the task block for DISCOVERED pins. Forecast mode is byte-identical.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.observer_note_queue import ObserverNoteQueue  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskKind,
+    TaskStatus,
+)
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class _RecordingPlanner:
+    """Records refine / refine_steer calls; returns a trivial revision."""
+
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+        self.refine_steer_calls: list[dict[str, Any]] = []
+
+    async def generate(self, *, goals: Any, available_agents: Any, context: Any = None) -> Any:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        self.refine_calls.append(kwargs)
+        plan = kwargs.get("plan")
+        return plan  # echo — enough for _apply_revision to accept
+
+    async def refine_steer(self, **kwargs: Any) -> Plan | None:
+        self.refine_steer_calls.append(kwargs)
+        return kwargs.get("plan")
+
+    @property
+    def refined(self) -> bool:
+        return bool(self.refine_calls or self.refine_steer_calls)
+
+
+def _make_steerer(*, plan_mode: str) -> tuple[DefaultSteerer, _RecordingPlanner]:
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(
+            observation_only=False,
+            plan_mode=plan_mode,
+            threshold="warning",
+        ),
+    )
+    planner = _RecordingPlanner()
+    steerer.bind(sinks=[_ListSink()], planner=planner)
+    return steerer, planner
+
+
+def _ledger_plan() -> Plan:
+    return Plan(
+        id="p",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=(
+            Task(id="o1", title="Summary delivered", kind=TaskKind.OUTCOME),
+            Task(
+                id="d1",
+                title="writer: drafting",
+                discovered=True,
+                kind=TaskKind.DISCOVERED,
+                status=TaskStatus.RUNNING,
+            ),
+        ),
+        edges=(),
+        revision_index=1,
+    )
+
+
+def _session() -> Session:
+    return Session(
+        run_id="r",
+        goals=[Goal(id="g", summary="summarise the deck")],
+        plan=_ledger_plan(),
+    )
+
+
+def _drift(kind: DriftKind, *, task_id: str = "d1", authored_by: str = "goldfive") -> DriftEvent:
+    return DriftEvent(
+        kind=kind,
+        severity=DriftSeverity.WARNING,
+        detail="agent wandered",
+        current_task_id=task_id,
+        authored_by=authored_by,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — drift-triggered forecast-repair refine retirement
+# ---------------------------------------------------------------------------
+
+
+async def test_ledger_goldfive_drift_no_refine_enqueues_note() -> None:
+    steerer, planner = _make_steerer(plan_mode="ledger")
+    session = _session()
+
+    await steerer.drift.handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+
+    # No forecast-repair refine of either flavour.
+    assert planner.refine_calls == []
+    assert planner.refine_steer_calls == []
+    # The ledger rung for a non-looping drift is the advisory note. Under
+    # the default legacy signal_channel the SIGNAL note lands on
+    # ``session.pending_nudges`` (the request_context surface uses the
+    # ObserverNoteQueue); accept either so the test is channel-agnostic.
+    noted = bool(getattr(session, "pending_nudges", None)) or bool(
+        ObserverNoteQueue.for_session(session).pending()
+    )
+    assert noted, "a SIGNAL note should be enqueued in place of the refine"
+
+
+async def test_forecast_goldfive_drift_still_refines() -> None:
+    # Control: the SAME drift in forecast mode exercises a forecast-repair
+    # refine (ladder ABSORB or promotion refine_steer) — proving the
+    # ledger gate is what retires it.
+    steerer, planner = _make_steerer(plan_mode="forecast")
+    session = _session()
+
+    await steerer.drift.handle_drift(_drift(DriftKind.OFF_TOPIC), session)
+
+    assert planner.refined, "forecast mode must still run a forecast-repair refine"
+
+
+async def test_ledger_looping_force_fails_bound_task() -> None:
+    steerer, planner = _make_steerer(plan_mode="ledger")
+    session = _session()
+
+    await steerer.drift.handle_drift(
+        _drift(DriftKind.LOOPING_TOOL_CALL, task_id="d1"), session
+    )
+
+    # No refine; the looping deterministic fallback reduces to force-FAIL.
+    assert planner.refine_calls == []
+    assert planner.refine_steer_calls == []
+    d1 = next(t for t in session.plan.tasks if t.id == "d1")
+    assert d1.status is TaskStatus.FAILED
+
+
+async def test_ledger_user_steer_refine_survives() -> None:
+    steerer, planner = _make_steerer(plan_mode="ledger")
+    session = _session()
+
+    await steerer.drift.handle_drift(
+        _drift(DriftKind.USER_STEER, task_id="d1", authored_by="user"), session
+    )
+
+    # USER_STEER is one of the three surviving refine authors — it still
+    # refines even in ledger mode.
+    assert planner.refined, "USER_STEER refine must survive in ledger mode"
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — [GOALS] block for DISCOVERED pins (_compose_instruction)
+# ---------------------------------------------------------------------------
+
+
+def _compose():
+    from goldfive.adapters.adk_llm_instrumentation import _compose_instruction
+
+    return _compose_instruction
+
+
+def test_compose_discovered_pin_renders_goals_block() -> None:
+    out = _compose()(
+        original="SYS",
+        task_id="d1",
+        task_title="agent: work",
+        task_description="did stuff",
+        pending_correction="",
+        task_kind="DISCOVERED",
+        goals_block="  - summarise the deck",
+    )
+    assert "[GOALS]" in out
+    assert "summarise the deck" in out
+    assert "Current assigned task" not in out
+
+
+def test_compose_forecast_pin_unchanged_task_block() -> None:
+    # Default (no kind/goals) — the legacy task block, byte-for-byte.
+    out = _compose()(
+        original="SYS",
+        task_id="f1",
+        task_title="T",
+        task_description="D",
+        pending_correction="",
+    )
+    assert "Current assigned task:" in out
+    assert "[GOALS]" not in out
+
+
+def test_compose_outcome_pin_renders_task_block() -> None:
+    out = _compose()(
+        original="SYS",
+        task_id="o1",
+        task_title="Summary delivered",
+        task_description="",
+        pending_correction="",
+        task_kind="OUTCOME",
+        goals_block="  - g",
+    )
+    # Only DISCOVERED pins switch to [GOALS]; OUTCOME keeps the task block.
+    assert "Current assigned task:" in out
+    assert "[GOALS]" not in out
+
+
+def test_compose_discovered_without_goals_falls_back_to_task_block() -> None:
+    out = _compose()(
+        original="SYS",
+        task_id="d1",
+        task_title="T",
+        task_description="D",
+        pending_correction="",
+        task_kind="DISCOVERED",
+        goals_block="",
+    )
+    assert "Current assigned task:" in out
+    assert "[GOALS]" not in out
+
+
+def test_compose_discovered_pin_keeps_pending_correction() -> None:
+    out = _compose()(
+        original="SYS",
+        task_id="d1",
+        task_title="T",
+        task_description="D",
+        pending_correction="[CORRECTION] do X",
+        task_kind="DISCOVERED",
+        goals_block="  - g",
+    )
+    assert "[GOALS]" in out
+    assert "[CORRECTION] do X" in out
+
+
+def test_task_kind_and_goals_helpers() -> None:
+    from goldfive.adapters.adk_llm_instrumentation import (
+        _goals_block_from_session,
+        _task_kind_from_session,
+    )
+
+    plan = Plan(
+        id="p",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=(
+            Task(id="d1", title="disc", discovered=True, kind=TaskKind.DISCOVERED),
+            Task(id="f1", title="fc"),
+        ),
+        edges=(),
+    )
+    sess = Session(
+        run_id="r",
+        goals=[Goal(id="g", summary="summarise"), Goal(id="g2", summary="")],
+        plan=plan,
+    )
+    assert _task_kind_from_session(sess, "d1") == "DISCOVERED"
+    assert _task_kind_from_session(sess, "f1") == "FORECAST"
+    assert _task_kind_from_session(sess, "missing") == ""
+    # Empty-summary goal is skipped.
+    assert _goals_block_from_session(sess) == "  - summarise"

--- a/tests/test_ledger_refine_retirement.py
+++ b/tests/test_ledger_refine_retirement.py
@@ -30,6 +30,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.control import ControlChannel, ControlKind  # noqa: E402
 from goldfive.observer_note_queue import ObserverNoteQueue  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
@@ -193,6 +194,52 @@ async def test_ledger_user_steer_refine_survives() -> None:
     # USER_STEER is one of the three surviving refine authors — it still
     # refines even in ledger mode.
     assert planner.refined, "USER_STEER refine must survive in ledger mode"
+
+
+async def test_ledger_runaway_delegation_pauses_not_note() -> None:
+    """RUNAWAY_DELEGATION (hard-safety) in ledger mode → PAUSE_ESCALATE.
+
+    The forecast CANCEL_REINVOKE follow-on continues via the refine's
+    revised plan (the GOLDFIVE_STEER restart carries replacement_task_ids
+    from the post-refine plan — audit #402). In ledger mode there is no
+    refine to produce that plan, so a note-replay would re-invoke the same
+    coordinator on the same plan and likely re-trip the guardrail.
+    Stop-and-ask is the safe follow-on — and it must be a CLEAN,
+    observable pause (a GOLDFIVE_PAUSE_ESCALATE control + a
+    HUMAN_INTERVENTION_REQUIRED drift), never a hang or a silent death.
+    """
+    steerer, planner = _make_steerer(plan_mode="ledger")
+    channel = ControlChannel()
+    steerer.bind_control_channel(channel)
+    session = _session()
+
+    drift = DriftEvent(
+        kind=DriftKind.RUNAWAY_DELEGATION,
+        severity=DriftSeverity.CRITICAL,
+        detail="coordinator delegated past the cap",
+        current_task_id="d1",
+        authored_by="goldfive",
+    )
+    await steerer.drift.handle_drift(drift, session)
+
+    # No forecast repair of either flavour.
+    assert planner.refine_calls == []
+    assert planner.refine_steer_calls == []
+    # Did NOT force-fail the bound task (that's the looping rung, not the
+    # hard-safety rung) and did NOT degrade to a mere advisory note.
+    d1 = next(t for t in session.plan.tasks if t.id == "d1")
+    assert d1.status is not TaskStatus.FAILED
+    assert not getattr(session, "pending_nudges", None)
+    # A clean, observable stop-and-ask: a GOLDFIVE_PAUSE_ESCALATE control
+    # message was dispatched on the channel.
+    drained: list[Any] = []
+    inbox = channel._inbox  # noqa: SLF001 — test inspection
+    while not inbox.empty():
+        drained.append(inbox.get_nowait())
+    kinds = [getattr(m, "kind", None) for m in drained]
+    assert ControlKind.GOLDFIVE_PAUSE_ESCALATE in kinds, (
+        f"expected a GOLDFIVE_PAUSE_ESCALATE control; got {kinds}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Stage 3 PR 12 of the AGENCY-PRESERVATION roadmap. Ledger-gated; forecast mode byte-identical; existing suites pass unmodified. Branched off `agency-preservation` (PR 7/9/11 in base). **Full suite 3091 passed, 59 skipped.** Both review open-questions resolved.

## Refine retirement (`drift_observer.py`)

In ledger plan mode the Plan is a ledger (OUTCOME deliverables + a DISCOVERED trajectory record), not a forecast the agent is graded against — so the drift-triggered forecast-repair refine has nothing to repair. **Two** forecast-repair paths, both gated on `plan_mode == "forecast"`:
1. the ladder **ABSORB/CANCEL_REINVOKE** `planner.refine` (refine section of `_handle_drift_dispatch`);
2. the **promotion** `refine_steer` (`_promote_drift_to_steer`, which PR 7 kept — it fires *before* the ladder, so it needs its own gate). *(Discovered necessity the roadmap missed; team-lead confirmed it goes into the doc-fold.)*

In ledger mode a goldfive-authored drift takes the ledger rung via `_ledger_retire_refine`:
- **hard-safety kinds** (`_HARD_SAFETY_DRIFT_KINDS` — `RUNAWAY_DELEGATION` is the only one reaching here) → **PAUSE_ESCALATE** (see Q2 below);
- **looping kinds** (`LOOPING_TOOL_CALL` / `LOOPING_REASONING`) with a bound task → **force-FAIL** the bound ledger task (the deterministic looping fallback — no forecast to route around);
- **everything else** → the advisory **SIGNAL note**.

The `OBSERVE` / `SIGNAL` / `PAUSE_ESCALATE` rungs already return earlier and are mode-agnostic. **Refine survives for exactly three authors**: `USER_STEER` (excluded from the refine-section gate *and* from promotion), `handle_turn` replans, and descriptive absorption — both separate dispatch paths, untouched.

## `[GOALS]` block for DISCOVERED pins (`adk_llm_instrumentation.py` + `prompt_shaper.py`)

`_compose_instruction` renders a `[GOALS]` block (from `session.goals`) instead of the `[CURRENT ASSIGNED TASK]` block when the pinned task is DISCOVERED-kind — a discovered task is the agent's own observed means-work, not a prescription to re-pin. New helpers `_task_kind_from_session` / `_goals_block_from_session`; the resolver threads `task_kind` + `goals_block`. FORECAST/OUTCOME pins and the no-goals case keep the task block (byte-identical). **PR 9 diet interaction** (documented in the compose docstring): under `request_context` + `pin_assigned_task` off, the resolver returns before `_compose_instruction`, so the `[GOALS]` block applies only where a pin WOULD render.

## Review resolutions

- **Q1 (non-looping rung → note): APPROVED as implemented.** Failing the bound DISCOVERED task on a WARNING-level judge opinion would manufacture failure verdicts (anti-§0); the note advises, the agent decides. Looping force-FAIL stays the exception (deterministic evidence).
- **Q2 (RUNAWAY_DELEGATION in ledger): resolved to PAUSE_ESCALATE, verified against code.** The forecast CANCEL_REINVOKE continues via the refine's revised plan — `_dispatch_goldfive_steer_control` picks `replacement_task_ids` from the post-refine `session.plan` (audit #402). In ledger there is no refine to produce that plan, so the restart machinery needs the refined plan → flip to stop-and-ask (consistent with PR 7's PAUSE_ESCALATE-first hard-safety treatment). Pinned by a test asserting a clean `GOLDFIVE_PAUSE_ESCALATE` control (observable stop, never a hang/silent death).

## §5 correctness

Every new path ledger-gated; forecast mode byte-identical. Full suite **3091 passed, 59 skipped** (existing intervention-ladder / promote-drift / instrumentation / prompt-shaper suites unmodified). ruff clean. `_ledger_retire_refine` never raises into the dispatch. The PR 11 `_stamp_ledger_outcome_kinds` prior-kind-preservation guard stays load-bearing (`handle_turn` / `generate` untouched).

## Tests

`tests/test_ledger_refine_retirement.py` (11): ledger no-refine + note, forecast-refines control, looping force-FAIL, USER_STEER refine survives, RUNAWAY → clean PAUSE_ESCALATE, and the `[GOALS]` block matrix + kind/goals helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)