### PR TITLE
fix(signal+ledger): precision fix-pack — truthful re-authoring, agent-scoped annotation, run-end cascade suppression, plan-shaped ledger bypass

### DIFF
--- a/goldfive/adapters/_adk_plugin.py
+++ b/goldfive/adapters/_adk_plugin.py
@@ -4379,7 +4379,25 @@ def make_adk_plugin(
             # AGENCY-PRESERVATION.md Stage 3 PR 10 — ledger plan mode.
             # When on, the pin tiers are bypassed: every unforecast
             # delegation dedup-checks then grows a DISCOVERED ledger task.
+            # The bypass keys on the LIVE PLAN's shape, not on config
+            # alone: ``plan_mode="ledger"`` with a FORECAST-shaped plan
+            # (a hand-authored StaticPlanner template) keeps the forecast
+            # pin tiers — "StaticPlanner users keep forecast semantics —
+            # a hand-authored plan is genuine prescriptive intent" (design
+            # doc Stage 3). Without the shape gate, the config-only bypass
+            # silently stripped pinning + drift-repair from hand-authored
+            # forecast plans. The incoherent combo is warned about once at
+            # run start (``Runner._warn_if_ledger_mode_without_ledger_plan``).
             ledger_mode = _ledger_mode_enabled(ctx.steerer)
+            if ledger_mode:
+                try:
+                    from goldfive.types import (  # noqa: PLC0415 — lazy
+                        plan_has_ledger_shape,
+                    )
+
+                    ledger_mode = plan_has_ledger_shape(plan)
+                except Exception:  # noqa: BLE001 — fail toward forecast
+                    ledger_mode = False
             grow_capable = growth_mode or ledger_mode
             if not tasks and not grow_capable:
                 return False
@@ -7282,7 +7300,9 @@ def make_adk_plugin(
             # keys. Gated on ``signal_channel == "request_context"`` so the
             # legacy default is byte-identical (returns None as before).
             try:
-                annotated = await self._maybe_annotate_tool_result(ctx, result)
+                annotated = await self._maybe_annotate_tool_result(
+                    ctx, result, agent_name=agent_name
+                )
                 if annotated is not None:
                     return annotated
             except Exception as exc:  # noqa: BLE001
@@ -7292,7 +7312,9 @@ def make_adk_plugin(
                 )
             return None
 
-        async def _maybe_annotate_tool_result(self, ctx: Any, result: Any) -> Any:
+        async def _maybe_annotate_tool_result(
+            self, ctx: Any, result: Any, *, agent_name: str = ""
+        ) -> Any:
             """Return an annotated copy of ``result`` for a loop note, or ``None``.
 
             Surface 4 of the observer-note channel. Consumes the most-severe
@@ -7310,6 +7332,16 @@ def make_adk_plugin(
             dry-run delivery for decision parity but nothing is annotated,
             matching the other three surfaces) — so both the legacy path
             and the strict-passive campaign are untouched.
+
+            ``agent_name`` (task #11 agent-scoped delivery) is the agent
+            whose tool result this is — ``after_tool_callback`` passes the
+            ADK-resolved invoking agent. This surface is agent-aware: the
+            peek is scoped so it selects only broadcast notes or notes for
+            THIS agent, never annotating agent A's loop note onto agent B's
+            tool result (misdelivery). Empty ``agent_name`` (direct callers
+            / stubs that cannot resolve an agent) keeps the unscoped
+            broadcast behaviour, matching ``peek_for_render``'s
+            ``agent_id=None`` contract.
             """
             if ctx is None or ctx.steerer is None or ctx.session is None:
                 return None
@@ -7340,8 +7372,14 @@ def make_adk_plugin(
             # agent-targeted corrections do NOT (they ride the agent-aware
             # block surfaces). Exclude correction-origin notes structurally
             # even if a correction's triggering drift was a loop kind.
+            # Agent scoping: only broadcast notes or notes for the invoking
+            # agent are eligible — another agent's loop note stays pending
+            # for its own agent's surfaces (better undelivered than
+            # misdelivered, §0 dormancy bias).
             note = queue.peek_for_render(
-                kinds=_LOOP_KINDS, exclude_correction_notes=True
+                kinds=_LOOP_KINDS,
+                agent_id=agent_name or None,
+                exclude_correction_notes=True,
             )
             if note is None:
                 return None

--- a/goldfive/drift_observer.py
+++ b/goldfive/drift_observer.py
@@ -1240,14 +1240,26 @@ class DriftObserver:
                 # suppression of in-window re-fires, and the 3rd-occurrence
                 # escalation are all decided in ``_signal_pacing_decision``
                 # before we get here; this only threads the quote into the
-                # body when exactly one prior note for the key exists.)
+                # body when exactly one prior SIGNAL note for the key
+                # exists.) Truthfulness gates on the claim (§0 — goldfive
+                # never lies to the agent):
+                #
+                # * priors are SIGNAL notes only (``signal_notes``) — a
+                #   task-#11 correction note is a plan-revision notice, not
+                #   "an earlier observer note" about this drift, so quoting
+                #   it here would be a false claim;
+                # * the prior must have been actually RENDERED to the agent
+                #   (``delivered`` and not ``delivered_dry_run``) — "This
+                #   repeats an earlier observer note" is only true if the
+                #   agent SAW that note; an enqueued-but-never-rendered or
+                #   dry-run-consumed prior repeats nothing the agent saw,
+                #   so the 2nd note composes without the claim.
                 body = note_text
-                priors = [
-                    n for n in queue.notes() if n.kind == kind and n.task_id == task
-                ]
+                priors = queue.signal_notes(kind, task)
                 if len(priors) == 1:
-                    first_obs = (priors[0].observation or "").strip()
-                    if first_obs:
+                    prior = priors[0]
+                    first_obs = (prior.observation or "").strip()
+                    if first_obs and prior.delivered and not prior.delivered_dry_run:
                         body = (
                             f"{note_text}\n\nThis repeats an earlier observer "
                             f'note for this work, which observed: "{first_obs}". '
@@ -4314,7 +4326,9 @@ class DriftObserver:
         # been revised in between (a USER_STEER refine can regenerate
         # OUTCOME deliverables under reused ids). Pass the snapshot so the
         # apply path can drop any verdict whose target no longer matches.
-        await self._apply_outcome_transitions(session, transitions, snapshot_plan=plan)
+        await self._apply_outcome_transitions(
+            session, transitions, snapshot_plan=plan, run_ending=run_ending
+        )
 
     @staticmethod
     def _outcome_stability_token(task: Any) -> tuple[str, str]:
@@ -4337,6 +4351,7 @@ class DriftObserver:
         transitions: list[Any],
         *,
         snapshot_plan: Any | None = None,
+        run_ending: bool = False,
     ) -> None:
         """Apply outcome transitions: stamp contributes_to, then transition.
 
@@ -4347,6 +4362,15 @@ class DriftObserver:
         Marking an OUTCOME terminal re-enters ``mark_task_*`` → the
         task-boundary hook, which the PR 11(c) OUTCOME-skip guard
         short-circuits, so this does not recurse.
+
+        ``run_ending=True`` (the ``finalize_outcomes`` cadence) suppresses
+        the FAILED transitions' advisory drift cascade: the run is over, so
+        the cascade's observer note / nudge could never be delivered to the
+        agent — dispatching it would only pollute signal telemetry with
+        forever-pending notes and phantom fire records. The FAILED status,
+        ``TaskFailed`` / ``TaskTransitioned`` events, and ledger
+        finalization all still land; only the never-deliverable signal
+        dispatch is skipped.
 
         ``snapshot_plan`` (when supplied) is the plan the verdicts were
         computed against, before the judge's LLM round-trip. The freshness
@@ -4426,6 +4450,9 @@ class DriftObserver:
                         reason=tr.reason,
                         recoverable=True,
                         source=OUTCOME_JUDGE_SOURCE,
+                        # Run-ending finalize: the advisory cascade's note
+                        # could never reach the agent (see docstring).
+                        dispatch_drift_cascade=not run_ending,
                     )
             except Exception as exc:  # noqa: BLE001 — never break the run
                 log.warning(

--- a/goldfive/observer_note_queue.py
+++ b/goldfive/observer_note_queue.py
@@ -528,6 +528,27 @@ class ObserverNoteQueue:
                 best = max(best, int(n.delivered_turn))
         return best
 
+    def signal_notes(self, kind: str, task_id: str) -> list[ObserverNote]:
+        """Return the SIGNAL notes enqueued for a ``(kind, task)`` key.
+
+        In enqueue order. Correction notes (task #11) are excluded — they
+        are a distinct mechanism, not drift signals (see
+        :meth:`_is_signal_note`). This is the read the 2nd-signal
+        re-authoring in ``DriftObserver._route_corrective_note`` keys on:
+        counting a correction as a prior signal would let the composer
+        falsely claim a plan-revision notice was "an earlier observer
+        note", and the caller additionally checks ``delivered`` /
+        ``delivered_dry_run`` on the single prior so it never quotes a
+        note the agent was never shown.
+        """
+        k = str(kind or "")
+        t = str(task_id or "")
+        return [
+            n
+            for n in self.notes()
+            if n.kind == k and n.task_id == t and self._is_signal_note(n)
+        ]
+
     def signal_count(self, kind: str, task_id: str) -> int:
         """Return the number of SIGNAL notes ENQUEUED for a ``(kind, task)`` key.
 
@@ -539,13 +560,7 @@ class ObserverNoteQueue:
         (task #11) are excluded — they are not drift signals and must not
         trip signal escalation.
         """
-        k = str(kind or "")
-        t = str(task_id or "")
-        return sum(
-            1
-            for n in self.notes()
-            if n.kind == k and n.task_id == t and self._is_signal_note(n)
-        )
+        return len(self.signal_notes(kind, task_id))
 
     def rendered_keys(self) -> set[tuple[str, str]]:
         """Return every ``(kind, task)`` with at least one RENDERED SIGNAL note.

--- a/goldfive/plan_reviser.py
+++ b/goldfive/plan_reviser.py
@@ -117,6 +117,7 @@ from goldfive.types import (
     bump_revision,
     channel_processor_active,
     discovery_identity_hash,
+    plan_has_ledger_shape,
     replace_edges,
     set_session_plan,
 )
@@ -1492,10 +1493,29 @@ class PlanReviser:
         Terminal DISCOVERED tasks are already validator-protected
         (terminal-task preservation) so they are never re-added here.
 
+        Both repairs additionally require the PRIOR plan to actually carry
+        ledger shape (:func:`goldfive.types.plan_has_ledger_shape`): the
+        repairs exist to restore a taxonomy the LLM rebuild ERASED, so
+        there must have been one to erase. A prior with no ledger-shaped
+        task — the initial install (the ``Plan.empty()`` seed) or a
+        hand-authored forecast-shaped plan under a ledger config — is not
+        a degraded ledger; stamping it would relabel genuine prescriptive
+        intent as OUTCOME deliverables, violating the documented
+        "StaticPlanner users keep forecast semantics" contract (design doc
+        Stage 3). Ledger-mode planners stamp their OWN initial output
+        (:func:`goldfive.planner._stamp_ledger_outcome_kinds`), so an
+        LLMPlanner ledger arrives here already shaped and the repairs
+        engage from the first revision onward.
+
         Returns a NEW :class:`Plan` when anything changed (frozen-Plan
         invariant, goldfive#247); the input reference otherwise.
         """
         if not self._ledger_mode():
+            return revised
+        if not plan_has_ledger_shape(prior):
+            # Nothing to preserve/restore: the prior was never a ledger
+            # (initial empty-seed install, or a hand-authored forecast
+            # plan that keeps forecast semantics under a ledger config).
             return revised
         prior_tasks = list(getattr(prior, "tasks", None) or ())
         prior_by_id: dict[str, Task] = {t.id: t for t in prior_tasks if t.id}

--- a/goldfive/runner.py
+++ b/goldfive/runner.py
@@ -458,6 +458,10 @@ class Runner:
         self._fail_fast_on_revision_rejection: bool = bool(
             fail_fast_on_revision_rejection
         )
+        # One-shot latch for the ledger-mode / forecast-shaped-plan
+        # incoherent-combo warning (see
+        # :meth:`_warn_if_ledger_mode_without_ledger_plan`).
+        self._ledger_shape_warned: bool = False
         # Cross-turn prior-plan stash lives on :class:`Conversation`
         # (keyed by session id) so a Runner shared across multiple
         # outer ADK sessions does not leak one session's plan into
@@ -489,6 +493,51 @@ class Runner:
             return "ledger" if mode == "ledger" else "forecast"
         except Exception:  # noqa: BLE001
             return "forecast"
+
+    def _warn_if_ledger_mode_without_ledger_plan(self, session: Any) -> None:
+        """One-shot WARNING for the ledger-config / forecast-plan combo.
+
+        AGENCY-PRESERVATION.md Stage 3 PR 10 incoherent-combo guard:
+        ``SteeringConfig.plan_mode == "ledger"`` resolved but the installed
+        plan carries no ledger-shaped task (no ``TaskKind.OUTCOME`` /
+        ``DISCOVERED``) — typically a hand-authored ``StaticPlanner``
+        template under a ledger config. Per the documented contract
+        ("StaticPlanner users keep forecast semantics — a hand-authored
+        plan is genuine prescriptive intent") the ledger-only pin-tier
+        bypass keys on the live plan's shape, so such a run keeps forecast
+        pin semantics; this warning is the operator's signal that the
+        configured ledger regime is not actually engaged. Fires at most
+        once per Runner; never raises.
+        """
+        if self._ledger_shape_warned:
+            return
+        try:
+            from goldfive.steerer import plan_mode_is_ledger
+            from goldfive.types import plan_has_ledger_shape
+
+            plan = getattr(session, "plan", None)
+            tasks = getattr(plan, "tasks", None) if plan is not None else None
+            if (
+                plan_mode_is_ledger(self.steerer)
+                and tasks
+                and not plan_has_ledger_shape(plan)
+            ):
+                self._ledger_shape_warned = True
+                log.warning(
+                    "Runner.run: plan_mode=ledger is configured but the "
+                    "installed plan has NO ledger-shaped task (no OUTCOME/"
+                    "DISCOVERED kind) — likely a hand-authored StaticPlanner "
+                    "plan. This run keeps forecast pin semantics (the "
+                    "ledger pin-tier bypass keys on plan shape, not config); "
+                    "use an LLMPlanner or opt tasks into the ledger taxonomy "
+                    "via Task.kind to engage ledger mode. plan_id=%s tasks=%d",
+                    (getattr(plan, "id", "") or "")[:16] or "<none>",
+                    len(tasks),
+                )
+        except Exception as exc:  # noqa: BLE001 — advisory only
+            log.debug(
+                "Runner._warn_if_ledger_mode_without_ledger_plan raised: %s", exc
+            )
 
     def _conversation_key(self, session_id: str | None) -> str:
         """Map an optional outer-session-id pin to the lookup key.
@@ -976,6 +1025,11 @@ class Runner:
                 int(session.plan.revision_index),
             )
             session._conversational_turn = True  # type: ignore[attr-defined]
+
+        # Incoherent-combo guard (AGENCY-PRESERVATION.md PR 10): warn once
+        # when plan_mode=ledger resolved but the plan that just landed has
+        # no ledger-shaped task — that run keeps forecast pin semantics.
+        self._warn_if_ledger_mode_without_ledger_plan(session)
 
         # 5. Register the canonical reporting tools on the adapter.
         # goldfive#196: ``drift_self_reporting`` decides whether the

--- a/goldfive/task_state_machine.py
+++ b/goldfive/task_state_machine.py
@@ -288,6 +288,7 @@ class TaskStateMachine:
         reason: str = "",
         recoverable: bool = True,
         source: str = "other",
+        dispatch_drift_cascade: bool = True,
     ) -> None:
         """Transition ``task_id`` to ``FAILED`` and emit ``TaskFailed``.
 
@@ -295,6 +296,17 @@ class TaskStateMachine:
         ``TASK_FAILED_FATAL``. The drift event is dispatched through the
         same drift pipeline as observer-detected drift: if severity is
         ``>= WARNING`` (both of these are) we invoke ``planner.refine``.
+
+        ``dispatch_drift_cascade=False`` skips ONLY that fire-and-forget
+        drift dispatch (the intervention-ladder cascade whose advisory
+        note / nudge targets the still-running agent). The one caller is
+        the run-ending outcome-progress finalize
+        (:meth:`~goldfive.drift_observer.DriftObserver._apply_outcome_transitions`
+        with ``run_ending=True``): the run is over, so a cascade signal
+        could never be delivered — dispatching it would pollute signal
+        telemetry with forever-pending notes and phantom fire records.
+        Status transition, ``TaskFailed`` / ``TaskTransitioned`` emission,
+        lineage cleanup, and the fatal downstream cascade are unaffected.
 
         When ``recoverable=False`` the failure is fatal for this task
         lineage: **cascade-cancel every reachable downstream non-terminal
@@ -355,6 +367,15 @@ class TaskStateMachine:
             # ``"cancellation"`` from the framework's perspective — the
             # cascaded tasks weren't moved by the LLM directly).
             await self.cascade_cancel_downstream(session, task_id, source="cancellation")
+        if not dispatch_drift_cascade:
+            # Run-ending outcome finalize: no agent remains to receive the
+            # cascade's advisory signal (see docstring) — skip the dispatch.
+            log.debug(
+                "TaskStateMachine.mark_task_failed: drift cascade for task "
+                "%s suppressed (run-ending outcome finalize)",
+                task_id,
+            )
+            return
         kind = DriftKind.TASK_FAILED_RECOVERABLE if recoverable else DriftKind.TASK_FAILED_FATAL
         severity = DriftSeverity.WARNING if recoverable else DriftSeverity.CRITICAL
         drift = DriftEvent(

--- a/goldfive/types.py
+++ b/goldfive/types.py
@@ -1288,6 +1288,35 @@ def task_upstream_ready(plan: Plan, task_id: str) -> bool:
     return True
 
 
+def plan_has_ledger_shape(plan: Any) -> bool:
+    """Return ``True`` iff ``plan`` carries any ledger-taxonomy task.
+
+    AGENCY-PRESERVATION.md Stage 3 PR 10: a plan is *ledger-shaped* when at
+    least one task carries :attr:`TaskKind.OUTCOME` or
+    :attr:`TaskKind.DISCOVERED` — the taxonomy only the ledger regime
+    produces (an :class:`LLMPlanner` OUTCOME ledger, or a hand-authored
+    plan whose author explicitly opted tasks in). A purely FORECAST-kind
+    plan (notably a ``StaticPlanner`` template that never set ``kind``) is
+    NOT ledger-shaped even when ``SteeringConfig.plan_mode == "ledger"``:
+    "StaticPlanner users keep forecast semantics — a hand-authored plan is
+    genuine prescriptive intent" (design doc Stage 3), so ledger-only
+    behaviour (the delegation pin-tier bypass) must key on the live plan's
+    actual shape, not on config alone. Defensive: any read failure
+    resolves ``False`` (forecast — the default, inert regime).
+    """
+    try:
+        for t in getattr(plan, "tasks", None) or ():
+            kind = getattr(t, "kind", None)
+            if kind is None:
+                continue
+            value = str(getattr(kind, "value", kind) or "").strip().upper()
+            if value in (TaskKind.OUTCOME.value, TaskKind.DISCOVERED.value):
+                return True
+    except Exception:  # noqa: BLE001 — shape probe must never raise
+        return False
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Plan / Task derivation helpers (goldfive#247)
 # ---------------------------------------------------------------------------

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -78,15 +78,14 @@ async def test_three_arm_harness_runs_and_emits_telemetry(tmp_path: Path) -> Non
 
     for m in results:
         # §6.4: goal grading is UNMEASURED on EVERY arm (not silently True) —
-        # the exact gap that blocks a flip decision on this workload. For
-        # baseline/legacy (forecast mode) that is because the workload defines
-        # no goal predicate and mints no OUTCOME task. For the signal arm
-        # (plan_mode=ledger) the StaticPlanner tasks ARE stamped OUTCOME at
-        # install (#500), but this run is non-overlay — the legacy per-task loop
-        # force-completes those stamped tasks and the outcome-progress judge
-        # never runs — so that OUTCOME terminality is a PHANTOM, not a genuine
-        # ledger deliverable, and still grades UNMEASURED (for the right
-        # reason, asserted below). run.success alone is not a flip signal.
+        # the exact gap that blocks a flip decision on this workload. The
+        # workload defines no goal predicate and mints no OUTCOME task: the
+        # bench plan is a hand-authored StaticPlanner template, and per the
+        # "StaticPlanner users keep forecast semantics" contract the
+        # ledger-shape gate on ``_preserve_ledger_identity`` no longer stamps
+        # a forecast-shaped plan OUTCOME at install even on the signal arm
+        # (plan_mode=ledger) — the #501 "stamped, not exercised" phantom is
+        # gone at its source. run.success alone is not a flip signal.
         assert m.goal_grade == "unmeasured", m.goal_reason
         assert m.goal_success is False
         assert m.goal_predicate_count == 0
@@ -101,8 +100,13 @@ async def test_three_arm_harness_runs_and_emits_telemetry(tmp_path: Path) -> Non
         assert m.signals_total > 0, f"{m.arm_name}: 0 signals — telemetry not wired"
 
     by_kind = {m.arm_kind: m for m in results}
-    # baseline/legacy run in forecast mode: no OUTCOME task is minted at all.
-    for kind in ("baseline", "legacy"):
+    # NO arm mints an OUTCOME task. baseline/legacy run in forecast mode;
+    # the signal arm (plan_mode=ledger) drives a hand-authored StaticPlanner
+    # plan, which keeps forecast semantics (the ledger-shape gate on
+    # ``_preserve_ledger_identity`` no longer OUTCOME-stamps a
+    # forecast-shaped plan at install — the pre-gate behaviour produced the
+    # #501 "stamped, not exercised" phantom this block used to pin).
+    for kind in ("baseline", "signal", "legacy"):
         m = by_kind[kind]
         assert m.outcome_tasks_total == 0
         assert m.outcome_terminal == {
@@ -112,28 +116,13 @@ async def test_three_arm_harness_runs_and_emits_telemetry(tmp_path: Path) -> Non
             "cancelled": 0,
             "non_terminal": 0,
         }
-    # The signal arm (plan_mode=ledger) legitimately DOES carry stamped OUTCOME
-    # tasks now — #500's install-time stamping labels the StaticPlanner tasks
-    # OUTCOME and the legacy per-task loop drives them to COMPLETED. This is
-    # exactly the phantom: OUTCOME tasks are present and terminal, yet NONE were
-    # transitioned by the outcome-progress judge, so the run stays UNMEASURED
-    # and the ledger reads NOT exercised (stamped, not exercised).
     sig = by_kind["signal"]
-    assert sig.outcome_tasks_total == 3
-    assert sig.outcome_terminal == {
-        "completed": 3,
-        "failed": 0,
-        "not_needed": 0,
-        "cancelled": 0,
-        "non_terminal": 0,
-    }
-    assert "outcome-progress judge" in sig.goal_reason
+    assert "no OUTCOME task" in sig.goal_reason
 
-    # plan_mode=ledger is CONFIGURED on arm B (a KNOWN/applied flag) AND its
-    # tasks are stamped OUTCOME — but a non-overlay run never fires the
-    # outcome-progress judge, so the ledger regime is stamped yet NOT genuinely
-    # EXERCISED. Configured-and-stamped must not read as validated: OUTCOME
-    # terminality from the legacy per-task loop does not validate the ledger.
+    # plan_mode=ledger is CONFIGURED on arm B (a KNOWN/applied flag) but the
+    # hand-authored plan is forecast-shaped, so the ledger regime is neither
+    # stamped nor genuinely EXERCISED (the outcome-progress judge never
+    # transitioned a deliverable). Configured must not read as validated.
     assert by_kind["signal"].plan_mode == "ledger"
     assert by_kind["signal"].ledger_exercised is False
     assert by_kind["signal"].discovered_tasks_total == 0

--- a/tests/test_ledger_outcome_wiring.py
+++ b/tests/test_ledger_outcome_wiring.py
@@ -146,6 +146,48 @@ def test_finalize_outcomes_fails_confidently_unmet() -> None:
     assert by_id["o1"].status is TaskStatus.PENDING  # untouched (no verdict)
 
 
+def test_finalize_outcomes_failed_suppresses_drift_cascade() -> None:
+    """A run-ending confidently-unmet FAILED must NOT spawn the standard
+    FAILED drift cascade: the run is over, so the cascade's advisory
+    note/nudge could never be delivered — dispatching it would pollute
+    signal telemetry with forever-pending notes and phantom fire records.
+    The FAILED status itself (and its Task* events) still lands."""
+    payload = (
+        '{"outcomes": [{"task_id": "o2", "assessment": "failed", '
+        '"reason": "user cancelled the translation"}]}'
+    )
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=_judge(payload))
+    session = _ledger_session()
+    spawned: list[Any] = []
+    steerer.drift._spawn_drift_handler_background = (  # type: ignore[method-assign]
+        lambda drift, session: spawned.append(drift)
+    )
+
+    asyncio.run(steerer.finalize_outcomes(session))
+
+    by_id = {t.id: t for t in session.plan.tasks}
+    assert by_id["o2"].status is TaskStatus.FAILED  # transition still lands
+    assert spawned == []  # never-deliverable advisory dispatch suppressed
+
+
+def test_mark_task_failed_still_dispatches_cascade_by_default() -> None:
+    """Control for the run-ending suppression: every other
+    ``mark_task_failed`` caller keeps the fire-and-forget drift cascade."""
+    steerer = _make_steerer(plan_mode="ledger", judge_llm=_judge("{}"))
+    session = _ledger_session()
+    spawned: list[Any] = []
+    steerer.drift._spawn_drift_handler_background = (  # type: ignore[method-assign]
+        lambda drift, session: spawned.append(drift)
+    )
+
+    asyncio.run(
+        steerer.tasks.mark_task_failed("o1", session=session, reason="boom")
+    )
+
+    assert {t.id: t for t in session.plan.tasks}["o1"].status is TaskStatus.FAILED
+    assert len(spawned) == 1  # default path unchanged
+
+
 def test_finalize_outcomes_forecast_mode_is_noop() -> None:
     calls: list[str] = []
 

--- a/tests/test_ledger_pin_bypass.py
+++ b/tests/test_ledger_pin_bypass.py
@@ -233,3 +233,51 @@ async def test_forecast_control_pins_via_tier2_without_growth() -> None:
     assert session.current_task_id == "review"
     review = next(t for t in session.plan.tasks if t.id == "review")
     assert review.assignee_agent_id == "reviewer_agent"
+
+
+def _forecast_plan() -> Plan:
+    """The SAME titles as ``_outcome_plan`` but FORECAST-shaped — a
+    hand-authored StaticPlanner-style plan (no ``kind`` set)."""
+    return Plan(
+        id="p-static",
+        run_id="r-led",
+        goal_ids=["g-led"],
+        tasks=(
+            Task(id="summary", title="Summary delivered"),
+            Task(id="review", title="reviewer sign-off delivered"),
+        ),
+        edges=(),
+        revision_index=1,
+    )
+
+
+async def test_ledger_config_with_forecast_shaped_plan_keeps_pin_tiers() -> None:
+    """The documented contract: "StaticPlanner users keep forecast
+    semantics — a hand-authored plan is genuine prescriptive intent."
+    ``plan_mode="ledger"`` with a FORECAST-shaped plan (no OUTCOME /
+    DISCOVERED task) must NOT bypass the pin tiers: the delegation pins to
+    the stem-matching forecast task instead of silently stripping pinning
+    + drift-repair from the hand-authored plan."""
+    steerer, _sink = _make_steerer(plan_mode="ledger")
+    session = Session(
+        run_id="r-led",
+        goals=[Goal(id="g-led", summary="deliver the deck")],
+        plan=_forecast_plan(),
+    )
+    plugin, adk_state = _wire_plugin(session, steerer)
+
+    await _dispatch(
+        plugin,
+        adk_state,
+        agent=_FakeSubAgent("reviewer_agent"),
+        tool_args={"request": "review the deck"},
+    )
+
+    # No ledger bypass: the tier-2 stem match pins to "review"; the
+    # hand-authored tasks keep their forecast semantics.
+    assert session.current_task_id == "review"
+    review = next(t for t in session.plan.tasks if t.id == "review")
+    assert review.assignee_agent_id == "reviewer_agent"
+    assert review.kind is TaskKind.FORECAST
+    # No OUTCOME task was skipped-over into growth.
+    assert [t for t in session.plan.tasks if getattr(t, "discovered", False)] == []

--- a/tests/test_ledger_shape_guard.py
+++ b/tests/test_ledger_shape_guard.py
@@ -1,0 +1,180 @@
+"""Ledger-shape gating for the ledger regime (AGENCY-PRESERVATION.md PR 10).
+
+The ledger-only pin-tier bypass keys on the LIVE PLAN's shape
+(:func:`goldfive.types.plan_has_ledger_shape`), not on
+``SteeringConfig.plan_mode`` alone — "StaticPlanner users keep forecast
+semantics — a hand-authored plan is genuine prescriptive intent" (design doc
+Stage 3). Two pieces are pinned here:
+
+* the shape probe itself (``plan_has_ledger_shape``);
+* the Runner's one-shot incoherent-combo WARNING when ``plan_mode=ledger``
+  resolves but the installed plan has no ledger-shaped task (the run keeps
+  forecast pin semantics — the operator should know the configured regime
+  is not engaged).
+
+The pin-path behaviour under the combo is covered (ADK-gated) in
+``test_ledger_pin_bypass.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from tests._pbsetup import ensure_pb_available
+
+pytestmark = pytest.mark.skipif(
+    not ensure_pb_available(),
+    reason="goldfive protobuf stubs not available (install the `dev` extra)",
+)
+
+from goldfive import (  # noqa: E402
+    CallableAdapter,
+    InMemorySink,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Runner,
+    SequentialExecutor,
+    StaticPlanner,
+)
+from goldfive.config import SteeringConfig  # noqa: E402
+from goldfive.steerer import DefaultSteerer  # noqa: E402
+from goldfive.types import (  # noqa: E402
+    Plan,
+    Session,
+    Task,
+    TaskKind,
+    plan_has_ledger_shape,
+)
+
+_WARNING_MARKER = "NO ledger-shaped task"
+
+
+# ---------------------------------------------------------------------------
+# plan_has_ledger_shape
+# ---------------------------------------------------------------------------
+
+
+def _plan(*tasks: Task) -> Plan:
+    return Plan(id="p", run_id="r", goal_ids=["g"], tasks=list(tasks), edges=[])
+
+
+def test_shape_false_for_forecast_only_plan() -> None:
+    assert plan_has_ledger_shape(_plan(Task(id="t1", title="x"))) is False
+
+
+def test_shape_true_for_outcome_task() -> None:
+    plan = _plan(
+        Task(id="t1", title="x"),
+        Task(id="t2", title="y", kind=TaskKind.OUTCOME),
+    )
+    assert plan_has_ledger_shape(plan) is True
+
+
+def test_shape_true_for_discovered_task() -> None:
+    plan = _plan(Task(id="t1", title="x", kind=TaskKind.DISCOVERED))
+    assert plan_has_ledger_shape(plan) is True
+
+
+def test_shape_false_for_none_and_empty() -> None:
+    assert plan_has_ledger_shape(None) is False
+    assert plan_has_ledger_shape(_plan()) is False
+
+
+def test_shape_tolerates_string_kinds() -> None:
+    # Serialised / stub tasks may carry the kind as a bare string.
+    class _T:
+        kind = "OUTCOME"
+
+    class _P:
+        tasks = (_T(),)
+
+    assert plan_has_ledger_shape(_P()) is True
+
+
+# ---------------------------------------------------------------------------
+# Runner one-shot incoherent-combo warning
+# ---------------------------------------------------------------------------
+
+
+def _forecast_plan() -> Plan:
+    return Plan(
+        id="plan-static",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[Task(id="work", title="Do the work", assignee_agent_id="writer")],
+        edges=[],
+        summary="One hand-authored task.",
+    )
+
+
+def _ledger_shaped_plan() -> Plan:
+    return Plan(
+        id="plan-ledger",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(
+                id="deliverable",
+                title="Summary delivered",
+                assignee_agent_id="writer",
+                kind=TaskKind.OUTCOME,
+            )
+        ],
+        edges=[],
+        summary="One OUTCOME deliverable.",
+    )
+
+
+async def _happy_agent(task: Task, session: Session, tools: list) -> InvocationResult:
+    _ = tools
+    return InvocationResult(task_id=task.id, text=f"done: {task.title}")
+
+
+def _runner(*, plan: Plan, plan_mode: str) -> Runner:
+    return Runner(
+        agent=CallableAdapter(_happy_agent, available_agents=["writer"]),
+        planner=StaticPlanner(plan),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver("do the work"),
+        steerer=DefaultSteerer(steering_config=SteeringConfig(plan_mode=plan_mode)),
+        sinks=[InMemorySink()],
+    )
+
+
+def _combo_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if _WARNING_MARKER in r.message]
+
+
+async def test_ledger_config_with_forecast_plan_warns_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runner = _runner(plan=_forecast_plan(), plan_mode="ledger")
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
+        await runner.run("go")
+        assert len(_combo_warnings(caplog)) == 1
+        # One-shot per Runner: a second turn does not re-warn.
+        await runner.run("go again")
+        assert len(_combo_warnings(caplog)) == 1
+    await runner.close()
+
+
+async def test_forecast_config_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runner = _runner(plan=_forecast_plan(), plan_mode="forecast")
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
+        await runner.run("go")
+    await runner.close()
+    assert _combo_warnings(caplog) == []
+
+
+async def test_ledger_config_with_ledger_shaped_plan_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runner = _runner(plan=_ledger_shaped_plan(), plan_mode="ledger")
+    with caplog.at_level(logging.WARNING, logger="goldfive"):
+        await runner.run("go")
+    await runner.close()
+    assert _combo_warnings(caplog) == []

--- a/tests/test_observer_note_tool_annotation.py
+++ b/tests/test_observer_note_tool_annotation.py
@@ -243,3 +243,79 @@ async def test_after_tool_callback_annotates_result_when_active() -> None:
     assert returned["ok"] is True  # real result preserved verbatim
     assert returned["goldfive_observer_note"].startswith("[goldfive observer:")
     assert ObserverNoteQueue.for_session(session).get("d1").delivered is True
+
+
+async def test_annotation_scoped_to_invoking_agent() -> None:
+    """Agent scoping on surface 4: agent A's loop note is never annotated
+    onto agent B's tool result (misdelivery) — it stays pending for A's own
+    surfaces. The SAME note IS annotated when A's own tool result comes
+    through, and a broadcast (empty agent_id) note reaches any agent."""
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    session = Session(run_id="r1")
+    ctx = _ctx(session, _steerer(active=True))
+    _enqueue_loop_note(session)  # agent_id="worker" (agent A)
+    result = {"content": "x"}
+
+    # Agent B's tool result: A's note must NOT land there.
+    annotated = await plugin._maybe_annotate_tool_result(
+        ctx, result, agent_name="researcher"
+    )
+    assert annotated is None
+    # ...and the note is untouched — still pending for A's surfaces
+    # (better undelivered than misdelivered).
+    assert ObserverNoteQueue.for_session(session).get("d1").delivered is False
+
+    # Agent A's own tool result: the note lands.
+    annotated = await plugin._maybe_annotate_tool_result(
+        ctx, result, agent_name="worker"
+    )
+    assert annotated is not None
+    assert annotated["goldfive_observer_note"].startswith("[goldfive observer:")
+    assert ObserverNoteQueue.for_session(session).get("d1").delivered is True
+
+    # A broadcast note (empty agent_id) reaches any agent.
+    ObserverNoteQueue.for_session(session).enqueue(
+        body="Observation: broadcast loop", observation="broadcast loop",
+        severity="warning", drift_id="d-bcast", kind="looping_tool_call",
+        task_id="t1", agent_id="", turn=0,
+    )
+    annotated = await plugin._maybe_annotate_tool_result(
+        ctx, result, agent_name="researcher"
+    )
+    assert annotated is not None
+    assert ObserverNoteQueue.for_session(session).get("d-bcast").delivered is True
+
+
+async def test_after_tool_callback_two_agents_no_misdelivery() -> None:
+    """End-to-end: a loop note enqueued for agent A never rides agent B's
+    repeated-tool result through ``after_tool_callback``."""
+    plugin = make_adk_plugin(host_agent_name="test_agent")
+    session = Session(run_id="r1")
+    steerer = _steerer(active=True)
+    steerer.bind(sinks=[_ListSink()], planner=_StubPlanner())
+    ctx = _ctx(session, steerer)
+    plugin.set_active_context(ctx)
+    # Agent A's note, with a distinctive observation.
+    ObserverNoteQueue.for_session(session).enqueue(
+        body="Observation: AGENT-A-LOOP-MARKER",
+        observation="AGENT-A-LOOP-MARKER: `search_web` looped for agent_a",
+        severity="warning", drift_id="dA", kind="looping_tool_call",
+        task_id="t1", agent_id="agent_a", turn=0,
+    )
+
+    # Drive agent B into a repeated-tool loop.
+    tool = _ToolStub("patch_file")
+    args = {"path": "a.py", "diff": "x"}
+    tool_ctx = _ToolCtxStub("inv-two-agents", "agent_b")
+    result = {"content": [{"type": "text", "text": "patched"}], "ok": True}
+    returned: Any = None
+    for _ in range(3):  # exact-repeat x3 -> WARNING loop drift
+        returned = await plugin.after_tool_callback(
+            tool=tool, tool_args=args, tool_context=tool_ctx, result=dict(result)
+        )
+
+    # A's note was never consumed by B's surface...
+    assert ObserverNoteQueue.for_session(session).get("dA").delivered is False
+    # ...and whatever annotation (if any) rode B's result, it is not A's.
+    if isinstance(returned, dict) and "goldfive_observer_note" in returned:
+        assert "AGENT-A-LOOP-MARKER" not in returned["goldfive_observer_note"]

--- a/tests/test_pacing_grace_window.py
+++ b/tests/test_pacing_grace_window.py
@@ -281,13 +281,17 @@ def test_pacing_grace_disabled_still_applies_user_steer_gate() -> None:
 async def test_second_signal_quotes_the_first() -> None:
     steerer = _steerer()
     session = _session(turn=5)
-    # Enqueue a first note manually so _route_corrective_note sees one prior.
-    ObserverNoteQueue.for_session(session).enqueue(
+    # Enqueue a first note manually so _route_corrective_note sees one prior,
+    # and RENDER it — the "This repeats an earlier observer note" claim is
+    # only truthful when the agent actually saw the prior.
+    q = ObserverNoteQueue.for_session(session)
+    q.enqueue(
         body="Observation: search_web looped",
         observation="search_web was called 5 times with identical args",
         severity="warning", drift_id="d1", kind="looping_tool_call",
         task_id="t1", turn=0,
     )
+    q.mark_delivered("d1", channel="request_context", turn=1)
     await steerer.drift._route_corrective_note(
         session, _drift(), "Observation: still looping", ladder_level="signal"
     )
@@ -297,6 +301,97 @@ async def test_second_signal_quotes_the_first() -> None:
     # The 2nd note's body quotes the first note's observation.
     assert "repeats an earlier observer note" in second[0].body
     assert "search_web was called 5 times" in second[0].body
+
+
+async def test_second_signal_unrendered_prior_is_not_quoted() -> None:
+    """Truthfulness: a prior the agent never SAW must not be claimed as
+    "an earlier observer note" — enqueued-but-never-rendered priors compose
+    the 2nd note WITHOUT the repeat claim."""
+    steerer = _steerer()
+    session = _session(turn=5)
+    ObserverNoteQueue.for_session(session).enqueue(
+        body="Observation: search_web looped",
+        observation="search_web was called 5 times with identical args",
+        severity="warning", drift_id="d1", kind="looping_tool_call",
+        task_id="t1", turn=0,
+    )  # NOT marked delivered — never rendered to the agent
+    await steerer.drift._route_corrective_note(
+        session, _drift(), "Observation: still looping", ladder_level="signal"
+    )
+    second = [
+        n
+        for n in ObserverNoteQueue.for_session(session).notes()
+        if n.drift_id != "d1"
+    ]
+    assert len(second) == 1
+    assert second[0].body == "Observation: still looping"
+    assert "repeats an earlier observer note" not in second[0].body
+
+
+async def test_second_signal_dry_run_prior_is_not_quoted() -> None:
+    """A dry-run consume (observation_only shadow) never reached the agent,
+    so it must not be quoted as a repeat either."""
+    steerer = _steerer()
+    session = _session(turn=5)
+    q = ObserverNoteQueue.for_session(session)
+    q.enqueue(
+        body="Observation: search_web looped",
+        observation="search_web was called 5 times with identical args",
+        severity="warning", drift_id="d1", kind="looping_tool_call",
+        task_id="t1", turn=0,
+    )
+    q.mark_delivered("d1", channel="request_context", turn=1, dry_run=True)
+    await steerer.drift._route_corrective_note(
+        session, _drift(), "Observation: still looping", ladder_level="signal"
+    )
+    second = [n for n in q.notes() if n.drift_id != "d1"]
+    assert len(second) == 1
+    assert "repeats an earlier observer note" not in second[0].body
+
+
+async def test_second_signal_correction_prior_is_not_counted_or_quoted() -> None:
+    """A task-#11 correction note is a plan-revision notice, not a drift
+    signal — it must never be quoted as "an earlier observer note" (a false
+    claim), nor count as the single prior that triggers the quote."""
+    from goldfive.observer_note_queue import CORRECTION_DRIFT_ID_PREFIX
+
+    steerer = _steerer()
+    session = _session(turn=5)
+    q = ObserverNoteQueue.for_session(session)
+    # A RENDERED correction note for the SAME (kind, task) key.
+    cid = f"{CORRECTION_DRIFT_ID_PREFIX}writer:t1:1"
+    q.enqueue(
+        body="The plan changed", observation="the plan was revised",
+        severity="warning", drift_id=cid, kind="looping_tool_call",
+        task_id="t1", agent_id="writer", turn=0,
+    )
+    q.mark_delivered(cid, channel="request_context", turn=1)
+    await steerer.drift._route_corrective_note(
+        session, _drift(), "Observation: still looping", ladder_level="signal"
+    )
+    new = [n for n in q.notes() if n.drift_id != cid]
+    assert len(new) == 1
+    # Treated as the FIRST signal: no repeat claim, and never quoting the
+    # correction's observation.
+    assert "repeats an earlier observer note" not in new[0].body
+    assert "the plan was revised" not in new[0].body
+
+
+def test_signal_notes_excludes_corrections_and_keeps_order() -> None:
+    from goldfive.observer_note_queue import CORRECTION_DRIFT_ID_PREFIX
+
+    session = _session()
+    q = ObserverNoteQueue.for_session(session)
+    _enqueue(session, drift_id="d1", turn=1)
+    q.enqueue(
+        body="b", observation="o", severity="warning",
+        drift_id=f"{CORRECTION_DRIFT_ID_PREFIX}writer:t1:1",
+        kind="looping_tool_call", task_id="t1", turn=2,
+    )
+    _enqueue(session, drift_id="d2", turn=3)
+    got = q.signal_notes("looping_tool_call", "t1")
+    assert [n.drift_id for n in got] == ["d1", "d2"]
+    assert q.signal_notes("off_topic", "t1") == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plan_reviser.py
+++ b/tests/test_plan_reviser.py
@@ -515,6 +515,44 @@ def test_preserve_ledger_identity_restores_kinds_and_identity() -> None:
     assert by_id["d2"].status is TaskStatus.RUNNING
 
 
+def test_preserve_ledger_identity_skips_non_ledger_shaped_prior() -> None:
+    """The repairs only restore a taxonomy that EXISTED: a prior with no
+    ledger-shaped task (the initial empty-seed install, or a hand-authored
+    forecast plan under a ledger config) must NOT have its tasks stamped
+    OUTCOME — "StaticPlanner users keep forecast semantics — a hand-authored
+    plan is genuine prescriptive intent" (design doc Stage 3)."""
+    steerer = DefaultSteerer(
+        steering_config=SteeringConfig(observation_only=False, plan_mode="ledger")
+    )
+    hand_authored = Plan(
+        id="p-static",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=[Task(id="t1", title="Do the work"), Task(id="t2", title="Review it")],
+        edges=[],
+        revision_index=1,
+    )
+
+    # Initial install: prior is the empty seed.
+    out = steerer.plans._preserve_ledger_identity(hand_authored, Plan.empty())
+    assert out is hand_authored
+    assert all(t.kind is TaskKind.FORECAST for t in out.tasks)
+
+    # Later revision of a forecast-shaped (never-a-ledger) prior: new
+    # tasks are NOT stamped OUTCOME either.
+    revised = Plan(
+        id="p-static",
+        run_id="r",
+        goal_ids=["g"],
+        tasks=[*hand_authored.tasks, Task(id="t3", title="Ship it")],
+        edges=[],
+        revision_index=2,
+    )
+    out = steerer.plans._preserve_ledger_identity(revised, hand_authored)
+    assert out is revised
+    assert all(t.kind is TaskKind.FORECAST for t in out.tasks)
+
+
 def test_preserve_ledger_identity_is_noop_in_forecast_mode() -> None:
     prior = _ledger_prior()
     revised = _refined_forecast_shape(prior)


### PR DESCRIPTION
Final correctness gate for the `agency-preservation` merge: four verified-in-diagnosis defects, each re-verified against the current branch (post #496–#505, rebased on #504's flag-accessor helpers). Every fix is inert under the default flags (`signal_channel=legacy_user_message`, `plan_mode=forecast`, `observation_only=True`, `signal_telemetry=False`); no default-flag behavior or §6.6-deferred escalation semantics are touched.

## Finding 1 — truthful second-signal re-authoring
**Verification: CONFIRMED present.** `drift_observer._route_corrective_note` (request_context leg) counted priors as `[n for n in queue.notes() if n.kind == kind and n.task_id == task]` — (a) correction notes counted as priors, so a plan-revision notice could be quoted as "an earlier observer note" (false claim); (b) the quoted prior may never have been rendered (enqueued-but-pending, or a post-#502 `delivered_dry_run` shadow consume).

**Fix:** new `ObserverNoteQueue.signal_notes(kind, task)` (correction notes excluded via the existing `_is_signal_note`; `signal_count` refactored over it). The composer quotes the single prior only when it is a signal note that was actually RENDERED (`delivered and not delivered_dry_run`); otherwise the 2nd note composes without the repeat claim. Non-default regime (`request_context`) → inert under defaults.

**Tests:** rendered prior quoted (existing test corrected — its prior was never rendered); unrendered prior not quoted; dry-run prior not quoted; correction prior neither counted nor quoted; `signal_notes` ordering/exclusion unit test.

## Finding 2 — tool-annotation agent scoping (surface 4)
**Verification: CONFIRMED present.** `_maybe_annotate_tool_result` peeked with `kinds=_LOOP_KINDS` and no agent filter, so agent A's loop note could be annotated onto agent B's tool result. `after_tool_callback` already resolves the invoking agent (`inv_ctx.agent.name`, host fallback) — it just never passed it down.

**Fix:** `after_tool_callback` threads `agent_name` into `_maybe_annotate_tool_result`, which passes `agent_id=agent_name or None` to `peek_for_render` — invoking-agent + broadcast selection per the existing peek semantics; another agent's note stays pending for its own agent-aware surfaces (better undelivered than misdelivered). Request_context-only surface → inert under defaults.

**Tests:** direct two-agent scoping (wrong agent → no annotation, note untouched; right agent → annotated; broadcast → any agent) and an end-to-end two-agent drive through `after_tool_callback` asserting A's note never lands on B's result.

## Finding 3 — run-end FAILED-outcome cascade pollution (ledger mode)
**Verification: CONFIRMED present.** `finalize_outcomes` → `_run_outcome_progress(run_ending=True)` → `_apply_outcome_transitions` → `mark_task_failed(...)`, which unconditionally spawned the fire-and-forget drift cascade — an advisory note/nudge that can never be delivered (the run is ending), leaving forever-pending queue notes and phantom fire records in signal telemetry.

**Fix:** `run_ending` threads `_run_outcome_progress` → `_apply_outcome_transitions` → new keyword-only `mark_task_failed(dispatch_drift_cascade=True)`; the run-ending finalize passes `False`, which skips ONLY the cascade spawn. The FAILED status, `TaskFailed`/`TaskTransitioned` events, lineage cleanup, downstream cascade, and ledger finalization are unchanged; all other `mark_task_failed` callers (steerer, reporting handlers, ledger force-FAIL, fatal gate) keep the default cascade. Ledger-gated path → inert under defaults.

**Tests:** run-end confidently-unmet FAILED lands with zero cascade spawns; control test that a default `mark_task_failed` still spawns exactly one.

## Finding 4 — ledger pin-tier bypass keyed on config alone
**Verification: CONFIRMED present, with one as-built wrinkle.** The pin bypass keyed on `_ledger_mode_enabled` (config only), so `plan_mode=ledger` + a hand-authored FORECAST-shaped plan silently stripped pinning + drift-repair — contradicting the documented "StaticPlanner users keep forecast semantics" contract (design doc Stage 3 + `config.py`). Re-verification also found the diagnosis's premise requires a companion fix: #500's `_preserve_ledger_identity` OUTCOME-stamps every task at the INITIAL (empty-seed) install in ledger mode, so a StaticPlanner plan became "ledger-shaped" before the pin path ever ran — the exact "stamped, not exercised" phantom bench #501 had to special-case.

**Fix:** new `goldfive.types.plan_has_ledger_shape(plan)` (any `TaskKind.OUTCOME`/`DISCOVERED` task; defensive, tolerates string kinds). Three consumers:
- the pin bypass engages only when the LIVE plan actually has ledger shape;
- `_preserve_ledger_identity`'s repairs require a ledger-shaped PRIOR — they restore a taxonomy the LLM rebuild erased, so one must have existed; ledger planners stamp their own initial output (`_stamp_ledger_outcome_kinds`), so LLMPlanner ledgers are unaffected and the repairs engage from the first revision onward, while hand-authored forecast plans are no longer relabeled (contract restored end-to-end; #501 phantom removed at its source — bench test updated accordingly);
- one-shot `Runner` WARNING at run start when `plan_mode=ledger` resolves but the installed plan has no ledger-shaped task (the requested incoherent-combo guard; the message is truthful — such a run genuinely keeps forecast pin semantics now).

Non-default regime (`plan_mode=ledger`) → inert under defaults (`_preserve_ledger_identity` and the bypass both short-circuit in forecast mode before the new gate; the warning requires `plan_mode_is_ledger`).

**Tests:** shape-probe unit tests; ledger-config + forecast-shaped plan keeps tier-2 pinning (ADK pin path); reviser skips non-ledger-shaped priors (initial install + later revision); Runner warning fires once per Runner and not in either coherent configuration; bench harness test updated for the phantom's removal (signal arm now mints zero OUTCOME tasks, still `UNMEASURED` / not exercised).

## Validation
- Touched-module tests + FULL suite: **3319 passed, 61 skipped** (`uv run pytest -q -x`)
- `uv run ruff check goldfive/ tests/ bench/`: clean
- Rebased on `origin/agency-preservation` (#504 flag-accessor helpers in ancestry; channel reads in touched code already route through `_signal_channel_of`/`plan_mode_is_ledger`)
- No prompt-cooperation contracts, no regex/keyword NL heuristics, kill-switch reads unchanged (`_is_observation_only` / `steering_is_active` untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA