### PR TITLE
fix(events): drift_detected_event now stamps kind/severity on the wire (was UNSPECIFIED)

### DIFF
--- a/goldfive/events.py
+++ b/goldfive/events.py
@@ -49,6 +49,82 @@ def _events_pb_module() -> Any:
     return events_pb2
 
 
+def _types_pb_module() -> Any:
+    """Return the ``types_pb2`` stub module (lazy, like ``_events_pb_module``).
+
+    ``DriftKind`` / ``DriftSeverity`` and the shared dataclass protos live
+    here — NOT in ``events_pb2``. Resolving a drift enum through
+    ``_events_pb_module()`` raises ``AttributeError`` (the enum is absent);
+    the drift-enum bridge below deliberately reads from *this* module.
+    """
+    try:
+        from goldfive.pb.goldfive.v1 import types_pb2
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise ModuleNotFoundError(
+            "goldfive protobuf stubs not available; generate them via "
+            "`make proto` (requires the `proto` optional-dependency group) "
+            "or install the package with the `proto` extra. See issue #3."
+        ) from exc
+    return types_pb2
+
+
+def _proto_enum_member(value: Any, prefix: str) -> str:
+    """Normalize a drift kind/severity to its unprefixed UPPER proto member.
+
+    Accepts a :class:`~enum.Enum` (``.name`` is authoritative — for a
+    ``StrEnum`` it is the UPPER member like ``OFF_TOPIC`` regardless of the
+    lowercase ``.value``), a bare value/name string (``"off_topic"`` ->
+    ``"OFF_TOPIC"``), or an already-prefixed ``{prefix}_...`` string (which
+    is stripped so ``f"{prefix}_{member}"`` does not double up).
+    """
+    name = getattr(value, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    s = str(value or "").strip().upper()
+    if s.startswith(prefix + "_"):
+        s = s[len(prefix) + 1 :]
+    return s
+
+
+def _drift_kind_pb_value(kind: Any, *, unknown_member: str = "UNSPECIFIED") -> int:
+    """Resolve a ``DriftKind`` to its ``types_pb2`` enum int by member name.
+
+    The proto ``DriftKind`` enum lives in ``types_pb2`` with prefixed value
+    names (``DRIFT_KIND_OFF_TOPIC``); this bridges from a
+    :class:`goldfive.types.DriftKind` (or a name/value string) via
+    :func:`_proto_enum_member`. On an unknown/synthetic name, log.debug and
+    fall back to ``DRIFT_KIND_{unknown_member}`` (``UNSPECIFIED`` = 0 by
+    default; the steerer passes ``"CUSTOM"``) without raising, so a future
+    regression is visible in logs rather than masked.
+
+    Shared bridge: :meth:`goldfive.steerer.DefaultSteerer._drift_kind_pb_value`
+    delegates here. Keep the two in lockstep.
+    """
+    types_pb = _types_pb_module()
+    member = _proto_enum_member(kind, "DRIFT_KIND")
+    resolved = getattr(types_pb, f"DRIFT_KIND_{member}", None)
+    if resolved is not None:
+        return int(resolved)
+    log.debug("drift kind %r (proto member DRIFT_KIND_%s) is unknown", kind, member)
+    return int(getattr(types_pb, f"DRIFT_KIND_{unknown_member}", 0))
+
+
+def _drift_severity_pb_value(severity: Any, *, unknown_member: str = "UNSPECIFIED") -> int:
+    """Resolve a ``DriftSeverity`` to its ``types_pb2`` enum int by member name.
+
+    Mirror of :func:`_drift_kind_pb_value` for the ``DriftSeverity`` enum
+    (also in ``types_pb2``, value names prefixed ``DRIFT_SEVERITY_``).
+    Shared bridge for :meth:`goldfive.steerer.DefaultSteerer._drift_severity_pb_value`.
+    """
+    types_pb = _types_pb_module()
+    member = _proto_enum_member(severity, "DRIFT_SEVERITY")
+    resolved = getattr(types_pb, f"DRIFT_SEVERITY_{member}", None)
+    if resolved is not None:
+        return int(resolved)
+    log.debug("drift severity %r (proto member DRIFT_SEVERITY_%s) is unknown", severity, member)
+    return int(getattr(types_pb, f"DRIFT_SEVERITY_{unknown_member}", 0))
+
+
 def new_event(
     run_id: str,
     sequence: int,
@@ -295,22 +371,23 @@ def plan_revised_event(
         severity = severity or str(getattr(drift, "severity", ""))
         reason = reason or getattr(drift, "detail", "")
 
+    # DriftKind/DriftSeverity live in types_pb2, resolved via the shared
+    # by-name bridge (same one DefaultSteerer uses). A prior version read
+    # ``_events_pb_module().DriftKind`` — absent there — and the broad
+    # ``except AttributeError`` silently left both UNSPECIFIED on the wire
+    # (same telemetry bug fixed in ``drift_detected_event``). The try/except
+    # is now a defensive backstop only; unknown names degrade to UNSPECIFIED
+    # inside the bridge (log.debug) without raising.
     if drift_kind:
-        pb = _events_pb_module()
         try:
-            normalized = drift_kind.upper() if not drift_kind.startswith("DRIFT_") else drift_kind
-            evt.plan_revised.drift_kind = pb.DriftKind.Value(normalized)
-        except (ValueError, AttributeError):
-            pass
+            evt.plan_revised.drift_kind = _drift_kind_pb_value(drift_kind)
+        except Exception:  # noqa: BLE001 - observability must never raise
+            log.debug("plan_revised_event: unresolved drift_kind %r", drift_kind, exc_info=True)
     if severity:
-        pb = _events_pb_module()
         try:
-            normalized = (
-                severity.upper() if not severity.startswith("DRIFT_SEVERITY_") else severity
-            )
-            evt.plan_revised.severity = pb.DriftSeverity.Value(normalized)
-        except (ValueError, AttributeError):
-            pass
+            evt.plan_revised.severity = _drift_severity_pb_value(severity)
+        except Exception:  # noqa: BLE001 - observability must never raise
+            log.debug("plan_revised_event: could not resolve severity %r", severity, exc_info=True)
     evt.plan_revised.reason = reason
     evt.plan_revised.revision_index = int(
         revision_index if revision_index is not None else getattr(plan, "revision_index", 0)
@@ -1202,24 +1279,29 @@ def drift_detected_event(
     session_id: str = "",
     event_id: str = "",
 ) -> Any:
-    pb = _events_pb_module()
     evt = new_event(run_id, sequence, session_id=session_id, event_id=event_id)
-    kind_name = str(getattr(drift, "kind", ""))
-    sev_name = str(getattr(drift, "severity", ""))
-    if kind_name:
+    kind = getattr(drift, "kind", None)
+    severity = getattr(drift, "severity", None)
+    # Stamp the two proto enums via the shared by-name bridge. DriftKind /
+    # DriftSeverity live in types_pb2 (NOT events_pb2); a prior version
+    # resolved them through ``_events_pb_module().DriftKind`` which raised
+    # ``AttributeError`` and, swallowed by a broad ``except``, silently left
+    # BOTH enums UNSPECIFIED (0) on every event this factory produced. The
+    # bridge passes the enum straight through so ``.name`` (the UPPER member,
+    # e.g. OFF_TOPIC) resolves regardless of the StrEnum's lowercase value.
+    # The try/except is a defensive backstop only — a genuinely-unknown kind
+    # degrades to UNSPECIFIED inside the bridge (log.debug) without raising,
+    # so the normal path is never masked.
+    if kind:
         try:
-            evt.drift_detected.kind = pb.DriftKind.Value(
-                kind_name.upper() if not kind_name.startswith("DRIFT_") else kind_name
-            )
-        except (ValueError, AttributeError):
-            pass
-    if sev_name:
+            evt.drift_detected.kind = _drift_kind_pb_value(kind)
+        except Exception:  # noqa: BLE001 - observability must never raise
+            log.debug("drift_detected_event: could not resolve kind %r", kind, exc_info=True)
+    if severity:
         try:
-            evt.drift_detected.severity = pb.DriftSeverity.Value(
-                sev_name.upper() if not sev_name.startswith("DRIFT_SEVERITY_") else sev_name
-            )
-        except (ValueError, AttributeError):
-            pass
+            evt.drift_detected.severity = _drift_severity_pb_value(severity)
+        except Exception:  # noqa: BLE001 - observability must never raise
+            log.debug("drift_detected_event: unresolved severity %r", severity, exc_info=True)
     evt.drift_detected.detail = getattr(drift, "detail", "")
     evt.drift_detected.current_task_id = getattr(drift, "current_task_id", "")
     evt.drift_detected.current_agent_id = getattr(drift, "current_agent_id", "")

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -1416,15 +1416,20 @@ class DefaultSteerer:
 
     @staticmethod
     def _drift_kind_pb_value(kind: DriftKind) -> int:
-        from goldfive.pb.goldfive.v1 import types_pb2
+        # Delegate to the shared by-name bridge in goldfive.events so the
+        # steerer's primary DriftObserver emit path and the events.py
+        # factories (drift_detected_event / plan_revised_event) resolve the
+        # proto enum through ONE implementation and can never re-diverge.
+        # Unknown kinds fall back to DRIFT_KIND_CUSTOM here (historical
+        # steerer behavior); the factories fall back to UNSPECIFIED. Lazy
+        # import — events.py never imports steerer at module load.
+        from goldfive.events import _drift_kind_pb_value as _bridge
 
-        name = f"DRIFT_KIND_{kind.name}"
-        return getattr(types_pb2, name, getattr(types_pb2, "DRIFT_KIND_CUSTOM", 0))
+        return _bridge(kind, unknown_member="CUSTOM")
 
     @staticmethod
     def _drift_severity_pb_value(severity: DriftSeverity) -> int:
-        from goldfive.pb.goldfive.v1 import types_pb2
+        from goldfive.events import _drift_severity_pb_value as _bridge
 
-        name = f"DRIFT_SEVERITY_{severity.name}"
-        return getattr(types_pb2, name, getattr(types_pb2, "DRIFT_SEVERITY_UNSPECIFIED", 0))
+        return _bridge(severity)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -22,7 +22,9 @@ pytestmark = pytest.mark.skipif(
 from goldfive.control import ControlKind, ControlMessage  # noqa: E402
 from goldfive.events import (  # noqa: E402
     build_plan_revision_diff,
+    control_received_event,
     delegation_observed_event,
+    drift_detected_event,
     invocation_cancelled_event,
     plan_revised_event,
 )
@@ -360,6 +362,171 @@ def test_plan_revised_event_proto_round_trips_trigger_event_id() -> None:
     decoded.ParseFromString(encoded)
     assert decoded.plan_revised.trigger_event_id == "ann_roundtrip"
     assert decoded.plan_revised.plan.revision_trigger_event_id == "ann_roundtrip"
+
+
+# ---------------------------------------------------------------------------
+# drift_detected_event / plan_revised_event — kind & severity stamping.
+#
+# Regression for the telemetry bug where both factories resolved DriftKind /
+# DriftSeverity through ``_events_pb_module().DriftKind`` (absent — the enums
+# live in types_pb2), which AttributeError'd and, swallowed by a broad
+# ``except``, left both enums UNSPECIFIED (0) on every event they produced.
+# ---------------------------------------------------------------------------
+
+
+def _types_pb() -> object:
+    from goldfive.pb.goldfive.v1 import types_pb2
+
+    return types_pb2
+
+
+def test_drift_detected_event_stamps_kind_and_severity() -> None:
+    types_pb2 = _types_pb()
+    drift = DriftEvent(kind=DriftKind.OFF_TOPIC, severity=DriftSeverity.WARNING, detail="x")
+    evt = drift_detected_event("r", 1, drift)
+    # The proto values are prefixed + nonzero; the StrEnum value ("off_topic")
+    # differs in case from the .name ("OFF_TOPIC") the bridge resolves by.
+    assert evt.drift_detected.kind == types_pb2.DRIFT_KIND_OFF_TOPIC
+    assert evt.drift_detected.severity == types_pb2.DRIFT_SEVERITY_WARNING
+    assert evt.drift_detected.kind != 0
+    assert evt.drift_detected.severity != 0
+    # Sibling string fields still stamped correctly (never regressed).
+    assert evt.drift_detected.detail == "x"
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        DriftKind.OFF_TOPIC,
+        DriftKind.TOOL_ERROR,
+        DriftKind.USER_STEER,
+        DriftKind.RUNAWAY_DELEGATION,
+        DriftKind.CAPABILITY_MISMATCH,
+    ],
+)
+@pytest.mark.parametrize(
+    "severity",
+    [DriftSeverity.INFO, DriftSeverity.WARNING, DriftSeverity.CRITICAL],
+)
+def test_drift_detected_event_kind_severity_table(kind: DriftKind, severity: DriftSeverity) -> None:
+    types_pb2 = _types_pb()
+    # Every DriftKind's StrEnum .value is the lowercase of its .name, so
+    # str(kind) != kind.name in case; the bridge resolves by .name.
+    assert str(kind) != kind.name
+    expected_kind = getattr(types_pb2, f"DRIFT_KIND_{kind.name}")
+    expected_sev = getattr(types_pb2, f"DRIFT_SEVERITY_{severity.name}")
+    assert expected_kind != 0
+    assert expected_sev != 0
+    drift = DriftEvent(kind=kind, severity=severity, detail="d")
+    evt = drift_detected_event("r", 2, drift)
+    assert evt.drift_detected.kind == expected_kind
+    assert evt.drift_detected.severity == expected_sev
+
+
+def test_drift_detected_event_accepts_bare_string_kind() -> None:
+    """The bridge also resolves a lowercase value string (plan_revised path)."""
+    types_pb2 = _types_pb()
+
+    class _DuckDrift:
+        kind = "off_topic"  # StrEnum .value form, not the enum
+        severity = "warning"
+        detail = "d"
+
+    evt = drift_detected_event("r", 3, _DuckDrift())
+    assert evt.drift_detected.kind == types_pb2.DRIFT_KIND_OFF_TOPIC
+    assert evt.drift_detected.severity == types_pb2.DRIFT_SEVERITY_WARNING
+
+
+def test_control_received_event_stamps_kind_and_severity() -> None:
+    """The control-drift wrapper (fires on every operator steer/cancel) stamps kind."""
+    types_pb2 = _types_pb()
+    evt = control_received_event("r", 4, ControlKind.STEER, "ctl-1")
+    assert evt.drift_detected.kind == types_pb2.DRIFT_KIND_USER_STEER
+    assert evt.drift_detected.kind != 0
+    assert evt.drift_detected.severity == types_pb2.DRIFT_SEVERITY_WARNING
+    # CANCEL maps to USER_CANCEL — also nonzero.
+    cancel = control_received_event("r", 5, ControlKind.CANCEL, "ctl-2")
+    assert cancel.drift_detected.kind == types_pb2.DRIFT_KIND_USER_CANCEL
+    assert cancel.drift_detected.kind != 0
+
+
+def test_drift_detected_event_unknown_kind_degrades_to_unspecified() -> None:
+    """A synthetic/unknown kind name degrades to UNSPECIFIED without raising."""
+    types_pb2 = _types_pb()
+
+    class _DuckDrift:
+        kind = "TOTALLY_BOGUS_KIND"
+        severity = "ALSO_BOGUS"
+        detail = "d"
+
+    # Must not raise.
+    evt = drift_detected_event("r", 6, _DuckDrift())
+    assert evt.drift_detected.kind == types_pb2.DRIFT_KIND_UNSPECIFIED == 0
+    assert evt.drift_detected.severity == types_pb2.DRIFT_SEVERITY_UNSPECIFIED == 0
+    # detail is unaffected by the enum miss.
+    assert evt.drift_detected.detail == "d"
+
+
+def test_drift_detected_event_round_trips_kind_severity() -> None:
+    """kind/severity survive SerializeToString + FromString."""
+    from goldfive.pb.goldfive.v1 import events_pb2
+
+    types_pb2 = _types_pb()
+    drift = DriftEvent(
+        kind=DriftKind.CAPABILITY_MISMATCH, severity=DriftSeverity.CRITICAL, detail="d"
+    )
+    evt = drift_detected_event("r", 7, drift)
+    decoded = events_pb2.Event()
+    decoded.ParseFromString(evt.SerializeToString())
+    assert decoded.drift_detected.kind == types_pb2.DRIFT_KIND_CAPABILITY_MISMATCH != 0
+    assert decoded.drift_detected.severity == types_pb2.DRIFT_SEVERITY_CRITICAL != 0
+
+
+def test_plan_revised_event_stamps_drift_kind_and_severity() -> None:
+    """Sibling regression: plan_revised_event also stamps the two enums."""
+    types_pb2 = _types_pb()
+    plan = _revised_plan(trigger_event_id="ann_x")
+    evt = plan_revised_event(
+        run_id="r1",
+        sequence=8,
+        plan=plan,
+        drift_kind=plan.revision_kind,  # "user_steer" (StrEnum value)
+        severity=plan.revision_severity,  # "warning"
+        reason=plan.revision_reason,
+    )
+    assert evt.plan_revised.drift_kind == types_pb2.DRIFT_KIND_USER_STEER != 0
+    assert evt.plan_revised.severity == types_pb2.DRIFT_SEVERITY_WARNING != 0
+
+
+def test_plan_revised_event_round_trips_drift_kind_and_severity() -> None:
+    from goldfive.pb.goldfive.v1 import events_pb2
+
+    types_pb2 = _types_pb()
+    plan = _revised_plan(trigger_event_id="ann_y")
+    evt = plan_revised_event(
+        run_id="r1",
+        sequence=9,
+        plan=plan,
+        drift_kind=DriftKind.RUNAWAY_DELEGATION.value,
+        severity=DriftSeverity.CRITICAL.value,
+    )
+    decoded = events_pb2.Event()
+    decoded.ParseFromString(evt.SerializeToString())
+    assert decoded.plan_revised.drift_kind == types_pb2.DRIFT_KIND_RUNAWAY_DELEGATION != 0
+    assert decoded.plan_revised.severity == types_pb2.DRIFT_SEVERITY_CRITICAL != 0
+
+
+def test_factory_and_steerer_resolve_enums_identically() -> None:
+    """Lockstep guard: the shared bridge means the primary steerer emit path
+    (DefaultSteerer._drift_*_pb_value) and the factories never re-diverge."""
+    from goldfive.steerer import DefaultSteerer
+
+    for kind in [DriftKind.OFF_TOPIC, DriftKind.RUNAWAY_DELEGATION, DriftKind.USER_STEER]:
+        evt = drift_detected_event("r", 1, DriftEvent(kind=kind, severity=DriftSeverity.WARNING))
+        assert evt.drift_detected.kind == DefaultSteerer._drift_kind_pb_value(kind) != 0
+    for sev in [DriftSeverity.INFO, DriftSeverity.WARNING, DriftSeverity.CRITICAL]:
+        evt = drift_detected_event("r", 1, DriftEvent(kind=DriftKind.OFF_TOPIC, severity=sev))
+        assert evt.drift_detected.severity == DefaultSteerer._drift_severity_pb_value(sev) != 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runaway_delegation_cap.py
+++ b/tests/test_runaway_delegation_cap.py
@@ -295,3 +295,63 @@ def test_adapter_records_configured_cap() -> None:
     assert adapter._agent_tool_cap == 7
     # The plugin's internal cap tracks the adapter's.
     assert adapter._plugin._agent_tool_cap == 7
+
+
+async def test_runaway_fallback_direct_sink_emit_stamps_nonzero_kind() -> None:
+    """E2E regression (goldfive drift-event kind/severity stamping).
+
+    The plugin's direct-sink fallback — taken when the steerer exposes no
+    ``drift.handle_drift`` — must emit a ``DriftDetected`` whose ``kind`` and
+    ``severity`` are the real NONZERO proto enum values. Before the events.py
+    fix this exact path reached harmonograf/zicato with kind=UNSPECIFIED
+    because ``drift_detected_event`` resolved ``DriftKind`` through the wrong
+    proto module (``events_pb2`` has no ``DriftKind``) and swallowed the
+    resulting AttributeError.
+
+    Exercises the real fallback code in ``_emit_runaway_delegation_drift``
+    (not the ``handle_drift`` branch the other tests in this file cover).
+    """
+    from goldfive.adapters._adk_plugin import SessionContext, make_adk_plugin
+    from goldfive.pb.goldfive.v1 import types_pb2
+    from goldfive.sinks import InMemorySink
+    from goldfive.types import DriftKind, DriftSeverity, Session
+
+    sink = InMemorySink()
+
+    class _FallbackSteerer:
+        # ``drift`` is None → getattr(..., "handle_drift", None) is None, so
+        # the emit method falls through to the direct-sink branch.
+        drift = None
+
+        def __init__(self, sinks: list[Any]) -> None:
+            self._sinks = sinks
+
+    plugin = make_adk_plugin(host_agent_name="host", agent_tool_cap=1)
+    ctx = SessionContext(
+        session=Session(run_id="r1"),
+        steerer=_FallbackSteerer([sink]),
+        task=None,
+        host_agent_name="host",
+    )
+
+    await plugin._emit_runaway_delegation_drift(
+        ctx=ctx,
+        from_agent="coord",
+        to_agent="worker",
+        task_id="t1",
+        invocation_id="inv1",
+        spawn_count=5,
+    )
+
+    drifts = [
+        e
+        for e in sink.events
+        if hasattr(e, "DESCRIPTOR") and e.WhichOneof("payload") == "drift_detected"
+    ]
+    assert len(drifts) == 1, "fallback path should emit exactly one DriftDetected"
+    dd = drifts[0].drift_detected
+    assert dd.kind == types_pb2.DRIFT_KIND_RUNAWAY_DELEGATION != 0
+    assert dd.severity == types_pb2.DRIFT_SEVERITY_CRITICAL != 0
+    # Sanity: the enum ints match the dataclass the plugin built.
+    assert dd.kind == getattr(types_pb2, f"DRIFT_KIND_{DriftKind.RUNAWAY_DELEGATION.name}")
+    assert dd.severity == getattr(types_pb2, f"DRIFT_SEVERITY_{DriftSeverity.CRITICAL.name}")


### PR DESCRIPTION
## The bug

`drift_detected_event` (and its sibling `plan_revised_event`) resolved the
`DriftKind` / `DriftSeverity` proto enums through
`pb.DriftKind.Value(...)` / `pb.DriftSeverity.Value(...)`, where
`pb = _events_pb_module()` (= `goldfive/pb/goldfive/v1/events_pb2`).

But those enums do **not** live in `events_pb2` — they live in `types_pb2`.
`events_pb2.DriftKind` therefore raised `AttributeError`, which the surrounding
`except (ValueError, AttributeError): pass` **silently swallowed**. Result:
`kind` and `severity` were left `UNSPECIFIED` (0) on every event these two
factories produced. The string fields (`detail`, `id`, `annotation_id`, …)
were always stamped correctly — only the two enums were lost.

Empirical proof on the pre-fix tree:

```
drift_detected_event('r',1, DriftEvent(OFF_TOPIC, WARNING, 'x'))
  .drift_detected.kind     == 0   # expected 29
  .drift_detected.severity == 0   # expected 2
plan_revised_event(... drift_kind='user_steer', severity='warning')
  .plan_revised.drift_kind == 0   # expected 5
  .plan_revised.severity   == 0   # expected 2
```

while `DefaultSteerer._drift_kind_pb_value(DriftKind.OFF_TOPIC) == 29` and
`_drift_severity_pb_value(DriftSeverity.WARNING) == 2` were already correct.

## Impact (accurate scope)

The **primary** steerer emit path — `DriftObserver` → `DefaultSteerer._drift_kind_pb_value`
— was always correct and is **unaffected**. The bug only hit the emitters that
call `drift_detected_event` / `plan_revised_event` directly:

- **`events.py` control-drift wrapper** (`control_received_event`) — fires on
  **every operator steer/cancel/pause**, mapping `USER_STEER` / `USER_CANCEL` /
  `USER_PAUSE`.
- **Three ADK-plugin direct-sink fallbacks** in
  `goldfive/adapters/_adk_plugin.py` (the branch taken when the steerer exposes
  no `drift.handle_drift`):
  - `_maybe_emit_capability_mismatch` (~L4676) — `CAPABILITY_MISMATCH`
  - `_emit_runaway_delegation_drift` (~L4774) — `RUNAWAY_DELEGATION`
  - `_emit_pin_unresolved_drift` (~L4863) — `OFF_TOPIC` (pin-unresolved)
- **`plan_revised_event`** (the sibling factory) — same latent bug on
  `plan_revised.drift_kind` / `.severity`.

All of these reached harmonograf / zicato with `kind=UNSPECIFIED`,
`severity=UNSPECIFIED`.

## The fix

Resolve both enums by proto member **name** — the mechanism the steerer already
used: `getattr(types_pb2, f"DRIFT_KIND_{member}")`. Enum `.name` is the UPPER
member (`OFF_TOPIC`) regardless of the `StrEnum`'s lowercase `.value`.

Extracted a **single shared bridge** into `events.py`
(`_drift_kind_pb_value` / `_drift_severity_pb_value` + a `_proto_enum_member`
normalizer + a `_types_pb_module()` accessor). Both factories use it, and
`DefaultSteerer._drift_kind_pb_value` / `_drift_severity_pb_value` now
**delegate** to it — so the primary path and the factory paths resolve enums
through one implementation and can never re-diverge. The lazy import keeps the
seam cycle-free (events.py never imports steerer at module load). The steerer
keeps its historical `DRIFT_KIND_CUSTOM` unknown-fallback via the
`unknown_member="CUSTOM"` kwarg; the factories fall back to `UNSPECIFIED`.

The defensive `try/except` is kept as a backstop, but the normal path is no
longer masked: a genuinely-unknown / synthetic kind name degrades to
`UNSPECIFIED` inside the bridge with a `log.debug`, without raising — so a
future regression is visible in logs.

Sibling sweep: grepped `events.py` (and the whole `goldfive/` tree) for other
`pb.<Enum>.Value(` / `.upper()` casing bridges that resolve a `types_pb2` enum
through `_events_pb_module()`. `plan_revised_event` was the only other
offender (fixed here). The remaining `.upper()` sites (`control_received_event`
control-kind mapping, the `authored_by` inference) are pure-Python and do not
touch proto resolution.

## Tests

`tests/test_events.py`:
- `drift_detected_event` on `DriftEvent(OFF_TOPIC, WARNING)` → kind == the
  `OFF_TOPIC` proto value, severity == the `WARNING` proto value (both nonzero).
- Table test parametrized over 5 kinds × 3 severities (asserts each StrEnum's
  `.value` differs in case from its `.name`, so `.name`-based resolution is
  what's exercised).
- Bare lowercase-string kind path (the `plan_revised` input shape) resolves.
- Control-drift wrapper (`USER_STEER` / `USER_CANCEL`) stamps a nonzero kind.
- Guard: an unknown/synthetic kind name degrades to `UNSPECIFIED` without raising.
- `SerializeToString` / `FromString` round-trip preserves both enums.
- Sibling `plan_revised_event` stamps + round-trips `drift_kind` / `severity`.
- Lockstep guard: the steerer's `_drift_*_pb_value` and the factory resolve
  every enum identically.

`tests/test_runaway_delegation_cap.py`:
- End-to-end: drives the real `_emit_runaway_delegation_drift` **direct-sink
  fallback** into an `InMemorySink` and asserts the emitted `DriftDetected`
  carries `kind == RUNAWAY_DELEGATION` (35) and `severity == CRITICAL` (3),
  nonzero on the wire.

Full suite: `2936 passed, 61 skipped`. `ruff check .` clean.

Complements #480's decision-telemetry label work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA
