### PR TITLE
test+docs(steering): PR-8 follow-ups — #469×#470 composition guard + resolve_task attribution caveat

### DIFF
--- a/goldfive/signal_ledger.py
+++ b/goldfive/signal_ledger.py
@@ -450,6 +450,21 @@ class SignalLedger:
           where the queued message IS the delivery, and existing
           observe-only / shadow tests) — fall back to the dispatch-time
           ``has_real_delivery`` attribution (byte-identical to pre-PR-8).
+
+        Bench caveat (read before extracting 13b ``self_corrected`` rates).
+        The two regimes use DIFFERENT clocks, so the per-arm
+        ``self_corrected_after_signal`` base rate is asymmetric by design:
+        arm B (``request_context``) is render-VISIBILITY-keyed (accurate — a
+        dispatched-but-unrendered note resolves ``unaided``), while arm C
+        (legacy) is DISPATCH-keyed (a note dispatched but not actually
+        replayed still resolves ``after_signal``). In real runs both channels
+        deliver, so the rates converge; the asymmetry only bites in the
+        dispatched-but-not-delivered tail, where arm C can slightly
+        OVER-attribute ``after_signal``. This is acceptable because the
+        primary default-flip gate is the A-vs-B comparison (NOT the B-vs-C
+        self-correction rate) and the legacy channel retires in PR 13 — but a
+        B-vs-C self-correction delta must not be over-read for arm C. (Bench
+        annotates the same caveat in its 13b metric extraction.)
         """
         store = self._read_all()
         resolved: list[LedgerEntry] = []

--- a/tests/test_pacing_grace_window.py
+++ b/tests/test_pacing_grace_window.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.control import ControlChannel, ControlKind  # noqa: E402
 from goldfive.events import (  # noqa: E402
     SIGNAL_OUTCOME_SELF_CORRECTED_AFTER_SIGNAL,
     SIGNAL_OUTCOME_SELF_CORRECTED_UNAIDED,
@@ -47,6 +48,8 @@ from goldfive.types import (  # noqa: E402
     Plan,
     Session,
     Task,
+    TaskKind,
+    TaskStatus,
 )
 
 # ---------------------------------------------------------------------------
@@ -338,6 +341,179 @@ def test_resolve_task_legacy_falls_back_to_has_real_delivery() -> None:
     # rendered_keys=None (legacy regime) → attribution by has_real_delivery.
     resolved = ledger.resolve_task(task_id="t1", turn=5, rendered_keys=None)
     assert resolved[0].outcome == SIGNAL_OUTCOME_SELF_CORRECTED_AFTER_SIGNAL
+
+
+# ---------------------------------------------------------------------------
+# Composition with #469 (PR 12) — promotion-path pacing gates BEFORE the
+# ledger/forecast fork.
+#
+# A promotion-eligible goldfive drift in ledger + request_context mode now hits
+# BOTH PR 8's pacing gate AND #469's `_ledger_retire_refine` routing at the
+# `if promote_to_steer:` site. Pacing MUST run first: a within-window re-fire
+# must be a no-op (NOT a ledger force-FAIL), and a pacing-escalate must dispatch
+# exactly one pause (NOT also #469's force-FAIL). LOOPING_TOOL_CALL is the probe
+# kind — it is promotion-eligible AND a ledger force-FAIL kind, so a missed
+# short-circuit is observable as a FAILED bound task.
+# ---------------------------------------------------------------------------
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class _RecordingPlanner:
+    """Records refine / refine_steer calls so 'no refine ran' is assertable."""
+
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+        self.refine_steer_calls: list[dict[str, Any]] = []
+
+    async def generate(self, *, goals: Any, available_agents: Any, context: Any = None) -> Any:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        self.refine_calls.append(kwargs)
+        return kwargs.get("plan")
+
+    async def refine_steer(self, **kwargs: Any) -> Plan | None:
+        self.refine_steer_calls.append(kwargs)
+        return kwargs.get("plan")
+
+    @property
+    def refined(self) -> bool:
+        return bool(self.refine_calls or self.refine_steer_calls)
+
+
+def _ledger_session(turn: int) -> Session:
+    s = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="ship a memo")],
+        plan=Plan(
+            id="p1",
+            run_id="r1",
+            goal_ids=["g1"],
+            tasks=[
+                Task(
+                    id="t1",
+                    title="writer: drafting",
+                    discovered=True,
+                    kind=TaskKind.DISCOVERED,
+                    status=TaskStatus.RUNNING,
+                )
+            ],
+            edges=[],
+        ),
+        current_task_id="t1",
+    )
+    s._reasoning_turn = turn
+    return s
+
+
+def _ledger_steerer(*, grace: int = 3) -> tuple[DefaultSteerer, _RecordingPlanner]:
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(
+            signal_channel="request_context",
+            grace_window_turns=grace,
+            plan_mode="ledger",
+            threshold="warning",
+            observation_only=False,
+        )
+    )
+    planner = _RecordingPlanner()
+    steerer.bind(sinks=[_ListSink()], planner=planner)
+    return steerer, planner
+
+
+def _promotion_drift() -> DriftEvent:
+    # WARNING (clears threshold="warning" without tripping the CRITICAL cancel)
+    # + LOOPING_TOOL_CALL (promotion-eligible AND ledger force-FAIL kind).
+    return DriftEvent(
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        severity=DriftSeverity.WARNING,
+        detail="search_web looped",
+        current_task_id="t1",
+        current_agent_id="agent",
+        authored_by="goldfive",
+    )
+
+
+def _t1(session: Session) -> Task:
+    return next(t for t in session.plan.tasks if t.id == "t1")
+
+
+async def test_promotion_suppress_does_not_force_fail_in_ledger_mode() -> None:
+    """Within-window promotion re-fire → suppressed BEFORE #469's ledger fork.
+
+    If pacing did not gate first, the looping kind would force-FAIL the bound
+    task; the grace window exists precisely to give the agent room to
+    self-correct after it saw the prior note, so a suppressed re-fire must be a
+    no-op.
+    """
+    steerer, planner = _ledger_steerer(grace=3)
+    session = _ledger_session(turn=6)
+    _enqueue(session, drift_id="d1", turn=5)
+    ObserverNoteQueue.for_session(session).mark_delivered(
+        "d1", channel="request_context", turn=5
+    )
+    await steerer.drift.handle_drift(_promotion_drift(), session)
+    assert _t1(session).status is not TaskStatus.FAILED
+    assert not planner.refined
+
+
+async def test_promotion_escalate_pauses_once_no_force_fail() -> None:
+    """3rd-occurrence promotion re-fire → exactly ONE pause, no force-FAIL.
+
+    The pacing-escalate dispatches PAUSE_ESCALATE itself and returns 'stop'; it
+    must NOT fall through to #469's `_ledger_retire_refine`, which for a looping
+    kind would force-FAIL the task (and a hard-safety kind would dispatch a
+    SECOND pause). Composition bug = a FAILED task or two pauses.
+    """
+    steerer, planner = _ledger_steerer(grace=3)
+    channel = ControlChannel()
+    steerer.bind_control_channel(channel)
+    session = _ledger_session(turn=20)
+    q = ObserverNoteQueue.for_session(session)
+    for i in range(steerer.REFINE_FAILURE_THRESHOLD):
+        _enqueue(session, drift_id=f"d{i}", turn=i)
+        q.mark_delivered(f"d{i}", channel="request_context", turn=i)
+    await steerer.drift.handle_drift(_promotion_drift(), session)
+    assert _t1(session).status is not TaskStatus.FAILED
+    assert not planner.refined
+    drained: list[Any] = []
+    inbox = channel._inbox  # noqa: SLF001 — test inspection
+    while not inbox.empty():
+        drained.append(inbox.get_nowait())
+    pauses = [
+        m
+        for m in drained
+        if getattr(m, "kind", None) is ControlKind.GOLDFIVE_PAUSE_ESCALATE
+    ]
+    assert len(pauses) == 1, (
+        f"expected exactly one pause; got {[getattr(m, 'kind', None) for m in drained]}"
+    )
+
+
+async def test_promotion_proceed_runs_ledger_retire_in_ledger_mode() -> None:
+    """Past the window, < threshold prior signals → proceed → #469's ledger
+    fork fires (force-FAIL the looping bound task). The 'else' arm of the
+    composition: when pacing proceeds, the ledger retirement still happens."""
+    steerer, planner = _ledger_steerer(grace=3)
+    session = _ledger_session(turn=8)
+    _enqueue(session, drift_id="d1", turn=4)
+    ObserverNoteQueue.for_session(session).mark_delivered(
+        "d1", channel="request_context", turn=4
+    )
+    await steerer.drift.handle_drift(_promotion_drift(), session)
+    assert _t1(session).status is TaskStatus.FAILED
+    # Ledger mode retires the forecast-repair refine — no planner refine ran.
+    assert not planner.refined
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two small PR-8 (#470) follow-ups that raced the squash-merge. Both are additive and **zero behavior change** (one test file + one docstring).

## 1. Promotion-path composition guard test (`tests/test_pacing_grace_window.py`)
Bench's focused-delta review of the #470↔#469 rebase asked for an explicit test on the one spot the two PRs genuinely interleave — the goldfive-drift PROMOTION branch (`if promote_to_steer:` in `drift_observer.py`), where PR 8's pacing gate and #469's `_ledger_retire_refine` routing both apply in **ledger + request_context** mode. The rebase resolved it **pacing-first**; this pins that ordering.

`LOOPING_TOOL_CALL` is the probe (promotion-eligible AND a ledger force-FAIL kind, so a missed short-circuit shows as a FAILED bound task):
- **suppress** (within grace window) → task NOT failed, no refine;
- **escalate** (3rd occurrence) → exactly ONE `GOLDFIVE_PAUSE_ESCALATE`, task NOT failed (no double-dispatch with the ledger fork);
- **proceed** (past window, < threshold) → the ledger fork DOES fire (force-FAIL) — pacing only *gates*, never *replaces*, #469's retirement.

`suppress`-vs-`proceed` is a clean differential (same drift/kind, only grace state differs). Drives `handle_drift` end-to-end via #469's `_ListSink`/`_RecordingPlanner` harness.

## 2. `resolve_task` attribution caveat docstring (`goldfive/signal_ledger.py`)
Team-lead-approved post-merge fast-follow. Documents, next to the code, the B-vs-C attribution-clock asymmetry bench annotates in its 13b metric extraction: arm B (`request_context`) is render-visibility-keyed; arm C (legacy) is dispatch-keyed and can slightly over-attribute `after_signal` in the dispatched-but-not-delivered tail. Notes that the A-vs-B comparison (not B-vs-C self-correction) is the default-flip gate, so it's a documented caveat, not a correctness problem.

Full suite green; CI green on 3.11 + 3.12.