### PR TITLE
fix: preserve ADK {var} session-state templating under dynamic_instruction

### DIFF
--- a/goldfive/adapters/adk_llm_instrumentation.py
+++ b/goldfive/adapters/adk_llm_instrumentation.py
@@ -368,6 +368,10 @@ def _apply_agent_max_output_tokens_cap(llm_request: Any, ceiling: int) -> tuple[
 # ``canonical_instruction`` invokes the callable per turn and returns
 # ``bypass_state_injection=True`` for the result, so refine landing in
 # state is picked up on the NEXT turn with no transcript rewrite.
+# Because of that bypass, the resolver itself re-applies ADK's
+# ``inject_session_state`` to the original template when it carries
+# ``{var}`` / ``{artifact.var}`` placeholders — otherwise wrapping
+# would silently disable the documented session-state templating.
 #
 # The resolver is **agent-agnostic**: works for any wrapped ``LlmAgent``
 # (coordinator, sub-agent, root-with-tools, leaf). Current-task
@@ -654,6 +658,30 @@ def is_dynamic_instruction(value: Any) -> bool:
     return bool(getattr(value, "_goldfive_dynamic_instruction", False))
 
 
+def _adk_inject_session_state() -> Any:
+    """Return ADK's async ``inject_session_state`` helper, or ``None``.
+
+    ADK treats a callable ``instruction`` as ``bypass_state_injection=
+    True`` (``LlmAgent.canonical_instruction``), so swapping a string
+    instruction for a resolver silently disables the documented
+    ``{var}`` / ``{artifact.var}`` templating unless the resolver
+    re-applies it. The resolver calls this helper's return value on the
+    original template to restore wrapped == unwrapped semantics.
+
+    Probed lazily (never at import) so the module stays importable
+    without google-adk, and defensively so an ADK release that moves
+    the helper degrades to ``None`` instead of raising — the installer
+    then skips placeholder-bearing instructions with a WARNING rather
+    than break their templating.
+    """
+    try:
+        from google.adk.utils import instructions_utils
+    except Exception:  # noqa: BLE001 — ADK absent or restructured
+        return None
+    fn = getattr(instructions_utils, "inject_session_state", None)
+    return fn if callable(fn) else None
+
+
 def _looks_like_llm_agent(node: Any) -> bool:
     """Duck-type check for an ADK ``LlmAgent`` without importing ADK.
 
@@ -684,6 +712,9 @@ def install_dynamic_instructions(root_agent: Any) -> int:
     * If it is a string (the common case): capture the string as the
       closure's ``original``, capture ``agent.name`` for correction
       lookup, install the resolver.
+    * If the string carries ``{var}`` placeholders but ADK's
+      ``inject_session_state`` cannot be resolved: skip with a WARNING
+      so the agent keeps ADK's native string-instruction templating.
 
     Non-``LlmAgent`` nodes are walked through but not modified.
 
@@ -734,6 +765,20 @@ def install_dynamic_instructions(root_agent: Any) -> int:
             )
             continue
         original = existing if isinstance(existing, str) else ""
+        if "{" in original and _adk_inject_session_state() is None:
+            # ADK substitutes {var}/{artifact.var} for string
+            # instructions only; a resolver bypasses that. Without the
+            # inject helper the resolver cannot re-apply it, so leave
+            # the string in place — native templating beats goldfive's
+            # per-turn augmentation for this agent.
+            log.warning(
+                "goldfive.wrap: agent %r has a templated instruction "
+                "but ADK's inject_session_state is unavailable — "
+                "leaving the static instruction in place "
+                "(dynamic instruction disabled for this agent)",
+                getattr(cur, "name", "<unnamed>"),
+            )
+            continue
 
         agent_name = str(getattr(cur, "name", "") or "")
         # Wave B1 (refactor/prompt-shaper): the resolver factory lives

--- a/goldfive/prompt_shaper.py
+++ b/goldfive/prompt_shaper.py
@@ -62,7 +62,7 @@ are NOT collapsed into one ``inject(...)`` method.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -475,7 +475,7 @@ class PromptShaper:
         self,
         original_instruction: str,
         agent_name: str,
-    ) -> Callable[[Any], str]:
+    ) -> Callable[[Any], str | Awaitable[str]]:
         """Return a resolver matching ADK's ``InstructionProvider`` signature.
 
         The returned callable:
@@ -499,6 +499,19 @@ class PromptShaper:
         The resolver is pure: given the same Session.state it returns
         the same string. No side effects, no persistence.
 
+        ADK session-state templating: ``LlmAgent.canonical_instruction``
+        marks callable instructions ``bypass_state_injection=True``, so
+        installing the resolver over a string instruction would silently
+        disable the documented ``{var}`` / ``{artifact.var}``
+        substitution. When ``original_instruction`` carries a ``{`` the
+        resolver therefore returns an awaitable that first runs ADK's
+        own ``inject_session_state`` over the template (substitution
+        errors propagate exactly as they would unwrapped) and then
+        applies the goldfive augmentation to the templated result.
+        Placeholder-free instructions keep the synchronous, byte-
+        identical fast path. Both shapes satisfy ADK's
+        ``InstructionProvider`` alias (``str | Awaitable[str]``).
+
         Phase 2.0 of goldfive#271 — the bridge from goldfive
         Session.state onto ADK session.state is gone. The resolver
         reads goldfive Session directly via the SessionContext stash,
@@ -507,9 +520,12 @@ class PromptShaper:
         goldfive#275).
 
         Under ``observation_only=True`` (:meth:`should_inject` →
-        ``False``) the resolver returns ``original_instruction``
-        verbatim — no "Current assigned task" block, no pending-
-        correction block, no goldfive augmentation of any kind.
+        ``False``) the resolver returns the templated
+        ``original_instruction`` and nothing else — no "Current
+        assigned task" block, no pending-correction block, no goldfive
+        augmentation of any kind. State templating still runs because
+        ADK applies it to string instructions regardless of goldfive;
+        suppressing it would itself be a behaviour change.
 
         Legacy fallback: when the SessionContext stash is unreachable
         (a unit test drives the resolver against a plain state dict
@@ -521,7 +537,12 @@ class PromptShaper:
         # shaper's :meth:`should_inject` predicate.
         shaper = self
 
-        def resolver(readonly_ctx: Any) -> str:
+        def _resolve(readonly_ctx: Any, base_instruction: str) -> str:
+            # ``base_instruction`` is ``original_instruction`` with ADK
+            # session-state templating already applied (or verbatim on
+            # the placeholder-free fast path). Every degradation path
+            # below returns it so a goldfive failure never costs the
+            # agent its templated instruction.
             try:
                 # Reach the goldfive SessionContext to read the
                 # steerer + session. The same walk supplies both the
@@ -543,10 +564,10 @@ class PromptShaper:
                         "PromptShaper.make_dynamic_instruction resolver: "
                         "observation_only=True — SKIPPING goldfive "
                         "prompt augmentation for agent=%r "
-                        "(returning original instruction verbatim)",
+                        "(returning the caller's instruction un-augmented)",
                         agent_name,
                     )
-                    return original_instruction
+                    return base_instruction
 
                 state = _state_from_readonly_context(readonly_ctx)
                 session = getattr(ctx, "session", None) if ctx is not None else None
@@ -562,8 +583,8 @@ class PromptShaper:
                 if not current_task_id:
                     # No pin — pre-plan turn, or an agent that doesn't
                     # need plan-causal augmentation this turn. Return
-                    # the caller's instruction verbatim.
-                    return original_instruction
+                    # the caller's instruction un-augmented.
+                    return base_instruction
 
                 if session is not None:
                     current_task_title, current_task_description = (
@@ -586,7 +607,7 @@ class PromptShaper:
                 )
 
                 return _compose_instruction(
-                    original=original_instruction,
+                    original=base_instruction,
                     task_id=current_task_id,
                     task_title=current_task_title,
                     task_description=current_task_description,
@@ -594,18 +615,48 @@ class PromptShaper:
                 )
             except Exception as exc:  # noqa: BLE001
                 # Instrumentation path — any failure here degrades to
-                # the original instruction so the agent still runs.
+                # the base instruction so the agent still runs.
                 # ADK's own pipeline would otherwise surface this as an
                 # InternalError mid-turn, which is the worst possible
                 # failure mode.
                 log.debug(
                     "PromptShaper.make_dynamic_instruction resolver "
                     "raised for agent=%r: %s "
-                    "(falling back to original instruction)",
+                    "(falling back to the caller's instruction)",
                     agent_name,
                     exc,
                 )
-                return original_instruction
+                return base_instruction
+
+        def resolver(readonly_ctx: Any) -> str | Awaitable[str]:
+            # ADK marks callable instructions ``bypass_state_injection=
+            # True`` (``LlmAgent.canonical_instruction``), so the
+            # ``{var}`` / ``{artifact.var}`` templating a string
+            # instruction receives from ADK's flow must be re-applied
+            # here. A placeholder-free template cannot substitute, so
+            # it keeps the synchronous byte-identical path.
+            if "{" not in original_instruction:
+                return _resolve(readonly_ctx, original_instruction)
+
+            from goldfive.adapters.adk_llm_instrumentation import (
+                _adk_inject_session_state,
+            )
+
+            inject = _adk_inject_session_state()
+            if inject is None:
+                # install_dynamic_instructions refuses to wrap templated
+                # instructions when the helper is absent; a resolver
+                # built directly degrades to the literal template.
+                return _resolve(readonly_ctx, original_instruction)
+
+            async def _inject_then_resolve() -> str:
+                # Substitution errors (missing state var / artifact)
+                # propagate — a string instruction fails the same way
+                # unwrapped.
+                base = await inject(original_instruction, readonly_ctx)
+                return _resolve(readonly_ctx, base)
+
+            return _inject_then_resolve()
 
         # Stamp provenance on the closure so test code and tree-walk
         # idempotency checks can recognise it without relying on repr.

--- a/tests/test_dynamic_instruction.py
+++ b/tests/test_dynamic_instruction.py
@@ -375,3 +375,246 @@ def test_resolver_survives_canonical_instruction_contract() -> None:
     # When the resolved instruction is from a provider, ADK returns True
     # so state-template ``{placeholder}`` substitution is skipped.
     assert bypass_state_injection is True
+
+
+# ---------------------------------------------------------------------------
+# ADK session-state templating parity ({var} / {artifact.var})
+# ---------------------------------------------------------------------------
+#
+# ADK's ``canonical_instruction`` marks callable instructions
+# ``bypass_state_injection=True``, so the resolver must re-apply
+# ``inject_session_state`` itself or wrapping silently disables the
+# documented ``{var}`` templating. These tests drive ADK's real
+# instructions request processor on wrapped vs unwrapped agents and
+# require byte-identical system instructions.
+
+
+async def _flow_system_instruction(
+    agent: Any,
+    *,
+    state: dict[str, Any] | None = None,
+) -> str | None:
+    """Run ADK's instructions request processor and return the system instruction."""
+    from google.adk.agents.invocation_context import InvocationContext  # type: ignore
+    from google.adk.flows.llm_flows import instructions as adk_instructions  # type: ignore
+    from google.adk.models.llm_request import LlmRequest  # type: ignore
+    from google.adk.sessions.in_memory_session_service import (  # type: ignore
+        InMemorySessionService,
+    )
+
+    svc = InMemorySessionService()
+    session = await svc.create_session(
+        app_name="app", user_id="u", state=dict(state or {})
+    )
+    inv_ctx = InvocationContext(
+        session_service=svc,
+        invocation_id="inv1",
+        agent=agent,
+        session=session,
+    )
+    llm_request = LlmRequest()
+    async for _ in adk_instructions.request_processor.run_async(inv_ctx, llm_request):
+        pass
+    return llm_request.config.system_instruction
+
+
+async def test_state_placeholder_resolves_identically_wrapped_vs_unwrapped() -> None:
+    """``{var}`` substitution survives wrapping (no pin -> parity is exact)."""
+    template = "Research {topic} and summarise {style?}."
+    state = {"topic": "llamas", "style": "briefly"}
+
+    unwrapped = _mk_llm_agent(name="plain", instruction=template)
+    wrapped = _mk_llm_agent(name="wrapped", instruction=template)
+    assert install_dynamic_instructions(wrapped) == 1
+
+    plain_si = await _flow_system_instruction(unwrapped, state=state)
+    wrapped_si = await _flow_system_instruction(wrapped, state=state)
+    assert plain_si == "Research llamas and summarise briefly."
+    assert wrapped_si == plain_si
+
+
+async def test_placeholder_free_instruction_is_byte_identical() -> None:
+    """The fast path leaves brace-less instructions untouched end-to-end."""
+    template = "You are a careful research assistant."
+    unwrapped = _mk_llm_agent(name="plain", instruction=template)
+    wrapped = _mk_llm_agent(name="wrapped", instruction=template)
+    assert install_dynamic_instructions(wrapped) == 1
+
+    plain_si = await _flow_system_instruction(unwrapped, state={"topic": "x"})
+    wrapped_si = await _flow_system_instruction(wrapped, state={"topic": "x"})
+    assert wrapped_si == plain_si == template
+    # The fast path also stays synchronous — no awaitable in the sync
+    # resolver contract older callers rely on.
+    resolver = wrapped.instruction
+    assert isinstance(resolver(_ReadonlyCtxStub(state={})), str)
+
+
+async def test_artifact_placeholder_resolves_identically_wrapped_vs_unwrapped() -> None:
+    """``{artifact.var}`` loads through the invocation's artifact service."""
+    from google.adk.artifacts.in_memory_artifact_service import (  # type: ignore
+        InMemoryArtifactService,
+    )
+    from google.genai import types  # type: ignore
+
+    template = "Use the notes: {artifact.notes}"
+
+    async def _si_for(agent: Any) -> str | None:
+        # The artifact must exist under the exact session id the flow
+        # runs with, so this inlines the flow instead of reusing
+        # _flow_system_instruction.
+        svc = InMemoryArtifactService()
+        from google.adk.agents.invocation_context import InvocationContext  # type: ignore
+        from google.adk.flows.llm_flows import instructions as adk_instructions  # type: ignore
+        from google.adk.models.llm_request import LlmRequest  # type: ignore
+        from google.adk.sessions.in_memory_session_service import (  # type: ignore
+            InMemorySessionService,
+        )
+
+        sess_svc = InMemorySessionService()
+        session = await sess_svc.create_session(app_name="app", user_id="u")
+        await svc.save_artifact(
+            app_name="app",
+            user_id="u",
+            session_id=session.id,
+            filename="notes",
+            artifact=types.Part(text="llamas are camelids"),
+        )
+        inv_ctx = InvocationContext(
+            session_service=sess_svc,
+            artifact_service=svc,
+            invocation_id="inv1",
+            agent=agent,
+            session=session,
+        )
+        llm_request = LlmRequest()
+        async for _ in adk_instructions.request_processor.run_async(inv_ctx, llm_request):
+            pass
+        return llm_request.config.system_instruction
+
+    unwrapped = _mk_llm_agent(name="plain", instruction=template)
+    wrapped = _mk_llm_agent(name="wrapped", instruction=template)
+    assert install_dynamic_instructions(wrapped) == 1
+
+    plain_si = await _si_for(unwrapped)
+    wrapped_si = await _si_for(wrapped)
+    assert plain_si is not None and "llamas are camelids" in plain_si
+    assert wrapped_si == plain_si
+
+
+async def test_missing_state_var_raises_wrapped_and_unwrapped() -> None:
+    """Substitution errors keep ADK's native failure mode after wrapping."""
+    template = "Research {no_such_var}."
+    unwrapped = _mk_llm_agent(name="plain", instruction=template)
+    wrapped = _mk_llm_agent(name="wrapped", instruction=template)
+    assert install_dynamic_instructions(wrapped) == 1
+
+    with pytest.raises(KeyError):
+        await _flow_system_instruction(unwrapped, state={})
+    with pytest.raises(KeyError):
+        await _flow_system_instruction(wrapped, state={})
+
+
+async def test_templating_composes_with_task_pin_in_active_mode() -> None:
+    """Active mode: {var} substitution feeds the composed instruction's base."""
+    import inspect
+    from types import SimpleNamespace
+
+    resolver = make_dynamic_instruction(
+        original_instruction="Research {topic}.",
+        agent_name="inner_agent",
+    )
+    state: dict[str, Any] = {
+        "topic": "llamas",
+        _sp.KEY_CURRENT_TASK_ID: "t1",
+        _sp.KEY_CURRENT_TASK_TITLE: "the task",
+        _sp.KEY_CURRENT_TASK_DESCRIPTION: "do the thing",
+    }
+    ctx = _ReadonlyCtxStub(state=state)
+    # inject_session_state reads state through the readonly context's
+    # invocation context; give the stub the same backing dict.
+    ctx._invocation_context = SimpleNamespace(
+        session=SimpleNamespace(state=state), artifact_service=None
+    )
+
+    out = resolver(ctx)
+    assert inspect.isawaitable(out)
+    resolved = await out
+    assert resolved.startswith("Research llamas.")
+    assert "Current assigned task:" in resolved
+    assert "{topic}" not in resolved
+
+
+async def test_templating_still_runs_under_observation_only() -> None:
+    """observation_only=True suppresses goldfive augmentation but NOT the
+    templating ADK applies to string instructions regardless of goldfive."""
+    import inspect
+    from types import SimpleNamespace
+
+    resolver = make_dynamic_instruction(
+        original_instruction="Research {topic}.",
+        agent_name="inner_agent",
+    )
+    stash = SimpleNamespace(
+        steerer=SimpleNamespace(_observation_only=True), session=None
+    )
+    state: dict[str, Any] = {
+        "topic": "llamas",
+        "goldfive._session_context": stash,
+        _sp.KEY_CURRENT_TASK_ID: "t1",
+        _sp.KEY_CURRENT_TASK_TITLE: "the task",
+        _sp.KEY_CURRENT_TASK_DESCRIPTION: "do the thing",
+    }
+    ctx = _ReadonlyCtxStub(state=state)
+    ctx._invocation_context = SimpleNamespace(
+        session=SimpleNamespace(state=state), artifact_service=None
+    )
+
+    out = resolver(ctx)
+    assert inspect.isawaitable(out)
+    resolved = await out
+    # Templated exactly as unwrapped ADK would...
+    assert resolved == "Research llamas."
+    # ...with zero goldfive augmentation.
+    assert "Current assigned task:" not in resolved
+
+
+def test_install_skips_templated_instruction_when_inject_api_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No inject helper -> placeholder-bearing agents keep their string
+    instruction (WARNING), placeholder-free agents still get the resolver."""
+    from goldfive.adapters import adk_llm_instrumentation as mod
+
+    monkeypatch.setattr(mod, "_adk_inject_session_state", lambda: None)
+
+    templated = _mk_llm_agent(name="templated", instruction="Research {topic}.")
+    plain = _mk_llm_agent(name="plain", instruction="Just research.")
+
+    with caplog.at_level("WARNING", logger=mod.log.name):
+        assert install_dynamic_instructions(templated) == 0
+        assert install_dynamic_instructions(plain) == 1
+
+    assert templated.instruction == "Research {topic}."
+    assert is_dynamic_instruction(plain.instruction)
+    assert any("inject_session_state is unavailable" in r.message for r in caplog.records)
+
+
+async def test_user_callable_instruction_keeps_bypass_semantics() -> None:
+    """A user InstructionProvider is never wrapped, so its output keeps
+    ADK's native bypass: literal braces pass through unsubstituted."""
+    from google.adk.agents.llm_agent import LlmAgent  # type: ignore
+
+    def user_provider(ctx: Any) -> str:
+        return "user-dynamic {topic}"
+
+    agent = LlmAgent(
+        name="user_dyn",
+        model="fake-model",
+        description="user-managed dynamic",
+        instruction=user_provider,  # type: ignore[arg-type]
+    )
+    assert install_dynamic_instructions(agent) == 0
+
+    si = await _flow_system_instruction(agent, state={"topic": "llamas"})
+    assert si == "user-dynamic {topic}"


### PR DESCRIPTION
## Problem

Default-on `dynamic_instruction` silently disables ADK's documented `{var}` / `{artifact.var}` session-state templating.

`install_dynamic_instructions` (`goldfive/adapters/adk_llm_instrumentation.py:698` on main) replaces every string agent instruction with a callable resolver at wrap time. ADK's `LlmAgent.canonical_instruction` (google-adk 1.31.0, `agents/llm_agent.py:568-574`) returns `bypass_state_injection=True` for callable instructions, and the instructions flow processor (`flows/llm_flows/instructions.py:55-58`) only calls `instructions_utils.inject_session_state` when that flag is False. Net effect: an agent instructed `"Research {topic}"` sees the literal placeholder on every turn of a wrapped run, while the unwrapped run substitutes from session state. Placeholder-free instructions were unaffected (byte-identical wrapped vs unwrapped).

## Fix

- `PromptShaper.make_dynamic_instruction` (`goldfive/prompt_shaper.py`): the resolver now re-applies ADK's own `inject_session_state` to the original template before goldfive augmentation.
  - Placeholder-free templates (`"{" not in template`) keep the synchronous, byte-identical fast path — no behavior change.
  - Placeholder-bearing templates return an awaitable (ADK's `InstructionProvider` alias is `Callable[[ReadonlyContext], str | Awaitable[str]]`; `canonical_instruction` awaits it). Substitution errors (missing state var / artifact) propagate exactly as they would unwrapped.
  - All resolver return paths (observation-only, no-pin, composed, exception fallback) use the templated base, so a goldfive failure never costs the agent its templated instruction.
- `install_dynamic_instructions` (`goldfive/adapters/adk_llm_instrumentation.py`): if ADK's `inject_session_state` cannot be resolved (defensive probe `_adk_inject_session_state`), placeholder-bearing instructions are skipped with a WARNING so those agents keep ADK's native string-instruction templating; placeholder-free agents are still wrapped.
- User-supplied `InstructionProvider` callables remain untouched (existing behavior): they keep ADK's native bypass semantics and are never double-substituted.

## Behavior notes

- `observation_only=True` still runs the templating (unwrapped ADK applies it to string instructions regardless of goldfive; suppressing it would itself be a behavior change) while continuing to suppress all goldfive augmentation.
- The resolver's return type widened from `str` to `str | Awaitable[str]` — only for placeholder-bearing templates; the sync contract is preserved for everything that existed before.

## Tests

`tests/test_dynamic_instruction.py` — new "templating parity" section drives ADK's real instructions request processor on wrapped vs unwrapped agents:

- `{var}` (incl. optional `{style?}`) resolves identically wrapped vs unwrapped.
- `{artifact.var}` resolves identically via `InMemoryArtifactService`.
- Placeholder-free instruction is byte-identical end-to-end and the resolver stays synchronous.
- Missing state var raises `KeyError` both wrapped and unwrapped (error-semantics parity).
- Active mode: substitution feeds the composed instruction's base alongside the task pin block.
- `observation_only=True`: output is exactly the templated original with zero augmentation.
- Probe-absent fallback: templated agent left unwrapped with WARNING; plain agent still wrapped.
- User callable instruction: never wrapped; literal braces pass through unsubstituted (native bypass).

Results: `tests/test_dynamic_instruction.py tests/test_prompt_shaper.py tests/test_observation_only_strict_passive.py tests/test_correction_injection.py` — 65 passed. Full suite: 2805 passed, 59 skipped (~29s). `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA
