### PR TITLE
docs(dev-guide): currency caveat for the agency-preservation merge

### DIFF
--- a/docs/dev-guide/00-index.md
+++ b/docs/dev-guide/00-index.md
@@ -17,6 +17,28 @@ grep/pytest commands.
 
 ---
 
+## ⚠ Currency caveat: the agency-preservation merge
+
+The **agency-preservation re-architecture is merged** (PRs #453–#504 via the
+`agency-preservation` integration branch): interventions are advisory
+**observer notes** (`goldfive/observer_notes.py`, `observer_note_queue.py`),
+the ladder's Level-2 rung is **`SIGNAL`** (renamed from `NUDGE`; enum value 2
+unchanged), corrective command templates are retired behind a deprecating
+shim, a **plan-as-ledger** mode (`TaskKind`, `plan_mode`) and
+**signal telemetry** (`signal_ledger.py`, `SignalDelivered`/`SignalOutcome`)
+exist behind default-OFF flags, and in-flight cancellation is gated on drift
+**authority** (`cancel_inflight_scope`). All new-regime flags default OFF, so
+default-config behavior descriptions below remain accurate — but chapters
+**04, 09, 10, 12, 13, 14** predate the merge and describe the pre-merge
+mechanics of nudges/corrective templates/ladder cells and omit the new
+modules and config knobs. Until those chapters are refreshed:
+**`docs/design/AGENCY-PRESERVATION.md` §6 is the authoritative as-built
+record** for everything the merge changed; where this guide and that doc
+disagree, §6 wins. The invariants in chapter 17 are unchanged and remain
+binding (the kill-switch predicate gained siblings:
+`steerer.signal_channel()` / `steerer.plan_mode_is_ledger()` — same
+one-default fail-safe discipline).
+
 ## READ-FIRST rule
 
 **Before any nontrivial edit, read [17-invariants-hazards-history.md](17-invariants-hazards-history.md).**

--- a/docs/dev-guide/04-executors-and-control.md
+++ b/docs/dev-guide/04-executors-and-control.md
@@ -1,5 +1,12 @@
 # 04. Executors and the Control Channel
 
+> **⚠ Predates the agency-preservation merge.** This chapter describes the
+> pre-merge mechanics; the merge (PRs #453–#504) renamed `NUDGE`→`SIGNAL`,
+> replaced corrective templates with advisory observer notes, and added the
+> default-OFF ledger/signal regimes. Default-flag behavior described here is
+> still accurate; for the merged as-built state read
+> `docs/design/AGENCY-PRESERVATION.md` §6 first — it wins on any conflict.
+
 **Read this chapter when...**
 
 - You need to change how a `Plan` is walked to completion: the sequential legacy loop,

--- a/docs/dev-guide/09-steering-ladder-and-gates.md
+++ b/docs/dev-guide/09-steering-ladder-and-gates.md
@@ -1,5 +1,12 @@
 # 09. Steering: the Ladder, the Gates, and the observation_only Contract
 
+> **⚠ Predates the agency-preservation merge.** This chapter describes the
+> pre-merge mechanics; the merge (PRs #453–#504) renamed `NUDGE`→`SIGNAL`,
+> replaced corrective templates with advisory observer notes, and added the
+> default-OFF ledger/signal regimes. Default-flag behavior described here is
+> still accurate; for the merged as-built state read
+> `docs/design/AGENCY-PRESERVATION.md` §6 first — it wins on any conflict.
+
 ## Read this chapter when...
 
 - You are about to change **what goldfive does in response to a drift** — nudge, refine, cancel, pause, terminate — or the mapping from a `(kind, severity, occurrence)` triple to one of those actions.

--- a/docs/dev-guide/10-planning-and-revision.md
+++ b/docs/dev-guide/10-planning-and-revision.md
@@ -1,5 +1,12 @@
 # 10. Planning and Revision
 
+> **⚠ Predates the agency-preservation merge.** This chapter describes the
+> pre-merge mechanics; the merge (PRs #453–#504) renamed `NUDGE`→`SIGNAL`,
+> replaced corrective templates with advisory observer notes, and added the
+> default-OFF ledger/signal regimes. Default-flag behavior described here is
+> still accurate; for the merged as-built state read
+> `docs/design/AGENCY-PRESERVATION.md` §6 first — it wins on any conflict.
+
 ## Read this chapter when...
 
 - You are touching how goldfive **produces a plan** (initial plan, per-turn

--- a/docs/dev-guide/12-events-sinks-telemetry.md
+++ b/docs/dev-guide/12-events-sinks-telemetry.md
@@ -1,5 +1,12 @@
 # 12. Events, Sinks, and Telemetry
 
+> **⚠ Predates the agency-preservation merge.** This chapter describes the
+> pre-merge mechanics; the merge (PRs #453–#504) renamed `NUDGE`→`SIGNAL`,
+> replaced corrective templates with advisory observer notes, and added the
+> default-OFF ledger/signal regimes. Default-flag behavior described here is
+> still accurate; for the merged as-built state read
+> `docs/design/AGENCY-PRESERVATION.md` §6 first — it wins on any conflict.
+
 ## Read this chapter when...
 
 - You are adding a new event kind, or a new field to an existing event

--- a/docs/dev-guide/13-reporting-tools-and-approval.md
+++ b/docs/dev-guide/13-reporting-tools-and-approval.md
@@ -1,5 +1,12 @@
 # 13. Reporting Tools and Approval
 
+> **⚠ Predates the agency-preservation merge.** This chapter describes the
+> pre-merge mechanics; the merge (PRs #453–#504) renamed `NUDGE`→`SIGNAL`,
+> replaced corrective templates with advisory observer notes, and added the
+> default-OFF ledger/signal regimes. Default-flag behavior described here is
+> still accurate; for the merged as-built state read
+> `docs/design/AGENCY-PRESERVATION.md` §6 first — it wins on any conflict.
+
 ## Read this chapter when...
 
 - You are adding, removing, or renaming a reporting tool (anything in the

--- a/docs/dev-guide/14-config-reference.md
+++ b/docs/dev-guide/14-config-reference.md
@@ -1,5 +1,12 @@
 # 14. Config Reference
 
+> **⚠ Predates the agency-preservation merge.** This chapter describes the
+> pre-merge mechanics; the merge (PRs #453–#504) renamed `NUDGE`→`SIGNAL`,
+> replaced corrective templates with advisory observer notes, and added the
+> default-OFF ledger/signal regimes. Default-flag behavior described here is
+> still accurate; for the merged as-built state read
+> `docs/design/AGENCY-PRESERVATION.md` §6 first — it wins on any conflict.
+
 ## Read this chapter when...
 
 - You are adding, removing, renaming, or changing the default of ANY tunable knob.


### PR DESCRIPTION
The dev-guide (written against post-#492 main) goes stale the moment the branch merges: 8 chapters describe the pending_nudges world, 2 pin `NUDGE = 2` (now `SIGNAL = 2`), and the config reference omits the ~10 new regime knobs. A confidently-wrong citation is exactly the weak-model hazard the guide exists to prevent. This adds a prominent banner in 00-index.md plus a short caveat atop the six most-affected chapters (04/09/10/12/13/14), routing readers to AGENCY-PRESERVATION.md §6 as authoritative until the chapters are refreshed (follow-up). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA