### PR TITLE
fix: make ledger plan mode functional at completion time

### DIFF
--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -4283,10 +4283,34 @@ class DriftObserver:
             run_ending=run_ending,
             goal_predicates_met=predicates_met,
         )
-        await self._apply_outcome_transitions(session, transitions)
+        # ``plan`` is the snapshot the verdicts were computed against
+        # BEFORE the judge's LLM round-trip; ``session.plan`` may have
+        # been revised in between (a USER_STEER refine can regenerate
+        # OUTCOME deliverables under reused ids). Pass the snapshot so the
+        # apply path can drop any verdict whose target no longer matches.
+        await self._apply_outcome_transitions(session, transitions, snapshot_plan=plan)
+
+    @staticmethod
+    def _outcome_stability_token(task: Any) -> tuple[str, str]:
+        """Stability token for an OUTCOME task's identity across a revision.
+
+        Pairs the ledger ``kind`` with the (normalised) title. A verdict
+        computed against a snapshot task is only safe to apply to the live
+        task of the same id when this token still matches — a reused id
+        carrying a different deliverable (different kind or title) is a
+        distinct task the stale verdict must not touch.
+        """
+        kind = getattr(task, "kind", None)
+        kind_str = str(getattr(kind, "value", kind) or "")
+        title = (getattr(task, "title", "") or "").strip()
+        return (kind_str, title)
 
     async def _apply_outcome_transitions(
-        self, session: Session, transitions: list[Any]
+        self,
+        session: Session,
+        transitions: list[Any],
+        *,
+        snapshot_plan: Any | None = None,
     ) -> None:
         """Apply outcome transitions: stamp contributes_to, then transition.
 
@@ -4297,9 +4321,54 @@ class DriftObserver:
         Marking an OUTCOME terminal re-enters ``mark_task_*`` → the
         task-boundary hook, which the PR 11(c) OUTCOME-skip guard
         short-circuits, so this does not recurse.
+
+        ``snapshot_plan`` (when supplied) is the plan the verdicts were
+        computed against, before the judge's LLM round-trip. The freshness
+        gate below mirrors the reasoning-judge late-verdict discipline
+        (goldfive#319): the evaluate → apply gap yields the event loop, so
+        a concurrent USER_STEER refine may have swapped ``session.plan``.
+        A transition is applied only when the LIVE task of the same id
+        still carries the snapshot's stability token and is non-terminal;
+        otherwise the verdict is stale (the deliverable it graded is gone
+        or has been replaced under the same id) and is skipped, so a stale
+        ``met`` verdict cannot false-complete a different deliverable.
         """
         if not transitions:
             return
+        if snapshot_plan is not None:
+            snap_tokens = {
+                t.id: self._outcome_stability_token(t)
+                for t in (getattr(snapshot_plan, "tasks", None) or ())
+                if getattr(t, "id", "")
+            }
+            live_by_id = {
+                t.id: t
+                for t in (getattr(session.plan, "tasks", None) or ())
+                if getattr(t, "id", "")
+            }
+            fresh: list[Any] = []
+            for tr in transitions:
+                live = live_by_id.get(tr.task_id)
+                snap_token = snap_tokens.get(tr.task_id)
+                if (
+                    live is None
+                    or snap_token is None
+                    or self._outcome_stability_token(live) != snap_token
+                    or getattr(live, "status", None) in TERMINAL_TASK_STATUSES
+                ):
+                    log.info(
+                        "DefaultSteerer: stale outcome verdict for task %r "
+                        "skipped; plan was revised under the judge round-trip "
+                        "(snapshot token %r, live token %r)",
+                        tr.task_id,
+                        snap_token,
+                        None if live is None else self._outcome_stability_token(live),
+                    )
+                    continue
+                fresh.append(tr)
+            transitions = fresh
+            if not transitions:
+                return
         stamps: list[tuple[str, str]] = [
             pair for tr in transitions for pair in getattr(tr, "contributes_stamps", ())
         ]

--- a/goldfive/plan_reviser.py
+++ b/goldfive/plan_reviser.py
@@ -1460,6 +1460,91 @@ class PlanReviser:
         )
         return dataclasses.replace(revised, tasks=tuple(new_tasks))
 
+    def _preserve_ledger_identity(self, revised: Plan, prior: Plan | None) -> Plan:
+        """Carry the ledger taxonomy + DISCOVERED identity across a revision.
+
+        AGENCY-PRESERVATION.md Stage 3 PR 10/11(c). A no-op unless
+        ``SteeringConfig.plan_mode == "ledger"`` — forecast-mode installs
+        return ``revised`` untouched (bit-identical guarantee).
+
+        In ledger mode the plan is a ledger of goal-anchored OUTCOME
+        deliverables plus a descriptively-grown DISCOVERED trajectory. The
+        LLM-driven refine / user-steer paths reconstruct the plan from
+        JSON (``_plan_from_json``), which resets every ``Task.kind`` to the
+        FORECAST default and drops ``discovered`` / ``discovery_identity_hash``
+        / ``contributes_to`` / ``assignee_agent_id``. Left alone that
+        relabels OUTCOME deliverables as FORECAST (the outcome-progress
+        judge only grades OUTCOME tasks, so the flagship regime goes dark)
+        and severs the DISCOVERED lane's provenance. Two repairs, keyed by
+        id against ``prior``:
+
+        * **Preserve** — for a revised task whose id exists in ``prior``
+          with a non-FORECAST ledger kind, copy the prior ``kind`` and the
+          DISCOVERED identity fields (a non-empty prior value wins for the
+          hash / contributes_to / assignee; the revised task never carries
+          them since ``_plan_from_json`` drops them).
+        * **Stamp** — a genuinely new task (id absent from ``prior``,
+          still FORECAST) is a new OUTCOME deliverable, matching
+          :func:`goldfive.planner._stamp_ledger_outcome_kinds`.
+
+        Additionally, a NON-TERMINAL DISCOVERED task in ``prior`` that the
+        revision silently dropped is re-appended as an independent node
+        (no edges — DISCOVERED tasks are sub-DAG roots): the observed
+        trajectory is a historical record a refine must not erase.
+        Terminal DISCOVERED tasks are already validator-protected
+        (terminal-task preservation) so they are never re-added here.
+
+        Returns a NEW :class:`Plan` when anything changed (frozen-Plan
+        invariant, goldfive#247); the input reference otherwise.
+        """
+        if not self._ledger_mode():
+            return revised
+        prior_tasks = list(getattr(prior, "tasks", None) or ())
+        prior_by_id: dict[str, Task] = {t.id: t for t in prior_tasks if t.id}
+        revised_ids = {t.id for t in revised.tasks if t.id}
+        new_tasks: list[Task] = []
+        changed = False
+        for t in revised.tasks:
+            pt = prior_by_id.get(t.id)
+            if pt is not None and pt.kind is not TaskKind.FORECAST:
+                replacement = dataclasses.replace(
+                    t,
+                    kind=pt.kind,
+                    discovered=pt.discovered or t.discovered,
+                    discovery_identity_hash=(
+                        pt.discovery_identity_hash or t.discovery_identity_hash
+                    ),
+                    contributes_to=pt.contributes_to or t.contributes_to,
+                    assignee_agent_id=t.assignee_agent_id or pt.assignee_agent_id,
+                )
+                if replacement != t:
+                    changed = True
+                new_tasks.append(replacement)
+            elif pt is None and t.kind is TaskKind.FORECAST:
+                new_tasks.append(dataclasses.replace(t, kind=TaskKind.OUTCOME))
+                changed = True
+            else:
+                new_tasks.append(t)
+        readded: list[str] = []
+        for pt in prior_tasks:
+            if not pt.id or pt.id in revised_ids:
+                continue
+            is_discovered = pt.kind is TaskKind.DISCOVERED or pt.discovered
+            if is_discovered and pt.status not in TERMINAL_TASK_STATUSES:
+                new_tasks.append(pt)
+                readded.append(pt.id)
+        if readded:
+            changed = True
+            log.info(
+                "PlanReviser._preserve_ledger_identity: re-added %d dropped "
+                "non-terminal DISCOVERED task(s): %s",
+                len(readded),
+                ", ".join(readded),
+            )
+        if not changed:
+            return revised
+        return dataclasses.replace(revised, tasks=tuple(new_tasks))
+
     @staticmethod
     def _plans_structurally_identical(prior: Plan | None, revised: Plan) -> bool:
         """Return ``True`` iff ``revised`` has the same structural shape as ``prior``.
@@ -1817,6 +1902,18 @@ class PlanReviser:
         # already matches prior's terminal, this is a no-op. Returns a
         # NEW Plan (goldfive#247: Plan is frozen).
         revised = self._fold_runtime_terminal_statuses(revised, prev)
+        # AGENCY-PRESERVATION.md Stage 3 — ledger taxonomy preservation.
+        # The refine / user-steer paths rebuild the plan from LLM JSON via
+        # ``_plan_from_json``, which resets every ``Task.kind`` to the
+        # FORECAST default and drops the DISCOVERED identity fields. In
+        # ledger mode that silently erases the OUTCOME / DISCOVERED
+        # taxonomy — permanently disabling outcome judging — and can drop
+        # the DISCOVERED trajectory record. Re-fold the ledger identity
+        # from the prior plan here, the single chokepoint every install
+        # path (drift refine, user-steer, handle_turn, initial) funnels
+        # through. Ledger-gated: a no-op in forecast mode (Plan returned
+        # unchanged), so forecast-mode installs stay bit-identical.
+        revised = self._preserve_ledger_identity(revised, prev)
         prior_id = (getattr(prev, "id", "") or "") if prev is not None else ""
         next_index = (prev.revision_index + 1) if prev is not None else 1
         # goldfive#247: Plan is frozen — derive a new instance with the

--- a/goldfive/reconciler.py
+++ b/goldfive/reconciler.py
@@ -372,6 +372,19 @@ class PlanReconciler:
                 self._session.state, task, TaskStatus.FAILED
             )
             return
+        # AGENCY-PRESERVATION.md PR 11(c): capture the observed output as
+        # outcome-progress evidence BEFORE the COMPLETED transition (the
+        # transition re-enters the task-boundary hook that spawns the
+        # outcome-progress judge, which reads ``session.completed_outputs``).
+        # In overlay mode — the ONLY execution mode ledger plan mode
+        # supports — the executors that normally populate
+        # ``completed_outputs`` never run, so without this the outcome
+        # judge has no evidence and can never decide OUTCOME completion.
+        # Keyed by the closed task id (the DISCOVERED trajectory task) so
+        # the judge can attribute contributing steps. Ledger-gated: in
+        # forecast mode the dict is left untouched (bit-identical to
+        # pre-PR-11).
+        self._maybe_record_completed_output(task_id, summary)
         try:
             await self._steerer.transition(
                 task_id,
@@ -650,6 +663,50 @@ class PlanReconciler:
                 exc,
             )
             return None
+
+    def _ledger_mode(self) -> bool:
+        """Return True iff ``SteeringConfig.plan_mode == "ledger"``.
+
+        Reads through the bound steerer's typed config exactly as
+        :meth:`_maybe_grow_discovered_task` reads
+        ``descriptive_growth_enabled``. Defensive: any read failure
+        (custom steerer without a typed config, test stub) resolves to
+        forecast mode so the legacy overlay path is untouched.
+        """
+        try:
+            cfg = getattr(self._steerer, "_steering_config", None)
+            if cfg is None:
+                return False
+            return str(getattr(cfg, "plan_mode", "forecast")).strip().lower() == "ledger"
+        except Exception:  # noqa: BLE001
+            return False
+
+    def _maybe_record_completed_output(self, task_id: str, summary: str) -> None:
+        """Record ``summary`` as the outcome-progress evidence for ``task_id``.
+
+        AGENCY-PRESERVATION.md PR 11(c). In ledger plan mode the
+        outcome-progress judge (``drift/outcome_progress.py``) grades
+        OUTCOME deliverables against ``session.completed_outputs`` — the
+        full-output capture the executors populate in the driving model.
+        Ledger plan mode only ever runs the overlay model, where the
+        executors never see task outputs, so this is the observation
+        entry point that populates that evidence source. No-op (and no
+        write) in forecast mode, so forecast-mode observation state is
+        byte-identical to pre-PR-11.
+        """
+        if not task_id or not summary:
+            return
+        if not self._ledger_mode():
+            return
+        try:
+            self._session.completed_outputs[task_id] = summary
+        except Exception as exc:  # noqa: BLE001 — observability capture
+            log.debug(
+                "PlanReconciler._maybe_record_completed_output: capture "
+                "for %r raised: %s",
+                task_id,
+                exc,
+            )
 
     def _find_task(self, task_id: str) -> Task | None:
         plan = self._session.plan

--- a/tests/test_ledger_outcome_wiring.py
+++ b/tests/test_ledger_outcome_wiring.py
@@ -294,3 +294,102 @@ def test_executor_plan_mode_reads_steerer_config() -> None:
     assert _executor_plan_mode(forecast) == "forecast"
     # Defensive: a steerer without a typed config → forecast.
     assert _executor_plan_mode(object()) == "forecast"
+
+
+# ---------------------------------------------------------------------------
+# Outcome-verdict freshness gate (same-id false-complete guard).
+#
+# The judge computes verdicts against a plan snapshot BEFORE an LLM
+# round-trip; ``session.plan`` may be swapped by a concurrent USER_STEER
+# refine during that round-trip. A verdict is applied only when the live
+# task of the same id still carries the snapshot's stability token.
+# ---------------------------------------------------------------------------
+
+
+def _swap_plan(session: Session, new_plan: Plan) -> None:
+    from goldfive.types import channel_processor_active, set_session_plan
+
+    with channel_processor_active():
+        set_session_plan(session, new_plan)
+
+
+def test_finalize_outcomes_skips_stale_verdict_after_reused_id_revision() -> None:
+    # The judge says the OLD o1 is met, but a refine lands DURING the
+    # round-trip that regenerates o1 as a DIFFERENT deliverable under the
+    # same id. The stale "met" must NOT false-complete the new o1.
+    session = _ledger_session()
+    payload = (
+        '{"outcomes": [{"task_id": "o1", "assessment": "met", '
+        '"reason": "old summary present"}]}'
+    )
+
+    async def racing_llm(system: str, user: str, model: str) -> str:
+        _swap_plan(
+            session,
+            Plan(
+                id=session.plan.id,
+                run_id=session.plan.run_id,
+                goal_ids=list(session.plan.goal_ids),
+                tasks=(
+                    Task(id="o1", title="Entirely different deliverable", kind=TaskKind.OUTCOME),
+                    Task(id="o2", title="Translation delivered", kind=TaskKind.OUTCOME),
+                ),
+                edges=(),
+                revision_index=session.plan.revision_index + 1,
+            ),
+        )
+        return payload
+
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=racing_llm)
+    asyncio.run(steerer.finalize_outcomes(session))
+
+    by_id = {t.id: t for t in session.plan.tasks}
+    assert by_id["o1"].status is TaskStatus.PENDING  # stale verdict skipped
+
+
+def test_finalize_outcomes_skips_verdict_when_outcome_task_removed() -> None:
+    # A refine drops o1 entirely during the round-trip; the verdict for a
+    # now-absent task is skipped rather than raising / mis-applying.
+    session = _ledger_session()
+    payload = (
+        '{"outcomes": [{"task_id": "o1", "assessment": "met", "reason": "x"},'
+        '{"task_id": "o2", "assessment": "met", "reason": "y"}]}'
+    )
+
+    async def racing_llm(system: str, user: str, model: str) -> str:
+        _swap_plan(
+            session,
+            Plan(
+                id=session.plan.id,
+                run_id=session.plan.run_id,
+                goal_ids=list(session.plan.goal_ids),
+                tasks=(
+                    Task(id="o2", title="Translation delivered", kind=TaskKind.OUTCOME),
+                ),
+                edges=(),
+                revision_index=session.plan.revision_index + 1,
+            ),
+        )
+        return payload
+
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=racing_llm)
+    asyncio.run(steerer.finalize_outcomes(session))
+
+    by_id = {t.id: t for t in session.plan.tasks}
+    assert "o1" not in by_id  # dropped by the refine, not resurrected
+    # o2 still matches its snapshot token → its met verdict applies.
+    assert by_id["o2"].status is TaskStatus.COMPLETED
+
+
+def test_finalize_outcomes_applies_verdict_when_token_stable() -> None:
+    # Control: an unchanged plan (matching stability token) still applies
+    # the met verdict — the freshness gate does not over-reject.
+    session = _ledger_session()
+    payload = (
+        '{"outcomes": [{"task_id": "o1", "assessment": "met", "reason": "present"}]}'
+    )
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=_judge(payload))
+    asyncio.run(steerer.finalize_outcomes(session))
+
+    by_id = {t.id: t for t in session.plan.tasks}
+    assert by_id["o1"].status is TaskStatus.COMPLETED

--- a/tests/test_plan_reconciler.py
+++ b/tests/test_plan_reconciler.py
@@ -782,3 +782,90 @@ async def test_lifecycle_deep_hierarchy() -> None:
     assert statuses == {"t0": TaskStatus.COMPLETED, "t1": TaskStatus.COMPLETED}
     # coord1 is plumbing — no PLAN_DIVERGENCE.
     assert steerer.drifts == []
+
+
+# ---------------------------------------------------------------------------
+# 9. Outcome-progress evidence capture (AGENCY-PRESERVATION.md PR 11(c)).
+#
+# In overlay mode — the ONLY execution mode ledger plan mode supports —
+# the executors that normally populate ``session.completed_outputs``
+# never run, so the outcome-progress judge would have no evidence. The
+# reconciler is the observation entry point that captures the agent's
+# observed output on task completion. Ledger-gated: forecast mode leaves
+# ``completed_outputs`` untouched.
+# ---------------------------------------------------------------------------
+
+
+class _LedgerSteerer(_RecordingSteerer):
+    """Recording steerer that also exposes a typed ledger/forecast config."""
+
+    def __init__(self, *, plan_mode: str) -> None:
+        super().__init__()
+        from goldfive.config import SteeringConfig
+
+        self._steering_config = SteeringConfig(plan_mode=plan_mode)
+
+
+async def test_after_agent_captures_completed_output_in_ledger_mode() -> None:
+    session = _make_session(
+        [
+            Task(id="t0", title="research", assignee_agent_id="research_agent"),
+        ]
+    )
+    steerer = _LedgerSteerer(plan_mode="ledger")
+    rec = PlanReconciler(session=session, steerer=steerer, host_agent_name="coordinator")
+
+    await rec.on_before_agent(agent_name="research_agent", invocation_id="inv1")
+    await rec.on_after_agent(
+        agent_name="research_agent",
+        invocation_id="inv1",
+        summary="found 3 facts about cherry trees",
+    )
+
+    # The observed output is now available to the outcome-progress judge,
+    # keyed by the closed task id.
+    assert session.completed_outputs["t0"] == "found 3 facts about cherry trees"
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+
+
+async def test_after_agent_does_not_capture_output_in_forecast_mode() -> None:
+    session = _make_session(
+        [
+            Task(id="t0", title="research", assignee_agent_id="research_agent"),
+        ]
+    )
+    steerer = _LedgerSteerer(plan_mode="forecast")
+    rec = PlanReconciler(session=session, steerer=steerer, host_agent_name="coordinator")
+
+    await rec.on_before_agent(agent_name="research_agent", invocation_id="inv1")
+    await rec.on_after_agent(
+        agent_name="research_agent",
+        invocation_id="inv1",
+        summary="found 3 facts",
+    )
+
+    # Forecast mode: the capture is a no-op — bit-identical to pre-PR-11.
+    assert session.completed_outputs == {}
+    assert session.plan.tasks[0].status is TaskStatus.COMPLETED
+
+
+async def test_after_agent_failed_task_does_not_capture_output() -> None:
+    session = _make_session(
+        [
+            Task(id="t0", title="research", assignee_agent_id="research_agent"),
+        ]
+    )
+    steerer = _LedgerSteerer(plan_mode="ledger")
+    rec = PlanReconciler(session=session, steerer=steerer, host_agent_name="coordinator")
+
+    await rec.on_before_agent(agent_name="research_agent", invocation_id="inv1")
+    await rec.on_after_agent(
+        agent_name="research_agent",
+        invocation_id="inv1",
+        error=RuntimeError("boom"),
+        summary="partial",
+    )
+
+    # A FAILED task is not evidence of a produced deliverable.
+    assert session.completed_outputs == {}
+    assert session.plan.tasks[0].status is TaskStatus.FAILED

--- a/tests/test_plan_reviser.py
+++ b/tests/test_plan_reviser.py
@@ -46,6 +46,7 @@ from goldfive.types import (  # noqa: E402
     SupersessionKind,
     Task,
     TaskEdge,
+    TaskKind,
     TaskStatus,
 )
 
@@ -410,3 +411,141 @@ async def test_apply_revision_does_not_mutate_session_before_emit() -> None:
         "target) watermark — the stamp moved into _emit_plan_revised's "
         "lock so it never appears without the matching session.plan swap"
     )
+
+
+# ---------------------------------------------------------------------------
+# Ledger taxonomy preservation across a revision
+# (AGENCY-PRESERVATION.md Stage 3 PR 10/11(c)).
+#
+# The refine / user-steer paths rebuild the plan from LLM JSON, which
+# resets every ``Task.kind`` to FORECAST and drops the DISCOVERED
+# identity fields. ``_apply_revision`` (the single install chokepoint)
+# re-folds the ledger identity from the prior plan in ledger mode.
+# ---------------------------------------------------------------------------
+
+
+def _ledger_prior() -> Plan:
+    """A ledger plan: two OUTCOME deliverables + two DISCOVERED tasks."""
+    return Plan(
+        id="p-led",
+        run_id="r-led",
+        goal_ids=["g-led"],
+        tasks=[
+            Task(id="o1", title="Summary delivered", kind=TaskKind.OUTCOME),
+            Task(id="o2", title="Translation delivered", kind=TaskKind.OUTCOME),
+            Task(
+                id="d1",
+                title="writer: drafted summary",
+                assignee_agent_id="writer",
+                discovered=True,
+                discovery_identity_hash="hash-d1",
+                contributes_to="o1",
+                kind=TaskKind.DISCOVERED,
+                status=TaskStatus.COMPLETED,
+            ),
+            Task(
+                id="d2",
+                title="translator: running",
+                assignee_agent_id="translator",
+                discovered=True,
+                discovery_identity_hash="hash-d2",
+                kind=TaskKind.DISCOVERED,
+                status=TaskStatus.RUNNING,
+            ),
+        ],
+        edges=[],
+        revision_index=3,
+    )
+
+
+def _refined_forecast_shape(prior: Plan) -> Plan:
+    """The plan as it comes back from ``_plan_from_json`` after a refine.
+
+    Every task carries the FORECAST default and has lost the DISCOVERED
+    identity fields (assignee, discovered bool, hash, contributes_to) —
+    exactly what the LLM-rebuild path produces. ``d2`` (a non-terminal
+    DISCOVERED task) is silently DROPPED, and a genuinely-new task is
+    added.
+    """
+    return Plan(
+        id=prior.id,
+        run_id=prior.run_id,
+        goal_ids=list(prior.goal_ids),
+        tasks=[
+            # OUTCOME kind lost → FORECAST.
+            Task(id="o1", title="Summary delivered", status=TaskStatus.COMPLETED),
+            Task(id="o2", title="Translation delivered"),
+            # DISCOVERED identity lost → bare FORECAST task.
+            Task(id="d1", title="writer: drafted summary", status=TaskStatus.COMPLETED),
+            # d2 dropped entirely.
+            # brand-new deliverable produced by the steer.
+            Task(id="o3", title="Glossary delivered"),
+        ],
+        edges=[],
+        revision_index=prior.revision_index + 1,
+    )
+
+
+def test_preserve_ledger_identity_restores_kinds_and_identity() -> None:
+    prior = _ledger_prior()
+    revised = _refined_forecast_shape(prior)
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(observation_only=False, plan_mode="ledger")
+    )
+
+    out = steerer.plans._preserve_ledger_identity(revised, prior)
+    by_id = {t.id: t for t in out.tasks}
+
+    # OUTCOME taxonomy restored on surviving deliverables.
+    assert by_id["o1"].kind is TaskKind.OUTCOME
+    assert by_id["o2"].kind is TaskKind.OUTCOME
+    # DISCOVERED identity restored verbatim.
+    assert by_id["d1"].kind is TaskKind.DISCOVERED
+    assert by_id["d1"].discovered is True
+    assert by_id["d1"].discovery_identity_hash == "hash-d1"
+    assert by_id["d1"].contributes_to == "o1"
+    assert by_id["d1"].assignee_agent_id == "writer"
+    # A genuinely-new task becomes an OUTCOME deliverable.
+    assert by_id["o3"].kind is TaskKind.OUTCOME
+    # The dropped non-terminal DISCOVERED task is re-added, intact.
+    assert "d2" in by_id
+    assert by_id["d2"].kind is TaskKind.DISCOVERED
+    assert by_id["d2"].discovered is True
+    assert by_id["d2"].discovery_identity_hash == "hash-d2"
+    assert by_id["d2"].status is TaskStatus.RUNNING
+
+
+def test_preserve_ledger_identity_is_noop_in_forecast_mode() -> None:
+    prior = _ledger_prior()
+    revised = _refined_forecast_shape(prior)
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(observation_only=False, plan_mode="forecast")
+    )
+
+    out = steerer.plans._preserve_ledger_identity(revised, prior)
+
+    # Forecast mode: returned unchanged (same reference), kinds untouched.
+    assert out is revised
+    assert all(t.kind is TaskKind.FORECAST for t in out.tasks)
+    assert "d2" not in {t.id for t in out.tasks}
+
+
+def test_apply_revision_preserves_ledger_taxonomy_end_to_end() -> None:
+    prior = _ledger_prior()
+    session = _make_session(prior)
+    revised = _refined_forecast_shape(prior)
+    drift = _drift(kind=DriftKind.USER_STEER, task_id="o2")
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(observation_only=False, plan_mode="ledger")
+    )
+
+    returned, _was_installed = steerer.plans._apply_revision(session, revised, drift)
+    by_id = {t.id: t for t in returned.tasks}
+
+    # The install chokepoint carried the ledger taxonomy through — the
+    # outcome judge will still see OUTCOME tasks to grade.
+    assert by_id["o1"].kind is TaskKind.OUTCOME
+    assert by_id["o2"].kind is TaskKind.OUTCOME
+    assert by_id["o3"].kind is TaskKind.OUTCOME
+    assert by_id["d1"].kind is TaskKind.DISCOVERED
+    assert by_id["d2"].kind is TaskKind.DISCOVERED  # dropped task re-added


### PR DESCRIPTION
## Problem

Ledger plan mode (`plan_mode="ledger"`, the flagship agency-preservation regime, non-default) shipped **structurally inert at completion time**: the outcome-progress judge that decides "run complete = all OUTCOME deliverables terminal" could never actually decide, and USER_STEER/refine revisions silently destroyed the ledger taxonomy. All four defects were re-located by symbol on the current branch tip and confirmed present; all fixes are ledger-gated and inert under the `forecast` default.

### 1 — HIGH: outcome judge's evidence source never populated in overlay mode
`goldfive/drift/outcome_progress.py::evaluate_outcome_progress` grades OUTCOME tasks against `session.completed_outputs`. That dict is populated **only by the executors** (`executors/parallel.py`, `executors/sequential.py`) — but ledger mode only ever runs the **overlay** model, where the executors never see task outputs. So the judge always ran with empty evidence → the regime could never complete a deliverable.

**Fix:** `PlanReconciler.on_after_agent` (`goldfive/reconciler.py`) now captures the observed agent output (keyed by the closed task id) into `session.completed_outputs` **before** the COMPLETED transition that re-enters the task-boundary hook spawning the judge. Distinct location from `_adk_plugin.py::_maybe_annotate_tool_result` / the pin-tier region (untouched per brief). Ledger-gated via a new `_ledger_mode()` helper mirroring `_maybe_grow_discovered_task`'s config read.

### 2 — HIGH: USER_STEER refine erases the ledger taxonomy
`planner._plan_from_json` (used by every refine/user-steer attempt, e.g. `_user_steer_one_attempt`) rebuilds tasks with `kind=FORECAST` and drops `discovered` / `discovery_identity_hash` / `contributes_to` / `assignee_agent_id`. `_stamp_ledger_outcome_kinds` is only called on the `generate` / `handle_turn` paths — **never on refine** — so a USER_STEER reset every OUTCOME task to FORECAST, permanently disabling outcome judging (the judge only grades `TaskKind.OUTCOME`).

### 3 — MEDIUM: refine strips DISCOVERED identity and can drop discovered tasks
Same root as #2 for surviving tasks; additionally a non-terminal DISCOVERED task the refine LLM omits is dropped entirely (terminal ones are validator-protected, non-terminal ones are not).

**Fix for 2+3:** `PlanReviser._preserve_ledger_identity`, called at `_apply_revision` — the single chokepoint every install path (drift refine, user-steer, `handle_turn`, initial) funnels through. It re-folds `kind` + the DISCOVERED identity fields from the prior plan, stamps genuinely-new tasks OUTCOME (matching `_stamp_ledger_outcome_kinds`), and re-appends any silently-dropped non-terminal DISCOVERED task as an independent node. Ledger-gated no-op in forecast (returns the input reference unchanged).

### 4 — MEDIUM: outcome verdicts applied against a stale plan snapshot
`_run_outcome_progress` computes verdicts against a `plan` snapshot, then the async LLM round-trip yields the loop; `_apply_outcome_transitions` then marks tasks on the **live** `session.plan`. A concurrent USER_STEER refine can regenerate an OUTCOME deliverable under a reused id → same-id false-complete.

**Fix:** `_apply_outcome_transitions` takes the `snapshot_plan` and applies a verdict only when the live task of the same id still carries the snapshot's `(kind, title)` stability token and is non-terminal; otherwise it skips (re-judged next boundary). Mirrors the reasoning-judge late-verdict discipline (goldfive#319).

## Why it's inert under default flags
Every code path added is gated on `SteeringConfig.plan_mode == "ledger"` (default `"forecast"`): the reconciler capture no-ops and writes nothing; `_preserve_ledger_identity` returns the input plan unchanged; the freshness gate lives inside the ledger-only `_run_outcome_progress`. No default flag behavior changes; no `is_active_steering()` gate is bypassed (none is involved here).

## Tests (both modes)
- `tests/test_plan_reconciler.py` — ledger mode captures completed output; **forecast mode captures nothing** (bit-identical); FAILED tasks are not captured.
- `tests/test_plan_reviser.py` — `_preserve_ledger_identity` restores OUTCOME/DISCOVERED kinds + identity, stamps new tasks OUTCOME, re-adds a dropped non-terminal DISCOVERED task; **forecast mode is a no-op** (same reference); end-to-end through `_apply_revision` on a USER_STEER drift.
- `tests/test_ledger_outcome_wiring.py` — stale reused-id verdict skipped; verdict for a removed OUTCOME skipped; **stable-token verdict still applies** (no over-rejection).

Full suite: `3276 passed, 61 skipped`. `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA