### PR TITLE
fix: gate F3 pre-dispatch redirect on observation_only; align its predicate with the delegation pin

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -586,6 +586,45 @@ def _agent_has_pending_candidates(ctx: Any, agent_name: str) -> bool:
     return False
 
 
+def _completed_task_ids(tasks: Any) -> set[str]:
+    """Return the ids of tasks whose status is COMPLETED."""
+    from goldfive.types import TaskStatus
+
+    out: set[str] = set()
+    for t in tasks or ():
+        if _safe_attr(t, "status", None) is TaskStatus.COMPLETED:
+            tid = str(_safe_attr(t, "id", "") or "")
+            if tid:
+                out.add(tid)
+    return out
+
+
+def _predecessors_completed(task_id: str, *, edges: Any, completed_ids: set[str]) -> bool:
+    """True iff every incoming-edge predecessor of ``task_id`` is COMPLETED.
+
+    The single DAG-readiness predicate shared by the delegation-pin
+    paths (:meth:`_GoldfiveADKPlugin._pin_delegation_task_id`,
+    :meth:`_GoldfiveADKPlugin._maybe_pin_delegation_task`) and the F3
+    pre-dispatch redirect (:func:`_maybe_redirect_completed_agent`).
+
+    COMPLETED — not merely terminal — is the semantics that won when F3
+    was aligned with the pin paths: a FAILED / CANCELLED / NOT_NEEDED
+    predecessor produced no output for a successor to consume, so the
+    pins never bind such a successor. F3's original local copy counted
+    merely-terminal predecessors, so a NOT_NEEDED sweep could make F3
+    refuse-and-redirect toward a task the pin machinery would then
+    decline to pin. A task with no incoming edges trivially passes.
+    """
+    for e in edges or ():
+        to_id = str(_safe_attr(e, "to_task_id", "") or "")
+        if to_id != task_id:
+            continue
+        from_id = str(_safe_attr(e, "from_task_id", "") or "")
+        if from_id and from_id not in completed_ids:
+            return False
+    return True
+
+
 def _maybe_redirect_completed_agent(
     *,
     ctx: Any,
@@ -613,6 +652,11 @@ def _maybe_redirect_completed_agent(
     completed task and re-invokes the same agent because nothing told
     it to stop. F1's directive payload is the proactive anchor; this
     is the structural fence.
+
+    ``next_pending`` uses the delegation pin's DAG-readiness predicate
+    (:func:`_predecessors_completed` — COMPLETED predecessors, not
+    merely terminal) so a redirect never points at a task the pin
+    would decline to bind.
     """
     if not target_agent:
         return None
@@ -648,18 +692,12 @@ def _maybe_redirect_completed_agent(
             return None
 
         # All assigned tasks are terminal. Find the next PENDING task
-        # whose every predecessor is terminal — same definition the F1
-        # plan_state helper uses, kept local so this module stays
-        # decoupled from goldfive.reporting.
+        # whose every predecessor is COMPLETED — the same readiness
+        # predicate the delegation pin uses, so F3 never redirects the
+        # coordinator toward a task the pin would decline to bind (see
+        # :func:`_predecessors_completed` for the semantics rationale).
         edges = list(_safe_attr(plan, "edges", None) or ())
-        by_id = {str(_safe_attr(t, "id", "") or ""): t for t in tasks}
-        incoming: dict[str, list[str]] = {tid: [] for tid in by_id}
-        for e in edges:
-            to_id = str(_safe_attr(e, "to_task_id", "") or "")
-            from_id = str(_safe_attr(e, "from_task_id", "") or "")
-            if to_id in incoming and from_id:
-                incoming[to_id].append(from_id)
-
+        completed_ids = _completed_task_ids(tasks)
         next_pending: Any = None
         for task in tasks:
             if _safe_attr(task, "status", None) is not TaskStatus.PENDING:
@@ -667,12 +705,7 @@ def _maybe_redirect_completed_agent(
             tid = str(_safe_attr(task, "id", "") or "")
             if not tid:
                 continue
-            preds = incoming.get(tid, [])
-            if all(
-                by_id.get(p) is not None
-                and _safe_attr(by_id[p], "status", None) in TERMINAL_TASK_STATUSES
-                for p in preds
-            ):
+            if _predecessors_completed(tid, edges=edges, completed_ids=completed_ids):
                 next_pending = task
                 break
 
@@ -1550,6 +1583,44 @@ async def _emit_approval_requested_from_plugin(
         await emit(sinks, evt)
     except Exception as exc:  # noqa: BLE001
         log.debug("_emit_approval_requested_from_plugin: sink emit failed: %s", exc)
+
+
+async def _emit_policy_applied_from_plugin(
+    *,
+    session: Any,
+    steerer: Any,
+    policy_name: str,
+    outcome: str,
+    reason: str = "",
+    detail: str = "",
+) -> None:
+    """Emit a ``PolicyApplied`` envelope from a plugin callback.
+
+    Mirrors ``DriftObserver._emit_policy_applied`` for decision
+    telemetry that originates inside the ADK plugin (e.g. the F3
+    redirect suppressed by the observation-only gate). Best-effort;
+    any failure is logged at DEBUG and dropped.
+    """
+    sinks = getattr(steerer, "_sinks", None) or []
+    if not sinks:
+        return
+    try:
+        from goldfive.events import emit, policy_applied_event
+
+        seq, event_id = session.next_sequence_and_event_id()
+        evt = policy_applied_event(
+            str(getattr(session, "run_id", "") or ""),
+            seq,
+            policy_name=policy_name,
+            outcome=outcome,
+            reason=reason,
+            detail=detail,
+            session_id=str(getattr(session, "id", "") or ""),
+            event_id=event_id,
+        )
+        await emit(sinks, evt)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("_emit_policy_applied_from_plugin: sink emit failed: %s", exc)
 
 
 def _jsonable(v: Any) -> Any:
@@ -3741,22 +3812,7 @@ def make_adk_plugin(
             edges = _safe_attr(plan, "edges", None) or ()
             from goldfive.types import TaskStatus
 
-            completed_ids: set[str] = set()
-            for t in tasks:
-                if _safe_attr(t, "status", None) is TaskStatus.COMPLETED:
-                    tid = str(_safe_attr(t, "id", "") or "")
-                    if tid:
-                        completed_ids.add(tid)
-
-            def _upstream_ok(task_id: str) -> bool:
-                for e in edges:
-                    to_id = str(_safe_attr(e, "to_task_id", "") or "")
-                    if to_id != task_id:
-                        continue
-                    from_id = str(_safe_attr(e, "from_task_id", "") or "")
-                    if from_id and from_id not in completed_ids:
-                        return False
-                return True
+            completed_ids = _completed_task_ids(tasks)
 
             candidates: list[Any] = []
             for task in tasks:
@@ -3767,7 +3823,9 @@ def make_adk_plugin(
                 if status is not TaskStatus.PENDING and status is not TaskStatus.RUNNING:
                     continue
                 tid = str(_safe_attr(task, "id", "") or "")
-                if not tid or not _upstream_ok(tid):
+                if not tid or not _predecessors_completed(
+                    tid, edges=edges, completed_ids=completed_ids
+                ):
                     continue
                 candidates.append(task)
 
@@ -4146,29 +4204,16 @@ def make_adk_plugin(
                 return
 
             edges = tuple(_safe_attr(plan, "edges", None) or ())
-            completed_ids: set[str] = set()
-            for t in tasks:
-                if _safe_attr(t, "status", None) is TaskStatus.COMPLETED:
-                    tid = str(_safe_attr(t, "id", "") or "")
-                    if tid:
-                        completed_ids.add(tid)
-
-            def _upstream_ok(task_id: str) -> bool:
-                for e in edges:
-                    to_id = str(_safe_attr(e, "to_task_id", "") or "")
-                    if to_id != task_id:
-                        continue
-                    from_id = str(_safe_attr(e, "from_task_id", "") or "")
-                    if from_id and from_id not in completed_ids:
-                        return False
-                return True
+            completed_ids = _completed_task_ids(tasks)
 
             eligible: list[Any] = []
             for task in tasks:
                 if _safe_attr(task, "status", None) is not TaskStatus.PENDING:
                     continue
                 tid = str(_safe_attr(task, "id", "") or "")
-                if not tid or not _upstream_ok(tid):
+                if not tid or not _predecessors_completed(
+                    tid, edges=edges, completed_ids=completed_ids
+                ):
                     continue
                 eligible.append(task)
 
@@ -5874,6 +5919,8 @@ def make_adk_plugin(
                 # next_pending task assigned to a *different* agent,
                 # refuse the dispatch with a redirect error so the
                 # coordinator stops re-invoking a completed-work agent.
+                # Active mode only — under observation_only the refusal
+                # is suppressed (telemetry-only) below.
                 # The post-hoc PLAN_DIVERGENCE detector still exists as
                 # a safety net, but closing the loop at the dispatch
                 # point eliminates the round-trip-and-detect cost.
@@ -5887,13 +5934,38 @@ def make_adk_plugin(
                     target_agent=to_agent,
                 )
                 if redirect is not None:
-                    log.info(
-                        "before_tool_callback: F3 redirect — all plan tasks "
-                        "for %s are terminal; redirecting coordinator to %s",
-                        to_agent,
-                        redirect.get("redirect_to") or "?",
-                    )
-                    return redirect
+                    # Observation-only gate (strict-passive pattern from
+                    # goldfive#254/#271): refusing the dispatch is an
+                    # intervention. Log + telemetry only; the AgentTool
+                    # dispatch proceeds untouched.
+                    if _is_observation_only(ctx):
+                        log.info(
+                            "before_tool_callback: observation_only=True — "
+                            "F3 redirect for %s SUPPRESSED (would have "
+                            "redirected coordinator to %s); dispatch proceeds",
+                            to_agent,
+                            redirect.get("redirect_to") or "?",
+                        )
+                        await _emit_policy_applied_from_plugin(
+                            session=ctx.session,
+                            steerer=ctx.steerer,
+                            policy_name="observation_only_gate",
+                            outcome="suppressed",
+                            reason="observation_only=True",
+                            detail=(
+                                f"intervention=f3_predispatch_redirect "
+                                f"target_agent={to_agent} "
+                                f"redirect_to={redirect.get('redirect_to') or ''}"
+                            ),
+                        )
+                    else:
+                        log.info(
+                            "before_tool_callback: F3 redirect — all plan tasks "
+                            "for %s are terminal; redirecting coordinator to %s",
+                            to_agent,
+                            redirect.get("redirect_to") or "?",
+                        )
+                        return redirect
                 # Fall through: AgentTool still runs, we're just observing.
 
             # Tool-level approval (Flow B). If the tool opts into

--- a/tests/test_tier1_loop_prevention.py
+++ b/tests/test_tier1_loop_prevention.py
@@ -362,6 +362,235 @@ def test_f3_allows_dispatch_when_next_pending_is_same_agent() -> None:
     assert _maybe_redirect_completed_agent(ctx=ctx, target_agent="researcher") is None
 
 
+def test_f3_not_needed_swept_predecessor_no_longer_causes_refusal() -> None:
+    """F3 predicate alignment: a PENDING task behind a NOT_NEEDED-swept
+    predecessor is NOT pin-ready (the delegation pin requires COMPLETED
+    predecessors), so F3 must not treat it as ``next_pending`` and
+    refuse a dispatch the pin machinery would let fall through.
+
+    Pre-fix F3 counted merely-terminal predecessors: t2's predecessors
+    (COMPLETED t1 + NOT_NEEDED t_pre) both passed, so F3 refused the
+    researcher dispatch and redirected toward a task the pin would then
+    decline to bind."""
+    from goldfive.adapters._adk_plugin import (
+        _completed_task_ids,
+        _maybe_redirect_completed_agent,
+        _predecessors_completed,
+    )
+
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Research",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="t_pre",
+                title="Optional prep",
+                assignee_agent_id="helper",
+                status=TaskStatus.NOT_NEEDED,
+            ),
+            Task(
+                id="t2",
+                title="Draft",
+                assignee_agent_id="writer",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[
+            TaskEdge(from_task_id="t1", to_task_id="t2"),
+            TaskEdge(from_task_id="t_pre", to_task_id="t2"),
+        ],
+    )
+    ctx = _ctx_for_plan(plan)
+
+    # Pin-side readiness agrees: t2 is not DAG-ready because t_pre is
+    # NOT_NEEDED, not COMPLETED.
+    completed = _completed_task_ids(plan.tasks)
+    assert not _predecessors_completed("t2", edges=plan.edges, completed_ids=completed)
+
+    assert _maybe_redirect_completed_agent(ctx=ctx, target_agent="researcher") is None
+
+
+def test_f3_still_redirects_when_unrelated_task_swept_not_needed() -> None:
+    """F3: a NOT_NEEDED sweep on a task that is NOT a predecessor of the
+    next pending task must not suppress a legitimate redirect."""
+    from goldfive.adapters._adk_plugin import _maybe_redirect_completed_agent
+
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Research",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="t_opt",
+                title="Optional extra",
+                assignee_agent_id="helper",
+                status=TaskStatus.NOT_NEEDED,
+            ),
+            Task(
+                id="t2",
+                title="Draft",
+                assignee_agent_id="writer",
+                status=TaskStatus.PENDING,
+            ),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    ctx = _ctx_for_plan(plan)
+
+    result = _maybe_redirect_completed_agent(ctx=ctx, target_agent="researcher")
+    assert result is not None
+    assert result["redirect_to"] == "writer"
+
+
+# ---------------------------------------------------------------------------
+# F3 — observation-only gate at the before_tool_callback dispatch point
+# ---------------------------------------------------------------------------
+
+
+class _StubSteererWithFlag:
+    def __init__(self, *, observation_only: bool, sinks: list[Any]) -> None:
+        self._observation_only = observation_only
+        self._sinks = sinks
+
+
+def _plugin_redirect_harness(
+    monkeypatch: pytest.MonkeyPatch, *, observation_only: bool
+) -> tuple[Any, Any, _ListSink]:
+    """Build a plugin + AgentTool call harness with a canned F3 redirect.
+
+    ``_maybe_redirect_completed_agent`` is monkeypatched to always
+    return a redirect so the gate at the dispatch point is exercised
+    independently of the pin hook (which, on a live plan, binds the
+    next ready task to the invoked agent before F3 runs). The predicate
+    itself is covered by the helper-level tests above."""
+    pytest.importorskip("google.adk")
+    from goldfive.adapters import _adk_plugin as plugin_mod
+
+    plugin = plugin_mod.make_adk_plugin(host_agent_name="coord")
+    sink = _ListSink()
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="t1",
+                title="Research",
+                assignee_agent_id="researcher",
+                status=TaskStatus.COMPLETED,
+            ),
+        ],
+        edges=[],
+    )
+    session = Session(run_id="r1", goals=[Goal(id="g1", summary="x")], plan=plan)
+    ctx_obj = plugin_mod.SessionContext(
+        session=session,
+        steerer=_StubSteererWithFlag(observation_only=observation_only, sinks=[sink]),
+        task=None,
+        tool_handlers={},
+        host_agent_name="coord",
+    )
+    plugin.set_active_context(ctx_obj)
+
+    monkeypatch.setattr(
+        plugin_mod,
+        "_maybe_redirect_completed_agent",
+        lambda **_kw: {
+            "error": "All plan tasks for researcher are complete.",
+            "redirect_to": "writer",
+        },
+    )
+
+    class _FakeAgent:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class _FakeAgentTool:
+        def __init__(self, agent_name: str) -> None:
+            self.agent = _FakeAgent(agent_name)
+            self.name = agent_name
+
+    class _FakeInvocationContext:
+        def __init__(self, state: dict, agent_name: str) -> None:
+            class _ADKSession:
+                def __init__(self, state: dict) -> None:
+                    self.state = state
+
+            self.session = _ADKSession(state)
+            self.invocation_id = "inv-1"
+            self.agent = _FakeAgent(agent_name)
+
+    class _FakeToolContext:
+        def __init__(self, inv_ctx: Any) -> None:
+            self._invocation_context = inv_ctx
+            self.function_call_id = "fc-1"
+
+    adk_state: dict[str, Any] = {plugin_mod.SESSION_CONTEXT_STATE_KEY: ctx_obj}
+    tool_ctx = _FakeToolContext(_FakeInvocationContext(adk_state, "coord"))
+    return plugin, (_FakeAgentTool("researcher"), tool_ctx), sink
+
+
+def _policy_applied_events(sink: _ListSink) -> list[Any]:
+    return [
+        e
+        for e in sink.events
+        if hasattr(e, "DESCRIPTOR") and e.WhichOneof("payload") == "policy_applied"
+    ]
+
+
+async def test_f3_redirect_suppressed_under_observation_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """observation_only=True: the F3 refusal is an intervention and must
+    not fire — the AgentTool dispatch proceeds untouched and the
+    would-have-redirected decision lands as PolicyApplied telemetry."""
+    plugin, (tool, tool_ctx), sink = _plugin_redirect_harness(monkeypatch, observation_only=True)
+
+    res = await plugin.before_tool_callback(
+        tool=tool, tool_args={"request": "go"}, tool_context=tool_ctx
+    )
+
+    assert res is None
+    events = _policy_applied_events(sink)
+    assert len(events) == 1
+    payload = events[0].policy_applied
+    assert payload.policy_name == "observation_only_gate"
+    assert payload.outcome == "suppressed"
+    assert payload.reason == "observation_only=True"
+    assert "intervention=f3_predispatch_redirect" in payload.detail
+    assert "target_agent=researcher" in payload.detail
+    assert "redirect_to=writer" in payload.detail
+
+
+async def test_f3_redirect_still_refuses_in_active_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """observation_only=False: the refusal short-circuits the dispatch
+    with the redirect payload, and no suppression telemetry is emitted."""
+    plugin, (tool, tool_ctx), sink = _plugin_redirect_harness(monkeypatch, observation_only=False)
+
+    res = await plugin.before_tool_callback(
+        tool=tool, tool_args={"request": "go"}, tool_context=tool_ctx
+    )
+
+    assert isinstance(res, dict)
+    assert res["redirect_to"] == "writer"
+    assert _policy_applied_events(sink) == []
+
+
 # ---------------------------------------------------------------------------
 # F4 — NUDGE for GOAL_DRIFT
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Two defects in the Tier 1 / F3 pre-dispatch AgentTool redirect:

1. **F3 intervenes in observation-only mode.** The redirect at the `before_tool_callback` dispatch point (`goldfive/adapters/_adk_plugin.py:5934`, pre-fix ~5887) returned the refusal payload unconditionally — a passive observer (`observation_only=True`, the production default) could block a legitimate delegation. Every other steering surface in this file is gated via `_is_observation_only(ctx)` (#476, #271 strict-passive pattern); F3 was not.

2. **F3's next-pending predicate diverged from the delegation pin's.** F3 counted merely-*terminal* predecessors (`TERMINAL_TASK_STATUSES`, pre-fix `_adk_plugin.py:651-676`) while both delegation-pin paths (`_pin_delegation_task_id`, `_maybe_pin_delegation_task`) require *COMPLETED* predecessors. After a NOT_NEEDED sweep (overlay reap, `declare_task_not_needed`), F3 could find a "next pending" task the pin machinery would decline to bind, and refuse a dispatch that should have fallen through as effectively-done.

## Fix

- **Observation-only gate** at the dispatch point: when `_is_observation_only(ctx)` is true, the redirect decision is logged and emitted as `PolicyApplied(policy_name="observation_only_gate", outcome="suppressed", detail="intervention=f3_predispatch_redirect ...")` — the same decision-telemetry pattern #475 established in `drift_observer.py` — and the AgentTool dispatch proceeds untouched. Active mode keeps refusing exactly as before. New best-effort emit helper `_emit_policy_applied_from_plugin` mirrors `DriftObserver._emit_policy_applied`.
- **Predicate alignment**: extracted the pin's readiness predicate into one shared helper, `_predecessors_completed` (+ `_completed_task_ids`), now used by F3 and both pin paths (which previously carried two identical local `_upstream_ok` closures). COMPLETED-predecessor semantics won — the helper's docstring records why: a FAILED / CANCELLED / NOT_NEEDED predecessor produced no output for a successor to consume (NOT_NEEDED marks work the reconciler deemed skipped/superseded, `types.py:75-80`; nothing downstream can consume its nonexistent output), the pins never bind such a successor, and the looser predicate is what made F3 redirect toward a task the pin would then refuse to pin. Loosening only ever *suppresses* a refusal, and the post-hoc PLAN_DIVERGENCE detector remains as the safety net.

## Behavior-change notes

- Under `observation_only=True` (default), F3 no longer short-circuits AgentTool dispatches; operators see the would-have-fired decision via the `PolicyApplied` sink event + INFO log.
- In active mode, F3 no longer refuses when the only "next pending" candidates sit behind non-COMPLETED (e.g. NOT_NEEDED-swept) predecessors — it falls through, matching the pin's view that the plan is effectively done.
- F1's directive `plan_state.next_pending` (reporting/rendering.py) intentionally keeps terminal-predecessor semantics: it only *informs* the LLM and never refuses a dispatch, so it is not part of this alignment.
- No flags added: the gate rides the existing `SteeringConfig.observation_only` flag (safe default = suppressed), and the predicate alignment is a bug fix that strictly narrows an existing intervention.

## Tests

`tests/test_tier1_loop_prevention.py` (extends the existing F3 section; no existing tests changed):
- `test_f3_not_needed_swept_predecessor_no_longer_causes_refusal` — the divergence case: NOT_NEEDED-swept predecessor → pin readiness is False AND F3 no longer refuses (pre-fix it redirected).
- `test_f3_still_redirects_when_unrelated_task_swept_not_needed` — a NOT_NEEDED task off the critical path doesn't suppress a legitimate redirect.
- `test_f3_redirect_suppressed_under_observation_only` — callback-level: dispatch proceeds (`None` returned) and exactly one `PolicyApplied` suppressed event records the decision.
- `test_f3_redirect_still_refuses_in_active_mode` — callback-level: the redirect payload is returned, no suppression telemetry.

Full suite: 2842 passed, 59 skipped (~29s). `ruff check .` clean; touched test file format-clean (`_adk_plugin.py` was format-dirty on main before this change; untouched hunks left as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA