### PR TITLE
fix(drift): cap uncorroborated tool-loop name-axis at INFO; emit aggregated no-drift decision

### DIFF
--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -156,7 +156,7 @@ parts). See `goldfive/drift/reasoning.py` for the detector pipeline.
 
 | Kind | Trigger | Default severity | Recoverable |
 |---|---|---|---|
-| `LOOPING_REASONING` | Consecutive reasoning blocks share the same SHA-256 prefix (always-on) or cosine-similar above `0.9` (opt-in, `goldfive[embedding]`). Also fired by the tool-call-loop detector in `goldfive.drift.tool_loops` when the ADK plugin's `after_tool_callback` observes repeated `(tool_name, args_hash)` patterns (exact / name / alternating) — see goldfive#181 and the graduated-severity table in goldfive#204. | `info` · `warning` · `critical` (graduated per tool category + count; `info` for the alternating-cycle variant) | yes |
+| `LOOPING_REASONING` | Consecutive reasoning blocks share the same SHA-256 prefix (always-on) or cosine-similar above `0.9` (opt-in, `goldfive[embedding]`). Also fired by the tool-call-loop detector in `goldfive.drift.tool_loops` when the ADK plugin's `after_tool_callback` observes repeated `(tool_name, args_hash)` patterns (exact / name / alternating) — see goldfive#181 and the graduated-severity table in goldfive#204. | `info` · `warning` · `critical` (graduated per tool category + count; `info` for the alternating-cycle variant; name-axis hits without exact-repeat corroboration are capped at `info` by default — see §"Name-axis precision") | yes |
 | `REASONING_CLUSTER_TIGHTENING` | Max cosine similarity between current reasoning and the last N=5 blocks falls in `[0.75, 0.9)` (opt-in, `goldfive[embedding]`). Graduated early-warning tier below the `LOOPING_REASONING` cliff. One-shot per task. | `info` | yes |
 | `OFF_TOPIC` | Reasoning cosine-distance from the current task description ≥ `0.7` (requires `goldfive[embedding]`). | `warning` | yes |
 | `INTENT_DIVERGENCE` | Reasoning has drifted from `session.goals` + the current task topic. Severity is **graduated** — see table below. | `info` · `warning` · `critical` | depends on severity |
@@ -582,13 +582,41 @@ emits ONE drift at the first matching tier — no cascade of
 | `meta`   | exact | 3 | 6 | 10 |
 | `meta`   | name  | —  | — | —  |
 | `work`   | exact | 3 | 3 | 6  |
-| `work`   | name  | — | 5 | 7  |
+| `work`   | name  | — | 5\* | 7\* |
 
 "exact" counts identical `(tool_name, args_hash)` signatures in the
 window; "name" counts same-`tool_name`-any-args signatures. Category
 is determined per tool — a window containing 3 meta retries **and** 3
 work retries classifies each tool independently and picks the highest
 severity across tools.
+
+\* Name-axis tiers keep their thresholds but the **emitted** severity
+is capped without corroboration — see the next section.
+
+### Name-axis precision: corroboration cap
+
+The name axis alone is ambiguous between a stuck loop and
+definitionally-healthy behaviour — an agent reading six different
+files with the same tool is doing its job, yet counts 6 on the name
+axis. Because the window is keyed on `(session.run_id, agent_name)`
+and accumulates across re-invocations (goldfive#420), and is reset
+only by acknowledged `report_task_*` calls (cooperation goldfive's
+design does not require), the uncapped WARNING-at-5 / CRITICAL-at-7
+name tiers false-positived on healthy varied-args bursts.
+
+A name-axis hit is therefore capped at **INFO** (signal-only
+telemetry, ladder Level 0 `OBSERVE`) unless the window corroborates
+the loop hypothesis with **exact-repeat evidence**: at least 2
+identical `(tool_name, args_hash)` calls for the same tool. The
+matched tier is still recorded on `raw["tier"]`, and a capped drift
+carries `raw["severity_capped_from"]` naming the uncapped severity so
+telemetry consumers see what would have fired. Exact-axis hits are
+unchanged at any cap setting.
+
+The cap is configurable via `ToolLoopConfig.name_axis_max_severity` /
+`GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY` (`"info"` | `"warning"` |
+`"critical"`; default `"info"`). Operators who want the legacy
+uncapped behaviour set `"critical"`.
 
 An independent **alternating-cycle** mode still fires INFO when the
 last `alternating_threshold=5` calls match an `A,B,A,B,A` pattern
@@ -607,10 +635,11 @@ via `GOLDFIVE_TOOL_LOOP_WINDOW` / `GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD`.
 The legacy `GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD` /
 `GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD` env vars still work and override
 the **work-category WARNING tier** only (preserving pre-#204
-single-threshold semantics). The graduated CRITICAL tiers and the
-meta-category thresholds are module-level constants (grouped in
-`_META_THRESHOLDS` / `_WORK_THRESHOLDS`) pending a follow-up that
-exposes them via `ServerConfig`.
+single-threshold semantics). The name-axis severity cap is tunable
+via `GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY`. The graduated
+CRITICAL tiers and the meta-category thresholds are module-level
+constants (grouped in `_META_THRESHOLDS` / `_WORK_THRESHOLDS`)
+pending a follow-up that exposes them via `ServerConfig`.
 
 ### Ladder routing for graduated severity
 
@@ -618,10 +647,13 @@ The intervention ladder (below) routes `LOOPING_REASONING` by
 severity:
 
 - **INFO** → Level 0 (`OBSERVE`): record the drift, no plan mutation.
-  This is the benign tier — meta-tool retries at count 3 land here.
+  This is the benign tier — meta-tool retries at count 3 land here,
+  as do uncorroborated name-axis hits at any count (default cap).
 - **WARNING** → Level 1 (`ABSORB`): call `planner.refine`. Unchanged
-  from pre-#204 — work-tool loops at 3+ calls, meta at 6+, work
-  name-axis at 5.
+  from pre-#204 for the exact axis — work-tool loops at 3+ identical
+  calls, meta at 6+. Work name-axis at 5 reaches WARNING only with
+  exact-repeat corroboration in the window (or a raised
+  `name_axis_max_severity`).
 - **CRITICAL** first → Level 2 (`NUDGE`): refine **and** queue a soft
   corrective follow-up on `session.pending_nudges` for the overlay
   loop to pick up. Coordinates with the forward-progress work that
@@ -629,6 +661,16 @@ severity:
 - **CRITICAL** repeat → Level 4 (`PAUSE_ESCALATE`): if the loop
   survives the nudge and re-fires CRITICAL after
   `REFINE_FAILURE_THRESHOLD` occurrences, escalate to a human pause.
+
+### Negative class
+
+When an invocation ends with at least one tracker observation and
+zero tool-loop drifts fired, the ADK plugin's `after_run_callback`
+emits one aggregated `SteeringDecisionMade(outcome="no_drift",
+detector_name="tool_loops")` — telemetry only, identical in
+observe-only and active modes — so downstream optimizers can
+distinguish "tracker quiet" from "tracker never ran". Aggregated
+per invocation rather than per tool call to keep wire volume bounded.
 
 ### Task-progress gate
 

--- a/docs/guides/common-failure-modes.md
+++ b/docs/guides/common-failure-modes.md
@@ -46,6 +46,10 @@ env vars:
 - `GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD` (default 3, work-WARNING only)
 - `GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD` (default 5, work-WARNING only)
 - `GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD` (default 5)
+- `GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY` (default `info`; the
+  same-name-varied-args axis emits at most this severity unless the
+  window also holds an exact-args repeat — set `critical` for the
+  legacy uncapped behaviour)
 
 See `goldfive/drift/tool_loops.py` for the full contract.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -794,6 +794,7 @@ class ToolLoopTracker:
         exact_threshold: int = 3,          # DEFAULT_EXACT_THRESHOLD (overrides work-WARNING exact)
         name_threshold: int = 5,           # DEFAULT_NAME_THRESHOLD (overrides work-WARNING name)
         alternating_threshold: int = 5,    # DEFAULT_ALTERNATING_THRESHOLD
+        name_axis_max_severity: str = "info",  # DEFAULT_NAME_AXIS_MAX_SEVERITY (uncorroborated name-axis cap)
     ) -> None: ...
 
     def observe_tool_call(
@@ -816,7 +817,7 @@ class ToolLoopTracker:
 
 
 def args_hash(args: Any) -> str: ...          # 8-char md5 hex of sorted-keys JSON
-def load_thresholds_from_env() -> dict[str, int]: ...
+def load_thresholds_from_env() -> dict[str, int | str]: ...
 ```
 
 Detection modes:
@@ -824,7 +825,7 @@ Detection modes:
 | Mode | Pattern | Default | Severity |
 |---|---|---|---|
 | Exact | same `(tool_name, args_hash)` ≥ threshold in last `window` | 3 / 7 | WARNING |
-| Name | same `tool_name` ≥ threshold in last `window`, no task progress | 5 / 7 | WARNING |
+| Name | same `tool_name` ≥ threshold in last `window`, no task progress | 5 / 7 | tier severity when the window also holds an exact repeat; capped at `name_axis_max_severity` (default `"info"`) otherwise |
 | Alternating | A,B,A,B,A pattern in last `alternating_threshold` | 5 | INFO |
 
 Progress-reporting tools (`report_task_*`) call
@@ -835,7 +836,8 @@ Env-var overrides:
 `GOLDFIVE_TOOL_LOOP_WINDOW`,
 `GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD`,
 `GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD`,
-`GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD`.
+`GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD`,
+`GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY`.
 
 Follow-ups tracked: #179 (umbrella), #182 (args-quality),
 #183 (silent-success), #185 (wrong-tool).

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -2183,6 +2183,14 @@ def make_adk_plugin(
             self._tool_loop_tracker = _tool_loops.ToolLoopTracker(
                 **_tool_loops.resolve_thresholds()
             )
+            # Negative-class aggregation for the tool-loop detector:
+            # per-invocation counters of tracker observations and drifts
+            # fired. ``after_run_callback`` consumes an entry to emit ONE
+            # aggregated ``no_drift`` SteeringDecisionMade when the
+            # tracker ran for the invocation and fired nothing, so
+            # optimizers can tell "tracker quiet" from "tracker never
+            # ran".
+            self._tool_loop_invocation_stats: dict[str, dict[str, int]] = {}
             # Reporting-tool names that indicate forward task progress
             # and therefore can clear the tool-loop tracker's window
             # for the current (invocation, agent) key — SUBJECT to the
@@ -2361,6 +2369,10 @@ def make_adk_plugin(
             # state from the just-finished dispatch doesn't leak into
             # the next one on the same plugin instance (goldfive#181).
             self._tool_loop_tracker.clear()
+            # Drop straggling negative-class counters (normal operation
+            # pops each entry in ``after_run_callback``; this catches
+            # invocations that errored before their after_run fired).
+            self._tool_loop_invocation_stats.clear()
             # Drop any lingering cancellation state / parent map so the
             # next dispatch starts clean (goldfive#251). A request that
             # was never consumed means the callback path never ran —
@@ -3967,6 +3979,16 @@ def make_adk_plugin(
                 finishing_agent_name=agent_name,
             )
 
+            # Tool-loop negative class: one aggregated ``no_drift``
+            # decision per invocation whose tracker ran and fired
+            # nothing. Consumes the per-invocation stats entry either
+            # way so the dict stays bounded.
+            await self._maybe_emit_tool_loop_no_drift(
+                ctx=ctx,
+                inv_id=inv_id,
+                agent_name=agent_name,
+            )
+
             # If the finishing invocation is the top-level one, release
             # the pin so a subsequent invoke() on the same plugin gets a
             # fresh dispatch.
@@ -4115,6 +4137,52 @@ def make_adk_plugin(
             except Exception as exc:  # noqa: BLE001
                 log.debug(
                     "_maybe_emit_confabulation_risk: steerer.drift.observe raised: %s",
+                    exc,
+                )
+
+        async def _maybe_emit_tool_loop_no_drift(
+            self,
+            *,
+            ctx: SessionContext,
+            inv_id: str,
+            agent_name: str,
+        ) -> None:
+            """Emit one aggregated ``no_drift`` decision for a clean invocation.
+
+            The tool-loop tracker runs per tool call; a per-call silent-
+            path decision would flood the wire, so the negative class is
+            aggregated: when the invocation ends with >= 1 observed tool
+            call and zero tool-loop drifts fired, emit a single
+            ``SteeringDecisionMade(outcome="no_drift")`` via the
+            steerer's :meth:`emit_no_drift_decision` hook. Telemetry
+            only — identical in observe-only and active modes. Silent
+            when the steerer stub doesn't expose the hook.
+            """
+            stats = self._tool_loop_invocation_stats.pop(inv_id, None) if inv_id else None
+            if not stats or stats["drifts"] or not stats["calls"]:
+                return
+            if ctx.steerer is None:
+                return
+            emit = getattr(
+                getattr(ctx.steerer, "drift", None), "emit_no_drift_decision", None
+            )
+            if emit is None:
+                return
+            try:
+                await emit(
+                    session=ctx.session,
+                    detector_name="tool_loops",
+                    reason=(
+                        f"tool-loop tracker observed {stats['calls']} tool "
+                        f"call(s); no loop pattern matched"
+                    ),
+                    task_id=str(_safe_attr(ctx.task, "id", "") or ""),
+                    agent_name=agent_name,
+                    invocation_id=inv_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "_maybe_emit_tool_loop_no_drift: emit_no_drift_decision raised: %s",
                     exc,
                 )
 
@@ -6549,6 +6617,17 @@ def make_adk_plugin(
                     exc,
                 )
                 return None
+
+            # Negative-class aggregation: count the observation (and any
+            # drifts it produced) against the invocation so
+            # ``after_run_callback`` can emit one aggregated ``no_drift``
+            # decision for clean windows.
+            if inv_id:
+                stats = self._tool_loop_invocation_stats.setdefault(
+                    inv_id, {"calls": 0, "drifts": 0}
+                )
+                stats["calls"] += 1
+                stats["drifts"] += len(drifts)
 
             # Iter-10 PR 2: record the call in the session-scoped
             # ``recent_tool_observations`` ring buffer so the

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -415,12 +415,20 @@ class ToolLoopConfig:
     preserves the pre-#204 single-threshold semantics for work tools.
     See :mod:`goldfive.drift.tool_loops` §"Graduated thresholds per
     category" for the full table.
+
+    ``name_axis_max_severity`` caps the severity of same-name-varied-
+    args (name-axis) hits that lack exact-repeat corroboration in the
+    window -- ``"info"`` (default) keeps the uncorroborated name axis
+    signal-only; ``"critical"`` restores the legacy uncapped
+    behaviour. See :mod:`goldfive.drift.tool_loops` §"Name-axis
+    precision".
     """
 
     window: int = 10
     exact_threshold: int = 3
     name_threshold: int = 5
     alternating_threshold: int = 5
+    name_axis_max_severity: str = "info"
 
     @classmethod
     def from_env(cls) -> ToolLoopConfig:
@@ -428,6 +436,8 @@ class ToolLoopConfig:
 
         Names preserved from :func:`goldfive.drift.tool_loops.load_thresholds_from_env`.
         """
+        from goldfive.drift.tool_loops import _read_severity_env
+
         defaults = cls()
         return cls(
             window=_read_int_env("GOLDFIVE_TOOL_LOOP_WINDOW", defaults.window),
@@ -440,6 +450,10 @@ class ToolLoopConfig:
             alternating_threshold=_read_int_env(
                 "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD",
                 defaults.alternating_threshold,
+            ),
+            name_axis_max_severity=_read_severity_env(
+                "GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY",
+                defaults.name_axis_max_severity,
             ),
         )
 

--- a/goldfive/drift/tool_loops.py
+++ b/goldfive/drift/tool_loops.py
@@ -67,11 +67,38 @@ any other call in the window.)
 Work-tier thresholds are chosen to be backwards-compatible with the
 pre-#204 detector: three identical work calls still fire WARNING (what
 the single-threshold detector did), and same-name 5-in-window still
-fires WARNING. CRITICAL is new -- escalates plan revision into cancel-
-reinvoke at higher counts. Meta-tier thresholds push the first WARNING
-out from 3 to 6 so benign ``report_task_*`` retries trigger only an
-INFO drift (OBSERVE -- no plan mutation) until the loop genuinely
-persists.
+matches the WARNING tier (though the emitted severity is subject to
+the name-axis cap below). CRITICAL is new -- escalates plan revision
+into cancel-reinvoke at higher counts. Meta-tier thresholds push the
+first WARNING out from 3 to 6 so benign ``report_task_*`` retries
+trigger only an INFO drift (OBSERVE -- no plan mutation) until the
+loop genuinely persists.
+
+Name-axis precision
+-------------------
+
+The name axis counts same-``name``-any-args calls -- a signal that is
+ambiguous between a stuck loop and definitionally-healthy behaviour
+(an agent reading six different files with the same tool is doing its
+job). Because the window is keyed on ``(session.run_id, agent_name)``
+and accumulates across re-invocations (goldfive#420), the old WARNING-
+at-5 / CRITICAL-at-7 name tiers false-positived on healthy varied-args
+bursts and escalated on that axis alone.
+
+By default the name axis is therefore **capped at INFO** (signal-only telemetry)
+unless the window corroborates the loop hypothesis with exact-repeat
+evidence: at least :data:`_NAME_AXIS_CORROBORATION_MIN_EXACT` identical
+``(name, args_hash)`` calls for the same tool. The graduated tiers
+keep their thresholds -- the matched tier is still recorded on
+``raw["tier"]`` (with ``raw["severity_capped_from"]`` naming the
+uncapped severity) so telemetry consumers see what would have fired.
+The exact axis is unchanged: identical-args repeats are definitionally
+redundant and keep their full graduated severities.
+
+The cap is configurable via ``ToolLoopConfig.name_axis_max_severity``
+/ :envvar:`GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY` (``"info"`` |
+``"warning"`` | ``"critical"``; default ``"info"``). Operators who
+want the legacy uncapped behaviour set ``"critical"``.
 
 The alternating-cycle mode (A,B,A,B,A in the tail) remains INFO-only
 and is independent of category -- it's a textural signal that can
@@ -133,7 +160,9 @@ thresholds are module-level constants (:data:`_META_THRESHOLDS`,
 ``GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD`` / ``GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD``
 vars are still read by :func:`load_thresholds_from_env` for backwards
 compatibility and override the **work** category's WARNING tier
-(preserving the pre-#204 single-threshold semantics).
+(preserving the pre-#204 single-threshold semantics). The name-axis
+severity cap is env-overridable via
+``GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY``.
 
 The detector is intentionally deterministic (no embeddings, no LLM
 calls). O(1) per tool call modulo the `window` length.
@@ -158,6 +187,7 @@ __all__ = [
     "DEFAULT_EXACT_THRESHOLD",
     "DEFAULT_NAME_THRESHOLD",
     "DEFAULT_ALTERNATING_THRESHOLD",
+    "DEFAULT_NAME_AXIS_MAX_SEVERITY",
     "ToolLoopTracker",
     "args_hash",
     "load_thresholds_from_env",
@@ -190,7 +220,7 @@ def configure(config: ToolLoopConfig | None) -> None:
     _CONFIG = config
 
 
-def resolve_thresholds() -> dict[str, int]:
+def resolve_thresholds() -> dict[str, int | str]:
     """Return tracker-constructor kwargs sourced from the active config.
 
     Precedence: the installed :class:`~goldfive.config.ToolLoopConfig`
@@ -288,6 +318,27 @@ _SEVERITY_TIERS: tuple[tuple[str, DriftSeverity], ...] = (
     ("info", DriftSeverity.INFO),
 )
 
+#: Severity intrusiveness rank: lower is more severe. Drives both the
+#: name-axis cap comparison and the cross-tool "highest emitted
+#: severity wins" selection in :meth:`ToolLoopTracker._classify`.
+_SEVERITY_RANK: dict[DriftSeverity, int] = {
+    DriftSeverity.CRITICAL: 0,
+    DriftSeverity.WARNING: 1,
+    DriftSeverity.INFO: 2,
+}
+
+#: Valid values for ``name_axis_max_severity`` (ctor kwarg, config
+#: field, and env var alike).
+_VALID_SEVERITY_NAMES: frozenset[str] = frozenset({"info", "warning", "critical"})
+
+#: Minimum identical ``(name, args_hash)`` repeats in the window for the
+#: name axis to count as corroborated. ``2`` is the smallest count that
+#: is a genuine exact repeat: a window with 5+ same-name calls AND at
+#: least one identical-args repeat looks like a stuck loop; 5+ same-name
+#: calls with all-distinct args looks like legitimate iteration (e.g.
+#: reading six different files with the same tool).
+_NAME_AXIS_CORROBORATION_MIN_EXACT: int = 2
+
 
 # ---------------------------------------------------------------------------
 # Legacy tunables (retained for env-override compatibility + docs)
@@ -313,6 +364,12 @@ DEFAULT_NAME_THRESHOLD: int = 5
 
 #: Mode 3 threshold: alternating pattern length (A,B,A,B,A == 5).
 DEFAULT_ALTERNATING_THRESHOLD: int = 5
+
+#: Maximum severity the name axis may emit WITHOUT exact-repeat
+#: corroboration in the window (see §"Name-axis precision"). ``"info"``
+#: keeps the uncorroborated name axis signal-only; the exact axis and
+#: corroborated name-axis hits are unaffected.
+DEFAULT_NAME_AXIS_MAX_SEVERITY: str = "info"
 
 
 def _read_int_env(name: str, default: int) -> int:
@@ -341,7 +398,28 @@ def _read_int_env(name: str, default: int) -> int:
     return val
 
 
-def load_thresholds_from_env() -> dict[str, int]:
+def _read_severity_env(name: str, default: str) -> str:
+    """Best-effort severity-name env override; returns default when invalid.
+
+    Mirrors :func:`_read_int_env`'s lenient contract so a typo'd env
+    var degrades to the safe default instead of failing plugin init.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    val = raw.strip().lower()
+    if val not in _VALID_SEVERITY_NAMES:
+        log.debug(
+            "tool-loop detector: ignoring invalid %s=%r (using default %r)",
+            name,
+            raw,
+            default,
+        )
+        return default
+    return val
+
+
+def load_thresholds_from_env() -> dict[str, int | str]:
     """Read ``GOLDFIVE_TOOL_LOOP_*`` env vars; return overrides dict.
 
     Suitable for ``**kwargs``-splatting into :class:`ToolLoopTracker`.
@@ -367,10 +445,13 @@ def load_thresholds_from_env() -> dict[str, int]:
         "alternating_threshold": _read_int_env(
             "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD", DEFAULT_ALTERNATING_THRESHOLD
         ),
+        "name_axis_max_severity": _read_severity_env(
+            "GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY", DEFAULT_NAME_AXIS_MAX_SEVERITY
+        ),
     }
 
 
-def thresholds_from_config(config: ToolLoopConfig) -> dict[str, int]:
+def thresholds_from_config(config: ToolLoopConfig) -> dict[str, int | str]:
     """Adapt a :class:`~goldfive.config.ToolLoopConfig` to tracker kwargs.
 
     Mirrors :func:`load_thresholds_from_env` so callers can splat the
@@ -383,6 +464,7 @@ def thresholds_from_config(config: ToolLoopConfig) -> dict[str, int]:
         "exact_threshold": config.exact_threshold,
         "name_threshold": config.name_threshold,
         "alternating_threshold": config.alternating_threshold,
+        "name_axis_max_severity": config.name_axis_max_severity,
     }
 
 
@@ -423,6 +505,11 @@ class ToolLoopTracker:
     alternating-cycle mode (independent, A,B,A,B,A-shaped) still fires
     INFO only.
 
+    Name-axis hits without exact-repeat corroboration are capped at
+    ``name_axis_max_severity`` (default ``"info"`` -- see the module
+    docstring's §"Name-axis precision"). Exact-axis behaviour is
+    unchanged at any cap setting.
+
     The classifier never mutates its buffers after firing -- we do not
     dedupe drifts here. Upstream (the steerer's intervention ladder)
     already dedupes by ``(kind, task_id)`` occurrence count, and a
@@ -446,6 +533,7 @@ class ToolLoopTracker:
         exact_threshold: int = DEFAULT_EXACT_THRESHOLD,
         name_threshold: int = DEFAULT_NAME_THRESHOLD,
         alternating_threshold: int = DEFAULT_ALTERNATING_THRESHOLD,
+        name_axis_max_severity: str = DEFAULT_NAME_AXIS_MAX_SEVERITY,
     ) -> None:
         if window <= 0:
             raise ValueError(f"window must be positive, got {window}")
@@ -455,11 +543,18 @@ class ToolLoopTracker:
             raise ValueError(f"name_threshold must be positive, got {name_threshold}")
         if alternating_threshold <= 0:
             raise ValueError(f"alternating_threshold must be positive, got {alternating_threshold}")
+        if name_axis_max_severity not in _VALID_SEVERITY_NAMES:
+            raise ValueError(
+                f"name_axis_max_severity must be one of "
+                f"{sorted(_VALID_SEVERITY_NAMES)}, got {name_axis_max_severity!r}"
+            )
 
         self.window = window
         self.exact_threshold = exact_threshold
         self.name_threshold = name_threshold
         self.alternating_threshold = alternating_threshold
+        self.name_axis_max_severity = name_axis_max_severity
+        self._name_axis_severity_cap = DriftSeverity(name_axis_max_severity)
 
         # Build the effective threshold tables. The work-WARNING tier
         # is overridden by the legacy kwargs so callers supplying the
@@ -654,8 +749,9 @@ class ToolLoopTracker:
         """Return zero or more drift observations for the current window.
 
         Emits **at most one** exact/name-based drift (the highest
-        severity tier matched for the tool that hit threshold) plus,
-        independently, **at most one** alternating-cycle INFO drift.
+        EMITTED severity across tools that hit threshold, after the
+        name-axis corroboration cap) plus, independently, **at most
+        one** alternating-cycle INFO drift.
         Alternating is suppressed when an exact/name drift already
         fired -- same rationale as pre-#204 (the weaker signal would
         be noise on top of the stronger).
@@ -693,11 +789,12 @@ class ToolLoopTracker:
         # We iterate over unique tool names (not signatures) so a tool
         # with varied args contributes to "name" counts even when no
         # single signature hits the "exact" threshold. We pick the
-        # name with the highest matched tier; if several names match,
-        # we pick the highest severity first (ties broken by
-        # dictionary iteration order, which is stable on CPython).
+        # name with the highest EMITTED severity (post name-axis cap);
+        # if several names match, we pick the highest severity first
+        # (ties broken by dictionary iteration order, which is stable
+        # on CPython).
         best_drift: DriftEvent | None = None
-        best_tier_index: int | None = None  # 0=critical, 1=warning, 2=info (lower = better)
+        best_rank: int | None = None  # _SEVERITY_RANK of emitted severity (lower = better)
 
         for name in name_counts:
             thresholds = self._thresholds_for_tool(name)
@@ -707,8 +804,14 @@ class ToolLoopTracker:
                 (c for sig, c in exact_counts.items() if sig[0] == name),
                 default=0,
             )
-            # Walk tiers from highest severity to lowest.
-            for tier_index, (tier_key, severity) in enumerate(_SEVERITY_TIERS):
+            # Walk tiers from highest severity to lowest, tracking the
+            # tool's best candidate by EMITTED severity. A hit whose
+            # severity was not capped ends the walk (lower tiers cannot
+            # emit higher); a capped name-axis hit keeps walking so a
+            # lower tier's uncapped exact hit is not shadowed.
+            tool_best_rank: int | None = None
+            tool_best_drift: DriftEvent | None = None
+            for tier_key, severity in _SEVERITY_TIERS:
                 tier = thresholds.get(tier_key) or {}
                 exact_thr = tier.get("exact")
                 name_thr = tier.get("name")
@@ -721,6 +824,19 @@ class ToolLoopTracker:
                 # Prefer the "exact" detail when both axes are
                 # satisfied -- the more specific signal.
                 mode = "exact" if hit_exact else "name"
+                emit_severity = severity
+                capped_from = ""
+                if mode == "name":
+                    # Name-axis precision: same-name-varied-args alone is
+                    # ambiguous with healthy iteration, so without an
+                    # exact-repeat in the window the emitted severity is
+                    # capped at ``name_axis_max_severity``. The tier keeps
+                    # its threshold and is still recorded on ``raw``.
+                    corroborated = exact_for_name >= _NAME_AXIS_CORROBORATION_MIN_EXACT
+                    cap = self._name_axis_severity_cap
+                    if not corroborated and _SEVERITY_RANK[severity] < _SEVERITY_RANK[cap]:
+                        emit_severity = cap
+                        capped_from = severity.value
                 if mode == "exact":
                     sig = next(
                         sig
@@ -743,6 +859,8 @@ class ToolLoopTracker:
                         f"tool_loop_name: {name} x {name_total} in last "
                         f"{len(buf)} calls (no task progress)"
                     )
+                    if capped_from:
+                        detail += " (severity capped: no exact-repeat corroboration)"
                     raw = {
                         "mode": "name",
                         "tool_name": name,
@@ -752,6 +870,8 @@ class ToolLoopTracker:
                         "category": _classify_tool_category(name),
                         "tier": tier_key,
                     }
+                    if capped_from:
+                        raw["severity_capped_from"] = capped_from
 
                 # trigger_input: summarise the window the detector
                 # matched so sinks can render "what were the tool calls
@@ -763,7 +883,7 @@ class ToolLoopTracker:
                 )
                 candidate = DriftEvent(
                     kind=DriftKind.LOOPING_REASONING,
-                    severity=severity,
+                    severity=emit_severity,
                     detail=detail,
                     current_task_id=current_task_id,
                     current_agent_id=agent_name,
@@ -775,13 +895,19 @@ class ToolLoopTracker:
                     # source so decision telemetry attributes correctly.
                     detector_name="tool_loops",
                 )
-                # Keep the highest-severity candidate seen across all
-                # tools. tier_index is 0 for CRITICAL, so "lower is
-                # better" for our "best" accumulator.
-                if best_tier_index is None or tier_index < best_tier_index:
-                    best_drift = candidate
-                    best_tier_index = tier_index
-                break  # stop at the highest tier for this tool
+                rank = _SEVERITY_RANK[emit_severity]
+                if tool_best_rank is None or rank < tool_best_rank:
+                    tool_best_rank = rank
+                    tool_best_drift = candidate
+                if not capped_from:
+                    break  # uncapped hit: lower tiers cannot emit higher
+
+            # Keep the candidate with the highest EMITTED severity
+            # across all tools, so a capped name-axis INFO never
+            # shadows another tool's genuine exact-axis WARNING.
+            if tool_best_rank is not None and (best_rank is None or tool_best_rank < best_rank):
+                best_drift = tool_best_drift
+                best_rank = tool_best_rank
 
         if best_drift is not None:
             observations.append(best_drift)

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -490,7 +490,7 @@ class DefaultSteerer:
             vars. The steerer itself does NOT instantiate a
             :class:`~goldfive.drift.tool_loops.ToolLoopTracker` — the
             plugin still owns that — but exposing the config here
-            keeps the four typed knobs co-located on a single
+            keeps the typed knobs co-located on a single
             component. Precedence: the config field is advisory; the
             plugin is free to honour or ignore it. Added in #225.
         reasoning_drift_config:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,6 +371,7 @@ _TOOL_LOOP_ENV: dict[str, str] = {
     "exact_threshold": "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD",
     "name_threshold": "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD",
     "alternating_threshold": "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD",
+    "name_axis_max_severity": "GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY",
 }
 
 _REASONING_DRIFT_ENV: dict[str, str] = {

--- a/tests/test_capability_mismatch.py
+++ b/tests/test_capability_mismatch.py
@@ -711,8 +711,15 @@ async def test_integration_capability_mismatch_flows_through_handle_drift() -> N
     assert drift.severity is DriftSeverity.CRITICAL
     assert drift.current_task_id == "t-draft"
     assert drift.current_agent_id == "underqualified"
-    # Positive fire must NOT also record a no-drift decision.
-    assert steerer.drift.no_drift_decisions == []
+    # Positive fire must NOT also record a capability-check no-drift
+    # decision. (The tool-loop tracker's aggregated negative class may
+    # legitimately fire for the same invocation -- scope by detector.)
+    capability_decisions = [
+        d
+        for d in steerer.drift.no_drift_decisions
+        if d["detector_name"] == "capability_check"
+    ]
+    assert capability_decisions == []
 
 
 async def test_integration_rule_c_dag_order_mismatch_through_pin() -> None:
@@ -877,9 +884,14 @@ async def test_integration_no_capability_mismatch_when_agent_has_leaf_tool() -> 
         f"tool; got {capability_drifts}"
     )
     # Negative class for the optimizer: the detector ran on a resolved
-    # task and passed, so a no-drift decision is recorded.
-    decisions = steerer.drift.no_drift_decisions
+    # task and passed, so a no-drift decision is recorded. Scope by
+    # detector -- the tool-loop tracker's aggregated negative class may
+    # also fire for the same invocation.
+    decisions = [
+        d
+        for d in steerer.drift.no_drift_decisions
+        if d["detector_name"] == "capability_check"
+    ]
     assert len(decisions) == 1, decisions
-    assert decisions[0]["detector_name"] == "capability_check"
     assert decisions[0]["task_id"] == "t-draft"
     assert decisions[0]["agent_name"] == "qualified"

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -107,23 +107,26 @@ def test_tool_loop_config_defaults() -> None:
     assert cfg.exact_threshold == 3
     assert cfg.name_threshold == 5
     assert cfg.alternating_threshold == 5
+    assert cfg.name_axis_max_severity == "info"
 
 
 def test_tool_loop_config_from_env_all_vars(
     goldfive_tool_loop_env: Any,
 ) -> None:
-    """All four env vars map to the matching fields."""
+    """All five env vars map to the matching fields."""
     goldfive_tool_loop_env.set(
         window=12,
         exact_threshold=4,
         name_threshold=7,
         alternating_threshold=6,
+        name_axis_max_severity="critical",
     )
     cfg = ToolLoopConfig.from_env()
     assert cfg.window == 12
     assert cfg.exact_threshold == 4
     assert cfg.name_threshold == 7
     assert cfg.alternating_threshold == 6
+    assert cfg.name_axis_max_severity == "critical"
 
 
 def test_tool_loop_config_from_env_subset(
@@ -137,6 +140,16 @@ def test_tool_loop_config_from_env_subset(
     assert cfg.exact_threshold == 3
     assert cfg.name_threshold == 5
     assert cfg.alternating_threshold == 5
+    assert cfg.name_axis_max_severity == "info"
+
+
+def test_tool_loop_config_from_env_rejects_bad_severity(
+    goldfive_tool_loop_env: Any,
+) -> None:
+    """An unknown severity name degrades to the default, not an error."""
+    goldfive_tool_loop_env.set(name_axis_max_severity="loud")
+    cfg = ToolLoopConfig.from_env()
+    assert cfg.name_axis_max_severity == "info"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_loop_name_axis_precision.py
+++ b/tests/test_tool_loop_name_axis_precision.py
@@ -1,0 +1,360 @@
+"""Name-axis precision for the tool-loop detector + negative class.
+
+The tool-loop tracker's name axis (same tool name, varied args) used
+to fire WARNING at 5 and CRITICAL at 7 calls in the window -- a false
+positive on definitionally-healthy behaviour (an agent reading six
+different files with the same tool), amplified by run-scoped
+accumulation across re-invocations (goldfive#420). Downstream those
+drifts drove ``planner.refine`` and, at CRITICAL, ladder escalation.
+
+Fixed behaviour (this suite):
+
+* An uncorroborated name-axis hit emits at most INFO; the drift routes
+  to ladder Level 0 ``OBSERVE`` -- no refine, no nudge, no
+  ``goldfive.active_steer.*`` stamps -- in BOTH observation-only and
+  active modes.
+* Exact-repeat corroboration in the window restores the tier's full
+  severity; the pure exact axis is untouched.
+* The ADK plugin emits one aggregated
+  ``SteeringDecisionMade(outcome="no_drift", detector_name="tool_loops")``
+  per invocation whose tracker ran and fired nothing (the negative
+  class for threshold-tuning optimizers).
+
+Note: tests pass ``observation_only`` EXPLICITLY -- tests/conftest.py
+flips the *implicit* default to False for the legacy corpus, so
+``observation_only=True`` here is exactly the production default.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.drift.tool_loops import ToolLoopTracker  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftEvent,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+)
+
+# ---------------------------------------------------------------------------
+# Shared harness
+# ---------------------------------------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class StubPlanner:
+    def __init__(self) -> None:
+        self.refine_calls: list[dict[str, Any]] = []
+
+    async def generate(self, **kwargs: Any) -> None:  # noqa: ARG002
+        return None
+
+    async def refine(self, **kwargs: Any) -> None:
+        self.refine_calls.append(kwargs)
+        return None
+
+
+def _make_session() -> Session:
+    plan = Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="Read the corpus", description="Read source files"),
+            Task(id="t2", title="Write summary", description="Summarise findings"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="Summarise the corpus")],
+        plan=plan,
+        current_task_id="t1",
+    )
+
+
+def _payload_kinds(sink: ListSink) -> list[str]:
+    return [e.WhichOneof("payload") for e in sink.events if hasattr(e, "WhichOneof")]
+
+
+def _active_steer_keys(session: Session) -> list[str]:
+    return [k for k in session.state if "active_steer" in str(k)]
+
+
+def _varied_args_drifts(n: int = 6) -> list[DriftEvent]:
+    """Tracker output for ``n`` same-name-varied-args calls (default config)."""
+    tracker = ToolLoopTracker()
+    fired: list[DriftEvent] = []
+    for i in range(n):
+        fired.extend(
+            tracker.observe_tool_call(
+                invocation_id="inv-1",
+                agent_name="reader_agent",
+                tool_name="read_file",
+                args={"path": f"chapter_{i}.md"},
+                task_id="t1",
+                session_run_id="r1",
+            )
+        )
+    return fired
+
+
+# ---------------------------------------------------------------------------
+# Detector -> steerer: uncorroborated name-axis drifts stay OBSERVE-level.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("observation_only", [True, False])
+async def test_varied_args_burst_never_refines_or_stamps_steer(
+    observation_only: bool,
+) -> None:
+    """6 same-name-varied-args calls -> INFO only, OBSERVE routing.
+
+    Both modes: the production default (observation_only=True) and
+    active mode must agree here because the fix is at the detector --
+    an INFO drift routes to Level 0 before any mode gate is consulted.
+    """
+    fired = _varied_args_drifts(6)
+    assert fired, "the name tier should still produce INFO telemetry"
+    assert all(d.severity is DriftSeverity.INFO for d in fired), (
+        f"expected INFO only, got {[d.severity for d in fired]}"
+    )
+
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=observation_only))
+    planner = StubPlanner()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    for drift in fired:
+        await steerer.drift.handle_drift(drift, session)
+
+    # Telemetry fires; intervention machinery stays cold.
+    assert "drift_detected" in _payload_kinds(sink)
+    assert planner.refine_calls == []
+    assert session.pending_nudges == []
+    assert _active_steer_keys(session) == []
+
+
+async def test_exact_repeat_burst_still_refines_in_active_mode() -> None:
+    """Control case: the exact axis is untouched by the cap.
+
+    Three identical work calls fire WARNING and, in active mode, still
+    route to ABSORB (``planner.refine``) exactly as before.
+    """
+    tracker = ToolLoopTracker()
+    fired: list[DriftEvent] = []
+    for _ in range(3):
+        fired.extend(
+            tracker.observe_tool_call(
+                invocation_id="inv-1",
+                agent_name="worker",
+                tool_name="patch_file",
+                args={"path": "a.py", "diff": "x"},
+                task_id="t1",
+                session_run_id="r1",
+            )
+        )
+    assert [d.severity for d in fired] == [DriftSeverity.WARNING]
+
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
+    planner = StubPlanner()
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=planner)
+    session = _make_session()
+
+    await steerer.drift.handle_drift(fired[0], session)
+
+    assert len(planner.refine_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Negative class: aggregated no-drift decision from the ADK plugin.
+# ---------------------------------------------------------------------------
+
+
+class _NoDriftRecordingDrift:
+    """Drift sub-component recording drifts + ``emit_no_drift_decision``."""
+
+    def __init__(self) -> None:
+        self.drifts: list[DriftEvent] = []
+        self.no_drift_calls: list[dict[str, Any]] = []
+
+    async def observe(self, event: Any, session: Any) -> None:
+        pass
+
+    async def handle_drift(self, drift: DriftEvent, session: Any) -> None:
+        self.drifts.append(drift)
+
+    async def emit_no_drift_decision(self, **kwargs: Any) -> None:
+        self.no_drift_calls.append(kwargs)
+
+
+class _NoDriftRecordingSteerer:
+    def __init__(self) -> None:
+        self.drift = _NoDriftRecordingDrift()
+        self._sinks: list[Any] = []
+
+
+def _plugin_with_ctx(task: Task, session: Session, steerer: Any):
+    pytest.importorskip("google.adk")
+    from goldfive.adapters._adk_plugin import (
+        SESSION_CONTEXT_STATE_KEY,
+        SessionContext,
+        make_adk_plugin,
+    )
+
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    state: dict = {
+        SESSION_CONTEXT_STATE_KEY: SessionContext(
+            session=session,
+            steerer=steerer,
+            task=task,
+            tool_handlers={},
+            host_agent_name="test_agent",
+        )
+    }
+    plugin.set_active_context(state[SESSION_CONTEXT_STATE_KEY])
+    return plugin, state
+
+
+class _ToolStub:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _InvCtxStub:
+    def __init__(self, invocation_id: str, agent_name: str) -> None:
+        self.invocation_id = invocation_id
+        self.agent = type("_A", (), {"name": agent_name})()
+
+
+class _ToolCtxStub:
+    def __init__(self, invocation_id: str, agent_name: str) -> None:
+        self._invocation_context = _InvCtxStub(invocation_id, agent_name)
+
+
+async def test_clean_invocation_emits_one_aggregated_no_drift_decision() -> None:
+    """Tracker ran, fired nothing -> exactly one no_drift decision."""
+    steerer = _NoDriftRecordingSteerer()
+    session = Session(run_id="run-negclass-1")
+    task = Task(id="t1", title="Fetch", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    tool_ctx = _ToolCtxStub("inv-clean", "worker")
+    # Two distinct tools, distinct args -- far below every threshold.
+    await plugin.after_tool_callback(
+        tool=_ToolStub("read_file"),
+        tool_args={"path": "a.md"},
+        tool_context=tool_ctx,
+        result={"ok": True},
+    )
+    await plugin.after_tool_callback(
+        tool=_ToolStub("web_search"),
+        tool_args={"q": "raccoons"},
+        tool_context=tool_ctx,
+        result={"ok": True},
+    )
+    assert steerer.drift.drifts == []
+
+    await plugin.after_run_callback(invocation_context=_InvCtxStub("inv-clean", "worker"))
+
+    assert len(steerer.drift.no_drift_calls) == 1
+    call = steerer.drift.no_drift_calls[0]
+    assert call["detector_name"] == "tool_loops"
+    assert call["invocation_id"] == "inv-clean"
+    assert call["agent_name"] == "worker"
+    assert "2 tool call(s)" in call["reason"]
+
+    # The stats entry is consumed: a second after_run for the same
+    # invocation does not double-emit.
+    await plugin.after_run_callback(invocation_context=_InvCtxStub("inv-clean", "worker"))
+    assert len(steerer.drift.no_drift_calls) == 1
+
+
+async def test_no_decision_when_tracker_fired_a_drift() -> None:
+    """A window that fired (even INFO) is not a clean window."""
+    steerer = _NoDriftRecordingSteerer()
+    session = Session(run_id="run-negclass-2")
+    task = Task(id="t1", title="Fetch", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    tool_ctx = _ToolCtxStub("inv-loop", "worker")
+    tool = _ToolStub("patch_file")
+    args = {"path": "a.py", "diff": "x"}
+    for _ in range(3):  # exact repeat x 3 -> WARNING fires
+        await plugin.after_tool_callback(
+            tool=tool, tool_args=args, tool_context=tool_ctx, result={"ok": True}
+        )
+    assert steerer.drift.drifts, "expected the exact axis to fire"
+
+    await plugin.after_run_callback(invocation_context=_InvCtxStub("inv-loop", "worker"))
+
+    assert steerer.drift.no_drift_calls == []
+
+
+async def test_no_decision_when_tracker_never_ran() -> None:
+    """No tool calls -> no negative-class decision (tracker never ran)."""
+    steerer = _NoDriftRecordingSteerer()
+    session = Session(run_id="run-negclass-3")
+    task = Task(id="t1", title="Fetch", assignee_agent_id="worker")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    await plugin.after_run_callback(invocation_context=_InvCtxStub("inv-idle", "worker"))
+
+    assert steerer.drift.no_drift_calls == []
+
+
+async def test_no_drift_decision_reaches_the_wire_via_real_steerer() -> None:
+    """End-to-end: with a real DefaultSteerer the aggregated decision
+    lands on the sink as ``steering_decision_made(outcome="no_drift")``."""
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=True))
+    sink = ListSink()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+    session = _make_session()
+    task = Task(id="t1", title="Read the corpus", assignee_agent_id="reader_agent")
+    plugin, _state = _plugin_with_ctx(task, session, steerer)
+
+    tool_ctx = _ToolCtxStub("inv-wire", "reader_agent")
+    await plugin.after_tool_callback(
+        tool=_ToolStub("read_file"),
+        tool_args={"path": "a.md"},
+        tool_context=tool_ctx,
+        result={"ok": True},
+    )
+    await plugin.after_run_callback(invocation_context=_InvCtxStub("inv-wire", "reader_agent"))
+
+    decisions = [
+        e.steering_decision_made
+        for e in sink.events
+        if hasattr(e, "WhichOneof") and e.WhichOneof("payload") == "steering_decision_made"
+    ]
+    ours = [d for d in decisions if d.detector_name == "tool_loops"]
+    assert len(ours) == 1
+    assert ours[0].outcome == "no_drift"
+    assert ours[0].invocation_id == "inv-wire"

--- a/tests/test_tool_loops.py
+++ b/tests/test_tool_loops.py
@@ -3,7 +3,8 @@
 Covers the eight contracts named in the PR plan:
 
 1. Exact ``(tool_name, args_hash)`` repeat fires a WARNING.
-2. Same-name (args-varying) repeat fires a WARNING.
+2. Same-name (args-varying) repeat matches the WARNING tier but emits
+   INFO without exact-repeat corroboration (name-axis precision cap).
 3. Alternating A,B,A,B,A fires an INFO.
 4. ``on_task_progress`` clears the window.
 5. Cross-invocation buffers are isolated.
@@ -27,6 +28,7 @@ import pytest
 from goldfive.drift.tool_loops import (
     DEFAULT_ALTERNATING_THRESHOLD,
     DEFAULT_EXACT_THRESHOLD,
+    DEFAULT_NAME_AXIS_MAX_SEVERITY,
     DEFAULT_NAME_THRESHOLD,
     DEFAULT_WINDOW,
     ToolLoopTracker,
@@ -101,6 +103,7 @@ def test_load_thresholds_defaults_when_unset() -> None:
             "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD",
             "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD",
             "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD",
+            "GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY",
         ):
             os.environ.pop(var, None)
         thresholds = load_thresholds_from_env()
@@ -109,6 +112,7 @@ def test_load_thresholds_defaults_when_unset() -> None:
         "exact_threshold": DEFAULT_EXACT_THRESHOLD,
         "name_threshold": DEFAULT_NAME_THRESHOLD,
         "alternating_threshold": DEFAULT_ALTERNATING_THRESHOLD,
+        "name_axis_max_severity": DEFAULT_NAME_AXIS_MAX_SEVERITY,
     }
 
 
@@ -118,6 +122,7 @@ def test_load_thresholds_respects_env_overrides() -> None:
         "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD": "4",
         "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD": "7",
         "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD": "6",
+        "GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY": "critical",
     }
     with mock.patch.dict(os.environ, overrides, clear=False):
         thresholds = load_thresholds_from_env()
@@ -126,16 +131,19 @@ def test_load_thresholds_respects_env_overrides() -> None:
         "exact_threshold": 4,
         "name_threshold": 7,
         "alternating_threshold": 6,
+        "name_axis_max_severity": "critical",
     }
 
 
 def test_load_thresholds_rejects_bad_values() -> None:
-    # Non-integer and non-positive overrides degrade to defaults.
+    # Non-integer / non-positive / unknown-severity overrides degrade
+    # to defaults.
     bad = {
         "GOLDFIVE_TOOL_LOOP_WINDOW": "not-an-int",
         "GOLDFIVE_TOOL_LOOP_EXACT_THRESHOLD": "0",
         "GOLDFIVE_TOOL_LOOP_NAME_THRESHOLD": "-3",
         "GOLDFIVE_TOOL_LOOP_ALTERNATING_THRESHOLD": "  ",
+        "GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY": "loud",
     }
     with mock.patch.dict(os.environ, bad, clear=False):
         thresholds = load_thresholds_from_env()
@@ -143,6 +151,7 @@ def test_load_thresholds_rejects_bad_values() -> None:
     assert thresholds["exact_threshold"] == DEFAULT_EXACT_THRESHOLD
     assert thresholds["name_threshold"] == DEFAULT_NAME_THRESHOLD
     assert thresholds["alternating_threshold"] == DEFAULT_ALTERNATING_THRESHOLD
+    assert thresholds["name_axis_max_severity"] == DEFAULT_NAME_AXIS_MAX_SEVERITY
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +172,11 @@ def test_load_thresholds_rejects_bad_values() -> None:
 def test_constructor_rejects_non_positive(kwargs: dict[str, int]) -> None:
     with pytest.raises(ValueError):
         ToolLoopTracker(**kwargs)
+
+
+def test_constructor_rejects_unknown_name_axis_max_severity() -> None:
+    with pytest.raises(ValueError):
+        ToolLoopTracker(name_axis_max_severity="loud")
 
 
 # ---------------------------------------------------------------------------
@@ -206,8 +220,15 @@ def test_exact_repeat_fires_warning() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_name_repeat_fires_warning() -> None:
-    """Mode 2: five same-name, distinct-args calls fire a WARNING."""
+def test_name_repeat_uncorroborated_emits_info_only() -> None:
+    """Mode 2: five same-name, distinct-args calls emit INFO, not WARNING.
+
+    Name-axis precision: same-name-varied-args is ambiguous with
+    definitionally-healthy iteration (reading five different files with
+    the same tool), so without an exact-repeat in the window the
+    WARNING tier's threshold still matches but the emitted severity is
+    capped at INFO. The tier is preserved on ``raw`` for telemetry.
+    """
     tracker = ToolLoopTracker()
     drifts_per_call = _seed(
         tracker,
@@ -220,13 +241,136 @@ def test_name_repeat_fires_warning() -> None:
     assert len(drifts_per_call[4]) == 1
     drift = drifts_per_call[4][0]
     assert drift.kind is DriftKind.LOOPING_REASONING
-    assert drift.severity is DriftSeverity.WARNING
+    assert drift.severity is DriftSeverity.INFO
     assert "tool_loop_name" in drift.detail
+    assert "severity capped" in drift.detail
     assert drift.raw is not None
     assert drift.raw.get("mode") == "name"
     assert drift.raw.get("tool_name") == "read_file"
     assert drift.raw.get("count") == 5
+    assert drift.raw.get("tier") == "warning"
+    assert drift.raw.get("severity_capped_from") == "warning"
+    # detector_name stamping (#480) must survive the capped emission path.
     assert drift.detector_name == "tool_loops"
+
+
+def test_six_varied_args_reads_emit_info_only() -> None:
+    """The headline false-positive: 6 reads of 6 different files stays INFO.
+
+    Pre-fix this window fired WARNING at call 5 -- routing a
+    definitionally-healthy pattern into ``planner.refine`` (ABSORB).
+    Now every drift the window produces is INFO (OBSERVE: telemetry
+    only, no refine, no active-steer promotion -- LOOPING_REASONING is
+    excluded from ``_GOLDFIVE_STEER_ELIGIBLE_KINDS``).
+    """
+    tracker = ToolLoopTracker()
+    drifts_per_call = _seed(
+        tracker,
+        [("read_file", {"path": f"chapter_{i}.md"}) for i in range(6)],
+    )
+    fired = [d for drifts in drifts_per_call for d in drifts]
+    assert fired, "the name tier should still produce INFO telemetry"
+    assert all(d.severity is DriftSeverity.INFO for d in fired), (
+        f"expected INFO only, got {[d.severity for d in fired]}"
+    )
+
+
+def test_name_axis_with_exact_repeat_corroboration_keeps_tier_severity() -> None:
+    """Corroborated name-axis hits keep the tier's full severity.
+
+    A window with 5 same-name calls where two share identical args is
+    no longer plain iteration -- the exact-repeat corroborates the
+    loop hypothesis, so the WARNING tier fires uncapped.
+    """
+    tracker = ToolLoopTracker()
+    calls: list[tuple[str, dict[str, Any]]] = [
+        ("read_file", {"path": "p0.txt"}),
+        ("read_file", {"path": "p1.txt"}),
+        ("read_file", {"path": "p2.txt"}),
+        ("read_file", {"path": "p0.txt"}),  # exact repeat of call 1
+        ("read_file", {"path": "p3.txt"}),
+    ]
+    drifts_per_call = _seed(tracker, calls)
+    fifth = drifts_per_call[4]
+    assert len(fifth) == 1
+    drift = fifth[0]
+    assert drift.severity is DriftSeverity.WARNING
+    assert drift.raw is not None
+    assert drift.raw.get("mode") == "name"
+    assert drift.raw.get("tier") == "warning"
+    assert "severity_capped_from" not in drift.raw
+
+
+def test_name_axis_max_severity_critical_restores_legacy_behavior() -> None:
+    """``name_axis_max_severity="critical"`` disables the cap entirely.
+
+    Operators who want the pre-cap semantics get them back: WARNING at
+    5 same-name-varied-args calls, CRITICAL at 7.
+    """
+    tracker = ToolLoopTracker(name_axis_max_severity="critical")
+    drifts_per_call = _seed(
+        tracker,
+        [("web_developer_agent", {"q": f"q{i}"}) for i in range(7)],
+    )
+    fifth = drifts_per_call[4]
+    assert len(fifth) == 1
+    assert fifth[0].severity is DriftSeverity.WARNING
+    assert "severity_capped_from" not in fifth[0].raw
+    seventh = drifts_per_call[6]
+    assert len(seventh) == 1
+    assert seventh[0].severity is DriftSeverity.CRITICAL
+    assert seventh[0].raw.get("tier") == "critical"
+    assert "severity_capped_from" not in seventh[0].raw
+
+
+def test_name_axis_max_severity_warning_caps_critical_tier() -> None:
+    """An intermediate cap: CRITICAL-tier name hits emit WARNING."""
+    tracker = ToolLoopTracker(name_axis_max_severity="warning")
+    drifts_per_call = _seed(
+        tracker,
+        [("web_developer_agent", {"q": f"q{i}"}) for i in range(7)],
+    )
+    # WARNING tier at 5 is at-or-below the cap -- unchanged.
+    assert drifts_per_call[4][0].severity is DriftSeverity.WARNING
+    # CRITICAL tier at 7 is capped to WARNING.
+    seventh = drifts_per_call[6]
+    assert len(seventh) == 1
+    drift = seventh[0]
+    assert drift.severity is DriftSeverity.WARNING
+    assert drift.raw.get("tier") == "critical"
+    assert drift.raw.get("severity_capped_from") == "critical"
+
+
+def test_capped_name_hit_does_not_shadow_other_tools_exact_warning() -> None:
+    """Cross-tool selection ranks by EMITTED severity, not matched tier.
+
+    A window holding an uncorroborated name-axis CRITICAL-tier hit
+    (capped to INFO) for one tool AND a genuine exact-axis WARNING for
+    another must emit the WARNING -- the capped INFO would otherwise
+    win on raw tier and hide the actionable signal.
+    """
+    tracker = ToolLoopTracker()
+    calls: list[tuple[str, dict[str, Any]]] = [
+        ("browse", {"u": "0"}),
+        ("browse", {"u": "1"}),
+        ("patch_file", {"path": "a", "diff": "x"}),
+        ("browse", {"u": "2"}),
+        ("patch_file", {"path": "a", "diff": "x"}),
+        ("browse", {"u": "3"}),
+        ("browse", {"u": "4"}),
+        ("browse", {"u": "5"}),
+        ("browse", {"u": "6"}),
+        ("patch_file", {"path": "a", "diff": "x"}),
+    ]
+    drifts_per_call = _seed(tracker, calls)
+    last = drifts_per_call[-1]
+    # Window: browse x 7 varied (name CRITICAL tier, capped to INFO) +
+    # patch_file x 3 identical (exact WARNING). WARNING wins.
+    assert len(last) == 1
+    drift = last[0]
+    assert drift.severity is DriftSeverity.WARNING
+    assert drift.raw.get("mode") == "exact"
+    assert drift.raw.get("tool_name") == "patch_file"
 
 
 # ---------------------------------------------------------------------------
@@ -350,16 +494,19 @@ def test_run_scoped_bucket_accumulates_across_reinvocations() -> None:
     failure mode where ``debugger_agent`` was re-invoked 11+ times,
     each time calling ``find_presentation_files`` with varying args.
     Pre-#420 the per-(invocation_id, agent_name) bucket gave every
-    re-invocation a fresh 2-entry window — never tripping the 7-call
-    CRITICAL name-tier. With ``session_run_id`` threaded, the calls
-    accumulate into one bucket and CRITICAL fires once the cumulative
-    name-tier threshold is met.
+    re-invocation a fresh 2-entry window — never tripping the name-
+    tier thresholds. With ``session_run_id`` threaded, the calls
+    accumulate into one bucket and the tiers match on the cumulative
+    counts. Under the name-axis precision cap the varied-args signal
+    emits INFO (the tier is preserved on ``raw``); the
+    corroborated / legacy-config paths are covered by the name-axis
+    tests above.
     """
     tracker = ToolLoopTracker()
     # 11 re-invocations of the same agent, each emitting one
     # find_presentation_files call with varying args. After 7 cumulative
     # calls on the (run-id, agent) bucket the WORK name-tier CRITICAL
-    # (count >= 7) fires.
+    # threshold (count >= 7) matches.
     drifts_per_call: list[list[Any]] = []
     for i in range(11):
         result = tracker.observe_tool_call(
@@ -371,21 +518,24 @@ def test_run_scoped_bucket_accumulates_across_reinvocations() -> None:
             session_run_id="run-cherry-tree",
         )
         drifts_per_call.append(result)
-    # By call 5: name count = 5 -> WARNING (work name warning=5).
-    assert drifts_per_call[4], "expected WARNING at cumulative call 5"
-    assert drifts_per_call[4][0].severity is DriftSeverity.WARNING
-    # By call 7: name count = 7 -> CRITICAL.
+    # By call 5: name count = 5 -> WARNING tier matches; emitted as
+    # INFO (uncorroborated name axis).
+    assert drifts_per_call[4], "expected a drift at cumulative call 5"
+    assert drifts_per_call[4][0].severity is DriftSeverity.INFO
+    assert drifts_per_call[4][0].raw.get("tier") == "warning"
+    # By call 7: name count = 7 -> CRITICAL tier matches; still INFO.
     seventh = drifts_per_call[6]
     assert len(seventh) == 1, (
         f"goldfive#420: cumulative same-name calls across re-invocations "
-        f"should trip CRITICAL at 7, got {seventh}"
+        f"should match the CRITICAL tier at 7, got {seventh}"
     )
     drift = seventh[0]
-    assert drift.severity is DriftSeverity.CRITICAL
+    assert drift.severity is DriftSeverity.INFO
     assert drift.kind is DriftKind.LOOPING_REASONING
     assert drift.raw is not None
     assert drift.raw.get("category") == "work"
     assert drift.raw.get("tier") == "critical"
+    assert drift.raw.get("severity_capped_from") == "critical"
     assert drift.raw.get("mode") == "name"
     # The drift event records the actual ADK invocation id (so the
     # cancel target is right), not the run-scoped bucket key.
@@ -755,25 +905,30 @@ def test_critical_tool_loops_at_10_meta_or_6_work() -> None:
     assert sixth[0].raw.get("tier") == "critical"
 
 
-def test_work_name_tier_fires_critical_at_7() -> None:
-    """Work tool, args varying, 7 same-name calls -> CRITICAL."""
+def test_work_name_tier_at_7_is_capped_without_corroboration() -> None:
+    """Work tool, args varying, 7 same-name calls -> CRITICAL tier, INFO emit.
+
+    Formerly asserted CRITICAL: the name-axis precision cap keeps the
+    tier thresholds but emits INFO when the window has no exact-repeat
+    corroboration. ``test_name_axis_max_severity_critical_restores_legacy_behavior``
+    covers the uncapped severities under the legacy config.
+    """
     tracker = ToolLoopTracker()
-    # 7 calls to the same work tool with distinct args -- no exact
-    # signature hits, but the name axis trips CRITICAL at 7.
     drifts = _seed(
         tracker,
         [("web_developer_agent", {"q": f"q{i}"}) for i in range(7)],
     )
-    # Call 5: name count = 5 -> WARNING tier (work name warning=5).
-    assert drifts[4], "expected WARNING at call 5"
-    assert drifts[4][0].severity is DriftSeverity.WARNING
-    # Call 7: name count = 7 -> CRITICAL.
+    # Call 5: name count = 5 -> WARNING tier matches, INFO emitted.
+    assert drifts[4], "expected a drift at call 5"
+    assert drifts[4][0].severity is DriftSeverity.INFO
+    # Call 7: name count = 7 -> CRITICAL tier matches, INFO emitted.
     seventh = drifts[6]
     assert len(seventh) == 1
     drift = seventh[0]
-    assert drift.severity is DriftSeverity.CRITICAL
+    assert drift.severity is DriftSeverity.INFO
     assert drift.raw.get("category") == "work"
     assert drift.raw.get("tier") == "critical"
+    assert drift.raw.get("severity_capped_from") == "critical"
     assert drift.raw.get("mode") == "name"
 
 

--- a/tests/test_wrap_runtime_config.py
+++ b/tests/test_wrap_runtime_config.py
@@ -111,6 +111,7 @@ def test_wrap_threads_runtime_config() -> None:
         "exact_threshold": 4,
         "name_threshold": 6,
         "alternating_threshold": 6,
+        "name_axis_max_severity": "info",
     }
 
     # Steerer picks up goal-drift + tool-loop + reasoning-drift configs.


### PR DESCRIPTION
## Problem

The tool-loop detector's **name axis** (same tool name, any args) false-positives on definitionally-healthy behaviour and escalates on that signal alone:

- `goldfive/drift/tool_loops.py` (`_WORK_THRESHOLDS`): same-name-varied-args calls fired WARNING at 5 and CRITICAL at 7 in a 10-call window. An agent legitimately reading 6 different files with the same tool trips WARNING.
- The window is keyed on `(session.run_id, agent_name)` and accumulates across re-invocations (#420), and is reset only by acknowledged `report_task_*` calls -- cooperation goldfive's design explicitly does not require (no prompt-cooperation contracts), so healthy long-running agents accumulate into the tiers.
- Downstream, those WARNING/CRITICAL drifts route through `handle_drift` into `planner.refine` (ABSORB) and ladder escalation (`goldfive/drift_observer.py` ladder dispatch), burning LLM calls on the agent's own endpoint for a non-problem.

History preserved (read before coding): #204 (d215c30) graduated severity + CRITICAL-first->NUDGE, #206 (636c3dc) ToolLoopGuard retirement. This PR does **not** re-split the kind taxonomy and does **not** touch ladder rows -- the fix is precision at the detector.

## Fix

1. **Corroboration cap (detector-level).** Name-axis hits keep their tier thresholds, but the *emitted* severity is capped at INFO unless the window corroborates the loop hypothesis with exact-repeat evidence: at least 2 identical `(name, args_hash)` calls for the same tool. Capped drifts keep `raw["tier"]` (what would have fired) and add `raw["severity_capped_from"]`. INFO routes to ladder Level 0 `OBSERVE` -- no refine, no nudge, no `goldfive.active_steer.*` stamps -- and `LOOPING_REASONING` is excluded from steer promotion, so the escalation path is fully closed. The **exact axis is byte-for-byte unchanged** at any cap setting.
2. **Configurable cap.** `ToolLoopConfig.name_axis_max_severity` / `GOLDFIVE_TOOL_LOOP_NAME_AXIS_MAX_SEVERITY` (`info` | `warning` | `critical`, default `info`). `critical` restores the legacy uncapped behaviour. Invalid env values degrade to the default (matching `_read_int_env`'s lenient contract); invalid ctor/config values raise `ValueError` like the other ctor validation.
3. **Cross-tool selection by emitted severity.** The classifier now picks the highest *emitted* severity across tools (was: highest matched tier), so a capped name-axis INFO never shadows another tool's genuine exact-axis WARNING. The per-tool tier walk continues past a capped hit so a lower tier's uncapped exact hit is not shadowed under legacy threshold overrides.
4. **Negative class.** The ADK plugin now emits one aggregated `SteeringDecisionMade(outcome="no_drift", detector_name="tool_loops")` per invocation whose tracker observed >= 1 tool call and fired nothing (`after_run_callback` consumes a per-invocation counter; `clear_active_context` drops stragglers). Telemetry only -- identical in observe-only and active modes.
5. **Docs.** DRIFT.md tool-loop section (severity table footnote, new "Name-axis precision" + "Negative class" sections, ladder-routing bullets), `docs/reference/api.md`, `docs/guides/common-failure-modes.md`, and the module docstring.

## Deliberate behavior change (default)

The default `name_axis_max_severity="info"` **changes detection behavior on purpose** -- that IS the fix. Same-name-varied-args windows that previously fired WARNING@5 / CRITICAL@7 (and triggered `planner.refine`) now emit INFO telemetry only, unless the window also shows exact-repeat calls. Operators who want the old behavior set `name_axis_max_severity="critical"` (config or env var). Exact-args detection, meta-category tiers, the alternating mode, and all ladder rows are unchanged.

## Tests

- `tests/test_tool_loops.py` (43 pass): headline case (6 varied-args reads -> INFO only), corroborated name hit keeps tier severity, `critical` override restores legacy WARNING@5/CRITICAL@7 byte-for-byte, `warning` intermediate cap, capped INFO does not shadow another tool's exact WARNING, ctor/env validation, env round-trips.
- `tests/test_tool_loop_name_axis_precision.py` (new, 7 pass): detector->steerer integration in **both** `observation_only=True` (production default) and active mode -- 6 varied-args calls produce INFO only, `DriftDetected` telemetry fires, `planner.refine` never called, no `pending_nudges`, no `active_steer` state keys; control case proves 3 exact repeats still refine in active mode; plugin-level negative-class tests (one aggregated decision per clean invocation, consumed entry doesn't double-emit, none when a drift fired or no calls ran, real-steerer wire test asserting `steering_decision_made(outcome="no_drift")` on the sink).
- `tests/test_runtime_config.py`, `tests/test_wrap_runtime_config.py`, `tests/conftest.py`: new config field/env var coverage.
- Full suite: `uv run pytest -q -x` -> 2852 passed, 59 skipped (~29s). `uv run ruff check .` clean.

### Existing tests updated (asserted the old name-axis severities)

- `tests/test_tool_loops.py::test_name_repeat_fires_warning` -> renamed `test_name_repeat_uncorroborated_emits_info_only` (WARNING -> INFO + cap markers).
- `tests/test_tool_loops.py::test_work_name_tier_fires_critical_at_7` -> renamed `test_work_name_tier_at_7_is_capped_without_corroboration` (CRITICAL -> INFO, tier preserved on `raw`).
- `tests/test_tool_loops.py::test_run_scoped_bucket_accumulates_across_reinvocations` (#420 regression) -> still pins run-scoped accumulation and the invocation-id stamp; severity asserts updated to INFO + `severity_capped_from`.
- `tests/test_wrap_runtime_config.py::test_wrap_threads_runtime_config` and the `load_thresholds_from_env` round-trip tests: expected dicts gained the `name_axis_max_severity` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA
