### PR TITLE
feat: judge-scheduling guards — concurrency cap, coalescing, verdict-utility ledger

### DIFF
--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -472,6 +472,19 @@ class ReasoningDriftConfig:
     looping_reasoning_similarity_threshold: float = 0.9
     reasoning_cluster_similarity_threshold: float = 0.75
     looping_reasoning_hash_window: int = 5
+    max_concurrent_judges: int = 3
+    """Per-steerer cap on concurrently RUNNING background reasoning-judge
+    LLM calls (judge-scheduling guards).
+
+    N agents thinking in the same event-loop tick used to fire N
+    parallel judge calls (each with a 16384-token output ceiling) at
+    the judge endpoint — which, under the default :func:`goldfive.wrap`
+    auto-detect, is the agent tree's OWN model. The cap bounds the
+    burst; requests beyond it queue on a per-steerer
+    ``asyncio.Semaphore`` and per-(agent, task) queued windows coalesce
+    onto the newest observation. Values below 1 are clamped to 1.
+    Env: ``GOLDFIVE_DRIFT_MAX_CONCURRENT_JUDGES``.
+    """
     fallback_to_content_when_no_reasoning: bool = False
     """Synthesize a reasoning signal from the response body on
     non-thinking models (goldfive#263).
@@ -548,6 +561,10 @@ class ReasoningDriftConfig:
             looping_reasoning_hash_window=_read_int_env(
                 "GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW",
                 defaults.looping_reasoning_hash_window,
+            ),
+            max_concurrent_judges=_read_int_env(
+                "GOLDFIVE_DRIFT_MAX_CONCURRENT_JUDGES",
+                defaults.max_concurrent_judges,
             ),
             fallback_to_content_when_no_reasoning=_read_bool_env(
                 "GOLDFIVE_DRIFT_FALLBACK_TO_CONTENT",

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -634,13 +634,25 @@ def wrap(
         # LLM was detected from. Fall through to the class name only when the
         # object has no usable ``.name`` attribute (non-ADK shapes).
         _agent_label = getattr(agent, "name", "") or type(agent).__name__
+        # Name the cost explicitly: background reasoning-judge calls
+        # (up to ``max_concurrent_judges`` in flight, each with the
+        # judge's output-token ceiling) land on the SAME endpoint the
+        # agent tree bills against, competing with the tree's own
+        # calls for capacity / rate limits.
+        from goldfive.drift.reasoning_judge import REASONING_JUDGE_MAX_OUTPUT_TOKENS
+
         log.warning(
             "goldfive.wrap: judge LLM not explicitly configured; inheriting "
-            "%r from agent %r (detected via ADK model attribute). Set "
+            "%r from agent %r (detected via ADK model attribute). Judge "
+            "traffic (up to %d concurrent background calls, %d output "
+            "tokens each) will share this endpoint with — and compete "
+            "against — the agent tree's own calls. Set "
             "GOLDFIVE_JUDGE_BASE_URL / GOLDFIVE_JUDGE_MODEL to route "
             "goldfive's judges to a dedicated endpoint.",
             _detected_model_name,
             _agent_label,
+            max(1, int(resolved_runtime.reasoning_drift.max_concurrent_judges)),
+            REASONING_JUDGE_MAX_OUTPUT_TOKENS,
         )
 
     resolved_planner: Planner

--- a/goldfive/drift/reasoning.py
+++ b/goldfive/drift/reasoning.py
@@ -39,6 +39,7 @@ semantic ground robustly.
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import logging
 import re
@@ -1172,23 +1173,18 @@ async def analyze_reasoning_with_focus(
         # (deterministic, synchronous path). Either way, the
         # attribution fields come from the judge — the embedding
         # pipeline doesn't produce them.
+        # ``dataclasses.replace`` (vs field-by-field reconstruction)
+        # keeps every judge-derived field — attribution, classification /
+        # provenance, and the judge-scheduling measurement fields
+        # (``judge_ran`` / ``elapsed_ms``) — on the returned verdict
+        # even when the embedding drift wins.
         if judge_verdict.drift is None:
-            return ReasoningJudgeVerdict(
-                drift=embedding_drift,
-                focused_task_id=judge_verdict.focused_task_id,
-                focus_confidence=judge_verdict.focus_confidence,
-                stated_intent=judge_verdict.stated_intent,
-            )
+            return dataclasses.replace(judge_verdict, drift=embedding_drift)
         if _SEVERITY_ORDER[judge_verdict.drift.severity] > _SEVERITY_ORDER[
             embedding_drift.severity
         ]:
             return judge_verdict
-        return ReasoningJudgeVerdict(
-            drift=embedding_drift,
-            focused_task_id=judge_verdict.focused_task_id,
-            focus_confidence=judge_verdict.focus_confidence,
-            stated_intent=judge_verdict.stated_intent,
-        )
+        return dataclasses.replace(judge_verdict, drift=embedding_drift)
     log.warning(
         "analyze_reasoning_with_focus: unknown mode=%r; falling back "
         "to 'embedding'",

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -656,6 +656,15 @@ class ReasoningJudgeVerdict:
     # change ships in PR 3 (parser) + PR 4 (routing).
     classification: str = ""
     provenance: str = ""
+    # Judge-scheduling guards: measurement fields. ``judge_ran`` is
+    # True iff the judge LLM was actually dispatched (False on the
+    # empty-reasoning early return, the embedding-only path, and
+    # ``mode="off"``), so callers can distinguish "quiet-fail sentinel"
+    # (``judge_ran and not classification``) from "judge never ran".
+    # ``elapsed_ms`` mirrors the value stamped on the
+    # ``ReasoningJudgeInvoked`` event; 0 when ``judge_ran`` is False.
+    judge_ran: bool = False
+    elapsed_ms: int = 0
 
 
 # Map the judge's ``severity`` string to a :class:`DriftSeverity`. Missing
@@ -1289,6 +1298,8 @@ async def classify_reasoning_drift_with_focus(
         stated_intent=stated_intent_parsed,
         classification=classification_parsed,
         provenance=provenance_parsed,
+        judge_ran=True,
+        elapsed_ms=elapsed_ms,
     )
 
 

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -133,6 +133,7 @@ components decoupled and lets the router own the shared state
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import inspect
 import json
 import logging
@@ -178,6 +179,36 @@ ReflectiveCallLLM = Callable[[str, str, str], Awaitable[str]]
 # for an on-call operator to intervene, short enough that unattended
 # deployments do not wedge indefinitely.
 DEFAULT_TERMINATE_PAUSE_DEADLINE_S: float = 600.0
+
+
+@dataclasses.dataclass
+class _QueuedJudgeWindow:
+    """Mutable payload for a scheduled-but-not-yet-running judge request.
+
+    While the owning background task waits on the per-steerer
+    judge-concurrency semaphore the request is QUEUED: a newer
+    reasoning observation for the same (session, agent, task) key
+    replaces ``text`` / ``pinned_history`` in place (coalescing —
+    newest window wins) instead of scheduling another task. A granted
+    judge slot (``call_llm``) is never downgraded by a slotless newer
+    observation. Once the semaphore is acquired the entry leaves
+    :attr:`DriftObserver._queued_judge_windows` and the call is
+    RUNNING — never coalesced again.
+    """
+
+    text: str
+    pinned_history: list[str]
+    call_llm: ReflectiveCallLLM | None
+    coalesced: int = 0
+
+
+def _nearest_rank_percentile(sorted_samples: list[int], q: float) -> int:
+    """Nearest-rank percentile of an already-sorted sample list; 0 when empty."""
+    if not sorted_samples:
+        return 0
+    idx = min(len(sorted_samples) - 1, max(0, round(q * (len(sorted_samples) - 1))))
+    return int(sorted_samples[idx])
+
 
 log = logging.getLogger(__name__)
 # Wave C bucket 3b/3c post-cleanup: the module previously kept a
@@ -373,6 +404,36 @@ class DriftObserver:
         # firings (separate dispatch instances at higher occurrence
         # counts) each get their own slot.
         self._cancelled_drift_ids: set[str] = set()
+        # Judge-scheduling guards — concurrency cap. Bounds the number
+        # of concurrently RUNNING background reasoning-judge LLM calls.
+        # Per-steerer-instance (NOT module-global) so multi-Runner
+        # processes never share one gate. Sized from
+        # ``ReasoningDriftConfig.max_concurrent_judges`` (env:
+        # ``GOLDFIVE_DRIFT_MAX_CONCURRENT_JUDGES``); a bare
+        # ``DefaultSteerer()`` without a config uses the dataclass
+        # default. Clamped to >= 1 so a bad value can never wedge the
+        # judge pipeline shut.
+        _rd_config = getattr(steerer, "_reasoning_drift_config", None)
+        try:
+            _judge_limit = int(getattr(_rd_config, "max_concurrent_judges", 3))
+        except (TypeError, ValueError):
+            _judge_limit = 3
+        self._judge_semaphore = asyncio.Semaphore(max(1, _judge_limit))
+        # QUEUED judge windows keyed by (session_id, agent_name,
+        # task_id). Entries are removed when the owning background task
+        # acquires the semaphore (QUEUED -> RUNNING) or is cancelled
+        # while still queued; while present, newer observations for the
+        # same key coalesce onto the entry instead of scheduling
+        # another task. See :class:`_QueuedJudgeWindow`.
+        self._queued_judge_windows: dict[tuple[str, str, str], _QueuedJudgeWindow] = {}
+        # Verdict-utility ledger, keyed by session id: plain counters
+        # {acted_on, emitted_late, emitted_redundant, parse_fail} plus
+        # a bounded elapsed_ms sample list. Created lazily on first
+        # increment; popped and summarised as a
+        # ``reasoning_judge_utility_summary`` dict event by
+        # :meth:`drain_session_background_tasks` (run boundary) with a
+        # :meth:`shutdown` flush as the process-teardown fallback.
+        self._verdict_ledgers: dict[str, dict[str, Any]] = {}
 
     # ------------------------------------------------------------------
     # Drift event emission + lifecycle stamping
@@ -1553,6 +1614,11 @@ class DriftObserver:
     # and is not affected by this guard.
     _GOAL_DRIFT_TASK_BOUNDARY_MIN_INTERVAL_S: float = 10.0
 
+    # Upper bound on per-session judge-latency samples retained for the
+    # verdict-utility summary. Keeps the ledger cheap on pathological
+    # runs; p50/p95 over the first N calls is representative enough.
+    _LEDGER_ELAPSED_SAMPLES_CAP: ClassVar[int] = 1024
+
     # ------------------------------------------------------------------
     # Observation entry points
     # ------------------------------------------------------------------
@@ -1741,13 +1807,44 @@ class DriftObserver:
         # one-shot test). ``text`` was appended above, so it is the
         # snapshot's last entry.
         pinned_history = list(session.reasoning_history)
+        # Judge-scheduling guards — coalescing. When a request for the
+        # same (session, agent, task) key is still QUEUED (its
+        # background task has not yet acquired the judge-concurrency
+        # semaphore), fold this observation into it: newest window
+        # wins, a granted judge slot is never downgraded, and no
+        # second task is scheduled. A RUNNING call is never coalesced —
+        # its entry left the registry when it acquired the semaphore.
+        queue_key = (
+            str(session.id or ""),
+            agent_name or "",
+            str(session.current_task_id or ""),
+        )
+        queued = self._queued_judge_windows.get(queue_key)
+        if queued is not None:
+            queued.text = text
+            queued.pinned_history = pinned_history
+            if rl_call_llm is not None:
+                queued.call_llm = rl_call_llm
+            queued.coalesced += 1
+            log.debug(
+                "DefaultSteerer.observe_reasoning: coalesced queued judge "
+                "window for key=%r (%d observation(s) folded)",
+                queue_key,
+                queued.coalesced,
+            )
+            return
+        window = _QueuedJudgeWindow(
+            text=text,
+            pinned_history=pinned_history,
+            call_llm=rl_call_llm,
+        )
+        self._queued_judge_windows[queue_key] = window
         bg_task = asyncio.create_task(
             self._run_judge_background(
-                text=text,
+                queue_key=queue_key,
+                window=window,
                 session=session,
-                call_llm=rl_call_llm,
                 judge_sink=judge_sink,
-                pinned_history=pinned_history,
                 agent_name=agent_name,
             ),
             # goldfive#243: encode session.id in the task name so
@@ -1830,6 +1927,52 @@ class DriftObserver:
     async def _run_judge_background(
         self,
         *,
+        queue_key: tuple[str, str, str],
+        window: _QueuedJudgeWindow,
+        session: Session,
+        judge_sink: Any,
+        agent_name: str = "",
+    ) -> None:
+        """Semaphore-gated dispatch of one queued judge window.
+
+        Scheduled by :meth:`observe_reasoning` as an
+        :func:`asyncio.create_task`. Waits on the per-steerer
+        judge-concurrency semaphore (:attr:`_judge_semaphore`) so at
+        most ``ReasoningDriftConfig.max_concurrent_judges`` background
+        judge calls run at once — while waiting, the ``window`` payload
+        stays coalescable in :attr:`_queued_judge_windows` (newest
+        observation for the same key replaces it in place). On acquire
+        the entry is removed (QUEUED -> RUNNING) and the pipeline runs
+        via :meth:`_run_judge_window` on the freshest payload.
+
+        A task cancelled while still queued (run-boundary drain,
+        shutdown) removes its registry entry in the ``finally`` so
+        later observations cannot coalesce onto a dead window and
+        silently vanish.
+        """
+        try:
+            async with self._judge_semaphore:
+                # QUEUED -> RUNNING: release the coalescing slot BEFORE
+                # reading the payload so a newer observation for the
+                # same key schedules a fresh request instead of
+                # mutating a window that is already being judged.
+                if self._queued_judge_windows.get(queue_key) is window:
+                    del self._queued_judge_windows[queue_key]
+                await self._run_judge_window(
+                    text=window.text,
+                    session=session,
+                    call_llm=window.call_llm,
+                    judge_sink=judge_sink,
+                    pinned_history=window.pinned_history,
+                    agent_name=agent_name,
+                )
+        finally:
+            if self._queued_judge_windows.get(queue_key) is window:
+                del self._queued_judge_windows[queue_key]
+
+    async def _run_judge_window(
+        self,
+        *,
         text: str,
         session: Session,
         call_llm: ReflectiveCallLLM | None,
@@ -1839,10 +1982,9 @@ class DriftObserver:
     ) -> None:
         """Run the mode-selected reasoning drift pipeline off the critical path.
 
-        Scheduled by :meth:`observe_reasoning` as an
-        :func:`asyncio.create_task` so the adapter's model-response
-        callback can return before ADK dispatches the response's tool
-        calls. Awaits :func:`~goldfive.drift.reasoning.analyze_reasoning`
+        Body of the historical ``_run_judge_background`` (which is now
+        the semaphore-gated wrapper above). Awaits
+        :func:`~goldfive.drift.reasoning.analyze_reasoning`
         and, if it yields a :class:`DriftEvent`, routes it through
         :meth:`_handle_drift` — same effect as the historical inline
         path, just resolving later.
@@ -1893,6 +2035,19 @@ class DriftObserver:
                 available_agents=judge_available_agents,
                 reasoning_history=pinned_history,
             )
+
+            # Verdict-utility ledger — latency + quiet-fail accounting.
+            # ``judge_ran`` distinguishes "the judge LLM was dispatched"
+            # from the embedding-only / mode-off paths; the empty
+            # ``classification`` on a ran judge is the quiet-fail
+            # sentinel (call raised, non-JSON response, missing keys).
+            if getattr(verdict, "judge_ran", False):
+                ledger = self._verdict_ledger(session)
+                samples = ledger["elapsed_ms"]
+                if len(samples) < self._LEDGER_ELAPSED_SAMPLES_CAP:
+                    samples.append(int(getattr(verdict, "elapsed_ms", 0)))
+                if not getattr(verdict, "classification", ""):
+                    ledger["parse_fail"] += 1
 
             # Record the reasoning-extracted binding onto the
             # orchestration store regardless of the drift verdict —
@@ -1948,10 +2103,12 @@ class DriftObserver:
                     drift.current_task_id or "-",
                     drift.kind.value,
                 )
+                self._verdict_ledger(session)["emitted_late"] += 1
                 if not drift.authored_by:
                     drift.authored_by = self._resolve_authored_by(drift)
                 await self._emit_drift_detected(session, drift)
                 return
+            self._verdict_ledger(session)["acted_on"] += 1
             await self.handle_drift(drift, session)
         except asyncio.CancelledError:
             # Propagate cancellation so :meth:`shutdown` / event-loop
@@ -2031,6 +2188,86 @@ class DriftObserver:
             )
 
     # ------------------------------------------------------------------
+    # Verdict-utility ledger (judge-scheduling guards)
+    # ------------------------------------------------------------------
+
+    def _verdict_ledger(self, session: Session) -> dict[str, Any]:
+        """Get-or-create the per-session verdict-utility ledger.
+
+        Plain dict on the steerer — cheap by design. ``session`` is
+        retained on the entry so the teardown summary can stamp
+        ``run_id`` and draw a gap-free sequence number. Counters:
+
+        * ``acted_on`` — reasoning-judge verdicts dispatched into
+          :meth:`handle_drift` (past the late gate).
+        * ``emitted_late`` — verdicts emitted-only because the
+          originating invocation had already terminated (goldfive#319
+          gate in :meth:`_run_judge_window`).
+        * ``emitted_redundant`` — verdicts emitted-only at
+          :meth:`handle_drift`'s entry gates (addressed-watermark and
+          in-flight-refine); counts every observation-stamped verdict
+          that hits those gates, reasoning-judge or otherwise.
+        * ``parse_fail`` — judge calls that quiet-failed (empty
+          classification sentinel).
+        * ``elapsed_ms`` — bounded judge-call latency samples.
+        """
+        sid = str(session.id or "")
+        ledger = self._verdict_ledgers.get(sid)
+        if ledger is None:
+            ledger = {
+                "session": session,
+                "acted_on": 0,
+                "emitted_late": 0,
+                "emitted_redundant": 0,
+                "parse_fail": 0,
+                "elapsed_ms": [],
+            }
+            self._verdict_ledgers[sid] = ledger
+        return ledger
+
+    async def _emit_verdict_utility_summary(self, session_id: str) -> None:
+        """Pop the session's ledger and emit its summary, if one exists.
+
+        Emits a ``reasoning_judge_utility_summary`` dict envelope (via
+        :func:`goldfive.events.make_event` — no proto change) carrying
+        the four utility counters plus judge-call count and nearest-rank
+        p50/p95 of the in-session ``elapsed_ms`` samples. A session with
+        no judge activity never created a ledger, so quiet runs emit
+        nothing; the pop makes repeat drains idempotent.
+        """
+        ledger = self._verdict_ledgers.pop(session_id, None)
+        if ledger is None:
+            return
+        session = ledger["session"]
+        samples = sorted(int(s) for s in ledger["elapsed_ms"])
+        payload: dict[str, Any] = {
+            "acted_on": int(ledger["acted_on"]),
+            "emitted_late": int(ledger["emitted_late"]),
+            "emitted_redundant": int(ledger["emitted_redundant"]),
+            "parse_fail": int(ledger["parse_fail"]),
+            "judge_calls": len(samples),
+            "elapsed_ms_p50": _nearest_rank_percentile(samples, 0.5),
+            "elapsed_ms_p95": _nearest_rank_percentile(samples, 0.95),
+        }
+        try:
+            from goldfive.events import emit, make_event
+
+            evt = make_event(
+                str(session.run_id or ""),
+                session.next_sequence(),
+                "reasoning_judge_utility_summary",
+                payload,
+                session_id=session_id,
+            )
+            await emit(self._steerer._sinks, evt)
+        except Exception as exc:  # noqa: BLE001 — observability only
+            log.warning(
+                "DriftObserver._emit_verdict_utility_summary: emit failed "
+                "(swallowed): %s",
+                exc,
+            )
+
+    # ------------------------------------------------------------------
     # Background-task lifecycle (drain + shutdown)
     # ------------------------------------------------------------------
 
@@ -2059,6 +2296,11 @@ class DriftObserver:
             await self._drain_background_set(
                 self._steerer._background_drifts, label="drift", timeout=timeout
             )
+        # Flush verdict-utility ledgers whose sessions never hit a
+        # run-boundary drain (custom executors, aborted loops). Sessions
+        # already summarised at their run boundary were popped there.
+        for sid in list(self._verdict_ledgers):
+            await self._emit_verdict_utility_summary(sid)
 
     async def drain_session_background_tasks(
         self, *, session_id: str, timeout: float = 2.0
@@ -2122,6 +2364,11 @@ class DriftObserver:
             await self._drain_background_set(
                 judge_subset, label="judge", timeout=timeout
             )
+        # Run-boundary summary: judges that finished during the drain
+        # above have already counted; stragglers were cancelled and
+        # count nothing. Emitted BEFORE the executor's terminal
+        # RunAborted / RunCompleted so the summary rides inside the run.
+        await self._emit_verdict_utility_summary(session_id)
 
     async def _drain_background_set(
         self,
@@ -3342,6 +3589,7 @@ class DriftObserver:
                 )
                 # Emit for observability so operators see the detector
                 # ran; do NOT cancel / refine on a redundant view.
+                self._verdict_ledger(session)["emitted_redundant"] += 1
                 await self._emit_drift_detected(
                     session,
                     drift,
@@ -3383,6 +3631,7 @@ class DriftObserver:
                     drift.current_task_id or "<trajectory>",
                     drift.observed_revision_index,
                 )
+                self._verdict_ledger(session)["emitted_redundant"] += 1
                 await self._emit_drift_detected(
                     session,
                     drift,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -382,6 +382,7 @@ _REASONING_DRIFT_ENV: dict[str, str] = {
     "looping_similarity": "GOLDFIVE_DRIFT_LOOPING_SIMILARITY",
     "cluster_similarity": "GOLDFIVE_DRIFT_CLUSTER_SIMILARITY",
     "looping_hash_window": "GOLDFIVE_DRIFT_LOOPING_HASH_WINDOW",
+    "max_concurrent_judges": "GOLDFIVE_DRIFT_MAX_CONCURRENT_JUDGES",
     "fallback_to_content": "GOLDFIVE_DRIFT_FALLBACK_TO_CONTENT",
 }
 

--- a/tests/test_judge_scheduling_guards.py
+++ b/tests/test_judge_scheduling_guards.py
@@ -1,0 +1,516 @@
+"""Judge-scheduling guards: concurrency cap, queued-window coalescing,
+verdict-utility ledger, and the wrap()-time shared-endpoint cost warning.
+
+Deterministic guards + measurement for the reasoning-judge pipeline.
+No cadence / coverage / threshold change is asserted here on purpose —
+that work is deferred pending the regression harness. What IS pinned:
+
+* at most ``ReasoningDriftConfig.max_concurrent_judges`` background
+  judge LLM calls run concurrently (per-steerer semaphore);
+* a judge request that is still QUEUED behind the semaphore coalesces
+  with a newer observation for the same (agent, task) key — the newest
+  window always wins and a RUNNING call is never coalesced;
+* the per-session verdict-utility ledger counts
+  {acted_on, emitted_late, emitted_redundant, parse_fail} at the
+  existing verdict code points and surfaces a
+  ``reasoning_judge_utility_summary`` event at the run-boundary drain
+  (with a shutdown flush fallback);
+* :func:`goldfive.wrap`'s named-model WARNING names the concurrency /
+  token cost when the judges inherit the agent tree's own model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+import goldfive  # noqa: E402
+from goldfive.config import ReasoningDriftConfig, SteeringConfig  # noqa: E402
+from goldfive.results import InvocationResult  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_process_wide_reasoning_config() -> Any:
+    """Tests below install ReasoningDriftConfig process-wide via the
+    steerer / wrap(); clear it around each test to avoid leakage."""
+    from goldfive.drift import reasoning as _reasoning
+
+    _reasoning.configure(None)
+    yield
+    _reasoning.configure(None)
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class NullPlanner:
+    """Non-None planner recording refine calls (handle_drift requires one)."""
+
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        self.refine_calls.append(kwargs)
+        return None
+
+
+def _session(run_id: str = "r1", task_id: str = "t1") -> Session:
+    task = Task(id=task_id, title="Research solar panels", description="Find specs")
+    plan = Plan(
+        id="p1",
+        run_id=run_id,
+        goal_ids=["g1"],
+        tasks=[task],
+        edges=[],
+    )
+    return Session(
+        run_id=run_id,
+        goals=[Goal(id="g1", summary="Publish a memo on solar panels")],
+        plan=plan,
+        current_task_id=task_id,
+    )
+
+
+async def _drain_judges(steerer: DefaultSteerer) -> None:
+    pending = list(steerer._background_judges)
+    results = await asyncio.gather(*pending, return_exceptions=True)
+    for r in results:
+        assert not isinstance(r, BaseException), (
+            f"background judge raised {r!r}; expected clean completion"
+        )
+
+
+def _summaries(sink: ListSink) -> list[dict[str, Any]]:
+    return [
+        e
+        for e in sink.events
+        if isinstance(e, dict) and e.get("kind") == "reasoning_judge_utility_summary"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Concurrency cap
+# ---------------------------------------------------------------------------
+
+
+async def test_semaphore_caps_concurrent_judge_calls() -> None:
+    """Five queued judges never exceed ``max_concurrent_judges=2`` in flight."""
+    inflight = 0
+    max_seen = 0
+    calls = 0
+
+    async def slow_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        nonlocal inflight, max_seen, calls
+        calls += 1
+        inflight += 1
+        max_seen = max(max_seen, inflight)
+        await asyncio.sleep(0.05)
+        inflight -= 1
+        return json.dumps({"on_task": True})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=slow_call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+        reasoning_drift_config=ReasoningDriftConfig(max_concurrent_judges=2),
+    )
+    session = _session()
+    steerer.bind(sinks=[ListSink()], planner=NullPlanner())
+
+    # Distinct agent names -> distinct coalescing keys -> five separate
+    # judge windows all contending on the semaphore (mirrors N agents
+    # thinking concurrently).
+    texts = [
+        "study raccoon habitats in urban parks",
+        "compare monocrystalline and polycrystalline panels",
+        "draft the memo introduction",
+        "collect inverter efficiency benchmarks",
+        "summarise net-metering policy changes",
+    ]
+    for i, text in enumerate(texts):
+        await steerer.drift.observe_reasoning(text, session=session, agent_name=f"agent-{i}")
+    assert len(steerer._background_judges) == 5
+    await _drain_judges(steerer)
+
+    assert calls == 5, "distinct (agent, task) keys must never coalesce"
+    assert max_seen == 2, (
+        f"semaphore must cap concurrency at 2 (and allow reaching 2); observed max {max_seen}"
+    )
+
+
+async def test_semaphore_size_defaults_and_reads_config() -> None:
+    """Cap comes from ``ReasoningDriftConfig.max_concurrent_judges``; bare
+    steerers use the dataclass default; the gate is per-instance."""
+    bare = DefaultSteerer()
+    assert bare.drift._judge_semaphore._value == 3
+
+    configured = DefaultSteerer(
+        reasoning_drift_config=ReasoningDriftConfig(max_concurrent_judges=7),
+    )
+    assert configured.drift._judge_semaphore._value == 7
+    assert configured.drift._judge_semaphore is not bare.drift._judge_semaphore
+
+    clamped = DefaultSteerer(
+        reasoning_drift_config=ReasoningDriftConfig(max_concurrent_judges=0),
+    )
+    assert clamped.drift._judge_semaphore._value == 1
+
+
+# ---------------------------------------------------------------------------
+# Coalescing
+# ---------------------------------------------------------------------------
+
+
+async def test_coalescing_replaces_queued_window_and_never_running() -> None:
+    """A QUEUED window coalesces onto the newest observation; the RUNNING
+    call keeps the window it started with; the newest text is never lost."""
+    gate = asyncio.Event()
+    prompts: list[str] = []
+
+    async def gated_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        prompts.append(user)
+        await gate.wait()
+        return json.dumps({"on_task": True})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=gated_call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+        reasoning_drift_rate_limit=1,
+        reasoning_drift_config=ReasoningDriftConfig(max_concurrent_judges=1),
+    )
+    session = _session()
+    steerer.bind(sinks=[ListSink()], planner=NullPlanner())
+
+    await steerer.drift.observe_reasoning("study raccoon habitats", session=session, agent_name="a")
+    # Let the first task acquire the semaphore: QUEUED -> RUNNING, so
+    # its coalescing slot must be gone and its window frozen.
+    for _ in range(20):
+        if prompts:
+            break
+        await asyncio.sleep(0)
+    assert prompts, "first judge call must have started"
+    assert steerer.drift._queued_judge_windows == {}
+
+    await steerer.drift.observe_reasoning(
+        "compare solar panel specs", session=session, agent_name="a"
+    )
+    assert len(steerer.drift._queued_judge_windows) == 1
+    tasks_after_second = len(steerer._background_judges)
+
+    await steerer.drift.observe_reasoning("draft the final memo", session=session, agent_name="a")
+    # Coalesced: no third task; the queued window carries the newest text.
+    assert len(steerer._background_judges) == tasks_after_second
+    (queued,) = steerer.drift._queued_judge_windows.values()
+    assert queued.text == "draft the final memo"
+    assert queued.coalesced == 1
+
+    gate.set()
+    await _drain_judges(steerer)
+    assert steerer.drift._queued_judge_windows == {}
+
+    # Two judge calls total: the RUNNING one saw the first window
+    # (never mutated); the queued one ran with the newest. The
+    # superseded middle window was never dispatched.
+    assert len(prompts) == 2
+    assert "study raccoon habitats" in prompts[0]
+    assert "draft the final memo" in prompts[1]
+    assert not any("compare solar panel specs" in p for p in prompts)
+
+
+async def test_cancelled_queued_window_is_removed_from_registry() -> None:
+    """A task cancelled while still waiting on the semaphore must drop its
+    registry entry so later observations don't coalesce into a dead window."""
+    gate = asyncio.Event()
+
+    async def gated_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        await gate.wait()
+        return json.dumps({"on_task": True})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=gated_call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+        reasoning_drift_rate_limit=1,
+        reasoning_drift_config=ReasoningDriftConfig(max_concurrent_judges=1),
+    )
+    session = _session()
+    steerer.bind(sinks=[ListSink()], planner=NullPlanner())
+
+    await steerer.drift.observe_reasoning("study raccoon habitats", session=session, agent_name="a")
+    await asyncio.sleep(0)  # first task acquires the semaphore
+    await steerer.drift.observe_reasoning(
+        "compare solar panel specs", session=session, agent_name="a"
+    )
+    await asyncio.sleep(0)  # second task starts waiting on the semaphore
+    assert len(steerer.drift._queued_judge_windows) == 1
+
+    for task in list(steerer._background_judges):
+        task.cancel()
+    await asyncio.gather(*list(steerer._background_judges), return_exceptions=True)
+
+    assert steerer.drift._queued_judge_windows == {}, (
+        "cancelled queued window must not linger in the coalescing registry"
+    )
+    gate.set()
+
+
+# ---------------------------------------------------------------------------
+# Verdict-utility ledger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("observation_only", [True, False])
+async def test_ledger_counts_acted_on_and_drain_emits_summary(
+    observation_only: bool,
+) -> None:
+    """An off-task verdict on a live invocation counts ``acted_on`` (in both
+    observation-only and active modes) and the run-boundary drain emits one
+    summary event; a second drain emits nothing."""
+    from goldfive.state_store import StateStore
+
+    async def call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        return json.dumps({"on_task": False, "severity": "warning", "reason": "drifted"})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+        steering_config=SteeringConfig(observation_only=observation_only),
+    )
+    session = _session()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    # Live invocation so the late gate does not fire.
+    store = StateStore.for_session(session)
+
+    async def _placeholder() -> None:
+        await asyncio.sleep(0.5)
+
+    fake_task = asyncio.create_task(_placeholder())
+    store.register_invocation_task("inv-live", fake_task)
+    try:
+        await steerer.drift.observe_reasoning("raccoons are nocturnal", session=session)
+        await _drain_judges(steerer)
+    finally:
+        store.deregister_invocation_task("inv-live")
+        fake_task.cancel()
+        await asyncio.gather(fake_task, return_exceptions=True)
+
+    ledger = steerer.drift._verdict_ledgers[session.id]
+    assert ledger["acted_on"] == 1
+    assert ledger["emitted_late"] == 0
+    assert ledger["parse_fail"] == 0
+    assert len(ledger["elapsed_ms"]) == 1
+
+    await steerer.drift.drain_session_background_tasks(session_id=session.id)
+    summaries = _summaries(sink)
+    assert len(summaries) == 1
+    payload = summaries[0]["payload"]
+    assert payload["acted_on"] == 1
+    assert payload["emitted_late"] == 0
+    assert payload["emitted_redundant"] == 0
+    assert payload["parse_fail"] == 0
+    assert payload["judge_calls"] == 1
+    assert payload["elapsed_ms_p50"] >= 0
+    assert payload["elapsed_ms_p95"] >= payload["elapsed_ms_p50"]
+    assert summaries[0]["session_id"] == session.id
+
+    # Idempotent: the pop makes a second drain a no-op.
+    await steerer.drift.drain_session_background_tasks(session_id=session.id)
+    assert len(_summaries(sink)) == 1
+
+
+async def test_ledger_counts_emitted_late() -> None:
+    """A verdict landing after its invocation terminated counts
+    ``emitted_late`` and not ``acted_on``."""
+
+    async def call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        return json.dumps({"on_task": False, "severity": "warning", "reason": "drifted"})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    # No invocation registered — the agent has moved on (goldfive#319).
+    await steerer.drift.observe_reasoning("raccoons are nocturnal", session=session)
+    await _drain_judges(steerer)
+
+    ledger = steerer.drift._verdict_ledgers[session.id]
+    assert ledger["emitted_late"] == 1
+    assert ledger["acted_on"] == 0
+    assert ledger["parse_fail"] == 0
+
+
+async def test_ledger_counts_parse_fail_and_shutdown_flushes_summary() -> None:
+    """A quiet-failed judge response (empty classification sentinel) counts
+    ``parse_fail``; :meth:`shutdown` flushes the summary for sessions that
+    never hit a run-boundary drain."""
+
+    async def garbage_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        return "definitely not json"
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=garbage_call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+    )
+    session = _session()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+
+    await steerer.drift.observe_reasoning("raccoons are nocturnal", session=session)
+    await _drain_judges(steerer)
+
+    ledger = steerer.drift._verdict_ledgers[session.id]
+    assert ledger["parse_fail"] == 1
+    assert ledger["acted_on"] == 0
+    assert len(ledger["elapsed_ms"]) == 1
+
+    await steerer.drift.shutdown(timeout=1.0)
+    summaries = _summaries(sink)
+    assert len(summaries) == 1
+    assert summaries[0]["payload"]["parse_fail"] == 1
+    assert steerer.drift._verdict_ledgers == {}
+
+
+async def test_ledger_counts_redundant_verdicts_at_handle_drift_gates() -> None:
+    """Both handle_drift entry gates (addressed-watermark and in-flight
+    refine) count ``emitted_redundant`` and skip refine."""
+    steerer = DefaultSteerer()
+    session = _session()
+    sink = ListSink()
+    planner = NullPlanner()
+    steerer.bind(sinks=[sink], planner=planner)
+
+    # Gate 1: same (kind, target) already addressed at a later revision.
+    session.last_addressed_revision_by_drift_key[(DriftKind.OFF_TOPIC.value, "t1")] = 5
+    stale = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="stale view",
+        current_task_id="t1",
+        observed_revision_index=3,
+    )
+    await steerer.drift.handle_drift(stale, session)
+    assert steerer.drift._verdict_ledgers[session.id]["emitted_redundant"] == 1
+
+    # Gate 2: same key already in-flight.
+    session.last_addressed_revision_by_drift_key.clear()
+    steerer.drift._inflight_refine_keys.add((session.id, DriftKind.OFF_TOPIC.value, "t1"))
+    concurrent = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="concurrent view",
+        current_task_id="t1",
+        observed_revision_index=4,
+    )
+    await steerer.drift.handle_drift(concurrent, session)
+    assert steerer.drift._verdict_ledgers[session.id]["emitted_redundant"] == 2
+
+    assert planner.refine_calls == [], "gated verdicts must never reach refine"
+    drift_events = [
+        e
+        for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "drift_detected"
+    ]
+    assert len(drift_events) == 2, "gated verdicts stay on the wire (emit-only)"
+
+
+# ---------------------------------------------------------------------------
+# wrap()-time shared-endpoint cost warning
+# ---------------------------------------------------------------------------
+
+
+async def _noop_agent(task: Any, session: Any, tools: Any) -> InvocationResult:  # noqa: ARG001
+    return InvocationResult(task_id=getattr(task, "id", ""), text="ok")
+
+
+def _scripted_detector(model: str = "gpt-4o-mini") -> Any:
+    async def call_llm(system: str, user: str, model_str: str) -> str:  # noqa: ARG001
+        return ""
+
+    def detect(agent: Any) -> tuple[Any, str]:  # noqa: ARG001
+        return (call_llm, model)
+
+    return detect
+
+
+def test_wrap_warning_names_shared_endpoint_cost(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The auto-detect WARNING fires exactly once and names the concurrency
+    cap + per-call output-token ceiling of the inherited judge traffic."""
+    from goldfive.drift.reasoning_judge import REASONING_JUDGE_MAX_OUTPUT_TOKENS
+
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
+        goldfive.wrap(_noop_agent, sinks=[], llm_detector=_scripted_detector())
+
+    matching = [
+        r for r in caplog.records if "judge LLM not explicitly configured" in r.getMessage()
+    ]
+    assert len(matching) == 1, f"expected exactly one shared-endpoint WARNING, got {len(matching)}"
+    msg = matching[0].getMessage()
+    assert "gpt-4o-mini" in msg
+    assert "up to 3 concurrent background calls" in msg
+    assert f"{REASONING_JUDGE_MAX_OUTPUT_TOKENS} output" in msg
+    assert "GOLDFIVE_JUDGE_BASE_URL" in msg
+
+
+def test_wrap_warning_suppressed_when_call_llm_explicit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No shared-endpoint WARNING when the operator supplied ``call_llm=``."""
+
+    async def explicit_call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        return ""
+
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
+        goldfive.wrap(
+            _noop_agent,
+            call_llm=explicit_call_llm,
+            sinks=[],
+            llm_detector=_scripted_detector("should-not-appear"),
+        )
+
+    assert not [
+        r for r in caplog.records if "judge LLM not explicitly configured" in r.getMessage()
+    ]

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -157,6 +157,7 @@ def test_reasoning_drift_config_defaults() -> None:
     assert cfg.looping_reasoning_similarity_threshold == 0.9
     assert cfg.reasoning_cluster_similarity_threshold == 0.75
     assert cfg.looping_reasoning_hash_window == 5
+    assert cfg.max_concurrent_judges == 3
 
 
 @pytest.mark.parametrize("mode", ["judge", "embedding", "both", "off"])
@@ -205,6 +206,7 @@ def test_reasoning_drift_config_from_env_all_vars(
         looping_similarity="0.85",
         cluster_similarity="0.7",
         looping_hash_window="8",
+        max_concurrent_judges="7",
     )
     cfg = ReasoningDriftConfig.from_env()
     assert cfg.off_topic_distance_threshold == 0.55
@@ -214,6 +216,7 @@ def test_reasoning_drift_config_from_env_all_vars(
     assert cfg.looping_reasoning_similarity_threshold == 0.85
     assert cfg.reasoning_cluster_similarity_threshold == 0.7
     assert cfg.looping_reasoning_hash_window == 8
+    assert cfg.max_concurrent_judges == 7
 
 
 def test_reasoning_drift_config_from_env_missing_falls_back(


### PR DESCRIPTION
## Problem

The background reasoning-judge pipeline has no scheduling guards and no utility measurement:

- `_background_judges` is an unbounded plain set — no `Semaphore` anywhere in `goldfive/drift_observer.py`. N agents thinking in the same tick fire N parallel judge calls (`REASONING_JUDGE_MAX_OUTPUT_TOKENS = 16384` each, `goldfive/drift/reasoning_judge.py:109`) at the judge endpoint — which, under default `wrap()` auto-detect (`goldfive/convenience.py:581-644`), is the agent tree's OWN detected model.
- Late verdicts (`goldfive/drift_observer.py` goldfive#319 gate, pre-change ~line 1905) and redundant verdicts (`handle_drift` addressed-watermark + in-flight gates, ~lines 3295/3331) are silently emitted-not-dispatched with nothing counting how often.
- `elapsed_ms` is captured on every `ReasoningJudgeInvoked` event but nothing aggregates judge latency or verdict utility per run.

## Fix

Deliberately **no cadence / coverage / threshold change** (deferred pending the regression harness):

1. **Concurrency cap** — per-steerer-instance `asyncio.Semaphore` around the background judge dispatch (`_run_judge_background` is now a semaphore-gated wrapper; the historical body moved verbatim to `_run_judge_window`). Sized from the new `ReasoningDriftConfig.max_concurrent_judges` knob (default **3**, env `GOLDFIVE_DRIFT_MAX_CONCURRENT_JUDGES`, clamped ≥ 1). Per-instance, not module-global, so multi-Runner processes never share a gate.
2. **Coalescing** — per-(session, agent, task) queued windows (`_queued_judge_windows`, mirroring the `_inflight_refine_keys` dedup pattern): while a request waits on the semaphore, a newer observation for the same key replaces its text/pinned-history in place (newest wins; a granted judge slot is never downgraded). A RUNNING call is never coalesced — its entry leaves the registry on semaphore acquire, before the payload is read. Cancelled-while-queued tasks remove their entry in a `finally` so later observations can't coalesce onto a dead window.
3. **Verdict-utility ledger** — plain per-session dict on the observer: `{acted_on, emitted_late, emitted_redundant, parse_fail}` + bounded `elapsed_ms` samples, incremented at the existing code points: (a) dispatch into `handle_drift`, (b) the #319 late gate and both `handle_drift` entry gates, (c) the empty-classification quiet-fail sentinel. New `judge_ran` / `elapsed_ms` fields on `ReasoningJudgeVerdict` carry the measurement out of the classifier. Surfaced as a `reasoning_judge_utility_summary` dict event (counters + `judge_calls` + nearest-rank p50/p95) emitted by `drain_session_background_tasks` (the executors' run-boundary hook, so it rides inside the run before RunCompleted/RunAborted), with a `shutdown` flush fallback; the pop makes repeat drains idempotent and quiet runs emit nothing.
4. **Endpoint warning** — the existing named-model WARNING at `wrap()` (extended, not duplicated) now names the cost: "up to N concurrent background calls, 16384 output tokens each will share this endpoint with — and compete against — the agent tree's own calls". Still fires exactly once, only when the judge callable came from `detect_llm` with no explicit `call_llm=` / `JudgeConfig`.

## Behavior-change notes

- Coalescing can merge back-to-back same-(agent, task) observations that land while a request is still queued (including same-tick bursts); the newest observation is never lost. In `judge` mode the per-key rate limiter already spaced these; the effect is confined to burst pressure.
- `analyze_reasoning_with_focus` "both"-mode reconstructions now use `dataclasses.replace`, so `classification` / `provenance` (previously dropped when the embedding drift won) and the new measurement fields survive on the returned verdict. No consumer read those fields on that path before.
- New event kind `reasoning_judge_utility_summary` (dict envelope via `make_event`; no proto change). New default-on but measurement-only; all counters are observability, no dispatch behavior depends on them.
- `observation_only` untouched: detection/measurement runs identically in both modes (parametrized test), and no 13b-gated default changes.

## Tests

`tests/test_judge_scheduling_guards.py` (11 tests):
- semaphore caps 5 concurrent slow judge fakes at 2 (and reaches 2); size read from config, per-instance, clamped;
- coalescing replaces the queued window with the newest text, never mutates the RUNNING call, never dispatches the superseded middle window; cancelled queued windows leave the registry;
- ledger increments on each path — `acted_on` (live invocation; parametrized over `observation_only` True/False), `emitted_late` (no live invocation), `parse_fail` (garbage JSON), `emitted_redundant` (both `handle_drift` gates, refine never called);
- run-boundary drain emits exactly one summary with counts + p50/p95 (second drain no-op); `shutdown` flushes un-drained sessions;
- `wrap()` warning fires exactly once with the cost figures, suppressed with explicit `call_llm=`.

Updated: `tests/test_runtime_config.py` (new knob in defaults + all-vars env tests), `tests/conftest.py` (env fixture map). No existing test needed behavioral changes — full suite `uv run pytest -q`: 2849 passed, 59 skipped; `ruff check` clean.

Also verified end-to-end: a real `Runner` + `SequentialExecutor` run with a stub judge emits the summary through the executor's run-boundary drain, sequenced before the terminal run event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA
