### PR TITLE
refactor(executors): canonical terminal-status set + shared helpers; skip terminal tasks in parallel scheduling

### DIFF
--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -567,20 +567,21 @@ Open issues against the design, ranked by impact. The current
 implementation is sound for the common happy path; these are edge
 cases or failure-mode ergonomics.
 
-### 7.1 Multiple sources of truth for `_TERMINAL_TASK_STATUSES`
+### 7.1 Multiple sources of truth for `_TERMINAL_TASK_STATUSES` (closed)
 
-Three modules each define the same frozenset:
-
-- `steerer.py:47–55`
-- `adapters/_tool_invocation.py:30–37`
-- `adapters/adk.py:239–244`
-
-Each carries a comment warning maintainers to update all three in
-lockstep. No automated check enforces it.
-
-**Fix direction:** extract to a single module (e.g.
-`goldfive.types._constants`) and import from it. Low effort, high
-impact.
+Closed. `goldfive.types.TERMINAL_TASK_STATUSES` is the single
+definition; every other module imports it (some alias it to a
+module-local `_TERMINAL_TASK_STATUSES` name, which is fine — the
+alias references the canonical set). Historic duplicates in
+`steerer.py`, `adapters/_tool_invocation.py`, and `adapters/adk.py`
+were folded in earlier; the last two divergent copies lived in the
+executors — `executors/parallel.py` defined a three-status frozenset
+*without* `NOT_NEEDED` (so a reconciler-stamped `NOT_NEEDED` task was
+still scheduled for an LLM turn) plus a second four-status inline
+tuple, and `executors/sequential.py` carried a three-status tuple in
+its cancel bookkeeping. All are now imports of the canonical set, and
+`tests/test_terminal_statuses_single_source.py` walks the package
+AST to reject any future redefinition.
 
 ### 7.2 Plan validation at creation and revision (closed)
 

--- a/goldfive/executors/_shared.py
+++ b/goldfive/executors/_shared.py
@@ -1,0 +1,183 @@
+"""Helpers shared verbatim by both executors.
+
+:class:`~goldfive.executors.SequentialExecutor` and
+:class:`~goldfive.executors.ParallelDAGExecutor` need the same glue for
+steer-driven cancels, cancel bookkeeping, and drift-pipeline failure
+reporting. Control-message *dispatch* lives in
+:mod:`goldfive.executors._control`; this module hosts the non-dispatch
+helpers so the two executors cannot drift apart.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from goldfive.events import emit, new_event
+from goldfive.types import (
+    TERMINAL_TASK_STATUSES,
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    Session,
+    TaskStatus,
+)
+
+if TYPE_CHECKING:
+    from goldfive.protocols import EventSink, Steerer
+
+log = logging.getLogger(__name__)
+
+
+__all__ = [
+    "CANCEL_REASON_USER_STEER",
+    "apply_steer",
+    "emit_drift_event",
+    "emit_pipeline_failure_drift",
+    "mark_cancelled_if_live",
+    "tag_adapter_cancel_user_steer",
+]
+
+
+# Symbolic cancel-reason for USER_STEER. Mirrors
+# :data:`goldfive.adapters.adk.SYMBOLIC_REASON_USER_STEER` but duplicated
+# as a plain string to avoid importing the optional ADK adapter module
+# from the provider-agnostic executors. Keep in sync. See goldfive#139.
+CANCEL_REASON_USER_STEER: str = "user_steer"
+
+
+def tag_adapter_cancel_user_steer(adapter: Any, session: Any = None) -> None:
+    """Tag the adapter's next mid-invocation cancel with the USER_STEER reason.
+
+    Called just before the executor triggers ``task.cancel()`` on an
+    in-flight invoke task so the adapter's mid-invocation cancel
+    handler picks up the tag and appends an LLM-actionable synthetic
+    ``function_response`` (instead of the legacy generic jargon). See
+    goldfive#139.
+
+    Routes through :meth:`ADKAdapter.set_next_cancel_reason` when the
+    adapter exposes it (PR #294 audit / goldfive#271 follow-up) so the
+    tag is keyed by ``session.id`` and cannot bleed across concurrent
+    goldfive sessions sharing one adapter. Falls back to the bare
+    ``_next_cancel_reason`` attribute for adapters / stubs that
+    predate the helper.
+    """
+    setter = getattr(adapter, "set_next_cancel_reason", None)
+    if callable(setter) and session is not None:
+        try:
+            setter(session, CANCEL_REASON_USER_STEER)
+            return
+        except Exception as exc:  # noqa: BLE001
+            log.debug("executor: set_next_cancel_reason raised: %s", exc)
+    try:
+        adapter._next_cancel_reason = CANCEL_REASON_USER_STEER
+    except Exception as exc:  # noqa: BLE001
+        log.debug("executor: could not tag adapter cancel reason: %s", exc)
+
+
+async def mark_cancelled_if_live(
+    *,
+    task_id: str,
+    steerer: Steerer,
+    session: Session,
+    cancel_reason: str = "",
+) -> None:
+    """Transition a not-yet-terminal task to CANCELLED.
+
+    ``cancel_reason`` (goldfive#205): structured reason stamped on the
+    emitted ``TaskCancelled``. Defaults to a generic
+    ``user_cancel:cancelled_by_control`` when the caller does not pass
+    something more specific (e.g. an annotation_id).
+    """
+    if session.plan is None:
+        return
+    for t in session.plan.tasks:
+        if t.id == task_id:
+            if t.status in TERMINAL_TASK_STATUSES:
+                return
+            reason_value = cancel_reason or "user_cancel:cancelled_by_control"
+            try:
+                await steerer.transition(
+                    task_id,
+                    TaskStatus.CANCELLED,
+                    detail="cancelled by control",
+                    cancel_reason=reason_value,
+                    session=session,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug("executor: cancelled transition raised: %s", exc)
+            return
+
+
+async def apply_steer(
+    message: object,
+    *,
+    steerer: Steerer,
+    session: Session,
+) -> None:
+    """Feed a STEER :class:`ControlMessage` to the steerer."""
+    try:
+        await steerer.drift.observe(message, session)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("executor: steerer.drift.observe(STEER) raised: %s", exc)
+
+
+async def emit_drift_event(
+    *,
+    session: Session,
+    sinks: list[EventSink],
+    drift: DriftEvent,
+) -> None:
+    """Build a DriftDetected envelope with proto enum mapping, then emit.
+
+    Uses the same enum-mapping shape
+    :meth:`DefaultSteerer._emit_drift_detected` uses — the
+    :func:`drift_detected_event` helper in :mod:`goldfive.events` does
+    a best-effort name lookup that silently fails for StrEnum-style
+    kind/severity names (stored as lowercase like ``critical``), which
+    would leave the event with enum value ``0`` (UNSPECIFIED).
+    """
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    evt = new_event(session.run_id, session.next_sequence(), session_id=session.id)
+    evt.drift_detected.kind = getattr(
+        types_pb2,
+        f"DRIFT_KIND_{drift.kind.name}",
+        getattr(types_pb2, "DRIFT_KIND_CUSTOM", 0),
+    )
+    evt.drift_detected.severity = getattr(
+        types_pb2,
+        f"DRIFT_SEVERITY_{drift.severity.name}",
+        getattr(types_pb2, "DRIFT_SEVERITY_UNSPECIFIED", 0),
+    )
+    evt.drift_detected.detail = drift.detail
+    evt.drift_detected.current_task_id = drift.current_task_id or ""
+    evt.drift_detected.current_agent_id = drift.current_agent_id or ""
+    try:
+        await emit(sinks, evt)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("emit_drift_event: sink emit raised: %s", exc)
+
+
+async def emit_pipeline_failure_drift(
+    *,
+    session: Session,
+    sinks: list[EventSink],
+    task_id: str,
+    reason: str,
+) -> None:
+    """Emit an INFO ``CUSTOM`` drift when the drift pipeline itself raised.
+
+    Surfaces plumbing failures in ``steerer.drift.observe`` /
+    ``detect_drift`` that would otherwise be swallowed. INFO severity
+    so this is record-only and does not trigger another refine. Sinks
+    that care can filter on the ``drift_pipeline_failed:`` detail
+    prefix. See goldfive#134.
+    """
+    drift = DriftEvent(
+        kind=DriftKind.CUSTOM,
+        severity=DriftSeverity.INFO,
+        detail=reason,
+        current_task_id=task_id or "",
+    )
+    await emit_drift_event(session=session, sinks=sinks, drift=drift)

--- a/goldfive/executors/parallel.py
+++ b/goldfive/executors/parallel.py
@@ -47,6 +47,13 @@ from goldfive.executors._control import (
     drain_controls,
     pause_deadline_s,
 )
+from goldfive.executors._shared import (
+    apply_steer,
+    emit_drift_event,
+    emit_pipeline_failure_drift,
+    mark_cancelled_if_live,
+    tag_adapter_cancel_user_steer,
+)
 from goldfive.protocols import (
     AgentAdapter,
     EventSink,
@@ -56,8 +63,8 @@ from goldfive.protocols import (
 )
 from goldfive.results import ExecutionOutcome, InvocationResult, evaluate_goal_predicates
 from goldfive.types import (
+    TERMINAL_TASK_STATUSES,
     DriftEvent,
-    DriftKind,
     DriftSeverity,
     Plan,
     RefineOutcome,
@@ -78,55 +85,9 @@ log = logging.getLogger(__name__)
 
 _WARNING_RANK = severity_rank(DriftSeverity.WARNING)
 
-_TERMINAL_TASK_STATUSES: frozenset[TaskStatus] = frozenset(
-    {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED}
-)
-
-
 # A (task, result_or_drift) carrier for stage gather. Using a dataclass
 # would add import weight; a tuple is fine and stays local to this file.
 _StageResult = tuple[Task, InvocationResult | None, DriftEvent | None, BaseException | None]
-
-
-# Symbolic cancel-reason for USER_STEER. Mirrors
-# :data:`goldfive.adapters.adk.SYMBOLIC_REASON_USER_STEER` but duplicated
-# as a plain string to avoid importing the optional ADK adapter module
-# from the provider-agnostic executor. Keep in sync. See goldfive#139.
-_CANCEL_REASON_USER_STEER: str = "user_steer"
-
-
-def _tag_adapter_cancel_user_steer(adapter: Any, session: Any = None) -> None:
-    """Tag the adapter's next mid-invocation cancel with the USER_STEER reason.
-
-    Called just before the executor triggers ``task.cancel()`` on any
-    in-flight stage invoke task so the adapter's mid-invocation cancel
-    handler picks up the tag and appends an LLM-actionable synthetic
-    ``function_response`` (instead of the legacy generic jargon). See
-    goldfive#139.
-
-    Routes through :meth:`ADKAdapter.set_next_cancel_reason` when the
-    adapter exposes it (PR #294 audit / goldfive#271 follow-up) so
-    the tag is keyed by ``session.id`` and cannot bleed across
-    concurrent goldfive sessions sharing one adapter. Falls back to
-    the bare attribute write for adapters / stubs that predate the
-    helper.
-    """
-    setter = getattr(adapter, "set_next_cancel_reason", None)
-    if callable(setter) and session is not None:
-        try:
-            setter(session, _CANCEL_REASON_USER_STEER)
-            return
-        except Exception as exc:  # noqa: BLE001
-            log.debug(
-                "ParallelDAGExecutor: set_next_cancel_reason raised: %s", exc
-            )
-    try:
-        adapter._next_cancel_reason = _CANCEL_REASON_USER_STEER
-    except Exception as exc:  # noqa: BLE001
-        log.debug(
-            "ParallelDAGExecutor: could not tag adapter cancel reason: %s",
-            exc,
-        )
 
 
 class ParallelDAGExecutor:
@@ -245,28 +206,32 @@ class ParallelDAGExecutor:
                     abort_reason = "cancelled by control"
                     break
                 if pending_steer is not None:
-                    await self._apply_steer(pending_steer, steerer=steerer, session=session)
+                    await apply_steer(pending_steer, steerer=steerer, session=session)
                     # Fall through: refresh plan on next iteration.
 
-                # Recompute stages from current plan each outer iteration;
-                # tasks already completed in previous stages are filtered
-                # out by ``topological_stages`` (they sit in a terminal
-                # status). This mirrors harmonograf's approach of
+                # Recompute stages from current plan each outer iteration.
+                # ``topological_stages`` is purely structural — it does
+                # NOT filter by status — so terminal tasks (e.g. a
+                # reconciler-stamped NOT_NEEDED, or tasks completed
+                # before a refinement) must be dropped here or they get
+                # re-invoked. This mirrors harmonograf's approach of
                 # re-querying plan state after every batch.
                 current_plan = session.plan or plan
                 stages = current_plan.topological_stages()
-                # Drop any stage composed entirely of tasks we already ran
-                # (defensive — planner.refine may leave older tasks in).
-                pending_stages = [
-                    stage for stage in stages if any(t.id not in completed_stage_ids for t in stage)
-                ]
+
+                def _pending(t: Task) -> bool:
+                    return (
+                        t.id not in completed_stage_ids and t.status not in TERMINAL_TASK_STATUSES
+                    )
+
+                pending_stages = [stage for stage in stages if any(_pending(t) for t in stage)]
                 if not pending_stages:
                     break
 
                 stage = pending_stages[0]
-                # Filter already-completed tasks within this stage so we
-                # don't re-invoke them after a refinement.
-                stage_tasks = [t for t in stage if t.id not in completed_stage_ids]
+                # Filter tasks already run this call (or in a terminal
+                # status) so we don't re-invoke them after a refinement.
+                stage_tasks = [t for t in stage if _pending(t)]
                 if not stage_tasks:
                     continue
 
@@ -282,7 +247,7 @@ class ParallelDAGExecutor:
                         "user_cancel:cancelled_by_control"
                     )
                     for task, _inv, _drift, _err in stage_results:
-                        await self._mark_cancelled_if_live(
+                        await mark_cancelled_if_live(
                             task_id=task.id,
                             steerer=steerer,
                             session=session,
@@ -307,7 +272,7 @@ class ParallelDAGExecutor:
                 )
                 for task, inv, _task_drift, error in stage_results:
                     live_status = live_status_by_id.get(task.id, task.status)
-                    already_terminal = live_status in _TERMINAL_TASK_STATUSES
+                    already_terminal = live_status in TERMINAL_TASK_STATUSES
                     if error is not None and not isinstance(error, asyncio.CancelledError):
                         if not already_terminal:
                             await steerer.transition(
@@ -361,7 +326,7 @@ class ParallelDAGExecutor:
                 # cancelled by _run_stage, so the fold-back above has
                 # already recorded the tasks as CANCELLED).
                 if control_outcome is not None and control_outcome.steer_message is not None:
-                    await self._apply_steer(
+                    await apply_steer(
                         control_outcome.steer_message,
                         steerer=steerer,
                         session=session,
@@ -584,11 +549,9 @@ class ParallelDAGExecutor:
                 # consults the live plan post-fold for terminal
                 # detection.
                 prev_status = task.status
-                if prev_status is not TaskStatus.RUNNING and prev_status not in (
-                    TaskStatus.COMPLETED,
-                    TaskStatus.FAILED,
-                    TaskStatus.CANCELLED,
-                    TaskStatus.NOT_NEEDED,
+                if (
+                    prev_status is not TaskStatus.RUNNING
+                    and prev_status not in TERMINAL_TASK_STATUSES
                 ):
                     if session.plan is not None and any(
                         t.id == task.id for t in session.plan.tasks
@@ -655,7 +618,7 @@ class ParallelDAGExecutor:
                         task.id,
                         detect_exc,
                     )
-                    await _emit_pipeline_failure_drift(
+                    await emit_pipeline_failure_drift(
                         session=session,
                         sinks=sinks,
                         task_id=task.id,
@@ -759,7 +722,7 @@ class ParallelDAGExecutor:
                             # content instead of the legacy generic
                             # jargon. See goldfive#139.
                             if outcome.steer_message is not None:
-                                _tag_adapter_cancel_user_steer(adapter, session=session)
+                                tag_adapter_cancel_user_steer(adapter, session=session)
                             await _cancel_stage_tasks()
                             break
                         # Non-interrupting control (PAUSE/RESUME/
@@ -1123,7 +1086,7 @@ class ParallelDAGExecutor:
             current_task_id=source.current_task_id,
             current_agent_id=source.current_agent_id,
         )
-        await _emit_drift_event(session=session, sinks=sinks, drift=failure)
+        await emit_drift_event(session=session, sinks=sinks, drift=failure)
 
     def _bump_refine_failure(self, *, session: Session, drift: DriftEvent) -> int:
         """Bump the per-``(kind, task_id)`` refine-failure counter.
@@ -1271,56 +1234,6 @@ class ParallelDAGExecutor:
 
         return False, steer_msg
 
-    @staticmethod
-    async def _mark_cancelled_if_live(
-        *,
-        task_id: str,
-        steerer: Steerer,
-        session: Session,
-        cancel_reason: str = "",
-    ) -> None:
-        """Transition a not-yet-terminal task to CANCELLED.
-
-        ``cancel_reason`` (goldfive#205): structured reason stamped on
-        the emitted ``TaskCancelled``. Defaults to a generic
-        ``user_cancel:cancelled_by_control`` when unspecified.
-        """
-        if session.plan is None:
-            return
-        for t in session.plan.tasks:
-            if t.id == task_id:
-                if t.status in _TERMINAL_TASK_STATUSES:
-                    return
-                reason_value = cancel_reason or "user_cancel:cancelled_by_control"
-                try:
-                    await steerer.transition(
-                        task_id,
-                        TaskStatus.CANCELLED,
-                        detail="cancelled by control",
-                        cancel_reason=reason_value,
-                        session=session,
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    log.debug(
-                        "ParallelDAGExecutor: cancelled transition raised: %s",
-                        exc,
-                    )
-                return
-
-    @staticmethod
-    async def _apply_steer(
-        message: object,
-        *,
-        steerer: Steerer,
-        session: Session,
-    ) -> None:
-        """Feed a STEER :class:`ControlMessage` to the steerer."""
-        try:
-            await steerer.drift.observe(message, session)
-        except Exception as exc:  # noqa: BLE001
-            log.warning("ParallelDAGExecutor: steerer.drift.observe(STEER) raised: %s", exc)
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1328,68 +1241,6 @@ class ParallelDAGExecutor:
 
 def _outcome_summary(completed_task_ids: set[str]) -> str:
     return f"{len(completed_task_ids)} tasks completed"
-
-
-async def _emit_pipeline_failure_drift(
-    *,
-    session: Session,
-    sinks: list[EventSink],
-    task_id: str,
-    reason: str,
-) -> None:
-    """Emit an INFO ``CUSTOM`` drift when the drift pipeline itself raised.
-
-    Surfaces plumbing failures in ``steerer.drift.observe`` / ``detect_drift``
-    that would otherwise be swallowed. INFO severity so this is
-    record-only and does not trigger another refine. Sinks that care
-    can filter on the ``drift_pipeline_failed:`` detail prefix. See
-    goldfive#134.
-    """
-    drift = DriftEvent(
-        kind=DriftKind.CUSTOM,
-        severity=DriftSeverity.INFO,
-        detail=reason,
-        current_task_id=task_id or "",
-    )
-    await _emit_drift_event(session=session, sinks=sinks, drift=drift)
-
-
-async def _emit_drift_event(
-    *,
-    session: Session,
-    sinks: list[EventSink],
-    drift: DriftEvent,
-) -> None:
-    """Build a DriftDetected envelope with proto enum mapping, then emit.
-
-    Uses the same enum-mapping shape
-    :meth:`DefaultSteerer._emit_drift_detected` uses — the
-    :func:`drift_detected_event` helper in :mod:`goldfive.events` does
-    a best-effort name lookup that silently fails for StrEnum-style
-    kind/severity names (stored as lowercase like ``critical``), which
-    would leave the event with enum value ``0`` (UNSPECIFIED).
-    """
-    from goldfive.events import new_event
-    from goldfive.pb.goldfive.v1 import types_pb2
-
-    evt = new_event(session.run_id, session.next_sequence(), session_id=session.id)
-    evt.drift_detected.kind = getattr(
-        types_pb2,
-        f"DRIFT_KIND_{drift.kind.name}",
-        getattr(types_pb2, "DRIFT_KIND_CUSTOM", 0),
-    )
-    evt.drift_detected.severity = getattr(
-        types_pb2,
-        f"DRIFT_SEVERITY_{drift.severity.name}",
-        getattr(types_pb2, "DRIFT_SEVERITY_UNSPECIFIED", 0),
-    )
-    evt.drift_detected.detail = drift.detail
-    evt.drift_detected.current_task_id = drift.current_task_id or ""
-    evt.drift_detected.current_agent_id = drift.current_agent_id or ""
-    try:
-        await emit_event(sinks, evt)
-    except Exception as exc:  # noqa: BLE001
-        log.debug("_emit_drift_event: sink emit raised: %s", exc)
 
 
 # Runtime conformance check — the class must satisfy the Executor protocol.

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -56,6 +56,12 @@ from goldfive.executors._control import (
     drain_controls,
     pause_deadline_s,
 )
+from goldfive.executors._shared import (
+    apply_steer,
+    emit_pipeline_failure_drift,
+    mark_cancelled_if_live,
+    tag_adapter_cancel_user_steer,
+)
 from goldfive.protocols import AgentAdapter, EventSink, Executor, Planner, Steerer
 from goldfive.results import ExecutionOutcome, evaluate_goal_predicates
 from goldfive.types import (
@@ -73,13 +79,6 @@ if TYPE_CHECKING:
     from goldfive.control import ControlChannel
 
 log = logging.getLogger(__name__)
-
-
-# Symbolic cancel-reason for USER_STEER. Mirrors
-# :data:`goldfive.adapters.adk.SYMBOLIC_REASON_USER_STEER` but duplicated
-# as a plain string to avoid importing the optional ADK adapter module
-# from the provider-agnostic executor. Keep in sync. See goldfive#139.
-_CANCEL_REASON_USER_STEER: str = "user_steer"
 
 
 def _steer_cancel_reason_prefix(steer_msg: Any) -> str:
@@ -101,40 +100,6 @@ def _steer_cancel_reason_prefix(steer_msg: Any) -> str:
     if msg_id:
         return f"user_steer:{msg_id}"
     return "user_steer:steer"
-
-
-def _tag_adapter_cancel_user_steer(adapter: Any, session: Any = None) -> None:
-    """Tag the adapter's next mid-invocation cancel with the USER_STEER reason.
-
-    Called just before the executor triggers ``task.cancel()`` on the
-    in-flight invoke task so the adapter's mid-invocation cancel
-    handler picks up the tag and appends an LLM-actionable synthetic
-    ``function_response`` (instead of the legacy generic jargon). See
-    goldfive#139.
-
-    Routes through :meth:`ADKAdapter.set_next_cancel_reason` when the
-    adapter exposes it (PR #294 audit / goldfive#271 follow-up) so the
-    tag is keyed by ``session.id`` and cannot bleed across concurrent
-    goldfive sessions sharing one adapter. Falls back to the bare
-    ``_next_cancel_reason`` attribute for adapters / stubs that
-    predate the helper.
-    """
-    setter = getattr(adapter, "set_next_cancel_reason", None)
-    if callable(setter) and session is not None:
-        try:
-            setter(session, _CANCEL_REASON_USER_STEER)
-            return
-        except Exception as exc:  # noqa: BLE001
-            log.debug(
-                "SequentialExecutor: set_next_cancel_reason raised: %s", exc
-            )
-    try:
-        adapter._next_cancel_reason = _CANCEL_REASON_USER_STEER
-    except Exception as exc:  # noqa: BLE001
-        log.debug(
-            "SequentialExecutor: could not tag adapter cancel reason: %s",
-            exc,
-        )
 
 
 async def _drain_steerer_at_run_boundary(
@@ -432,7 +397,7 @@ class SequentialExecutor(Executor):
                 run_failed = True
                 break
             if steer_msg is not None:
-                await self._apply_steer(steer_msg, steerer=steerer, session=session)
+                await apply_steer(steer_msg, steerer=steerer, session=session)
                 # The steerer swapped session.plan; pick up the revision
                 # on the next outer iteration.
 
@@ -577,7 +542,7 @@ class SequentialExecutor(Executor):
                 # emitted TaskCancelled carries the reason.
                 cancel_prefix = getattr(session, "_last_cancel_reason_prefix", "")
                 session._last_cancel_reason_prefix = ""
-                await self._mark_cancelled_if_live(
+                await mark_cancelled_if_live(
                     task_id=task.id,
                     steerer=steerer,
                     session=session,
@@ -604,13 +569,13 @@ class SequentialExecutor(Executor):
                 # distinguish "superseded by user steering" from
                 # generic run-aborts / cascade-cancels.
                 steer_prefix = _steer_cancel_reason_prefix(outcome_payload)
-                await self._mark_cancelled_if_live(
+                await mark_cancelled_if_live(
                     task_id=task.id,
                     steerer=steerer,
                     session=session,
                     cancel_reason=steer_prefix,
                 )
-                await self._apply_steer(outcome_payload, steerer=steerer, session=session)
+                await apply_steer(outcome_payload, steerer=steerer, session=session)
                 continue
 
             # outcome_kind == "result"
@@ -646,7 +611,7 @@ class SequentialExecutor(Executor):
                         task.id,
                         observe_exc,
                     )
-                    await _emit_pipeline_failure_drift(
+                    await emit_pipeline_failure_drift(
                         session=session,
                         sinks=sinks,
                         task_id=task.id,
@@ -1212,7 +1177,7 @@ class SequentialExecutor(Executor):
                     "SequentialExecutor._run_overlay: STEER received; "
                     "feeding steerer.drift.observe for USER_STEER drift + refine",
                 )
-                await self._apply_steer(payload, steerer=steerer, session=session)
+                await apply_steer(payload, steerer=steerer, session=session)
                 # goldfive#152: wrap the steer body in a goldfive-authored
                 # override header so the LLM sees it as a USER STEERING
                 # CONTROL directive, not a fresh user turn. Supersedes
@@ -1927,7 +1892,7 @@ class SequentialExecutor(Executor):
                 # handler (and the synthetic function_response it
                 # appends) carries LLM-actionable content instead of
                 # the legacy generic jargon. See goldfive#139.
-                _tag_adapter_cancel_user_steer(adapter, session=session)
+                tag_adapter_cancel_user_steer(adapter, session=session)
                 await self._cancel_invoke_task(invoke_task)
                 return ("steer", outcome.steer_message)
 
@@ -1958,54 +1923,6 @@ class SequentialExecutor(Executor):
         log.warning(
             "SequentialExecutor: adapter ignored task.cancel(); abandoning after 5s grace window"
         )
-
-    @staticmethod
-    async def _mark_cancelled_if_live(
-        *,
-        task_id: str,
-        steerer: Steerer,
-        session: Session,
-        cancel_reason: str = "",
-    ) -> None:
-        """Transition a not-yet-terminal task to CANCELLED.
-
-        ``cancel_reason`` (goldfive#205): structured reason stamped on the
-        emitted ``TaskCancelled``. Defaults to a generic
-        ``user_cancel:cancelled_by_control`` when the caller does not
-        pass something more specific (e.g. an annotation_id).
-        """
-        if session.plan is None:
-            return
-        for t in session.plan.tasks:
-            if t.id == task_id:
-                if t.status in (
-                    TaskStatus.COMPLETED,
-                    TaskStatus.FAILED,
-                    TaskStatus.CANCELLED,
-                ):
-                    return
-                reason_value = cancel_reason or "user_cancel:cancelled_by_control"
-                await steerer.transition(
-                    task_id,
-                    TaskStatus.CANCELLED,
-                    detail="cancelled by control",
-                    cancel_reason=reason_value,
-                    session=session,
-                )
-                return
-
-    @staticmethod
-    async def _apply_steer(
-        message: object,
-        *,
-        steerer: Steerer,
-        session: Session,
-    ) -> None:
-        """Feed a STEER :class:`ControlMessage` to the steerer."""
-        try:
-            await steerer.drift.observe(message, session)
-        except Exception as exc:  # noqa: BLE001
-            log.warning("SequentialExecutor: steerer.drift.observe(STEER) raised: %s", exc)
 
     @staticmethod
     def _compose_nudge_replay_message(
@@ -2471,49 +2388,6 @@ def _unreachable_pending_task_ids(plan: Plan) -> set[str]:
                     break
 
     return unreachable_pending
-
-
-async def _emit_pipeline_failure_drift(
-    *,
-    session: Session,
-    sinks: list[EventSink],
-    task_id: str,
-    reason: str,
-) -> None:
-    """Emit an INFO ``CUSTOM`` drift when the drift pipeline itself raised.
-
-    Mirrors the helper in
-    :mod:`goldfive.executors.parallel`: a bug in the steerer's observe
-    path must not silently disappear. INFO severity so the run does not
-    trigger another refine — the goal is to make the plumbing failure
-    visible, not to recover from it. Sinks that care can filter on
-    the ``drift_pipeline_failed:`` detail prefix. See goldfive#134.
-
-    Uses the steerer's proto-enum mapping shape
-    (``DRIFT_KIND_<NAME>``) so the emitted envelope carries a real
-    enum value rather than UNSPECIFIED — the
-    :func:`goldfive.events.drift_detected_event` helper does a
-    best-effort lookup that silently drops StrEnum-style values.
-    """
-    from goldfive.pb.goldfive.v1 import types_pb2
-
-    evt = new_event(session.run_id, session.next_sequence(), session_id=session.id)
-    evt.drift_detected.kind = getattr(
-        types_pb2,
-        f"DRIFT_KIND_{DriftKind.CUSTOM.name}",
-        0,
-    )
-    evt.drift_detected.severity = getattr(
-        types_pb2,
-        f"DRIFT_SEVERITY_{DriftSeverity.INFO.name}",
-        0,
-    )
-    evt.drift_detected.detail = reason
-    evt.drift_detected.current_task_id = task_id or ""
-    try:
-        await emit(sinks, evt)
-    except Exception as exc:  # noqa: BLE001
-        log.debug("_emit_pipeline_failure_drift: sink emit raised: %s", exc)
 
 
 def _plan_divergence_drift_event(session: Session, detail: str) -> object:

--- a/tests/test_parallel_executor.py
+++ b/tests/test_parallel_executor.py
@@ -966,3 +966,73 @@ async def test_observer_exception_emits_pipeline_failure_drift() -> None:
         == types_pb2.DRIFT_SEVERITY_INFO
     )
     assert "classifier exploded" in pipeline_failures[0].drift_detected.detail
+
+
+@pytest.mark.asyncio
+async def test_not_needed_task_is_never_scheduled() -> None:
+    """A terminal-stamped task (e.g. reconciler NOT_NEEDED) must not
+    reach the adapter.
+
+    ``Plan.topological_stages`` is purely structural — it does not
+    filter by status — so the executor's stage filter has to drop
+    terminal tasks itself. Before the fix, only tasks completed within
+    the current ``run()`` call (``completed_stage_ids``) were filtered,
+    so a NOT_NEEDED task stamped before the run got at least one full
+    LLM turn.
+    """
+    tasks = [
+        Task(id="A", title="A"),
+        Task(id="B", title="B"),
+        Task(id="C", title="C", status=TaskStatus.NOT_NEEDED),
+        Task(id="D", title="D"),
+        Task(id="E", title="E"),
+    ]
+    plan = Plan(
+        id="plan-1",
+        run_id="run-1",
+        goal_ids=[],
+        tasks=tasks,
+        edges=list(_diamond_plan().edges),
+    )
+
+    adapter = TracingAdapter(delay=0.01)
+    executor = ParallelDAGExecutor(max_concurrency=0)
+    outcome = await executor.run(
+        plan=plan,
+        session=_new_session(),
+        adapter=adapter,
+        steerer=RecordingSteerer(),
+        planner=RecordingPlanner(),
+        sinks=[NoopSink()],
+    )
+
+    assert outcome.success is True
+    assert "C" not in adapter.order, "NOT_NEEDED task reached the adapter"
+    assert set(adapter.completed) == {"A", "B", "D", "E"}
+
+
+@pytest.mark.asyncio
+async def test_stage_of_only_terminal_tasks_is_skipped() -> None:
+    """A stage whose every task is already terminal is skipped entirely
+    (COMPLETED / CANCELLED tasks stamped before the run are not re-run)."""
+    tasks = [
+        Task(id="A", title="A", status=TaskStatus.COMPLETED),
+        Task(id="B", title="B", status=TaskStatus.CANCELLED),
+        Task(id="C", title="C"),
+    ]
+    edges = [TaskEdge("A", "C"), TaskEdge("B", "C")]
+    plan = Plan(id="plan-1", run_id="run-1", goal_ids=[], tasks=tasks, edges=edges)
+
+    adapter = TracingAdapter(delay=0.01)
+    executor = ParallelDAGExecutor(max_concurrency=0)
+    outcome = await executor.run(
+        plan=plan,
+        session=_new_session(),
+        adapter=adapter,
+        steerer=RecordingSteerer(),
+        planner=RecordingPlanner(),
+        sinks=[NoopSink()],
+    )
+
+    assert outcome.success is True
+    assert adapter.order == ["C"]

--- a/tests/test_terminal_statuses_single_source.py
+++ b/tests/test_terminal_statuses_single_source.py
@@ -1,0 +1,57 @@
+"""Guard: ``TERMINAL_TASK_STATUSES`` has exactly one definition.
+
+``goldfive.types.TERMINAL_TASK_STATUSES`` is documented as the single
+source of truth for terminal task statuses (TASK-LIFECYCLE.md §7.1).
+Divergent copies have caused real bugs — the parallel executor's local
+frozenset omitted ``NOT_NEEDED``, so reconciler-stamped tasks were
+still scheduled for an LLM turn. This test walks the package AST and
+rejects any assignment that rebuilds the set instead of aliasing the
+canonical one.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_CANONICAL = "TERMINAL_TASK_STATUSES"
+_PKG_ROOT = pathlib.Path(__file__).resolve().parent.parent / "goldfive"
+
+
+def _is_alias_of_canonical(value: ast.expr | None) -> bool:
+    """True when the assigned value merely references the canonical set."""
+    if isinstance(value, ast.Name):
+        return value.id == _CANONICAL
+    if isinstance(value, ast.Attribute):
+        return value.attr == _CANONICAL
+    return False
+
+
+def test_no_module_redefines_terminal_task_statuses() -> None:
+    offenders: list[str] = []
+    for path in sorted(_PKG_ROOT.rglob("*.py")):
+        rel = path.relative_to(_PKG_ROOT)
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                targets = node.targets
+                value = node.value
+            elif isinstance(node, ast.AnnAssign):
+                targets = [node.target]
+                value = node.value
+            else:
+                continue
+            for target in targets:
+                if not isinstance(target, ast.Name) or _CANONICAL not in target.id:
+                    continue
+                # The one real definition lives in goldfive/types.py.
+                if str(rel) == "types.py" and target.id == _CANONICAL:
+                    continue
+                # Module-local aliases of the canonical set are fine.
+                if _is_alias_of_canonical(value):
+                    continue
+                offenders.append(f"{rel}:{node.lineno}: {target.id} redefined")
+    assert not offenders, (
+        "TERMINAL_TASK_STATUSES must only be defined in goldfive/types.py "
+        "(import or alias it elsewhere):\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Problem

`goldfive/types.py:99-108` declares `TERMINAL_TASK_STATUSES` as "the single source of truth ... Do not duplicate this set", yet the executors carried three divergent copies:

- `executors/parallel.py:81-83` defined a module-local `_TERMINAL_TASK_STATUSES` **without** `NOT_NEEDED` (COMPLETED/FAILED/CANCELLED only).
- `executors/parallel.py:587-592` carried a second inline four-status tuple **with** `NOT_NEEDED` — file-internally inconsistent with the frozenset above it.
- `executors/sequential.py:1981-1985` had a three-status tuple (no `NOT_NEEDED`) in `_mark_cancelled_if_live`.

Consequence (real behavior bug): the parallel scheduler's stage filter only excluded tasks in `completed_stage_ids` — i.e. tasks completed **within the current `run()` call** (`parallel.py:222-231`). A reconciler-stamped `NOT_NEEDED` task therefore got scheduled for at least one full LLM turn, and the comment claiming `topological_stages` filters terminal tasks was false (`types.py:1105-1140` — Kahn's algorithm is purely structural, no status filtering).

Separately, four helpers were duplicated verbatim (modulo log prefix) across `sequential.py` and `parallel.py`: `_tag_adapter_cancel_user_steer`, `_mark_cancelled_if_live`, `_apply_steer`, `_emit_pipeline_failure_drift`.

## Fix

- Both executors now import `TERMINAL_TASK_STATUSES` from `goldfive.types`; all three divergent copies are deleted.
- The parallel scheduler's pending-stage predicate now also drops tasks whose status is terminal, so a `NOT_NEEDED`-stamped task never reaches the adapter. The false comment is corrected. The same predicate is used for both the stage-level and task-level filters, so the `continue` branch cannot spin.
- New `goldfive/executors/_shared.py` hosts the four extracted helpers (public names, no leading underscore) plus `emit_drift_event`, which `emit_pipeline_failure_drift` and parallel's refine-failure path both use. `executors/_control.py` stays scoped to control-message *dispatch* per its module docstring.
- `_outcome_summary` left per-executor (deliberately different signatures/semantics). `CANCEL_REASON_USER_STEER` moved with its sole consumer into `_shared.py` but remains a plain string — the rationale (avoid importing the optional ADK adapter from provider-agnostic executors) still holds, verified: `_shared.py` imports nothing from `goldfive.adapters`.
- `docs/design/TASK-LIFECYCLE.md` §7.1 rewritten as closed: its listed duplicate sites were stale (already fixed) and the executors — the actual remaining offenders — were never listed.

## Behavior-change notes

- `mark_cancelled_if_live` (both executors) now treats `NOT_NEEDED` as terminal and skips the CANCELLED transition; previously sequential (and parallel's inline copies) would attempt a transition the state machine rejects anyway.
- Sequential's `mark_cancelled_if_live` now wraps `steerer.transition` in try/except (debug log), adopting parallel's more defensive variant — cancel bookkeeping failure no longer propagates out of the sequential run loop.
- Parallel's `already_terminal` fold-back check (`parallel.py:275`) now includes `NOT_NEEDED`, so a task stamped `NOT_NEEDED` mid-stage is no longer force-transitioned to COMPLETED/FAILED.
- Shared-helper log prefixes changed from `SequentialExecutor:`/`ParallelDAGExecutor:` to `executor:`.
- The scheduling fix is executor-level and independent of `observation_only` — no steering-surface change in either mode; existing suites covering both modes pass unchanged.

## Tests

- `tests/test_parallel_executor.py::test_not_needed_task_is_never_scheduled` — NOT_NEEDED-stamped task in a diamond DAG never reaches the adapter (zero invocations); verified to FAIL against the pre-fix filter.
- `tests/test_parallel_executor.py::test_stage_of_only_terminal_tasks_is_skipped` — a stage composed entirely of terminal tasks is skipped; also verified to fail pre-fix.
- `tests/test_terminal_statuses_single_source.py` — AST guard: no module under `goldfive/` may redefine `TERMINAL_TASK_STATUSES` (aliases of the canonical set allowed).
- Helper extraction is covered by the existing executor suites passing unchanged (`test_sequential_executor.py`, `test_parallel_executor.py`, `test_executor_control.py`); no existing test asserted the old duplicated behavior.
- Full suite: 2890 passed, 59 skipped (~26s). `ruff check .` clean; remaining `ruff format` drift in touched files is pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA