### PR TITLE
fix: five small judge/embedding/events/corrections hardening fixes

### DIFF
--- a/goldfive/_correction_injection.py
+++ b/goldfive/_correction_injection.py
@@ -119,27 +119,22 @@ def _now_ms() -> int:
     return int(time.time() * 1000)
 
 
-def _bare_agent_name(value: Any) -> str:
-    """Normalise a raw agent id to its bare form.
+def _normalize_agent_name(value: Any) -> str:
+    """Normalise a raw agent id to the string used in correction keys.
 
-    Accepts strings like ``"agent.sub"`` or namespaced variants and
-    returns the last dotted segment. Tolerates anything mapping-shaped
-    or with a ``.name`` attribute so the caller doesn't have to
-    pre-strip. Empty / malformed input yields ``""``.
+    Keeps the id verbatim (whitespace-stripped) — a fully-qualified
+    path like ``"team_a.researcher"`` stays intact so two same-named
+    agents in different subtrees get distinct correction keys.
+    (Collapsing to the last dotted segment made ``team_a.researcher``
+    and ``team_b.researcher`` collide on one key.) Tolerates anything
+    mapping-shaped or with a ``.name`` attribute so the caller doesn't
+    have to pre-strip. Empty / malformed input yields ``""``.
     """
     if value is None:
         return ""
     if isinstance(value, str):
-        s = value.strip()
-    else:
-        s = str(getattr(value, "name", value) or "").strip()
-    if not s:
-        return ""
-    # Many call sites already pass a bare name; this is defensive for
-    # call sites that may pass a fully-qualified id.
-    if "." in s:
-        return s.rsplit(".", 1)[-1]
-    return s
+        return value.strip()
+    return str(getattr(value, "name", value) or "").strip()
 
 
 def build_correction_payload(
@@ -173,7 +168,7 @@ def build_correction_payload(
     ts = issued_at_ms if issued_at_ms is not None else _now_ms()
 
     return {
-        "agent_name": _bare_agent_name(getattr(new_task, "assignee_agent_id", "")),
+        "agent_name": _normalize_agent_name(getattr(new_task, "assignee_agent_id", "")),
         "task_id": str(getattr(new_task, "id", "") or ""),
         "superseded_task_id": str(getattr(new_task, "supersedes", "") or ""),
         "superseded_task_title": str(getattr(old_task, "title", "") or ""),
@@ -277,7 +272,7 @@ def queue_corrections_for_revision(
         new_id = str(getattr(new_task, "id", "") or "").strip()
         if not old_id or not new_id:
             continue
-        assignee = _bare_agent_name(getattr(new_task, "assignee_agent_id", ""))
+        assignee = _normalize_agent_name(getattr(new_task, "assignee_agent_id", ""))
         if not assignee:
             # Without an assignee we have no (agent, task) key to write.
             # Log and skip; the plan is still structurally valid (the

--- a/goldfive/drift/_embed.py
+++ b/goldfive/drift/_embed.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from collections import OrderedDict
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -81,10 +82,20 @@ _BACKEND_CLASS_OVERRIDE: Any | None = None
 # :func:`distance_to_topic`. The counter below trips the same flag
 # after :data:`_RUNTIME_FAILURE_THRESHOLD` consecutive failures so a
 # dead endpoint degrades to "no signal" after a bounded period of
-# wasted I/O. ``reset_circuit_breaker()`` exposes a test escape hatch.
+# wasted I/O. A tripped breaker recovers via a timed half-open probe
+# (see :func:`_get_model`) so a transient outage does not disable
+# embeddings for the process lifetime. ``reset_circuit_breaker()``
+# exposes a test escape hatch.
 _RUNTIME_FAILURE_COUNT: int = 0
 _RUNTIME_FAILURE_THRESHOLD: int = 3
 _RUNTIME_FAILURE_TRIPPED: bool = False
+# Monotonic timestamp of the trip (or the last failed half-open probe).
+# ``None`` while the breaker is closed.
+_RUNTIME_TRIPPED_AT: float | None = None
+# Cooldown before a tripped breaker admits a half-open probe encode.
+# ``GOLDFIVE_EMBEDDING_BREAKER_COOLDOWN_S`` overrides at read time —
+# same env pattern as ``GOLDFIVE_EMBEDDING_TIMEOUT_MS``.
+_RUNTIME_RECOVERY_COOLDOWN_S: float = 60.0
 
 # Installed per-Runner embedding config (goldfive#225). When non-None,
 # the :func:`_get_model` lazy-load path reads backend parameters from
@@ -184,10 +195,12 @@ def reset_circuit_breaker() -> None:
     over.
     """
     global _RUNTIME_FAILURE_COUNT, _RUNTIME_FAILURE_TRIPPED, _MODEL_UNAVAILABLE
+    global _RUNTIME_TRIPPED_AT
     if _RUNTIME_FAILURE_TRIPPED:
         _MODEL_UNAVAILABLE = False
     _RUNTIME_FAILURE_COUNT = 0
     _RUNTIME_FAILURE_TRIPPED = False
+    _RUNTIME_TRIPPED_AT = None
 
 
 def configure(config: EmbeddingConfig | None) -> None:
@@ -223,6 +236,29 @@ def _reset_cache() -> None:
     _CACHE.clear()
 
 
+def _recovery_cooldown_s() -> float:
+    """Return the half-open cooldown, honouring the env override."""
+    raw = os.environ.get("GOLDFIVE_EMBEDDING_BREAKER_COOLDOWN_S", "")
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+    return _RUNTIME_RECOVERY_COOLDOWN_S
+
+
+def _breaker_cooldown_elapsed() -> bool:
+    """True when a *tripped* breaker has waited out its cooldown.
+
+    Always False for a non-tripped ``_MODEL_UNAVAILABLE`` (import
+    failure / :func:`force_unavailable`) — those states have no
+    recovery path by design.
+    """
+    if not _RUNTIME_FAILURE_TRIPPED or _RUNTIME_TRIPPED_AT is None:
+        return False
+    return time.monotonic() - _RUNTIME_TRIPPED_AT >= _recovery_cooldown_s()
+
+
 def _get_model() -> Any | None:
     """Return the lazily-loaded encoder, or ``None``.
 
@@ -237,14 +273,27 @@ def _get_model() -> Any | None:
     The first failed path flips ``_MODEL_UNAVAILABLE`` so subsequent
     calls skip the import cost. Callers must check for ``None``.
     """
-    global _MODEL, _MODEL_UNAVAILABLE
+    global _MODEL, _MODEL_UNAVAILABLE, _RUNTIME_TRIPPED_AT
     # Check ``_MODEL_UNAVAILABLE`` before ``_MODEL`` so the runtime
     # circuit breaker (see :func:`_note_backend_failure`) actually
     # short-circuits. The tripped flag is also cleared by
     # :func:`reset_circuit_breaker` / :func:`set_model` /
     # :func:`configure` for callers that want a fresh start.
     if _MODEL_UNAVAILABLE:
-        return None
+        if not _breaker_cooldown_elapsed():
+            return None
+        # Half-open: admit one probe encode. A success closes the
+        # breaker (:func:`_note_backend_success`); a failure re-opens
+        # it (:func:`_note_backend_failure`). Restart the cooldown
+        # clock now so a probe that dies during backend construction
+        # (below) also waits a full cooldown before the next attempt.
+        _RUNTIME_TRIPPED_AT = time.monotonic()
+        _MODEL_UNAVAILABLE = False
+        log.info(
+            "embedding circuit breaker half-open after %.0fs cooldown; "
+            "probing backend",
+            _recovery_cooldown_s(),
+        )
     if _MODEL is not None:
         return _MODEL
 
@@ -475,16 +524,24 @@ def _note_backend_success() -> None:
     non-empty vector list comes back. Keeping the reset in one place
     means a transient outage (two failures, one success, two more
     failures) never trips the circuit breaker — only *consecutive*
-    failures count.
+    failures count. A success on a half-open probe fully closes a
+    tripped breaker.
     """
-    global _RUNTIME_FAILURE_COUNT
-    if _RUNTIME_FAILURE_COUNT:
+    global _RUNTIME_FAILURE_COUNT, _RUNTIME_FAILURE_TRIPPED, _RUNTIME_TRIPPED_AT
+    if _RUNTIME_FAILURE_TRIPPED:
+        log.info(
+            "embedding backend recovered on half-open probe; "
+            "circuit breaker closed",
+        )
+    elif _RUNTIME_FAILURE_COUNT:
         log.debug(
             "embedding backend recovered after %d failures; "
             "resetting circuit breaker",
             _RUNTIME_FAILURE_COUNT,
         )
     _RUNTIME_FAILURE_COUNT = 0
+    _RUNTIME_FAILURE_TRIPPED = False
+    _RUNTIME_TRIPPED_AT = None
 
 
 def _note_backend_failure(base_url: str) -> None:
@@ -499,9 +556,14 @@ def _note_backend_failure(base_url: str) -> None:
     default without paying the network timeout. The WARNING mentions
     ``GOLDFIVE_EMBEDDING_BASE_URL`` so operators can identify the
     unreachable endpoint from logs.
+
+    A failure while the breaker is already tripped is a failed
+    half-open probe (:func:`_get_model` admitted one encode after the
+    cooldown): the breaker re-opens immediately and the cooldown
+    restarts.
     """
     global _RUNTIME_FAILURE_COUNT, _MODEL_UNAVAILABLE
-    global _RUNTIME_FAILURE_TRIPPED, _MODEL
+    global _RUNTIME_FAILURE_TRIPPED, _RUNTIME_TRIPPED_AT, _MODEL
     _RUNTIME_FAILURE_COUNT += 1
     log.debug(
         "embedding backend %r: failure %d/%d",
@@ -509,22 +571,33 @@ def _note_backend_failure(base_url: str) -> None:
         _RUNTIME_FAILURE_COUNT,
         _RUNTIME_FAILURE_THRESHOLD,
     )
-    if (
-        _RUNTIME_FAILURE_COUNT >= _RUNTIME_FAILURE_THRESHOLD
-        and not _RUNTIME_FAILURE_TRIPPED
-    ):
+    if _RUNTIME_FAILURE_TRIPPED:
+        _MODEL_UNAVAILABLE = True
+        _MODEL = None
+        _RUNTIME_TRIPPED_AT = time.monotonic()
+        log.debug(
+            "embedding backend %r: half-open probe failed; breaker "
+            "re-opened for %.0fs",
+            base_url,
+            _recovery_cooldown_s(),
+        )
+        return
+    if _RUNTIME_FAILURE_COUNT >= _RUNTIME_FAILURE_THRESHOLD:
         _RUNTIME_FAILURE_TRIPPED = True
         _MODEL_UNAVAILABLE = True
         # Drop the cached backend too: ``_get_model`` short-circuits on
         # ``_MODEL_UNAVAILABLE`` only when ``_MODEL is None``, otherwise
         # the already-cached (dead) backend keeps getting handed back.
         _MODEL = None
+        _RUNTIME_TRIPPED_AT = time.monotonic()
         log.warning(
             "embedding backend at %s has failed %d times in a row; "
-            "disabling for this process (set GOLDFIVE_EMBEDDING_BASE_URL=... "
-            "to redirect or unset to disable silently)",
+            "disabling for %.0fs, then probing once "
+            "(set GOLDFIVE_EMBEDDING_BASE_URL=... to redirect or unset "
+            "to disable silently)",
             base_url,
             _RUNTIME_FAILURE_COUNT,
+            _recovery_cooldown_s(),
         )
 
 

--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
 from goldfive.drift import _embed
@@ -550,7 +551,7 @@ def _has_unreferenced_keyword(
 
 
 def detect_looping_reasoning(
-    text: str, session: Session
+    text: str, session: Session, history: Sequence[str] | None = None
 ) -> DriftEvent | None:
     """Return :data:`DriftKind.LOOPING_REASONING` when ``text``
     byte-identically or semantically matches a recent entry in
@@ -559,11 +560,15 @@ def detect_looping_reasoning(
     The hash-based check is always on; the semantic check fires only
     when the embedding model is loadable. ``session.reasoning_history``
     is inspected but not mutated here -- the steerer appends the new
-    reasoning block before running the pipeline.
+    reasoning block before running the pipeline. ``history`` overrides
+    the session's live list (background judge runs pass the snapshot
+    captured at schedule time — ``text`` is its last entry).
     """
+    if history is None:
+        history = session.reasoning_history
     hash_window = _looping_hash_window()
     history = [
-        h for h in session.reasoning_history[-hash_window - 1 : -1]
+        h for h in history[-hash_window - 1 : -1]
         if h
     ]
     if not history or not text:
@@ -606,7 +611,7 @@ def detect_looping_reasoning(
 
 
 def detect_reasoning_cluster_tightening(
-    text: str, session: Session
+    text: str, session: Session, history: Sequence[str] | None = None
 ) -> DriftEvent | None:
     """Return :data:`DriftKind.REASONING_CLUSTER_TIGHTENING` when recent
     reasoning blocks are semantically clustering tight -- max cosine
@@ -631,12 +636,14 @@ def detect_reasoning_cluster_tightening(
     """
     if not text:
         return None
+    if history is None:
+        history = session.reasoning_history
     task_id = session.current_task_id or ""
     if task_id and task_id in session.reasoning_cluster_flagged:
         return None
     hash_window = _looping_hash_window()
     history = [
-        h for h in session.reasoning_history[-hash_window - 1 : -1]
+        h for h in history[-hash_window - 1 : -1]
         if h
     ]
     if not history:
@@ -909,14 +916,18 @@ _SEVERITY_ORDER: dict[DriftSeverity, int] = {
 }
 
 
-def _embedding_pipeline(text: str, session: Session) -> DriftEvent | None:
+def _embedding_pipeline(
+    text: str, session: Session, history: Sequence[str] | None = None
+) -> DriftEvent | None:
     """Run the embedding-based pipeline (``mode="embedding"``).
 
     Detectors run in worst-signal-wins order:
     INTENT_DIVERGENCE -> LOOPING_REASONING -> OFF_TOPIC (with the
     sentence-level min-cosine path from #224) ->
     REASONING_CLUSTER_TIGHTENING. Ordering rationale lives in
-    :func:`analyze_reasoning`.
+    :func:`analyze_reasoning`. ``history`` overrides the live
+    ``session.reasoning_history`` for the history-window detectors
+    (background judge runs pass a snapshot pinned at schedule time).
 
     .. note::
 
@@ -932,13 +943,13 @@ def _embedding_pipeline(text: str, session: Session) -> DriftEvent | None:
     drift = detect_intent_divergence(text, session)
     if drift is not None:
         return drift
-    drift = detect_looping_reasoning(text, session)
+    drift = detect_looping_reasoning(text, session, history)
     if drift is not None:
         return drift
     drift = detect_off_topic(text, session)
     if drift is not None:
         return drift
-    drift = detect_reasoning_cluster_tightening(text, session)
+    drift = detect_reasoning_cluster_tightening(text, session, history)
     if drift is not None:
         return drift
     return None
@@ -1069,6 +1080,7 @@ async def analyze_reasoning_with_focus(
     available_agents: list[str] | list[dict[str, Any]] | None = None,
     embedding_pipeline: Any = None,
     judge_runner: Any = None,
+    reasoning_history: Sequence[str] | None = None,
 ) -> ReasoningJudgeVerdict:
     """Phase-1 sibling of :func:`analyze_reasoning` returning a focused verdict.
 
@@ -1105,8 +1117,23 @@ async def analyze_reasoning_with_focus(
     :func:`_run_judge_with_focus`; tests use it to short-circuit the
     judge round-trip. Both default to ``None`` (use the in-module
     implementations) so production callers see no behaviour change.
+
+    ``reasoning_history`` pins the view the history-window detectors
+    see instead of the live ``session.reasoning_history`` — the
+    background judge passes the snapshot captured at schedule time so
+    entries appended by later turns cannot produce false self-match
+    LOOPING signals. ``None`` (the default) reads the live session
+    list. A caller-supplied ``embedding_pipeline`` keeps its
+    ``(text, session)`` signature and is responsible for its own
+    history handling.
     """
-    embed = embedding_pipeline if embedding_pipeline is not None else _embedding_pipeline
+    if embedding_pipeline is not None:
+        embed = embedding_pipeline
+    else:
+
+        def embed(t: str, s: Session) -> DriftEvent | None:
+            return _embedding_pipeline(t, s, reasoning_history)
+
     judge = judge_runner if judge_runner is not None else _run_judge_with_focus
     if not text or mode == "off":
         return ReasoningJudgeVerdict(drift=None)

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -659,8 +659,10 @@ class ReasoningJudgeVerdict:
 
 
 # Map the judge's ``severity`` string to a :class:`DriftSeverity`. Missing
-# or unknown values fall through to WARNING so a drift verdict is never
-# silently swallowed by a bad severity string.
+# or unknown values fall through to INFO: the drift verdict is still
+# emitted (never silently swallowed), but a malformed severity string
+# must not be promotion-eligible —
+# :meth:`DriftObserver._should_promote_to_steer` gates on WARNING-and-up.
 _SEVERITY_MAP: dict[str, DriftSeverity] = {
     "info": DriftSeverity.INFO,
     "warning": DriftSeverity.WARNING,
@@ -669,9 +671,16 @@ _SEVERITY_MAP: dict[str, DriftSeverity] = {
 
 
 def _severity_from_verdict(raw: Any) -> DriftSeverity:
-    if not isinstance(raw, str):
-        return DriftSeverity.WARNING
-    return _SEVERITY_MAP.get(raw.strip().lower(), DriftSeverity.WARNING)
+    if isinstance(raw, str):
+        severity = _SEVERITY_MAP.get(raw.strip().lower())
+        if severity is not None:
+            return severity
+    log.debug(
+        "classify_reasoning_drift: severity %r missing or unrecognised; "
+        "defaulting to INFO",
+        raw,
+    )
+    return DriftSeverity.INFO
 
 
 # iter-10 PR 3: three-state classification + provenance enums. Keep

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -1693,25 +1693,24 @@ class DriftObserver:
         # regardless of verdict. ``None`` when no sinks are bound —
         # the classifier then stays sink-less and behaves as before.
         judge_sink = self._steerer._sinks[0] if self._steerer._sinks else None
-        # Snapshot the reasoning-history position at schedule time so
-        # the bg pipeline sees the same view the inline pattern
-        # detectors just saw, even if subsequent turns append more
-        # entries before the bg task runs. Without this, a detector
-        # that slices ``history[-N:-1]`` (expecting ``text`` to be the
-        # last entry) would see ``text`` itself in the comparison
-        # window and trivially self-match (goldfive#251 ordering
-        # regression surfaced by the cluster-tightening one-shot
-        # test). ``history_length`` is the length AFTER ``text`` was
-        # appended — the bg path trims ``session.reasoning_history``
-        # to this length for its invocation.
-        history_length = len(session.reasoning_history)
+        # Snapshot the reasoning history at schedule time so the bg
+        # pipeline sees the same view the inline pattern detectors
+        # just saw, even if subsequent turns append more entries (or
+        # the cap trims old ones) before the bg task runs. Without
+        # this, a detector that slices ``history[-N:-1]`` (expecting
+        # ``text`` to be the last entry) would see ``text`` itself in
+        # the comparison window and trivially self-match (goldfive#251
+        # ordering regression surfaced by the cluster-tightening
+        # one-shot test). ``text`` was appended above, so it is the
+        # snapshot's last entry.
+        pinned_history = list(session.reasoning_history)
         bg_task = asyncio.create_task(
             self._run_judge_background(
                 text=text,
                 session=session,
                 call_llm=rl_call_llm,
                 judge_sink=judge_sink,
-                history_length=history_length,
+                pinned_history=pinned_history,
                 agent_name=agent_name,
             ),
             # goldfive#243: encode session.id in the task name so
@@ -1798,7 +1797,7 @@ class DriftObserver:
         session: Session,
         call_llm: ReflectiveCallLLM | None,
         judge_sink: Any,
-        history_length: int,
+        pinned_history: list[str],
         agent_name: str = "",
     ) -> None:
         """Run the mode-selected reasoning drift pipeline off the critical path.
@@ -1811,17 +1810,14 @@ class DriftObserver:
         :meth:`_handle_drift` — same effect as the historical inline
         path, just resolving later.
 
-        ``history_length`` pins the ``session.reasoning_history`` view
-        the pipeline sees to the same tail index that was in effect
-        when the bg task was scheduled. Later turns that append to
-        the shared history (this same session receiving more
-        reasoning blocks before the bg task runs) would otherwise
-        shift the detectors' "exclude self" slice and generate false
-        self-match LOOPING signals. We temporarily truncate the
-        session view for the duration of this bg invocation and
-        restore it after; concurrent bg tasks serialize on the same
-        session's reasoning_history via the asyncio event loop (no
-        threading) so the save/restore pattern is safe in practice.
+        ``pinned_history`` is the ``session.reasoning_history``
+        snapshot captured at schedule time, forwarded to the pipeline
+        explicitly. Later turns that append to the shared live history
+        (this same session receiving more reasoning blocks before the
+        bg task runs) would otherwise shift the detectors' "exclude
+        self" slice and generate false self-match LOOPING signals.
+        ``session.reasoning_history`` itself is never touched here, so
+        concurrent readers always see the live list.
 
         Never raises: any exception (from the judge LLM, the embedding
         pipeline, or ``_handle_drift``) is logged at ``WARNING`` and
@@ -1831,50 +1827,35 @@ class DriftObserver:
         try:
             from goldfive.drift.reasoning import analyze_reasoning_with_focus
 
-            # Save the shared live history and swap in a list snapshot
-            # truncated to the length captured at schedule time. Using
-            # list slicing (not mutation) keeps any already-escaped
-            # reference (e.g. a concurrent detector) pointing at the
-            # original list. We restore the live reference in a
-            # ``finally`` so intervening appends are not lost.
-            original_history = session.reasoning_history
-            pinned_history = list(original_history[:history_length])
-            session.reasoning_history = pinned_history
-            try:
-                # Phase 1 of goldfive#271 — call the focused-verdict
-                # path so we get the judge's plan-task attribution
-                # alongside the drift signal. ``analyze_reasoning_with_focus``
-                # is a sibling of ``analyze_reasoning`` that threads a
-                # :class:`ReasoningJudgeVerdict` instead of just the
-                # drift; legacy callers of ``analyze_reasoning`` keep
-                # their existing return shape.
-                #
-                # goldfive#244 — also forward the wrapped agent tree so
-                # the judge can recognise legitimate coordinator → sub-
-                # agent delegation as ON-TASK rather than OFF_TOPIC.
-                # Reuses the same shape the planner already consumes
-                # (``ADKAdapter.available_agents_tree``); legacy adapters
-                # without the property fall back to a flat
-                # ``available_agents`` list, and adapters with neither
-                # leave ``available_agents=None`` — the judge prompt
-                # then renders byte-identically to pre-#244.
-                judge_available_agents = self._resolve_available_agents()
-                verdict = await analyze_reasoning_with_focus(
-                    text,
-                    session,
-                    mode=self._steerer._reasoning_drift_mode,
-                    call_llm=call_llm,
-                    model=self._steerer._reasoning_drift_model,
-                    sink=judge_sink,
-                    agent_name=agent_name,
-                    available_agents=judge_available_agents,
-                )
-            finally:
-                # Restore the live history. Any entries appended by
-                # subsequent turns are preserved because we pointed
-                # ``session.reasoning_history`` at a separate list for
-                # our window.
-                session.reasoning_history = original_history
+            # Phase 1 of goldfive#271 — call the focused-verdict
+            # path so we get the judge's plan-task attribution
+            # alongside the drift signal. ``analyze_reasoning_with_focus``
+            # is a sibling of ``analyze_reasoning`` that threads a
+            # :class:`ReasoningJudgeVerdict` instead of just the
+            # drift; legacy callers of ``analyze_reasoning`` keep
+            # their existing return shape.
+            #
+            # goldfive#244 — also forward the wrapped agent tree so
+            # the judge can recognise legitimate coordinator → sub-
+            # agent delegation as ON-TASK rather than OFF_TOPIC.
+            # Reuses the same shape the planner already consumes
+            # (``ADKAdapter.available_agents_tree``); legacy adapters
+            # without the property fall back to a flat
+            # ``available_agents`` list, and adapters with neither
+            # leave ``available_agents=None`` — the judge prompt
+            # then renders byte-identically to pre-#244.
+            judge_available_agents = self._resolve_available_agents()
+            verdict = await analyze_reasoning_with_focus(
+                text,
+                session,
+                mode=self._steerer._reasoning_drift_mode,
+                call_llm=call_llm,
+                model=self._steerer._reasoning_drift_model,
+                sink=judge_sink,
+                agent_name=agent_name,
+                available_agents=judge_available_agents,
+                reasoning_history=pinned_history,
+            )
 
             # Record the reasoning-extracted binding onto the
             # orchestration store regardless of the drift verdict —

--- a/goldfive/events.py
+++ b/goldfive/events.py
@@ -13,7 +13,10 @@ optional-dependency group.
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 # NOTE: EventSink is a protocol with an async ``emit(event_pb)`` method.
 # We type it as ``Any`` here to avoid a circular dependency on the
@@ -102,9 +105,10 @@ async def emit(sinks: list[Any], event_pb: Any) -> None:
     """Fan ``event_pb`` out to every sink concurrently.
 
     Each sink's ``emit`` coroutine is awaited. Exceptions from individual
-    sinks are collected via ``return_exceptions=True`` so one faulty sink
-    cannot prevent others from observing the event. The first exception
-    encountered is re-raised after all sinks have been awaited.
+    sinks are collected via ``return_exceptions=True`` and logged so one
+    faulty sink can neither prevent others from observing the event nor
+    abort the emitting run — sinks are observability, never control flow.
+    ``CancelledError`` is re-raised so task cancellation still propagates.
     """
     if not sinks:
         return
@@ -112,9 +116,15 @@ async def emit(sinks: list[Any], event_pb: Any) -> None:
         *(sink.emit(event_pb) for sink in sinks),
         return_exceptions=True,
     )
-    for r in results:
-        if isinstance(r, BaseException):
+    for sink, r in zip(sinks, results, strict=True):
+        if isinstance(r, asyncio.CancelledError):
             raise r
+        if isinstance(r, BaseException):
+            log.exception(
+                "sink %s.emit raised; event dropped for this sink only",
+                type(sink).__name__,
+                exc_info=r,
+            )
 
 
 def make_event(

--- a/goldfive/reporting/handlers.py
+++ b/goldfive/reporting/handlers.py
@@ -411,9 +411,9 @@ def _clear_correction_on_started(session: Session, task: Task | None) -> None:
     task_id = str(getattr(task, "id", "") or "").strip()
     if not assignee or not task_id:
         return
-    # Normalise the same way the write-side does so keys round-trip.
-    if "." in assignee:
-        assignee = assignee.rsplit(".", 1)[-1]
+    # The write-side keys corrections by the verbatim assignee id
+    # (``_correction_injection._normalize_agent_name``), so the clear
+    # uses the same string and keys round-trip.
     try:
         clear_correction(session, agent_name=assignee, task_id=task_id)
     except Exception as exc:  # noqa: BLE001

--- a/goldfive/reporting/rendering.py
+++ b/goldfive/reporting/rendering.py
@@ -104,10 +104,11 @@ def _next_pending_with_completed_predecessors(plan: Any) -> Any | None:
 def _bare_agent_name(name: str) -> str:
     """Return the bare agent name (last dot-separated segment).
 
-    Mirrors the normalization used by ``_correction_injection`` —
-    fully-qualified ADK agent paths like ``coordinator.research_agent``
-    collapse to ``research_agent`` so the LLM sees a name it can pass
-    back as the AgentTool target.
+    Display-only: fully-qualified ADK agent paths like
+    ``coordinator.research_agent`` collapse to ``research_agent`` so
+    the LLM sees a name it can pass back as the AgentTool target.
+    (Correction keys, by contrast, use the verbatim assignee id — see
+    ``_correction_injection._normalize_agent_name``.)
     """
     s = (name or "").strip()
     if not s:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -357,6 +357,7 @@ _EMBEDDING_ENV: dict[str, str] = {
     "model": "GOLDFIVE_EMBEDDING_MODEL",
     "api_key": "GOLDFIVE_EMBEDDING_API_KEY",
     "timeout_ms": "GOLDFIVE_EMBEDDING_TIMEOUT_MS",
+    "breaker_cooldown_s": "GOLDFIVE_EMBEDDING_BREAKER_COOLDOWN_S",
 }
 
 _STEER_ENV: dict[str, str] = {

--- a/tests/test_correction_injection.py
+++ b/tests/test_correction_injection.py
@@ -817,3 +817,103 @@ def test_pending_correction_key_prefix_is_stable() -> None:
     assert pending_correction_key("a", "t") == "goldfive.pending_corrections.a.t"
     assert is_pending_correction_key("goldfive.pending_corrections.a.t")
     assert not is_pending_correction_key("goldfive.current_task_id")
+
+
+# ---------------------------------------------------------------------------
+# Same-named agents in different subtrees must not share a correction key.
+# ---------------------------------------------------------------------------
+
+
+def _plan_with_same_named_agents(revision_index: int, corrected: bool) -> Plan:
+    tasks = [
+        Task(
+            id="research_a",
+            title="Research (team A)",
+            status=TaskStatus.COMPLETED,
+            assignee_agent_id="team_a.researcher",
+        ),
+        Task(
+            id="research_b",
+            title="Research (team B)",
+            status=TaskStatus.COMPLETED,
+            assignee_agent_id="team_b.researcher",
+        ),
+    ]
+    if corrected:
+        tasks += [
+            Task(
+                id="research_a_corrected",
+                title="Research (team A, corrected)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="team_a.researcher",
+                supersedes="research_a",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+            Task(
+                id="research_b_corrected",
+                title="Research (team B, corrected)",
+                status=TaskStatus.PENDING,
+                assignee_agent_id="team_b.researcher",
+                supersedes="research_b",
+                supersedes_kind=SupersessionKind.CORRECT,
+            ),
+        ]
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=tasks,
+        edges=[],
+        revision_index=revision_index,
+    )
+
+
+def test_same_named_agents_in_different_subtrees_get_distinct_keys() -> None:
+    """Fully-qualified assignee ids are keyed verbatim: corrections for
+    ``team_a.researcher`` and ``team_b.researcher`` land under distinct
+    keys instead of colliding on a shared ``researcher`` entry."""
+    prev = _plan_with_same_named_agents(0, corrected=False)
+    revised = _plan_with_same_named_agents(1, corrected=True)
+    session = _session(prev)
+
+    keys = queue_corrections_for_revision(
+        session=session,
+        revised=revised,
+        prev_plan=prev,
+        drift=_drift(),
+    )
+
+    key_a = pending_correction_key("team_a.researcher", "research_a_corrected")
+    key_b = pending_correction_key("team_b.researcher", "research_b_corrected")
+    assert sorted(keys) == sorted([key_a, key_b])
+    assert session.state[key_a]["agent_name"] == "team_a.researcher"
+    assert session.state[key_b]["agent_name"] == "team_b.researcher"
+    assert session.state[key_a]["superseded_task_id"] == "research_a"
+    assert session.state[key_b]["superseded_task_id"] == "research_b"
+
+
+async def test_full_path_correction_cleared_on_report_task_started() -> None:
+    """The clear on ``report_task_started`` uses the same verbatim
+    assignee id as the write side, so full-path keys round-trip."""
+    plan = _plan_with_same_named_agents(1, corrected=True)
+    session = _session(plan)
+    keys = queue_corrections_for_revision(
+        session=session,
+        revised=plan,
+        prev_plan=None,
+        drift=_drift(),
+    )
+    key_a = pending_correction_key("team_a.researcher", "research_a_corrected")
+    key_b = pending_correction_key("team_b.researcher", "research_b_corrected")
+    assert sorted(keys) == sorted([key_a, key_b])
+
+    steerer = DefaultSteerer()
+    steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
+    await _tool("report_task_started").handler(
+        {"task_id": "research_a_corrected", "detail": "starting"},
+        session,
+        steerer,
+    )
+    # Only team A's correction is acknowledged; team B's survives.
+    assert key_a not in session.state
+    assert key_b in session.state

--- a/tests/test_drift_reasoning.py
+++ b/tests/test_drift_reasoning.py
@@ -880,3 +880,31 @@ async def test_observe_reasoning_truncates_long_trigger_input() -> None:
     # At the 2048-char cap + suffix length.
     assert len(trigger_input) == 2048 + len(" … [truncated]")
 
+
+
+# ---------------------------------------------------------------------------
+# Pinned-history threading (background judge snapshot)
+# ---------------------------------------------------------------------------
+
+
+async def test_analyze_with_focus_honours_pinned_history() -> None:
+    """``reasoning_history`` pins the detectors' window: entries appended
+    to the live session list after the snapshot cannot self-match."""
+    session = _session_with_task()
+    text = "Let me re-examine the slide content and look for typos."
+    # Snapshot at schedule time: ``text`` is the last (and only) entry.
+    pinned = [text]
+    # A later turn appends a byte-identical block to the live list.
+    session.reasoning_history = [text, text]
+
+    verdict = await dreason.analyze_reasoning_with_focus(
+        text, session, mode="embedding", reasoning_history=pinned
+    )
+    assert verdict.drift is None
+
+    # Without the pin the live list is read and the duplicate matches.
+    verdict = await dreason.analyze_reasoning_with_focus(
+        text, session, mode="embedding"
+    )
+    assert verdict.drift is not None
+    assert verdict.drift.kind is DriftKind.LOOPING_REASONING

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -506,3 +506,123 @@ def test_reset_circuit_breaker_clears_state() -> None:
     _embed.reset_circuit_breaker()
     assert _embed._RUNTIME_FAILURE_COUNT == 0
     assert _embed._RUNTIME_FAILURE_TRIPPED is False
+
+
+# ---------------------------------------------------------------------------
+# Runtime circuit breaker: timed half-open recovery
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_clock(
+    monkeypatch: pytest.MonkeyPatch, start: float = 1000.0
+) -> dict[str, float]:
+    """Replace ``_embed.time`` with a controllable monotonic clock."""
+    import types
+
+    clock = {"t": start}
+    monkeypatch.setattr(
+        _embed, "time", types.SimpleNamespace(monotonic=lambda: clock["t"])
+    )
+    return clock
+
+
+def _make_working_backend() -> Any:
+    """Build a backend whose httpx path always returns one unit vector."""
+
+    class _OK:
+        def post(self, *args: Any, **kwargs: Any) -> Any:
+            class _Resp:
+                def raise_for_status(self) -> None:
+                    pass
+
+                def json(self) -> dict[str, Any]:
+                    return _canonical_response([[1.0, 0.0]])
+
+            return _Resp()
+
+    backend = _embed._OpenAIEmbeddingBackend(
+        base_url="http://alive:9999",
+        model="",
+        api_key=None,
+        timeout_ms=1000,
+    )
+    backend._prefer_sdk = False
+    backend._openai_client = None
+    backend._httpx_client = _OK()
+    return backend
+
+
+def test_circuit_breaker_half_open_probe_failure_reopens_success_closes(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    goldfive_embedding_env: Any,
+) -> None:
+    """A tripped breaker admits one probe per cooldown; a failed probe
+    re-opens it and restarts the cooldown, a successful one closes it."""
+    clock = _install_fake_clock(monkeypatch)
+    goldfive_embedding_env.set(base_url="http://dead:9999")
+    failing = _make_always_failing_backend()
+    _embed.set_backend_loader(lambda _url: failing)
+    request.addfinalizer(lambda: _embed.set_backend_loader(None))
+
+    for _ in range(3):
+        failing.encode(["x"])
+    assert _embed._MODEL_UNAVAILABLE is True
+
+    # Open: cooldown not elapsed -- still short-circuits.
+    clock["t"] += 59.0
+    assert _embed._get_model() is None
+
+    # Half-open: cooldown elapsed -- one probe encode is admitted.
+    clock["t"] += 2.0
+    assert _embed._get_model() is failing
+
+    # Probe fails: breaker re-opens immediately and the cooldown restarts.
+    assert failing.encode(["y"]) == []
+    assert _embed._MODEL_UNAVAILABLE is True
+    assert _embed._RUNTIME_FAILURE_TRIPPED is True
+    clock["t"] += 59.0
+    assert _embed._get_model() is None
+
+    # Next probe succeeds: the breaker closes and stays closed.
+    clock["t"] += 2.0
+    working = _make_working_backend()
+    _embed.set_backend_loader(lambda _url: working)
+    model = _embed._get_model()
+    assert model is working
+    assert model.encode(["z"]) == [[1.0, 0.0]]
+    assert _embed._MODEL_UNAVAILABLE is False
+    assert _embed._RUNTIME_FAILURE_TRIPPED is False
+    assert _embed._RUNTIME_FAILURE_COUNT == 0
+    assert _embed._get_model() is working
+
+
+def test_circuit_breaker_cooldown_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    goldfive_embedding_env: Any,
+) -> None:
+    """``GOLDFIVE_EMBEDDING_BREAKER_COOLDOWN_S`` shortens the cooldown."""
+    clock = _install_fake_clock(monkeypatch)
+    goldfive_embedding_env.set(base_url="http://dead:9999", breaker_cooldown_s="5")
+    failing = _make_always_failing_backend()
+    _embed.set_backend_loader(lambda _url: failing)
+    request.addfinalizer(lambda: _embed.set_backend_loader(None))
+
+    for _ in range(3):
+        failing.encode(["x"])
+    clock["t"] += 4.0
+    assert _embed._get_model() is None
+    clock["t"] += 1.5
+    assert _embed._get_model() is failing
+
+
+def test_import_unavailability_has_no_timed_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-tripped unavailability (import failure / ``force_unavailable``)
+    keeps the pre-existing process-lifetime semantics."""
+    clock = _install_fake_clock(monkeypatch)
+    _embed.force_unavailable()
+    clock["t"] += 10_000.0
+    assert _embed._get_model() is None

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -619,3 +619,91 @@ def test_delegation_observed_event_wire_bytes_change_only_when_tool_args_passed(
     )
     evt_with_args.emitted_at.CopyFrom(evt_empty.emitted_at)
     assert evt_empty.SerializeToString() != evt_with_args.SerializeToString()
+
+
+# ---------------------------------------------------------------------------
+# emit: fan-out isolation
+# ---------------------------------------------------------------------------
+
+
+class _RaisingSink:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def emit(self, event_pb: object) -> None:
+        self.calls += 1
+        raise RuntimeError("sink is broken")
+
+    async def close(self) -> None:
+        return None
+
+
+async def test_emit_logs_and_swallows_sink_exceptions(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raising sink is logged with its class name; siblings still see
+    the event and the caller never observes the exception."""
+    import logging
+
+    from goldfive.events import emit, new_event
+    from goldfive.sinks import InMemorySink
+
+    bad = _RaisingSink()
+    good = InMemorySink()
+    evt = new_event(run_id="r1", sequence=0)
+
+    with caplog.at_level(logging.ERROR, logger="goldfive.events"):
+        await emit([bad, good], evt)
+
+    assert bad.calls == 1
+    assert [e.sequence for e in good.events] == [0]
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("_RaisingSink" in m for m in messages)
+
+
+async def test_runner_survives_raising_sink() -> None:
+    """Lifecycle emits in Runner.run must not abort the turn when a
+    sink raises (documented fan-out isolation)."""
+    from goldfive import (
+        CallableAdapter,
+        InMemorySink,
+        InvocationResult,
+        Plan,
+        ReportingToolSpec,
+        Runner,
+        SequentialExecutor,
+        Session,
+        StaticPlanner,
+    )
+
+    async def agent(
+        task: Task, session: Session, tools: list[ReportingToolSpec]
+    ) -> InvocationResult:
+        return InvocationResult(task_id=task.id, text=task.title)
+
+    plan = Plan(
+        id="p",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[Task(id="t1", title="a", assignee_agent_id="worker")],
+        edges=[],
+        summary="",
+    )
+    bad = _RaisingSink()
+    good = InMemorySink()
+    runner = Runner(
+        agent=CallableAdapter(agent, available_agents=["worker"]),
+        planner=StaticPlanner(plan),
+        executor=SequentialExecutor(),
+        sinks=[bad, good],
+    )
+    outcome = await runner.run("go")
+    await runner.close()
+
+    assert outcome.success
+    assert bad.calls > 0
+    kinds = [
+        e.WhichOneof("payload") for e in good.events if hasattr(e, "DESCRIPTOR")
+    ]
+    assert "run_started" in kinds
+    assert "task_completed" in kinds

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -702,8 +702,6 @@ async def test_runner_survives_raising_sink() -> None:
 
     assert outcome.success
     assert bad.calls > 0
-    kinds = [
-        e.WhichOneof("payload") for e in good.events if hasattr(e, "DESCRIPTOR")
-    ]
+    kinds = [e.WhichOneof("payload") for e in good.events if hasattr(e, "DESCRIPTOR")]
     assert "run_started" in kinds
     assert "task_completed" in kinds

--- a/tests/test_judge_task_lifetime.py
+++ b/tests/test_judge_task_lifetime.py
@@ -366,3 +366,57 @@ async def test_synchronous_tool_flow_unaffected_by_late_drift_guard() -> None:
         "still reach planner.refine; got "
         f"{len(planner.refine_calls)} call(s)"
     )
+
+
+# ---------------------------------------------------------------------------
+# Shared-state safety: the judge never mutates session.reasoning_history
+# ---------------------------------------------------------------------------
+
+
+async def test_judge_never_mutates_session_reasoning_history() -> None:
+    """The background judge receives its history snapshot as an explicit
+    argument; ``session.reasoning_history`` keeps its identity and its
+    live contents for the whole judge round-trip, so concurrent readers
+    (and appends from later turns) are never affected."""
+    session = _session()
+    live_history = session.reasoning_history
+    seen: dict[str, Any] = {}
+
+    async def slow_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        # Runs mid-judge: the session must still expose the live list.
+        seen["identity_mid_judge"] = session.reasoning_history
+        seen["contents_mid_judge"] = list(session.reasoning_history)
+        await asyncio.sleep(0.05)
+        seen["identity_after_sleep"] = session.reasoning_history
+        return json.dumps({"on_task": True})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=slow_call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    await steerer.drift.observe_reasoning("first reasoning block", session=session)
+    # Let the background judge start and enter the slow LLM call.
+    await asyncio.sleep(0)
+    # A later turn appends while the judge is in flight.
+    session.reasoning_history.append("second reasoning block")
+
+    pending = list(steerer._background_judges)
+    results = await asyncio.gather(*pending, return_exceptions=True)
+    for r in results:
+        assert not isinstance(r, BaseException), (
+            f"background judge raised {r!r}; expected clean completion"
+        )
+
+    assert seen["identity_mid_judge"] is live_history
+    assert seen["identity_after_sleep"] is live_history
+    assert seen["contents_mid_judge"] == ["first reasoning block"]
+    # The mid-flight append landed on the live list and survived.
+    assert session.reasoning_history is live_history
+    assert session.reasoning_history == [
+        "first reasoning block",
+        "second reasoning block",
+    ]

--- a/tests/test_reasoning_judge.py
+++ b/tests/test_reasoning_judge.py
@@ -180,7 +180,9 @@ async def test_on_task_false_maps_severity(
     assert drift.current_agent_id == "a1"
 
 
-async def test_missing_severity_defaults_to_warning() -> None:
+async def test_missing_severity_defaults_to_info() -> None:
+    # INFO, not WARNING: a malformed severity must not make the drift
+    # promotion-eligible (_should_promote_to_steer gates on WARNING+).
     call_llm = _stub_call_llm([{"on_task": False, "reason": "drifted"}])
     drift = await rjudge.classify_reasoning_drift(
         reasoning="off-topic thought",
@@ -190,10 +192,10 @@ async def test_missing_severity_defaults_to_warning() -> None:
         call_llm=call_llm,
     )
     assert drift is not None
-    assert drift.severity is DriftSeverity.WARNING
+    assert drift.severity is DriftSeverity.INFO
 
 
-async def test_unknown_severity_defaults_to_warning() -> None:
+async def test_unknown_severity_defaults_to_info() -> None:
     call_llm = _stub_call_llm([{"on_task": False, "severity": "CATASTROPHIC"}])
     drift = await rjudge.classify_reasoning_drift(
         reasoning="off-topic thought",
@@ -203,7 +205,7 @@ async def test_unknown_severity_defaults_to_warning() -> None:
         call_llm=call_llm,
     )
     assert drift is not None
-    assert drift.severity is DriftSeverity.WARNING
+    assert drift.severity is DriftSeverity.INFO
 
 
 async def test_tolerates_markdown_fenced_json() -> None:


### PR DESCRIPTION
Five small verified fixes across the judge, embedding, event, and correction surfaces. One commit each.

## 1. Malformed judge severity is no longer promotion-eligible

**Problem.** `goldfive/drift/reasoning_judge.py:671-674`: `_severity_from_verdict` silently defaulted missing/unknown severity strings to `WARNING` — exactly the tier `DriftObserver._should_promote_to_steer` gates on (`drift_observer.py:4791-4799`, default threshold `"warning"`). A judge that emitted `"severity": "CATASTROPHIC"` (or omitted the field) produced a steer-promotable drift by accident.

**Fix.** Fallback is now `INFO` with a debug log; `info` / `warning` / `critical` map unchanged. The verdict is still emitted (never swallowed) — it just cannot cross the intervention threshold on a parse artifact.

**Tests.** `test_missing_severity_defaults_to_info`, `test_unknown_severity_defaults_to_info` (renamed from `..._to_warning` — they asserted the buggy fallback).

## 2. Embedding circuit breaker recovers via timed half-open probe

**Problem.** `goldfive/drift/_embed.py:490-528`: after 3 consecutive encode failures the breaker latched `_MODEL_UNAVAILABLE` for the process lifetime (reset only via test hooks). A transient endpoint outage permanently disabled every embedding detector.

**Fix.** Trip now stamps a monotonic timestamp. After `_RUNTIME_RECOVERY_COOLDOWN_S` (60s; `GOLDFIVE_EMBEDDING_BREAKER_COOLDOWN_S` overrides, same env pattern as `GOLDFIVE_EMBEDDING_TIMEOUT_MS`) `_get_model` admits one probe encode: success closes the breaker (`_note_backend_success`), failure re-opens it and restarts the cooldown (`_note_backend_failure`). Import-failure / `force_unavailable()` unavailability keeps its no-recovery semantics. The trip WARNING now names the cooldown instead of "for this process".

**Tests.** Fake monotonic clock via a module-attribute shim: probe-failure-reopens / probe-success-closes, env override, and no-timed-recovery for import-failure unavailability. `GOLDFIVE_EMBEDDING_BREAKER_COOLDOWN_S` added to the `goldfive_embedding_env` fixture allow-list.

## 3. One faulty sink no longer aborts a run

**Problem.** `goldfive/events.py:101-117`: `emit()` fanned out with `return_exceptions=True` but then re-raised the first sink exception. Runner lifecycle emit sites (`runner.py` `_emit_run_started` / `_emit_goal_derived` and ~40 sibling call sites) are unwrapped, so a raising sink aborted the turn — contradicting the documented fan-out isolation intent.

**Fix.** `emit()` now logs each sink exception (`log.exception` with the sink class name) and continues. `CancelledError` is still re-raised so task cancellation propagates. No caller depends on propagation (the handful of try/except wrappers around `emit` already swallowed), so no `raise_on_error` parameter was needed.

**Tests.** `test_emit_logs_and_swallows_sink_exceptions` (bad sink logged by name, sibling still receives), `test_runner_survives_raising_sink` (full `Runner.run` with a raising sink completes successfully and the good sink sees `run_started` / `task_completed`).

## 4. Correction keys no longer collide across same-named agents

**Problem.** `goldfive/_correction_injection.py:122-142`: `_bare_agent_name` keyed `goldfive.pending_corrections.<agent>.<task>` by the LAST dot-segment of the assignee id, so plans assigning `team_a.researcher` and `team_b.researcher` collided on one `researcher` key family.

**Fix.** Renamed to `_normalize_agent_name`; keys use the verbatim (whitespace-stripped) assignee id. `_clear_correction_on_started` (`reporting/handlers.py:415-417`) dropped its mirrored dot-strip so clears round-trip. `reporting/rendering.py._bare_agent_name` (display-only) is unchanged; its stale "mirrors `_correction_injection`" docstring was corrected.

**No read-side fallback for old bare keys:** the keys are process-transient — written on plan revision, cleared on `report_task_started` ack or the next revision, and `reconstruct_session` never restores them — so no persisted state can contain the old format.

**Behavior note.** In supported flows nothing changes: the planner normalizes assignees to bare names validated against `available_agents`, and ADK agent names contain no dots, so write and read keys are byte-identical before and after. For plans that hand-author dotted assignee ids, the correction now stays keyed to the exact assignee instead of being silently collapsed onto (and potentially delivered to / clobbered by) a different same-named agent.

**Tests.** `test_same_named_agents_in_different_subtrees_get_distinct_keys` (two CORRECT-kind supersedes for `team_a.researcher` / `team_b.researcher` produce two distinct keys with per-agent payloads) and `test_full_path_correction_cleared_on_report_task_started` (write/clear round-trip on full-path keys; the sibling agent's correction survives).

## 5. Judge history pinning without shared-state mutation

**Problem.** `goldfive/drift_observer.py:1840-1877`: `_run_judge_background` save/swap/restored `session.reasoning_history` around the judge await so detectors saw a pinned snapshot — fragile shared-state mutation that breaks any concurrent reader (and loses mid-flight appends onto the swapped-in list).

**Fix.** The scheduler snapshots `list(session.reasoning_history)` at schedule time and `_run_judge_background` forwards it as `analyze_reasoning_with_focus(..., reasoning_history=...)`. The parameter threads to `_embedding_pipeline` → `detect_looping_reasoning` / `detect_reasoning_cluster_tightening`, each defaulting to the live `session.reasoning_history` (current behavior) when unset. The swap/restore is deleted; `session.reasoning_history` is never reassigned. Snapshotting contents (not a length index) also makes the pin robust to the `reasoning_history_max` cap trimming entries between schedule and run. Caller-supplied `embedding_pipeline` test seams keep their `(text, session)` signature.

**Tests.** `test_judge_never_mutates_session_reasoning_history` (slow fake judge; identity + contents of the live list asserted mid-flight, mid-flight append survives) and `test_analyze_with_focus_honours_pinned_history` (pinned snapshot suppresses the false self-match a live duplicate would cause; live path still fires).

## Modes

`observation_only=True` (production default) and active mode both exercised: the full suite (2806 passed, 59 skipped) covers both, including `tests/test_observation_only.py` over the judge dispatch path. Fixes 2-5 are mode-independent surfaces (backend availability, event fan-out, state keying, snapshot plumbing); fix 1 only lowers what active mode may promote — observe-only emission is unchanged.

## Test plan

- `uv run pytest -q` — 2806 passed, 59 skipped.
- `uv run ruff check .` — clean. Touched files format-checked (repo-wide `ruff format --check` fails pre-existing on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA
