### PR TITLE
feat(bench): make the 13b three-arm bench adjudicate its own flip criterion

### DIFF
--- a/bench/harness.py
+++ b/bench/harness.py
@@ -80,11 +80,21 @@ from goldfive.config import RuntimeConfig
 from goldfive.results import ExecutionOutcome, evaluate_goal_predicates
 from goldfive.sinks import InMemorySink, JSONLPersistenceSink
 from goldfive.steerer import DefaultSteerer
-from goldfive.types import DriftEvent, DriftKind, DriftSeverity
+from goldfive.types import (
+    DriftEvent,
+    DriftKind,
+    DriftSeverity,
+    TaskKind,
+    TaskStatus,
+)
 
 __all__ = [
     "Arm",
     "ArmMetrics",
+    "GOAL_GRADE_ABORTED",
+    "GOAL_GRADE_MET",
+    "GOAL_GRADE_UNMEASURED",
+    "GOAL_GRADE_UNMET",
     "MANAGED_STEER_ENV",
     "KNOWN_STEER_ENV",
     "Scenario",
@@ -94,9 +104,21 @@ __all__ = [
     "inject_demo_signals",
     "make_linear_run_driver",
     "metrics_from_events",
+    "outcome_terminality",
     "run_arm",
     "run_arms",
 ]
+
+#: The §6.4 goal-grading vocabulary. A run is only ``MET`` / ``UNMET`` when a
+#: grading SIGNAL exists — a :attr:`Goal.success_predicate` or an
+#: :attr:`TaskKind.OUTCOME` deliverable task. With neither, the run is
+#: ``UNMEASURED`` (NOT silently ``MET``): ``run.success`` alone is explicitly
+#: not a flip signal (§6.4 rule 1, deviation 1). An aborted run is a measured
+#: failure regardless of grading signals (``ABORTED``).
+GOAL_GRADE_MET = "met"
+GOAL_GRADE_UNMET = "unmet"
+GOAL_GRADE_ABORTED = "aborted"
+GOAL_GRADE_UNMEASURED = "unmeasured"
 
 
 # ---------------------------------------------------------------------------
@@ -287,13 +309,43 @@ class ArmMetrics:
     arm_name: str
     arm_kind: str
     # --- captured-artifact outcome (goldfive#447) ---------------------
+    #: ``True`` ONLY when :attr:`goal_grade` is ``MET`` (a grading signal
+    #: exists and it passed). ``False`` for UNMET / ABORTED **and** for
+    #: UNMEASURED — a run with no goal predicate and no OUTCOME task is NOT a
+    #: silent success (§6.4 rule 1). Read :attr:`goal_grade` to tell UNMET
+    #: (measured failure) from UNMEASURED (no flip signal on this workload).
     goal_success: bool
+    #: One of :data:`GOAL_GRADE_MET` / ``_UNMET`` / ``_ABORTED`` / ``_UNMEASURED``.
+    goal_grade: str
     goal_reason: str
+    #: Number of goals carrying a :attr:`Goal.success_predicate` (the first
+    #: grading signal). ``0`` on the stub workload.
+    goal_predicate_count: int
+    # --- OUTCOME-task terminality (§6.4 rule 1) ------------------------
+    #: Count of :attr:`TaskKind.OUTCOME` tasks in the final plan (the
+    #: goal-anchored deliverables; only minted in ``plan_mode=ledger``).
+    outcome_tasks_total: int
+    #: Terminal-disposition census over the OUTCOME tasks, deterministic key
+    #: order: ``completed`` / ``failed`` / ``not_needed`` / ``cancelled`` /
+    #: ``non_terminal`` (the #208 carry-forward PENDING/RUNNING/BLOCKED set).
+    outcome_terminal: dict[str, int]
+    #: Count of :attr:`TaskKind.DISCOVERED` tasks (descriptive-growth records).
+    discovered_tasks_total: int
     completed_outputs: int
     turns: int
     tokens: int | None  # best-effort; None when the adapter reports no usage
     aborted: bool
     abort_reason: str
+    # --- regime provenance: configured vs. EXERCISED ------------------
+    #: The resolved :attr:`SteeringConfig.plan_mode` this build ran under
+    #: (``forecast`` / ``ledger``) — what the flag *applied* to.
+    plan_mode: str
+    #: ``True`` iff the ledger regime was actually EXERCISED on this workload
+    #: (plan_mode=ledger AND at least one OUTCOME or DISCOVERED task fired).
+    #: A ``plan_mode=ledger`` arm whose workload never mints an OUTCOME /
+    #: DISCOVERED task reports ``False`` — configured is not exercised, and a
+    #: stub that never fires the ledger path must not read as validating it.
+    ledger_exercised: bool
     # --- sink-event telemetry (PR 5) ----------------------------------
     drift_detected: int
     signals_total: int
@@ -353,12 +405,119 @@ def _ledger_refire_rate(session: Session | None) -> float | None:
     return refires / len(delivered)
 
 
+#: OUTCOME-task disposition buckets, in a fixed order so the census dict has
+#: deterministic key order regardless of task iteration.
+_OUTCOME_DISPOSITIONS: tuple[tuple[str, TaskStatus | None], ...] = (
+    ("completed", TaskStatus.COMPLETED),
+    ("failed", TaskStatus.FAILED),
+    ("not_needed", TaskStatus.NOT_NEEDED),
+    ("cancelled", TaskStatus.CANCELLED),
+    ("non_terminal", None),  # PENDING / RUNNING / BLOCKED (#208 carry-forward)
+)
+
+
+def outcome_terminality(
+    session: Session | None,
+) -> tuple[int, dict[str, int], int]:
+    """Census the OUTCOME-task terminal dispositions on a run's final plan.
+
+    Returns ``(outcome_total, disposition_counts, discovered_total)``:
+
+    * ``outcome_total`` — number of :attr:`TaskKind.OUTCOME` tasks (the
+      goal-anchored deliverables; only minted in ``plan_mode=ledger``).
+    * ``disposition_counts`` — deterministic-key census over those tasks:
+      ``completed`` / ``failed`` / ``not_needed`` / ``cancelled`` /
+      ``non_terminal`` (the #208 carry-forward set: uncertain OUTCOME tasks
+      legitimately stay PENDING across turn boundaries — deviation 1).
+    * ``discovered_total`` — number of :attr:`TaskKind.DISCOVERED` tasks
+      (descriptive-growth records); used only to tell whether the ledger
+      path fired at all.
+
+    Pure over ``session.plan.tasks`` (a captured artifact); no runtime state
+    is mutated. Empty/zero when no session or no plan is available.
+    """
+    counts: dict[str, int] = {name: 0 for name, _ in _OUTCOME_DISPOSITIONS}
+    if session is None or getattr(session, "plan", None) is None:
+        return 0, counts, 0
+    outcome_total = 0
+    discovered_total = 0
+    for task in session.plan.tasks:
+        if task.kind is TaskKind.DISCOVERED:
+            discovered_total += 1
+        if task.kind is not TaskKind.OUTCOME:
+            continue
+        outcome_total += 1
+        status = task.status
+        bucket = "non_terminal"
+        for name, wanted in _OUTCOME_DISPOSITIONS:
+            if wanted is not None and status == wanted:
+                bucket = name
+                break
+        counts[bucket] += 1
+    return outcome_total, counts, discovered_total
+
+
+def _grade_goal(
+    session: Session | None,
+    *,
+    aborted: bool,
+    abort_reason: str,
+    predicate_count: int,
+    outcome_total: int,
+    outcome_terminal: dict[str, int],
+) -> tuple[str, str]:
+    """Grade a run on goal predicates + OUTCOME-task terminality (§6.4 rule 1).
+
+    Returns ``(grade, reason)`` where ``grade`` is one of the
+    :data:`GOAL_GRADE_MET` vocabulary. The cardinal rule: a run is graded a
+    success ONLY when a grading SIGNAL exists and it passes. ``run.success``
+    alone is never a flip signal — with no goal ``success_predicate`` and no
+    OUTCOME deliverable, the run is :data:`GOAL_GRADE_UNMEASURED`, never
+    silently ``MET`` (deviation 1). An abort is a measured failure.
+    """
+    if session is None:
+        return GOAL_GRADE_UNMEASURED, "no session captured"
+    if aborted:
+        return GOAL_GRADE_ABORTED, abort_reason or "run aborted"
+    has_signal = predicate_count > 0 or outcome_total > 0
+    if not has_signal:
+        return (
+            GOAL_GRADE_UNMEASURED,
+            "no goal success_predicate and no OUTCOME task — run success is "
+            "not gradeable (run.success alone is not a flip signal)",
+        )
+    if predicate_count > 0:
+        reason = evaluate_goal_predicates(session)
+        if reason is not None:
+            return GOAL_GRADE_UNMET, reason
+    if outcome_total > 0:
+        failed = outcome_terminal.get("failed", 0)
+        if failed:
+            return GOAL_GRADE_UNMET, f"{failed} OUTCOME task(s) FAILED"
+        cancelled = outcome_terminal.get("cancelled", 0)
+        if cancelled:
+            return GOAL_GRADE_UNMET, f"{cancelled} OUTCOME task(s) CANCELLED"
+        non_terminal = outcome_terminal.get("non_terminal", 0)
+        if non_terminal:
+            # Conservative for the flip criterion: a deliverable that never
+            # reached a successful terminal is not a demonstrated success (it
+            # is legitimately uncertain/carried-forward — deviation 1 — but
+            # not gradeable as MET).
+            return (
+                GOAL_GRADE_UNMET,
+                f"{non_terminal} OUTCOME task(s) non-terminal "
+                "(deliverable not demonstrably met; #208 carry-forward)",
+            )
+    return GOAL_GRADE_MET, ""
+
+
 def metrics_from_events(
     events: Sequence[Any],
     *,
     arm: Arm,
     session: Session | None = None,
     tokens: int | None = None,
+    plan_mode: str = "forecast",
     jsonl_path: str = "",
 ) -> ArmMetrics:
     """Reduce a captured event stream (+ optional session) to an :class:`ArmMetrics`.
@@ -411,25 +570,44 @@ def metrics_from_events(
         turns = int(getattr(session, "_reasoning_turn", 0) or 0)
     turns = max(turns, task_terminal)
 
-    goal_reason = ""
-    goal_success = not aborted
-    if session is not None:
-        reason = evaluate_goal_predicates(session)
-        if reason is not None:
-            goal_success = False
-            goal_reason = reason
+    # OUTCOME-task terminality (§6.4 rule 1) + ledger-exercised provenance.
+    outcome_total, outcome_terminal, discovered_total = outcome_terminality(session)
+    predicate_count = (
+        sum(1 for g in session.goals if g.success_predicate is not None)
+        if session is not None
+        else 0
+    )
+    goal_grade, goal_reason = _grade_goal(
+        session,
+        aborted=aborted,
+        abort_reason=abort_reason,
+        predicate_count=predicate_count,
+        outcome_total=outcome_total,
+        outcome_terminal=outcome_terminal,
+    )
+    goal_success = goal_grade == GOAL_GRADE_MET
+    ledger_exercised = plan_mode == "ledger" and (
+        outcome_total > 0 or discovered_total > 0
+    )
 
     applied, pending = arm_flag_status(arm)
     return ArmMetrics(
         arm_name=arm.name,
         arm_kind=arm.kind,
         goal_success=goal_success,
+        goal_grade=goal_grade,
         goal_reason=goal_reason,
+        goal_predicate_count=predicate_count,
+        outcome_tasks_total=outcome_total,
+        outcome_terminal=outcome_terminal,
+        discovered_tasks_total=discovered_total,
         completed_outputs=completed_outputs,
         turns=turns,
         tokens=tokens,
         aborted=aborted,
         abort_reason=abort_reason,
+        plan_mode=plan_mode,
+        ledger_exercised=ledger_exercised,
         drift_detected=drift_detected,
         signals_total=signals_total,
         signals_real=signals_real,
@@ -502,6 +680,7 @@ async def run_arm(
         arm=arm,
         session=outcome.session,
         tokens=tokens,
+        plan_mode=str(getattr(runtime.steering, "plan_mode", "forecast") or "forecast"),
         jsonl_path=str(jsonl_path),
     )
 

--- a/bench/run_100_tasks.py
+++ b/bench/run_100_tasks.py
@@ -181,7 +181,21 @@ def _print_arm_metrics_table(results: list) -> None:
         signals = f"{m.signals_total} / {m.signals_real} / {m.signals_dry_run}"
         print(f"\narm {m.arm_name}  [{m.arm_kind}]")
         print("-" * 72)
-        print(f"  goal_success:            {m.goal_success}  {reason}")
+        print(f"  goal_grade:              {m.goal_grade.upper()}  {reason}")
+        print(f"  goal_success (==MET):    {m.goal_success}")
+        print(f"  goal_predicate_count:    {m.goal_predicate_count}")
+        print(
+            f"  OUTCOME tasks:           {m.outcome_tasks_total}  "
+            f"terminal={m.outcome_terminal}"
+        )
+        print(
+            f"  plan_mode / exercised:   {m.plan_mode} / {m.ledger_exercised}"
+            + (
+                "  (configured but NOT exercised — does not validate ledger)"
+                if m.plan_mode == "ledger" and not m.ledger_exercised
+                else ""
+            )
+        )
         print(f"  completed_outputs:       {m.completed_outputs}")
         print(f"  turns / tokens:          {m.turns} / {tokens}")
         print(f"  run aborted:             {m.aborted}  {m.abort_reason}")

--- a/bench/shadow_diff.py
+++ b/bench/shadow_diff.py
@@ -156,9 +156,22 @@ class KeyDivergence:
     #: Per-regime transport fields (channel / channel_action) that differ.
     #: Informational only — a key that differs ONLY here is NOT ``diverged``.
     transport_fields: list[str] = dataclasses.field(default_factory=list)
+    #: ``True`` when a one-sided key is a **join artifact**, not a real
+    #: silence: the other regime DID fire this drift kind, but on a disjoint
+    #: ``task_id`` namespace, so ``(kind, task_id, occurrence)`` structurally
+    #: cannot match. The flip-target comparison (ledger OUTCOME task ids vs.
+    #: forecast task ids) is exactly this case — the ids differ by
+    #: construction. Un-joinable keys are EXCLUDED from the divergence verdict
+    #: and logged separately, so a 13b operator is not misled by a silently
+    #: partial diff (a run-vs-run join that never aligned).
+    unjoinable: bool = False
 
     @property
     def diverged(self) -> bool:
+        if self.unjoinable:
+            # A join artifact, not a decision divergence: the other regime
+            # fired this kind on a different task-id namespace.
+            return False
         return self.present_in != "both" or bool(self.diverged_fields)
 
     @property
@@ -185,11 +198,21 @@ class DivergenceReport:
 
     @property
     def legacy_only(self) -> list[KeyDivergence]:
-        return [k for k in self.keys if k.present_in == "legacy_only"]
+        """Drifts the LEGACY regime fired and the new regime genuinely did not.
+
+        Excludes un-joinable keys (a join artifact — the new regime fired the
+        same kind on a different task-id namespace, so it is not a silence).
+        """
+        return [
+            k for k in self.keys if k.present_in == "legacy_only" and not k.unjoinable
+        ]
 
     @property
     def new_only(self) -> list[KeyDivergence]:
-        return [k for k in self.keys if k.present_in == "new_only"]
+        """Drifts the NEW regime fired and the legacy regime genuinely did not."""
+        return [
+            k for k in self.keys if k.present_in == "new_only" and not k.unjoinable
+        ]
 
     @property
     def field_divergences(self) -> list[KeyDivergence]:
@@ -199,6 +222,17 @@ class DivergenceReport:
     def transport_only_keys(self) -> list[KeyDivergence]:
         """Keys that differ ONLY in transport (channel) — informational, not divergences."""
         return [k for k in self.keys if k.transport_only]
+
+    @property
+    def unjoinable_keys(self) -> list[KeyDivergence]:
+        """One-sided keys that are join artifacts, not decision divergences.
+
+        The other regime fired the same drift kind on a disjoint ``task_id``
+        namespace (e.g. ledger OUTCOME ids vs. forecast ids), so the
+        ``(kind, task_id, occurrence)`` key structurally cannot align. Logged
+        separately so a partial join is never silently read as divergence.
+        """
+        return [k for k in self.keys if k.unjoinable]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -212,6 +246,7 @@ class DivergenceReport:
             "new_only": len(self.new_only),
             "field_divergences": len(self.field_divergences),
             "transport_only_keys": len(self.transport_only_keys),
+            "unjoinable_keys": len(self.unjoinable_keys),
             "keys": [dataclasses.asdict(k) for k in self.keys],
         }
 
@@ -315,10 +350,34 @@ def diff_two_logs(
     legacy_path: str = "legacy",
     new_path: str = "new",
 ) -> DivergenceReport:
-    """Align two logs per drift key and report decision divergences."""
+    """Align two logs per drift key and report decision divergences.
+
+    The cross-run join key is ``(kind, task_id, occurrence#)`` — drift ids are
+    per-run minted so cannot join across logs. ``task_id`` is stable within a
+    regime but NOT across regimes when the plan taxonomy differs (the
+    flip-target case: ledger OUTCOME task ids vs. forecast task ids). A
+    one-sided key whose kind DID fire in the other regime but on a disjoint
+    ``task_id`` namespace is therefore a **join artifact**, not a real
+    silence; it is flagged ``unjoinable`` and excluded from the divergence
+    verdict (see :attr:`KeyDivergence.unjoinable`) so a partial join is never
+    misread as divergence. A true cross-regime deliverable-identity join would
+    need a goal-anchored id on the wire (``SignalDelivered`` has none today —
+    a dependency for a sibling runtime PR); until then the un-joinable set is
+    surfaced explicitly rather than silently mis-bucketed.
+    """
     legacy_keyed = dict(_assign_occurrences(legacy))
     new_keyed = dict(_assign_occurrences(new))
     all_keys = sorted(set(legacy_keyed) | set(new_keyed))
+
+    # Per-kind task-id namespaces, to tell a genuine one-sided silence (the
+    # other regime never fired this kind at all) from a join artifact (it
+    # fired the kind, but on task ids that cannot align across regimes).
+    legacy_tids: dict[str, set[str]] = defaultdict(set)
+    new_tids: dict[str, set[str]] = defaultdict(set)
+    for rec in legacy:
+        legacy_tids[rec.kind].add(rec.task_id)
+    for rec in new:
+        new_tids[rec.kind].add(rec.task_id)
 
     keys: list[KeyDivergence] = []
     for key in all_keys:
@@ -343,6 +402,10 @@ def diff_two_logs(
                 )
             )
         elif lrec is not None:
+            # Un-joinable iff the new regime fired this kind but never on this
+            # task_id — same drift, disjoint task-id namespace (a join
+            # artifact), not a new-regime silence.
+            unjoinable = bool(new_tids[kind]) and task_id not in new_tids[kind]
             keys.append(
                 KeyDivergence(
                     kind=kind,
@@ -352,10 +415,12 @@ def diff_two_logs(
                     legacy=lrec.decision_view(),
                     new=None,
                     diverged_fields=[],
+                    unjoinable=unjoinable,
                 )
             )
         else:
             assert nrec is not None
+            unjoinable = bool(legacy_tids[kind]) and task_id not in legacy_tids[kind]
             keys.append(
                 KeyDivergence(
                     kind=kind,
@@ -365,6 +430,7 @@ def diff_two_logs(
                     legacy=None,
                     new=nrec.decision_view(),
                     diverged_fields=[],
+                    unjoinable=unjoinable,
                 )
             )
 
@@ -394,7 +460,36 @@ def render_two_log_text(report: DivergenceReport) -> str:
         f"  transport-only (channel): {len(report.transport_only_keys)}  "
         "(per-regime transport, not a divergence)"
     )
+    unjoinable = report.unjoinable_keys
+    lines.append(
+        f"  UN-JOINABLE (task-id ns):{len(unjoinable)}  "
+        "(disjoint task-id namespaces — NOT a divergence)"
+    )
     lines.append("-" * 64)
+
+    if unjoinable:
+        lines.append(
+            f"WARNING: {len(unjoinable)} drift key(s) could not be joined across "
+            "regimes:"
+        )
+        lines.append(
+            "  the two logs fire the same drift kind on DISJOINT task-id "
+            "namespaces (e.g. ledger OUTCOME ids vs. forecast ids), so the"
+        )
+        lines.append(
+            "  (kind, task_id, occurrence) key cannot align. These are join "
+            "artifacts, NOT decision divergences — do not read them as one"
+        )
+        lines.append(
+            "  regime staying silent. A goal-anchored deliverable id on the "
+            "wire would join them (a runtime dependency, not this tool's)."
+        )
+        for kd in unjoinable:
+            lines.append(
+                f"  [{kd.kind} / {kd.task_id} #{kd.occurrence}] {kd.present_in} "
+                "(un-joinable)"
+            )
+        lines.append("-" * 64)
 
     if not report.diverged_keys:
         lines.append("VERDICT: no decision divergence — the two regimes' steering")
@@ -437,14 +532,40 @@ def render_two_log_text(report: DivergenceReport) -> str:
 # ---------------------------------------------------------------------------
 
 
+#: Delivery channels the LEGACY regime rides (the four goldfive-authored
+#: dispatch decision points). On a log made of these, ``would_cancel_inflight``
+#: IS the legacy regime's own cancel verdict, so the single-event
+#: legacy-vs-new derivation below is valid.
+_LEGACY_TRANSPORT: frozenset[str] = frozenset(
+    {"nudge_replay", "steer_control", "pause_control", "promotion"}
+)
+#: The channel the NEW (signal) regime rides (PR 6). On a new-regime log,
+#: ``would_cancel_inflight`` is the NEW regime's (narrower) cancel verdict —
+#: it CANNOT reveal what legacy would have done, so a single-log census of a
+#: new-regime log is blind to cancel divergences (see :func:`single_log_report`).
+_NEW_TRANSPORT: frozenset[str] = frozenset({"request_context"})
+
+
+def _record_regime(rec: SignalRecord) -> str:
+    """Infer which regime a delivery belongs to from its transport channel.
+
+    Returns ``"new"`` for the request_context channel, ``"legacy"`` otherwise
+    (the four legacy dispatch channels; unknown channels default to legacy so
+    the derivation stays applicable rather than silently dropping the record).
+    """
+    return "new" if rec.channel in _NEW_TRANSPORT else "legacy"
+
+
 def _legacy_vs_new_within_event(rec: SignalRecord) -> dict[str, Any]:
     """Derive legacy-would-do vs. new-would-do from one delivery's payload.
 
-    The ``decision`` payload carries the legacy cancel intent
-    (``would_cancel_inflight``) and the chosen channel/ladder. The new
-    regime's contract is "signal without preempting in-flight work", so the
-    divergence within a single event is: does the legacy regime cancel /
-    swap the plan where the new regime would only signal?
+    VALID ONLY on a LEGACY-regime delivery. The ``decision`` payload carries
+    the running regime's cancel intent (``would_cancel_inflight``); on a
+    legacy log that IS the legacy verdict, so the divergence within a single
+    event is: does the legacy regime cancel / swap the plan where the new
+    regime would only signal? On a NEW-regime log the same field is the new
+    regime's (narrower) verdict and reveals nothing about legacy — the caller
+    (:func:`single_log_report`) must gate this to legacy-transport records.
     """
     cancels = bool(rec.decision.get("would_cancel_inflight")) or rec.channel in (
         "steer_control",
@@ -469,11 +590,23 @@ def _legacy_vs_new_within_event(rec: SignalRecord) -> dict[str, Any]:
 
 
 def single_log_report(records: list[SignalRecord]) -> dict[str, Any]:
-    """Census + per-event legacy-vs-new derivation for one shadow log."""
+    """Census + per-event legacy-vs-new derivation for one shadow log.
+
+    The legacy-vs-new derivation is derived ONLY from LEGACY-transport
+    deliveries: ``would_cancel_inflight`` is the *running* regime's cancel
+    verdict, so on a NEW-regime (request_context) log it is the new regime's
+    narrower verdict and reveals nothing about what legacy would have done.
+    Those deliveries are counted as ``undecidable`` and the report flags a
+    ``blind_spot`` — a single new-regime log CANNOT surface a cancel
+    divergence; use two-log mode (``--legacy``/``--new``) for that.
+    """
     by_channel: dict[str, int] = defaultdict(int)
     by_ladder: dict[str, int] = defaultdict(int)
     by_kind: dict[str, int] = defaultdict(int)
     dry = 0
+    legacy_transport = 0
+    new_transport = 0
+    undecidable = 0
     diverging: list[dict[str, Any]] = []
     for rec in records:
         by_channel[rec.channel] += 1
@@ -481,6 +614,13 @@ def single_log_report(records: list[SignalRecord]) -> dict[str, Any]:
         by_kind[rec.kind] += 1
         if rec.dry_run:
             dry += 1
+        if _record_regime(rec) == "new":
+            # would_cancel_inflight here is the NEW regime's (narrower) cancel
+            # verdict; it cannot reveal a legacy cancel divergence.
+            new_transport += 1
+            undecidable += 1
+            continue
+        legacy_transport += 1
         derived = _legacy_vs_new_within_event(rec)
         if derived["diverges"]:
             diverging.append(
@@ -492,6 +632,12 @@ def single_log_report(records: list[SignalRecord]) -> dict[str, Any]:
                     "new_action": derived["new_action"],
                 }
             )
+    if legacy_transport and new_transport:
+        regime = "mixed"
+    elif new_transport:
+        regime = "new"
+    else:
+        regime = "legacy"
     return {
         "deliveries": len(records),
         "dry_run": dry,
@@ -499,6 +645,14 @@ def single_log_report(records: list[SignalRecord]) -> dict[str, Any]:
         "by_channel": dict(by_channel),
         "by_ladder_level": dict(by_ladder),
         "by_kind": dict(by_kind),
+        "regime": regime,
+        "legacy_transport": legacy_transport,
+        "new_transport": new_transport,
+        # A single log can only derive legacy-vs-new from legacy-transport
+        # deliveries; new-transport deliveries are blind to cancel divergence.
+        "divergence_derivable": legacy_transport > 0,
+        "blind_spot": new_transport > 0,
+        "undecidable_deliveries": undecidable,
         "diverging_events": diverging,
     }
 
@@ -515,10 +669,38 @@ def render_single_log_text(report: dict[str, Any], *, path: str) -> str:
     lines.append(f"by channel:    {report['by_channel']}")
     lines.append(f"by ladder:     {report['by_ladder_level']}")
     lines.append(f"by kind:       {report['by_kind']}")
+    lines.append(
+        f"regime:        {report['regime']}  "
+        f"(legacy-transport={report['legacy_transport']}, "
+        f"new-transport={report['new_transport']})"
+    )
     lines.append("-" * 64)
+    if report["blind_spot"]:
+        lines.append(
+            f"BLIND SPOT: {report['undecidable_deliveries']} delivery(ies) ride "
+            "the NEW regime's transport (request_context)."
+        )
+        lines.append(
+            "  would_cancel_inflight on those is the NEW regime's own "
+            "(narrower) cancel verdict — it CANNOT reveal what legacy would"
+        )
+        lines.append(
+            "  have done, so a single-log census is blind to cancel "
+            "divergences here. Use two-log mode (--legacy/--new) to diff them."
+        )
+        lines.append("-" * 64)
     diverging = report["diverging_events"]
     if not diverging:
-        lines.append("no per-event legacy/new divergence derivable from the payloads.")
+        if report["divergence_derivable"]:
+            lines.append(
+                "no per-event legacy/new divergence derivable from the "
+                "legacy-transport payloads."
+            )
+        else:
+            lines.append(
+                "no legacy-transport deliveries — no legacy/new divergence is "
+                "derivable from this log alone (see BLIND SPOT above)."
+            )
         return "\n".join(lines)
     lines.append(f"{len(diverging)} delivery(ies) where legacy != new:")
     for d in diverging:

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -40,6 +40,8 @@ from bench.harness import (  # noqa: E402
     arm_flag_status,
     default_arms,
     make_linear_run_driver,
+    metrics_from_events,
+    outcome_terminality,
     run_arm,
     run_arms,
     shadow_arms,
@@ -49,9 +51,12 @@ from bench.shadow_diff import (  # noqa: E402
     SignalRecord,
     diff_two_logs,
     load_signals,
+    render_single_log_text,
     render_two_log_text,
     single_log_report,
 )
+from goldfive import Goal, Plan, Session, Task  # noqa: E402
+from goldfive.types import TaskKind, TaskStatus  # noqa: E402
 
 
 def _scenario(tasks: int = 3, inject: bool = True) -> Scenario:
@@ -71,8 +76,22 @@ async def test_three_arm_harness_runs_and_emits_telemetry(tmp_path: Path) -> Non
     assert [m.arm_kind for m in results] == ["baseline", "signal", "legacy"]
 
     for m in results:
-        # The workload completed: captured-artifact outcome is healthy.
-        assert m.goal_success, m.goal_reason
+        # §6.4: the stub workload defines NO goal predicate and NO OUTCOME
+        # task, so goal grading is UNMEASURED (not silently True) — the exact
+        # gap that blocks a flip decision on this workload. run.success alone
+        # is not a flip signal (deviation 1).
+        assert m.goal_grade == "unmeasured", m.goal_reason
+        assert m.goal_success is False
+        assert m.goal_predicate_count == 0
+        assert m.outcome_tasks_total == 0
+        assert m.outcome_terminal == {
+            "completed": 0,
+            "failed": 0,
+            "not_needed": 0,
+            "cancelled": 0,
+            "non_terminal": 0,
+        }
+        # The captured-artifact outcome is otherwise healthy.
         assert m.completed_outputs == 3
         assert m.turns >= 1
         # Telemetry flowed: the JSONL artifact exists and carries signals.
@@ -80,6 +99,16 @@ async def test_three_arm_harness_runs_and_emits_telemetry(tmp_path: Path) -> Non
         assert m.signals_total > 0, f"{m.arm_name}: 0 signals — telemetry not wired"
 
     by_kind = {m.arm_kind: m for m in results}
+    # plan_mode=ledger is CONFIGURED on arm B (a KNOWN/applied flag), but the
+    # StaticPlanner stub mints only FORECAST tasks, so the ledger regime is
+    # NOT exercised. Configured-and-applied must not read as validated: a stub
+    # that never fires an OUTCOME/DISCOVERED path does not validate ledger.
+    assert by_kind["signal"].plan_mode == "ledger"
+    assert by_kind["signal"].ledger_exercised is False
+    assert by_kind["signal"].discovered_tasks_total == 0
+    assert by_kind["baseline"].plan_mode == "forecast"
+    assert by_kind["baseline"].ledger_exercised is False
+    assert by_kind["legacy"].ledger_exercised is False
     # The baseline runs observation-only: every signal is dry-run, so the
     # self-correction *base rate* is fully unaided (the §2 counterfactual).
     base = by_kind["baseline"]
@@ -318,7 +347,9 @@ async def test_unknown_flag_degrades_gracefully(tmp_path: Path) -> None:
         },
     )
     metrics = await run_arm(arm, _scenario(), jsonl_dir=tmp_path)
-    assert metrics.goal_success
+    # The arm still runs and emits telemetry (the made-up flag no-ops); goal
+    # grading is UNMEASURED on the stub workload (no predicate / OUTCOME).
+    assert metrics.goal_grade == "unmeasured"
     assert metrics.signals_total > 0
     _, pending = arm_flag_status(arm)
     assert "GOLDFIVE_TOTALLY_MADE_UP_FLAG" in pending
@@ -342,6 +373,256 @@ def test_apply_arm_env_clears_and_restores(monkeypatch: pytest.MonkeyPatch) -> N
     # restored afterwards:
     assert os.environ["GOLDFIVE_STEER_OBSERVATION_ONLY"] == "1"
     assert "GOLDFIVE_STEER_SIGNAL_TELEMETRY" not in os.environ
+
+
+# ---------------------------------------------------------------------------
+# 7. Goal grading requires a signal; OUTCOME-terminality census (§6.4 rule 1)
+# ---------------------------------------------------------------------------
+
+
+def _outcome_session(
+    statuses: list[TaskStatus],
+    *,
+    predicate=None,
+    kind: TaskKind = TaskKind.OUTCOME,
+) -> Session:
+    """A synthetic run session whose plan carries tasks of the given kind."""
+    tasks = [
+        Task(id=f"o{i}", title=f"deliverable {i}", kind=kind, status=st)
+        for i, st in enumerate(statuses)
+    ]
+    plan = Plan(id="p", run_id="r", goal_ids=["g"], tasks=tasks, edges=[])
+    goal = Goal(id="g", summary="deliver the thing", success_predicate=predicate)
+    return Session(run_id="r", goals=[goal], plan=plan)
+
+
+class _FakeEvent:
+    """Minimal duck-typed proto event for the metric reducer (WhichOneof)."""
+
+    def __init__(self, which: str, payload: object) -> None:
+        self._which = which
+        setattr(self, which, payload)
+
+    def WhichOneof(self, _field: str) -> str:  # noqa: N802 - proto API shape
+        return self._which
+
+
+class _Aborted:
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+
+
+_ARM = Arm(name="unit", kind="signal")
+
+
+def test_outcome_terminality_census_is_deterministic() -> None:
+    session = _outcome_session(
+        [
+            TaskStatus.COMPLETED,
+            TaskStatus.COMPLETED,
+            TaskStatus.FAILED,
+            TaskStatus.NOT_NEEDED,
+            TaskStatus.PENDING,
+            TaskStatus.CANCELLED,
+        ]
+    )
+    total, census, discovered = outcome_terminality(session)
+    assert total == 6
+    assert discovered == 0
+    # Fixed key order, exact counts.
+    assert list(census.keys()) == [
+        "completed",
+        "failed",
+        "not_needed",
+        "cancelled",
+        "non_terminal",
+    ]
+    assert census == {
+        "completed": 2,
+        "failed": 1,
+        "not_needed": 1,
+        "cancelled": 1,
+        "non_terminal": 1,  # PENDING (the #208 carry-forward set)
+    }
+    # None session / no plan → all-zero census, not a crash.
+    assert outcome_terminality(None) == (
+        0,
+        {k: 0 for k in census},
+        0,
+    )
+
+
+def test_outcome_all_terminal_success_grades_met() -> None:
+    session = _outcome_session([TaskStatus.COMPLETED, TaskStatus.NOT_NEEDED])
+    m = metrics_from_events([], arm=_ARM, session=session, plan_mode="ledger")
+    assert m.goal_grade == "met"
+    assert m.goal_success is True
+    assert m.outcome_tasks_total == 2
+    # plan_mode=ledger AND OUTCOME tasks fired → the ledger regime was exercised.
+    assert m.ledger_exercised is True
+
+
+def test_outcome_failed_grades_unmet() -> None:
+    session = _outcome_session([TaskStatus.COMPLETED, TaskStatus.FAILED])
+    m = metrics_from_events([], arm=_ARM, session=session, plan_mode="ledger")
+    assert m.goal_grade == "unmet"
+    assert m.goal_success is False
+    assert "FAILED" in m.goal_reason
+
+
+def test_outcome_non_terminal_grades_unmet_not_silently_met() -> None:
+    # A deliverable still PENDING (uncertain, #208 carry-forward) is NOT a
+    # demonstrated success — it grades UNMET for the flip criterion, never MET.
+    session = _outcome_session([TaskStatus.COMPLETED, TaskStatus.PENDING])
+    m = metrics_from_events([], arm=_ARM, session=session, plan_mode="ledger")
+    assert m.goal_grade == "unmet"
+    assert "non-terminal" in m.goal_reason
+
+
+def test_goal_predicate_gate_precedes_outcome() -> None:
+    # A failing predicate fails the run even when the OUTCOME tasks completed.
+    session = _outcome_session(
+        [TaskStatus.COMPLETED], predicate=lambda _s: False
+    )
+    m = metrics_from_events([], arm=_ARM, session=session, plan_mode="ledger")
+    assert m.goal_grade == "unmet"
+    assert m.goal_predicate_count == 1
+    # A passing predicate + completed OUTCOME → met.
+    ok = _outcome_session([TaskStatus.COMPLETED], predicate=lambda _s: True)
+    m2 = metrics_from_events([], arm=_ARM, session=ok, plan_mode="ledger")
+    assert m2.goal_grade == "met"
+    assert m2.goal_success is True
+
+
+def test_no_signal_is_unmeasured_not_true() -> None:
+    # FORECAST-only plan, no predicate → no grading signal at all. The run is
+    # UNMEASURED, and goal_success is False (never a silent True).
+    session = _outcome_session(
+        [TaskStatus.COMPLETED, TaskStatus.COMPLETED], kind=TaskKind.FORECAST
+    )
+    m = metrics_from_events([], arm=_ARM, session=session, plan_mode="forecast")
+    assert m.goal_grade == "unmeasured"
+    assert m.goal_success is False
+    assert m.outcome_tasks_total == 0
+    assert m.ledger_exercised is False
+
+
+def test_abort_is_a_measured_failure() -> None:
+    session = _outcome_session([TaskStatus.COMPLETED])
+    events = [_FakeEvent("run_aborted", _Aborted("runaway delegation"))]
+    m = metrics_from_events(events, arm=_ARM, session=session, plan_mode="ledger")
+    assert m.aborted is True
+    assert m.goal_grade == "aborted"
+    assert m.goal_success is False
+    assert "runaway delegation" in m.goal_reason
+
+
+def test_ledger_exercised_needs_ledger_mode_and_a_ledger_task() -> None:
+    outcome_session = _outcome_session([TaskStatus.COMPLETED])
+    # OUTCOME tasks present but plan_mode=forecast → not exercised.
+    m_forecast = metrics_from_events(
+        [], arm=_ARM, session=outcome_session, plan_mode="forecast"
+    )
+    assert m_forecast.ledger_exercised is False
+    # DISCOVERED task in ledger mode also counts as exercised.
+    disc = _outcome_session([TaskStatus.COMPLETED], kind=TaskKind.DISCOVERED)
+    m_disc = metrics_from_events([], arm=_ARM, session=disc, plan_mode="ledger")
+    assert m_disc.discovered_tasks_total == 1
+    assert m_disc.outcome_tasks_total == 0
+    assert m_disc.ledger_exercised is True
+
+
+# ---------------------------------------------------------------------------
+# 8. Shadow-diff un-joinable cross-regime keys (§6.4 flip-target comparison)
+# ---------------------------------------------------------------------------
+
+
+def _sig(seq: int, *, task_id: str, kind: str = "off_topic", channel: str = "nudge_replay",
+         **decision: object) -> SignalRecord:
+    return SignalRecord(
+        sequence=seq,
+        drift_id=f"d{seq}",
+        kind=kind,
+        task_id=task_id,
+        channel=channel,
+        severity="critical",
+        turn=1,
+        dry_run=True,
+        ladder_level=str(decision.get("ladder_level", "nudge")),
+        note_text="",
+        decision=dict(decision),
+    )
+
+
+def test_disjoint_task_id_namespaces_are_unjoinable_not_divergence() -> None:
+    # The flip-target case: the legacy log fires OFF_TOPIC on forecast id
+    # "t000"; the new (ledger) log fires the same kind on OUTCOME id "oc-0".
+    # The (kind, task_id, occurrence) key cannot align — this is a join
+    # artifact, NOT a "regime stayed silent" divergence.
+    legacy = [_sig(1, task_id="t000", would_cancel_inflight=True)]
+    new = [_sig(1, task_id="oc-0", channel="request_context", would_cancel_inflight=False)]
+    report = diff_two_logs(legacy, new)
+    assert len(report.unjoinable_keys) == 2
+    assert report.diverged_keys == []  # excluded from the verdict
+    assert report.legacy_only == []  # not counted as genuine silence
+    assert report.new_only == []
+    text = render_two_log_text(report)
+    assert "UN-JOINABLE" in text
+    assert "no decision divergence" in text
+    assert report.to_dict()["unjoinable_keys"] == 2
+
+
+def test_genuine_one_sided_silence_is_not_flagged_unjoinable() -> None:
+    # The new regime never fires LOOPING at all → a genuine new-silence, a real
+    # legacy_only divergence (not a namespace artifact).
+    legacy = [_sig(1, task_id="t0", kind="looping_tool_call", would_cancel_inflight=False)]
+    new = [_sig(1, task_id="t0", kind="off_topic",
+                channel="request_context", would_cancel_inflight=False)]
+    report = diff_two_logs(legacy, new)
+    looping = [k for k in report.keys if k.kind == "looping_tool_call"][0]
+    assert looping.present_in == "legacy_only"
+    assert looping.unjoinable is False
+    assert looping.diverged is True
+    assert looping in report.legacy_only
+
+
+# ---------------------------------------------------------------------------
+# 9. Single-log census blind spot on new-regime logs (defect 4)
+# ---------------------------------------------------------------------------
+
+
+def test_single_log_new_regime_is_blind_to_cancel_divergence() -> None:
+    # A new-regime (request_context) log. would_cancel_inflight is the NEW
+    # regime's own (narrower) verdict, so the single-log census CANNOT reveal
+    # the legacy cancel divergence — it must flag the blind spot, not silently
+    # report "no divergence".
+    records = [
+        _sig(1, task_id="t0", channel="request_context", would_cancel_inflight=False),
+        _sig(2, task_id="t1", channel="request_context", would_cancel_inflight=False),
+    ]
+    census = single_log_report(records)
+    assert census["regime"] == "new"
+    assert census["blind_spot"] is True
+    assert census["divergence_derivable"] is False
+    assert census["undecidable_deliveries"] == 2
+    assert census["diverging_events"] == []
+    text = render_single_log_text(census, path="new.jsonl")
+    assert "BLIND SPOT" in text
+    # It must NOT claim a benign "no divergence derivable from the payloads".
+    assert "no per-event legacy/new divergence derivable from the payloads" not in text
+
+
+def test_single_log_legacy_regime_derivation_still_works() -> None:
+    records = [
+        _sig(1, task_id="t0", channel="nudge_replay", would_cancel_inflight=True),
+        _sig(2, task_id="t1", channel="nudge_replay", would_cancel_inflight=False),
+    ]
+    census = single_log_report(records)
+    assert census["regime"] == "legacy"
+    assert census["blind_spot"] is False
+    assert census["divergence_derivable"] is True
+    # The cancelling delivery is derivably a legacy-vs-new divergence.
+    assert [d["task_id"] for d in census["diverging_events"]] == ["t0"]
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Problem

The three-arm bench (`bench/`, PR 13a) under-measured the primary criterion the AGENCY-PRESERVATION.md §6.4 pre-flip checklist needs, so a real 13b run could not actually adjudicate the `plan_mode=ledger` / `observation_only=False` flip. All defects re-located by symbol on the current branch tip and confirmed still present (the reconcile moved code but did not change them).

**Defect 1 (HIGH) — no OUTCOME-terminality metric; `goal_success` degenerates to "not aborted".** `bench/harness.py::metrics_from_events` set `goal_success = not aborted` and only downgraded it if `evaluate_goal_predicates` (`goldfive/results.py`) returned a reason. With no `Goal.success_predicate` and no OUTCOME task — exactly the stub workload — it returned `None`, so every arm printed `goal_success: True` with zero grading signal. §6.4 rule 1: grade on goal predicates + OUTCOME-task terminality, never `run.success`.

**Defect 2 (MED) — ledger reported "applied" while never exercised.** Arm B sets `GOLDFIVE_PLAN_MODE=ledger` (a `KNOWN_STEER_ENV` flag, so `arm_flag_status` reports it *applied*), but `make_linear_run_driver` uses a `StaticPlanner` that mints only `TaskKind.FORECAST` tasks. The runtime even logs `plan_mode=ledger but the legacy per-task loop was selected ... OUTCOME deliverables are not per-task dispatchable`. Configured/applied was conflated with exercised.

**Defect 3 (MED) — shadow-diff cross-regime join structurally breaks.** `bench/shadow_diff.py::_assign_occurrences` joins on `(kind, task_id, occurrence)`. The flip-target comparison (ledger OUTCOME ids vs. forecast ids) has disjoint `task_id` namespaces, so every key falls to `legacy_only`/`new_only` — a silently-partial diff that reads as massive divergence.

**Defect 4 (MED) — single-log census blind to cancel divergence on new-regime logs.** `_legacy_vs_new_within_event` derives "legacy-would-do" from `would_cancel_inflight`, which `goldfive/drift_observer.py` computes with the *running* regime's cancel scope. On a new-regime (`request_context`, `user_and_safety`) log it is the new regime's narrower verdict and reveals nothing about legacy, so a real cancel divergence reads as "no divergence".

## Fix (measurement/harness code only — no `goldfive/` runtime touched)

1. New `outcome_terminality()` census (`outcome_tasks_total` + `outcome_terminal`: completed/failed/not_needed/cancelled/non_terminal, fixed key order). `_grade_goal()` yields `goal_grade` ∈ {met, unmet, aborted, **unmeasured**}; `goal_success == (grade is MET)`. No predicate and no OUTCOME → UNMEASURED, never silently True. Abort is a measured failure. Non-terminal OUTCOME is conservatively UNMET for the flip criterion (the #208 carry-forward is exposed in the census).
2. `ArmMetrics.plan_mode` + `ledger_exercised` (`plan_mode=ledger` AND ≥1 OUTCOME/DISCOVERED task fired). The table prints `configured but NOT exercised — does not validate ledger`.
3. `KeyDivergence.unjoinable`: a one-sided key whose kind fired in the other regime but on a disjoint `task_id` namespace is a join artifact — excluded from `diverged`/`legacy_only`/`new_only`, surfaced in `unjoinable_keys` + a loud report section. A goal-anchored wire id would join them; `SignalDelivered` has none today — **noted as a dependency for a sibling runtime PR** rather than adding runtime code here.
4. `single_log_report` infers regime from transport channel, gates the legacy-vs-new derivation to legacy-transport records, and reports `regime` / `blind_spot` / `undecidable_deliveries` — directing the operator to two-log mode instead of falsely reporting "no divergence".

## Why inert under default flags

Every change is in `bench/` (a non-installed harness never imported by the goldfive package/runtime) and `tests/`. No `goldfive/` source changed, no proto touched, no default flipped. Production behavior under `plan_mode=forecast` / `observation_only=True` / `signal_channel=legacy_user_message` / `signal_telemetry=False` is byte-identical.

## Tests (both modes)

`tests/test_bench_harness.py` (22 pass). Passive/unmeasured: the stub three-arm run now asserts `goal_grade == "unmeasured"`, `goal_success is False`, and `ledger_exercised is False` for arm B (the honest gap). Active/exercised: synthetic OUTCOME sessions cover met / failed / non-terminal / predicate-gate / abort grading and `ledger_exercised` for OUTCOME and DISCOVERED tasks. Shadow-diff: disjoint-namespace keys flagged un-joinable and excluded from the verdict, genuine one-sided silence still counted. Census: new-regime log flags `blind_spot`/undecidable and emits no false "no divergence"; legacy-regime derivation still works. Determinism verified (identical JSON across repeated stub runs). Full suite: 3279 passed, 61 skipped; `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA
