### PR TITLE
fix(bench): grade ledger exercise on the outcome-progress judge's trace, not stamped-OUTCOME terminality

### DIFF
--- a/bench/harness.py
+++ b/bench/harness.py
@@ -97,6 +97,7 @@ __all__ = [
     "GOAL_GRADE_UNMET",
     "MANAGED_STEER_ENV",
     "KNOWN_STEER_ENV",
+    "OUTCOME_JUDGE_SOURCE",
     "Scenario",
     "apply_arm_env",
     "arm_flag_status",
@@ -119,6 +120,25 @@ GOAL_GRADE_MET = "met"
 GOAL_GRADE_UNMET = "unmet"
 GOAL_GRADE_ABORTED = "aborted"
 GOAL_GRADE_UNMEASURED = "unmeasured"
+
+#: The ``TaskTransitioned.source`` string goldfive's own outcome-progress judge
+#: stamps when it transitions an OUTCOME deliverable to a terminal status (see
+#: ``goldfive/drift_observer.py::_apply_outcome_transitions``). This is the
+#: GENUINE ledger-exercise trace. In ledger plan mode an OUTCOME task reaches a
+#: terminal status *only* when this judge grades it — the wrapped agent never
+#: reports on deliverables (``goldfive/drift/outcome_progress.py``), so "run
+#: completion = all OUTCOMEs terminal" is decidable without agent cooperation.
+#: The catch (the defect this constant guards): install-time OUTCOME stamping
+#: (``_stamp_ledger_outcome_kinds`` / ``PlanReviser._preserve_ledger_identity``)
+#: labels a plan's tasks OUTCOME the moment ``plan_mode=ledger`` resolves, so a
+#: NON-overlay run (StaticPlanner + the legacy per-task loop, which cannot
+#: dispatch OUTCOME deliverables) still force-completes those stamped tasks —
+#: with the default ``"other"`` source, NOT this judge. That terminality is a
+#: PHANTOM: OUTCOME-labelled tasks completed by per-task dispatch are not
+#: genuine ledger deliverables. Grading/exercise must therefore key on the
+#: judge's own transition trace, never on OUTCOME terminality alone (the
+#: "plan_mode=ledger consulted-but-ineffective yet reported-as-applied" defect).
+OUTCOME_JUDGE_SOURCE = "goldfive_outcome_judge"
 
 
 # ---------------------------------------------------------------------------
@@ -340,11 +360,18 @@ class ArmMetrics:
     #: The resolved :attr:`SteeringConfig.plan_mode` this build ran under
     #: (``forecast`` / ``ledger``) — what the flag *applied* to.
     plan_mode: str
-    #: ``True`` iff the ledger regime was actually EXERCISED on this workload
-    #: (plan_mode=ledger AND at least one OUTCOME or DISCOVERED task fired).
-    #: A ``plan_mode=ledger`` arm whose workload never mints an OUTCOME /
-    #: DISCOVERED task reports ``False`` — configured is not exercised, and a
-    #: stub that never fires the ledger path must not read as validating it.
+    #: ``True`` iff the ledger regime was actually EXERCISED on this workload:
+    #: plan_mode=ledger AND goldfive's own ledger machinery genuinely *fired* —
+    #: the outcome-progress judge transitioned an OUTCOME deliverable (an
+    #: observed ``TaskTransitioned`` whose source is
+    #: :data:`OUTCOME_JUDGE_SOURCE`), or a DISCOVERED trajectory task was
+    #: descriptively grown. Merely *stamping* a plan's tasks ``OUTCOME`` at
+    #: install (``_stamp_ledger_outcome_kinds`` / #500) and then force-completing
+    #: them via the legacy per-task loop is NOT exercise: those transitions
+    #: carry the default ``"other"`` source, the judge never ran, and no ledger
+    #: deliverable was produced. Configured is not exercised — a non-overlay
+    #: stub that never fires the outcome-progress judge must not read as
+    #: validating the ledger regime (the reported-as-applied phantom).
     ledger_exercised: bool
     # --- sink-event telemetry (PR 5) ----------------------------------
     drift_detected: int
@@ -465,6 +492,7 @@ def _grade_goal(
     predicate_count: int,
     outcome_total: int,
     outcome_terminal: dict[str, int],
+    outcome_exercised: bool,
 ) -> tuple[str, str]:
     """Grade a run on goal predicates + OUTCOME-task terminality (§6.4 rule 1).
 
@@ -474,13 +502,34 @@ def _grade_goal(
     alone is never a flip signal — with no goal ``success_predicate`` and no
     OUTCOME deliverable, the run is :data:`GOAL_GRADE_UNMEASURED`, never
     silently ``MET`` (deviation 1). An abort is a measured failure.
+
+    OUTCOME-task terminality is a grading signal ONLY when ``outcome_exercised``
+    — i.e. goldfive's own outcome-progress judge genuinely transitioned an
+    OUTCOME deliverable (:data:`OUTCOME_JUDGE_SOURCE`). OUTCOME tasks merely
+    *stamped* at install (#500) and force-completed by the legacy per-task loop
+    are a PHANTOM: their terminality proves no ledger deliverable was produced,
+    so it does not gate MET/UNMET and the run falls through to UNMEASURED (a
+    user goal predicate, if present, still grades independently).
     """
     if session is None:
         return GOAL_GRADE_UNMEASURED, "no session captured"
     if aborted:
         return GOAL_GRADE_ABORTED, abort_reason or "run aborted"
-    has_signal = predicate_count > 0 or outcome_total > 0
+    # An OUTCOME task's terminal disposition counts as a grading signal only
+    # when the ledger machinery (the outcome-progress judge) transitioned it;
+    # a stamped-but-legacy-completed OUTCOME task is not a genuine deliverable.
+    outcome_signal = outcome_total > 0 and outcome_exercised
+    has_signal = predicate_count > 0 or outcome_signal
     if not has_signal:
+        if outcome_total > 0:
+            return (
+                GOAL_GRADE_UNMEASURED,
+                f"{outcome_total} OUTCOME task(s) stamped but not transitioned "
+                "by the ledger outcome-progress judge (completed via the legacy "
+                "per-task dispatch loop, not a genuine ledger deliverable) — "
+                "run success is not gradeable (run.success alone is not a flip "
+                "signal)",
+            )
         return (
             GOAL_GRADE_UNMEASURED,
             "no goal success_predicate and no OUTCOME task — run success is "
@@ -490,7 +539,7 @@ def _grade_goal(
         reason = evaluate_goal_predicates(session)
         if reason is not None:
             return GOAL_GRADE_UNMET, reason
-    if outcome_total > 0:
+    if outcome_signal:
         failed = outcome_terminal.get("failed", 0)
         if failed:
             return GOAL_GRADE_UNMET, f"{failed} OUTCOME task(s) FAILED"
@@ -536,11 +585,21 @@ def metrics_from_events(
     aborted = False
     abort_reason = ""
     task_terminal = 0
+    #: OUTCOME deliverable ids the outcome-progress judge itself transitioned
+    #: (``TaskTransitioned.source == OUTCOME_JUDGE_SOURCE``) — the genuine
+    #: ledger-exercise trace. Empty when the ledger regime was configured but a
+    #: non-overlay run's legacy per-task loop merely force-completed stamped
+    #: OUTCOME tasks (the phantom this reducer must not grade off).
+    outcome_judge_task_ids: set[str] = set()
 
     for evt in events:
         which = evt.WhichOneof("payload") if hasattr(evt, "WhichOneof") else None
         if which == "drift_detected":
             drift_detected += 1
+        elif which == "task_transitioned":
+            tt = evt.task_transitioned
+            if tt.source == OUTCOME_JUDGE_SOURCE:
+                outcome_judge_task_ids.add(str(tt.task_id or ""))
         elif which == "signal_delivered":
             sd = evt.signal_delivered
             signals_total += 1
@@ -577,6 +636,10 @@ def metrics_from_events(
         if session is not None
         else 0
     )
+    # Genuine ledger exercise: the outcome-progress judge transitioned an
+    # OUTCOME deliverable on this run (its own source trace on the event
+    # stream), NOT the legacy per-task loop force-completing a stamped task.
+    outcome_exercised = bool(outcome_judge_task_ids)
     goal_grade, goal_reason = _grade_goal(
         session,
         aborted=aborted,
@@ -584,10 +647,17 @@ def metrics_from_events(
         predicate_count=predicate_count,
         outcome_total=outcome_total,
         outcome_terminal=outcome_terminal,
+        outcome_exercised=outcome_exercised,
     )
     goal_success = goal_grade == GOAL_GRADE_MET
+    # EXERCISED, not merely configured/stamped: the ledger machinery genuinely
+    # fired — the outcome-progress judge transitioned an OUTCOME deliverable, or
+    # a DISCOVERED trajectory task was descriptively grown (DISCOVERED tasks are
+    # only ever minted by descriptive growth, never stamped onto a StaticPlanner
+    # task, so their presence is itself genuine). A plan whose tasks were merely
+    # stamped OUTCOME and completed by the legacy loop reports False.
     ledger_exercised = plan_mode == "ledger" and (
-        outcome_total > 0 or discovered_total > 0
+        outcome_exercised or discovered_total > 0
     )
 
     applied, pending = arm_flag_status(arm)

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -34,6 +34,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 from bench.harness import (  # noqa: E402
     KNOWN_STEER_ENV,
+    OUTCOME_JUDGE_SOURCE,
     Arm,
     Scenario,
     apply_arm_env,
@@ -76,21 +77,22 @@ async def test_three_arm_harness_runs_and_emits_telemetry(tmp_path: Path) -> Non
     assert [m.arm_kind for m in results] == ["baseline", "signal", "legacy"]
 
     for m in results:
-        # §6.4: the stub workload defines NO goal predicate and NO OUTCOME
-        # task, so goal grading is UNMEASURED (not silently True) — the exact
-        # gap that blocks a flip decision on this workload. run.success alone
-        # is not a flip signal (deviation 1).
+        # §6.4: goal grading is UNMEASURED on EVERY arm (not silently True) —
+        # the exact gap that blocks a flip decision on this workload. For
+        # baseline/legacy (forecast mode) that is because the workload defines
+        # no goal predicate and mints no OUTCOME task. For the signal arm
+        # (plan_mode=ledger) the StaticPlanner tasks ARE stamped OUTCOME at
+        # install (#500), but this run is non-overlay — the legacy per-task loop
+        # force-completes those stamped tasks and the outcome-progress judge
+        # never runs — so that OUTCOME terminality is a PHANTOM, not a genuine
+        # ledger deliverable, and still grades UNMEASURED (for the right
+        # reason, asserted below). run.success alone is not a flip signal.
         assert m.goal_grade == "unmeasured", m.goal_reason
         assert m.goal_success is False
         assert m.goal_predicate_count == 0
-        assert m.outcome_tasks_total == 0
-        assert m.outcome_terminal == {
-            "completed": 0,
-            "failed": 0,
-            "not_needed": 0,
-            "cancelled": 0,
-            "non_terminal": 0,
-        }
+        # No arm GENUINELY exercised the ledger: the outcome-progress judge
+        # transitioned no OUTCOME deliverable on any arm (stub is non-overlay).
+        assert m.ledger_exercised is False
         # The captured-artifact outcome is otherwise healthy.
         assert m.completed_outputs == 3
         assert m.turns >= 1
@@ -99,10 +101,39 @@ async def test_three_arm_harness_runs_and_emits_telemetry(tmp_path: Path) -> Non
         assert m.signals_total > 0, f"{m.arm_name}: 0 signals — telemetry not wired"
 
     by_kind = {m.arm_kind: m for m in results}
-    # plan_mode=ledger is CONFIGURED on arm B (a KNOWN/applied flag), but the
-    # StaticPlanner stub mints only FORECAST tasks, so the ledger regime is
-    # NOT exercised. Configured-and-applied must not read as validated: a stub
-    # that never fires an OUTCOME/DISCOVERED path does not validate ledger.
+    # baseline/legacy run in forecast mode: no OUTCOME task is minted at all.
+    for kind in ("baseline", "legacy"):
+        m = by_kind[kind]
+        assert m.outcome_tasks_total == 0
+        assert m.outcome_terminal == {
+            "completed": 0,
+            "failed": 0,
+            "not_needed": 0,
+            "cancelled": 0,
+            "non_terminal": 0,
+        }
+    # The signal arm (plan_mode=ledger) legitimately DOES carry stamped OUTCOME
+    # tasks now — #500's install-time stamping labels the StaticPlanner tasks
+    # OUTCOME and the legacy per-task loop drives them to COMPLETED. This is
+    # exactly the phantom: OUTCOME tasks are present and terminal, yet NONE were
+    # transitioned by the outcome-progress judge, so the run stays UNMEASURED
+    # and the ledger reads NOT exercised (stamped, not exercised).
+    sig = by_kind["signal"]
+    assert sig.outcome_tasks_total == 3
+    assert sig.outcome_terminal == {
+        "completed": 3,
+        "failed": 0,
+        "not_needed": 0,
+        "cancelled": 0,
+        "non_terminal": 0,
+    }
+    assert "outcome-progress judge" in sig.goal_reason
+
+    # plan_mode=ledger is CONFIGURED on arm B (a KNOWN/applied flag) AND its
+    # tasks are stamped OUTCOME — but a non-overlay run never fires the
+    # outcome-progress judge, so the ledger regime is stamped yet NOT genuinely
+    # EXERCISED. Configured-and-stamped must not read as validated: OUTCOME
+    # terminality from the legacy per-task loop does not validate the ledger.
     assert by_kind["signal"].plan_mode == "ledger"
     assert by_kind["signal"].ledger_exercised is False
     assert by_kind["signal"].discovered_tasks_total == 0
@@ -412,6 +443,26 @@ class _Aborted:
         self.reason = reason
 
 
+class _Transitioned:
+    """Duck-typed ``TaskTransitioned`` payload (task_id + source attribution)."""
+
+    def __init__(self, task_id: str, source: str) -> None:
+        self.task_id = task_id
+        self.source = source
+
+
+def _outcome_judge_events(*task_ids: str) -> list[_FakeEvent]:
+    """The ``TaskTransitioned`` events goldfive's outcome-progress judge emits
+    when it GENUINELY transitions OUTCOME deliverables (source is
+    :data:`OUTCOME_JUDGE_SOURCE`). The stub harness is non-overlay and never
+    fires that judge, so a unit test simulates a real ledger exercise by
+    injecting the judge's own source trace onto the reduced event stream."""
+    return [
+        _FakeEvent("task_transitioned", _Transitioned(tid, OUTCOME_JUDGE_SOURCE))
+        for tid in task_ids
+    ]
+
+
 _ARM = Arm(name="unit", kind="signal")
 
 
@@ -454,17 +505,24 @@ def test_outcome_terminality_census_is_deterministic() -> None:
 
 def test_outcome_all_terminal_success_grades_met() -> None:
     session = _outcome_session([TaskStatus.COMPLETED, TaskStatus.NOT_NEEDED])
-    m = metrics_from_events([], arm=_ARM, session=session, plan_mode="ledger")
+    # Genuine ledger exercise: the outcome-progress judge transitioned both
+    # OUTCOME deliverables (its own source trace on the stream), so their
+    # all-terminal-success terminality is a valid grading signal → MET.
+    events = _outcome_judge_events("o0", "o1")
+    m = metrics_from_events(events, arm=_ARM, session=session, plan_mode="ledger")
     assert m.goal_grade == "met"
     assert m.goal_success is True
     assert m.outcome_tasks_total == 2
-    # plan_mode=ledger AND OUTCOME tasks fired → the ledger regime was exercised.
+    # plan_mode=ledger AND the judge transitioned OUTCOME tasks → exercised.
     assert m.ledger_exercised is True
 
 
 def test_outcome_failed_grades_unmet() -> None:
     session = _outcome_session([TaskStatus.COMPLETED, TaskStatus.FAILED])
-    m = metrics_from_events([], arm=_ARM, session=session, plan_mode="ledger")
+    # The judge ran (it graded the deliverables) → genuine exercise, so the
+    # FAILED OUTCOME deliverable grades the run UNMET.
+    events = _outcome_judge_events("o0", "o1")
+    m = metrics_from_events(events, arm=_ARM, session=session, plan_mode="ledger")
     assert m.goal_grade == "unmet"
     assert m.goal_success is False
     assert "FAILED" in m.goal_reason
@@ -474,22 +532,30 @@ def test_outcome_non_terminal_grades_unmet_not_silently_met() -> None:
     # A deliverable still PENDING (uncertain, #208 carry-forward) is NOT a
     # demonstrated success — it grades UNMET for the flip criterion, never MET.
     session = _outcome_session([TaskStatus.COMPLETED, TaskStatus.PENDING])
-    m = metrics_from_events([], arm=_ARM, session=session, plan_mode="ledger")
+    # The judge ran (it completed o0) → genuine exercise; the non-terminal o1
+    # still bars MET.
+    events = _outcome_judge_events("o0")
+    m = metrics_from_events(events, arm=_ARM, session=session, plan_mode="ledger")
     assert m.goal_grade == "unmet"
     assert "non-terminal" in m.goal_reason
 
 
 def test_goal_predicate_gate_precedes_outcome() -> None:
-    # A failing predicate fails the run even when the OUTCOME tasks completed.
+    # A failing predicate fails the run even when the OUTCOME tasks completed
+    # (and the judge genuinely graded them) — the predicate gate precedes the
+    # OUTCOME-terminality branch.
     session = _outcome_session(
         [TaskStatus.COMPLETED], predicate=lambda _s: False
     )
-    m = metrics_from_events([], arm=_ARM, session=session, plan_mode="ledger")
+    events = _outcome_judge_events("o0")
+    m = metrics_from_events(events, arm=_ARM, session=session, plan_mode="ledger")
     assert m.goal_grade == "unmet"
     assert m.goal_predicate_count == 1
-    # A passing predicate + completed OUTCOME → met.
+    # A passing predicate + completed OUTCOME (judge-graded) → met.
     ok = _outcome_session([TaskStatus.COMPLETED], predicate=lambda _s: True)
-    m2 = metrics_from_events([], arm=_ARM, session=ok, plan_mode="ledger")
+    m2 = metrics_from_events(
+        _outcome_judge_events("o0"), arm=_ARM, session=ok, plan_mode="ledger"
+    )
     assert m2.goal_grade == "met"
     assert m2.goal_success is True
 
@@ -524,12 +590,72 @@ def test_ledger_exercised_needs_ledger_mode_and_a_ledger_task() -> None:
         [], arm=_ARM, session=outcome_session, plan_mode="forecast"
     )
     assert m_forecast.ledger_exercised is False
-    # DISCOVERED task in ledger mode also counts as exercised.
+    # OUTCOME tasks present, plan_mode=ledger, but NO outcome-progress-judge
+    # transition on the stream (legacy-loop force-completion) → stamped, NOT
+    # exercised. This is the phantom: configured/stamped is not exercised.
+    m_stamped = metrics_from_events(
+        [], arm=_ARM, session=outcome_session, plan_mode="ledger"
+    )
+    assert m_stamped.outcome_tasks_total == 1
+    assert m_stamped.ledger_exercised is False
+    # The SAME session, but WITH the judge's own transition trace → exercised.
+    m_judge = metrics_from_events(
+        _outcome_judge_events("o0"),
+        arm=_ARM,
+        session=outcome_session,
+        plan_mode="ledger",
+    )
+    assert m_judge.ledger_exercised is True
+    # A DISCOVERED task in ledger mode also counts as exercised: DISCOVERED
+    # tasks are only ever minted by descriptive growth (genuine ledger
+    # machinery), never stamped onto a StaticPlanner task, so their presence is
+    # itself a genuine-exercise signal — no judge transition needed.
     disc = _outcome_session([TaskStatus.COMPLETED], kind=TaskKind.DISCOVERED)
     m_disc = metrics_from_events([], arm=_ARM, session=disc, plan_mode="ledger")
     assert m_disc.discovered_tasks_total == 1
     assert m_disc.outcome_tasks_total == 0
     assert m_disc.ledger_exercised is True
+
+
+def test_stamped_outcome_grades_only_when_judge_transitioned() -> None:
+    """The #499×#500 phantom-grade guard, isolated: two runs with IDENTICAL
+    terminal OUTCOME tasks grade differently by PROVENANCE. The outcome-progress
+    judge's own transition (``OUTCOME_JUDGE_SOURCE``) is a genuine ledger
+    deliverable → MET/exercised; the legacy per-task loop's force-completion of
+    a merely-stamped OUTCOME task (default ``"other"`` source) is a phantom →
+    UNMEASURED/not-exercised. The fix must NOT simply make everything
+    unmeasured — the genuine path still grades MET."""
+    session = _outcome_session([TaskStatus.COMPLETED, TaskStatus.COMPLETED])
+    # Genuine: the outcome-progress judge transitioned both deliverables.
+    genuine = metrics_from_events(
+        _outcome_judge_events("o0", "o1"),
+        arm=_ARM,
+        session=session,
+        plan_mode="ledger",
+    )
+    assert genuine.goal_grade == "met"
+    assert genuine.goal_success is True
+    assert genuine.ledger_exercised is True
+    # Phantom: the SAME terminal OUTCOME tasks, transitioned by the legacy
+    # per-task loop (default "other" source) — not a genuine deliverable.
+    legacy_events = [
+        _FakeEvent("task_transitioned", _Transitioned("o0", "other")),
+        _FakeEvent("task_transitioned", _Transitioned("o1", "other")),
+    ]
+    phantom = metrics_from_events(
+        legacy_events, arm=_ARM, session=session, plan_mode="ledger"
+    )
+    assert phantom.goal_grade == "unmeasured"
+    assert phantom.goal_success is False
+    assert phantom.ledger_exercised is False
+    assert "outcome-progress judge" in phantom.goal_reason
+    # No transition events at all is likewise a phantom (OUTCOME tasks are
+    # stamped-terminal in the session, but the judge left no trace).
+    no_trace = metrics_from_events(
+        [], arm=_ARM, session=session, plan_mode="ledger"
+    )
+    assert no_trace.goal_grade == "unmeasured"
+    assert no_trace.ledger_exercised is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug: a phantom ledger success that would corrupt a 13b flip decision

`tests/test_bench_harness.py::test_three_arm_harness_runs_and_emits_telemetry` failed on the branch tip: it asserts every arm grades `goal_grade == "unmeasured"`, but the **signal arm** graded `"met"` — and reported `ledger_exercised=True`. Both were **phantoms**: the ledger machinery never actually ran on this workload, yet the measurement said it produced a graded deliverable. On a real three-arm bench that mis-grade is exactly the kind of false positive that would wrongly justify flipping a default.

## Root cause: a cross-PR interaction (#499 × #500)

The stub harness (`bench/harness.py`) drives **all** arms with `StaticPlanner` + a **non-overlay** executor (#499). For the signal arm the executor logs the tell:

```
SequentialExecutor.run: plan_mode=ledger but the legacy per-task loop was selected
(overlay_mode=True, invoke_passthrough=False). Ledger plan mode expects overlay execution;
OUTCOME deliverables are not per-task dispatchable.
```

Recently-merged **#500** wired install-time ledger OUTCOME stamping (`_stamp_ledger_outcome_kinds` / `PlanReviser._preserve_ledger_identity`), so the signal arm's `plan_mode=ledger` `StaticPlanner` tasks now get labelled `TaskKind.OUTCOME` the moment the plan installs. The **legacy per-task loop then force-completes all 3 stamped OUTCOME tasks** — the outcome-progress judge (`goldfive/drift/outcome_progress.py`), which requires overlay execution, **never runs**. The reducer saw `outcome_tasks_total=3`, `outcome_terminal={completed:3,…}` and concluded `goal_grade="met"`, `ledger_exercised=True`.

`_grade_goal` graded MET off raw `outcome_total>0` + all-terminal-success; `ledger_exercised` was `plan_mode=="ledger" and (outcome_total>0 or discovered_total>0)`. Both conflated **OUTCOME-tasks-were-STAMPED** with **the-ledger-was-genuinely-EXERCISED** — precisely the "Arm B's `plan_mode=ledger` is consulted-but-ineffective yet ArmMetrics reports it applied" defect.

## The genuine-exercise signal I chose (and why)

**A `TaskTransitioned` event whose `source == "goldfive_outcome_judge"`.**

In ledger mode an OUTCOME task reaches a terminal status *only* when goldfive's own outcome-progress judge grades it — the wrapped agent never reports on deliverables (design §2/§3 PR 11c; the re-entrancy comment at `drift_observer.py` ~3868: "task only transitions via goldfive's own outcome-progress judge"). When the judge does transition one, `_apply_outcome_transitions` calls `mark_task_completed(..., source="goldfive_outcome_judge")` / `mark_task_failed(..., source="goldfive_outcome_judge")`, which emits a `TaskTransitioned` carrying that source. The legacy per-task loop transitions with the default `source="other"`.

This is candidate (a) from the diagnosis — the judge's own observable trace — and it is the most robust option:
- It is read straight from the bench's existing reduction input (`mem_sink.events`); no new runtime plumbing.
- The `Task` dataclass carries **no** completion-source field, so the session artifact alone cannot distinguish the two; the event stream is the only observable that can.
- It ties terminality to the machinery that produced it, not to a label applied at install.

**Empirically distinguishes genuine-ledger from legacy-loop?** Yes — verified in the worktree. On the actual signal-arm run the 3 tasks are `kind=OUTCOME`, all `COMPLETED`, but **every** transition carries `source='other'` and there are **0** `goldfive_outcome_judge` transitions. A synthesized genuine judge trace over the identical session grades `met`/`exercised`; the same session with `source='other'` (or no trace) grades `unmeasured`/not-exercised.

## The fix (bench/measurement + tests only — no goldfive/ runtime change)

- **`ledger_exercised`** now means *genuinely fired*: `plan_mode=="ledger" and (the outcome-progress judge transitioned an OUTCOME deliverable OR a DISCOVERED trajectory task was descriptively grown)`. DISCOVERED stays a valid signal because those tasks are only ever minted by descriptive growth, never stamped onto a `StaticPlanner` task. Merely-stamped-and-legacy-completed OUTCOME tasks now report `False`, matching the field's own docstring intent ("configured is not exercised").
- **`_grade_goal`** gates the OUTCOME-terminality branch on genuine exercise: stamped OUTCOME tasks force-completed by the legacy loop are no longer a grading signal → the run falls through to **UNMEASURED** with a clear reason (`"… OUTCOME task(s) stamped but not transitioned by the ledger outcome-progress judge (completed via the legacy per-task dispatch loop, not a genuine ledger deliverable) …"`). The genuine-ledger path is untouched: when the judge did run, terminality still grades MET/UNMET as before. A user goal `success_predicate`, if present, still grades independently.
- `metrics_from_events` collects the judge-sourced transition ids from the event stream and threads the boolean into both consumers.

## Tests

- Fixed the three-arm smoke test to the honest new reality: baseline/legacy have no OUTCOME tasks; the signal arm legitimately carries 3 **stamped** OUTCOME tasks (`completed:3`) but is UNMEASURED with `ledger_exercised=False` — for the right reason (asserted on `goal_reason`).
- Updated the OUTCOME-grading unit tests to represent genuine exercise by injecting the judge's own source trace (the stub is non-overlay and cannot drive the real judge), so MET/UNMET still exercise the real grading path.
- Added `test_stamped_outcome_grades_only_when_judge_transitioned`: two runs with **identical** terminal OUTCOME tasks grade differently by **provenance** — judge-transitioned → MET/exercised, legacy-`"other"`/no-trace → UNMEASURED/not-exercised — proving the fix does not merely make everything unmeasured.

Validation: `tests/test_bench_harness.py` 23 passed; full suite `3293 passed, 61 skipped`; `ruff check .` clean. Stub mode only, no real-model bench run; deterministic (a `set` used only via `bool()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA
