### PR TITLE
feat(steering): minimum-intervention pacing — visibility-keyed grace windows (AGENCY-PRESERVATION PR 8)

### DIFF
--- a/bench/harness.py
+++ b/bench/harness.py
@@ -124,6 +124,7 @@ KNOWN_STEER_ENV: frozenset[str] = frozenset(
         "GOLDFIVE_STEER_SIGNAL_CHANNEL",  # PR 6 — SteeringConfig.from_env now reads it
         "GOLDFIVE_STEER_LEGACY_LADDER",  # PR 7 — SteeringConfig.from_env now reads it
         "GOLDFIVE_STEER_PIN_ASSIGNED_TASK",  # PR 9 — SteeringConfig.from_env now reads it
+        "GOLDFIVE_STEER_GRACE_WINDOW_TURNS",  # PR 8 — SteeringConfig.from_env now reads it
     }
 )
 
@@ -649,8 +650,32 @@ async def inject_demo_signals(
         authored_by="goldfive",
     )
     await steerer.drift._dispatch_nudge(looping, drift_session)
+    # AGENCY-PRESERVATION.md PR 8: self_corrected_after_signal attribution is
+    # now keyed on VISIBILITY (the ObserverNoteQueue's rendered set), not on
+    # dispatch. Under request_context with active steering the synthetic driver
+    # stands in for a delivery surface (before_model / boundary) actually
+    # SHOWING the queued notes — render them so the resolution attributes
+    # after_signal. Under observation_only (the shadow arms) we deliberately do
+    # NOT render: the note is never really shown, so the key resolves
+    # self_corrected_unaided (the §2 base-rate the shadow campaign measures).
+    if (
+        runtime.steering.signal_channel == "request_context"
+        and not runtime.steering.observation_only
+    ):
+        from goldfive.observer_note_queue import ObserverNoteQueue
+
+        rq = ObserverNoteQueue.for_session(drift_session)
+        render_turn = int(getattr(drift_session, "_reasoning_turn", 0) or 0)
+        for note in rq.pending():
+            rq.mark_delivered(
+                note.note_id,
+                channel="request_context",
+                turn=render_turn,
+                surface="bench_render",
+            )
     # Resolve the bound task → SignalOutcome for both delivered keys
-    # (self_corrected_unaided under observation_only, after_signal otherwise).
+    # (self_corrected_unaided under observation_only / unrendered,
+    # after_signal once rendered).
     await steerer.tasks.mark_task_completed("dt0", session=drift_session, summary="done")
     # Finalize any still-open delivered keys at the run boundary (idempotent).
     await steerer.drift.finalize_signal_ledger(drift_session)

--- a/docs/design/CONTROL-CHANNEL.md
+++ b/docs/design/CONTROL-CHANNEL.md
@@ -732,6 +732,35 @@ selects the channel:
 
 Env: `GOLDFIVE_STEER_SIGNAL_CHANNEL=request_context`.
 
+**Pacing — minimum-intervention grace windows (AGENCY-PRESERVATION.md
+PR 8).** Under `request_context`, a signal for a `(drift_kind, task)`
+key is gated by three ordered gates before dispatch
+(`DriftObserver._signal_pacing_decision`):
+
+1. **fresh user steer** — a user-authored `active_steer` within the #441
+   `suppression_window_turns` suppresses the goldfive signal (the
+   operator's correction is already in flight);
+2. **same-key grace window** — after a note for the key is *rendered*,
+   that key cannot re-signal or escalate for `grace_window_turns`
+   logical turns (default 3). It keys on **visibility** — the
+   `ObserverNoteQueue.last_rendered_turn` (stamped at render), NOT the
+   SignalLedger's dispatch turn: under request_context dispatch and
+   render can be turns apart, and an enqueued-but-never-rendered note
+   never started a window (the agent has not seen it);
+3. **per-request coalescing** — `peek_for_render` already renders ≤1
+   block per request (most-severe wins).
+
+Past the window the same key re-signals (the 2nd note is re-authored
+quoting the first — a self-reference is lower-footprint than a fresh
+statement); the 3rd occurrence (`>= REFINE_FAILURE_THRESHOLD` prior
+signals) escalates to `PAUSE_ESCALATE`. Resolution attribution is
+likewise **visibility-keyed**: `self_corrected_after_signal` requires
+the agent to have actually *seen* a note (the queue's rendered set); a
+note dispatched but never rendered resolves `self_corrected_unaided`.
+`grace_window_turns=0` disables the window (the pre-PR-8 behaviour); the
+legacy channel has no queue notes so PR 8 is a no-op there (§5.1). Env:
+`GOLDFIVE_STEER_GRACE_WINDOW_TURNS`.
+
 ---
 
 ## §6. References

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -920,6 +920,25 @@ class SteeringConfig:
     #: then lets them keep the pin if their tree depends on it.
     #: Env: ``GOLDFIVE_STEER_PIN_ASSIGNED_TASK``.
     pin_assigned_task: bool = False
+    #: AGENCY-PRESERVATION.md Stage 2 PR 8 — minimum-intervention pacing for
+    #: the observer-note channel. After a note for a ``(drift_kind, task)`` key
+    #: is RENDERED to the agent, that key cannot re-signal or escalate for this
+    #: many *logical turns* (``Session._reasoning_turn`` — the goldfive#441
+    #: clock; one tick per reasoning observation). The window keys on actual
+    #: VISIBILITY (the ObserverNoteQueue's ``delivered_turn``, stamped at
+    #: render), NOT the dispatch turn — under ``request_context`` dispatch and
+    #: render can be turns apart. Detectors keep running; a key resolving inside
+    #: the window still records ``self_corrected_after_signal``. After the
+    #: window the same key re-signals (the 2nd note re-authored quoting the
+    #: first); the 3rd occurrence escalates to a pause (REFINE_FAILURE_THRESHOLD
+    #: semantics).
+    #:
+    #: Default ``3``. ``0`` disables the grace window (every drift re-signals
+    #: immediately — the pre-PR-8 behaviour). Only takes effect under
+    #: ``signal_channel == "request_context"`` (the queue tracks visibility
+    #: there); the legacy regime has no queue notes, so PR 8 is a no-op there
+    #: (§5.1). Env: ``GOLDFIVE_STEER_GRACE_WINDOW_TURNS``.
+    grace_window_turns: int = 3
 
     @classmethod
     def from_env(cls) -> SteeringConfig:
@@ -950,6 +969,11 @@ class SteeringConfig:
         * ``GOLDFIVE_STEER_LEGACY_LADDER`` — boolean. The PR-7 escape hatch
           restoring the pre-PR-7 ladder cells + promotion side-effects
           (AGENCY-PRESERVATION.md PR 7 / §5.8); default ``False``.
+        * ``GOLDFIVE_STEER_GRACE_WINDOW_TURNS`` — positive int. The PR-8
+          minimum-intervention grace window in logical turns
+          (AGENCY-PRESERVATION.md PR 8); default ``3``. (Set ``0`` to disable
+          via the typed config; ``_read_int_env`` rejects non-positive env
+          values, so the env minimum is ``1``.)
         """
         defaults = cls()
         raw_rules = os.environ.get("GOLDFIVE_STEER_CONTEXT_EDITOR_RULES", "").strip()
@@ -998,6 +1022,10 @@ class SteeringConfig:
             pin_assigned_task=_read_bool_env(
                 "GOLDFIVE_STEER_PIN_ASSIGNED_TASK",
                 defaults.pin_assigned_task,
+            ),
+            grace_window_turns=_read_int_env(
+                "GOLDFIVE_STEER_GRACE_WINDOW_TURNS",
+                defaults.grace_window_turns,
             ),
         )
 

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -962,6 +962,97 @@ class DriftObserver:
     # Observer-note channel (AGENCY-PRESERVATION.md PR 6)
     # ------------------------------------------------------------------
 
+    def _signal_pacing_decision(self, session: Session, drift: DriftEvent) -> str:
+        """Grace-window / escalation gate for a SIGNAL-level or promotion drift.
+
+        AGENCY-PRESERVATION.md PR 8 (minimum-intervention pacing). Returns one
+        of ``"proceed"`` / ``"suppress"`` / ``"escalate"`` for a
+        ``(drift.kind, drift.current_task_id)`` key:
+
+        * ``"suppress"`` — a note for the key was RENDERED within the last
+          ``grace_window_turns`` logical turns; the agent has not yet had a full
+          window to self-correct since it SAW the signal, so do not re-signal or
+          escalate. Keys on the ObserverNoteQueue's render-visibility
+          (``last_rendered_turn``), NOT the SignalLedger dispatch turn (binding
+          requirement: under request_context dispatch and render can be turns
+          apart).
+        * ``"escalate"`` — the key is past its grace window AND has already
+          signalled ``>= REFINE_FAILURE_THRESHOLD`` times (the 3rd-occurrence
+          rule); escalate to a pause rather than signal again.
+        * ``"proceed"`` — signal normally (the 1st note, or the 2nd which
+          ``_route_corrective_note`` re-authors quoting the first).
+
+        Only active under ``signal_channel == "request_context"`` with
+        ``grace_window_turns > 0`` (the queue tracks visibility there). The
+        legacy regime has no queue notes, so this returns ``"proceed"`` and PR 8
+        is a no-op there (§5.1). Best-effort: any failure degrades to
+        ``"proceed"`` so pacing never blocks a legitimate signal.
+        """
+        channel = getattr(self._steerer, "_signal_channel", "legacy_user_message")
+        if channel != "request_context":
+            # Legacy regime: no queue visibility, and the promotion path's #441
+            # gate is unchanged — PR 8 is a no-op here (§5.1).
+            return "proceed"
+        # Ordered gate 1: a fresh user steer suppresses the goldfive signal
+        # (the operator's correction is already in flight). Applies even when
+        # the grace window is disabled.
+        if self._user_steer_is_fresh(session):
+            return "suppress"
+        window = int(getattr(self._steerer, "_grace_window_turns", 0) or 0)
+        if window <= 0:
+            return "proceed"
+        try:
+            from goldfive.observer_note_queue import ObserverNoteQueue
+
+            queue = ObserverNoteQueue.for_session(session)
+            kind = drift.kind.value
+            task = drift.current_task_id or ""
+            current_turn = int(getattr(session, "_reasoning_turn", 0) or 0)
+            # Ordered gate 2: same-key grace window, keyed on render-VISIBILITY
+            # (the queue's last render turn for the key), not the dispatch turn.
+            last_rendered = queue.last_rendered_turn(kind, task)
+            if last_rendered >= 0 and (current_turn - last_rendered) < window:
+                return "suppress"
+            # Past the window: the 3rd occurrence (>= REFINE_FAILURE_THRESHOLD
+            # prior signals) escalates to a pause. (Ordered gate 3, per-request
+            # coalescing, is enforced at render time by peek_for_render.)
+            if queue.signal_count(kind, task) >= self._steerer.REFINE_FAILURE_THRESHOLD:
+                return "escalate"
+            return "proceed"
+        except Exception as exc:  # noqa: BLE001 -- pacing must never wedge dispatch
+            log.debug("signal pacing decision failed: %s", exc)
+            return "proceed"
+
+    async def _apply_signal_pacing(
+        self, session: Session, drift: DriftEvent, decision: str
+    ) -> bool:
+        """Act on a non-``proceed`` :meth:`_signal_pacing_decision`.
+
+        Returns ``True`` when the caller should STOP (the signal was suppressed
+        or replaced by an escalation), ``False`` when it should proceed to the
+        normal signal dispatch. Centralises the suppress / escalate handling so
+        the promotion path and the ladder SIGNAL branch stay identical.
+        """
+        if decision == "suppress":
+            log.debug(
+                "DefaultSteerer: signal suppressed by grace window (kind=%s task=%s)",
+                drift.kind.value,
+                drift.current_task_id or "-",
+            )
+            return True
+        if decision == "escalate":
+            log.info(
+                "DefaultSteerer: signal escalated to pause — key re-signalled "
+                ">= REFINE_FAILURE_THRESHOLD times past its grace window "
+                "(kind=%s task=%s)",
+                drift.kind.value,
+                drift.current_task_id or "-",
+            )
+            await self._dispatch_pause_escalate(drift, session)
+            await self._record_signal_outcome_escalated(session, drift)
+            return True
+        return False
+
     async def _route_corrective_note(
         self,
         session: Session,
@@ -998,14 +1089,38 @@ class DriftObserver:
             from goldfive.observer_notes import observation_for_drift
 
             try:
+                queue = ObserverNoteQueue.for_session(session)
+                kind = drift.kind.value
+                task = drift.current_task_id or ""
                 observation, _question = observation_for_drift(drift)
-                ObserverNoteQueue.for_session(session).enqueue(
-                    body=note_text,
+                # AGENCY-PRESERVATION.md PR 8: the 2nd signal for a
+                # ``(kind, task)`` key is re-authored quoting the first — a
+                # self-reference is a lower-footprint reminder than a fresh
+                # statement, and it tells the agent goldfive is repeating, not
+                # raising a new concern. (The 1st signal, the grace-window
+                # suppression of in-window re-fires, and the 3rd-occurrence
+                # escalation are all decided in ``_signal_pacing_decision``
+                # before we get here; this only threads the quote into the
+                # body when exactly one prior note for the key exists.)
+                body = note_text
+                priors = [
+                    n for n in queue.notes() if n.kind == kind and n.task_id == task
+                ]
+                if len(priors) == 1:
+                    first_obs = (priors[0].observation or "").strip()
+                    if first_obs:
+                        body = (
+                            f"{note_text}\n\nThis repeats an earlier observer "
+                            f'note for this work, which observed: "{first_obs}". '
+                            f"That situation appears unchanged."
+                        )
+                queue.enqueue(
+                    body=body,
                     observation=observation,
                     severity=drift.severity.value,
                     drift_id=str(getattr(drift, "id", "") or ""),
-                    kind=drift.kind.value,
-                    task_id=drift.current_task_id or "",
+                    kind=kind,
+                    task_id=task,
                     agent_id=drift.current_agent_id or "",
                     turn=int(getattr(session, "_reasoning_turn", 0) or 0),
                     ladder_level=ladder_level,
@@ -1101,8 +1216,23 @@ class DriftObserver:
             from goldfive.signal_ledger import SignalLedger
 
             turn = int(getattr(session, "_reasoning_turn", 0) or 0)
+            # AGENCY-PRESERVATION.md PR 8 (binding requirement, #462 review):
+            # attribute ``after_signal`` by VISIBILITY, not dispatch. Under
+            # request_context the queue's render-set is the source of truth — a
+            # note dispatched (recorded in the ledger) but never RENDERED
+            # resolves ``self_corrected_unaided``. In the legacy regime the
+            # queued message IS the delivery, so ``rendered_keys=None`` keeps
+            # the dispatch-time ``has_real_delivery`` attribution.
+            rendered_keys: set[tuple[str, str]] | None = None
+            if (
+                getattr(self._steerer, "_signal_channel", "legacy_user_message")
+                == "request_context"
+            ):
+                from goldfive.observer_note_queue import ObserverNoteQueue
+
+                rendered_keys = ObserverNoteQueue.for_session(session).rendered_keys()
             for entry in SignalLedger.for_session(session).resolve_task(
-                task_id=str(task_id or ""), turn=turn
+                task_id=str(task_id or ""), turn=turn, rendered_keys=rendered_keys
             ):
                 await self._emit_signal_outcome(session, entry)
         except Exception as exc:  # noqa: BLE001 -- telemetry best-effort
@@ -4346,6 +4476,15 @@ class DriftObserver:
                     exc,
                 )
         if promote_to_steer:
+            # AGENCY-PRESERVATION.md PR 8: pace the promotion signal — suppress
+            # a re-signal inside the grace window, escalate to a pause on the
+            # 3rd occurrence. ``"proceed"`` falls through to the normal
+            # promotion (the note re-authoring for the 2nd is in
+            # ``_route_corrective_note``).
+            if await self._apply_signal_pacing(
+                session, drift, self._signal_pacing_decision(session, drift)
+            ):
+                return
             await self._promote_drift_to_steer(drift, session)
             return
         # Route through the intervention ladder. The per-(kind, task)
@@ -4391,6 +4530,13 @@ class DriftObserver:
             # were demoted to: proportional, trajectory-preserving influence.
             # The dispatch method keeps its ``_dispatch_nudge`` name (internal;
             # widely referenced) — it enqueues the SIGNAL-level note.
+            #
+            # AGENCY-PRESERVATION.md PR 8: pace it — suppress a re-signal inside
+            # the grace window, escalate to a pause on the 3rd occurrence.
+            if await self._apply_signal_pacing(
+                session, drift, self._signal_pacing_decision(session, drift)
+            ):
+                return
             await self._dispatch_nudge(drift, session)
             return
         if level is InterventionLevel.PAUSE_ESCALATE:
@@ -5869,34 +6015,48 @@ class DriftObserver:
             return False
         if not self._severity_meets_promotion_threshold(drift.severity):
             return False
-        # Consult the active user steer freshness window.
-        # Phase 1 of goldfive#271 — read through StateStore so
-        # the active-steer slot reads from a single named accessor; the
-        # underlying ``_ostate.read`` calls still funnel through the
-        # goldfive Session.state dict, just behind a typed surface.
+        # Ordered-gate #1 (AGENCY-PRESERVATION.md PR 8 unification): a fresh
+        # operator USER_STEER suppresses the goldfive promotion — the operator's
+        # correction is already in flight; running goldfive's on top races it.
+        # ``_user_steer_is_fresh`` is the shared #441 freshness predicate (also
+        # gate 1 of the SIGNAL-level path in ``_signal_pacing_decision``).
+        if self._user_steer_is_fresh(session):
+            drift.suppressed_by_user_steer = True
+            log.info(
+                "goldfive steer suppressed: a fresh user steer is active "
+                "(kind=%s task=%s)",
+                drift.kind.value,
+                drift.current_task_id or "-",
+            )
+            return False
+        return True
+
+    def _user_steer_is_fresh(self, session: Session) -> bool:
+        """True iff an operator USER_STEER is active within the #441 window.
+
+        The shared ordered-gate #1 predicate: a user-authored ``active_steer``
+        whose age (in logical turns — ``Session._reasoning_turn``, goldfive#441,
+        NOT event sequence) is within ``suppression_window_turns``. Consulted by
+        both :meth:`_should_promote_to_steer` (the promotion path, all regimes)
+        and :meth:`_signal_pacing_decision` (the SIGNAL-level path, PR 8). Pure
+        predicate — never mutates the drift; callers stamp
+        ``suppressed_by_user_steer`` themselves where the wire flag is wanted.
+        """
         window = self._steerer._goldfive_steer_suppression_window_turns
-        if window > 0:
+        if window <= 0:
+            return False
+        try:
             from goldfive.state_store import StateStore
 
             active = StateStore.for_session(session).get_active_steer()
-            if active is not None and active.source.lower() == "user":
-                # goldfive#441 — freshness is measured in *logical
-                # turns* (``_reasoning_turn``: one tick per reasoning
-                # observation), NOT ``_next_sequence`` (per-event, and
-                # inflated by decision-telemetry volume from #436/#440).
-                current_turn = int(getattr(session, "_reasoning_turn", 0) or 0)
-                age = current_turn - active.at_turn
-                if 0 <= age < window:
-                    drift.suppressed_by_user_steer = True
-                    log.info(
-                        "goldfive steer suppressed: user steer %r is active "
-                        "(age=%d turns, window=%d)",
-                        active.body,
-                        age,
-                        window,
-                    )
-                    return False
-        return True
+            if active is None or active.source.lower() != "user":
+                return False
+            current_turn = int(getattr(session, "_reasoning_turn", 0) or 0)
+            age = current_turn - active.at_turn
+            return 0 <= age < window
+        except Exception as exc:  # noqa: BLE001
+            log.debug("user-steer freshness check failed: %s", exc)
+            return False
 
     async def _promote_drift_to_steer(self, drift: DriftEvent, session: Session) -> None:
         """Promote a goldfive-detected drift into a full steer.

--- a/goldfive/observer_note_queue.py
+++ b/goldfive/observer_note_queue.py
@@ -477,47 +477,73 @@ class ObserverNoteQueue:
     # self-correct since it SAW the signal?" (binding requirement, #462
     # review). PR 8 reads these; PR 6's ``delivered`` flag supplies them.
 
-    def last_rendered_turn(self, kind: str, task_id: str) -> int:
-        """Return the most-recent render turn for a ``(kind, task)`` key.
+    @staticmethod
+    def _is_signal_note(n: ObserverNote) -> bool:
+        """True for a drift-signal note, False for a task-#11 correction note.
 
-        The max ``delivered_turn`` over delivered (rendered) notes matching
-        ``(kind, task_id)``; ``-1`` when no note for that key has been
+        The PR-8 pacing reads (grace window / escalation / attribution) gate
+        and attribute goldfive's drift SIGNALS only. A *correction* note
+        (task #11 — drift_id carries :data:`CORRECTION_DRIFT_ID_PREFIX`) is a
+        distinct mechanism (plan-revision notice on the agent-scoped channel),
+        not a drift advisory: it must NOT start a signal grace window, count
+        toward signal escalation, or stand in for "the agent saw the SIGNAL"
+        in ``after_signal`` attribution. Corrections also carry no SignalLedger
+        entry, so excluding them keeps the queue pacing reads aligned with the
+        ledger's signal keys.
+        """
+        return not str(n.drift_id or "").startswith(CORRECTION_DRIFT_ID_PREFIX)
+
+    def last_rendered_turn(self, kind: str, task_id: str) -> int:
+        """Return the most-recent SIGNAL render turn for a ``(kind, task)`` key.
+
+        The max ``delivered_turn`` over delivered (rendered) *signal* notes
+        matching ``(kind, task_id)`` (correction notes excluded — see
+        :meth:`_is_signal_note`); ``-1`` when no signal for that key has been
         rendered yet. This is the grace-window anchor: an enqueued-but-never-
-        rendered note returns ``-1`` (it never started a grace window — the
+        rendered signal returns ``-1`` (it never started a grace window — the
         agent has not seen it).
         """
         k = str(kind or "")
         t = str(task_id or "")
         best = -1
         for n in self.notes():
-            if n.kind == k and n.task_id == t and n.delivered:
+            if n.kind == k and n.task_id == t and n.delivered and self._is_signal_note(n):
                 best = max(best, int(n.delivered_turn))
         return best
 
     def signal_count(self, kind: str, task_id: str) -> int:
-        """Return the number of notes ENQUEUED for a ``(kind, task)`` key.
+        """Return the number of SIGNAL notes ENQUEUED for a ``(kind, task)`` key.
 
         Each enqueue is one signal that passed the upstream gates (re-fires
         suppressed inside a grace window are never enqueued — see the dispatch
         path), so this is the escalation counter: count ``0`` is the first
         signal, ``1`` the second (re-authored quoting the first), and
-        ``>= REFINE_FAILURE_THRESHOLD`` escalates to a pause.
+        ``>= REFINE_FAILURE_THRESHOLD`` escalates to a pause. Correction notes
+        (task #11) are excluded — they are not drift signals and must not
+        trip signal escalation.
         """
         k = str(kind or "")
         t = str(task_id or "")
-        return sum(1 for n in self.notes() if n.kind == k and n.task_id == t)
+        return sum(
+            1
+            for n in self.notes()
+            if n.kind == k and n.task_id == t and self._is_signal_note(n)
+        )
 
     def rendered_keys(self) -> set[tuple[str, str]]:
-        """Return every ``(kind, task)`` that has at least one RENDERED note.
+        """Return every ``(kind, task)`` with at least one RENDERED SIGNAL note.
 
         The visibility source of truth for ``self_corrected_after_signal``
         attribution (binding requirement): a key resolves ``after_signal`` only
-        if the agent actually SAW a note for it; an enqueued-but-never-rendered
-        key resolves ``self_corrected_unaided``.
+        if the agent actually SAW a drift SIGNAL for it; an
+        enqueued-but-never-rendered key resolves ``self_corrected_unaided``.
+        Correction notes (task #11) are excluded — a rendered correction is
+        not "the agent saw the SIGNAL" (and corrections carry no ledger entry
+        to attribute anyway).
         """
         out: set[tuple[str, str]] = set()
         for n in self.notes():
-            if n.delivered:
+            if n.delivered and self._is_signal_note(n):
                 out.add((n.kind, n.task_id))
         return out
 

--- a/goldfive/observer_note_queue.py
+++ b/goldfive/observer_note_queue.py
@@ -348,6 +348,61 @@ class ObserverNoteQueue:
                 best = n
         return best
 
+    # -- pacing reads (AGENCY-PRESERVATION.md PR 8) -----------------------
+    #
+    # The grace window keys on VISIBILITY — when a note for a ``(kind, task)``
+    # key was actually RENDERED onto a surface (``delivered_turn``, stamped by
+    # :meth:`mark_delivered`) — NOT on when it was dispatched/enqueued. Under
+    # ``request_context`` a dispatch and its render can be turns apart (the
+    # note waits in the queue until a surface peeks it), so the SignalLedger's
+    # dispatch-turn record is the wrong clock for "has the agent had time to
+    # self-correct since it SAW the signal?" (binding requirement, #462
+    # review). PR 8 reads these; PR 6's ``delivered`` flag supplies them.
+
+    def last_rendered_turn(self, kind: str, task_id: str) -> int:
+        """Return the most-recent render turn for a ``(kind, task)`` key.
+
+        The max ``delivered_turn`` over delivered (rendered) notes matching
+        ``(kind, task_id)``; ``-1`` when no note for that key has been
+        rendered yet. This is the grace-window anchor: an enqueued-but-never-
+        rendered note returns ``-1`` (it never started a grace window — the
+        agent has not seen it).
+        """
+        k = str(kind or "")
+        t = str(task_id or "")
+        best = -1
+        for n in self.notes():
+            if n.kind == k and n.task_id == t and n.delivered:
+                best = max(best, int(n.delivered_turn))
+        return best
+
+    def signal_count(self, kind: str, task_id: str) -> int:
+        """Return the number of notes ENQUEUED for a ``(kind, task)`` key.
+
+        Each enqueue is one signal that passed the upstream gates (re-fires
+        suppressed inside a grace window are never enqueued — see the dispatch
+        path), so this is the escalation counter: count ``0`` is the first
+        signal, ``1`` the second (re-authored quoting the first), and
+        ``>= REFINE_FAILURE_THRESHOLD`` escalates to a pause.
+        """
+        k = str(kind or "")
+        t = str(task_id or "")
+        return sum(1 for n in self.notes() if n.kind == k and n.task_id == t)
+
+    def rendered_keys(self) -> set[tuple[str, str]]:
+        """Return every ``(kind, task)`` that has at least one RENDERED note.
+
+        The visibility source of truth for ``self_corrected_after_signal``
+        attribution (binding requirement): a key resolves ``after_signal`` only
+        if the agent actually SAW a note for it; an enqueued-but-never-rendered
+        key resolves ``self_corrected_unaided``.
+        """
+        out: set[tuple[str, str]] = set()
+        for n in self.notes():
+            if n.delivered:
+                out.add((n.kind, n.task_id))
+        return out
+
     # -- mutators --------------------------------------------------------
 
     def enqueue(

--- a/goldfive/signal_ledger.py
+++ b/goldfive/signal_ledger.py
@@ -427,15 +427,29 @@ class SignalLedger:
         *,
         task_id: str,
         turn: int,
+        rendered_keys: set[tuple[str, str]] | None = None,
     ) -> list[LedgerEntry]:
         """Resolve every open, delivered key bound to ``task_id``.
 
         Called when the task reaches a terminal state (the conservative
         "resolved" signal — we do not attempt to detect mid-task "progressing"
-        here; that never over-claims self-correction). A key with at least one
-        real (non-dry-run) delivery resolves ``self_corrected_after_signal``;
-        a key with only dry-run deliveries resolves ``self_corrected_unaided``
-        (the ``observation_only`` base-rate case).
+        here; that never over-claims self-correction).
+
+        Attribution (AGENCY-PRESERVATION.md PR 8, binding requirement from the
+        #462 review): ``after_signal`` requires the agent to have actually SEEN
+        a note, not merely that one was dispatched.
+
+        * ``rendered_keys`` given (the ``request_context`` regime) — a key
+          resolves ``self_corrected_after_signal`` ONLY if ``(drift_kind,
+          task_id)`` is in ``rendered_keys`` (the ObserverNoteQueue's
+          render-visibility set); a note dispatched but never rendered resolves
+          ``self_corrected_unaided``. Dispatch-time ``has_real_delivery`` is the
+          WRONG clock here — under request_context dispatch and render can be
+          turns apart, and an unrendered note never reached the agent.
+        * ``rendered_keys`` is ``None`` (the legacy ``nudge_replay`` regime,
+          where the queued message IS the delivery, and existing
+          observe-only / shadow tests) — fall back to the dispatch-time
+          ``has_real_delivery`` attribution (byte-identical to pre-PR-8).
         """
         store = self._read_all()
         resolved: list[LedgerEntry] = []
@@ -445,9 +459,13 @@ class SignalLedger:
                 continue
             if not entry.is_open or not entry.has_delivery:
                 continue
+            if rendered_keys is not None:
+                seen = (entry.drift_kind, entry.task_id) in rendered_keys
+            else:
+                seen = entry.has_real_delivery
             outcome = (
                 SIGNAL_OUTCOME_SELF_CORRECTED_AFTER_SIGNAL
-                if entry.has_real_delivery
+                if seen
                 else SIGNAL_OUTCOME_SELF_CORRECTED_UNAIDED
             )
             done = self._resolve_in_store(store, entry, outcome=outcome, turn=turn)

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -634,6 +634,18 @@ class DefaultSteerer:
         self._legacy_ladder: bool = bool(
             getattr(steering_config, "legacy_ladder", False)
         )
+        # AGENCY-PRESERVATION.md PR 8: minimum-intervention grace window. After
+        # a note for a ``(kind, task)`` key is RENDERED, that key can't
+        # re-signal/escalate for this many logical turns (default 3; 0
+        # disables). The drift observer reads this in the signal-pacing gate,
+        # keyed on the ObserverNoteQueue's render-visibility (NOT the ledger's
+        # dispatch turn). Only active under ``signal_channel ==
+        # "request_context"`` (the queue tracks visibility there).
+        try:
+            _grace = int(getattr(steering_config, "grace_window_turns", 3))
+        except (TypeError, ValueError):
+            _grace = 3
+        self._grace_window_turns: int = max(0, _grace)
         # Background reasoning-judge tasks (goldfive#251). The LLM-judge
         # path in :meth:`observe_reasoning` is fire-and-forget so the
         # adapter's model-response callback can return immediately and

--- a/tests/test_pacing_grace_window.py
+++ b/tests/test_pacing_grace_window.py
@@ -1,0 +1,380 @@
+"""Minimum-intervention pacing — grace windows + escalation (PR 8).
+
+AGENCY-PRESERVATION.md Stage 2 PR 8. After a note for a ``(kind, task)`` key is
+RENDERED, that key cannot re-signal/escalate for ``grace_window_turns`` logical
+turns; the 2nd signal is re-authored quoting the first; the 3rd occurrence
+escalates to a pause. Two BINDING requirements from the #462 review are pinned
+here:
+
+1. the grace window keys on VISIBILITY — the ObserverNoteQueue's
+   ``delivered_turn`` (stamped at render), NOT the SignalLedger's dispatch turn;
+2. ``self_corrected_after_signal`` attribution uses visibility — a note
+   enqueued-but-never-rendered records ``self_corrected_unaided``.
+
+The hypothesis interleaving tests (§5.5) hammer the queue + ledger pacing
+bookkeeping under concurrent fires, late drifts, user steers, and restarts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.events import (  # noqa: E402
+    SIGNAL_OUTCOME_SELF_CORRECTED_AFTER_SIGNAL,
+    SIGNAL_OUTCOME_SELF_CORRECTED_UNAIDED,
+)
+from goldfive.observer_note_queue import ObserverNoteQueue  # noqa: E402
+from goldfive.signal_ledger import SignalLedger  # noqa: E402
+from goldfive.state_store import set_active_steer  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _session(turn: int = 0) -> Session:
+    s = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="ship a memo")],
+        plan=Plan(
+            id="p1",
+            run_id="r1",
+            goal_ids=["g1"],
+            tasks=[Task(id="t1", title="research")],
+            edges=[],
+        ),
+        current_task_id="t1",
+    )
+    s._reasoning_turn = turn
+    return s
+
+
+def _steerer(*, grace: int = 3, channel: str = "request_context") -> DefaultSteerer:
+    return DefaultSteerer(
+        steering_config=SteeringConfig(
+            signal_channel=channel, grace_window_turns=grace
+        )
+    )
+
+
+def _enqueue(
+    session: Session,
+    *,
+    drift_id: str,
+    kind: str = "looping_tool_call",
+    task: str = "t1",
+    turn: int = 0,
+) -> None:
+    ObserverNoteQueue.for_session(session).enqueue(
+        body="Observation: x", observation="x", severity="warning",
+        drift_id=drift_id, kind=kind, task_id=task, turn=turn,
+    )
+
+
+def _drift(
+    kind: DriftKind = DriftKind.LOOPING_TOOL_CALL,
+    severity: DriftSeverity = DriftSeverity.CRITICAL,
+) -> DriftEvent:
+    return DriftEvent(
+        kind=kind, severity=severity, detail="x",
+        current_task_id="t1", current_agent_id="agent", authored_by="goldfive",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Queue pacing reads (visibility source of truth)
+# ---------------------------------------------------------------------------
+
+
+def test_last_rendered_turn_is_render_not_enqueue() -> None:
+    session = _session()
+    q = ObserverNoteQueue.for_session(session)
+    _enqueue(session, drift_id="d1", turn=5)
+    # Enqueued but NOT rendered → -1 (no grace window started).
+    assert q.last_rendered_turn("looping_tool_call", "t1") == -1
+    q.mark_delivered("d1", channel="request_context", turn=7, surface="before_model")
+    # Rendered at turn 7 → that is the grace anchor (not the enqueue turn 5).
+    assert q.last_rendered_turn("looping_tool_call", "t1") == 7
+
+
+def test_last_rendered_turn_takes_max() -> None:
+    session = _session()
+    q = ObserverNoteQueue.for_session(session)
+    _enqueue(session, drift_id="d1")
+    _enqueue(session, drift_id="d2")
+    q.mark_delivered("d1", channel="request_context", turn=3)
+    q.mark_delivered("d2", channel="request_context", turn=9)
+    assert q.last_rendered_turn("looping_tool_call", "t1") == 9
+
+
+def test_signal_count_counts_enqueued_notes() -> None:
+    session = _session()
+    q = ObserverNoteQueue.for_session(session)
+    assert q.signal_count("looping_tool_call", "t1") == 0
+    _enqueue(session, drift_id="d1")
+    _enqueue(session, drift_id="d2")
+    assert q.signal_count("looping_tool_call", "t1") == 2
+    # Distinct key is independent.
+    assert q.signal_count("off_topic", "t1") == 0
+
+
+def test_rendered_keys_only_includes_rendered() -> None:
+    session = _session()
+    q = ObserverNoteQueue.for_session(session)
+    _enqueue(session, drift_id="d1", kind="looping_tool_call")
+    _enqueue(session, drift_id="d2", kind="off_topic")
+    q.mark_delivered("d1", channel="request_context", turn=1)
+    # d2 enqueued but never rendered → not in rendered_keys.
+    assert q.rendered_keys() == {("looping_tool_call", "t1")}
+
+
+# ---------------------------------------------------------------------------
+# Ordered gates — _signal_pacing_decision
+# ---------------------------------------------------------------------------
+
+
+def test_pacing_proceed_on_first_signal() -> None:
+    steerer, session = _steerer(), _session(turn=0)
+    assert steerer.drift._signal_pacing_decision(session, _drift()) == "proceed"
+
+
+def test_pacing_suppresses_inside_grace_window() -> None:
+    steerer = _steerer(grace=3)
+    session = _session(turn=6)
+    _enqueue(session, drift_id="d1")
+    ObserverNoteQueue.for_session(session).mark_delivered(
+        "d1", channel="request_context", turn=5
+    )
+    # Rendered at 5, now turn 6 (age 1 < 3) → suppress.
+    assert steerer.drift._signal_pacing_decision(session, _drift()) == "suppress"
+
+
+def test_pacing_proceeds_after_grace_window_expires() -> None:
+    steerer = _steerer(grace=3)
+    session = _session(turn=8)
+    _enqueue(session, drift_id="d1")
+    ObserverNoteQueue.for_session(session).mark_delivered(
+        "d1", channel="request_context", turn=5
+    )
+    # Rendered at 5, now turn 8 (age 3 >= 3) → window expired; 1 prior signal
+    # (< threshold) → proceed (this is the 2nd signal).
+    assert steerer.drift._signal_pacing_decision(session, _drift()) == "proceed"
+
+
+def test_pacing_escalates_on_third_occurrence() -> None:
+    steerer = _steerer(grace=3)
+    threshold = steerer.REFINE_FAILURE_THRESHOLD  # 2
+    session = _session(turn=20)
+    q = ObserverNoteQueue.for_session(session)
+    for i in range(threshold):
+        _enqueue(session, drift_id=f"d{i}")
+        q.mark_delivered(f"d{i}", channel="request_context", turn=i)
+    # Past the window (turn 20 >> last render), signal_count == threshold →
+    # escalate.
+    assert steerer.drift._signal_pacing_decision(session, _drift()) == "escalate"
+
+
+def test_pacing_unrendered_note_does_not_start_grace() -> None:
+    steerer = _steerer(grace=3)
+    session = _session(turn=1)
+    _enqueue(session, drift_id="d1", turn=0)  # enqueued, never rendered
+    # No render → no grace window; 1 prior note (< threshold) → proceed.
+    assert steerer.drift._signal_pacing_decision(session, _drift()) == "proceed"
+
+
+def test_pacing_gate1_fresh_user_steer_suppresses() -> None:
+    steerer = _steerer(grace=3)
+    session = _session(turn=2)
+    # No queue note at all — but a fresh user steer is active → gate 1 suppress.
+    set_active_steer(
+        session.state, body="user says stop", at_turn=1, author="op", source="user"
+    )
+    assert steerer.drift._signal_pacing_decision(session, _drift()) == "suppress"
+
+
+def test_pacing_noop_in_legacy_channel() -> None:
+    steerer = _steerer(channel="legacy_user_message", grace=3)
+    session = _session(turn=6)
+    _enqueue(session, drift_id="d1")
+    ObserverNoteQueue.for_session(session).mark_delivered(
+        "d1", channel="request_context", turn=5
+    )
+    # Legacy regime: PR 8 is a no-op → always proceed.
+    assert steerer.drift._signal_pacing_decision(session, _drift()) == "proceed"
+
+
+def test_pacing_grace_disabled_still_applies_user_steer_gate() -> None:
+    steerer = _steerer(grace=0)  # grace disabled
+    session = _session(turn=6)
+    _enqueue(session, drift_id="d1")
+    ObserverNoteQueue.for_session(session).mark_delivered(
+        "d1", channel="request_context", turn=5
+    )
+    # Grace disabled → no grace suppress (proceed despite recent render)...
+    assert steerer.drift._signal_pacing_decision(session, _drift()) == "proceed"
+    # ...but a fresh user steer still suppresses (gate 1 is independent).
+    set_active_steer(
+        session.state, body="stop", at_turn=6, author="op", source="user"
+    )
+    assert steerer.drift._signal_pacing_decision(session, _drift()) == "suppress"
+
+
+# ---------------------------------------------------------------------------
+# 2nd-signal re-authoring (quoting the first)
+# ---------------------------------------------------------------------------
+
+
+async def test_second_signal_quotes_the_first() -> None:
+    steerer = _steerer()
+    session = _session(turn=5)
+    # Enqueue a first note manually so _route_corrective_note sees one prior.
+    ObserverNoteQueue.for_session(session).enqueue(
+        body="Observation: search_web looped",
+        observation="search_web was called 5 times with identical args",
+        severity="warning", drift_id="d1", kind="looping_tool_call",
+        task_id="t1", turn=0,
+    )
+    await steerer.drift._route_corrective_note(
+        session, _drift(), "Observation: still looping", ladder_level="signal"
+    )
+    notes = ObserverNoteQueue.for_session(session).notes()
+    second = [n for n in notes if n.drift_id != "d1"]
+    assert len(second) == 1
+    # The 2nd note's body quotes the first note's observation.
+    assert "repeats an earlier observer note" in second[0].body
+    assert "search_web was called 5 times" in second[0].body
+
+
+# ---------------------------------------------------------------------------
+# Visibility attribution (binding requirement #2)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_task_after_signal_only_when_rendered() -> None:
+    state: dict[str, Any] = {}
+    ledger = SignalLedger(state)
+    # A real (non-dry-run) delivery is recorded at dispatch for (looping, t1).
+    ledger.record_delivery(
+        drift_kind="looping_tool_call", task_id="t1", drift_id="d1",
+        channel="request_context", turn=1, dry_run=False,
+    )
+    # ...but the note was NEVER rendered → rendered_keys empty → unaided.
+    resolved = ledger.resolve_task(task_id="t1", turn=5, rendered_keys=set())
+    assert len(resolved) == 1
+    assert resolved[0].outcome == SIGNAL_OUTCOME_SELF_CORRECTED_UNAIDED
+
+
+def test_resolve_task_after_signal_when_rendered() -> None:
+    state: dict[str, Any] = {}
+    ledger = SignalLedger(state)
+    ledger.record_delivery(
+        drift_kind="looping_tool_call", task_id="t1", drift_id="d1",
+        channel="request_context", turn=1, dry_run=False,
+    )
+    resolved = ledger.resolve_task(
+        task_id="t1", turn=5, rendered_keys={("looping_tool_call", "t1")}
+    )
+    assert resolved[0].outcome == SIGNAL_OUTCOME_SELF_CORRECTED_AFTER_SIGNAL
+
+
+def test_resolve_task_legacy_falls_back_to_has_real_delivery() -> None:
+    state: dict[str, Any] = {}
+    ledger = SignalLedger(state)
+    ledger.record_delivery(
+        drift_kind="looping_tool_call", task_id="t1", drift_id="d1",
+        channel="nudge_replay", turn=1, dry_run=False,
+    )
+    # rendered_keys=None (legacy regime) → attribution by has_real_delivery.
+    resolved = ledger.resolve_task(task_id="t1", turn=5, rendered_keys=None)
+    assert resolved[0].outcome == SIGNAL_OUTCOME_SELF_CORRECTED_AFTER_SIGNAL
+
+
+# ---------------------------------------------------------------------------
+# §5.5 — property-based interleaving over queue + ledger pacing bookkeeping
+# ---------------------------------------------------------------------------
+
+
+_OPS = st.lists(
+    st.tuples(
+        st.sampled_from(["enqueue", "render", "fire", "resolve", "user_steer"]),
+        st.sampled_from(["a", "b"]),  # drift ids
+        st.sampled_from(["looping_tool_call", "off_topic"]),  # kinds
+        st.integers(min_value=0, max_value=6),  # turn
+    ),
+    min_size=0,
+    max_size=40,
+)
+
+
+@settings(max_examples=150)
+@given(ops=_OPS)
+def test_pacing_interleaving_invariants(
+    ops: list[tuple[str, str, str, int]],
+) -> None:
+    session = _session()
+    q = ObserverNoteQueue.for_session(session)
+    ledger = SignalLedger.for_session(session)
+    for op, did, kind, turn in ops:
+        session._reasoning_turn = turn
+        if op == "enqueue":
+            q.enqueue(
+                body="b", observation="o", severity="warning",
+                drift_id=did, kind=kind, task_id="t1", turn=turn,
+            )
+        elif op == "render":
+            q.mark_delivered(did, channel="request_context", turn=turn)
+        elif op == "fire":
+            ledger.record_fire(drift_kind=kind, task_id="t1", turn=turn, drift_id=did)
+        elif op == "resolve":
+            ledger.resolve_task(
+                task_id="t1", turn=turn, rendered_keys=q.rendered_keys()
+            )
+        elif op == "user_steer":
+            set_active_steer(
+                session.state, body="x", at_turn=turn, author="op", source="user"
+            )
+        # Invariant: queue + ledger state always re-parse without error.
+        for n in q.notes():
+            assert n.note_id
+        for entry in ledger.entries():
+            assert entry.drift_kind is not None
+
+    # Invariant: rendered_keys ⊆ all enqueued keys; last_rendered_turn never
+    # exceeds the max turn we ever stamped (no time travel).
+    all_keys = {(n.kind, n.task_id) for n in q.notes()}
+    assert q.rendered_keys() <= all_keys
+    for kind in ("looping_tool_call", "off_topic"):
+        lr = q.last_rendered_turn(kind, "t1")
+        assert lr == -1 or 0 <= lr <= 6
+        # signal_count is the number of distinct enqueued notes for the key.
+        assert q.signal_count(kind, "t1") == sum(
+            1 for n in q.notes() if n.kind == kind and n.task_id == "t1"
+        )
+    # Invariant: every resolved ledger entry has a terminal outcome in the
+    # visibility-attributed set (never after_signal for an unrendered key).
+    rendered = q.rendered_keys()
+    for entry in ledger.entries():
+        if entry.outcome == SIGNAL_OUTCOME_SELF_CORRECTED_AFTER_SIGNAL:
+            assert (entry.drift_kind, entry.task_id) in rendered

--- a/tests/test_pacing_grace_window.py
+++ b/tests/test_pacing_grace_window.py
@@ -150,6 +150,35 @@ def test_rendered_keys_only_includes_rendered() -> None:
     assert q.rendered_keys() == {("looping_tool_call", "t1")}
 
 
+def test_pacing_reads_exclude_correction_notes() -> None:
+    """Task-#11 correction notes are not drift signals — excluded from the
+    grace window / escalation / attribution reads (composition with #468)."""
+    from goldfive.observer_note_queue import CORRECTION_DRIFT_ID_PREFIX
+
+    session = _session()
+    q = ObserverNoteQueue.for_session(session)
+    # A RENDERED correction note for (off_topic, t1).
+    cid = f"{CORRECTION_DRIFT_ID_PREFIX}writer:t1:1"
+    q.enqueue(
+        body="b", observation="o", severity="warning", drift_id=cid,
+        kind="off_topic", task_id="t1", agent_id="writer", turn=2,
+    )
+    q.mark_delivered(cid, channel="request_context", turn=2)
+    # The correction does NOT count as a signal render / count / rendered key.
+    assert q.last_rendered_turn("off_topic", "t1") == -1
+    assert q.signal_count("off_topic", "t1") == 0
+    assert ("off_topic", "t1") not in q.rendered_keys()
+    # A genuine drift-signal note for the SAME key IS counted.
+    q.enqueue(
+        body="b", observation="o", severity="warning", drift_id="real-uuid",
+        kind="off_topic", task_id="t1", turn=3,
+    )
+    q.mark_delivered("real-uuid", channel="request_context", turn=3)
+    assert q.last_rendered_turn("off_topic", "t1") == 3
+    assert q.signal_count("off_topic", "t1") == 1
+    assert ("off_topic", "t1") in q.rendered_keys()
+
+
 # ---------------------------------------------------------------------------
 # Ordered gates — _signal_pacing_decision
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Stage 2 **PR 8**: pace the observer-note channel so goldfive signals proportionally — after a note is *seen*, give the agent room to self-correct before re-signaling, escalate only when it doesn't.

### Ordered gates (`DriftObserver._signal_pacing_decision`, request_context only)
1. **fresh user steer** (#441) — a user-authored `active_steer` within `suppression_window_turns` suppresses the goldfive signal (the operator's correction is already in flight). Unified via a shared `_user_steer_is_fresh` predicate (`_should_promote_to_steer` refactored to use it).
2. **same-key grace window** — after a note for `(drift_kind, task)` is RENDERED, that key can't re-signal/escalate for `grace_window_turns` logical turns (default 3).
3. **per-request coalescing** — already enforced by `peek_for_render` (≤1 block/request).

### BINDING requirements (from the #462 review, lead-approved)
1. **The grace window keys on VISIBILITY**, not dispatch: `ObserverNoteQueue.last_rendered_turn` (stamped at render via `mark_delivered`), NOT the SignalLedger's dispatch turn — under request_context dispatch and render can be turns apart, and an enqueued-but-never-rendered note never started a window. New queue reads: `last_rendered_turn` / `signal_count` / `rendered_keys`.
2. **`self_corrected_after_signal` attribution uses visibility**: `SignalLedger.resolve_task` takes `rendered_keys`; a note dispatched (recorded in the ledger) but never rendered resolves `self_corrected_unaided`. Legacy regime (`rendered_keys=None`) keeps the dispatch-time `has_real_delivery` attribution.

### Escalation
The **2nd** signal for a key is re-authored quoting the first (`_route_corrective_note` — a self-reference is lower-footprint than a fresh statement); the **3rd** occurrence (`>= REFINE_FAILURE_THRESHOLD` prior signals, past the window) escalates to `PAUSE_ESCALATE`.

### Config + bench
`SteeringConfig.grace_window_turns` (default 3; 0 disables) + `GOLDFIVE_STEER_GRACE_WINDOW_TURNS` → promoted to the bench `KNOWN_STEER_ENV` (same-PR contract). `inject_demo_signals` now **renders** the queued notes under request_context + active steering so the visibility attribution records `after_signal` (the shadow/`observation_only` arms stay unrendered → `unaided` base rate, exactly the §2 counterfactual).

## §5 / requirements satisfied
- **§5.1 no-op by default**: the legacy channel has no queue notes → PR 8 is inert there; `grace_window_turns=0` disables; existing suites pass unmodified.
- **Binding #1 + #2**: pinned by `test_pacing_grace_window.py` (visibility vs dispatch; after_signal only when rendered; enqueued-but-never-rendered → unaided).
- **§5.5 hypothesis interleaving**: random sequences of enqueue/render/fire/resolve/user-steer over the queue+ledger, asserting rendered_keys ⊆ enqueued keys, no after_signal for an unrendered key, state always parseable.
- Ordered gates + escalation + re-authoring covered by unit/decision tests.

## Tests
**Full suite `2604 passed, 131 skipped`; ruff clean.** Doc: `CONTROL-CHANNEL.md` §5.6.

## Notes for review
- **Scoping**: the grace window is request_context-only (where the queue tracks visibility); legacy keeps pre-PR-8 behaviour. Flagged this read of the binding req to the lead at kickoff — visibility-only, not also ledger-dispatch-turn for legacy.
- **Bench composition**: `inject_demo_signals` gained a render step (gated on request_context + not observation_only) — necessary because visibility attribution means dispatch-without-render is now `unaided`. Flagging the bench owner.
- **#468 (agent-scoped peek)** has merged-status in the tracker but is NOT yet on `agency-preservation` (HEAD is PR 7); my queue reads are additive and compose with `peek_for_render(agent_id=)`. Will rebase when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)