### PR TITLE
refactor: one public predicate for the observation_only kill-switch; suite runs the shipped default

### DIFF
--- a/docs/design/CONTROL-CHANNEL.md
+++ b/docs/design/CONTROL-CHANNEL.md
@@ -596,8 +596,10 @@ that allowed stale verdicts to cascade is gone.
 explicitly), detection still runs in full and `planner.refine_steer`
 still runs, but no side effect lands on the in-flight invocation.
 
-The three gated sites — all routed through a single named helper
-`DefaultSteerer._should_inject()` so the contract is grep-able:
+The three gated sites — all routed through the single public
+predicate `DefaultSteerer.is_active_steering()` (consumers holding a
+maybe-steerer resolve through `goldfive.steerer.steering_is_active`,
+whose documented fallback is passive) so the contract is grep-able:
 
 1. **Plan mutation** — `DefaultSteerer._apply_revision` skips the
    `set_session_plan(session, revised)` write and the
@@ -643,11 +645,12 @@ goldfive.wrap(
 
 Or via env: `GOLDFIVE_STEER_OBSERVATION_ONLY=0` /
 `false` / `no` for active steering; `=1` / `true` / `yes` for
-passive observation. The test suite flips the implicit default to
-`False` via the autouse `_goldfive_active_steering_default`
-fixture in `tests/conftest.py` so the existing test corpus
-(written against the prior active-steering default) stays green
-without per-test surgery.
+passive observation. The test suite runs against the shipped
+default (`observation_only=True`); tests that exercise
+interventions opt into active mode explicitly (the
+`active_steering_config` / `make_active_steerer` fixtures in
+`tests/conftest.py`, or an inline
+`SteeringConfig(observation_only=False)`).
 
 ---
 

--- a/goldfive/__init__.py
+++ b/goldfive/__init__.py
@@ -57,7 +57,7 @@ from goldfive.sinks import (
     LoggingSink,
     SQLitePersistenceSink,
 )
-from goldfive.steerer import DefaultSteerer
+from goldfive.steerer import DefaultSteerer, steering_is_active
 from goldfive.types import (
     GOAL_SOURCE_USER_STEER,
     DriftEvent,
@@ -137,5 +137,6 @@ __all__ = [
     "classify_tool_error",
     "quickstart",
     "run",
+    "steering_is_active",
     "wrap",
 ]

--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -95,6 +95,7 @@ from goldfive.state_store import (
     BindingSource,
     StateStore,
 )
+from goldfive.steerer import steering_is_active
 
 if TYPE_CHECKING:
     from goldfive.protocols import Steerer
@@ -1931,27 +1932,19 @@ DEFAULT_LLM_CALL_TIMEOUT_MS: int = 1_800_000
 def _is_observation_only(ctx: Any) -> bool:
     """Return True iff the steerer behind ``ctx`` is in observation-only mode.
 
-    Read by the request-side :class:`~goldfive.context_editor.ContextEditor`
-    (goldfive#397) — every steering surface MUST be a complete no-op
-    under :class:`~goldfive.config.SteeringConfig.observation_only=True`
+    Read by the plugin's intervention surfaces (cancel-flag writes, the
+    F3 pre-dispatch redirect, the request-side
+    :class:`~goldfive.context_editor.ContextEditor`; goldfive#397) —
+    every steering surface MUST be a complete no-op under
+    :class:`~goldfive.config.SteeringConfig.observation_only=True`
     (the strict-passive pattern established by goldfive#271).
 
-    The steerer exposes ``_observation_only`` as its public-ish field
-    (set from ``SteeringConfig.observation_only`` at construction). We
-    treat any failure to read it as "observation_only" — the safer
-    default for a surface whose whole purpose is to NOT fire when the
-    operator has opted into passive observation.
+    Delegates to :func:`goldfive.steerer.steering_is_active`, the one
+    kill-switch predicate: a missing / broken steerer resolves passive
+    — the safer default for a surface whose whole purpose is to NOT
+    fire when the operator has opted into passive observation.
     """
-    try:
-        steerer = _safe_attr(ctx, "steerer", None)
-        if steerer is None:
-            return True
-        flag = _safe_attr(steerer, "_observation_only", None)
-        if flag is None:
-            return True
-        return bool(flag)
-    except Exception:  # noqa: BLE001
-        return True
+    return not steering_is_active(_safe_attr(ctx, "steerer", None))
 
 
 # ``_apply_agent_max_output_tokens_cap`` (goldfive#256) was lifted into
@@ -5661,8 +5654,8 @@ def make_adk_plugin(
             # goldfive#271 strict-passive carve-out + Wave B1: the
             # injection + ``observation_only`` gate live in
             # :class:`~goldfive.prompt_shaper.PromptShaper`. The shaper
-            # short-circuits when ``ctx.steerer._observation_only`` is
-            # True; otherwise the byte-identical pre-#271 inject runs.
+            # short-circuits unless ``steering_is_active(ctx.steerer)``;
+            # otherwise the byte-identical pre-#271 inject runs.
             try:
                 await self._prompt_shaper.inject_goldfive_planner_instruction(
                     callback_context=callback_context,
@@ -5723,8 +5716,8 @@ def make_adk_plugin(
             # goldfive#271 strict-passive carve-out + Wave B1: the
             # hint + ``observation_only`` gate live in
             # :class:`~goldfive.prompt_shaper.PromptShaper`. The shaper
-            # short-circuits when ``ctx.steerer._observation_only`` is
-            # True; otherwise the byte-identical pre-#271 inject runs.
+            # short-circuits unless ``steering_is_active(ctx.steerer)``;
+            # otherwise the byte-identical pre-#271 inject runs.
             try:
                 if ctx is not None and ctx.session is not None:
                     self._prompt_shaper.inject_runtime_tools_hint(

--- a/goldfive/config.py
+++ b/goldfive/config.py
@@ -81,32 +81,6 @@ __all__ = [
 _VALID_STEER_THRESHOLDS: frozenset[str] = frozenset({"off", "warning", "critical"})
 
 
-# Test-only override hook for :class:`SteeringConfig.observation_only`'s
-# default (goldfive#254). Production code path: this stays ``None`` and
-# every fresh ``SteeringConfig()`` instance gets the documented production
-# default of ``True`` (passive observation). The pytest autouse fixture
-# ``tests/conftest.py::_goldfive_active_steering_default`` flips this to
-# ``False`` for the test suite so the broad existing test corpus —
-# written against the prior active-steering default — stays green
-# without per-test surgery. Tests that explicitly pass
-# ``observation_only=True`` (or ``=False``) still win — the override
-# only applies when the field was not explicitly set by the caller.
-_OBSERVATION_ONLY_DEFAULT: bool | None = None
-
-
-def _resolve_observation_only_default() -> bool:
-    """Resolve the active default for :class:`SteeringConfig.observation_only`.
-
-    Reads :data:`_OBSERVATION_ONLY_DEFAULT`. ``None`` means "no test
-    override is in effect" — return the production default (``True``).
-    Anything else means a test fixture has flipped the default
-    explicitly; honour the override.
-    """
-    if _OBSERVATION_ONLY_DEFAULT is None:
-        return True
-    return bool(_OBSERVATION_ONLY_DEFAULT)
-
-
 def _read_bool_env(name: str, default: bool) -> bool:
     """Read ``os.environ[name]`` as a boolean; fall back to ``default``.
 
@@ -660,8 +634,15 @@ class SteeringConfig:
     cancel or refine fires. Default ``3`` keeps a live operator
     override dominant across a few agent turns.
 
-    ``observation_only`` (goldfive#254) gates the actual steering
-    injection points on :class:`~goldfive.steerer.DefaultSteerer`:
+    ``observation_only`` (goldfive#254) is the master kill-switch for
+    steering interventions. The single source of truth at runtime is
+    :meth:`~goldfive.steerer.DefaultSteerer.is_active_steering`
+    (``True`` iff interventions may mutate or inject); consumers
+    holding a maybe-steerer resolve through
+    :func:`~goldfive.steerer.steering_is_active`, which treats a
+    missing steerer / missing predicate as passive. No other code may
+    read the flag directly. The gated injection points on
+    :class:`~goldfive.steerer.DefaultSteerer`:
 
     * the would-be revised plan replacing ``session.plan`` in
       :meth:`~goldfive.steerer.DefaultSteerer._apply_revision`;
@@ -713,9 +694,7 @@ class SteeringConfig:
 
     threshold: str = "warning"
     suppression_window_turns: int = 3
-    observation_only: bool = dataclasses.field(
-        default_factory=_resolve_observation_only_default
-    )
+    observation_only: bool = True
     #: Names of :class:`~goldfive.context_editor.ContextEditRule` rules to
     #: register on the ADK plugin's :class:`~goldfive.context_editor.ContextEditor`
     #: (goldfive#397). ``None`` (the default) AND an empty list both leave
@@ -814,9 +793,7 @@ class SteeringConfig:
         * ``GOLDFIVE_STEER_OBSERVATION_ONLY`` — boolean
           (``1``/``true``/``yes``/``on`` truthy; ``0``/``false``/
           ``no``/``off`` falsy; case-insensitive). Defaults to the
-          built-in default (``True`` in production, flipped to
-          ``False`` for the goldfive test suite via the autouse
-          ``_goldfive_active_steering_default`` fixture).
+          built-in default (``True``).
         * ``GOLDFIVE_STEER_CONTEXT_EDITOR_RULES`` — comma-separated rule
           names (goldfive#397). Empty / unset → ``None`` (editor unwired).
           Example: ``GOLDFIVE_STEER_CONTEXT_EDITOR_RULES=prune_cancelled_reasoning``.

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -376,8 +376,8 @@ class DriftObserver:
         # :class:`~goldfive.task_state_machine.TaskStateMachine`), and
         # the router-owned shared state (the per-async-task
         # ``_active_session_var`` ContextVar plumbing for the planner
-        # span-context provider, the ``_observation_only`` gate read
-        # via :meth:`DefaultSteerer._should_inject`, and the
+        # span-context provider, the ``observation_only`` gate read
+        # via :meth:`DefaultSteerer.is_active_steering`, and the
         # ``REFINE_FAILURE_THRESHOLD`` / ``PROGRESS_STALL_THRESHOLD_SECONDS``
         # class constants).
         self._steerer = steerer
@@ -4410,7 +4410,7 @@ class DriftObserver:
             # observation. Skip the enqueue but log the would-be message
             # and stamp the gate, mirroring
             # ``_dispatch_goldfive_steer_control``.
-            if not self._steerer._should_inject():
+            if not self._steerer.is_active_steering():
                 log.info(
                     "DefaultSteerer._handle_drift: observation_only=True — "
                     "SKIPPING post-ABSORB nudge enqueue. would_have_queued "
@@ -4458,7 +4458,7 @@ class DriftObserver:
 
         Observation-only: the overlay drains the queue into a
         goldfive-authored user turn that re-invokes the tree, so the
-        enqueue is gated on :meth:`DefaultSteerer._should_inject` like
+        enqueue is gated on :meth:`DefaultSteerer.is_active_steering` like
         the other injection points; the would-be nudge is logged and
         the gate stamped as decision telemetry.
         """
@@ -4468,7 +4468,7 @@ class DriftObserver:
             drift=drift,
             refined_plan=session.plan,
         )
-        if not self._steerer._should_inject():
+        if not self._steerer.is_active_steering():
             log.info(
                 "DefaultSteerer._dispatch_nudge: observation_only=True — "
                 "SKIPPING nudge enqueue. would_have_queued kind=%s "
@@ -4562,7 +4562,7 @@ class DriftObserver:
         # see what would have been dispatched (drift kind, task id, body).
         # No cancel-and-restart fires on the executor; the live invocation
         # continues against the prior plan.
-        if not self._steerer._should_inject():
+        if not self._steerer.is_active_steering():
             log.info(
                 "DefaultSteerer._dispatch_goldfive_steer_control: "
                 "observation_only=True — SKIPPING GOLDFIVE_STEER enqueue. "
@@ -4670,7 +4670,7 @@ class DriftObserver:
         """
         from goldfive.control import ControlKind, ControlMessage
 
-        if not self._steerer._should_inject():
+        if not self._steerer.is_active_steering():
             log.info(
                 "DefaultSteerer._dispatch_goldfive_pause_control: "
                 "observation_only=True — SKIPPING GOLDFIVE_PAUSE_ESCALATE "
@@ -5092,14 +5092,14 @@ class DriftObserver:
           break — the task-cancel step is silently skipped.
 
         Observation-only mode (goldfive#254): when
-        :meth:`DefaultSteerer._should_inject` is ``False`` this method
+        :meth:`DefaultSteerer.is_active_steering` is ``False`` this method
         returns ``[]`` without consulting the plugin or stamping
         ``cancel_requested_invocation_ids``. Logged at INFO so an
         operator can see WHAT would have been cancelled (drift kind,
         task / agent id) without the cancel actually firing on the
         live invocation.
         """
-        if not self._steerer._should_inject():
+        if not self._steerer.is_active_steering():
             log.info(
                 "DefaultSteerer.request_invocation_cancel: "
                 "observation_only=True — SKIPPING cancel for "

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -64,6 +64,7 @@ from goldfive.executors._shared import (
 )
 from goldfive.protocols import AgentAdapter, EventSink, Executor, Planner, Steerer
 from goldfive.results import ExecutionOutcome, evaluate_goal_predicates
+from goldfive.steerer import steering_is_active
 from goldfive.types import (
     DriftKind,
     DriftSeverity,
@@ -683,7 +684,7 @@ class SequentialExecutor(Executor):
                             task.id,
                         )
                         failure_reason = ""  # not actually fatal
-                    elif getattr(steerer, "_observation_only", False):
+                    elif not steering_is_active(steerer):
                         # goldfive#260: under observation_only, do NOT
                         # enforce the "failed-task must have a live
                         # replacement" invariant. The replacement-
@@ -774,7 +775,7 @@ class SequentialExecutor(Executor):
             # observation_only's "passive — observe, don't enforce"
             # contract; the coordinator's autonomous flow decides
             # whether the failure is recoverable.
-            if getattr(steerer, "_observation_only", False):
+            if not steering_is_active(steerer):
                 log.info(
                     "SequentialExecutor: observation_only=True — "
                     "skipping abort-on-failed-without-replacement "
@@ -1280,7 +1281,7 @@ class SequentialExecutor(Executor):
                 # originating ``HUMAN_INTERVENTION_REQUIRED`` drift
                 # the steerer emitted remains the durable signal on
                 # the sink stream.
-                if getattr(steerer, "_observation_only", False):
+                if not steering_is_active(steerer):
                     log.info(
                         "SequentialExecutor._run_overlay: "
                         "observation_only=True — would have paused on "
@@ -1336,7 +1337,7 @@ class SequentialExecutor(Executor):
                 # the tree here — exactly the enforcement
                 # ``observation_only`` exists to suppress. Discard the
                 # queue (never inject it later) and end the turn.
-                if getattr(steerer, "_observation_only", False):
+                if not steering_is_active(steerer):
                     log.info(
                         "SequentialExecutor._run_overlay: "
                         "observation_only=True — would have replayed %d "
@@ -1457,7 +1458,7 @@ class SequentialExecutor(Executor):
             # failure to the user). If it can't, the run terminates
             # naturally when the coordinator stops dispatching
             # invocations and we fall through to run_completed below.
-            if getattr(steerer, "_observation_only", False):
+            if not steering_is_active(steerer):
                 log.info(
                     "SequentialExecutor._run_overlay: observation_only=True "
                     "— skipping abort-on-failed-without-replacement for "
@@ -1630,7 +1631,7 @@ class SequentialExecutor(Executor):
                 # ``HUMAN_INTERVENTION_REQUIRED`` drift on the sink
                 # stream remains the durable signal) and keep waiting
                 # on the invoke task / next control message.
-                if getattr(steerer, "_observation_only", False):
+                if not steering_is_active(steerer):
                     log.info(
                         "SequentialExecutor: observation_only=True — "
                         "dropping GOLDFIVE_PAUSE_ESCALATE without "

--- a/goldfive/plan_reviser.py
+++ b/goldfive/plan_reviser.py
@@ -1866,7 +1866,7 @@ class PlanReviser:
             (not is_bootstrap)
             and (not is_user_authored)
             and (not is_discovery)
-            and (not self._steerer._should_inject())
+            and (not self._steerer.is_active_steering())
         )
         if gate_active:
             log.info(
@@ -1965,7 +1965,7 @@ class PlanReviser:
             # every side-effect site below can gate consistently. Mirrors
             # the wire-stamp resolution further down (caller threads through
             # ``not was_installed``; legacy callers pass ``None`` and fall
-            # back to ``not self._should_inject()``). Computed once,
+            # back to ``not is_active_steering()``). Computed once,
             # consumed by:
             #   * the supersedes-integration ``set_session_plan`` swap;
             #   * ``clear_obsolete_corrections_on_revision`` (state pop);
@@ -1980,7 +1980,7 @@ class PlanReviser:
             effective_dry_run = (
                 bool(dry_run)
                 if dry_run is not None
-                else (not self._steerer._should_inject())
+                else (not self._steerer.is_active_steering())
             )
             prior_plan_id_short = (
                 (session.plan.id if session.plan is not None else "")[:16]
@@ -2186,7 +2186,7 @@ class PlanReviser:
             # marker reflects whether this SPECIFIC revision was actually
             # suppressed (a bootstrap install or user-authored steer
             # under observation_only is a REAL revision — dry_run False
-            # — even though ``self._should_inject()`` is False). Legacy
+            # — even though ``is_active_steering()`` is False). Legacy
             # callers that don't pass ``dry_run`` fall back to the
             # pre-#255 behaviour for back-compat.
             #

--- a/goldfive/prompt_shaper.py
+++ b/goldfive/prompt_shaper.py
@@ -65,6 +65,8 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
+from goldfive.steerer import steering_is_active
+
 if TYPE_CHECKING:
     from goldfive.types import Session
 
@@ -92,25 +94,17 @@ class PromptShaper:
     def should_inject(steerer: Any) -> bool:
         """Return True when prompt-shaping injections are permitted.
 
-        Reads ``steerer._observation_only`` and returns its logical
-        complement: under strict-passive (``observation_only=True``)
-        injections are suppressed; otherwise the active-steering path
-        runs.
-
-        Tolerant of ``steerer is None`` and steerers that don't carry
-        a ``_observation_only`` attribute — both cases return ``True``
-        so pre-#271 paths and minimal test stubs (which never set up a
-        steerer) keep working byte-identically.
-
-        This is the single source of truth the four inject methods
-        consult. Mirrors :meth:`DefaultSteerer._should_inject` in
-        intent — that predicate gates enforcement-side dispatch (steer,
-        pause-escalate, cancel); this one gates prompt-shape
-        injections.
+        Delegates to :func:`goldfive.steerer.steering_is_active` — the
+        one kill-switch predicate for
+        :class:`~goldfive.config.SteeringConfig.observation_only`.
+        ``steerer is None`` and steerers that don't expose
+        :meth:`~goldfive.steerer.DefaultSteerer.is_active_steering`
+        resolve to ``False`` (injections suppressed): passive is the
+        fail-safe direction. Pre-refactor this site defaulted ACTIVE on
+        a missing attribute; the flip to the passive fallback is
+        deliberate.
         """
-        if steerer is None:
-            return True
-        return not bool(getattr(steerer, "_observation_only", False))
+        return steering_is_active(steerer)
 
     # ----------------------------------------------------------------
     # Site 1 — conversational follow-up wrap
@@ -236,9 +230,9 @@ class PromptShaper:
 
         ``session_context`` carries the live
         :class:`~goldfive.adapters._adk_plugin.SessionContext` from the
-        plugin so the gate can reach the steerer. May be ``None`` on
-        unit-test stubs that never wire one up — those paths default
-        to the active-steering branch (pre-#271 behaviour).
+        plugin so the gate can reach the steerer. ``None`` (or a
+        context without a steerer) resolves passive — injections
+        suppressed, the fail-safe direction.
         """
         steerer = getattr(session_context, "steerer", None) if session_context is not None else None
         if not self.should_inject(steerer):

--- a/goldfive/protocols.py
+++ b/goldfive/protocols.py
@@ -120,6 +120,18 @@ class Steerer(Protocol):
     plans: Any
     drift: Any
 
+    def is_active_steering(self) -> bool:
+        """Return ``True`` iff interventions may mutate state or inject.
+
+        The kill-switch predicate for
+        :class:`~goldfive.config.SteeringConfig.observation_only`.
+        Consumers holding a maybe-steerer resolve through
+        :func:`goldfive.steerer.steering_is_active`, which treats a
+        missing implementation as passive (``False``) — the fail-safe
+        direction.
+        """
+        ...
+
     async def transition(
         self,
         task_id: str,

--- a/goldfive/reporting/rendering.py
+++ b/goldfive/reporting/rendering.py
@@ -10,8 +10,8 @@ read on the next turn — they're the contract surface between
   This is the F1 / Tier 1 loop-prevention pattern. ``plan_state`` is a
   goldfive-authored steering surface, so it is suppressed under
   ``observation_only`` via the same
-  :meth:`~goldfive.prompt_shaper.PromptShaper.should_inject` predicate
-  the prompt-shaping sites consult.
+  :func:`~goldfive.steerer.steering_is_active` predicate the
+  prompt-shaping sites consult.
 * **Idempotent / invalid / refused** responses — branch shapes for
   retries, contract violations, and stale-pin refusals. Distinct
   shapes so loop-detector / observability layers can tell them apart.
@@ -28,8 +28,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from goldfive.prompt_shaper import PromptShaper
 from goldfive.reporting._internal import _ACK, _TERMINAL_STATUSES
+from goldfive.steerer import steering_is_active
 from goldfive.types import TaskStatus
 
 if TYPE_CHECKING:
@@ -170,7 +170,7 @@ def _directive_ack(
     ``plan_state`` (completed ids + next_pending hand-off) is a
     goldfive-authored directive fed to the model, so it rides the same
     ``observation_only`` gate as the four prompt-shaping sites
-    (:meth:`~goldfive.prompt_shaper.PromptShaper.should_inject`). Under
+    (:func:`~goldfive.steerer.steering_is_active`). Under
     strict-passive the ack keeps only the factual echo of the
     transition the agent itself reported.
     """
@@ -178,7 +178,7 @@ def _directive_ack(
         "acknowledged": True,
         "task": {"id": task_id, "status": new_status.value},
     }
-    if PromptShaper.should_inject(steerer):
+    if steering_is_active(steerer):
         response["plan_state"] = _build_plan_state(getattr(session, "plan", None))
     return response
 
@@ -207,7 +207,7 @@ def _idempotent_response(
     }
     if session is not None:
         response["task"] = {"id": task_id, "status": current_status.value}
-        if PromptShaper.should_inject(steerer):
+        if steering_is_active(steerer):
             response["plan_state"] = _build_plan_state(getattr(session, "plan", None))
     return response
 

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -100,7 +100,30 @@ __all__ = [
     "InterventionLevel",
     "RefineExhausted",
     "compose_corrective_user_message",
+    "steering_is_active",
 ]
+
+
+def steering_is_active(steerer: Any) -> bool:
+    """Return ``True`` iff ``steerer`` permits active-steering interventions.
+
+    The one documented fallback for consumers holding a maybe-steerer
+    (executors, the ADK plugin, prompt shaping, reporting acks):
+    delegates to :meth:`DefaultSteerer.is_active_steering` when the
+    steerer exposes it, and answers ``False`` when ``steerer`` is
+    ``None``, lacks the predicate, or the predicate raises. Passive is
+    the fail-safe direction — a surface whose whole purpose is to NOT
+    intervene under :class:`~goldfive.config.SteeringConfig.observation_only`
+    must not start intervening because a stub steerer forgot a method.
+    Consumers must not read ``_observation_only`` directly.
+    """
+    predicate = getattr(steerer, "is_active_steering", None)
+    if not callable(predicate):
+        return False
+    try:
+        return bool(predicate())
+    except Exception:  # noqa: BLE001
+        return False
 
 
 class RefineExhausted(Exception):
@@ -670,23 +693,18 @@ class DefaultSteerer:
         # (``session.plan`` mutation in ``_apply_revision``, the
         # ``GOLDFIVE_STEER`` ControlMessage enqueue, the
         # ``request_invocation_cancel`` plugin call) are gated by
-        # :meth:`_should_inject`. The flag lives on :class:`SteeringConfig`
-        # — NOT a constructor parameter on this class — so operators
-        # set it via ``RuntimeConfig(steering=SteeringConfig(...))``
-        # at :func:`goldfive.wrap` time. Default for the bare
+        # :meth:`is_active_steering`. The flag lives on
+        # :class:`SteeringConfig` — NOT a constructor parameter on this
+        # class — so operators set it via
+        # ``RuntimeConfig(steering=SteeringConfig(...))`` at
+        # :func:`goldfive.wrap` time. Default for the bare
         # ``DefaultSteerer()`` constructor (no config) is the safer
         # passive observation (``True``) — matches the production
         # default on :class:`SteeringConfig` and avoids surprising
         # third-party callers who construct ``DefaultSteerer`` directly.
-        if steering_config is not None:
-            self._observation_only: bool = bool(steering_config.observation_only)
-        else:
-            # Honour the test-only override hook so the autouse fixture
-            # in ``tests/conftest.py`` can flip the implicit default for
-            # the entire test suite without touching every call site.
-            from goldfive.config import _resolve_observation_only_default
-
-            self._observation_only = _resolve_observation_only_default()
+        self._observation_only: bool = (
+            bool(steering_config.observation_only) if steering_config is not None else True
+        )
         # Wall-clock stall watchdog knobs (flag-gated, default OFF). Read
         # by the ADK plugin's per-dispatch watchdog task — see
         # :class:`~goldfive.config.SteeringConfig.stall_watchdog_enabled`.
@@ -1318,11 +1336,13 @@ class DefaultSteerer:
     # :meth:`__init__` from :class:`~goldfive.config.SteeringConfig`).
     # ------------------------------------------------------------------
 
-    def _should_inject(self) -> bool:
-        """Return ``True`` iff the steerer should actually inject side effects.
+    def is_active_steering(self) -> bool:
+        """Return ``True`` iff interventions may mutate state or inject.
 
-        Single named gate for the steering injection points
-        (goldfive#254):
+        The single source of truth for the
+        :class:`~goldfive.config.SteeringConfig.observation_only`
+        kill-switch (goldfive#254). Named gate for the steering
+        injection points:
 
         * plan mutation in :meth:`PlanReviser._apply_revision`
           (``set_session_plan`` + ``last_addressed_revision_by_drift_key``);
@@ -1334,17 +1354,29 @@ class DefaultSteerer:
           :meth:`DriftObserver._dispatch_nudge` and the post-ABSORB
           nudge handoff (goldfive#202) — the overlay drains the queue
           into a synthetic user turn and re-invokes the tree, so the
-          enqueue is an injection, not an observation.
+          enqueue is an injection, not an observation;
+        * the prompt-shape injections
+          (:meth:`~goldfive.prompt_shaper.PromptShaper.should_inject`),
+          the executor carve-outs, the plugin's pre-dispatch gates, and
+          the F1 directive acks — all via :func:`steering_is_active`.
 
         ``False`` when :class:`~goldfive.config.SteeringConfig.observation_only`
         is in effect — detection still runs, ``planner.refine_steer``
         still runs, ``PlanRevised`` still emits (with ``dry_run=True``),
-        but the in-flight invocation is not touched. Defined as a tiny
-        helper rather than inlining ``not self._observation_only`` at
-        each site so the intent is grep-able and a future injection
-        point has a single gate to honour.
+        but the in-flight invocation is not touched. Consumers holding a
+        maybe-steerer resolve through :func:`steering_is_active`, which
+        treats a missing implementation as passive.
         """
         return not self._observation_only
+
+    def _should_inject(self) -> bool:
+        """Steerer-internal alias for :meth:`is_active_steering`.
+
+        Same truth source — kept because "should inject" reads
+        naturally at the dispatch gates and pre-refactor callers/tests
+        address it by name.
+        """
+        return self.is_active_steering()
 
     # Consecutive refine failures tolerated per (drift_kind, task_id)
     # before we give up and mark the task FAILED. Class attribute so

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,41 +66,38 @@ def no_state_audit() -> Iterator[None]:
             os.environ["GOLDFIVE_STRICT_STATE_OWNERSHIP"] = prior
 
 
-@pytest.fixture(autouse=True)
-def _goldfive_active_steering_default() -> Iterator[None]:
-    """Flip :class:`SteeringConfig.observation_only`'s implicit default to
-    ``False`` for the test suite (goldfive#254).
+@pytest.fixture
+def active_steering_config() -> Any:
+    """Return a ``SteeringConfig`` with the kill-switch off.
 
-    Production default is ``True`` (passive observation — see the
-    docstring on :class:`goldfive.config.SteeringConfig`). The existing
-    test corpus was written against the prior active-steering default
-    and asserts e.g. ``session.plan`` mutating after a refine; flipping
-    every test to construct a ``RuntimeConfig`` explicitly is overkill.
-    This fixture sets a module-level test-only override
-    (``goldfive.config._OBSERVATION_ONLY_DEFAULT``) that the
-    ``observation_only`` field consults via a ``default_factory`` — so
-    any test that constructs ``SteeringConfig()`` (or builds a
-    ``DefaultSteerer`` without a config) sees active steering.
-
-    Tests that explicitly pass ``observation_only=True`` (or
-    ``observation_only=False``) still win — the dataclass honours
-    explicit kwargs over the default factory, and a
-    ``SteeringConfig(observation_only=True)`` instance retains the
-    True the test asked for regardless of this fixture.
+    The suite runs against the shipped default
+    (``observation_only=True`` — strict-passive). Tests that exercise
+    interventions (plan installs, steer/cancel dispatch, prompt-shape
+    injections) request active mode EXPLICITLY via this fixture or by
+    constructing ``SteeringConfig(observation_only=False)`` inline.
     """
-    try:
-        from goldfive import config as _gf_config
-    except ImportError:
-        # Config module not importable yet — no-op for back-compat with
-        # pre-#225 worktrees.
-        yield
-        return
-    prior = _gf_config._OBSERVATION_ONLY_DEFAULT
-    _gf_config._OBSERVATION_ONLY_DEFAULT = False
-    try:
-        yield
-    finally:
-        _gf_config._OBSERVATION_ONLY_DEFAULT = prior
+    config_mod = pytest.importorskip("goldfive.config")
+    return config_mod.SteeringConfig(observation_only=False)
+
+
+@pytest.fixture
+def make_active_steerer() -> Callable[..., Any]:
+    """Return a factory building a ``DefaultSteerer`` in active mode.
+
+    Keyword arguments pass through to the constructor; a
+    ``steering_config`` kwarg supplied by the caller wins (the factory
+    only defaults it to ``SteeringConfig(observation_only=False)``).
+    """
+    config_mod = pytest.importorskip("goldfive.config")
+    steerer_mod = pytest.importorskip("goldfive.steerer")
+
+    def _factory(**kwargs: Any) -> Any:
+        kwargs.setdefault(
+            "steering_config", config_mod.SteeringConfig(observation_only=False)
+        )
+        return steerer_mod.DefaultSteerer(**kwargs)
+
+    return _factory
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_adk_adapter.py
+++ b/tests/test_adk_adapter.py
@@ -1903,6 +1903,11 @@ async def test_reporting_tool_duplicate_returns_idempotent_ack(state_ctx_cls) ->
         def __init__(self) -> None:
             self.tasks = _Tasks()
 
+        def is_active_steering(self) -> bool:
+            # Explicit active mode: the F1 directive ack under test is
+            # suppressed under the shipped observation-only default.
+            return True
+
         @property
         def running_calls(self) -> int:
             return self.tasks.running_calls

--- a/tests/test_agent_budget.py
+++ b/tests/test_agent_budget.py
@@ -220,15 +220,17 @@ class _CapturingSteerer:
     Shape mirrors the live :class:`DefaultSteerer` interface for the
     watcher's emission path after goldfive#410: the watcher reaches
     for ``steerer.drift.observe`` and ``steerer.drift._emit_drift_detected``.
-    ``_observation_only=False`` pins active mode — the watcher's
-    cancel-flag write is gated on the flag and a missing attribute
+    ``is_active_steering() -> True`` pins active mode — the watcher's
+    cancel-flag write is gated on the predicate and a missing method
     reads as passive.
     """
 
     def __init__(self) -> None:
         self.drift = _CapturingDrift()
         self._sinks: list[Any] = []
-        self._observation_only = False
+
+    def is_active_steering(self) -> bool:
+        return True
 
     @property
     def observations(self) -> list[Any]:

--- a/tests/test_cancel_inflight_on_refine.py
+++ b/tests/test_cancel_inflight_on_refine.py
@@ -59,6 +59,7 @@ from goldfive.adapters._adk_plugin import (  # noqa: E402
     SessionContext,
     make_adk_plugin,
 )
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
     CancellationRequest,
@@ -436,7 +437,7 @@ async def test_cancel_inflight_for_revision_fires_for_real_drift() -> None:
             self.calls.append(kwargs)
             return [str(kwargs.get("invocation_id", ""))]
 
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     adapter = _CountingAdapter()
     steerer.bind_adapter(adapter)
     drift = DriftEvent(
@@ -515,6 +516,7 @@ async def test_plan_divergence_refine_cancels_inflight_coordinator_task() -> Non
     steerer = DefaultSteerer(
         goldfive_steer_threshold="warning",
         goldfive_steer_suppression_window_turns=3,
+        steering_config=SteeringConfig(observation_only=False),
     )
     steerer.bind(sinks=[], planner=_StubPlanner())
 

--- a/tests/test_cooperative_cancellation.py
+++ b/tests/test_cooperative_cancellation.py
@@ -50,6 +50,7 @@ from goldfive.adapters._adk_plugin import (  # noqa: E402
     SessionContext,
     make_adk_plugin,
 )
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
     CancellationRequest,
@@ -562,7 +563,7 @@ async def test_info_drift_does_not_request_cancel() -> None:
 async def test_critical_drift_requests_cancel() -> None:
     plugin, _sink, session = _make_plugin()
     adapter = _StubAdapter(plugin)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[], planner=None)
     steerer.bind_adapter(adapter)
     plugin._top_invocation_id = "inv-A"
@@ -641,7 +642,7 @@ async def test_cancel_inflight_for_revision_still_fires_without_precancel() -> N
     """
     plugin, _sink, session = _make_plugin()
     adapter = _StubAdapter(plugin)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[], planner=None)
     steerer.bind_adapter(adapter)
     plugin._top_invocation_id = "inv-A"
@@ -835,7 +836,7 @@ async def test_no_auto_redispatch_after_cancel() -> None:
 async def test_user_steer_drift_bypasses_severity_gate() -> None:
     plugin, _sink, session = _make_plugin()
     adapter = _StubAdapter(plugin)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[], planner=None)
     steerer.bind_adapter(adapter)
     plugin._top_invocation_id = "inv-A"

--- a/tests/test_correction_injection.py
+++ b/tests/test_correction_injection.py
@@ -44,6 +44,7 @@ from goldfive._correction_injection import (  # noqa: E402
     write_correction,
 )
 from goldfive.adapters import _adk_state_protocol as _sp  # noqa: E402
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.reporting import BUILTIN_REPORTING_TOOLS  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
@@ -187,7 +188,7 @@ async def _emit(
 async def test_correct_kind_supersedes_writes_correction_to_state() -> None:
     session = _session(_base_plan())
     revised = _revised_with_one_correct()
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
 
     drift = _drift(kind=DriftKind.OFF_TOPIC, detail="veered to batteries")
@@ -327,7 +328,7 @@ async def test_multiple_correct_supersedes_write_multiple_corrections() -> None:
         revision_index=1,
     )
 
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
     await _emit(steerer, session, revised, _drift())
 
@@ -481,7 +482,7 @@ async def test_correction_cleared_when_correction_task_itself_superseded() -> No
         revision_index=2,
     )
 
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[ListSink()], planner=_StubPlanner())
     await _emit(steerer, session, revised, _drift())
 
@@ -601,7 +602,20 @@ def test_dynamic_resolver_picks_up_correction_dict() -> None:
         def __init__(self, state: dict[str, Any]) -> None:
             self.state = state
 
+    class _ActiveSteerer:
+        def is_active_steering(self) -> bool:
+            return True
+
+    from types import SimpleNamespace
+
     state: dict[str, Any] = {
+        # The resolver's augmentation rides the ``steering_is_active``
+        # gate; plant an active-steerer stash so this test exercises
+        # the composed instruction (suppressed under the shipped
+        # observation-only default).
+        "goldfive._session_context": SimpleNamespace(
+            steerer=_ActiveSteerer(), session=None
+        ),
         _sp.KEY_CURRENT_TASK_ID: "research_solar_corrected",
         _sp.KEY_CURRENT_TASK_TITLE: "Research solar options (corrected)",
         _sp.KEY_CURRENT_TASK_DESCRIPTION: "narrowed scope",

--- a/tests/test_drift_drain_at_run_boundary.py
+++ b/tests/test_drift_drain_at_run_boundary.py
@@ -63,6 +63,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.executors.sequential import (  # noqa: E402
     SequentialExecutor,
     _drain_steerer_at_run_boundary,
@@ -515,7 +516,7 @@ async def test_executor_run_aborted_drains_in_flight_drift_end_to_end() -> None:
     from goldfive.results import InvocationResult
 
     slow_planner = _SlowPlanner(delay=30.0)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     sink = _ListSink()
 
     class _Adapter:

--- a/tests/test_drift_version_pin.py
+++ b/tests/test_drift_version_pin.py
@@ -37,6 +37,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.drift.goals import classify_goal_drift  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
@@ -633,7 +634,7 @@ async def test_apply_revision_stamps_per_key_watermark() -> None:
     # NOT mutate session state; _emit_plan_revised performs the
     # session-mutation triad (set_session_plan + watermark stamp +
     # orchestration-state pointer) atomically under the lock.
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     revised, _ = steerer.plans._apply_revision(session, revised, drift)
     await steerer.plans._emit_plan_revised(session, revised, drift, prev_plan=session.plan)
 

--- a/tests/test_dynamic_instruction.py
+++ b/tests/test_dynamic_instruction.py
@@ -30,7 +30,9 @@ from goldfive.adapters.adk_llm_instrumentation import (
     is_dynamic_instruction,
     pending_correction_key,
 )
+from goldfive.config import SteeringConfig
 from goldfive.prompt_shaper import PromptShaper
+from goldfive.steerer import DefaultSteerer
 from goldfive.types import Plan, Task
 
 
@@ -97,6 +99,25 @@ class _ReadonlyCtxStub:
         self.state = state
 
 
+class _ActiveSteerer:
+    def is_active_steering(self) -> bool:
+        return True
+
+
+def _active_steering_stash() -> Any:
+    """Legacy V7 SessionContext stash carrying an active steerer.
+
+    The resolver's augmentation rides the ``steering_is_active`` gate,
+    which resolves passive when no steerer is reachable — tests that
+    assert the composed instruction opt into active mode explicitly by
+    planting this stash on the state dict (``session=None`` keeps the
+    legacy ADK-state read path these tests exercise).
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(steerer=_ActiveSteerer(), session=None)
+
+
 # ---------------------------------------------------------------------------
 # Resolver semantics
 # ---------------------------------------------------------------------------
@@ -125,6 +146,7 @@ def test_resolver_composes_when_pinned() -> None:
     )
     ctx = _ReadonlyCtxStub(
         state={
+            "goldfive._session_context": _active_steering_stash(),
             _sp.KEY_CURRENT_TASK_ID: "t1",
             _sp.KEY_CURRENT_TASK_TITLE: "the task",
             _sp.KEY_CURRENT_TASK_DESCRIPTION: "do the thing",
@@ -144,7 +166,12 @@ def test_resolver_uses_placeholders_for_legacy_state() -> None:
         original_instruction="you are a helper",
         agent_name="inner_agent",
     )
-    ctx = _ReadonlyCtxStub(state={_sp.KEY_CURRENT_TASK_ID: "t1"})
+    ctx = _ReadonlyCtxStub(
+        state={
+            "goldfive._session_context": _active_steering_stash(),
+            _sp.KEY_CURRENT_TASK_ID: "t1",
+        }
+    )
     out = resolver(ctx)
     assert "id: t1" in out
     assert "(title unset)" in out
@@ -160,6 +187,7 @@ def test_resolver_appends_correction_when_present() -> None:
     key = pending_correction_key("inner_agent", "t1")
     ctx = _ReadonlyCtxStub(
         state={
+            "goldfive._session_context": _active_steering_stash(),
             _sp.KEY_CURRENT_TASK_ID: "t1",
             _sp.KEY_CURRENT_TASK_TITLE: "the task",
             _sp.KEY_CURRENT_TASK_DESCRIPTION: "do the thing",
@@ -198,6 +226,7 @@ def test_resolver_re_evaluates_per_turn() -> None:
         agent_name="inner_agent",
     )
     state: dict[str, Any] = {
+        "goldfive._session_context": _active_steering_stash(),
         _sp.KEY_CURRENT_TASK_ID: "t1",
         _sp.KEY_CURRENT_TASK_TITLE: "first",
         _sp.KEY_CURRENT_TASK_DESCRIPTION: "first description",
@@ -333,6 +362,7 @@ def test_multiple_agents_resolve_independently() -> None:
     install_dynamic_instructions(container)
 
     state = {
+        "goldfive._session_context": _active_steering_stash(),
         _sp.KEY_CURRENT_TASK_ID: "tA",
         _sp.KEY_CURRENT_TASK_TITLE: "title for A",
         _sp.KEY_CURRENT_TASK_DESCRIPTION: "description for A",
@@ -360,6 +390,7 @@ def test_resolver_survives_canonical_instruction_contract() -> None:
     install_dynamic_instructions(leaf)
 
     state = {
+        "goldfive._session_context": _active_steering_stash(),
         _sp.KEY_CURRENT_TASK_ID: "t1",
         _sp.KEY_CURRENT_TASK_TITLE: "title",
         _sp.KEY_CURRENT_TASK_DESCRIPTION: "desc",
@@ -525,6 +556,7 @@ async def test_templating_composes_with_task_pin_in_active_mode() -> None:
     )
     state: dict[str, Any] = {
         "topic": "llamas",
+        "goldfive._session_context": _active_steering_stash(),
         _sp.KEY_CURRENT_TASK_ID: "t1",
         _sp.KEY_CURRENT_TASK_TITLE: "the task",
         _sp.KEY_CURRENT_TASK_DESCRIPTION: "do the thing",
@@ -555,7 +587,10 @@ async def test_templating_still_runs_under_observation_only() -> None:
         agent_name="inner_agent",
     )
     stash = SimpleNamespace(
-        steerer=SimpleNamespace(_observation_only=True), session=None
+        steerer=DefaultSteerer(
+            steering_config=SteeringConfig(observation_only=True)
+        ),
+        session=None,
     )
     state: dict[str, Any] = {
         "topic": "llamas",

--- a/tests/test_e2e_plan_causal_correction.py
+++ b/tests/test_e2e_plan_causal_correction.py
@@ -70,6 +70,7 @@ from goldfive.adapters.adk_llm_instrumentation import (  # noqa: E402
     format_correction_block,
     is_dynamic_instruction,
 )
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.reporting import BUILTIN_REPORTING_TOOLS  # noqa: E402
 from goldfive.sinks import InMemorySink  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
@@ -341,7 +342,9 @@ async def _drive_refine_cycle(
     """
     planner = _ScriptedRefinePlanner([revised])
     sink = _ListSink()
-    steerer = DefaultSteerer()
+    # Explicit active mode: the corrective install under test is
+    # suppressed under the shipped observation-only default.
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=planner)
 
     prev = session.plan
@@ -358,8 +361,21 @@ def _pin_task(session: Session, task: Task) -> None:
     The ADK plugin normally does this at ``before_run`` time; stamping
     directly keeps the test focused on the resolver's read contract
     rather than on the plugin's pinning pipeline (which has its own
-    dedicated tests).
+    dedicated tests). Also plants the legacy SessionContext stash with
+    an active steerer: the resolver's augmentation rides the
+    ``steering_is_active`` gate and is suppressed under the shipped
+    observation-only default (``session=None`` keeps the legacy
+    ADK-state read path these tests exercise).
     """
+    from types import SimpleNamespace
+
+    class _ActiveSteerer:
+        def is_active_steering(self) -> bool:
+            return True
+
+    session.state["goldfive._session_context"] = SimpleNamespace(
+        steerer=_ActiveSteerer(), session=None
+    )
     session.state[_sp.KEY_CURRENT_TASK_ID] = task.id
     session.state[_sp.KEY_CURRENT_TASK_TITLE] = task.title
     session.state[_sp.KEY_CURRENT_TASK_DESCRIPTION] = task.description
@@ -630,7 +646,7 @@ async def test_critical_drift_composes_cancel_with_correction() -> None:
     adapter = _StubAdapterWithPlugin(top_invocation_id="inv-research-1")
 
     planner = _ScriptedRefinePlanner()
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[_ListSink()], planner=planner)
     steerer.bind_adapter(adapter)
 

--- a/tests/test_goal_drift_classifier.py
+++ b/tests/test_goal_drift_classifier.py
@@ -38,6 +38,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.drift import classify_goal_drift  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
@@ -392,6 +393,9 @@ async def test_steerer_off_track_emits_critical_drift_and_nudges() -> None:
     steerer = DefaultSteerer(
         goal_drift_check_interval=2,
         goal_drift_call_llm=call_llm,
+        # Explicit active mode: the Level 2 nudge enqueue under test is
+        # suppressed under the shipped observation-only default.
+        steering_config=SteeringConfig(observation_only=False),
     )
     planner = StubPlanner()
     sink = ListSink()

--- a/tests/test_goldfive_drift_routing.py
+++ b/tests/test_goldfive_drift_routing.py
@@ -43,6 +43,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.control import (  # noqa: E402
     ControlChannel,
     ControlKind,
@@ -141,9 +142,12 @@ def _bound_steerer(
     revised: Plan | None = None,
     threshold: str = "warning",
 ) -> tuple[DefaultSteerer, _RevisedPlanPlanner, ControlChannel, _ListSink]:
+    # Explicit active mode: the control-channel dispatches under test
+    # are suppressed under the shipped observation-only default.
     steerer = DefaultSteerer(
         goldfive_steer_threshold=threshold,
         goldfive_steer_suppression_window_turns=3,
+        steering_config=SteeringConfig(observation_only=False),
     )
     planner = _RevisedPlanPlanner(revised=revised or _make_revised_plan())
     sink = _ListSink()
@@ -194,6 +198,38 @@ async def test_goldfive_off_topic_drift_dispatches_goldfive_steer_control() -> N
     assert "raccoons" in payload["body"]
     # Superseded task ids carry the originating task.
     assert payload["superseded_task_ids"] == ["t2"]
+
+
+async def test_goldfive_steer_dispatch_suppressed_under_observation_only() -> None:
+    """Observation-only counterpart of the dispatch test above: detection
+    and ``refine_steer`` still run under the shipped default, but no
+    ``GOLDFIVE_STEER`` ControlMessage reaches the channel — the
+    ``is_active_steering`` gate suppresses the enqueue."""
+    steerer = DefaultSteerer(
+        goldfive_steer_threshold="warning",
+        goldfive_steer_suppression_window_turns=3,
+        steering_config=SteeringConfig(observation_only=True),
+    )
+    planner = _RevisedPlanPlanner(revised=_make_revised_plan())
+    sink = _ListSink()
+    channel = ControlChannel()
+    steerer.bind(sinks=[sink], planner=planner)
+    steerer.bind_control_channel(channel)
+
+    drift = DriftEvent(
+        kind=DriftKind.OFF_TOPIC,
+        severity=DriftSeverity.WARNING,
+        detail="agent wandered off into raccoons",
+        current_task_id="t2",
+        authored_by="goldfive",
+    )
+    session = _make_session()
+    await steerer.drift.handle_drift(drift, session)
+
+    # Detection-side machinery still ran.
+    assert planner.refine_steer_calls, "refine_steer must still run passively"
+    # But nothing was enqueued on the channel.
+    assert _drain_channel(channel) == []
 
 
 # ---------------------------------------------------------------------------
@@ -331,6 +367,7 @@ async def test_multiple_goldfive_drifts_queue_in_order_on_channel() -> None:
     steerer = DefaultSteerer(
         goldfive_steer_threshold="warning",
         goldfive_steer_suppression_window_turns=3,
+        steering_config=SteeringConfig(observation_only=False),
     )
     planner = _DistinctRevisedPlanner()
     sink = _ListSink()

--- a/tests/test_goldfive_planner.py
+++ b/tests/test_goldfive_planner.py
@@ -22,6 +22,11 @@ from goldfive.adapters._adk_plugin import (  # noqa: E402
 from goldfive.prompt_shaper import PromptShaper  # noqa: E402
 
 
+class _ActiveSteerer:
+    def is_active_steering(self) -> bool:
+        return True
+
+
 async def _inject_goldfive_planner_instruction(
     *, callback_context: Any, llm_request: Any
 ) -> None:
@@ -31,14 +36,16 @@ async def _inject_goldfive_planner_instruction(
     The pre-refactor signature took only ``(callback_context,
     llm_request)``; the shaper additionally accepts a
     ``session_context`` to read the steerer. These tests don't exercise
-    the strict-passive gate (they predate it and pass no SessionContext),
-    so we pin ``session_context=None`` — the gate then defaults to
-    "inject" (matches pre-refactor behaviour byte-identically).
+    the strict-passive gate, so we pin an explicit active-steerer stub —
+    with no reachable steerer the gate resolves passive and the
+    injection under test would be suppressed.
     """
+    from types import SimpleNamespace
+
     await PromptShaper().inject_goldfive_planner_instruction(
         callback_context=callback_context,
         llm_request=llm_request,
-        session_context=None,
+        session_context=SimpleNamespace(steerer=_ActiveSteerer()),
     )
 from goldfive.adapters._adk_state_protocol import (  # noqa: E402
     KEY_CURRENT_TASK_ID,
@@ -964,7 +971,10 @@ async def test_plugin_injection_via_full_before_model_callback() -> None:
     state = {
         SESSION_CONTEXT_STATE_KEY: SessionContext(
             session=session,
-            steerer=None,
+            # Explicit active mode: the injection under test rides the
+            # ``steering_is_active`` gate and a missing steerer
+            # resolves passive.
+            steerer=_ActiveSteerer(),
             task=task,
             tool_handlers={},
             host_agent_name="h",

--- a/tests/test_iter11d_cancel_race.py
+++ b/tests/test_iter11d_cancel_race.py
@@ -49,6 +49,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.state_store import StateStore  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
@@ -289,7 +290,7 @@ async def test_request_invocation_cancel_stamps_cancel_pending_synchronously() -
     """
     plugin = _RecordingPlugin()
     adapter = _StubAdapter(plugin)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer._adapter = adapter  # type: ignore[assignment]
 
     session = _session(run_id="r-stamp")

--- a/tests/test_llm_call_timeout_watcher.py
+++ b/tests/test_llm_call_timeout_watcher.py
@@ -49,14 +49,17 @@ class _CapturingSteerer:
     captures every observation seen + every drift emitted via the
     conventional ``_emit_drift_detected`` path.
 
-    ``_observation_only`` mirrors :class:`DefaultSteerer`'s field: the
-    watcher's cancel-flag write is gated on it (missing flag reads as
-    passive — the fail-safe direction)."""
+    ``is_active_steering`` mirrors :class:`DefaultSteerer`'s predicate:
+    the watcher's cancel-flag write is gated on it (a missing predicate
+    reads as passive — the fail-safe direction)."""
 
     def __init__(self, *, observation_only: bool = False) -> None:
         self.drift = _CapturingDrift()
         self._sinks: list[Any] = []
         self._observation_only = observation_only
+
+    def is_active_steering(self) -> bool:
+        return not self._observation_only
 
     @property
     def observations(self) -> list[Any]:

--- a/tests/test_llm_call_timeout_watcher_sticky.py
+++ b/tests/test_llm_call_timeout_watcher_sticky.py
@@ -45,6 +45,7 @@ from goldfive.adapters._adk_plugin import (  # noqa: E402
     SessionContext,
     make_adk_plugin,
 )
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
     CancellationRequest,
@@ -172,7 +173,9 @@ def _make_plan() -> Plan:
 def _make_plugin_with_ctx() -> tuple[Any, _ListSink]:
     plugin = make_adk_plugin(host_agent_name="coordinator")
     sink = _ListSink()
-    steerer = DefaultSteerer()
+    # Explicit active mode: the watcher's cancel-flag write under test
+    # is suppressed under the shipped observation-only default.
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=None)
     session = Session(
         run_id="run-test",

--- a/tests/test_observation_only.py
+++ b/tests/test_observation_only.py
@@ -15,12 +15,10 @@ operators can see what the planner WOULD have produced via the
 ``PlanRevised`` event with ``dry_run=True``. The in-flight invocation
 is otherwise untouched.
 
-The autouse ``_goldfive_active_steering_default`` fixture in
-``tests/conftest.py`` flips the implicit default to ``False`` for the
-test suite (matching pre-#254 active-steering semantics). Tests in this
-file deliberately pass ``observation_only=True`` (or
-``observation_only=False``) explicitly — the dataclass honours explicit
-kwargs over the fixture's override, so the test's intent wins.
+The suite runs against the shipped default (``observation_only=True``
+— strict-passive). Tests in this file pass ``observation_only=True``
+(or ``observation_only=False``) explicitly so each test's mode is
+visible at its construction site.
 """
 
 from __future__ import annotations
@@ -40,11 +38,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 import goldfive  # noqa: E402
-from goldfive.config import (  # noqa: E402
-    RuntimeConfig,
-    SteeringConfig,
-    _resolve_observation_only_default,
-)
+from goldfive.config import RuntimeConfig, SteeringConfig  # noqa: E402
 from goldfive.control import ControlKind  # noqa: E402
 from goldfive.results import InvocationResult  # noqa: E402
 from goldfive.state_store import StateStore  # noqa: E402
@@ -209,25 +203,53 @@ def _plan_revised_events(sink: ListSink) -> list[Any]:
 
 
 # ---------------------------------------------------------------------------
-# Conftest fixture interaction
+# Shipped default
 # ---------------------------------------------------------------------------
 
 
-def test_conftest_fixture_flips_implicit_default_to_active() -> None:
-    """Inside the test suite, the implicit default is active-steering.
+def test_shipped_default_is_observation_only() -> None:
+    """The suite exercises the production default: strict-passive.
 
-    Sanity check that the autouse
-    ``_goldfive_active_steering_default`` fixture in
-    ``tests/conftest.py`` is in effect — without it the bulk of the
-    existing test corpus would silently skip the injection paths and
-    pass for the wrong reason.
+    ``SteeringConfig()`` and a bare ``DefaultSteerer()`` both come up
+    with ``observation_only=True`` — there is no test-only override
+    hook. Tests that need active mode say so explicitly.
     """
-    assert _resolve_observation_only_default() is False
-    # SteeringConfig() (no explicit kwarg) honours the override.
-    assert SteeringConfig().observation_only is False
-    # An explicit kwarg still wins over the fixture (test intent
-    # beats the fixture's override).
-    assert SteeringConfig(observation_only=True).observation_only is True
+    assert SteeringConfig().observation_only is True
+    steerer = DefaultSteerer()
+    assert steerer.is_active_steering() is False
+    assert steerer._should_inject() is False
+    # An explicit kwarg wins in either direction.
+    assert SteeringConfig(observation_only=False).observation_only is False
+    active = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
+    assert active.is_active_steering() is True
+
+
+def test_steering_is_active_fallback_is_passive(active_steering_config: Any) -> None:
+    """:func:`goldfive.steerer.steering_is_active` is the one documented
+    fallback for consumers holding a maybe-steerer: ``None``, a steerer
+    without the predicate, and a raising predicate all resolve passive.
+    """
+    from goldfive.steerer import steering_is_active
+
+    assert steering_is_active(None) is False
+
+    class _Legacy:
+        pass
+
+    assert steering_is_active(_Legacy()) is False
+
+    class _Broken:
+        def is_active_steering(self) -> bool:
+            raise RuntimeError("boom")
+
+    assert steering_is_active(_Broken()) is False
+
+    # Real steerers resolve through the predicate.
+    assert steering_is_active(DefaultSteerer()) is False
+    assert (
+        steering_is_active(DefaultSteerer(steering_config=active_steering_config))
+        is True
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -455,10 +477,7 @@ def test_steering_config_from_env_observation_only(
 
     * ``"0"`` / ``"false"`` / ``"no"`` / ``"off"`` -> False.
     * ``"1"`` / ``"true"`` / ``"yes"`` / ``"on"`` -> True.
-    * Unset -> the effective default. In the test-suite fixture path
-      that's ``False`` (the autouse fixture overrides the implicit
-      default); a test that suppresses the fixture would see the
-      production ``True`` default.
+    * Unset -> the production default (``True``).
     """
     for falsey in ("0", "false", "no", "off"):
         goldfive_steer_env.set(observation_only=falsey)
@@ -468,31 +487,10 @@ def test_steering_config_from_env_observation_only(
         goldfive_steer_env.set(observation_only=truthy)
         assert SteeringConfig.from_env().observation_only is True
 
-    # Unset: in the suite, the autouse fixture overrides to False.
+    # Unset: the production default (strict-passive).
     goldfive_steer_env.unset("observation_only")
-    assert SteeringConfig.from_env().observation_only is False
-
-
-def test_steering_config_from_env_production_default(
-    monkeypatch: pytest.MonkeyPatch,
-    goldfive_steer_env: Any,
-) -> None:
-    """Outside the suite override, the production default is ``True``.
-
-    Suppresses the autouse fixture's override for this test (by
-    flipping the module-level hook back to ``None``) so the unset env
-    path returns the production default. Restored on exit.
-    """
-    from goldfive import config as _gf_config
-
-    goldfive_steer_env.unset("observation_only")
-    prior = _gf_config._OBSERVATION_ONLY_DEFAULT
-    _gf_config._OBSERVATION_ONLY_DEFAULT = None
-    try:
-        assert SteeringConfig().observation_only is True
-        assert SteeringConfig.from_env().observation_only is True
-    finally:
-        _gf_config._OBSERVATION_ONLY_DEFAULT = prior
+    assert SteeringConfig().observation_only is True
+    assert SteeringConfig.from_env().observation_only is True
 
 
 # ---------------------------------------------------------------------------
@@ -870,17 +868,20 @@ async def test_goldfive_corrective_drift_is_gated_under_observation_only() -> No
     )
 
 
-async def test_goldfive_corrective_drift_lands_with_observation_only_false() -> None:
+async def test_goldfive_corrective_drift_lands_with_observation_only_false(
+    make_active_steerer: Any,
+) -> None:
     """goldfive#255 positive control: with ``observation_only=False`` the
     same corrective drift lands.
 
     Toggling the flag off removes ALL three sources of gating
-    (``gate_active`` becomes False because ``not self._should_inject()``
-    is False). The refactor must not introduce a hidden gate that
-    survives the flag flip.
+    (``gate_active`` becomes False because ``is_active_steering()``
+    is True). The refactor must not introduce a hidden gate that
+    survives the flag flip. Uses the ``make_active_steerer`` conftest
+    fixture — the sanctioned way for tests to opt into active mode.
     """
-    cfg = SteeringConfig(observation_only=False)
-    steerer = DefaultSteerer(steering_config=cfg)
+    steerer = make_active_steerer()
+    assert steerer.is_active_steering() is True
     session = _make_session()
     prior_plan = session.plan
     assert prior_plan is not None

--- a/tests/test_observation_only_abort_carveout.py
+++ b/tests/test_observation_only_abort_carveout.py
@@ -49,8 +49,8 @@ from goldfive.types import (
 
 # ---------------------------------------------------------------------------
 # Stubs (mirror tests/test_sequential_executor.py shapes; the steerer
-# carries the ``_observation_only`` attribute the executor's carve-out
-# reads).
+# exposes the ``is_active_steering`` predicate the executor's carve-out
+# resolves via ``steering_is_active``).
 # ---------------------------------------------------------------------------
 
 
@@ -78,10 +78,9 @@ class RecordingSink:
 
 
 class StubSteerer:
-    """Minimal Steerer that exposes ``_observation_only`` the way the
+    """Minimal Steerer that exposes ``is_active_steering`` the way the
     real :class:`~goldfive.steerer.DefaultSteerer` does (the executor's
-    carve-out reads the private attribute directly so the goldfive#260
-    patch stays small).
+    carve-out resolves it via ``steering_is_active``).
     """
 
     def __init__(self, *, observation_only: bool = False) -> None:
@@ -91,6 +90,9 @@ class StubSteerer:
         self.observed: list[Any] = []
         self.transitions: list[tuple[str, TaskStatus]] = []
         self.emitted_plan_revised: list[Any] = []
+
+    def is_active_steering(self) -> bool:
+        return not self._observation_only
 
     def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
         self._sinks = sinks

--- a/tests/test_observation_only_acks.py
+++ b/tests/test_observation_only_acks.py
@@ -149,11 +149,14 @@ async def test_idempotent_ack_includes_plan_state_in_active_mode() -> None:
     assert second["plan_state"]["next_pending"]["id"] == "t2"
 
 
-def test_rendering_helpers_default_to_directive_shape_without_steerer() -> None:
-    # Legacy callers / stubs that pass no steerer keep the pre-gate
-    # shape — same tolerance as PromptShaper.should_inject.
+def test_rendering_helpers_suppress_directive_shape_without_steerer() -> None:
+    # No reachable steerer resolves passive (the fail-safe direction of
+    # ``steering_is_active``): the goldfive-authored ``plan_state``
+    # directive is suppressed, leaving the factual echo only.
     session = _session()
     out = _directive_ack(session=session, task_id="t1", new_status=TaskStatus.COMPLETED)
-    assert "plan_state" in out
+    assert "plan_state" not in out
+    assert out["acknowledged"] is True
     idem = _idempotent_response(TaskStatus.COMPLETED, session=session, task_id="t1")
-    assert "plan_state" in idem
+    assert "plan_state" not in idem
+    assert idem["idempotent"] is True

--- a/tests/test_observation_only_pause_escalate_carveout.py
+++ b/tests/test_observation_only_pause_escalate_carveout.py
@@ -546,11 +546,11 @@ async def test_active_steering_no_op_refine_dispatches_pause_escalate() -> None:
 
 
 class _StubSteererForOverlay:
-    """Bare-bones Steerer for overlay tests; carries the
-    ``_observation_only`` attribute the executor's defense-in-depth gate
-    reads. Avoids the full DefaultSteerer to keep these overlay tests
-    fast and avoid wiring planner / refine plumbing — the executor's
-    gate is read structurally from ``steerer._observation_only``.
+    """Bare-bones Steerer for overlay tests; exposes the
+    ``is_active_steering`` predicate the executor's defense-in-depth
+    gate resolves via ``steering_is_active``. Avoids the full
+    DefaultSteerer to keep these overlay tests fast and avoid wiring
+    planner / refine plumbing.
     """
 
     def __init__(self, *, observation_only: bool = False) -> None:
@@ -558,6 +558,9 @@ class _StubSteererForOverlay:
         self._sinks: list[EventSink] = []
         self._planner: Any = None
         self.observed: list[Any] = []
+
+    def is_active_steering(self) -> bool:
+        return not self._observation_only
 
     def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
         self._sinks = sinks

--- a/tests/test_observation_only_strict_passive.py
+++ b/tests/test_observation_only_strict_passive.py
@@ -299,21 +299,21 @@ async def test_conversational_wrap_log_emitted_under_observation_only(
 #     block listing pending agents
 #
 # Both fire inside ``_GoldfiveADKPlugin.before_model_callback``. The
-# strict-passive gate is a single check on
-# ``ctx.steerer._observation_only`` via :meth:`PromptShaper.should_inject`
-# — the same shape DefaultSteerer._should_inject uses elsewhere. The
+# strict-passive gate is :func:`goldfive.steerer.steering_is_active`
+# via :meth:`PromptShaper.should_inject` — the same truth source
+# ``DefaultSteerer.is_active_steering`` provides elsewhere. The
 # unit test below drives the gate predicate directly (the full ADK
 # callback requires google-adk + a live LlmRequest; the predicate is
 # the behaviour-defining surface).
 
 
-def test_should_inject_returns_true_when_no_steerer() -> None:
-    """:meth:`PromptShaper.should_inject` degrades safely to ``True``
-    when no steerer is reachable — pre-#271 paths (unit-test stubs that
-    never call ``set_active_context``) keep working byte-identically."""
+def test_should_inject_returns_false_when_no_steerer() -> None:
+    """:meth:`PromptShaper.should_inject` degrades safely to ``False``
+    (suppress) when no steerer is reachable — passive is the fail-safe
+    direction of :func:`goldfive.steerer.steering_is_active`."""
     from goldfive.prompt_shaper import PromptShaper
 
-    assert PromptShaper.should_inject(None) is True
+    assert PromptShaper.should_inject(None) is False
 
 
 def test_should_inject_returns_false_when_steerer_passive() -> None:
@@ -340,16 +340,16 @@ def test_should_inject_returns_true_when_steerer_active() -> None:
     assert PromptShaper.should_inject(steerer) is True
 
 
-def test_should_inject_returns_true_when_steerer_lacks_attribute() -> None:
-    """A duck-typed steerer that doesn't carry ``_observation_only``
-    (custom :class:`~goldfive.protocols.Steerer` impls predating #254)
-    returns ``True`` so pre-#254 paths keep working."""
+def test_should_inject_returns_false_when_steerer_lacks_predicate() -> None:
+    """A duck-typed steerer without ``is_active_steering`` (custom
+    :class:`~goldfive.protocols.Steerer` impls predating the predicate)
+    resolves passive — the fail-safe direction."""
     from goldfive.prompt_shaper import PromptShaper
 
     class _LegacySteerer:
         pass
 
-    assert PromptShaper.should_inject(_LegacySteerer()) is True
+    assert PromptShaper.should_inject(_LegacySteerer()) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_overlay_forward_progress.py
+++ b/tests/test_overlay_forward_progress.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from goldfive.config import SteeringConfig
 from goldfive.executors.sequential import (
     SequentialExecutor,
     _fatally_failed_task_ids,
@@ -69,6 +70,12 @@ class StubSteerer:
         self._planner: Any = None
         self.observed: list[Any] = []
         self.transitions: list[tuple[str, TaskStatus]] = []
+
+    def is_active_steering(self) -> bool:
+        # Explicit active mode: the executor's nudge replay and
+        # abort-on-fatal-failure enforcement under test are suppressed
+        # under the shipped observation-only default.
+        return True
 
     def bind(self, *, sinks: list[EventSink], planner: Any) -> None:
         self._sinks = sinks
@@ -681,7 +688,10 @@ async def test_absorb_on_looping_reasoning_queues_nudge() -> None:
     # LEGACY ABSORB-with-nudge behaviour for operators who disable
     # promotion; cover the promotion path in
     # tests/test_steer_unification.py.
-    steerer = DefaultSteerer(goldfive_steer_threshold="off")
+    steerer = DefaultSteerer(
+        goldfive_steer_threshold="off",
+        steering_config=SteeringConfig(observation_only=False, threshold="off"),
+    )
     steerer.bind(sinks=[sink], planner=_StubPlanner())
 
     drift = DriftEvent(

--- a/tests/test_pause_deadline.py
+++ b/tests/test_pause_deadline.py
@@ -322,6 +322,11 @@ async def test_parallel_pause_deadline_expiry_aborts_run() -> None:
 def _bound_steerer(
     steering_config: SteeringConfig | None = None,
 ) -> tuple[DefaultSteerer, Session, RecordingSink, ControlChannel]:
+    # Explicit active mode unless the caller supplies its own config:
+    # the pause dispatch under test is suppressed under the shipped
+    # observation-only default.
+    if steering_config is None:
+        steering_config = SteeringConfig(observation_only=False)
     steerer = DefaultSteerer(goldfive_steer_threshold="off", steering_config=steering_config)
     session = Session(run_id="terminate-test", current_task_id="t1")
     session.plan = Plan(

--- a/tests/test_pause_escalate.py
+++ b/tests/test_pause_escalate.py
@@ -30,6 +30,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.control import (  # noqa: E402
     ControlChannel,
     ControlKind,
@@ -89,7 +90,13 @@ def _fresh() -> tuple[DefaultSteerer, Session, ListSink, StubPlanner, ControlCha
     # Phase 2 of the path-duality fix: bind a real ControlChannel so
     # the steerer's ``GOLDFIVE_PAUSE_ESCALATE`` dispatch lands somewhere
     # observable to the assertions.
-    steerer = DefaultSteerer(goldfive_steer_threshold="off")
+    #
+    # Explicit active mode: the dispatch under test is suppressed under
+    # the shipped observation-only default.
+    steerer = DefaultSteerer(
+        goldfive_steer_threshold="off",
+        steering_config=SteeringConfig(observation_only=False),
+    )
     session = Session(run_id="pause-test", current_task_id="t1")
     session.plan = Plan(
         id="p1",
@@ -162,6 +169,46 @@ async def test_pause_escalate_dispatches_control_and_emits_drift() -> None:
     assert _drift_kind_pb("HUMAN_INTERVENTION_REQUIRED") in kinds
     # Level 4 does not call refine.
     assert planner.refine_calls == []
+
+
+async def test_pause_escalate_dispatch_suppressed_under_observation_only() -> None:
+    """Observation-only counterpart of the dispatch test above: under
+    the shipped default the drift still emits on the sink stream but no
+    ``GOLDFIVE_PAUSE_ESCALATE`` reaches the channel — the
+    ``is_active_steering`` gate suppresses the send."""
+    steerer = DefaultSteerer(
+        goldfive_steer_threshold="off",
+        steering_config=SteeringConfig(observation_only=True),
+    )
+    session = Session(run_id="pause-test", current_task_id="t1")
+    session.plan = Plan(
+        id="p1",
+        run_id="pause-test",
+        goal_ids=[],
+        tasks=[Task(id="t1", title="work", status=TaskStatus.RUNNING)],
+        edges=[],
+    )
+    sink = ListSink()
+    channel = ControlChannel()
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+    steerer.bind_control_channel(channel)
+
+    drift = DriftEvent(
+        kind=DriftKind.INTENT_DIVERGENCE,
+        severity=DriftSeverity.CRITICAL,
+        detail="critical intent drift",
+        current_task_id="t1",
+    )
+    await steerer.drift.handle_drift(drift, session)
+
+    assert _drain_goldfive_pause(channel) == []
+    # Detection is independent of injection: the drift still emitted.
+    kinds = [
+        evt.drift_detected.kind
+        for evt in sink.events
+        if evt.WhichOneof("payload") == "drift_detected"
+    ]
+    assert _drift_kind_pb("INTENT_DIVERGENCE") in kinds
 
 
 async def test_pause_escalate_does_not_double_emit_human_intervention() -> None:

--- a/tests/test_plan_descriptive_growth_race.py
+++ b/tests/test_plan_descriptive_growth_race.py
@@ -34,6 +34,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
     DriftEvent,
@@ -410,7 +411,7 @@ async def test_pre_fix_lock_free_growth_demonstrates_race() -> None:
         session = _make_session()
         planner = _StubPlanner(revised_factory=_refine_revised)
         sink = _ListSink()
-        steerer = DefaultSteerer()
+        steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
         steerer.bind(sinks=[sink], planner=planner)
 
         steerer.plans.install_descriptive_growth = (  # type: ignore[method-assign]

--- a/tests/test_plan_reviser.py
+++ b/tests/test_plan_reviser.py
@@ -34,6 +34,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
     DriftEvent,
@@ -269,7 +270,7 @@ async def test_apply_revision_no_partial_state_visible_during_cancel_inflight_yi
 
     planner = _StubPlanner(revised=revised)
     sink = _ListSink()
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=planner)
 
     drift = _drift(kind=DriftKind.TOOL_ERROR, task_id="t1")
@@ -385,7 +386,7 @@ async def test_apply_revision_does_not_mutate_session_before_emit() -> None:
 
     drift = _drift(kind=DriftKind.OFF_TOPIC, task_id="t1")
 
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     returned, was_installed = steerer.plans._apply_revision(session, revised, drift)
 
     # The decision is "install" (no observation-only carve-out fires).

--- a/tests/test_promote_drift_to_steer.py
+++ b/tests/test_promote_drift_to_steer.py
@@ -32,6 +32,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.control import (  # noqa: E402
     ControlChannel,
     ControlKind,
@@ -147,9 +148,13 @@ def _make_session() -> Session:
 def _bound_steerer() -> tuple[
     DefaultSteerer, _RevisedPlanPlanner, ControlChannel, _ListSink
 ]:
+    # Explicit active mode: the plan swap + GOLDFIVE_STEER dispatch
+    # under test are suppressed under the shipped observation-only
+    # default.
     steerer = DefaultSteerer(
         goldfive_steer_threshold="warning",
         goldfive_steer_suppression_window_turns=3,
+        steering_config=SteeringConfig(observation_only=False),
     )
     planner = _RevisedPlanPlanner(revised=_make_revised_plan())
     sink = _ListSink()

--- a/tests/test_prompt_shaper.py
+++ b/tests/test_prompt_shaper.py
@@ -79,22 +79,23 @@ def test_should_inject_false_when_steerer_passive() -> None:
     assert PromptShaper.should_inject(_make_steerer(observation_only=True)) is False
 
 
-def test_should_inject_true_when_steerer_is_none() -> None:
-    """Defensive: a missing steerer (unit-test stubs without a wired
-    DefaultSteerer) must not flip the gate closed — pre-#271 paths
-    keep working byte-identically."""
-    assert PromptShaper.should_inject(None) is True
+def test_should_inject_false_when_steerer_is_none() -> None:
+    """A missing steerer resolves passive — injections suppressed.
+
+    Passive is the documented fail-safe direction of
+    :func:`goldfive.steerer.steering_is_active` (pre-refactor this
+    site defaulted ACTIVE on a missing steerer)."""
+    assert PromptShaper.should_inject(None) is False
 
 
-def test_should_inject_true_when_steerer_lacks_attribute() -> None:
-    """A duck-typed steerer that doesn't carry ``_observation_only``
-    (custom impls predating #254) returns True so pre-#254 paths keep
-    working."""
+def test_should_inject_false_when_steerer_lacks_predicate() -> None:
+    """A duck-typed steerer without ``is_active_steering`` resolves
+    passive — same fail-safe direction as a missing steerer."""
 
     class _LegacySteerer:
         pass
 
-    assert PromptShaper.should_inject(_LegacySteerer()) is True
+    assert PromptShaper.should_inject(_LegacySteerer()) is False
 
 
 # ---------------------------------------------------------------------------
@@ -338,12 +339,10 @@ def test_inject_runtime_tools_hint_byte_identical_when_active() -> None:
     assert _RUNTIME_TOOLS_HINT_END in expected
 
 
-def test_inject_runtime_tools_hint_gate_open_with_no_session_context() -> None:
-    """Without a ``SessionContext`` (test stubs) the gate defaults to
-    open — the inject runs. This preserves the pre-#271 paths that
-    drove the helper without ever wiring a steerer."""
-    from goldfive.adapters._adk_plugin import _RUNTIME_TOOLS_HINT_PREFIX
-
+def test_inject_runtime_tools_hint_gate_closed_with_no_session_context() -> None:
+    """Without a ``SessionContext`` (no reachable steerer) the gate
+    resolves passive — the inject is suppressed. Fail-safe direction of
+    :func:`goldfive.steerer.steering_is_active`."""
     shaper = PromptShaper()
     sess = Session(
         run_id="r-test",
@@ -372,8 +371,7 @@ def test_inject_runtime_tools_hint_gate_open_with_no_session_context() -> None:
         session_context=None,
     )
 
-    assert llm_request.append_calls, "inject must run when no SessionContext"
-    assert _RUNTIME_TOOLS_HINT_PREFIX in llm_request.append_calls[0][0]
+    assert llm_request.append_calls == [], "inject must be suppressed without a steerer"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -85,6 +85,9 @@ class _SteererStub:
         self.plans: Any = object()
         self.drift: Any = object()
 
+    def is_active_steering(self) -> bool:
+        return False
+
     async def transition(
         self,
         task_id: str,

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.reporting import (  # noqa: E402
     BUILTIN_REPORTING_TOOLS,
     REPORTING_TOOL_NAMES,
@@ -86,7 +87,9 @@ def _fresh() -> tuple[DefaultSteerer, Session, ListSink, StubPlanner]:
     )
     sink = ListSink()
     planner = StubPlanner()
-    steerer = DefaultSteerer()
+    # Explicit active mode: the F1 ``plan_state`` directive surface is
+    # suppressed under the shipped observation-only default.
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=planner)
     return steerer, session, sink, planner
 
@@ -137,6 +140,31 @@ async def test_report_task_started_marks_running() -> None:
     assert session.plan.tasks[0].status is TaskStatus.RUNNING
     # task_started lands in the stream (followed by goldfive#251 R4
     # TaskTransitioned envelope; see test_task_transitioned_events.py).
+    kinds = [e.WhichOneof("payload") for e in sink.events]
+    assert "task_started" in kinds
+
+
+async def test_report_task_started_ack_is_factual_under_observation_only() -> None:
+    """Observation-only counterpart: the transition (the agent's own
+    self-report) still lands and still emits, but the goldfive-authored
+    F1 ``plan_state`` directive is suppressed by ``is_active_steering``."""
+    session = Session(
+        run_id="r1",
+        goals=[Goal(id="g1", summary="do it")],
+        plan=_plan(),
+    )
+    sink = ListSink()
+    steerer = DefaultSteerer()  # shipped default: observation_only=True
+    steerer.bind(sinks=[sink], planner=StubPlanner())
+
+    out = await _tool("report_task_started").handler(
+        {"task_id": "t1", "detail": "starting"}, session, steerer
+    )
+
+    assert out["acknowledged"] is True
+    assert out["task"] == {"id": "t1", "status": TaskStatus.RUNNING.value}
+    assert "plan_state" not in out
+    assert session.plan.tasks[0].status is TaskStatus.RUNNING
     kinds = [e.WhichOneof("payload") for e in sink.events]
     assert "task_started" in kinds
 

--- a/tests/test_reporting_idempotency.py
+++ b/tests/test_reporting_idempotency.py
@@ -17,6 +17,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.reporting import BUILTIN_REPORTING_TOOLS, ReportingToolSpec  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
@@ -77,7 +78,9 @@ def _fresh(
             edges=[],
         ),
     )
-    steerer = DefaultSteerer()
+    # Explicit active mode: the F1 ``plan_state`` directive surface is
+    # suppressed under the shipped observation-only default.
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=planner)
     return steerer, session, sink
 

--- a/tests/test_runtime_tool_surface_hint.py
+++ b/tests/test_runtime_tool_surface_hint.py
@@ -31,20 +31,27 @@ from goldfive.prompt_shaper import PromptShaper
 from goldfive.types import Plan, Session, Task, TaskStatus
 
 
+class _ActiveSteerer:
+    def is_active_steering(self) -> bool:
+        return True
+
+
 def _inject_runtime_tools_hint(
     *, callback_context: Any, llm_request: Any, session: Any
 ) -> None:
     """Wave B1 shim: forward to :meth:`PromptShaper.inject_runtime_tools_hint`.
 
-    These unit tests drive the helper without a ``SessionContext`` so the
-    gate falls back to "inject" (steerer is None → ``should_inject`` →
-    True) — exactly the pre-refactor behaviour.
+    Pins an explicit active-steerer stub: with no reachable steerer the
+    ``steering_is_active`` gate resolves passive and the injection under
+    test would be suppressed.
     """
+    from types import SimpleNamespace
+
     PromptShaper().inject_runtime_tools_hint(
         callback_context=callback_context,
         llm_request=llm_request,
         session=session,
-        session_context=None,
+        session_context=SimpleNamespace(steerer=_ActiveSteerer()),
     )
 
 # ---------------------------------------------------------------------------
@@ -487,7 +494,10 @@ async def test_before_model_callback_injects_runtime_tools_hint() -> None:
     session = _make_session(tasks)
     ctx = SessionContext(
         session=session,
-        steerer=None,
+        # Explicit active mode: the hint injection rides the
+        # ``steering_is_active`` gate and a missing steerer resolves
+        # passive.
+        steerer=_ActiveSteerer(),
         task=tasks[0],
         tool_handlers={},
         host_agent_name="coordinator",

--- a/tests/test_sequential_executor.py
+++ b/tests/test_sequential_executor.py
@@ -85,6 +85,12 @@ class StubSteerer:
         self._planner: Any = None
         self.drift = _StubDrift()
 
+    def is_active_steering(self) -> bool:
+        # Explicit active mode: the executor's failed-without-replacement
+        # enforcement under test is suppressed under the shipped
+        # observation-only default.
+        return True
+
     @property
     def observed(self) -> list[Any]:
         return self.drift.observed

--- a/tests/test_sequential_executor_overlay.py
+++ b/tests/test_sequential_executor_overlay.py
@@ -88,6 +88,11 @@ class StubSteerer:
         # assert on the structured reason strings the executor emits.
         self.transition_details: list[tuple[str, TaskStatus, str, str]] = []
 
+    def is_active_steering(self) -> bool:
+        # Explicit active mode: the overlay enforcement paths under test
+        # are suppressed under the shipped observation-only default.
+        return True
+
     @property
     def observed(self) -> list[Any]:
         return self.drift.observed

--- a/tests/test_state_protocol_propagation.py
+++ b/tests/test_state_protocol_propagation.py
@@ -22,6 +22,7 @@ import pytest
 
 pytest.importorskip("google.adk")
 
+from goldfive.config import SteeringConfig
 from goldfive.types import Plan, Session, Task
 
 # ---------------------------------------------------------------------------
@@ -343,7 +344,7 @@ async def test_user_steer_to_planner_instruction_no_bridge() -> None:
         instruction="",
     )
     adapter = ADKAdapter(agent)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[], planner=None)  # type: ignore[arg-type]
     steerer.bind_adapter(adapter)
     adapter.bind_steerer(steerer)
@@ -489,7 +490,7 @@ async def test_user_steer_between_invocations_no_stale_session_valueerror() -> N
     agent = Agent(name="agent_a", model=_ScriptedLLM(), instruction="")
     adapter = ADKAdapter(agent)
     sink = InMemorySink()
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=_RefiningPlanner())  # type: ignore[arg-type]
     steerer.bind_adapter(adapter)
     adapter.bind_steerer(steerer)

--- a/tests/test_steerer.py
+++ b/tests/test_steerer.py
@@ -18,6 +18,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.drift import (  # noqa: E402
     classify_refusal,
     classify_stop_reason,
@@ -549,7 +550,7 @@ async def test_observe_emits_drift_and_refines() -> None:
     revised = _make_plan(("t1", "t2", "t3"))
     planner = StubPlanner(revised=revised)
     sink = ListSink()
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
 
@@ -837,7 +838,7 @@ async def test_successful_refine_resets_failure_counter() -> None:
     revised = _make_plan(("t1", "t2", "t3"))
     planner = StubPlanner(raise_exc=RuntimeError("planner down"))
     sink = ListSink()
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session()
 
@@ -1153,7 +1154,7 @@ async def test_apply_revision_silently_folds_terminal_regression(
     )
     planner = StubPlanner(revised=stale_revised)
     sink = ListSink()
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=planner)
     session = _make_session(plan=prior)
 

--- a/tests/test_task_binding_follows_revision.py
+++ b/tests/test_task_binding_follows_revision.py
@@ -33,6 +33,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 from goldfive import state_store as _ostate  # noqa: E402
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.plan_reviser import PlanReviser  # noqa: E402
 from goldfive.reporting import (  # noqa: E402
     BUILTIN_REPORTING_TOOLS,
@@ -167,7 +168,7 @@ async def test_current_task_id_repins_on_revision() -> None:
 
     revised = _revised_with_replacement()
     planner = _StubPlanner(revised=revised)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[ListSink()], planner=planner)
     # goldfive#247: rebind to the stamped instance.
     # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.
@@ -820,7 +821,7 @@ async def test_correct_integration_via_emit_plan_revised_end_to_end() -> None:
 
     sink = ListSink()
     planner = _StubPlanner(revised=revised)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=planner)
     # goldfive#247: rebind to the stamped instance.
     # goldfive#255: _apply_revision now returns ``(revised, was_installed)``.

--- a/tests/test_task_transitioned_events.py
+++ b/tests/test_task_transitioned_events.py
@@ -50,6 +50,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.reporting import BUILTIN_REPORTING_TOOLS  # noqa: E402
 from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import (  # noqa: E402
@@ -155,7 +156,10 @@ def _session(plan: Plan | None) -> Session:
 
 
 def _bound_steerer(sink: ListSink) -> DefaultSteerer:
-    steerer = DefaultSteerer()
+    # Explicit active mode: the plan-revision transitions under test
+    # ride installs that are dry-run under the shipped observation-only
+    # default.
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=StubPlanner())
     return steerer
 

--- a/tests/test_tier1_loop_prevention.py
+++ b/tests/test_tier1_loop_prevention.py
@@ -37,6 +37,7 @@ pytestmark = pytest.mark.skipif(
     reason="goldfive protobuf stubs not available (install the `dev` extra)",
 )
 
+from goldfive.config import SteeringConfig  # noqa: E402
 from goldfive.reporting import BUILTIN_REPORTING_TOOLS, ReportingToolSpec  # noqa: E402
 from goldfive.steerer import (  # noqa: E402
     DefaultSteerer,
@@ -132,7 +133,7 @@ async def test_f1_report_task_completed_returns_plan_state_pointer() -> None:
     an information-free ack."""
     session = _multi_task_session(initial_status=TaskStatus.RUNNING)
     sink = _ListSink()
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[sink], planner=_StubPlanner())
 
     out = await _tool("report_task_completed").handler(
@@ -159,7 +160,7 @@ async def test_f1_skips_predecessor_blocked_pending_tasks() -> None:
     edge predecessor is terminal. t3 should NOT be surfaced over t2 even
     though both are PENDING — t3's predecessor (t2) is still PENDING."""
     session = _multi_task_session(initial_status=TaskStatus.RUNNING)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[_ListSink()], planner=_StubPlanner())
 
     out = await _tool("report_task_completed").handler(
@@ -174,7 +175,7 @@ async def test_f1_idempotent_re_report_still_includes_plan_state() -> None:
     task still carries the rich payload so the LLM sees the live plan
     state, not just an ack — that's the anchor that breaks the loop."""
     session = _multi_task_session(initial_status=TaskStatus.RUNNING)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[_ListSink()], planner=_StubPlanner())
 
     # First call: real transition.
@@ -209,7 +210,7 @@ async def test_f1_no_next_pending_when_plan_done() -> None:
         edges=[],
     )
     session = Session(run_id="r1", goals=[Goal(id="g1", summary="x")], plan=plan)
-    steerer = DefaultSteerer()
+    steerer = DefaultSteerer(steering_config=SteeringConfig(observation_only=False))
     steerer.bind(sinks=[_ListSink()], planner=_StubPlanner())
 
     out = await _tool("report_task_completed").handler(
@@ -464,6 +465,9 @@ class _StubSteererWithFlag:
     def __init__(self, *, observation_only: bool, sinks: list[Any]) -> None:
         self._observation_only = observation_only
         self._sinks = sinks
+
+    def is_active_steering(self) -> bool:
+        return not self._observation_only
 
 
 def _plugin_redirect_harness(
@@ -755,7 +759,10 @@ async def test_f10_overlay_returns_early_on_goldfive_pause() -> None:
             await asyncio.sleep(60)
 
     class _StubSteerer:
-        pass
+        # Explicit active mode: the executor drops the pause message
+        # under the shipped observation-only default.
+        def is_active_steering(self) -> bool:
+            return True
 
     class _StubReconciler:
         def reset_for_new_plan(self, plan: Any) -> None:

--- a/tests/test_tier2_steer_pipeline.py
+++ b/tests/test_tier2_steer_pipeline.py
@@ -54,6 +54,8 @@ from goldfive import (  # noqa: E402
     TaskEdge,
     TaskStatus,
 )
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers (model on tests/test_planner_handle_turn.py + test_runner_multi_turn.py)
@@ -406,6 +408,9 @@ async def test_f6_conversational_turn_wraps_user_input_for_executor() -> None:
         executor=SequentialExecutor(),
         goal_deriver=PassthroughGoalDeriver("demo"),
         sinks=[sink],
+        # Explicit active mode: the F6 conversational wrap under test is
+        # suppressed under the shipped observation-only default.
+        steerer=DefaultSteerer(steering_config=SteeringConfig(observation_only=False)),
     )
 
     # Wrap the executor.run to snapshot the user_input it receives.


### PR DESCRIPTION
## Problem

The `observation_only` master kill-switch was read via raw `getattr` at many surfaces with **inconsistent fallback semantics**, and the gate logic was re-implemented at 4+ places:

- `goldfive/steerer.py` — `DefaultSteerer._should_inject()` (the "single named gate" that wasn't).
- `goldfive/prompt_shaper.py:113` — `PromptShaper.should_inject` read `getattr(steerer, "_observation_only", False)` and treated a missing steerer / missing attribute as **ACTIVE** (inject).
- `goldfive/executors/sequential.py` (6 sites: 721, 812, 1318, 1374, 1495, 1668) — raw `getattr(steerer, "_observation_only", False)`, also defaulting **ACTIVE** on a missing attribute; includes the Wave-1 nudge-drain gate and the leaked-pause drops.
- `goldfive/adapters/_adk_plugin.py:1919` — `_is_observation_only(ctx)` hand-rolled its own read of `steerer._observation_only`, treating a missing steerer/flag as **PASSIVE** — the opposite fallback direction from the executor/shaper sites.
- `goldfive/plan_reviser.py:1869/1983` and `goldfive/drift_observer.py` (5 sites) — `self._steerer._should_inject()`.
- `goldfive/reporting/rendering.py:181/210` (Wave-1 #478) — via `PromptShaper.should_inject`.

Worse: a mutable module-global test hook (`config.py` `_OBSERVATION_ONLY_DEFAULT` + `_resolve_observation_only_default`, consulted by a `default_factory` and by `DefaultSteerer.__init__`) was flipped by an **autouse** fixture in `tests/conftest.py`, so the entire test corpus ran active steering while production ships observation-only — the shipped default was the less-tested path.

## Fix

- **One public predicate**: `DefaultSteerer.is_active_steering() -> bool` (True iff interventions may mutate/inject). `_should_inject` remains as a steerer-internal alias delegating to it (same truth source, one attribute read in one place). Added to the `Steerer` protocol.
- **One documented fallback**: module-level `goldfive.steerer.steering_is_active(steerer)` for consumers holding a maybe-steerer — returns `False` when the steerer is `None`, lacks the predicate, or the predicate raises. **Passive is the fail-safe direction.** Re-exported from `goldfive/__init__`.
- **All read sites migrated**:
  - `PromptShaper.should_inject` → delegates to `steering_is_active` (public API kept).
  - `executors/sequential.py` × 6 → `not steering_is_active(steerer)`.
  - `_adk_plugin._is_observation_only` (cancel-flag write, ContextEditor, Wave-2 F3 pre-dispatch redirect gate at ~6029) → delegates to the helper.
  - `plan_reviser.py` `_apply_revision` carve-outs + `_emit_plan_revised` dry-run resolution → `is_active_steering()`.
  - `drift_observer.py` × 5 (nudge enqueues, GOLDFIVE_STEER, PAUSE_ESCALATE, `request_invocation_cancel`) → `is_active_steering()`.
  - `reporting/rendering.py` F1 directive acks → `steering_is_active` directly.
- **Deleted the test hook**: `_OBSERVATION_ONLY_DEFAULT`, `_resolve_observation_only_default`, the `DefaultSteerer.__init__` branch consulting it, and the autouse `_goldfive_active_steering_default` fixture. `SteeringConfig.observation_only` is a plain `= True`; its docstring names `is_active_steering` / `steering_is_active` as the single source of truth ("no other code may read the flag directly"). `docs/design/CONTROL-CHANNEL.md` §5.5 updated to match.
- **Test-fidelity migration**: the suite now runs against the shipped strict-passive default. The ~90 tests that implicitly relied on the autouse active flip were migrated to make their mode EXPLICIT — inline `SteeringConfig(observation_only=False)`, an `is_active_steering() -> True` stub method, or the new non-autouse `active_steering_config` / `make_active_steerer` conftest fixtures. Mode-insensitive tests (~2,800) now exercise the production default for free.
- **New observation-only counterparts** in central pipeline files that only had active-mode coverage locally: `test_reporting.py` (F1 ack is factual-only, transition still lands), `test_goldfive_drift_routing.py` (no GOLDFIVE_STEER on the channel; refine_steer still runs), `test_pause_escalate.py` (no GOLDFIVE_PAUSE_ESCALATE; drift still emits), plus direct unit tests for `steering_is_active`'s fallback matrix and the shipped default (`test_observation_only.py`).

## Behavior changes (deliberate, all in the fail-safe direction)

For a **wired `DefaultSteerer`** nothing changes in either mode — same gates, same semantics. What flips is the missing-attr fallback at three surfaces, previously ACTIVE, now PASSIVE:

1. `PromptShaper.should_inject(None / legacy steerer)` → now `False` (all four prompt-shape injections suppressed when no steerer is reachable).
2. Executor carve-out gates → a steerer without the predicate now takes the observation-only branch (no abort-on-failed-without-replacement, pause messages dropped, queued nudges discarded rather than replayed).
3. F1 directive acks (`_directive_ack` / `_idempotent_response`) → `plan_state` omitted when no steerer is passed.

The plugin's `_is_observation_only` already used the passive fallback; it is unchanged in direction. Tests that pinned the old ACTIVE fallback were updated and renamed: `test_prompt_shaper.py` (`test_should_inject_false_when_steerer_is_none`, `..._lacks_predicate`, `test_inject_runtime_tools_hint_gate_closed_with_no_session_context`), `test_observation_only_strict_passive.py` (same pair), `test_observation_only_acks.py` (`test_rendering_helpers_suppress_directive_shape_without_steerer`).

## Tests

- `uv run pytest -q`: **2890 passed, 59 skipped** (~26s), now under the shipped `observation_only=True` default.
- `uv run ruff check .`: clean.
- Both modes exercised: active mode via the explicit-opt-in migrations above; observation-only via the whole mode-insensitive corpus + the existing gate tests + the new counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA
