### PR TITLE
docs: accuracy sweep — reconcile design docs with live code

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ inspect the event stream. Concrete and runnable.
 ### Reference
 
 - [`docs/reference/api.md`](docs/reference/api.md) — public API surface.
-- [`docs/reference/tool-protocol.md`](docs/reference/tool-protocol.md) — the eight reporting tools.
+- [`docs/reference/tool-protocol.md`](docs/reference/tool-protocol.md) — the reporting tools (seven lifecycle tools registered by default; three drift self-reporting tools opt-in via `drift_self_reporting`).
 - [`docs/performance.md`](docs/performance.md) — orchestration-overhead baseline.
 
 ## License

--- a/docs/design/APPROVAL.md
+++ b/docs/design/APPROVAL.md
@@ -246,12 +246,10 @@ Unlike flows A and B — which are agent-initiated approvals — flow C is
 
 Typical Level-4 triggers:
 
-- `GOAL_DRIFT` at CRITICAL (every occurrence — the trajectory LLM
-  judge says the tree is no longer advancing goals).
 - `REFINE_VALIDATION_FAILED` at CRITICAL (planner exhausted its
   retry budget; steerer deliberately does NOT re-refine to avoid an
   infinite loop).
-- `INTENT_DIVERGENCE` at CRITICAL (or at WARNING on repeat).
+- `INTENT_DIVERGENCE` at CRITICAL (first and repeat).
 - `RUNAWAY_DELEGATION` on repeat.
 - Any `CRITICAL` drift whose first-occurrence Level-3 CANCEL_REINVOKE
   didn't resolve and it repeats.

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -58,8 +58,10 @@ swapped in.
 **GoalDeriver** — one job: take whatever the caller handed in
 (`user_input: str` or a pre-built `list[Goal]`) and return an explicit
 list of `Goal`s. Each goal has a `summary` and, optionally, a
-`success_predicate: Callable[[Session], bool]` that the framework can
-consult to decide "are we done yet?".
+`success_predicate: Callable[[Session], bool]` that the executors
+evaluate at end-of-run (`evaluate_goal_predicates`,
+PLAN-LIFECYCLE.md §6.1): an unmet or raising predicate fails the run.
+There is no mid-run consultation.
 
 **Planner** — produces a `Plan` (DAG of `Task`s) from goals, and
 revises it on drift via `refine(plan, drift, goals)`. The planner is

--- a/docs/design/CONTROL-CHANNEL.md
+++ b/docs/design/CONTROL-CHANNEL.md
@@ -590,13 +590,13 @@ that allowed stale verdicts to cascade is gone.
 
 ## §5.5 Observation-only mode (goldfive#254)
 
-`SteeringConfig.observation_only` gates the three actual steering
+`SteeringConfig.observation_only` gates the four actual steering
 **injection points** in `DefaultSteerer`. When the flag is `True`
 (the production default — operators graduate to active steering
 explicitly), detection still runs in full and `planner.refine_steer`
 still runs, but no side effect lands on the in-flight invocation.
 
-The three gated sites — all routed through the single public
+The four gated sites — all routed through the single public
 predicate `DefaultSteerer.is_active_steering()` (consumers holding a
 maybe-steerer resolve through `goldfive.steerer.steering_is_active`,
 whose documented fallback is passive) so the contract is grep-able:
@@ -615,6 +615,14 @@ whose documented fallback is passive) so the contract is grep-able:
    returns `[]` without consulting the plugin, so no
    `CancellationRequest` is written and the
    `cancel_requested_invocation_ids()` registry stays empty.
+4. **Level 2 nudge enqueue** (goldfive#475) — `_dispatch_nudge` and
+   the post-ABSORB handoff skip the `session.pending_nudges` write
+   (the overlay would otherwise drain the queue into a
+   goldfive-authored synthetic user turn and re-invoke the tree).
+   The would-be nudge is logged and an `observation_only_gate`
+   `PolicyApplied` event is stamped; the executor's drain carries a
+   matching defense-in-depth gate for steerer subclasses that bypass
+   the dispatcher.
 
 The paired `PlanRevised` event carries `dry_run=true` so consumers
 (harmonograf, custom sinks) can surface a "would-have-applied"
@@ -627,7 +635,7 @@ tracks the producer's live state.
 injection. Suppression accounting (`suppressed_by_user_steer`),
 drift lifecycle (PR #271), and reporting events (`ReasoningJudgeInvoked`,
 `GoldfiveLLMCallStart`/`End`, sink-side observability) all keep
-running. The mode is purely about whether the steerer's three
+running. The mode is purely about whether the steerer's four
 **write** paths fire.
 
 Operators opt in / out via the typed config surface — no

--- a/docs/design/CONTROL.md
+++ b/docs/design/CONTROL.md
@@ -547,21 +547,23 @@ STEER / CANCEL against an offline canned-LLM planner lives at
 A STEER control message is the user-initiated entry into a broader
 intervention story. Goldfive-internal drift detectors (loop, refusal,
 goal drift, ...) enter the same pipeline via synthesized drifts, and
-both paths route through `DefaultSteerer._handle_drift` which maps
+both paths route through `DriftObserver.handle_drift` (the steerer's
+`drift` component) which maps
 `(drift_kind, severity, occurrence_count)` to one of six levels:
 
 | Level | Name | What happens |
 |---|---|---|
 | **0** | `OBSERVE` | Emit `DriftDetected`; no further action. |
 | **1** | `ABSORB` | Call `planner.refine`; install revised plan; continue. This is where USER_STEER lands. |
-| **2** | `NUDGE` | Queue a corrective user message on `session.pending_nudges`. Not on the default table today; reserved for future policies. |
+| **2** | `NUDGE` | Queue a corrective user message on `session.pending_nudges` for the overlay loop to replay at the next invocation boundary. On the default table for `LOOPING_REASONING` CRITICAL-first (goldfive#204), `GOAL_DRIFT` WARNING / CRITICAL-first (goldfive#324), and `TASK_TIMEOUT` WARNING (goldfive#487). The enqueue is gated on `is_active_steering()` (goldfive#475): under `observation_only=True` the would-be nudge is logged and a `PolicyApplied` gate event is stamped instead. |
 | **3** | `CANCEL_REINVOKE` | Refine; install revised plan; **dispatch a `GOLDFIVE_STEER` ControlMessage on the bound channel** so the executor's invoke loop cancels the in-flight invocation and restarts with a `[GOLDFIVE STEERING CONTROL …]` framed corrective. |
 | **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; **dispatch a `GOLDFIVE_PAUSE_ESCALATE` ControlMessage on the bound channel** so the executor's pre-task loop blocks for user input. (Phase 2 of #246 replaced the deleted `session.paused_for_human_intervention` flag with this channel-routed signal.) |
 | **5** | `TERMINATE` | Pause-with-deadline: same dispatch as Level 4 but the payload always carries `deadline_s` (`SteeringConfig.pause_escalate_deadline_s`, or 600 s when unset). On expiry the executor cancels non-terminal tasks and emits `RunAborted` with the escalation lineage. Reached on repeat Level-4 that didn't resolve. |
 
 The per-`(drift_kind, severity)` mapping lives in
-`DefaultSteerer._LADDER` (see `goldfive/steerer.py`). A subclass can
-override `_ladder_level_for` to tune the table.
+`DriftObserver._LADDER` (see `goldfive/drift_observer.py`; the
+steerer's `drift` component). Replace the component or subclass
+`DriftObserver` and override `_ladder_level_for` to tune the table.
 
 USER_STEER specifically maps to **Level 1 (ABSORB)** at WARNING (the
 default severity) — refine runs synchronously, the revised plan
@@ -572,7 +574,7 @@ ladder into an unconditional `RunAborted`.
 
 See [DRIFT.md §"Intervention ladder (Levels 0-5)"](DRIFT.md#intervention-ladder-levels-0-5)
 for the full per-drift-kind mapping and the corresponding code
-path in `goldfive/steerer.py`.
+path in `goldfive/drift_observer.py`.
 
 ## 8. What ControlChannel is *not*
 

--- a/docs/design/DRIFT.md
+++ b/docs/design/DRIFT.md
@@ -136,8 +136,8 @@ the full Rule A/B/C table under the new model.
 | `RUNAWAY_DELEGATION` | `35` | ADK coordinator delegated via `AgentTool` more than `ADKAdapter(agent_tool_cap=N)` allows (default 16). | `critical` | `_GoldfiveADKPlugin._emit_runaway_delegation_drift` | Level 3 → Level 4 (cancel + refine; escalate on repeat) |
 | `CONFABULATION_RISK` | `34` | Two sources: (a) `GoldfivePlanner.process_planning_response` sees a `function_call` whose name is neither in the running agent's own tools nor in the tree agent registry (pure hallucination, three-stage gate #178); (b) `goldfive.drift.classify_confabulation_risk` spots the cheap structural pattern "task title implies external data access but the agent produced output without calling any tool." | `warning` (three-stage gate) / `info` (structural) | `GoldfivePlanner` or `after_run_callback` | Level 1 → Level 3 on repeat |
 | `REFINE_VALIDATION_FAILED` | `36` | `LLMPlanner` exhausted its refine retry budget (attempts 1 & 2 both rejected by the structural validator). Terminal signal. | `critical` | `LLMPlanner._emit_refine_validation_failed` | Level 4 (PAUSE_ESCALATE — steerer deliberately does NOT re-refine) |
-| `HUMAN_INTERVENTION_REQUIRED` | `37` | Escalation target emitted by the intervention ladder when Level 4 fires (persistent refine failures, goal drift, repeated critical drift). | `critical` | `DefaultSteerer._dispatch_pause_escalate` | Level 4; repeat → Level 5 (TERMINATE) |
-| `GOAL_DRIFT` | `38` | Periodic trajectory-level LLM-judge: every N invocations, classify whether accumulated activity advances `session.goals`. Gated behind `Runner(goal_drift_enabled=...)` + a `goal_drift_call_llm` callable on the steerer. **On the `goldfive.wrap(...)` path the judge is wired automatically** from the resolved planner `call_llm` (goldfive#217): any `wrap()` call that ends up with a real LLM — explicit `call_llm=` or `detect_llm(agent)` hit — also arms this judge. Opt out by passing an explicit steerer, e.g. `goldfive.wrap(agent, steerer=DefaultSteerer(goal_drift_call_llm=None))`, or by setting `Runner(goal_drift_enabled=False)` when building manually. When `goal_drift_enabled=True` but no callable is wired (operator-built `Runner` with a bare `DefaultSteerer()`), the Runner emits a one-shot WARNING and the check stays inert. | `critical` | `goldfive.drift.goals.classify_goal_drift` | Level 4 both on first and repeat (refine cannot recover from trajectory-level drift) |
+| `HUMAN_INTERVENTION_REQUIRED` | `37` | Escalation target emitted by the intervention ladder when Level 4 fires (persistent refine failures, repeated critical drift). | `critical` | `DriftObserver._dispatch_pause_escalate` | Level 4; repeat → Level 5 (TERMINATE) |
+| `GOAL_DRIFT` | `38` | Periodic trajectory-level LLM-judge: every N invocations, classify whether accumulated activity advances `session.goals`. Gated behind `Runner(goal_drift_enabled=...)` + a `goal_drift_call_llm` callable on the steerer. **On the `goldfive.wrap(...)` path the judge is wired automatically** from the resolved planner `call_llm` (goldfive#217): any `wrap()` call that ends up with a real LLM — explicit `call_llm=` or `detect_llm(agent)` hit — also arms this judge. Opt out by passing an explicit steerer, e.g. `goldfive.wrap(agent, steerer=DefaultSteerer(goal_drift_call_llm=None))`, or by setting `Runner(goal_drift_enabled=False)` when building manually. When `goal_drift_enabled=True` but no callable is wired (operator-built `Runner` with a bare `DefaultSteerer()`), the Runner emits a one-shot WARNING and the check stays inert. | `critical` | `goldfive.drift.goals.classify_goal_drift` | WARNING → Level 2 (NUDGE); CRITICAL first → Level 2 (NUDGE), repeat → Level 3 (CANCEL_REINVOKE). goldfive#324 F4: the plan is usually still right — the agent's next-action reasoning is what's stuck — so a corrective message naming the next pending task and its agent beats a refine. |
 
 ### Goal category — we will not be able to finish
 
@@ -708,17 +708,19 @@ Drift handling routes through an explicit six-level ladder
 (goldfive#142) so "when does goldfive interrupt the tree" is a single
 table, not a tangle of conditionals. The live mapping from
 `(drift_kind, severity, occurrence_count)` to level is
-`DefaultSteerer._LADDER` plus the fallback in
-`DefaultSteerer._ladder_level_for`. See `goldfive/steerer.py` for
-the authoritative table.
+`DriftObserver._LADDER` plus the fallback in
+`DriftObserver._ladder_level_for` (the ladder moved from
+`DefaultSteerer` into the `steerer.drift` component in the steerer
+split, bucket 3c). See `goldfive/drift_observer.py` for the
+authoritative table.
 
 | Level | Name | Action | Typical triggers |
 |---|---|---|---|
 | **0** | `OBSERVE` | Emit `DriftDetected`; no further action. | Every `INFO` drift. |
-| **1** | `ABSORB` | Call `planner.refine`; install the revised plan; continue. | `WARNING` drifts with a known kind (`LOOPING_REASONING`, `LOOPING_TOOL_CALL`, `PLAN_DIVERGENCE`, `TOOL_ERROR`, `AGENT_REFUSAL`, `INTENT_DIVERGENCE`, etc.); CRITICAL first-occurrence of most kinds. |
-| **2** | `NUDGE` | Queue a short corrective user message on `session.pending_nudges` for the Runner's overlay loop to pick up at the next invocation boundary. | `LOOPING_REASONING` at CRITICAL (first occurrence) after goldfive#204 — gives the agent a soft corrective prompt before escalating. Also available for caller overrides. |
-| **3** | `CANCEL_REINVOKE` | Refine the plan; install the revision; **dispatch a `GOLDFIVE_STEER` ControlMessage on the bound channel**. The executor's invoke loop cancels the in-flight invocation and restarts the passthrough with a `[GOLDFIVE STEERING CONTROL …]` framed corrective body. | CRITICAL first-occurrence for most refinable kinds (`PLAN_DIVERGENCE`, `TOOL_ERROR`, `RUNAWAY_DELEGATION`, ...). (`LOOPING_REASONING` CRITICAL-first now routes to Level 2 via goldfive#204.) |
-| **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; **dispatch a `GOLDFIVE_PAUSE_ESCALATE` ControlMessage on the bound channel**; do NOT call `planner.refine`. The executor's pre-task loop blocks until a user `RESUME` / `STEER` / `CANCEL` arrives on the channel — unbounded unless `SteeringConfig.pause_escalate_deadline_s` is set, in which case the message carries a `deadline_s` payload and expiry aborts the run. | `GOAL_DRIFT` (first & repeat); `REFINE_VALIDATION_FAILED`; `HUMAN_INTERVENTION_REQUIRED`; `INTENT_DIVERGENCE` at CRITICAL; CRITICAL-repeat of almost every kind. |
+| **1** | `ABSORB` | Call `planner.refine`; install the revised plan; continue. | `WARNING` drifts with a known kind (`LOOPING_REASONING`, `LOOPING_TOOL_CALL`, `PLAN_DIVERGENCE`, `TOOL_ERROR`, `AGENT_REFUSAL`, `INTENT_DIVERGENCE`, etc. — but `GOAL_DRIFT` and `TASK_TIMEOUT` route WARNING to Level 2 instead); `JUSTIFIED_DEVIATION` at CRITICAL (first & repeat); CRITICAL first-occurrence of kinds with no explicit table row (severity fallback). |
+| **2** | `NUDGE` | Queue a short corrective user message on `session.pending_nudges` for the Runner's overlay loop to pick up at the next invocation boundary. The enqueue is gated on `is_active_steering()` (goldfive#475) — under `observation_only=True` the would-be nudge is logged and a `PolicyApplied` gate event is stamped instead. | `LOOPING_REASONING` at CRITICAL (first occurrence) after goldfive#204; `GOAL_DRIFT` at WARNING and CRITICAL-first (goldfive#324 F4); `TASK_TIMEOUT` at WARNING (goldfive#487). Also available for caller overrides. |
+| **3** | `CANCEL_REINVOKE` | Refine the plan; install the revision; **dispatch a `GOLDFIVE_STEER` ControlMessage on the bound channel**. The executor's invoke loop cancels the in-flight invocation and restarts the passthrough with a `[GOLDFIVE STEERING CONTROL …]` framed corrective body. | CRITICAL first-occurrence for most refinable kinds (`PLAN_DIVERGENCE`, `TOOL_ERROR`, `RUNAWAY_DELEGATION`, ...); `GOAL_DRIFT` at CRITICAL-repeat. (`LOOPING_REASONING` CRITICAL-first now routes to Level 2 via goldfive#204.) |
+| **4** | `PAUSE_ESCALATE` | Emit `HUMAN_INTERVENTION_REQUIRED`; **dispatch a `GOLDFIVE_PAUSE_ESCALATE` ControlMessage on the bound channel**; do NOT call `planner.refine`. The executor's pre-task loop blocks until a user `RESUME` / `STEER` / `CANCEL` arrives on the channel — unbounded unless `SteeringConfig.pause_escalate_deadline_s` is set, in which case the message carries a `deadline_s` payload and expiry aborts the run. | `REFINE_VALIDATION_FAILED`; `HUMAN_INTERVENTION_REQUIRED`; `INTENT_DIVERGENCE` at CRITICAL; `TASK_TIMEOUT` at CRITICAL (first & repeat); CRITICAL-repeat of almost every kind. |
 | **5** | `TERMINATE` | Pause-with-deadline. Same dispatch as Level 4 but the payload ALWAYS carries `deadline_s` (`SteeringConfig.pause_escalate_deadline_s`, or `DEFAULT_TERMINATE_PAUSE_DEADLINE_S` = 600 s when unset). On expiry the executor cancels every non-terminal task and emits `RunAborted` carrying the escalation lineage (drift kind + ladder level). | Repeat `HUMAN_INTERVENTION_REQUIRED`. |
 
 ### Dispatch routing — single junction (Phase 2 of #246)
@@ -777,8 +779,10 @@ table entry fall through to:
 - `WARNING` → `ABSORB`
 - `CRITICAL` first → `ABSORB`; repeat → `PAUSE_ESCALATE`
 
-Subclasses of `DefaultSteerer` override `_ladder_level_for` to tune
-the table without re-implementing `_handle_drift`.
+The tune point is `DriftObserver._ladder_level_for`
+(`goldfive/drift_observer.py`); a custom steerer replaces its
+`drift` component (or subclasses `DriftObserver`) to adjust the
+table without re-implementing `handle_drift`.
 
 See goldfive#179 (umbrella) for future detection work — additional
 detectors will register new rows on `_LADDER` rather than editing the

--- a/docs/design/RATIONALE.md
+++ b/docs/design/RATIONALE.md
@@ -160,7 +160,9 @@ universal and which should not be re-implemented per executor:
   moments.
 - Calling `goal_deriver.derive` (or accepting `list[Goal]` directly).
 - Calling `planner.generate` and swapping the result onto the session.
-- Registering the seven canonical reporting tools on the adapter.
+- Registering the canonical reporting tools on the adapter (the
+  seven-tool lifecycle subset by default; drift self-reporting tools
+  opt-in via `drift_self_reporting`).
 - Binding the steerer to sinks+planner.
 - Emitting `RunAborted` on any pre-executor failure.
 
@@ -280,7 +282,7 @@ adapter knows how to:
 
 - Render the current `Task` + `Session` into whatever input channel
   the framework expects.
-- Register the seven canonical reporting tools in the framework's
+- Register the canonical reporting tools in the framework's
   tool-registration format.
 - Intercept tool calls and route them through the Steerer.
 - Return an `InvocationResult` with the stop reason and final text.

--- a/docs/design/TASK-LIFECYCLE.md
+++ b/docs/design/TASK-LIFECYCLE.md
@@ -59,21 +59,24 @@ and dispatches to one of three paths:
 
 ### 1.3 Invariants the steerer enforces on any refined plan
 
-`DefaultSteerer._apply_revision` (`steerer.py:512–531`):
+`PlanReviser._apply_revision` (`goldfive/plan_reviser.py`; the
+steerer's `plans` component):
 
 - `revision_index` monotonically increases: `new_index ≥
   old_index + 1`.
 - `revision_kind` / `revision_severity` / `revision_reason` are
   stamped from the triggering drift if the planner didn't set them.
-- `session.plan` is replaced as a single atomic assignment — readers
-  in the adapter / executor see either the old plan or the new plan,
-  never a half-merged state.
+- `session.plan` is replaced atomically under the per-session plan
+  lock in `_emit_plan_revised` (goldfive#403) — readers in the
+  adapter / executor see either the old plan or the new plan, never
+  a half-merged state.
 
-**Soundness gap (open):** `Plan` has no structural validation at
-creation or revision — duplicate task IDs, edges referencing missing
-tasks, or cycles are silently accepted. `topological_stages()`
-tolerates cycles by appending un-placeable tasks to a final stage.
-See §7.
+**Structural validation (closed by #100/#105, see §7.2):**
+`Plan.validate(for_revision=..., prior=...)` runs at creation and on
+every revision — duplicate task IDs, dangling edges, and cycles are
+rejected with `ValueError` before install. `topological_stages()`
+still tolerates cycles defensively by appending un-placeable tasks
+to a final stage.
 
 ---
 

--- a/docs/design/VOCABULARY.md
+++ b/docs/design/VOCABULARY.md
@@ -430,8 +430,12 @@ enum values and [DRIFT.md](DRIFT.md) for per-kind semantics.
 
 Every event on every sink is a proto `Event` envelope (see
 [EVENT-MODEL.md](EVENT-MODEL.md) for the envelope spec). The payload
-is a `oneof` with thirteen variants. This section lists all thirteen
-and who emits each. Factories for every kind live in `goldfive/events.py`.
+is a `oneof`; `proto/goldfive/v1/events.proto` is the authoritative
+variant list (well past thirty by now — observability payloads such
+as `SteeringDecisionMade`, `PolicyApplied`, and `JudgementEmitted`
+joined the original set). This section lists the core thirteen
+run/task/drift variants and who emits each. Factories for every kind
+live in `goldfive/events.py`.
 
 | Payload `oneof` variant | Factory | Emitter | When |
 |---|---|---|---|

--- a/docs/guides/common-failure-modes.md
+++ b/docs/guides/common-failure-modes.md
@@ -11,6 +11,18 @@ catch-all, reach for
 For the taxonomy of every drift kind, severity rules, and the refine
 policy, see [../design/DRIFT.md](../design/DRIFT.md).
 
+> **Mode caveat.** The shipped default is
+> `SteeringConfig(observation_only=True)` (goldfive#254): detection
+> runs in full and every drift below still fires, but goldfive-authored
+> interventions (plan installs from refine, `GOLDFIVE_STEER` cancels,
+> nudge injection, `GOLDFIVE_PAUSE_ESCALATE` pauses) are suppressed —
+> `PlanRevised` events carry
+> `dry_run=true` and no plan mutates. Recovery narratives below that
+> lean on refine / the intervention ladder apply as described only
+> under active steering (`observation_only=False`); in the default
+> mode they tell you what goldfive *would have done*, and recovery is
+> the operator's move (steer, cancel, fix the prompt).
+
 ## 1. Tool-call loop — agent stuck calling the same tool
 
 The canonical filler loop post-#181: the agent keeps calling the same
@@ -35,9 +47,10 @@ are excluded — they're progress signals, not work.
   `detail` starting `tool_loop_exact:`, `tool_loop_name:`, or
   `tool_loop_alternating:`.
 - `raw.mode` on the drift identifies which mode fired.
-- Downstream: the steerer escalates through the intervention ladder
-  (Level 1 ABSORB → refine; escalates to Level 3 CANCEL_REINVOKE on
-  repeat).
+- Downstream: the steerer routes through the intervention ladder
+  (WARNING → Level 1 ABSORB / refine; CRITICAL first → Level 2 NUDGE,
+  repeat → Level 4 PAUSE_ESCALATE) — interventions suppressed under
+  the default observation-only mode.
 
 **Configuration.** Defaults tuned for a 10-call window. Override via
 env vars:
@@ -60,8 +73,10 @@ See `goldfive/drift/tool_loops.py` for the full contract.
    or clear the buffer with `ToolLoopTracker.on_task_progress(...)`
    on your own progress signal.
 3. If it's genuine drift, let the intervention ladder handle it —
-   `planner.refine` typically produces a revised task that escapes
-   the loop.
+   under active steering (`observation_only=False`), `planner.refine`
+   typically produces a revised task that escapes the loop. Under the
+   default observation-only mode the refine is dry-run
+   (`PlanRevised{dry_run=true}`); steer or cancel manually.
 
 ## 2. Plan divergence — agent ran an unplanned agent
 
@@ -95,8 +110,9 @@ are stripped before classification runs.
 
 **Recovery path.**
 
-- `PLAN_DIVERGENCE` → the refine path typically narrows the tool /
-  agent scope or adjusts assignee hints.
+- `PLAN_DIVERGENCE` → under active steering the refine path typically
+  narrows the tool / agent scope or adjusts assignee hints; in the
+  default observation-only mode the drift is signal for the operator.
 - `CONFABULATION_RISK` → usually the prompt is wrong. Either (a)
   narrow the coordinator's instruction to only describe tools it
   actually has, or (b) add the missing tool / agent to the tree.
@@ -160,9 +176,11 @@ LLM keeps re-routing. Goldfive cannot require prompt cooperation
 2. **Reasoning-content drift detectors.** `LOOPING_REASONING` (hash-
    or embedding-based) and `INTENT_DIVERGENCE` fire when the
    coordinator's chain-of-thought shows the pattern.
-3. **Refine-driven recovery.** A WARNING-or-higher drift flows
-   through the ladder into `planner.refine`, which can narrow the
-   assignee hint or split into sub-tasks before the next turn.
+3. **Refine-driven recovery** (active steering only). A
+   WARNING-or-higher drift flows through the ladder into
+   `planner.refine`, which can narrow the assignee hint or split into
+   sub-tasks before the next turn. Under the default observation-only
+   mode the refine is dry-run and the plan does not change.
 4. **AgentTool cap.** The last-resort safety net.
 
 **Recovery path.**
@@ -175,35 +193,45 @@ LLM keeps re-routing. Goldfive cannot require prompt cooperation
 - Raise `agent_tool_cap` only if legitimate delegation exceeds 16
   per turn.
 
-## 5. Goal drift (opt-in)
+## 5. Goal drift
 
 Periodic trajectory-level check: every N agent turns, an LLM-judge
 looks at the recent activity window and decides whether the tree is
 advancing `session.goals` (goldfive#143). Emits `GOAL_DRIFT` /
 CRITICAL when the judge concludes progress has stalled.
 
-**Feature gate.** Opt-in via `DefaultSteerer(goal_drift_enabled=True,
-goal_drift_call_llm=...)`. Operators who don't configure it never
-trigger it and pay no LLM cost.
+**Feature gate.** On the `goldfive.wrap(...)` path the judge is wired
+automatically from the resolved planner `call_llm` (goldfive#217);
+opt out with an explicit steerer
+(`DefaultSteerer(goal_drift_call_llm=None)`) or
+`Runner(goal_drift_enabled=False)`. Operators hand-building a Runner
+with a bare `DefaultSteerer()` never trigger it and pay no LLM cost.
 
 **Signature.**
 
 - `DriftDetected{kind=goal_drift, severity=critical}`.
-- Routes to Level 4 PAUSE_ESCALATE → `HUMAN_INTERVENTION_REQUIRED`.
+- Routes to Level 2 NUDGE on first fire (goldfive#324: the plan is
+  usually still right — the agent's next-action reasoning is stuck,
+  so the corrective names the next pending task and its agent);
+  CRITICAL-repeat escalates to Level 3 CANCEL_REINVOKE. Both are
+  suppressed under the default observation-only mode.
 
 ## 6. Human intervention required
 
-The steerer escalated a drift to Level 4. Paused the run by
-dispatching a `GOLDFIVE_PAUSE_ESCALATE` ControlMessage on the bound
-channel (Phase 2 of #246 replaced the deleted
-`session.paused_for_human_intervention` flag); the executor's
+The steerer escalated a drift to Level 4. Under active steering it
+pauses the run by dispatching a `GOLDFIVE_PAUSE_ESCALATE`
+ControlMessage on the bound channel (Phase 2 of #246 replaced the
+deleted `session.paused_for_human_intervention` flag); the executor's
 pre-task loop blocks waiting for a `CONTROL_RESUME` /
-`CONTROL_STEER` / `CONTROL_CANCEL`. Emitted for:
+`CONTROL_STEER` / `CONTROL_CANCEL`. Under the default
+observation-only mode the drift is emitted but the pause dispatch is
+suppressed and the run keeps going. Emitted for:
 
 - Persistent refine failures.
-- `GOAL_DRIFT` (CRITICAL).
 - `REFINE_VALIDATION_FAILED`.
 - `RUNAWAY_DELEGATION` on repeat.
+- `INTENT_DIVERGENCE` at CRITICAL.
+- `TASK_TIMEOUT` at CRITICAL (flag-gated stall watchdog, goldfive#487).
 
 **Signature.**
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -462,8 +462,10 @@ Tasks whose dependencies are satisfied run concurrently via
   control channel.
 - [troubleshooting.md](troubleshooting.md) — common install / run-time
   failures.
-- [tool-protocol.md](../reference/tool-protocol.md) — the seven
-  reporting tools that drive task state.
+- [tool-protocol.md](../reference/tool-protocol.md) — the reporting
+  tools that drive task state (seven lifecycle tools registered by
+  default; three drift self-reporting tools opt-in via
+  `drift_self_reporting`).
 - [ARCHITECTURE.md](../design/ARCHITECTURE.md) — the full design
   reference.
 

--- a/docs/guides/goals-and-plans.md
+++ b/docs/guides/goals-and-plans.md
@@ -355,11 +355,16 @@ See [DRIFT.md](../design/DRIFT.md) for the full kind list.
 
 ## Success predicates
 
-A `Goal` can carry an optional `success_predicate: Callable[[Session], bool]`
-that the caller or a future `Runner` can consult to decide "are we
-done yet?". In v0.1, the predicate is not auto-consulted — the
-`Runner` just carries it. Sinks and custom executors can call it; the
-contract is that the predicate is pure and cheap.
+A `Goal` can carry an optional `success_predicate: Callable[[Session], bool]`.
+Both bundled executors consult it at end-of-run: once every task is
+terminal (and no orphans remain), `evaluate_goal_predicates`
+(`goldfive/results.py`, PLAN-LIFECYCLE.md §6.1 third clause) evaluates
+every goal's predicate in order. The first predicate that returns
+`False` — or raises; a crashing predicate is never a pass — fails the
+run with `success=False` and a descriptive `reason` on the
+`ExecutionOutcome` (and a matching `RunAborted`). `None` predicates
+are vacuously met. The contract is that the predicate is pure and
+cheap.
 
 A typical use:
 
@@ -374,9 +379,11 @@ goal = Goal(
 )
 ```
 
-A future version is likely to consult the predicate between tasks and
-fire `GOAL_UNREACHABLE` drift if the plan hasn't made progress toward
-it after N tasks. For now, the mechanism is opt-in.
+There is no mid-run consultation: the predicate is only evaluated at
+the end-of-run gate. A future version may consult it between tasks
+and fire `GOAL_UNREACHABLE` drift if the plan hasn't made progress
+toward it after N tasks (the enum value exists; nothing emits it
+today).
 
 ## Tuning the LLM planner prompts
 

--- a/docs/guides/runner-and-session.md
+++ b/docs/guides/runner-and-session.md
@@ -28,7 +28,7 @@ The Runner itself is small — it sequences the six primitives and owns a Sessio
 
 ### Constructing one
 
-For a custom tree you usually don't hand-wire this — use `goldfive.wrap(tree)` for ADK or `goldfive.quickstart(call_llm=..., goal="...")` for a plain callable. But the hand-wired form makes the composition explicit:
+For a custom tree you usually don't hand-wire this — use `goldfive.wrap(tree)` for ADK or `goldfive.quickstart(agent, goals)` for a plain callable (or pre-built adapter) plus goal summaries. But the hand-wired form makes the composition explicit:
 
 ```python
 from goldfive import Runner

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1165,7 +1165,7 @@ class ReportingToolSpec:
     ]
 
 
-# The seven canonical tool names (stable contract).
+# The ten canonical tool names (stable contract).
 REPORTING_TOOL_NAMES: tuple[str, ...] = (
     "report_task_started",
     "report_task_progress",
@@ -1174,13 +1174,22 @@ REPORTING_TOOL_NAMES: tuple[str, ...] = (
     "report_task_blocked",
     "report_new_work_discovered",
     "report_plan_divergence",
+    "report_awaiting_approval",
+    "declare_task_skipped",
+    "declare_task_not_needed",
 )
 
 
-# Pre-built list of the seven canonical specs. ``Runner`` registers
-# these with the adapter automatically; custom adapters can consume
-# the list directly.
+# Pre-built list of the ten canonical specs. ``Runner`` registers the
+# seven-tool lifecycle subset (LIFECYCLE_REPORTING_TOOLS) with the
+# adapter automatically; the three drift self-reporting tools
+# (report_plan_divergence, declare_task_skipped,
+# declare_task_not_needed) are opt-in via
+# ``Runner(drift_self_reporting=...)``. Custom adapters can consume
+# the lists directly.
 BUILTIN_REPORTING_TOOLS: list[ReportingToolSpec]
+LIFECYCLE_REPORTING_TOOLS: list[ReportingToolSpec]
+DRIFT_SELF_REPORTING_TOOLS: list[ReportingToolSpec]
 ```
 
 See [tool-protocol.md](tool-protocol.md) for full semantics.

--- a/docs/reference/tool-protocol.md
+++ b/docs/reference/tool-protocol.md
@@ -24,6 +24,8 @@ REPORTING_TOOL_NAMES: tuple[str, ...] = (
     "report_new_work_discovered",
     "report_plan_divergence",
     "report_awaiting_approval",
+    "declare_task_skipped",
+    "declare_task_not_needed",
 )
 ```
 
@@ -101,13 +103,17 @@ The current `task_id` is made available to the agent by the adapter —
 either in a shared session-state dict (ADK), a system prompt (Claude
 SDK), or as a direct argument (CallableAdapter).
 
-## The eight tools
+## The eight `report_*` tools
 
 Names are stable contract — do not rename. Mirrors harmonograf's
 canonical reporting tools; goldfive owns the list from v0.1 forward.
 `report_awaiting_approval` is documented at the end of this file —
 it's the task-level half of the human-in-the-loop approval flow
-(see [APPROVAL.md](../design/APPROVAL.md)).
+(see [APPROVAL.md](../design/APPROVAL.md)). The two `declare_task_*`
+tools (goldfive#271 Phase 3) complete the ten-name canonical set;
+they are observability-only — no state transition — and, like
+`report_plan_divergence`, register only when `drift_self_reporting`
+opts in (see the note above).
 
 ### 1. `report_task_started`
 
@@ -494,13 +500,13 @@ prefer them.
 
 ## Customizing the tool list
 
-The seven tools above are the minimum contract. Custom adapters can
-extend the list by appending to `tools` before calling
+The canonical tools above are the minimum contract. Custom adapters
+can extend the list by appending to `tools` before calling
 `adapter.register_reporting_tools(tools)`. The steerer ignores names
 it doesn't recognize, so custom tools pass through to the framework's
 normal tool-call path. A typical extension: domain-specific reporting
 tools like `report_budget_remaining` or `report_confidence`.
 
-Renaming or removing the seven canonical tools is not supported.
+Renaming or removing the canonical tools is not supported.
 Downstream consumers (harmonograf, planners, sinks) pattern-match on
 the canonical names.


### PR DESCRIPTION
## Problem

Several design docs and guides make claims the code contradicts (verified against current main, post Waves 1-3 / PRs #475-#488):

- **DRIFT.md** ladder table: `GOAL_DRIFT` listed as "Level 4 both on first and repeat" — the live `DriftObserver._LADDER` row has been `(None, NUDGE, (NUDGE, CANCEL_REINVOKE))` since #324 F4. The table also predated the `TASK_TIMEOUT` row (#487) and the #475 nudge gate, and still pointed at `DefaultSteerer._LADDER` / `goldfive/steerer.py` — the ladder moved to `goldfive/drift_observer.py` in the steerer split (bucket 3c).
- **CONTROL.md:557** claimed NUDGE is "not on the default table today; reserved for future policies" — false: `LOOPING_REASONING` CRITICAL-first (#204), `GOAL_DRIFT` WARNING/CRITICAL-first (#324), `TASK_TIMEOUT` WARNING (#487).
- **CONTROL-CHANNEL.md §5.5** said observation_only gates *three* injection points — #475 added the Level-2 nudge enqueue as a fourth (matches the `SteeringConfig` contract docstring).
- **VOCABULARY.md §6** said the Event payload `oneof` has "thirteen variants" — `events.proto` has 35 (fields 10-44).
- **goals-and-plans.md:358-362** said `success_predicate` "is not auto-consulted — the Runner just carries it"; **ARCHITECTURE.md:61** implied mid-run "are we done yet?" consultation. Reality: both executors call `evaluate_goal_predicates` at end-of-run (`goldfive/results.py`, PLAN-LIFECYCLE §6.1 third clause); there is no mid-run consultation and nothing emits `GOAL_UNREACHABLE`.
- **README.md:278** "eight reporting tools" vs **getting-started.md:465** "seven" — `goldfive/reporting/handlers.py` has ten canonical names; the Runner registers the 7-tool lifecycle subset by default, 3 drift tools opt-in via `drift_self_reporting` (#196). tool-protocol.md's `REPORTING_TOOL_NAMES` snippet and api.md's were also missing the two `declare_task_*` names.
- **common-failure-modes.md** recovery narratives assumed active steering ("planner.refine typically produces a revised task that escapes the loop") — under the shipped `observation_only=True` default no plan mutates; §5 also carried the pre-#324 GOAL_DRIFT routing and pre-#217 "opt-in" gate description.
- **TASK-LIFECYCLE.md §1.3** still recorded "Plan has no structural validation (open)" while §7.2 records it closed by #100/#105; it also pointed at `DefaultSteerer._apply_revision (steerer.py:512-531)` — the method lives on `PlanReviser` and installs under the plan lock (#403).
- **runner-and-session.md:31** showed `goldfive.quickstart(call_llm=..., goal="...")` — the real signature is `quickstart(agent, goals, *, planner=None, sinks=None)`.
- **APPROVAL.md** Level-4 trigger list included `GOAL_DRIFT` and claimed `INTENT_DIVERGENCE` escalates "at WARNING on repeat" (live row: WARNING → ABSORB always; CRITICAL → PAUSE_ESCALATE first & repeat).

## Fix

Surgical accuracy edits to 15 docs — every changed claim was verified against the live code (grep/read, not line numbers). Where the doc's style allowed, hardcoded counts were replaced with pointers to the authoritative source (`events.proto`, `DriftObserver._LADDER`). Verified-clean items left untouched: STATE-MACHINE.md stall section (already fixed by #487), TASK-LIFECYCLE §7.1 duplicate-sites list (already updated by #485), no doc references to the deleted `_OBSERVATION_ONLY_DEFAULT` / `_resolve_observation_only_default` remain.

## Tests

Docs-only change. Full suite green: `uv run pytest -q -x` — 2926 passed, 59 skipped (~33s). `uv run ruff check .` clean. No doc-lint exists in the repo.

## Notes

- No code changes; observation_only semantics untouched.
- LOOPING_TOOL_CALL / PLAN_DIVERGENCE doc mentions left as-is except where they appeared inside the reconciled ladder-table cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA