### PR TITLE
fix(signal): make observer-note delivery telemetry truthful (delivered_dry_run + USER_PAUSE + drain order)

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -7350,17 +7350,18 @@ def make_adk_plugin(
                 channel="request_context",
                 turn=turn,
                 surface="tool_annotation",
+                dry_run=passive,
             )
             if not newly:
                 return None
             if passive:
                 # observation_only: ``mark_delivered`` ran above (decision
                 # parity — pacing / coalescing behave identically to the
-                # active path), but return None so the real tool result
-                # passes through UNANNOTATED. Follow-up: a sibling PR owns
-                # the dry_run-truthfulness refactor; once it lands the
-                # dry-run marker on this consume lets telemetry attribution
-                # distinguish it from an active delivery.
+                # active path) and stamped ``delivered_dry_run=True`` so the
+                # ledger's ``rendered_keys`` excludes this consume from
+                # ``after_signal`` attribution (the agent never saw it), while
+                # ``last_rendered_turn`` still counts it for the grace window.
+                # Return None so the real tool result passes through UNANNOTATED.
                 return None
             # Append-only: copy the result and add the reserved annotation key.
             annotated = dict(result)

--- a/goldfive/adapters/claude.py
+++ b/goldfive/adapters/claude.py
@@ -582,6 +582,7 @@ class ClaudeAgentSDKAdapter:
                 channel="request_context",
                 turn=turn,
                 surface=surface,
+                dry_run=not should,
             )
         except Exception as exc:  # noqa: BLE001
             log.debug("claude adapter: observer-note mark_delivered raised: %s", exc)

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -1342,6 +1342,18 @@ class DriftObserver:
             turn = int(getattr(session, "_reasoning_turn", 0) or 0)
             ledger = SignalLedger.for_session(session)
             authored_by = str(getattr(drift, "authored_by", "") or "").lower()
+            # USER_PAUSE is a NON-terminal user control (the run resumes after a
+            # later RESUME), and it carries ``authored_by="user"`` — so it would
+            # otherwise fall into the terminal ``resolve_user_intervened`` branch
+            # below and black-hole every open signal key as ``user_intervened``,
+            # losing all post-resume outcome telemetry. Guard it explicitly: a
+            # pause is neither a goldfive signal (no key opened) nor a terminal
+            # intervention (no keys resolved) — leave open keys open.
+            if drift.kind is DriftKind.USER_PAUSE:
+                return
+            # USER_STEER / USER_CANCEL are TERMINAL user interventions: they
+            # resolve every open, delivered key as ``user_intervened`` rather
+            # than opening a ``(USER_*, task)`` signal entry.
             if authored_by == "user" or drift.kind in self._USER_AUTHORED_DRIFT_KINDS:
                 for entry in ledger.resolve_user_intervened(turn=turn):
                     await self._emit_signal_outcome(session, entry)

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -131,11 +131,28 @@ async def _drain_steerer_at_run_boundary(
     :meth:`shutdown` drain.
     """
     drift_observer = getattr(steerer, "drift", None)
+    # ORDER MATTERS: drain the background drift / judge tasks FIRST, then
+    # finalize the SignalLedger. A late-resolving background drift (e.g. a
+    # fire-and-forget reasoning/goal judge still in flight) records its fire /
+    # outcome onto the ledger as it drains; if finalize ran first it would
+    # resolve every open key as ``invocation_ended`` and the drained drift
+    # would then write into an already-finalized ledger — a lost or
+    # double-counted outcome that corrupts the §5.4 self-correction rates.
+    # Both steps are best-effort and gate nothing.
+    drain = getattr(drift_observer, "drain_session_background_tasks", None)
+    if callable(drain):
+        try:
+            await drain(session_id=session.id)
+        except Exception as exc:  # noqa: BLE001 — never block run termination
+            log.warning(
+                "SequentialExecutor: steerer.drift.drain_session_background_tasks "
+                "raised at run boundary (swallowed): %s",
+                exc,
+            )
     # AGENCY-PRESERVATION.md PR 5 (observe-only): finalize the SignalLedger at
     # the run boundary — every still-open, delivered key resolves to
-    # ``invocation_ended`` (the conservative catch-all). Done here because this
-    # helper is the documented run-boundary chokepoint with the ``session`` in
-    # scope; best-effort and gates nothing.
+    # ``invocation_ended`` (the conservative catch-all). Done AFTER the drain so
+    # every drift that was still in flight has landed on the ledger first.
     finalize = getattr(drift_observer, "finalize_signal_ledger", None)
     if callable(finalize):
         try:
@@ -146,17 +163,6 @@ async def _drain_steerer_at_run_boundary(
                 "raised at run boundary (swallowed): %s",
                 exc,
             )
-    drain = getattr(drift_observer, "drain_session_background_tasks", None)
-    if not callable(drain):
-        return
-    try:
-        await drain(session_id=session.id)
-    except Exception as exc:  # noqa: BLE001 — never block run termination
-        log.warning(
-            "SequentialExecutor: steerer.drift.drain_session_background_tasks "
-            "raised at run boundary (swallowed): %s",
-            exc,
-        )
 
 
 async def _finalize_outcomes_at_run_boundary(steerer: Any, session: Session) -> None:

--- a/goldfive/observer_note_queue.py
+++ b/goldfive/observer_note_queue.py
@@ -172,6 +172,15 @@ class ObserverNote:
     delivered_channel: str = ""
     delivered_surface: str = ""
     delivered_turn: int = -1
+    #: Whether the exactly-once consume was a DRY-RUN: the surface was passive
+    #: (``observation_only=True`` / ``is_active_steering`` False), so the note
+    #: was consumed for pacing/coalescing decision parity but NEVER rendered to
+    #: the agent. Excluded from :meth:`ObserverNoteQueue.rendered_keys` (the
+    #: ``after_signal`` attribution source — the agent did not SEE it, so the
+    #: drift resolves ``self_corrected_unaided``), but KEPT in
+    #: :meth:`ObserverNoteQueue.last_rendered_turn` so grace-window pacing is
+    #: byte-identical between the §5.4 shadow (dry-run) and live campaigns.
+    delivered_dry_run: bool = False
 
     @property
     def is_pending(self) -> bool:
@@ -194,6 +203,7 @@ class ObserverNote:
             "delivered_channel": str(self.delivered_channel or ""),
             "delivered_surface": str(self.delivered_surface or ""),
             "delivered_turn": int(self.delivered_turn),
+            "delivered_dry_run": bool(self.delivered_dry_run),
         }
 
     @classmethod
@@ -214,6 +224,7 @@ class ObserverNote:
             delivered_channel=str(data.get("delivered_channel", "") or ""),
             delivered_surface=str(data.get("delivered_surface", "") or ""),
             delivered_turn=_coerce_int(data.get("delivered_turn", -1), default=-1),
+            delivered_dry_run=bool(data.get("delivered_dry_run", False)),
         )
 
 
@@ -496,12 +507,18 @@ class ObserverNoteQueue:
     def last_rendered_turn(self, kind: str, task_id: str) -> int:
         """Return the most-recent SIGNAL render turn for a ``(kind, task)`` key.
 
-        The max ``delivered_turn`` over delivered (rendered) *signal* notes
+        The max ``delivered_turn`` over delivered (consumed) *signal* notes
         matching ``(kind, task_id)`` (correction notes excluded — see
         :meth:`_is_signal_note`); ``-1`` when no signal for that key has been
-        rendered yet. This is the grace-window anchor: an enqueued-but-never-
-        rendered signal returns ``-1`` (it never started a grace window — the
-        agent has not seen it).
+        consumed yet. This is the grace-window anchor: an enqueued-but-never-
+        consumed signal returns ``-1`` (it never started a grace window).
+
+        Unlike :meth:`rendered_keys`, this DELIBERATELY includes DRY-RUN
+        consumes (``delivered_dry_run``): the grace window is a pacing decision
+        that must be byte-identical between the §5.4 shadow (dry-run) and live
+        campaigns, so a note consumed-but-not-shown still anchors the window.
+        Do not add a ``delivered_dry_run`` filter here — that would fork pacing
+        behavior between the two campaigns and break the shadow diff.
         """
         k = str(kind or "")
         t = str(task_id or "")
@@ -539,11 +556,16 @@ class ObserverNoteQueue:
         enqueued-but-never-rendered key resolves ``self_corrected_unaided``.
         Correction notes (task #11) are excluded — a rendered correction is
         not "the agent saw the SIGNAL" (and corrections carry no ledger entry
-        to attribute anyway).
+        to attribute anyway). DRY-RUN consumes are excluded too
+        (:attr:`ObserverNote.delivered_dry_run`): under ``observation_only`` a
+        surface consumes the note for pacing parity but never shows it to the
+        agent, so it must NOT count as "the agent saw the SIGNAL" — otherwise
+        the §5.4 shadow campaign over-attributes ``after_signal`` and inflates
+        the self-correction rate the flip decision reads.
         """
         out: set[tuple[str, str]] = set()
         for n in self.notes():
-            if n.delivered and self._is_signal_note(n):
+            if n.delivered and not n.delivered_dry_run and self._is_signal_note(n):
                 out.add((n.kind, n.task_id))
         return out
 
@@ -615,15 +637,24 @@ class ObserverNoteQueue:
         channel: str,
         turn: int,
         surface: str = "",
+        dry_run: bool = False,
     ) -> bool:
         """Mark ``note_id`` delivered; return ``True`` iff newly delivered.
 
         Idempotent: a second mark (or a mark of an unknown id) returns
         ``False`` and leaves the record untouched. This is the exactly-once
-        chokepoint — the first surface to render a note flips the flag, and
+        chokepoint — the first surface to consume a note flips the flag, and
         :meth:`peek_for_render` skips it forever after, so no other surface
-        re-delivers it. The ``True`` return is the caller's signal to emit
+        re-consumes it. The ``True`` return is the caller's signal to emit
         exactly one ``SignalDelivered``.
+
+        ``dry_run`` records whether this consume was a passive/shadow consume
+        (the surface was under ``observation_only`` and did NOT render the note
+        to the agent — it consumed it only for pacing/coalescing decision
+        parity). It is stamped onto :attr:`ObserverNote.delivered_dry_run` so
+        :meth:`rendered_keys` can exclude it from ``after_signal`` attribution
+        while :meth:`last_rendered_turn` still counts it for grace-window
+        pacing (§5.4 decision parity). Exactly-once still holds either way.
         """
         notes = self._read_notes()
         for raw in notes:
@@ -635,6 +666,7 @@ class ObserverNoteQueue:
             raw["delivered_channel"] = str(channel or "")
             raw["delivered_surface"] = str(surface or "")
             raw["delivered_turn"] = _coerce_int(turn)
+            raw["delivered_dry_run"] = bool(dry_run)
             self._write_notes(notes)
             return True
         return False

--- a/goldfive/prompt_shaper.py
+++ b/goldfive/prompt_shaper.py
@@ -916,7 +916,8 @@ class PromptShaper:
         if note is None:
             return None
 
-        if self.should_inject(steerer):
+        rendered = self.should_inject(steerer)
+        if rendered:
             # task #11 cross-surface fold: render_block composes the
             # plan-state Status line from the plan INSIDE the marker block
             # (strip-and-refresh removes it as one unit; marker count stays
@@ -963,6 +964,7 @@ class PromptShaper:
                 channel="request_context",
                 turn=turn,
                 surface="before_model",
+                dry_run=not rendered,
             )
         except Exception as exc:  # noqa: BLE001
             log.debug("PromptShaper.inject_observer_note: mark_delivered raised: %s", exc)

--- a/tests/test_observer_note_queue.py
+++ b/tests/test_observer_note_queue.py
@@ -151,6 +151,66 @@ def test_mark_delivered_idempotent() -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# delivered_dry_run — attribution truthfulness vs pacing decision-parity
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_consume_excluded_from_rendered_keys_but_kept_for_pacing() -> None:
+    # A DRY-RUN consume (a passive surface under observation_only) marks the
+    # note delivered for pacing/coalescing decision parity, but the agent never
+    # SAW it: it must be excluded from rendered_keys (else after_signal
+    # attribution is a lie and the §5.4 shadow campaign over-counts
+    # self_corrected_after_signal) yet KEPT in last_rendered_turn (grace-window
+    # pacing must be byte-identical between the shadow and live campaigns).
+    q = ObserverNoteQueue({})
+    note = _enqueue(q, kind="looping_tool_call", task_id="t1")
+    assert q.mark_delivered(
+        note.note_id,
+        channel="request_context",
+        turn=5,
+        surface="before_model",
+        dry_run=True,
+    )
+    # exactly-once still holds — a dry-run consume consumes the note.
+    assert q.peek_for_render() is None
+    # attribution: the agent did NOT see it.
+    assert ("looping_tool_call", "t1") not in q.rendered_keys()
+    # pacing: the grace window IS anchored at the consume turn.
+    assert q.last_rendered_turn("looping_tool_call", "t1") == 5
+    stored = q.notes()[0]
+    assert stored.delivered is True
+    assert stored.delivered_dry_run is True
+
+
+def test_real_render_counts_for_both_attribution_and_pacing() -> None:
+    q = ObserverNoteQueue({})
+    note = _enqueue(q, kind="looping_tool_call", task_id="t1")
+    assert q.mark_delivered(
+        note.note_id,
+        channel="request_context",
+        turn=5,
+        surface="before_model",
+        dry_run=False,
+    )
+    assert ("looping_tool_call", "t1") in q.rendered_keys()
+    assert q.last_rendered_turn("looping_tool_call", "t1") == 5
+    assert q.notes()[0].delivered_dry_run is False
+
+
+def test_delivered_dry_run_defaults_false_and_survives_serialization() -> None:
+    # Back-compat: a note serialized before the field existed reads False.
+    note = ObserverNote(note_id="n1", body="b", observation="o", severity="warning")
+    assert note.delivered_dry_run is False
+    round_tripped = ObserverNote.from_dict(note.to_dict())
+    assert round_tripped.delivered_dry_run is False
+    # And a dry-run mark survives the dict round-trip.
+    marked = ObserverNote.from_dict(
+        {**note.to_dict(), "delivered": True, "delivered_dry_run": True}
+    )
+    assert marked.delivered_dry_run is True
+
+
 def test_delivered_note_skipped_by_peek() -> None:
     q = ObserverNoteQueue({})
     _enqueue(q, drift_id="d1")

--- a/tests/test_signal_telemetry.py
+++ b/tests/test_signal_telemetry.py
@@ -380,6 +380,27 @@ async def test_user_steer_resolves_user_intervened() -> None:
     assert [o.signal_outcome.outcome for o in outcomes] == [SIGNAL_OUTCOME_USER_INTERVENED]
 
 
+async def test_user_pause_does_not_black_hole_open_keys() -> None:
+    # USER_PAUSE is NON-terminal (the run resumes after a later RESUME) and
+    # carries authored_by="user"; it must NOT fall into the terminal
+    # user-intervened branch and resolve every open key, or all post-resume
+    # outcome telemetry is lost. The key stays OPEN — proven by a later
+    # finalize resolving it invocation_ended (not user_intervened at pause).
+    steerer, session, sink = _setup(observation_only=False)
+    await steerer.drift._dispatch_nudge(_drift(), session)
+    pause_drift = _drift(kind=DriftKind.USER_PAUSE, authored_by="user")
+    await steerer.drift._emit_drift_detected(session, pause_drift)
+    # The pause emitted no user_intervened outcome — the key was left open.
+    assert all(
+        o.signal_outcome.outcome != SIGNAL_OUTCOME_USER_INTERVENED for o in _outcomes(sink)
+    )
+    # Still open: finalize now resolves it invocation_ended.
+    await steerer.drift.finalize_signal_ledger(session)
+    assert [o.signal_outcome.outcome for o in _outcomes(sink)] == [
+        SIGNAL_OUTCOME_INVOCATION_ENDED
+    ]
+
+
 async def test_run_end_finalize_resolves_invocation_ended() -> None:
     steerer, session, sink = _setup(observation_only=False)
     await steerer.drift._dispatch_nudge(_drift(), session)
@@ -401,6 +422,33 @@ async def test_executor_drain_helper_finalizes_ledger() -> None:
     assert [o.signal_outcome.outcome for o in _outcomes(sink)] == [
         SIGNAL_OUTCOME_INVOCATION_ENDED
     ]
+
+
+async def test_run_boundary_drains_background_before_finalizing_ledger() -> None:
+    # ORDER MATTERS: a late-resolving background drift records onto the ledger
+    # as it drains; if finalize ran first it would resolve every open key and
+    # the drained drift would write into an already-finalized ledger (a lost or
+    # double-counted outcome). The helper must drain THEN finalize.
+    from goldfive.executors.sequential import _drain_steerer_at_run_boundary
+
+    steerer, session, _sink = _setup(observation_only=False)
+    order: list[str] = []
+    drift_obs = steerer.drift
+    real_drain = drift_obs.drain_session_background_tasks
+    real_finalize = drift_obs.finalize_signal_ledger
+
+    async def _spy_drain(*a: object, **k: object) -> object:
+        order.append("drain")
+        return await real_drain(*a, **k)
+
+    async def _spy_finalize(*a: object, **k: object) -> object:
+        order.append("finalize")
+        return await real_finalize(*a, **k)
+
+    drift_obs.drain_session_background_tasks = _spy_drain  # type: ignore[method-assign]
+    drift_obs.finalize_signal_ledger = _spy_finalize  # type: ignore[method-assign]
+    await _drain_steerer_at_run_boundary(steerer, session)
+    assert order == ["drain", "finalize"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The observer-note delivery telemetry — the SignalDelivered/SignalOutcome substrate the §5.4 shadow campaign diffs to decide the 13b flip — misreports delivery in three ways found in review. All are telemetry-only and inert under the default flags (signal_telemetry defaults off), but they corrupt exactly the self-correction rates the flip reads.

## Fixes

**1. `delivered_dry_run` (the centerpiece — the #498 follow-up).** Passive surfaces consume a note as a DRY-RUN for pacing/coalescing decision parity but stamped it `delivered` with no marker, so `rendered_keys()` counted it and `resolve_task` attributed `self_corrected_after_signal` even though the agent never saw it — inflating arm-B/arm-C. New `ObserverNote.delivered_dry_run`; `mark_delivered(dry_run=...)` records it; `rendered_keys()` (attribution) **excludes** dry-run consumes → truthful `self_corrected_unaided`; `last_rendered_turn()` (grace-window pacing) **keeps** them so pacing is byte-identical between shadow and live campaigns. Threaded from the three passive-capable surfaces (`before_model`, `claude`, `tool_annotation`); the boundary-replay surface is active-only gated, so it stays a real render (default `dry_run=False`).

**2. USER_PAUSE no longer black-holes telemetry.** USER_PAUSE is non-terminal (the run resumes) but carries `authored_by="user"`, so it fell into the terminal `resolve_user_intervened` branch and closed every open signal key, losing all post-resume outcomes. Guarded explicitly: a pause opens no key and resolves none.

**3. finalize-after-drain ordering.** `_drain_steerer_at_run_boundary` finalized the ledger *before* draining background drift/judge tasks, so a late-resolving drift wrote into an already-finalized ledger (lost/double-counted). Now drains first, then finalizes.

## Re-verification status (post-reconcile)
All three confirmed still-present on the current branch tip. Two adjacent diagnosis items reviewed and **deferred as not-clear-bugs**: the escalation path already dispatches before recording (line 1163 precedes 1164), and "dry-run escalation closes the key" is ambiguous shadow-semantics (a re-fire opens a fresh key) — noted rather than speculatively changed.

## Tests
`test_observer_note_queue.py`: dry-run consume excluded from `rendered_keys` but kept in `last_rendered_turn` + serialization back-compat. `test_signal_telemetry.py`: USER_PAUSE leaves open keys open (finalize later resolves invocation_ended); the run-boundary helper drains before finalizing. Full suite 3298 passed / 61 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA