### PR TITLE
refactor: one internal LLM-call module; retire the closure-attribute diagnostics side channel

### DIFF
--- a/goldfive/_llm.py
+++ b/goldfive/_llm.py
@@ -1,4 +1,4 @@
-"""Shared typing + lifecycle helpers for the planner / goal-deriver LLM callable.
+"""The one internal LLM-call module: typing, lifecycle, budget, and builders.
 
 Goldfive accepts an opaque ``call_llm(system, user, model) -> str`` async
 callable for both :class:`LLMPlanner` and :class:`LLMGoalDeriver`. That
@@ -6,6 +6,15 @@ keeps the framework decoupled from any specific SDK, but it also leaves
 resource cleanup ambiguous — the most common pattern (an OpenAI
 ``AsyncClient`` whose ``aiohttp.ClientSession`` lives until garbage
 collection) leaks at process exit.
+
+Besides the protocols and ContextVar plumbing, this module owns the two
+default ``call_llm`` builders (:func:`make_default_adk_call_llm` for ADK
+trees, :func:`make_default_openai_call_llm` for a dedicated
+:class:`~goldfive.config.JudgeConfig` endpoint), the model-capability
+table for vendor thinking-disable conventions, and the per-dispatch
+diagnostics channel (:func:`llm_call_diagnostics`). They previously
+lived as two divergent copies in :mod:`goldfive._llm_detect` and
+:mod:`goldfive.convenience`; those modules keep thin re-export shims.
 
 This module standardises a duck-typed close protocol:
 
@@ -52,7 +61,11 @@ import contextvars
 import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any, Protocol, runtime_checkable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from goldfive.config import JudgeConfig
 
 log = logging.getLogger("goldfive.llm")
 
@@ -198,6 +211,157 @@ def call_llm_budget(max_output_tokens: int | None) -> Iterator[None]:
         MAX_OUTPUT_TOKENS_VAR.reset(token)
 
 
+# ---------------------------------------------------------------------------
+# Model-capability table: vendor thinking-disable conventions
+# ---------------------------------------------------------------------------
+#
+# How a "disable thinking" request is expressed on the wire is a vendor
+# convention, not a property of the transport. The genai
+# ``ThinkingConfig(include_thoughts=False, thinking_budget=0)`` opt-out is
+# first-class SDK surface on the ADK path and is applied there for every
+# model (unchanged behaviour). The two Qwen-specific hacks — the
+# ``enable_thinking`` extra-body field and the ``/no_think`` prompt
+# prefix — ride the OpenAI-compatible wire format and are meaningful only
+# to the Qwen / litellm family, so they are keyed off the model name
+# here. This is a lookup table of vendor conventions (configuration),
+# not NL classification.
+
+
+@dataclass(frozen=True)
+class ThinkingDisableCaps:
+    """Vendor-convention knobs available for suppressing thinking."""
+
+    #: ``extra_body={"enable_thinking": False}`` on
+    #: ``chat.completions.create`` (Qwen-via-litellm / OpenAI-compatible).
+    openai_enable_thinking_field: bool = False
+    #: ``/no_think`` prepended to the system prompt (Qwen prompt-level
+    #: toggle; fallback for endpoints that drop unknown request fields).
+    no_think_prompt_prefix: bool = False
+
+
+_NO_VENDOR_THINKING_CAPS = ThinkingDisableCaps()
+
+#: ``(model-name substring, caps)`` pairs, matched case-insensitively in
+#: order. Models that match no entry get NO vendor hacks — the genai
+#: ``ThinkingConfig`` opt-out on the ADK path still applies regardless.
+THINKING_DISABLE_CAPABILITIES: tuple[tuple[str, ThinkingDisableCaps], ...] = (
+    (
+        "qwen",
+        ThinkingDisableCaps(openai_enable_thinking_field=True, no_think_prompt_prefix=True),
+    ),
+)
+
+
+def thinking_disable_caps(model_name: str) -> ThinkingDisableCaps:
+    """Return the vendor thinking-disable conventions for ``model_name``.
+
+    Matches :data:`THINKING_DISABLE_CAPABILITIES` by lowercase substring
+    so litellm-prefixed names (``"openai/Qwen3-32B"``,
+    ``"hosted_vllm/Qwen/Qwen3-32B"``) route to the same family. Unknown
+    models get the empty caps — no vendor hacks.
+    """
+    lowered = (model_name or "").lower()
+    for marker, caps in THINKING_DISABLE_CAPABILITIES:
+        if marker in lowered:
+            return caps
+    return _NO_VENDOR_THINKING_CAPS
+
+
+# ---------------------------------------------------------------------------
+# Per-dispatch diagnostics (goldfive#271 follow-up to #311)
+# ---------------------------------------------------------------------------
+#
+# When a judge / reflective-check response fails to parse, the call site
+# wants to distinguish "the model spent its budget thinking and emitted
+# no answer" from "the model returned garbage". The default builders
+# below count thought vs answer parts on every dispatch. The counts used
+# to be smuggled as attributes mutated on the shared callable
+# (``call_llm.last_thought_count``) — last-writer-wins once concurrent
+# background judges dispatch through the same closure. They now travel
+# through a ContextVar-bound per-call object: each consumer installs a
+# fresh :class:`LlmCallDiagnostics` via :func:`llm_call_diagnostics`
+# around its own ``await call_llm(...)``, so concurrent tasks cannot
+# observe each other's counts. Diagnostics are optional — user-supplied
+# callables that never call :func:`record_llm_call_diagnostics` simply
+# leave the counts at zero.
+
+
+@dataclass
+class LlmCallDiagnostics:
+    """Per-dispatch part counts recorded by goldfive's default builders.
+
+    ``thought_count`` counts real ``thought=True`` parts on the ADK
+    path; the OpenAI-compatible path reports the presence of
+    ``reasoning_content`` as a 0/1 sentinel. ``answer_count`` counts
+    non-empty answer parts (0/1 sentinel on the OpenAI path).
+    """
+
+    thought_count: int = 0
+    answer_count: int = 0
+
+
+#: ContextVar carrying the per-call diagnostics object, or ``None`` when
+#: no consumer asked for diagnostics (user-supplied dispatch paths).
+LLM_CALL_DIAGNOSTICS_VAR: contextvars.ContextVar[LlmCallDiagnostics | None] = (
+    contextvars.ContextVar("goldfive_call_llm_diagnostics", default=None)
+)
+
+
+@contextmanager
+def llm_call_diagnostics() -> Iterator[LlmCallDiagnostics]:
+    """Install a fresh diagnostics object for the dispatch inside the block.
+
+    Yields the object; the caller reads its counts after ``await
+    call_llm(...)`` returns (the object outlives the with-block). Resets
+    the var on exit even if the body raises, so a failed dispatch cannot
+    leak stale counts into a sibling call in the same context.
+    """
+    diag = LlmCallDiagnostics()
+    token = LLM_CALL_DIAGNOSTICS_VAR.set(diag)
+    try:
+        yield diag
+    finally:
+        LLM_CALL_DIAGNOSTICS_VAR.reset(token)
+
+
+def record_llm_call_diagnostics(*, thought_count: int, answer_count: int) -> None:
+    """Record part counts into the current dispatch's diagnostics object.
+
+    No-op when no consumer installed one via
+    :func:`llm_call_diagnostics` — recording is strictly optional, and
+    user-supplied ``call_llm`` callables are not expected to call this.
+    """
+    diag = LLM_CALL_DIAGNOSTICS_VAR.get()
+    if diag is None:
+        return
+    diag.thought_count = thought_count
+    diag.answer_count = answer_count
+
+
+def _note_dispatch_result(
+    *, transport: str, result: str, thought_count: int, answer_count: int
+) -> None:
+    """Record diagnostics and log the all-thought-no-answer failure shape.
+
+    Shared by both default builders so success and failure expose the
+    same observable shape (goldfive#271 follow-up to #311: pre-fix, an
+    all-thought response returned an indistinguishable ``raw=''`` that
+    cost two days of misdiagnosis on v16 / Qwen 35B).
+    """
+    record_llm_call_diagnostics(thought_count=thought_count, answer_count=answer_count)
+    if not result and thought_count > 0:
+        log.info(
+            "goldfive._llm.%s: model returned %d thought part(s), %d answer "
+            "part(s), answer text empty — check thinking-mode config or "
+            "max_output_tokens (the model spent its budget thinking and "
+            "emitted no answer). Goldfive's judges should run with "
+            "call_llm_thinking_disabled() entered.",
+            transport,
+            thought_count,
+            answer_count,
+        )
+
+
 @runtime_checkable
 class CallLLM(Protocol):
     """Async callable shape: ``(system, user, model) -> str``.
@@ -241,15 +405,286 @@ async def maybe_close_call_llm(call_llm: Any, *, label: str = "call_llm") -> Non
         log.warning("%s.close() raised %s; ignored", label, exc)
 
 
+# ---------------------------------------------------------------------------
+# Default ``call_llm`` builders (ADK tree LLM / OpenAI-compatible endpoint)
+# ---------------------------------------------------------------------------
+
+
+async def _probe_close(target: Any, *, label: str) -> None:
+    """Close ``target``'s network resources via duck-typed probing.
+
+    Probes ``aclose`` / ``close`` on ``target`` itself, then on a nested
+    ``._client`` / ``.client`` (LiteLlm and friends stash the HTTP
+    session there). Awaits the first hit; silently no-ops when nothing
+    is found. Exceptions are logged and swallowed — teardown must not
+    raise.
+    """
+    candidates: list[tuple[str, Any]] = [(label, target)]
+    for client_attr in ("_client", "client"):
+        client = getattr(target, client_attr, None)
+        if client is not None:
+            candidates.append((f"{label}.{client_attr}", client))
+    for name, obj in candidates:
+        for attr_name in ("aclose", "close"):
+            closer = getattr(obj, attr_name, None)
+            if callable(closer):
+                try:
+                    result = closer()
+                    if hasattr(result, "__await__"):
+                        await result
+                except Exception as exc:  # noqa: BLE001 - cleanup must not raise
+                    log.debug("%s.%s raised %s", name, attr_name, exc)
+                return
+
+
+def make_default_adk_call_llm(model: Any) -> CallLLM | None:
+    """Return a ``call_llm(system, user, model) -> str`` backed by ADK.
+
+    ``model`` may be a string alias (``"gpt-4o"``), a ``BaseLlm``
+    instance (including ``LiteLlm``), or anything ``LLMRegistry`` can
+    resolve. Returns ``None`` when ADK is not installed or the model
+    cannot be resolved to a ``BaseLlm``.
+    """
+    try:
+        from google.adk.models.base_llm import BaseLlm  # type: ignore
+        from google.adk.models.llm_request import LlmRequest  # type: ignore
+        from google.adk.models.registry import LLMRegistry  # type: ignore
+        from google.genai import types as genai_types  # type: ignore
+    except ImportError:
+        log.debug("goldfive._llm: google.adk not installed")
+        return None
+
+    if isinstance(model, BaseLlm):
+        llm: Any = model
+    elif isinstance(model, str) and model:
+        try:
+            llm_cls = LLMRegistry.new_llm(model)  # type: ignore[arg-type]
+        except Exception as exc:  # noqa: BLE001
+            log.debug("goldfive._llm: LLMRegistry.new_llm(%r) raised: %s", model, exc)
+            return None
+        llm = llm_cls
+    else:
+        return None
+
+    async def _call_llm(system: str, user: str, model_str: str) -> str:
+        _ = model_str  # ADK's BaseLlm is already model-bound
+        # Per-callsite cap (see :func:`call_llm_budget`); ``None`` falls
+        # back to DEFAULT_MAX_OUTPUT_TOKENS so an unsupervised dispatch
+        # still has a finite ceiling (goldfive#271: pre-fix evidence in
+        # demo-v8.log showed unbounded calls reaching 9961 completion
+        # tokens / 9.6 minutes wall on a Qwen Q4 endpoint).
+        max_output_tokens = get_max_output_tokens()
+        # Per-callsite disable-thinking signal (goldfive#271 follow-up
+        # to #311). The genai ``ThinkingConfig`` opt-out is first-class
+        # SDK surface on this path and applies to every model —
+        # without it, the 16k cap from #311 is spent inside ``<think>``
+        # and the JSON answer comes back truncated. The Qwen-only
+        # prompt/extra-body hacks live in the OpenAI builder, gated on
+        # :func:`thinking_disable_caps`.
+        thinking_config: Any = None
+        if get_thinking_disabled():
+            try:
+                thinking_config = genai_types.ThinkingConfig(
+                    include_thoughts=False,
+                    thinking_budget=0,
+                )
+            except Exception as exc:  # noqa: BLE001
+                # Older google.genai shapes may not expose ThinkingConfig;
+                # the model just keeps thinking, as before this fix.
+                log.debug(
+                    "goldfive._llm: ThinkingConfig unavailable (%s); "
+                    "continuing without thinking-disabled hint",
+                    exc,
+                )
+                thinking_config = None
+        config_kwargs: dict[str, Any] = {
+            "system_instruction": system,
+            "max_output_tokens": max_output_tokens,
+        }
+        if thinking_config is not None:
+            config_kwargs["thinking_config"] = thinking_config
+        req = LlmRequest(
+            contents=[
+                genai_types.Content(
+                    role="user",
+                    parts=[genai_types.Part(text=user)],
+                ),
+            ],
+            config=genai_types.GenerateContentConfig(**config_kwargs),
+        )
+        chunks: list[str] = []
+        thought_part_count = 0
+        answer_part_count = 0
+        async for resp in llm.generate_content_async(req, stream=False):
+            content = getattr(resp, "content", None)
+            if content is None:
+                continue
+            for part in getattr(content, "parts", None) or ():
+                if getattr(part, "thought", False):
+                    thought_part_count += 1
+                    continue
+                text = getattr(part, "text", "") or ""
+                if text:
+                    answer_part_count += 1
+                    chunks.append(str(text))
+        result = "".join(chunks).strip()
+        _note_dispatch_result(
+            transport="adk_call_llm",
+            result=result,
+            thought_count=thought_part_count,
+            answer_count=answer_part_count,
+        )
+        return result
+
+    async def _close() -> None:
+        await _probe_close(llm, label="adk_call_llm")
+
+    _call_llm.close = _close  # type: ignore[attr-defined]
+    return _call_llm
+
+
+def make_default_openai_call_llm(config: JudgeConfig) -> tuple[CallLLM, str] | None:
+    """Construct an OpenAI-compatible ``CallLLM`` from a :class:`JudgeConfig`.
+
+    Returns ``(call_llm, model)`` or ``None`` when the ``openai``
+    package is not importable / the client cannot be built. Shape
+    mirrors :func:`make_default_adk_call_llm`: the returned callable
+    exposes a ``close`` coroutine so :class:`Runner` can tear down its
+    HTTP session on shutdown.
+
+    Design parallels :class:`goldfive.drift._embed._OpenAIEmbeddingBackend`
+    — we intentionally tolerate missing / placeholder ``api_key`` so
+    llama.cpp / Ollama endpoints "just work" (they don't check the
+    header).
+    """
+    base_url = (config.base_url or "").strip()
+    if not base_url:
+        return None
+    try:
+        from openai import AsyncOpenAI  # type: ignore[import-not-found]
+    except Exception as exc:  # noqa: BLE001
+        log.debug(
+            "goldfive._llm: openai SDK not importable for JudgeConfig (base_url=%r): %s",
+            base_url,
+            exc,
+        )
+        return None
+    timeout_s = max(0.1, config.timeout_ms / 1000.0)
+    try:
+        client: Any = AsyncOpenAI(
+            base_url=f"{base_url.rstrip('/')}/v1",
+            api_key=config.api_key or "not-needed",
+            timeout=timeout_s,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.debug(
+            "goldfive._llm: AsyncOpenAI client construction failed for "
+            "JudgeConfig (base_url=%r): %s",
+            base_url,
+            exc,
+        )
+        return None
+
+    model_name = config.model or ""
+
+    async def _call_llm(system: str, user: str, model_str: str) -> str:
+        # Prefer the model argument supplied by the caller (matches the
+        # contract used by :class:`~goldfive.planner.LLMPlanner`); fall
+        # back to the config model when the caller passes the empty
+        # string. An empty-string model is tolerated by llama.cpp /
+        # Ollama even against an OpenAI endpoint that requires one,
+        # because we only hit endpoints the operator configured.
+        effective_model = model_str or model_name
+        # Per-callsite disable-thinking signal (goldfive#271 follow-up
+        # to #311). The ``enable_thinking`` extra-body field and the
+        # ``/no_think`` prompt prefix are Qwen / litellm conventions —
+        # applied only when the model matches that family (see
+        # :func:`thinking_disable_caps`). Other vendors get no hacks on
+        # this wire format.
+        effective_system = system
+        extra_body: dict[str, Any] = {}
+        if get_thinking_disabled():
+            caps = thinking_disable_caps(effective_model)
+            if caps.openai_enable_thinking_field:
+                extra_body["enable_thinking"] = False
+            if caps.no_think_prompt_prefix and "/no_think" not in (system or ""):
+                effective_system = f"/no_think\n{system}" if system else "/no_think"
+
+        create_kwargs: dict[str, Any] = {
+            "model": effective_model,
+            "messages": [
+                {"role": "system", "content": effective_system},
+                {"role": "user", "content": user},
+            ],
+            # Per-callsite cap (see :func:`call_llm_budget`). Pre-fix:
+            # unbounded → 9961-token responses (goldfive#271 demo-v8.log).
+            "max_tokens": get_max_output_tokens(),
+        }
+        if extra_body:
+            create_kwargs["extra_body"] = extra_body
+        try:
+            resp = await client.chat.completions.create(**create_kwargs)
+        except TypeError as exc:
+            # Older OpenAI client versions don't accept ``extra_body``.
+            # Retry without it — the ``/no_think`` system-prompt prefix
+            # still does its job for Qwen. Other TypeErrors are real
+            # failures; fall through.
+            if "extra_body" not in create_kwargs:
+                raise
+            log.debug(
+                "goldfive._llm: AsyncOpenAI rejected extra_body=%r (%s); retrying without it",
+                extra_body,
+                exc,
+            )
+            create_kwargs.pop("extra_body", None)
+            resp = await client.chat.completions.create(**create_kwargs)
+        try:
+            content = resp.choices[0].message.content or ""
+        except Exception:  # noqa: BLE001
+            return ""
+        # Qwen-via-litellm returns reasoning text on a sibling field
+        # (``reasoning_content``); when ``content == ""`` but reasoning
+        # is present, the model spent its budget thinking and produced
+        # no answer — the OpenAI-compatible analogue of the ADK
+        # all-thought-no-answer shape, reported as 0/1 sentinels.
+        result = str(content)
+        try:
+            reasoning_content = getattr(resp.choices[0].message, "reasoning_content", "") or ""
+        except Exception:  # noqa: BLE001
+            reasoning_content = ""
+        _note_dispatch_result(
+            transport="openai_call_llm",
+            result=result,
+            thought_count=1 if reasoning_content else 0,
+            answer_count=1 if result else 0,
+        )
+        return result
+
+    async def _close() -> None:
+        await _probe_close(client, label="openai_call_llm")
+
+    _call_llm.close = _close  # type: ignore[attr-defined]
+    return _call_llm, model_name
+
+
 __all__ = [
     "CallLLM",
     "ClosableCallLLM",
     "DEFAULT_MAX_OUTPUT_TOKENS",
+    "LLM_CALL_DIAGNOSTICS_VAR",
+    "LlmCallDiagnostics",
     "MAX_OUTPUT_TOKENS_VAR",
     "THINKING_DISABLED_VAR",
+    "THINKING_DISABLE_CAPABILITIES",
+    "ThinkingDisableCaps",
     "call_llm_budget",
     "call_llm_thinking_disabled",
     "get_max_output_tokens",
     "get_thinking_disabled",
+    "llm_call_diagnostics",
+    "make_default_adk_call_llm",
+    "make_default_openai_call_llm",
     "maybe_close_call_llm",
+    "record_llm_call_diagnostics",
+    "thinking_disable_caps",
 ]

--- a/goldfive/_llm_detect.py
+++ b/goldfive/_llm_detect.py
@@ -5,15 +5,12 @@ the convenience layer tries to reuse whatever model that agent is
 already configured with so the planner and goal-deriver can talk to
 the same endpoint without the caller writing a bespoke ``call_llm``.
 
-This module exposes two helpers:
-
-* :func:`detect_llm` — inspect an agent and, if it looks like an ADK
-  ``BaseAgent`` with a usable ``.model`` attribute, return a
-  ``(call_llm, model_name)`` pair suitable for :class:`LLMPlanner` and
-  :class:`LLMGoalDeriver`.
-* :func:`make_default_adk_call_llm` — build a ``call_llm(system, user,
-  model) -> str`` coroutine that dispatches through ADK's
-  ``LLMRegistry`` / ``BaseLlm.generate_content_async`` stream.
+This module exposes :func:`detect_llm` — inspect an agent and, if it
+looks like an ADK ``BaseAgent`` with a usable ``.model`` attribute,
+return a ``(call_llm, model_name)`` pair suitable for
+:class:`LLMPlanner` and :class:`LLMGoalDeriver`. The builder it hands
+the model to, :func:`goldfive._llm.make_default_adk_call_llm`, is
+re-exported here for back-compat.
 
 Neither helper hard-imports ``google.adk`` at module-import time. Both
 tolerate missing deps and return ``None`` when detection fails so the
@@ -25,6 +22,8 @@ from __future__ import annotations
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
+
+from goldfive._llm import make_default_adk_call_llm
 
 log = logging.getLogger("goldfive.llm_detect")
 
@@ -73,175 +72,6 @@ def _extract_adk_model(agent: Any) -> Any:
             if nested is not None:
                 stack.append(nested)
     return None
-
-
-def make_default_adk_call_llm(model: Any) -> CallLLM | None:
-    """Return a ``call_llm(system, user, model) -> str`` backed by ADK.
-
-    ``model`` may be a string alias (``"gpt-4o"``), a ``BaseLlm``
-    instance (including ``LiteLlm``), or anything ``LLMRegistry`` can
-    resolve. Returns ``None`` when ADK is not installed or the model
-    cannot be resolved to a ``BaseLlm``.
-    """
-    try:
-        from google.adk.models.base_llm import BaseLlm  # type: ignore
-        from google.adk.models.llm_request import LlmRequest  # type: ignore
-        from google.adk.models.registry import LLMRegistry  # type: ignore
-        from google.genai import types as genai_types  # type: ignore
-    except ImportError:
-        log.debug("goldfive._llm_detect: google.adk not installed")
-        return None
-
-    if isinstance(model, BaseLlm):
-        llm: Any = model
-    elif isinstance(model, str) and model:
-        try:
-            llm_cls = LLMRegistry.new_llm(model)  # type: ignore[arg-type]
-        except Exception as exc:  # noqa: BLE001
-            log.debug("goldfive._llm_detect: LLMRegistry.new_llm(%r) raised: %s", model, exc)
-            return None
-        llm = llm_cls
-    else:
-        return None
-
-    async def _call_llm(system: str, user: str, model_str: str) -> str:
-        _ = model_str  # ADK's BaseLlm is already model-bound
-        # Pull the per-callsite cap (set by goldfive consumers via
-        # :func:`goldfive._llm.call_llm_budget`). ``None`` from the var
-        # falls back to ``DEFAULT_MAX_OUTPUT_TOKENS`` (4096) so an
-        # unsupervised dispatch still has a finite ceiling. See
-        # goldfive#271 follow-up — pre-fix evidence in demo-v8.log
-        # showed unbounded calls reaching 9961 completion tokens (9.6
-        # minutes wall) on a Qwen Q4 endpoint.
-        from goldfive._llm import get_max_output_tokens, get_thinking_disabled
-
-        max_output_tokens = get_max_output_tokens()
-        # Pull the per-callsite "disable thinking" signal (goldfive#271
-        # follow-up to #311). When goldfive's judges / goal_deriver /
-        # planner-refine dispatch through this builder they enter
-        # :func:`goldfive._llm.call_llm_thinking_disabled` first, which
-        # flips this flag on. We then attach
-        # ``ThinkingConfig(include_thoughts=False, thinking_budget=0)``
-        # to the genai config so the SDK suppresses the ``<think>``
-        # prelude entirely. Without this, the 16k cap from #311 ends up
-        # spent inside ``<think>`` and the JSON answer comes back
-        # truncated — the cause v16 was failing for, not the symptom
-        # #311 patched.
-        thinking_disabled = get_thinking_disabled()
-        thinking_config: Any = None
-        if thinking_disabled:
-            try:
-                thinking_config = genai_types.ThinkingConfig(
-                    include_thoughts=False,
-                    thinking_budget=0,
-                )
-            except Exception as exc:  # noqa: BLE001
-                # Older google.genai shapes may not expose ThinkingConfig.
-                # Fall through silently — the model just keeps thinking,
-                # the same as it did before this fix.
-                log.debug(
-                    "goldfive._llm_detect: ThinkingConfig unavailable (%s); "
-                    "continuing without thinking-disabled hint",
-                    exc,
-                )
-                thinking_config = None
-        config_kwargs: dict[str, Any] = {
-            "system_instruction": system,
-            "max_output_tokens": max_output_tokens,
-        }
-        if thinking_config is not None:
-            config_kwargs["thinking_config"] = thinking_config
-        req = LlmRequest(
-            contents=[
-                genai_types.Content(
-                    role="user",
-                    parts=[genai_types.Part(text=user)],
-                ),
-            ],
-            config=genai_types.GenerateContentConfig(**config_kwargs),
-        )
-        chunks: list[str] = []
-        # Diagnostic counters (goldfive#271 follow-up to #311). When the
-        # final answer text comes back empty AND we received only
-        # ``thought=True`` parts, we want to surface "model returned all
-        # thinking, no answer" rather than the indistinguishable
-        # ``raw=''`` that caused two days of misdiagnosis. Counted on
-        # every dispatch so observability is symmetric (success and
-        # failure both expose the same shape).
-        thought_part_count = 0
-        answer_part_count = 0
-        async for resp in llm.generate_content_async(req, stream=False):
-            content = getattr(resp, "content", None)
-            if content is None:
-                continue
-            for part in getattr(content, "parts", None) or ():
-                if getattr(part, "thought", False):
-                    thought_part_count += 1
-                    continue
-                text = getattr(part, "text", "") or ""
-                if text:
-                    answer_part_count += 1
-                    chunks.append(str(text))
-        result = "".join(chunks).strip()
-        # Stash the part counts on the function so the caller's span /
-        # log path can surface "empty answer (N thought parts)" instead
-        # of just ``raw=''``. Closure-attached so we don't need to break
-        # the ``(system, user, model) -> str`` contract. Read by the
-        # judge call sites via ``getattr(call_llm, 'last_thought_count', 0)``.
-        _call_llm.last_thought_count = thought_part_count  # type: ignore[attr-defined]
-        _call_llm.last_answer_count = answer_part_count  # type: ignore[attr-defined]
-        if not result and thought_part_count > 0:
-            log.info(
-                "goldfive._llm_detect._call_llm: model returned %d thought "
-                "part(s), %d answer part(s), answer text empty — check "
-                "thinking-mode config or max_output_tokens (the model spent "
-                "its budget thinking and emitted no answer). Goldfive's "
-                "judges should run with call_llm_thinking_disabled() entered.",
-                thought_part_count,
-                answer_part_count,
-            )
-        return result
-
-    async def _close() -> None:
-        # ADK's BaseLlm doesn't pin a uniform close protocol, but several
-        # subclasses (LiteLlm, custom HTTP-backed adapters) wrap an
-        # aiohttp / httpx client. Probe a few known attribute names and
-        # await whichever exists. Silently no-op if nothing is found.
-        for attr_name in ("aclose", "close"):
-            target = getattr(llm, attr_name, None)
-            if callable(target):
-                try:
-                    result = target()
-                    if hasattr(result, "__await__"):
-                        await result
-                    return
-                except Exception as exc:  # noqa: BLE001
-                    log.debug("ADK call_llm.%s raised %s", attr_name, exc)
-                    return
-        # Some LiteLlm versions stash the client as ._client / .client.
-        for client_attr in ("_client", "client"):
-            client = getattr(llm, client_attr, None)
-            if client is None:
-                continue
-            for attr_name in ("aclose", "close"):
-                target = getattr(client, attr_name, None)
-                if callable(target):
-                    try:
-                        result = target()
-                        if hasattr(result, "__await__"):
-                            await result
-                        return
-                    except Exception as exc:  # noqa: BLE001
-                        log.debug(
-                            "ADK call_llm.%s.%s raised %s",
-                            client_attr,
-                            attr_name,
-                            exc,
-                        )
-                        return
-
-    _call_llm.close = _close  # type: ignore[attr-defined]
-    return _call_llm
 
 
 def detect_llm(agent: Any) -> tuple[CallLLM, str] | None:

--- a/goldfive/convenience.py
+++ b/goldfive/convenience.py
@@ -26,6 +26,7 @@ import warnings
 from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from goldfive._llm import make_default_openai_call_llm
 from goldfive._llm_detect import CallLLM, detect_llm
 from goldfive.adapters.auto import auto_adapter, is_adk_agent
 from goldfive.config import JudgeConfig, RuntimeConfig
@@ -107,160 +108,12 @@ def _build_judge_only_planner() -> StaticPlanner:
 
 
 def _build_judge_call_llm(config: JudgeConfig) -> tuple[CallLLM, str] | None:
-    """Construct an OpenAI-compatible ``CallLLM`` from a :class:`JudgeConfig`.
+    """Back-compat shim over :func:`goldfive._llm.make_default_openai_call_llm`.
 
-    Returns ``(call_llm, model)`` or ``None`` when the ``openai``
-    package is not importable / the client cannot be built. Shape
-    mirrors :func:`goldfive._llm_detect.make_default_adk_call_llm`: the
-    returned callable exposes a ``close`` coroutine so
-    :class:`Runner` can tear down its HTTP session on shutdown.
-
-    Design parallels :class:`goldfive.drift._embed._OpenAIEmbeddingBackend`
-    — we intentionally tolerate missing / placeholder ``api_key`` so
-    llama.cpp / Ollama endpoints "just work" (they don't check the
-    header).
+    Kept because ``wrap(judge_call_llm_builder=...)`` documents this
+    symbol as the default and external callers / tests import it here.
     """
-    base_url = (config.base_url or "").strip()
-    if not base_url:
-        return None
-    try:
-        from openai import AsyncOpenAI  # type: ignore[import-not-found]
-    except Exception as exc:  # noqa: BLE001
-        log.debug(
-            "goldfive.wrap: openai SDK not importable for JudgeConfig (base_url=%r): %s",
-            base_url,
-            exc,
-        )
-        return None
-    timeout_s = max(0.1, config.timeout_ms / 1000.0)
-    try:
-        client: Any = AsyncOpenAI(
-            base_url=f"{base_url.rstrip('/')}/v1",
-            api_key=config.api_key or "not-needed",
-            timeout=timeout_s,
-        )
-    except Exception as exc:  # noqa: BLE001
-        log.debug(
-            "goldfive.wrap: AsyncOpenAI client construction failed for "
-            "JudgeConfig (base_url=%r): %s",
-            base_url,
-            exc,
-        )
-        return None
-
-    model_name = config.model or ""
-
-    async def _call_llm(system: str, user: str, model_str: str) -> str:
-        # Prefer the model argument supplied by the caller (matches the
-        # contract used by :class:`~goldfive.planner.LLMPlanner`); fall
-        # back to the config model when the caller passes the empty
-        # string. An empty-string model is tolerated by llama.cpp /
-        # Ollama even against an OpenAI endpoint that requires one,
-        # because we only hit endpoints the operator configured.
-        effective_model = model_str or model_name
-        # Pull the per-callsite cap (set by goldfive consumers via
-        # :func:`goldfive._llm.call_llm_budget`). Default ``4096`` is
-        # large enough for plan refines while bounding the worst case
-        # under typical Q4 throughput. Pre-fix: unbounded → 9961-token
-        # responses (goldfive#271 demo-v8.log).
-        from goldfive._llm import get_max_output_tokens, get_thinking_disabled
-
-        # Pull the per-callsite "disable thinking" signal (goldfive#271
-        # follow-up to #311). When goldfive's judges / goal_deriver /
-        # planner-refine dispatch we set ``enable_thinking=False`` via
-        # ``extra_body`` (the Qwen-via-litellm convention) AND prepend
-        # ``/no_think`` to the system prompt as a model-prompt-level
-        # fallback. Vendors that don't recognise the kwarg drop it
-        # server-side; vendors that don't recognise ``/no_think`` ignore
-        # the line. Belt-and-suspenders so a misconfigured endpoint
-        # still exits the think prelude.
-        thinking_disabled = get_thinking_disabled()
-        effective_system = system
-        extra_body: dict[str, Any] = {}
-        if thinking_disabled:
-            extra_body["enable_thinking"] = False
-            # ``/no_think`` is the Qwen prompt-level toggle. Cheap to
-            # include for non-Qwen models — they treat it as ordinary
-            # text and ignore it.
-            if "/no_think" not in (system or ""):
-                effective_system = f"/no_think\n{system}" if system else "/no_think"
-
-        create_kwargs: dict[str, Any] = {
-            "model": effective_model,
-            "messages": [
-                {"role": "system", "content": effective_system},
-                {"role": "user", "content": user},
-            ],
-            "max_tokens": get_max_output_tokens(),
-        }
-        if extra_body:
-            create_kwargs["extra_body"] = extra_body
-        try:
-            resp = await client.chat.completions.create(**create_kwargs)
-        except TypeError as exc:
-            # Older OpenAI client versions don't accept ``extra_body``.
-            # Retry without it — the ``/no_think`` system-prompt prefix
-            # still does its job for Qwen. Other TypeErrors are real
-            # failures; fall through.
-            if "extra_body" not in create_kwargs:
-                raise
-            log.debug(
-                "goldfive.wrap: AsyncOpenAI rejected extra_body=%r (%s); retrying without it",
-                extra_body,
-                exc,
-            )
-            create_kwargs.pop("extra_body", None)
-            resp = await client.chat.completions.create(**create_kwargs)
-        try:
-            content = resp.choices[0].message.content or ""
-        except Exception:  # noqa: BLE001
-            return ""
-        # Diagnostic for empty-content + non-empty reasoning_content
-        # (the OpenAI-compatible analogue of "all-thought, no-answer").
-        # Qwen-via-litellm returns reasoning text on a sibling field
-        # (``reasoning_content``); when ``content == ""`` but reasoning
-        # is present, the model spent its budget thinking and produced
-        # no answer. Surface this rather than letting the parser see an
-        # indistinguishable empty string.
-        result = str(content)
-        reasoning_content = ""
-        try:
-            reasoning_content = getattr(resp.choices[0].message, "reasoning_content", "") or ""
-        except Exception:  # noqa: BLE001
-            reasoning_content = ""
-        _call_llm.last_thought_count = (  # type: ignore[attr-defined]
-            1 if reasoning_content else 0
-        )
-        _call_llm.last_answer_count = 1 if result else 0  # type: ignore[attr-defined]
-        if not result and reasoning_content:
-            log.info(
-                "goldfive.wrap._build_judge_call_llm: model returned "
-                "reasoning_content (%d chars) with empty content — check "
-                "thinking-mode config or max_output_tokens (the model spent "
-                "its budget thinking and emitted no answer).",
-                len(reasoning_content),
-            )
-        return result
-
-    async def _close() -> None:
-        for attr_name in ("aclose", "close"):
-            target = getattr(client, attr_name, None)
-            if callable(target):
-                try:
-                    result = target()
-                    if hasattr(result, "__await__"):
-                        await result
-                    return
-                except Exception as exc:  # noqa: BLE001
-                    log.debug(
-                        "goldfive.wrap: JudgeConfig client.%s raised %s",
-                        attr_name,
-                        exc,
-                    )
-                    return
-
-    _call_llm.close = _close  # type: ignore[attr-defined]
-    return _call_llm, model_name
+    return make_default_openai_call_llm(config)
 
 
 def wrap(

--- a/goldfive/drift/goals.py
+++ b/goldfive/drift/goals.py
@@ -317,9 +317,17 @@ async def classify_goal_drift(
             # question, not deep reasoning. See `call_llm_thinking_disabled`
             # docstring for why we don't want to share the 16k cap with
             # ``<think>`` reasoning here.
-            from goldfive._llm import call_llm_budget, call_llm_thinking_disabled
+            from goldfive._llm import (
+                call_llm_budget,
+                call_llm_thinking_disabled,
+                llm_call_diagnostics,
+            )
 
-            with call_llm_budget(GOAL_DRIFT_MAX_OUTPUT_TOKENS), call_llm_thinking_disabled():
+            with (
+                call_llm_budget(GOAL_DRIFT_MAX_OUTPUT_TOKENS),
+                call_llm_thinking_disabled(),
+                llm_call_diagnostics() as llm_diag,
+            ):
                 raw = await call_llm(system, user, model)
             # Parse inside the with-block so span.decision_summary /
             # output_preview see the verdict before the End emission.
@@ -327,9 +335,10 @@ async def classify_goal_drift(
             if parsed is None:
                 # Distinguish "model returned all thinking, no answer"
                 # from "model returned garbage". The default ADK /
-                # OpenAI builders stash part counts on the call_llm
-                # closure; surface them when the raw text is empty.
-                _thought_n = int(getattr(call_llm, "last_thought_count", 0) or 0)
+                # OpenAI builders record part counts into the per-call
+                # diagnostics object; surface them when the raw text is
+                # empty.
+                _thought_n = llm_diag.thought_count
                 _raw_str = raw if isinstance(raw, str) else ""
                 if not _raw_str.strip() and _thought_n > 0:
                     span.output_preview = (

--- a/goldfive/drift/reasoning_judge.py
+++ b/goldfive/drift/reasoning_judge.py
@@ -969,9 +969,17 @@ async def classify_reasoning_drift_with_focus(
             # deep reasoning. Letting the model burn the 16k budget on
             # ``<think>`` was the v16 / Qwen 35B failure mode — the cap
             # bump was the symptom-fix, this is the cause-fix.
-            from goldfive._llm import call_llm_budget, call_llm_thinking_disabled
+            from goldfive._llm import (
+                call_llm_budget,
+                call_llm_thinking_disabled,
+                llm_call_diagnostics,
+            )
 
-            with call_llm_budget(REASONING_JUDGE_MAX_OUTPUT_TOKENS), call_llm_thinking_disabled():
+            with (
+                call_llm_budget(REASONING_JUDGE_MAX_OUTPUT_TOKENS),
+                call_llm_thinking_disabled(),
+                llm_call_diagnostics() as llm_diag,
+            ):
                 raw = await call_llm(system, user, model)
             # Parse inside the with-block so we can stamp
             # decision-context onto the span before the End event fires
@@ -1072,12 +1080,12 @@ async def classify_reasoning_drift_with_focus(
             if on_task_parsed is None:
                 # Distinguish "model returned all thinking, no answer"
                 # from "model returned garbage" (goldfive#271 follow-up
-                # to #311). The default ADK / OpenAI builders stash the
-                # part counts on the call_llm closure; when the answer
-                # is empty AND we saw ``thought=True`` parts the
-                # diagnostic should say so rather than show an
+                # to #311). The default ADK / OpenAI builders record the
+                # part counts into the per-call diagnostics object; when
+                # the answer is empty AND we saw ``thought=True`` parts
+                # the diagnostic should say so rather than show an
                 # indistinguishable ``raw=''``.
-                _thought_n = int(getattr(call_llm, "last_thought_count", 0) or 0)
+                _thought_n = llm_diag.thought_count
                 if not raw_str_inline.strip() and _thought_n > 0:
                     span.output_preview = (
                         f"empty answer ({_thought_n} thought part(s); "

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -91,8 +91,8 @@ Responsibilities (this PR)
   :meth:`_summarize_recent_reasoning`. Bounded summarisation used by
   the reflective check prompt and by ``trigger_input`` stamping.
 
-* :meth:`_parse_reflective_response` — tolerant JSON-from-LLM parser
-  used by the reflective check verdict path.
+* :meth:`_parse_reflective_response` — the reflective check's verdict
+  parser; delegates to :func:`goldfive.drift.registry.parse_json_response`.
 
 The module DOES NOT own
 ----------------------
@@ -135,9 +135,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import inspect
-import json
 import logging
-import re
 import time
 from collections.abc import Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -359,10 +357,6 @@ class DriftObserver:
             DriftKind.GOAL_DRIFT,
         }
     )
-
-    # Liberal JSON extractor: tolerates markdown code fences and leading /
-    # trailing prose around the object.
-    _JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 
     def __init__(self, steerer: DefaultSteerer) -> None:
         # Back-reference to the router. Used to reach the shared
@@ -1492,11 +1486,9 @@ class DriftObserver:
         observability event so consumers see one truncation marker
         regardless of which detector produced the drift.
         """
-        if not isinstance(text, str):
-            return ""
-        if len(text) <= limit:
-            return text
-        return text[:limit] + " … [truncated]"
+        from goldfive.drift.registry import truncate_for_observability
+
+        return truncate_for_observability(text, limit)
 
     @staticmethod
     def _summarize_recent_tool_calls(session: Session, *, limit: int = 10) -> str:
@@ -1555,33 +1547,16 @@ class DriftObserver:
         trimmed = [r[:240] + ("…" if len(r) > 240 else "") for r in tail]
         return " | ".join(trimmed)
 
-    @classmethod
-    def _parse_reflective_response(cls, raw: Any) -> dict[str, Any] | None:
-        """Extract the first JSON object from ``raw`` or return None.
+    @staticmethod
+    def _parse_reflective_response(raw: Any) -> dict[str, Any] | None:
+        """Parse the reflective-check verdict via the shared judge parser.
 
-        Tolerates markdown code fences (``\\`\\`\\`json ... \\`\\`\\``) and
-        prose wrapping, which real LLMs emit even with strong "reply JSON
-        only" instructions. Returns ``None`` for any shape that is not a
-        dict once parsed, so downstream code can check one failure mode.
+        Delegates to :func:`goldfive.drift.registry.parse_json_response`
+        — one liberal JSON-from-LLM parser for every verdict path.
         """
-        if not isinstance(raw, str) or not raw.strip():
-            return None
-        stripped = raw.strip()
-        # Fast path: parse verbatim.
-        try:
-            decoded = json.loads(stripped)
-        except (json.JSONDecodeError, ValueError):
-            # Try extracting the first {...} block.
-            match = cls._JSON_OBJECT_RE.search(stripped)
-            if match is None:
-                return None
-            try:
-                decoded = json.loads(match.group(0))
-            except (json.JSONDecodeError, ValueError):
-                return None
-        if not isinstance(decoded, dict):
-            return None
-        return decoded
+        from goldfive.drift.registry import parse_json_response
+
+        return parse_json_response(raw)
 
     # ------------------------------------------------------------------
     # Structural-escalation helpers (progress-stall, handler-exhausted)
@@ -2830,11 +2805,13 @@ class DriftObserver:
                 from goldfive._llm import (
                     call_llm_budget,
                     call_llm_thinking_disabled,
+                    llm_call_diagnostics,
                 )
 
                 with (
                     call_llm_budget(self.REFLECTIVE_MAX_OUTPUT_TOKENS),
                     call_llm_thinking_disabled(),
+                    llm_call_diagnostics() as llm_diag,
                 ):
                     raw = await call_llm(
                         self.REFLECTIVE_SYSTEM_PROMPT,
@@ -2845,11 +2822,10 @@ class DriftObserver:
                 if parsed is None:
                     # Distinguish "model returned all thinking, no
                     # answer" from "model returned garbage" — see
-                    # goldfive#271 follow-up to #311. ``call_llm`` is
-                    # the closure built by ``make_default_adk_call_llm``
-                    # / ``_build_judge_call_llm`` which stashes part
-                    # counts on itself.
-                    _thought_n = int(getattr(call_llm, "last_thought_count", 0) or 0)
+                    # goldfive#271 follow-up to #311. The default
+                    # builders record part counts into the per-call
+                    # diagnostics object.
+                    _thought_n = llm_diag.thought_count
                     _raw_str = raw if isinstance(raw, str) else ""
                     if not _raw_str.strip() and _thought_n > 0:
                         span.output_preview = (

--- a/tests/test_call_llm_diagnostic.py
+++ b/tests/test_call_llm_diagnostic.py
@@ -7,27 +7,34 @@ parts, the function returned ``""`` — indistinguishable from "the model
 truly produced empty output" or "the network ate the response". Two
 days were lost to that ambiguity in the v16 / Qwen 35B investigation.
 
-Post-fix:
+Post-fix (one-llm-call-module refactor):
 
-1. The default ADK builder counts ``thought=True`` vs answer parts on
-   every dispatch and stashes the counts on the closure
-   (``_call_llm.last_thought_count`` / ``last_answer_count``).
+1. The default builders count ``thought=True`` vs answer parts on every
+   dispatch and record them into the per-call
+   :class:`goldfive._llm.LlmCallDiagnostics` object installed by the
+   consumer via :func:`goldfive._llm.llm_call_diagnostics`. The counts
+   previously travelled as attributes mutated on the shared callable —
+   last-writer-wins under concurrent background judges.
 2. When the answer is empty AND there were thought parts, the builder
    logs at INFO with a diagnostic message naming the failure shape so
    operators can distinguish "model spent its budget thinking" from
    "real empty response".
 3. The judge call sites (reasoning_judge, classify_goal_drift,
-   reflective check) read the stashed counts when they fail to parse
+   reflective check) read the recorded counts when they fail to parse
    the response and surface ``"empty answer (N thought parts)"`` on the
    span ``output_preview`` rather than the indistinguishable ``raw=''``.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
+
+from goldfive._llm import llm_call_diagnostics, record_llm_call_diagnostics
 
 
 @pytest.mark.asyncio
@@ -67,12 +74,13 @@ async def test_adk_builder_logs_diagnostic_when_all_thoughts_no_answer(caplog):
     assert call_llm is not None
 
     with caplog.at_level(logging.INFO, logger="goldfive"):
-        out = await call_llm("system", "user", "stub")
+        with llm_call_diagnostics() as diag:
+            out = await call_llm("system", "user", "stub")
 
     assert out == "", "all-thought response must produce empty answer"
-    # Part counts stashed on the closure for the caller.
-    assert getattr(call_llm, "last_thought_count", None) == 3
-    assert getattr(call_llm, "last_answer_count", None) == 0
+    # Part counts recorded into the per-call diagnostics object.
+    assert diag.thought_count == 3
+    assert diag.answer_count == 0
     # Diagnostic INFO log fired.
     matching = [
         rec
@@ -118,34 +126,115 @@ async def test_adk_builder_no_diagnostic_on_normal_response(caplog):
     assert call_llm is not None
 
     with caplog.at_level(logging.INFO, logger="goldfive"):
-        out = await call_llm("system", "user", "stub")
+        with llm_call_diagnostics() as diag:
+            out = await call_llm("system", "user", "stub")
 
     assert out == '{"on_task": true}'
-    assert getattr(call_llm, "last_thought_count", None) == 1
-    assert getattr(call_llm, "last_answer_count", None) == 1
+    assert diag.thought_count == 1
+    assert diag.answer_count == 1
     # No diagnostic fired.
-    diag = [rec for rec in caplog.records if "answer text empty" in rec.message]
-    assert not diag
+    diag_records = [rec for rec in caplog.records if "answer text empty" in rec.message]
+    assert not diag_records
+
+
+@pytest.mark.asyncio
+async def test_openai_builder_records_diagnostic_when_all_reasoning_no_answer(caplog):
+    """The OpenAI-compatible builder reports ``reasoning_content`` with
+    empty ``content`` as the all-thought-no-answer shape (0/1 sentinel
+    counts) through the same diagnostics channel as the ADK builder."""
+    pytest.importorskip("openai")
+    from goldfive._llm import make_default_openai_call_llm
+    from goldfive.config import JudgeConfig
+
+    built = make_default_openai_call_llm(
+        JudgeConfig(base_url="http://stub-judge.invalid", model="stub-judge")
+    )
+    assert built is not None
+    call_llm, _model = built
+
+    fake_message = MagicMock(content="")
+    type(fake_message).reasoning_content = "chain of thought " * 20  # type: ignore[attr-defined]
+    fake_response = MagicMock()
+    fake_response.choices = [MagicMock(message=fake_message)]
+
+    async def fake_create(**kwargs: Any) -> Any:
+        return fake_response
+
+    client_cell = None
+    for c in call_llm.__closure__ or ():
+        if hasattr(c.cell_contents, "chat"):
+            client_cell = c
+            break
+    assert client_cell is not None
+    client_cell.cell_contents.chat.completions.create = fake_create
+
+    with caplog.at_level(logging.INFO, logger="goldfive"):
+        with llm_call_diagnostics() as diag:
+            out = await call_llm("system", "user", "stub-judge")
+
+    assert out == ""
+    assert diag.thought_count == 1
+    assert diag.answer_count == 0
+    matching = [
+        rec
+        for rec in caplog.records
+        if "thought part" in rec.message and "answer text empty" in rec.message
+    ]
+    assert matching, (
+        f"expected the all-thought-no-answer diagnostic; got log records: "
+        f"{[r.message for r in caplog.records]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_isolated_across_concurrent_calls():
+    """Three concurrent judge-shaped dispatches each observe their own
+    counts — the race the old closure-attribute side channel had once
+    Wave-2's semaphore allowed up to 3 background judges in flight."""
+    started = asyncio.Event()
+
+    async def fake_call_llm(thought_count: int) -> str:
+        # Simulate the consolidated builder: record after a suspension
+        # point so the three calls fully interleave.
+        started.set()
+        await asyncio.sleep(0.01 * thought_count)
+        record_llm_call_diagnostics(thought_count=thought_count, answer_count=0)
+        await asyncio.sleep(0.01)
+        return ""
+
+    async def judge_dispatch(thought_count: int) -> tuple[int, int]:
+        # Each consumer installs its own per-call diagnostics object,
+        # exactly like the judge / reflective-check call sites.
+        with llm_call_diagnostics() as diag:
+            await fake_call_llm(thought_count)
+        return diag.thought_count, diag.answer_count
+
+    results = await asyncio.gather(judge_dispatch(1), judge_dispatch(2), judge_dispatch(3))
+    assert results == [(1, 0), (2, 0), (3, 0)]
+
+
+def test_record_is_noop_without_installed_diagnostics():
+    """Recording outside ``llm_call_diagnostics()`` must not raise —
+    diagnostics are optional and absent for operator-supplied callables."""
+    record_llm_call_diagnostics(thought_count=5, answer_count=1)
 
 
 @pytest.mark.asyncio
 async def test_reasoning_judge_surfaces_diagnostic_in_span():
     """``classify_reasoning_drift`` records an "empty answer (N thought
     parts)" output_preview on the span when the call_llm returned ``""``
-    and stashed a positive thought count. Replaces the previous
+    and recorded a positive thought count. Replaces the previous
     indistinguishable ``raw=''`` shape."""
     from goldfive.drift.reasoning_judge import classify_reasoning_drift
     from goldfive.protocols import EventSink
     from goldfive.types import Task
 
-    # Stub call_llm returning empty AND advertising 3 thought parts via
-    # the closure-attached attribute (the same shape the default ADK
-    # builder produces).
+    # Stub call_llm returning empty AND recording 3 thought parts via
+    # the per-call diagnostics channel (the same shape the default
+    # builders produce).
     async def stub_call_llm(system: str, user: str, model: str) -> str:
+        record_llm_call_diagnostics(thought_count=3, answer_count=0)
         return ""
-
-    stub_call_llm.last_thought_count = 3  # type: ignore[attr-defined]
-    stub_call_llm.last_answer_count = 0  # type: ignore[attr-defined]
 
     captured: list[Any] = []
 

--- a/tests/test_judge_thinking_disabled.py
+++ b/tests/test_judge_thinking_disabled.py
@@ -16,8 +16,10 @@ These tests pin the contract:
    ``ThinkingConfig(include_thoughts=False, thinking_budget=0)`` to the
    ``GenerateContentConfig`` it sends to ``BaseLlm.generate_content_async``.
 3. The default OpenAI / Qwen-via-litellm judge builder reads the var
-   and sends ``extra_body={"enable_thinking": False}`` plus a
-   ``/no_think`` system-prompt prefix.
+   and — for Qwen-family models only, per the
+   :data:`goldfive._llm.THINKING_DISABLE_CAPABILITIES` table — sends
+   ``extra_body={"enable_thinking": False}`` plus a ``/no_think``
+   system-prompt prefix. Non-Qwen models get no vendor hacks.
 4. Each judge / goal_deriver / planner-refine call site enters
    :func:`call_llm_thinking_disabled` around its
    ``await call_llm(...)`` so a wrapping shim sees the flag.
@@ -126,29 +128,33 @@ async def test_adk_builder_attaches_thinking_config_when_disabled():
 
 
 # ---------------------------------------------------------------------------
+# Capability-table routing (vendor thinking-disable conventions)
+# ---------------------------------------------------------------------------
+
+
+def test_thinking_disable_caps_routes_by_model_family():
+    """Qwen-family names (including litellm-prefixed) get the vendor
+    hacks; Gemini / OpenAI / unknown models get none."""
+    from goldfive._llm import thinking_disable_caps
+
+    for name in ("qwen3-35b", "openai/Qwen3-32B", "hosted_vllm/Qwen/Qwen3-32B"):
+        caps = thinking_disable_caps(name)
+        assert caps.openai_enable_thinking_field, name
+        assert caps.no_think_prompt_prefix, name
+
+    for name in ("gemini-2.0-flash", "gpt-4o", "stub-judge", ""):
+        caps = thinking_disable_caps(name)
+        assert not caps.openai_enable_thinking_field, name
+        assert not caps.no_think_prompt_prefix, name
+
+
+# ---------------------------------------------------------------------------
 # OpenAI / Qwen builder integration
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_openai_builder_threads_enable_thinking_false_when_disabled():
-    """``_build_judge_call_llm`` must send ``extra_body={"enable_thinking":
-    False}`` and prepend ``/no_think`` to the system prompt when the
-    disable-thinking flag is set."""
-    pytest.importorskip("openai")
-    from goldfive.config import JudgeConfig
-    from goldfive.convenience import _build_judge_call_llm
-
-    config = JudgeConfig(
-        base_url="http://stub-judge.invalid",
-        model="stub-judge",
-        api_key="not-needed",
-    )
-
-    built = _build_judge_call_llm(config)
-    assert built is not None
-    call_llm, _model = built
-
+def _patch_openai_client(call_llm: Any) -> list[dict[str, Any]]:
+    """Swap the builder's AsyncOpenAI client for a capture stub."""
     captured_kwargs: list[dict[str, Any]] = []
     fake_response = MagicMock()
     fake_response.choices = [MagicMock(message=MagicMock(content="ok"))]
@@ -166,9 +172,31 @@ async def test_openai_builder_threads_enable_thinking_false_when_disabled():
             break
     assert client_cell is not None
     client_cell.cell_contents.chat.completions.create = fake_create
+    return captured_kwargs
+
+
+@pytest.mark.asyncio
+async def test_openai_builder_threads_enable_thinking_false_when_disabled():
+    """``_build_judge_call_llm`` must send ``extra_body={"enable_thinking":
+    False}`` and prepend ``/no_think`` to the system prompt when the
+    disable-thinking flag is set and the model is Qwen-family."""
+    pytest.importorskip("openai")
+    from goldfive.config import JudgeConfig
+    from goldfive.convenience import _build_judge_call_llm
+
+    config = JudgeConfig(
+        base_url="http://stub-judge.invalid",
+        model="qwen3-35b",
+        api_key="not-needed",
+    )
+
+    built = _build_judge_call_llm(config)
+    assert built is not None
+    call_llm, _model = built
+    captured_kwargs = _patch_openai_client(call_llm)
 
     # Default: no extra_body, no /no_think prefix.
-    out = await call_llm("system", "user", "stub-judge")
+    out = await call_llm("system", "user", "qwen3-35b")
     assert out == "ok"
     assert "extra_body" not in captured_kwargs[-1]
     sys_msg = captured_kwargs[-1]["messages"][0]["content"]
@@ -176,11 +204,39 @@ async def test_openai_builder_threads_enable_thinking_false_when_disabled():
 
     # With disable-thinking flag: extra_body present, /no_think prepended.
     with call_llm_thinking_disabled():
-        await call_llm("system", "user", "stub-judge")
+        await call_llm("system", "user", "qwen3-35b")
     last = captured_kwargs[-1]
     assert last["extra_body"] == {"enable_thinking": False}
     sys_msg = last["messages"][0]["content"]
     assert sys_msg.startswith("/no_think"), "Qwen prompt-level fallback must be prepended"
+
+
+@pytest.mark.asyncio
+async def test_openai_builder_no_vendor_hacks_for_unknown_model():
+    """Non-Qwen models must get neither ``extra_body`` nor the
+    ``/no_think`` prefix even with the disable-thinking flag set — the
+    hacks are Qwen / litellm conventions, not core wrap() behaviour."""
+    pytest.importorskip("openai")
+    from goldfive.config import JudgeConfig
+    from goldfive.convenience import _build_judge_call_llm
+
+    config = JudgeConfig(
+        base_url="http://stub-judge.invalid",
+        model="stub-judge",
+        api_key="not-needed",
+    )
+
+    built = _build_judge_call_llm(config)
+    assert built is not None
+    call_llm, _model = built
+    captured_kwargs = _patch_openai_client(call_llm)
+
+    with call_llm_thinking_disabled():
+        out = await call_llm("system", "user", "stub-judge")
+    assert out == "ok"
+    last = captured_kwargs[-1]
+    assert "extra_body" not in last
+    assert "/no_think" not in last["messages"][0]["content"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Verified defects, all in the internal `call_llm` plumbing:

- **Two divergent builder copies.** `make_default_adk_call_llm` (`goldfive/_llm_detect.py`) and `_build_judge_call_llm` (`goldfive/convenience.py`) each re-implemented the output-token budget read, the vendor thinking-disable mappings, retry/close-probing, and the all-thought-no-answer diagnostic — and had already diverged semantically (the ADK path counts real `thought=True` parts; the OpenAI path fakes 0/1 sentinels from `reasoning_content`).
- **Closure-attribute side channel.** The diagnostic was smuggled by mutating attributes on the shared callable (`call_llm.last_thought_count` / `last_answer_count`) and read back via `getattr` at three sites (`drift/reasoning_judge.py`, `drift/goals.py`, `drift_observer.py`). That is last-writer-wins under the up-to-3 concurrent background judges the #483 semaphore allows.
- **Qwen hacks applied to every model.** The `/no_think` system-prompt prefix and `enable_thinking=False` extra-body were sent for ALL models on the judge callable — core `wrap()` coupled to Qwen/litellm conventions.
- **Byte-identical liberal JSON parser duplicated:** `registry.parse_json_response` vs `DriftObserver._parse_reflective_response`.

## Fix

- Both builders now live in `goldfive/_llm.py` (`make_default_adk_call_llm`, `make_default_openai_call_llm`): one budget read, one duck-typed close-prober (`_probe_close`), one diagnostic recorder/logger (`_note_dispatch_result`), and one model-capability table (`THINKING_DISABLE_CAPABILITIES`, matched case-insensitively on model-name substrings — a lookup table of vendor conventions, not NL classification). `_llm_detect.py` and `convenience.py` keep thin re-export shims (`make_default_adk_call_llm`, `_build_judge_call_llm`) for external importers and the `wrap(judge_call_llm_builder=...)` default.
- Per-call diagnostics travel through a ContextVar-bound object: consumers install a fresh `LlmCallDiagnostics` via `llm_call_diagnostics()` around their own `await call_llm(...)`; the builders record into it via `record_llm_call_diagnostics()` (a no-op when nothing is installed — diagnostics stay optional and absent for operator-supplied callables; the public `(system, user, model) -> str` contract is untouched). All three `getattr` blocks and both attribute writes are deleted.
- `DriftObserver._parse_reflective_response` now delegates to `registry.parse_json_response` (whose docstring already claimed consolidation), and `_truncate_trigger_input` routes through `registry.truncate_for_observability` so one truncation-suffix convention remains.

**Deliberate behavior change (flagged):** the Qwen-specific `/no_think` prefix + `enable_thinking` extra-body now apply ONLY when the model matches the Qwen/litellm family they were written for; unknown/non-Qwen models get no vendor hacks on the OpenAI-compatible wire. The genai `ThinkingConfig(include_thoughts=False, thinking_budget=0)` opt-out on the ADK path is first-class SDK surface and still applies to every model there, exactly as before. Everything else is behavior-preserving; observation_only semantics untouched.

## Tests

- `tests/test_judge_thinking_disabled.py`: new capability-table routing test (Qwen family incl. litellm-prefixed names → hacks; gemini/gpt/unknown → none); new `test_openai_builder_no_vendor_hacks_for_unknown_model`; the existing Qwen extra-body test updated to use a Qwen model name (it previously pinned the hacks firing for a non-Qwen `"stub-judge"` model — the flagged behavior change).
- `tests/test_call_llm_diagnostic.py`: ADK all-thought-no-answer diagnostic tests updated from closure-attribute assertions to the `llm_call_diagnostics()` object; new OpenAI-path all-thought (`reasoning_content`, empty content) diagnostic test; new 3-way concurrency test asserting each dispatch observes its own counts (the exact race the old side channel had); no-op recording test for user callables; the reasoning-judge span test's stub now records via `record_llm_call_diagnostics` instead of setting attributes.
- JSON-parser fold covered by the existing `tests/test_drift_registry.py` + reflective-check suites passing unchanged.
- Full suite: 2933 passed, 57 skipped (~33s), `ruff check .` clean. The `openai` extra was installed locally so the previously-skipped OpenAI-builder tests ran.

## Notes

- The three pre-existing format-dirty files touched here (`drift/goals.py`, `drift/reasoning_judge.py`, `drift_observer.py`) were already `ruff format`-dirty on main; no new drift introduced.
- LOOPING_TOOL_CALL dispatch surfaces and PLAN_DIVERGENCE machinery untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA