### PR TITLE
feat(drift): wire drift-condition resolution — terminal tasks + on-task verdicts emit DRIFT_LIFECYCLE_RESOLVED

### DIFF
--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -160,6 +160,7 @@ from goldfive.types import (
     Session,
     Task,
     TaskStatus,
+    _uuid_hex,
     filter_recent_events_by_kind,
 )
 
@@ -312,6 +313,24 @@ class DriftObserver:
         {
             DriftKind.HUMAN_INTERVENTION_REQUIRED,
             DriftKind.REPEATED_FAILURE,
+        }
+    )
+
+    # Drift kinds the reasoning-analysis pipeline
+    # (:func:`~goldfive.drift.reasoning.analyze_reasoning_with_focus`)
+    # can open. An ON-TASK verdict from that pipeline is the negative
+    # outcome of exactly these checks, so it (and only it) can resolve
+    # their open conditions. GOAL_DRIFT is deliberately absent: it is
+    # opened by the goal-drift judge, which answers a trajectory-level
+    # question a reasoning-scoped on-task verdict carries no evidence
+    # about; its conditions resolve at task-terminal instead.
+    _REASONING_PIPELINE_DRIFT_KINDS: frozenset[DriftKind] = frozenset(
+        {
+            DriftKind.LOOPING_REASONING,
+            DriftKind.REASONING_CLUSTER_TIGHTENING,
+            DriftKind.OFF_TOPIC,
+            DriftKind.JUSTIFIED_DEVIATION,
+            DriftKind.INTENT_DIVERGENCE,
         }
     )
 
@@ -1041,6 +1060,147 @@ class DriftObserver:
         }
         name = mapping.get(lifecycle, "DRIFT_LIFECYCLE_UNSPECIFIED")
         return getattr(types_pb2, name, getattr(types_pb2, "DRIFT_LIFECYCLE_UNSPECIFIED", 0))
+
+    # ------------------------------------------------------------------
+    # Drift-condition resolution (lifecycle truth, observability-only)
+    # ------------------------------------------------------------------
+
+    async def resolve_conditions_for_terminal_task(
+        self,
+        session: Session,
+        *,
+        task_id: str,
+        to_status: TaskStatus,
+    ) -> None:
+        """Resolve every open condition pinned to a task that went terminal.
+
+        A terminal task (COMPLETED / FAILED / CANCELLED / NOT_NEEDED)
+        moots every condition still open against it: no further
+        observation on that task can escalate or recover them, so
+        leaving them in ``KEY_ACTIVE_DRIFTS`` makes the active set grow
+        monotonically per run and downstream consumers never see an
+        intervention succeed. Pure lifecycle telemetry — no intervention
+        decision reads the result, so behaviour is identical under
+        ``observation_only`` True and False.
+        """
+        if not task_id:
+            return
+        try:
+            resolved = _ostate.resolve_drifts_matching(session.state, task_id=task_id)
+        except Exception as exc:  # noqa: BLE001
+            # Lifecycle bookkeeping must never break a live transition
+            # path (same contract as :meth:`_stamp_drift_lifecycle`).
+            log.debug(
+                "DriftObserver.resolve_conditions_for_terminal_task: "
+                "resolve skipped (%s)",
+                exc,
+            )
+            return
+        if not resolved:
+            return
+        status_label = str(getattr(to_status, "value", to_status) or "")
+        await self._emit_resolved_conditions(
+            session,
+            resolved,
+            reason=f"task {task_id} reached terminal status {status_label}",
+        )
+
+    async def _resolve_conditions_on_on_task_verdict(
+        self,
+        session: Session,
+        *,
+        agent_name: str,
+    ) -> None:
+        """Resolve reasoning-pipeline conditions after an ON-TASK verdict.
+
+        The verdict is the same pipeline's clean bill for the current
+        ``(task, agent, run)``, so only the kinds that pipeline can open
+        (:data:`_REASONING_PIPELINE_DRIFT_KINDS`) resolve — deterministic
+        detector conditions (tool loops, task failures, plan divergence)
+        keep their own lifecycle. The empty agent_id is accepted because
+        the embedding-side detectors open conditions without agent
+        attribution. Callers gate on the same late-verdict staleness
+        check as the drift side (:meth:`_invocation_target_gone`).
+        """
+        task_id = str(getattr(session, "current_task_id", "") or "")
+        if not task_id:
+            return
+        resolved = _ostate.resolve_drifts_matching(
+            session.state,
+            task_id=task_id,
+            agent_ids={agent_name, ""},
+            turn_id=str(getattr(session, "run_id", "") or ""),
+            kinds=self._REASONING_PIPELINE_DRIFT_KINDS,
+        )
+        if not resolved:
+            return
+        await self._emit_resolved_conditions(
+            session,
+            resolved,
+            reason=(
+                f"reasoning judge returned on-task verdict for agent "
+                f"{agent_name or '(unknown)'}"
+            ),
+        )
+
+    async def _emit_resolved_conditions(
+        self,
+        session: Session,
+        resolved: list[_ostate.Drift],
+        *,
+        reason: str,
+    ) -> None:
+        """Emit one ``DriftDetected(lifecycle=RESOLVED)`` per resolved condition.
+
+        Wire mirror of a batch :func:`state_store.resolve_drifts_matching`
+        call — the state mutation already happened in the caller, so a
+        missing sink list or proto stub leaves lifecycle truth intact.
+        Severity is INFO (the resolving emit is a recovery marker, not a
+        new firing); ``prev_severity`` carries the condition's last
+        recorded severity so sinks can render "recovered from WARNING".
+        Deliberately does NOT route through :meth:`_emit_drift_detected`:
+        resolution is not a detector decision, so no paired
+        ``SteeringDecisionMade`` / ``JudgementEmitted`` and no
+        ``session.drift_events`` append.
+        """
+        if not self._steerer._sinks:
+            return
+        try:
+            from goldfive.pb.goldfive.v1 import types_pb2
+        except Exception as exc:  # noqa: BLE001 — proto stubs may be missing
+            log.debug(
+                "DriftObserver._emit_resolved_conditions: proto stubs unavailable: %s",
+                exc,
+            )
+            return
+        for condition in resolved:
+            try:
+                evt = self._steerer._new_envelope(session)
+                payload = evt.drift_detected
+                if condition.kind is not None:
+                    payload.kind = self._steerer._drift_kind_pb_value(condition.kind)
+                payload.severity = self._steerer._drift_severity_pb_value(DriftSeverity.INFO)
+                if condition.severity is not None:
+                    payload.prev_severity = self._steerer._drift_severity_pb_value(
+                        condition.severity
+                    )
+                payload.detail = reason
+                payload.current_task_id = condition.task_id
+                payload.current_agent_id = condition.agent_id
+                payload.id = _uuid_hex()
+                payload.authored_by = "goldfive"
+                payload.condition_id = condition.condition_id
+                payload.lifecycle = self._drift_lifecycle_pb_value(
+                    condition.lifecycle, types_pb2
+                )
+                await self._steerer._emit(evt)
+            except Exception as exc:  # noqa: BLE001 — observability-only
+                log.debug(
+                    "DriftObserver._emit_resolved_conditions: emit failed for "
+                    "condition %s: %s",
+                    condition.condition_id,
+                    exc,
+                )
 
     # ------------------------------------------------------------------
     # Source attribution helpers
@@ -2076,6 +2236,16 @@ class DriftObserver:
                     task_id=session.current_task_id,
                     agent_name=agent_name,
                 )
+                # An on-task verdict is the recovery signal for
+                # conditions this same pipeline opened. Gated on the
+                # same staleness predicate as the drift branch below
+                # (goldfive#319) so a verdict landing after its
+                # invocation terminated cannot resolve a fresh
+                # condition opened by a newer turn.
+                if not self._invocation_target_gone(session):
+                    await self._resolve_conditions_on_on_task_verdict(
+                        session, agent_name=agent_name
+                    )
                 return
             if not drift.trigger_input:
                 drift.trigger_input = self._truncate_trigger_input(text)
@@ -4732,6 +4902,17 @@ class DriftObserver:
         # normalised at the top of :meth:`handle_drift`.
         if (drift.authored_by or "").lower() == "user":
             return False
+        return self._invocation_target_gone(session)
+
+    def _invocation_target_gone(self, session: Session) -> bool:
+        """Return True when no invocation is live for the session.
+
+        Store-backed half of the late-verdict staleness gate, shared by
+        :meth:`_is_late_drift_for_terminated_invocation` (drift-side)
+        and the on-task condition-resolution path so a stale background
+        verdict can neither dispatch against nor resolve a fresh
+        condition.
+        """
         try:
             from goldfive.state_store import StateStore
 
@@ -4740,7 +4921,7 @@ class DriftObserver:
             cancel_pending = store.cancel_requested_invocation_ids()
         except Exception as exc:  # noqa: BLE001 — defensive
             log.debug(
-                "DefaultSteerer._is_late_drift_for_terminated_invocation: "
+                "DefaultSteerer._invocation_target_gone: "
                 "active_invocation_ids lookup raised (treating as not-late): %s",
                 exc,
             )

--- a/goldfive/state_store.py
+++ b/goldfive/state_store.py
@@ -891,6 +891,52 @@ def resolve_drift(
     return drift
 
 
+def resolve_drifts_matching(
+    state: MutableMapping[str, Any],
+    *,
+    task_id: str | None = None,
+    agent_ids: Iterable[str] | None = None,
+    turn_id: str | None = None,
+    kinds: Iterable[DriftKind] | None = None,
+) -> list[Drift]:
+    """Resolve every active condition matching all supplied filters.
+
+    Batch counterpart of :func:`resolve_drift`: a single read + single
+    write over the active set, so a task-terminal transition that moots
+    several conditions does not rewrite ``KEY_ACTIVE_DRIFTS`` once per
+    condition. Filters are conjunctive; a ``None`` filter matches every
+    condition, so callers must supply at least one. ``agent_ids`` /
+    ``kinds`` are membership filters (e.g. ``{"agent", ""}`` to include
+    conditions a detector opened without agent attribution).
+
+    Returns the resolved :class:`Drift` objects (``lifecycle`` set to
+    :data:`LIFECYCLE_RESOLVED`, same finalisation as
+    :func:`resolve_drift`) in active-set order; ``[]`` when nothing
+    matches.
+    """
+    agent_set = frozenset(agent_ids) if agent_ids is not None else None
+    kind_set = frozenset(kinds) if kinds is not None else None
+    active = _read_active_drifts(state)
+    resolved: list[Drift] = []
+    for cid in list(active):
+        drift = Drift.from_dict(active[cid])
+        if task_id is not None and drift.task_id != task_id:
+            continue
+        if agent_set is not None and drift.agent_id not in agent_set:
+            continue
+        if turn_id is not None and drift.turn_id != turn_id:
+            continue
+        if kind_set is not None and drift.kind not in kind_set:
+            continue
+        del active[cid]
+        drift.prev_severity = None
+        drift.lifecycle = LIFECYCLE_RESOLVED
+        resolved.append(drift)
+    if resolved:
+        _write_active_drifts(state, active)
+    return resolved
+
+
 def escalate_drift_to_human_intervention(
     state: MutableMapping[str, Any],
     condition_id: str,
@@ -1913,6 +1959,25 @@ class StateStore:
             return None
         return resolve_drift(self._state, condition_id)
 
+    def resolve_drifts_matching(
+        self,
+        *,
+        task_id: str | None = None,
+        agent_ids: Iterable[str] | None = None,
+        turn_id: str | None = None,
+        kinds: Iterable[DriftKind] | None = None,
+    ) -> list[Drift]:
+        """Batch-resolve active conditions matching the supplied filters."""
+        if not isinstance(self._state, MutableMapping):
+            return []
+        return resolve_drifts_matching(
+            self._state,
+            task_id=task_id,
+            agent_ids=agent_ids,
+            turn_id=turn_id,
+            kinds=kinds,
+        )
+
     def escalate_to_human_intervention(self, condition_id: str) -> Drift | None:
         """Mark a condition as escalated to human intervention."""
         if not isinstance(self._state, MutableMapping):
@@ -1966,6 +2031,7 @@ __all__ = [
     "record_processed_steer_id",
     "refresh_goals_summary",
     "resolve_drift",
+    "resolve_drifts_matching",
     "rotate_current_task_id",
     "set_active_steer",
     "set_current_plan",

--- a/goldfive/task_state_machine.py
+++ b/goldfive/task_state_machine.py
@@ -733,6 +733,16 @@ class TaskStateMachine:
         task_id_for_progress = str(getattr(task, "id", "") or "")
         if task_id_for_progress:
             session.task_last_progress_at[task_id_for_progress] = time.monotonic()
+        # Drift-condition lifecycle: a terminal task moots every
+        # condition still open against it. Done here because every
+        # transition path funnels through this method (mark_task_*,
+        # cascade, plan-revision transitions), and BEFORE the sink
+        # check because the ``KEY_ACTIVE_DRIFTS`` cleanup is lifecycle
+        # truth that must land even when emission is impossible.
+        if task_id_for_progress and to_status in _TERMINAL_TASK_STATUSES:
+            await self._steerer.drift.resolve_conditions_for_terminal_task(
+                session, task_id=task_id_for_progress, to_status=to_status
+            )
         sinks = self._steerer._sinks
         if not sinks:
             return

--- a/tests/test_drift_resolution_wiring.py
+++ b/tests/test_drift_resolution_wiring.py
@@ -1,0 +1,409 @@
+"""Drift-condition resolution wiring — the event stream can represent recovery.
+
+``state_store.resolve_drift`` and the ``DRIFT_LIFECYCLE_RESOLVED`` wire
+enum shipped with goldfive#271 PR1 but had no production caller:
+conditions only ever OPENED or ESCALATED, so ``KEY_ACTIVE_DRIFTS`` grew
+monotonically per run and downstream consumers never saw an
+intervention succeed. This file pins the two resolution paths:
+
+* **Task-terminal** — every transition to a terminal status
+  (COMPLETED / FAILED / CANCELLED / NOT_NEEDED) funnels through
+  ``TaskStateMachine._emit_task_transitioned``, which batch-resolves
+  every open condition pinned to that task and emits one
+  ``DriftDetected(lifecycle=RESOLVED, severity=INFO)`` per condition.
+* **On-task verdict** — a reasoning-judge ON-TASK verdict resolves the
+  open conditions the reasoning pipeline itself can open (and only
+  those) for the verdict's (task, agent, run), gated on the same
+  late-verdict staleness check as the drift branch (goldfive#319).
+
+Both paths are telemetry/lifecycle truth only: no intervention decision
+reads the result, so behaviour is identical under
+``observation_only`` True and False (asserted below).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+import json  # noqa: E402
+
+from goldfive import state_store as _ostate  # noqa: E402
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.state_store import StateStore  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    DriftKind,
+    DriftSeverity,
+    Goal,
+    Plan,
+    Session,
+    Task,
+    TaskEdge,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_process_wide_reasoning_config() -> Any:
+    """The judge-mode steerer installs ReasoningDriftConfig process-wide;
+    clear it around each test to avoid leakage."""
+    from goldfive.drift import reasoning as _reasoning
+
+    _reasoning.configure(None)
+    yield
+    _reasoning.configure(None)
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class NullPlanner:
+    async def generate(self, **kwargs: Any) -> Plan | None:
+        return None
+
+    async def refine(self, **kwargs: Any) -> Plan | None:
+        return None
+
+
+def _plan() -> Plan:
+    return Plan(
+        id="p1",
+        run_id="r1",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="t1", title="research", assignee_agent_id="worker"),
+            Task(id="t2", title="write", assignee_agent_id="writer"),
+        ],
+        edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+    )
+
+
+def _session() -> Session:
+    return Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="publish a memo")],
+        plan=_plan(),
+        current_task_id="t1",
+    )
+
+
+def _bound_steerer(sink: ListSink, *, observation_only: bool) -> DefaultSteerer:
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(observation_only=observation_only),
+    )
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+    return steerer
+
+
+def _open(
+    session: Session,
+    *,
+    kind: DriftKind,
+    task_id: str,
+    agent_id: str,
+    severity: DriftSeverity = DriftSeverity.WARNING,
+) -> str:
+    """Open a condition on the session and return its condition_id."""
+    drift = _ostate.open_or_escalate_drift(
+        session.state,
+        kind=kind,
+        task_id=task_id,
+        agent_id=agent_id,
+        turn_id=session.run_id,
+        severity=severity,
+    )
+    return drift.condition_id
+
+
+def _resolved_events(sink: ListSink) -> list[Any]:
+    """Return DriftDetected envelopes carrying DRIFT_LIFECYCLE_RESOLVED."""
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    out: list[Any] = []
+    for evt in sink.events:
+        which = getattr(evt, "WhichOneof", None)
+        if which is None:
+            continue
+        try:
+            if which("payload") != "drift_detected":
+                continue
+        except Exception:
+            continue
+        if evt.drift_detected.lifecycle == types_pb2.DRIFT_LIFECYCLE_RESOLVED:
+            out.append(evt)
+    return out
+
+
+def _active_condition_ids(session: Session) -> set[str]:
+    return {d.condition_id for d in _ostate.list_active_drifts(session.state)}
+
+
+# ---------------------------------------------------------------------------
+# state_store.resolve_drifts_matching — batch primitive
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_drifts_matching_filters_and_batches() -> None:
+    """One read/write pass resolves every match; non-matches survive."""
+    session = _session()
+    cid_t1_a = _open(session, kind=DriftKind.OFF_TOPIC, task_id="t1", agent_id="worker")
+    cid_t1_b = _open(session, kind=DriftKind.LOOPING_TOOL_CALL, task_id="t1", agent_id="worker")
+    cid_t2 = _open(session, kind=DriftKind.OFF_TOPIC, task_id="t2", agent_id="writer")
+
+    resolved = _ostate.resolve_drifts_matching(session.state, task_id="t1")
+
+    assert {d.condition_id for d in resolved} == {cid_t1_a, cid_t1_b}
+    assert all(d.lifecycle == _ostate.LIFECYCLE_RESOLVED for d in resolved)
+    assert all(d.prev_severity is None for d in resolved)
+    assert _active_condition_ids(session) == {cid_t2}
+    # Idempotent: a second pass matches nothing.
+    assert _ostate.resolve_drifts_matching(session.state, task_id="t1") == []
+
+
+def test_resolve_drifts_matching_kind_and_agent_filters_conjoin() -> None:
+    """kinds / agent_ids / turn_id filters are conjunctive membership tests."""
+    session = _session()
+    cid_match = _open(session, kind=DriftKind.OFF_TOPIC, task_id="t1", agent_id="worker")
+    cid_unattributed = _open(session, kind=DriftKind.LOOPING_REASONING, task_id="t1", agent_id="")
+    cid_wrong_kind = _open(
+        session, kind=DriftKind.LOOPING_TOOL_CALL, task_id="t1", agent_id="worker"
+    )
+    cid_wrong_agent = _open(session, kind=DriftKind.OFF_TOPIC, task_id="t1", agent_id="other")
+
+    resolved = _ostate.resolve_drifts_matching(
+        session.state,
+        task_id="t1",
+        agent_ids={"worker", ""},
+        turn_id="r1",
+        kinds={DriftKind.OFF_TOPIC, DriftKind.LOOPING_REASONING},
+    )
+
+    assert {d.condition_id for d in resolved} == {cid_match, cid_unattributed}
+    assert _active_condition_ids(session) == {cid_wrong_kind, cid_wrong_agent}
+
+
+def test_state_store_veneer_resolves_matching() -> None:
+    """StateStore exposes the batch helper with the same semantics."""
+    session = _session()
+    cid = _open(session, kind=DriftKind.GOAL_DRIFT, task_id="t1", agent_id="a")
+    store = StateStore.for_session(session)
+    resolved = store.resolve_drifts_matching(task_id="t1")
+    assert [d.condition_id for d in resolved] == [cid]
+    assert store.active_drifts() == []
+
+
+# ---------------------------------------------------------------------------
+# Task-terminal resolution — identical in both steering modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("observation_only", [True, False])
+async def test_terminal_transition_resolves_task_conditions(
+    observation_only: bool,
+) -> None:
+    """COMPLETED resolves the task's open conditions, emits RESOLVED
+    markers, and leaves other tasks' conditions open."""
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    sink = ListSink()
+    steerer = _bound_steerer(sink, observation_only=observation_only)
+    session = _session()
+
+    cid_loop = _open(
+        session,
+        kind=DriftKind.LOOPING_TOOL_CALL,
+        task_id="t1",
+        agent_id="worker",
+        severity=DriftSeverity.WARNING,
+    )
+    cid_goal = _open(
+        session,
+        kind=DriftKind.GOAL_DRIFT,
+        task_id="t1",
+        agent_id="worker",
+        severity=DriftSeverity.CRITICAL,
+    )
+    cid_other_task = _open(session, kind=DriftKind.OFF_TOPIC, task_id="t2", agent_id="writer")
+
+    await steerer.tasks.mark_task_completed("t1", session=session, summary="done")
+
+    # KEY_ACTIVE_DRIFTS shrank to the untouched task's condition.
+    assert _active_condition_ids(session) == {cid_other_task}
+
+    resolved = _resolved_events(sink)
+    assert {e.drift_detected.condition_id for e in resolved} == {cid_loop, cid_goal}
+    for evt in resolved:
+        payload = evt.drift_detected
+        assert payload.severity == types_pb2.DRIFT_SEVERITY_INFO
+        assert payload.current_task_id == "t1"
+        assert payload.authored_by == "goldfive"
+        assert payload.id != ""
+        assert payload.id != payload.condition_id
+        assert "terminal status COMPLETED" in payload.detail
+    # prev_severity carries the condition's last recorded severity.
+    by_cid = {e.drift_detected.condition_id: e.drift_detected for e in resolved}
+    assert by_cid[cid_loop].prev_severity == types_pb2.DRIFT_SEVERITY_WARNING
+    assert by_cid[cid_goal].prev_severity == types_pb2.DRIFT_SEVERITY_CRITICAL
+
+
+async def test_cancel_cascade_resolves_downstream_conditions() -> None:
+    """The cancellation cascade's downstream transitions also resolve."""
+    sink = ListSink()
+    steerer = _bound_steerer(sink, observation_only=True)
+    session = _session()
+
+    cid_t1 = _open(session, kind=DriftKind.LOOPING_TOOL_CALL, task_id="t1", agent_id="worker")
+    cid_t2 = _open(session, kind=DriftKind.OFF_TOPIC, task_id="t2", agent_id="writer")
+
+    await steerer.tasks.mark_task_cancelled("t1", session=session, reason="stop")
+
+    assert _active_condition_ids(session) == set()
+    resolved = _resolved_events(sink)
+    details = {e.drift_detected.condition_id: e.drift_detected.detail for e in resolved}
+    assert set(details) == {cid_t1, cid_t2}
+    assert "terminal status CANCELLED" in details[cid_t1]
+    assert "terminal status CANCELLED" in details[cid_t2]
+
+
+async def test_terminal_transition_without_conditions_emits_nothing() -> None:
+    """No open conditions -> no RESOLVED markers on the wire."""
+    sink = ListSink()
+    steerer = _bound_steerer(sink, observation_only=True)
+    session = _session()
+
+    await steerer.tasks.mark_task_completed("t1", session=session)
+
+    assert _resolved_events(sink) == []
+
+
+# ---------------------------------------------------------------------------
+# On-task verdict resolution — judge-authored kinds only, staleness-gated
+# ---------------------------------------------------------------------------
+
+
+def _on_task_steerer(sink: ListSink, *, observation_only: bool) -> DefaultSteerer:
+    async def call_llm(system: str, user: str, model: str) -> str:  # noqa: ARG001
+        return json.dumps({"classification": "on_task", "reason": "focused"})
+
+    steerer = DefaultSteerer(
+        reasoning_drift_call_llm=call_llm,
+        reasoning_drift_model="fake",
+        reasoning_drift_mode="judge",
+        steering_config=SteeringConfig(observation_only=observation_only),
+    )
+    steerer.bind(sinks=[sink], planner=NullPlanner())
+    return steerer
+
+
+async def _drain_judges(steerer: DefaultSteerer) -> None:
+    pending = list(steerer._background_judges)
+    results = await asyncio.gather(*pending, return_exceptions=True)
+    for r in results:
+        assert not isinstance(r, BaseException), (
+            f"background judge raised {r!r}; expected clean completion"
+        )
+
+
+@pytest.mark.parametrize("observation_only", [True, False])
+async def test_on_task_verdict_resolves_reasoning_pipeline_conditions(
+    observation_only: bool,
+) -> None:
+    """A live ON-TASK verdict resolves reasoning-pipeline kinds for its
+    (task, agent, run) — including unattributed embedding conditions —
+    and leaves deterministic-detector and other-task conditions open."""
+    sink = ListSink()
+    steerer = _on_task_steerer(sink, observation_only=observation_only)
+    session = _session()
+
+    cid_judge = _open(session, kind=DriftKind.OFF_TOPIC, task_id="t1", agent_id="worker")
+    cid_embed = _open(session, kind=DriftKind.LOOPING_REASONING, task_id="t1", agent_id="")
+    cid_tool_loop = _open(
+        session, kind=DriftKind.LOOPING_TOOL_CALL, task_id="t1", agent_id="worker"
+    )
+    cid_other_task = _open(session, kind=DriftKind.OFF_TOPIC, task_id="t2", agent_id="worker")
+
+    # Live invocation so the late-verdict staleness gate does not fire.
+    store = StateStore.for_session(session)
+
+    async def _placeholder() -> None:
+        await asyncio.sleep(0.5)
+
+    fake_task = asyncio.create_task(_placeholder())
+    store.register_invocation_task("inv-live", fake_task)
+    try:
+        await steerer.drift.observe_reasoning(
+            "compare panel efficiency specs", session=session, agent_name="worker"
+        )
+        await _drain_judges(steerer)
+    finally:
+        store.deregister_invocation_task("inv-live")
+        fake_task.cancel()
+        await asyncio.gather(fake_task, return_exceptions=True)
+
+    # Judge-authored + unattributed reasoning conditions resolved;
+    # deterministic-detector and other-task conditions untouched.
+    assert _active_condition_ids(session) == {cid_tool_loop, cid_other_task}
+    resolved = _resolved_events(sink)
+    assert {e.drift_detected.condition_id for e in resolved} == {cid_judge, cid_embed}
+    for evt in resolved:
+        assert "on-task verdict" in evt.drift_detected.detail
+
+
+async def test_stale_on_task_verdict_does_not_resolve() -> None:
+    """A verdict landing with no live invocation (goldfive#319) must not
+    resolve anything — same staleness gate as the drift branch."""
+    sink = ListSink()
+    steerer = _on_task_steerer(sink, observation_only=True)
+    session = _session()
+
+    cid = _open(session, kind=DriftKind.OFF_TOPIC, task_id="t1", agent_id="worker")
+
+    # No invocation registered — the agent has moved on.
+    await steerer.drift.observe_reasoning(
+        "compare panel efficiency specs", session=session, agent_name="worker"
+    )
+    await _drain_judges(steerer)
+
+    assert _active_condition_ids(session) == {cid}
+    assert _resolved_events(sink) == []
+
+
+# ---------------------------------------------------------------------------
+# Wire round-trip
+# ---------------------------------------------------------------------------
+
+
+async def test_resolved_event_round_trips_on_the_wire() -> None:
+    """DRIFT_LIFECYCLE_RESOLVED survives serialize -> parse."""
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    sink = ListSink()
+    steerer = _bound_steerer(sink, observation_only=True)
+    session = _session()
+    cid = _open(session, kind=DriftKind.OFF_TOPIC, task_id="t1", agent_id="worker")
+
+    await steerer.tasks.mark_task_completed("t1", session=session)
+
+    (evt,) = _resolved_events(sink)
+    restored = type(evt).FromString(evt.SerializeToString())
+    assert restored.WhichOneof("payload") == "drift_detected"
+    assert restored.drift_detected.condition_id == cid
+    assert restored.drift_detected.lifecycle == types_pb2.DRIFT_LIFECYCLE_RESOLVED
+    assert restored.drift_detected.severity == types_pb2.DRIFT_SEVERITY_INFO

--- a/tests/test_task_state_machine.py
+++ b/tests/test_task_state_machine.py
@@ -71,6 +71,7 @@ class _StubDrift:
         self.note_agent_activity_calls: list[dict[str, Any]] = []
         self.spawn_drift_calls: list[tuple[DriftEvent, Session]] = []
         self.goal_drift_boundary_calls: int = 0
+        self.resolve_terminal_calls: list[tuple[str, TaskStatus]] = []
 
     def note_agent_activity(
         self,
@@ -97,6 +98,11 @@ class _StubDrift:
 
     async def _maybe_run_goal_drift_on_task_boundary(self, session: Session) -> None:
         self.goal_drift_boundary_calls += 1
+
+    async def resolve_conditions_for_terminal_task(
+        self, session: Session, *, task_id: str, to_status: TaskStatus
+    ) -> None:
+        self.resolve_terminal_calls.append((task_id, to_status))
 
 
 class _StubRouter:


### PR DESCRIPTION
## Problem

`state_store.resolve_drift` and the `DRIFT_LIFECYCLE_RESOLVED` wire enum are implemented and tested but had **zero production callers** (`goldfive/state_store.py:870`; the only lifecycle stamping site is `DriftObserver._stamp_drift_lifecycle`, which routes exclusively through `open_or_escalate_drift` — `goldfive/drift_observer.py:1010`). Conditions therefore only ever OPENED or ESCALATED: `KEY_ACTIVE_DRIFTS` grew monotonically per run and downstream consumers (harmonograf/zicato) saw a stream in which no intervention ever succeeds.

## Fix

**1. Task-terminal resolution** — hooked at `TaskStateMachine._emit_task_transitioned` (`goldfive/task_state_machine.py:736`), the documented single choke point every status-transition path funnels through. On a transition to any status in the canonical `types.TERMINAL_TASK_STATUSES`, all open conditions whose `task_id` matches are batch-resolved via the new `state_store.resolve_drifts_matching` (single read + single write over the active set — one pass even when several conditions resolve) and one `DriftDetected(lifecycle=RESOLVED, severity=INFO, prev_severity=<last recorded>, detail="task <id> reached terminal status <S>")` is emitted per condition. State cleanup runs before the sink/proto guards so lifecycle truth lands even when emission is impossible.

Transition paths verified to flow through this hook:
- **reporting tools** — `report_task_*` handlers → `steerer.tasks.mark_task_*` (`goldfive/reporting`, pinned by `tests/test_task_transitioned_events.py`); also driven end-to-end manually via `report_task_completed`.
- **reconciler stamps** — `PlanReconciler.on_before_agent`/`on_after_agent` → `self._steerer.transition(...)` → `mark_task_*` (`goldfive/reconciler.py:212-350`).
- **cancel cascades** — `cascade_cancel_downstream` calls `_emit_task_transitioned` per downstream task (`goldfive/task_state_machine.py:623`); `mark_task_failed(recoverable=False)` shares the same primitive.
- **plan-revision-carried status changes** — `_emit_plan_revision_transitions` → `_emit_task_transitioned` (`goldfive/task_state_machine.py:786`).
- **executor/control paths** — `executors/sequential.py`, `executors/parallel.py`, `executors/_control.py` all route through `steerer.transition`; the only direct `with_task_status` writers outside the TSM are non-terminal (PENDING/RUNNING) or the crash-recovery replay in `sinks/persistence.py`.

**2. On-task verdict resolution** — in `_run_judge_background_inner`'s `drift is None` branch (`goldfive/drift_observer.py:2239`), an ON-TASK verdict resolves open conditions for the same `(task, agent, run)` whose kind the reasoning pipeline itself can open. The empty `agent_id` is also matched because the embedding-side detectors open conditions without agent attribution. Guarded by the **same** late-verdict staleness predicate the drift branch applies (goldfive#319) — extracted as `_invocation_target_gone` and shared by `_is_late_drift_for_terminated_invocation` — so a stale background verdict cannot resolve a fresh condition. The #483 verdict-utility ledger counters are untouched.

**Kind-list verification** (the brief hypothesised GOAL_DRIFT, OFF_TOPIC, LOOPING_REASONING, INTENT_DIVERGENCE): `analyze_reasoning_with_focus` can open `LOOPING_REASONING`, `REASONING_CLUSTER_TIGHTENING`, `OFF_TOPIC`, `JUSTIFIED_DEVIATION`, `INTENT_DIVERGENCE` (`goldfive/drift/reasoning.py`, `goldfive/drift/reasoning_judge.py:1405-1416`) — all five are in the resolve set, since the ON-TASK verdict is that pipeline's negative outcome. `GOAL_DRIFT` is **deliberately excluded**: it is opened by the separate goal-drift judge (`goldfive/drift/goals.py:478`), which answers a trajectory-level question a reasoning-scoped on-task verdict carries no evidence about. GOAL_DRIFT conditions still resolve at task-terminal (path 1).

**3. Not wired** into ladder escalation memory (`session.refine_outcomes`) or any intervention decision — the resolving emit deliberately bypasses `_emit_drift_detected` so no paired `SteeringDecisionMade`/`JudgementEmitted` and no `session.drift_events` append. Both hooks are emit+state-cleanup only, so behaviour is identical under `observation_only=True` (production default) and `False` — asserted by parametrized tests.

## Tests

`tests/test_drift_resolution_wiring.py` (new, 11 tests):
- terminal transition resolves the task's open conditions, emits RESOLVED markers (severity INFO, prev_severity = last recorded severity), leaves other tasks' conditions open; `KEY_ACTIVE_DRIFTS` shrinks — parametrized over `observation_only` True/False;
- cancel cascade resolves downstream conditions too;
- ON-TASK verdict resolves judge/reasoning-pipeline kinds (incl. unattributed embedding conditions) for its (task, agent, run) and NOT deterministic-detector (`LOOPING_TOOL_CALL`) or other-task conditions — parametrized over both steering modes;
- stale verdict (no live invocation, goldfive#319 gate) resolves nothing;
- wire round-trip: `DRIFT_LIFECYCLE_RESOLVED` + condition_id survive serialize → parse;
- `resolve_drifts_matching` unit coverage: batching, conjunctive filters, idempotence, StateStore veneer.

Updated test: `tests/test_task_state_machine.py` — `_StubDrift` grew `resolve_conditions_for_terminal_task` (the TSM now reaches it via the router on terminal transitions).

Full suite: `uv run pytest -q -x` → 2898 passed, 59 skipped. `uv run ruff check .` clean. Also drove the `report_task_completed` reporting-tool path end-to-end manually (RESOLVED emitted, active set empty).

## Behavior-change notes

- New `DriftDetected` rows with `lifecycle=RESOLVED`, `severity=INFO`, `authored_by="goldfive"` appear on sinks at task-terminal transitions and on live on-task verdicts. Legacy sinks that ignore `lifecycle` see extra INFO rows; consumers that understand the enum now see recovery.
- No flag: this is not a detector — it is the missing half of the already-shipped #271 condition lifecycle, and no intervention decision reads it.
- Known pre-existing gap left as-is: `mark_task_failed`/`mark_task_blocked` open a `TASK_FAILED_*`/`BLOCKED` condition via the background drift dispatch *after* the transition, so a condition about the failure itself is opened on an already-terminal task and stays open for the run. Resolving those would require lifecycle semantics for failure-kind conditions and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA