### PR TITLE
fix: observation_only no longer cancels on LLM_CALL_TIMEOUT; loud warning when reasoning channel disarms

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -5005,6 +5005,14 @@ def make_adk_plugin(
               :meth:`request_invocation_cancel` so subsequent callbacks
               short-circuit. The current LLM call still completes, but
               the invocation as a whole stops at the next checkpoint.
+              ACTIVE MODE ONLY — under
+              :attr:`~goldfive.config.SteeringConfig.observation_only`
+              the drift/telemetry above still fires but the cancel-flag
+              write is skipped: healthy local models can genuinely need
+              longer than the budget (see
+              :attr:`~goldfive.config.AgentConfig.call_timeout_ms`), and
+              a passive observer must not discard work the unwrapped
+              system would complete.
 
             CancelledError propagates back to the caller (the
             after_model_callback path that cancels us) so the watcher
@@ -5091,6 +5099,19 @@ def make_adk_plugin(
                         "_run_llm_call_timeout_watcher: drift emission raised: %s",
                         exc,
                     )
+            # Observation-only gate (strict-passive pattern from
+            # goldfive#254/#271): the drift above is telemetry, the
+            # cancel-flag write below is an intervention.
+            # :func:`_is_observation_only` treats a missing steerer /
+            # missing flag as passive — the fail-safe direction for a
+            # surface that cancels in-flight work.
+            if _is_observation_only(ctx):
+                log.info(
+                    "goldfive.llm.timeout invocation_id=%s observation_only=True "
+                    "— cancel-flag write skipped",
+                    invocation_id,
+                )
+                return
             # Flag the invocation for cooperative cancel so the next
             # callback (whether after_model fires first, or the next
             # before_tool / before_model on a follow-up) short-circuits.

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -1381,6 +1381,13 @@ def _choose_reasoning_text(
     return "", ""
 
 
+#: Consecutive no-reasoning text turns per agent before the one-shot
+#: reasoning-channel-disarmed WARNING fires. Three rules out a thinking
+#: model's occasional streamless turn without letting a whole run pass
+#: unnoticed.
+_NO_REASONING_WARN_STREAK: int = 3
+
+
 def _extract_function_calls(llm_response: Any) -> list[dict]:
     content = _safe_attr(llm_response, "content", None)
     if content is None:
@@ -2055,6 +2062,15 @@ def make_adk_plugin(
             # sub-Runners get their own counters.
             self._invocation_tool_calls: dict[str, int] = {}
             self._invocation_last_text: dict[str, str] = {}
+            # Reasoning-channel silent-disarm visibility (goldfive#263
+            # follow-up). Per-agent count of CONSECUTIVE LLM responses
+            # whose reasoning extraction came back empty despite a
+            # non-empty text body, plus the agents already warned about.
+            # Plugin-lifetime state — deliberately NOT cleared in
+            # :meth:`clear_active_context` so the WARNING stays one-shot
+            # per agent across dispatches on the same wrapped tree.
+            self._no_reasoning_streak: dict[str, int] = {}
+            self._no_reasoning_warned: set[str] = set()
             # AgentTool-per-invoke counter (goldfive#130). Scoped to
             # the current top-level invocation; reset in
             # :meth:`clear_active_context`. When the counter exceeds
@@ -5895,6 +5911,99 @@ def make_adk_plugin(
 
         # --- Drift observation -----------------------------------------
 
+        async def _note_reasoning_channel_signal(
+            self,
+            *,
+            ctx: SessionContext,
+            agent_name: str,
+            reasoning: str,
+            texts: list[str],
+        ) -> None:
+            """One-shot per-agent visibility for a disarmed reasoning channel.
+
+            Non-thinking models (Gemma 4, Mistral, several base-model
+            deployments) never emit a separate reasoning/thinking
+            stream, so ``observe_reasoning`` never fires and every
+            LLM-judge reasoning detector (OFF_TOPIC, GOAL_DRIFT,
+            INTENT_DIVERGENCE, LOOPING_REASONING) silently disarms for
+            the whole run — pre-fix the only trace was a DEBUG line
+            behind the opt-in fallback flag. Mirrors the judge-LLM
+            misconfiguration precedent in :func:`goldfive.wrap`: a loud
+            WARNING plus a record-only sink event naming the remedy
+            (:attr:`~goldfive.config.ReasoningDriftConfig.fallback_to_content_when_no_reasoning`).
+            The fallback is NOT auto-enabled — that behaviour change is
+            reserved for the operator.
+
+            Counting rules: a turn that fed the channel (real reasoning
+            or content-fallback) resets the per-agent streak; a turn
+            with an empty reasoning source but a non-empty text body
+            increments it; function-call-only / empty turns neither
+            count nor reset — thinking models frequently omit the
+            stream on pure tool turns, so counting them would
+            false-positive.
+            """
+            key = agent_name or "?"
+            if reasoning:
+                self._no_reasoning_streak.pop(key, None)
+                return
+            body = " ".join(t for t in texts if t).strip()
+            if not body:
+                return
+            streak = self._no_reasoning_streak.get(key, 0) + 1
+            self._no_reasoning_streak[key] = streak
+            if streak < _NO_REASONING_WARN_STREAK or key in self._no_reasoning_warned:
+                return
+            self._no_reasoning_warned.add(key)
+            log.warning(
+                "goldfive.reasoning.disarmed agent=%s — %d consecutive LLM "
+                "responses carried a text body but no reasoning/thinking "
+                "stream; the reasoning-judge detectors are receiving no "
+                "input for this agent. If the model is non-thinking, set "
+                "ReasoningDriftConfig.fallback_to_content_when_no_reasoning=True "
+                "(or GOLDFIVE_DRIFT_FALLBACK_TO_CONTENT=1) to synthesise a "
+                "signal from the response body.",
+                key,
+                streak,
+            )
+            # Record-only sink event so operators watching the wire (not
+            # stderr) also see the disarm + remedy. ``_emit_drift_detected``
+            # is the plugin's established record-only emission path — no
+            # policy dispatch, so it is equally safe under
+            # ``observation_only``.
+            steerer = ctx.steerer if ctx is not None else None
+            session = ctx.session if ctx is not None else None
+            emit_drift = getattr(getattr(steerer, "drift", None), "_emit_drift_detected", None)
+            if emit_drift is None or session is None:
+                return
+            try:
+                from goldfive.types import (  # noqa: PLC0415 — lazy
+                    DriftEvent,
+                    DriftKind,
+                    DriftSeverity,
+                )
+
+                await emit_drift(
+                    session,
+                    DriftEvent(
+                        kind=DriftKind.CUSTOM,
+                        severity=DriftSeverity.INFO,
+                        detail=(
+                            f"reasoning_channel_disarmed: agent {key!r} produced "
+                            f"{streak} consecutive responses with a text body but "
+                            "no reasoning/thinking stream; reasoning-judge "
+                            "detectors are receiving no input. Remedy: "
+                            "ReasoningDriftConfig.fallback_to_content_when_no_reasoning=True "
+                            "(GOLDFIVE_DRIFT_FALLBACK_TO_CONTENT=1)."
+                        ),
+                        current_agent_id=key,
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_note_reasoning_channel_signal: sink emit raised: %s",
+                    exc,
+                )
+
         async def after_model_callback(self, *, callback_context: Any, llm_response: Any) -> None:
             ctx = self._resolve_ctx(callback_context)
             if ctx is None or ctx.steerer is None:
@@ -5941,6 +6050,27 @@ def make_adk_plugin(
                     joined = " ".join(texts).strip()
                     if joined:
                         self._invocation_last_text[inv_id] = joined
+            # Reasoning-channel silent-disarm visibility (goldfive#263
+            # follow-up). Runs on every model turn — including the ones
+            # where ``reasoning`` is empty and the observe_reasoning
+            # block below never fires. Best-effort: visibility must not
+            # shadow the real response path.
+            try:
+                running_agent = _safe_attr(inv_ctx, "agent", None)
+                agent_label = str(_safe_attr(running_agent, "name", "") or "") or (
+                    self._host_agent_name or ""
+                )
+                await self._note_reasoning_channel_signal(
+                    ctx=ctx,
+                    agent_name=agent_label,
+                    reasoning=reasoning,
+                    texts=texts,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "after_model_callback: reasoning-channel visibility raised: %s",
+                    exc,
+                )
             # Per-LLM-call instrumentation (goldfive#172). Pair with the
             # before_model_callback stash to compute duration, extract
             # token usage, log the result, and enrich the observation

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -750,9 +750,14 @@ class AgentConfig:
     ``max_output_tokens`` on ``llm_request.config``, that smaller value
     wins — goldfive only ratchets the cap DOWN, never up.
 
-    ``call_timeout_ms`` is the wall-clock budget per call. On expiry the
-    call cancels and an ``LLM_CALL_TIMEOUT`` drift fires (CRITICAL,
-    capacity-shaped) so the existing drift dispatch handles escalation.
+    ``call_timeout_ms`` is the wall-clock budget per call. On expiry an
+    ``LLM_CALL_TIMEOUT`` drift fires (CRITICAL, capacity-shaped) so the
+    existing drift dispatch handles escalation; in active mode
+    (``SteeringConfig.observation_only=False``) the invocation is also
+    flagged for cooperative cancel. Under ``observation_only`` (the
+    production default) the drift is telemetry-only — the in-flight
+    call is never cancelled, since healthy models can genuinely need
+    longer than the budget (see below).
     Default 120s — Qwen 35B-class models can take 60-90s on long
     prompts; operators who genuinely need longer (slow judges, weak
     hardware, multi-step research synthesis) override via env or the

--- a/tests/test_agent_budget.py
+++ b/tests/test_agent_budget.py
@@ -220,11 +220,15 @@ class _CapturingSteerer:
     Shape mirrors the live :class:`DefaultSteerer` interface for the
     watcher's emission path after goldfive#410: the watcher reaches
     for ``steerer.drift.observe`` and ``steerer.drift._emit_drift_detected``.
+    ``_observation_only=False`` pins active mode — the watcher's
+    cancel-flag write is gated on the flag and a missing attribute
+    reads as passive.
     """
 
     def __init__(self) -> None:
         self.drift = _CapturingDrift()
         self._sinks: list[Any] = []
+        self._observation_only = False
 
     @property
     def observations(self) -> list[Any]:

--- a/tests/test_llm_call_timeout_watcher.py
+++ b/tests/test_llm_call_timeout_watcher.py
@@ -5,8 +5,12 @@ completion tokens, demo-v8.log) without any goldfive-level timeout. The
 fix adds an asyncio watcher task spawned from
 ``_GoldfiveADKPlugin.before_model_callback`` that sleeps for the
 configured budget; if the LLM call hasn't returned by then, the watcher
-emits a CRITICAL ``LLM_CALL_TIMEOUT`` drift and flags the invocation
-for cooperative cancel via :meth:`request_invocation_cancel`.
+emits a CRITICAL ``LLM_CALL_TIMEOUT`` drift and — in active mode only —
+flags the invocation for cooperative cancel via
+:meth:`request_invocation_cancel`. Under
+``SteeringConfig.observation_only=True`` (the production default) the
+drift is telemetry-only: the cancel-flag write is skipped so a slow but
+healthy LLM call completes exactly as it would unwrapped.
 
 These tests pin the watcher's behaviour without exercising a real ADK
 runner — we drive the watcher coroutine directly and assert on the
@@ -43,11 +47,16 @@ class _CapturingDrift:
 class _CapturingSteerer:
     """Minimal steerer stub — exposes a ``drift`` sub-component that
     captures every observation seen + every drift emitted via the
-    conventional ``_emit_drift_detected`` path."""
+    conventional ``_emit_drift_detected`` path.
 
-    def __init__(self) -> None:
+    ``_observation_only`` mirrors :class:`DefaultSteerer`'s field: the
+    watcher's cancel-flag write is gated on it (missing flag reads as
+    passive — the fail-safe direction)."""
+
+    def __init__(self, *, observation_only: bool = False) -> None:
         self.drift = _CapturingDrift()
         self._sinks: list[Any] = []
+        self._observation_only = observation_only
 
     @property
     def observations(self) -> list[Any]:
@@ -105,13 +114,13 @@ def test_make_adk_plugin_zero_disables_watcher():
 @pytest.mark.asyncio
 async def test_watcher_emits_drift_and_flags_cancel_on_expiry():
     """When the watcher sleeps to completion (the LLM call did NOT
-    return in time), it must:
+    return in time) in ACTIVE mode, it must:
 
     * Emit a CRITICAL LLM_CALL_TIMEOUT drift via the steerer.
     * Flag the invocation in ``_cancel_state``.
     """
     plugin = adk_plugin.make_adk_plugin(host_agent_name="agent_x", llm_call_timeout_ms=10)
-    steerer = _CapturingSteerer()
+    steerer = _CapturingSteerer(observation_only=False)
     ctx = _make_session_context(steerer)
 
     # Drive the watcher with a tiny budget. ``timeout_s=0`` would race
@@ -138,6 +147,58 @@ async def test_watcher_emits_drift_and_flags_cancel_on_expiry():
     assert drift.kind == DriftKind.LLM_CALL_TIMEOUT
     assert drift.severity == DriftSeverity.CRITICAL
     assert drift.current_agent_id == "agent_x"
+
+
+@pytest.mark.asyncio
+async def test_watcher_observation_only_emits_drift_without_cancel():
+    """Under ``observation_only=True`` the watcher's expiry is
+    telemetry-only: the CRITICAL drift still reaches the steerer /
+    sinks, but the invocation is NOT flagged for cooperative cancel —
+    a legitimately slow LLM call completes exactly as it would
+    unwrapped."""
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="agent_x", llm_call_timeout_ms=10)
+    steerer = _CapturingSteerer(observation_only=True)
+    ctx = _make_session_context(steerer)
+
+    await plugin._run_llm_call_timeout_watcher(
+        invocation_id="inv-test",
+        timeout_s=0.01,
+        ctx=ctx,
+    )
+
+    from goldfive.types import DriftKind, DriftSeverity
+
+    assert len(steerer.emitted_drifts) == 1
+    drift = steerer.emitted_drifts[0]
+    assert drift.kind == DriftKind.LLM_CALL_TIMEOUT
+    assert drift.severity == DriftSeverity.CRITICAL
+    # No cancel flagged — the in-flight work is left alone.
+    assert plugin._cancel_state == {}
+
+
+@pytest.mark.asyncio
+async def test_watcher_missing_observation_flag_reads_as_passive():
+    """A steerer without ``_observation_only`` (custom steerer, partial
+    stub) must resolve to passive — the fail-safe direction for a
+    surface that cancels in-flight work."""
+
+    class _FlaglessSteerer:
+        def __init__(self) -> None:
+            self.drift = _CapturingDrift()
+            self._sinks: list[Any] = []
+
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="agent_x", llm_call_timeout_ms=10)
+    steerer = _FlaglessSteerer()
+    ctx = _make_session_context(steerer)
+
+    await plugin._run_llm_call_timeout_watcher(
+        invocation_id="inv-test",
+        timeout_s=0.01,
+        ctx=ctx,
+    )
+
+    assert len(steerer.drift.emitted_drifts) == 1
+    assert plugin._cancel_state == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_reasoning_channel_disarm_warning.py
+++ b/tests/test_reasoning_channel_disarm_warning.py
@@ -1,0 +1,224 @@
+"""Reasoning-channel silent-disarm WARNING (goldfive#263 follow-up).
+
+Pre-fix: on a non-thinking model (Gemma 4, Mistral, ...) the reasoning
+extraction returns empty on every turn, ``observe_reasoning`` never
+fires, and every LLM-judge reasoning detector silently disarms for the
+whole run — the only trace was a DEBUG line behind the opt-in
+``fallback_to_content_when_no_reasoning`` flag. Post-fix the plugin
+tracks per-agent consecutive text responses without a reasoning stream
+and, after ``_NO_REASONING_WARN_STREAK`` of them, emits a ONE-SHOT
+per-agent WARNING plus a record-only sink event naming the remedy. The
+fallback itself is never auto-enabled.
+
+These tests drive ``after_model_callback`` directly with duck-typed
+LLM responses — no real ADK runner, no LLM.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+adk_plugin = pytest.importorskip("goldfive.adapters._adk_plugin")
+pytest.importorskip("google.adk")
+
+
+class _CapturingDrift:
+    """Captures observations + drifts emitted via ``_emit_drift_detected``."""
+
+    def __init__(self) -> None:
+        self.observations: list[Any] = []
+        self.emitted_drifts: list[Any] = []
+
+    async def observe(self, observation: Any, session: Any) -> None:
+        self.observations.append(observation)
+
+    async def _emit_drift_detected(self, session: Any, drift: Any) -> None:
+        self.emitted_drifts.append(drift)
+
+
+class _CapturingSteerer:
+    """Minimal steerer stub for ``after_model_callback``.
+
+    ``_observation_only=True`` on purpose: the disarm warning is
+    telemetry and must fire under the passive production default too.
+    """
+
+    def __init__(self) -> None:
+        self.drift = _CapturingDrift()
+        self._sinks: list[Any] = []
+        self._observation_only = True
+
+
+def _make_response(
+    *,
+    text: str = "",
+    reasoning: str = "",
+    function_call: bool = False,
+) -> Any:
+    """Duck-typed ``llm_response``: content.parts + optional reasoning."""
+    parts: list[Any] = []
+    if text:
+        parts.append(SimpleNamespace(text=text, thought=False, function_call=None))
+    if function_call:
+        parts.append(
+            SimpleNamespace(
+                text="",
+                thought=False,
+                function_call=SimpleNamespace(name="some_tool", args={}),
+            )
+        )
+    response = SimpleNamespace(
+        content=SimpleNamespace(parts=parts),
+        finish_reason=None,
+    )
+    if reasoning:
+        # Plain string field — one of the shapes _extract_reasoning reads.
+        response.reasoning_content = reasoning
+    return response
+
+
+def _make_plugin(host_agent_name: str = "coordinator") -> tuple[Any, _CapturingSteerer]:
+    from goldfive.types import Session
+
+    plugin = adk_plugin.make_adk_plugin(host_agent_name=host_agent_name)
+    steerer = _CapturingSteerer()
+    ctx = SimpleNamespace(
+        steerer=steerer,
+        session=Session(run_id="r1"),
+        task=SimpleNamespace(id="t1"),
+        host_agent_name=host_agent_name,
+    )
+    plugin.set_active_context(ctx)
+    return plugin, steerer
+
+
+def _make_callback_context(*, invocation_id: str = "inv-1", agent_name: str = "") -> Any:
+    inv_ctx = SimpleNamespace(
+        invocation_id=invocation_id,
+        agent=SimpleNamespace(name=agent_name) if agent_name else None,
+    )
+    return SimpleNamespace(_invocation_context=inv_ctx, state={})
+
+
+def _disarm_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "goldfive.reasoning.disarmed" in r.getMessage()
+    ]
+
+
+def _disarm_events(steerer: _CapturingSteerer) -> list[Any]:
+    return [
+        d
+        for d in steerer.drift.emitted_drifts
+        if "reasoning_channel_disarmed" in str(getattr(d, "detail", ""))
+    ]
+
+
+async def test_thinking_model_never_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """Responses that carry a real reasoning stream keep the channel
+    armed — no warning no matter how many turns."""
+    plugin, steerer = _make_plugin()
+    with caplog.at_level(logging.WARNING):
+        for i in range(6):
+            await plugin.after_model_callback(
+                callback_context=_make_callback_context(),
+                llm_response=_make_response(text=f"answer {i}", reasoning=f"thinking {i}"),
+            )
+    assert _disarm_warnings(caplog) == []
+    assert _disarm_events(steerer) == []
+
+
+async def test_non_thinking_model_warns_exactly_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Three consecutive text-only responses with no reasoning stream
+    fire the WARNING + sink event exactly once, even across many more
+    such turns. The warning names the remedy flag and never auto-enables
+    it."""
+    plugin, steerer = _make_plugin()
+    with caplog.at_level(logging.WARNING):
+        for i in range(7):
+            await plugin.after_model_callback(
+                callback_context=_make_callback_context(),
+                llm_response=_make_response(text=f"answer {i}"),
+            )
+    warnings = _disarm_warnings(caplog)
+    assert len(warnings) == 1
+    assert "fallback_to_content_when_no_reasoning" in warnings[0].getMessage()
+
+    events = _disarm_events(steerer)
+    assert len(events) == 1
+    from goldfive.types import DriftKind, DriftSeverity
+
+    assert events[0].kind == DriftKind.CUSTOM
+    assert events[0].severity == DriftSeverity.INFO
+    assert "fallback_to_content_when_no_reasoning" in events[0].detail
+    assert events[0].current_agent_id == "coordinator"
+
+
+async def test_function_call_only_turns_do_not_count(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Function-call-only turns are weak evidence (thinking models often
+    omit the stream on pure tool turns) — they neither increment nor
+    reset the streak, so interleaving them among fewer than three text
+    turns never warns."""
+    plugin, steerer = _make_plugin()
+    with caplog.at_level(logging.WARNING):
+        # 2 text turns + 4 function-call-only turns: streak stays at 2.
+        for response in (
+            _make_response(text="a"),
+            _make_response(function_call=True),
+            _make_response(function_call=True),
+            _make_response(text="b"),
+            _make_response(function_call=True),
+            _make_response(function_call=True),
+        ):
+            await plugin.after_model_callback(
+                callback_context=_make_callback_context(),
+                llm_response=response,
+            )
+    assert _disarm_warnings(caplog) == []
+    assert _disarm_events(steerer) == []
+
+
+async def test_reasoning_turn_resets_streak(caplog: pytest.LogCaptureFixture) -> None:
+    """A turn that feeds the channel resets the count — 2 empty turns, a
+    reasoning turn, then 2 more empty turns never reach the threshold."""
+    plugin, steerer = _make_plugin()
+    with caplog.at_level(logging.WARNING):
+        for response in (
+            _make_response(text="a"),
+            _make_response(text="b"),
+            _make_response(text="c", reasoning="thinking"),
+            _make_response(text="d"),
+            _make_response(text="e"),
+        ):
+            await plugin.after_model_callback(
+                callback_context=_make_callback_context(),
+                llm_response=response,
+            )
+    assert _disarm_warnings(caplog) == []
+    assert _disarm_events(steerer) == []
+
+
+async def test_warning_is_per_agent(caplog: pytest.LogCaptureFixture) -> None:
+    """Each agent gets its own streak and its own one-shot warning."""
+    plugin, steerer = _make_plugin()
+    with caplog.at_level(logging.WARNING):
+        for i in range(4):
+            for agent in ("coordinator", "research_agent"):
+                await plugin.after_model_callback(
+                    callback_context=_make_callback_context(agent_name=agent),
+                    llm_response=_make_response(text=f"answer {i}"),
+                )
+    warnings = _disarm_warnings(caplog)
+    assert len(warnings) == 2
+    events = _disarm_events(steerer)
+    assert {e.current_agent_id for e in events} == {"coordinator", "research_agent"}


### PR DESCRIPTION
## Problem

**A — observation_only cancels in-flight work on LLM_CALL_TIMEOUT.** The per-LLM-call wall-clock watcher (spawned in `before_model_callback`, `goldfive/adapters/_adk_plugin.py:5355-5369`) unconditionally calls `request_invocation_cancel` on expiry (`_adk_plugin.py:5128-5140` pre-fix); the cancel-flag write has no steering-mode gate, and the next `before_model_callback` converts the flag into a synthetic cancelled response (`_adk_plugin.py:5305-5320`). `AgentConfig.call_timeout_ms`'s own docstring (`goldfive/config.py:756-765`) says healthy local models take 60-90s and can genuinely need longer — so under pure production defaults (`observation_only=True`, 120s budget) a legitimately slow call cancelled work the unwrapped system would have completed. Every other steering surface (PromptShaper, ContextEditor) is already a hard no-op under `observation_only`; this one wasn't.

**B — non-thinking models silently disarm the reasoning-judge channel.** When a model never emits a reasoning/thinking stream, `_extract_reasoning` returns empty on every turn, `observe_reasoning` never fires, and all LLM-judge reasoning detectors disarm for the whole run (documented live repro on `config.py:451-484`). The only trace was a DEBUG log that itself only fires when the opt-in fallback flag is already ON (`_adk_plugin.py:6154-6161` pre-fix) — while judge-LLM misconfiguration got a loud WARNING (`convenience.py:622-646` precedent).

## Fix

**A** (`f9ce320`): the watcher still emits the CRITICAL `LLM_CALL_TIMEOUT` drift + telemetry in both modes, but the cancel-flag write is now gated on the existing `_is_observation_only(ctx)` accessor (`_adk_plugin.py:1848`), which reads a missing steerer / missing flag as passive — the fail-safe direction for a surface that cancels in-flight work. Active mode (`observation_only=False`) keeps cancelling, sticky-flag semantics unchanged.

**B** (`a6d505a`): `after_model_callback` tracks per-agent consecutive responses whose reasoning source is empty despite a non-empty text body. Function-call-only turns neither count nor reset (weak evidence; thinking models often omit the stream on pure tool turns). After 3 consecutive, a ONE-SHOT per-agent WARNING (`goldfive.reasoning.disarmed`) plus a record-only CUSTOM/INFO `DriftDetected` sink event name the remedy (`ReasoningDriftConfig.fallback_to_content_when_no_reasoning` / `GOLDFIVE_DRIFT_FALLBACK_TO_CONTENT=1`). The fallback is NOT auto-enabled.

## Tests

- `tests/test_llm_call_timeout_watcher.py`: new `test_watcher_observation_only_emits_drift_without_cancel` and `test_watcher_missing_observation_flag_reads_as_passive`; existing active-mode expiry tests kept (stubs updated — see behavior notes).
- `tests/test_reasoning_channel_disarm_warning.py` (new): thinking model never warns; non-thinking model warns exactly once (log + sink event, remedy named); function-call-only turns don't count; a reasoning turn resets the streak; warning is per-agent. Steerer stub pins `observation_only=True` to show the telemetry fires under the passive default.
- Full suite: `uv run pytest -q -x` — 2804 passed, 59 skipped. `uv run ruff check .` clean.

## Behavior-change notes

- Under `observation_only=True` (production default), an `LLM_CALL_TIMEOUT` expiry no longer cancels the invocation — drift/telemetry only. Active mode is unchanged.
- The `_CapturingSteerer` stubs in `tests/test_llm_call_timeout_watcher.py` and `tests/test_agent_budget.py` previously carried no `_observation_only` flag and their expiry tests asserted the unconditional cancel; they now pin `_observation_only=False` (active) to preserve the original assertions, since a missing flag now deliberately reads as passive.
- New WARNING log + CUSTOM/INFO `DriftDetected` sink event (detail prefix `reasoning_channel_disarmed:`) fire at most once per agent per wrapped tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA