### PR TITLE
fix(adk): gate observer-note tool annotation on the kill-switch (surface 4)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -7303,8 +7303,12 @@ def make_adk_plugin(
             *rendering* chokepoint so the block surfaces never re-render it.
             (``SignalDelivered`` is emitted once at the dispatch point, not
             here.) Returns ``None`` (no result replacement) when not in
-            request_context mode, the result is not a mapping, or no loop note
-            is pending — so the legacy path is untouched.
+            request_context mode, the result is not a mapping, no loop note
+            is pending, or the steerer is passive
+            (``observation_only=True`` — the note is still consumed as a
+            dry-run delivery for decision parity but nothing is annotated,
+            matching the other three surfaces) — so both the legacy path
+            and the strict-passive campaign are untouched.
             """
             if ctx is None or ctx.steerer is None or ctx.session is None:
                 return None
@@ -7315,6 +7319,15 @@ def make_adk_plugin(
                 return None
             if not isinstance(result, Mapping):
                 return None
+            # Kill-switch gate (parity with the other three observer-note
+            # surfaces: prompt_shaper.inject_observer_note,
+            # claude._consume_observer_note, sequential replay). Under
+            # ``observation_only=True`` the note is consumed as a dry-run
+            # delivery below but the real tool result passes through
+            # UNANNOTATED so nothing reaches the model — zero production
+            # authority until 13b (AGENCY-PRESERVATION §5.4). Resolved once
+            # here so ``mark_delivered`` still runs for decision parity.
+            passive = _is_observation_only(ctx)
             from goldfive.observer_note_queue import (
                 ObserverNoteQueue,
                 render_tool_annotation,
@@ -7339,6 +7352,15 @@ def make_adk_plugin(
                 surface="tool_annotation",
             )
             if not newly:
+                return None
+            if passive:
+                # observation_only: ``mark_delivered`` ran above (decision
+                # parity — pacing / coalescing behave identically to the
+                # active path), but return None so the real tool result
+                # passes through UNANNOTATED. Follow-up: a sibling PR owns
+                # the dry_run-truthfulness refactor; once it lands the
+                # dry-run marker on this consume lets telemetry attribution
+                # distinguish it from an active delivery.
                 return None
             # Append-only: copy the result and add the reserved annotation key.
             annotated = dict(result)

--- a/tests/test_observation_only_nudge_gate.py
+++ b/tests/test_observation_only_nudge_gate.py
@@ -20,9 +20,12 @@ and the injected text is truthful: the GOAL_DRIFT corrective only
 claims "already complete" for a COMPLETED task, and the replay header
 only claims a plan revision when one was actually installed.
 
-Note: tests pass ``observation_only`` EXPLICITLY — tests/conftest.py
-flips the *implicit* default to False for the legacy corpus, so
-``observation_only=True`` here is exactly the production default.
+Note: bare steerers / configs run PASSIVE — ``observation_only=True``
+is the shipped production default (there is no conftest override that
+flips it). Tests that exercise active interventions opt in explicitly
+(``SteeringConfig(observation_only=False)`` inline, or the
+``active_steering_config`` / ``make_active_steerer`` fixtures), so the
+``observation_only=True`` cases here are exactly the production default.
 """
 
 from __future__ import annotations

--- a/tests/test_observer_note_tool_annotation.py
+++ b/tests/test_observer_note_tool_annotation.py
@@ -27,6 +27,41 @@ from goldfive.steerer import DefaultSteerer  # noqa: E402
 from goldfive.types import Session, Task  # noqa: E402
 
 
+class _ListSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def emit(self, event_pb: Any) -> None:
+        self.events.append(event_pb)
+
+    async def close(self) -> None:
+        pass
+
+
+class _StubPlanner:
+    async def generate(self, **kwargs: Any) -> None:  # noqa: ARG002
+        return None
+
+    async def refine(self, **kwargs: Any) -> None:  # noqa: ARG002
+        return None
+
+
+class _ToolStub:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _InvCtxStub:
+    def __init__(self, invocation_id: str, agent_name: str) -> None:
+        self.invocation_id = invocation_id
+        self.agent = type("_A", (), {"name": agent_name})()
+
+
+class _ToolCtxStub:
+    def __init__(self, invocation_id: str, agent_name: str) -> None:
+        self._invocation_context = _InvCtxStub(invocation_id, agent_name)
+
+
 def _ctx(session: Session, steerer: Any) -> SessionContext:
     return SessionContext(
         session=session,
@@ -50,16 +85,26 @@ def _enqueue_loop_note(session: Session, *, drift_id: str = "d1") -> None:
     )
 
 
-def _steerer() -> DefaultSteerer:
+def _steerer(*, active: bool = False) -> DefaultSteerer:
+    """Build a ``request_context`` steerer.
+
+    Bare (``active=False``) is PASSIVE — ``observation_only=True`` is the
+    shipped production default and the branch's §5.4 shadow-campaign
+    config. Surface 4 must consume-but-not-annotate in that mode. Tests
+    that assert the active annotation delivery opt in via ``active=True``.
+    """
     return DefaultSteerer(
-        steering_config=SteeringConfig(signal_channel="request_context")
+        steering_config=SteeringConfig(
+            signal_channel="request_context",
+            observation_only=not active,
+        )
     )
 
 
 async def test_annotation_appends_without_modifying_real_result() -> None:
     plugin = make_adk_plugin(host_agent_name="test_agent")
     session = Session(run_id="r1")
-    steerer = _steerer()
+    steerer = _steerer(active=True)
     ctx = _ctx(session, steerer)
     _enqueue_loop_note(session)
 
@@ -111,3 +156,90 @@ async def test_annotation_noop_in_legacy_channel() -> None:
     # Legacy default: surface 4 is inert (returns None, note untouched).
     assert await plugin._maybe_annotate_tool_result(ctx, {"content": "x"}) is None
     assert ObserverNoteQueue.for_session(session).get("d1").delivered is False
+
+
+async def test_annotation_suppressed_under_observation_only() -> None:
+    """Surface-4 kill-switch gate: request_context + observation_only=True.
+
+    The §5.4 shadow-campaign config (request_context channel, passive
+    kill-switch — the branch default) must NOT annotate the tool result;
+    nothing reaches the model. But the note is still consumed as a
+    dry-run delivery (``mark_delivered`` runs for decision parity) so
+    pacing / coalescing behave identically to the active path.
+    """
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    session = Session(run_id="r1")
+    # Bare steerer -> observation_only=True (production default).
+    ctx = _ctx(session, _steerer())
+    _enqueue_loop_note(session)
+
+    result = {"content": [{"type": "text", "text": "search results..."}]}
+    annotated = await plugin._maybe_annotate_tool_result(ctx, result)
+
+    # No result replacement — after_tool_callback returns None and the
+    # real tool result passes through UNANNOTATED.
+    assert annotated is None
+    # Dry-run consume: the note is marked delivered for decision parity.
+    assert ObserverNoteQueue.for_session(session).get("d1").delivered is True
+
+
+async def _drive_repeated_loop(steerer: DefaultSteerer) -> tuple[Any, Session]:
+    """Drive a real repeated tool call through ``after_tool_callback``.
+
+    Exact-repeat x3 trips the tool-loop tracker's WARNING tier, so
+    ``after_tool_callback`` reaches surface 4 (it early-returns when the
+    call fired no drift). A loop note is pre-enqueued so the surface has
+    something to render. Returns the final callback return value and the
+    session.
+    """
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    session = Session(run_id="r1")
+    steerer.bind(sinks=[_ListSink()], planner=_StubPlanner())
+    ctx = _ctx(session, steerer)
+    plugin.set_active_context(ctx)
+    _enqueue_loop_note(session)
+
+    tool = _ToolStub("patch_file")
+    args = {"path": "a.py", "diff": "x"}
+    tool_ctx = _ToolCtxStub("inv-surface4", "worker")
+    result = {"content": [{"type": "text", "text": "patched"}], "ok": True}
+    returned: Any = None
+    for _ in range(3):  # exact-repeat x3 -> WARNING loop drift
+        returned = await plugin.after_tool_callback(
+            tool=tool, tool_args=args, tool_context=tool_ctx, result=dict(result)
+        )
+    return returned, session
+
+
+async def test_after_tool_callback_passes_result_through_unannotated_when_passive() -> None:
+    """End-to-end negative control through ``after_tool_callback``.
+
+    A repeated tool call under signal_channel="request_context" +
+    observation_only=True (the branch default) must NOT annotate the tool
+    result — the callback returns ``None`` so ADK keeps the real result
+    verbatim and nothing reaches the model — yet the note is still
+    consumed as a dry-run delivery for decision parity.
+    """
+    returned, session = await _drive_repeated_loop(_steerer())  # passive
+
+    # Passive: no annotated replacement — never carries the reserved key.
+    assert returned is None
+    if isinstance(returned, dict):  # defensive
+        assert "goldfive_observer_note" not in returned
+    # Consumed as a dry-run delivery (mark_delivered ran for parity).
+    assert ObserverNoteQueue.for_session(session).get("d1").delivered is True
+
+
+async def test_after_tool_callback_annotates_result_when_active() -> None:
+    """End-to-end positive control through ``after_tool_callback``.
+
+    The same drive under active mode (observation_only=False) DOES return
+    a result carrying the ``goldfive_observer_note`` annotation, with the
+    real result preserved verbatim.
+    """
+    returned, session = await _drive_repeated_loop(_steerer(active=True))
+
+    assert isinstance(returned, dict)
+    assert returned["ok"] is True  # real result preserved verbatim
+    assert returned["goldfive_observer_note"].startswith("[goldfive observer:")
+    assert ObserverNoteQueue.for_session(session).get("d1").delivered is True


### PR DESCRIPTION
## Defect (verified surviving the reconcile)

Observer-note **surface 4** — the tool-result annotation in
`goldfive/adapters/_adk_plugin.py`, `_maybe_annotate_tool_result`
(re-located on the current tip; called from `after_tool_callback`).

It returned `None` only when `signal_channel != "request_context"` or the
result was not a `Mapping`. It had **no `observation_only` check**, so under
`signal_channel="request_context"` + `observation_only=True` — the branch
default and the §5.4 shadow-campaign config — a freshly-enqueued
`looping_tool_call` / `looping_reasoning` note was rendered onto the tool
result (`annotated["goldfive_observer_note"] = render_tool_annotation(note)`)
and **reached the model**, violating "zero production authority until 13b".

The other three surfaces gate correctly and were the reference for this fix:
- `prompt_shaper.inject_observer_note` (`should_inject`, else dry-run consume)
- `adapters/claude.py::_consume_observer_note` (`_should_inject`)
- `executors/sequential.py` replay (`_steerer_should_inject`)

Evidence it was live: the pre-existing positive test built a bare
`request_context` steerer (`observation_only=True` by default) and asserted
the result **was** annotated — i.e. the leak was pinned as correct behavior.

## Fix

After the channel + mapping gates, resolve `passive = _is_observation_only(ctx)`
(delegates to `steering_is_active`, the one kill-switch predicate, per #488).
The peek + `mark_delivered` run identically in both modes (decision parity so
pacing / coalescing behave the same). When passive, return `None` so the real
tool result passes through **unannotated**; when active, current behavior.

Per the brief, the `delivered_dry_run` marker on the passive consume is left
as a follow-up (a sibling PR owns the dry_run-truthfulness refactor) — a code
comment records it so telemetry attribution can later distinguish it.

## Why it's inert under default flags

The legacy channel path (`signal_channel="legacy_user_message"`, the shipped
default) is byte-identical — it returns before the new gate. The only default
behavior that changes is the `observation_only=True` request_context case,
which is exactly the **leak being closed** (an observation_only leak fix is
always correct).

## Tests (both modes)

- `test_after_tool_callback_passes_result_through_unannotated_when_passive` —
  drives a real repeated tool loop (exact-repeat x3 fires the WARNING tier so
  `after_tool_callback` reaches surface 4) under request_context +
  observation_only=True; asserts the callback returns `None` (no
  `goldfive_observer_note`) **and** the note is still consumed (`delivered`).
- `test_after_tool_callback_annotates_result_when_active` — same drive under
  active mode; asserts the annotated dict is returned with the real result
  preserved.
- `test_annotation_suppressed_under_observation_only` — direct passive-gate unit.
- Retargeted the existing positive `_maybe_annotate_tool_result` test to opt
  into active mode explicitly; `_steerer(active=...)` documents that bare =
  passive (production default).
- Fixed the stale docstring in `tests/test_observation_only_nudge_gate.py`
  that claimed conftest flips the implicit default to False (false post-#488;
  conftest only provides opt-in active fixtures).

Full suite: 3270 passed, 61 skipped. `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA