### PR TITLE
fix: gate the NUDGE injection path on observation_only

### DIFF
--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -597,7 +597,7 @@ class SteeringConfig:
     cancel or refine fires. Default ``3`` keeps a live operator
     override dominant across a few agent turns.
 
-    ``observation_only`` (goldfive#254) gates the three actual steering
+    ``observation_only`` (goldfive#254) gates the actual steering
     injection points on :class:`~goldfive.steerer.DefaultSteerer`:
 
     * the would-be revised plan replacing ``session.plan`` in
@@ -605,7 +605,14 @@ class SteeringConfig:
     * the ``GOLDFIVE_STEER`` ControlMessage enqueue in
       :meth:`~goldfive.steerer.DefaultSteerer._dispatch_goldfive_steer_control`;
     * the ``request_invocation_cancel`` plugin call in
-      :meth:`~goldfive.steerer.DefaultSteerer.request_invocation_cancel`.
+      :meth:`~goldfive.steerer.DefaultSteerer.request_invocation_cancel`;
+    * the Level 2 nudge enqueues onto ``session.pending_nudges``
+      (``_dispatch_nudge`` and the post-ABSORB handoff, goldfive#202) —
+      the overlay would otherwise drain the queue into a
+      goldfive-authored synthetic user turn and re-invoke the tree.
+      The executor's drain carries a matching defense-in-depth gate
+      (goldfive#264 pattern) for steerer subclasses that bypass the
+      dispatcher.
 
     The plan-install gate suppresses only **corrective**
     goldfive-authored revisions. Three categories always land as real

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -3889,7 +3889,39 @@ class DriftObserver:
                 drift=drift,
                 refined_plan=session.plan,
             )
+            # Observation-only: the queued nudge would be drained by the
+            # overlay's replay path into a goldfive-authored user turn
+            # that re-invokes the tree — an injection, not an
+            # observation. Skip the enqueue but log the would-be message
+            # and stamp the gate, mirroring
+            # ``_dispatch_goldfive_steer_control``.
+            if not self._steerer._should_inject():
+                log.info(
+                    "DefaultSteerer._handle_drift: observation_only=True — "
+                    "SKIPPING post-ABSORB nudge enqueue. would_have_queued "
+                    "kind=%s task=%s body=%r",
+                    drift.kind.value,
+                    drift.current_task_id or "-",
+                    nudge_msg[:200],
+                )
+                await self._emit_policy_applied(
+                    session=session,
+                    policy_name="observation_only_gate",
+                    outcome="suppressed",
+                    reason="observation_only=True",
+                    detail=(
+                        f"intervention=post_absorb_nudge "
+                        f"kind={drift.kind.value} "
+                        f"task_id={drift.current_task_id or ''}"
+                    ),
+                )
+                return
             session.pending_nudges.append(nudge_msg)
+            # Thread the install fact to the overlay so the replay
+            # header only claims a plan revision when ``_apply_revision``
+            # actually installed one.
+            if was_installed:
+                session.pending_nudges_revision_installed = True
             log.debug(
                 "DefaultSteerer._handle_drift: queued post-ABSORB nudge for kind=%s task=%s: %s",
                 drift.kind.value,
@@ -3908,6 +3940,12 @@ class DriftObserver:
         nudge at the next invocation boundary and sends it as a gentle
         corrective user message. Until #141 lands, the queue is
         observable but inert; nothing consumes it.
+
+        Observation-only: the overlay drains the queue into a
+        goldfive-authored user turn that re-invokes the tree, so the
+        enqueue is gated on :meth:`DefaultSteerer._should_inject` like
+        the other injection points; the would-be nudge is logged and
+        the gate stamped as decision telemetry.
         """
         from goldfive.steerer import compose_corrective_user_message
 
@@ -3915,6 +3953,27 @@ class DriftObserver:
             drift=drift,
             refined_plan=session.plan,
         )
+        if not self._steerer._should_inject():
+            log.info(
+                "DefaultSteerer._dispatch_nudge: observation_only=True — "
+                "SKIPPING nudge enqueue. would_have_queued kind=%s "
+                "task=%s body=%r",
+                drift.kind.value,
+                drift.current_task_id or "-",
+                msg[:200],
+            )
+            await self._emit_policy_applied(
+                session=session,
+                policy_name="observation_only_gate",
+                outcome="suppressed",
+                reason="observation_only=True",
+                detail=(
+                    f"intervention=nudge "
+                    f"kind={drift.kind.value} "
+                    f"task_id={drift.current_task_id or ''}"
+                ),
+            )
+            return
         session.pending_nudges.append(msg)
         log.debug(
             "DefaultSteerer: queued nudge for kind=%s task=%s: %s",

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -1357,9 +1357,35 @@ class SequentialExecutor(Executor):
                 and nudge_replays < self._MAX_NUDGE_REPLAYS
                 and _has_live_pending_or_running(session.plan or plan)
             ):
+                # goldfive#264-style observation-only carve-out
+                # (defense-in-depth). The primary gates are at the
+                # steerer's nudge enqueue sites (``_dispatch_nudge`` /
+                # the post-ABSORB handoff): under
+                # ``observation_only=True`` nothing is queued and this
+                # branch never sees a nudge. Custom steerer subclasses
+                # or direct ``session.pending_nudges`` writers would
+                # otherwise drive a goldfive-authored re-invocation of
+                # the tree here — exactly the enforcement
+                # ``observation_only`` exists to suppress. Discard the
+                # queue (never inject it later) and end the turn.
+                if getattr(steerer, "_observation_only", False):
+                    log.info(
+                        "SequentialExecutor._run_overlay: "
+                        "observation_only=True — would have replayed %d "
+                        "queued nudge(s) but observation_only is in "
+                        "effect; ending the turn without re-invoking",
+                        len(pending),
+                    )
+                    session.pending_nudges.clear()
+                    session.pending_nudges_revision_installed = False
+                    break
+                plan_revised = session.pending_nudges_revision_installed
                 session.pending_nudges.clear()
+                session.pending_nudges_revision_installed = False
                 nudge_replays += 1
-                current_user_input = self._compose_nudge_replay_message(pending)
+                current_user_input = self._compose_nudge_replay_message(
+                    pending, plan_revised=plan_revised
+                )
                 log.info(
                     "SequentialExecutor._run_overlay: nudge replay %d/%d "
                     "(nudges=%d) — re-invoking passthrough with queued nudge",
@@ -1937,7 +1963,9 @@ class SequentialExecutor(Executor):
             log.warning("SequentialExecutor: steerer.drift.observe(STEER) raised: %s", exc)
 
     @staticmethod
-    def _compose_nudge_replay_message(nudges: list[str]) -> str:
+    def _compose_nudge_replay_message(
+        nudges: list[str], *, plan_revised: bool = False
+    ) -> str:
         """Wrap queued nudges in a goldfive-authored framing header.
 
         Mirrors :meth:`_compose_steer_restart_message` but for the
@@ -1945,20 +1973,42 @@ class SequentialExecutor(Executor):
 
         * A header distinguishing this from a fresh user turn: the
           operator did not intervene; goldfive detected drift (e.g.
-          repeated ``report_task_completed`` calls), revised the plan,
-          and is directing the coordinator to the new next task.
+          repeated ``report_task_completed`` calls) and is directing
+          the coordinator to the next useful step.
         * Each queued nudge verbatim (short, action-focused strings
           composed by :func:`compose_corrective_user_message`).
-        * A brief instruction to continue with the revised plan.
+        * A brief instruction to continue.
+
+        ``plan_revised`` selects the framing: the header only claims a
+        plan revision when the steerer recorded that ``_apply_revision``
+        actually installed one
+        (``session.pending_nudges_revision_installed``); a Level 2
+        nudge with no refine, or a dry-run revision, gets a
+        course-correction header that asserts nothing about the plan.
 
         The scoped replay path is the carefully-narrowed successor to
         the blanket follow-up loop that goldfive#163 removed. #163's
         removal was correct when every PENDING task triggered a
         follow-up; this path only fires when the STEERER explicitly
-        queued a nudge in response to a tracked drift + plan
-        revision — not on every PENDING-at-invocation-end.
+        queued a nudge in response to a tracked drift — not on every
+        PENDING-at-invocation-end.
         """
         body = "\n".join(f"- {n}" for n in nudges if n)
+        if not plan_revised:
+            return (
+                "[GOLDFIVE COURSE CORRECTION]\n"
+                "\n"
+                "Goldfive detected drift during the prior turn. The "
+                "active plan is unchanged; the directive(s) below "
+                "redirect you to the next useful step.\n"
+                "\n"
+                f"{body}\n"
+                "\n"
+                "Notes:\n"
+                "- Continue the run with the current plan. Resume with "
+                "the next unfinished task.\n"
+                "- Do not repeat the prior attempt unchanged."
+            )
         return (
             "[GOLDFIVE PLAN REVISION — replace superseded task(s)]\n"
             "\n"

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -211,11 +211,24 @@ _CORRECTIVE_TEMPLATES: dict[DriftKind, str] = {
     # itself is fine; the agent just needs a pointer at the next hand-
     # off. Includes ``{next_task_agent}`` so the coordinator can route
     # to the assignee directly rather than re-invoking the stuck agent.
+    # Only used when the referenced task really is COMPLETED at compose
+    # time; :func:`compose_corrective_user_message` falls back to
+    # :data:`_GOAL_DRIFT_NOT_COMPLETE_TEMPLATE` otherwise so the
+    # message never asserts a completion the plan does not show.
     DriftKind.GOAL_DRIFT: (
         "Task '{current_task_id}' is already complete. "
         "Please proceed to '{next_task_title}' via {next_task_agent}."
     ),
 }
+
+# GOAL_DRIFT variant for a referenced task that is NOT COMPLETED at
+# compose time (the judge can fire while the task is still PENDING /
+# RUNNING, or after it FAILED). A directive rather than a status
+# assertion, so it stays truthful whatever the task's actual state.
+_GOAL_DRIFT_NOT_COMPLETE_TEMPLATE: str = (
+    "Set task '{current_task_id}' aside for now. "
+    "Please proceed to '{next_task_title}' via {next_task_agent}."
+)
 
 
 def compose_corrective_user_message(
@@ -234,6 +247,12 @@ def compose_corrective_user_message(
     next_title = _next_pending_task_title(refined_plan) or "the next planned step"
     next_agent = _next_pending_task_agent(refined_plan) or "the next assigned agent"
     template = _CORRECTIVE_TEMPLATES.get(drift.kind)
+    if drift.kind is DriftKind.GOAL_DRIFT and not _task_is_completed(
+        refined_plan, drift.current_task_id
+    ):
+        # The default GOAL_DRIFT template asserts "already complete";
+        # only true when the plan shows the task terminal-COMPLETED.
+        template = _GOAL_DRIFT_NOT_COMPLETE_TEMPLATE
     if template is None:
         # Generic fallback for drift kinds that didn't get a
         # custom shape. Keep it tight and action-focused.
@@ -246,6 +265,16 @@ def compose_corrective_user_message(
         next_task_title=next_title,
         next_task_agent=next_agent,
     )
+
+
+def _task_is_completed(plan: Plan | None, task_id: str) -> bool:
+    """True iff ``task_id`` resolves on ``plan`` with COMPLETED status."""
+    if plan is None or not task_id:
+        return False
+    for t in plan.tasks:
+        if t.id == task_id:
+            return t.status is TaskStatus.COMPLETED
+    return False
 
 
 def _next_pending_task_title(plan: Plan | None) -> str:
@@ -1272,7 +1301,7 @@ class DefaultSteerer:
     def _should_inject(self) -> bool:
         """Return ``True`` iff the steerer should actually inject side effects.
 
-        Single named gate for the three steering injection points
+        Single named gate for the steering injection points
         (goldfive#254):
 
         * plan mutation in :meth:`PlanReviser._apply_revision`
@@ -1280,15 +1309,20 @@ class DefaultSteerer:
         * ``GOLDFIVE_STEER`` ControlMessage enqueue in
           :meth:`DriftObserver._dispatch_goldfive_steer_control`;
         * the plugin ``request_invocation_cancel`` flag in
-          :meth:`DriftObserver.request_invocation_cancel`.
+          :meth:`DriftObserver.request_invocation_cancel`;
+        * the ``session.pending_nudges`` enqueues in
+          :meth:`DriftObserver._dispatch_nudge` and the post-ABSORB
+          nudge handoff (goldfive#202) — the overlay drains the queue
+          into a synthetic user turn and re-invokes the tree, so the
+          enqueue is an injection, not an observation.
 
         ``False`` when :class:`~goldfive.config.SteeringConfig.observation_only`
         is in effect — detection still runs, ``planner.refine_steer``
         still runs, ``PlanRevised`` still emits (with ``dry_run=True``),
         but the in-flight invocation is not touched. Defined as a tiny
         helper rather than inlining ``not self._observation_only`` at
-        three sites so the intent is grep-able and a future fourth
-        injection point has a single gate to honour.
+        each site so the intent is grep-able and a future injection
+        point has a single gate to honour.
         """
         return not self._observation_only
 

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1904,6 +1904,13 @@ class Session:
     # :class:`goldfive.control.ControlKind.GOLDFIVE_STEER` and
     # :class:`goldfive.control.ControlKind.GOLDFIVE_PAUSE_ESCALATE`.
     pending_nudges: list[str] = dataclasses.field(default_factory=list)
+    # Whether the current ``pending_nudges`` batch follows a plan
+    # revision that was actually installed (post-ABSORB enqueue with
+    # ``was_installed=True``). The overlay's replay path threads this
+    # into its framing header so the header only claims a plan revision
+    # when one really landed; Level 2 NUDGE dispatch never refines, so
+    # it never sets this. Reset when the drain consumes the batch.
+    pending_nudges_revision_installed: bool = False
     # Orchestration-level session state dict (goldfive#152). Goldfive
     # owns keys under the ``goldfive.*`` namespace — see
     # :mod:`goldfive.state_store` for the documented key names

--- a/tests/test_observation_only_nudge_gate.py
+++ b/tests/test_observation_only_nudge_gate.py
@@ -1,0 +1,454 @@
+"""``observation_only`` must gate the NUDGE injection path.
+
+Regression tests for the observation-mode injection leak: with the
+production default ``SteeringConfig(observation_only=True)`` a
+NUDGE-routed drift used to enqueue a synthetic corrective message on
+``session.pending_nudges`` (``_dispatch_nudge`` and the post-ABSORB
+handoff carried no ``_should_inject()`` gate) and the overlay drain
+(``SequentialExecutor._run_overlay``) consumed it and RE-INVOKED the
+wrapped tree with a goldfive-authored user turn.
+
+Fixed behaviour under ``observation_only=True``:
+
+* drift detection + ``DriftDetected`` telemetry still fire;
+* the nudge enqueue is suppressed (``PolicyApplied`` gate stamp);
+* the overlay never re-invokes the tree (defense-in-depth gate on the
+  drain for steerer subclasses that bypass the dispatcher).
+
+Active mode (``observation_only=False``) keeps the nudge-replay path,
+and the injected text is truthful: the GOAL_DRIFT corrective only
+claims "already complete" for a COMPLETED task, and the replay header
+only claims a plan revision when one was actually installed.
+
+Note: tests pass ``observation_only`` EXPLICITLY — tests/conftest.py
+flips the *implicit* default to False for the legacy corpus, so
+``observation_only=True`` here is exactly the production default.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.executors.sequential import SequentialExecutor  # noqa: E402
+from goldfive.results import InvocationResult  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class StubPlanner:
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(self, **kwargs: Any) -> None:  # noqa: ARG002
+        return None
+
+    async def refine(self, **kwargs: Any) -> None:
+        self.refine_calls.append(kwargs)
+        return None
+
+
+class OverlayStubAdapter:
+    """Overlay-path adapter: scripted coordinator tree."""
+
+    def __init__(self, *, passthrough_effect: Any = None) -> None:
+        self._passthrough_effect = passthrough_effect
+        self.passthrough_calls: list[str] = []
+
+    @property
+    def available_agents(self) -> list[str]:
+        return ["stub"]
+
+    async def register_reporting_tools(self, tools: list[Any]) -> None:  # noqa: ARG002
+        return None
+
+    async def invoke(self, task: Task, session: Session) -> InvocationResult:  # noqa: ARG002
+        return InvocationResult(task_id=task.id, text="")
+
+    async def invoke_passthrough(
+        self,
+        user_message: str,
+        *,
+        session: Session,
+        reconciler: Any = None,
+        ctx: Any = None,  # noqa: ARG002
+    ) -> InvocationResult:
+        self.passthrough_calls.append(user_message)
+        if self._passthrough_effect is not None:
+            result = await self._passthrough_effect(user_message, session, reconciler)
+            if result is not None:
+                return result
+        return InvocationResult(task_id="", text="")
+
+
+def _stub_call_llm(responses: list[Any]):
+    queue = list(responses)
+
+    async def _call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        if not queue:
+            raise AssertionError("stub call_llm exhausted")
+        resp = queue.pop(0)
+        if isinstance(resp, (dict, list)):
+            return json.dumps(resp)
+        return str(resp)
+
+    return _call_llm
+
+
+async def _drain_background_judges(steerer: DefaultSteerer) -> None:
+    pending = list(steerer._background_judges)
+    if not pending:
+        return
+    await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
+
+
+def _make_session() -> Session:
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="Gather facts", description="Collect sources"),
+            Task(id="t2", title="Write draft", description="Draft the memo"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="Publish a memo on topic X")],
+        plan=plan,
+        current_task_id="t1",
+    )
+
+
+def _payload_kinds(sink: ListSink) -> list[str]:
+    return [e.WhichOneof("payload") for e in sink.events if hasattr(e, "WhichOneof")]
+
+
+def _gate_stamps(sink: ListSink) -> list[Any]:
+    return [
+        e.policy_applied
+        for e in sink.events
+        if hasattr(e, "WhichOneof")
+        and e.WhichOneof("payload") == "policy_applied"
+        and e.policy_applied.policy_name == "observation_only_gate"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Observation-only: the steerer must not enqueue nudges.
+# ---------------------------------------------------------------------------
+
+
+async def test_goal_drift_judge_does_not_enqueue_nudge_under_observation_only() -> None:
+    """Full built-in judge pipeline: the goal-drift judge fires and the
+    ladder routes to NUDGE, but under ``observation_only=True`` nothing
+    lands on ``session.pending_nudges`` — only telemetry."""
+    call_llm = _stub_call_llm([{"progressing": False, "reason": "off in the weeds"}])
+    steerer = DefaultSteerer(
+        goal_drift_check_interval=2,
+        goal_drift_call_llm=call_llm,
+        steering_config=SteeringConfig(observation_only=True),
+    )
+    planner = StubPlanner()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    assert steerer._should_inject() is False
+
+    for _ in range(2):
+        await steerer.drift.note_agent_turn(session)
+    await _drain_background_judges(steerer)
+
+    # Detection telemetry still fires in full.
+    assert "drift_detected" in _payload_kinds(sink)
+    # The injection is suppressed and the gate is stamped.
+    assert session.pending_nudges == []
+    assert planner.refine_calls == []
+    stamps = _gate_stamps(sink)
+    assert stamps and all(s.outcome == "suppressed" for s in stamps)
+
+
+async def test_dispatch_nudge_suppressed_under_observation_only() -> None:
+    """Direct Level 2 dispatch: ``_dispatch_nudge`` honours the same
+    ``_should_inject()`` discipline as steer/pause dispatch."""
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=True))
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+    session = _make_session()
+
+    drift = DriftEvent(
+        kind=DriftKind.GOAL_DRIFT,
+        severity=DriftSeverity.WARNING,
+        detail="synthetic WARNING goal drift",
+        current_task_id="t1",
+    )
+    await steerer.drift.handle_drift(drift, session)
+
+    assert session.pending_nudges == []
+    stamps = _gate_stamps(sink)
+    assert len(stamps) == 1
+    assert "intervention=nudge" in stamps[0].detail
+
+
+async def test_post_absorb_nudge_suppressed_under_observation_only() -> None:
+    """The post-ABSORB nudge handoff (goldfive#202) is equally gated:
+    a LOOPING_REASONING drift whose refine returns a revised plan must
+    not queue the mid-invocation rescue nudge in observation mode."""
+    revised = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="Gather facts", status=TaskStatus.FAILED),
+            Task(id="t1_v2", title="Gather facts (v2)", status=TaskStatus.PENDING),
+            Task(id="t2", title="Write draft"),
+        ],
+        edges=[TaskEdge(from_task_id="t1_v2", to_task_id="t2")],
+        revision_index=1,
+    )
+
+    class _RefiningPlanner(StubPlanner):
+        async def refine(self, **kwargs: Any) -> Plan:
+            self.refine_calls.append(kwargs)
+            return revised
+
+    steerer = DefaultSteerer(
+        goldfive_steer_threshold="off",
+        steering_config=SteeringConfig(observation_only=True, threshold="off"),
+    )
+    planner = _RefiningPlanner()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    drift = DriftEvent(
+        kind=DriftKind.LOOPING_REASONING,
+        severity=DriftSeverity.WARNING,
+        detail="tool-loop detector fired",
+        current_task_id="t1",
+    )
+    await steerer.drift.handle_drift(drift, session)
+
+    # Refine still ran (dry-run visibility) but nothing was queued.
+    assert planner.refine_calls
+    assert session.pending_nudges == []
+    assert session.pending_nudges_revision_installed is False
+    stamps = _gate_stamps(sink)
+    assert any("intervention=post_absorb_nudge" in s.detail for s in stamps)
+
+
+# ---------------------------------------------------------------------------
+# Observation-only, end to end: one user turn == one tree invocation.
+# ---------------------------------------------------------------------------
+
+
+async def test_overlay_never_reinvokes_tree_under_observation_only() -> None:
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=True))
+    session = _make_session()
+    sink = ListSink()
+
+    async def _passthrough(
+        user_message: str,
+        session: Session,
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        # Mid-invocation, a NUDGE-routed drift fires.
+        drift = DriftEvent(
+            kind=DriftKind.GOAL_DRIFT,
+            severity=DriftSeverity.WARNING,
+            detail="synthetic WARNING goal drift",
+            current_task_id="t1",
+        )
+        await steerer.drift.handle_drift(drift, session)
+        await steerer.transition("t1", TaskStatus.COMPLETED, session=session)
+        await steerer.transition("t2", TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id="", text="done")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    executor = SequentialExecutor(overlay_mode=True)
+    outcome = await executor.run(
+        plan=session.plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="write the memo",
+    )
+
+    assert outcome.success is True
+    # ONE user turn, ONE invocation — no goldfive-authored re-invoke.
+    assert adapter.passthrough_calls == ["write the memo"]
+    assert session.pending_nudges == []
+
+
+async def test_overlay_drain_gate_blocks_bypassing_writers_under_observation_only() -> None:
+    """Defense-in-depth (goldfive#264 pattern): even when something
+    bypasses the dispatcher and writes ``session.pending_nudges``
+    directly, an observation-only steerer's drain must not re-invoke;
+    the queue is discarded so it cannot inject later."""
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=True))
+    session = _make_session()
+    sink = ListSink()
+
+    async def _passthrough(
+        user_message: str,
+        session: Session,
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        session.pending_nudges.append("bypassed the dispatcher")
+        await steerer.transition("t1", TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id="", text="")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    executor = SequentialExecutor(overlay_mode=True, fail_fast=False)
+    await executor.run(
+        plan=session.plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="go",
+    )
+
+    assert adapter.passthrough_calls == ["go"]
+    assert session.pending_nudges == []
+
+
+# ---------------------------------------------------------------------------
+# Active mode: the nudge path still works, and the text is truthful.
+# ---------------------------------------------------------------------------
+
+
+async def test_active_mode_nudge_still_enqueued_and_drained() -> None:
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
+    session = _make_session()
+    sink = ListSink()
+
+    async def _passthrough(
+        user_message: str,
+        session: Session,
+        reconciler: Any,  # noqa: ARG001
+    ) -> InvocationResult:
+        if len(adapter.passthrough_calls) == 1:
+            drift = DriftEvent(
+                kind=DriftKind.GOAL_DRIFT,
+                severity=DriftSeverity.WARNING,
+                detail="synthetic WARNING goal drift",
+                current_task_id="t1",
+            )
+            await steerer.drift.handle_drift(drift, session)
+            return InvocationResult(task_id="", text="healthy turn output")
+        await steerer.transition("t1", TaskStatus.COMPLETED, session=session)
+        await steerer.transition("t2", TaskStatus.COMPLETED, session=session)
+        return InvocationResult(task_id="", text="done")
+
+    adapter = OverlayStubAdapter(passthrough_effect=_passthrough)
+    executor = SequentialExecutor(overlay_mode=True)
+    outcome = await executor.run(
+        plan=session.plan,
+        session=session,
+        adapter=adapter,
+        steerer=steerer,
+        planner=StubPlanner(),
+        sinks=[sink],
+        user_input="write the memo",
+    )
+
+    assert outcome.success is True
+    assert len(adapter.passthrough_calls) == 2
+    assert adapter.passthrough_calls[0] == "write the memo"
+    replay = adapter.passthrough_calls[1]
+    assert "GOLDFIVE" in replay
+    # Truthful text: t1 was PENDING when the drift fired, so the
+    # corrective must not assert completion; no refine ran, so the
+    # header must not claim a plan revision.
+    assert "already complete" not in replay
+    assert "PLAN REVISION" not in replay
+    assert "revised the active plan" not in replay
+    assert session.pending_nudges == []
+    assert _gate_stamps(sink) == []
+
+
+def test_goal_drift_corrective_claims_completion_only_when_completed() -> None:
+    from goldfive.steerer import compose_corrective_user_message
+
+    def _plan(t1_status: TaskStatus) -> Plan:
+        return Plan(
+            id="p1",
+            run_id="r1",
+            goal_ids=[],
+            tasks=[
+                Task(id="t1", title="Gather facts", status=t1_status),
+                Task(
+                    id="t2",
+                    title="Write draft",
+                    assignee_agent_id="writer",
+                    status=TaskStatus.PENDING,
+                ),
+            ],
+            edges=[],
+        )
+
+    drift = DriftEvent(
+        kind=DriftKind.GOAL_DRIFT,
+        severity=DriftSeverity.WARNING,
+        detail="grinding",
+        current_task_id="t1",
+    )
+    for status in (TaskStatus.PENDING, TaskStatus.RUNNING, TaskStatus.FAILED):
+        msg = compose_corrective_user_message(drift=drift, refined_plan=_plan(status))
+        assert "already complete" not in msg, (status, msg)
+        assert "t1" in msg
+    completed_msg = compose_corrective_user_message(
+        drift=drift, refined_plan=_plan(TaskStatus.COMPLETED)
+    )
+    assert "already complete" in completed_msg
+
+
+def test_replay_header_claims_revision_only_when_installed() -> None:
+    nudges = ["Proceed with the next step."]
+    plain = SequentialExecutor._compose_nudge_replay_message(nudges, plan_revised=False)
+    assert "PLAN REVISION" not in plain
+    assert "revised the active plan" not in plain
+    assert "superseded" not in plain
+    assert "GOLDFIVE" in plain and nudges[0] in plain
+    revised = SequentialExecutor._compose_nudge_replay_message(nudges, plan_revised=True)
+    assert "PLAN REVISION" in revised
+    assert nudges[0] in revised

--- a/tests/test_overlay_forward_progress.py
+++ b/tests/test_overlay_forward_progress.py
@@ -531,6 +531,9 @@ async def test_level_2_nudge_triggers_overlay_replay() -> None:
                 "The prior attempt looped on define_structure. Refined plan: "
                 "define (v2). Please try a different approach."
             )
+            # The real steerer records the install fact alongside the
+            # enqueue so the replay header may claim a plan revision.
+            session.pending_nudges_revision_installed = True
             return InvocationResult(task_id="", text="")
         # Second invocation (nudge replay): coordinator sees the framing
         # message, proceeds with the replacement + downstream.
@@ -696,7 +699,9 @@ async def test_absorb_on_looping_reasoning_queues_nudge() -> None:
     assert session.plan is not None
     assert session.plan.id == revised.id
     assert session.plan.revision_index == 1
-    # Nudge queued for consumption by the overlay.
+    # Nudge queued for consumption by the overlay, with the install
+    # fact threaded so the replay header may claim a plan revision.
     assert len(session.pending_nudges) == 1
     nudge = session.pending_nudges[0]
     assert "define_structure" in nudge
+    assert session.pending_nudges_revision_installed is True


### PR DESCRIPTION
## Problem

Under the production default `SteeringConfig(observation_only=True)`, one NUDGE-routed drift injected a goldfive-authored synthetic user turn and re-invoked the whole wrapped tree:

- `_dispatch_nudge` (goldfive/drift_observer.py:3904) appended to `session.pending_nudges` with no `_should_inject()` gate — in contrast to `_dispatch_goldfive_steer_control`, which gates at the equivalent point (drift_observer.py:3991).
- The post-ABSORB nudge enqueue (drift_observer.py:3887, kinds LOOPING_REASONING / LOOPING_TOOL_CALL / SELF_REPORTED_STUCK / GOAL_DRIFT) was equally ungated.
- The executor drain (goldfive/executors/sequential.py:1354) re-invoked the tree with no observation_only check, while the adjacent GOLDFIVE_PAUSE_ESCALATE branch carries a defense-in-depth gate (sequential.py:1315, goldfive#264).
- The injected text also lied twice in active mode: the GOAL_DRIFT template (goldfive/steerer.py:214) unconditionally asserted "Task '{id}' is already complete" even for a PENDING task, and the replay header (`_compose_nudge_replay_message`, sequential.py:1940) claimed "Goldfive ... revised the active plan" even when NUDGE never ran refine.
- `config.py:600` documented observation_only as gating exactly three injection points and promised "The in-flight invocation is otherwise untouched" — false while the nudge path leaked.

## Fix

- Gate both nudge enqueue sites on `_should_inject()`; under observation-only the would-be nudge is logged at INFO and an `observation_only_gate` / `suppressed` PolicyApplied event is stamped (detail distinguishes `intervention=nudge` vs `intervention=post_absorb_nudge`), mirroring the steer-dispatch suppression pattern. Detection telemetry (DriftDetected, ladder transitions, dry-run refine) is unchanged.
- Add a goldfive#264-style defense-in-depth gate to the overlay drain: an observation-only steerer never triggers a nudge replay even if a subclass or direct writer bypasses the dispatcher; the queue is discarded so it cannot inject later.
- Truthful text in active mode:
  - GOAL_DRIFT corrective only asserts "already complete" when the referenced task is COMPLETED on the plan at compose time; otherwise a directive variant ("Set task '{id}' aside for now ...") that asserts nothing false.
  - The replay header only claims a plan revision when `_apply_revision` actually installed one — the post-ABSORB site records `was_installed` onto the new `Session.pending_nudges_revision_installed` field, and the drain threads it into `_compose_nudge_replay_message(plan_revised=...)`. Level 2 NUDGE (no refine) and dry-run revisions get a course-correction header instead.
- Updated the `SteeringConfig.observation_only` and `DefaultSteerer._should_inject` contract docstrings to include the nudge gate.

## Tests

New `tests/test_observation_only_nudge_gate.py` (8 tests), adapted from the empirical repro:

- observation-only: goal-drift judge pipeline emits DriftDetected but queues nothing; direct WARNING GOAL_DRIFT dispatch suppressed with gate stamp; post-ABSORB (LOOPING_REASONING + refining planner) suppressed with gate stamp; end-to-end overlay run performs exactly ONE tree invocation; drain gate blocks direct `pending_nudges` writers.
- active mode: nudge still enqueued + drained (two invocations, goldfive-authored replay), and the replay text asserts neither completion nor a plan revision when neither happened; unit tests pin the completed-vs-not template split and the plan_revised header split.

Updated `tests/test_overlay_forward_progress.py::test_level_2_nudge_triggers_overlay_replay` to set `pending_nudges_revision_installed = True` (it simulates a steerer whose refine installed a revision, and asserts the PLAN REVISION header) and extended `test_absorb_on_looping_reasoning_queues_nudge` to assert the new flag.

Full suite: `uv run pytest -q -x` — 2805 passed, 59 skipped. `ruff check .` clean.

## Behavior-change notes

- Active-mode replay messages for nudges queued WITHOUT an installed plan revision now use a `[GOLDFIVE COURSE CORRECTION]` header instead of falsely claiming `[GOLDFIVE PLAN REVISION ...]`; batches following a real install keep the original header.
- New public dataclass field `Session.pending_nudges_revision_installed` (default False).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA