### PR TITLE
fix(context-editor): PR 6b rule defects — new-channel note staleness, truthful compaction, redaction-aware composition, telemetry honesty

### DIFF
--- a/goldfive/context_editor.py
+++ b/goldfive/context_editor.py
@@ -593,6 +593,12 @@ class ContextEditor:
         )
 
         current = original_contents
+        # ``ContextEdited`` emissions are DEFERRED until the final
+        # ``llm_request.contents`` swap succeeds — an event describing an
+        # edit that never reached the request would be a false claim in
+        # the timeline. Rejected events still emit inline (a rejection is
+        # a fact regardless of the swap outcome).
+        pending_applied_emits: list[dict[str, Any]] = []
         for rule in self._rules:
             rule_name = str(_safe_attr(rule, "name", "") or rule.__class__.__name__)
             rule_class = _resolve_rule_class(rule)
@@ -705,41 +711,54 @@ class ContextEditor:
                 continue
 
             # Edit passed all invariants. Accept; subsequent rules
-            # see the edited contents.
+            # see the edited contents. The event's before-counts are
+            # PER-RULE (this rule's actual input), not the pre-chain
+            # totals — so two composing rules each report their own
+            # honest delta.
+            pre_rule_count = len(current)
             current = candidate
             result.applied_rules.append(rule_name)
-            try:
-                await self._emit_applied(
-                    session=session,
-                    rule_name=rule_name,
-                    rule_class=rule_class,
-                    bytes_before=pre_rule_bytes,
-                    bytes_after=cand_bytes,
-                    contents_count_before=len(original_contents),
-                    contents_count_after=len(candidate),
-                    observed_rev=observed_rev,
-                )
-            except Exception as exc:  # noqa: BLE001
-                log.debug(
-                    "ContextEditor.apply: emit ContextEdited raised: %s",
-                    exc,
-                )
+            pending_applied_emits.append(
+                {
+                    "session": session,
+                    "rule_name": rule_name,
+                    "rule_class": rule_class,
+                    "bytes_before": pre_rule_bytes,
+                    "bytes_after": cand_bytes,
+                    "contents_count_before": pre_rule_count,
+                    "contents_count_after": len(candidate),
+                    "observed_rev": observed_rev,
+                }
+            )
 
         # Commit the final ``contents`` onto the request only if a
         # rule actually applied. The defensive ``current is
         # original_contents`` check avoids touching the attribute when
         # nothing changed.
+        swap_failed = False
         if current is not original_contents and result.applied_rules:
             try:
                 llm_request.contents = current
             except Exception as exc:  # noqa: BLE001
                 log.warning(
                     "ContextEditor.apply: could not swap llm_request.contents "
-                    "— reverting: %s",
+                    "— reverting (suppressing %d ContextEdited event(s)): %s",
+                    len(pending_applied_emits),
                     exc,
                 )
                 result.applied_rules.clear()
                 current = original_contents
+                swap_failed = True
+
+        if not swap_failed:
+            for emit_kwargs in pending_applied_emits:
+                try:
+                    await self._emit_applied(**emit_kwargs)
+                except Exception as exc:  # noqa: BLE001
+                    log.debug(
+                        "ContextEditor.apply: emit ContextEdited raised: %s",
+                        exc,
+                    )
 
         result.bytes_after = _content_bytes(current)
         result.contents_count_after = len(current)
@@ -1179,6 +1198,35 @@ def _response_error_text(resp: Any) -> str:
     return " ".join(chunks).lower()
 
 
+#: Key of the payload :class:`PruneTransientErrorRule` writes when it
+#: redacts a transient-error ``function_response`` in place. Shared so
+#: :class:`CompactPriorReasoningRule` can recognise an already-redacted
+#: failure (rule-composition contract: redaction upstream must not blind
+#: compaction to the loop it exists to compact). Structured exact-key
+#: check — not an NL heuristic.
+_REDACTION_KEY = "goldfive_redacted"
+
+
+def _is_goldfive_redaction(resp: Any) -> bool:
+    """True iff ``resp`` is a goldfive transient-error redaction payload."""
+    return isinstance(resp, dict) and _REDACTION_KEY in resp
+
+
+def _canonical_response_payload(resp: Any) -> str:
+    """Canonical serialised view of a ``function_response.response`` payload.
+
+    Order-insensitive JSON (``sort_keys=True``) so two structurally-equal
+    dicts compare equal regardless of key order — the result-identity key
+    :class:`CompactPriorReasoningRule` uses to decide whether repeated
+    calls truly returned IDENTICAL results (structured-data hashing, not
+    NL matching). Falls back to ``repr`` for unserialisable payloads.
+    """
+    try:
+        return json.dumps(resp, sort_keys=True, default=repr)
+    except Exception:  # noqa: BLE001
+        return repr(resp)
+
+
 def _function_call_signature(fc: Any) -> tuple[str, str]:
     """Return ``(name, canonical-args-json)`` identifying a function call.
 
@@ -1203,20 +1251,23 @@ def _content_owned_by_id(content: Any, fc_id: str) -> bool:
     The ownership guard for :class:`CompactPriorReasoningRule`: it only
     drops / rewrites a ``Content`` when that content's tool parts ALL
     belong to the call id being collapsed. A content batching parts for
-    several ids is left untouched (conservative — dropping it would
-    affect unrelated calls). Text parts are allowed (the reasoning text
-    alongside the collapsed call is part of what we're compacting).
+    several ids — or carrying an ID-LESS tool part, which cannot be
+    attributed to any call and would otherwise be silently clobbered /
+    dropped alongside the collapsed pair — is left untouched
+    (conservative; dropping it would affect unrelated calls). Text parts
+    are allowed (the reasoning text alongside the collapsed call is part
+    of what we're compacting).
     """
     for part in _iter_parts(content):
         fc = _safe_attr(part, "function_call", None)
         if fc is not None:
             pid = str(_safe_attr(fc, "id", "") or "")
-            if pid and pid != fc_id:
+            if pid != fc_id:
                 return False
         fr = _safe_attr(part, "function_response", None)
         if fr is not None:
             pid = str(_safe_attr(fr, "id", "") or "")
-            if pid and pid != fc_id:
+            if pid != fc_id:
                 return False
     return True
 
@@ -1360,7 +1411,7 @@ class PruneTransientErrorRule:
 
     def _redaction_value(self) -> dict[str, str]:
         """A fresh, minimal redaction payload (new object each call)."""
-        return {"goldfive_redacted": "transient_error_elided"}
+        return {_REDACTION_KEY: "transient_error_elided"}
 
     def _is_transient(self, resp: Any) -> bool:
         if not isinstance(resp, dict):
@@ -1452,19 +1503,38 @@ class PruneStaleSteerRule:
 
     Staleness (the trigger)
     -----------------------
-    A candidate is stale when it is no longer the CURRENTLY-ACTIVE steer.
-    "Active" is read from ``goldfive.active_steer.body`` on session state
-    (:func:`goldfive.state_store.set_active_steer` /
-    :func:`~goldfive.state_store.clear_active_steer`): the note whose
-    text still contains the active-steer body is kept; every other
-    goldfive note is stale. When no steer is active (the body was
-    cleared once the steered work resolved — runner clears it on
-    completion) ALL goldfive notes are stale.
+    A candidate is stale when the agent has already had its chance to
+    see it. Two bookkeeping sources decide that, matching the two ways
+    goldfive notes reach ``contents``:
 
-    This is the stable-keyed proxy for "the steered plan revision is
-    COMPLETED": goldfive clears / supersedes the active steer when the
-    correction has taken, so a goldfive note that no longer matches the
-    active steer is a residue of a resolved correction.
+    * **New-channel notes** (the PR 6 request-context channel) — the
+      boundary replay renders a queued
+      :class:`~goldfive.observer_note_queue.ObserverNote` into
+      ``contents`` as the next user turn and stamps ``delivered`` /
+      ``delivered_turn`` on the queue (exactly-once). The new regime
+      does NOT write ``goldfive.active_steer.body`` (PR 7 scoped
+      ``set_active_steer`` to ``legacy_ladder`` only), so staleness for
+      these notes keys on the note channel's OWN bookkeeping: a
+      marker-wrapped content matching a delivered (non-dry-run) note's
+      body is FRESH while the session's reasoning turn has not advanced
+      past that note's ``delivered_turn`` — the agent has not yet had a
+      full turn to see it. Once the turn advances, the note is residue
+      and drops. Per-note clocks (rather than a single "most recent
+      delivered" winner) keep a contents-rendered note alive even when
+      another surface (``before_model`` → ``system_instruction``)
+      consumed a different note at the same turn.
+    * **Legacy-ladder footer bodies** — ``goldfive.active_steer.body``
+      (:func:`goldfive.state_store.set_active_steer` /
+      :func:`~goldfive.state_store.clear_active_steer`) is still
+      written under the ``legacy_ladder`` escape hatch: the note whose
+      text contains the active-steer body is kept.
+
+    A goldfive note matching NEITHER source is residue of a resolved
+    correction and drops. Both matches are exact substring containment
+    of goldfive-minted strings (the queue's stored ``body`` / the
+    active-steer body) — stable-identity checks, never NL heuristics.
+    Deterministic per ``(session.state, _reasoning_turn)`` snapshot;
+    drop-only is preserved (whole entries are removed, never rewritten).
 
     Dormancy
     --------
@@ -1501,10 +1571,11 @@ class PruneStaleSteerRule:
             return None
 
         active_body = self._read_active_steer_body(ctx.session)
+        fresh_bodies = self._fresh_delivered_note_bodies(ctx.session)
         survivors: list[Any] = []
         dropped = False
         for i, content in enumerate(contents):
-            if i in note_idx and self._is_stale(content, active_body):
+            if i in note_idx and self._is_stale(content, active_body, fresh_bodies):
                 dropped = True
                 continue
             survivors.append(content)
@@ -1549,6 +1620,20 @@ class PruneStaleSteerRule:
             return ("", cls._MARKER_FALLBACK)
 
     def _is_goldfive_note(self, content: Any, footer: str, marker: str) -> bool:
+        # Shape gate: goldfive's surfaces inject notes ONLY as plain
+        # user-text turns (the boundary replay's next-user-turn render
+        # and the legacy synthetic-steer injection). A MODEL turn that
+        # merely quotes the marker string, or any content carrying tool
+        # parts (function_call / function_response), is never a
+        # goldfive note and must not be dropped.
+        role = str(_safe_attr(content, "role", "") or "").strip().lower()
+        if role and role != "user":
+            return False
+        for part in _iter_parts(content):
+            if _safe_attr(part, "function_call", None) is not None:
+                return False
+            if _safe_attr(part, "function_response", None) is not None:
+                return False
         text = _content_text(content)
         if not text:
             return False
@@ -1556,11 +1641,58 @@ class PruneStaleSteerRule:
             return True
         return bool(footer) and footer in text
 
-    def _is_stale(self, content: Any, active_body: str) -> bool:
-        if not active_body:
-            # No active steer — every goldfive note is residue.
-            return True
-        return active_body not in _content_text(content)
+    def _is_stale(
+        self,
+        content: Any,
+        active_body: str,
+        fresh_bodies: tuple[str, ...],
+    ) -> bool:
+        text = _content_text(content)
+        # New-channel bookkeeping: a content carrying the body of a
+        # delivered note whose reasoning-turn window is still open is
+        # FRESH — the agent has not yet had a full turn to see it.
+        for body in fresh_bodies:
+            if body in text:
+                return False
+        # Legacy-ladder bookkeeping: the note matching the active-steer
+        # body is the currently-active steer.
+        if active_body and active_body in text:
+            return False
+        return True
+
+    @staticmethod
+    def _fresh_delivered_note_bodies(session: Any) -> tuple[str, ...]:
+        """Bodies of channel-delivered notes still inside their visibility window.
+
+        Reads the PR 6 :class:`~goldfive.observer_note_queue.ObserverNoteQueue`
+        off the session — the SAME bookkeeping the delivery surfaces stamp —
+        and returns the ``body`` of every note that was actually rendered
+        (``delivered`` and NOT a dry-run consume) whose ``delivered_turn``
+        the session's reasoning turn has not advanced past. Such a note was
+        just placed in front of the agent (e.g. the boundary replay's
+        next-user-turn render) and MUST survive the edit pass; once the
+        reasoning turn advances the agent has had its full turn to see it
+        and the note becomes prunable residue. Dry-run consumes are
+        excluded — the agent never saw those, so no content can
+        legitimately match them and they must not anchor freshness.
+        Best-effort: returns ``()`` on any failure.
+        """
+        try:
+            from goldfive.observer_note_queue import ObserverNoteQueue  # noqa: PLC0415
+
+            current_turn = int(_safe_attr(session, "_reasoning_turn", 0) or 0)
+            fresh: list[str] = []
+            for note in ObserverNoteQueue.for_session(session).notes():
+                if not note.delivered or note.delivered_dry_run:
+                    continue
+                body = str(note.body or "").strip()
+                if not body:
+                    continue
+                if current_turn <= int(note.delivered_turn):
+                    fresh.append(body)
+            return tuple(fresh)
+        except Exception:  # noqa: BLE001
+            return ()
 
     @staticmethod
     def _read_active_steer_body(session: Any) -> str:
@@ -1590,6 +1722,22 @@ class CompactPriorReasoningRule:
     call/response pair of each identical-failed run, replaces its
     response with a one-line summary noting how many duplicates were
     collapsed, and drops the rest.
+
+    Truthful summaries (result identity)
+    ------------------------------------
+    Grouping is by call SIGNATURE (name + canonical args), but the
+    synthesized claim is checked against result IDENTITY
+    (:func:`_canonical_response_payload` — structured-data comparison,
+    not NL matching): "identical results" is claimed only when the
+    compared payloads ARE identical; when args-identical calls returned
+    DIFFERING results the summary says so and preserves the LAST result
+    verbatim. Responses already redacted by
+    :class:`PruneTransientErrorRule` (the shared ``goldfive_redacted``
+    marker) count as failed and group naturally (every redaction of a
+    signature carries the same marker payload), so upstream redaction in
+    the same chain never blinds this rule — their summary states that
+    the transient-error payloads were elided rather than claiming
+    identical tool results.
 
     Why byte-monotonic-replace
     --------------------------
@@ -1656,8 +1804,16 @@ class CompactPriorReasoningRule:
                 call_idx_by_id[fc_id] = i
                 sig_by_id[fc_id] = _function_call_signature(fc)
 
-        # Locate every call id's response content + whether it failed.
+        # Locate every call id's response content + whether it failed +
+        # its canonical result payload (the result-identity key). A
+        # payload already redacted by ``PruneTransientErrorRule`` counts
+        # as failed too — rule composition: upstream redaction must not
+        # blind this rule to the loop it exists to compact (and all
+        # redactions of a signature share one identical marker payload,
+        # so they group under result identity).
         resp_idx_by_id: dict[str, int] = {}
+        resp_payload_by_id: dict[str, str] = {}
+        redacted_ids: set[str] = set()
         failed_ids: set[str] = set()
         for i, content in enumerate(contents):
             for part in _iter_parts(content):
@@ -1669,7 +1825,11 @@ class CompactPriorReasoningRule:
                     continue
                 resp_idx_by_id[fr_id] = i
                 resp = _safe_attr(fr, "response", None)
-                if _response_has_error_indicator(resp):
+                resp_payload_by_id[fr_id] = _canonical_response_payload(resp)
+                if _is_goldfive_redaction(resp):
+                    redacted_ids.add(fr_id)
+                    failed_ids.add(fr_id)
+                elif _response_has_error_indicator(resp):
                     failed_ids.add(fr_id)
 
         # Group failed, fully-paired ids by call signature.
@@ -1700,6 +1860,23 @@ class CompactPriorReasoningRule:
             keep = ids_sorted[0]
             _keep_ci, keep_ri = owned[keep]
 
+            # Result-identity check (truthfulness contract): only claim
+            # "identical results" when the compared payloads ARE
+            # identical. When the args were identical but the results
+            # differed (e.g. an error progression), the summary says so
+            # honestly and preserves the LAST result verbatim — the
+            # progression's endpoint is the one datum the model still
+            # needs.
+            payloads = [resp_payload_by_id.get(fc_id, "") for fc_id in ids_sorted]
+            identical_results = len(set(payloads)) == 1
+            summary = self._summary_value(
+                name=sig[0],
+                count=len(ids_sorted),
+                identical_results=identical_results,
+                results_redacted=identical_results and keep in redacted_ids,
+                last_result=payloads[-1],
+            )
+
             # Build the summarized survivor and only collapse this group
             # when doing so STRICTLY reduces bytes. The summary is
             # synthesized text, so a run of tiny failed responses could
@@ -1709,7 +1886,7 @@ class CompactPriorReasoningRule:
             # the not-beneficial case instead of emitting a spurious
             # ContextEditRejected.
             clone = self._summarize_response(
-                contents[keep_ri], name=sig[0], count=len(ids_sorted)
+                contents[keep_ri], fc_id=keep, summary=summary
             )
             if clone is None:
                 continue
@@ -1744,18 +1921,62 @@ class CompactPriorReasoningRule:
     # ---- internals ----------------------------------------------------
 
     @staticmethod
-    def _summary_value(*, name: str, count: int) -> dict[str, str]:
-        return {
-            "goldfive_compacted": (
+    def _summary_value(
+        *,
+        name: str,
+        count: int,
+        identical_results: bool,
+        results_redacted: bool,
+        last_result: str,
+    ) -> dict[str, str]:
+        """Synthesize the survivor's summary payload — truthfully.
+
+        Three shapes (truthfulness contract — the summary must never
+        claim more than the compared payloads support):
+
+        * identical results, plain — the original "identical arguments
+          and identical results" claim (byte-pinned by tests).
+        * identical results, but each was a goldfive transient-error
+          redaction — the true statement is that every attempt returned
+          a transient error whose payload was already elided, not that
+          the tool returned "identical results".
+        * differing results — say so, and preserve the LAST result
+          verbatim (canonical JSON) so the error progression's endpoint
+          survives the collapse.
+        """
+        if identical_results and not results_redacted:
+            text = (
                 f"The tool '{name}' was invoked {count} times with identical "
                 f"arguments and identical results; {count - 1} duplicate "
                 f"invocations were collapsed to keep the context focused."
             )
-        }
+        elif identical_results:
+            text = (
+                f"The tool '{name}' was invoked {count} times with identical "
+                f"arguments; each attempt returned a transient error whose "
+                f"payload was elided; {count - 1} duplicate invocations were "
+                f"collapsed to keep the context focused."
+            )
+        else:
+            text = (
+                f"The tool '{name}' was invoked {count} times with identical "
+                f"arguments but the results differed across attempts; "
+                f"{count - 1} earlier invocations were collapsed to keep the "
+                f"context focused. Last result (verbatim): {last_result}"
+            )
+        return {"goldfive_compacted": text}
 
-    def _summarize_response(self, content: Any, *, name: str, count: int) -> Any | None:
-        """Return a deepcopy of ``content`` with its response part(s) summarized."""
-        summary = self._summary_value(name=name, count=count)
+    def _summarize_response(
+        self, content: Any, *, fc_id: str, summary: dict[str, str]
+    ) -> Any | None:
+        """Return a deepcopy of ``content`` with the ``fc_id`` response summarized.
+
+        Only the ``function_response`` part(s) whose ``id`` matches the
+        collapsed call are rewritten — any other part on the content is
+        preserved verbatim (belt-and-braces alongside the
+        :func:`_content_owned_by_id` guard, which already skips contents
+        carrying foreign or id-less tool parts).
+        """
         try:
             clone = copy.deepcopy(content)
         except Exception:  # noqa: BLE001
@@ -1764,6 +1985,8 @@ class CompactPriorReasoningRule:
         for part in _iter_parts(clone):
             fr = _safe_attr(part, "function_response", None)
             if fr is None:
+                continue
+            if str(_safe_attr(fr, "id", "") or "") != fc_id:
                 continue
             try:
                 fr.response = dict(summary)

--- a/tests/test_context_editor.py
+++ b/tests/test_context_editor.py
@@ -792,7 +792,14 @@ def _note_content(body: str) -> FakeContent:
 
 @pytest.mark.asyncio
 async def test_prune_stale_steer_no_active_steer_drops_all_notes() -> None:
-    """With no active steer recorded, every goldfive note is residue."""
+    """Notes with NO bookkeeping match anywhere are residue and drop.
+
+    No active steer (legacy slot empty) AND no delivered note on the
+    ObserverNoteQueue matches these contents — so both staleness sources
+    agree they are residue. A freshly-delivered new-channel note is the
+    OPPOSITE case, covered by
+    ``test_prune_stale_steer_keeps_freshly_delivered_note``.
+    """
     sink = InMemorySink()
     editor = ContextEditor(rules=[PruneStaleSteerRule()], sinks=[sink])
     request = FakeRequest(
@@ -877,6 +884,180 @@ async def test_prune_stale_steer_detects_observer_note_marker() -> None:
 
     assert result.applied_rules == ["prune_stale_steer"]
     assert [c.parts[0].text for c in request.contents] == ["real user request"]
+
+
+def _delivered_note_session(
+    *,
+    body: str,
+    delivered_turn: int,
+    reasoning_turn: int,
+    dry_run: bool = False,
+    surface: str = "boundary_replay",
+) -> tuple[FakeSession, FakeContent]:
+    """A session whose ObserverNoteQueue delivered ``body``, plus its rendered content.
+
+    Mirrors the new-regime boundary-replay path
+    (``SequentialExecutor._consume_observer_note_for_replay``): enqueue →
+    ``mark_delivered`` (exactly-once) → ``render_block`` fed as the next
+    user turn. ``goldfive.active_steer.body`` is deliberately NOT written
+    — the new regime never stamps it (PR 7).
+    """
+    from goldfive.observer_note_queue import ObserverNoteQueue, render_block
+
+    session = FakeSession()
+    session._reasoning_turn = reasoning_turn
+    queue = ObserverNoteQueue.for_session(session)
+    note = queue.enqueue(
+        body=body,
+        observation=body,
+        severity="warning",
+        drift_id="d-1",
+        kind="looping_tool_call",
+        task_id="t-1",
+        turn=delivered_turn,
+    )
+    assert queue.mark_delivered(
+        note.note_id,
+        channel="request_context",
+        turn=delivered_turn,
+        surface=surface,
+        dry_run=dry_run,
+    )
+    return session, _text_content(render_block(note))
+
+
+@pytest.mark.asyncio
+async def test_prune_stale_steer_keeps_freshly_delivered_note() -> None:
+    """Finding-1 regression: a boundary-replay note delivered THIS turn survives.
+
+    The new regime never writes ``goldfive.active_steer.body``, so the
+    old active-steer proxy would call this note stale and drop it on the
+    FIRST request after delivery — permanently losing an exactly-once
+    delivery the SignalDelivered record claims was live. Staleness must
+    key on the note channel's own bookkeeping instead.
+    """
+    session, note_content = _delivered_note_session(
+        body="Observation: search_web called 5x with identical args.",
+        delivered_turn=3,
+        reasoning_turn=3,  # the agent has NOT had a full turn yet
+    )
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[PruneStaleSteerRule()], sinks=[sink])
+    request = FakeRequest(
+        contents=[
+            _text_content("real user request"),
+            _note_content("Observation: an older note from a resolved drift"),
+            note_content,
+        ]
+    )
+
+    result = await editor.apply(
+        request, session=session, host_agent_name="a", observation_only=False
+    )
+
+    # The stale footer note dropped; the freshly-delivered note SURVIVED.
+    assert result.applied_rules == ["prune_stale_steer"]
+    texts = [c.parts[0].text for c in request.contents]
+    assert len(texts) == 2
+    assert texts[0] == "real user request"
+    assert "search_web called 5x" in texts[1]
+
+
+@pytest.mark.asyncio
+async def test_prune_stale_steer_prunes_delivered_note_after_turn_advances() -> None:
+    """A delivered note from an EARLIER reasoning turn is residue and drops."""
+    session, note_content = _delivered_note_session(
+        body="Observation: search_web called 5x with identical args.",
+        delivered_turn=3,
+        reasoning_turn=4,  # the agent had a full turn to see it
+    )
+    editor = ContextEditor(rules=[PruneStaleSteerRule()], sinks=[InMemorySink()])
+    request = FakeRequest(
+        contents=[_text_content("real user request"), note_content]
+    )
+
+    result = await editor.apply(
+        request, session=session, host_agent_name="a", observation_only=False
+    )
+
+    assert result.applied_rules == ["prune_stale_steer"]
+    assert [c.parts[0].text for c in request.contents] == ["real user request"]
+
+
+@pytest.mark.asyncio
+async def test_prune_stale_steer_dry_run_delivery_does_not_anchor_freshness() -> None:
+    """A dry-run consume never reached the agent — it must not keep a note alive."""
+    session, note_content = _delivered_note_session(
+        body="Observation: search_web called 5x with identical args.",
+        delivered_turn=3,
+        reasoning_turn=3,
+        dry_run=True,
+    )
+    editor = ContextEditor(rules=[PruneStaleSteerRule()], sinks=[InMemorySink()])
+    request = FakeRequest(
+        contents=[_text_content("real user request"), note_content]
+    )
+
+    result = await editor.apply(
+        request, session=session, host_agent_name="a", observation_only=False
+    )
+
+    assert result.applied_rules == ["prune_stale_steer"]
+    assert [c.parts[0].text for c in request.contents] == ["real user request"]
+
+
+@pytest.mark.asyncio
+async def test_prune_stale_steer_ignores_model_turn_quoting_marker() -> None:
+    """A MODEL turn quoting the marker string is not a goldfive note (finding 4)."""
+    from goldfive.observer_notes import OBSERVER_NOTE_MARKER_PREFIX
+
+    editor = ContextEditor(rules=[PruneStaleSteerRule()], sinks=[InMemorySink()])
+    quoting_model_turn = _text_content(
+        f"The transcript contains a block starting with "
+        f"{OBSERVER_NOTE_MARKER_PREFIX} which I will now discuss.",
+        role="model",
+    )
+    request = FakeRequest(
+        contents=[_text_content("real user request"), quoting_model_turn]
+    )
+    original = list(request.contents)
+
+    result = await editor.apply(
+        request, session=FakeSession(), host_agent_name="a", observation_only=False
+    )
+
+    assert result.applied_rules == []
+    assert request.contents == original
+
+
+@pytest.mark.asyncio
+async def test_prune_stale_steer_ignores_tool_part_content_with_marker_text() -> None:
+    """A content carrying tool parts is never treated as a goldfive note (finding 4)."""
+    from goldfive.observer_notes import OBSERVER_NOTE_MARKER_PREFIX
+
+    editor = ContextEditor(rules=[PruneStaleSteerRule()], sinks=[InMemorySink()])
+    mixed = FakeContent(
+        role="user",
+        parts=[
+            FakePart(text=f"{OBSERVER_NOTE_MARKER_PREFIX} quoted next to a tool result"),
+            FakePart(
+                function_response=FakeFunctionResponse(
+                    id="fc-1", name="read", response={"ok": True}
+                )
+            ),
+        ],
+    )
+    request = FakeRequest(
+        contents=[_text_content("user"), _call_content("fc-1", name="read"), mixed]
+    )
+    original = list(request.contents)
+
+    result = await editor.apply(
+        request, session=FakeSession(), host_agent_name="a", observation_only=False
+    )
+
+    assert result.applied_rules == []
+    assert request.contents == original
 
 
 @pytest.mark.asyncio
@@ -1009,6 +1190,296 @@ async def test_compact_prior_reasoning_drift_verdict_lowers_threshold() -> None:
         if p.function_call is not None
     ]
     assert fc_ids == ["fc-1"]
+
+
+@pytest.mark.asyncio
+async def test_compact_identical_claim_requires_identical_results() -> None:
+    """Finding-2 regression: differing errors are never called 'identical results'.
+
+    Three same-signature calls with three DIFFERENT errors collapse under
+    an HONEST summary that says the results differed and preserves the
+    LAST error verbatim — the progression's endpoint.
+    """
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[CompactPriorReasoningRule()], sinks=[sink])
+    request = FakeRequest(
+        contents=[
+            _text_content("user input"),
+            _call_content("fc-1", name="search"),
+            _failed_response_content("fc-1", name="search", detail="error A: index missing"),
+            _call_content("fc-2", name="search"),
+            _failed_response_content("fc-2", name="search", detail="error B: index corrupt"),
+            _call_content("fc-3", name="search"),
+            _failed_response_content("fc-3", name="search", detail="error C: index rebuilt"),
+        ]
+    )
+
+    result = await editor.apply(
+        request, session=FakeSession(), host_agent_name="a", observation_only=False
+    )
+
+    assert result.applied_rules == ["compact_prior_reasoning"]
+    kept = {
+        p.function_response.id: p.function_response.response
+        for c in request.contents
+        for p in c.parts
+        if p.function_response is not None
+    }
+    assert set(kept) == {"fc-1"}
+    summary = kept["fc-1"]["goldfive_compacted"]
+    # Honest claim: results differed; the FALSE claim never appears.
+    assert "identical results" not in summary
+    assert "results differed" in summary
+    # The LAST error is preserved verbatim inside the summary.
+    assert "error C: index rebuilt" in summary
+    # Earlier errors are the collapsed material.
+    assert "error A" not in summary
+
+
+@pytest.mark.asyncio
+async def test_compact_identical_results_keeps_identical_claim() -> None:
+    """The original 'identical results' claim survives when payloads ARE identical."""
+    editor = ContextEditor(rules=[CompactPriorReasoningRule()], sinks=[InMemorySink()])
+    request = FakeRequest(
+        contents=[
+            _text_content("user input"),
+            _call_content("fc-1", name="search"),
+            _failed_response_content("fc-1", name="search"),
+            _call_content("fc-2", name="search"),
+            _failed_response_content("fc-2", name="search"),
+            _call_content("fc-3", name="search"),
+            _failed_response_content("fc-3", name="search"),
+        ]
+    )
+    result = await editor.apply(
+        request, session=FakeSession(), host_agent_name="a", observation_only=False
+    )
+    assert result.applied_rules == ["compact_prior_reasoning"]
+    kept = {
+        p.function_response.id: p.function_response.response
+        for c in request.contents
+        for p in c.parts
+        if p.function_response is not None
+    }
+    assert "identical arguments and identical results" in kept["fc-1"]["goldfive_compacted"]
+
+
+def _big_args_call_content(fc_id: str, name: str = "fetch") -> FakeContent:
+    """A call with sizeable args so collapsing clearly beats the summary bytes."""
+    return FakeContent(
+        role="model",
+        parts=[
+            FakePart(
+                function_call=FakeFunctionCall(
+                    id=fc_id,
+                    name=name,
+                    args={"query": "the same long query string " * 6},
+                )
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_compact_composes_with_transient_redaction() -> None:
+    """Finding-3 regression: redaction upstream must not blind compaction.
+
+    Chain order [prune_transient_error, compact_prior_reasoning]: three
+    same-signature transient errors with DIFFERING messages are first
+    redacted in place (identical marker payloads), then compacted — the
+    redacted payloads count as failed, group under result identity, and
+    the summary honestly reports elided transient errors rather than
+    claiming identical tool results. Pins the rule composition.
+    """
+    sink = InMemorySink()
+    editor = ContextEditor(
+        rules=[PruneTransientErrorRule(), CompactPriorReasoningRule()],
+        sinks=[sink],
+    )
+    request = FakeRequest(
+        contents=[
+            _text_content("user input"),
+            _big_args_call_content("fc-1"),
+            _transient_response_content(
+                "fc-1",
+                response={"error": {"code": 429, "message": "rate limit exceeded; retry in 10s"}},
+            ),
+            _big_args_call_content("fc-2"),
+            _transient_response_content(
+                "fc-2",
+                response={"error": {"code": 429, "message": "rate limit exceeded; retry in 30s"}},
+            ),
+            _big_args_call_content("fc-3"),
+            _transient_response_content(
+                "fc-3",
+                response={"error": {"code": 429, "message": "rate limit exceeded; retry in 60s"}},
+            ),
+        ]
+    )
+
+    result = await editor.apply(
+        request, session=FakeSession(), host_agent_name="a", observation_only=False
+    )
+
+    assert result.applied_rules == [
+        "prune_transient_error",
+        "compact_prior_reasoning",
+    ]
+    kept = {
+        p.function_response.id: p.function_response.response
+        for c in request.contents
+        for p in c.parts
+        if p.function_response is not None
+    }
+    assert set(kept) == {"fc-1"}
+    summary = kept["fc-1"]["goldfive_compacted"]
+    assert "transient error" in summary
+    assert "elided" in summary
+    # The transcript's payloads WERE identical post-redaction, but the
+    # tool's results were not observed to be — never claim they were.
+    assert "identical results" not in summary
+    # Pairing invariant held across the composed chain.
+    fc_ids = [
+        p.function_call.id
+        for c in request.contents
+        for p in c.parts
+        if p.function_call is not None
+    ]
+    assert fc_ids == ["fc-1"]
+
+
+@pytest.mark.asyncio
+async def test_compact_skips_content_with_idless_tool_part() -> None:
+    """Finding-5 regression: an id-less tool part is never clobbered or dropped.
+
+    A response content that batches the failed response WITH an id-less
+    function_response (unattributable to any call) fails the ownership
+    guard, so the whole group is conservatively left untouched.
+    """
+    mixed_response = FakeContent(
+        role="user",
+        parts=[
+            FakePart(
+                function_response=FakeFunctionResponse(
+                    id="fc-2", name="search", response={"error": "boom " * 12}
+                )
+            ),
+            # Id-less sibling part — unrelated payload that must survive.
+            FakePart(
+                function_response=FakeFunctionResponse(
+                    id="", name="stream_chunk", response={"data": "precious"}
+                )
+            ),
+        ],
+    )
+    editor = ContextEditor(rules=[CompactPriorReasoningRule()], sinks=[InMemorySink()])
+    request = FakeRequest(
+        contents=[
+            _text_content("user input"),
+            _call_content("fc-1", name="search"),
+            _failed_response_content("fc-1", name="search", detail="boom"),
+            _call_content("fc-2", name="search"),
+            mixed_response,
+            _call_content("fc-3", name="search"),
+            _failed_response_content("fc-3", name="search", detail="boom"),
+        ]
+    )
+    original = list(request.contents)
+
+    result = await editor.apply(
+        request, session=FakeSession(), host_agent_name="a", observation_only=False
+    )
+
+    assert result.applied_rules == []
+    assert request.contents == original
+    # The id-less part's payload is untouched.
+    assert mixed_response.parts[1].function_response.response == {"data": "precious"}
+
+
+# ---------------------------------------------------------------------------
+# ContextEdited telemetry truthfulness (finding 6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_edited_before_count_is_per_rule() -> None:
+    """Each ContextEdited reports ITS rule's input count, not the pre-chain count."""
+
+    class _DropFirst:
+        name = "drop_first"
+
+        def edit(self, contents, ctx):  # type: ignore[no-untyped-def]
+            return contents[1:] if len(contents) > 1 else None
+
+    class _DropLast:
+        name = "drop_last"
+
+        def edit(self, contents, ctx):  # type: ignore[no-untyped-def]
+            return contents[:-1] if len(contents) > 1 else None
+
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[_DropFirst(), _DropLast()], sinks=[sink])
+    request = FakeRequest(
+        contents=[_text_content("a"), _text_content("b"), _text_content("c")]
+    )
+
+    result = await editor.apply(
+        request, session=FakeSession(), host_agent_name="a", observation_only=False
+    )
+
+    assert result.applied_rules == ["drop_first", "drop_last"]
+    edited = [
+        e for e in sink.events if isinstance(e, dict) and e.get("kind") == "context_edited"
+    ]
+    by_rule = {e["payload"]["rule_name"]: e["payload"] for e in edited}
+    assert by_rule["drop_first"]["contents_count_before"] == 3
+    assert by_rule["drop_first"]["contents_count_after"] == 2
+    # The second rule saw the FIRST rule's output (2), not the original 3.
+    assert by_rule["drop_last"]["contents_count_before"] == 2
+    assert by_rule["drop_last"]["contents_count_after"] == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_swap_suppresses_context_edited_events() -> None:
+    """No ContextEdited survives a failed contents swap — the edit never landed."""
+
+    class _FrozenRequest:
+        """Request whose ``contents`` setter raises (swap failure)."""
+
+        def __init__(self, contents: list[FakeContent]) -> None:
+            self._contents = contents
+
+        @property
+        def contents(self) -> list[FakeContent]:
+            return self._contents
+
+        @contents.setter
+        def contents(self, value: list[FakeContent]) -> None:
+            raise RuntimeError("frozen request")
+
+    class _DropFirst:
+        name = "drop_first"
+
+        def edit(self, contents, ctx):  # type: ignore[no-untyped-def]
+            return contents[1:] if len(contents) > 1 else None
+
+    sink = InMemorySink()
+    editor = ContextEditor(rules=[_DropFirst()], sinks=[sink])
+    request = _FrozenRequest([_text_content("a"), _text_content("b")])
+    original = list(request.contents)
+
+    result = await editor.apply(
+        request, session=FakeSession(), host_agent_name="a", observation_only=False
+    )
+
+    # The edit was reverted and NO ContextEdited event claims otherwise.
+    assert result.applied_rules == []
+    assert request.contents == original
+    edited = [
+        e for e in sink.events if isinstance(e, dict) and e.get("kind") == "context_edited"
+    ]
+    assert edited == []
+    assert result.contents_count_after == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Cluster A of the pre-merge fix-pack: the six context_editor.py rule defects (PR 6b). All findings re-verified on post-#506 code before fixing — **all six confirmed present**. The rules are default-UNWIRED (`SteeringConfig.context_editor_rules` defaults to `None`, so the plugin never constructs the editor); every fix is inert under default flags. Finding 1 matters for the 13b target regime, which enables the rules.

## Per-finding status

| # | Finding | Re-verified status | Fix |
|---|---------|--------------------|-----|
| 1 | HIGH — PruneStaleSteerRule strips new-channel observer notes before the agent sees them | **Confirmed** — `_is_stale` keyed solely on `goldfive.active_steer.body`; the new regime never writes it (PR 7 scoped `set_active_steer` to `legacy_ladder`; `_route_corrective_note` only enqueues). A boundary-replay note (`_consume_observer_note_for_replay` → `mark_delivered` → `render_block` as next user turn) was dropped on the FIRST post-delivery request while SignalDelivered recorded a live delivery. | Staleness now keys on the note channel's own bookkeeping: a marker-wrapped content matching a delivered (non-dry-run) `ObserverNoteQueue` note is FRESH while the session's reasoning turn has not advanced past that note's `delivered_turn`; the `active_steer.body` match is kept for legacy-ladder footer bodies. Per-note visibility clocks (rather than a single most-recent-delivered winner) so a `before_model` (system_instruction) consume at the same turn can never displace a contents-rendered replay note. Dry-run consumes never anchor freshness. Deterministic per `(session.state, _reasoning_turn)` snapshot; drop-only preserved. |
| 2 | MEDIUM — "identical results" claimed without comparing results | **Confirmed** — grouping by call signature only; `_summary_value` claimed identical results unconditionally. | Result identity checked via canonical payload JSON (`sort_keys=True` — structured-data comparison, not NL). Identical payloads keep the original claim byte-for-byte; differing results get an honest "results differed across attempts" summary that preserves the LAST result verbatim (the error progression's endpoint). |
| 3 | MEDIUM — transient-error redaction blinds compaction | **Confirmed** — the redaction payload has no error indicator, so redacted loops never entered `failed_ids`. | Shared `_REDACTION_KEY` constant; a `goldfive_redacted` payload counts as failed and all redactions of a signature carry one identical marker payload, so they group under result identity. Their summary truthfully reports "transient error whose payload was elided" instead of claiming identical tool results. Composition `[prune_transient_error, compact_prior_reasoning]` pinned by test. |
| 4 | LOW — marker detection role/tool-part-blind | **Confirmed** — `_is_goldfive_note` matched text on any content. | Shape gate matching how surfaces actually inject notes (plain user-text turns): explicit non-user roles and any content carrying `function_call`/`function_response` parts are never treated as goldfive notes. |
| 5 | LOW — compaction clobbers/drops id-less tool parts | **Confirmed** — `_content_owned_by_id` passed empty-id parts (`if pid and ...`) and `_summarize_response` rewrote every response part on the clone. | Id-less tool parts are un-owned → the group is conservatively skipped and the part preserved; `_summarize_response` additionally rewrites only the matching-id part. |
| 6 | LOW — ContextEdited telemetry: pre-chain before-count + events survive failed swap | **Confirmed** — `contents_count_before=len(original_contents)` and emission preceded the swap attempt. | Per-rule before-count (the rule's actual input length); applied-event emission deferred until the `llm_request.contents` swap succeeds — a failed swap suppresses all pending ContextEdited events (with a warning log) while rejection events still emit inline. |

## Discipline

- Inert under defaults: rules only exist when `context_editor_rules` is configured non-empty; no dispatch-path changes.
- No prompt-cooperation contracts; result-identity/redaction checks are exact structured-data comparisons (canonical JSON / exact key), never NL heuristics.
- No kill-switch/channel/ledger reads added; §6.6-deferred escalation semantics untouched.

## Tests

- 11 new tests in `tests/test_context_editor.py` (finding-1 regression pair: freshly-delivered boundary-replay note SURVIVES the first post-delivery edit pass via the real `ObserverNoteQueue` + `render_block` path, earlier-turn note still pruned; dry-run non-anchoring; both compaction summary shapes; redaction→compaction composition; model-turn/tool-part marker quoting; id-less part preservation; per-rule before-count; failed-swap suppression). Pinned test `test_prune_stale_steer_no_active_steer_drops_all_notes` updated (docstring — behavior unchanged for the no-bookkeeping case).
- `tests/test_context_editor.py`: 34 passed.
- Full suite: **3330 passed, 61 skipped**. `ruff check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZmpB3RYzxzTxR64THo1oA
