### PR TITLE
fix: report_awaiting_approval cannot hang runs; gate plan_state acks on observation_only

### DIFF
--- a/docs/design/APPROVAL.md
+++ b/docs/design/APPROVAL.md
@@ -57,9 +57,25 @@ Notes:
 - The `ApprovalGranted` / `ApprovalRejected` events are a separate channel from
   the task state machine — they are *resolution* events, not transitions. A
   rejected approval does not automatically fail the task; the agent chooses.
-- A `timeout_ms` parameter on `report_awaiting_approval` is accepted but
-  currently implemented as a pure `asyncio.wait_for`. On timeout the handler
-  returns `{"decision": "timeout", "detail": ...}` and leaves the task blocked.
+- **No control channel bound** (the default `goldfive.wrap()` posture —
+  `control=None`): nothing can ever dispatch APPROVE / REJECT, so the handler
+  returns `{"decision": "unavailable", "detail": ...}` immediately without
+  blocking the task, registering a waiter, or emitting `ApprovalRequested`.
+  The agent is told approval is unavailable and decides for itself how to
+  continue; goldfive does not force a transition. (Historically this path
+  awaited a waiter that could never be set — the tool call, and the run,
+  hung forever.)
+- The wait is always finite. An explicit `timeout_ms > 0` is honoured
+  verbatim; `timeout_ms <= 0` (including the omitted default) substitutes
+  `SteeringConfig.approval_default_timeout_ms` (600 s;
+  env `GOLDFIVE_STEER_APPROVAL_DEFAULT_TIMEOUT_MS`) instead of the historical
+  unbounded wait — no invocation wall clock covers tool waits, so infinity
+  was a run-hang.
+- On timeout the handler returns `{"decision": "timeout", "detail": ...}`,
+  leaves the task blocked (a later APPROVE / REJECT still resolves via
+  `session.pending_approvals`), and emits a `HUMAN_INTERVENTION_REQUIRED`
+  drift at WARNING severity (emit-only — no ladder dispatch) so operators
+  see the unresolved approval instead of a silently BLOCKED task.
 
 ## Flow B — ADK tool confirmation (ADK-specific)
 

--- a/docs/design/CONTROL.md
+++ b/docs/design/CONTROL.md
@@ -442,8 +442,12 @@ handler:
    stashes metadata in `session.pending_approvals_meta[task_id]`.
 3. Emits `ApprovalRequested{target_id=task_id, kind="task", prompt=...}`.
 4. `await`s the event.
-5. Returns `{"decision": "approve"|"reject"|"timeout", "detail": ...}`
-   to the agent.
+5. Returns `{"decision": "approve"|"reject"|"timeout"|"unavailable",
+   "detail": ...}` to the agent. The wait is finite (`timeout_ms`, or
+   `SteeringConfig.approval_default_timeout_ms` when omitted); with no
+   control channel bound at all the handler skips steps 1-4 and
+   returns `"unavailable"` immediately — see
+   [APPROVAL.md](APPROVAL.md).
 
 The UI renders buttons on `ApprovalRequested` and sends
 `ControlMessage(kind=APPROVE|REJECT, payload={"target_id": task_id})`.

--- a/docs/reference/tool-protocol.md
+++ b/docs/reference/tool-protocol.md
@@ -350,16 +350,23 @@ report_awaiting_approval(
 **Call when:** a task needs a human decision before it can proceed.
 Blocks the calling tool-call until an `APPROVE` or `REJECT`
 `ControlMessage` targeting the same id lands on the runner's
-`ControlChannel`.
+`ControlChannel`. The wait is finite: an explicit `timeout_ms > 0`
+is honoured; omitting it applies
+`SteeringConfig.approval_default_timeout_ms` (default 600 s). Expiry
+returns `decision="timeout"` and emits a
+`HUMAN_INTERVENTION_REQUIRED` WARNING drift. When the runner has no
+`ControlChannel` at all (the default `wrap()` posture) the handler
+returns `decision="unavailable"` immediately instead of blocking a
+task no human can ever unblock.
 
 **Side effects:**
 
 - Registers an `asyncio.Event` on
   `session.pending_approvals[target_id]` (defaults to `task_id`).
 - Emits `ApprovalRequested(task_id, target_id, detail)`.
-- Blocks until the control dispatcher sets the event, then returns
-  `{"acknowledged": True, "decision": "approve"|"reject",
-  "detail": "..."}`.
+- Blocks until the control dispatcher sets the event (or the finite
+  wait expires), then returns `{"acknowledged": True, "decision":
+  "approve"|"reject"|"timeout"|"unavailable", "detail": "..."}`.
 
 **Example:**
 

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -563,6 +563,14 @@ class GoalDriftConfig:
         )
 
 
+#: Fallback wait budget, in milliseconds, for a ``report_awaiting_approval``
+#: call that omits ``timeout_ms`` (or passes ``<= 0``) while a control
+#: channel is attached. Referenced by
+#: :attr:`SteeringConfig.approval_default_timeout_ms` and by the handler's
+#: fallback when the steerer carries no :class:`SteeringConfig` at all.
+DEFAULT_APPROVAL_TIMEOUT_MS: int = 600_000
+
+
 @dataclasses.dataclass
 class SteeringConfig:
     """Drift → steer promotion policy (goldfive-steer-unification).
@@ -679,6 +687,19 @@ class SteeringConfig:
     #: ``Task.discovery_identity_hash``, ``DelegationObserved.tool_args_json``)
     #: are always available regardless of this flag.
     descriptive_growth_enabled: bool = False
+    #: Wait budget, in milliseconds, substituted when a
+    #: ``report_awaiting_approval`` call omits ``timeout_ms`` (or passes
+    #: ``<= 0``) and a control channel is attached. Historically that
+    #: path awaited the APPROVE / REJECT waiter with no bound, so an
+    #: operator who never dispatched a decision hung the tool call — and
+    #: the run — forever (no invocation wall clock covers tool waits).
+    #: On expiry the handler returns ``decision="timeout"`` and emits a
+    #: ``HUMAN_INTERVENTION_REQUIRED`` WARNING drift so operators see
+    #: the unresolved approval. An explicit positive ``timeout_ms`` from
+    #: the agent still wins; a non-positive value here falls back to
+    #: :data:`DEFAULT_APPROVAL_TIMEOUT_MS`.
+    #: Env: ``GOLDFIVE_STEER_APPROVAL_DEFAULT_TIMEOUT_MS``.
+    approval_default_timeout_ms: int = DEFAULT_APPROVAL_TIMEOUT_MS
 
     @classmethod
     def from_env(cls) -> SteeringConfig:
@@ -698,6 +719,9 @@ class SteeringConfig:
         * ``GOLDFIVE_STEER_CONTEXT_EDITOR_RULES`` — comma-separated rule
           names (goldfive#397). Empty / unset → ``None`` (editor unwired).
           Example: ``GOLDFIVE_STEER_CONTEXT_EDITOR_RULES=prune_cancelled_reasoning``.
+        * ``GOLDFIVE_STEER_APPROVAL_DEFAULT_TIMEOUT_MS`` — positive int
+          (milliseconds); non-positive / non-integer values fall back
+          to the default.
         """
         defaults = cls()
         raw_rules = os.environ.get("GOLDFIVE_STEER_CONTEXT_EDITOR_RULES", "").strip()
@@ -722,6 +746,10 @@ class SteeringConfig:
             descriptive_growth_enabled=_read_bool_env(
                 "GOLDFIVE_STEER_DESCRIPTIVE_GROWTH",
                 defaults.descriptive_growth_enabled,
+            ),
+            approval_default_timeout_ms=_read_int_env(
+                "GOLDFIVE_STEER_APPROVAL_DEFAULT_TIMEOUT_MS",
+                defaults.approval_default_timeout_ms,
             ),
         )
 

--- a/goldfive/reporting/__init__.py
+++ b/goldfive/reporting/__init__.py
@@ -13,7 +13,9 @@ framework wants (ADK ``FunctionTool``, Claude Agent SDK tool blocks, …).
 The eighth tool, ``report_awaiting_approval``, is the task-level half of
 the human-in-the-loop approval flow described in
 ``docs/design/APPROVAL.md``. Its handler blocks the calling tool-call
-until the control dispatcher lands an ``APPROVE`` or ``REJECT``.
+until the control dispatcher lands an ``APPROVE`` or ``REJECT`` (with a
+finite timeout, and an immediate degraded ack when no control channel
+is bound).
 
 Package structure (post-split, Wave A piece 3):
 

--- a/goldfive/reporting/handlers.py
+++ b/goldfive/reporting/handlers.py
@@ -13,7 +13,9 @@ framework wants (ADK ``FunctionTool``, Claude Agent SDK tool blocks, …).
 The eighth tool, ``report_awaiting_approval``, is the task-level half of
 the human-in-the-loop approval flow described in
 ``docs/design/APPROVAL.md``. Its handler blocks the calling tool-call
-until the control dispatcher lands an ``APPROVE`` or ``REJECT``.
+until the control dispatcher lands an ``APPROVE`` or ``REJECT`` (with a
+finite timeout, and an immediate degraded ack when no control channel
+is bound).
 """
 
 from __future__ import annotations
@@ -25,6 +27,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from goldfive import _state_audit
+from goldfive.config import DEFAULT_APPROVAL_TIMEOUT_MS
 from goldfive.reporting._internal import (
     _ACK,
     _TERMINAL_STATUSES,
@@ -65,7 +68,7 @@ from goldfive.reporting.schemas import (
     _SCHEMA_TASK_PROGRESS,
     _SCHEMA_TASK_STARTED,
 )
-from goldfive.types import TaskStatus
+from goldfive.types import DriftEvent, DriftKind, DriftSeverity, TaskStatus
 
 if TYPE_CHECKING:
     from goldfive.protocols import Steerer
@@ -350,7 +353,9 @@ async def _handle_task_started(
     if task is not None:
         decision = _classify_transition(tool_name="report_task_started", current_status=task.status)
         if decision == "idempotent":
-            return _idempotent_response(task.status, session=session, task_id=task_id)
+            return _idempotent_response(
+                task.status, session=session, task_id=task_id, steerer=steerer
+            )
         if decision == "invalid":
             return _invalid_transition_response(
                 tool_name="report_task_started",
@@ -387,7 +392,9 @@ async def _handle_task_started(
             # exited. The boundary catch site can now confirm we
             # didn't bypass the stash.
             _state_audit.mark_stash_completed()
-    return _directive_ack(session=session, task_id=task_id, new_status=TaskStatus.RUNNING)
+    return _directive_ack(
+        session=session, task_id=task_id, new_status=TaskStatus.RUNNING, steerer=steerer
+    )
 
 
 def _clear_correction_on_started(session: Session, task: Task | None) -> None:
@@ -462,7 +469,9 @@ async def _handle_task_progress(
     await steerer.tasks.mark_task_progress(
         task_id, session=session, fraction=fraction, detail=detail
     )
-    return _directive_ack(session=session, task_id=task_id, new_status=TaskStatus.RUNNING)
+    return _directive_ack(
+        session=session, task_id=task_id, new_status=TaskStatus.RUNNING, steerer=steerer
+    )
 
 
 async def _handle_task_completed(
@@ -499,7 +508,9 @@ async def _handle_task_completed(
             tool_name="report_task_completed", current_status=task.status
         )
         if decision == "idempotent":
-            return _idempotent_response(task.status, session=session, task_id=task_id)
+            return _idempotent_response(
+                task.status, session=session, task_id=task_id, steerer=steerer
+            )
         if decision == "invalid":
             return _invalid_transition_response(
                 tool_name="report_task_completed",
@@ -513,7 +524,9 @@ async def _handle_task_completed(
     # Rotate the current-task pin now that this one has landed terminal.
     if task is not None:
         _rotate_after_terminal(session, task)
-    return _directive_ack(session=session, task_id=task_id, new_status=TaskStatus.COMPLETED)
+    return _directive_ack(
+        session=session, task_id=task_id, new_status=TaskStatus.COMPLETED, steerer=steerer
+    )
 
 
 async def _handle_task_failed(
@@ -543,7 +556,9 @@ async def _handle_task_failed(
     if task is not None:
         decision = _classify_transition(tool_name="report_task_failed", current_status=task.status)
         if decision == "idempotent":
-            return _idempotent_response(task.status, session=session, task_id=task_id)
+            return _idempotent_response(
+                task.status, session=session, task_id=task_id, steerer=steerer
+            )
         if decision == "invalid":
             return _invalid_transition_response(
                 tool_name="report_task_failed",
@@ -560,7 +575,9 @@ async def _handle_task_failed(
     )
     if task is not None:
         _rotate_after_terminal(session, task)
-    return _directive_ack(session=session, task_id=task_id, new_status=TaskStatus.FAILED)
+    return _directive_ack(
+        session=session, task_id=task_id, new_status=TaskStatus.FAILED, steerer=steerer
+    )
 
 
 async def _handle_task_blocked(
@@ -590,7 +607,9 @@ async def _handle_task_blocked(
     if task is not None:
         decision = _classify_transition(tool_name="report_task_blocked", current_status=task.status)
         if decision == "idempotent":
-            return _idempotent_response(task.status, session=session, task_id=task_id)
+            return _idempotent_response(
+                task.status, session=session, task_id=task_id, steerer=steerer
+            )
         if decision == "invalid":
             return _invalid_transition_response(
                 tool_name="report_task_blocked",
@@ -601,7 +620,9 @@ async def _handle_task_blocked(
     await steerer.tasks.mark_task_blocked(
         task_id, session=session, blocker=blocker, needed=needed, source=source
     )
-    return _directive_ack(session=session, task_id=task_id, new_status=TaskStatus.BLOCKED)
+    return _directive_ack(
+        session=session, task_id=task_id, new_status=TaskStatus.BLOCKED, steerer=steerer
+    )
 
 
 async def _handle_new_work_discovered(
@@ -746,6 +767,51 @@ async def _handle_declare_task_not_needed(
     )
 
 
+# Distinguishes "steerer exposes no channel state" (custom / stub
+# steerers — assume a controller may exist) from "steerer knows no
+# channel is bound" (``DefaultSteerer._control_channel is None`` — no
+# APPROVE / REJECT can ever arrive).
+_UNKNOWN_CHANNEL = object()
+
+
+async def _emit_approval_timeout_drift(
+    *,
+    session: Session,
+    steerer: Steerer,
+    task_id: str,
+    timeout_ms: int,
+) -> None:
+    """Surface an expired approval wait as a WARNING drift.
+
+    Emit-only (no ladder dispatch) — mirrors the Runner's
+    revision-rejection observability drift. The task stays BLOCKED and
+    the waiter stays registered; the drift is the operator-facing
+    signal that a human decision is still owed. Best-effort: steerers
+    without a ``drift`` component (test stubs) skip silently.
+    """
+    drift = DriftEvent(
+        kind=DriftKind.HUMAN_INTERVENTION_REQUIRED,
+        severity=DriftSeverity.WARNING,
+        detail=(
+            f"approval request for task {task_id!r} received no "
+            f"APPROVE/REJECT within {timeout_ms}ms; task remains "
+            "BLOCKED pending a decision"
+        ),
+        current_task_id=task_id,
+        authored_by="goldfive",
+    )
+    emit_helper = getattr(getattr(steerer, "drift", None), "_emit_drift_detected", None)
+    if not callable(emit_helper):
+        return
+    try:
+        await emit_helper(session, drift)
+    except Exception as exc:  # noqa: BLE001 — observability must not mask the timeout ack
+        log.warning(
+            "report_awaiting_approval: emitting approval-timeout drift raised: %s",
+            exc,
+        )
+
+
 async def _handle_awaiting_approval(
     args: dict[str, Any], session: Session, steerer: Steerer
 ) -> dict[str, Any]:
@@ -758,9 +824,22 @@ async def _handle_awaiting_approval(
 
     Returns ``{"decision": "approve" | "reject", "detail": ...}`` so the
     agent can decide whether to proceed or transition the task to
-    ``FAILED`` itself. A ``timeout_ms > 0`` that elapses before a
-    decision lands returns ``{"decision": "timeout", "detail": ...}``
-    and leaves the task blocked (the caller may re-prompt or fail).
+    ``FAILED`` itself. Two degraded decisions cover runs where no human
+    ever answers:
+
+    * ``"unavailable"`` — the steerer has no control channel bound, so
+      no APPROVE / REJECT can ever be dispatched. The handler does not
+      block the task or register a waiter; it returns immediately.
+    * ``"timeout"`` — the wait elapsed before a decision landed. The
+      task stays blocked (a later APPROVE / REJECT still resolves via
+      the pending map) and a ``HUMAN_INTERVENTION_REQUIRED`` WARNING
+      drift is emitted so operators see the unresolved approval.
+
+    ``timeout_ms <= 0`` (including the omitted default) no longer means
+    "wait forever" — the handler substitutes
+    :attr:`~goldfive.config.SteeringConfig.approval_default_timeout_ms`
+    so a run whose operator never answers cannot hang on the tool call.
+    An explicit positive ``timeout_ms`` wins over the config default.
     """
     err = _validate_required(args, _SCHEMA_AWAITING_APPROVAL, "report_awaiting_approval")
     if err is not None:
@@ -783,6 +862,32 @@ async def _handle_awaiting_approval(
             attempted=TaskStatus.BLOCKED,
             task_id=task_id,
         )
+
+    # A pending approval can only resolve through the control channel
+    # (``dispatch_control`` sets the waiter on APPROVE / REJECT). When
+    # the steerer exposes its bound channel and it is ``None`` — the
+    # default ``wrap()`` posture — no decision can ever arrive, so
+    # waiting any amount would wedge the tool call: return immediately
+    # without blocking the task, registering a waiter, or emitting
+    # ``ApprovalRequested`` (there is no controller to render it to).
+    # The agent learns approval is unavailable and decides for itself.
+    # Steerers that don't expose the attribute (custom implementations,
+    # legacy stubs) fall through to the finite-default wait below.
+    if getattr(steerer, "_control_channel", _UNKNOWN_CHANNEL) is None:
+        log.warning(
+            "report_awaiting_approval(task_id=%r): no control channel "
+            "attached to this run; returning decision='unavailable' "
+            "without blocking",
+            task_id,
+        )
+        return {
+            "acknowledged": True,
+            "decision": "unavailable",
+            "detail": (
+                "no approval controller is attached to this run; the "
+                "request cannot be received or answered by a human"
+            ),
+        }
 
     # Idempotency: reuse an existing waiter if one is already pending.
     waiter = session.pending_approvals.get(task_id)
@@ -814,16 +919,28 @@ async def _handle_awaiting_approval(
         metadata={},
     )
 
+    # ``timeout_ms <= 0`` historically meant an unbounded wait; no
+    # invocation wall clock covers tool waits, so a never-answered
+    # approval hung the run. Substitute the configured finite default.
+    effective_timeout_ms = timeout_ms
+    if effective_timeout_ms <= 0:
+        config = getattr(steerer, "_steering_config", None)
+        effective_timeout_ms = int(getattr(config, "approval_default_timeout_ms", 0) or 0)
+        if effective_timeout_ms <= 0:
+            effective_timeout_ms = DEFAULT_APPROVAL_TIMEOUT_MS
     try:
-        if timeout_ms > 0:
-            await asyncio.wait_for(waiter.wait(), timeout=timeout_ms / 1000.0)
-        else:
-            await waiter.wait()
+        await asyncio.wait_for(waiter.wait(), timeout=effective_timeout_ms / 1000.0)
     except TimeoutError:
+        await _emit_approval_timeout_drift(
+            session=session,
+            steerer=steerer,
+            task_id=task_id,
+            timeout_ms=effective_timeout_ms,
+        )
         return {
             "acknowledged": True,
             "decision": "timeout",
-            "detail": f"no decision after {timeout_ms}ms",
+            "detail": f"no decision after {effective_timeout_ms}ms",
         }
 
     decision = str(meta.get("decision", "")) or "approve"
@@ -936,11 +1053,16 @@ BUILTIN_REPORTING_TOOLS: list[ReportingToolSpec] = [
             "the control channel. Use this when the task has a side effect "
             "that needs sign-off (spending money, writing to a shared "
             "system, sending a message). The call blocks until the UI "
-            "dispatches an APPROVE or REJECT and returns "
-            "{'decision': 'approve' | 'reject' | 'timeout', 'detail': ...}. "
-            "The agent decides what to do with the decision: on approve, "
-            "proceed; on reject, typically report_task_failed with a "
-            "user-rejection reason."
+            "dispatches an APPROVE or REJECT and returns {'decision': "
+            "'approve' | 'reject' | 'timeout' | 'unavailable', 'detail': "
+            "...}. 'unavailable' means no approval controller is attached "
+            "to this run, so no human can answer; the call returns "
+            "immediately. Omitting timeout_ms (or passing 0) waits for a "
+            "framework-configured default period, not forever; 'timeout' "
+            "means the wait elapsed with no decision. The agent decides "
+            "what to do with the decision: on approve, proceed; on "
+            "reject, typically report_task_failed with a user-rejection "
+            "reason."
         ),
         parameters=_SCHEMA_AWAITING_APPROVAL,
         handler=_handle_awaiting_approval,

--- a/goldfive/reporting/rendering.py
+++ b/goldfive/reporting/rendering.py
@@ -7,7 +7,11 @@ read on the next turn — they're the contract surface between
 * **Directive acks** (:func:`_build_plan_state`, :func:`_directive_ack`)
   — successful transitions return ``plan_state`` so the coordinator
   sees the next pending hand-off instead of an information-free ack.
-  This is the F1 / Tier 1 loop-prevention pattern.
+  This is the F1 / Tier 1 loop-prevention pattern. ``plan_state`` is a
+  goldfive-authored steering surface, so it is suppressed under
+  ``observation_only`` via the same
+  :meth:`~goldfive.prompt_shaper.PromptShaper.should_inject` predicate
+  the prompt-shaping sites consult.
 * **Idempotent / invalid / refused** responses — branch shapes for
   retries, contract violations, and stale-pin refusals. Distinct
   shapes so loop-detector / observability layers can tell them apart.
@@ -24,6 +28,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from goldfive.prompt_shaper import PromptShaper
 from goldfive.reporting._internal import _ACK, _TERMINAL_STATUSES
 from goldfive.types import TaskStatus
 
@@ -153,18 +158,28 @@ def _directive_ack(
     session: Session,
     task_id: str,
     new_status: TaskStatus,
+    steerer: Any | None = None,
 ) -> dict[str, Any]:
     """Build the F1 directive payload for a report_task_* handler.
 
     ``new_status`` is the status the call moved (or would move) the task
     INTO. Idempotent / invalid / refused branches use their own shapes
     and do not call this helper.
+
+    ``plan_state`` (completed ids + next_pending hand-off) is a
+    goldfive-authored directive fed to the model, so it rides the same
+    ``observation_only`` gate as the four prompt-shaping sites
+    (:meth:`~goldfive.prompt_shaper.PromptShaper.should_inject`). Under
+    strict-passive the ack keeps only the factual echo of the
+    transition the agent itself reported.
     """
-    return {
+    response: dict[str, Any] = {
         "acknowledged": True,
         "task": {"id": task_id, "status": new_status.value},
-        "plan_state": _build_plan_state(getattr(session, "plan", None)),
     }
+    if PromptShaper.should_inject(steerer):
+        response["plan_state"] = _build_plan_state(getattr(session, "plan", None))
+    return response
 
 
 def _idempotent_response(
@@ -172,6 +187,7 @@ def _idempotent_response(
     *,
     session: Session | None = None,
     task_id: str = "",
+    steerer: Any | None = None,
 ) -> dict[str, Any]:
     """Idempotent ack for a re-report on a task already in ``current_status``.
 
@@ -180,7 +196,8 @@ def _idempotent_response(
     coordinator sees the next pending hand-off instead of an
     information-free ack — the same anchor the directive ack provides
     on real transitions. Without ``session`` the helper degrades to the
-    pre-F1 shape (legacy callers, test stubs).
+    pre-F1 shape (legacy callers, test stubs). ``plan_state`` is gated
+    on ``observation_only`` exactly as in :func:`_directive_ack`.
     """
     response: dict[str, Any] = {
         "acknowledged": True,
@@ -189,7 +206,8 @@ def _idempotent_response(
     }
     if session is not None:
         response["task"] = {"id": task_id, "status": current_status.value}
-        response["plan_state"] = _build_plan_state(getattr(session, "plan", None))
+        if PromptShaper.should_inject(steerer):
+            response["plan_state"] = _build_plan_state(getattr(session, "plan", None))
     return response
 
 

--- a/tests/test_approval_flow.py
+++ b/tests/test_approval_flow.py
@@ -37,7 +37,9 @@ from goldfive.adapters._adk_plugin import (  # noqa: E402
     _await_tool_approval,
     _tool_requires_confirmation,
 )
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.control import (  # noqa: E402
+    ControlChannel,
     ControlKind,
     ControlMessage,
 )
@@ -48,6 +50,8 @@ from goldfive.reporting import (  # noqa: E402
 )
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
+    DriftKind,
+    DriftSeverity,
     Goal,
     Plan,
     Session,
@@ -152,6 +156,9 @@ async def test_task_level_approve_resumes_handler() -> None:
     sink = ListSink()
     steerer = DefaultSteerer()
     steerer.bind(sinks=[sink], planner=None)
+    # A bound channel is what makes waiting meaningful — without one the
+    # handler degrades to decision='unavailable' (covered below).
+    steerer.bind_control_channel(ControlChannel())
 
     handler = _find_handler("report_awaiting_approval")
 
@@ -197,6 +204,7 @@ async def test_task_level_reject_resumes_handler() -> None:
     sink = ListSink()
     steerer = DefaultSteerer()
     steerer.bind(sinks=[sink], planner=None)
+    steerer.bind_control_channel(ControlChannel())
 
     handler = _find_handler("report_awaiting_approval")
 
@@ -230,6 +238,7 @@ async def test_task_level_approval_timeout_returns_timeout_decision() -> None:
     sink = ListSink()
     steerer = DefaultSteerer()
     steerer.bind(sinks=[sink], planner=None)
+    steerer.bind_control_channel(ControlChannel())
 
     handler = _find_handler("report_awaiting_approval")
 
@@ -239,9 +248,95 @@ async def test_task_level_approval_timeout_returns_timeout_decision() -> None:
         steerer,
     )
     assert result["decision"] == "timeout"
+    assert "50ms" in result["detail"]
     # Task remains blocked; next APPROVE / REJECT still resolves via the map.
     assert "t1" in session.pending_approvals
     assert session.plan.tasks[0].status == TaskStatus.BLOCKED
+    # The expiry is surfaced to operators as a WARNING drift.
+    timeout_drifts = [
+        d for d in session.drift_events if d.kind is DriftKind.HUMAN_INTERVENTION_REQUIRED
+    ]
+    assert len(timeout_drifts) == 1
+    assert timeout_drifts[0].severity is DriftSeverity.WARNING
+    assert timeout_drifts[0].current_task_id == "t1"
+    assert "drift_detected" in sink.payload_kinds()
+
+
+async def test_no_control_channel_returns_unavailable_without_blocking() -> None:
+    """Default wrap() posture (control=None): nothing can ever dispatch
+    APPROVE / REJECT, so the handler must not wait, block the task, or
+    register a waiter — it degrades to decision='unavailable'."""
+    session = _session_with_plan("t1")
+    sink = ListSink()
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[sink], planner=None)
+
+    handler = _find_handler("report_awaiting_approval")
+    result = await asyncio.wait_for(
+        handler({"task_id": "t1", "prompt": "ok to spend $500?"}, session, steerer),
+        timeout=1.0,
+    )
+
+    assert result["acknowledged"] is True
+    assert result["decision"] == "unavailable"
+    assert result["detail"]
+    # No waiter, no BLOCKED transition, no ApprovalRequested — there is
+    # no controller that could ever answer.
+    assert "t1" not in session.pending_approvals
+    assert session.plan.tasks[0].status == TaskStatus.PENDING
+    assert "approval_requested" not in sink.payload_kinds()
+
+
+async def test_no_control_channel_unavailable_under_observation_only() -> None:
+    """The degraded ack is mode-independent: strict-passive runs return
+    the same immediate 'unavailable' decision."""
+    session = _session_with_plan("t1")
+    sink = ListSink()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=True))
+    steerer.bind(sinks=[sink], planner=None)
+
+    handler = _find_handler("report_awaiting_approval")
+    result = await asyncio.wait_for(
+        handler({"task_id": "t1", "prompt": "?"}, session, steerer),
+        timeout=1.0,
+    )
+    assert result["decision"] == "unavailable"
+    assert "t1" not in session.pending_approvals
+
+
+@pytest.mark.parametrize("observation_only", [True, False])
+async def test_omitted_timeout_uses_configured_finite_default(
+    observation_only: bool,
+) -> None:
+    """timeout_ms omitted (or <= 0) no longer means wait-forever: the
+    SteeringConfig default applies, and expiry emits the WARNING drift
+    in both steering modes."""
+    session = _session_with_plan("t1")
+    sink = ListSink()
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(
+            observation_only=observation_only,
+            approval_default_timeout_ms=50,
+        )
+    )
+    steerer.bind(sinks=[sink], planner=None)
+    steerer.bind_control_channel(ControlChannel())
+
+    handler = _find_handler("report_awaiting_approval")
+    result = await asyncio.wait_for(
+        handler({"task_id": "t1", "prompt": "?"}, session, steerer),
+        timeout=5.0,
+    )
+
+    assert result["decision"] == "timeout"
+    assert "50ms" in result["detail"]
+    # Task stays blocked and resolvable; the drift is the operator signal.
+    assert "t1" in session.pending_approvals
+    assert session.plan.tasks[0].status == TaskStatus.BLOCKED
+    assert any(
+        d.kind is DriftKind.HUMAN_INTERVENTION_REQUIRED and d.severity is DriftSeverity.WARNING
+        for d in session.drift_events
+    )
 
 
 async def test_dispatch_approve_unknown_target_fails_ack() -> None:
@@ -468,6 +563,7 @@ async def test_task_and_tool_waiters_resolve_independently() -> None:
     sink = ListSink()
     steerer = DefaultSteerer()
     steerer.bind(sinks=[sink], planner=None)
+    steerer.bind_control_channel(ControlChannel())
 
     # Register a task-level waiter via the reporting handler.
     task_handler = _find_handler("report_awaiting_approval")

--- a/tests/test_observation_only_acks.py
+++ b/tests/test_observation_only_acks.py
@@ -1,0 +1,159 @@
+"""Observation-only gating of the F1 ``plan_state`` directive surface.
+
+The report_task_* directive / idempotent acks embed goldfive's live
+``plan_state`` (completed ids + the ``next_pending`` hand-off with
+``assigned_to``) — a goldfive-authored steering signal fed straight to
+the coordinator's next turn. Under
+``SteeringConfig(observation_only=True)`` — the production default —
+that surface must be suppressed exactly like the four prompt-shaping
+sites: the agent sees a neutral ack (acknowledged + factual task echo)
+with no ``plan_state``. Active mode keeps the full directive payload.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.reporting import BUILTIN_REPORTING_TOOLS  # noqa: E402
+from goldfive.reporting.rendering import (  # noqa: E402
+    _directive_ack,
+    _idempotent_response,
+)
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+    TaskStatus,
+)
+
+
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class _StubPlanner:
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        return None
+
+
+def _handler(name: str) -> Any:
+    for spec in BUILTIN_REPORTING_TOOLS:
+        if spec.name == name:
+            return spec.handler
+    raise AssertionError(f"missing builtin tool {name!r}")
+
+
+def _session() -> Session:
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Research",
+                assignee_agent_id="researcher",
+                status=TaskStatus.RUNNING,
+            ),
+            Task(id="t2", title="Draft", assignee_agent_id="writer", status=TaskStatus.PENDING),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    return Session(run_id="r1", goals=[Goal(id="g1", summary="brief")], plan=plan)
+
+
+def _steerer(*, observation_only: bool, sink: _ListSink) -> DefaultSteerer:
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=observation_only))
+    steerer.bind(sinks=[sink], planner=_StubPlanner())
+    return steerer
+
+
+async def test_directive_ack_omits_plan_state_under_observation_only() -> None:
+    session = _session()
+    steerer = _steerer(observation_only=True, sink=_ListSink())
+
+    out = await _handler("report_task_completed")(
+        {"task_id": "t1", "summary": "done"}, session, steerer
+    )
+
+    # Neutral ack: the transition the agent itself reported is echoed,
+    # but no goldfive-authored plan_state directive rides along.
+    assert out["acknowledged"] is True
+    assert out["task"] == {"id": "t1", "status": TaskStatus.COMPLETED.value}
+    assert "plan_state" not in out
+    # The transition itself still landed — observation_only gates the
+    # directive surface, not the reporting-driven state machine.
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+
+
+async def test_directive_ack_includes_plan_state_in_active_mode() -> None:
+    session = _session()
+    steerer = _steerer(observation_only=False, sink=_ListSink())
+
+    out = await _handler("report_task_completed")(
+        {"task_id": "t1", "summary": "done"}, session, steerer
+    )
+
+    assert out["acknowledged"] is True
+    assert out["plan_state"]["completed_task_ids"] == ["t1"]
+    assert out["plan_state"]["next_pending"]["id"] == "t2"
+    assert out["plan_state"]["next_pending"]["assigned_to"] == "writer"
+
+
+async def test_idempotent_ack_omits_plan_state_under_observation_only() -> None:
+    session = _session()
+    steerer = _steerer(observation_only=True, sink=_ListSink())
+    handler = _handler("report_task_completed")
+
+    await handler({"task_id": "t1", "summary": "done"}, session, steerer)
+    second = await handler({"task_id": "t1", "summary": "again"}, session, steerer)
+
+    assert second["acknowledged"] is True
+    assert second["idempotent"] is True
+    assert second["task"] == {"id": "t1", "status": "COMPLETED"}
+    assert "plan_state" not in second
+
+
+async def test_idempotent_ack_includes_plan_state_in_active_mode() -> None:
+    session = _session()
+    steerer = _steerer(observation_only=False, sink=_ListSink())
+    handler = _handler("report_task_completed")
+
+    await handler({"task_id": "t1", "summary": "done"}, session, steerer)
+    second = await handler({"task_id": "t1", "summary": "again"}, session, steerer)
+
+    assert second["idempotent"] is True
+    assert second["plan_state"]["next_pending"]["id"] == "t2"
+
+
+def test_rendering_helpers_default_to_directive_shape_without_steerer() -> None:
+    # Legacy callers / stubs that pass no steerer keep the pre-gate
+    # shape — same tolerance as PromptShaper.should_inject.
+    session = _session()
+    out = _directive_ack(session=session, task_id="t1", new_status=TaskStatus.COMPLETED)
+    assert "plan_state" in out
+    idem = _idempotent_response(TaskStatus.COMPLETED, session=session, task_id="t1")
+    assert "plan_state" in idem


### PR DESCRIPTION
## Problem

**A — `report_awaiting_approval` can hang a run forever under defaults.**
`goldfive/reporting/handlers.py` defaulted `timeout_ms=0` and awaited the approval waiter unbounded on that path (`await waiter.wait()` at the old handlers.py:818-821). The default `wrap()` posture has `control=None` (`convenience.py:274`), so nothing can ever dispatch `APPROVE`/`REJECT` — a model that calls this injected tool blocks its tool call forever, and no invocation-level wall clock covers tool waits.

**B — reporting-tool acks steer in passive mode.**
`goldfive/reporting/rendering.py:37-55` embeds goldfive's `plan_state` (completed_task_ids + `next_pending` with `assigned_to`) in successful `report_task_*` acks, fed to the model ungated by `observation_only` — goldfive's forecast plan steered a coordinator's reasoning in the mode that promises observe-only.

## Fix

**A** (`handlers.py::_handle_awaiting_approval`):
- **No control channel bound** (`DefaultSteerer._control_channel is None`, i.e. the default `wrap()`): return `{"decision": "unavailable", ...}` immediately — no BLOCKED transition, no waiter, no `ApprovalRequested` (there is no controller to answer). The agent is told approval is unavailable; goldfive does not instruct it what to do. Steerers that don't expose the attribute (custom/stub) fall through to the finite wait (sentinel `_UNKNOWN_CHANNEL`).
- **`timeout_ms <= 0` with a channel**: substitutes the new `SteeringConfig.approval_default_timeout_ms` knob (default 600 000 ms, env `GOLDFIVE_STEER_APPROVAL_DEFAULT_TIMEOUT_MS`) instead of infinity. Explicit positive `timeout_ms` wins. Semantic change documented in the tool description, handler docstring, APPROVAL.md, CONTROL.md, and tool-protocol.md.
- **On expiry**: emits a `HUMAN_INTERVENTION_REQUIRED` drift at **WARNING** (emit-only via `steerer.drift._emit_drift_detected`, mirroring the Runner's revision-rejection observability drift — the ladder's WARNING slot for that kind is `None`→OBSERVE, and routing through `handle_drift` would let the default `threshold="warning"` promotion cancel/refine a healthy run). Task stays BLOCKED and the waiter stays registered, so a late APPROVE/REJECT still resolves.

**B** (`rendering.py`): `_directive_ack` / `_idempotent_response` take an optional `steerer` and gate `plan_state` on `PromptShaper.should_inject(steerer)` — the exact predicate the four existing prompt-shaping sites consult (missing attribute / `None` steerer → inject, preserving legacy stub behaviour). Handlers already receive the steerer; the nine call sites now pass it through. Under `observation_only=True` the model sees the neutral ack (`acknowledged` + factual `task` echo of the transition it itself reported); active mode is byte-identical to before.

## Tests

- `tests/test_approval_flow.py` — new: no-channel immediate `unavailable` (no waiter/BLOCKED/`ApprovalRequested`, in both steering modes); omitted `timeout_ms` uses the configured finite default and emits the WARNING drift (parametrized over `observation_only` True/False); explicit-timeout test now also asserts the drift. **Updated**: the pre-existing Flow A tests (approve/reject/timeout/cross-flow) asserted the buggy behaviour — blocking on the waiter with no channel bound — and now bind a `ControlChannel()` to represent the controller they simulate via `dispatch_control`.
- `tests/test_observation_only_acks.py` — new: directive and idempotent acks omit `plan_state` under `observation_only=True` and include it (with `next_pending`) in active mode; state machine still transitions in passive mode; steerer-less rendering helpers keep the legacy shape.
- Full suite: `uv run pytest -q` → **2806 passed, 59 skipped**; `uv run ruff check .` clean.
- E2E: real `Runner` run with `CallableAdapter` and no control channel — the agent's `report_awaiting_approval` call returns `decision='unavailable'` immediately and the run completes (pre-fix: hangs forever).

## Behaviour changes

- `timeout_ms=0` no longer waits forever (finite configurable default).
- Decision vocabulary gains `'unavailable'`.
- Approval timeout now emits a `HUMAN_INTERVENTION_REQUIRED` WARNING drift.
- Passive-mode `report_task_*` acks no longer carry `plan_state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA
