### PR TITLE
refactor(flags): one definition per flag default — signal_channel + plan_mode_is_ledger helpers

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -95,6 +95,7 @@ from goldfive.state_store import (
     BindingSource,
     StateStore,
 )
+from goldfive.steerer import signal_channel as _signal_channel_of
 from goldfive.steerer import steering_is_active
 
 if TYPE_CHECKING:
@@ -5934,7 +5935,7 @@ def make_adk_plugin(
                 if (
                     ctx is not None
                     and ctx.session is not None
-                    and getattr(ctx.steerer, "_signal_channel", "legacy_user_message")
+                    and _signal_channel_of(ctx.steerer)
                     == "request_context"
                 ):
                     # Resolve the agent whose model call this is, so the
@@ -7313,7 +7314,7 @@ def make_adk_plugin(
             if ctx is None or ctx.steerer is None or ctx.session is None:
                 return None
             if (
-                getattr(ctx.steerer, "_signal_channel", "legacy_user_message")
+                _signal_channel_of(ctx.steerer)
                 != "request_context"
             ):
                 return None

--- a/goldfive/adapters/claude.py
+++ b/goldfive/adapters/claude.py
@@ -44,6 +44,7 @@ from goldfive.adapters._tool_invocation import invoke_tool
 from goldfive.drift import classify_stop_reason
 from goldfive.reporting import REPORTING_TOOL_NAMES, ReportingToolSpec
 from goldfive.results import InvocationResult
+from goldfive.steerer import signal_channel as _signal_channel_of
 from goldfive.types import Session, Task
 
 # --------------------------------------------------------------------------- #
@@ -390,7 +391,7 @@ class ClaudeAgentSDKAdapter:
         # which never sets ``signal_channel``) keeps the unchanged single-hook
         # options object.
         if (
-            getattr(self._steerer, "_signal_channel", "legacy_user_message")
+            _signal_channel_of(self._steerer)
             == "request_context"
         ):
             hooks["PostToolUse"] = [
@@ -550,7 +551,7 @@ class ClaudeAgentSDKAdapter:
         if steerer is None:
             return None
         if (
-            getattr(steerer, "_signal_channel", "legacy_user_message")
+            _signal_channel_of(steerer)
             != "request_context"
         ):
             return None

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -217,6 +217,19 @@ def _nearest_rank_percentile(sorted_samples: list[int], q: float) -> int:
 
 
 log = logging.getLogger(__name__)
+
+
+def _signal_channel_of(steerer):
+    """Resolve the signal channel via :func:`goldfive.steerer.signal_channel`.
+
+    Lazy-import shim: this module cannot import :mod:`goldfive.steerer` at
+    load time (the steerer constructs :class:`DriftObserver`), so the shared
+    single-default helper is reached per call. Import cost is a dict hit
+    after the first call.
+    """
+    from goldfive.steerer import signal_channel
+
+    return signal_channel(steerer)
 # Wave C bucket 3b/3c post-cleanup: the module previously kept a
 # sibling ``_steerer_log = logging.getLogger("goldfive.steerer")``
 # because the test corpus asserted on ``record.name == "goldfive.steerer"``.
@@ -1101,7 +1114,7 @@ class DriftObserver:
         is a no-op there (§5.1). Best-effort: any failure degrades to
         ``"proceed"`` so pacing never blocks a legitimate signal.
         """
-        channel = getattr(self._steerer, "_signal_channel", "legacy_user_message")
+        channel = _signal_channel_of(self._steerer)
         if channel != "request_context":
             # Legacy regime: no queue visibility, and the promotion path's #441
             # gate is unchanged — PR 8 is a no-op here (§5.1).
@@ -1208,7 +1221,7 @@ class DriftObserver:
         the executor's replay header only claims a plan revision when one
         truly installed (goldfive#475 truthfulness).
         """
-        channel = getattr(self._steerer, "_signal_channel", "legacy_user_message")
+        channel = _signal_channel_of(self._steerer)
         if channel == "request_context":
             from goldfive.events import SIGNAL_CHANNEL_REQUEST_CONTEXT
             from goldfive.observer_note_queue import ObserverNoteQueue
@@ -1413,7 +1426,7 @@ class DriftObserver:
             # the dispatch-time ``has_real_delivery`` attribution.
             rendered_keys: set[tuple[str, str]] | None = None
             if (
-                getattr(self._steerer, "_signal_channel", "legacy_user_message")
+                _signal_channel_of(self._steerer)
                 == "request_context"
             ):
                 from goldfive.observer_note_queue import ObserverNoteQueue
@@ -3909,16 +3922,16 @@ class DriftObserver:
     def _ledger_mode(self) -> bool:
         """Return True iff ``SteeringConfig.plan_mode == "ledger"``.
 
-        AGENCY-PRESERVATION.md Stage 3 PR 11. Read off the steerer's
-        typed config exactly as the pin path / reviser read it. Defensive:
-        any read failure resolves to forecast mode, so the goal-drift
-        judge stays on its pre-PR-11 binary/CRITICAL path by default.
+        AGENCY-PRESERVATION.md Stage 3 PR 11. Delegates to
+        :func:`goldfive.steerer.plan_mode_is_ledger` — the single
+        implementation of the parse. Defensive: any failure resolves to
+        forecast mode, so the goal-drift judge stays on its pre-PR-11
+        binary/CRITICAL path by default.
         """
         try:
-            cfg = getattr(self._steerer, "_steering_config", None)
-            if cfg is None:
-                return False
-            return str(getattr(cfg, "plan_mode", "forecast")).strip().lower() == "ledger"
+            from goldfive.steerer import plan_mode_is_ledger
+
+            return plan_mode_is_ledger(self._steerer)
         except Exception:  # noqa: BLE001
             return False
 

--- a/goldfive/executors/sequential.py
+++ b/goldfive/executors/sequential.py
@@ -65,6 +65,7 @@ from goldfive.executors._shared import (
 )
 from goldfive.protocols import AgentAdapter, EventSink, Executor, Planner, Steerer
 from goldfive.results import ExecutionOutcome, evaluate_goal_predicates
+from goldfive.steerer import signal_channel as _signal_channel_of
 from goldfive.steerer import steering_is_active
 from goldfive.types import (
     DriftKind,
@@ -1632,7 +1633,7 @@ class SequentialExecutor(Executor):
         is no longer pending here, so it is never re-delivered
         (exactly-once, §5.2).
         """
-        if getattr(steerer, "_signal_channel", "legacy_user_message") == "request_context":
+        if _signal_channel_of(steerer) == "request_context":
             replay_msg: str | None = None
             if (
                 state.nudge_replays < self._MAX_NUDGE_REPLAYS

--- a/goldfive/plan_reviser.py
+++ b/goldfive/plan_reviser.py
@@ -151,17 +151,15 @@ class PlanReviser:
     def _ledger_mode(self) -> bool:
         """Return True iff ``SteeringConfig.plan_mode == "ledger"``.
 
-        AGENCY-PRESERVATION.md Stage 3 PR 10. Reads through
-        ``steerer._steering_config.plan_mode`` (the typed config), exactly
-        as the pin path reads ``descriptive_growth_enabled``. Defensive:
-        any read failure (custom steerer without a typed config, test
-        stub) resolves to forecast mode, keeping the legacy behaviour.
+        AGENCY-PRESERVATION.md Stage 3 PR 10. Delegates to
+        :func:`goldfive.steerer.plan_mode_is_ledger` — the single
+        implementation of the parse. Defensive: any failure resolves to
+        forecast mode, keeping the legacy behaviour.
         """
         try:
-            cfg = getattr(self._steerer, "_steering_config", None)
-            if cfg is None:
-                return False
-            return str(getattr(cfg, "plan_mode", "forecast")).strip().lower() == "ledger"
+            from goldfive.steerer import plan_mode_is_ledger
+
+            return plan_mode_is_ledger(self._steerer)
         except Exception:  # noqa: BLE001
             return False
 

--- a/goldfive/prompt_shaper.py
+++ b/goldfive/prompt_shaper.py
@@ -81,6 +81,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
+from goldfive.steerer import signal_channel as _signal_channel_of
 from goldfive.steerer import steering_is_active
 
 if TYPE_CHECKING:
@@ -134,7 +135,7 @@ class PromptShaper:
         both resolve to ``"legacy_user_message"`` so the legacy path is
         the safe fallback.
         """
-        channel = getattr(steerer, "_signal_channel", "legacy_user_message")
+        channel = _signal_channel_of(steerer)
         return str(channel or "legacy_user_message")
 
     @classmethod

--- a/goldfive/reconciler.py
+++ b/goldfive/reconciler.py
@@ -667,17 +667,15 @@ class PlanReconciler:
     def _ledger_mode(self) -> bool:
         """Return True iff ``SteeringConfig.plan_mode == "ledger"``.
 
-        Reads through the bound steerer's typed config exactly as
-        :meth:`_maybe_grow_discovered_task` reads
-        ``descriptive_growth_enabled``. Defensive: any read failure
-        (custom steerer without a typed config, test stub) resolves to
+        Delegates to :func:`goldfive.steerer.plan_mode_is_ledger` — the
+        single implementation of the parse (three modules previously
+        re-implemented it verbatim). Defensive: any failure resolves to
         forecast mode so the legacy overlay path is untouched.
         """
         try:
-            cfg = getattr(self._steerer, "_steering_config", None)
-            if cfg is None:
-                return False
-            return str(getattr(cfg, "plan_mode", "forecast")).strip().lower() == "ledger"
+            from goldfive.steerer import plan_mode_is_ledger
+
+            return plan_mode_is_ledger(self._steerer)
         except Exception:  # noqa: BLE001
             return False
 

--- a/goldfive/steerer.py
+++ b/goldfive/steerer.py
@@ -104,6 +104,8 @@ __all__ = [
     "InterventionLevel",
     "RefineExhausted",
     "compose_corrective_user_message",
+    "plan_mode_is_ledger",
+    "signal_channel",
     "steering_is_active",
 ]
 
@@ -126,6 +128,43 @@ def steering_is_active(steerer: Any) -> bool:
         return False
     try:
         return bool(predicate())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def signal_channel(steerer: Any) -> str:
+    """Return the resolved signal channel for a maybe-steerer.
+
+    The single definition of the ``"legacy_user_message"`` default — the
+    sibling of :func:`steering_is_active` for the channel flag. Before this
+    helper the default string was duplicated at nine read sites across five
+    modules; any one of them drifting (a typo, a stale copy after a rename)
+    would silently fork routing between surfaces. Consumers must not read
+    ``_signal_channel`` directly.
+
+    Fail-safe direction: ``None`` / missing attribute / non-string resolves to
+    the legacy channel — the regime whose delivery surfaces are fully
+    ``observation_only``-gated and default-inert.
+    """
+    raw = getattr(steerer, "_signal_channel", None)
+    if not isinstance(raw, str) or not raw:
+        return "legacy_user_message"
+    return raw
+
+
+def plan_mode_is_ledger(steerer: Any) -> bool:
+    """Return ``True`` iff the steerer's typed config selects ledger plan mode.
+
+    The single implementation of the ``plan_mode == "ledger"`` parse
+    (normalising case/whitespace, defaulting to ``"forecast"``) — previously
+    re-implemented verbatim by three ``_ledger_mode`` methods (reconciler,
+    plan reviser, drift observer). Reads the typed
+    :class:`~goldfive.config.SteeringConfig` stashed on the steerer; any
+    failure resolves ``False`` (forecast — the default, inert regime).
+    """
+    try:
+        cfg = getattr(steerer, "_steering_config", None)
+        return str(getattr(cfg, "plan_mode", "forecast")).strip().lower() == "ledger"
     except Exception:  # noqa: BLE001
         return False
 

--- a/tests/test_observation_only.py
+++ b/tests/test_observation_only.py
@@ -1122,3 +1122,60 @@ async def test_discovery_via_install_revision_for_drift_under_observation_only()
     revised_events = _plan_revised_events(sink)
     assert len(revised_events) == 1
     assert revised_events[0].plan_revised.dry_run is False
+
+
+# ---------------------------------------------------------------------------
+# Shared flag accessors (siblings of steering_is_active — one default each)
+# ---------------------------------------------------------------------------
+
+
+def test_signal_channel_single_default_and_failsafe() -> None:
+    from goldfive.steerer import signal_channel
+
+    class _WithChannel:
+        _signal_channel = "request_context"
+
+    class _Bare:
+        pass
+
+    class _Wrong:
+        _signal_channel = 7  # non-string resolves to the fail-safe default
+
+    assert signal_channel(_WithChannel()) == "request_context"
+    assert signal_channel(_Bare()) == "legacy_user_message"
+    assert signal_channel(None) == "legacy_user_message"
+    assert signal_channel(_Wrong()) == "legacy_user_message"
+    assert signal_channel(type("E", (), {"_signal_channel": ""})()) == "legacy_user_message"
+
+
+def test_plan_mode_is_ledger_single_parse_and_failsafe() -> None:
+    from goldfive.steerer import plan_mode_is_ledger
+
+    class _Cfg:
+        def __init__(self, mode: object) -> None:
+            self.plan_mode = mode
+
+    class _Steerer:
+        def __init__(self, mode: object) -> None:
+            self._steering_config = _Cfg(mode)
+
+    assert plan_mode_is_ledger(_Steerer("ledger")) is True
+    assert plan_mode_is_ledger(_Steerer("  LEDGER  ")) is True  # normalised
+    assert plan_mode_is_ledger(_Steerer("forecast")) is False
+    assert plan_mode_is_ledger(None) is False
+    assert plan_mode_is_ledger(type("B", (), {})()) is False
+
+
+def test_ledger_mode_methods_delegate_to_shared_helper() -> None:
+    # The three _ledger_mode methods (reconciler / plan reviser / drift
+    # observer) must agree with the shared parse by construction — a stub
+    # steerer with a ledger config reads True through every one of them.
+    from goldfive.config import SteeringConfig
+    from goldfive.steerer import DefaultSteerer, plan_mode_is_ledger
+
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(plan_mode="ledger", observation_only=True)
+    )
+    assert plan_mode_is_ledger(steerer) is True
+    assert steerer.drift._ledger_mode() is True
+    assert steerer.plans._ledger_mode() is True


### PR DESCRIPTION
The known deferred maintainability item, done as the last pre-main-merge cleanup: the `"legacy_user_message"` default was duplicated at **nine** getattr read sites across five modules, and the `plan_mode == "ledger"` parse was re-implemented **verbatim three times** (`reconciler`, `plan_reviser`, `drift_observer`). Both are the divergence-bug pattern #488 eliminated for the kill-switch.

New `steerer.signal_channel(steerer)` and `steerer.plan_mode_is_ledger(steerer)` — siblings of `steering_is_active`, same fail-safe discipline (None/missing/invalid → the inert default). All nine channel reads route through the helper (drift_observer via a lazy shim due to the import cycle); the three `_ledger_mode` methods delegate to the shared parse.

Pure refactor, zero behavior change. Tests: fail-safe matrix for both helpers + a delegation-consistency test through a real `DefaultSteerer`. Full suite 3301 passed / 61 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA