### PR TITLE
feat(drift): flag-gated wall-clock stall watchdog — the missing TASK_TIMEOUT producer

### DIFF
--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -79,7 +79,7 @@ kinds group naturally into six categories.
 | `TASK_FAILED_RECOVERABLE` | `report_task_failed(task_id, reason, recoverable=True)` | `warning` | yes |
 | `TASK_FAILED_FATAL` | `report_task_failed(task_id, reason, recoverable=False)` | `critical` | no |
 | `REPEATED_FAILURE` | Same task has now failed `>= N` times in one run. | `critical` | sometimes |
-| `TASK_TIMEOUT` | Task exceeded its predicted duration by a wide factor. | `warning` | yes |
+| `TASK_TIMEOUT` | Wall-clock stall watchdog (`SteeringConfig.stall_watchdog_enabled`, default OFF): the session's liveness watermark (`task_last_progress_at` + `last_observed_event_at`) silent for `stall_timeout_s`. Graduated: WARNING on first fire, CRITICAL at each further multiple of the timeout with no fresh activity. Suppressed while an LLM call is in flight under its own per-call budget (that hang is `LLM_CALL_TIMEOUT`). | `warning`, escalating `critical` | yes |
 
 ### Divergence category — work no longer matches the plan
 
@@ -754,6 +754,15 @@ with `source="goldfive"`) is byte-distinct from the `[USER STEERING
 CONTROL …]` header, so plugins / sinks can attribute the corrective
 to its actual origin. See `tests/test_goldfive_drift_routing.py` for
 the contract pins.
+
+**`TASK_TIMEOUT` row (stall watchdog).** The flag-gated wall-clock
+stall watchdog's drift has a deliberately conservative row:
+`INFO → OBSERVE`, `WARNING → NUDGE` (a stall is a liveness signal,
+not a plan defect — `ABSORB` would loop the planner against a plan
+that isn't wrong), `CRITICAL → PAUSE_ESCALATE` (first and repeat —
+the watchdog only emits CRITICAL on *continued* silence after its
+WARNING, so a CRITICAL is by construction already a repeat). Under
+`observation_only` the whole dispatch is telemetry-only as usual.
 
 **Repeat detection.** Occurrence count per `(drift.kind, task_id)` is
 tracked on the session; a drift crosses "repeat" once

--- a/docs/design/STATE-MACHINE.md
+++ b/docs/design/STATE-MACHINE.md
@@ -204,9 +204,29 @@ transition**. It:
 - Writes `session.agent_notes[task_id] = detail`.
 - Emits `TaskProgress(task_id, fraction, detail)`.
 
-Sinks can use progress events for liveness indicators. goldfive does
-not use them internally (not even for drift — stalled tasks are
-detected via elapsed time, not via progress gaps).
+Sinks can use progress events for liveness indicators. Internally,
+each progress report (like every task transition) refreshes
+`session.task_last_progress_at` — the per-task liveness watermark
+consulted by two mechanisms:
+
+- the steerer's progress-stall escalation gate: a *drift* firing on a
+  task that has been silent longer than
+  `DefaultSteerer.PROGRESS_STALL_THRESHOLD_SECONDS` escalates to
+  `HUMAN_INTERVENTION_REQUIRED` instead of looping the planner;
+- the flag-gated wall-clock stall watchdog
+  (`SteeringConfig.stall_watchdog_enabled`, default OFF): a
+  per-dispatch background task that emits `TASK_TIMEOUT` drifts
+  (WARNING, then CRITICAL on continued silence) when the session-wide
+  watermark — `task_last_progress_at` plus
+  `session.last_observed_event_at`, stamped on every observation the
+  drift pipeline sees — goes silent for
+  `SteeringConfig.stall_timeout_s`.
+
+There is **no always-on elapsed-time stall detector**: with the
+watchdog flag off (the default), a run wedged in a hung async tool
+call or idling with no transitions produces no drift signal at all.
+Sync-blocking tools starve the event loop and are out of scope even
+with the watchdog on (see `goldfive/adapters/_adk_plugin.py`).
 
 ## Cascade semantics on unrecoverable drift
 

--- a/docs/design/VOCABULARY.md
+++ b/docs/design/VOCABULARY.md
@@ -373,7 +373,7 @@ rather than a reasoning error."
 |---|---|---|---|
 | `CONTEXT_PRESSURE` | `"context_pressure"` | `WARNING` | `classify_stop_reason` matched a `CONTEXT_PRESSURE_STOP_REASONS` value (`MAX_TOKENS`, `LENGTH`, `TRUNCATED`, `CONTENT_FILTER`, `MAX_OUTPUT_TOKENS`). |
 | `TOO_MANY_STEPS` | `"too_many_steps"` | `WARNING` | Adapter observed an unreasonable step count in a single invocation. Adapter-synthesized. |
-| `TASK_TIMEOUT` | `"task_timeout"` | `WARNING` | Task exceeded its predicted duration by a large factor. |
+| `TASK_TIMEOUT` | `"task_timeout"` | `WARNING` (escalating `CRITICAL`) | Wall-clock stall watchdog (`SteeringConfig.stall_watchdog_enabled`, default OFF): session liveness watermark silent for `stall_timeout_s`; CRITICAL on continued silence. |
 | `REPEATED_FAILURE` | `"repeated_failure"` | `CRITICAL` | Same task has now failed `>= N` times in one run. |
 | `RESOURCE_EXHAUSTED` | `"resource_exhausted"` | `WARNING` | Rate-limit or quota exhaustion observed by the adapter. |
 | `TASK_FAILED_RECOVERABLE` | `"task_failed_recoverable"` | `WARNING` | `mark_task_failed(..., recoverable=True)` (default). |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -362,7 +362,7 @@ use snake_case for forward compatibility with sinks.
 | 14 | STOPPED_EARLY | `"stopped_early"` | Response truncated before the task completed. |
 | 15 | TOO_MANY_STEPS | `"too_many_steps"` | Per-task / per-lineage step cap exceeded. |
 | 16 | GOAL_UNREACHABLE | `"goal_unreachable"` | Planner concluded no plan can satisfy the goal. |
-| 17 | TASK_TIMEOUT | `"task_timeout"` | Task exceeded `predicted_duration_ms` by threshold. |
+| 17 | TASK_TIMEOUT | `"task_timeout"` | Stall watchdog (`SteeringConfig.stall_watchdog_enabled`, default OFF): no observed activity for `stall_timeout_s`. |
 | 18 | REPEATED_FAILURE | `"repeated_failure"` | N consecutive refine failures for the same `(kind, task)` pair. |
 | 19 | UNEXPECTED_OUTPUT | `"unexpected_output"` | Output shape violates declared schema. |
 | 20 | SCHEMA_VIOLATION | `"schema_violation"` | Hard JSON / schema parse failure. |

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -25,6 +25,18 @@ goldfive's :class:`~goldfive.protocols.Steerer`. It does four jobs:
    ``on_tool_error_callback`` feed raw signals into
    ``steerer.drift.observe(...)`` so the steerer can classify drift.
 
+The plugin also hosts the flag-gated **wall-clock stall watchdog**
+(``SteeringConfig.stall_watchdog_enabled``, default OFF): one
+background task per dispatch that fires ``TASK_TIMEOUT`` drifts when
+the session's liveness watermark goes silent. Honest limitation: the
+watchdog is an asyncio task on the same event loop as the wrapped
+tree, so a **synchronously-blocking tool** (a ``def`` tool doing
+blocking I/O / CPU work without yielding) starves the loop and the
+watchdog cannot fire until the block ends. Detecting sync-blocked
+loops is out of scope; the watchdog covers hung *async* tool calls
+and idle-with-no-transitions runs — the cases that previously
+produced zero signal.
+
 The plugin never imports ``google.adk`` at module load. It imports the
 ADK ``BasePlugin`` base class lazily inside :func:`make_adk_plugin`,
 which is only called from the adapter's ``__init__``. That keeps this
@@ -2165,6 +2177,12 @@ def make_adk_plugin(
             # sub-Runners get their own invocation_id). Each entry is
             # a small dict to keep the payload auditable in tests.
             self._invocation_llm_pending: dict[str, dict[str, Any]] = {}
+            # Wall-clock stall watchdog (flag-gated, default OFF).
+            # Spawned by :meth:`set_active_context` when the bound
+            # steerer carries ``SteeringConfig.stall_watchdog_enabled``;
+            # cancelled by :meth:`clear_active_context` (the adapter's
+            # ``finally`` teardown) so it never outlives the dispatch.
+            self._stall_watchdog_task: asyncio.Task[None] | None = None
             # Tool-loop drift detector (goldfive#181). Observes every
             # tool call the plugin sees in ``after_tool_callback`` and
             # fires a ``LOOPING_REASONING`` drift when any of the
@@ -2333,6 +2351,10 @@ def make_adk_plugin(
             # invocation so a prior trip doesn't leak into this one.
             self._agent_tool_spawn_count = 0
             self.runaway_delegation_tripped = False
+            # Wall-clock stall watchdog (flag-gated, default OFF). One
+            # task per dispatch; a fresh dispatch replaces any prior
+            # watchdog (sequential invocations reuse the adapter).
+            self._maybe_start_stall_watchdog(ctx)
 
         def clear_active_context(self) -> None:
             """Release the active ``SessionContext`` reference.
@@ -2349,6 +2371,10 @@ def make_adk_plugin(
                 self._invocation_tasks.clear()
             except Exception as exc:  # noqa: BLE001
                 log.debug("clear_active_context: registry clear raised: %s", exc)
+            # Cancel the stall watchdog BEFORE dropping the context so
+            # a watchdog waking up mid-teardown cannot observe a
+            # half-cleared plugin.
+            self._cancel_stall_watchdog()
             self._active_ctx = None
             self._top_invocation_id = ""
             self._agent_tool_spawn_count = 0
@@ -5290,6 +5316,266 @@ def make_adk_plugin(
                     "_run_llm_call_timeout_watcher: cancel-flag write raised: %s",
                     exc,
                 )
+
+        # --- Wall-clock stall watchdog (flag-gated, default OFF) --------
+
+        def _maybe_start_stall_watchdog(self, ctx: SessionContext) -> None:
+            """Spawn the per-dispatch stall watchdog when the flag is on.
+
+            Called from :meth:`set_active_context`. Gated on the bound
+            steerer carrying ``_stall_watchdog_enabled=True`` (stashed
+            from :class:`~goldfive.config.SteeringConfig` by
+            ``DefaultSteerer.__init__``) and a positive
+            ``_stall_timeout_s``; both default OFF, so the un-flagged
+            path costs one attribute read and spawns nothing. A prior
+            watchdog (sequential dispatch reusing the adapter) is
+            cancelled first so at most one runs per plugin.
+            """
+            self._cancel_stall_watchdog()
+            steerer = getattr(ctx, "steerer", None)
+            session = getattr(ctx, "session", None)
+            if steerer is None or session is None:
+                return
+            if not bool(getattr(steerer, "_stall_watchdog_enabled", False)):
+                return
+            try:
+                timeout_s = float(getattr(steerer, "_stall_timeout_s", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                return
+            if timeout_s <= 0:
+                return
+            try:
+                self._stall_watchdog_task = asyncio.create_task(
+                    self._run_stall_watchdog(ctx=ctx, timeout_s=timeout_s),
+                    name=f"goldfive_stall_watchdog_{getattr(session, 'id', '') or ''}",
+                )
+            except RuntimeError as exc:
+                # No running loop (synchronous harnesses) — the
+                # watchdog degrades to off, same as the LLM watcher.
+                log.debug(
+                    "_maybe_start_stall_watchdog: cannot schedule: %s", exc
+                )
+
+        def _cancel_stall_watchdog(self) -> None:
+            """Cancel the stall watchdog if one is live. Idempotent."""
+            task = self._stall_watchdog_task
+            self._stall_watchdog_task = None
+            if task is not None and not task.done():
+                task.cancel()
+
+        def _llm_watcher_inflight(self) -> bool:
+            """True while any LLM call runs under its own per-call watcher.
+
+            The stall watchdog consults this to avoid double-reporting:
+            a hung LLM dispatch within its wall-clock budget is the
+            per-call watcher's case (``LLM_CALL_TIMEOUT``), not a stall.
+            Entries without a live watcher (budget disabled via
+            ``llm_call_timeout_ms<=0``) do NOT count — nothing else
+            covers that hang, so the stall watchdog must.
+            """
+            for pending in self._invocation_llm_pending.values():
+                watcher = pending.get("watcher") if isinstance(pending, dict) else None
+                if watcher is not None and not watcher.done():
+                    return True
+            return False
+
+        @staticmethod
+        def _stall_liveness_watermark(session: Any, *, floor: float) -> float:
+            """Newest liveness signal on ``session`` (monotonic seconds).
+
+            The max of every ``task_last_progress_at`` stamp (task
+            transitions + progress reports) and
+            ``last_observed_event_at`` (every observation dispatched
+            into the drift pipeline — reasoning, tool observations,
+            agent activity), floored at ``floor`` (watchdog start) so a
+            fresh session with no stamps yet is not instantly stale.
+            """
+            watermark = floor
+            progress = getattr(session, "task_last_progress_at", None)
+            if isinstance(progress, dict):
+                for value in progress.values():
+                    try:
+                        watermark = max(watermark, float(value))
+                    except (TypeError, ValueError):
+                        continue
+            try:
+                observed = float(getattr(session, "last_observed_event_at", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                observed = 0.0
+            return max(watermark, observed)
+
+        @staticmethod
+        def _goal_drift_idle_seconds() -> float:
+            """Live read of :data:`goldfive.drift.goals.GOAL_DRIFT_IDLE_SECONDS`.
+
+            Module-attribute read per poll (not captured at spawn) so
+            an optimization-manifest ``setattr`` on the knob takes
+            effect on a running watchdog.
+            """
+            try:
+                from goldfive.drift import goals as _goals  # noqa: PLC0415 — lazy
+
+                # Floor keeps a zero/negative override from turning the
+                # idle trigger into a per-poll judge storm.
+                return max(0.001, float(getattr(_goals, "GOAL_DRIFT_IDLE_SECONDS", 300)))
+            except Exception:  # noqa: BLE001
+                return 300.0
+
+        def _trigger_idle_goal_drift_check(
+            self, steerer: Any, session: Any, idle_s: float
+        ) -> None:
+            """Fire the trajectory-level goal-drift judge for an idle episode.
+
+            The ``GOAL_DRIFT_IDLE_SECONDS`` consumer (goldfive#143
+            promised idle-based judge scheduling; the stall watchdog is
+            its producer). Spawn-and-detach through the steerer's
+            tracked background-judge machinery; no-ops when the judge
+            ``call_llm`` is unconfigured or the steerer is a stub.
+            """
+            drift_obs = getattr(steerer, "drift", None)
+            spawn = (
+                getattr(drift_obs, "_spawn_goal_drift_judge_background", None)
+                if drift_obs is not None
+                else None
+            )
+            if spawn is None:
+                return
+            note = f"{idle_s:.0f}s since last observed activity"
+            try:
+                spawn(session, idle_note=note)
+            except TypeError:
+                # Custom DriftObserver predating the idle_note kwarg.
+                try:
+                    spawn(session)
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "_trigger_idle_goal_drift_check: spawn raised: %s", exc
+                    )
+            except Exception as exc:  # noqa: BLE001
+                log.debug("_trigger_idle_goal_drift_check: spawn raised: %s", exc)
+
+        async def _run_stall_watchdog(
+            self, *, ctx: SessionContext, timeout_s: float
+        ) -> None:
+            """Poll the session's liveness watermark; fire ``TASK_TIMEOUT`` on silence.
+
+            Spawned by :meth:`set_active_context` (one per dispatch)
+            and cancelled by :meth:`clear_active_context` — the
+            adapter's ``finally`` teardown — so it never outlives the
+            run. Behaviour per poll tick:
+
+            * Watermark advanced since the last tick → the stall
+              episode (if any) is over; reset the graduated-severity
+              and idle-judge bookkeeping.
+            * Idle beyond :data:`~goldfive.drift.goals.GOAL_DRIFT_IDLE_SECONDS`
+              → trigger the trajectory-level goal-drift judge, once per
+              idle episode.
+            * Idle beyond ``timeout_s`` → emit a ``TASK_TIMEOUT`` drift
+              at WARNING, escalating to CRITICAL at each further
+              multiple of ``timeout_s`` with no fresh activity
+              (graduated severity — same shape as tool_loops). Routed
+              through ``steerer.drift.handle_drift`` so under
+              ``observation_only`` (production default) it is
+              telemetry-only and in active mode the intervention
+              ladder handles it.
+            * SKIPPED while an LLM call is in flight under its own
+              per-call budget — :meth:`_run_llm_call_timeout_watcher`
+              owns that hang (``LLM_CALL_TIMEOUT``); firing here too
+              would double-report.
+
+            Honest limitation: this is an asyncio task on the wrapped
+            tree's own event loop. A synchronously-blocking tool (a
+            ``def`` tool doing blocking I/O or CPU work) starves the
+            loop, so the watchdog cannot fire until the block ends —
+            sync-blocked stalls are out of scope. The covered cases are
+            hung *async* tool calls and idle-with-no-transitions runs.
+            """
+            session = ctx.session if ctx is not None else None
+            steerer = ctx.steerer if ctx is not None else None
+            if session is None or steerer is None:
+                return
+            try:
+                from goldfive.types import (  # noqa: PLC0415 — lazy
+                    DriftEvent,
+                    DriftKind,
+                    DriftSeverity,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.debug("_run_stall_watchdog: cannot import types: %s", exc)
+                return
+            started = time.monotonic()
+            last_watermark = started
+            episode_fires = 0
+            goal_judge_fired = False
+            try:
+                while True:
+                    idle_goal_s = self._goal_drift_idle_seconds()
+                    # Poll cadence tracks the tighter of the two
+                    # thresholds so neither fires grossly late; floored
+                    # so a tiny test timeout cannot busy-spin the loop.
+                    await asyncio.sleep(max(0.005, min(timeout_s, idle_goal_s) / 8.0))
+                    watermark = self._stall_liveness_watermark(session, floor=started)
+                    if watermark > last_watermark:
+                        # Fresh activity ends the stall episode.
+                        last_watermark = watermark
+                        episode_fires = 0
+                        goal_judge_fired = False
+                    idle_s = time.monotonic() - watermark
+                    if not goal_judge_fired and idle_s >= idle_goal_s:
+                        goal_judge_fired = True
+                        self._trigger_idle_goal_drift_check(steerer, session, idle_s)
+                    if idle_s < timeout_s * (episode_fires + 1):
+                        continue
+                    if self._llm_watcher_inflight():
+                        continue
+                    severity = (
+                        DriftSeverity.WARNING
+                        if episode_fires == 0
+                        else DriftSeverity.CRITICAL
+                    )
+                    episode_fires += 1
+                    task_id = str(getattr(session, "current_task_id", "") or "") or str(
+                        _safe_attr(getattr(ctx, "task", None), "id", "") or ""
+                    )
+                    log.warning(
+                        "goldfive.stall.watchdog idle_s=%.1f threshold_s=%.1f "
+                        "severity=%s agent=%s task_id=%s",
+                        idle_s,
+                        timeout_s,
+                        severity.value,
+                        self._host_agent_name or "?",
+                        task_id or "?",
+                    )
+                    # goldfive#245 — stamp observation-time plan revision.
+                    _gf_plan = getattr(session, "plan", None)
+                    _observed_rev = (
+                        int(getattr(_gf_plan, "revision_index", 0) or 0)
+                        if _gf_plan is not None
+                        else 0
+                    )
+                    drift = DriftEvent(
+                        kind=DriftKind.TASK_TIMEOUT,
+                        severity=severity,
+                        detail=(
+                            f"no observed activity for {idle_s:.1f}s "
+                            f"(stall watchdog, threshold {timeout_s:.1f}s)"
+                        ),
+                        current_task_id=task_id,
+                        current_agent_id=self._host_agent_name or "",
+                        observed_revision_index=_observed_rev,
+                    )
+                    handle = getattr(getattr(steerer, "drift", None), "handle_drift", None)
+                    if handle is None:
+                        continue
+                    try:
+                        await handle(drift, session)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:  # noqa: BLE001
+                        log.debug("_run_stall_watchdog: handle_drift raised: %s", exc)
+            except asyncio.CancelledError:
+                # Teardown (clear_active_context) — exit cleanly.
+                return
 
         # --- Plan + current-task context -------------------------------
 

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -779,6 +779,28 @@ class SteeringConfig:
     #: Operator-issued ``PAUSE`` controls are never bounded by this knob.
     #: Env: ``GOLDFIVE_STEER_PAUSE_ESCALATE_DEADLINE_S``.
     pause_escalate_deadline_s: float | None = None
+    #: Wall-clock stall watchdog (default OFF). When enabled, the ADK
+    #: plugin spawns one background task per dispatch that watches a
+    #: liveness watermark — the max of every
+    #: :attr:`~goldfive.types.Session.task_last_progress_at` stamp and
+    #: :attr:`~goldfive.types.Session.last_observed_event_at` (stamped on
+    #: every observation dispatched into the drift pipeline). When the
+    #: watermark goes silent for :attr:`stall_timeout_s` seconds, a
+    #: ``TASK_TIMEOUT`` drift fires at WARNING, escalating to CRITICAL
+    #: on continued silence. Routed through the normal drift dispatch,
+    #: so under ``observation_only`` (the production default) the drift
+    #: is telemetry-only; in active mode the intervention ladder handles
+    #: it. This is the producer for runs wedged in a hung async tool
+    #: call or idling with no task transitions — which previously
+    #: produced ZERO signal. Env: ``GOLDFIVE_STEER_STALL_WATCHDOG_ENABLED``.
+    stall_watchdog_enabled: bool = False
+    #: Idle threshold, in seconds, before the stall watchdog fires its
+    #: first ``TASK_TIMEOUT`` WARNING; each further multiple of the
+    #: timeout with no fresh activity fires a CRITICAL. Non-positive
+    #: values disable the watchdog even when
+    #: :attr:`stall_watchdog_enabled` is True.
+    #: Env: ``GOLDFIVE_STEER_STALL_TIMEOUT_S``.
+    stall_timeout_s: float = 600.0
 
     @classmethod
     def from_env(cls) -> SteeringConfig:
@@ -804,6 +826,11 @@ class SteeringConfig:
         * ``GOLDFIVE_STEER_PAUSE_ESCALATE_DEADLINE_S`` — positive float
           (seconds); non-positive values disable the deadline (``None``),
           non-float values fall back to the default.
+        * ``GOLDFIVE_STEER_STALL_WATCHDOG_ENABLED`` — boolean (same
+          literals as ``GOLDFIVE_STEER_OBSERVATION_ONLY``). Default
+          False (watchdog off).
+        * ``GOLDFIVE_STEER_STALL_TIMEOUT_S`` — float (seconds);
+          non-float values fall back to the default (600).
         """
         defaults = cls()
         raw_rules = os.environ.get("GOLDFIVE_STEER_CONTEXT_EDITOR_RULES", "").strip()
@@ -836,6 +863,14 @@ class SteeringConfig:
             pause_escalate_deadline_s=_read_optional_float_env(
                 "GOLDFIVE_STEER_PAUSE_ESCALATE_DEADLINE_S",
                 defaults.pause_escalate_deadline_s,
+            ),
+            stall_watchdog_enabled=_read_bool_env(
+                "GOLDFIVE_STEER_STALL_WATCHDOG_ENABLED",
+                defaults.stall_watchdog_enabled,
+            ),
+            stall_timeout_s=_read_float_env(
+                "GOLDFIVE_STEER_STALL_TIMEOUT_S",
+                defaults.stall_timeout_s,
             ),
         )
 

--- a/goldfive/drift/goals.py
+++ b/goldfive/drift/goals.py
@@ -63,10 +63,23 @@ __all__ = [
 ]
 
 
-# Default periodic-check cadence. Consumed by ``DefaultSteerer`` (see
-# :class:`~goldfive.steerer.DefaultSteerer` -- ``goal_drift_check_interval``
-# parameter). One LLM call per check, so defaults are deliberately
-# low-frequency; operators who want tighter monitoring can shorten it.
+# Default check cadences. One LLM call per check, so defaults are
+# deliberately low-frequency; operators who want tighter monitoring
+# can shorten them.
+#
+# ``GOAL_DRIFT_CHECK_INTERVAL`` documents the turn-based default; the
+# LIVE runtime knob is :attr:`goldfive.config.GoalDriftConfig.check_interval`
+# (which ``DefaultSteerer`` reads — this constant is a public re-export
+# kept for back-compat and is not consulted at runtime).
+#
+# ``GOAL_DRIFT_IDLE_SECONDS`` is the idle-based scheduling threshold:
+# when the wall-clock stall watchdog is enabled
+# (``SteeringConfig.stall_watchdog_enabled``) and the session's
+# liveness watermark has been silent this long, the watchdog triggers
+# :meth:`~goldfive.drift_observer.DriftObserver.maybe_run_goal_drift_check`
+# once per idle episode. Read live from this module attribute on every
+# watchdog poll, so optimization-manifest ``setattr`` mutations take
+# effect on a running watchdog.
 GOAL_DRIFT_CHECK_INTERVAL: int = 5
 GOAL_DRIFT_IDLE_SECONDS: int = 300
 

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -1623,6 +1623,23 @@ class DriftObserver:
     # Observation entry points
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _stamp_last_observed(session: Session) -> None:
+        """Refresh ``session.last_observed_event_at`` (liveness watermark).
+
+        Called from every observation entry point (``observe`` /
+        ``observe_reasoning`` / ``note_agent_activity`` /
+        ``note_tool_observation``) so the wall-clock stall watchdog
+        (``SteeringConfig.stall_watchdog_enabled``) sees any observed
+        activity — including tool calls on a long-running single task
+        that never transitions — as liveness. Best-effort: a session
+        stub without the field must not break observation dispatch.
+        """
+        try:
+            session.last_observed_event_at = time.monotonic()
+        except Exception as exc:  # noqa: BLE001
+            log.debug("_stamp_last_observed: swallowed: %s", exc)
+
     async def observe(self, event: Any, session: Session) -> None:
         """Inspect ``event``, classify drift, and refine if severe enough.
 
@@ -1641,6 +1658,7 @@ class DriftObserver:
         based drifts (LOOPING_REASONING, tool errors, …) are NOT
         deduped — they're heuristic signals, not user actions.
         """
+        self._stamp_last_observed(session)
         # First observe call on a session snapshots the detector
         # dispatch order so an optimizer can see WHICH detectors were
         # in play independent of which ones fired. Idempotent (the
@@ -1738,6 +1756,7 @@ class DriftObserver:
         """
         if not text:
             return
+        self._stamp_last_observed(session)
         # goldfive#441 — advance the logical-turn counter once per
         # reasoning observation. The user-steer suppression window
         # (:meth:`_should_promote_to_steer`) measures freshness against
@@ -2822,6 +2841,7 @@ class DriftObserver:
         """
         if not kind:
             return
+        self._stamp_last_observed(session)
         entry: dict[str, Any] = {"kind": kind}
         if agent_name:
             entry["agent_name"] = agent_name
@@ -2874,6 +2894,7 @@ class DriftObserver:
         an ADK callback. The catch is intentionally broad.
         """
         try:
+            self._stamp_last_observed(session)
             ts_ms = time.monotonic_ns() // 1_000_000
             try:
                 args_preview = repr(args)[:240]
@@ -3063,7 +3084,9 @@ class DriftObserver:
         session._agent_turns_since_goal_check = 0
         self._spawn_goal_drift_judge_background(session)
 
-    async def maybe_run_goal_drift_check(self, session: Session) -> None:
+    async def maybe_run_goal_drift_check(
+        self, session: Session, *, idle_note: str = ""
+    ) -> None:
         """Run the trajectory-level GOAL_DRIFT judge once, cost-bounded.
 
         Opt-in, feature-gated by ``goal_drift_call_llm``. Does NOT
@@ -3071,6 +3094,13 @@ class DriftObserver:
         scheduling go through :meth:`note_agent_turn`. Public so
         operators can trigger a one-shot check from outside the
         interval (e.g. on a long idle period with no task transitions).
+
+        ``idle_note`` — non-empty when the caller is the wall-clock
+        stall watchdog's idle trigger (the ``GOAL_DRIFT_IDLE_SECONDS``
+        consumer). Appended to the activity snapshot as a synthetic
+        entry so the judge's activity block renders e.g.
+        ``- idle_observed: 300s since last observed activity`` without
+        any change to the prompt template.
 
         Outcomes:
 
@@ -3099,6 +3129,8 @@ class DriftObserver:
         activity = filter_recent_events_by_kind(
             session.recent_events, RECENT_EVENT_AGENT_ACTIVITY_KINDS
         )
+        if idle_note:
+            activity = [*activity, {"kind": "idle_observed", "detail": idle_note}]
         drift = await classify_goal_drift(
             goals=session.goals,
             plan=session.plan,
@@ -3130,7 +3162,9 @@ class DriftObserver:
             return
         await self.handle_drift(drift, session)
 
-    def _spawn_goal_drift_judge_background(self, session: Session) -> None:
+    def _spawn_goal_drift_judge_background(
+        self, session: Session, *, idle_note: str = ""
+    ) -> None:
         """Spawn :meth:`maybe_run_goal_drift_check` as a fire-and-forget task.
 
         Goldfive v22 regression fix. The trajectory-level GOAL_DRIFT
@@ -3165,6 +3199,10 @@ class DriftObserver:
         synchronous test harnesses that build a steerer outside an
         async context from raising). No-op when no judge ``call_llm``
         is configured.
+
+        ``idle_note`` (stall watchdog, goldfive#143 idle scheduling) is
+        threaded to :meth:`maybe_run_goal_drift_check`, which renders
+        it into the judge's activity block.
         """
         if self._steerer._goal_drift_call_llm is None:
             return
@@ -3178,7 +3216,7 @@ class DriftObserver:
             # judge anyway.
             return
         bg_task = asyncio.create_task(
-            self._run_goal_drift_judge_background(session),
+            self._run_goal_drift_judge_background(session, idle_note=idle_note),
             # goldfive#243: encode session.id in the task name so
             # :meth:`drain_session_background_tasks` can filter pending
             # tasks by the run boundary that's terminating, leaving any
@@ -3188,7 +3226,9 @@ class DriftObserver:
         self._steerer._background_judges.add(bg_task)
         bg_task.add_done_callback(self._steerer._background_judges.discard)
 
-    async def _run_goal_drift_judge_background(self, session: Session) -> None:
+    async def _run_goal_drift_judge_background(
+        self, session: Session, *, idle_note: str = ""
+    ) -> None:
         """Body of the fire-and-forget GOAL_DRIFT judge task.
 
         Mirrors :meth:`_run_judge_background` (the reasoning-judge
@@ -3203,7 +3243,7 @@ class DriftObserver:
         cancellable agent task that hosted us.
         """
         try:
-            await self.maybe_run_goal_drift_check(session)
+            await self.maybe_run_goal_drift_check(session, idle_note=idle_note)
         except asyncio.CancelledError:
             # Propagate so :meth:`shutdown` / teardown sees a clean
             # cancel. The shutdown path expects this and counts it
@@ -3456,6 +3496,22 @@ class DriftObserver:
                 None,
                 _IL.ABSORB,
                 (_IL.CANCEL_REINVOKE, _IL.PAUSE_ESCALATE),
+            ),
+            # Wall-clock stall watchdog (flag-gated, default OFF —
+            # ``SteeringConfig.stall_watchdog_enabled``). Conservative
+            # row: a stall is a liveness signal, not a plan defect, so
+            # WARNING nudges rather than refining (ABSORB would loop
+            # the planner against a plan that isn't wrong). CRITICAL
+            # pauses at BOTH positions: the watchdog only emits
+            # CRITICAL on continued silence after its WARNING, so a
+            # CRITICAL is by construction already a repeat — and the
+            # refine-outcome-based occurrence counter never advances on
+            # the NUDGE path, so the pair's repeat slot alone would be
+            # unreachable.
+            DriftKind.TASK_TIMEOUT: (
+                _IL.OBSERVE,
+                _IL.NUDGE,
+                (_IL.PAUSE_ESCALATE, _IL.PAUSE_ESCALATE),
             ),
         }
         cls._LADDER_LOADED = True

--- a/goldfive/optimization/manifest.toml
+++ b/goldfive/optimization/manifest.toml
@@ -329,9 +329,9 @@ tags = ["threshold", "tool_loops"]
 [[mutation]]
 id = "goal_drift_check_interval"
 kind = "numeric"
-source = "goldfive/drift/goals.py:GOAL_DRIFT_CHECK_INTERVAL"
-python_attr = "goldfive.drift.goals:GOAL_DRIFT_CHECK_INTERVAL"
-description = "Number of agent-invocation turns between trajectory-level GOAL_DRIFT judge calls."
+source = "goldfive/config.py:GoalDriftConfig.check_interval"
+python_attr = "goldfive.config:GoalDriftConfig.check_interval"
+description = "Dataclass-default number of agent-invocation turns between trajectory-level GOAL_DRIFT judge calls. DefaultSteerer reads this via GoalDriftConfig; the legacy goldfive.drift.goals:GOAL_DRIFT_CHECK_INTERVAL constant is a back-compat re-export with no runtime consumer."
 type = "int"
 range = [1, 100]
 default = 5
@@ -342,11 +342,22 @@ id = "goal_drift_idle_seconds"
 kind = "numeric"
 source = "goldfive/drift/goals.py:GOAL_DRIFT_IDLE_SECONDS"
 python_attr = "goldfive.drift.goals:GOAL_DRIFT_IDLE_SECONDS"
-description = "Wall-clock idle threshold (seconds) above which the trajectory-level GOAL_DRIFT judge fires."
+description = "Wall-clock idle threshold (seconds) above which the stall watchdog (SteeringConfig.stall_watchdog_enabled) triggers the trajectory-level GOAL_DRIFT judge, once per idle episode. Read live per watchdog poll."
 type = "int"
 range = [10, 3600]
 default = 300
 tags = ["threshold", "goal_drift"]
+
+[[mutation]]
+id = "stall_watchdog_timeout_seconds"
+kind = "numeric"
+source = "goldfive/config.py:SteeringConfig.stall_timeout_s"
+python_attr = "goldfive.config:SteeringConfig.stall_timeout_s"
+description = "Dataclass-default idle threshold (seconds) before the flag-gated wall-clock stall watchdog fires TASK_TIMEOUT at WARNING (CRITICAL at each further multiple with no fresh activity). Inert unless SteeringConfig.stall_watchdog_enabled is set."
+type = "float"
+range = [10.0, 7200.0]
+default = 600.0
+tags = ["config", "steerer", "timeout", "watchdog"]
 
 # ---------------------------------------------------------------------------
 # Reasoning-judge prompt size budgets

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -687,6 +687,18 @@ class DefaultSteerer:
             from goldfive.config import _resolve_observation_only_default
 
             self._observation_only = _resolve_observation_only_default()
+        # Wall-clock stall watchdog knobs (flag-gated, default OFF). Read
+        # by the ADK plugin's per-dispatch watchdog task — see
+        # :class:`~goldfive.config.SteeringConfig.stall_watchdog_enabled`.
+        # Bare-constructor default matches the ``SteeringConfig`` field
+        # defaults so a steerer built without a config keeps the
+        # watchdog off.
+        if steering_config is not None:
+            self._stall_watchdog_enabled: bool = bool(steering_config.stall_watchdog_enabled)
+            self._stall_timeout_s: float = float(steering_config.stall_timeout_s)
+        else:
+            self._stall_watchdog_enabled = False
+            self._stall_timeout_s = 600.0
         # Background reasoning-judge tasks (goldfive#251). The LLM-judge
         # path in :meth:`observe_reasoning` is fire-and-forget so the
         # adapter's model-response callback can return immediately and

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1829,6 +1829,17 @@ class Session:
     # does not. Sentinel task_id ``""`` covers trajectory-wide signals
     # which never gate (no task to be stalled).
     task_last_progress_at: dict[str, float] = dataclasses.field(default_factory=dict)
+    # Session-level ``time.monotonic()`` timestamp of the most recent
+    # observation dispatched into the drift pipeline — stamped by
+    # :class:`~goldfive.drift_observer.DriftObserver` on every
+    # ``observe`` / ``observe_reasoning`` / ``note_agent_activity`` /
+    # ``note_tool_observation`` entry. Complements
+    # :attr:`task_last_progress_at` (which only moves on task
+    # transitions): a long-running single task that emits many tool
+    # calls without transitioning keeps this stamp fresh, so the
+    # wall-clock stall watchdog (``SteeringConfig.stall_watchdog_enabled``)
+    # does not false-positive on it. ``0.0`` means "never stamped".
+    last_observed_event_at: float = 0.0
     # Counter of LLM turns observed since the last reflective self-progress
     # check. Incremented by ``DefaultSteerer.note_llm_call`` (which adapters
     # call once per LLM invocation when the opt-in reflective check is

--- a/tests/test_optimization_manifest.py
+++ b/tests/test_optimization_manifest.py
@@ -17,8 +17,11 @@ Covers:
 
 from __future__ import annotations
 
+import ast
 import importlib
 import textwrap
+from collections import Counter
+from pathlib import Path
 
 import pytest
 
@@ -213,6 +216,108 @@ def test_numeric_mutations_match_live_python_attrs() -> None:
             "numeric default diverged from live Python attribute for: "
             + ", ".join(f"{i} (code={c!r}, manifest={m!r})" for i, c, m in drifts)
         )
+
+
+# ---------------------------------------------------------------------------
+# Manifest liveness — every numeric knob must have a runtime consumer
+# ---------------------------------------------------------------------------
+
+
+def _goldfive_attr_read_counts() -> Counter[str]:
+    """Count *read* sites per attribute leaf-name across goldfive sources.
+
+    A read is any of:
+
+    * a bare ``Name`` in ``Load`` context (module constants used after
+      import or within their own module);
+    * an ``Attribute`` in ``Load`` context (``config.check_interval``,
+      ``self.MAX_OUTPUT_TOKENS``, ``_goals.GOAL_DRIFT_IDLE_SECONDS``);
+    * a ``getattr(obj, "leaf", ...)`` call with a string-literal name.
+
+    Definitions (``Store`` contexts), ``import`` aliases, ``__all__``
+    strings, comments, and docstrings do NOT count — so a constant that
+    is merely defined + re-exported registers zero reads. Name-based,
+    so a generic leaf (``timeout_ms``) can alias across classes; the
+    check is a liveness smoke test, not a proof of the exact consumer.
+    """
+    import goldfive
+
+    counts: Counter[str] = Counter()
+    root = Path(goldfive.__file__).parent
+    for path in sorted(root.rglob("*.py")):
+        if "pb" in path.parts:
+            continue  # generated proto stubs
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+                counts[node.id] += 1
+            elif isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
+                counts[node.attr] += 1
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "getattr"
+                and len(node.args) >= 2
+                and isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)
+            ):
+                counts[node.args[1].value] += 1
+    return counts
+
+
+def test_numeric_mutations_have_live_runtime_consumers() -> None:
+    """Every numeric knob's ``python_attr`` must be read somewhere at runtime.
+
+    The default-sync test above only proves the manifest's ``default``
+    matches the attribute's value — a constant that nothing consumes
+    still passes it (the historical ``goal_drift_check_interval`` entry
+    pointed at ``goldfive.drift.goals:GOAL_DRIFT_CHECK_INTERVAL``,
+    which was defined + re-exported but read by no runtime code, so an
+    optimizer mutating it changed nothing). This test statically counts
+    read sites for the attribute's leaf name across the ``goldfive``
+    package; zero reads means the knob is dead and its ``python_attr``
+    must be repointed at the live path.
+    """
+    manifest = Manifest.load()
+    counts = _goldfive_attr_read_counts()
+    dead: list[str] = []
+    for mut in manifest:
+        if mut.kind != "numeric":
+            continue
+        leaf = mut.python_attr.partition(":")[2].split(".")[-1]
+        if counts[leaf] == 0:
+            dead.append(f"{mut.id} ({mut.python_attr})")
+    assert not dead, (
+        "numeric manifest knobs whose python_attr has no runtime read "
+        f"site: {dead} — repoint python_attr at the attribute a runtime "
+        "consumer actually reads"
+    )
+
+
+def test_liveness_counter_flags_the_known_dead_constant() -> None:
+    """Self-check for the liveness heuristic: the legacy
+    ``GOAL_DRIFT_CHECK_INTERVAL`` constant (defined + re-exported, no
+    runtime consumer — the live path is
+    ``GoalDriftConfig.check_interval``) must register zero reads, and
+    the newly-consumed ``GOAL_DRIFT_IDLE_SECONDS`` (stall watchdog)
+    must register at least one."""
+    counts = _goldfive_attr_read_counts()
+    assert counts["GOAL_DRIFT_CHECK_INTERVAL"] == 0
+    assert counts["GOAL_DRIFT_IDLE_SECONDS"] >= 1
+
+
+def test_goal_drift_check_interval_points_at_live_config_path() -> None:
+    """Regression pin for the repointed knob (see liveness test above)."""
+    manifest = Manifest.load()
+    mut = {m.id: m for m in manifest}["goal_drift_check_interval"]
+    assert mut.python_attr == "goldfive.config:GoalDriftConfig.check_interval"
+
+
+def test_manifest_covers_stall_watchdog_knob() -> None:
+    manifest = Manifest.load()
+    mut = {m.id: m for m in manifest}["stall_watchdog_timeout_seconds"]
+    assert mut.python_attr == "goldfive.config:SteeringConfig.stall_timeout_s"
+    assert mut.default == 600.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stall_watchdog.py
+++ b/tests/test_stall_watchdog.py
@@ -1,0 +1,476 @@
+"""Wall-clock stall watchdog (flag-gated producer for ``TASK_TIMEOUT``).
+
+Pre-fix, a run wedged in a hung async tool call or idling with no task
+transitions produced ZERO signal: ``DriftKind.TASK_TIMEOUT`` had no
+producer anywhere and ``GOAL_DRIFT_IDLE_SECONDS`` was exported with no
+consumer. The watchdog is a per-dispatch asyncio task spawned by
+``_GoldfiveADKPlugin.set_active_context`` (when
+``SteeringConfig.stall_watchdog_enabled`` — default OFF) and cancelled
+by ``clear_active_context``. It polls a liveness watermark —
+``max(Session.task_last_progress_at.values())`` and
+``Session.last_observed_event_at`` (stamped on every observation
+dispatch) — and fires ``TASK_TIMEOUT`` at WARNING, escalating to
+CRITICAL on continued silence, through the normal ``handle_drift``
+path.
+
+These tests drive the watchdog coroutine directly with tiny timeouts
+(same style as ``tests/test_llm_call_timeout_watcher.py``) plus a few
+integration cases through a real ``DefaultSteerer`` to pin the
+observe-only vs active-mode split.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+adk_plugin = pytest.importorskip("goldfive.adapters._adk_plugin")
+pytest.importorskip("google.adk")
+
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.types import DriftKind, DriftSeverity, Session  # noqa: E402
+
+
+class _CapturingDrift:
+    """Captures ``handle_drift`` dispatches + idle goal-judge spawns."""
+
+    def __init__(self) -> None:
+        self.handled: list[Any] = []
+        self.goal_judge_spawns: list[str] = []
+
+    async def handle_drift(self, drift: Any, session: Any) -> None:
+        self.handled.append(drift)
+
+    def _spawn_goal_drift_judge_background(self, session: Any, *, idle_note: str = "") -> None:
+        self.goal_judge_spawns.append(idle_note)
+
+
+class _CapturingSteerer:
+    """Minimal steerer stub carrying the watchdog knobs the plugin reads."""
+
+    def __init__(self, *, enabled: bool = True, timeout_s: float = 0.05) -> None:
+        self.drift = _CapturingDrift()
+        self._sinks: list[Any] = []
+        self._stall_watchdog_enabled = enabled
+        self._stall_timeout_s = timeout_s
+
+
+def _make_ctx(steerer: Any, session: Session | None = None) -> Any:
+    return SimpleNamespace(
+        steerer=steerer,
+        session=session if session is not None else Session(run_id="r1"),
+        task=SimpleNamespace(id="t1"),
+    )
+
+
+async def _wait_for(cond: Any, *, timeout: float = 2.0, message: str = "") -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if cond():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError(message or "condition not met within timeout")
+
+
+# ---------------------------------------------------------------------------
+# Flag gating + lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_steering_config_defaults_watchdog_off() -> None:
+    cfg = SteeringConfig()
+    assert cfg.stall_watchdog_enabled is False
+    assert cfg.stall_timeout_s == 600.0
+
+
+def test_steering_config_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOLDFIVE_STEER_STALL_WATCHDOG_ENABLED", "1")
+    monkeypatch.setenv("GOLDFIVE_STEER_STALL_TIMEOUT_S", "42.5")
+    cfg = SteeringConfig.from_env()
+    assert cfg.stall_watchdog_enabled is True
+    assert cfg.stall_timeout_s == 42.5
+
+
+def test_default_steerer_stashes_watchdog_knobs() -> None:
+    from goldfive.steerer import DefaultSteerer
+
+    bare = DefaultSteerer()
+    assert bare._stall_watchdog_enabled is False
+    assert bare._stall_timeout_s == 600.0
+    configured = DefaultSteerer(
+        steering_config=SteeringConfig(stall_watchdog_enabled=True, stall_timeout_s=1.5)
+    )
+    assert configured._stall_watchdog_enabled is True
+    assert configured._stall_timeout_s == 1.5
+
+
+async def test_disabled_by_default_no_task_spawned() -> None:
+    """The un-flagged path must spawn nothing (default OFF)."""
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="root")
+    steerer = _CapturingSteerer(enabled=False)
+    plugin.set_active_context(_make_ctx(steerer))
+    assert plugin._stall_watchdog_task is None
+    plugin.clear_active_context()
+
+
+async def test_flagless_steerer_stub_spawns_nothing() -> None:
+    """A steerer without the knob attributes reads as OFF (fail-safe)."""
+
+    class _Flagless:
+        drift = _CapturingDrift()
+
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="root")
+    plugin.set_active_context(_make_ctx(_Flagless()))
+    assert plugin._stall_watchdog_task is None
+    plugin.clear_active_context()
+
+
+async def test_nonpositive_timeout_disables() -> None:
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="root")
+    steerer = _CapturingSteerer(enabled=True, timeout_s=0.0)
+    plugin.set_active_context(_make_ctx(steerer))
+    assert plugin._stall_watchdog_task is None
+    plugin.clear_active_context()
+
+
+async def test_enabled_spawns_and_teardown_cancels_cleanly() -> None:
+    """``set_active_context`` spawns; ``clear_active_context`` cancels —
+    the task ends cancelled with no lingering pending task."""
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="root")
+    steerer = _CapturingSteerer(enabled=True, timeout_s=10.0)
+    plugin.set_active_context(_make_ctx(steerer))
+    task = plugin._stall_watchdog_task
+    assert task is not None
+    assert not task.done()
+    await asyncio.sleep(0)  # let the watchdog reach its poll sleep
+    plugin.clear_active_context()
+    assert plugin._stall_watchdog_task is None
+    # The watchdog absorbs the cancel and exits; awaiting must not raise.
+    await task
+    assert task.done()
+    assert steerer.drift.handled == []
+
+
+async def test_second_dispatch_replaces_prior_watchdog() -> None:
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="root")
+    steerer = _CapturingSteerer(enabled=True, timeout_s=10.0)
+    plugin.set_active_context(_make_ctx(steerer))
+    first = plugin._stall_watchdog_task
+    plugin.set_active_context(_make_ctx(steerer))
+    second = plugin._stall_watchdog_task
+    assert first is not None and second is not None
+    assert first is not second
+    await _wait_for(first.done, message="prior watchdog not cancelled")
+    plugin.clear_active_context()
+    await second
+
+
+# ---------------------------------------------------------------------------
+# Firing behaviour — graduated severity + watermark resets
+# ---------------------------------------------------------------------------
+
+
+async def test_fires_warning_then_critical_on_continued_silence() -> None:
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="agent_x")
+    steerer = _CapturingSteerer()
+    session = Session(run_id="r1")
+    session.current_task_id = "t-live"
+    ctx = _make_ctx(steerer, session)
+
+    task = asyncio.create_task(plugin._run_stall_watchdog(ctx=ctx, timeout_s=0.05))
+    try:
+        await _wait_for(
+            lambda: len(steerer.drift.handled) >= 2,
+            message="watchdog did not escalate to a second drift",
+        )
+    finally:
+        task.cancel()
+        await task
+
+    first, second = steerer.drift.handled[0], steerer.drift.handled[1]
+    assert first.kind is DriftKind.TASK_TIMEOUT
+    assert first.severity is DriftSeverity.WARNING
+    assert second.kind is DriftKind.TASK_TIMEOUT
+    assert second.severity is DriftSeverity.CRITICAL
+    assert first.current_task_id == "t-live"
+    assert first.current_agent_id == "agent_x"
+    assert "stall watchdog" in first.detail
+
+
+async def test_observation_stamp_resets_watermark_no_fire() -> None:
+    """Active tool traffic (the observation stamp) keeps the watchdog
+    quiet even with zero task transitions — then a fresh episode fires
+    WARNING (not CRITICAL) once the traffic stops."""
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="agent_x")
+    steerer = _CapturingSteerer()
+    session = Session(run_id="r1")
+    ctx = _make_ctx(steerer, session)
+
+    task = asyncio.create_task(plugin._run_stall_watchdog(ctx=ctx, timeout_s=0.08))
+    try:
+        # Simulate steady observation dispatches for ~4x the timeout.
+        deadline = time.monotonic() + 0.32
+        while time.monotonic() < deadline:
+            session.last_observed_event_at = time.monotonic()
+            await asyncio.sleep(0.01)
+        assert steerer.drift.handled == []
+        # Silence — a fresh episode starts at WARNING.
+        await _wait_for(
+            lambda: len(steerer.drift.handled) >= 1,
+            message="watchdog did not fire after traffic stopped",
+        )
+    finally:
+        task.cancel()
+        await task
+    assert steerer.drift.handled[0].severity is DriftSeverity.WARNING
+
+
+async def test_task_progress_stamp_counts_as_liveness() -> None:
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="agent_x")
+    steerer = _CapturingSteerer()
+    session = Session(run_id="r1")
+    ctx = _make_ctx(steerer, session)
+
+    task = asyncio.create_task(plugin._run_stall_watchdog(ctx=ctx, timeout_s=0.08))
+    try:
+        deadline = time.monotonic() + 0.32
+        while time.monotonic() < deadline:
+            session.task_last_progress_at["t1"] = time.monotonic()
+            await asyncio.sleep(0.01)
+        assert steerer.drift.handled == []
+    finally:
+        task.cancel()
+        await task
+
+
+async def test_no_fire_while_llm_call_inflight_under_budget() -> None:
+    """A hung LLM call under its own per-call watcher is the
+    ``LLM_CALL_TIMEOUT`` watcher's case — the stall watchdog must not
+    double-report. Once the per-call watcher resolves, the stall
+    watchdog resumes."""
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="agent_x")
+    steerer = _CapturingSteerer()
+    ctx = _make_ctx(steerer)
+
+    fake_watcher = asyncio.create_task(asyncio.sleep(30.0))
+    plugin._invocation_llm_pending["inv-1"] = {"watcher": fake_watcher}
+
+    task = asyncio.create_task(plugin._run_stall_watchdog(ctx=ctx, timeout_s=0.05))
+    try:
+        await asyncio.sleep(0.25)
+        assert steerer.drift.handled == []
+        # Per-call watcher resolves (call returned / watcher cancelled);
+        # the stall watchdog takes over on the very next tick.
+        fake_watcher.cancel()
+        await _wait_for(
+            lambda: len(steerer.drift.handled) >= 1,
+            message="watchdog did not resume after LLM watcher resolved",
+        )
+    finally:
+        task.cancel()
+        await task
+        if not fake_watcher.done():
+            fake_watcher.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Idle-based goal-drift judge trigger (the GOAL_DRIFT_IDLE_SECONDS consumer)
+# ---------------------------------------------------------------------------
+
+
+async def test_idle_goal_judge_fires_once_per_episode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from goldfive.drift import goals as goals_mod
+
+    monkeypatch.setattr(goals_mod, "GOAL_DRIFT_IDLE_SECONDS", 0.05)
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="agent_x")
+    # Large stall timeout so only the idle trigger engages.
+    steerer = _CapturingSteerer(timeout_s=30.0)
+    session = Session(run_id="r1")
+    ctx = _make_ctx(steerer, session)
+
+    task = asyncio.create_task(plugin._run_stall_watchdog(ctx=ctx, timeout_s=30.0))
+    try:
+        await _wait_for(
+            lambda: len(steerer.drift.goal_judge_spawns) >= 1,
+            message="idle goal-judge trigger did not fire",
+        )
+        # Stay idle for several more polls — still exactly one spawn.
+        await asyncio.sleep(0.2)
+        assert len(steerer.drift.goal_judge_spawns) == 1
+        assert "since last observed activity" in steerer.drift.goal_judge_spawns[0]
+        # Fresh activity ends the episode; renewed silence re-arms it.
+        session.last_observed_event_at = time.monotonic()
+        await _wait_for(
+            lambda: len(steerer.drift.goal_judge_spawns) >= 2,
+            message="idle trigger did not re-arm after a new episode",
+        )
+    finally:
+        task.cancel()
+        await task
+    assert steerer.drift.handled == []
+
+
+async def test_idle_note_rendered_into_goal_judge_activity_block() -> None:
+    """``maybe_run_goal_drift_check(idle_note=...)`` lands the note in
+    the judge's activity block (the ``_format_activity`` slot)."""
+    from goldfive.steerer import DefaultSteerer
+
+    prompts: list[str] = []
+
+    async def judge(system: str, user: str, model: str) -> str:
+        prompts.append(user)
+        return '{"progressing": true}'
+
+    steerer = DefaultSteerer(goal_drift_call_llm=judge)
+    session = Session(run_id="r1")
+    await steerer.drift.maybe_run_goal_drift_check(
+        session, idle_note="300s since last observed activity"
+    )
+    assert len(prompts) == 1
+    assert "idle_observed" in prompts[0]
+    assert "300s since last observed activity" in prompts[0]
+
+
+# ---------------------------------------------------------------------------
+# Observation stamping at the drift-pipeline entry points
+# ---------------------------------------------------------------------------
+
+
+async def test_drift_observer_entry_points_stamp_last_observed() -> None:
+    from goldfive.steerer import DefaultSteerer
+
+    steerer = DefaultSteerer()
+    session = Session(run_id="r1")
+    assert session.last_observed_event_at == 0.0
+
+    steerer.drift.note_tool_observation(
+        session,
+        agent_name="a",
+        task_id="t1",
+        tool_name="search",
+        args={"q": "x"},
+        result={"ok": True},
+    )
+    stamp1 = session.last_observed_event_at
+    assert stamp1 > 0.0
+
+    steerer.drift.note_agent_activity(session, kind="agent_invocation_started")
+    assert session.last_observed_event_at >= stamp1
+
+    await steerer.drift.observe_reasoning(
+        "thinking about the task", session=session, agent_name="a"
+    )
+    assert session.last_observed_event_at >= stamp1
+
+
+# ---------------------------------------------------------------------------
+# Both modes through the real dispatch (observation_only vs active)
+# ---------------------------------------------------------------------------
+
+
+def _sink_has_drift_detected(sink: Any) -> bool:
+    return any(
+        e.WhichOneof("payload") == "drift_detected" for e in sink.events if hasattr(e, "DESCRIPTOR")
+    )
+
+
+async def _drive_one_warning_through(steerer: Any, *, done: Any) -> tuple[Session, Any]:
+    """Run the watchdog against a real steerer until ``done(session, sink)``."""
+    from goldfive import InMemorySink, Plan, StaticPlanner, Task
+
+    plan = Plan(
+        id="p",
+        run_id="r1",
+        goal_ids=[],
+        tasks=[Task(id="t1", title="do it", assignee_agent_id="worker")],
+        edges=[],
+        summary="",
+    )
+    sink = InMemorySink()
+    steerer.bind(sinks=[sink], planner=StaticPlanner(plan))
+    session = Session(run_id="r1")
+    session.plan = plan
+    session.current_task_id = "t1"
+
+    plugin = adk_plugin.make_adk_plugin(host_agent_name="agent_x")
+    ctx = _make_ctx(steerer, session)
+    task = asyncio.create_task(plugin._run_stall_watchdog(ctx=ctx, timeout_s=0.05))
+    try:
+        await _wait_for(
+            lambda: done(session, sink),
+            message="watchdog dispatch did not reach the expected state",
+        )
+    finally:
+        task.cancel()
+        await task
+    return session, sink
+
+
+async def test_observation_only_is_telemetry_only() -> None:
+    """Under the production default the drift reaches the sinks but no
+    intervention lands (no nudge enqueued)."""
+    from goldfive.steerer import DefaultSteerer
+
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(
+            observation_only=True,
+            stall_watchdog_enabled=True,
+            stall_timeout_s=0.05,
+        )
+    )
+    session, _sink = await _drive_one_warning_through(
+        steerer, done=lambda session, sink: _sink_has_drift_detected(sink)
+    )
+    # Grace period: let any (wrongly) queued intervention land before
+    # asserting its absence.
+    await asyncio.sleep(0.05)
+    assert session.pending_nudges == []
+
+
+async def test_active_mode_warning_routes_to_nudge() -> None:
+    """In active mode the ladder's TASK_TIMEOUT WARNING row queues a
+    corrective nudge."""
+    from goldfive.steerer import DefaultSteerer
+
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(
+            observation_only=False,
+            stall_watchdog_enabled=True,
+            stall_timeout_s=0.05,
+        )
+    )
+    session, sink = await _drive_one_warning_through(
+        steerer, done=lambda session, sink: len(session.pending_nudges) >= 1
+    )
+    assert len(session.pending_nudges) >= 1
+    assert _sink_has_drift_detected(sink)
+
+
+def test_task_timeout_has_a_ladder_row() -> None:
+    """The ladder table carries the conservative TASK_TIMEOUT row:
+    INFO→OBSERVE, WARNING→NUDGE, CRITICAL→PAUSE_ESCALATE (first and
+    repeat — the watchdog's CRITICAL is by construction a repeat)."""
+    from goldfive.drift_observer import DriftObserver
+    from goldfive.steerer import DefaultSteerer, InterventionLevel
+
+    steerer = DefaultSteerer()
+    observer = steerer.drift
+    assert isinstance(observer, DriftObserver)
+    assert (
+        observer._ladder_level_for(DriftKind.TASK_TIMEOUT, DriftSeverity.WARNING, 0)
+        is InterventionLevel.NUDGE
+    )
+    assert (
+        observer._ladder_level_for(DriftKind.TASK_TIMEOUT, DriftSeverity.CRITICAL, 0)
+        is InterventionLevel.PAUSE_ESCALATE
+    )
+    assert (
+        observer._ladder_level_for(DriftKind.TASK_TIMEOUT, DriftSeverity.CRITICAL, 5)
+        is InterventionLevel.PAUSE_ESCALATE
+    )


### PR DESCRIPTION
## Problem

A run wedged in a hung async tool call, or idling with no task transitions, produces **zero signal** today:

- `DriftKind.TASK_TIMEOUT` (goldfive/types.py:129) has no producer anywhere in the codebase (grep confirms — only the testkit adversary and taxonomy tests mention it).
- `Session.task_last_progress_at` (goldfive/types.py:1831) is stamped on every transition (goldfive/task_state_machine.py:168,214,735) but nothing watches it on a wall clock.
- `GOAL_DRIFT_IDLE_SECONDS = 300` (goldfive/drift/goals.py:71) is exported with zero consumers, despite the docstring promising idle-based goal-judge scheduling.
- `docs/design/STATE-MACHINE.md` (progress-reporting section) falsely claimed "stalled tasks are detected via elapsed time".
- The manifest's `goal_drift_check_interval` knob pointed at `goldfive.drift.goals:GOAL_DRIFT_CHECK_INTERVAL` — a defined-and-re-exported constant with **no runtime reader** (the live path is `GoalDriftConfig.check_interval`, read at goldfive/steerer.py:590), so an optimizer mutating it changed nothing.

## Fix

**Flag-gated, default OFF** (`SteeringConfig.stall_watchdog_enabled=False`, `stall_timeout_s=600.0`; env `GOLDFIVE_STEER_STALL_WATCHDOG_ENABLED` / `GOLDFIVE_STEER_STALL_TIMEOUT_S`, following the existing `GOLDFIVE_STEER_*` pattern; knobs stashed on `DefaultSteerer` next to `_observation_only`).

- **Watchdog task** in the ADK plugin, modelled on the per-LLM-call watcher: spawned by `set_active_context` (one per dispatch, a fresh dispatch replaces the prior), cancelled by `clear_active_context` (the adapter's `finally` teardown), so it never outlives the run.
- **Liveness watermark** = `max(task_last_progress_at.values())` **plus** a new `Session.last_observed_event_at` monotonic stamp refreshed at every `DriftObserver` observation entry (`observe`, `observe_reasoning`, `note_agent_activity`, `note_tool_observation`) — so a long-running single task emitting steady tool calls without transitions never false-positives.
- **On silence**: `TASK_TIMEOUT` at WARNING, escalating to CRITICAL at each further multiple of the timeout (graduated severity per the tool_loops precedent), routed through the normal `handle_drift` path — telemetry-only under `observation_only` (production default); in active mode the ladder handles it. New `_LADDER` row (TASK_TIMEOUT had none): `INFO→OBSERVE, WARNING→NUDGE, CRITICAL→(PAUSE_ESCALATE, PAUSE_ESCALATE)` — the watchdog's CRITICAL is by construction already a repeat, and the refine-outcome-based occurrence counter never advances on the NUDGE path, so a `(NUDGE, PAUSE_ESCALATE)` pair's repeat slot would be unreachable. Noted in DRIFT.md.
- **No double-reporting**: firing is skipped while an LLM call is in flight under its own per-call watcher (`_invocation_llm_pending` entries with a live `watcher` task — the `LLM_CALL_TIMEOUT` case). Entries without a watcher (budget disabled) do not suppress.
- **`GOAL_DRIFT_IDLE_SECONDS` consumed**: once per idle episode the watchdog triggers the goal-drift judge via the existing tracked `_spawn_goal_drift_judge_background` machinery, threading an `idle_note` ("Ns since last observed activity") that `maybe_run_goal_drift_check` appends to the judge's activity snapshot — `_format_activity` renders it naturally, no prompt-template change. Read live off the module attribute per poll so manifest `setattr` mutations take effect on a running watchdog.
- **Docs**: STATE-MACHINE.md now describes the real per-task/pipeline watermarks and the flag-gated watchdog, and states plainly there is no always-on stall detector; DRIFT.md / VOCABULARY.md / api.md `TASK_TIMEOUT` rows updated; module + method docstrings state honestly that sync-blocking tools starve the event loop and are out of scope.
- **Manifest**: new liveness test asserts every numeric knob's `python_attr` has at least one AST-level read site in the `goldfive` package (Name/Attribute loads + `getattr` strings; definitions, imports, `__all__`, docstrings don't count) — this catches the dead-constant class the default-sync test misses; `goal_drift_check_interval` repointed at `goldfive.config:GoalDriftConfig.check_interval`; `stall_watchdog_timeout_seconds` added.

## Tests

`tests/test_stall_watchdog.py` (18 tests): disabled-by-default spawns nothing (plus flagless-stub and non-positive-timeout fail-safes); enabled + short timeout fires WARNING then CRITICAL on continued silence; observation stamps and `task_last_progress_at` stamps both reset the watermark (no fire during active traffic, fresh episode restarts at WARNING); no fire while an LLM call is in flight under its own watcher, resumes once it resolves; idle goal-judge trigger fires exactly once per episode and re-arms on a new episode; `idle_note` renders into the judge's prompt; teardown cancels cleanly (awaiting the task raises nothing, no drifts, no pending task); ladder-row pins; and both modes end-to-end through a real `DefaultSteerer` + `InMemorySink` (observe-only: `DriftDetected` on the wire, no nudge; active: WARNING queues a nudge).

`tests/test_optimization_manifest.py`: liveness test over all numeric knobs; self-check pinning that the heuristic flags the known-dead `GOAL_DRIFT_CHECK_INTERVAL` (0 reads) and sees the newly-consumed `GOAL_DRIFT_IDLE_SECONDS`; regression pins for the repointed `goal_drift_check_interval` and the new watchdog knob.

Full suite: `uv run pytest -q` — 2909 passed, 59 skipped (~28s). `uv run ruff check .` clean.

## Behavior-change notes

- No behavior change with the flag off (production default): `set_active_context` gains one attribute read; the four observation entry points gain a monotonic stamp write.
- Updated no existing tests' assertions; `maybe_run_goal_drift_check` / `_spawn_goal_drift_judge_background` gained a keyword-only `idle_note=""` parameter (backwards-compatible; the plugin falls back to the no-kwarg call for custom observers).
- `SteeringConfig.stall_watchdog_enabled` (bool) is not in the optimization manifest — the manifest supports `prompt`/`numeric` mutation kinds only; the numeric `stall_timeout_s` knob is listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA